### PR TITLE
fix(llm-connections): Add Bedrock Geo Surcharges, differentiated 5m vs. 1hr TTL

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2,7 +2,7 @@
   {
     "id": "b9854a5c92dc496b997d99d20",
     "modelName": "gpt-4o",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o)$",
     "createdAt": "2024-05-13T23:15:07.670Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -19,10 +19,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000025,
-          "input_cached_tokens": 0.00000125,
-          "input_cache_read": 0.00000125,
-          "output": 0.00001
+          "input": 2.5e-06,
+          "input_cached_tokens": 1.25e-06,
+          "input_cache_read": 1.25e-06,
+          "output": 1e-05
         }
       }
     ]
@@ -30,7 +30,7 @@
   {
     "id": "b9854a5c92dc496b997d99d21",
     "modelName": "gpt-4o-2024-05-13",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-05-13)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-05-13)$",
     "createdAt": "2024-05-13T23:15:07.670Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -47,8 +47,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000005,
-          "output": 0.000015
+          "input": 5e-06,
+          "output": 1.5e-05
         }
       }
     ]
@@ -56,7 +56,7 @@
   {
     "id": "clrkvq6iq000008ju6c16gynt",
     "modelName": "gpt-4-1106-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-1106-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-1106-preview)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -73,8 +73,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -82,7 +82,7 @@
   {
     "id": "clrkvx5gp000108juaogs54ea",
     "modelName": "gpt-4-turbo-vision",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4(-\\d{4})?-vision-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4(-\\d{4})?-vision-preview)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -99,8 +99,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -108,7 +108,7 @@
   {
     "id": "clrkvyzgw000308jue4hse4j9",
     "modelName": "gpt-4-32k",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-32k)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -125,7 +125,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00006,
+          "input": 6e-05,
           "output": 0.00012
         }
       }
@@ -134,7 +134,7 @@
   {
     "id": "clrkwk4cb000108l5hwwh3zdi",
     "modelName": "gpt-4-32k-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-32k-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -151,7 +151,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00006,
+          "input": 6e-05,
           "output": 0.00012
         }
       }
@@ -160,7 +160,7 @@
   {
     "id": "clrkwk4cb000208l59yvb9yq8",
     "modelName": "gpt-3.5-turbo-1106",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-1106)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-1106)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -177,8 +177,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000001,
-          "output": 0.000002
+          "input": 1e-06,
+          "output": 2e-06
         }
       }
     ]
@@ -186,7 +186,7 @@
   {
     "id": "clrkwk4cc000808l51xmk4uic",
     "modelName": "gpt-3.5-turbo-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -203,8 +203,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000015,
-          "output": 0.000002
+          "input": 1.5e-06,
+          "output": 2e-06
         }
       }
     ]
@@ -212,7 +212,7 @@
   {
     "id": "clrkwk4cc000908l537kl0rx3",
     "modelName": "gpt-4-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -229,8 +229,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00003,
-          "output": 0.00006
+          "input": 3e-05,
+          "output": 6e-05
         }
       }
     ]
@@ -238,7 +238,7 @@
   {
     "id": "clrkwk4cc000a08l562uc3s9g",
     "modelName": "gpt-3.5-turbo-instruct",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-instruct)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-instruct)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -255,8 +255,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000015,
-          "output": 0.000002
+          "input": 1.5e-06,
+          "output": 2e-06
         }
       }
     ]
@@ -279,7 +279,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 0.000004
+          "total": 4e-06
         }
       }
     ]
@@ -302,7 +302,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 5e-7
+          "total": 5e-07
         }
       }
     ]
@@ -325,7 +325,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 0.00002
+          "total": 2e-05
         }
       }
     ]
@@ -348,7 +348,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 0.00002
+          "total": 2e-05
         }
       }
     ]
@@ -371,7 +371,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 0.00002
+          "total": 2e-05
         }
       }
     ]
@@ -394,7 +394,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 0.00002
+          "total": 2e-05
         }
       }
     ]
@@ -417,7 +417,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-7
+          "total": 1e-07
         }
       }
     ]
@@ -440,7 +440,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-7
+          "total": 1e-07
         }
       }
     ]
@@ -448,7 +448,7 @@
   {
     "id": "clrntjt89000a08jw0gcdbd5a",
     "modelName": "gpt-3.5-turbo-16k-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-16k-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-16k-0613)$",
     "createdAt": "2024-02-03T17:29:57.350Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -465,8 +465,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "output": 0.000004
+          "input": 3e-06,
+          "output": 4e-06
         }
       }
     ]
@@ -474,7 +474,7 @@
   {
     "id": "clrntkjgy000a08jx4e062mr0",
     "modelName": "gpt-3.5-turbo-0301",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0301)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0301)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -491,8 +491,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000002,
-          "output": 0.000002
+          "input": 2e-06,
+          "output": 2e-06
         }
       }
     ]
@@ -500,7 +500,7 @@
   {
     "id": "clrntkjgy000d08jx0p4y9h4l",
     "modelName": "gpt-4-32k-0314",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k-0314)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-32k-0314)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -517,7 +517,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00006,
+          "input": 6e-05,
           "output": 0.00012
         }
       }
@@ -526,7 +526,7 @@
   {
     "id": "clrntkjgy000e08jx4x6uawoo",
     "modelName": "gpt-4-0314",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-0314)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-0314)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -543,8 +543,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00003,
-          "output": 0.00006
+          "input": 3e-05,
+          "output": 6e-05
         }
       }
     ]
@@ -552,7 +552,7 @@
   {
     "id": "clrntkjgy000f08jx79v9g1xj",
     "modelName": "gpt-4",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -569,8 +569,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00003,
-          "output": 0.00006
+          "input": 3e-05,
+          "output": 6e-05
         }
       }
     ]
@@ -578,7 +578,7 @@
   {
     "id": "clrnwb41q000308jsfrac9uh6",
     "modelName": "claude-instant-1.2",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-instant-1.2)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-instant-1.2)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -590,8 +590,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000163,
-          "output": 0.00000551
+          "input": 1.63e-06,
+          "output": 5.51e-06
         }
       }
     ]
@@ -599,7 +599,7 @@
   {
     "id": "clrnwb836000408jsallr6u11",
     "modelName": "claude-2.0",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-2.0)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-2.0)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -611,8 +611,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000008,
-          "output": 0.000024
+          "input": 8e-06,
+          "output": 2.4e-05
         }
       }
     ]
@@ -620,7 +620,7 @@
   {
     "id": "clrnwbd1m000508js4hxu6o7n",
     "modelName": "claude-2.1",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-2.1)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-2.1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -632,8 +632,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000008,
-          "output": 0.000024
+          "input": 8e-06,
+          "output": 2.4e-05
         }
       }
     ]
@@ -641,7 +641,7 @@
   {
     "id": "clrnwbg2b000608jse2pp4q2d",
     "modelName": "claude-1.3",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-1.3)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-1.3)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -653,8 +653,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000008,
-          "output": 0.000024
+          "input": 8e-06,
+          "output": 2.4e-05
         }
       }
     ]
@@ -662,7 +662,7 @@
   {
     "id": "clrnwbi9d000708jseiy44k26",
     "modelName": "claude-1.2",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-1.2)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-1.2)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -674,8 +674,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000008,
-          "output": 0.000024
+          "input": 8e-06,
+          "output": 2.4e-05
         }
       }
     ]
@@ -683,7 +683,7 @@
   {
     "id": "clrnwblo0000808jsc1385hdp",
     "modelName": "claude-1.1",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-1.1)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-1.1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -695,8 +695,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000008,
-          "output": 0.000024
+          "input": 8e-06,
+          "output": 2.4e-05
         }
       }
     ]
@@ -704,7 +704,7 @@
   {
     "id": "clrnwbota000908jsgg9mb1ml",
     "modelName": "claude-instant-1",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-instant-1)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-instant-1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -716,8 +716,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000163,
-          "output": 0.00000551
+          "input": 1.63e-06,
+          "output": 5.51e-06
         }
       }
     ]
@@ -740,8 +740,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 4e-7,
-          "output": 0.0000016
+          "input": 4e-07,
+          "output": 1.6e-06
         }
       }
     ]
@@ -764,8 +764,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000006,
-          "output": 0.000012
+          "input": 6e-06,
+          "output": 1.2e-05
         }
       }
     ]
@@ -788,7 +788,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 2e-8
+          "total": 2e-08
         }
       }
     ]
@@ -811,7 +811,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1.3e-7
+          "total": 1.3e-07
         }
       }
     ]
@@ -819,7 +819,7 @@
   {
     "id": "clruwnahl00030al7ab9rark7",
     "modelName": "gpt-3.5-turbo-0125",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0125)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0125)$",
     "createdAt": "2024-01-26T17:35:21.129Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -836,8 +836,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-7,
-          "output": 0.0000015
+          "input": 5e-07,
+          "output": 1.5e-06
         }
       }
     ]
@@ -845,7 +845,7 @@
   {
     "id": "clruwnahl00040al78f1lb0at",
     "modelName": "gpt-3.5-turbo",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo)$",
     "createdAt": "2024-02-13T12:00:37.424Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -862,8 +862,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-7,
-          "output": 0.0000015
+          "input": 5e-07,
+          "output": 1.5e-06
         }
       }
     ]
@@ -871,7 +871,7 @@
   {
     "id": "clruwnahl00050al796ck3p44",
     "modelName": "gpt-4-0125-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-0125-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-0125-preview)$",
     "createdAt": "2024-01-26T17:35:21.129Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -888,8 +888,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -914,8 +914,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "output": 0.000006
+          "input": 3e-06,
+          "output": 6e-06
         }
       }
     ]
@@ -940,8 +940,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000012,
-          "output": 0.000016
+          "input": 1.2e-05,
+          "output": 1.6e-05
         }
       }
     ]
@@ -964,8 +964,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000012,
-          "output": 0.000012
+          "input": 1.2e-05,
+          "output": 1.2e-05
         }
       }
     ]
@@ -988,8 +988,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000016,
-          "output": 0.0000016
+          "input": 1.6e-06,
+          "output": 1.6e-06
         }
       }
     ]
@@ -1008,8 +1008,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1028,8 +1028,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1048,8 +1048,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1068,8 +1068,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1088,8 +1088,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1108,8 +1108,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000025,
-          "output": 0.0000075
+          "input": 2.5e-06,
+          "output": 7.5e-06
         }
       }
     ]
@@ -1128,8 +1128,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1148,7 +1148,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-7
+          "total": 1e-07
         }
       }
     ]
@@ -1167,7 +1167,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-7
+          "total": 1e-07
         }
       }
     ]
@@ -1186,8 +1186,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1206,8 +1206,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1226,8 +1226,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1235,7 +1235,7 @@
   {
     "id": "clsk9lntu000008jwfc51bbqv",
     "modelName": "gpt-3.5-turbo-16k",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-16k)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-16k)$",
     "createdAt": "2024-02-13T12:00:37.424Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1252,8 +1252,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-7,
-          "output": 0.0000015
+          "input": 5e-07,
+          "output": 1.5e-06
         }
       }
     ]
@@ -1261,7 +1261,7 @@
   {
     "id": "clsnq07bn000008l4e46v1ll8",
     "modelName": "gpt-4-turbo-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo-preview)$",
     "createdAt": "2024-02-15T21:21:50.947Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1278,8 +1278,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -1287,7 +1287,7 @@
   {
     "id": "cltgy0iuw000008le3vod1hhy",
     "modelName": "claude-3-opus-20240229",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-opus-20240229|anthropic\\.claude-3-opus-20240229-v1:0|claude-3-opus@20240229)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-opus-20240229|anthropic\\.claude-3-opus-20240229-v1:0|claude-3-opus@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1299,8 +1299,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "output": 0.000075
+          "input": 1.5e-05,
+          "output": 7.5e-05
         }
       }
     ]
@@ -1308,7 +1308,7 @@
   {
     "id": "cltgy0pp6000108le56se7bl3",
     "modelName": "claude-3-sonnet-20240229",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-sonnet-20240229|anthropic\\.claude-3-sonnet-20240229-v1:0|claude-3-sonnet@20240229)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-sonnet-20240229|anthropic\\.claude-3-sonnet-20240229-v1:0|claude-3-sonnet@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1320,14 +1320,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "cache_read_input_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cache_read": 3e-07,
+          "cache_write_5m_input_tokens": 3.75e-06,
+          "cache_write_1h_input_tokens": 6e-06
         }
       }
     ]
@@ -1335,7 +1337,7 @@
   {
     "id": "cltr0w45b000008k1407o9qv1",
     "modelName": "claude-3-haiku-20240307",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-haiku-20240307|anthropic\\.claude-3-haiku-20240307-v1:0|claude-3-haiku@20240307)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-haiku-20240307|anthropic\\.claude-3-haiku-20240307-v1:0|claude-3-haiku@20240307)$",
     "createdAt": "2024-03-14T09:41:18.736Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1347,8 +1349,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 0.00000125
+          "input": 2.5e-07,
+          "output": 1.25e-06
         }
       }
     ]
@@ -1356,7 +1358,7 @@
   {
     "id": "cluv2sjeo000008ih0fv23hi0",
     "modelName": "gemini-1.0-pro-latest",
-    "matchPattern": "(?i)^(google\/)?(gemini-1.0-pro-latest)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google/)?(gemini-1.0-pro-latest)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1367,8 +1369,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1376,7 +1378,7 @@
   {
     "id": "cluv2subq000108ih2mlrga6a",
     "modelName": "gemini-1.0-pro",
-    "matchPattern": "(?i)^(google\/)?(gemini-1.0-pro)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google/)?(gemini-1.0-pro)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1387,8 +1389,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-7,
-          "output": 3.75e-7
+          "input": 1.25e-07,
+          "output": 3.75e-07
         }
       }
     ]
@@ -1396,7 +1398,7 @@
   {
     "id": "cluv2sx04000208ihbek75lsz",
     "modelName": "gemini-1.0-pro-001",
-    "matchPattern": "(?i)^(google\/)?(gemini-1.0-pro-001)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google/)?(gemini-1.0-pro-001)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1407,8 +1409,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-7,
-          "output": 3.75e-7
+          "input": 1.25e-07,
+          "output": 3.75e-07
         }
       }
     ]
@@ -1416,7 +1418,7 @@
   {
     "id": "cluv2szw0000308ihch3n79x7",
     "modelName": "gemini-pro",
-    "matchPattern": "(?i)^(google\/)?(gemini-pro)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google/)?(gemini-pro)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1427,8 +1429,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-7,
-          "output": 3.75e-7
+          "input": 1.25e-07,
+          "output": 3.75e-07
         }
       }
     ]
@@ -1436,7 +1438,7 @@
   {
     "id": "cluv2t2x0000408ihfytl45l1",
     "modelName": "gemini-1.5-pro-latest",
-    "matchPattern": "(?i)^(google\/)?(gemini-1.5-pro-latest)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google/)?(gemini-1.5-pro-latest)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1447,8 +1449,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000025,
-          "output": 0.0000075
+          "input": 2.5e-06,
+          "output": 7.5e-06
         }
       }
     ]
@@ -1456,7 +1458,7 @@
   {
     "id": "cluv2t5k3000508ih5kve9zag",
     "modelName": "gpt-4-turbo-2024-04-09",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo-2024-04-09)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo-2024-04-09)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1473,8 +1475,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -1482,7 +1484,7 @@
   {
     "id": "cluvpl4ls000008l6h2gx3i07",
     "modelName": "gpt-4-turbo",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo)$",
     "createdAt": "2024-04-11T21:13:44.989Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1499,8 +1501,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -1508,7 +1510,7 @@
   {
     "id": "clv2o2x0p000008jsf9afceau",
     "modelName": " gpt-4-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-preview)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1525,8 +1527,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -1534,7 +1536,7 @@
   {
     "id": "clxt0n0m60000pumz1j5b7zsf",
     "modelName": "claude-3-5-sonnet-20240620",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
     "createdAt": "2024-06-25T11:47:24.475Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1546,14 +1548,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "cache_read_input_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cache_read": 3e-07,
+          "cache_write_5m_input_tokens": 3.75e-06,
+          "cache_write_1h_input_tokens": 6e-06
         }
       }
     ]
@@ -1561,7 +1565,7 @@
   {
     "id": "clyrjp56f0000t0mzapoocd7u",
     "modelName": "gpt-4o-mini",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-mini)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-mini)$",
     "createdAt": "2024-07-18T17:56:09.591Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1578,10 +1582,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-7,
-          "output": 6e-7,
-          "input_cached_tokens": 7.5e-8,
-          "input_cache_read": 7.5e-8
+          "input": 1.5e-07,
+          "output": 6e-07,
+          "input_cached_tokens": 7.5e-08,
+          "input_cache_read": 7.5e-08
         }
       }
     ]
@@ -1589,7 +1593,7 @@
   {
     "id": "clyrjpbe20000t0mzcbwc42rg",
     "modelName": "gpt-4o-mini-2024-07-18",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-mini-2024-07-18)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-mini-2024-07-18)$",
     "createdAt": "2024-07-18T17:56:09.591Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1606,10 +1610,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-7,
-          "input_cached_tokens": 7.5e-8,
-          "input_cache_read": 7.5e-8,
-          "output": 6e-7
+          "input": 1.5e-07,
+          "input_cached_tokens": 7.5e-08,
+          "input_cache_read": 7.5e-08,
+          "output": 6e-07
         }
       }
     ]
@@ -1617,7 +1621,7 @@
   {
     "id": "clzjr85f70000ymmzg7hqffra",
     "modelName": "gpt-4o-2024-08-06",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-08-06)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-08-06)$",
     "createdAt": "2024-08-07T11:54:31.298Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1634,10 +1638,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000025,
-          "input_cached_tokens": 0.00000125,
-          "input_cache_read": 0.00000125,
-          "output": 0.00001
+          "input": 2.5e-06,
+          "input_cached_tokens": 1.25e-06,
+          "input_cache_read": 1.25e-06,
+          "output": 1e-05
         }
       }
     ]
@@ -1645,7 +1649,7 @@
   {
     "id": "cm10ivcdp0000gix7lelmbw80",
     "modelName": "o1-preview",
-    "matchPattern": "(?i)^(openai\/)?(o1-preview)$",
+    "matchPattern": "(?i)^(openai/)?(o1-preview)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1656,12 +1660,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_cached_tokens": 0.0000075,
-          "input_cache_read": 0.0000075,
-          "output": 0.00006,
-          "output_reasoning_tokens": 0.00006,
-          "output_reasoning": 0.00006
+          "input": 1.5e-05,
+          "input_cached_tokens": 7.5e-06,
+          "input_cache_read": 7.5e-06,
+          "output": 6e-05,
+          "output_reasoning_tokens": 6e-05,
+          "output_reasoning": 6e-05
         }
       }
     ]
@@ -1669,7 +1673,7 @@
   {
     "id": "cm10ivo130000n8x7qopcjjcg",
     "modelName": "o1-preview-2024-09-12",
-    "matchPattern": "(?i)^(openai\/)?(o1-preview-2024-09-12)$",
+    "matchPattern": "(?i)^(openai/)?(o1-preview-2024-09-12)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1680,12 +1684,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_cached_tokens": 0.0000075,
-          "input_cache_read": 0.0000075,
-          "output": 0.00006,
-          "output_reasoning_tokens": 0.00006,
-          "output_reasoning": 0.00006
+          "input": 1.5e-05,
+          "input_cached_tokens": 7.5e-06,
+          "input_cache_read": 7.5e-06,
+          "output": 6e-05,
+          "output_reasoning_tokens": 6e-05,
+          "output_reasoning": 6e-05
         }
       }
     ]
@@ -1693,7 +1697,7 @@
   {
     "id": "cm10ivwo40000r1x7gg3syjq0",
     "modelName": "o1-mini",
-    "matchPattern": "(?i)^(openai\/)?(o1-mini)$",
+    "matchPattern": "(?i)^(openai/)?(o1-mini)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1704,12 +1708,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 5.5e-7,
-          "input_cache_read": 5.5e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 5.5e-07,
+          "input_cache_read": 5.5e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
         }
       }
     ]
@@ -1717,7 +1721,7 @@
   {
     "id": "cm10iw6p20000wgx7it1hlb22",
     "modelName": "o1-mini-2024-09-12",
-    "matchPattern": "(?i)^(openai\/)?(o1-mini-2024-09-12)$",
+    "matchPattern": "(?i)^(openai/)?(o1-mini-2024-09-12)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1728,12 +1732,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 5.5e-7,
-          "input_cache_read": 5.5e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 5.5e-07,
+          "input_cache_read": 5.5e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
         }
       }
     ]
@@ -1741,7 +1745,7 @@
   {
     "id": "cm2krz1uf000208jjg5653iud",
     "modelName": "claude-3.5-sonnet-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1753,14 +1757,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "cache_read_input_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cache_read": 3e-07,
+          "cache_write_5m_input_tokens": 3.75e-06,
+          "cache_write_1h_input_tokens": 6e-06
         }
       }
     ]
@@ -1768,7 +1774,7 @@
   {
     "id": "cm2ks2vzn000308jjh4ze1w7q",
     "modelName": "claude-3.5-sonnet-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-latest)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1780,14 +1786,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "cache_read_input_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cache_read": 3e-07,
+          "cache_write_5m_input_tokens": 3.75e-06,
+          "cache_write_1h_input_tokens": 6e-06
         }
       }
     ]
@@ -1795,7 +1803,7 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "modelName": "claude-3-5-haiku-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1807,14 +1815,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-7,
-          "input_tokens": 8e-7,
-          "output": 0.000004,
-          "output_tokens": 0.000004,
-          "cache_creation_input_tokens": 0.000001,
-          "input_cache_creation": 0.000001,
-          "cache_read_input_tokens": 8e-8,
-          "input_cache_read": 8e-8
+          "input": 8e-07,
+          "input_tokens": 8e-07,
+          "output": 4e-06,
+          "output_tokens": 4e-06,
+          "cache_creation_input_tokens": 1e-06,
+          "input_cache_creation": 1e-06,
+          "cache_read_input_tokens": 8e-08,
+          "input_cache_read": 8e-08,
+          "cache_write_5m_input_tokens": 1e-06,
+          "cache_write_1h_input_tokens": 1.6e-06
         }
       }
     ]
@@ -1822,7 +1832,7 @@
   {
     "id": "cm34aqb9h000307ml6nypd618",
     "modelName": "claude-3.5-haiku-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-haiku-latest)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1834,14 +1844,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-7,
-          "input_tokens": 8e-7,
-          "output": 0.000004,
-          "output_tokens": 0.000004,
-          "cache_creation_input_tokens": 0.000001,
-          "input_cache_creation": 0.000001,
-          "cache_read_input_tokens": 8e-8,
-          "input_cache_read": 8e-8
+          "input": 8e-07,
+          "input_tokens": 8e-07,
+          "output": 4e-06,
+          "output_tokens": 4e-06,
+          "cache_creation_input_tokens": 1e-06,
+          "input_cache_creation": 1e-06,
+          "cache_read_input_tokens": 8e-08,
+          "input_cache_read": 8e-08,
+          "cache_write_5m_input_tokens": 1e-06,
+          "cache_write_1h_input_tokens": 1.6e-06
         }
       }
     ]
@@ -1866,8 +1878,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000005,
-          "output": 0.000015
+          "input": 5e-06,
+          "output": 1.5e-05
         }
       }
     ]
@@ -1875,7 +1887,7 @@
   {
     "id": "cm48akqgo000008ldbia24qg0",
     "modelName": "gpt-4o-2024-11-20",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-11-20)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-11-20)$",
     "createdAt": "2024-12-03T10:06:12.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1892,10 +1904,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000025,
-          "input_cached_tokens": 0.00000125,
-          "input_cache_read": 0.00000125,
-          "output": 0.00001
+          "input": 2.5e-06,
+          "input_cached_tokens": 1.25e-06,
+          "input_cache_read": 1.25e-06,
+          "output": 1e-05
         }
       }
     ]
@@ -1903,7 +1915,7 @@
   {
     "id": "cm48b2ksh000008l0hn3u0hl3",
     "modelName": "gpt-4o-audio-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-audio-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-audio-preview)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1914,8 +1926,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 0.0000025,
-          "output_text_tokens": 0.00001,
+          "input_text_tokens": 2.5e-06,
+          "output_text_tokens": 1e-05,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
           "output_audio_tokens": 0.0002,
@@ -1927,7 +1939,7 @@
   {
     "id": "cm48bbm0k000008l69nsdakwf",
     "modelName": "gpt-4o-audio-preview-2024-10-01",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-audio-preview-2024-10-01)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-audio-preview-2024-10-01)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1938,8 +1950,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 0.0000025,
-          "output_text_tokens": 0.00001,
+          "input_text_tokens": 2.5e-06,
+          "output_text_tokens": 1e-05,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
           "output_audio_tokens": 0.0002,
@@ -1951,7 +1963,7 @@
   {
     "id": "cm48c2qh4000008mhgy4mg2qc",
     "modelName": "gpt-4o-realtime-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-realtime-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-realtime-preview)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1962,12 +1974,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 0.000005,
-          "input_cached_text_tokens": 0.0000025,
-          "output_text_tokens": 0.00002,
+          "input_text_tokens": 5e-06,
+          "input_cached_text_tokens": 2.5e-06,
+          "output_text_tokens": 2e-05,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
-          "input_cached_audio_tokens": 0.00002,
+          "input_cached_audio_tokens": 2e-05,
           "output_audio_tokens": 0.0002,
           "output_audio": 0.0002
         }
@@ -1977,7 +1989,7 @@
   {
     "id": "cm48cjxtc000008jrcsso3avv",
     "modelName": "gpt-4o-realtime-preview-2024-10-01",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-realtime-preview-2024-10-01)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-realtime-preview-2024-10-01)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1988,12 +2000,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 0.000005,
-          "input_cached_text_tokens": 0.0000025,
-          "output_text_tokens": 0.00002,
+          "input_text_tokens": 5e-06,
+          "input_cached_text_tokens": 2.5e-06,
+          "output_text_tokens": 2e-05,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
-          "input_cached_audio_tokens": 0.00002,
+          "input_cached_audio_tokens": 2e-05,
           "output_audio_tokens": 0.0002,
           "output_audio": 0.0002
         }
@@ -2003,7 +2015,7 @@
   {
     "id": "cm48cjxtc000108jrcsso3avv",
     "modelName": "o1",
-    "matchPattern": "(?i)^(openai\/)?(o1)$",
+    "matchPattern": "(?i)^(openai/)?(o1)$",
     "createdAt": "2025-01-17T00:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2014,12 +2026,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_cached_tokens": 0.0000075,
-          "input_cache_read": 0.0000075,
-          "output": 0.00006,
-          "output_reasoning_tokens": 0.00006,
-          "output_reasoning": 0.00006
+          "input": 1.5e-05,
+          "input_cached_tokens": 7.5e-06,
+          "input_cache_read": 7.5e-06,
+          "output": 6e-05,
+          "output_reasoning_tokens": 6e-05,
+          "output_reasoning": 6e-05
         }
       }
     ]
@@ -2027,7 +2039,7 @@
   {
     "id": "cm48cjxtc000208jrcsso3avv",
     "modelName": "o1-2024-12-17",
-    "matchPattern": "(?i)^(openai\/)?(o1-2024-12-17)$",
+    "matchPattern": "(?i)^(openai/)?(o1-2024-12-17)$",
     "createdAt": "2025-01-17T00:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2038,12 +2050,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_cached_tokens": 0.0000075,
-          "input_cache_read": 0.0000075,
-          "output": 0.00006,
-          "output_reasoning_tokens": 0.00006,
-          "output_reasoning": 0.00006
+          "input": 1.5e-05,
+          "input_cached_tokens": 7.5e-06,
+          "input_cache_read": 7.5e-06,
+          "output": 6e-05,
+          "output_reasoning_tokens": 6e-05,
+          "output_reasoning": 6e-05
         }
       }
     ]
@@ -2051,7 +2063,7 @@
   {
     "id": "cm6l8j7vs0000tymz9vk7ew8t",
     "modelName": "o3-mini",
-    "matchPattern": "(?i)^(openai\/)?(o3-mini)$",
+    "matchPattern": "(?i)^(openai/)?(o3-mini)$",
     "createdAt": "2025-01-31T20:41:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2062,12 +2074,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 5.5e-7,
-          "input_cache_read": 5.5e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 5.5e-07,
+          "input_cache_read": 5.5e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
         }
       }
     ]
@@ -2075,7 +2087,7 @@
   {
     "id": "cm6l8jan90000tymz52sh0ql8",
     "modelName": "o3-mini-2025-01-31",
-    "matchPattern": "(?i)^(openai\/)?(o3-mini-2025-01-31)$",
+    "matchPattern": "(?i)^(openai/)?(o3-mini-2025-01-31)$",
     "createdAt": "2025-01-31T20:41:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2086,12 +2098,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 5.5e-7,
-          "input_cache_read": 5.5e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 5.5e-07,
+          "input_cache_read": 5.5e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
         }
       }
     ]
@@ -2099,7 +2111,7 @@
   {
     "id": "cm6l8jdef0000tymz52sh0ql0",
     "modelName": "gemini-2.0-flash-001",
-    "matchPattern": "(?i)^(google\/)?(gemini-2.0-flash-001)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google/)?(gemini-2.0-flash-001)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-02-06T11:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2110,8 +2122,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-7,
-          "output": 4e-7
+          "input": 1e-07,
+          "output": 4e-07
         }
       }
     ]
@@ -2119,7 +2131,7 @@
   {
     "id": "cm6l8jfgh0000tymz52sh0ql1",
     "modelName": "gemini-2.0-flash-lite-preview-02-05",
-    "matchPattern": "(?i)^(google\/)?(gemini-2.0-flash-lite-preview-02-05)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google/)?(gemini-2.0-flash-lite-preview-02-05)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-02-06T11:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2130,8 +2142,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 7.5e-8,
-          "output": 3e-7
+          "input": 7.5e-08,
+          "output": 3e-07
         }
       }
     ]
@@ -2139,7 +2151,7 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "modelName": "claude-3.7-sonnet-20250219",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -2151,14 +2163,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "cache_read_input_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cache_read": 3e-07,
+          "cache_write_5m_input_tokens": 3.75e-06,
+          "cache_write_1h_input_tokens": 6e-06
         }
       }
     ]
@@ -2166,7 +2180,7 @@
   {
     "id": "cm7ka7zob000208jsfs9h5ajj",
     "modelName": "claude-3.7-sonnet-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-7-sonnet-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-7-sonnet-latest)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -2178,14 +2192,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "cache_read_input_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cache_read": 3e-07,
+          "cache_write_5m_input_tokens": 3.75e-06,
+          "cache_write_1h_input_tokens": 6e-06
         }
       }
     ]
@@ -2193,7 +2209,7 @@
   {
     "id": "cm7nusjvk0000tvmz71o85jwg",
     "modelName": "gpt-4.5-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.5-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.5-preview)$",
     "createdAt": "2025-02-27T21:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2204,10 +2220,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000075,
-          "input_cached_tokens": 0.0000375,
-          "input_cached_text_tokens": 0.0000375,
-          "input_cache_read": 0.0000375,
+          "input": 7.5e-05,
+          "input_cached_tokens": 3.75e-05,
+          "input_cached_text_tokens": 3.75e-05,
+          "input_cache_read": 3.75e-05,
           "output": 0.00015
         }
       }
@@ -2216,7 +2232,7 @@
   {
     "id": "cm7nusn640000tvmzf10z2x65",
     "modelName": "gpt-4.5-preview-2025-02-27",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.5-preview-2025-02-27)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.5-preview-2025-02-27)$",
     "createdAt": "2025-02-27T21:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2227,10 +2243,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000075,
-          "input_cached_tokens": 0.0000375,
-          "input_cached_text_tokens": 0.0000375,
-          "input_cache_read": 0.0000375,
+          "input": 7.5e-05,
+          "input_cached_tokens": 3.75e-05,
+          "input_cached_text_tokens": 3.75e-05,
+          "input_cache_read": 3.75e-05,
           "output": 0.00015
         }
       }
@@ -2239,7 +2255,7 @@
   {
     "id": "cm7nusn643377tvmzh27m33kl",
     "modelName": "gpt-4.1",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2256,11 +2272,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000002,
-          "input_cached_tokens": 5e-7,
-          "input_cached_text_tokens": 5e-7,
-          "input_cache_read": 5e-7,
-          "output": 0.000008
+          "input": 2e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cached_text_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 8e-06
         }
       }
     ]
@@ -2268,7 +2284,7 @@
   {
     "id": "cm7qahw732891bpmzy45r3x70",
     "modelName": "gpt-4.1-2025-04-14",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-2025-04-14)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2285,11 +2301,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000002,
-          "input_cached_tokens": 5e-7,
-          "input_cached_text_tokens": 5e-7,
-          "input_cache_read": 5e-7,
-          "output": 0.000008
+          "input": 2e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cached_text_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 8e-06
         }
       }
     ]
@@ -2297,7 +2313,7 @@
   {
     "id": "cm7sglt825463kxnza72p6v81",
     "modelName": "gpt-4.1-mini-2025-04-14",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-mini-2025-04-14)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-mini-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2314,11 +2330,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 4e-7,
-          "input_cached_tokens": 1e-7,
-          "input_cached_text_tokens": 1e-7,
-          "input_cache_read": 1e-7,
-          "output": 0.0000016
+          "input": 4e-07,
+          "input_cached_tokens": 1e-07,
+          "input_cached_text_tokens": 1e-07,
+          "input_cache_read": 1e-07,
+          "output": 1.6e-06
         }
       }
     ]
@@ -2326,7 +2342,7 @@
   {
     "id": "cm7vxpz967124dhjtb95w8f92",
     "modelName": "gpt-4.1-nano-2025-04-14",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-nano-2025-04-14)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-nano-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2343,11 +2359,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-7,
-          "input_cached_tokens": 2.5e-8,
-          "input_cached_text_tokens": 2.5e-8,
-          "input_cache_read": 2.5e-8,
-          "output": 4e-7
+          "input": 1e-07,
+          "input_cached_tokens": 2.5e-08,
+          "input_cached_text_tokens": 2.5e-08,
+          "input_cache_read": 2.5e-08,
+          "output": 4e-07
         }
       }
     ]
@@ -2355,7 +2371,7 @@
   {
     "id": "cm7wmny967124dhjtb95w8f81",
     "modelName": "o3",
-    "matchPattern": "(?i)^(openai\/)?(o3)$",
+    "matchPattern": "(?i)^(openai/)?(o3)$",
     "createdAt": "2025-04-16T23:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2366,12 +2382,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000002,
-          "input_cached_tokens": 5e-7,
-          "input_cache_read": 5e-7,
-          "output": 0.000008,
-          "output_reasoning_tokens": 0.000008,
-          "output_reasoning": 0.000008
+          "input": 2e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 8e-06,
+          "output_reasoning_tokens": 8e-06,
+          "output_reasoning": 8e-06
         }
       }
     ]
@@ -2379,7 +2395,7 @@
   {
     "id": "cm7wopq3327124dhjtb95w8f81",
     "modelName": "o3-2025-04-16",
-    "matchPattern": "(?i)^(openai\/)?(o3-2025-04-16)$",
+    "matchPattern": "(?i)^(openai/)?(o3-2025-04-16)$",
     "createdAt": "2025-04-16T23:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2390,12 +2406,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000002,
-          "input_cached_tokens": 5e-7,
-          "input_cache_read": 5e-7,
-          "output": 0.000008,
-          "output_reasoning_tokens": 0.000008,
-          "output_reasoning": 0.000008
+          "input": 2e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 8e-06,
+          "output_reasoning_tokens": 8e-06,
+          "output_reasoning": 8e-06
         }
       }
     ]
@@ -2414,12 +2430,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 2.75e-7,
-          "input_cache_read": 2.75e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 2.75e-07,
+          "input_cache_read": 2.75e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
         }
       }
     ]
@@ -2438,12 +2454,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 2.75e-7,
-          "input_cache_read": 2.75e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 2.75e-07,
+          "input_cache_read": 2.75e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
         }
       }
     ]
@@ -2451,7 +2467,7 @@
   {
     "id": "cm7zsrs1327124dhjtb95w8f74",
     "modelName": "gemini-2.0-flash",
-    "matchPattern": "(?i)^(google\/)?(gemini-2.0-flash)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google/)?(gemini-2.0-flash)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2462,8 +2478,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-7,
-          "output": 4e-7
+          "input": 1e-07,
+          "output": 4e-07
         }
       }
     ]
@@ -2471,7 +2487,7 @@
   {
     "id": "cm7ztrs1327124dhjtb95w8f19",
     "modelName": "gemini-2.0-flash-lite-preview",
-    "matchPattern": "(?i)^(google\/)?(gemini-2.0-flash-lite-preview)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google/)?(gemini-2.0-flash-lite-preview)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2482,8 +2498,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 7.5e-8,
-          "output": 3e-7
+          "input": 7.5e-08,
+          "output": 3e-07
         }
       }
     ]
@@ -2491,7 +2507,7 @@
   {
     "id": "cm7zxrs1327124dhjtb95w8f45",
     "modelName": "gpt-4.1-nano",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-nano)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-nano)$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2508,11 +2524,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-7,
-          "input_cached_tokens": 2.5e-8,
-          "input_cached_text_tokens": 2.5e-8,
-          "input_cache_read": 2.5e-8,
-          "output": 4e-7
+          "input": 1e-07,
+          "input_cached_tokens": 2.5e-08,
+          "input_cached_text_tokens": 2.5e-08,
+          "input_cache_read": 2.5e-08,
+          "output": 4e-07
         }
       }
     ]
@@ -2520,7 +2536,7 @@
   {
     "id": "cm7zzrs1327124dhjtb95w8p96",
     "modelName": "gpt-4.1-mini",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-mini)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-mini)$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2537,11 +2553,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 4e-7,
-          "input_cached_tokens": 1e-7,
-          "input_cached_text_tokens": 1e-7,
-          "input_cache_read": 1e-7,
-          "output": 0.0000016
+          "input": 4e-07,
+          "input_cached_tokens": 1e-07,
+          "input_cached_text_tokens": 1e-07,
+          "input_cache_read": 1e-07,
+          "output": 1.6e-06
         }
       }
     ]
@@ -2549,7 +2565,7 @@
   {
     "id": "c5qmrqolku82tra3vgdixmys",
     "modelName": "claude-sonnet-4-5-20250929",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4-5(-20250929)?|anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
     "createdAt": "2025-09-29T00:00:00.000Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2561,14 +2577,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "cache_read_input_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cache_read": 3e-07,
+          "cache_write_5m_input_tokens": 3.75e-06,
+          "cache_write_1h_input_tokens": 6e-06
         }
       },
       {
@@ -2585,14 +2603,71 @@
           }
         ],
         "prices": {
-          "input": 0.000006,
-          "input_tokens": 0.000006,
-          "output": 0.0000225,
-          "output_tokens": 0.0000225,
-          "cache_creation_input_tokens": 0.0000075,
-          "input_cache_creation": 0.0000075,
-          "cache_read_input_tokens": 6e-7,
-          "input_cache_read": 6e-7
+          "input": 6e-06,
+          "input_tokens": 6e-06,
+          "output": 2.25e-05,
+          "output_tokens": 2.25e-05,
+          "cache_creation_input_tokens": 7.5e-06,
+          "input_cache_creation": 7.5e-06,
+          "cache_read_input_tokens": 6e-07,
+          "input_cache_read": 6e-07,
+          "cache_write_5m_input_tokens": 7.5e-06,
+          "cache_write_1h_input_tokens": 1.2e-05
+        }
+      }
+    ]
+  },
+  {
+    "id": "519a52c2-72b1-4fc7-ab93-e25511a434f2",
+    "modelName": "claude-sonnet-4-5-20250929-cris",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|global\\.)anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?$",
+    "createdAt": "2025-09-29T00:00:00.000Z",
+    "updatedAt": "2026-02-26T00:00:00.000Z",
+    "tokenizerId": "claude",
+    "pricingTiers": [
+      {
+        "id": "519a52c2-72b1-4fc7-ab93-e25511a434f2_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 3.3e-06,
+          "input_tokens": 3.3e-06,
+          "output": 1.65e-05,
+          "output_tokens": 1.65e-05,
+          "cache_creation_input_tokens": 4.125e-06,
+          "input_cache_creation": 4.125e-06,
+          "cache_read_input_tokens": 3.3e-07,
+          "input_cache_read": 3.3e-07,
+          "cache_write_5m_input_tokens": 4.125e-06,
+          "cache_write_1h_input_tokens": 6.6e-06
+        }
+      },
+      {
+        "id": "00b65240-047b-4722-9590-808edbc2067f",
+        "name": "Large Context",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "input",
+            "operator": "gt",
+            "value": 200000,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 6.6e-06,
+          "input_tokens": 6.6e-06,
+          "output": 2.475e-05,
+          "output_tokens": 2.475e-05,
+          "cache_creation_input_tokens": 8.25e-06,
+          "input_cache_creation": 8.25e-06,
+          "cache_read_input_tokens": 6.6e-07,
+          "input_cache_read": 6.6e-07,
+          "cache_write_5m_input_tokens": 8.25e-06,
+          "cache_write_1h_input_tokens": 1.32e-05
         }
       }
     ]
@@ -2600,7 +2675,7 @@
   {
     "id": "cmazmkzlm00000djp1e1qe4k4",
     "modelName": "claude-sonnet-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2612,14 +2687,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "cache_read_input_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cache_read": 3e-07,
+          "cache_write_5m_input_tokens": 3.75e-06,
+          "cache_write_1h_input_tokens": 6e-06
         }
       }
     ]
@@ -2627,7 +2704,7 @@
   {
     "id": "cmazmlbnv00010djpazed91va",
     "modelName": "claude-sonnet-4-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4-latest)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -2639,14 +2716,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "cache_read_input_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cache_read": 3e-07,
+          "cache_write_5m_input_tokens": 3.75e-06,
+          "cache_write_1h_input_tokens": 6e-06
         }
       }
     ]
@@ -2654,7 +2733,7 @@
   {
     "id": "cmazmlm2p00020djpa9s64jw5",
     "modelName": "claude-opus-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2666,14 +2745,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_tokens": 0.000015,
-          "output": 0.000075,
-          "output_tokens": 0.000075,
-          "cache_creation_input_tokens": 0.00001875,
-          "input_cache_creation": 0.00001875,
-          "cache_read_input_tokens": 0.0000015,
-          "input_cache_read": 0.0000015
+          "input": 1.5e-05,
+          "input_tokens": 1.5e-05,
+          "output": 7.5e-05,
+          "output_tokens": 7.5e-05,
+          "cache_creation_input_tokens": 1.875e-05,
+          "input_cache_creation": 1.875e-05,
+          "cache_read_input_tokens": 1.5e-06,
+          "input_cache_read": 1.5e-06,
+          "cache_write_5m_input_tokens": 1.875e-05,
+          "cache_write_1h_input_tokens": 3e-05
         }
       }
     ]
@@ -2681,7 +2762,7 @@
   {
     "id": "cmz9x72kq55721pqrs83y4n2bx",
     "modelName": "o3-pro",
-    "matchPattern": "(?i)^(openai\/)?(o3-pro)$",
+    "matchPattern": "(?i)^(openai/)?(o3-pro)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2692,10 +2773,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00002,
-          "output": 0.00008,
-          "output_reasoning_tokens": 0.00008,
-          "output_reasoning": 0.00008
+          "input": 2e-05,
+          "output": 8e-05,
+          "output_reasoning_tokens": 8e-05,
+          "output_reasoning": 8e-05
         }
       }
     ]
@@ -2703,7 +2784,7 @@
   {
     "id": "cmz9x72kq55721pqrs83y4n2by",
     "modelName": "o3-pro-2025-06-10",
-    "matchPattern": "(?i)^(openai\/)?(o3-pro-2025-06-10)$",
+    "matchPattern": "(?i)^(openai/)?(o3-pro-2025-06-10)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2714,10 +2795,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00002,
-          "output": 0.00008,
-          "output_reasoning_tokens": 0.00008,
-          "output_reasoning": 0.00008
+          "input": 2e-05,
+          "output": 8e-05,
+          "output_reasoning_tokens": 8e-05,
+          "output_reasoning": 8e-05
         }
       }
     ]
@@ -2725,7 +2806,7 @@
   {
     "id": "cmbrold5b000107lbftb9fdoo",
     "modelName": "o1-pro",
-    "matchPattern": "(?i)^(openai\/)?(o1-pro)$",
+    "matchPattern": "(?i)^(openai/)?(o1-pro)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2747,7 +2828,7 @@
   {
     "id": "cmbrolpax000207lb3xkedysz",
     "modelName": "o1-pro-2025-03-19",
-    "matchPattern": "(?i)^(openai\/)?(o1-pro-2025-03-19)$",
+    "matchPattern": "(?i)^(openai/)?(o1-pro-2025-03-19)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2769,7 +2850,7 @@
   {
     "id": "cmcnjkfwn000107l43bf5e8ax",
     "modelName": "gemini-2.5-flash",
-    "matchPattern": "(?i)^(google\/)?(gemini-2.5-flash)$",
+    "matchPattern": "(?i)^(google/)?(gemini-2.5-flash)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2780,20 +2861,20 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-7,
-          "input_modality_1": 3e-7,
-          "prompt_token_count": 3e-7,
-          "promptTokenCount": 3e-7,
-          "input_cached_tokens": 3e-8,
-          "cached_content_token_count": 3e-8,
-          "output": 0.0000025,
-          "output_modality_1": 0.0000025,
-          "candidates_token_count": 0.0000025,
-          "candidatesTokenCount": 0.0000025,
-          "thoughtsTokenCount": 0.0000025,
-          "thoughts_token_count": 0.0000025,
-          "output_reasoning": 0.0000025,
-          "input_audio_tokens": 0.000001
+          "input": 3e-07,
+          "input_modality_1": 3e-07,
+          "prompt_token_count": 3e-07,
+          "promptTokenCount": 3e-07,
+          "input_cached_tokens": 3e-08,
+          "cached_content_token_count": 3e-08,
+          "output": 2.5e-06,
+          "output_modality_1": 2.5e-06,
+          "candidates_token_count": 2.5e-06,
+          "candidatesTokenCount": 2.5e-06,
+          "thoughtsTokenCount": 2.5e-06,
+          "thoughts_token_count": 2.5e-06,
+          "output_reasoning": 2.5e-06,
+          "input_audio_tokens": 1e-06
         }
       }
     ]
@@ -2801,7 +2882,7 @@
   {
     "id": "cmcnjkrfa000207l4fpnh5mnv",
     "modelName": "gemini-2.5-flash-lite",
-    "matchPattern": "(?i)^(google\/)?(gemini-2.5-flash-lite)$",
+    "matchPattern": "(?i)^(google/)?(gemini-2.5-flash-lite)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2812,20 +2893,20 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-7,
-          "input_modality_1": 1e-7,
-          "prompt_token_count": 1e-7,
-          "promptTokenCount": 1e-7,
-          "input_cached_tokens": 2.5e-8,
-          "cached_content_token_count": 2.5e-8,
-          "output": 4e-7,
-          "output_modality_1": 4e-7,
-          "candidates_token_count": 4e-7,
-          "candidatesTokenCount": 4e-7,
-          "thoughtsTokenCount": 4e-7,
-          "thoughts_token_count": 4e-7,
-          "output_reasoning": 4e-7,
-          "input_audio_tokens": 5e-7
+          "input": 1e-07,
+          "input_modality_1": 1e-07,
+          "prompt_token_count": 1e-07,
+          "promptTokenCount": 1e-07,
+          "input_cached_tokens": 2.5e-08,
+          "cached_content_token_count": 2.5e-08,
+          "output": 4e-07,
+          "output_modality_1": 4e-07,
+          "candidates_token_count": 4e-07,
+          "candidatesTokenCount": 4e-07,
+          "thoughtsTokenCount": 4e-07,
+          "thoughts_token_count": 4e-07,
+          "output_reasoning": 4e-07,
+          "input_audio_tokens": 5e-07
         }
       }
     ]
@@ -2833,7 +2914,7 @@
   {
     "id": "cmdysde5w0000rkmzbc1g5au3",
     "modelName": "claude-opus-4-1-20250805",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
     "createdAt": "2025-08-05T15:00:00.000Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2845,14 +2926,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_tokens": 0.000015,
-          "output": 0.000075,
-          "output_tokens": 0.000075,
-          "cache_creation_input_tokens": 0.00001875,
-          "input_cache_creation": 0.00001875,
-          "cache_read_input_tokens": 0.0000015,
-          "input_cache_read": 0.0000015
+          "input": 1.5e-05,
+          "input_tokens": 1.5e-05,
+          "output": 7.5e-05,
+          "output_tokens": 7.5e-05,
+          "cache_creation_input_tokens": 1.875e-05,
+          "input_cache_creation": 1.875e-05,
+          "cache_read_input_tokens": 1.5e-06,
+          "input_cache_read": 1.5e-06,
+          "cache_write_5m_input_tokens": 1.875e-05,
+          "cache_write_1h_input_tokens": 3e-05
         }
       }
     ]
@@ -2860,7 +2943,7 @@
   {
     "id": "38c3822a-09a3-457b-b200-2c6f17f7cf2f",
     "modelName": "gpt-5",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2877,12 +2960,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000125,
-          "input_cached_tokens": 1.25e-7,
-          "output": 0.00001,
-          "input_cache_read": 1.25e-7,
-          "output_reasoning_tokens": 0.00001,
-          "output_reasoning": 0.00001
+          "input": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "output": 1e-05,
+          "input_cache_read": 1.25e-07,
+          "output_reasoning_tokens": 1e-05,
+          "output_reasoning": 1e-05
         }
       }
     ]
@@ -2890,7 +2973,7 @@
   {
     "id": "12543803-2d5f-4189-addc-821ad71c8b55",
     "modelName": "gpt-5-2025-08-07",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-2025-08-07)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2907,12 +2990,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000125,
-          "input_cached_tokens": 1.25e-7,
-          "output": 0.00001,
-          "input_cache_read": 1.25e-7,
-          "output_reasoning_tokens": 0.00001,
-          "output_reasoning": 0.00001
+          "input": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "output": 1e-05,
+          "input_cache_read": 1.25e-07,
+          "output_reasoning_tokens": 1e-05,
+          "output_reasoning": 1e-05
         }
       }
     ]
@@ -2920,7 +3003,7 @@
   {
     "id": "3d6a975a-a42d-4ea2-a3ec-4ae567d5a364",
     "modelName": "gpt-5-mini",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-mini)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-mini)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2937,12 +3020,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "input_cached_tokens": 2.5e-8,
-          "output": 0.000002,
-          "input_cache_read": 2.5e-8,
-          "output_reasoning_tokens": 0.000002,
-          "output_reasoning": 0.000002
+          "input": 2.5e-07,
+          "input_cached_tokens": 2.5e-08,
+          "output": 2e-06,
+          "input_cache_read": 2.5e-08,
+          "output_reasoning_tokens": 2e-06,
+          "output_reasoning": 2e-06
         }
       }
     ]
@@ -2950,7 +3033,7 @@
   {
     "id": "03b83894-7172-4e1e-8e8b-37d792484efd",
     "modelName": "gpt-5-mini-2025-08-07",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-mini-2025-08-07)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-mini-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2967,12 +3050,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "input_cached_tokens": 2.5e-8,
-          "output": 0.000002,
-          "input_cache_read": 2.5e-8,
-          "output_reasoning_tokens": 0.000002,
-          "output_reasoning": 0.000002
+          "input": 2.5e-07,
+          "input_cached_tokens": 2.5e-08,
+          "output": 2e-06,
+          "input_cache_read": 2.5e-08,
+          "output_reasoning_tokens": 2e-06,
+          "output_reasoning": 2e-06
         }
       }
     ]
@@ -2980,7 +3063,7 @@
   {
     "id": "f0b40234-b694-4c40-9494-7b0efd860fb9",
     "modelName": "gpt-5-nano",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-nano)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-nano)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2997,12 +3080,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-8,
-          "input_cached_tokens": 5e-9,
-          "output": 4e-7,
-          "input_cache_read": 5e-9,
-          "output_reasoning_tokens": 4e-7,
-          "output_reasoning": 4e-7
+          "input": 5e-08,
+          "input_cached_tokens": 5e-09,
+          "output": 4e-07,
+          "input_cache_read": 5e-09,
+          "output_reasoning_tokens": 4e-07,
+          "output_reasoning": 4e-07
         }
       }
     ]
@@ -3010,7 +3093,7 @@
   {
     "id": "4489fde4-a594-4011-948b-526989300cd3",
     "modelName": "gpt-5-nano-2025-08-07",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-nano-2025-08-07)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-nano-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3027,12 +3110,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-8,
-          "input_cached_tokens": 5e-9,
-          "output": 4e-7,
-          "input_cache_read": 5e-9,
-          "output_reasoning_tokens": 4e-7,
-          "output_reasoning": 4e-7
+          "input": 5e-08,
+          "input_cached_tokens": 5e-09,
+          "output": 4e-07,
+          "input_cache_read": 5e-09,
+          "output_reasoning_tokens": 4e-07,
+          "output_reasoning": 4e-07
         }
       }
     ]
@@ -3040,7 +3123,7 @@
   {
     "id": "8ba72ee3-ebe8-4110-a614-bf81094447e5",
     "modelName": "gpt-5-chat-latest",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-chat-latest)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-chat-latest)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3057,12 +3140,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000125,
-          "input_cached_tokens": 1.25e-7,
-          "output": 0.00001,
-          "input_cache_read": 1.25e-7,
-          "output_reasoning_tokens": 0.00001,
-          "output_reasoning": 0.00001
+          "input": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "output": 1e-05,
+          "input_cache_read": 1.25e-07,
+          "output_reasoning_tokens": 1e-05,
+          "output_reasoning": 1e-05
         }
       }
     ]
@@ -3070,7 +3153,7 @@
   {
     "id": "cmgg9zco3000004l258um9xk8",
     "modelName": "gpt-5-pro",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-pro)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-pro)$",
     "createdAt": "2025-10-07T08:03:54.727Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3087,7 +3170,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
+          "input": 1.5e-05,
           "output": 0.00012,
           "output_reasoning_tokens": 0.00012,
           "output_reasoning": 0.00012
@@ -3098,7 +3181,7 @@
   {
     "id": "cmgga0vh9000104l22qe4fes4",
     "modelName": "gpt-5-pro-2025-10-06",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-pro-2025-10-06)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-pro-2025-10-06)$",
     "createdAt": "2025-10-07T08:03:54.727Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3115,7 +3198,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
+          "input": 1.5e-05,
           "output": 0.00012,
           "output_reasoning_tokens": 0.00012,
           "output_reasoning": 0.00012
@@ -3126,7 +3209,7 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5-20251001|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-haiku-4-5-20251001|anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -3138,14 +3221,45 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000001,
-          "input_tokens": 0.000001,
-          "output": 0.000005,
-          "output_tokens": 0.000005,
-          "cache_creation_input_tokens": 0.00000125,
-          "input_cache_creation": 0.00000125,
-          "cache_read_input_tokens": 1e-7,
-          "input_cache_read": 1e-7
+          "input": 1e-06,
+          "input_tokens": 1e-06,
+          "output": 5e-06,
+          "output_tokens": 5e-06,
+          "cache_creation_input_tokens": 1.25e-06,
+          "input_cache_creation": 1.25e-06,
+          "cache_read_input_tokens": 1e-07,
+          "input_cache_read": 1e-07,
+          "cache_write_5m_input_tokens": 1.25e-06,
+          "cache_write_1h_input_tokens": 2e-06
+        }
+      }
+    ]
+  },
+  {
+    "id": "01f22771-76a5-4e41-a252-661d02b9ab88",
+    "modelName": "claude-haiku-4-5-20251001-cris",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|global\\.)anthropic\\.claude-haiku-4-5-20251001-v1:0$",
+    "createdAt": "2025-10-16T08:20:44.558Z",
+    "updatedAt": "2026-02-26T00:00:00.000Z",
+    "tokenizerId": "claude",
+    "pricingTiers": [
+      {
+        "id": "01f22771-76a5-4e41-a252-661d02b9ab88_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 1.1e-06,
+          "input_tokens": 1.1e-06,
+          "output": 5.5e-06,
+          "output_tokens": 5.5e-06,
+          "cache_creation_input_tokens": 1.375e-06,
+          "input_cache_creation": 1.375e-06,
+          "cache_read_input_tokens": 1.1e-07,
+          "input_cache_read": 1.1e-07,
+          "cache_write_5m_input_tokens": 1.375e-06,
+          "cache_write_1h_input_tokens": 2.2e-06
         }
       }
     ]
@@ -3153,7 +3267,7 @@
   {
     "id": "cmhymgpym000d04ih34rndvhr",
     "modelName": "gpt-5.1",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.1)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.1)$",
     "createdAt": "2025-11-14T08:57:23.481Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3170,12 +3284,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000125,
-          "input_cached_tokens": 1.25e-7,
-          "output": 0.00001,
-          "input_cache_read": 1.25e-7,
-          "output_reasoning_tokens": 0.00001,
-          "output_reasoning": 0.00001
+          "input": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "output": 1e-05,
+          "input_cache_read": 1.25e-07,
+          "output_reasoning_tokens": 1e-05,
+          "output_reasoning": 1e-05
         }
       }
     ]
@@ -3183,7 +3297,7 @@
   {
     "id": "cmhymgxiw000e04ihh9pw12ef",
     "modelName": "gpt-5.1-2025-11-13",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.1-2025-11-13)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.1-2025-11-13)$",
     "createdAt": "2025-11-14T08:57:23.481Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3200,12 +3314,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000125,
-          "input_cached_tokens": 1.25e-7,
-          "output": 0.00001,
-          "input_cache_read": 1.25e-7,
-          "output_reasoning_tokens": 0.00001,
-          "output_reasoning": 0.00001
+          "input": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "output": 1e-05,
+          "input_cache_read": 1.25e-07,
+          "output_reasoning_tokens": 1e-05,
+          "output_reasoning": 1e-05
         }
       }
     ]
@@ -3213,7 +3327,7 @@
   {
     "id": "cmieupdva000004l541kwae70",
     "modelName": "claude-opus-4-5-20251101",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-5(-20251101)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-5(-20251101)?|anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
     "createdAt": "2025-11-24T20:53:27.571Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3226,14 +3340,46 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_tokens": 5e-6,
-          "output": 25e-6,
-          "output_tokens": 25e-6,
-          "cache_creation_input_tokens": 6.25e-6,
-          "input_cache_creation": 6.25e-6,
-          "cache_read_input_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input": 5e-06,
+          "input_tokens": 5e-06,
+          "output": 2.5e-05,
+          "output_tokens": 2.5e-05,
+          "cache_creation_input_tokens": 6.25e-06,
+          "input_cache_creation": 6.25e-06,
+          "cache_read_input_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "cache_write_5m_input_tokens": 6.25e-06,
+          "cache_write_1h_input_tokens": 1e-05
+        }
+      }
+    ]
+  },
+  {
+    "id": "9853c95c-bcf5-447d-a7b5-5fb402a94f03",
+    "modelName": "claude-opus-4-5-20251101-cris",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?$",
+    "createdAt": "2025-11-24T20:53:27.571Z",
+    "updatedAt": "2026-02-26T00:00:00.000Z",
+    "tokenizerConfig": null,
+    "tokenizerId": "claude",
+    "pricingTiers": [
+      {
+        "id": "9853c95c-bcf5-447d-a7b5-5fb402a94f03_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 5.5e-06,
+          "input_tokens": 5.5e-06,
+          "output": 2.75e-05,
+          "output_tokens": 2.75e-05,
+          "cache_creation_input_tokens": 6.875e-06,
+          "input_cache_creation": 6.875e-06,
+          "cache_read_input_tokens": 5.5e-07,
+          "input_cache_read": 5.5e-07,
+          "cache_write_5m_input_tokens": 6.875e-06,
+          "cache_write_1h_input_tokens": 1.1e-05
         }
       }
     ]
@@ -3241,7 +3387,7 @@
   {
     "id": "90ec5ec3-1a48-4ff0-919c-70cdb8f632ed",
     "modelName": "claude-sonnet-4-6",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-sonnet-4-6-v1(:0)?|claude-sonnet-4-6)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6|anthropic\\.claude-sonnet-4-6-v1(:0)?|claude-sonnet-4-6)$",
     "createdAt": "2026-02-18T00:00:00.000Z",
     "updatedAt": "2026-02-18T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3254,14 +3400,16 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-6,
-          "input_tokens": 3e-6,
-          "output": 15e-6,
-          "output_tokens": 15e-6,
-          "cache_creation_input_tokens": 3.75e-6,
-          "input_cache_creation": 3.75e-6,
-          "cache_read_input_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cache_read": 3e-07,
+          "cache_write_5m_input_tokens": 3.75e-06,
+          "cache_write_1h_input_tokens": 6e-06
         }
       },
       {
@@ -3278,14 +3426,72 @@
           }
         ],
         "prices": {
-          "input": 6e-6,
-          "input_tokens": 6e-6,
-          "output": 22.5e-6,
-          "output_tokens": 22.5e-6,
-          "cache_creation_input_tokens": 7.5e-6,
-          "input_cache_creation": 7.5e-6,
-          "cache_read_input_tokens": 6e-7,
-          "input_cache_read": 6e-7
+          "input": 6e-06,
+          "input_tokens": 6e-06,
+          "output": 2.25e-05,
+          "output_tokens": 2.25e-05,
+          "cache_creation_input_tokens": 7.5e-06,
+          "input_cache_creation": 7.5e-06,
+          "cache_read_input_tokens": 6e-07,
+          "input_cache_read": 6e-07,
+          "cache_write_5m_input_tokens": 7.5e-06,
+          "cache_write_1h_input_tokens": 1.2e-05
+        }
+      }
+    ]
+  },
+  {
+    "id": "04d3f9a4-6504-4488-b3e5-65aa41c5a4ea",
+    "modelName": "claude-sonnet-4-6-cris",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-sonnet-4-6-v1(:0)?$",
+    "createdAt": "2026-02-18T00:00:00.000Z",
+    "updatedAt": "2026-02-26T00:00:00.000Z",
+    "tokenizerConfig": null,
+    "tokenizerId": "claude",
+    "pricingTiers": [
+      {
+        "id": "04d3f9a4-6504-4488-b3e5-65aa41c5a4ea_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 3.3e-06,
+          "input_tokens": 3.3e-06,
+          "output": 1.65e-05,
+          "output_tokens": 1.65e-05,
+          "cache_creation_input_tokens": 4.125e-06,
+          "input_cache_creation": 4.125e-06,
+          "cache_read_input_tokens": 3.3e-07,
+          "input_cache_read": 3.3e-07,
+          "cache_write_5m_input_tokens": 4.125e-06,
+          "cache_write_1h_input_tokens": 6.6e-06
+        }
+      },
+      {
+        "id": "7830bfc2-c464-4ffe-b9a2-6e741f6c5486",
+        "name": "Large Context",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "input",
+            "operator": "gt",
+            "value": 200000,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 6.6e-06,
+          "input_tokens": 6.6e-06,
+          "output": 2.475e-05,
+          "output_tokens": 2.475e-05,
+          "cache_creation_input_tokens": 8.25e-06,
+          "input_cache_creation": 8.25e-06,
+          "cache_read_input_tokens": 6.6e-07,
+          "input_cache_read": 6.6e-07,
+          "cache_write_5m_input_tokens": 8.25e-06,
+          "cache_write_1h_input_tokens": 1.32e-05
         }
       }
     ]
@@ -3293,7 +3499,7 @@
   {
     "id": "13458bc0-1c20-44c2-8753-172f54b67647",
     "modelName": "claude-opus-4-6",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-6|anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
     "createdAt": "2026-02-09T00:00:00.000Z",
     "updatedAt": "2026-02-09T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3306,14 +3512,46 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_tokens": 5e-6,
-          "output": 25e-6,
-          "output_tokens": 25e-6,
-          "cache_creation_input_tokens": 6.25e-6,
-          "input_cache_creation": 6.25e-6,
-          "cache_read_input_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input": 5e-06,
+          "input_tokens": 5e-06,
+          "output": 2.5e-05,
+          "output_tokens": 2.5e-05,
+          "cache_creation_input_tokens": 6.25e-06,
+          "input_cache_creation": 6.25e-06,
+          "cache_read_input_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "cache_write_5m_input_tokens": 6.25e-06,
+          "cache_write_1h_input_tokens": 1e-05
+        }
+      }
+    ]
+  },
+  {
+    "id": "7d1e0364-75c5-4803-b8a7-88ddcc3c719f",
+    "modelName": "claude-opus-4-6-cris",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-opus-4-6-v1(:0)?$",
+    "createdAt": "2026-02-09T00:00:00.000Z",
+    "updatedAt": "2026-02-26T00:00:00.000Z",
+    "tokenizerConfig": null,
+    "tokenizerId": "claude",
+    "pricingTiers": [
+      {
+        "id": "7d1e0364-75c5-4803-b8a7-88ddcc3c719f_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 5.5e-06,
+          "input_tokens": 5.5e-06,
+          "output": 2.75e-05,
+          "output_tokens": 2.75e-05,
+          "cache_creation_input_tokens": 6.875e-06,
+          "input_cache_creation": 6.875e-06,
+          "cache_read_input_tokens": 5.5e-07,
+          "input_cache_read": 5.5e-07,
+          "cache_write_5m_input_tokens": 6.875e-06,
+          "cache_write_1h_input_tokens": 1.1e-05
         }
       }
     ]
@@ -3321,7 +3559,7 @@
   {
     "id": "cmig1hb7i000104l72qrzgc6h",
     "modelName": "gemini-2.5-pro",
-    "matchPattern": "(?i)^(google\/)?(gemini-2.5-pro)$",
+    "matchPattern": "(?i)^(google/)?(gemini-2.5-pro)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -3332,19 +3570,19 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-6,
-          "input_modality_1": 1.25e-6,
-          "prompt_token_count": 1.25e-6,
-          "promptTokenCount": 1.25e-6,
-          "input_cached_tokens": 0.125e-6,
-          "cached_content_token_count": 0.125e-6,
-          "output": 10e-6,
-          "output_modality_1": 10e-6,
-          "candidates_token_count": 10e-6,
-          "candidatesTokenCount": 10e-6,
-          "thoughtsTokenCount": 10e-6,
-          "thoughts_token_count": 10e-6,
-          "output_reasoning": 10e-6
+          "input": 1.25e-06,
+          "input_modality_1": 1.25e-06,
+          "prompt_token_count": 1.25e-06,
+          "promptTokenCount": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "cached_content_token_count": 1.25e-07,
+          "output": 1e-05,
+          "output_modality_1": 1e-05,
+          "candidates_token_count": 1e-05,
+          "candidatesTokenCount": 1e-05,
+          "thoughtsTokenCount": 1e-05,
+          "thoughts_token_count": 1e-05,
+          "output_reasoning": 1e-05
         }
       },
       {
@@ -3361,19 +3599,19 @@
           }
         ],
         "prices": {
-          "input": 2.5e-6,
-          "input_modality_1": 2.5e-6,
-          "prompt_token_count": 2.5e-6,
-          "promptTokenCount": 2.5e-6,
-          "input_cached_tokens": 0.25e-6,
-          "cached_content_token_count": 0.25e-6,
-          "output": 15e-6,
-          "output_modality_1": 15e-6,
-          "candidates_token_count": 15e-6,
-          "candidatesTokenCount": 15e-6,
-          "thoughtsTokenCount": 15e-6,
-          "thoughts_token_count": 15e-6,
-          "output_reasoning": 15e-6
+          "input": 2.5e-06,
+          "input_modality_1": 2.5e-06,
+          "prompt_token_count": 2.5e-06,
+          "promptTokenCount": 2.5e-06,
+          "input_cached_tokens": 2.5e-07,
+          "cached_content_token_count": 2.5e-07,
+          "output": 1.5e-05,
+          "output_modality_1": 1.5e-05,
+          "candidates_token_count": 1.5e-05,
+          "candidatesTokenCount": 1.5e-05,
+          "thoughtsTokenCount": 1.5e-05,
+          "thoughts_token_count": 1.5e-05,
+          "output_reasoning": 1.5e-05
         }
       }
     ]
@@ -3381,7 +3619,7 @@
   {
     "id": "cmig1wmep000404l7fh6q5uog",
     "modelName": "gemini-3-pro-preview",
-    "matchPattern": "(?i)^(google\/)?(gemini-3-pro-preview)$",
+    "matchPattern": "(?i)^(google/)?(gemini-3-pro-preview)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -3392,19 +3630,19 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-6,
-          "input_modality_1": 2e-6,
-          "prompt_token_count": 2e-6,
-          "promptTokenCount": 2e-6,
-          "input_cached_tokens": 0.2e-6,
-          "cached_content_token_count": 0.2e-6,
-          "output": 12e-6,
-          "output_modality_1": 12e-6,
-          "candidates_token_count": 12e-6,
-          "candidatesTokenCount": 12e-6,
-          "thoughtsTokenCount": 12e-6,
-          "thoughts_token_count": 12e-6,
-          "output_reasoning": 12e-6
+          "input": 2e-06,
+          "input_modality_1": 2e-06,
+          "prompt_token_count": 2e-06,
+          "promptTokenCount": 2e-06,
+          "input_cached_tokens": 2e-07,
+          "cached_content_token_count": 2e-07,
+          "output": 1.2e-05,
+          "output_modality_1": 1.2e-05,
+          "candidates_token_count": 1.2e-05,
+          "candidatesTokenCount": 1.2e-05,
+          "thoughtsTokenCount": 1.2e-05,
+          "thoughts_token_count": 1.2e-05,
+          "output_reasoning": 1.2e-05
         }
       },
       {
@@ -3421,19 +3659,19 @@
           }
         ],
         "prices": {
-          "input": 4e-6,
-          "input_modality_1": 4e-6,
-          "prompt_token_count": 4e-6,
-          "promptTokenCount": 4e-6,
-          "input_cached_tokens": 0.4e-6,
-          "cached_content_token_count": 0.4e-6,
-          "output": 18e-6,
-          "output_modality_1": 18e-6,
-          "candidates_token_count": 18e-6,
-          "candidatesTokenCount": 18e-6,
-          "thoughtsTokenCount": 18e-6,
-          "thoughts_token_count": 18e-6,
-          "output_reasoning": 18e-6
+          "input": 4e-06,
+          "input_modality_1": 4e-06,
+          "prompt_token_count": 4e-06,
+          "promptTokenCount": 4e-06,
+          "input_cached_tokens": 4e-07,
+          "cached_content_token_count": 4e-07,
+          "output": 1.8e-05,
+          "output_modality_1": 1.8e-05,
+          "candidates_token_count": 1.8e-05,
+          "candidatesTokenCount": 1.8e-05,
+          "thoughtsTokenCount": 1.8e-05,
+          "thoughts_token_count": 1.8e-05,
+          "output_reasoning": 1.8e-05
         }
       }
     ]
@@ -3441,7 +3679,7 @@
   {
     "id": "55106bba-a5dd-441b-bc0d-5652582b349d",
     "modelName": "gemini-3.1-pro-preview",
-    "matchPattern": "(?i)^(google\/)?(gemini-3.1-pro-preview(-customtools)?)$",
+    "matchPattern": "(?i)^(google/)?(gemini-3.1-pro-preview(-customtools)?)$",
     "createdAt": "2026-02-19T00:00:00.000Z",
     "updatedAt": "2026-02-19T00:00:00.000Z",
     "pricingTiers": [
@@ -3452,19 +3690,19 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-6,
-          "input_modality_1": 2e-6,
-          "prompt_token_count": 2e-6,
-          "promptTokenCount": 2e-6,
-          "input_cached_tokens": 0.2e-6,
-          "cached_content_token_count": 0.2e-6,
-          "output": 12e-6,
-          "output_modality_1": 12e-6,
-          "candidates_token_count": 12e-6,
-          "candidatesTokenCount": 12e-6,
-          "thoughtsTokenCount": 12e-6,
-          "thoughts_token_count": 12e-6,
-          "output_reasoning": 12e-6
+          "input": 2e-06,
+          "input_modality_1": 2e-06,
+          "prompt_token_count": 2e-06,
+          "promptTokenCount": 2e-06,
+          "input_cached_tokens": 2e-07,
+          "cached_content_token_count": 2e-07,
+          "output": 1.2e-05,
+          "output_modality_1": 1.2e-05,
+          "candidates_token_count": 1.2e-05,
+          "candidatesTokenCount": 1.2e-05,
+          "thoughtsTokenCount": 1.2e-05,
+          "thoughts_token_count": 1.2e-05,
+          "output_reasoning": 1.2e-05
         }
       },
       {
@@ -3481,19 +3719,19 @@
           }
         ],
         "prices": {
-          "input": 4e-6,
-          "input_modality_1": 4e-6,
-          "prompt_token_count": 4e-6,
-          "promptTokenCount": 4e-6,
-          "input_cached_tokens": 0.4e-6,
-          "cached_content_token_count": 0.4e-6,
-          "output": 18e-6,
-          "output_modality_1": 18e-6,
-          "candidates_token_count": 18e-6,
-          "candidatesTokenCount": 18e-6,
-          "thoughtsTokenCount": 18e-6,
-          "thoughts_token_count": 18e-6,
-          "output_reasoning": 18e-6
+          "input": 4e-06,
+          "input_modality_1": 4e-06,
+          "prompt_token_count": 4e-06,
+          "promptTokenCount": 4e-06,
+          "input_cached_tokens": 4e-07,
+          "cached_content_token_count": 4e-07,
+          "output": 1.8e-05,
+          "output_modality_1": 1.8e-05,
+          "candidates_token_count": 1.8e-05,
+          "candidatesTokenCount": 1.8e-05,
+          "thoughtsTokenCount": 1.8e-05,
+          "thoughts_token_count": 1.8e-05,
+          "output_reasoning": 1.8e-05
         }
       }
     ]
@@ -3501,7 +3739,7 @@
   {
     "id": "cmj2n4f2a000304kz49g4c43u",
     "modelName": "gpt-5.2",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3518,12 +3756,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.75e-6,
-          "input_cached_tokens": 0.175e-6,
-          "input_cache_read": 0.175e-6,
-          "output": 14e-6,
-          "output_reasoning_tokens": 14e-6,
-          "output_reasoning": 14e-6
+          "input": 1.75e-06,
+          "input_cached_tokens": 1.75e-07,
+          "input_cache_read": 1.75e-07,
+          "output": 1.4e-05,
+          "output_reasoning_tokens": 1.4e-05,
+          "output_reasoning": 1.4e-05
         }
       }
     ]
@@ -3531,7 +3769,7 @@
   {
     "id": "cmj2muxg6000104kzd2tc8953",
     "modelName": "gpt-5.2-2025-12-11",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-2025-12-11)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2-2025-12-11)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3548,12 +3786,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.75e-6,
-          "input_cached_tokens": 0.175e-6,
-          "input_cache_read": 0.175e-6,
-          "output": 14e-6,
-          "output_reasoning_tokens": 14e-6,
-          "output_reasoning": 14e-6
+          "input": 1.75e-06,
+          "input_cached_tokens": 1.75e-07,
+          "input_cache_read": 1.75e-07,
+          "output": 1.4e-05,
+          "output_reasoning_tokens": 1.4e-05,
+          "output_reasoning": 1.4e-05
         }
       }
     ]
@@ -3561,7 +3799,7 @@
   {
     "id": "cmj2n6pkq000404kz2s0b6if7",
     "modelName": "gpt-5.2-pro",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-pro)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2-pro)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3578,10 +3816,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 21e-6,
-          "output": 168e-6,
-          "output_reasoning_tokens": 168e-6,
-          "output_reasoning": 168e-6
+          "input": 2.1e-05,
+          "output": 0.000168,
+          "output_reasoning_tokens": 0.000168,
+          "output_reasoning": 0.000168
         }
       }
     ]
@@ -3589,7 +3827,7 @@
   {
     "id": "cmj2n70oe000504kz21b76mes",
     "modelName": "gpt-5.2-pro-2025-12-11",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-pro-2025-12-11)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2-pro-2025-12-11)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3606,10 +3844,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 21e-6,
-          "output": 168e-6,
-          "output_reasoning_tokens": 168e-6,
-          "output_reasoning": 168e-6
+          "input": 2.1e-05,
+          "output": 0.000168,
+          "output_reasoning_tokens": 0.000168,
+          "output_reasoning": 0.000168
         }
       }
     ]
@@ -3617,7 +3855,7 @@
   {
     "id": "cmjfoeykl000004l8ffzra8c7",
     "modelName": "gemini-3-flash-preview",
-    "matchPattern": "(?i)^(google\/)?(gemini-3-flash-preview)$",
+    "matchPattern": "(?i)^(google/)?(gemini-3-flash-preview)$",
     "createdAt": "2025-12-21T12:01:42.282Z",
     "updatedAt": "2025-12-21T12:01:42.282Z",
     "pricingTiers": [
@@ -3628,19 +3866,19 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.5e-6,
-          "input_modality_1": 0.5e-6,
-          "prompt_token_count": 0.5e-6,
-          "promptTokenCount": 0.5e-6,
-          "input_cached_tokens": 0.05e-6,
-          "cached_content_token_count": 0.05e-6,
-          "output": 3e-6,
-          "output_modality_1": 3e-6,
-          "candidates_token_count": 3e-6,
-          "candidatesTokenCount": 3e-6,
-          "thoughtsTokenCount": 3e-6,
-          "thoughts_token_count": 3e-6,
-          "output_reasoning": 3e-6
+          "input": 5e-07,
+          "input_modality_1": 5e-07,
+          "prompt_token_count": 5e-07,
+          "promptTokenCount": 5e-07,
+          "input_cached_tokens": 5e-08,
+          "cached_content_token_count": 5e-08,
+          "output": 3e-06,
+          "output_modality_1": 3e-06,
+          "candidates_token_count": 3e-06,
+          "candidatesTokenCount": 3e-06,
+          "thoughtsTokenCount": 3e-06,
+          "thoughts_token_count": 3e-06,
+          "output_reasoning": 3e-06
         }
       }
     ]

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2,7 +2,7 @@
   {
     "id": "b9854a5c92dc496b997d99d20",
     "modelName": "gpt-4o",
-    "matchPattern": "(?i)^(openai/)?(gpt-4o)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4o)$",
     "createdAt": "2024-05-13T23:15:07.670Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -19,10 +19,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-06,
-          "input_cached_tokens": 1.25e-06,
-          "input_cache_read": 1.25e-06,
-          "output": 1e-05
+          "input": 0.0000025,
+          "input_cached_tokens": 0.00000125,
+          "input_cache_read": 0.00000125,
+          "output": 0.00001
         }
       }
     ]
@@ -30,7 +30,7 @@
   {
     "id": "b9854a5c92dc496b997d99d21",
     "modelName": "gpt-4o-2024-05-13",
-    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-05-13)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-05-13)$",
     "createdAt": "2024-05-13T23:15:07.670Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -47,8 +47,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-06,
-          "output": 1.5e-05
+          "input": 0.000005,
+          "output": 0.000015
         }
       }
     ]
@@ -56,7 +56,7 @@
   {
     "id": "clrkvq6iq000008ju6c16gynt",
     "modelName": "gpt-4-1106-preview",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-1106-preview)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-1106-preview)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -73,8 +73,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-05,
-          "output": 3e-05
+          "input": 0.00001,
+          "output": 0.00003
         }
       }
     ]
@@ -82,7 +82,7 @@
   {
     "id": "clrkvx5gp000108juaogs54ea",
     "modelName": "gpt-4-turbo-vision",
-    "matchPattern": "(?i)^(openai/)?(gpt-4(-\\d{4})?-vision-preview)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4(-\\d{4})?-vision-preview)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -99,8 +99,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-05,
-          "output": 3e-05
+          "input": 0.00001,
+          "output": 0.00003
         }
       }
     ]
@@ -108,7 +108,7 @@
   {
     "id": "clrkvyzgw000308jue4hse4j9",
     "modelName": "gpt-4-32k",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-32k)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -125,7 +125,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 6e-05,
+          "input": 0.00006,
           "output": 0.00012
         }
       }
@@ -134,7 +134,7 @@
   {
     "id": "clrkwk4cb000108l5hwwh3zdi",
     "modelName": "gpt-4-32k-0613",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-32k-0613)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -151,7 +151,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 6e-05,
+          "input": 0.00006,
           "output": 0.00012
         }
       }
@@ -160,7 +160,7 @@
   {
     "id": "clrkwk4cb000208l59yvb9yq8",
     "modelName": "gpt-3.5-turbo-1106",
-    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-1106)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-1106)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -177,8 +177,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-06,
-          "output": 2e-06
+          "input": 0.000001,
+          "output": 0.000002
         }
       }
     ]
@@ -186,7 +186,7 @@
   {
     "id": "clrkwk4cc000808l51xmk4uic",
     "modelName": "gpt-3.5-turbo-0613",
-    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0613)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -203,8 +203,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-06,
-          "output": 2e-06
+          "input": 0.0000015,
+          "output": 0.000002
         }
       }
     ]
@@ -212,7 +212,7 @@
   {
     "id": "clrkwk4cc000908l537kl0rx3",
     "modelName": "gpt-4-0613",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-0613)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -229,8 +229,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-05,
-          "output": 6e-05
+          "input": 0.00003,
+          "output": 0.00006
         }
       }
     ]
@@ -238,7 +238,7 @@
   {
     "id": "clrkwk4cc000a08l562uc3s9g",
     "modelName": "gpt-3.5-turbo-instruct",
-    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-instruct)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-instruct)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -255,8 +255,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-06,
-          "output": 2e-06
+          "input": 0.0000015,
+          "output": 0.000002
         }
       }
     ]
@@ -279,7 +279,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 4e-06
+          "total": 0.000004
         }
       }
     ]
@@ -302,7 +302,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 5e-07
+          "total": 5e-7
         }
       }
     ]
@@ -325,7 +325,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 2e-05
+          "total": 0.00002
         }
       }
     ]
@@ -348,7 +348,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 2e-05
+          "total": 0.00002
         }
       }
     ]
@@ -371,7 +371,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 2e-05
+          "total": 0.00002
         }
       }
     ]
@@ -394,7 +394,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 2e-05
+          "total": 0.00002
         }
       }
     ]
@@ -417,7 +417,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-07
+          "total": 1e-7
         }
       }
     ]
@@ -440,7 +440,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-07
+          "total": 1e-7
         }
       }
     ]
@@ -448,7 +448,7 @@
   {
     "id": "clrntjt89000a08jw0gcdbd5a",
     "modelName": "gpt-3.5-turbo-16k-0613",
-    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-16k-0613)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-16k-0613)$",
     "createdAt": "2024-02-03T17:29:57.350Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -465,8 +465,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "output": 4e-06
+          "input": 0.000003,
+          "output": 0.000004
         }
       }
     ]
@@ -474,7 +474,7 @@
   {
     "id": "clrntkjgy000a08jx4e062mr0",
     "modelName": "gpt-3.5-turbo-0301",
-    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0301)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0301)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -491,8 +491,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-06,
-          "output": 2e-06
+          "input": 0.000002,
+          "output": 0.000002
         }
       }
     ]
@@ -500,7 +500,7 @@
   {
     "id": "clrntkjgy000d08jx0p4y9h4l",
     "modelName": "gpt-4-32k-0314",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-32k-0314)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k-0314)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -517,7 +517,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 6e-05,
+          "input": 0.00006,
           "output": 0.00012
         }
       }
@@ -526,7 +526,7 @@
   {
     "id": "clrntkjgy000e08jx4x6uawoo",
     "modelName": "gpt-4-0314",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-0314)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-0314)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -543,8 +543,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-05,
-          "output": 6e-05
+          "input": 0.00003,
+          "output": 0.00006
         }
       }
     ]
@@ -552,7 +552,7 @@
   {
     "id": "clrntkjgy000f08jx79v9g1xj",
     "modelName": "gpt-4",
-    "matchPattern": "(?i)^(openai/)?(gpt-4)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -569,8 +569,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-05,
-          "output": 6e-05
+          "input": 0.00003,
+          "output": 0.00006
         }
       }
     ]
@@ -578,7 +578,7 @@
   {
     "id": "clrnwb41q000308jsfrac9uh6",
     "modelName": "claude-instant-1.2",
-    "matchPattern": "(?i)^(anthropic/)?(claude-instant-1.2)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-instant-1.2)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -590,8 +590,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.63e-06,
-          "output": 5.51e-06
+          "input": 0.00000163,
+          "output": 0.00000551
         }
       }
     ]
@@ -599,7 +599,7 @@
   {
     "id": "clrnwb836000408jsallr6u11",
     "modelName": "claude-2.0",
-    "matchPattern": "(?i)^(anthropic/)?(claude-2.0)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-2.0)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -611,8 +611,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-06,
-          "output": 2.4e-05
+          "input": 0.000008,
+          "output": 0.000024
         }
       }
     ]
@@ -620,7 +620,7 @@
   {
     "id": "clrnwbd1m000508js4hxu6o7n",
     "modelName": "claude-2.1",
-    "matchPattern": "(?i)^(anthropic/)?(claude-2.1)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-2.1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -632,8 +632,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-06,
-          "output": 2.4e-05
+          "input": 0.000008,
+          "output": 0.000024
         }
       }
     ]
@@ -641,7 +641,7 @@
   {
     "id": "clrnwbg2b000608jse2pp4q2d",
     "modelName": "claude-1.3",
-    "matchPattern": "(?i)^(anthropic/)?(claude-1.3)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-1.3)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -653,8 +653,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-06,
-          "output": 2.4e-05
+          "input": 0.000008,
+          "output": 0.000024
         }
       }
     ]
@@ -662,7 +662,7 @@
   {
     "id": "clrnwbi9d000708jseiy44k26",
     "modelName": "claude-1.2",
-    "matchPattern": "(?i)^(anthropic/)?(claude-1.2)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-1.2)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -674,8 +674,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-06,
-          "output": 2.4e-05
+          "input": 0.000008,
+          "output": 0.000024
         }
       }
     ]
@@ -683,7 +683,7 @@
   {
     "id": "clrnwblo0000808jsc1385hdp",
     "modelName": "claude-1.1",
-    "matchPattern": "(?i)^(anthropic/)?(claude-1.1)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-1.1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -695,8 +695,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-06,
-          "output": 2.4e-05
+          "input": 0.000008,
+          "output": 0.000024
         }
       }
     ]
@@ -704,7 +704,7 @@
   {
     "id": "clrnwbota000908jsgg9mb1ml",
     "modelName": "claude-instant-1",
-    "matchPattern": "(?i)^(anthropic/)?(claude-instant-1)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-instant-1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -716,8 +716,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.63e-06,
-          "output": 5.51e-06
+          "input": 0.00000163,
+          "output": 0.00000551
         }
       }
     ]
@@ -740,8 +740,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 4e-07,
-          "output": 1.6e-06
+          "input": 4e-7,
+          "output": 0.0000016
         }
       }
     ]
@@ -764,8 +764,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 6e-06,
-          "output": 1.2e-05
+          "input": 0.000006,
+          "output": 0.000012
         }
       }
     ]
@@ -788,7 +788,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 2e-08
+          "total": 2e-8
         }
       }
     ]
@@ -811,7 +811,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1.3e-07
+          "total": 1.3e-7
         }
       }
     ]
@@ -819,7 +819,7 @@
   {
     "id": "clruwnahl00030al7ab9rark7",
     "modelName": "gpt-3.5-turbo-0125",
-    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0125)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0125)$",
     "createdAt": "2024-01-26T17:35:21.129Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -836,8 +836,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-07,
-          "output": 1.5e-06
+          "input": 5e-7,
+          "output": 0.0000015
         }
       }
     ]
@@ -845,7 +845,7 @@
   {
     "id": "clruwnahl00040al78f1lb0at",
     "modelName": "gpt-3.5-turbo",
-    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo)$",
     "createdAt": "2024-02-13T12:00:37.424Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -862,8 +862,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-07,
-          "output": 1.5e-06
+          "input": 5e-7,
+          "output": 0.0000015
         }
       }
     ]
@@ -871,7 +871,7 @@
   {
     "id": "clruwnahl00050al796ck3p44",
     "modelName": "gpt-4-0125-preview",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-0125-preview)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-0125-preview)$",
     "createdAt": "2024-01-26T17:35:21.129Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -888,8 +888,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-05,
-          "output": 3e-05
+          "input": 0.00001,
+          "output": 0.00003
         }
       }
     ]
@@ -914,8 +914,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "output": 6e-06
+          "input": 0.000003,
+          "output": 0.000006
         }
       }
     ]
@@ -940,8 +940,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.2e-05,
-          "output": 1.6e-05
+          "input": 0.000012,
+          "output": 0.000016
         }
       }
     ]
@@ -964,8 +964,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.2e-05,
-          "output": 1.2e-05
+          "input": 0.000012,
+          "output": 0.000012
         }
       }
     ]
@@ -988,8 +988,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.6e-06,
-          "output": 1.6e-06
+          "input": 0.0000016,
+          "output": 0.0000016
         }
       }
     ]
@@ -1008,8 +1008,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 5e-07
+          "input": 2.5e-7,
+          "output": 5e-7
         }
       }
     ]
@@ -1028,8 +1028,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 5e-07
+          "input": 2.5e-7,
+          "output": 5e-7
         }
       }
     ]
@@ -1048,8 +1048,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 5e-07
+          "input": 2.5e-7,
+          "output": 5e-7
         }
       }
     ]
@@ -1068,8 +1068,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 5e-07
+          "input": 2.5e-7,
+          "output": 5e-7
         }
       }
     ]
@@ -1088,8 +1088,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 5e-07
+          "input": 2.5e-7,
+          "output": 5e-7
         }
       }
     ]
@@ -1108,8 +1108,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-06,
-          "output": 7.5e-06
+          "input": 0.0000025,
+          "output": 0.0000075
         }
       }
     ]
@@ -1128,8 +1128,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 5e-07
+          "input": 2.5e-7,
+          "output": 5e-7
         }
       }
     ]
@@ -1148,7 +1148,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-07
+          "total": 1e-7
         }
       }
     ]
@@ -1167,7 +1167,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-07
+          "total": 1e-7
         }
       }
     ]
@@ -1186,8 +1186,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 5e-07
+          "input": 2.5e-7,
+          "output": 5e-7
         }
       }
     ]
@@ -1206,8 +1206,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 5e-07
+          "input": 2.5e-7,
+          "output": 5e-7
         }
       }
     ]
@@ -1226,8 +1226,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 5e-07
+          "input": 2.5e-7,
+          "output": 5e-7
         }
       }
     ]
@@ -1235,7 +1235,7 @@
   {
     "id": "clsk9lntu000008jwfc51bbqv",
     "modelName": "gpt-3.5-turbo-16k",
-    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-16k)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-16k)$",
     "createdAt": "2024-02-13T12:00:37.424Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1252,8 +1252,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-07,
-          "output": 1.5e-06
+          "input": 5e-7,
+          "output": 0.0000015
         }
       }
     ]
@@ -1261,7 +1261,7 @@
   {
     "id": "clsnq07bn000008l4e46v1ll8",
     "modelName": "gpt-4-turbo-preview",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo-preview)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo-preview)$",
     "createdAt": "2024-02-15T21:21:50.947Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1278,8 +1278,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-05,
-          "output": 3e-05
+          "input": 0.00001,
+          "output": 0.00003
         }
       }
     ]
@@ -1287,7 +1287,7 @@
   {
     "id": "cltgy0iuw000008le3vod1hhy",
     "modelName": "claude-3-opus-20240229",
-    "matchPattern": "(?i)^(anthropic/)?(claude-3-opus-20240229|anthropic\\.claude-3-opus-20240229-v1:0|claude-3-opus@20240229)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-opus-20240229|anthropic\\.claude-3-opus-20240229-v1:0|claude-3-opus@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1299,8 +1299,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-05,
-          "output": 7.5e-05
+          "input": 0.000015,
+          "output": 0.000075
         }
       }
     ]
@@ -1308,7 +1308,7 @@
   {
     "id": "cltgy0pp6000108le56se7bl3",
     "modelName": "claude-3-sonnet-20240229",
-    "matchPattern": "(?i)^(anthropic/)?(claude-3-sonnet-20240229|anthropic\\.claude-3-sonnet-20240229-v1:0|claude-3-sonnet@20240229)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-sonnet-20240229|anthropic\\.claude-3-sonnet-20240229-v1:0|claude-3-sonnet@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1320,15 +1320,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "input_tokens": 3e-06,
-          "output": 1.5e-05,
-          "output_tokens": 1.5e-05,
-          "cache_creation_input_tokens": 3.75e-06,
-          "input_cache_creation": 3.75e-06,
-          "cache_read_input_tokens": 3e-07,
-          "input_cache_read": 3e-07,
-          "cache_write_5m_input_tokens": 3.75e-06,
+          "input": 0.000003,
+          "input_tokens": 0.000003,
+          "output": 0.000015,
+          "output_tokens": 0.000015,
+          "cache_creation_input_tokens": 0.00000375,
+          "input_cache_creation": 0.00000375,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7,
+          "cache_write_5m_input_tokens": 0.00000375,
           "cache_write_1h_input_tokens": 6e-06
         }
       }
@@ -1337,7 +1337,7 @@
   {
     "id": "cltr0w45b000008k1407o9qv1",
     "modelName": "claude-3-haiku-20240307",
-    "matchPattern": "(?i)^(anthropic/)?(claude-3-haiku-20240307|anthropic\\.claude-3-haiku-20240307-v1:0|claude-3-haiku@20240307)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-haiku-20240307|anthropic\\.claude-3-haiku-20240307-v1:0|claude-3-haiku@20240307)$",
     "createdAt": "2024-03-14T09:41:18.736Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1349,8 +1349,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 1.25e-06
+          "input": 2.5e-7,
+          "output": 0.00000125
         }
       }
     ]
@@ -1358,7 +1358,7 @@
   {
     "id": "cluv2sjeo000008ih0fv23hi0",
     "modelName": "gemini-1.0-pro-latest",
-    "matchPattern": "(?i)^(google/)?(gemini-1.0-pro-latest)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google\/)?(gemini-1.0-pro-latest)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1369,8 +1369,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "output": 5e-07
+          "input": 2.5e-7,
+          "output": 5e-7
         }
       }
     ]
@@ -1378,7 +1378,7 @@
   {
     "id": "cluv2subq000108ih2mlrga6a",
     "modelName": "gemini-1.0-pro",
-    "matchPattern": "(?i)^(google/)?(gemini-1.0-pro)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google\/)?(gemini-1.0-pro)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1389,8 +1389,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-07,
-          "output": 3.75e-07
+          "input": 1.25e-7,
+          "output": 3.75e-7
         }
       }
     ]
@@ -1398,7 +1398,7 @@
   {
     "id": "cluv2sx04000208ihbek75lsz",
     "modelName": "gemini-1.0-pro-001",
-    "matchPattern": "(?i)^(google/)?(gemini-1.0-pro-001)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google\/)?(gemini-1.0-pro-001)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1409,8 +1409,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-07,
-          "output": 3.75e-07
+          "input": 1.25e-7,
+          "output": 3.75e-7
         }
       }
     ]
@@ -1418,7 +1418,7 @@
   {
     "id": "cluv2szw0000308ihch3n79x7",
     "modelName": "gemini-pro",
-    "matchPattern": "(?i)^(google/)?(gemini-pro)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google\/)?(gemini-pro)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1429,8 +1429,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-07,
-          "output": 3.75e-07
+          "input": 1.25e-7,
+          "output": 3.75e-7
         }
       }
     ]
@@ -1438,7 +1438,7 @@
   {
     "id": "cluv2t2x0000408ihfytl45l1",
     "modelName": "gemini-1.5-pro-latest",
-    "matchPattern": "(?i)^(google/)?(gemini-1.5-pro-latest)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google\/)?(gemini-1.5-pro-latest)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1449,8 +1449,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-06,
-          "output": 7.5e-06
+          "input": 0.0000025,
+          "output": 0.0000075
         }
       }
     ]
@@ -1458,7 +1458,7 @@
   {
     "id": "cluv2t5k3000508ih5kve9zag",
     "modelName": "gpt-4-turbo-2024-04-09",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo-2024-04-09)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo-2024-04-09)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1475,8 +1475,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-05,
-          "output": 3e-05
+          "input": 0.00001,
+          "output": 0.00003
         }
       }
     ]
@@ -1484,7 +1484,7 @@
   {
     "id": "cluvpl4ls000008l6h2gx3i07",
     "modelName": "gpt-4-turbo",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo)$",
     "createdAt": "2024-04-11T21:13:44.989Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1501,8 +1501,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-05,
-          "output": 3e-05
+          "input": 0.00001,
+          "output": 0.00003
         }
       }
     ]
@@ -1510,7 +1510,7 @@
   {
     "id": "clv2o2x0p000008jsf9afceau",
     "modelName": " gpt-4-preview",
-    "matchPattern": "(?i)^(openai/)?(gpt-4-preview)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4-preview)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1527,8 +1527,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-05,
-          "output": 3e-05
+          "input": 0.00001,
+          "output": 0.00003
         }
       }
     ]
@@ -1536,7 +1536,7 @@
   {
     "id": "clxt0n0m60000pumz1j5b7zsf",
     "modelName": "claude-3-5-sonnet-20240620",
-    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
     "createdAt": "2024-06-25T11:47:24.475Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1548,15 +1548,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "input_tokens": 3e-06,
-          "output": 1.5e-05,
-          "output_tokens": 1.5e-05,
-          "cache_creation_input_tokens": 3.75e-06,
-          "input_cache_creation": 3.75e-06,
-          "cache_read_input_tokens": 3e-07,
-          "input_cache_read": 3e-07,
-          "cache_write_5m_input_tokens": 3.75e-06,
+          "input": 0.000003,
+          "input_tokens": 0.000003,
+          "output": 0.000015,
+          "output_tokens": 0.000015,
+          "cache_creation_input_tokens": 0.00000375,
+          "input_cache_creation": 0.00000375,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7,
+          "cache_write_5m_input_tokens": 0.00000375,
           "cache_write_1h_input_tokens": 6e-06
         }
       }
@@ -1565,7 +1565,7 @@
   {
     "id": "clyrjp56f0000t0mzapoocd7u",
     "modelName": "gpt-4o-mini",
-    "matchPattern": "(?i)^(openai/)?(gpt-4o-mini)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4o-mini)$",
     "createdAt": "2024-07-18T17:56:09.591Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1582,10 +1582,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-07,
-          "output": 6e-07,
-          "input_cached_tokens": 7.5e-08,
-          "input_cache_read": 7.5e-08
+          "input": 1.5e-7,
+          "output": 6e-7,
+          "input_cached_tokens": 7.5e-8,
+          "input_cache_read": 7.5e-8
         }
       }
     ]
@@ -1593,7 +1593,7 @@
   {
     "id": "clyrjpbe20000t0mzcbwc42rg",
     "modelName": "gpt-4o-mini-2024-07-18",
-    "matchPattern": "(?i)^(openai/)?(gpt-4o-mini-2024-07-18)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4o-mini-2024-07-18)$",
     "createdAt": "2024-07-18T17:56:09.591Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1610,10 +1610,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-07,
-          "input_cached_tokens": 7.5e-08,
-          "input_cache_read": 7.5e-08,
-          "output": 6e-07
+          "input": 1.5e-7,
+          "input_cached_tokens": 7.5e-8,
+          "input_cache_read": 7.5e-8,
+          "output": 6e-7
         }
       }
     ]
@@ -1621,7 +1621,7 @@
   {
     "id": "clzjr85f70000ymmzg7hqffra",
     "modelName": "gpt-4o-2024-08-06",
-    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-08-06)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-08-06)$",
     "createdAt": "2024-08-07T11:54:31.298Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1638,10 +1638,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-06,
-          "input_cached_tokens": 1.25e-06,
-          "input_cache_read": 1.25e-06,
-          "output": 1e-05
+          "input": 0.0000025,
+          "input_cached_tokens": 0.00000125,
+          "input_cache_read": 0.00000125,
+          "output": 0.00001
         }
       }
     ]
@@ -1649,7 +1649,7 @@
   {
     "id": "cm10ivcdp0000gix7lelmbw80",
     "modelName": "o1-preview",
-    "matchPattern": "(?i)^(openai/)?(o1-preview)$",
+    "matchPattern": "(?i)^(openai\/)?(o1-preview)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1660,12 +1660,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-05,
-          "input_cached_tokens": 7.5e-06,
-          "input_cache_read": 7.5e-06,
-          "output": 6e-05,
-          "output_reasoning_tokens": 6e-05,
-          "output_reasoning": 6e-05
+          "input": 0.000015,
+          "input_cached_tokens": 0.0000075,
+          "input_cache_read": 0.0000075,
+          "output": 0.00006,
+          "output_reasoning_tokens": 0.00006,
+          "output_reasoning": 0.00006
         }
       }
     ]
@@ -1673,7 +1673,7 @@
   {
     "id": "cm10ivo130000n8x7qopcjjcg",
     "modelName": "o1-preview-2024-09-12",
-    "matchPattern": "(?i)^(openai/)?(o1-preview-2024-09-12)$",
+    "matchPattern": "(?i)^(openai\/)?(o1-preview-2024-09-12)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1684,12 +1684,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-05,
-          "input_cached_tokens": 7.5e-06,
-          "input_cache_read": 7.5e-06,
-          "output": 6e-05,
-          "output_reasoning_tokens": 6e-05,
-          "output_reasoning": 6e-05
+          "input": 0.000015,
+          "input_cached_tokens": 0.0000075,
+          "input_cache_read": 0.0000075,
+          "output": 0.00006,
+          "output_reasoning_tokens": 0.00006,
+          "output_reasoning": 0.00006
         }
       }
     ]
@@ -1697,7 +1697,7 @@
   {
     "id": "cm10ivwo40000r1x7gg3syjq0",
     "modelName": "o1-mini",
-    "matchPattern": "(?i)^(openai/)?(o1-mini)$",
+    "matchPattern": "(?i)^(openai\/)?(o1-mini)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1708,12 +1708,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.1e-06,
-          "input_cached_tokens": 5.5e-07,
-          "input_cache_read": 5.5e-07,
-          "output": 4.4e-06,
-          "output_reasoning_tokens": 4.4e-06,
-          "output_reasoning": 4.4e-06
+          "input": 0.0000011,
+          "input_cached_tokens": 5.5e-7,
+          "input_cache_read": 5.5e-7,
+          "output": 0.0000044,
+          "output_reasoning_tokens": 0.0000044,
+          "output_reasoning": 0.0000044
         }
       }
     ]
@@ -1721,7 +1721,7 @@
   {
     "id": "cm10iw6p20000wgx7it1hlb22",
     "modelName": "o1-mini-2024-09-12",
-    "matchPattern": "(?i)^(openai/)?(o1-mini-2024-09-12)$",
+    "matchPattern": "(?i)^(openai\/)?(o1-mini-2024-09-12)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1732,12 +1732,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.1e-06,
-          "input_cached_tokens": 5.5e-07,
-          "input_cache_read": 5.5e-07,
-          "output": 4.4e-06,
-          "output_reasoning_tokens": 4.4e-06,
-          "output_reasoning": 4.4e-06
+          "input": 0.0000011,
+          "input_cached_tokens": 5.5e-7,
+          "input_cache_read": 5.5e-7,
+          "output": 0.0000044,
+          "output_reasoning_tokens": 0.0000044,
+          "output_reasoning": 0.0000044
         }
       }
     ]
@@ -1745,7 +1745,7 @@
   {
     "id": "cm2krz1uf000208jjg5653iud",
     "modelName": "claude-3.5-sonnet-20241022",
-    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1757,15 +1757,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "input_tokens": 3e-06,
-          "output": 1.5e-05,
-          "output_tokens": 1.5e-05,
-          "cache_creation_input_tokens": 3.75e-06,
-          "input_cache_creation": 3.75e-06,
-          "cache_read_input_tokens": 3e-07,
-          "input_cache_read": 3e-07,
-          "cache_write_5m_input_tokens": 3.75e-06,
+          "input": 0.000003,
+          "input_tokens": 0.000003,
+          "output": 0.000015,
+          "output_tokens": 0.000015,
+          "cache_creation_input_tokens": 0.00000375,
+          "input_cache_creation": 0.00000375,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7,
+          "cache_write_5m_input_tokens": 0.00000375,
           "cache_write_1h_input_tokens": 6e-06
         }
       }
@@ -1774,7 +1774,7 @@
   {
     "id": "cm2ks2vzn000308jjh4ze1w7q",
     "modelName": "claude-3.5-sonnet-latest",
-    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-latest)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-latest)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1786,15 +1786,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "input_tokens": 3e-06,
-          "output": 1.5e-05,
-          "output_tokens": 1.5e-05,
-          "cache_creation_input_tokens": 3.75e-06,
-          "input_cache_creation": 3.75e-06,
-          "cache_read_input_tokens": 3e-07,
-          "input_cache_read": 3e-07,
-          "cache_write_5m_input_tokens": 3.75e-06,
+          "input": 0.000003,
+          "input_tokens": 0.000003,
+          "output": 0.000015,
+          "output_tokens": 0.000015,
+          "cache_creation_input_tokens": 0.00000375,
+          "input_cache_creation": 0.00000375,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7,
+          "cache_write_5m_input_tokens": 0.00000375,
           "cache_write_1h_input_tokens": 6e-06
         }
       }
@@ -1803,7 +1803,7 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "modelName": "claude-3-5-haiku-20241022",
-    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1815,15 +1815,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-07,
-          "input_tokens": 8e-07,
-          "output": 4e-06,
-          "output_tokens": 4e-06,
-          "cache_creation_input_tokens": 1e-06,
-          "input_cache_creation": 1e-06,
-          "cache_read_input_tokens": 8e-08,
-          "input_cache_read": 8e-08,
-          "cache_write_5m_input_tokens": 1e-06,
+          "input": 8e-7,
+          "input_tokens": 8e-7,
+          "output": 0.000004,
+          "output_tokens": 0.000004,
+          "cache_creation_input_tokens": 0.000001,
+          "input_cache_creation": 0.000001,
+          "cache_read_input_tokens": 8e-8,
+          "input_cache_read": 8e-8,
+          "cache_write_5m_input_tokens": 0.000001,
           "cache_write_1h_input_tokens": 1.6e-06
         }
       }
@@ -1832,7 +1832,7 @@
   {
     "id": "cm34aqb9h000307ml6nypd618",
     "modelName": "claude-3.5-haiku-latest",
-    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-haiku-latest)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-latest)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1844,15 +1844,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-07,
-          "input_tokens": 8e-07,
-          "output": 4e-06,
-          "output_tokens": 4e-06,
-          "cache_creation_input_tokens": 1e-06,
-          "input_cache_creation": 1e-06,
-          "cache_read_input_tokens": 8e-08,
-          "input_cache_read": 8e-08,
-          "cache_write_5m_input_tokens": 1e-06,
+          "input": 8e-7,
+          "input_tokens": 8e-7,
+          "output": 0.000004,
+          "output_tokens": 0.000004,
+          "cache_creation_input_tokens": 0.000001,
+          "input_cache_creation": 0.000001,
+          "cache_read_input_tokens": 8e-8,
+          "input_cache_read": 8e-8,
+          "cache_write_5m_input_tokens": 0.000001,
           "cache_write_1h_input_tokens": 1.6e-06
         }
       }
@@ -1878,8 +1878,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-06,
-          "output": 1.5e-05
+          "input": 0.000005,
+          "output": 0.000015
         }
       }
     ]
@@ -1887,7 +1887,7 @@
   {
     "id": "cm48akqgo000008ldbia24qg0",
     "modelName": "gpt-4o-2024-11-20",
-    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-11-20)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-11-20)$",
     "createdAt": "2024-12-03T10:06:12.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1904,10 +1904,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-06,
-          "input_cached_tokens": 1.25e-06,
-          "input_cache_read": 1.25e-06,
-          "output": 1e-05
+          "input": 0.0000025,
+          "input_cached_tokens": 0.00000125,
+          "input_cache_read": 0.00000125,
+          "output": 0.00001
         }
       }
     ]
@@ -1915,7 +1915,7 @@
   {
     "id": "cm48b2ksh000008l0hn3u0hl3",
     "modelName": "gpt-4o-audio-preview",
-    "matchPattern": "(?i)^(openai/)?(gpt-4o-audio-preview)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4o-audio-preview)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1926,8 +1926,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 2.5e-06,
-          "output_text_tokens": 1e-05,
+          "input_text_tokens": 0.0000025,
+          "output_text_tokens": 0.00001,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
           "output_audio_tokens": 0.0002,
@@ -1939,7 +1939,7 @@
   {
     "id": "cm48bbm0k000008l69nsdakwf",
     "modelName": "gpt-4o-audio-preview-2024-10-01",
-    "matchPattern": "(?i)^(openai/)?(gpt-4o-audio-preview-2024-10-01)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4o-audio-preview-2024-10-01)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1950,8 +1950,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 2.5e-06,
-          "output_text_tokens": 1e-05,
+          "input_text_tokens": 0.0000025,
+          "output_text_tokens": 0.00001,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
           "output_audio_tokens": 0.0002,
@@ -1963,7 +1963,7 @@
   {
     "id": "cm48c2qh4000008mhgy4mg2qc",
     "modelName": "gpt-4o-realtime-preview",
-    "matchPattern": "(?i)^(openai/)?(gpt-4o-realtime-preview)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4o-realtime-preview)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1974,12 +1974,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 5e-06,
-          "input_cached_text_tokens": 2.5e-06,
-          "output_text_tokens": 2e-05,
+          "input_text_tokens": 0.000005,
+          "input_cached_text_tokens": 0.0000025,
+          "output_text_tokens": 0.00002,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
-          "input_cached_audio_tokens": 2e-05,
+          "input_cached_audio_tokens": 0.00002,
           "output_audio_tokens": 0.0002,
           "output_audio": 0.0002
         }
@@ -1989,7 +1989,7 @@
   {
     "id": "cm48cjxtc000008jrcsso3avv",
     "modelName": "gpt-4o-realtime-preview-2024-10-01",
-    "matchPattern": "(?i)^(openai/)?(gpt-4o-realtime-preview-2024-10-01)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4o-realtime-preview-2024-10-01)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2000,12 +2000,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 5e-06,
-          "input_cached_text_tokens": 2.5e-06,
-          "output_text_tokens": 2e-05,
+          "input_text_tokens": 0.000005,
+          "input_cached_text_tokens": 0.0000025,
+          "output_text_tokens": 0.00002,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
-          "input_cached_audio_tokens": 2e-05,
+          "input_cached_audio_tokens": 0.00002,
           "output_audio_tokens": 0.0002,
           "output_audio": 0.0002
         }
@@ -2015,7 +2015,7 @@
   {
     "id": "cm48cjxtc000108jrcsso3avv",
     "modelName": "o1",
-    "matchPattern": "(?i)^(openai/)?(o1)$",
+    "matchPattern": "(?i)^(openai\/)?(o1)$",
     "createdAt": "2025-01-17T00:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2026,12 +2026,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-05,
-          "input_cached_tokens": 7.5e-06,
-          "input_cache_read": 7.5e-06,
-          "output": 6e-05,
-          "output_reasoning_tokens": 6e-05,
-          "output_reasoning": 6e-05
+          "input": 0.000015,
+          "input_cached_tokens": 0.0000075,
+          "input_cache_read": 0.0000075,
+          "output": 0.00006,
+          "output_reasoning_tokens": 0.00006,
+          "output_reasoning": 0.00006
         }
       }
     ]
@@ -2039,7 +2039,7 @@
   {
     "id": "cm48cjxtc000208jrcsso3avv",
     "modelName": "o1-2024-12-17",
-    "matchPattern": "(?i)^(openai/)?(o1-2024-12-17)$",
+    "matchPattern": "(?i)^(openai\/)?(o1-2024-12-17)$",
     "createdAt": "2025-01-17T00:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2050,12 +2050,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-05,
-          "input_cached_tokens": 7.5e-06,
-          "input_cache_read": 7.5e-06,
-          "output": 6e-05,
-          "output_reasoning_tokens": 6e-05,
-          "output_reasoning": 6e-05
+          "input": 0.000015,
+          "input_cached_tokens": 0.0000075,
+          "input_cache_read": 0.0000075,
+          "output": 0.00006,
+          "output_reasoning_tokens": 0.00006,
+          "output_reasoning": 0.00006
         }
       }
     ]
@@ -2063,7 +2063,7 @@
   {
     "id": "cm6l8j7vs0000tymz9vk7ew8t",
     "modelName": "o3-mini",
-    "matchPattern": "(?i)^(openai/)?(o3-mini)$",
+    "matchPattern": "(?i)^(openai\/)?(o3-mini)$",
     "createdAt": "2025-01-31T20:41:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2074,12 +2074,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.1e-06,
-          "input_cached_tokens": 5.5e-07,
-          "input_cache_read": 5.5e-07,
-          "output": 4.4e-06,
-          "output_reasoning_tokens": 4.4e-06,
-          "output_reasoning": 4.4e-06
+          "input": 0.0000011,
+          "input_cached_tokens": 5.5e-7,
+          "input_cache_read": 5.5e-7,
+          "output": 0.0000044,
+          "output_reasoning_tokens": 0.0000044,
+          "output_reasoning": 0.0000044
         }
       }
     ]
@@ -2087,7 +2087,7 @@
   {
     "id": "cm6l8jan90000tymz52sh0ql8",
     "modelName": "o3-mini-2025-01-31",
-    "matchPattern": "(?i)^(openai/)?(o3-mini-2025-01-31)$",
+    "matchPattern": "(?i)^(openai\/)?(o3-mini-2025-01-31)$",
     "createdAt": "2025-01-31T20:41:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2098,12 +2098,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.1e-06,
-          "input_cached_tokens": 5.5e-07,
-          "input_cache_read": 5.5e-07,
-          "output": 4.4e-06,
-          "output_reasoning_tokens": 4.4e-06,
-          "output_reasoning": 4.4e-06
+          "input": 0.0000011,
+          "input_cached_tokens": 5.5e-7,
+          "input_cache_read": 5.5e-7,
+          "output": 0.0000044,
+          "output_reasoning_tokens": 0.0000044,
+          "output_reasoning": 0.0000044
         }
       }
     ]
@@ -2111,7 +2111,7 @@
   {
     "id": "cm6l8jdef0000tymz52sh0ql0",
     "modelName": "gemini-2.0-flash-001",
-    "matchPattern": "(?i)^(google/)?(gemini-2.0-flash-001)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google\/)?(gemini-2.0-flash-001)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-02-06T11:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2122,8 +2122,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-07,
-          "output": 4e-07
+          "input": 1e-7,
+          "output": 4e-7
         }
       }
     ]
@@ -2131,7 +2131,7 @@
   {
     "id": "cm6l8jfgh0000tymz52sh0ql1",
     "modelName": "gemini-2.0-flash-lite-preview-02-05",
-    "matchPattern": "(?i)^(google/)?(gemini-2.0-flash-lite-preview-02-05)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google\/)?(gemini-2.0-flash-lite-preview-02-05)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-02-06T11:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2142,8 +2142,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 7.5e-08,
-          "output": 3e-07
+          "input": 7.5e-8,
+          "output": 3e-7
         }
       }
     ]
@@ -2151,7 +2151,7 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "modelName": "claude-3.7-sonnet-20250219",
-    "matchPattern": "(?i)^(anthropic/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -2163,15 +2163,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "input_tokens": 3e-06,
-          "output": 1.5e-05,
-          "output_tokens": 1.5e-05,
-          "cache_creation_input_tokens": 3.75e-06,
-          "input_cache_creation": 3.75e-06,
-          "cache_read_input_tokens": 3e-07,
-          "input_cache_read": 3e-07,
-          "cache_write_5m_input_tokens": 3.75e-06,
+          "input": 0.000003,
+          "input_tokens": 0.000003,
+          "output": 0.000015,
+          "output_tokens": 0.000015,
+          "cache_creation_input_tokens": 0.00000375,
+          "input_cache_creation": 0.00000375,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7,
+          "cache_write_5m_input_tokens": 0.00000375,
           "cache_write_1h_input_tokens": 6e-06
         }
       }
@@ -2180,7 +2180,7 @@
   {
     "id": "cm7ka7zob000208jsfs9h5ajj",
     "modelName": "claude-3.7-sonnet-latest",
-    "matchPattern": "(?i)^(anthropic/)?(claude-3-7-sonnet-latest)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-7-sonnet-latest)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -2192,15 +2192,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "input_tokens": 3e-06,
-          "output": 1.5e-05,
-          "output_tokens": 1.5e-05,
-          "cache_creation_input_tokens": 3.75e-06,
-          "input_cache_creation": 3.75e-06,
-          "cache_read_input_tokens": 3e-07,
-          "input_cache_read": 3e-07,
-          "cache_write_5m_input_tokens": 3.75e-06,
+          "input": 0.000003,
+          "input_tokens": 0.000003,
+          "output": 0.000015,
+          "output_tokens": 0.000015,
+          "cache_creation_input_tokens": 0.00000375,
+          "input_cache_creation": 0.00000375,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7,
+          "cache_write_5m_input_tokens": 0.00000375,
           "cache_write_1h_input_tokens": 6e-06
         }
       }
@@ -2209,7 +2209,7 @@
   {
     "id": "cm7nusjvk0000tvmz71o85jwg",
     "modelName": "gpt-4.5-preview",
-    "matchPattern": "(?i)^(openai/)?(gpt-4.5-preview)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4.5-preview)$",
     "createdAt": "2025-02-27T21:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2220,10 +2220,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 7.5e-05,
-          "input_cached_tokens": 3.75e-05,
-          "input_cached_text_tokens": 3.75e-05,
-          "input_cache_read": 3.75e-05,
+          "input": 0.000075,
+          "input_cached_tokens": 0.0000375,
+          "input_cached_text_tokens": 0.0000375,
+          "input_cache_read": 0.0000375,
           "output": 0.00015
         }
       }
@@ -2232,7 +2232,7 @@
   {
     "id": "cm7nusn640000tvmzf10z2x65",
     "modelName": "gpt-4.5-preview-2025-02-27",
-    "matchPattern": "(?i)^(openai/)?(gpt-4.5-preview-2025-02-27)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4.5-preview-2025-02-27)$",
     "createdAt": "2025-02-27T21:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2243,10 +2243,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 7.5e-05,
-          "input_cached_tokens": 3.75e-05,
-          "input_cached_text_tokens": 3.75e-05,
-          "input_cache_read": 3.75e-05,
+          "input": 0.000075,
+          "input_cached_tokens": 0.0000375,
+          "input_cached_text_tokens": 0.0000375,
+          "input_cache_read": 0.0000375,
           "output": 0.00015
         }
       }
@@ -2255,7 +2255,7 @@
   {
     "id": "cm7nusn643377tvmzh27m33kl",
     "modelName": "gpt-4.1",
-    "matchPattern": "(?i)^(openai/)?(gpt-4.1)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4.1)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2272,11 +2272,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-06,
-          "input_cached_tokens": 5e-07,
-          "input_cached_text_tokens": 5e-07,
-          "input_cache_read": 5e-07,
-          "output": 8e-06
+          "input": 0.000002,
+          "input_cached_tokens": 5e-7,
+          "input_cached_text_tokens": 5e-7,
+          "input_cache_read": 5e-7,
+          "output": 0.000008
         }
       }
     ]
@@ -2284,7 +2284,7 @@
   {
     "id": "cm7qahw732891bpmzy45r3x70",
     "modelName": "gpt-4.1-2025-04-14",
-    "matchPattern": "(?i)^(openai/)?(gpt-4.1-2025-04-14)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2301,11 +2301,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-06,
-          "input_cached_tokens": 5e-07,
-          "input_cached_text_tokens": 5e-07,
-          "input_cache_read": 5e-07,
-          "output": 8e-06
+          "input": 0.000002,
+          "input_cached_tokens": 5e-7,
+          "input_cached_text_tokens": 5e-7,
+          "input_cache_read": 5e-7,
+          "output": 0.000008
         }
       }
     ]
@@ -2313,7 +2313,7 @@
   {
     "id": "cm7sglt825463kxnza72p6v81",
     "modelName": "gpt-4.1-mini-2025-04-14",
-    "matchPattern": "(?i)^(openai/)?(gpt-4.1-mini-2025-04-14)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-mini-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2330,11 +2330,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 4e-07,
-          "input_cached_tokens": 1e-07,
-          "input_cached_text_tokens": 1e-07,
-          "input_cache_read": 1e-07,
-          "output": 1.6e-06
+          "input": 4e-7,
+          "input_cached_tokens": 1e-7,
+          "input_cached_text_tokens": 1e-7,
+          "input_cache_read": 1e-7,
+          "output": 0.0000016
         }
       }
     ]
@@ -2342,7 +2342,7 @@
   {
     "id": "cm7vxpz967124dhjtb95w8f92",
     "modelName": "gpt-4.1-nano-2025-04-14",
-    "matchPattern": "(?i)^(openai/)?(gpt-4.1-nano-2025-04-14)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-nano-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2359,11 +2359,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-07,
-          "input_cached_tokens": 2.5e-08,
-          "input_cached_text_tokens": 2.5e-08,
-          "input_cache_read": 2.5e-08,
-          "output": 4e-07
+          "input": 1e-7,
+          "input_cached_tokens": 2.5e-8,
+          "input_cached_text_tokens": 2.5e-8,
+          "input_cache_read": 2.5e-8,
+          "output": 4e-7
         }
       }
     ]
@@ -2371,7 +2371,7 @@
   {
     "id": "cm7wmny967124dhjtb95w8f81",
     "modelName": "o3",
-    "matchPattern": "(?i)^(openai/)?(o3)$",
+    "matchPattern": "(?i)^(openai\/)?(o3)$",
     "createdAt": "2025-04-16T23:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2382,12 +2382,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-06,
-          "input_cached_tokens": 5e-07,
-          "input_cache_read": 5e-07,
-          "output": 8e-06,
-          "output_reasoning_tokens": 8e-06,
-          "output_reasoning": 8e-06
+          "input": 0.000002,
+          "input_cached_tokens": 5e-7,
+          "input_cache_read": 5e-7,
+          "output": 0.000008,
+          "output_reasoning_tokens": 0.000008,
+          "output_reasoning": 0.000008
         }
       }
     ]
@@ -2395,7 +2395,7 @@
   {
     "id": "cm7wopq3327124dhjtb95w8f81",
     "modelName": "o3-2025-04-16",
-    "matchPattern": "(?i)^(openai/)?(o3-2025-04-16)$",
+    "matchPattern": "(?i)^(openai\/)?(o3-2025-04-16)$",
     "createdAt": "2025-04-16T23:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2406,12 +2406,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-06,
-          "input_cached_tokens": 5e-07,
-          "input_cache_read": 5e-07,
-          "output": 8e-06,
-          "output_reasoning_tokens": 8e-06,
-          "output_reasoning": 8e-06
+          "input": 0.000002,
+          "input_cached_tokens": 5e-7,
+          "input_cache_read": 5e-7,
+          "output": 0.000008,
+          "output_reasoning_tokens": 0.000008,
+          "output_reasoning": 0.000008
         }
       }
     ]
@@ -2430,12 +2430,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.1e-06,
-          "input_cached_tokens": 2.75e-07,
-          "input_cache_read": 2.75e-07,
-          "output": 4.4e-06,
-          "output_reasoning_tokens": 4.4e-06,
-          "output_reasoning": 4.4e-06
+          "input": 0.0000011,
+          "input_cached_tokens": 2.75e-7,
+          "input_cache_read": 2.75e-7,
+          "output": 0.0000044,
+          "output_reasoning_tokens": 0.0000044,
+          "output_reasoning": 0.0000044
         }
       }
     ]
@@ -2454,12 +2454,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.1e-06,
-          "input_cached_tokens": 2.75e-07,
-          "input_cache_read": 2.75e-07,
-          "output": 4.4e-06,
-          "output_reasoning_tokens": 4.4e-06,
-          "output_reasoning": 4.4e-06
+          "input": 0.0000011,
+          "input_cached_tokens": 2.75e-7,
+          "input_cache_read": 2.75e-7,
+          "output": 0.0000044,
+          "output_reasoning_tokens": 0.0000044,
+          "output_reasoning": 0.0000044
         }
       }
     ]
@@ -2467,7 +2467,7 @@
   {
     "id": "cm7zsrs1327124dhjtb95w8f74",
     "modelName": "gemini-2.0-flash",
-    "matchPattern": "(?i)^(google/)?(gemini-2.0-flash)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google\/)?(gemini-2.0-flash)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2478,8 +2478,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-07,
-          "output": 4e-07
+          "input": 1e-7,
+          "output": 4e-7
         }
       }
     ]
@@ -2487,7 +2487,7 @@
   {
     "id": "cm7ztrs1327124dhjtb95w8f19",
     "modelName": "gemini-2.0-flash-lite-preview",
-    "matchPattern": "(?i)^(google/)?(gemini-2.0-flash-lite-preview)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google\/)?(gemini-2.0-flash-lite-preview)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2498,8 +2498,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 7.5e-08,
-          "output": 3e-07
+          "input": 7.5e-8,
+          "output": 3e-7
         }
       }
     ]
@@ -2507,7 +2507,7 @@
   {
     "id": "cm7zxrs1327124dhjtb95w8f45",
     "modelName": "gpt-4.1-nano",
-    "matchPattern": "(?i)^(openai/)?(gpt-4.1-nano)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-nano)$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2524,11 +2524,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-07,
-          "input_cached_tokens": 2.5e-08,
-          "input_cached_text_tokens": 2.5e-08,
-          "input_cache_read": 2.5e-08,
-          "output": 4e-07
+          "input": 1e-7,
+          "input_cached_tokens": 2.5e-8,
+          "input_cached_text_tokens": 2.5e-8,
+          "input_cache_read": 2.5e-8,
+          "output": 4e-7
         }
       }
     ]
@@ -2536,7 +2536,7 @@
   {
     "id": "cm7zzrs1327124dhjtb95w8p96",
     "modelName": "gpt-4.1-mini",
-    "matchPattern": "(?i)^(openai/)?(gpt-4.1-mini)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-mini)$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2553,11 +2553,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 4e-07,
-          "input_cached_tokens": 1e-07,
-          "input_cached_text_tokens": 1e-07,
-          "input_cache_read": 1e-07,
-          "output": 1.6e-06
+          "input": 4e-7,
+          "input_cached_tokens": 1e-7,
+          "input_cached_text_tokens": 1e-7,
+          "input_cache_read": 1e-7,
+          "output": 0.0000016
         }
       }
     ]
@@ -2565,7 +2565,7 @@
   {
     "id": "c5qmrqolku82tra3vgdixmys",
     "modelName": "claude-sonnet-4-5-20250929",
-    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4-5(-20250929)?|anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
     "createdAt": "2025-09-29T00:00:00.000Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2577,15 +2577,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "input_tokens": 3e-06,
-          "output": 1.5e-05,
-          "output_tokens": 1.5e-05,
-          "cache_creation_input_tokens": 3.75e-06,
-          "input_cache_creation": 3.75e-06,
-          "cache_read_input_tokens": 3e-07,
-          "input_cache_read": 3e-07,
-          "cache_write_5m_input_tokens": 3.75e-06,
+          "input": 0.000003,
+          "input_tokens": 0.000003,
+          "output": 0.000015,
+          "output_tokens": 0.000015,
+          "cache_creation_input_tokens": 0.00000375,
+          "input_cache_creation": 0.00000375,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7,
+          "cache_write_5m_input_tokens": 0.00000375,
           "cache_write_1h_input_tokens": 6e-06
         }
       },
@@ -2603,49 +2603,49 @@
           }
         ],
         "prices": {
-          "input": 6e-06,
-          "input_tokens": 6e-06,
-          "output": 2.25e-05,
-          "output_tokens": 2.25e-05,
-          "cache_creation_input_tokens": 7.5e-06,
-          "input_cache_creation": 7.5e-06,
-          "cache_read_input_tokens": 6e-07,
-          "input_cache_read": 6e-07,
-          "cache_write_5m_input_tokens": 7.5e-06,
+          "input": 0.000006,
+          "input_tokens": 0.000006,
+          "output": 0.0000225,
+          "output_tokens": 0.0000225,
+          "cache_creation_input_tokens": 0.0000075,
+          "input_cache_creation": 0.0000075,
+          "cache_read_input_tokens": 6e-7,
+          "input_cache_read": 6e-7,
+          "cache_write_5m_input_tokens": 0.0000075,
           "cache_write_1h_input_tokens": 1.2e-05
         }
       }
     ]
   },
   {
-    "id": "519a52c2-72b1-4fc7-ab93-e25511a434f2",
+    "id": "cris-claude-sonnet-4-5-20250929",
     "modelName": "claude-sonnet-4-5-20250929-cris",
     "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|global\\.)anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?$",
-    "createdAt": "2025-09-29T00:00:00.000Z",
+    "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
-        "id": "519a52c2-72b1-4fc7-ab93-e25511a434f2_tier_default",
+        "id": "cris-claude-sonnet-4-5-20250929_tier_default",
         "name": "Standard",
         "isDefault": true,
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3.3e-06,
-          "input_tokens": 3.3e-06,
-          "output": 1.65e-05,
-          "output_tokens": 1.65e-05,
-          "cache_creation_input_tokens": 4.125e-06,
-          "input_cache_creation": 4.125e-06,
-          "cache_read_input_tokens": 3.3e-07,
-          "input_cache_read": 3.3e-07,
-          "cache_write_5m_input_tokens": 4.125e-06,
-          "cache_write_1h_input_tokens": 6.6e-06
+          "input": 3.3e-6,
+          "input_tokens": 3.3e-6,
+          "output": 16.5e-6,
+          "output_tokens": 16.5e-6,
+          "cache_creation_input_tokens": 4.125e-6,
+          "input_cache_creation": 4.125e-6,
+          "cache_read_input_tokens": 3.3e-7,
+          "input_cache_read": 3.3e-7,
+          "cache_write_5m_input_tokens": 4.125e-6,
+          "cache_write_1h_input_tokens": 6.6e-6
         }
       },
       {
-        "id": "00b65240-047b-4722-9590-808edbc2067f",
+        "id": "cris-claude-sonnet-4-5-20250929_tier_large",
         "name": "Large Context",
         "isDefault": false,
         "priority": 1,
@@ -2658,15 +2658,15 @@
           }
         ],
         "prices": {
-          "input": 6.6e-06,
-          "input_tokens": 6.6e-06,
-          "output": 2.475e-05,
-          "output_tokens": 2.475e-05,
-          "cache_creation_input_tokens": 8.25e-06,
-          "input_cache_creation": 8.25e-06,
-          "cache_read_input_tokens": 6.6e-07,
-          "input_cache_read": 6.6e-07,
-          "cache_write_5m_input_tokens": 8.25e-06,
+          "input": 6.6e-6,
+          "input_tokens": 6.6e-6,
+          "output": 24.75e-6,
+          "output_tokens": 24.75e-6,
+          "cache_creation_input_tokens": 8.25e-6,
+          "input_cache_creation": 8.25e-6,
+          "cache_read_input_tokens": 6.6e-7,
+          "input_cache_read": 6.6e-7,
+          "cache_write_5m_input_tokens": 8.25e-6,
           "cache_write_1h_input_tokens": 1.32e-05
         }
       }
@@ -2675,7 +2675,7 @@
   {
     "id": "cmazmkzlm00000djp1e1qe4k4",
     "modelName": "claude-sonnet-4-20250514",
-    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2687,15 +2687,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "input_tokens": 3e-06,
-          "output": 1.5e-05,
-          "output_tokens": 1.5e-05,
-          "cache_creation_input_tokens": 3.75e-06,
-          "input_cache_creation": 3.75e-06,
-          "cache_read_input_tokens": 3e-07,
-          "input_cache_read": 3e-07,
-          "cache_write_5m_input_tokens": 3.75e-06,
+          "input": 0.000003,
+          "input_tokens": 0.000003,
+          "output": 0.000015,
+          "output_tokens": 0.000015,
+          "cache_creation_input_tokens": 0.00000375,
+          "input_cache_creation": 0.00000375,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7,
+          "cache_write_5m_input_tokens": 0.00000375,
           "cache_write_1h_input_tokens": 6e-06
         }
       }
@@ -2704,7 +2704,7 @@
   {
     "id": "cmazmlbnv00010djpazed91va",
     "modelName": "claude-sonnet-4-latest",
-    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4-latest)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-latest)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -2716,15 +2716,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "input_tokens": 3e-06,
-          "output": 1.5e-05,
-          "output_tokens": 1.5e-05,
-          "cache_creation_input_tokens": 3.75e-06,
-          "input_cache_creation": 3.75e-06,
-          "cache_read_input_tokens": 3e-07,
-          "input_cache_read": 3e-07,
-          "cache_write_5m_input_tokens": 3.75e-06,
+          "input": 0.000003,
+          "input_tokens": 0.000003,
+          "output": 0.000015,
+          "output_tokens": 0.000015,
+          "cache_creation_input_tokens": 0.00000375,
+          "input_cache_creation": 0.00000375,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7,
+          "cache_write_5m_input_tokens": 0.00000375,
           "cache_write_1h_input_tokens": 6e-06
         }
       }
@@ -2733,7 +2733,7 @@
   {
     "id": "cmazmlm2p00020djpa9s64jw5",
     "modelName": "claude-opus-4-20250514",
-    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2745,15 +2745,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-05,
-          "input_tokens": 1.5e-05,
-          "output": 7.5e-05,
-          "output_tokens": 7.5e-05,
-          "cache_creation_input_tokens": 1.875e-05,
-          "input_cache_creation": 1.875e-05,
-          "cache_read_input_tokens": 1.5e-06,
-          "input_cache_read": 1.5e-06,
-          "cache_write_5m_input_tokens": 1.875e-05,
+          "input": 0.000015,
+          "input_tokens": 0.000015,
+          "output": 0.000075,
+          "output_tokens": 0.000075,
+          "cache_creation_input_tokens": 0.00001875,
+          "input_cache_creation": 0.00001875,
+          "cache_read_input_tokens": 0.0000015,
+          "input_cache_read": 0.0000015,
+          "cache_write_5m_input_tokens": 0.00001875,
           "cache_write_1h_input_tokens": 3e-05
         }
       }
@@ -2762,7 +2762,7 @@
   {
     "id": "cmz9x72kq55721pqrs83y4n2bx",
     "modelName": "o3-pro",
-    "matchPattern": "(?i)^(openai/)?(o3-pro)$",
+    "matchPattern": "(?i)^(openai\/)?(o3-pro)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2773,10 +2773,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-05,
-          "output": 8e-05,
-          "output_reasoning_tokens": 8e-05,
-          "output_reasoning": 8e-05
+          "input": 0.00002,
+          "output": 0.00008,
+          "output_reasoning_tokens": 0.00008,
+          "output_reasoning": 0.00008
         }
       }
     ]
@@ -2784,7 +2784,7 @@
   {
     "id": "cmz9x72kq55721pqrs83y4n2by",
     "modelName": "o3-pro-2025-06-10",
-    "matchPattern": "(?i)^(openai/)?(o3-pro-2025-06-10)$",
+    "matchPattern": "(?i)^(openai\/)?(o3-pro-2025-06-10)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2795,10 +2795,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-05,
-          "output": 8e-05,
-          "output_reasoning_tokens": 8e-05,
-          "output_reasoning": 8e-05
+          "input": 0.00002,
+          "output": 0.00008,
+          "output_reasoning_tokens": 0.00008,
+          "output_reasoning": 0.00008
         }
       }
     ]
@@ -2806,7 +2806,7 @@
   {
     "id": "cmbrold5b000107lbftb9fdoo",
     "modelName": "o1-pro",
-    "matchPattern": "(?i)^(openai/)?(o1-pro)$",
+    "matchPattern": "(?i)^(openai\/)?(o1-pro)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2828,7 +2828,7 @@
   {
     "id": "cmbrolpax000207lb3xkedysz",
     "modelName": "o1-pro-2025-03-19",
-    "matchPattern": "(?i)^(openai/)?(o1-pro-2025-03-19)$",
+    "matchPattern": "(?i)^(openai\/)?(o1-pro-2025-03-19)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2850,7 +2850,7 @@
   {
     "id": "cmcnjkfwn000107l43bf5e8ax",
     "modelName": "gemini-2.5-flash",
-    "matchPattern": "(?i)^(google/)?(gemini-2.5-flash)$",
+    "matchPattern": "(?i)^(google\/)?(gemini-2.5-flash)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2861,20 +2861,20 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-07,
-          "input_modality_1": 3e-07,
-          "prompt_token_count": 3e-07,
-          "promptTokenCount": 3e-07,
-          "input_cached_tokens": 3e-08,
-          "cached_content_token_count": 3e-08,
-          "output": 2.5e-06,
-          "output_modality_1": 2.5e-06,
-          "candidates_token_count": 2.5e-06,
-          "candidatesTokenCount": 2.5e-06,
-          "thoughtsTokenCount": 2.5e-06,
-          "thoughts_token_count": 2.5e-06,
-          "output_reasoning": 2.5e-06,
-          "input_audio_tokens": 1e-06
+          "input": 3e-7,
+          "input_modality_1": 3e-7,
+          "prompt_token_count": 3e-7,
+          "promptTokenCount": 3e-7,
+          "input_cached_tokens": 3e-8,
+          "cached_content_token_count": 3e-8,
+          "output": 0.0000025,
+          "output_modality_1": 0.0000025,
+          "candidates_token_count": 0.0000025,
+          "candidatesTokenCount": 0.0000025,
+          "thoughtsTokenCount": 0.0000025,
+          "thoughts_token_count": 0.0000025,
+          "output_reasoning": 0.0000025,
+          "input_audio_tokens": 0.000001
         }
       }
     ]
@@ -2882,7 +2882,7 @@
   {
     "id": "cmcnjkrfa000207l4fpnh5mnv",
     "modelName": "gemini-2.5-flash-lite",
-    "matchPattern": "(?i)^(google/)?(gemini-2.5-flash-lite)$",
+    "matchPattern": "(?i)^(google\/)?(gemini-2.5-flash-lite)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2893,20 +2893,20 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-07,
-          "input_modality_1": 1e-07,
-          "prompt_token_count": 1e-07,
-          "promptTokenCount": 1e-07,
-          "input_cached_tokens": 2.5e-08,
-          "cached_content_token_count": 2.5e-08,
-          "output": 4e-07,
-          "output_modality_1": 4e-07,
-          "candidates_token_count": 4e-07,
-          "candidatesTokenCount": 4e-07,
-          "thoughtsTokenCount": 4e-07,
-          "thoughts_token_count": 4e-07,
-          "output_reasoning": 4e-07,
-          "input_audio_tokens": 5e-07
+          "input": 1e-7,
+          "input_modality_1": 1e-7,
+          "prompt_token_count": 1e-7,
+          "promptTokenCount": 1e-7,
+          "input_cached_tokens": 2.5e-8,
+          "cached_content_token_count": 2.5e-8,
+          "output": 4e-7,
+          "output_modality_1": 4e-7,
+          "candidates_token_count": 4e-7,
+          "candidatesTokenCount": 4e-7,
+          "thoughtsTokenCount": 4e-7,
+          "thoughts_token_count": 4e-7,
+          "output_reasoning": 4e-7,
+          "input_audio_tokens": 5e-7
         }
       }
     ]
@@ -2914,7 +2914,7 @@
   {
     "id": "cmdysde5w0000rkmzbc1g5au3",
     "modelName": "claude-opus-4-1-20250805",
-    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
     "createdAt": "2025-08-05T15:00:00.000Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2926,15 +2926,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-05,
-          "input_tokens": 1.5e-05,
-          "output": 7.5e-05,
-          "output_tokens": 7.5e-05,
-          "cache_creation_input_tokens": 1.875e-05,
-          "input_cache_creation": 1.875e-05,
-          "cache_read_input_tokens": 1.5e-06,
-          "input_cache_read": 1.5e-06,
-          "cache_write_5m_input_tokens": 1.875e-05,
+          "input": 0.000015,
+          "input_tokens": 0.000015,
+          "output": 0.000075,
+          "output_tokens": 0.000075,
+          "cache_creation_input_tokens": 0.00001875,
+          "input_cache_creation": 0.00001875,
+          "cache_read_input_tokens": 0.0000015,
+          "input_cache_read": 0.0000015,
+          "cache_write_5m_input_tokens": 0.00001875,
           "cache_write_1h_input_tokens": 3e-05
         }
       }
@@ -2943,7 +2943,7 @@
   {
     "id": "38c3822a-09a3-457b-b200-2c6f17f7cf2f",
     "modelName": "gpt-5",
-    "matchPattern": "(?i)^(openai/)?(gpt-5)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2960,12 +2960,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-06,
-          "input_cached_tokens": 1.25e-07,
-          "output": 1e-05,
-          "input_cache_read": 1.25e-07,
-          "output_reasoning_tokens": 1e-05,
-          "output_reasoning": 1e-05
+          "input": 0.00000125,
+          "input_cached_tokens": 1.25e-7,
+          "output": 0.00001,
+          "input_cache_read": 1.25e-7,
+          "output_reasoning_tokens": 0.00001,
+          "output_reasoning": 0.00001
         }
       }
     ]
@@ -2973,7 +2973,7 @@
   {
     "id": "12543803-2d5f-4189-addc-821ad71c8b55",
     "modelName": "gpt-5-2025-08-07",
-    "matchPattern": "(?i)^(openai/)?(gpt-5-2025-08-07)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2990,12 +2990,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-06,
-          "input_cached_tokens": 1.25e-07,
-          "output": 1e-05,
-          "input_cache_read": 1.25e-07,
-          "output_reasoning_tokens": 1e-05,
-          "output_reasoning": 1e-05
+          "input": 0.00000125,
+          "input_cached_tokens": 1.25e-7,
+          "output": 0.00001,
+          "input_cache_read": 1.25e-7,
+          "output_reasoning_tokens": 0.00001,
+          "output_reasoning": 0.00001
         }
       }
     ]
@@ -3003,7 +3003,7 @@
   {
     "id": "3d6a975a-a42d-4ea2-a3ec-4ae567d5a364",
     "modelName": "gpt-5-mini",
-    "matchPattern": "(?i)^(openai/)?(gpt-5-mini)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5-mini)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3020,12 +3020,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "input_cached_tokens": 2.5e-08,
-          "output": 2e-06,
-          "input_cache_read": 2.5e-08,
-          "output_reasoning_tokens": 2e-06,
-          "output_reasoning": 2e-06
+          "input": 2.5e-7,
+          "input_cached_tokens": 2.5e-8,
+          "output": 0.000002,
+          "input_cache_read": 2.5e-8,
+          "output_reasoning_tokens": 0.000002,
+          "output_reasoning": 0.000002
         }
       }
     ]
@@ -3033,7 +3033,7 @@
   {
     "id": "03b83894-7172-4e1e-8e8b-37d792484efd",
     "modelName": "gpt-5-mini-2025-08-07",
-    "matchPattern": "(?i)^(openai/)?(gpt-5-mini-2025-08-07)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5-mini-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3050,12 +3050,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-07,
-          "input_cached_tokens": 2.5e-08,
-          "output": 2e-06,
-          "input_cache_read": 2.5e-08,
-          "output_reasoning_tokens": 2e-06,
-          "output_reasoning": 2e-06
+          "input": 2.5e-7,
+          "input_cached_tokens": 2.5e-8,
+          "output": 0.000002,
+          "input_cache_read": 2.5e-8,
+          "output_reasoning_tokens": 0.000002,
+          "output_reasoning": 0.000002
         }
       }
     ]
@@ -3063,7 +3063,7 @@
   {
     "id": "f0b40234-b694-4c40-9494-7b0efd860fb9",
     "modelName": "gpt-5-nano",
-    "matchPattern": "(?i)^(openai/)?(gpt-5-nano)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5-nano)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3080,12 +3080,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-08,
-          "input_cached_tokens": 5e-09,
-          "output": 4e-07,
-          "input_cache_read": 5e-09,
-          "output_reasoning_tokens": 4e-07,
-          "output_reasoning": 4e-07
+          "input": 5e-8,
+          "input_cached_tokens": 5e-9,
+          "output": 4e-7,
+          "input_cache_read": 5e-9,
+          "output_reasoning_tokens": 4e-7,
+          "output_reasoning": 4e-7
         }
       }
     ]
@@ -3093,7 +3093,7 @@
   {
     "id": "4489fde4-a594-4011-948b-526989300cd3",
     "modelName": "gpt-5-nano-2025-08-07",
-    "matchPattern": "(?i)^(openai/)?(gpt-5-nano-2025-08-07)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5-nano-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3110,12 +3110,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-08,
-          "input_cached_tokens": 5e-09,
-          "output": 4e-07,
-          "input_cache_read": 5e-09,
-          "output_reasoning_tokens": 4e-07,
-          "output_reasoning": 4e-07
+          "input": 5e-8,
+          "input_cached_tokens": 5e-9,
+          "output": 4e-7,
+          "input_cache_read": 5e-9,
+          "output_reasoning_tokens": 4e-7,
+          "output_reasoning": 4e-7
         }
       }
     ]
@@ -3123,7 +3123,7 @@
   {
     "id": "8ba72ee3-ebe8-4110-a614-bf81094447e5",
     "modelName": "gpt-5-chat-latest",
-    "matchPattern": "(?i)^(openai/)?(gpt-5-chat-latest)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5-chat-latest)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3140,12 +3140,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-06,
-          "input_cached_tokens": 1.25e-07,
-          "output": 1e-05,
-          "input_cache_read": 1.25e-07,
-          "output_reasoning_tokens": 1e-05,
-          "output_reasoning": 1e-05
+          "input": 0.00000125,
+          "input_cached_tokens": 1.25e-7,
+          "output": 0.00001,
+          "input_cache_read": 1.25e-7,
+          "output_reasoning_tokens": 0.00001,
+          "output_reasoning": 0.00001
         }
       }
     ]
@@ -3153,7 +3153,7 @@
   {
     "id": "cmgg9zco3000004l258um9xk8",
     "modelName": "gpt-5-pro",
-    "matchPattern": "(?i)^(openai/)?(gpt-5-pro)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5-pro)$",
     "createdAt": "2025-10-07T08:03:54.727Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3170,7 +3170,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-05,
+          "input": 0.000015,
           "output": 0.00012,
           "output_reasoning_tokens": 0.00012,
           "output_reasoning": 0.00012
@@ -3181,7 +3181,7 @@
   {
     "id": "cmgga0vh9000104l22qe4fes4",
     "modelName": "gpt-5-pro-2025-10-06",
-    "matchPattern": "(?i)^(openai/)?(gpt-5-pro-2025-10-06)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5-pro-2025-10-06)$",
     "createdAt": "2025-10-07T08:03:54.727Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3198,7 +3198,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-05,
+          "input": 0.000015,
           "output": 0.00012,
           "output_reasoning_tokens": 0.00012,
           "output_reasoning": 0.00012
@@ -3209,7 +3209,7 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(anthropic/)?(claude-haiku-4-5-20251001|anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5-20251001|anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -3221,45 +3221,45 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-06,
-          "input_tokens": 1e-06,
-          "output": 5e-06,
-          "output_tokens": 5e-06,
-          "cache_creation_input_tokens": 1.25e-06,
-          "input_cache_creation": 1.25e-06,
-          "cache_read_input_tokens": 1e-07,
-          "input_cache_read": 1e-07,
-          "cache_write_5m_input_tokens": 1.25e-06,
+          "input": 0.000001,
+          "input_tokens": 0.000001,
+          "output": 0.000005,
+          "output_tokens": 0.000005,
+          "cache_creation_input_tokens": 0.00000125,
+          "input_cache_creation": 0.00000125,
+          "cache_read_input_tokens": 1e-7,
+          "input_cache_read": 1e-7,
+          "cache_write_5m_input_tokens": 0.00000125,
           "cache_write_1h_input_tokens": 2e-06
         }
       }
     ]
   },
   {
-    "id": "01f22771-76a5-4e41-a252-661d02b9ab88",
+    "id": "cris-claude-haiku-4-5-20251001",
     "modelName": "claude-haiku-4-5-20251001-cris",
     "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|global\\.)anthropic\\.claude-haiku-4-5-20251001-v1:0$",
-    "createdAt": "2025-10-16T08:20:44.558Z",
+    "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {
-        "id": "01f22771-76a5-4e41-a252-661d02b9ab88_tier_default",
+        "id": "cris-claude-haiku-4-5-20251001_tier_default",
         "name": "Standard",
         "isDefault": true,
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.1e-06,
-          "input_tokens": 1.1e-06,
-          "output": 5.5e-06,
-          "output_tokens": 5.5e-06,
-          "cache_creation_input_tokens": 1.375e-06,
-          "input_cache_creation": 1.375e-06,
-          "cache_read_input_tokens": 1.1e-07,
-          "input_cache_read": 1.1e-07,
-          "cache_write_5m_input_tokens": 1.375e-06,
-          "cache_write_1h_input_tokens": 2.2e-06
+          "input": 1.1e-6,
+          "input_tokens": 1.1e-6,
+          "output": 5.5e-6,
+          "output_tokens": 5.5e-6,
+          "cache_creation_input_tokens": 1.375e-6,
+          "input_cache_creation": 1.375e-6,
+          "cache_read_input_tokens": 1.1e-7,
+          "input_cache_read": 1.1e-7,
+          "cache_write_5m_input_tokens": 1.375e-6,
+          "cache_write_1h_input_tokens": 2.2e-6
         }
       }
     ]
@@ -3267,7 +3267,7 @@
   {
     "id": "cmhymgpym000d04ih34rndvhr",
     "modelName": "gpt-5.1",
-    "matchPattern": "(?i)^(openai/)?(gpt-5.1)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5.1)$",
     "createdAt": "2025-11-14T08:57:23.481Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3284,12 +3284,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-06,
-          "input_cached_tokens": 1.25e-07,
-          "output": 1e-05,
-          "input_cache_read": 1.25e-07,
-          "output_reasoning_tokens": 1e-05,
-          "output_reasoning": 1e-05
+          "input": 0.00000125,
+          "input_cached_tokens": 1.25e-7,
+          "output": 0.00001,
+          "input_cache_read": 1.25e-7,
+          "output_reasoning_tokens": 0.00001,
+          "output_reasoning": 0.00001
         }
       }
     ]
@@ -3297,7 +3297,7 @@
   {
     "id": "cmhymgxiw000e04ihh9pw12ef",
     "modelName": "gpt-5.1-2025-11-13",
-    "matchPattern": "(?i)^(openai/)?(gpt-5.1-2025-11-13)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5.1-2025-11-13)$",
     "createdAt": "2025-11-14T08:57:23.481Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3314,12 +3314,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-06,
-          "input_cached_tokens": 1.25e-07,
-          "output": 1e-05,
-          "input_cache_read": 1.25e-07,
-          "output_reasoning_tokens": 1e-05,
-          "output_reasoning": 1e-05
+          "input": 0.00000125,
+          "input_cached_tokens": 1.25e-7,
+          "output": 0.00001,
+          "input_cache_read": 1.25e-7,
+          "output_reasoning_tokens": 0.00001,
+          "output_reasoning": 0.00001
         }
       }
     ]
@@ -3327,7 +3327,7 @@
   {
     "id": "cmieupdva000004l541kwae70",
     "modelName": "claude-opus-4-5-20251101",
-    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-5(-20251101)?|anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-5(-20251101)?|anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
     "createdAt": "2025-11-24T20:53:27.571Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3340,45 +3340,45 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-06,
-          "input_tokens": 5e-06,
-          "output": 2.5e-05,
-          "output_tokens": 2.5e-05,
-          "cache_creation_input_tokens": 6.25e-06,
-          "input_cache_creation": 6.25e-06,
-          "cache_read_input_tokens": 5e-07,
-          "input_cache_read": 5e-07,
-          "cache_write_5m_input_tokens": 6.25e-06,
+          "input": 5e-6,
+          "input_tokens": 5e-6,
+          "output": 25e-6,
+          "output_tokens": 25e-6,
+          "cache_creation_input_tokens": 6.25e-6,
+          "input_cache_creation": 6.25e-6,
+          "cache_read_input_tokens": 0.5e-6,
+          "input_cache_read": 0.5e-6,
+          "cache_write_5m_input_tokens": 6.25e-6,
           "cache_write_1h_input_tokens": 1e-05
         }
       }
     ]
   },
   {
-    "id": "9853c95c-bcf5-447d-a7b5-5fb402a94f03",
+    "id": "cris-claude-opus-4-5-20251101",
     "modelName": "claude-opus-4-5-20251101-cris",
     "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?$",
-    "createdAt": "2025-11-24T20:53:27.571Z",
+    "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
       {
-        "id": "9853c95c-bcf5-447d-a7b5-5fb402a94f03_tier_default",
+        "id": "cris-claude-opus-4-5-20251101_tier_default",
         "name": "Standard",
         "isDefault": true,
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5.5e-06,
-          "input_tokens": 5.5e-06,
-          "output": 2.75e-05,
-          "output_tokens": 2.75e-05,
-          "cache_creation_input_tokens": 6.875e-06,
-          "input_cache_creation": 6.875e-06,
-          "cache_read_input_tokens": 5.5e-07,
-          "input_cache_read": 5.5e-07,
-          "cache_write_5m_input_tokens": 6.875e-06,
+          "input": 5.5e-6,
+          "input_tokens": 5.5e-6,
+          "output": 27.5e-6,
+          "output_tokens": 27.5e-6,
+          "cache_creation_input_tokens": 6.875e-6,
+          "input_cache_creation": 6.875e-6,
+          "cache_read_input_tokens": 0.55e-6,
+          "input_cache_read": 0.55e-6,
+          "cache_write_5m_input_tokens": 6.875e-6,
           "cache_write_1h_input_tokens": 1.1e-05
         }
       }
@@ -3400,15 +3400,15 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-06,
-          "input_tokens": 3e-06,
-          "output": 1.5e-05,
-          "output_tokens": 1.5e-05,
-          "cache_creation_input_tokens": 3.75e-06,
-          "input_cache_creation": 3.75e-06,
-          "cache_read_input_tokens": 3e-07,
-          "input_cache_read": 3e-07,
-          "cache_write_5m_input_tokens": 3.75e-06,
+          "input": 3e-6,
+          "input_tokens": 3e-6,
+          "output": 15e-6,
+          "output_tokens": 15e-6,
+          "cache_creation_input_tokens": 3.75e-6,
+          "input_cache_creation": 3.75e-6,
+          "cache_read_input_tokens": 3e-7,
+          "input_cache_read": 3e-7,
+          "cache_write_5m_input_tokens": 3.75e-6,
           "cache_write_1h_input_tokens": 6e-06
         }
       },
@@ -3426,50 +3426,50 @@
           }
         ],
         "prices": {
-          "input": 6e-06,
-          "input_tokens": 6e-06,
-          "output": 2.25e-05,
-          "output_tokens": 2.25e-05,
-          "cache_creation_input_tokens": 7.5e-06,
-          "input_cache_creation": 7.5e-06,
-          "cache_read_input_tokens": 6e-07,
-          "input_cache_read": 6e-07,
-          "cache_write_5m_input_tokens": 7.5e-06,
+          "input": 6e-6,
+          "input_tokens": 6e-6,
+          "output": 22.5e-6,
+          "output_tokens": 22.5e-6,
+          "cache_creation_input_tokens": 7.5e-6,
+          "input_cache_creation": 7.5e-6,
+          "cache_read_input_tokens": 6e-7,
+          "input_cache_read": 6e-7,
+          "cache_write_5m_input_tokens": 7.5e-6,
           "cache_write_1h_input_tokens": 1.2e-05
         }
       }
     ]
   },
   {
-    "id": "04d3f9a4-6504-4488-b3e5-65aa41c5a4ea",
+    "id": "cris-claude-sonnet-4-6",
     "modelName": "claude-sonnet-4-6-cris",
     "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-sonnet-4-6-v1(:0)?$",
-    "createdAt": "2026-02-18T00:00:00.000Z",
+    "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
       {
-        "id": "04d3f9a4-6504-4488-b3e5-65aa41c5a4ea_tier_default",
+        "id": "cris-claude-sonnet-4-6_tier_default",
         "name": "Standard",
         "isDefault": true,
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3.3e-06,
-          "input_tokens": 3.3e-06,
-          "output": 1.65e-05,
-          "output_tokens": 1.65e-05,
-          "cache_creation_input_tokens": 4.125e-06,
-          "input_cache_creation": 4.125e-06,
-          "cache_read_input_tokens": 3.3e-07,
-          "input_cache_read": 3.3e-07,
-          "cache_write_5m_input_tokens": 4.125e-06,
-          "cache_write_1h_input_tokens": 6.6e-06
+          "input": 3.3e-6,
+          "input_tokens": 3.3e-6,
+          "output": 16.5e-6,
+          "output_tokens": 16.5e-6,
+          "cache_creation_input_tokens": 4.125e-6,
+          "input_cache_creation": 4.125e-6,
+          "cache_read_input_tokens": 3.3e-7,
+          "input_cache_read": 3.3e-7,
+          "cache_write_5m_input_tokens": 4.125e-6,
+          "cache_write_1h_input_tokens": 6.6e-6
         }
       },
       {
-        "id": "7830bfc2-c464-4ffe-b9a2-6e741f6c5486",
+        "id": "cris-claude-sonnet-4-6_tier_large",
         "name": "Large Context",
         "isDefault": false,
         "priority": 1,
@@ -3482,15 +3482,15 @@
           }
         ],
         "prices": {
-          "input": 6.6e-06,
-          "input_tokens": 6.6e-06,
-          "output": 2.475e-05,
-          "output_tokens": 2.475e-05,
-          "cache_creation_input_tokens": 8.25e-06,
-          "input_cache_creation": 8.25e-06,
-          "cache_read_input_tokens": 6.6e-07,
-          "input_cache_read": 6.6e-07,
-          "cache_write_5m_input_tokens": 8.25e-06,
+          "input": 6.6e-6,
+          "input_tokens": 6.6e-6,
+          "output": 24.75e-6,
+          "output_tokens": 24.75e-6,
+          "cache_creation_input_tokens": 8.25e-6,
+          "input_cache_creation": 8.25e-6,
+          "cache_read_input_tokens": 6.6e-7,
+          "input_cache_read": 6.6e-7,
+          "cache_write_5m_input_tokens": 8.25e-6,
           "cache_write_1h_input_tokens": 1.32e-05
         }
       }
@@ -3499,7 +3499,7 @@
   {
     "id": "13458bc0-1c20-44c2-8753-172f54b67647",
     "modelName": "claude-opus-4-6",
-    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-6|anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
     "createdAt": "2026-02-09T00:00:00.000Z",
     "updatedAt": "2026-02-09T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3512,45 +3512,45 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-06,
-          "input_tokens": 5e-06,
-          "output": 2.5e-05,
-          "output_tokens": 2.5e-05,
-          "cache_creation_input_tokens": 6.25e-06,
-          "input_cache_creation": 6.25e-06,
-          "cache_read_input_tokens": 5e-07,
-          "input_cache_read": 5e-07,
-          "cache_write_5m_input_tokens": 6.25e-06,
+          "input": 5e-6,
+          "input_tokens": 5e-6,
+          "output": 25e-6,
+          "output_tokens": 25e-6,
+          "cache_creation_input_tokens": 6.25e-6,
+          "input_cache_creation": 6.25e-6,
+          "cache_read_input_tokens": 0.5e-6,
+          "input_cache_read": 0.5e-6,
+          "cache_write_5m_input_tokens": 6.25e-6,
           "cache_write_1h_input_tokens": 1e-05
         }
       }
     ]
   },
   {
-    "id": "7d1e0364-75c5-4803-b8a7-88ddcc3c719f",
+    "id": "cris-claude-opus-4-6",
     "modelName": "claude-opus-4-6-cris",
     "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-opus-4-6-v1(:0)?$",
-    "createdAt": "2026-02-09T00:00:00.000Z",
+    "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
       {
-        "id": "7d1e0364-75c5-4803-b8a7-88ddcc3c719f_tier_default",
+        "id": "cris-claude-opus-4-6_tier_default",
         "name": "Standard",
         "isDefault": true,
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5.5e-06,
-          "input_tokens": 5.5e-06,
-          "output": 2.75e-05,
-          "output_tokens": 2.75e-05,
-          "cache_creation_input_tokens": 6.875e-06,
-          "input_cache_creation": 6.875e-06,
-          "cache_read_input_tokens": 5.5e-07,
-          "input_cache_read": 5.5e-07,
-          "cache_write_5m_input_tokens": 6.875e-06,
+          "input": 5.5e-6,
+          "input_tokens": 5.5e-6,
+          "output": 27.5e-6,
+          "output_tokens": 27.5e-6,
+          "cache_creation_input_tokens": 6.875e-6,
+          "input_cache_creation": 6.875e-6,
+          "cache_read_input_tokens": 0.55e-6,
+          "input_cache_read": 0.55e-6,
+          "cache_write_5m_input_tokens": 6.875e-6,
           "cache_write_1h_input_tokens": 1.1e-05
         }
       }
@@ -3559,7 +3559,7 @@
   {
     "id": "cmig1hb7i000104l72qrzgc6h",
     "modelName": "gemini-2.5-pro",
-    "matchPattern": "(?i)^(google/)?(gemini-2.5-pro)$",
+    "matchPattern": "(?i)^(google\/)?(gemini-2.5-pro)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -3570,19 +3570,19 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-06,
-          "input_modality_1": 1.25e-06,
-          "prompt_token_count": 1.25e-06,
-          "promptTokenCount": 1.25e-06,
-          "input_cached_tokens": 1.25e-07,
-          "cached_content_token_count": 1.25e-07,
-          "output": 1e-05,
-          "output_modality_1": 1e-05,
-          "candidates_token_count": 1e-05,
-          "candidatesTokenCount": 1e-05,
-          "thoughtsTokenCount": 1e-05,
-          "thoughts_token_count": 1e-05,
-          "output_reasoning": 1e-05
+          "input": 1.25e-6,
+          "input_modality_1": 1.25e-6,
+          "prompt_token_count": 1.25e-6,
+          "promptTokenCount": 1.25e-6,
+          "input_cached_tokens": 0.125e-6,
+          "cached_content_token_count": 0.125e-6,
+          "output": 10e-6,
+          "output_modality_1": 10e-6,
+          "candidates_token_count": 10e-6,
+          "candidatesTokenCount": 10e-6,
+          "thoughtsTokenCount": 10e-6,
+          "thoughts_token_count": 10e-6,
+          "output_reasoning": 10e-6
         }
       },
       {
@@ -3599,19 +3599,19 @@
           }
         ],
         "prices": {
-          "input": 2.5e-06,
-          "input_modality_1": 2.5e-06,
-          "prompt_token_count": 2.5e-06,
-          "promptTokenCount": 2.5e-06,
-          "input_cached_tokens": 2.5e-07,
-          "cached_content_token_count": 2.5e-07,
-          "output": 1.5e-05,
-          "output_modality_1": 1.5e-05,
-          "candidates_token_count": 1.5e-05,
-          "candidatesTokenCount": 1.5e-05,
-          "thoughtsTokenCount": 1.5e-05,
-          "thoughts_token_count": 1.5e-05,
-          "output_reasoning": 1.5e-05
+          "input": 2.5e-6,
+          "input_modality_1": 2.5e-6,
+          "prompt_token_count": 2.5e-6,
+          "promptTokenCount": 2.5e-6,
+          "input_cached_tokens": 0.25e-6,
+          "cached_content_token_count": 0.25e-6,
+          "output": 15e-6,
+          "output_modality_1": 15e-6,
+          "candidates_token_count": 15e-6,
+          "candidatesTokenCount": 15e-6,
+          "thoughtsTokenCount": 15e-6,
+          "thoughts_token_count": 15e-6,
+          "output_reasoning": 15e-6
         }
       }
     ]
@@ -3619,7 +3619,7 @@
   {
     "id": "cmig1wmep000404l7fh6q5uog",
     "modelName": "gemini-3-pro-preview",
-    "matchPattern": "(?i)^(google/)?(gemini-3-pro-preview)$",
+    "matchPattern": "(?i)^(google\/)?(gemini-3-pro-preview)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -3630,19 +3630,19 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-06,
-          "input_modality_1": 2e-06,
-          "prompt_token_count": 2e-06,
-          "promptTokenCount": 2e-06,
-          "input_cached_tokens": 2e-07,
-          "cached_content_token_count": 2e-07,
-          "output": 1.2e-05,
-          "output_modality_1": 1.2e-05,
-          "candidates_token_count": 1.2e-05,
-          "candidatesTokenCount": 1.2e-05,
-          "thoughtsTokenCount": 1.2e-05,
-          "thoughts_token_count": 1.2e-05,
-          "output_reasoning": 1.2e-05
+          "input": 2e-6,
+          "input_modality_1": 2e-6,
+          "prompt_token_count": 2e-6,
+          "promptTokenCount": 2e-6,
+          "input_cached_tokens": 0.2e-6,
+          "cached_content_token_count": 0.2e-6,
+          "output": 12e-6,
+          "output_modality_1": 12e-6,
+          "candidates_token_count": 12e-6,
+          "candidatesTokenCount": 12e-6,
+          "thoughtsTokenCount": 12e-6,
+          "thoughts_token_count": 12e-6,
+          "output_reasoning": 12e-6
         }
       },
       {
@@ -3659,19 +3659,19 @@
           }
         ],
         "prices": {
-          "input": 4e-06,
-          "input_modality_1": 4e-06,
-          "prompt_token_count": 4e-06,
-          "promptTokenCount": 4e-06,
-          "input_cached_tokens": 4e-07,
-          "cached_content_token_count": 4e-07,
-          "output": 1.8e-05,
-          "output_modality_1": 1.8e-05,
-          "candidates_token_count": 1.8e-05,
-          "candidatesTokenCount": 1.8e-05,
-          "thoughtsTokenCount": 1.8e-05,
-          "thoughts_token_count": 1.8e-05,
-          "output_reasoning": 1.8e-05
+          "input": 4e-6,
+          "input_modality_1": 4e-6,
+          "prompt_token_count": 4e-6,
+          "promptTokenCount": 4e-6,
+          "input_cached_tokens": 0.4e-6,
+          "cached_content_token_count": 0.4e-6,
+          "output": 18e-6,
+          "output_modality_1": 18e-6,
+          "candidates_token_count": 18e-6,
+          "candidatesTokenCount": 18e-6,
+          "thoughtsTokenCount": 18e-6,
+          "thoughts_token_count": 18e-6,
+          "output_reasoning": 18e-6
         }
       }
     ]
@@ -3679,7 +3679,7 @@
   {
     "id": "55106bba-a5dd-441b-bc0d-5652582b349d",
     "modelName": "gemini-3.1-pro-preview",
-    "matchPattern": "(?i)^(google/)?(gemini-3.1-pro-preview(-customtools)?)$",
+    "matchPattern": "(?i)^(google\/)?(gemini-3.1-pro-preview(-customtools)?)$",
     "createdAt": "2026-02-19T00:00:00.000Z",
     "updatedAt": "2026-02-19T00:00:00.000Z",
     "pricingTiers": [
@@ -3690,19 +3690,19 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-06,
-          "input_modality_1": 2e-06,
-          "prompt_token_count": 2e-06,
-          "promptTokenCount": 2e-06,
-          "input_cached_tokens": 2e-07,
-          "cached_content_token_count": 2e-07,
-          "output": 1.2e-05,
-          "output_modality_1": 1.2e-05,
-          "candidates_token_count": 1.2e-05,
-          "candidatesTokenCount": 1.2e-05,
-          "thoughtsTokenCount": 1.2e-05,
-          "thoughts_token_count": 1.2e-05,
-          "output_reasoning": 1.2e-05
+          "input": 2e-6,
+          "input_modality_1": 2e-6,
+          "prompt_token_count": 2e-6,
+          "promptTokenCount": 2e-6,
+          "input_cached_tokens": 0.2e-6,
+          "cached_content_token_count": 0.2e-6,
+          "output": 12e-6,
+          "output_modality_1": 12e-6,
+          "candidates_token_count": 12e-6,
+          "candidatesTokenCount": 12e-6,
+          "thoughtsTokenCount": 12e-6,
+          "thoughts_token_count": 12e-6,
+          "output_reasoning": 12e-6
         }
       },
       {
@@ -3719,19 +3719,19 @@
           }
         ],
         "prices": {
-          "input": 4e-06,
-          "input_modality_1": 4e-06,
-          "prompt_token_count": 4e-06,
-          "promptTokenCount": 4e-06,
-          "input_cached_tokens": 4e-07,
-          "cached_content_token_count": 4e-07,
-          "output": 1.8e-05,
-          "output_modality_1": 1.8e-05,
-          "candidates_token_count": 1.8e-05,
-          "candidatesTokenCount": 1.8e-05,
-          "thoughtsTokenCount": 1.8e-05,
-          "thoughts_token_count": 1.8e-05,
-          "output_reasoning": 1.8e-05
+          "input": 4e-6,
+          "input_modality_1": 4e-6,
+          "prompt_token_count": 4e-6,
+          "promptTokenCount": 4e-6,
+          "input_cached_tokens": 0.4e-6,
+          "cached_content_token_count": 0.4e-6,
+          "output": 18e-6,
+          "output_modality_1": 18e-6,
+          "candidates_token_count": 18e-6,
+          "candidatesTokenCount": 18e-6,
+          "thoughtsTokenCount": 18e-6,
+          "thoughts_token_count": 18e-6,
+          "output_reasoning": 18e-6
         }
       }
     ]
@@ -3739,7 +3739,7 @@
   {
     "id": "cmj2n4f2a000304kz49g4c43u",
     "modelName": "gpt-5.2",
-    "matchPattern": "(?i)^(openai/)?(gpt-5.2)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5.2)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3756,12 +3756,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.75e-06,
-          "input_cached_tokens": 1.75e-07,
-          "input_cache_read": 1.75e-07,
-          "output": 1.4e-05,
-          "output_reasoning_tokens": 1.4e-05,
-          "output_reasoning": 1.4e-05
+          "input": 1.75e-6,
+          "input_cached_tokens": 0.175e-6,
+          "input_cache_read": 0.175e-6,
+          "output": 14e-6,
+          "output_reasoning_tokens": 14e-6,
+          "output_reasoning": 14e-6
         }
       }
     ]
@@ -3769,7 +3769,7 @@
   {
     "id": "cmj2muxg6000104kzd2tc8953",
     "modelName": "gpt-5.2-2025-12-11",
-    "matchPattern": "(?i)^(openai/)?(gpt-5.2-2025-12-11)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-2025-12-11)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3786,12 +3786,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.75e-06,
-          "input_cached_tokens": 1.75e-07,
-          "input_cache_read": 1.75e-07,
-          "output": 1.4e-05,
-          "output_reasoning_tokens": 1.4e-05,
-          "output_reasoning": 1.4e-05
+          "input": 1.75e-6,
+          "input_cached_tokens": 0.175e-6,
+          "input_cache_read": 0.175e-6,
+          "output": 14e-6,
+          "output_reasoning_tokens": 14e-6,
+          "output_reasoning": 14e-6
         }
       }
     ]
@@ -3799,7 +3799,7 @@
   {
     "id": "cmj2n6pkq000404kz2s0b6if7",
     "modelName": "gpt-5.2-pro",
-    "matchPattern": "(?i)^(openai/)?(gpt-5.2-pro)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-pro)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3816,10 +3816,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.1e-05,
-          "output": 0.000168,
-          "output_reasoning_tokens": 0.000168,
-          "output_reasoning": 0.000168
+          "input": 21e-6,
+          "output": 168e-6,
+          "output_reasoning_tokens": 168e-6,
+          "output_reasoning": 168e-6
         }
       }
     ]
@@ -3827,7 +3827,7 @@
   {
     "id": "cmj2n70oe000504kz21b76mes",
     "modelName": "gpt-5.2-pro-2025-12-11",
-    "matchPattern": "(?i)^(openai/)?(gpt-5.2-pro-2025-12-11)$",
+    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-pro-2025-12-11)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3844,10 +3844,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.1e-05,
-          "output": 0.000168,
-          "output_reasoning_tokens": 0.000168,
-          "output_reasoning": 0.000168
+          "input": 21e-6,
+          "output": 168e-6,
+          "output_reasoning_tokens": 168e-6,
+          "output_reasoning": 168e-6
         }
       }
     ]
@@ -3855,7 +3855,7 @@
   {
     "id": "cmjfoeykl000004l8ffzra8c7",
     "modelName": "gemini-3-flash-preview",
-    "matchPattern": "(?i)^(google/)?(gemini-3-flash-preview)$",
+    "matchPattern": "(?i)^(google\/)?(gemini-3-flash-preview)$",
     "createdAt": "2025-12-21T12:01:42.282Z",
     "updatedAt": "2025-12-21T12:01:42.282Z",
     "pricingTiers": [
@@ -3866,19 +3866,19 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-07,
-          "input_modality_1": 5e-07,
-          "prompt_token_count": 5e-07,
-          "promptTokenCount": 5e-07,
-          "input_cached_tokens": 5e-08,
-          "cached_content_token_count": 5e-08,
-          "output": 3e-06,
-          "output_modality_1": 3e-06,
-          "candidates_token_count": 3e-06,
-          "candidatesTokenCount": 3e-06,
-          "thoughtsTokenCount": 3e-06,
-          "thoughts_token_count": 3e-06,
-          "output_reasoning": 3e-06
+          "input": 0.5e-6,
+          "input_modality_1": 0.5e-6,
+          "prompt_token_count": 0.5e-6,
+          "promptTokenCount": 0.5e-6,
+          "input_cached_tokens": 0.05e-6,
+          "cached_content_token_count": 0.05e-6,
+          "output": 3e-6,
+          "output_modality_1": 3e-6,
+          "candidates_token_count": 3e-6,
+          "candidatesTokenCount": 3e-6,
+          "thoughtsTokenCount": 3e-6,
+          "thoughts_token_count": 3e-6,
+          "output_reasoning": 3e-6
         }
       }
     ]

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2565,7 +2565,7 @@
   {
     "id": "c5qmrqolku82tra3vgdixmys",
     "modelName": "claude-sonnet-4-5-20250929",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|global\\.anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
     "createdAt": "2025-09-29T00:00:00.000Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2620,7 +2620,7 @@
   {
     "id": "cris-claude-sonnet-4-5-20250929",
     "modelName": "claude-sonnet-4-5-20250929-cris",
-    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|global\\.)anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?$",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?$",
     "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3209,7 +3209,7 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5-20251001|anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5-20251001|global\\.anthropic\\.claude-haiku-4-5-20251001-v1:0|anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -3238,7 +3238,7 @@
   {
     "id": "cris-claude-haiku-4-5-20251001",
     "modelName": "claude-haiku-4-5-20251001-cris",
-    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|global\\.)anthropic\\.claude-haiku-4-5-20251001-v1:0$",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-haiku-4-5-20251001-v1:0$",
     "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerId": "claude",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1328,8 +1328,8 @@
           "input_cache_creation": 0.00000375,
           "cache_read_input_tokens": 3e-7,
           "input_cache_read": 3e-7,
-          "cache_write_5m_input_tokens": 0.00000375,
-          "cache_write_1h_input_tokens": 6e-06
+          "input_cache_write_5m": 0.00000375,
+          "input_cache_write_1h": 6e-06
         }
       }
     ]
@@ -1556,8 +1556,8 @@
           "input_cache_creation": 0.00000375,
           "cache_read_input_tokens": 3e-7,
           "input_cache_read": 3e-7,
-          "cache_write_5m_input_tokens": 0.00000375,
-          "cache_write_1h_input_tokens": 6e-06
+          "input_cache_write_5m": 0.00000375,
+          "input_cache_write_1h": 6e-06
         }
       }
     ]
@@ -1765,8 +1765,8 @@
           "input_cache_creation": 0.00000375,
           "cache_read_input_tokens": 3e-7,
           "input_cache_read": 3e-7,
-          "cache_write_5m_input_tokens": 0.00000375,
-          "cache_write_1h_input_tokens": 6e-06
+          "input_cache_write_5m": 0.00000375,
+          "input_cache_write_1h": 6e-06
         }
       }
     ]
@@ -1794,8 +1794,8 @@
           "input_cache_creation": 0.00000375,
           "cache_read_input_tokens": 3e-7,
           "input_cache_read": 3e-7,
-          "cache_write_5m_input_tokens": 0.00000375,
-          "cache_write_1h_input_tokens": 6e-06
+          "input_cache_write_5m": 0.00000375,
+          "input_cache_write_1h": 6e-06
         }
       }
     ]
@@ -1823,8 +1823,8 @@
           "input_cache_creation": 0.000001,
           "cache_read_input_tokens": 8e-8,
           "input_cache_read": 8e-8,
-          "cache_write_5m_input_tokens": 0.000001,
-          "cache_write_1h_input_tokens": 1.6e-06
+          "input_cache_write_5m": 0.000001,
+          "input_cache_write_1h": 1.6e-06
         }
       }
     ]
@@ -1852,8 +1852,8 @@
           "input_cache_creation": 0.000001,
           "cache_read_input_tokens": 8e-8,
           "input_cache_read": 8e-8,
-          "cache_write_5m_input_tokens": 0.000001,
-          "cache_write_1h_input_tokens": 1.6e-06
+          "input_cache_write_5m": 0.000001,
+          "input_cache_write_1h": 1.6e-06
         }
       }
     ]
@@ -2171,8 +2171,8 @@
           "input_cache_creation": 0.00000375,
           "cache_read_input_tokens": 3e-7,
           "input_cache_read": 3e-7,
-          "cache_write_5m_input_tokens": 0.00000375,
-          "cache_write_1h_input_tokens": 6e-06
+          "input_cache_write_5m": 0.00000375,
+          "input_cache_write_1h": 6e-06
         }
       }
     ]
@@ -2200,8 +2200,8 @@
           "input_cache_creation": 0.00000375,
           "cache_read_input_tokens": 3e-7,
           "input_cache_read": 3e-7,
-          "cache_write_5m_input_tokens": 0.00000375,
-          "cache_write_1h_input_tokens": 6e-06
+          "input_cache_write_5m": 0.00000375,
+          "input_cache_write_1h": 6e-06
         }
       }
     ]
@@ -2585,8 +2585,8 @@
           "input_cache_creation": 0.00000375,
           "cache_read_input_tokens": 3e-7,
           "input_cache_read": 3e-7,
-          "cache_write_5m_input_tokens": 0.00000375,
-          "cache_write_1h_input_tokens": 6e-06
+          "input_cache_write_5m": 0.00000375,
+          "input_cache_write_1h": 6e-06
         }
       },
       {
@@ -2611,8 +2611,8 @@
           "input_cache_creation": 0.0000075,
           "cache_read_input_tokens": 6e-7,
           "input_cache_read": 6e-7,
-          "cache_write_5m_input_tokens": 0.0000075,
-          "cache_write_1h_input_tokens": 1.2e-05
+          "input_cache_write_5m": 0.0000075,
+          "input_cache_write_1h": 1.2e-05
         }
       }
     ]
@@ -2640,8 +2640,8 @@
           "input_cache_creation": 4.125e-6,
           "cache_read_input_tokens": 3.3e-7,
           "input_cache_read": 3.3e-7,
-          "cache_write_5m_input_tokens": 4.125e-6,
-          "cache_write_1h_input_tokens": 6.6e-6
+          "input_cache_write_5m": 4.125e-6,
+          "input_cache_write_1h": 6.6e-6
         }
       },
       {
@@ -2666,8 +2666,8 @@
           "input_cache_creation": 8.25e-6,
           "cache_read_input_tokens": 6.6e-7,
           "input_cache_read": 6.6e-7,
-          "cache_write_5m_input_tokens": 8.25e-6,
-          "cache_write_1h_input_tokens": 1.32e-05
+          "input_cache_write_5m": 8.25e-6,
+          "input_cache_write_1h": 1.32e-05
         }
       }
     ]
@@ -2695,8 +2695,8 @@
           "input_cache_creation": 0.00000375,
           "cache_read_input_tokens": 3e-7,
           "input_cache_read": 3e-7,
-          "cache_write_5m_input_tokens": 0.00000375,
-          "cache_write_1h_input_tokens": 6e-06
+          "input_cache_write_5m": 0.00000375,
+          "input_cache_write_1h": 6e-06
         }
       }
     ]
@@ -2724,8 +2724,8 @@
           "input_cache_creation": 0.00000375,
           "cache_read_input_tokens": 3e-7,
           "input_cache_read": 3e-7,
-          "cache_write_5m_input_tokens": 0.00000375,
-          "cache_write_1h_input_tokens": 6e-06
+          "input_cache_write_5m": 0.00000375,
+          "input_cache_write_1h": 6e-06
         }
       }
     ]
@@ -2753,8 +2753,8 @@
           "input_cache_creation": 0.00001875,
           "cache_read_input_tokens": 0.0000015,
           "input_cache_read": 0.0000015,
-          "cache_write_5m_input_tokens": 0.00001875,
-          "cache_write_1h_input_tokens": 3e-05
+          "input_cache_write_5m": 0.00001875,
+          "input_cache_write_1h": 3e-05
         }
       }
     ]
@@ -2934,8 +2934,8 @@
           "input_cache_creation": 0.00001875,
           "cache_read_input_tokens": 0.0000015,
           "input_cache_read": 0.0000015,
-          "cache_write_5m_input_tokens": 0.00001875,
-          "cache_write_1h_input_tokens": 3e-05
+          "input_cache_write_5m": 0.00001875,
+          "input_cache_write_1h": 3e-05
         }
       }
     ]
@@ -3229,8 +3229,8 @@
           "input_cache_creation": 0.00000125,
           "cache_read_input_tokens": 1e-7,
           "input_cache_read": 1e-7,
-          "cache_write_5m_input_tokens": 0.00000125,
-          "cache_write_1h_input_tokens": 2e-06
+          "input_cache_write_5m": 0.00000125,
+          "input_cache_write_1h": 2e-06
         }
       }
     ]
@@ -3258,8 +3258,8 @@
           "input_cache_creation": 1.375e-6,
           "cache_read_input_tokens": 1.1e-7,
           "input_cache_read": 1.1e-7,
-          "cache_write_5m_input_tokens": 1.375e-6,
-          "cache_write_1h_input_tokens": 2.2e-6
+          "input_cache_write_5m": 1.375e-6,
+          "input_cache_write_1h": 2.2e-6
         }
       }
     ]
@@ -3348,8 +3348,8 @@
           "input_cache_creation": 6.25e-6,
           "cache_read_input_tokens": 0.5e-6,
           "input_cache_read": 0.5e-6,
-          "cache_write_5m_input_tokens": 6.25e-6,
-          "cache_write_1h_input_tokens": 1e-05
+          "input_cache_write_5m": 6.25e-6,
+          "input_cache_write_1h": 1e-05
         }
       }
     ]
@@ -3378,8 +3378,8 @@
           "input_cache_creation": 6.875e-6,
           "cache_read_input_tokens": 0.55e-6,
           "input_cache_read": 0.55e-6,
-          "cache_write_5m_input_tokens": 6.875e-6,
-          "cache_write_1h_input_tokens": 1.1e-05
+          "input_cache_write_5m": 6.875e-6,
+          "input_cache_write_1h": 1.1e-05
         }
       }
     ]
@@ -3408,8 +3408,8 @@
           "input_cache_creation": 3.75e-6,
           "cache_read_input_tokens": 3e-7,
           "input_cache_read": 3e-7,
-          "cache_write_5m_input_tokens": 3.75e-6,
-          "cache_write_1h_input_tokens": 6e-06
+          "input_cache_write_5m": 3.75e-6,
+          "input_cache_write_1h": 6e-06
         }
       },
       {
@@ -3434,8 +3434,8 @@
           "input_cache_creation": 7.5e-6,
           "cache_read_input_tokens": 6e-7,
           "input_cache_read": 6e-7,
-          "cache_write_5m_input_tokens": 7.5e-6,
-          "cache_write_1h_input_tokens": 1.2e-05
+          "input_cache_write_5m": 7.5e-6,
+          "input_cache_write_1h": 1.2e-05
         }
       }
     ]
@@ -3464,8 +3464,8 @@
           "input_cache_creation": 4.125e-6,
           "cache_read_input_tokens": 3.3e-7,
           "input_cache_read": 3.3e-7,
-          "cache_write_5m_input_tokens": 4.125e-6,
-          "cache_write_1h_input_tokens": 6.6e-6
+          "input_cache_write_5m": 4.125e-6,
+          "input_cache_write_1h": 6.6e-6
         }
       },
       {
@@ -3490,8 +3490,8 @@
           "input_cache_creation": 8.25e-6,
           "cache_read_input_tokens": 6.6e-7,
           "input_cache_read": 6.6e-7,
-          "cache_write_5m_input_tokens": 8.25e-6,
-          "cache_write_1h_input_tokens": 1.32e-05
+          "input_cache_write_5m": 8.25e-6,
+          "input_cache_write_1h": 1.32e-05
         }
       }
     ]
@@ -3520,8 +3520,8 @@
           "input_cache_creation": 6.25e-6,
           "cache_read_input_tokens": 0.5e-6,
           "input_cache_read": 0.5e-6,
-          "cache_write_5m_input_tokens": 6.25e-6,
-          "cache_write_1h_input_tokens": 1e-05
+          "input_cache_write_5m": 6.25e-6,
+          "input_cache_write_1h": 1e-05
         }
       }
     ]
@@ -3550,8 +3550,8 @@
           "input_cache_creation": 6.875e-6,
           "cache_read_input_tokens": 0.55e-6,
           "input_cache_read": 0.55e-6,
-          "cache_write_5m_input_tokens": 6.875e-6,
-          "cache_write_1h_input_tokens": 1.1e-05
+          "input_cache_write_5m": 6.875e-6,
+          "input_cache_write_1h": 1.1e-05
         }
       }
     ]

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1536,7 +1536,7 @@
   {
     "id": "clxt0n0m60000pumz1j5b7zsf",
     "modelName": "claude-3-5-sonnet-20240620",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.|jp\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
     "createdAt": "2024-06-25T11:47:24.475Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1745,7 +1745,7 @@
   {
     "id": "cm2krz1uf000208jjg5653iud",
     "modelName": "claude-3.5-sonnet-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.|jp\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1803,7 +1803,7 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "modelName": "claude-3-5-haiku-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.|jp\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -2151,7 +2151,7 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "modelName": "claude-3.7-sonnet-20250219",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.|jp\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -2620,7 +2620,7 @@
   {
     "id": "cris-claude-sonnet-4-5-20250929",
     "modelName": "claude-sonnet-4-5-20250929-cris",
-    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?$",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|jp\\.)anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?$",
     "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2733,7 +2733,7 @@
   {
     "id": "cmazmlm2p00020djpa9s64jw5",
     "modelName": "claude-opus-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.|jp\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2914,7 +2914,7 @@
   {
     "id": "cmdysde5w0000rkmzbc1g5au3",
     "modelName": "claude-opus-4-1-20250805",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.|jp\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
     "createdAt": "2025-08-05T15:00:00.000Z",
     "updatedAt": "2026-02-23T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3238,7 +3238,7 @@
   {
     "id": "cris-claude-haiku-4-5-20251001",
     "modelName": "claude-haiku-4-5-20251001-cris",
-    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-haiku-4-5-20251001-v1:0$",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|jp\\.)anthropic\\.claude-haiku-4-5-20251001-v1:0$",
     "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3357,7 +3357,7 @@
   {
     "id": "cris-claude-opus-4-5-20251101",
     "modelName": "claude-opus-4-5-20251101-cris",
-    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?$",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|jp\\.)anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?$",
     "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3443,7 +3443,7 @@
   {
     "id": "cris-claude-sonnet-4-6",
     "modelName": "claude-sonnet-4-6-cris",
-    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-sonnet-4-6-v1(:0)?$",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|jp\\.)anthropic\\.claude-sonnet-4-6-v1(:0)?$",
     "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3529,7 +3529,7 @@
   {
     "id": "cris-claude-opus-4-6",
     "modelName": "claude-opus-4-6-cris",
-    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.)anthropic\\.claude-opus-4-6-v1(:0)?$",
+    "matchPattern": "(?i)^(eu\\.|us\\.|apac\\.|jp\\.)anthropic\\.claude-opus-4-6-v1(:0)?$",
     "createdAt": "2026-02-26T00:00:00.000Z",
     "updatedAt": "2026-02-26T00:00:00.000Z",
     "tokenizerConfig": null,

--- a/worker/src/scripts/upsertDefaultModelPrices.ts
+++ b/worker/src/scripts/upsertDefaultModelPrices.ts
@@ -5,7 +5,7 @@ import { prisma, PrismaClient } from "@langfuse/shared/src/db";
  *
  * Key pricing rules for Anthropic models:
  * - Prompt caching: 5m TTL write = 1.25x base input, 1h TTL write = 2x base input, cache read = 0.1x base input
- * - CRIS (Cross-Region Inference) 10% surcharge on Bedrock regional endpoints (eu./us./apac.):
+ * - CRIS (Cross-Region Inference) 10% surcharge on Bedrock regional endpoints (eu./us./apac./jp.):
  *   Applies to Claude Sonnet 4.5, Haiku 4.5, and all future models only.
  *   Earlier models (Sonnet 4, Opus 4, Opus 4.1, and prior) retain standard pricing on regional endpoints.
  *   global. prefix = global cross-region inference (standard pricing, no surcharge).

--- a/worker/src/scripts/upsertDefaultModelPrices.ts
+++ b/worker/src/scripts/upsertDefaultModelPrices.ts
@@ -5,9 +5,10 @@ import { prisma, PrismaClient } from "@langfuse/shared/src/db";
  *
  * Key pricing rules for Anthropic models:
  * - Prompt caching: 5m TTL write = 1.25x base input, 1h TTL write = 2x base input, cache read = 0.1x base input
- * - CRIS (Cross-Region Inference) 10% surcharge on Bedrock regional endpoints (eu./us./apac./global.):
+ * - CRIS (Cross-Region Inference) 10% surcharge on Bedrock regional endpoints (eu./us./apac.):
  *   Applies to Claude Sonnet 4.5, Haiku 4.5, and all future models only.
  *   Earlier models (Sonnet 4, Opus 4, Opus 4.1, and prior) retain standard pricing on regional endpoints.
+ *   global. prefix = global cross-region inference (standard pricing, no surcharge).
  *   Vertex AI regional pricing is not detectable from model names (region is in the endpoint URL).
  */
 import defaultModelPrices from "../constants/default-model-prices.json";

--- a/worker/src/scripts/upsertDefaultModelPrices.ts
+++ b/worker/src/scripts/upsertDefaultModelPrices.ts
@@ -1,5 +1,14 @@
 import { z } from "zod/v4";
 import { prisma, PrismaClient } from "@langfuse/shared/src/db";
+/**
+ * Anthropic model pricing reference: https://platform.claude.com/docs/en/about-claude/pricing
+ *
+ * Key pricing rules for Anthropic models:
+ * - Prompt caching: 5m TTL write = 1.25x base input, 1h TTL write = 2x base input, cache read = 0.1x base input
+ * - CRIS (Cross-Region Inference) 10% surcharge on regional endpoints (eu./us./apac./global.):
+ *   Applies to Claude Sonnet 4.5, Haiku 4.5, and all future models only.
+ *   Earlier models (Sonnet 4, Opus 4, Opus 4.1, and prior) retain standard pricing on regional endpoints.
+ */
 import defaultModelPrices from "../constants/default-model-prices.json";
 import { clearFullModelCache, logger } from "@langfuse/shared/src/server";
 import {

--- a/worker/src/scripts/upsertDefaultModelPrices.ts
+++ b/worker/src/scripts/upsertDefaultModelPrices.ts
@@ -5,9 +5,10 @@ import { prisma, PrismaClient } from "@langfuse/shared/src/db";
  *
  * Key pricing rules for Anthropic models:
  * - Prompt caching: 5m TTL write = 1.25x base input, 1h TTL write = 2x base input, cache read = 0.1x base input
- * - CRIS (Cross-Region Inference) 10% surcharge on regional endpoints (eu./us./apac./global.):
+ * - CRIS (Cross-Region Inference) 10% surcharge on Bedrock regional endpoints (eu./us./apac./global.):
  *   Applies to Claude Sonnet 4.5, Haiku 4.5, and all future models only.
  *   Earlier models (Sonnet 4, Opus 4, Opus 4.1, and prior) retain standard pricing on regional endpoints.
+ *   Vertex AI regional pricing is not detectable from model names (region is in the endpoint URL).
  */
 import defaultModelPrices from "../constants/default-model-prices.json";
 import { clearFullModelCache, logger } from "@langfuse/shared/src/server";


### PR DESCRIPTION
## What does this PR do?

1. Pricing for models is wrong - on either Anthropic or Bedrock, geo-specific models has a 10% upcharge
2. Pricing for caching is wrong - caching can be either 5m or 1hr and are priced differently. (It's on the client to emit the correct caching, though, I need to fix this for vercel )

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add geo-specific surcharges and differentiate caching TTL pricing for Anthropic models in `default-model-prices.json` and update `upsertDefaultModelPrices.ts` to handle these changes.
> 
>   - **Pricing Updates**:
>     - Add 10% surcharge for geo-specific Anthropic models in `default-model-prices.json`.
>     - Differentiate pricing for 5m vs. 1hr TTL caching in `default-model-prices.json`.
>   - **Pattern Changes**:
>     - Update `matchPattern` for models like `claude-3-5-sonnet-20240620` to include `jp.` region.
>   - **Script Updates**:
>     - Add comments in `upsertDefaultModelPrices.ts` explaining new pricing rules for Anthropic models.
>     - Ensure `upsertDefaultModelPrices.ts` processes new pricing tiers and conditions correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 229652359e7a27eac43ecc86db47a19f0e36d993. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->