### PR TITLE
feat(annotation-queues): show comments section for sessions in annotation queue

### DIFF
--- a/web/src/features/annotation-queues/components/processors/SessionAnnotationProcessor.tsx
+++ b/web/src/features/annotation-queues/components/processors/SessionAnnotationProcessor.tsx
@@ -1,9 +1,17 @@
 import {
+  AnnotationQueueObjectType,
   type AnnotationQueueItem,
   type ScoreConfigDomain,
 } from "@langfuse/shared";
 import { AnnotationDrawerSection } from "../shared/AnnotationDrawerSection";
 import { AnnotationProcessingLayout } from "../shared/AnnotationProcessingLayout";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/src/components/ui/resizable";
+import useSessionStorage from "@/src/components/useSessionStorage";
+import { CommentsSection } from "../shared/CommentsSection";
 import { SessionIO } from "@/src/components/session";
 import { useState, useEffect } from "react";
 import { Button } from "@/src/components/ui/button";
@@ -31,6 +39,10 @@ export const SessionAnnotationProcessor: React.FC<
   SessionAnnotationProcessorProps
 > = ({ item, data, configs, projectId }) => {
   const [visibleTraces, setVisibleTraces] = useState(PAGE_SIZE);
+  const [verticalSize, setVerticalSize] = useSessionStorage(
+    `annotationQueueSessionComments-${projectId}`,
+    60,
+  );
   const [currentTraceIndex, setCurrentTraceIndex] = useState(1);
 
   // Intersection observer to which trace is currently in view
@@ -146,16 +158,40 @@ export const SessionAnnotationProcessor: React.FC<
   );
 
   const rightPanel = (
-    <AnnotationDrawerSection
-      item={item}
-      scoreTarget={{
-        type: "session",
-        sessionId: item.objectId,
+    <ResizablePanelGroup
+      orientation="vertical"
+      className="h-full"
+      onLayoutChanged={(layout) => {
+        const top = layout["session-annotation-top"];
+        if (top != null) setVerticalSize(top);
       }}
-      scores={data?.scores ?? []}
-      configs={configs}
-      environment={data?.environment}
-    />
+    >
+      <ResizablePanel
+        id="session-annotation-top"
+        className="overflow-y-auto"
+        minSize="30%"
+        defaultSize={`${verticalSize}%`}
+      >
+        <AnnotationDrawerSection
+          item={item}
+          scoreTarget={{
+            type: "session",
+            sessionId: item.objectId,
+          }}
+          scores={data?.scores ?? []}
+          configs={configs}
+          environment={data?.environment}
+        />
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel className="overflow-y-auto" minSize="20%">
+        <CommentsSection
+          projectId={projectId}
+          objectId={item.objectId}
+          objectType={AnnotationQueueObjectType.SESSION}
+        />
+      </ResizablePanel>
+    </ResizablePanelGroup>
   );
 
   return (


### PR DESCRIPTION
## Summary

Fixes #12061 — Session comments are not visible in annotation queue.

- Adds `CommentsSection` to the right panel of `SessionAnnotationProcessor` so that comments are visible and can be added while annotating a session
- Uses a vertical `ResizablePanelGroup` to split the right panel between the scoring form (top) and the comments list (bottom), following the exact pattern used in the datasets `AnnotationPanel`
- Panel sizes are persisted via `useSessionStorage`

## Details

When a session is in an annotation queue, the right panel previously only showed the scoring form (`AnnotationDrawerSection`). Unlike traces—which show comment counts and a comment drawer button on the trace preview—sessions had no comment support at all.

This change restructures the right panel into a resizable vertical split:
- **Top panel (60% default):** Scoring form (`AnnotationDrawerSection`) — unchanged
- **Bottom panel (40% default):** `CommentsSection` with `objectType=SESSION`

The `CommentsSection` component already existed and is proven in production via the datasets `AnnotationPanel`. The comment backend already supports SESSION as an `objectType`.

## Changes

- `web/src/features/annotation-queues/components/processors/SessionAnnotationProcessor.tsx` — Added `CommentsSection` in a vertical `ResizablePanelGroup` to the right panel

## Testing

- [x] ESLint: zero errors
- [x] LSP diagnostics: only pre-existing `react-resizable-panels` type errors (identical in `AnnotationProcessingLayout.tsx` and `AnnotationPanel.tsx`)
- [x] `pnpm run build:check`: pre-existing failure at `ResizableDesktopLayout.tsx:100` (unrelated)
- [x] Code review: follows exact pattern from datasets `AnnotationPanel.tsx`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a comments section to `SessionAnnotationProcessor` with a resizable panel for session comments visibility and addition.
> 
>   - **Behavior**:
>     - Adds `CommentsSection` to `SessionAnnotationProcessor` right panel for session comments visibility and addition.
>     - Implements vertical `ResizablePanelGroup` to split right panel between scoring form and comments list.
>     - Panel sizes are persisted using `useSessionStorage`.
>   - **Files**:
>     - `SessionAnnotationProcessor.tsx`: Adds `CommentsSection` and `ResizablePanelGroup` to right panel.
>   - **Testing**:
>     - ESLint: zero errors.
>     - LSP diagnostics: only pre-existing type errors.
>     - `pnpm run build:check`: pre-existing unrelated failure.
>     - Code review: follows pattern from datasets `AnnotationPanel.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for e6314ad7034a34af51d78df4e41e5a5ad3d81bb1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->