### PR TITLE
fix(ui): last-use badge renders more nicely with multiple row of sso providers

### DIFF
--- a/web/src/features/auth/components/AuthProviderButton.tsx
+++ b/web/src/features/auth/components/AuthProviderButton.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@/src/components/ui/badge";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 import React from "react";
@@ -17,25 +18,36 @@ export function AuthProviderButton({
   loading = false,
   showLastUsedBadge = false,
 }: AuthProviderButtonProps) {
+  const shouldShowLastUsedBadge = showLastUsedBadge && !loading;
+
   return (
-    <div>
+    <div className="relative">
       <Button
         onClick={onClick}
         variant="secondary"
         loading={loading}
-        className="w-full"
+        className={cn(
+          "w-full",
+          shouldShowLastUsedBadge && "ring-1 ring-ring/30",
+        )}
+        title={shouldShowLastUsedBadge ? "Last used" : undefined}
       >
         {icon}
         {label}
+        {shouldShowLastUsedBadge ? (
+          <span className="sr-only">, last used sign-in method</span>
+        ) : null}
       </Button>
-      <div
-        className={cn(
-          "mt-0.5 text-center text-xs text-muted-foreground",
-          showLastUsedBadge ? "visible" : "invisible",
-        )}
-      >
-        Last used
-      </div>
+      {shouldShowLastUsedBadge ? (
+        <Badge
+          variant="secondary"
+          size="sm"
+          aria-hidden="true"
+          className="pointer-events-none absolute -right-1 -top-2 border border-border text-[9px] font-medium leading-none ring-2 ring-card"
+        >
+          Last used
+        </Badge>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Summary
- show a compact “Last used” badge only when providers aren’t loading
- reduce extra spacing by merging the badge with the button and adding a subtle ring

Testing
- Not run (not requested)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 'Last used' badge to `AuthProviderButton`, shown when not loading, with integrated UI design.
> 
>   - **Behavior**:
>     - Adds a 'Last used' badge to `AuthProviderButton` when `showLastUsedBadge` is true and `loading` is false.
>     - Badge is visually integrated with the button using a subtle ring effect.
>   - **UI Components**:
>     - Imports `Badge` from `ui/badge` and uses it in `AuthProviderButton`.
>     - Adjusts button class to include ring effect when badge is shown.
>   - **Accessibility**:
>     - Adds `sr-only` span for screen readers when badge is shown.
>     - Badge is marked `aria-hidden` to avoid redundancy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 54159728aae7a8ce88986a087cbc54a4afa084b5. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->