### PR TITLE
fix(events-table): read from events_core again for position in trace

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -492,20 +492,18 @@ async function getObservationsFromEventsTableInternal<T>(
       ),
     );
     const appliedNativeFilter = nativeFilter.apply();
+    const qualifyingObsBuilder = new EventsQueryBuilder({ projectId })
+      .selectRaw(
+        "e.span_id",
+        `ROW_NUMBER() OVER (PARTITION BY e.trace_id ORDER BY e.start_time ${direction}, e.event_ts ${direction}, e.span_id ${direction}) as _rn`,
+      )
+      .where(appliedNativeFilter)
+      .where(search);
 
-    // Build CTE WHERE clause
-    const nativeFilterClause = appliedNativeFilter.query
-      .trim()
-      .replace(/^(AND|OR)\s+/i, "");
-    const searchClause = search.query.trim().replace(/^(AND|OR)\s+/i, "");
-    let cteWhere = "e.project_id = {projectId: String}";
-    if (nativeFilterClause) cteWhere += ` AND ${nativeFilterClause}`;
-    if (searchClause) cteWhere += ` AND ${searchClause}`;
-
-    queryBuilder.withCTE("qualifying_obs", {
-      query: `SELECT e.span_id, ROW_NUMBER() OVER (PARTITION BY e.trace_id ORDER BY e.start_time ${direction}, e.event_ts ${direction}, e.span_id ${direction}) as _rn FROM events_core e WHERE ${cteWhere}`,
-      params: { projectId, ...appliedNativeFilter.params, ...search.params },
-    });
+    queryBuilder.withCTE(
+      "qualifying_obs",
+      qualifyingObsBuilder.buildWithParams(),
+    );
 
     queryBuilder.whereRaw(
       "e.span_id IN (SELECT span_id FROM qualifying_obs WHERE _rn = {_posRn: UInt32})",

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -503,7 +503,7 @@ async function getObservationsFromEventsTableInternal<T>(
     if (searchClause) cteWhere += ` AND ${searchClause}`;
 
     queryBuilder.withCTE("qualifying_obs", {
-      query: `SELECT e.span_id, ROW_NUMBER() OVER (PARTITION BY e.trace_id ORDER BY e.start_time ${direction}, e.event_ts ${direction}, e.span_id ${direction}) as _rn FROM events e WHERE ${cteWhere}`,
+      query: `SELECT e.span_id, ROW_NUMBER() OVER (PARTITION BY e.trace_id ORDER BY e.start_time ${direction}, e.event_ts ${direction}, e.span_id ${direction}) as _rn FROM events_core e WHERE ${cteWhere}`,
       params: { projectId, ...appliedNativeFilter.params, ...search.params },
     });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `getObservationsFromEventsTableInternal` in `events.ts` to use `EventsQueryBuilder` for CTE query construction, optimizing position in trace handling.
> 
>   - **Behavior**:
>     - Refactor `getObservationsFromEventsTableInternal` in `events.ts` to use `EventsQueryBuilder` for CTE query construction.
>     - Handles position in trace using `ROW_NUMBER()` with `EventsQueryBuilder` instead of manual query string.
>   - **Misc**:
>     - Removes manual CTE query string construction for position in trace in `events.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for dc2d349ed5f12c37961f3a2b9b58e9b3c619a94a. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->