### PR TITLE
fix(evaluators): clarify Hallucination evaluator score description

### DIFF
--- a/worker/src/constants/managed-evaluators.json
+++ b/worker/src/constants/managed-evaluators.json
@@ -6,7 +6,7 @@
     "name": "Hallucination",
     "version": 1,
     "outputSchema": {
-      "score": "Score between 0 and 1. Score 0 if false or negative and 1 if true or positive",
+      "score": "Score between 0 and 1. Score 0 means no hallucination and 1 means complete hallucination",
       "reasoning": "One sentence reasoning for the score"
     },
     "prompt": "Evaluate the degree of hallucination in the generation on a continuous scale from 0 to 1. A generation can be considered to hallucinate (Score: 1) if it does not align with established knowledge, verifiable data, or logical inference, and often includes elements that are implausible, misleading, or entirely fictional.\n\nExample:\nQuery: Can eating carrots improve your vision?\nGeneration: Yes, eating carrots significantly improves your vision, especially at night. This is why people who eat lots of carrots never need glasses. Anyone who tells you otherwise is probably trying to sell you expensive eyewear or doesn't want you to benefit from this simple, natural remedy. It's shocking how the eyewear industry has led to a widespread belief that vegetables like carrots don't help your vision. People are so gullible to fall for these money-making schemes.\n\nScore: 1.0\nReasoning: Carrots only improve vision under specific circumstances, namely a lack of vitamin A that leads to decreased vision. Thus, the statement 'eating carrots significantly improves your vision' is wrong. Moreover, the impact of carrots on vision does not differ between day and night. So also the clause 'especially at night' is wrong. Any of the following comments on people trying to sell glasses and the eyewear industry cannot be supported in any kind.\n\nInput:\nQuery: {{query}}\nGeneration: {{generation}}\n\nThink step by step."


### PR DESCRIPTION
## What does this PR do?

The Hallucination evaluator's `outputSchema.score` description currently uses a generic wording: *"Score 0 if false or negative and 1 if true or positive"*. This is confusing because for hallucination, a score of 0 (the "negative" case) is actually the **best** outcome (no hallucination), while a score of 1 (the "positive" case) is the **worst** outcome (complete hallucination).

This PR updates the description to clearly state the meaning: *"Score 0 means no hallucination and 1 means complete hallucination"*, which aligns with the prompt's own language and standard convention.

Fixes #9719

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarifies Hallucination evaluator score description in `managed-evaluators.json` to accurately reflect score meanings.
> 
>   - **Behavior**:
>     - Updates `outputSchema.score` description for Hallucination evaluator in `managed-evaluators.json` to "Score 0 means no hallucination and 1 means complete hallucination".
>   - **Fixes**:
>     - Resolves confusion in score interpretation for Hallucination evaluator, aligning with standard conventions.
>     - Fixes #9719.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d24a17e9d2510a19f3a9e7cffbdb5fb078ec8230. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->