### PR TITLE
fix(score-analytics): correct mapping of boolean values

### DIFF
--- a/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.clienttest.tsx
+++ b/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.clienttest.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import { api } from "../../../utils/api";
+import { useScoreAnalyticsQuery } from "./useScoreAnalyticsQuery";
+
+jest.mock("../../../utils/api", () => ({
+  api: {
+    scoreAnalytics: {
+      getScoreComparisonAnalytics: {
+        useQuery: jest.fn(),
+      },
+    },
+  },
+}));
+
+const mockedUseQuery = api.scoreAnalytics.getScoreComparisonAnalytics
+  .useQuery as jest.Mock;
+
+function ScoreAnalyticsProbe() {
+  const result = useScoreAnalyticsQuery({
+    projectId: "project-test",
+    score1: {
+      name: "Correctness",
+      dataType: "BOOLEAN",
+      source: "ANNOTATION",
+    },
+    fromTimestamp: new Date("2026-02-01T00:00:00.000Z"),
+    toTimestamp: new Date("2026-02-02T00:00:00.000Z"),
+    interval: { count: 1, unit: "day" },
+  });
+
+  return (
+    <div data-testid="distribution">
+      {JSON.stringify(result.data?.distribution.score1 ?? null)}
+    </div>
+  );
+}
+
+describe("useScoreAnalyticsQuery", () => {
+  it("maps true-only boolean data to the True bucket", () => {
+    mockedUseQuery.mockReturnValue({
+      data: {
+        counts: { score1Total: 1, score2Total: 1, matchedCount: 1 },
+        heatmap: [],
+        confusionMatrix: [],
+        statistics: null,
+        timeSeries: [],
+        distribution1: [{ binIndex: 0, count: 1 }],
+        distribution2: [],
+        stackedDistribution: [],
+        stackedDistributionMatched: [],
+        score2Categories: [],
+        timeSeriesMatched: [],
+        distribution1Matched: [{ binIndex: 0, count: 1 }],
+        distribution2Matched: [],
+        distribution1Individual: [{ binIndex: 0, count: 1 }],
+        distribution2Individual: [],
+        timeSeriesCategorical1: [
+          {
+            timestamp: new Date("2026-02-01T12:00:00.000Z"),
+            category: "true",
+            count: 1,
+          },
+        ],
+        timeSeriesCategorical2: [],
+        timeSeriesCategorical1Matched: [
+          {
+            timestamp: new Date("2026-02-01T12:00:00.000Z"),
+            category: "true",
+            count: 1,
+          },
+        ],
+        timeSeriesCategorical2Matched: [],
+        samplingMetadata: {
+          isSampled: false,
+          samplingMethod: "none",
+          samplingRate: 1,
+          estimatedTotalMatches: 1,
+          actualSampleSize: 1,
+          samplingExpression: null,
+        },
+        metadata: {
+          mode: "single",
+          isSameScore: true,
+          dataType: "BOOLEAN",
+        },
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ScoreAnalyticsProbe />);
+
+    expect(screen.getByTestId("distribution").textContent).toBe(
+      '[{"binIndex":0,"count":0},{"binIndex":1,"count":1}]',
+    );
+  });
+});

--- a/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.clienttest.tsx
+++ b/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.clienttest.tsx
@@ -15,14 +15,21 @@ jest.mock("../../../utils/api", () => ({
 const mockedUseQuery = api.scoreAnalytics.getScoreComparisonAnalytics
   .useQuery as jest.Mock;
 
-function ScoreAnalyticsProbe() {
+function ScoreAnalyticsProbe({
+  includeScore2 = false,
+}: {
+  includeScore2?: boolean;
+}) {
+  const score = {
+    name: "Correctness",
+    dataType: "BOOLEAN" as const,
+    source: "ANNOTATION",
+  };
+
   const result = useScoreAnalyticsQuery({
     projectId: "project-test",
-    score1: {
-      name: "Correctness",
-      dataType: "BOOLEAN",
-      source: "ANNOTATION",
-    },
+    score1: score,
+    ...(includeScore2 ? { score2: score } : {}),
     fromTimestamp: new Date("2026-02-01T00:00:00.000Z"),
     toTimestamp: new Date("2026-02-02T00:00:00.000Z"),
     interval: { count: 1, unit: "day" },
@@ -30,12 +37,16 @@ function ScoreAnalyticsProbe() {
 
   return (
     <div data-testid="distribution">
-      {JSON.stringify(result.data?.distribution.score1 ?? null)}
+      {JSON.stringify(result.data?.distribution ?? null)}
     </div>
   );
 }
 
 describe("useScoreAnalyticsQuery", () => {
+  afterEach(() => {
+    mockedUseQuery.mockReset();
+  });
+
   it("maps true-only boolean data to the True bucket", () => {
     mockedUseQuery.mockReturnValue({
       data: {
@@ -89,9 +100,83 @@ describe("useScoreAnalyticsQuery", () => {
     });
 
     render(<ScoreAnalyticsProbe />);
+    const distribution = JSON.parse(
+      screen.getByTestId("distribution").textContent ?? "null",
+    );
 
-    expect(screen.getByTestId("distribution").textContent).toBe(
+    expect(JSON.stringify(distribution.score1)).toBe(
       '[{"binIndex":0,"count":0},{"binIndex":1,"count":1}]',
     );
+  });
+
+  it("keeps score2 boolean distribution aligned when comparing the same score twice", () => {
+    mockedUseQuery.mockReturnValue({
+      data: {
+        counts: { score1Total: 3, score2Total: 3, matchedCount: 3 },
+        heatmap: [],
+        confusionMatrix: [],
+        statistics: null,
+        timeSeries: [],
+        distribution1: [{ binIndex: 0, count: 3 }],
+        distribution2: [{ binIndex: 0, count: 3 }],
+        stackedDistribution: [],
+        stackedDistributionMatched: [],
+        score2Categories: [],
+        timeSeriesMatched: [],
+        distribution1Matched: [{ binIndex: 0, count: 3 }],
+        distribution2Matched: [{ binIndex: 0, count: 3 }],
+        distribution1Individual: [{ binIndex: 0, count: 3 }],
+        distribution2Individual: [{ binIndex: 0, count: 3 }],
+        timeSeriesCategorical1: [
+          {
+            timestamp: new Date("2026-02-01T12:00:00.000Z"),
+            category: "false",
+            count: 1,
+          },
+          {
+            timestamp: new Date("2026-02-01T13:00:00.000Z"),
+            category: "true",
+            count: 2,
+          },
+        ],
+        timeSeriesCategorical2: [],
+        timeSeriesCategorical1Matched: [
+          {
+            timestamp: new Date("2026-02-01T12:00:00.000Z"),
+            category: "false",
+            count: 1,
+          },
+          {
+            timestamp: new Date("2026-02-01T13:00:00.000Z"),
+            category: "true",
+            count: 2,
+          },
+        ],
+        timeSeriesCategorical2Matched: [],
+        samplingMetadata: {
+          isSampled: false,
+          samplingMethod: "none",
+          samplingRate: 1,
+          estimatedTotalMatches: 3,
+          actualSampleSize: 3,
+          samplingExpression: null,
+        },
+        metadata: {
+          mode: "two",
+          isSameScore: true,
+          dataType: "BOOLEAN",
+        },
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ScoreAnalyticsProbe includeScore2={true} />);
+    const distribution = JSON.parse(
+      screen.getByTestId("distribution").textContent ?? "null",
+    );
+
+    expect(distribution.score1).toEqual(distribution.score2);
+    expect(distribution.score2Categories).toEqual(["False", "True"]);
   });
 });

--- a/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts
+++ b/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts
@@ -250,6 +250,7 @@ export function useScoreAnalyticsQuery(
     const { mode, isSameScore } = apiData.metadata;
     const dataType = apiData.metadata.dataType as DataType;
     const isNumeric = dataType === "NUMERIC";
+    const isBoolean = dataType === "BOOLEAN";
 
     // ========================================================================
     // 1. Extract categories (categorical/boolean only)
@@ -260,10 +261,46 @@ export function useScoreAnalyticsQuery(
       stackedDistribution: apiData.stackedDistribution,
     });
 
+    const normalizeBooleanCategory = (
+      value: string,
+    ): "False" | "True" | null => {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === "true" || normalized === "1") return "True";
+      if (normalized === "false" || normalized === "0") return "False";
+      return null;
+    };
+
+    const buildBooleanDistribution = (
+      timeSeries: Array<{ category: string; count: number }>,
+      distributionCategories: string[],
+    ) => {
+      const countByCategory = new Map<string, number>(
+        distributionCategories.map((category) => [category, 0]),
+      );
+
+      timeSeries.forEach((item) => {
+        const normalizedCategory = normalizeBooleanCategory(item.category);
+        if (!normalizedCategory || !countByCategory.has(normalizedCategory)) {
+          return;
+        }
+
+        countByCategory.set(
+          normalizedCategory,
+          (countByCategory.get(normalizedCategory) ?? 0) + item.count,
+        );
+      });
+
+      return distributionCategories.map((category, index) => ({
+        binIndex: index,
+        count: countByCategory.get(category) ?? 0,
+      }));
+    };
+
     // Extract score2 categories for proper binning
     // When comparing two different categorical scores, score2 may have different categories
-    const score2Categories =
-      apiData.score2Categories && apiData.score2Categories.length > 0
+    const score2Categories = isBoolean
+      ? categories
+      : apiData.score2Categories && apiData.score2Categories.length > 0
         ? apiData.score2Categories
         : mode === "two" && categories
           ? categories // Fallback to score1 categories if score2Categories empty
@@ -275,40 +312,69 @@ export function useScoreAnalyticsQuery(
     // fillDistributionBins() already returns sorted data for categorical/boolean
     // For numeric, we sort to handle non-deterministic ClickHouse row ordering
     // ========================================================================
-    const distribution1 = categories
-      ? fillDistributionBins(apiData.distribution1, categories)
-      : apiData.distribution1.slice().sort((a, b) => a.binIndex - b.binIndex);
+    const booleanCategories = categories ?? ["False", "True"];
+    const booleanScore2Categories = score2Categories ?? booleanCategories;
 
-    const distribution2 =
-      categories && mode === "two"
+    const distribution1 = isBoolean
+      ? buildBooleanDistribution(
+          apiData.timeSeriesCategorical1,
+          booleanCategories,
+        )
+      : categories
+        ? fillDistributionBins(apiData.distribution1, categories)
+        : apiData.distribution1.slice().sort((a, b) => a.binIndex - b.binIndex);
+
+    const distribution2 = isBoolean
+      ? buildBooleanDistribution(
+          apiData.timeSeriesCategorical2,
+          booleanScore2Categories,
+        )
+      : categories && mode === "two"
         ? fillDistributionBins(apiData.distribution2, categories)
         : apiData.distribution2.slice().sort((a, b) => a.binIndex - b.binIndex);
 
-    const distribution1Individual = categories
-      ? fillDistributionBins(apiData.distribution1Individual, categories)
-      : apiData.distribution1Individual
-          .slice()
-          .sort((a, b) => a.binIndex - b.binIndex);
+    const distribution1Individual = isBoolean
+      ? distribution1
+      : categories
+        ? fillDistributionBins(apiData.distribution1Individual, categories)
+        : apiData.distribution1Individual
+            .slice()
+            .sort((a, b) => a.binIndex - b.binIndex);
 
     // Use score2Categories for score2Individual (not score1 categories)
-    const distribution2Individual = score2Categories
-      ? fillDistributionBins(apiData.distribution2Individual, score2Categories)
-      : apiData.distribution2Individual
-          .slice()
-          .sort((a, b) => a.binIndex - b.binIndex);
+    const distribution2Individual = isBoolean
+      ? distribution2
+      : score2Categories
+        ? fillDistributionBins(
+            apiData.distribution2Individual,
+            score2Categories,
+          )
+        : apiData.distribution2Individual
+            .slice()
+            .sort((a, b) => a.binIndex - b.binIndex);
 
-    const distribution1Matched = categories
-      ? fillDistributionBins(apiData.distribution1Matched, categories)
-      : apiData.distribution1Matched
-          .slice()
-          .sort((a, b) => a.binIndex - b.binIndex);
+    const distribution1Matched = isBoolean
+      ? buildBooleanDistribution(
+          apiData.timeSeriesCategorical1Matched,
+          booleanCategories,
+        )
+      : categories
+        ? fillDistributionBins(apiData.distribution1Matched, categories)
+        : apiData.distribution1Matched
+            .slice()
+            .sort((a, b) => a.binIndex - b.binIndex);
 
     // Use score2Categories for score2Matched (not score1 categories)
-    const distribution2Matched = score2Categories
-      ? fillDistributionBins(apiData.distribution2Matched, score2Categories)
-      : apiData.distribution2Matched
-          .slice()
-          .sort((a, b) => a.binIndex - b.binIndex);
+    const distribution2Matched = isBoolean
+      ? buildBooleanDistribution(
+          apiData.timeSeriesCategorical2Matched,
+          booleanScore2Categories,
+        )
+      : score2Categories
+        ? fillDistributionBins(apiData.distribution2Matched, score2Categories)
+        : apiData.distribution2Matched
+            .slice()
+            .sort((a, b) => a.binIndex - b.binIndex);
 
     // ========================================================================
     // 3. Generate bin labels (numeric only)
@@ -406,7 +472,7 @@ export function useScoreAnalyticsQuery(
     // ========================================================================
     const score1ModeMetrics = !isNumeric
       ? calculateModeMetrics({
-          distribution: apiData.distribution1,
+          distribution: isBoolean ? distribution1 : apiData.distribution1,
           timeSeries: apiData.timeSeriesCategorical1,
           totalCount: apiData.counts.score1Total,
         })
@@ -417,12 +483,12 @@ export function useScoreAnalyticsQuery(
       !isNumeric && mode === "two"
         ? isSameScore
           ? calculateModeMetrics({
-              distribution: apiData.distribution1, // Reuse Score 1 data
+              distribution: isBoolean ? distribution1 : apiData.distribution1, // Reuse Score 1 data
               timeSeries: apiData.timeSeriesCategorical1, // Reuse Score 1 data
               totalCount: apiData.counts.score2Total,
             })
           : calculateModeMetrics({
-              distribution: apiData.distribution2,
+              distribution: isBoolean ? distribution2 : apiData.distribution2,
               timeSeries: apiData.timeSeriesCategorical2,
               totalCount: apiData.counts.score2Total,
             })

--- a/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts
+++ b/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts
@@ -314,6 +314,14 @@ export function useScoreAnalyticsQuery(
     // ========================================================================
     const booleanCategories = categories ?? ["False", "True"];
     const booleanScore2Categories = score2Categories ?? booleanCategories;
+    const booleanTimeSeries2 =
+      isBoolean && isSameScore && mode === "two"
+        ? apiData.timeSeriesCategorical1
+        : apiData.timeSeriesCategorical2;
+    const booleanTimeSeries2Matched =
+      isBoolean && isSameScore && mode === "two"
+        ? apiData.timeSeriesCategorical1Matched
+        : apiData.timeSeriesCategorical2Matched;
 
     const distribution1 = isBoolean
       ? buildBooleanDistribution(
@@ -325,10 +333,7 @@ export function useScoreAnalyticsQuery(
         : apiData.distribution1.slice().sort((a, b) => a.binIndex - b.binIndex);
 
     const distribution2 = isBoolean
-      ? buildBooleanDistribution(
-          apiData.timeSeriesCategorical2,
-          booleanScore2Categories,
-        )
+      ? buildBooleanDistribution(booleanTimeSeries2, booleanScore2Categories)
       : categories && mode === "two"
         ? fillDistributionBins(apiData.distribution2, categories)
         : apiData.distribution2.slice().sort((a, b) => a.binIndex - b.binIndex);
@@ -367,7 +372,7 @@ export function useScoreAnalyticsQuery(
     // Use score2Categories for score2Matched (not score1 categories)
     const distribution2Matched = isBoolean
       ? buildBooleanDistribution(
-          apiData.timeSeriesCategorical2Matched,
+          booleanTimeSeries2Matched,
           booleanScore2Categories,
         )
       : score2Categories
@@ -681,12 +686,7 @@ export function useScoreAnalyticsQuery(
         // (e.g., boolean scores always have ["False", "True"])
         // We need this populated so the UI can correctly display score2's categories
         // when viewing the "score2" tab in the distribution card
-        score2Categories:
-          apiData.score2Categories && apiData.score2Categories.length > 0
-            ? apiData.score2Categories
-            : mode === "two" && categories
-              ? categories
-              : undefined,
+        score2Categories,
       },
       timeSeries: {
         numeric: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a test to verify correct mapping of boolean values in `useScoreAnalyticsQuery`.
> 
>   - **Tests**:
>     - Adds `useScoreAnalyticsQuery.clienttest.tsx` to test boolean value mapping in `useScoreAnalyticsQuery`.
>     - Verifies true-only boolean data maps to the True bucket in the distribution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for d87dbd3d8cf80efb86e0ca15238bd4c2a8132d7d. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->