### PR TITLE
perf(query): switch to INNER JOIN and add useFinal flag to tableRelations

### DIFF
--- a/web/src/__tests__/server/queryBuilder.servertest.ts
+++ b/web/src/__tests__/server/queryBuilder.servertest.ts
@@ -2123,8 +2123,8 @@ describe("queryBuilder", () => {
         );
 
         // Verify joins included
-        expect(compiledQuery).toContain("LEFT JOIN traces");
-        expect(compiledQuery).toContain("LEFT JOIN observations");
+        expect(compiledQuery).toContain("INNER JOIN traces");
+        expect(compiledQuery).toContain("INNER JOIN observations");
 
         // Execute query
         const result: { data: Array<any> } = { data: [] };
@@ -3435,7 +3435,7 @@ describe("queryBuilder", () => {
       expect(compiledQuery.match(/GROUP BY/g)?.length).toBe(2); // Two GROUP BY clauses
 
       // Should have the JOIN
-      expect(compiledQuery).toContain("LEFT JOIN scores");
+      expect(compiledQuery).toContain("INNER JOIN scores");
     });
 
     it("should handle complex multi-aggregation measure (tokensPerSecond)", async () => {
@@ -4649,5 +4649,84 @@ describe("query builder measure-aggregation validation", () => {
         expect(result[0].name).toBe("target-trace");
       },
     );
+  });
+
+  describe("useFinal flag on events_core joins", () => {
+    it("should omit FINAL for events_core joins in v2 scores-numeric view", async () => {
+      const projectId = randomUUID();
+      const builder = new QueryBuilder(undefined, "v2");
+      const { query: compiledQuery } = await builder.build(
+        {
+          view: "scores-numeric",
+          dimensions: [{ field: "traceName" }],
+          metrics: [{ measure: "count", aggregation: "count" }],
+          filters: [],
+          timeDimension: null,
+          fromTimestamp: new Date(
+            Date.now() - 7 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          toTimestamp: new Date(Date.now()).toISOString(),
+          orderBy: null,
+        },
+        projectId,
+      );
+
+      // events_core should be joined without FINAL (useFinal: false)
+      expect(compiledQuery).toContain("JOIN events_core");
+      expect(compiledQuery).not.toContain(
+        "JOIN events_core AS events_traces FINAL",
+      );
+      // scores base CTE should still use FINAL
+      expect(compiledQuery).toContain("scores scores_numeric FINAL");
+    });
+
+    it("should omit FINAL for events_observations join in v2 scores-categorical view", async () => {
+      const projectId = randomUUID();
+      const builder = new QueryBuilder(undefined, "v2");
+      const { query: compiledQuery } = await builder.build(
+        {
+          view: "scores-categorical",
+          dimensions: [{ field: "observationName" }],
+          metrics: [{ measure: "count", aggregation: "count" }],
+          filters: [],
+          timeDimension: null,
+          fromTimestamp: new Date(
+            Date.now() - 7 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          toTimestamp: new Date(Date.now()).toISOString(),
+          orderBy: null,
+        },
+        projectId,
+      );
+
+      // events_core should be joined without FINAL (useFinal: false)
+      expect(compiledQuery).toContain("JOIN events_core");
+      expect(compiledQuery).not.toContain(
+        "JOIN events_core AS events_observations FINAL",
+      );
+    });
+
+    it("should keep FINAL for non-events_core joins in v1 scores view", async () => {
+      const projectId = randomUUID();
+      const builder = new QueryBuilder(undefined, "v1");
+      const { query: compiledQuery } = await builder.build(
+        {
+          view: "scores-numeric",
+          dimensions: [{ field: "traceName" }],
+          metrics: [{ measure: "count", aggregation: "count" }],
+          filters: [],
+          timeDimension: null,
+          fromTimestamp: new Date(
+            Date.now() - 7 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          toTimestamp: new Date(Date.now()).toISOString(),
+          orderBy: null,
+        },
+        projectId,
+      );
+
+      // v1 traces join should still use FINAL (useFinal defaults to true)
+      expect(compiledQuery).toContain("JOIN traces FINAL");
+    });
   });
 });

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -834,7 +834,12 @@ const createScoreTableRelations = (
   version: "v1" | "v2",
 ): Record<
   string,
-  { name: string; joinConditionSql: string; timeDimension: string }
+  {
+    name: string;
+    joinConditionSql: string;
+    timeDimension: string;
+    useFinal?: boolean;
+  }
 > => {
   if (version === "v1") {
     return {
@@ -858,12 +863,14 @@ const createScoreTableRelations = (
         joinConditionSql:
           "ON scores.trace_id = events_traces.trace_id AND scores.project_id = events_traces.project_id AND events_traces.parent_span_id = ''",
         timeDimension: "start_time",
+        useFinal: false,
       },
       events_observations: {
         name: "events_core",
         joinConditionSql:
           "ON scores.project_id = events_observations.project_id AND scores.trace_id = events_observations.trace_id AND scores.observation_id = events_observations.span_id",
         timeDimension: "start_time",
+        useFinal: false,
       },
     };
   }

--- a/web/src/features/query/server/queryBuilder.ts
+++ b/web/src/features/query/server/queryBuilder.ts
@@ -579,13 +579,13 @@ export class QueryBuilder {
       }
 
       const relation = view.tableRelations[relationTableName];
-      // Conditionally add FINAL - skip for observations if flag is set
-      const shouldUseFinal = !(
-        relation.name === "observations" && skipObservationsFinal
-      );
+      // Conditionally add FINAL - skip for observations if flag is set, and respect per-relation useFinal
+      const shouldUseFinal =
+        (relation.useFinal ?? true) &&
+        !(relation.name === "observations" && skipObservationsFinal);
       const alias =
         relation.name !== relationTableName ? ` AS ${relationTableName}` : "";
-      let joinStatement = `LEFT JOIN ${relation.name}${alias}${shouldUseFinal ? " FINAL" : ""} ${relation.joinConditionSql}`;
+      let joinStatement = `INNER JOIN ${relation.name}${alias}${shouldUseFinal ? " FINAL" : ""} ${relation.joinConditionSql}`;
 
       // Create time dimension mapping for the relation table
       const relationTimeDimensionMapping = {

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -61,6 +61,7 @@ export const viewDeclaration = z.object({
       name: z.string(),
       joinConditionSql: z.string(),
       timeDimension: z.string(),
+      useFinal: z.boolean().optional(),
     }),
   ),
   // Segments are used to apply "constant" filters to the query. For example, if we only want one type of observations.


### PR DESCRIPTION
LEFT JOIN was unnecessary since joined relations always have timestamp filters in the global WHERE clause that reject NULLs. INNER JOIN lets ClickHouse optimize join strategy from the start. Also adds a per-relation useFinal flag (defaults to true) so already-deduplicated tables like events_core can skip the FINAL modifier.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switches to INNER JOIN for query optimization and adds useFinal flag to table relations, with tests verifying behavior.
> 
>   - **Behavior**:
>     - Switches from `LEFT JOIN` to `INNER JOIN` in `queryBuilder.ts` for better ClickHouse optimization.
>     - Adds `useFinal` flag to `tableRelations` in `dataModel.ts`, defaulting to true, allowing tables like `events_core` to skip FINAL.
>   - **Tests**:
>     - Updates `queryBuilder.servertest.ts` to verify `INNER JOIN` usage and `useFinal` flag behavior.
>     - Tests ensure `events_core` joins omit FINAL in v2 views, while v1 views retain it.
>   - **Misc**:
>     - Adjusts `createScoreTableRelations` in `dataModel.ts` to include `useFinal` flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for c2ff8ae5fd5f7a8966cfb5813c5accf6bbe22f14. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->