### PR TITLE
fix(sessions): show data in json beta viewer too

### DIFF
--- a/web/src/components/trace2/components/IOPreview/IOPreview.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreview.tsx
@@ -228,6 +228,9 @@ export function IOPreview({
        */}
       {selectedView === "json-beta" ? (
         <IOPreviewJSON
+          input={input}
+          output={output}
+          metadata={metadata}
           parsedInput={parsedInput}
           parsedOutput={parsedOutput}
           parsedMetadata={parsedMetadata}

--- a/web/src/components/trace2/components/IOPreview/IOPreviewJSON.tsx
+++ b/web/src/components/trace2/components/IOPreview/IOPreviewJSON.tsx
@@ -24,12 +24,15 @@ import { CommentableJsonView } from "@/src/features/comments/components/Commenta
 import { InlineCommentBubble } from "@/src/features/comments/components/InlineCommentBubble";
 import { type CommentedPathsByField } from "@/src/components/ui/AdvancedJsonViewer/utils/commentRanges";
 import { type ExpansionState } from "@/src/components/ui/AdvancedJsonViewer/types";
-import { type ScoreDomain } from "@langfuse/shared";
+import { type Prisma, type ScoreDomain, deepParseJson } from "@langfuse/shared";
 import { CorrectedOutputField } from "./components/CorrectedOutputField";
 
 const VIRTUALIZATION_THRESHOLD = 3333;
 
 export interface IOPreviewJSONProps {
+  input?: Prisma.JsonValue;
+  output?: Prisma.JsonValue;
+  metadata?: Prisma.JsonValue;
   outputCorrection?: ScoreDomain;
   // Pre-parsed data (from useParsedObservation hook)
   parsedInput?: unknown;
@@ -72,6 +75,9 @@ export interface IOPreviewJSONProps {
  * because it skips all ChatML processing.
  */
 function IOPreviewJSONInner({
+  input,
+  output,
+  metadata,
   parsedInput,
   parsedOutput,
   parsedMetadata,
@@ -114,18 +120,36 @@ function IOPreviewJSONInner({
     [isDark],
   );
 
-  const showInput = !hideInput && !(hideIfNull && parsedInput === undefined);
-  const showOutput = !hideOutput && !(hideIfNull && parsedOutput === undefined);
-  const showMetadata = !(hideIfNull && parsedMetadata === undefined);
+  // Fall back to raw values when caller does not provide pre-parsed fields
+  // (e.g. session events rows in v4 mode).
+  const effectiveInput = useMemo(() => {
+    if (isParsing) return undefined;
+    return parsedInput ?? deepParseJson(input);
+  }, [parsedInput, input, isParsing]);
+
+  const effectiveOutput = useMemo(() => {
+    if (isParsing) return undefined;
+    return parsedOutput ?? deepParseJson(output);
+  }, [parsedOutput, output, isParsing]);
+
+  const effectiveMetadata = useMemo(() => {
+    if (isParsing) return undefined;
+    return parsedMetadata ?? deepParseJson(metadata);
+  }, [parsedMetadata, metadata, isParsing]);
+
+  const showInput = !hideInput && !(hideIfNull && effectiveInput === undefined);
+  const showOutput =
+    !hideOutput && !(hideIfNull && effectiveOutput === undefined);
+  const showMetadata = !(hideIfNull && effectiveMetadata === undefined);
 
   // Count rows for each section to determine if virtualization is needed
   const rowCounts = useMemo(() => {
     return {
-      input: countJsonRows(parsedInput),
-      output: countJsonRows(parsedOutput),
-      metadata: countJsonRows(parsedMetadata),
+      input: countJsonRows(effectiveInput),
+      output: countJsonRows(effectiveOutput),
+      metadata: countJsonRows(effectiveMetadata),
     };
-  }, [parsedInput, parsedOutput, parsedMetadata]);
+  }, [effectiveInput, effectiveOutput, effectiveMetadata]);
 
   // Determine if virtualization is needed based on threshold
   const needsVirtualization = useMemo(() => {
@@ -196,18 +220,18 @@ function IOPreviewJSONInner({
 
   const handleCopy = useCallback(() => {
     const dataObj: Record<string, unknown> = {};
-    if (showInput) dataObj.input = parsedInput;
-    if (showOutput) dataObj.output = parsedOutput;
-    if (showMetadata) dataObj.metadata = parsedMetadata;
+    if (showInput) dataObj.input = effectiveInput;
+    if (showOutput) dataObj.output = effectiveOutput;
+    if (showMetadata) dataObj.metadata = effectiveMetadata;
     const jsonString = JSON.stringify(dataObj, null, 2);
     void navigator.clipboard.writeText(jsonString);
   }, [
     showInput,
     showOutput,
     showMetadata,
-    parsedInput,
-    parsedOutput,
-    parsedMetadata,
+    effectiveInput,
+    effectiveOutput,
+    effectiveMetadata,
   ]);
 
   const wrapIcon = useMemo(
@@ -229,7 +253,7 @@ function IOPreviewJSONInner({
       result.push({
         key: "input",
         title: "Input",
-        data: parsedInput,
+        data: effectiveInput,
         backgroundColor: inputBgColor,
         minHeight: "200px",
       });
@@ -238,7 +262,7 @@ function IOPreviewJSONInner({
       result.push({
         key: "output",
         title: "Output",
-        data: parsedOutput,
+        data: effectiveOutput,
         backgroundColor: outputBgColor,
         minHeight: "200px",
       });
@@ -254,7 +278,7 @@ function IOPreviewJSONInner({
         // Add corrected output as footer when corrections are enabled
         renderFooter: () => (
           <CorrectedOutputField
-            actualOutput={parsedOutput}
+            actualOutput={effectiveOutput}
             existingCorrection={outputCorrection}
             observationId={observationId}
             projectId={projectId}
@@ -269,7 +293,7 @@ function IOPreviewJSONInner({
       result.push({
         key: "metadata",
         title: "Metadata",
-        data: parsedMetadata,
+        data: effectiveMetadata,
         backgroundColor: metadataBgColor,
         minHeight: "200px",
       });
@@ -279,9 +303,9 @@ function IOPreviewJSONInner({
     showInput,
     showOutput,
     showMetadata,
-    parsedInput,
-    parsedOutput,
-    parsedMetadata,
+    effectiveInput,
+    effectiveOutput,
+    effectiveMetadata,
     inputBgColor,
     outputBgColor,
     metadataBgColor,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pass raw input, output, and metadata to `IOPreviewJSON` for `json-beta` view, using `deepParseJson` to handle unparsed data.
> 
>   - **Behavior**:
>     - Passes `input`, `output`, and `metadata` to `IOPreviewJSON` in `IOPreview.tsx` for `json-beta` view.
>     - Uses `deepParseJson` in `IOPreviewJSON.tsx` to parse raw `input`, `output`, and `metadata` if pre-parsed data is unavailable.
>   - **Functions**:
>     - Updates `IOPreviewJSONInner` in `IOPreviewJSON.tsx` to use `effectiveInput`, `effectiveOutput`, and `effectiveMetadata` for rendering and logic.
>     - Adjusts `handleCopy` and `sections` logic in `IOPreviewJSONInner` to use effective data variables.
>   - **Misc**:
>     - Adds `input`, `output`, and `metadata` props to `IOPreviewJSON` in `IOPreview.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 0d8760846e457f240e911ccd66be70bb4970a11f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->