### PR TITLE
fix(models): prevent focus loss when typing unit name in price editor

### DIFF
--- a/web/src/features/models/components/pricing-tiers/TierPriceEditor.tsx
+++ b/web/src/features/models/components/pricing-tiers/TierPriceEditor.tsx
@@ -28,8 +28,8 @@ export function TierPriceEditor({
         <span>Usage type</span>
         <span>Price</span>
       </div>
-      {Object.entries(prices).map(([key, value]) => (
-        <div key={key} className="grid grid-cols-2 gap-1">
+      {Object.entries(prices).map(([key, value], index) => (
+        <div key={index} className="grid grid-cols-2 gap-1">
           <Input
             placeholder="Key (e.g. input, output)"
             value={key}


### PR DESCRIPTION
## Summary

- Fixes focus loss when typing in the **Usage type** (unit name) input on the Model settings page
- Root cause: `key={key}` used the unit name as the React key; on every keystroke the `onChange` handler deleted the old key and inserted a new one, causing React to unmount/remount the row and lose focus
- Fix: changed to `key={index}` (array position) — stable during typing, safe because all inputs are fully controlled

Fixes [LFE-8629](https://linear.app/langfuse/issue/LFE-8629)

## Test plan

- [ ] Open Model settings page → edit a model → click **Add Price**
- [ ] Type in the **Usage type** field — cursor should stay focused throughout
- [ ] Delete a price row, verify remaining rows still display correctly
- [ ] Verify price values can still be edited normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes focus loss in `TierPriceEditor` by changing React key to maintain input focus during typing.
> 
>   - **Behavior**:
>     - Fixes focus loss in `TierPriceEditor` when typing in **Usage type** input by changing React key from `key={key}` to `key={index}`.
>     - Ensures input focus is maintained during typing.
>   - **Test Plan**:
>     - Verify focus retention when typing in **Usage type** field.
>     - Check correct display and editability of price rows after deletion.
>     - Confirm price values can be edited normally.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 03da51a86037608e8b01c363985d951de1556f9c. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->