### PR TITLE
chore(remote-experiment): increase timeout to 20s and improve error handling

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1776,12 +1776,14 @@ export const datasetRouter = createTRPCRouter({
             datasetName: dataset.name,
             payload: input.payload ?? dataset.remoteExperimentPayload,
           }),
-          signal: AbortSignal.timeout(30000), // 30 second timeout
+          signal: AbortSignal.timeout(20000), // 20 second timeout
         });
 
         if (!response.ok) {
+          logger.info(`Remote server returned error (${response.status})`);
           return {
             success: false,
+            error: `Remote server returned error (${response.status})`,
           };
         }
 
@@ -1790,8 +1792,13 @@ export const datasetRouter = createTRPCRouter({
         };
       } catch (error) {
         if (error instanceof Error) {
+          logger.info(`Failed to trigger remote experiment: ${error.name}`);
           return {
             success: false,
+            error:
+              error.name === "AbortError"
+                ? "Request timed out"
+                : "Failed to connect to remote server",
           };
         }
         return {

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1776,7 +1776,7 @@ export const datasetRouter = createTRPCRouter({
             datasetName: dataset.name,
             payload: input.payload ?? dataset.remoteExperimentPayload,
           }),
-          signal: AbortSignal.timeout(10000), // 10 second timeout
+          signal: AbortSignal.timeout(30000), // 30 second timeout
         });
 
         if (!response.ok) {

--- a/web/src/features/experiments/components/RemoteExperimentTriggerModal.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentTriggerModal.tsx
@@ -72,22 +72,18 @@ export const RemoteExperimentTriggerModal = ({
       onSuccess: (data) => {
         if (data.success) {
           showSuccessToast({
-            title: "Dataset run started",
-            description: "Your dataset run may take a few minutes to complete.",
+            title: "Remote experiment triggered",
+            description:
+              "Your remote experiment may take a few minutes to complete.",
           });
         } else {
           showErrorToast(
-            "Failed to start dataset run",
-            "Please try again or check your remote dataset run configuration.",
+            "Failed to trigger remote experiment",
+            data.error ||
+              "Please try again or check your remote experiment configuration.",
           );
         }
         setShowTriggerModal(false);
-      },
-      onError: (error) => {
-        showErrorToast(
-          error.message || "Failed to start dataset run",
-          "Please try again or check your remote dataset run configuration.",
-        );
       },
     });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase timeout for remote experiment requests to 20s and improve error handling with specific messages and logging.
> 
>   - **Behavior**:
>     - Increase timeout for remote experiment requests from 10s to 20s in `dataset-router.ts`.
>     - Improve error handling in `dataset-router.ts` by logging errors and returning specific error messages for request failures and timeouts.
>   - **UI**:
>     - Update success and error toast messages in `RemoteExperimentTriggerModal.tsx` to reflect changes in remote experiment triggering.
>     - Remove `onError` handler in `RemoteExperimentTriggerModal.tsx` as error handling is now centralized in `onSuccess`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6d5f0228e5d87e42b326d9d9501e2b093cad30c1. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->