### PR TITLE
chore(data-table): format total count and pages in select all banner

### DIFF
--- a/web/src/components/table/data-table-multi-select-actions/data-table-select-all-banner.tsx
+++ b/web/src/components/table/data-table-multi-select-actions/data-table-select-all-banner.tsx
@@ -1,5 +1,6 @@
 import { type MultiSelect } from "@/src/components/table/data-table-toolbar";
 import { Button } from "@/src/components/ui/button";
+import { numberFormatter } from "@/src/utils/numbers";
 
 export function DataTableSelectAllBanner({
   selectAll,
@@ -8,12 +9,17 @@ export function DataTableSelectAllBanner({
   pageSize,
   totalCount,
 }: MultiSelect) {
+  const totalPages = totalCount ? Math.ceil(totalCount / pageSize) : 0;
+
   return (
     <div className="mb-2 flex flex-wrap items-center justify-center gap-2 rounded-sm bg-input p-2 @container">
       {selectAll ? (
         <span className="text-sm">
-          All <span className="font-semibold">{totalCount}</span> items are
-          selected.{" "}
+          All{" "}
+          <span className="font-semibold">
+            {numberFormatter(totalCount ?? 0, 0)}
+          </span>{" "}
+          items are selected.{" "}
           <Button
             variant="ghost"
             className="h-auto p-0 font-semibold text-accent-dark-blue hover:text-accent-dark-blue/80"
@@ -36,7 +42,8 @@ export function DataTableSelectAllBanner({
               setSelectAll(true);
             }}
           >
-            Select all {totalCount} items
+            Select all {numberFormatter(totalCount ?? 0, 0)} items across{" "}
+            {numberFormatter(totalPages, 0)} pages
           </Button>
         </span>
       )}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Formats total count and pages in `DataTableSelectAllBanner` using `numberFormatter`.
> 
>   - **Behavior**:
>     - Formats `totalCount` and `totalPages` using `numberFormatter` in `DataTableSelectAllBanner`.
>     - Displays formatted total count and pages in the select all banner.
>   - **Functions**:
>     - Adds `numberFormatter` import to `data-table-select-all-banner.tsx`.
>     - Calculates `totalPages` as `Math.ceil(totalCount / pageSize)` in `DataTableSelectAllBanner`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 70408aa7c140d23481cd7c3f9edc9ae2db8c12d0. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->