### PR TITLE
fix(mixpanel): sanitize bad distinct_id values and handle partial import errors

### DIFF
--- a/worker/src/__tests__/mixpanelTransformers.test.ts
+++ b/worker/src/__tests__/mixpanelTransformers.test.ts
@@ -168,6 +168,139 @@ describe("Mixpanel transformers", () => {
     });
   });
 
+  describe("bad distinct_id handling", () => {
+    const badIds = [
+      "undefined",
+      "null",
+      "Null",
+      "NULL",
+      "0",
+      "-1",
+      "00000000-0000-0000-0000-000000000000",
+      "unknown",
+      "anonymous",
+      " undefined ",
+      "lmy47d",
+    ];
+
+    it.each(badIds)(
+      "transformTraceForMixpanel falls back to insert_id when user_id is '%s'",
+      (badId) => {
+        const trace: AnalyticsTraceEvent = {
+          langfuse_id: "trace-bad-id",
+          timestamp: new Date("2024-01-15T10:00:00Z"),
+          langfuse_trace_name: "test",
+          langfuse_project_id: projectId,
+          langfuse_project_name: "Test",
+          langfuse_user_id: badId,
+          langfuse_event_version: "1.0.0",
+          posthog_session_id: null,
+          mixpanel_session_id: null,
+        };
+
+        const result = transformTraceForMixpanel(trace, projectId);
+        expect(result.properties.distinct_id).toBe(
+          result.properties.$insert_id,
+        );
+        expect(result.properties.$user_id).toBeUndefined();
+      },
+    );
+
+    it.each(badIds)(
+      "transformGenerationForMixpanel falls back to insert_id when user_id is '%s'",
+      (badId) => {
+        const generation: AnalyticsGenerationEvent = {
+          langfuse_id: "gen-bad-id",
+          timestamp: new Date("2024-01-15T10:00:00Z"),
+          langfuse_generation_name: "test",
+          langfuse_trace_name: "test",
+          langfuse_trace_id: "trace-456",
+          langfuse_project_id: projectId,
+          langfuse_project_name: "Test",
+          langfuse_user_id: badId,
+          langfuse_event_version: "1.0.0",
+          posthog_session_id: null,
+          mixpanel_session_id: null,
+        };
+
+        const result = transformGenerationForMixpanel(generation, projectId);
+        expect(result.properties.distinct_id).toBe(
+          result.properties.$insert_id,
+        );
+        expect(result.properties.$user_id).toBeUndefined();
+      },
+    );
+
+    it.each(badIds)(
+      "transformScoreForMixpanel falls back to insert_id when user_id is '%s'",
+      (badId) => {
+        const score: AnalyticsScoreEvent = {
+          langfuse_id: "score-bad-id",
+          timestamp: new Date("2024-01-15T10:00:00Z"),
+          langfuse_score_name: "test",
+          langfuse_score_value: 1,
+          langfuse_score_data_type: "NUMERIC",
+          langfuse_trace_name: "test",
+          langfuse_trace_id: "trace-456",
+          langfuse_project_id: projectId,
+          langfuse_project_name: "Test",
+          langfuse_user_id: badId,
+          langfuse_event_version: "1.0.0",
+          langfuse_score_entity_type: "trace",
+          posthog_session_id: null,
+          mixpanel_session_id: null,
+        };
+
+        const result = transformScoreForMixpanel(score, projectId);
+        expect(result.properties.distinct_id).toBe(
+          result.properties.$insert_id,
+        );
+        expect(result.properties.$user_id).toBeUndefined();
+      },
+    );
+
+    it.each(badIds)(
+      "transformEventForMixpanel falls back to insert_id when user_id is '%s'",
+      (badId) => {
+        const event: AnalyticsObservationEvent = {
+          langfuse_id: "event-bad-id",
+          timestamp: new Date("2024-01-15T10:00:00Z"),
+          langfuse_observation_name: "test",
+          langfuse_project_id: projectId,
+          langfuse_project_name: "Test",
+          langfuse_user_id: badId,
+          langfuse_event_version: "1.0.0",
+          posthog_session_id: null,
+          mixpanel_session_id: null,
+        };
+
+        const result = transformEventForMixpanel(event, projectId);
+        expect(result.properties.distinct_id).toBe(
+          result.properties.$insert_id,
+        );
+        expect(result.properties.$user_id).toBeUndefined();
+      },
+    );
+
+    it("should still use a valid user_id as distinct_id", () => {
+      const event: AnalyticsObservationEvent = {
+        langfuse_id: "event-valid",
+        timestamp: new Date("2024-01-15T10:00:00Z"),
+        langfuse_observation_name: "test",
+        langfuse_project_id: projectId,
+        langfuse_project_name: "Test",
+        langfuse_user_id: "real-user-123",
+        langfuse_event_version: "1.0.0",
+        posthog_session_id: null,
+        mixpanel_session_id: null,
+      };
+
+      const result = transformEventForMixpanel(event, projectId);
+      expect(result.properties.distinct_id).toBe("real-user-123");
+      expect(result.properties.$user_id).toBe("real-user-123");
+    });
+  });
+
   describe("transformTraceForMixpanel", () => {
     it("should transform a trace with user_id", () => {
       const trace: AnalyticsTraceEvent = {

--- a/worker/src/features/mixpanel/mixpanelClient.ts
+++ b/worker/src/features/mixpanel/mixpanelClient.ts
@@ -75,6 +75,34 @@ export class MixpanelClient {
 
       if (!response.ok) {
         const errorText = await response.text();
+
+        // On 400, Mixpanel may report partial success (some records imported,
+        // some rejected). Only throw when zero records were imported.
+        if (response.status === 400) {
+          try {
+            const body = JSON.parse(errorText) as {
+              code?: number;
+              num_records_imported?: number;
+              failed_records?: Array<{
+                index: number;
+                insert_id: string;
+                field: string;
+                message: string;
+              }>;
+            };
+
+            if (body.num_records_imported && body.num_records_imported > 0) {
+              logger.warn(
+                `Mixpanel partial success: ${body.num_records_imported}/${events.length} records imported, ${body.failed_records?.length ?? 0} failed`,
+                { failed_records: body.failed_records },
+              );
+              return;
+            }
+          } catch {
+            // JSON parse failed — fall through to throw
+          }
+        }
+
         logger.error(
           `Failed to send events to Mixpanel: ${response.status} ${response.statusText}`,
           { body: errorText },

--- a/worker/src/features/mixpanel/transformers.ts
+++ b/worker/src/features/mixpanel/transformers.ts
@@ -9,6 +9,33 @@ import type {
 // UUID v5 namespace for Mixpanel (different from PostHog)
 const MIXPANEL_UUID_NAMESPACE = "8f7c3e42-9a1b-4d5f-8e2a-1c6b9d3f4e7a";
 
+// Values that Mixpanel's /import?strict=1 API rejects as distinct_id.
+const MIXPANEL_BAD_DISTINCT_IDS = new Set([
+  "undefined",
+  "null",
+  "nil",
+  "none",
+  "unknown",
+  "n/a",
+  "na",
+  "anon",
+  "anonymous",
+  "false",
+  "true",
+  "0",
+  "-1",
+  "00000000-0000-0000-0000-000000000000",
+  "<nil>",
+  "[]",
+  "{}",
+  "lmy47d",
+]);
+
+function isBadDistinctId(value: unknown): boolean {
+  if (typeof value !== "string" || !value) return true;
+  return MIXPANEL_BAD_DISTINCT_IDS.has(value.trim().toLowerCase());
+}
+
 export type MixpanelEvent = {
   event: string;
   properties: {
@@ -34,17 +61,17 @@ export const transformTraceForMixpanel = (
 
   const { posthog_session_id, mixpanel_session_id, ...otherProps } = trace;
 
+  const hasValidUserId = !isBadDistinctId(trace.langfuse_user_id);
+
   return {
     event: "[Langfuse] Trace",
     properties: {
       time: new Date(trace.timestamp as Date).getTime(),
-      distinct_id: trace.langfuse_user_id
+      distinct_id: hasValidUserId
         ? (trace.langfuse_user_id as string)
         : insertId,
       $insert_id: insertId,
-      ...(trace.langfuse_user_id
-        ? { $user_id: trace.langfuse_user_id as string }
-        : {}),
+      ...(hasValidUserId ? { $user_id: trace.langfuse_user_id as string } : {}),
       session_id:
         mixpanel_session_id || trace.langfuse_session_id
           ? (mixpanel_session_id as string) ||
@@ -68,15 +95,17 @@ export const transformGenerationForMixpanel = (
 
   const { posthog_session_id, mixpanel_session_id, ...otherProps } = generation;
 
+  const hasValidUserId = !isBadDistinctId(generation.langfuse_user_id);
+
   return {
     event: "[Langfuse] Generation",
     properties: {
       time: new Date(generation.timestamp as Date).getTime(),
-      distinct_id: generation.langfuse_user_id
+      distinct_id: hasValidUserId
         ? (generation.langfuse_user_id as string)
         : insertId,
       $insert_id: insertId,
-      ...(generation.langfuse_user_id
+      ...(hasValidUserId
         ? { $user_id: generation.langfuse_user_id as string }
         : {}),
       session_id:
@@ -102,17 +131,17 @@ export const transformScoreForMixpanel = (
 
   const { posthog_session_id, mixpanel_session_id, ...otherProps } = score;
 
+  const hasValidUserId = !isBadDistinctId(score.langfuse_user_id);
+
   return {
     event: "[Langfuse] Score",
     properties: {
       time: new Date(score.timestamp as Date).getTime(),
-      distinct_id: score.langfuse_user_id
+      distinct_id: hasValidUserId
         ? (score.langfuse_user_id as string)
         : insertId,
       $insert_id: insertId,
-      ...(score.langfuse_user_id
-        ? { $user_id: score.langfuse_user_id as string }
-        : {}),
+      ...(hasValidUserId ? { $user_id: score.langfuse_user_id as string } : {}),
       session_id:
         mixpanel_session_id || score.langfuse_session_id
           ? (mixpanel_session_id as string) ||
@@ -136,17 +165,17 @@ export const transformEventForMixpanel = (
 
   const { posthog_session_id, mixpanel_session_id, ...otherProps } = event;
 
+  const hasValidUserId = !isBadDistinctId(event.langfuse_user_id);
+
   return {
     event: "[Langfuse] Observation",
     properties: {
       time: new Date(event.timestamp as Date).getTime(),
-      distinct_id: event.langfuse_user_id
+      distinct_id: hasValidUserId
         ? (event.langfuse_user_id as string)
         : insertId,
       $insert_id: insertId,
-      ...(event.langfuse_user_id
-        ? { $user_id: event.langfuse_user_id as string }
-        : {}),
+      ...(hasValidUserId ? { $user_id: event.langfuse_user_id as string } : {}),
       session_id:
         mixpanel_session_id || event.langfuse_session_id
           ? (mixpanel_session_id as string) ||


### PR DESCRIPTION
## Summary
- Adds a blocklist of values Mixpanel's `/import?strict=1` API rejects as `distinct_id` (e.g. `"undefined"`, `"null"`, `"0"`, `"anonymous"`, `"00000000-0000-0000-0000-000000000000"`) and falls back to `$insert_id` when the user ID matches — applied to all four transformer functions
- Parses 400 response JSON in `sendBatch` so partial successes (e.g. 999/1000 imported) log a warning instead of throwing, preventing unnecessary job failures
- Adds 45 new test cases covering the bad `distinct_id` fallback behavior across all transformers

## Test plan
- [x] All 54 existing + new transformer tests pass (`pnpm run test --filter=worker -- mixpanelTransformers`)
- [ ] Verify in staging that events with blocked user IDs no longer cause 400 errors
- [ ] Verify partial import failures are logged as warnings, not thrown as errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bad `distinct_id` handling and partial import error logging in Mixpanel integration.
> 
>   - **Behavior**:
>     - Adds blocklist for invalid `distinct_id` values in `transformers.ts`, falling back to `$insert_id` for bad IDs in `transformTraceForMixpanel`, `transformGenerationForMixpanel`, `transformScoreForMixpanel`, and `transformEventForMixpanel`.
>     - Modifies `sendBatch` in `mixpanelClient.ts` to log warnings for partial import successes (e.g., 999/1000 records) instead of throwing errors.
>   - **Tests**:
>     - Adds 45 test cases in `mixpanelTransformers.test.ts` for bad `distinct_id` handling across all transformer functions.
>   - **Misc**:
>     - Updates logging in `mixpanelClient.ts` to handle partial import errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 88ba23d79a756cffb4ce1ae852f7384577a92e19. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->