### PR TITLE
fix(export): categorical scores with colons in name exported as null

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -67,6 +67,14 @@ interface BaseScoresAggregationParams {
   startTimeFrom?: string | null;
   level: "observation" | "trace";
   hasScoreAggregationFilters?: boolean;
+  /**
+   * Encoding format for categorical scores in the aggregation output.
+   * - "concat" (default): `concat(name, ':', string_value)` — compact but breaks
+   *   when score names contain colons. Suitable for display/filtering only.
+   * - "tuple": `tuple(name, string_value)` — safe for programmatic parsing
+   *   (e.g. batch exports where values must be accurately extracted).
+   */
+  categoricalEncoding?: "concat" | "tuple";
 }
 
 /**
@@ -107,7 +115,7 @@ const buildScoresAggregationCTE = (
         ${primaryKey},
         ${additionalOuterCols.length > 0 ? additionalOuterCols.join(",\n        ") + "," : ""}
         groupArrayIf(tuple(name, avg_value, data_type, string_value), data_type IN ('NUMERIC', 'BOOLEAN')) AS scores_avg,
-        groupArrayIf(concat(name, ':', string_value), data_type = 'CATEGORICAL' AND notEmpty(string_value)) AS score_categories
+        groupArrayIf(${params.categoricalEncoding === "tuple" ? "tuple(name, string_value)" : "concat(name, ':', string_value)"}, data_type = 'CATEGORICAL' AND notEmpty(string_value)) AS score_categories
       FROM (
         SELECT
           ${primaryKey},
@@ -139,6 +147,7 @@ const buildScoresAggregationCTE = (
 interface EventsScoresAggregationParams {
   projectId: string;
   startTimeFrom?: string | null;
+  categoricalEncoding?: "concat" | "tuple";
 }
 
 /**
@@ -160,6 +169,10 @@ interface EventsTracesScoresAggregationParams {
   projectId: string;
   startTimeFrom?: string | null;
   hasScoreAggregationFilters?: boolean;
+  // Note: categoricalEncoding is intentionally omitted. This function is only used
+  // in UI table queries where score_categories are used for filtering, not programmatic
+  // parsing. If this is ever used in an export path, add categoricalEncoding here and
+  // pass it through to buildScoresAggregationCTE (see EventsScoresAggregationParams).
 }
 
 /**

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -625,6 +625,91 @@ describe("batch export test suite", () => {
     );
   });
 
+  it("should export traces with categorical score names containing colons", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const trace = createTrace({
+      project_id: projectId,
+      id: randomUUID(),
+    });
+
+    await createTracesCh([trace]);
+
+    const categoricalScore = createTraceScore({
+      project_id: projectId,
+      trace_id: trace.id,
+      name: "QA: #1 Primary Failure",
+      value: undefined,
+      string_value: "yes",
+      data_type: "CATEGORICAL",
+    });
+
+    await createScoresCh([categoricalScore]);
+
+    const stream = await getTraceStream({
+      projectId,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [],
+    });
+
+    const rows: any[] = [];
+
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]["QA: #1 Primary Failure"]).toEqual(["yes"]);
+  });
+
+  it("should export observations with categorical score names containing colons", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId = randomUUID();
+    const trace = createTrace({
+      project_id: projectId,
+      id: traceId,
+    });
+
+    await createTracesCh([trace]);
+
+    const observation = createObservation({
+      project_id: projectId,
+      trace_id: traceId,
+      id: randomUUID(),
+      type: "GENERATION",
+    });
+
+    await createObservationsCh([observation]);
+
+    const categoricalScore = createTraceScore({
+      project_id: projectId,
+      trace_id: traceId,
+      observation_id: observation.id,
+      name: "QA: #1 Primary Failure",
+      value: undefined,
+      string_value: "yes",
+      data_type: "CATEGORICAL",
+    });
+
+    await createScoresCh([categoricalScore]);
+
+    const stream = await getObservationStream({
+      projectId,
+      cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+      filter: [],
+    });
+
+    const rows: any[] = [];
+
+    for await (const chunk of stream) {
+      rows.push(chunk);
+    }
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]["QA: #1 Primary Failure"]).toEqual(["yes"]);
+  });
+
   it("should export traces with filter and sort", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
 
@@ -2550,6 +2635,51 @@ describe("batch export test suite", () => {
       expect(rows[0].sentiment).toEqual(["positive"]);
     });
 
+    it("should export events with categorical score names containing colons", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+
+      const traceId = randomUUID();
+      const now = Date.now() * 1000;
+
+      const event = createEvent({
+        project_id: projectId,
+        trace_id: traceId,
+        type: "GENERATION",
+        name: "colon-scored-event",
+        start_time: now,
+      });
+
+      await createEventsCh([event]);
+
+      const score = createTraceScore({
+        project_id: projectId,
+        trace_id: traceId,
+        observation_id: event.span_id,
+        name: "QA: #1 Primary Failure",
+        value: undefined,
+        string_value: "yes",
+        data_type: "CATEGORICAL",
+      });
+
+      await createScoresCh([score]);
+
+      const stream = await getEventsStream({
+        projectId: projectId,
+        cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+        filter: [],
+      });
+
+      const rows: any[] = [];
+
+      for await (const chunk of stream) {
+        rows.push(chunk);
+      }
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].name).toBe("colon-scored-event");
+      expect(rows[0]["QA: #1 Primary Failure"]).toEqual(["yes"]);
+    });
+
     it("should handle empty events export", async () => {
       const { projectId } = await createOrgProjectAndApiKey();
 
@@ -3309,6 +3439,51 @@ describe("batch export test suite", () => {
       expect(rows[0].name).toBe("categorically-scored-event");
       // Verify categorical score is included
       expect(rows[0].sentiment).toEqual(["positive"]);
+    });
+
+    it("should export events with categorical score names containing colons", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+
+      const traceId = randomUUID();
+      const now = Date.now() * 1000;
+
+      const event = createEvent({
+        project_id: projectId,
+        trace_id: traceId,
+        type: "GENERATION",
+        name: "colon-scored-event",
+        start_time: now,
+      });
+
+      await createEventsCh([event]);
+
+      const score = createTraceScore({
+        project_id: projectId,
+        trace_id: traceId,
+        observation_id: event.span_id,
+        name: "QA: #1 Primary Failure",
+        value: undefined,
+        string_value: "yes",
+        data_type: "CATEGORICAL",
+      });
+
+      await createScoresCh([score]);
+
+      const stream = await getEventsStream({
+        projectId: projectId,
+        cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+        filter: [],
+      });
+
+      const rows: any[] = [];
+
+      for await (const chunk of stream) {
+        rows.push(chunk);
+      }
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].name).toBe("colon-scored-event");
+      expect(rows[0]["QA: #1 Primary Failure"]).toEqual(["yes"]);
     });
 
     it("should handle empty events export", async () => {

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -135,7 +135,10 @@ export const getEventsStream = async (props: {
       "s.scores_avg as scores_avg",
       "s.score_categories as score_categories",
     )
-    .withCTE("scores_agg", eventsScoresAggregation({ projectId }))
+    .withCTE(
+      "scores_agg",
+      eventsScoresAggregation({ projectId, categoricalEncoding: "tuple" }),
+    )
     .leftJoin(
       "scores_agg s",
       "ON s.trace_id = e.trace_id AND s.observation_id = e.span_id",
@@ -218,17 +221,14 @@ export const getEventsStream = async (props: {
       stringValue: score[3],
     }));
 
-    // Process categorical scores (format: "name:value")
+    // Process categorical scores (tuples from ClickHouse)
     const categoricalScores = (bufferedRow.score_categories ?? []).map(
-      (cat: string) => {
-        const [name, ...valueParts] = cat.split(":");
-        return {
-          name,
-          value: null,
-          dataType: ScoreDataTypeEnum.CATEGORICAL,
-          stringValue: valueParts.join(":"),
-        };
-      },
+      (cat: any) => ({
+        name: cat[0],
+        value: null,
+        dataType: ScoreDataTypeEnum.CATEGORICAL,
+        stringValue: cat[1],
+      }),
     );
 
     const outputScores: Record<string, string[] | number[]> =

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -176,9 +176,9 @@ export const getObservationStream = async (props: {
             tuple(name, avg_value, data_type, string_value),
             data_type IN ('NUMERIC', 'BOOLEAN')
           ) AS scores_avg,
-          -- For categorical scores, use name:value format for improved query performance
+          -- For categorical scores, use tuples to avoid delimiter issues with names containing colons
           groupArrayIf(
-            concat(name, ':', string_value),
+            tuple(name, string_value),
             data_type = 'CATEGORICAL' AND notEmpty(string_value)
           ) AS score_categories
         FROM (
@@ -330,17 +330,14 @@ export const getObservationStream = async (props: {
       stringValue: score[3],
     }));
 
-    // Process categorical scores (format: "name:value")
+    // Process categorical scores (tuples from ClickHouse)
     const categoricalScores = (bufferedRow.score_categories ?? []).map(
-      (cat: string) => {
-        const [name, ...valueParts] = cat.split(":");
-        return {
-          name,
-          value: null,
-          dataType: ScoreDataTypeEnum.CATEGORICAL,
-          stringValue: valueParts.join(":"),
-        };
-      },
+      (cat: any) => ({
+        name: cat[0],
+        value: null,
+        dataType: ScoreDataTypeEnum.CATEGORICAL,
+        stringValue: cat[1],
+      }),
     );
 
     const outputScores: Record<string, string[] | number[]> =

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -121,9 +121,9 @@ export const getTraceStream = async (props: {
           tuple(name, avg_value, data_type, string_value),
           data_type IN ('NUMERIC', 'BOOLEAN')
         ) AS scores_avg,
-        -- For categorical scores, use name:value format for improved query performance
+        -- For categorical scores, use tuples to avoid delimiter issues with names containing colons
         groupArrayIf(
-          concat(name, ':', string_value),
+          tuple(name, string_value),
           data_type = 'CATEGORICAL' AND notEmpty(string_value)
         ) AS score_categories
       FROM (
@@ -229,17 +229,14 @@ export const getTraceStream = async (props: {
       stringValue: score[3],
     }));
 
-    // Process categorical scores (format: "name:value")
+    // Process categorical scores (tuples from ClickHouse)
     const categoricalScores = (bufferedRow.score_categories ?? []).map(
-      (cat: string) => {
-        const [name, ...valueParts] = cat.split(":");
-        return {
-          name,
-          value: null,
-          dataType: ScoreDataTypeEnum.CATEGORICAL,
-          stringValue: valueParts.join(":"),
-        };
-      },
+      (cat: any) => ({
+        name: cat[0],
+        value: null,
+        dataType: ScoreDataTypeEnum.CATEGORICAL,
+        stringValue: cat[1],
+      }),
     );
 
     const outputScores: Record<string, string[] | number[]> =


### PR DESCRIPTION
Batch export streams encoded categorical scores as `concat(name, ':', string_value)` in ClickHouse and decoded with `split(":")` in TypeScript. When a score name contains colons (e.g. "Name: Subname"), the split incorrectly parses the name/value pair, causing the value to be dropped and exported as null.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes export of categorical scores with colons in names by using tuple encoding in ClickHouse queries.
> 
>   - **Behavior**:
>     - Introduces `categoricalEncoding` parameter in `query-fragments.ts` to handle categorical scores with colons in names using `tuple` encoding.
>     - Updates `getEventsStream`, `getObservationStream`, and `getTraceStream` to process categorical scores as tuples.
>   - **Tests**:
>     - Adds tests in `batchExport.test.ts` to verify export of traces, observations, and events with categorical score names containing colons.
>   - **Misc**:
>     - Updates comments and documentation in `query-fragments.ts` to reflect new encoding options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=langfuse%2Flangfuse&utm_source=github&utm_medium=referral)<sup> for 6280bef161534de67829b30a45d3741f57a84f0f. You can [customize](https://app.ellipsis.dev/langfuse/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->