### PR TITLE
Fix/pending deletions cleanup before index

### DIFF
--- a/packages/shared/prisma/migrations/20260203220622_pending_deletions_object_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20260203220622_pending_deletions_object_id_idx/migration.sql
@@ -1,12 +1,6 @@
 -- DropIndex
 DROP INDEX IF EXISTS "pending_deletions_project_id_object_is_deleted_idx";
 
--- Cleanup processed rows before creating the wider index.
--- `is_deleted = true` rows are no longer needed by the deletion worker and can
--- grow very large, causing index creation to time out on busy installations.
-DELETE FROM "pending_deletions"
-WHERE "is_deleted" = true;
-
 -- CreateIndex
 CREATE INDEX IF NOT EXISTS "pending_deletions_project_id_object_is_deleted_object_id_id_idx"
 ON "pending_deletions"("project_id", "object", "is_deleted", "object_id", "id");

--- a/packages/shared/prisma/migrations/20260203220622_pending_deletions_object_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20260203220622_pending_deletions_object_id_idx/migration.sql
@@ -1,6 +1,12 @@
 -- DropIndex
 DROP INDEX IF EXISTS "pending_deletions_project_id_object_is_deleted_idx";
 
+-- Cleanup processed rows before creating the wider index.
+-- `is_deleted = true` rows are no longer needed by the deletion worker and can
+-- grow very large, causing index creation to time out on busy installations.
+DELETE FROM "pending_deletions"
+WHERE "is_deleted" = true;
+
 -- CreateIndex
 CREATE INDEX IF NOT EXISTS "pending_deletions_project_id_object_is_deleted_object_id_id_idx"
 ON "pending_deletions"("project_id", "object", "is_deleted", "object_id", "id");

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -402,6 +402,12 @@ const EnvSchema = z.object({
     .positive()
     .default(2),
   LANGFUSE_DELETE_BATCH_SIZE: z.coerce.number().positive().default(2000),
+  // How to finalize processed pending_deletions rows:
+  // - "soft": keep row and mark isDeleted=true (legacy behavior)
+  // - "hard": remove row via deleteMany (prevents table growth)
+  LANGFUSE_PENDING_DELETIONS_COMPLETION_MODE: z
+    .enum(["soft", "hard"])
+    .default("soft"),
   LANGFUSE_TOKEN_COUNT_WORKER_POOL_SIZE: z.coerce
     .number()
     .positive()

--- a/worker/src/features/batch-trace-deletion-cleaner/index.ts
+++ b/worker/src/features/batch-trace-deletion-cleaner/index.ts
@@ -157,17 +157,33 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
       processClickhouseTraceDelete(projectId, traceIdsToDelete),
     ]);
 
-    // Remove processed pending deletion rows
-    await prisma.pendingDeletion.deleteMany({
-      where: {
-        projectId,
-        object: "trace",
-        objectId: {
-          in: traceIdsToDelete,
+    // Finalize processed pending_deletions rows (soft mark or hard delete)
+    if (env.LANGFUSE_PENDING_DELETIONS_COMPLETION_MODE === "hard") {
+      await prisma.pendingDeletion.deleteMany({
+        where: {
+          projectId,
+          object: "trace",
+          objectId: {
+            in: traceIdsToDelete,
+          },
+          isDeleted: false,
         },
-        isDeleted: false,
-      },
-    });
+      });
+    } else {
+      await prisma.pendingDeletion.updateMany({
+        where: {
+          projectId,
+          object: "trace",
+          objectId: {
+            in: traceIdsToDelete,
+          },
+          isDeleted: false,
+        },
+        data: {
+          isDeleted: true,
+        },
+      });
+    }
 
     recordIncrement(
       `${METRIC_PREFIX}.traces_deleted`,

--- a/worker/src/features/batch-trace-deletion-cleaner/index.ts
+++ b/worker/src/features/batch-trace-deletion-cleaner/index.ts
@@ -157,8 +157,8 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
       processClickhouseTraceDelete(projectId, traceIdsToDelete),
     ]);
 
-    // Mark traces as deleted
-    await prisma.pendingDeletion.updateMany({
+    // Remove processed pending deletion rows
+    await prisma.pendingDeletion.deleteMany({
       where: {
         projectId,
         object: "trace",
@@ -166,9 +166,6 @@ export class BatchTraceDeletionCleaner extends PeriodicExclusiveRunner {
           in: traceIdsToDelete,
         },
         isDeleted: false,
-      },
-      data: {
-        isDeleted: true,
       },
     });
 

--- a/worker/src/queues/traceDelete.ts
+++ b/worker/src/queues/traceDelete.ts
@@ -101,9 +101,9 @@ export const traceDeleteProcessor: Processor = async (
       processClickhouseTraceDelete(projectId, traceIdsToDelete),
     ]);
 
-    // Mark only the pending traces as deleted (not the ones from the event, as they might be legacy)
+    // Remove only the pending traces (not the ones from the event, as they might be legacy)
     if (toBeDeletedTraces.length > 0) {
-      await prisma.pendingDeletion.updateMany({
+      await prisma.pendingDeletion.deleteMany({
         where: {
           projectId,
           object: "trace",
@@ -112,14 +112,11 @@ export const traceDeleteProcessor: Processor = async (
           },
           isDeleted: false,
         },
-        data: {
-          isDeleted: true,
-        },
       });
     }
 
     logger.debug(
-      `Successfully batch deleted ${allTraceIds.length} traces and marked them as deleted in pending_deletions table`,
+      `Successfully batch deleted ${allTraceIds.length} traces and removed them from pending_deletions table`,
     );
   } catch (error) {
     logger.error(

--- a/worker/src/queues/traceDelete.ts
+++ b/worker/src/queues/traceDelete.ts
@@ -101,22 +101,38 @@ export const traceDeleteProcessor: Processor = async (
       processClickhouseTraceDelete(projectId, traceIdsToDelete),
     ]);
 
-    // Remove only the pending traces (not the ones from the event, as they might be legacy)
+    // Finalize only the pending traces (not the ones from the event, as they might be legacy)
     if (toBeDeletedTraces.length > 0) {
-      await prisma.pendingDeletion.deleteMany({
-        where: {
-          projectId,
-          object: "trace",
-          objectId: {
-            in: traceIdsToDelete,
+      if (env.LANGFUSE_PENDING_DELETIONS_COMPLETION_MODE === "hard") {
+        await prisma.pendingDeletion.deleteMany({
+          where: {
+            projectId,
+            object: "trace",
+            objectId: {
+              in: traceIdsToDelete,
+            },
+            isDeleted: false,
           },
-          isDeleted: false,
-        },
-      });
+        });
+      } else {
+        await prisma.pendingDeletion.updateMany({
+          where: {
+            projectId,
+            object: "trace",
+            objectId: {
+              in: traceIdsToDelete,
+            },
+            isDeleted: false,
+          },
+          data: {
+            isDeleted: true,
+          },
+        });
+      }
     }
 
     logger.debug(
-      `Successfully batch deleted ${allTraceIds.length} traces and removed them from pending_deletions table`,
+      `Successfully batch deleted ${allTraceIds.length} traces and finalized pending_deletions rows`,
     );
   } catch (error) {
     logger.error(


### PR DESCRIPTION

## What does this PR do?

Fixes operational pain around `pending_deletions` growth by making completion behavior configurable in worker cleanup paths.

Today, processed rows are always soft-marked (`isDeleted=true`), which can cause the table to grow very large over time in high-throughput environments.
This PR introduces an explicit runtime toggle so operators can choose between compatibility and aggressive cleanup.

### Changes
- Add new worker env:
- `LANGFUSE_PENDING_DELETIONS_COMPLETION_MODE=soft|hard`
- default: `soft` (keeps existing behavior)
- In both worker cleanup paths:
- `soft` -> `updateMany({ isDeleted: true })`
- `hard` -> `deleteMany(...)`
- Keep migration focused on index change only (no direct bulk data deletion in migration SQL).

### Why this approach
- **Safe by default**: existing behavior remains unchanged (`soft`).
- **Scalable option**: large installations can switch to `hard` mode to prevent unbounded queue-table growth.
- **Operationally clearer**: cleanup policy becomes explicit and reversible via env.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Notes

- I can open a follow-up issue to discuss whether `hard` should become default in a future major release after broader feedback.
