### PR TITLE
feat(clickhouse): add analytics_events_core view (LFE-8734)

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -692,6 +692,43 @@ SELECT
     is_deleted
 FROM events;
 
+CREATE VIEW analytics_events_core AS
+SELECT
+  project_id,
+  toStartOfHour(start_time) AS hour,
+  sumMap(map(type, toUInt64(1))) AS count_types,
+  uniq(trace_id) AS count_traces,
+  uniq(span_id) AS count_spans,
+  uniqIf(trace_name, trace_name != '') AS count_trace_names,
+  max(user_id != '') AS has_users,
+  uniqIf(user_id, user_id != '') AS count_users,
+  max(session_id != '') AS has_sessions,
+  uniqIf(session_id, session_id != '') AS count_sessions,
+  max(if(environment != 'default', 1, 0)) AS has_environments,
+  uniq(environment) as count_environments,
+  max(length(tags) > 0) AS has_tags,
+  uniqArray(tags) AS count_unique_tags,
+  max(level != 'DEFAULT') AS has_level,
+  max(provided_model_name != '') AS has_provided_model_name,
+  uniqIf(provided_model_name, provided_model_name != '') AS count_models,
+  max(length(provided_usage_details) > 0) AS has_provided_usage_details,
+  max(length(provided_cost_details) > 0) AS has_provided_cost_details,
+  max(prompt_name != '') AS has_prompt_name,
+  max(length(tool_definitions) > 0) AS has_tool_definitions,
+  max(length(tool_calls) > 0) AS has_tool_calls,
+  uniqArray(metadata_names) AS count_unique_metadata_names,
+  max(experiment_name != '') AS has_experiment_names,
+  uniqIf(experiment_name, experiment_name != '') AS count_unique_experiment_names,
+  sum(event_bytes) AS sum_event_bytes,
+  sumMap(map(if(source = '', '-', source), toUInt64(1))) AS count_sources,
+  uniqIf(service_name, service_name != '') as count_service_names,
+  sumMap(map(if(scope_name = '', '-', concat(scope_name, '-', scope_version)), toUInt64(1))) AS count_scopes,
+  sumMap(map(if(telemetry_sdk_language = '', '-', telemetry_sdk_language), toUInt64(1))) AS count_telemetry_sdk_languages,
+  sumMap(map(if(telemetry_sdk_name = '', '-', concat(telemetry_sdk_language, '-', telemetry_sdk_name, '-', telemetry_sdk_version)), toUInt64(1))) AS count_sdk_telemetry_sdks
+FROM events_core
+WHERE toStartOfHour(start_time) <= toStartOfHour(subtractHours(now(), 1))
+GROUP BY project_id, hour;
+
 EOF
 
 echo "Populating development tables with sample data..."


### PR DESCRIPTION
## Summary
- Adds `analytics_events_core` ClickHouse VIEW on `events_core` with per-project, per-hour aggregations
- Uses `sumMap` for type/source/scope/SDK distribution counts with empty-string fallback to `'-'`
- Uses `uniqIf` for string columns (users, sessions, trace names, models, etc.) to exclude empty strings
- Uses `uniqArray` for array columns (tags, metadata names) for memory-efficient unique counting

## Test plan
- [ ] Run `dev-tables.sh` against local ClickHouse and verify the view is created
- [ ] Query `analytics_events_core` and verify aggregations return expected results
- [ ] Verify empty strings are excluded from `uniqIf` counts and mapped to `'-'` in `sumMap` results

🤖 Generated with [Claude Code](https://claude.com/claude-code)