### PR TITLE
refactor: extract stringifyJsonNode to shared utils

### DIFF
--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -21,6 +21,8 @@ import { LangfuseMediaView } from "@/src/components/ui/LangfuseMediaView";
 import { MarkdownJsonViewHeader } from "@/src/components/ui/MarkdownJsonView";
 import { renderRichPromptContent } from "@/src/features/prompts/components/prompt-content-utils";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
+import { stringifyJsonNode } from "@/src/utils/jsonUtils";
+export { stringifyJsonNode } from "@/src/utils/jsonUtils";
 
 export const IO_TABLE_CHAR_LIMIT = 10000;
 
@@ -343,34 +345,3 @@ export const JsonSkeleton = ({
     </div>
   );
 };
-
-// TODO: deduplicate with PrettyJsonView.tsx
-export function stringifyJsonNode(node: unknown) {
-  // return single string nodes without quotes
-  if (typeof node === "string") {
-    return node;
-  }
-
-  try {
-    return JSON.stringify(
-      node,
-      (_key, value) => {
-        switch (typeof value) {
-          case "bigint":
-            return String(value) + "n";
-          case "number":
-          case "boolean":
-          case "object":
-          case "string":
-            return value as string;
-          default:
-            return String(value);
-        }
-      },
-      4,
-    );
-  } catch (error) {
-    console.error("JSON stringify error", error);
-    return "Error: JSON.stringify failed";
-  }
-}

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -6,6 +6,7 @@ import { type MediaReturnType } from "@/src/features/media/validation";
 import { LangfuseMediaView } from "@/src/components/ui/LangfuseMediaView";
 import { MarkdownJsonViewHeader } from "@/src/components/ui/MarkdownJsonView";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
+import { stringifyJsonNode } from "@/src/utils/jsonUtils";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { Button } from "@/src/components/ui/button";
 import { useClickWithoutSelection } from "@/src/hooks/useClickWithoutSelection";
@@ -1373,35 +1374,4 @@ export function PrettyJsonView(props: {
       )}
     </div>
   );
-}
-
-// TODO: deduplicate with CodeJsonViewer.tsx
-function stringifyJsonNode(node: unknown) {
-  // return single string nodes without quotes
-  if (typeof node === "string") {
-    return node;
-  }
-
-  try {
-    return JSON.stringify(
-      node,
-      (key, value) => {
-        switch (typeof value) {
-          case "bigint":
-            return String(value) + "n";
-          case "number":
-          case "boolean":
-          case "object":
-          case "string":
-            return value as string;
-          default:
-            return String(value);
-        }
-      },
-      4,
-    );
-  } catch (error) {
-    console.error("JSON stringify error", error);
-    return "Error: JSON.stringify failed";
-  }
 }

--- a/web/src/utils/jsonUtils.ts
+++ b/web/src/utils/jsonUtils.ts
@@ -1,0 +1,35 @@
+/**
+ * Serializes any JSON-compatible value to a human-readable string.
+ * Returns bare string values without JSON quotes.
+ *
+ * Extracted from CodeJsonViewer.tsx and PrettyJsonView.tsx to avoid duplication.
+ */
+export function stringifyJsonNode(node: unknown): string {
+  // return single string nodes without quotes
+  if (typeof node === "string") {
+    return node;
+  }
+
+  try {
+    return JSON.stringify(
+      node,
+      (_key, value) => {
+        switch (typeof value) {
+          case "bigint":
+            return String(value) + "n";
+          case "number":
+          case "boolean":
+          case "object":
+          case "string":
+            return value as string;
+          default:
+            return String(value);
+        }
+      },
+      4,
+    );
+  } catch (error) {
+    console.error("JSON stringify error", error);
+    return "Error: JSON.stringify failed";
+  }
+}


### PR DESCRIPTION
# What does this PR do?

This PR addresses the `TODO: deduplicate` comments in `CodeJsonViewer.tsx` and `PrettyJsonView.tsx`.
- Extracted shared `stringifyJsonNode` logic into `web/src/utils/jsonUtils.ts`.
- Refactored both components to use the shared utility, reducing code redundancy.
- Re-exported the function in `CodeJsonViewer.tsx` to maintain backward compatibility for other components (e.g., `IOTableCell.tsx`).

Fixes # (N/A - Refactoring)

## Type of change

- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings