### PR TITLE
fix(datasets): deep parse nested JSON strings in dataset and trace views

### DIFF
--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -12,6 +12,7 @@ import {
   HoverCardTrigger,
 } from "@/src/components/ui/hover-card";
 import { decodeUnicodeEscapesOnly } from "@/src/utils/unicode";
+import { deepParseJson } from "@langfuse/shared";
 
 const IOTableCellContent = ({
   data,
@@ -23,7 +24,9 @@ const IOTableCellContent = ({
   className?: string;
 }) => {
   const stringifiedJson =
-    data !== null && data !== undefined ? stringifyJsonNode(data) : undefined;
+    data !== null && data !== undefined
+      ? stringifyJsonNode(deepParseJson(data))
+      : undefined;
 
   // perf: truncate to IO_TABLE_CHAR_LIMIT characters as table becomes unresponsive attempting to render large JSONs with high levels of nesting
   const shouldTruncate =

--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -13,7 +13,7 @@ import {
 import { api } from "@/src/utils/api";
 import { useState, useMemo, useEffect } from "react";
 import { CodeMirrorEditor } from "@/src/components/editor";
-import { type Prisma } from "@langfuse/shared";
+import { type Prisma, deepParseJson } from "@langfuse/shared";
 import { cn } from "@/src/utils/tailwind";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { DatasetSchemaHoverCard } from "./DatasetSchemaHoverCard";
@@ -91,15 +91,13 @@ const formatJsonValue = (value: Prisma.JsonValue | undefined): string => {
 
   if (typeof value === "string") {
     try {
-      // Parse the string and re-stringify with proper formatting
       const parsed = JSON.parse(value);
-      return JSON.stringify(parsed, null, 2);
+      return JSON.stringify(deepParseJson(parsed), null, 2);
     } catch {
-      // If it's not valid JSON, stringify the string itself
       return JSON.stringify(value, null, 2);
     }
   }
-  return JSON.stringify(value, null, 2);
+  return JSON.stringify(deepParseJson(value), null, 2);
 };
 
 export const NewDatasetItemForm = (props: {

--- a/web/src/features/datasets/utils/datasetItemUtils.ts
+++ b/web/src/features/datasets/utils/datasetItemUtils.ts
@@ -1,15 +1,19 @@
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { deepParseJson } from "@langfuse/shared";
 import type { Prisma } from "@langfuse/shared";
 
 /**
  * Converts a dataset item field value to a formatted JSON string.
+ * Deep-parses nested JSON strings (e.g. LLM message content fields) so they
+ * display as structured JSON rather than escaped strings, consistent with how
+ * JSONView renders the same data in the overview table.
  * Returns empty string for null/undefined values.
  */
 export const stringifyDatasetItemData = (data: unknown): string => {
   if (!data) return "";
 
   try {
-    return JSON.stringify(data, null, 2);
+    return JSON.stringify(deepParseJson(data), null, 2);
   } catch {
     showErrorToast(
       "Failed to stringify data",


### PR DESCRIPTION
  ## What does this PR do?

  Fixes nested JSON strings (e.g. LLM message `content` fields with structured JSON output)
  not rendering as structured JSON in three places:
  - Dataset item detail view
  - "Add to dataset" form preview
  - Trace list input/output columns

  Root cause: `IOTableCell` stringified data before passing to `JSONView`, consuming one extra
  depth level and causing `deepParseJson`'s `maxDepth=3` to be reached before nested strings
  could be parsed. The fix applies the existing `deepParseJson` utility (already used by
  `JSONView`) consistently upstream in all three locations.

  Fixes #12404 
  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Mandatory Tasks

  - [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

  ## Checklist

  - [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
  - [x] My code follows the style guidelines of this project (`pnpm run format`)
  - [x] My changes generate no new warnings (`pnpm run lint`)

  For the unchecked items — you haven't added tests and haven't checked docs. That's fine to leave unchecked but you can add a note:

  - Tests: existing behavior is covered by the `deepParseJson` utility which already has tests.
    No new unit tests added as this is a display-only change with no new logic.
  - Docs: no documentation changes needed.