### PR TITLE
chore: extract shared helpers and decompose executeQuery

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -9,13 +9,13 @@ import { getTracer, instrumentAsync } from "../instrumentation";
 import { randomUUID } from "crypto";
 import { getClickhouseEntityType } from "../clickhouse/schemaUtils";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
-import { context, SpanKind, trace } from "@opentelemetry/api";
+import { type Span, context, SpanKind, trace } from "@opentelemetry/api";
 import { backOff } from "exponential-backoff";
 import {
   StorageService,
   StorageServiceFactory,
 } from "../services/StorageService";
-import { ClickHouseSettings } from "@clickhouse/client";
+import { ClickHouseSettings, type DataFormat } from "@clickhouse/client";
 import { RESOURCE_LIMIT_ERROR_MESSAGE } from "../../errors/errorMessages";
 
 /**
@@ -95,6 +95,22 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
   }
   return s3StorageServiceClient;
 };
+
+/**
+ * Guard against reads from the legacy 'events' table.
+ * Reads must use events_core or events_full instead.
+ * Matches "FROM events" or "JOIN events" as a standalone table name
+ * (not events_core, events_full, or CTE aliases like filtered_events).
+ */
+const LEGACY_EVENTS_TABLE_PATTERN = /\b(?:from|join)\s+events\b(?!_)/i;
+
+function assertNoLegacyEventsRead(query: string): void {
+  if (LEGACY_EVENTS_TABLE_PATTERN.test(query)) {
+    throw new Error(
+      `Reading from legacy 'events' table is forbidden. Use events_core or events_full. Query: ${query.slice(0, 200)}`,
+    );
+  }
+}
 
 export async function upsertClickhouse<
   T extends Record<string, unknown>,
@@ -202,69 +218,23 @@ export async function upsertClickhouse<
   );
 }
 
-export async function* queryClickhouseStream<T>(opts: {
-  query: string;
-  params?: Record<string, unknown> | undefined;
-  clickhouseConfigs?: NodeClickHouseClientConfigOptions;
-  tags?: Record<string, string>;
-  preferredClickhouseService?: PreferredClickhouseService;
-  clickhouseSettings?: ClickHouseSettings;
-}): AsyncGenerator<T> {
+export async function* queryClickhouseStream<T>(
+  opts: ClickhouseQueryOpts,
+): AsyncGenerator<T> {
+  if (!opts.allowLegacyEventsRead) assertNoLegacyEventsRead(opts.query);
   const tracer = getTracer("clickhouse-query-stream");
   const span = tracer.startSpan("clickhouse-query-stream", {
     kind: SpanKind.CLIENT,
   });
 
   try {
+    setSpanQueryAttributes(span, opts.query);
+
     const res = await context
-      .with(trace.setSpan(context.active(), span), async () => {
-        // https://opentelemetry.io/docs/specs/semconv/database/database-spans/
-        span.setAttribute("ch.query.text", opts.query);
-        span.setAttribute("db.system", "clickhouse");
-        span.setAttribute("db.query.text", opts.query);
-        span.setAttribute("db.operation.name", "SELECT");
-
-        const res = await clickhouseClient(
-          opts.clickhouseConfigs,
-          opts.preferredClickhouseService,
-        ).query({
-          query: opts.query,
-          format: "JSONEachRow",
-          query_params: opts.params,
-          clickhouse_settings: {
-            ...opts.clickhouseSettings,
-            log_comment: JSON.stringify(opts.tags ?? {}),
-          },
-        });
-
-        // same logic as for prisma. we want to see queries in development
-        if (env.NODE_ENV === "development") {
-          logger.info(`clickhouse:query ${res.query_id} ${opts.query}`);
-        }
-
-        span.setAttribute("ch.queryId", res.query_id);
-
-        // add summary headers to the span. Helps to tune performance
-        const summaryHeader = res.response_headers["x-clickhouse-summary"];
-        if (summaryHeader) {
-          try {
-            const summary = Array.isArray(summaryHeader)
-              ? JSON.parse(summaryHeader[0])
-              : JSON.parse(summaryHeader);
-            for (const key in summary) {
-              span.setAttribute(`ch.${key}`, summary[key]);
-            }
-          } catch (error) {
-            logger.debug(
-              `Failed to parse clickhouse summary header ${summaryHeader}`,
-              error,
-            );
-          }
-        }
-        return res;
-      })
+      .with(trace.setSpan(context.active(), span), () =>
+        sendClickhouseQuery({ ...opts, format: "JSONEachRow", span }),
+      )
       .catch((error) => {
-        // Transform resource errors to provide actionable advice
         throw ClickHouseResourceError.wrapIfResourceError(error as Error);
       });
 
@@ -274,7 +244,7 @@ export async function* queryClickhouseStream<T>(opts: {
       }
     }
   } catch (error) {
-    // Also catch errors during streaming
+    if (error instanceof ClickHouseResourceError) throw error;
     throw ClickHouseResourceError.wrapIfResourceError(error as Error);
   } finally {
     span.end();
@@ -318,6 +288,77 @@ function handleExceptionRow<T>(parsedRow: T): T {
   return parsedRow;
 }
 
+export type ClickhouseQueryOpts = {
+  query: string;
+  params?: Record<string, unknown>;
+  clickhouseConfigs?: NodeClickHouseClientConfigOptions;
+  tags?: Record<string, string>;
+  preferredClickhouseService?: PreferredClickhouseService;
+  clickhouseSettings?: ClickHouseSettings;
+  allowLegacyEventsRead?: boolean;
+};
+
+function recordSummaryOnSpan(
+  span: Span,
+  responseHeaders: Record<string, string | string[] | undefined>,
+): void {
+  const summaryHeader = responseHeaders["x-clickhouse-summary"];
+  if (!summaryHeader) return;
+  try {
+    const summary = Array.isArray(summaryHeader)
+      ? JSON.parse(summaryHeader[0])
+      : JSON.parse(summaryHeader);
+    for (const key in summary) {
+      span.setAttribute(`ch.${key}`, summary[key]);
+    }
+  } catch (error) {
+    logger.debug(
+      `Failed to parse clickhouse summary header ${summaryHeader}`,
+      error,
+    );
+  }
+}
+
+function setSpanQueryAttributes(span: Span, query: string): void {
+  span.setAttribute("ch.query.text", query);
+  span.setAttribute("db.system", "clickhouse");
+  span.setAttribute("db.query.text", query);
+  span.setAttribute("db.operation.name", "SELECT");
+}
+
+async function sendClickhouseQuery<F extends DataFormat>(opts: {
+  query: string;
+  params?: Record<string, unknown>;
+  clickhouseConfigs?: NodeClickHouseClientConfigOptions;
+  tags?: Record<string, string>;
+  preferredClickhouseService?: PreferredClickhouseService;
+  clickhouseSettings?: ClickHouseSettings;
+  format: F;
+  span: Span;
+}) {
+  const res = await clickhouseClient(
+    opts.clickhouseConfigs,
+    opts.preferredClickhouseService,
+  ).query({
+    query: opts.query,
+    format: opts.format,
+    query_params: opts.params,
+    clickhouse_settings: {
+      ...opts.clickhouseSettings,
+      log_comment: JSON.stringify(opts.tags ?? {}),
+    },
+  });
+
+  if (env.NODE_ENV === "development") {
+    logger.info(`clickhouse:query ${res.query_id} ${opts.query}`);
+  }
+
+  opts.span.setAttribute("ch.queryId", res.query_id);
+  recordSummaryOnSpan(opts.span, res.response_headers);
+
+  return res;
+}
+
 /**
  * Determines if an error is retryable (socket hang up, connection reset, broken pipe, etc.)
  */
@@ -340,65 +381,27 @@ function isRetryableError(error: unknown): boolean {
   return retryablePatterns.some((pattern) => errorMessage.includes(pattern));
 }
 
-export async function queryClickhouse<T>(opts: {
-  query: string;
-  params?: Record<string, unknown> | undefined;
-  clickhouseConfigs?: NodeClickHouseClientConfigOptions;
-  tags?: Record<string, string>;
-  preferredClickhouseService?: PreferredClickhouseService;
-  clickhouseSettings?: ClickHouseSettings;
-}): Promise<T[]> {
+export async function queryClickhouse<T>(
+  opts: ClickhouseQueryOpts,
+): Promise<T[]> {
+  if (!opts.allowLegacyEventsRead) assertNoLegacyEventsRead(opts.query);
   return await instrumentAsync(
     { name: "clickhouse-query", spanKind: SpanKind.CLIENT },
     async (span) => {
-      // https://opentelemetry.io/docs/specs/semconv/database/database-spans/
-      span.setAttribute("ch.query.text", opts.query);
-      span.setAttribute("db.system", "clickhouse");
-      span.setAttribute("db.query.text", opts.query);
-      span.setAttribute("db.operation.name", "SELECT");
+      setSpanQueryAttributes(span, opts.query);
 
-      // Retry logic for socket hang up and other network errors
       return await backOff(
         async () => {
-          // same logic as for prisma. we want to see queries in development
-          if (env.NODE_ENV === "development") {
-            logger.info(`clickhouse:query ${opts.query}`);
-          }
-          const res = await clickhouseClient(
-            opts.clickhouseConfigs,
-            opts.preferredClickhouseService,
-          ).query({
-            query: opts.query,
-            format: "JSONEachRow",
-            query_params: opts.params,
-            clickhouse_settings: {
+          const res = await sendClickhouseQuery({
+            ...opts,
+            clickhouseSettings: {
               asterisk_include_alias_columns: 1,
               asterisk_include_materialized_columns: 1,
               ...opts.clickhouseSettings,
-              log_comment: JSON.stringify(opts.tags ?? {}),
             },
+            format: "JSONEachRow",
+            span,
           });
-
-          span.setAttribute("ch.queryId", res.query_id);
-
-          // add summary headers to the span. Helps to tune performance
-          const summaryHeader = res.response_headers["x-clickhouse-summary"];
-          if (summaryHeader) {
-            try {
-              const summary = Array.isArray(summaryHeader)
-                ? JSON.parse(summaryHeader[0])
-                : JSON.parse(summaryHeader);
-              for (const key in summary) {
-                span.setAttribute(`ch.${key}`, summary[key]);
-              }
-            } catch (error) {
-              logger.debug(
-                `Failed to parse clickhouse summary header ${summaryHeader}`,
-                error,
-              );
-            }
-          }
-
           return (await res.json<T>()).map(handleExceptionRow);
         },
         {
@@ -434,7 +437,6 @@ export async function queryClickhouse<T>(opts: {
           maxDelay: 100,
         },
       ).catch((error) => {
-        // Transform resource errors to provide actionable advice
         throw ClickHouseResourceError.wrapIfResourceError(error as Error);
       });
     },

--- a/web/src/features/query/server/queryExecutor.ts
+++ b/web/src/features/query/server/queryExecutor.ts
@@ -1,4 +1,9 @@
-import { queryClickhouse, measureAndReturn } from "@langfuse/shared/src/server";
+import {
+  queryClickhouse,
+  measureAndReturn,
+  type ClickhouseQueryOpts,
+  type PreferredClickhouseService,
+} from "@langfuse/shared/src/server";
 import { QueryBuilder } from "@/src/features/query/server/queryBuilder";
 import { type QueryType, type ViewVersion } from "@/src/features/query/types";
 import { getViewDeclaration } from "@/src/features/query/dataModel";
@@ -10,40 +15,40 @@ export {
   type QueryValidationResult,
 } from "@/src/features/query/validateQuery";
 
-/**
- * Execute a query using the QueryBuilder.
- *
- * @param projectId - The project ID
- * @param query - The query configuration as defined in QueryType
- * @param version - The view version to use (v1 or v2), defaults to v1
- * @param enableSingleLevelOptimization - Enable single-level SELECT optimization (default: false)
- * @returns The query result data
- */
-export async function executeQuery(
-  projectId: string,
-  query: QueryType,
-  version: ViewVersion = "v1",
-  enableSingleLevelOptimization: boolean = false,
-): Promise<Array<Record<string, unknown>>> {
-  // Remap config to chartConfig for public API compatibility
-  // Public API uses "config" while internal QueryType uses "chartConfig"
+export type PreparedQuery = {
+  compiledQuery: string;
+  parameters: Record<string, unknown>;
+  preferredClickhouseService: PreferredClickhouseService | undefined;
+  tags: Record<string, string>;
+  clickhouseSettings: Record<string, string>;
+  usesTraceTable: boolean;
+  fromTimestamp: string;
+};
+
+export async function prepareExecuteQuery(opts: {
+  projectId: string;
+  query: QueryType;
+  version?: ViewVersion;
+  enableSingleLevelOptimization?: boolean;
+}): Promise<PreparedQuery> {
+  const {
+    projectId,
+    query,
+    version = "v1",
+    enableSingleLevelOptimization = false,
+  } = opts;
+
   const chartConfig =
     (query as unknown as { config?: QueryType["chartConfig"] }).config ??
     query.chartConfig;
   const queryBuilder = new QueryBuilder(chartConfig, version);
 
-  // Build the query (with or without optimization based on flag)
   const { query: compiledQuery, parameters } = await queryBuilder.build(
     query,
     projectId,
     enableSingleLevelOptimization,
   );
 
-  // Check if the query contains trace table references
-  const usesTraceTable = compiledQuery.includes("traces");
-
-  // Route events_core queries to the dedicated events read replica.
-  // Checked via the view declaration's baseCte rather than scanning the compiled SQL.
   const view = getViewDeclaration(query.view, version);
   const preferredClickhouseService = view.baseCte.includes("events_")
     ? ("EventsReadOnly" as const)
@@ -56,57 +61,76 @@ export async function executeQuery(
     projectId,
   };
 
-  if (!usesTraceTable) {
-    // No trace table placeholders, execute normally
-    return queryClickhouse<Record<string, unknown>>({
-      query: compiledQuery,
-      params: parameters,
-      clickhouseConfigs: {
-        clickhouse_settings: {
-          date_time_output_format: "iso",
-          ...(env.CLICKHOUSE_USE_QUERY_CONDITION_CACHE === "true"
-            ? { use_query_condition_cache: "true" }
-            : {}),
-          max_bytes_before_external_group_by: String(
-            env.CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
-          ),
-        },
-      },
-      tags,
-      preferredClickhouseService,
-    });
+  const clickhouseSettings: Record<string, string> = {
+    date_time_output_format: "iso",
+    ...(env.CLICKHOUSE_USE_QUERY_CONDITION_CACHE === "true"
+      ? { use_query_condition_cache: "true" }
+      : {}),
+    max_bytes_before_external_group_by: String(
+      env.CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
+    ),
+  };
+
+  return {
+    compiledQuery,
+    parameters,
+    preferredClickhouseService,
+    tags,
+    clickhouseSettings,
+    usesTraceTable: compiledQuery.includes("traces"),
+    fromTimestamp: query.fromTimestamp,
+  };
+}
+
+export function toClickhouseQueryOpts(
+  prepared: PreparedQuery,
+): Omit<ClickhouseQueryOpts, "allowLegacyEventsRead"> {
+  return {
+    query: prepared.compiledQuery,
+    params: prepared.parameters,
+    clickhouseSettings: prepared.clickhouseSettings,
+    tags: prepared.tags,
+    preferredClickhouseService: prepared.preferredClickhouseService,
+  };
+}
+
+export async function executeQuery(
+  projectId: string,
+  query: QueryType,
+  version: ViewVersion = "v1",
+  enableSingleLevelOptimization: boolean = false,
+): Promise<Array<Record<string, unknown>>> {
+  const prepared = await prepareExecuteQuery({
+    projectId,
+    query,
+    version,
+    enableSingleLevelOptimization,
+  });
+
+  const chOpts = toClickhouseQueryOpts(prepared);
+
+  if (!prepared.usesTraceTable) {
+    return queryClickhouse<Record<string, unknown>>(chOpts);
   }
 
-  // Use measureAndReturn for trace table queries
   return measureAndReturn({
     operationName: "executeQuery",
     projectId,
     input: {
-      query: compiledQuery,
-      params: parameters,
-      fromTimestamp: query.fromTimestamp,
+      query: prepared.compiledQuery,
+      params: prepared.parameters,
+      fromTimestamp: prepared.fromTimestamp,
       tags: {
-        ...tags,
+        ...prepared.tags,
         operation_name: "executeQuery",
       },
     },
     fn: async (input) => {
       return queryClickhouse<Record<string, unknown>>({
+        ...chOpts,
         query: input.query,
         params: input.params,
-        clickhouseConfigs: {
-          clickhouse_settings: {
-            date_time_output_format: "iso",
-            ...(env.CLICKHOUSE_USE_QUERY_CONDITION_CACHE === "true"
-              ? { use_query_condition_cache: "true" }
-              : {}),
-            max_bytes_before_external_group_by: String(
-              env.CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY,
-            ),
-          },
-        },
         tags: input.tags,
-        preferredClickhouseService,
       });
     },
   });


### PR DESCRIPTION
Refactored ClickHouse query execution by extracting common functionality into reusable helper functions and introducing a query preparation step.

### What changed?

- Extracted `sendClickhouseQuery`, `setSpanQueryAttributes`, and `recordSummaryOnSpan` helper functions from duplicated code in `queryClickhouseStream` and `queryClickhouse`
- Added `ClickhouseQueryOpts` type to standardize query options across functions
- Introduced `prepareExecuteQuery` function that separates query preparation from execution
- Added `PreparedQuery` type and `toClickhouseQueryOpts` converter function
- Improved error handling in `queryClickhouseStream` to preserve `ClickHouseResourceError` instances
- Added proper TypeScript imports for `Span` and `DataFormat` types

### 