### PR TITLE
fix: support Unicode characters in prompt variable names

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -200,8 +200,8 @@ export const PlaceholderMessageSchema = z.object({
   name: z
     .string()
     .regex(
-      /^[a-zA-Z][a-zA-Z0-9_]*$/,
-      "Placeholder name must start with a letter and contain only alphanumeric characters and underscores",
+      /^[\p{L}][\p{L}\p{N}_]*$/u,
+      "Placeholder name must start with a letter and contain only letters, digits, and underscores",
     ),
 });
 export type PlaceholderMessage = z.infer<typeof PlaceholderMessageSchema>;

--- a/packages/shared/src/utils/stringChecks.ts
+++ b/packages/shared/src/utils/stringChecks.ts
@@ -1,19 +1,11 @@
-const JAPANESE_CHAR_RANGE = "\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF";
-
 export function getIsCharOrUnderscore(value: string): boolean {
-  const charOrUnderscore = new RegExp(
-    `^[a-zA-Z_${JAPANESE_CHAR_RANGE}]+$`,
-    "u",
-  );
+  const charOrUnderscore = /^[\p{L}\p{N}_]+$/u;
 
   return charOrUnderscore.test(value);
 }
 
-// Regex for valid variable names (letters, underscores, starting with letter)
-export const VARIABLE_REGEX = new RegExp(
-  `^[a-zA-Z${JAPANESE_CHAR_RANGE}][a-zA-Z${JAPANESE_CHAR_RANGE}_]*$`,
-  "u",
-);
+// Regex for valid variable names (letters, digits, underscores, starting with letter or unicode)
+export const VARIABLE_REGEX = /^[\p{L}][\p{L}\p{N}_]*$/u;
 
 // Regex to find variables in mustache syntax
 export const MUSTACHE_REGEX = /{{([^{}]*)}}+/g;

--- a/web/src/features/prompts/components/NewPromptForm/validation.ts
+++ b/web/src/features/prompts/components/NewPromptForm/validation.ts
@@ -36,7 +36,7 @@ const NewChatPromptSchema = NewPromptBaseSchema.extend({
             PlaceholderMessageSchema.safeParse(message).success
           );
         }),
-      "Placeholder name must start with a letter and contain only alphanumeric characters and underscores",
+      "Placeholder name must start with a letter and contain only letters, digits, and underscores",
     )
     .refine(
       (messages: Array<{ type?: ChatMessageType; content?: string }>) =>


### PR DESCRIPTION
**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

## Summary

Fixes #12042

Prompt variables with non-ASCII names (e.g. `{{質問}}`, `{{변수}}`, `{{переменная}}`) were silently ignored because the variable name validation regexes only accepted ASCII letters (`[a-zA-Z]`) plus a hardcoded Japanese character range.

This PR replaces all ASCII-only and hardcoded character ranges with **Unicode property escapes** (`\p{L}` for any letter, `\p{N}` for any digit), which natively support all Unicode scripts — Japanese, Korean, Chinese, Cyrillic, Arabic, etc.

## Changes

### `packages/shared/src/utils/stringChecks.ts`
- **`VARIABLE_REGEX`**: Changed from `new RegExp` with `a-zA-Z` + `JAPANESE_CHAR_RANGE` to `/^[\p{L}][\p{L}\p{N}_]*$/u`
- **`getIsCharOrUnderscore()`**: Same pattern update — now uses `\p{L}` and `\p{N}` instead of ASCII + Japanese ranges
- Removed the `JAPANESE_CHAR_RANGE` constant (no longer needed)

### `packages/shared/src/server/llm/types.ts`
- **`PlaceholderMessageSchema`**: Updated name validation regex from `/^[a-zA-Z][a-zA-Z0-9_]*$/` to `/^[\p{L}][\p{L}\p{N}_]*$/u`

### `web/src/features/prompts/components/NewPromptForm/validation.ts`
- Updated error message to be consistent with the updated `PlaceholderMessageSchema` message

## How it works

JavaScript's `\p{L}` (Unicode property escape with the `u` flag) matches any Unicode letter — Hiragana, Katakana, CJK ideographs, Hangul, Cyrillic, Arabic, etc. `\p{N}` matches any Unicode digit. This is the standard, future-proof approach instead of enumerating character ranges per script.

## Test plan

- [ ] Verify `extractVariables("Hello {{質問}}")` returns `["質問"]`
- [ ] Verify `extractVariables("Hello {{question}}")` still returns `["question"]`
- [ ] Verify `isValidVariableName("질문")` returns `true` (Korean)
- [ ] Verify `isValidVariableName("переменная")` returns `true` (Cyrillic)
- [ ] Verify `isValidVariableName("_invalid")` returns `false` (must start with letter)
- [ ] Verify `isValidVariableName("")` returns `false`
- [ ] Verify placeholder messages with Unicode names pass `PlaceholderMessageSchema` validation