### PR TITLE
Add User-Agent header for Anthropic API calls

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -268,7 +268,10 @@ export async function fetchLLMCompletion(
       callbacks: finalCallbacks,
       clientOptions: {
         maxRetries,
-        defaultHeaders: extraHeaders,
+        defaultHeaders: {
+          "User-Agent": "langfuse",
+          ...extraHeaders,
+        },
         timeout: timeoutMs,
         ...(proxyDispatcher && {
           fetchOptions: { dispatcher: proxyDispatcher },


### PR DESCRIPTION
## What does this PR do?

Passes User-Agent: langfuse/{version} to the Anthropic SDK via LangChain so Anthropic can identify traffic from Langfuse.

## Type of change

- [X] Chore (refactoring code, technical debt, workflow improvements)
- [X] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

