### PR TITLE
fix(evals): jsonpath slicing returns full result in eval variable mapping preview

### DIFF
--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -60,7 +60,7 @@ function parseJsonDefault(selectedColumn: unknown, jsonSelector: string) {
     json: selectedColumn as any, // JSONPath accepts unknown but types are strict
   });
 
-  return Array.isArray(result) && result.length > 0 ? result[0] : undefined;
+  return Array.isArray(result) && result.length > 0 ? result : undefined;
 }
 
 export function extractValueFromObject(

--- a/web/src/__tests__/eval-extract-value.clienttest.ts
+++ b/web/src/__tests__/eval-extract-value.clienttest.ts
@@ -1,0 +1,75 @@
+import { extractValueFromObject } from "@langfuse/shared";
+
+describe("extractValueFromObject - JSONPath slicing", () => {
+  const messages = [
+    { role: "system" },
+    { role: "user" },
+    { role: "assistant" },
+    { role: "user" },
+  ];
+
+  it("$[1:] returns full sliced array, not just first element", () => {
+    const { value } = extractValueFromObject({ messages }, "messages", "$[1:]");
+    expect(value).toBe(
+      JSON.stringify([
+        { role: "user" },
+        { role: "assistant" },
+        { role: "user" },
+      ]),
+    );
+  });
+
+  it("$[0:] returns the full array", () => {
+    const { value } = extractValueFromObject({ messages }, "messages", "$[0:]");
+    expect(value).toBe(JSON.stringify(messages));
+  });
+
+  it("$[*].role wildcard returns all role values", () => {
+    const { value } = extractValueFromObject(
+      { messages },
+      "messages",
+      "$[*].role",
+    );
+    expect(value).toBe(JSON.stringify(["system", "user", "assistant", "user"]));
+  });
+
+  it("returns empty string when path does not match", () => {
+    const { value } = extractValueFromObject(
+      { messages },
+      "messages",
+      "$.nonexistent",
+    );
+    // parseJsonDefault returns undefined when no match -> parseUnknownToString gives ""
+    expect(value).toBe("");
+  });
+
+  it("returns full field value when no jsonSelector provided", () => {
+    const { value } = extractValueFromObject({ messages }, "messages");
+    expect(value).toBe(JSON.stringify(messages));
+  });
+
+  it("$[?(@.role=='assistant')] predicate returns all matching elements", () => {
+    const { value } = extractValueFromObject(
+      { messages },
+      "messages",
+      "$[?(@.role=='user')]",
+    );
+    expect(value).toBe(JSON.stringify([{ role: "user" }, { role: "user" }]));
+  });
+
+  it("works with JSON-string field containing an array", () => {
+    // Common case: field is stored as JSON string
+    const { value } = extractValueFromObject(
+      { input: JSON.stringify(messages) },
+      "input",
+      "$[1:]",
+    );
+    expect(value).toBe(
+      JSON.stringify([
+        { role: "user" },
+        { role: "assistant" },
+        { role: "user" },
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #11738
- `parseJsonDefault` in `packages/shared/src/features/evals/utilities.ts` was returning `result[0]` from the JSONPath result array, collapsing slice (`$[1:]`), wildcard (`$[*].role`), and predicate (`$[?(...)]`) expressions to only the first match in the UI preview
- Changed to return the full result array, making UI preview consistent with backend eval execution behavior

## Test plan

- [x] Added `web/src/__tests__/eval-extract-value.clienttest.ts` covering slice, wildcard, predicate, no-match, and JSON-string field cases
- [x] `pnpm --filter web run lint` passes
- [x] `pnpm --filter @langfuse/shared run lint` passes

Made with [Cursor](https://cursor.com)