### PR TITLE
fix(dashboards): load filterOptions based on events table if v4 enabled

### DIFF
--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -12,6 +12,7 @@ import {
   getEventsGroupedByModelId,
   getEventsGroupedByName,
   getEventsGroupedByTraceName,
+  getEventsGroupedByTraceTags,
   getEventsGroupedByPromptName,
   getEventsGroupedByType,
   getEventsGroupedByUserId,
@@ -27,7 +28,6 @@ import {
   getEventsGroupedByCalledToolName,
   getNumericScoresGroupedByName,
   getScoresGroupedByNameSourceType,
-  getTracesGroupedByTags,
   getObservationsBatchIOFromEventsTable,
   getScoresForObservations,
   getScoresForTraces,
@@ -241,14 +241,6 @@ export async function getEventFilterOptions(
         }))
       : [];
 
-  const getClickhouseTraceTags = async (): Promise<Array<{ tag: string }>> => {
-    const traces = await getTracesGroupedByTags({
-      projectId,
-      filter: traceTimestampFilters,
-    });
-    return traces.map((i) => ({ tag: i.value }));
-  };
-
   const [
     numericScoreNames,
     categoricalScoreNames,
@@ -281,7 +273,7 @@ export async function getEventFilterOptions(
     getEventsGroupedByModel(projectId, eventsFilter),
     getEventsGroupedByName(projectId, eventsFilter),
     getEventsGroupedByPromptName(projectId, eventsFilter),
-    getClickhouseTraceTags(),
+    getEventsGroupedByTraceTags(projectId, eventsFilter),
     getEventsGroupedByTraceName(projectId, eventsFilter),
     getEventsGroupedByModelId(projectId, eventsFilter),
     getEventsGroupedByType(projectId, eventsFilter),

--- a/web/src/hooks/useDashboardFilterOptions.ts
+++ b/web/src/hooks/useDashboardFilterOptions.ts
@@ -1,0 +1,53 @@
+import { useMemo } from "react";
+import { api } from "@/src/utils/api";
+
+type UseDashboardFilterOptionsParams = {
+  projectId: string;
+  isBetaEnabled: boolean;
+};
+
+const toNameOption = (n: { value: string; count: string | number }) => ({
+  value: n.value,
+  count: Number(n.count),
+});
+
+export function useDashboardFilterOptions({
+  projectId,
+  isBetaEnabled,
+}: UseDashboardFilterOptionsParams) {
+  const commonQueryOptions = {
+    trpc: { context: { skipBatch: true } },
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: Infinity,
+  } as const;
+
+  const traceFilterOptions = api.traces.filterOptions.useQuery(
+    { projectId },
+    { ...commonQueryOptions, enabled: !isBetaEnabled },
+  );
+
+  const eventsFilterOptions = api.events.filterOptions.useQuery(
+    { projectId },
+    { ...commonQueryOptions, enabled: isBetaEnabled },
+  );
+
+  const nameOptions = useMemo(
+    () =>
+      isBetaEnabled
+        ? (eventsFilterOptions.data?.traceName?.map(toNameOption) ?? [])
+        : (traceFilterOptions.data?.name?.map(toNameOption) ?? []),
+    [
+      isBetaEnabled,
+      eventsFilterOptions.data?.traceName,
+      traceFilterOptions.data?.name,
+    ],
+  );
+
+  const tagsOptions = isBetaEnabled
+    ? (eventsFilterOptions.data?.traceTags ?? [])
+    : (traceFilterOptions.data?.tags ?? []);
+
+  return { nameOptions, tagsOptions };
+}

--- a/web/src/hooks/useDashboardFilterOptions.ts
+++ b/web/src/hooks/useDashboardFilterOptions.ts
@@ -1,9 +1,14 @@
 import { useMemo } from "react";
 import { api } from "@/src/utils/api";
+import {
+  toAbsoluteTimeRange,
+  type TimeRange,
+} from "@/src/utils/date-range-utils";
 
 type UseDashboardFilterOptionsParams = {
   projectId: string;
   isBetaEnabled: boolean;
+  timeRange: TimeRange;
 };
 
 const toNameOption = (n: { value: string; count: string | number }) => ({
@@ -14,6 +19,7 @@ const toNameOption = (n: { value: string; count: string | number }) => ({
 export function useDashboardFilterOptions({
   projectId,
   isBetaEnabled,
+  timeRange,
 }: UseDashboardFilterOptionsParams) {
   const commonQueryOptions = {
     trpc: { context: { skipBatch: true } },
@@ -23,13 +29,43 @@ export function useDashboardFilterOptions({
     staleTime: Infinity,
   } as const;
 
+  const absoluteTimeRange = useMemo(
+    () => toAbsoluteTimeRange(timeRange) ?? undefined,
+    [timeRange],
+  );
+
+  const startTimeFilter = useMemo(
+    () =>
+      absoluteTimeRange
+        ? [
+            {
+              column: "startTime",
+              type: "datetime" as const,
+              operator: ">" as const,
+              value: absoluteTimeRange.from,
+            },
+            ...(absoluteTimeRange.to
+              ? [
+                  {
+                    column: "startTime",
+                    type: "datetime" as const,
+                    operator: "<" as const,
+                    value: absoluteTimeRange.to,
+                  },
+                ]
+              : []),
+          ]
+        : undefined,
+    [absoluteTimeRange],
+  );
+
   const traceFilterOptions = api.traces.filterOptions.useQuery(
     { projectId },
     { ...commonQueryOptions, enabled: !isBetaEnabled },
   );
 
   const eventsFilterOptions = api.events.filterOptions.useQuery(
-    { projectId },
+    { projectId, startTimeFilter },
     { ...commonQueryOptions, enabled: isBetaEnabled },
   );
 

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -1,5 +1,7 @@
 import { useRouter } from "next/router";
 import { api } from "@/src/utils/api";
+import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
+import { useDashboardFilterOptions } from "@/src/hooks/useDashboardFilterOptions";
 import Page from "@/src/components/layouts/page";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
 import { TimeRangePicker } from "@/src/components/date-picker";
@@ -54,6 +56,7 @@ export default function DashboardDetail() {
   };
 
   const lookbackLimit = useEntitlementLimit("data-access-days");
+  const { isBetaEnabled } = useV4Beta();
 
   // Fetch dashboard data
   const dashboard = api.dashboard.getDashboard.useQuery({
@@ -195,22 +198,10 @@ export default function DashboardDetail() {
     ],
   );
 
-  const traceFilterOptions = api.traces.filterOptions.useQuery(
-    {
-      projectId,
-    },
-    {
-      trpc: {
-        context: {
-          skipBatch: true,
-        },
-      },
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      staleTime: Infinity,
-    },
-  );
+  const { nameOptions, tagsOptions } = useDashboardFilterOptions({
+    projectId,
+    isBetaEnabled,
+  });
 
   const environmentOptionsState = useEnvironmentFilterOptionsCache({
     projectId,
@@ -221,9 +212,6 @@ export default function DashboardDetail() {
       value,
     }),
   );
-  const nameOptions = traceFilterOptions.data?.name || [];
-  const tagsOptions = traceFilterOptions.data?.tags || [];
-
   // Filter columns for PopoverFilterBuilder
   const filterColumns: ColumnDefinition[] = [
     {

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -201,6 +201,7 @@ export default function DashboardDetail() {
   const { nameOptions, tagsOptions } = useDashboardFilterOptions({
     projectId,
     isBetaEnabled,
+    timeRange,
   });
 
   const environmentOptionsState = useEnvironmentFilterOptionsCache({

--- a/web/src/pages/project/[projectId]/index.tsx
+++ b/web/src/pages/project/[projectId]/index.tsx
@@ -8,7 +8,7 @@ import { ModelUsageChart } from "@/src/features/dashboard/components/ModelUsageC
 import { TracesAndObservationsTimeSeriesChart } from "@/src/features/dashboard/components/TracesTimeSeriesChart";
 import { UserChart } from "@/src/features/dashboard/components/UserChart";
 import { TimeRangePicker } from "@/src/components/date-picker";
-import { api } from "@/src/utils/api";
+import { useDashboardFilterOptions } from "@/src/hooks/useDashboardFilterOptions";
 import { FeedbackButtonWrapper } from "@/src/features/feedback/component/FeedbackButton";
 import { BarChart2 } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
@@ -79,22 +79,10 @@ export default function Dashboard() {
     projectId,
   );
 
-  const traceFilterOptions = api.traces.filterOptions.useQuery(
-    {
-      projectId,
-    },
-    {
-      trpc: {
-        context: {
-          skipBatch: true,
-        },
-      },
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      staleTime: Infinity,
-    },
-  );
+  const { nameOptions, tagsOptions } = useDashboardFilterOptions({
+    projectId,
+    isBetaEnabled,
+  });
 
   const environmentOptionsState = useEnvironmentFilterOptionsCache({
     projectId,
@@ -105,13 +93,6 @@ export default function Dashboard() {
 
   const { selectedEnvironments, setSelectedEnvironments } =
     useEnvironmentFilter(environmentOptions, projectId);
-
-  const nameOptions =
-    traceFilterOptions.data?.name?.map((n) => ({
-      value: n.value,
-      count: Number(n.count),
-    })) || [];
-  const tagsOptions = traceFilterOptions.data?.tags || [];
 
   const filterColumns: ColumnDefinition[] = [
     {

--- a/web/src/pages/project/[projectId]/index.tsx
+++ b/web/src/pages/project/[projectId]/index.tsx
@@ -82,6 +82,7 @@ export default function Dashboard() {
   const { nameOptions, tagsOptions } = useDashboardFilterOptions({
     projectId,
     isBetaEnabled,
+    timeRange,
   });
 
   const environmentOptionsState = useEnvironmentFilterOptionsCache({


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Loads dashboard filterOptions (trace name and tags) based on isV4BetaEnabled toggle.

**Problem**: The v4 beta toggle switches dashboard charts to query from the `events_core` table (v2), but the filter option dropdowns (with counts) always queried `api.traces.filterOptions` (v1 tables). This meant the counts and available values in filters didn't match the data actually being charted.

**Fix**: Created a `useDashboardFilterOptions` hook that conditionally queries the correct endpoint based on the beta toggle — `api.traces.filterOptions` when OFF, `api.events.filterOptions` when ON — and normalizes the different field names (`name`/`tags` vs `traceName`/`traceTags`). Applied it to both the Home Dashboard and Custom Dashboards pages.

<div>
    <a href="https://www.loom.com/share/12b52a4f75d54ec98494e5c247fd0cb4">
      <p>Home | Langfuse - 9 March 2026 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/12b52a4f75d54ec98494e5c247fd0cb4">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/12b52a4f75d54ec98494e5c247fd0cb4-a0f14a4ed5373180-full-play.gif#t=0.1">
    </a>
  </div>

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->
