### PR TITLE
chore: document Codex environment setup and add bootstrap scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ Minimum verification matrix:
 - Root `AGENTS.md` is monorepo-level only.
 - Package-local runbooks, commands, and entry points belong in package `AGENTS.md` files.
 - Keep guidance DRY: canonicalize to the most specific file.
+- Repo-owned Codex cloud bootstrap lives in `scripts/codex/setup.sh` and `scripts/codex/maintenance.sh`; contributors still configure the actual environment in the Codex UI.
 
 ## Release Channel
 - Release workflow is managed at root (`pnpm run release`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,46 @@ Requirements
 
 **Note:** You can also simply run Langfuse in a **GitHub Codespace** via the provided devcontainer. To do this, click on the green "Code" button in the top right corner of the repository and select "Open with Codespaces".
 
+### Codex Cloud Setup
+
+You can also attach this repository to an OpenAI Codex cloud environment. The
+cloud environment itself is configured in the Codex UI, while the repo-owned
+bootstrap is versioned in:
+
+- `scripts/codex/setup.sh`
+- `scripts/codex/maintenance.sh`
+
+Recommended Codex UI configuration:
+
+1. Create a new cloud environment for this repository in the Codex UI.
+2. Choose a base environment with Node.js 24 support.
+3. Set the setup script to:
+
+   ```bash
+   bash scripts/codex/setup.sh
+   ```
+
+4. Set the maintenance script to:
+
+   ```bash
+   bash scripts/codex/maintenance.sh
+   ```
+
+5. Keep internet access disabled by default, or only allow the minimum domains
+   needed for your task.
+6. Add secrets and environment variables in the Codex UI instead of committing
+   them to the repository.
+
+Notes:
+
+- This Codex setup is intended for repository tasks such as code changes,
+  linting, typechecking, and targeted tests.
+- It does **not** start the full Langfuse stack. Local development still uses
+  Docker and `pnpm run dx` / `pnpm run dev`.
+- Running the full application inside Codex requires external services for
+  PostgreSQL, Redis, ClickHouse, and object storage, plus matching environment
+  variables in the Codex UI.
+
 **Steps**
 
 1. Install development dependencies:

--- a/scripts/codex/maintenance.sh
+++ b/scripts/codex/maintenance.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v corepack >/dev/null 2>&1; then
+  echo "corepack is required. Use a Codex base environment with Node.js 24 support."
+  exit 1
+fi
+
+corepack enable
+corepack prepare pnpm@9.5.0 --activate
+
+pnpm install --frozen-lockfile
+
+# Keep generated Prisma artifacts aligned after dependency or schema updates.
+pnpm run db:generate

--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v corepack >/dev/null 2>&1; then
+  echo "corepack is required. Use a Codex base environment with Node.js 24 support."
+  exit 1
+fi
+
+corepack enable
+corepack prepare pnpm@9.5.0 --activate
+
+if [ ! -f .env ]; then
+  cp .env.dev.example .env
+fi
+
+if [ ! -f .env.test ]; then
+  cp .env.test.example .env.test
+fi
+
+pnpm install --frozen-lockfile
+
+# Prisma client generation is needed for typecheck/build tasks in Codex.
+pnpm run db:generate


### PR DESCRIPTION
Summary
- add Codex setup and maintenance scripts that pin pnpm 9.5.0, populate env files, install deps, and regenerate Prisma clients
- document repository-owned Codex bootstrap guidance in `AGENTS.md` and add Codex UI setup steps to `CONTRIBUTING.md`
Testing
- Not run (not requested)