### PR TITLE
chore: Add type filter to default-expanded events table

### DIFF
--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -25,7 +25,7 @@ export const observationEventsFilterConfig: FilterConfig = {
 
   columnDefinitions: eventsTableCols,
 
-  defaultExpanded: ["environment", "name", "hasParentObservation"],
+  defaultExpanded: ["environment", "name", "hasParentObservation", "type"],
 
   facets: [
     {


### PR DESCRIPTION
## Summary
- auto-expand the events table "type" filter by including it in the default expanded list so new sessions see it open automatically

## Testing
- Not run (not requested)