### PR TITLE
feat(web): enable error level filtering in custom dashboard widgets

### DIFF
--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -87,6 +87,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "providedModelName",
     },
     {
+      uiTableName: "Level",
+      viewName: "level",
+    },
+    {
       uiTableName: "Tool Names",
       viewName: "toolNames",
     },

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -567,6 +567,12 @@ export function WidgetForm({
   const tagsOptions = traceFilterOptions.data?.tags || [];
   const modelOptions = generationsFilterOptions.data?.model || [];
   const toolNamesOptions = generationsFilterOptions.data?.toolNames || [];
+  const observationLevelOptions = [
+    { value: "DEBUG" },
+    { value: "DEFAULT" },
+    { value: "WARNING" },
+    { value: "ERROR" },
+  ];
 
   // Filter columns for PopoverFilterBuilder
   const filterColumns: ColumnDefinition[] = [
@@ -647,6 +653,13 @@ export function WidgetForm({
       id: "providedModelName",
       type: "stringOptions",
       options: modelOptions,
+      internal: "internalValue",
+    });
+    filterColumns.push({
+      name: "Level",
+      id: "level",
+      type: "stringOptions",
+      options: observationLevelOptions,
       internal: "internalValue",
     });
   }


### PR DESCRIPTION
### Motivation
- Allow dashboard custom widgets that use the `observations` view to filter by observation/error level (e.g. `DEBUG`, `DEFAULT`, `WARNING`, `ERROR`) so users can target error-level subsets in widgets.

### Description
- Add `observationLevelOptions` and expose a `Level` `stringOptions` filter in the widget form when `selectedView === "observations"` by updating `web/src/features/widgets/components/WidgetForm.tsx`.
- Map the legacy UI column `Level` to the observations view field `level` in `web/src/features/query/dashboardUiTableToViewMapping.ts` so saved legacy filters resolve to the correct view column at runtime.

### Testing
- Ran `pnpm --filter web run lint`, which completed successfully.
- Attempted to start the web dev server with `pnpm --filter web exec dotenv -e ../.env -- next dev --turbopack -p 3000`, but local startup emitted workspace module-resolution errors for `@langfuse/shared` in this environment so full UI verification / screenshot was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af304e56c883288797300da8b791ad)