### PR TITLE
feat(web): enable error level filtering in custom dashboard widgets

### DIFF
--- a/packages/shared/src/tableDefinitions/mapDashboards.ts
+++ b/packages/shared/src/tableDefinitions/mapDashboards.ts
@@ -70,6 +70,12 @@ export const dashboardColumnDefinitions: UiColumnMappings = [
     uiTableName: "Type",
   },
   {
+    clickhouseTableName: "observations",
+    clickhouseSelect: "o.level",
+    uiTableId: "level",
+    uiTableName: "Level",
+  },
+  {
     clickhouseTableName: "traces",
     clickhouseSelect: "t.user_id",
     uiTableId: "userId",

--- a/web/src/__tests__/server/queryBuilderDashboards.servertest.ts
+++ b/web/src/__tests__/server/queryBuilderDashboards.servertest.ts
@@ -7,6 +7,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { type QueryType } from "@/src/features/query/types";
 import { executeQuery } from "@/src/features/query/server/queryExecutor";
+import { mapLegacyUiTableFilterToView } from "@/src/features/query";
 
 describe("selfServeDashboards", () => {
   // Single project ID for all tests
@@ -31,6 +32,7 @@ describe("selfServeDashboards", () => {
     recentProductionTraces: 0, // within the last hour
     traceCounts: {} as Record<string, number>, // counts by trace name
     environmentCounts: {} as Record<string, number>, // counts by environment
+    observationLevelCounts: {} as Record<string, number>, // counts by level
   };
 
   beforeAll(async () => {
@@ -126,6 +128,7 @@ describe("selfServeDashboards", () => {
           trace_id: traceId,
           name: "gpt-4-turbo",
           type: "generation",
+          level: i === 0 ? "ERROR" : i === 1 ? "WARNING" : ("DEFAULT" as const),
           environment: "production",
           start_time: now.getTime() - i * 10000,
           completion_start_time: now.getTime() - i * 10000 + 800, // 800ms time to first token
@@ -144,6 +147,7 @@ describe("selfServeDashboards", () => {
           trace_id: traceId,
           name: "text-embedding-ada-002",
           type: "generation",
+          level: i === 0 ? "ERROR" : ("WARNING" as const),
           environment: "production",
           start_time: now.getTime() - i * 15000,
           completion_start_time: now.getTime() - i * 15000 + 200, // 200ms time to first token
@@ -162,6 +166,7 @@ describe("selfServeDashboards", () => {
           trace_id: traceId,
           name: "claude-3-opus",
           type: "generation",
+          level: i === 0 ? "DEFAULT" : ("ERROR" as const),
           environment: "development",
           start_time: oneHourAgo.getTime() - i * 20000,
           completion_start_time: oneHourAgo.getTime() - i * 20000 + 1200, // 1200ms time to first token
@@ -190,6 +195,13 @@ describe("selfServeDashboards", () => {
     traces.forEach((trace) => {
       stats.traceCounts[trace.name || ""] =
         (stats.traceCounts[trace.name || ""] || 0) + 1;
+    });
+
+    // Count observations by level
+    observations.forEach((observation) => {
+      const level = observation.level || "DEFAULT";
+      stats.observationLevelCounts[level] =
+        (stats.observationLevelCounts[level] || 0) + 1;
     });
 
     // Count recent production traces (within the last hour)
@@ -547,6 +559,41 @@ describe("selfServeDashboards", () => {
         expect(modelRow.sum_totalCost).toBeGreaterThan(500);
         expect(Number(modelRow.sum_totalTokens)).toBeGreaterThan(10000);
       });
+    });
+  });
+
+  describe("observations-level filter query", () => {
+    it("should support legacy dashboard Level filters after widget remapping", async () => {
+      const legacyFilters: Parameters<typeof mapLegacyUiTableFilterToView>[1] =
+        [
+          {
+            column: "Level",
+            operator: "any of",
+            value: ["ERROR"],
+            type: "stringOptions",
+          },
+        ];
+
+      const queryBuilderQuery: QueryType = {
+        view: "observations",
+        dimensions: [],
+        metrics: [{ measure: "count", aggregation: "count" }],
+        filters: mapLegacyUiTableFilterToView("observations", legacyFilters),
+        timeDimension: null,
+        fromTimestamp: defaultFromTime,
+        toTimestamp: defaultToTime,
+        orderBy: null,
+      };
+
+      const queryBuilderResult = await executeQuery(
+        projectId,
+        queryBuilderQuery,
+      );
+
+      expect(queryBuilderResult).toHaveLength(1);
+      expect(Number(queryBuilderResult[0].count_count)).toBe(
+        stats.observationLevelCounts["ERROR"],
+      );
     });
   });
 

--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -87,6 +87,10 @@ const viewMappings: Record<z.infer<typeof views>, Record<string, string>[]> = {
       viewName: "providedModelName",
     },
     {
+      uiTableName: "Level",
+      viewName: "level",
+    },
+    {
       uiTableName: "Tool Names",
       viewName: "toolNames",
     },

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -567,6 +567,12 @@ export function WidgetForm({
   const tagsOptions = traceFilterOptions.data?.tags || [];
   const modelOptions = generationsFilterOptions.data?.model || [];
   const toolNamesOptions = generationsFilterOptions.data?.toolNames || [];
+  const observationLevelOptions = [
+    { value: "DEBUG" },
+    { value: "DEFAULT" },
+    { value: "WARNING" },
+    { value: "ERROR" },
+  ];
 
   // Filter columns for PopoverFilterBuilder
   const filterColumns: ColumnDefinition[] = [
@@ -647,6 +653,13 @@ export function WidgetForm({
       id: "providedModelName",
       type: "stringOptions",
       options: modelOptions,
+      internal: "internalValue",
+    });
+    filterColumns.push({
+      name: "Level",
+      id: "level",
+      type: "stringOptions",
+      options: observationLevelOptions,
       internal: "internalValue",
     });
   }


### PR DESCRIPTION
### Motivation
- Allow dashboard custom widgets that use the `observations` view to filter by observation/error level (e.g. `DEBUG`, `DEFAULT`, `WARNING`, `ERROR`) so users can target error-level subsets in widgets.

### Description
- Add `observationLevelOptions` and expose a `Level` `stringOptions` filter in the widget form when `selectedView === "observations"` by updating `web/src/features/widgets/components/WidgetForm.tsx`.
- Map the legacy UI column `Level` to the observations view field `level` in `web/src/features/query/dashboardUiTableToViewMapping.ts` so saved legacy filters resolve to the correct view column at runtime.

### Testing
- Ran `pnpm --filter web run lint`, which completed successfully.
- Attempted to start the web dev server with `pnpm --filter web exec dotenv -e ../.env -- next dev --turbopack -p 3000`, but local startup emitted workspace module-resolution errors for `@langfuse/shared` in this environment so full UI verification / screenshot was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af304e56c883288797300da8b791ad)