### PR TITLE
feat: Add AG2 framework integration

### DIFF
--- a/packages/shared/scripts/seeder/utils/framework-traces/ag2-2026-03-09.json
+++ b/packages/shared/scripts/seeder/utils/framework-traces/ag2-2026-03-09.json
@@ -1,0 +1,467 @@
+{
+  "trace": {
+    "id": "a3b7c9d1e5f2a8b4c6d0e2f4a6b8c0d2",
+    "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+    "name": "conversation user_proxy",
+    "timestamp": "2026-03-09T10:15:00.000Z",
+    "environment": "default",
+    "tags": [
+      "ag2",
+      "multi-agent",
+      "tool-use"
+    ],
+    "bookmarked": false,
+    "release": null,
+    "version": "0.11.2",
+    "userId": "user_demo",
+    "sessionId": "session_ag2_demo",
+    "public": true,
+    "input": "\"What is the weather in San Francisco? Use the weather tool.\"",
+    "output": "\"The current weather in San Francisco is 62°F (17°C) with partly cloudy skies and a light breeze from the west at 12 mph.\"",
+    "metadata": "{\"resourceAttributes\":{\"telemetry.sdk.language\":\"python\",\"telemetry.sdk.name\":\"opentelemetry\",\"telemetry.sdk.version\":\"1.40.0\",\"service.name\":\"ag2-demo\"},\"scope\":{\"name\":\"autogen.opentelemetry\",\"version\":\"0.11.2\"},\"attributes\":{\"ag2.span.type\":\"conversation\",\"gen_ai.usage.input_tokens\":186,\"gen_ai.usage.output_tokens\":74,\"gen_ai.usage.cost\":0.000389}}",
+    "createdAt": "2026-03-09T10:15:08.000Z",
+    "updatedAt": "2026-03-09T10:15:08.500Z",
+    "scores": [],
+    "latency": 7.832
+  },
+  "observations": [
+    {
+      "id": "c0a1b2c3d4e5f6a7",
+      "traceId": "a3b7c9d1e5f2a8b4c6d0e2f4a6b8c0d2",
+      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      "type": "SPAN",
+      "environment": "default",
+      "parentObservationId": null,
+      "startTime": "2026-03-09T10:15:00.000Z",
+      "endTime": "2026-03-09T10:15:07.832Z",
+      "name": "conversation user_proxy",
+      "metadata": {
+        "resourceAttributes": {
+          "telemetry.sdk.language": "python",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.40.0",
+          "service.name": "ag2-demo"
+        },
+        "scope": {
+          "name": "autogen.opentelemetry",
+          "version": "0.11.2"
+        },
+        "attributes": {
+          "ag2.span.type": "conversation",
+          "gen_ai.usage.input_tokens": 186,
+          "gen_ai.usage.output_tokens": 74,
+          "gen_ai.usage.cost": 0.000389
+        }
+      },
+      "level": "DEFAULT",
+      "statusMessage": null,
+      "version": null,
+      "modelParameters": null,
+      "completionStartTime": null,
+      "promptId": null,
+      "createdAt": "2026-03-09T10:15:08.000Z",
+      "updatedAt": "2026-03-09T10:15:08.500Z",
+      "usageDetails": {},
+      "costDetails": {},
+      "providedCostDetails": {},
+      "model": null,
+      "internalModelId": null,
+      "promptName": null,
+      "promptVersion": null,
+      "latency": 7832,
+      "timeToFirstToken": null,
+      "inputCost": null,
+      "outputCost": null,
+      "totalCost": 0.000389,
+      "inputUsage": 186,
+      "outputUsage": 74,
+      "totalUsage": 260,
+      "input": [
+        {"role": "user", "content": "What is the weather in San Francisco? Use the weather tool."}
+      ],
+      "output": [
+        {"role": "assistant", "content": "The current weather in San Francisco is 62°F (17°C) with partly cloudy skies and a light breeze from the west at 12 mph."}
+      ]
+    },
+    {
+      "id": "d1b2c3d4e5f6a7b8",
+      "traceId": "a3b7c9d1e5f2a8b4c6d0e2f4a6b8c0d2",
+      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      "type": "SPAN",
+      "environment": "default",
+      "parentObservationId": "c0a1b2c3d4e5f6a7",
+      "startTime": "2026-03-09T10:15:00.050Z",
+      "endTime": "2026-03-09T10:15:03.200Z",
+      "name": "invoke_agent assistant",
+      "metadata": {
+        "resourceAttributes": {
+          "telemetry.sdk.language": "python",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.40.0",
+          "service.name": "ag2-demo"
+        },
+        "scope": {
+          "name": "autogen.opentelemetry",
+          "version": "0.11.2"
+        },
+        "attributes": {
+          "ag2.span.type": "agent",
+          "ag2.agent.name": "assistant"
+        }
+      },
+      "level": "DEFAULT",
+      "statusMessage": null,
+      "version": null,
+      "modelParameters": null,
+      "completionStartTime": null,
+      "promptId": null,
+      "createdAt": "2026-03-09T10:15:03.300Z",
+      "updatedAt": "2026-03-09T10:15:03.400Z",
+      "usageDetails": {},
+      "costDetails": {},
+      "providedCostDetails": {},
+      "model": null,
+      "internalModelId": null,
+      "promptName": null,
+      "promptVersion": null,
+      "latency": 3150,
+      "timeToFirstToken": null,
+      "inputCost": null,
+      "outputCost": null,
+      "totalCost": 0,
+      "inputUsage": 0,
+      "outputUsage": 0,
+      "totalUsage": 0,
+      "input": [
+        {"role": "system", "content": "You are a helpful weather assistant. Use the get_weather tool to answer weather questions."},
+        {"role": "user", "content": "What is the weather in San Francisco? Use the weather tool."}
+      ],
+      "output": [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_abc123", "function": {"name": "get_weather", "arguments": "{\"location\": \"San Francisco, CA\"}"}, "type": "function"}]}
+      ]
+    },
+    {
+      "id": "e2c3d4e5f6a7b8c9",
+      "traceId": "a3b7c9d1e5f2a8b4c6d0e2f4a6b8c0d2",
+      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      "type": "GENERATION",
+      "environment": "default",
+      "parentObservationId": "d1b2c3d4e5f6a7b8",
+      "startTime": "2026-03-09T10:15:00.100Z",
+      "endTime": "2026-03-09T10:15:02.850Z",
+      "name": "chat gpt-4o-mini",
+      "metadata": {
+        "resourceAttributes": {
+          "telemetry.sdk.language": "python",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.40.0",
+          "service.name": "ag2-demo"
+        },
+        "scope": {
+          "name": "autogen.opentelemetry",
+          "version": "0.11.2"
+        },
+        "attributes": {
+          "ag2.span.type": "llm",
+          "gen_ai.system": "openai",
+          "gen_ai.request.model": "gpt-4o-mini",
+          "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+          "gen_ai.response.finish_reasons": ["tool_calls"],
+          "gen_ai.usage.input_tokens": 82,
+          "gen_ai.usage.output_tokens": 24
+        }
+      },
+      "level": "DEFAULT",
+      "statusMessage": null,
+      "version": null,
+      "modelParameters": {
+        "temperature": 1,
+        "top_p": 1,
+        "frequency_penalty": 0,
+        "presence_penalty": 0,
+        "is_stream": false
+      },
+      "completionStartTime": null,
+      "promptId": null,
+      "createdAt": "2026-03-09T10:15:02.900Z",
+      "updatedAt": "2026-03-09T10:15:02.950Z",
+      "usageDetails": {
+        "input": 82,
+        "output": 24,
+        "total": 106
+      },
+      "costDetails": {
+        "total": 0.0000195
+      },
+      "providedCostDetails": {
+        "total": 0.0000195
+      },
+      "model": "gpt-4o-mini",
+      "internalModelId": null,
+      "promptName": null,
+      "promptVersion": null,
+      "latency": 2750,
+      "timeToFirstToken": null,
+      "inputCost": null,
+      "outputCost": null,
+      "totalCost": 0.0000195,
+      "inputUsage": 82,
+      "outputUsage": 24,
+      "totalUsage": 106,
+      "input": [
+        {"role": "system", "content": "You are a helpful weather assistant. Use the get_weather tool to answer weather questions."},
+        {"role": "user", "content": "What is the weather in San Francisco? Use the weather tool."}
+      ],
+      "output": [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_abc123", "function": {"name": "get_weather", "arguments": "{\"location\": \"San Francisco, CA\"}"}, "type": "function"}]}
+      ]
+    },
+    {
+      "id": "f3d4e5f6a7b8c9d0",
+      "traceId": "a3b7c9d1e5f2a8b4c6d0e2f4a6b8c0d2",
+      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      "type": "SPAN",
+      "environment": "default",
+      "parentObservationId": "c0a1b2c3d4e5f6a7",
+      "startTime": "2026-03-09T10:15:03.250Z",
+      "endTime": "2026-03-09T10:15:03.800Z",
+      "name": "invoke_agent user_proxy",
+      "metadata": {
+        "resourceAttributes": {
+          "telemetry.sdk.language": "python",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.40.0",
+          "service.name": "ag2-demo"
+        },
+        "scope": {
+          "name": "autogen.opentelemetry",
+          "version": "0.11.2"
+        },
+        "attributes": {
+          "ag2.span.type": "agent",
+          "ag2.agent.name": "user_proxy"
+        }
+      },
+      "level": "DEFAULT",
+      "statusMessage": null,
+      "version": null,
+      "modelParameters": null,
+      "completionStartTime": null,
+      "promptId": null,
+      "createdAt": "2026-03-09T10:15:03.900Z",
+      "updatedAt": "2026-03-09T10:15:03.950Z",
+      "usageDetails": {},
+      "costDetails": {},
+      "providedCostDetails": {},
+      "model": null,
+      "internalModelId": null,
+      "promptName": null,
+      "promptVersion": null,
+      "latency": 550,
+      "timeToFirstToken": null,
+      "inputCost": null,
+      "outputCost": null,
+      "totalCost": 0,
+      "inputUsage": 0,
+      "outputUsage": 0,
+      "totalUsage": 0,
+      "input": [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_abc123", "function": {"name": "get_weather", "arguments": "{\"location\": \"San Francisco, CA\"}"}, "type": "function"}]}
+      ],
+      "output": [
+        {"role": "tool", "tool_call_id": "call_abc123", "content": "{\"location\": \"San Francisco, CA\", \"temperature_f\": 62, \"temperature_c\": 17, \"condition\": \"Partly Cloudy\", \"wind\": \"W 12 mph\", \"humidity\": \"68%\"}"}
+      ]
+    },
+    {
+      "id": "a4e5f6a7b8c9d0e1",
+      "traceId": "a3b7c9d1e5f2a8b4c6d0e2f4a6b8c0d2",
+      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      "type": "SPAN",
+      "environment": "default",
+      "parentObservationId": "f3d4e5f6a7b8c9d0",
+      "startTime": "2026-03-09T10:15:03.300Z",
+      "endTime": "2026-03-09T10:15:03.750Z",
+      "name": "execute_tool get_weather",
+      "metadata": {
+        "resourceAttributes": {
+          "telemetry.sdk.language": "python",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.40.0",
+          "service.name": "ag2-demo"
+        },
+        "scope": {
+          "name": "autogen.opentelemetry",
+          "version": "0.11.2"
+        },
+        "attributes": {
+          "ag2.span.type": "tool",
+          "gen_ai.tool.name": "get_weather",
+          "gen_ai.tool.call.id": "call_abc123",
+          "gen_ai.tool.description": "Get current weather for a location"
+        }
+      },
+      "level": "DEFAULT",
+      "statusMessage": null,
+      "version": null,
+      "modelParameters": null,
+      "completionStartTime": null,
+      "promptId": null,
+      "createdAt": "2026-03-09T10:15:03.800Z",
+      "updatedAt": "2026-03-09T10:15:03.850Z",
+      "usageDetails": {},
+      "costDetails": {},
+      "providedCostDetails": {},
+      "model": null,
+      "internalModelId": null,
+      "promptName": null,
+      "promptVersion": null,
+      "latency": 450,
+      "timeToFirstToken": null,
+      "inputCost": null,
+      "outputCost": null,
+      "totalCost": 0,
+      "inputUsage": 0,
+      "outputUsage": 0,
+      "totalUsage": 0,
+      "input": "{\"location\": \"San Francisco, CA\"}",
+      "output": "{\"location\": \"San Francisco, CA\", \"temperature_f\": 62, \"temperature_c\": 17, \"condition\": \"Partly Cloudy\", \"wind\": \"W 12 mph\", \"humidity\": \"68%\"}"
+    },
+    {
+      "id": "b5f6a7b8c9d0e1f2",
+      "traceId": "a3b7c9d1e5f2a8b4c6d0e2f4a6b8c0d2",
+      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      "type": "SPAN",
+      "environment": "default",
+      "parentObservationId": "c0a1b2c3d4e5f6a7",
+      "startTime": "2026-03-09T10:15:03.850Z",
+      "endTime": "2026-03-09T10:15:07.800Z",
+      "name": "invoke_agent assistant",
+      "metadata": {
+        "resourceAttributes": {
+          "telemetry.sdk.language": "python",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.40.0",
+          "service.name": "ag2-demo"
+        },
+        "scope": {
+          "name": "autogen.opentelemetry",
+          "version": "0.11.2"
+        },
+        "attributes": {
+          "ag2.span.type": "agent",
+          "ag2.agent.name": "assistant"
+        }
+      },
+      "level": "DEFAULT",
+      "statusMessage": null,
+      "version": null,
+      "modelParameters": null,
+      "completionStartTime": null,
+      "promptId": null,
+      "createdAt": "2026-03-09T10:15:07.850Z",
+      "updatedAt": "2026-03-09T10:15:07.900Z",
+      "usageDetails": {},
+      "costDetails": {},
+      "providedCostDetails": {},
+      "model": null,
+      "internalModelId": null,
+      "promptName": null,
+      "promptVersion": null,
+      "latency": 3950,
+      "timeToFirstToken": null,
+      "inputCost": null,
+      "outputCost": null,
+      "totalCost": 0,
+      "inputUsage": 0,
+      "outputUsage": 0,
+      "totalUsage": 0,
+      "input": [
+        {"role": "system", "content": "You are a helpful weather assistant. Use the get_weather tool to answer weather questions."},
+        {"role": "user", "content": "What is the weather in San Francisco? Use the weather tool."},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_abc123", "function": {"name": "get_weather", "arguments": "{\"location\": \"San Francisco, CA\"}"}, "type": "function"}]},
+        {"role": "tool", "tool_call_id": "call_abc123", "content": "{\"location\": \"San Francisco, CA\", \"temperature_f\": 62, \"temperature_c\": 17, \"condition\": \"Partly Cloudy\", \"wind\": \"W 12 mph\", \"humidity\": \"68%\"}"}
+      ],
+      "output": [
+        {"role": "assistant", "content": "The current weather in San Francisco is 62°F (17°C) with partly cloudy skies and a light breeze from the west at 12 mph."}
+      ]
+    },
+    {
+      "id": "c6a7b8c9d0e1f2a3",
+      "traceId": "a3b7c9d1e5f2a8b4c6d0e2f4a6b8c0d2",
+      "projectId": "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a",
+      "type": "GENERATION",
+      "environment": "default",
+      "parentObservationId": "b5f6a7b8c9d0e1f2",
+      "startTime": "2026-03-09T10:15:03.900Z",
+      "endTime": "2026-03-09T10:15:07.750Z",
+      "name": "chat gpt-4o-mini",
+      "metadata": {
+        "resourceAttributes": {
+          "telemetry.sdk.language": "python",
+          "telemetry.sdk.name": "opentelemetry",
+          "telemetry.sdk.version": "1.40.0",
+          "service.name": "ag2-demo"
+        },
+        "scope": {
+          "name": "autogen.opentelemetry",
+          "version": "0.11.2"
+        },
+        "attributes": {
+          "ag2.span.type": "llm",
+          "gen_ai.system": "openai",
+          "gen_ai.request.model": "gpt-4o-mini",
+          "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+          "gen_ai.response.finish_reasons": ["stop"],
+          "gen_ai.usage.input_tokens": 104,
+          "gen_ai.usage.output_tokens": 50
+        }
+      },
+      "level": "DEFAULT",
+      "statusMessage": null,
+      "version": null,
+      "modelParameters": {
+        "temperature": 1,
+        "top_p": 1,
+        "frequency_penalty": 0,
+        "presence_penalty": 0,
+        "is_stream": false
+      },
+      "completionStartTime": null,
+      "promptId": null,
+      "createdAt": "2026-03-09T10:15:07.800Z",
+      "updatedAt": "2026-03-09T10:15:07.850Z",
+      "usageDetails": {
+        "input": 104,
+        "output": 50,
+        "total": 154
+      },
+      "costDetails": {
+        "total": 0.0000369
+      },
+      "providedCostDetails": {
+        "total": 0.0000369
+      },
+      "model": "gpt-4o-mini",
+      "internalModelId": null,
+      "promptName": null,
+      "promptVersion": null,
+      "latency": 3850,
+      "timeToFirstToken": null,
+      "inputCost": null,
+      "outputCost": null,
+      "totalCost": 0.0000369,
+      "inputUsage": 104,
+      "outputUsage": 50,
+      "totalUsage": 154,
+      "input": [
+        {"role": "system", "content": "You are a helpful weather assistant. Use the get_weather tool to answer weather questions."},
+        {"role": "user", "content": "What is the weather in San Francisco? Use the weather tool."},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_abc123", "function": {"name": "get_weather", "arguments": "{\"location\": \"San Francisco, CA\"}"}, "type": "function"}]},
+        {"role": "tool", "tool_call_id": "call_abc123", "content": "{\"location\": \"San Francisco, CA\", \"temperature_f\": 62, \"temperature_c\": 17, \"condition\": \"Partly Cloudy\", \"wind\": \"W 12 mph\", \"humidity\": \"68%\"}"}
+      ],
+      "output": [
+        {"role": "assistant", "content": "The current weather in San Francisco is 62°F (17°C) with partly cloudy skies and a light breeze from the west at 12 mph."}
+      ]
+    }
+  ]
+}

--- a/packages/shared/src/utils/chatml/adapters/ag2.ts
+++ b/packages/shared/src/utils/chatml/adapters/ag2.ts
@@ -118,6 +118,14 @@ export const ag2Adapter: ProviderAdapter = {
     // Explicit framework override
     if (ctx.framework === "ag2" || ctx.framework === "autogen") return true;
 
+    // Check observation name for AG2 patterns (before metadata, as metadata may be absent)
+    if (ctx.observationName) {
+      for (const pattern of AG2_NAME_PATTERNS) {
+        if (pattern.test(ctx.observationName)) return true;
+      }
+      // "chat <model>" pattern is too generic, only match if combined with other signals
+    }
+
     const meta = parseMetadata(ctx.metadata);
     if (!meta) return false;
 
@@ -136,14 +144,6 @@ export const ag2Adapter: ProviderAdapter = {
 
       // Check for ag2-prefixed attributes
       if (Object.keys(attrs).some((key) => key.startsWith("ag2."))) return true;
-    }
-
-    // Check observation name for AG2 patterns
-    if (ctx.observationName) {
-      for (const pattern of AG2_NAME_PATTERNS) {
-        if (pattern.test(ctx.observationName)) return true;
-      }
-      // "chat <model>" pattern is too generic, only match if combined with other signals
     }
 
     return false;

--- a/packages/shared/src/utils/chatml/adapters/ag2.ts
+++ b/packages/shared/src/utils/chatml/adapters/ag2.ts
@@ -1,0 +1,159 @@
+import type { NormalizerContext, ProviderAdapter } from "../types";
+import {
+  removeNullFields,
+  stringifyToolResultContent,
+  parseMetadata,
+  getNestedProperty,
+} from "../helpers";
+
+/**
+ * AG2 (formerly AutoGen) adapter
+ *
+ * AG2 v0.11+ emits native OpenTelemetry spans with GenAI semantic conventions.
+ * Span types (ag2.span.type): conversation, agent, llm, tool, code_execution,
+ * human_input, speaker_selection.
+ *
+ * Detection:
+ * - scope.name containing "autogen" or "ag2"
+ * - attributes with "ag2.span.type"
+ * - observation name patterns: "conversation ", "invoke_agent ", "chat ",
+ *   "execute_tool ", "execute_code ", "speaker_selection"
+ *
+ * Message format: AG2 uses OpenAI-compatible ChatML via OpenAIWrapper,
+ * so LLM span input/output follows OpenAI Chat Completions format.
+ * Agent-level spans carry conversation messages as arrays.
+ */
+
+// AG2 agent-level messages can have a "name" field for the agent identity
+// and use standard OpenAI roles, but may also include AG2-specific fields
+function normalizeMessage(msg: unknown): Record<string, unknown> {
+  if (!msg || typeof msg !== "object") return {};
+
+  const normalized = removeNullFields(msg);
+
+  // AG2 tool results: content may be an object
+  if (
+    normalized.role === "tool" &&
+    typeof normalized.content === "object" &&
+    normalized.content !== null &&
+    !Array.isArray(normalized.content)
+  ) {
+    normalized.content = stringifyToolResultContent(normalized.content);
+  }
+
+  // Flatten nested tool_calls format (OpenAI-style {function: {name, arguments}})
+  if (normalized.tool_calls && Array.isArray(normalized.tool_calls)) {
+    normalized.tool_calls = (normalized.tool_calls as unknown[])
+      .filter(
+        (tc): tc is Record<string, unknown> =>
+          Boolean(tc) && typeof tc === "object",
+      )
+      .map((tc) => {
+        if (tc.function && typeof tc.function === "object") {
+          const func = tc.function as Record<string, unknown>;
+          return {
+            id: tc.id,
+            name: func.name,
+            arguments:
+              typeof func.arguments === "string"
+                ? func.arguments
+                : JSON.stringify(func.arguments ?? {}),
+            type: tc.type || "function",
+          };
+        }
+        return {
+          ...tc,
+          arguments:
+            typeof tc.arguments === "string"
+              ? tc.arguments
+              : JSON.stringify(tc.arguments ?? {}),
+        };
+      });
+  }
+
+  return normalized;
+}
+
+function preprocessData(data: unknown): unknown {
+  if (!data) return data;
+
+  // Array of messages
+  if (Array.isArray(data)) {
+    return data.map(normalizeMessage);
+  }
+
+  // Object with messages key
+  if (typeof data === "object" && "messages" in data) {
+    const obj = data as Record<string, unknown>;
+    return {
+      ...obj,
+      messages: Array.isArray(obj.messages)
+        ? obj.messages.map(normalizeMessage)
+        : obj.messages,
+    };
+  }
+
+  // Single message
+  if (typeof data === "object" && "role" in data) {
+    return [normalizeMessage(data)];
+  }
+
+  return data;
+}
+
+/** AG2-specific observation name patterns */
+const AG2_NAME_PATTERNS = [
+  /^conversation\s/,
+  /^invoke_agent\s/,
+  /^execute_tool\s/,
+  /^execute_code\s/,
+  /^await_human_input\s/,
+  /^speaker_selection$/,
+];
+
+export const ag2Adapter: ProviderAdapter = {
+  id: "ag2",
+
+  detect(ctx: NormalizerContext): boolean {
+    // Explicit framework override
+    if (ctx.framework === "ag2" || ctx.framework === "autogen") return true;
+
+    const meta = parseMetadata(ctx.metadata);
+    if (!meta) return false;
+
+    // Check scope.name for autogen or ag2
+    const scopeName = getNestedProperty(meta, "scope", "name");
+    if (typeof scopeName === "string") {
+      const lower = scopeName.toLowerCase();
+      if (lower.includes("autogen") || lower.includes("ag2")) return true;
+    }
+
+    // Check for ag2.span.type attribute
+    const attributes = getNestedProperty(meta, "attributes");
+    if (attributes && typeof attributes === "object") {
+      const attrs = attributes as Record<string, unknown>;
+      if ("ag2.span.type" in attrs) return true;
+
+      // Check for ag2-prefixed attributes
+      if (Object.keys(attrs).some((key) => key.startsWith("ag2."))) return true;
+    }
+
+    // Check observation name for AG2 patterns
+    if (ctx.observationName) {
+      for (const pattern of AG2_NAME_PATTERNS) {
+        if (pattern.test(ctx.observationName)) return true;
+      }
+      // "chat <model>" pattern is too generic, only match if combined with other signals
+    }
+
+    return false;
+  },
+
+  preprocess(
+    data: unknown,
+    _kind: "input" | "output",
+    _ctx: NormalizerContext,
+  ): unknown {
+    return preprocessData(data);
+  },
+};

--- a/packages/shared/src/utils/chatml/adapters/index.ts
+++ b/packages/shared/src/utils/chatml/adapters/index.ts
@@ -1,4 +1,5 @@
 import type { NormalizerContext, ProviderAdapter } from "../types";
+import { ag2Adapter } from "./ag2";
 import { langgraphAdapter } from "./langgraph";
 import { aisdkAdapter } from "./aisdk";
 import { openAIAdapter } from "./openai";
@@ -9,6 +10,7 @@ import { pydanticAIAdapter } from "./pydantic-ai";
 import { genericAdapter } from "./generic";
 
 const adapters: ProviderAdapter[] = [
+  ag2Adapter, // AG2 (formerly AutoGen) - detects by scope.name or ag2.span.type
   langgraphAdapter, // Must be before openAI (both use langfuse-sdk scope)
   aisdkAdapter, // Vercel AI SDK v5 (for all LLM providers like OpenAI, Bedrock, Anthropic, etc.)
   openAIAdapter, // OpenAI (Chat Completions & Responses API)
@@ -40,6 +42,7 @@ function selectAdapter(ctx: NormalizerContext): ProviderAdapter {
 // Export selectAdapter and individual adapters for direct use
 export { selectAdapter };
 export type { NormalizerContext, ProviderAdapter } from "../types";
+export { ag2Adapter } from "./ag2";
 export { langgraphAdapter } from "./langgraph";
 export { aisdkAdapter } from "./aisdk";
 export { openAIAdapter } from "./openai";

--- a/packages/shared/src/utils/chatml/index.ts
+++ b/packages/shared/src/utils/chatml/index.ts
@@ -10,6 +10,7 @@ export {
 // Explicitly export adapters to ensure they're available
 export {
   selectAdapter,
+  ag2Adapter,
   langgraphAdapter,
   aisdkAdapter,
   openAIAdapter,

--- a/web/src/features/support-chat/formConstants.ts
+++ b/web/src/features/support-chat/formConstants.ts
@@ -55,6 +55,7 @@ export const IntegrationTypeSchema = z.enum([
   "Vercel AI SDK",
   "LangChain",
   "LangGraph",
+  "AG2 (AutoGen)",
   "OTel Instrumentation",
   "LLM Proxy (LiteLLM)",
   "3rd Party (Dify / LangFlow / Flowise)",

--- a/worker/src/__tests__/chatml/adapters/ag2.test.ts
+++ b/worker/src/__tests__/chatml/adapters/ag2.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect } from "vitest";
+import {
+  ag2Adapter,
+  selectAdapter,
+  normalizeInput,
+  SimpleChatMlArraySchema,
+  type NormalizerContext,
+} from "@langfuse/shared";
+
+describe("AG2 Adapter", () => {
+  describe("detection", () => {
+    it("should detect AG2 via scope.name containing autogen", () => {
+      expect(
+        ag2Adapter.detect({
+          metadata: {
+            scope: {
+              name: "autogen.opentelemetry",
+              version: "0.11.2",
+            },
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it("should detect AG2 via scope.name containing ag2", () => {
+      expect(
+        ag2Adapter.detect({
+          metadata: {
+            scope: {
+              name: "ag2.tracing",
+            },
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it("should detect AG2 via ag2.span.type attribute", () => {
+      expect(
+        ag2Adapter.detect({
+          metadata: {
+            attributes: {
+              "ag2.span.type": "conversation",
+            },
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it("should detect AG2 via ag2-prefixed attributes", () => {
+      expect(
+        ag2Adapter.detect({
+          metadata: {
+            attributes: {
+              "ag2.agent.name": "assistant",
+            },
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it("should detect AG2 via explicit framework override", () => {
+      expect(ag2Adapter.detect({ framework: "ag2" })).toBe(true);
+      expect(ag2Adapter.detect({ framework: "autogen" })).toBe(true);
+    });
+
+    it("should detect AG2 via observation name patterns", () => {
+      expect(
+        ag2Adapter.detect({ observationName: "conversation user_proxy" }),
+      ).toBe(true);
+      expect(
+        ag2Adapter.detect({ observationName: "invoke_agent assistant" }),
+      ).toBe(true);
+      expect(
+        ag2Adapter.detect({ observationName: "execute_tool get_weather" }),
+      ).toBe(true);
+      expect(
+        ag2Adapter.detect({ observationName: "execute_code assistant" }),
+      ).toBe(true);
+      expect(
+        ag2Adapter.detect({
+          observationName: "await_human_input user_proxy",
+        }),
+      ).toBe(true);
+      expect(ag2Adapter.detect({ observationName: "speaker_selection" })).toBe(
+        true,
+      );
+    });
+
+    it("should NOT detect unrelated frameworks", () => {
+      expect(
+        ag2Adapter.detect({
+          metadata: { scope: { name: "langfuse-sdk" } },
+        }),
+      ).toBe(false);
+
+      expect(
+        ag2Adapter.detect({
+          metadata: { scope: { name: "ai" } },
+        }),
+      ).toBe(false);
+
+      expect(
+        ag2Adapter.detect({
+          metadata: { scope: { name: "pydantic-ai" } },
+        }),
+      ).toBe(false);
+
+      expect(
+        ag2Adapter.detect({
+          metadata: { langgraph_node: "agent" },
+        }),
+      ).toBe(false);
+    });
+
+    it("should NOT detect generic observation names", () => {
+      expect(ag2Adapter.detect({ observationName: "chat gpt-4o-mini" })).toBe(
+        false,
+      );
+
+      expect(ag2Adapter.detect({ observationName: "my-agent" })).toBe(false);
+    });
+
+    it("should detect AG2 via stringified metadata", () => {
+      expect(
+        ag2Adapter.detect({
+          metadata: JSON.stringify({
+            scope: { name: "autogen.opentelemetry" },
+          }),
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("selectAdapter routing", () => {
+    it("should select AG2 adapter for AG2 traces via scope.name", () => {
+      const adapter = selectAdapter({
+        metadata: {
+          scope: {
+            name: "autogen.opentelemetry",
+            version: "0.11.2",
+          },
+        },
+      });
+      expect(adapter.id).toBe("ag2");
+    });
+
+    it("should select AG2 adapter for AG2 traces via ag2.span.type", () => {
+      const adapter = selectAdapter({
+        metadata: {
+          attributes: {
+            "ag2.span.type": "llm",
+            "gen_ai.system": "openai",
+          },
+        },
+      });
+      expect(adapter.id).toBe("ag2");
+    });
+
+    it("should NOT select AG2 adapter for LangGraph traces", () => {
+      const adapter = selectAdapter({
+        metadata: {
+          langgraph_node: "agent",
+          langgraph_step: 3,
+        },
+      });
+      expect(adapter.id).not.toBe("ag2");
+    });
+  });
+
+  describe("preprocessing", () => {
+    it("should normalize OpenAI-style messages with nested tool_calls", () => {
+      const input = [
+        {
+          role: "system",
+          content: "You are a helpful weather assistant.",
+        },
+        {
+          role: "user",
+          content: "What is the weather in San Francisco?",
+        },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call_abc123",
+              type: "function",
+              function: {
+                name: "get_weather",
+                arguments: '{"location": "San Francisco, CA"}',
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_abc123",
+          content: '{"temperature": 62, "condition": "Partly Cloudy"}',
+        },
+      ];
+
+      const ctx: NormalizerContext = {
+        metadata: {
+          scope: { name: "autogen.opentelemetry" },
+          attributes: { "ag2.span.type": "agent" },
+        },
+        data: input,
+      };
+
+      const adapter = selectAdapter(ctx);
+      expect(adapter.id).toBe("ag2");
+
+      const preprocessed = adapter.preprocess(input, "input", ctx);
+      const result = SimpleChatMlArraySchema.safeParse(preprocessed);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(4);
+
+      // System message
+      expect(result.data?.[0].role).toBe("system");
+      expect(result.data?.[0].content).toBe(
+        "You are a helpful weather assistant.",
+      );
+
+      // User message
+      expect(result.data?.[1].role).toBe("user");
+
+      // Assistant message with tool calls (flattened)
+      expect(result.data?.[2].role).toBe("assistant");
+      expect(result.data?.[2].tool_calls).toBeDefined();
+      expect(result.data?.[2].tool_calls?.[0].id).toBe("call_abc123");
+      expect(result.data?.[2].tool_calls?.[0].name).toBe("get_weather");
+      expect(result.data?.[2].tool_calls?.[0].arguments).toBe(
+        '{"location": "San Francisco, CA"}',
+      );
+
+      // Tool response
+      expect(result.data?.[3].role).toBe("tool");
+    });
+
+    it("should stringify object tool result content", () => {
+      const input = [
+        {
+          role: "tool",
+          tool_call_id: "call_xyz",
+          content: { temperature: 72, conditions: "sunny" },
+        },
+      ];
+
+      const preprocessed = ag2Adapter.preprocess(input, "output", {});
+      const result = SimpleChatMlArraySchema.safeParse(preprocessed);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].role).toBe("tool");
+      expect(result.data?.[0].content).toBe(
+        '{"temperature":72,"conditions":"sunny"}',
+      );
+    });
+
+    it("should handle messages wrapped in object with messages key", () => {
+      const input = {
+        messages: [
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Hi there!" },
+        ],
+      };
+
+      const preprocessed = ag2Adapter.preprocess(input, "input", {});
+      expect(preprocessed).toHaveProperty("messages");
+
+      const messages = (preprocessed as { messages: unknown[] }).messages;
+      expect(messages).toHaveLength(2);
+    });
+
+    it("should handle single message by wrapping in array", () => {
+      const input = { role: "user", content: "Hello" };
+
+      const preprocessed = ag2Adapter.preprocess(input, "input", {});
+      expect(Array.isArray(preprocessed)).toBe(true);
+      expect(preprocessed).toHaveLength(1);
+    });
+
+    it("should handle tool_calls with already-flat format", () => {
+      const input = [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call_1",
+              name: "search",
+              arguments: { query: "test" },
+              type: "function",
+            },
+          ],
+        },
+      ];
+
+      const preprocessed = ag2Adapter.preprocess(input, "output", {});
+      const result = SimpleChatMlArraySchema.safeParse(preprocessed);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[0].tool_calls?.[0].name).toBe("search");
+      expect(result.data?.[0].tool_calls?.[0].arguments).toBe(
+        '{"query":"test"}',
+      );
+    });
+
+    it("should pass through null/undefined data unchanged", () => {
+      expect(ag2Adapter.preprocess(null, "input", {})).toBeNull();
+      expect(ag2Adapter.preprocess(undefined, "input", {})).toBeUndefined();
+    });
+  });
+
+  describe("end-to-end with normalizeInput", () => {
+    it("should normalize AG2 multi-agent trace input through full pipeline", () => {
+      const input = [
+        {
+          role: "system",
+          content: "You are a helpful assistant.",
+        },
+        {
+          role: "user",
+          content: "What is the capital of France?",
+        },
+        {
+          role: "assistant",
+          content: "The capital of France is Paris.",
+        },
+      ];
+
+      const ctx: NormalizerContext = {
+        metadata: {
+          scope: { name: "autogen.opentelemetry", version: "0.11.2" },
+          attributes: { "ag2.span.type": "agent" },
+        },
+        data: input,
+      };
+
+      const result = normalizeInput(input, ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(3);
+      expect(result.data?.[0].role).toBe("system");
+      expect(result.data?.[1].role).toBe("user");
+      expect(result.data?.[2].role).toBe("assistant");
+      expect(result.data?.[2].content).toBe("The capital of France is Paris.");
+    });
+
+    it("should normalize AG2 tool execution trace through full pipeline", () => {
+      const input = [
+        {
+          role: "system",
+          content: "Use the get_weather tool to answer weather questions.",
+        },
+        {
+          role: "user",
+          content: "What is the weather in San Francisco?",
+        },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call_abc123",
+              function: {
+                name: "get_weather",
+                arguments: '{"location": "San Francisco, CA"}',
+              },
+              type: "function",
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call_abc123",
+          content:
+            '{"location": "San Francisco, CA", "temperature_f": 62, "condition": "Partly Cloudy"}',
+        },
+      ];
+
+      const ctx: NormalizerContext = {
+        metadata: {
+          scope: { name: "autogen.opentelemetry", version: "0.11.2" },
+          attributes: {
+            "ag2.span.type": "agent",
+            "ag2.agent.name": "assistant",
+          },
+        },
+        data: input,
+      };
+
+      const result = normalizeInput(input, ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toHaveLength(4);
+
+      // Verify tool call was flattened properly
+      const assistantMsg = result.data?.[2];
+      expect(assistantMsg?.role).toBe("assistant");
+      expect(assistantMsg?.tool_calls).toHaveLength(1);
+      expect(assistantMsg?.tool_calls?.[0].name).toBe("get_weather");
+      expect(assistantMsg?.tool_calls?.[0].id).toBe("call_abc123");
+
+      // Verify tool response
+      const toolMsg = result.data?.[3];
+      expect(toolMsg?.role).toBe("tool");
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

- Add dedicated ChatML adapter for AG2 (formerly AutoGen) framework traces
- Add seed trace demonstrating AG2 v0.11+ native OpenTelemetry tracing with multi-agent tool use
- Add "AG2 (AutoGen)" to the support chat integration type selector

## Why

AG2 is one of the most popular open-source multi-agent frameworks (4k+ GitHub stars, active development under ag2ai/ag2). Since v0.11 (Feb 2025), AG2 ships built-in OpenTelemetry tracing that emits rich, hierarchical spans following GenAI semantic conventions — covering conversations, agent turns, LLM calls, tool executions, code execution, human input, and speaker selection.

Today, Langfuse's AutoGen integration relies on OpenLIT as an intermediary, which only captures top-level spans and misses per-call LLM observability (#11505). AG2's native OTel output is significantly richer and doesn't need an intermediary library.

Langfuse already has dedicated adapters for LangGraph, Pydantic AI, Microsoft Agent, and Semantic Kernel. This PR brings AG2 to the same level of support — proper format detection, message normalization, and a realistic seed trace for the demo project.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

