### PR TITLE
fix: validate filter type compatibility to prevent 500 errors

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -1,9 +1,13 @@
 import z from "zod/v4";
 import { singleFilter } from "../../../interfaces/filters";
 import { FilterCondition } from "../../../types";
+import { InvalidRequestError } from "../../../errors";
 import { isValidTableName } from "../../clickhouse/schemaUtils";
 import { logger } from "../../logger";
-import { UiColumnMappings } from "../../../tableDefinitions";
+import {
+  type ColumnDefinition,
+  type UiColumnMappings,
+} from "../../../tableDefinitions";
 import {
   StringFilter,
   DateTimeFilter,
@@ -25,12 +29,28 @@ export class QueryBuilderError extends Error {
   }
 }
 
+// Maps each ColumnDefinition.type to the filter types that are structurally compatible
+// at the ClickHouse level. string/stringOptions both operate on String columns,
+// and stringOptions "any of" works on Array columns too.
+const COMPATIBLE_FILTER_TYPES: Record<string, string[]> = {
+  string: ["string", "stringOptions"],
+  stringOptions: ["string", "stringOptions"],
+  arrayOptions: ["arrayOptions", "stringOptions"],
+  datetime: ["datetime"],
+  number: ["number"],
+  boolean: ["boolean"],
+  stringObject: ["stringObject"],
+  numberObject: ["numberObject"],
+  categoryOptions: ["categoryOptions", "stringOptions"],
+};
+
 // This function ensures that the user only selects valid columns from the clickhouse schema.
 // The filter property in this column needs to be zod verified.
 // User input for values (e.g. project_id = <value>) are sent to Clickhouse as parameters to prevent SQL injection
 export const createFilterFromFilterState = (
   filter: FilterCondition[],
   columnMapping: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
 ) => {
   const applicableFilters = filter.filter(
     (frontEndFilter) => frontEndFilter.type !== "positionInTrace",
@@ -39,6 +59,18 @@ export const createFilterFromFilterState = (
   return applicableFilters.map((frontEndFilter) => {
     // checks if the column exists in the clickhouse schema
     const column = matchAndVerifyTracesUiColumn(frontEndFilter, columnMapping);
+
+    if (columnDefinitions && frontEndFilter.type !== "null") {
+      const colDef = columnDefinitions.find((c) => c.id === column.uiTableId);
+      if (colDef) {
+        const compatible = COMPATIBLE_FILTER_TYPES[colDef.type];
+        if (compatible && !compatible.includes(frontEndFilter.type)) {
+          throw new InvalidRequestError(
+            `Invalid filter type '${frontEndFilter.type}' for column '${frontEndFilter.column}'. Expected filter type '${colDef.type}'.`,
+          );
+        }
+      }
+    }
 
     switch (frontEndFilter.type) {
       case "string":

--- a/packages/shared/src/server/queries/public-api-filter-builder.ts
+++ b/packages/shared/src/server/queries/public-api-filter-builder.ts
@@ -11,7 +11,10 @@ import {
 } from "./clickhouse-sql/clickhouse-filter";
 import { z } from "zod/v4";
 import type { FilterState } from "../../types";
-import type { UiColumnMappings } from "../../tableDefinitions";
+import type {
+  UiColumnMappings,
+  ColumnDefinition,
+} from "../../tableDefinitions";
 import { createFilterFromFilterState } from "./clickhouse-sql/factory";
 
 export type ApiColumnMapping = {
@@ -353,10 +356,15 @@ export function deriveFilters<T extends BaseQueryType>(
   filterParamsMapping: ApiColumnMapping[],
   advancedFilters: FilterState | undefined,
   uiColumnDefinitions: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
 ): FilterList {
   // Start with advanced filters converted to FilterList
   const filterList = new FilterList(
-    createFilterFromFilterState(advancedFilters ?? [], uiColumnDefinitions),
+    createFilterFromFilterState(
+      advancedFilters ?? [],
+      uiColumnDefinitions,
+      columnDefinitions,
+    ),
   );
 
   // Convert simple parameters to filters

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -2,6 +2,8 @@ import { DatasetRunItemDomain } from "../../domain/dataset-run-items";
 import { type OrderByState } from "../../interfaces/orderBy";
 import { datasetRunItemsTableUiColumnDefinitions } from "../tableMappings";
 import { datasetRunsTableUiColumnDefinitions } from "../../tableDefinitions/mapDatasetRunsTable";
+import { datasetRunItemsTableCols } from "../../tableDefinitions/datasetRunItemsTable";
+import { datasetRunsTableCols } from "../../tableDefinitions/datasetRunsTable";
 import { FilterState } from "../../types";
 import {
   createFilterFromFilterState,
@@ -301,6 +303,7 @@ const getDatasetRunsTableInternal = async <T>(
   const userFilters = createFilterFromFilterState(
     filter,
     datasetRunsTableUiColumnDefinitions,
+    datasetRunsTableCols,
   );
   datasetRunItemsFilter.push(...userFilters);
 
@@ -582,6 +585,7 @@ const getQualifyingDatasetItems = async <T>(opts: {
     const userFilters = createFilterFromFilterState(
       filterState,
       datasetRunItemsTableUiColumnDefinitions,
+      datasetRunItemsTableCols,
     );
 
     // Combine run condition with user filters using AND and apply immediately
@@ -771,6 +775,7 @@ const getDatasetRunItemsTableInternal = async <
     ...createFilterFromFilterState(
       filter,
       datasetRunItemsTableUiColumnDefinitions,
+      datasetRunItemsTableCols,
     ),
   );
   const appliedFilter = datasetRunItemsFilter.apply();
@@ -1012,6 +1017,7 @@ export const getDatasetItemIdsByTraceIdCh = async (
     ...createFilterFromFilterState(
       filter,
       datasetRunItemsTableUiColumnDefinitions,
+      datasetRunItemsTableCols,
     ),
   );
   const appliedFilter = datasetRunItemsFilter.apply();

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -72,6 +72,8 @@ import {
 } from "../queries/clickhouse-sql/event-query-builder";
 import { type EventsObservationPublic } from "../queries/createGenerationsQuery";
 import { UiColumnMappings } from "../../tableDefinitions";
+import { eventsTableCols } from "../../eventsTable";
+import { tracesTableCols } from "../../tableDefinitions/tracesTable";
 import { parseMetadataCHRecordToDomain } from "../utils/metadata_conversion";
 
 /**
@@ -428,7 +430,11 @@ async function getObservationsFromEventsTableInternal<T>(
 
   // Build filter list from baseFilter (without positionInTrace)
   const observationsFilter = new FilterList(
-    createFilterFromFilterState(baseFilter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      baseFilter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const startTimeFrom = extractTimeFilter(observationsFilter);
@@ -910,6 +916,7 @@ function buildObservationsQueryComponents(
     PUBLIC_API_EVENTS_COLUMN_MAPPING,
     advancedFilters,
     columnDefinitions,
+    eventsTableCols,
   );
 
   // Determine if we need to join traces (check both simple params and advanced filters)
@@ -1251,6 +1258,7 @@ async function getTracesFromEventsTableForPublicApiInternal<T>(
     PUBLIC_API_TRACES_COLUMN_MAPPING,
     advancedFilters,
     TRACES_FROM_EVENTS_UI_COLUMN_DEFINITIONS,
+    tracesTableCols,
   );
 
   // Extract time filter for cut-off point in eventsTracesAggregation
@@ -1510,7 +1518,11 @@ export const getEventsGroupedByModel = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1551,7 +1563,11 @@ export const getEventsGroupedByModelId = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1590,7 +1606,11 @@ export const getEventsGroupedByName = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1630,7 +1650,11 @@ export const getEventsGroupedByTraceName = async (
   opts?: { extraWhereRaw?: string },
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1679,7 +1703,11 @@ export const getEventsGroupedByTraceTags = async (
   opts?: { extraWhereRaw?: string },
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1736,7 +1764,11 @@ export const getEventsGroupedByPromptName = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1777,7 +1809,11 @@ export const getEventsGroupedByType = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1817,7 +1853,11 @@ export const getEventsGroupedByUserId = async (
   opts?: { extraWhereRaw?: string },
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1860,7 +1900,11 @@ export const getEventsGroupedByVersion = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1901,7 +1945,11 @@ export const getEventsGroupedBySessionId = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1942,7 +1990,11 @@ export const getEventsGroupedByLevel = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -1983,7 +2035,11 @@ export const getEventsGroupedByEnvironment = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -2024,7 +2080,11 @@ export const getEventsGroupedByExperimentDatasetId = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -2069,7 +2129,11 @@ export const getEventsGroupedByExperimentId = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -2108,7 +2172,11 @@ export const getEventsGroupedByExperimentName = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -2147,7 +2215,11 @@ export const getEventsGroupedByHasParentObservation = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -2185,7 +2257,11 @@ export const getEventsGroupedByToolName = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();
@@ -2225,7 +2301,11 @@ export const getEventsGroupedByCalledToolName = async (
   filter: FilterState,
 ) => {
   const eventsFilter = new FilterList(
-    createFilterFromFilterState(filter, eventsTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
   );
 
   const appliedEventsFilter = eventsFilter.apply();

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -40,6 +40,7 @@ import {
 } from "./constants";
 import { env } from "../../env";
 import { TracingSearchType } from "../../interfaces/search";
+import { observationsTableCols } from "../../observationsTable";
 import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 import type { AnalyticsGenerationEvent } from "../analytics-integrations/types";
 import { ObservationType } from "../../domain";
@@ -742,6 +743,7 @@ const getObservationsTableInternal = async <T>(
     ...createFilterFromFilterState(
       filter,
       observationsTableUiColumnDefinitions,
+      observationsTableCols,
     ),
   );
 
@@ -884,6 +886,7 @@ export const getObservationsGroupedByModel = async (
     ...createFilterFromFilterState(
       filter,
       observationsTableUiColumnDefinitions,
+      observationsTableCols,
     ),
   );
 
@@ -934,6 +937,7 @@ export const getObservationsGroupedByModelId = async (
     ...createFilterFromFilterState(
       filter,
       observationsTableUiColumnDefinitions,
+      observationsTableCols,
     ),
   );
 
@@ -985,6 +989,7 @@ export const getObservationsGroupedByName = async (
     ...createFilterFromFilterState(
       filter,
       observationsTableUiColumnDefinitions,
+      observationsTableCols,
     ),
   );
 
@@ -1036,6 +1041,7 @@ export const getObservationsGroupedByToolName = async (
     ...createFilterFromFilterState(
       filter,
       observationsTableUiColumnDefinitions,
+      observationsTableCols,
     ),
   );
 
@@ -1084,6 +1090,7 @@ export const getObservationsGroupedByCalledToolName = async (
     ...createFilterFromFilterState(
       filter,
       observationsTableUiColumnDefinitions,
+      observationsTableCols,
     ),
   );
 
@@ -1132,6 +1139,7 @@ export const getObservationsGroupedByPromptName = async (
     ...createFilterFromFilterState(
       filter,
       observationsTableUiColumnDefinitions,
+      observationsTableCols,
     ),
   );
 

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -43,6 +43,7 @@ import { recordDistribution } from "../instrumentation";
 import { prisma } from "../../db";
 import { measureAndReturn } from "../clickhouse/measureAndReturn";
 import { scoresColumnsTableUiColumnDefinitions } from "../tableMappings/mapScoresColumnsTable";
+import { scoresTableCols } from "../../tableDefinitions/scoresTable";
 import { eventsTraceMetadata } from "../queries/clickhouse-sql/query-fragments";
 
 export const searchExistingAnnotationScore = async (
@@ -615,6 +616,7 @@ export const getScoresGroupedByNameSourceType = async ({
     ...createFilterFromFilterState(
       filter,
       scoresColumnsTableUiColumnDefinitions,
+      scoresTableCols,
     ),
   );
   const scoresFilterRes = scoresFilter.apply();
@@ -1001,7 +1003,11 @@ const getScoresUiGeneric = async <T>(props: {
     tracesPrefix: "t",
   });
   scoresFilter.push(
-    ...createFilterFromFilterState(filter, scoresTableUiColumnDefinitions),
+    ...createFilterFromFilterState(
+      filter,
+      scoresTableUiColumnDefinitions,
+      scoresTableCols,
+    ),
   );
   const scoresFilterRes = scoresFilter.apply();
 
@@ -1120,6 +1126,7 @@ const getScoresUiGenericFromEvents = async <T>(props: {
     ...createFilterFromFilterState(
       filter,
       scoresTableUiColumnDefinitionsFromEvents,
+      scoresTableCols,
     ),
   );
 
@@ -1160,6 +1167,7 @@ const getScoresUiGenericFromEvents = async <T>(props: {
         createFilterFromFilterState(
           traceFilterState,
           scoresTraceFilterEventsMapping,
+          scoresTableCols,
         ),
       );
       const cteTraceFilterRes = cteTraceFilters.apply();
@@ -1344,6 +1352,7 @@ export const getScoreNames = async (
     createFilterFromFilterState(
       timestampFilter,
       scoresTableUiColumnDefinitions,
+      scoresTableCols,
     ),
   );
   const timestampFilterRes = chFilter.apply();
@@ -1395,6 +1404,7 @@ export const getScoreStringValues = async (
     createFilterFromFilterState(
       timestampFilter,
       scoresTableUiColumnDefinitions,
+      scoresTableCols,
     ),
   );
   const timestampFilterRes = chFilter.apply();

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -17,7 +17,8 @@ import {
 } from "../queries/clickhouse-sql/clickhouse-filter";
 import { TraceRecordReadType } from "./definitions";
 import { tracesTableUiColumnDefinitions } from "../tableMappings/mapTracesTable";
-import { UiColumnMappings } from "../../tableDefinitions";
+import { UiColumnMappings, ColumnDefinition } from "../../tableDefinitions";
+import { tracesTableCols } from "../../tableDefinitions/tracesTable";
 import {
   convertDateToClickhouseDateTime,
   PreferredClickhouseService,
@@ -79,7 +80,11 @@ export const checkTraceExistsAndGetTimestamp = async ({
   ) as DateTimeFilter | undefined;
 
   tracesFilter.push(
-    ...createFilterFromFilterState(filter, tracesTableUiColumnDefinitions),
+    ...createFilterFromFilterState(
+      filter,
+      tracesTableUiColumnDefinitions,
+      tracesTableCols,
+    ),
     new StringFilter({
       clickhouseTable: "t",
       field: "id",
@@ -662,6 +667,7 @@ export const getTracesGroupedBySessionId = async (
   limit?: number,
   offset?: number,
   columns?: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
 ) => {
   const { tracesFilter } = getProjectIdDefaultFilter(projectId, {
     tracesPrefix: "t",
@@ -671,6 +677,7 @@ export const getTracesGroupedBySessionId = async (
     ...createFilterFromFilterState(
       filter,
       columns ?? tracesTableUiColumnDefinitions,
+      columnDefinitions ?? tracesTableCols,
     ),
   );
 
@@ -733,6 +740,7 @@ export const getTracesGroupedByUsers = async (
   limit?: number,
   offset?: number,
   columns?: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
 ) => {
   const { tracesFilter } = getProjectIdDefaultFilter(projectId, {
     tracesPrefix: "t",
@@ -742,6 +750,7 @@ export const getTracesGroupedByUsers = async (
     ...createFilterFromFilterState(
       filter,
       columns ?? tracesTableUiColumnDefinitions,
+      columnDefinitions ?? tracesTableCols,
     ),
   );
 
@@ -801,14 +810,16 @@ export type GroupedTracesQueryProp = {
   projectId: string;
   filter: FilterState;
   columns?: UiColumnMappings;
+  columnDefinitions?: ColumnDefinition[];
 };
 
 export const getTracesGroupedByTags = async (props: GroupedTracesQueryProp) => {
-  const { projectId, filter, columns } = props;
+  const { projectId, filter, columns, columnDefinitions } = props;
 
   const chFilter = createFilterFromFilterState(
     filter,
     columns ?? tracesTableUiColumnDefinitions,
+    columnDefinitions ?? tracesTableCols,
   );
 
   const filterRes = new FilterList(chFilter).apply();
@@ -1138,7 +1149,11 @@ export const getTotalUserCount = async (
   });
 
   tracesFilter.push(
-    ...createFilterFromFilterState(filter, tracesTableUiColumnDefinitions),
+    ...createFilterFromFilterState(
+      filter,
+      tracesTableUiColumnDefinitions,
+      tracesTableCols,
+    ),
   );
 
   const tracesFilterRes = tracesFilter.apply();
@@ -1190,7 +1205,11 @@ export const getUserMetrics = async (
 
   // filter state contains date range filter for traces so far.
   const chFilter = new FilterList(
-    createFilterFromFilterState(filter, tracesTableUiColumnDefinitions),
+    createFilterFromFilterState(
+      filter,
+      tracesTableUiColumnDefinitions,
+      tracesTableCols,
+    ),
   );
   const chFilterRes = chFilter.apply();
 

--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -18,6 +18,7 @@ import {
 } from "../queries/clickhouse-sql/query-fragments";
 import { queryClickhouse } from "../repositories";
 import { sessionCols } from "../tableMappings/mapSessionTable";
+import { sessionsViewCols } from "../../tableDefinitions/sessionsView";
 import { parseClickhouseUTCDateTimeFormat } from "../repositories/clickhouse";
 
 type SessionEventsBaseReturnType = {
@@ -169,7 +170,7 @@ const getSessionsTableFromEventsGeneric = async <T>(
     props;
 
   const sessionFilters = new FilterList(
-    createFilterFromFilterState(filter, sessionCols),
+    createFilterFromFilterState(filter, sessionCols, sessionsViewCols),
   );
   const sessionsFilterRes = sessionFilters.apply();
 

--- a/packages/shared/src/server/services/sessions-ui-table-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-service.ts
@@ -2,6 +2,7 @@ import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 import { OrderByState } from "../../interfaces/orderBy";
 import { sessionCols } from "../tableMappings/mapSessionTable";
 import { FilterState } from "../../types";
+import { sessionsViewCols } from "../../tableDefinitions/sessionsView";
 import { convertDateToClickhouseDateTime } from "../clickhouse/client";
 import { measureAndReturn } from "../clickhouse/measureAndReturn";
 import { DateTimeFilter, FilterList, orderByToClickhouseSql } from "../queries";
@@ -174,7 +175,9 @@ const getSessionsTableGeneric = async <T>(props: FetchSessionsTableProps) => {
     tracesPrefix: "s",
   });
 
-  tracesFilter.push(...createFilterFromFilterState(filter, sessionCols));
+  tracesFilter.push(
+    ...createFilterFromFilterState(filter, sessionCols, sessionsViewCols),
+  );
 
   const tracesFilterRes = tracesFilter
     .filter((f) => f.field !== "environment")

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -1,5 +1,6 @@
 import { OrderByState } from "../../interfaces/orderBy";
 import { tracesTableUiColumnDefinitions } from "../tableMappings";
+import { tracesTableCols } from "../../tableDefinitions/tracesTable";
 import { FilterState } from "../../types";
 import {
   StringFilter,
@@ -221,7 +222,11 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
     getProjectIdDefaultFilter(projectId, { tracesPrefix: "t" });
 
   tracesFilter.push(
-    ...createFilterFromFilterState(filter, tracesTableUiColumnDefinitions),
+    ...createFilterFromFilterState(
+      filter,
+      tracesTableUiColumnDefinitions,
+      tracesTableCols,
+    ),
   );
 
   const traceIdFilter = tracesFilter.find(

--- a/packages/shared/src/tableDefinitions/index.ts
+++ b/packages/shared/src/tableDefinitions/index.ts
@@ -7,3 +7,4 @@ export * from "./mapDatasetRunsTable";
 export * from "./datasetRunsTable";
 export * from "./datasetRunItemsTable";
 export * from "./usersTable";
+export * from "./scoresTable";

--- a/packages/shared/src/tableDefinitions/scoresTable.ts
+++ b/packages/shared/src/tableDefinitions/scoresTable.ts
@@ -1,0 +1,90 @@
+import { type ColumnDefinition } from "./types";
+import { ScoreSourceArray, ScoreDataTypeArray } from "../domain/scores";
+
+export const scoresTableCols: ColumnDefinition[] = [
+  {
+    name: "Trace ID",
+    id: "traceId",
+    type: "string",
+    internal: 's."trace_id"',
+  },
+  {
+    name: "Session ID",
+    id: "sessionId",
+    type: "string",
+    internal: 's."session_id"',
+  },
+  {
+    name: "Trace Name",
+    id: "traceName",
+    type: "stringOptions",
+    internal: 't."name"',
+    options: [],
+    nullable: true,
+  },
+  {
+    name: "Environment",
+    id: "environment",
+    type: "stringOptions",
+    internal: 's."environment"',
+    options: [],
+  },
+  {
+    name: "Observation ID",
+    id: "observationId",
+    type: "string",
+    internal: 's."observation_id"',
+  },
+  {
+    name: "Timestamp",
+    id: "timestamp",
+    type: "datetime",
+    internal: 's."timestamp"',
+  },
+  {
+    name: "Source",
+    id: "source",
+    type: "stringOptions",
+    internal: 's."source"::text',
+    options: ScoreSourceArray.map((value) => ({ value })),
+  },
+  {
+    name: "Data Type",
+    id: "dataType",
+    type: "stringOptions",
+    internal: 's."data_type"::text',
+    options: ScoreDataTypeArray.map((value) => ({ value })),
+  },
+  {
+    name: "Name",
+    id: "name",
+    type: "stringOptions",
+    internal: 's."name"',
+    options: [],
+  },
+  { name: "Value", id: "value", type: "number", internal: 's."value"' },
+  {
+    name: "String Value",
+    id: "stringValue",
+    type: "stringOptions",
+    internal: 's."string_value"',
+    options: [],
+    nullable: true,
+  },
+  {
+    name: "User ID",
+    id: "userId",
+    type: "stringOptions",
+    internal: 't."user_id"',
+    options: [],
+    nullable: true,
+  },
+  {
+    name: "Trace Tags",
+    id: "tags",
+    type: "arrayOptions",
+    internal: 't."tags"',
+    options: [],
+    nullable: true,
+  },
+];

--- a/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
+++ b/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
@@ -1,0 +1,202 @@
+import { createFilterFromFilterState } from "@langfuse/shared/src/server";
+import {
+  InvalidRequestError,
+  type UiColumnMapping,
+  type ColumnDefinition,
+} from "@langfuse/shared";
+
+describe("createFilterFromFilterState filter type validation", () => {
+  const mappings: Record<string, UiColumnMapping> = {
+    metadata: {
+      uiTableName: "Metadata",
+      uiTableId: "metadata",
+      clickhouseTableName: "traces",
+      clickhouseSelect: "metadata",
+      queryPrefix: "t",
+    },
+    name: {
+      uiTableName: "Name",
+      uiTableId: "name",
+      clickhouseTableName: "traces",
+      clickhouseSelect: "name",
+      queryPrefix: "t",
+    },
+    timestamp: {
+      uiTableName: "Timestamp",
+      uiTableId: "timestamp",
+      clickhouseTableName: "traces",
+      clickhouseSelect: "timestamp",
+      queryPrefix: "t",
+    },
+    environment: {
+      uiTableName: "Environment",
+      uiTableId: "environment",
+      clickhouseTableName: "traces",
+      clickhouseSelect: "environment",
+    },
+    tags: {
+      uiTableName: "Tags",
+      uiTableId: "tags",
+      clickhouseTableName: "traces",
+      clickhouseSelect: "tags",
+      queryPrefix: "t",
+    },
+    score_categories: {
+      uiTableName: "Scores (categorical)",
+      uiTableId: "score_categories",
+      clickhouseTableName: "scores",
+      clickhouseSelect: "s.score_categories",
+    },
+  };
+
+  const columnDefinitions: ColumnDefinition[] = [
+    {
+      name: "Metadata",
+      id: "metadata",
+      type: "stringObject",
+      internal: "t.metadata",
+    },
+    {
+      name: "Name",
+      id: "name",
+      type: "stringOptions",
+      internal: "t.name",
+      options: [],
+    },
+    {
+      name: "Timestamp",
+      id: "timestamp",
+      type: "datetime",
+      internal: "t.timestamp",
+    },
+    {
+      name: "Environment",
+      id: "environment",
+      type: "stringOptions",
+      internal: "t.environment",
+      options: [],
+    },
+    {
+      name: "Tags",
+      id: "tags",
+      type: "arrayOptions",
+      internal: "t.tags",
+      options: [],
+    },
+    {
+      name: "Scores (categorical)",
+      id: "score_categories",
+      type: "categoryOptions",
+      internal: "s.score_categories",
+      options: [],
+    },
+  ];
+
+  it.each([
+    {
+      column: "metadata",
+      filterType: "string",
+      operator: "contains",
+      value: "cartesia",
+      expectedType: "stringObject",
+    },
+    {
+      column: "name",
+      filterType: "number",
+      operator: "=",
+      value: 42,
+      expectedType: "stringOptions",
+    },
+    {
+      column: "timestamp",
+      filterType: "string",
+      operator: "contains",
+      value: "2024",
+      expectedType: "datetime",
+    },
+  ] as const)(
+    "rejects $filterType filter on $column column (expected $expectedType)",
+    ({ column, filterType, operator, value, expectedType }) => {
+      expect(() =>
+        createFilterFromFilterState(
+          [{ column, type: filterType, operator, value } as any],
+          [mappings[column]],
+          columnDefinitions,
+        ),
+      ).toThrow(
+        new InvalidRequestError(
+          `Invalid filter type '${filterType}' for column '${column}'. Expected filter type '${expectedType}'.`,
+        ),
+      );
+    },
+  );
+
+  it.each([
+    {
+      scenario: "matching filter type",
+      column: "metadata",
+      filter: {
+        type: "stringObject",
+        operator: "contains",
+        key: "env",
+        value: "production",
+      },
+      colDefs: columnDefinitions,
+    },
+    {
+      scenario: "null filter bypasses validation",
+      column: "metadata",
+      filter: { type: "null", operator: "is null", value: "" as const },
+      colDefs: columnDefinitions,
+    },
+    {
+      scenario: "no columnDefinitions provided",
+      column: "metadata",
+      filter: { type: "string", operator: "contains", value: "cartesia" },
+      colDefs: undefined,
+    },
+    {
+      scenario: "no matching ColumnDefinition for column",
+      column: "environment",
+      filter: { type: "string", operator: "=", value: "production" },
+      colDefs: [columnDefinitions[0]],
+    },
+    {
+      scenario: "string filter on stringOptions column (cross-compatible)",
+      column: "name",
+      filter: { type: "string", operator: "contains", value: "test" },
+      colDefs: columnDefinitions,
+    },
+    {
+      scenario: "stringOptions filter on stringOptions column",
+      column: "environment",
+      filter: { type: "stringOptions", operator: "any of", value: ["prod"] },
+      colDefs: columnDefinitions,
+    },
+    {
+      scenario:
+        "stringOptions filter on arrayOptions column (cross-compatible)",
+      column: "tags",
+      filter: { type: "stringOptions", operator: "any of", value: ["tag1"] },
+      colDefs: columnDefinitions,
+    },
+    {
+      scenario:
+        "stringOptions filter on categoryOptions column (cross-compatible)",
+      column: "score_categories",
+      filter: {
+        type: "stringOptions",
+        operator: "any of",
+        value: ["quality:good"],
+      },
+      colDefs: columnDefinitions,
+    },
+  ] as const)("allows filter when $scenario", ({ column, filter, colDefs }) => {
+    const result = createFilterFromFilterState(
+      [{ column, ...filter } as any],
+      [mappings[column]],
+      colDefs as ColumnDefinition[] | undefined,
+    );
+    expect(result).toHaveLength(1);
+  });
+});

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -9,7 +9,7 @@ import {
   convertObservation,
   shouldSkipObservationsFinal,
 } from "@langfuse/shared/src/server";
-import type { FilterState } from "@langfuse/shared";
+import { type FilterState, observationsTableCols } from "@langfuse/shared";
 
 type QueryType = {
   page: number;
@@ -173,6 +173,7 @@ const generateFilter = (query: QueryType) => {
     observationsTableUiColumnDefinitions.filter(
       (c) => c.clickhouseTableName !== "scores",
     ),
+    observationsTableCols,
   );
 
   // Remove score filters since observations don't support scores in response

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -13,6 +13,7 @@ import {
   removeObjectKeys,
   ScoreDataTypeEnum,
   type ScoreDataTypeType,
+  scoresTableCols,
   type ScoreDomain,
   type FilterState,
 } from "@langfuse/shared";
@@ -432,6 +433,7 @@ const generateScoreFilter = (
     secureScoreFilterOptions,
     filter.advancedFilters,
     scoresTableUiColumnDefinitions,
+    scoresTableCols,
   );
   scoresFilter.push(
     new StringFilter({

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -12,7 +12,11 @@ import {
   tracesTableUiColumnDefinitions,
   shouldSkipObservationsFinal,
 } from "@langfuse/shared/src/server";
-import { AGGREGATABLE_SCORE_TYPES, type OrderByState } from "@langfuse/shared";
+import {
+  AGGREGATABLE_SCORE_TYPES,
+  type OrderByState,
+  tracesTableCols,
+} from "@langfuse/shared";
 import {
   TRACE_FIELD_GROUPS,
   type TraceFieldGroup,
@@ -77,6 +81,7 @@ async function buildTracesBaseQuery(
     filterParams,
     advancedFilters,
     tracesTableUiColumnDefinitions,
+    tracesTableCols,
   );
   const appliedFilter = filter.apply();
 
@@ -388,6 +393,7 @@ export const getTracesCountForPublicApi = async ({
     filterParams,
     advancedFilters,
     tracesTableUiColumnDefinitions,
+    tracesTableCols,
   );
   const appliedFilter = filter.apply();
 

--- a/web/src/server/api/definitions/scoresTable.ts
+++ b/web/src/server/api/definitions/scoresTable.ts
@@ -2,97 +2,10 @@ import {
   type ColumnDefinition,
   formatColumnOptions,
   type SingleValueOption,
-  ScoreSourceArray,
-  ScoreDataTypeArray,
+  scoresTableCols,
 } from "@langfuse/shared";
 
-export const scoresTableCols: ColumnDefinition[] = [
-  {
-    name: "Trace ID",
-    id: "traceId",
-    type: "string",
-    internal: 's."trace_id"',
-  },
-  {
-    name: "Session ID",
-    id: "sessionId",
-    type: "string",
-    internal: 's."session_id"',
-  },
-  {
-    name: "Trace Name",
-    id: "traceName",
-    type: "stringOptions",
-    internal: 't."name"',
-    options: [], // to be added at runtime
-    nullable: true,
-  },
-  {
-    name: "Environment",
-    id: "environment",
-    type: "stringOptions",
-    internal: 's."environment"',
-    options: [], // to be added at runtime
-  },
-  {
-    name: "Observation ID",
-    id: "observationId",
-    type: "string",
-    internal: 's."observation_id"',
-  },
-  {
-    name: "Timestamp",
-    id: "timestamp",
-    type: "datetime",
-    internal: 's."timestamp"',
-  },
-  {
-    name: "Source",
-    id: "source",
-    type: "stringOptions",
-    internal: 's."source"::text',
-    options: ScoreSourceArray.map((value) => ({ value })),
-  },
-  {
-    name: "Data Type",
-    id: "dataType",
-    type: "stringOptions",
-    internal: 's."data_type"::text',
-    options: ScoreDataTypeArray.map((value) => ({ value })),
-  },
-  {
-    name: "Name",
-    id: "name",
-    type: "stringOptions",
-    internal: 's."name"',
-    options: [], // to be added at runtime
-  },
-  { name: "Value", id: "value", type: "number", internal: 's."value"' },
-  {
-    name: "String Value",
-    id: "stringValue",
-    type: "stringOptions",
-    internal: 's."string_value"',
-    options: [], // to be added at runtime
-    nullable: true,
-  },
-  {
-    name: "User ID",
-    id: "userId",
-    type: "stringOptions",
-    internal: 't."user_id"',
-    options: [], // to be added at runtime
-    nullable: true,
-  },
-  {
-    name: "Trace Tags",
-    id: "tags",
-    type: "arrayOptions",
-    internal: 't."tags"',
-    options: [], // to be added at runtime
-    nullable: true,
-  },
-];
+export { scoresTableCols };
 
 export type ScoreOptions = {
   name: Array<SingleValueOption>;

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -13,6 +13,7 @@ import {
   type ScoreDataTypeType,
   TimeFilter,
   TracingSearchType,
+  eventsTableCols,
 } from "@langfuse/shared";
 import {
   getDistinctScoreNames,
@@ -113,6 +114,7 @@ export const getEventsStream = async (props: {
         },
       ],
       eventsTableUiColumnDefinitions,
+      eventsTableCols,
     ),
   );
 
@@ -387,6 +389,7 @@ export const getEventsStreamForEval = async (props: {
         },
       ],
       eventsTableUiColumnDefinitions,
+      eventsTableCols,
     ),
   );
 
@@ -525,6 +528,7 @@ export const getEventsStreamForDataset = async (props: {
         },
       ],
       eventsTableUiColumnDefinitions,
+      eventsTableCols,
     ),
   );
 

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -5,6 +5,7 @@ import {
   type ScoreDataTypeType,
   TimeFilter,
   TracingSearchType,
+  observationsTableCols,
 } from "@langfuse/shared";
 import {
   getDistinctScoreNames,
@@ -164,6 +165,7 @@ export const getObservationStream = async (props: {
         },
       ],
       observationsTableUiColumnDefinitions,
+      observationsTableCols,
     ),
   );
 

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -3,6 +3,7 @@ import {
   ScoreDataTypeEnum,
   type ScoreDataTypeType,
   TracingSearchType,
+  tracesTableCols,
 } from "@langfuse/shared";
 import {
   getDistinctScoreNames,
@@ -93,6 +94,7 @@ export const getTraceStream = async (props: {
         },
       ],
       tracesTableUiColumnDefinitions,
+      tracesTableCols,
     ),
   );
 


### PR DESCRIPTION
Incompatible combinations are rejected with `InvalidRequestError`.
