### PR TITLE
feat(worker): add batch media cleanup for soft-deleted projects

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -114,6 +114,7 @@ export * from "./otel";
 export * from "./datasets/executeWithDatasetServiceStrategy";
 
 export * from "./data-deletion/ingestionFileDeletion";
+export * from "./media-deletion";
 export * from "./s3";
 
 // dataset run items

--- a/packages/shared/src/server/media-deletion.ts
+++ b/packages/shared/src/server/media-deletion.ts
@@ -1,0 +1,40 @@
+import { prisma } from "../db";
+import { env } from "../env";
+import { getS3MediaStorageClient } from "./s3";
+
+export async function deleteMediaByProjectId(params: {
+  projectId: string;
+  cutoffDate?: Date;
+  limit?: number;
+}): Promise<number> {
+  const mediaFiles = await prisma.media.findMany({
+    select: { id: true, bucketPath: true },
+    where: {
+      projectId: params.projectId,
+      createdAt: params.cutoffDate ? { lte: params.cutoffDate } : undefined,
+    },
+    take: params.limit,
+  });
+
+  if (mediaFiles.length === 0) {
+    return 0;
+  }
+
+  if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
+    const mediaStorageClient = getS3MediaStorageClient(
+      env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+    );
+    await mediaStorageClient.deleteFiles(
+      mediaFiles.map((file) => file.bucketPath),
+    );
+  }
+
+  await prisma.media.deleteMany({
+    where: {
+      id: { in: mediaFiles.map((file) => file.id) },
+      projectId: params.projectId,
+    },
+  });
+
+  return mediaFiles.length;
+}

--- a/worker/src/__tests__/batchProjectMediaCleaner.test.ts
+++ b/worker/src/__tests__/batchProjectMediaCleaner.test.ts
@@ -53,7 +53,13 @@ async function createMedia(projectId: string, count: number) {
 }
 
 describe("BatchProjectMediaCleaner", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await prisma.media.deleteMany({});
+    await prisma.project.updateMany({
+      where: { deletedAt: { not: null } },
+      data: { deletedAt: null },
+    });
+
     vi.clearAllMocks();
     vi.mocked(deleteMediaByProjectId).mockImplementation(async (params) => {
       const media = await prisma.media.findMany({

--- a/worker/src/__tests__/batchProjectMediaCleaner.test.ts
+++ b/worker/src/__tests__/batchProjectMediaCleaner.test.ts
@@ -21,13 +21,14 @@ vi.mock("@langfuse/shared/src/server", async () => {
   };
 });
 
-vi.mock("../../env", async () => {
-  const actual = await vi.importActual("../../env");
+vi.mock("../env", async () => {
+  const actual = await vi.importActual("../env");
   return {
     env: {
       ...(actual as { env: object }).env,
       LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_INTERVAL_MS: 60_000,
       LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS: 300_000,
+      LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_PROJECT_LIMIT: 1000,
       LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_MEDIA_BATCH_SIZE: 2,
       LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG: "true",
     },
@@ -109,9 +110,7 @@ describe("BatchProjectMediaCleaner", () => {
     const cleaner = new BatchProjectMediaCleaner();
     const delay = await cleaner.processBatch();
 
-    expect(delay).toBe(
-      env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS,
-    );
+    expect(delay).toBe(300_000);
     expect(deleteMediaByProjectId).not.toHaveBeenCalled();
     expect(await prisma.media.count({ where: { projectId } })).toBe(2);
   });
@@ -171,6 +170,20 @@ describe("BatchProjectMediaCleaner", () => {
     expect(await prisma.media.count({ where: { projectId } })).toBe(3);
   });
 
+  it("respects project limit when selecting deleted projects", async () => {
+    const cleaner = new BatchProjectMediaCleaner();
+
+    const queryRawSpy = vi.spyOn(prisma, "$queryRaw").mockResolvedValueOnce([]);
+
+    const delay = await cleaner.processBatch();
+
+    expect(delay).toBe(300_000);
+    expect(deleteMediaByProjectId).not.toHaveBeenCalled();
+    expect(queryRawSpy).toHaveBeenCalledTimes(1);
+
+    queryRawSpy.mockRestore();
+  });
+
   it("returns sleep interval when no work and interval when work exists", async () => {
     const cleaner = new BatchProjectMediaCleaner();
     const emptyDelay = await cleaner.processBatch();
@@ -185,8 +198,6 @@ describe("BatchProjectMediaCleaner", () => {
     await createMedia(projectId, 1);
 
     const workDelay = await cleaner.processBatch();
-    expect(workDelay).toBe(
-      env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_INTERVAL_MS,
-    );
+    expect(workDelay).toBe(60_000);
   });
 });

--- a/worker/src/__tests__/batchProjectMediaCleaner.test.ts
+++ b/worker/src/__tests__/batchProjectMediaCleaner.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "crypto";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  createOrgProjectAndApiKey,
+  deleteMediaByProjectId,
+  removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
+  redis,
+} from "@langfuse/shared/src/server";
+import {
+  BatchProjectMediaCleaner,
+  BATCH_PROJECT_MEDIA_CLEANER_LOCK_KEY,
+} from "../features/batch-project-media-cleaner";
+
+vi.mock("@langfuse/shared/src/server", async () => {
+  const actual = await vi.importActual("@langfuse/shared/src/server");
+  return {
+    ...actual,
+    deleteMediaByProjectId: vi.fn(),
+    removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject: vi.fn(),
+  };
+});
+
+vi.mock("../../env", async () => {
+  const actual = await vi.importActual("../../env");
+  return {
+    env: {
+      ...(actual as { env: object }).env,
+      LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_INTERVAL_MS: 60_000,
+      LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS: 300_000,
+      LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_MEDIA_BATCH_SIZE: 2,
+      LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG: "true",
+    },
+  };
+});
+
+async function createMedia(projectId: string, count: number) {
+  for (let i = 0; i < count; i++) {
+    const id = randomUUID();
+    await prisma.media.create({
+      data: {
+        id,
+        projectId,
+        sha256Hash: `hash-${randomUUID()}`.padEnd(44, "0"),
+        bucketPath: `projects/${projectId}/media/${id}`,
+        bucketName: "test-bucket",
+        contentType: "image/png",
+        contentLength: 1024,
+      },
+    });
+  }
+}
+
+describe("BatchProjectMediaCleaner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(deleteMediaByProjectId).mockImplementation(async (params) => {
+      const media = await prisma.media.findMany({
+        where: { projectId: params.projectId },
+        select: { id: true },
+        take: params.limit,
+      });
+
+      if (media.length === 0) {
+        return 0;
+      }
+
+      await prisma.media.deleteMany({
+        where: {
+          projectId: params.projectId,
+          id: { in: media.map((m) => m.id) },
+        },
+      });
+
+      return media.length;
+    });
+    vi.mocked(
+      removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
+    ).mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await redis?.del(BATCH_PROJECT_MEDIA_CLEANER_LOCK_KEY);
+  });
+
+  it("deletes media for soft-deleted project", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    await prisma.project.update({
+      where: { id: projectId },
+      data: { deletedAt: new Date() },
+    });
+    await createMedia(projectId, 2);
+
+    const cleaner = new BatchProjectMediaCleaner();
+    const delay = await cleaner.processBatch();
+
+    expect(delay).toBe(60_000);
+    expect(await prisma.media.count({ where: { projectId } })).toBe(0);
+    expect(deleteMediaByProjectId).toHaveBeenCalledWith({
+      projectId,
+      limit: 2,
+    });
+  });
+
+  it("skips active projects", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    await createMedia(projectId, 2);
+
+    const cleaner = new BatchProjectMediaCleaner();
+    const delay = await cleaner.processBatch();
+
+    expect(delay).toBe(
+      env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS,
+    );
+    expect(deleteMediaByProjectId).not.toHaveBeenCalled();
+    expect(await prisma.media.count({ where: { projectId } })).toBe(2);
+  });
+
+  it("continues blob cleanup if media cleanup fails", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    await prisma.project.update({
+      where: { id: projectId },
+      data: { deletedAt: new Date() },
+    });
+    await createMedia(projectId, 1);
+
+    vi.mocked(deleteMediaByProjectId).mockRejectedValueOnce(
+      new Error("media cleanup failed"),
+    );
+
+    const cleaner = new BatchProjectMediaCleaner();
+    const delay = await cleaner.processBatch();
+
+    expect(delay).toBe(60_000);
+    expect(
+      removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
+    ).toHaveBeenCalledWith(projectId, undefined);
+  });
+
+  it("continues media cleanup if blob cleanup fails", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    await prisma.project.update({
+      where: { id: projectId },
+      data: { deletedAt: new Date() },
+    });
+    await createMedia(projectId, 1);
+
+    vi.mocked(
+      removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
+    ).mockRejectedValueOnce(new Error("blob cleanup failed"));
+
+    const cleaner = new BatchProjectMediaCleaner();
+    const delay = await cleaner.processBatch();
+
+    expect(delay).toBe(60_000);
+    expect(deleteMediaByProjectId).toHaveBeenCalled();
+    expect(await prisma.media.count({ where: { projectId } })).toBe(0);
+  });
+
+  it("respects batch size limit", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    await prisma.project.update({
+      where: { id: projectId },
+      data: { deletedAt: new Date() },
+    });
+    await createMedia(projectId, 5);
+
+    const cleaner = new BatchProjectMediaCleaner();
+    await cleaner.processBatch();
+
+    expect(await prisma.media.count({ where: { projectId } })).toBe(3);
+  });
+
+  it("returns sleep interval when no work and interval when work exists", async () => {
+    const cleaner = new BatchProjectMediaCleaner();
+    const emptyDelay = await cleaner.processBatch();
+
+    expect(emptyDelay).toBe(300_000);
+
+    const { projectId } = await createOrgProjectAndApiKey();
+    await prisma.project.update({
+      where: { id: projectId },
+      data: { deletedAt: new Date() },
+    });
+    await createMedia(projectId, 1);
+
+    const workDelay = await cleaner.processBatch();
+    expect(workDelay).toBe(
+      env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_INTERVAL_MS,
+    );
+  });
+});

--- a/worker/src/__tests__/mediaRetentionCleaner.test.ts
+++ b/worker/src/__tests__/mediaRetentionCleaner.test.ts
@@ -2,7 +2,7 @@ import { expect, describe, it, vi, beforeEach, afterEach } from "vitest";
 import { randomUUID } from "crypto";
 import {
   createOrgProjectAndApiKey,
-  getS3MediaStorageClient,
+  deleteMediaByProjectId,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
@@ -13,7 +13,7 @@ vi.mock("@langfuse/shared/src/server", async () => {
   const actual = await vi.importActual("@langfuse/shared/src/server");
   return {
     ...actual,
-    getS3MediaStorageClient: vi.fn(),
+    deleteMediaByProjectId: vi.fn(),
     removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject: vi.fn(),
   };
 });
@@ -97,7 +97,31 @@ async function drainExpiredMedia(maxIterations = 20): Promise<void> {
 describe("MediaRetentionCleaner", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getS3MediaStorageClient).mockReturnValue(mockS3Client as never);
+    vi.mocked(deleteMediaByProjectId).mockImplementation(async (params) => {
+      const mediaFiles = await prisma.media.findMany({
+        select: { id: true, bucketPath: true },
+        where: {
+          projectId: params.projectId,
+          createdAt: params.cutoffDate ? { lte: params.cutoffDate } : undefined,
+        },
+        take: params.limit,
+      });
+
+      if (mediaFiles.length === 0) {
+        return 0;
+      }
+
+      await mockDeleteFiles(mediaFiles.map((file) => file.bucketPath));
+
+      await prisma.media.deleteMany({
+        where: {
+          id: { in: mediaFiles.map((file) => file.id) },
+          projectId: params.projectId,
+        },
+      });
+
+      return mediaFiles.length;
+    });
   });
 
   afterEach(() => {

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -83,6 +83,7 @@ import {
 } from "./features/batch-data-retention-cleaner";
 import { MediaRetentionCleaner } from "./features/media-retention-cleaner";
 import { BatchTraceDeletionCleaner } from "./features/batch-trace-deletion-cleaner";
+import { BatchProjectMediaCleaner } from "./features/batch-project-media-cleaner";
 
 const app = express();
 
@@ -633,6 +634,14 @@ export let batchTraceDeletionCleaner: BatchTraceDeletionCleaner | null = null;
 if (env.LANGFUSE_BATCH_TRACE_DELETION_CLEANER_ENABLED === "true") {
   batchTraceDeletionCleaner = new BatchTraceDeletionCleaner();
   batchTraceDeletionCleaner.start();
+}
+
+// Batch project media cleaner for soft-deleted project media/blob cleanup
+export let batchProjectMediaCleaner: BatchProjectMediaCleaner | null = null;
+
+if (env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_ENABLED === "true") {
+  batchProjectMediaCleaner = new BatchProjectMediaCleaner();
+  batchProjectMediaCleaner.start();
 }
 
 process.on("SIGINT", () => onShutdown("SIGINT"));

--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -4,9 +4,9 @@ import {
   deleteScoresOlderThanDays,
   deleteTracesOlderThanDays,
   logger,
-  getS3MediaStorageClient,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
   getCurrentSpan,
+  deleteMediaByProjectId,
 } from "@langfuse/shared/src/server";
 import { Job } from "bullmq";
 import { prisma } from "@langfuse/shared/src/db";
@@ -57,46 +57,18 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
     Date.now() - currentRetention * 24 * 60 * 60 * 1000,
   );
 
-  // Delete media files if bucket is configured
-  if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
-    logger.info(
-      `[Data Retention] Deleting media files older than ${currentRetention} days for project ${projectId}`,
-    );
-    const mediaFilesToDelete = await prisma.media.findMany({
-      select: {
-        id: true,
-        projectId: true,
-        createdAt: true,
-        bucketPath: true,
-        bucketName: true,
-      },
-      where: {
-        projectId,
-        createdAt: {
-          lte: cutoffDate,
-        },
-      },
-    });
-    const mediaStorageClient = getS3MediaStorageClient(
-      env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-    );
-    // Delete from Cloud Storage
-    await mediaStorageClient.deleteFiles(
-      mediaFilesToDelete.map((f) => f.bucketPath),
-    );
-    // Delete from postgres. We should automatically remove the corresponding traceMedia and observationMedia
-    await prisma.media.deleteMany({
-      where: {
-        id: {
-          in: mediaFilesToDelete.map((f) => f.id),
-        },
-        projectId,
-      },
-    });
-    logger.info(
-      `[Data Retention] Deleted ${mediaFilesToDelete.length} media files for project ${projectId}`,
-    );
-  }
+  logger.info(
+    `[Data Retention] Deleting media files older than ${currentRetention} days for project ${projectId}`,
+  );
+
+  const deletedMediaCount = await deleteMediaByProjectId({
+    projectId,
+    cutoffDate,
+  });
+
+  logger.info(
+    `[Data Retention] Deleted ${deletedMediaCount} media files for project ${projectId}`,
+  );
 
   // Delete ClickHouse (TTL / Delete Queries)
   logger.info(

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -349,6 +349,10 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(3_600_000), // 1 hour sleep when there is no work
+  LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_PROJECT_LIMIT: z.coerce
+    .number()
+    .positive()
+    .default(1000), // Max deleted projects to inspect per batch
   LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_MEDIA_BATCH_SIZE: z.coerce
     .number()
     .positive()

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -337,6 +337,23 @@ const EnvSchema = z.object({
     .positive()
     .default(3_600_000), // 1 hour for DELETE operations
 
+  // Batch Project Media Cleaner configuration
+  LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_ENABLED: z
+    .enum(["true", "false"])
+    .default("false"),
+  LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_INTERVAL_MS: z.coerce
+    .number()
+    .positive()
+    .default(600_000), // 10 minutes between runs when work is found
+  LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS: z.coerce
+    .number()
+    .positive()
+    .default(3_600_000), // 1 hour sleep when there is no work
+  LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_MEDIA_BATCH_SIZE: z.coerce
+    .number()
+    .positive()
+    .default(10_000), // Max media items to process per batch
+
   // Batch Data Retention Cleaner configuration (ClickHouse)
   LANGFUSE_BATCH_DATA_RETENTION_CLEANER_ENABLED: z
     .enum(["true", "false"])

--- a/worker/src/features/batch-project-media-cleaner/index.ts
+++ b/worker/src/features/batch-project-media-cleaner/index.ts
@@ -1,0 +1,101 @@
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  deleteMediaByProjectId,
+  logger,
+  removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
+  traceException,
+} from "@langfuse/shared/src/server";
+import { env } from "../../env";
+import { PeriodicExclusiveRunner } from "../../utils/PeriodicExclusiveRunner";
+
+export const BATCH_PROJECT_MEDIA_CLEANER_LOCK_KEY =
+  "langfuse:batch-project-media-cleaner";
+
+export class BatchProjectMediaCleaner extends PeriodicExclusiveRunner {
+  protected get defaultIntervalMs(): number {
+    return env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS;
+  }
+
+  constructor() {
+    const lockTtlSeconds =
+      Math.ceil(env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_INTERVAL_MS / 1000) +
+      300;
+
+    super({
+      name: "BatchProjectMediaCleaner",
+      lockKey: BATCH_PROJECT_MEDIA_CLEANER_LOCK_KEY,
+      lockTtlSeconds,
+      onUnavailable: "fail",
+    });
+  }
+
+  public override start(): void {
+    logger.info(`Starting ${this.instanceName}`, {
+      intervalMs: env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_INTERVAL_MS,
+      sleepOnEmptyMs:
+        env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS,
+      mediaBatchSize: env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_MEDIA_BATCH_SIZE,
+    });
+    super.start();
+  }
+
+  public override async processBatch(): Promise<number> {
+    return this.execute();
+  }
+
+  protected async execute(): Promise<number> {
+    const deletedProjects = await prisma.project.findMany({
+      select: { id: true },
+      where: { deletedAt: { not: null } },
+    });
+
+    for (const project of deletedProjects) {
+      const mediaCount = await prisma.media.count({
+        where: { projectId: project.id },
+      });
+
+      if (mediaCount === 0) {
+        continue;
+      }
+
+      return (
+        (await this.withLock(async () => {
+          try {
+            await deleteMediaByProjectId({
+              projectId: project.id,
+              limit: env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_MEDIA_BATCH_SIZE,
+            });
+          } catch (error) {
+            logger.error(`${this.instanceName}: Failed to delete media`, {
+              projectId: project.id,
+              error,
+            });
+            traceException(error);
+          }
+
+          try {
+            if (env.LANGFUSE_ENABLE_BLOB_STORAGE_FILE_LOG === "true") {
+              await removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject(
+                project.id,
+                undefined,
+              );
+            }
+          } catch (error) {
+            logger.error(
+              `${this.instanceName}: Failed to delete blob storage`,
+              {
+                projectId: project.id,
+                error,
+              },
+            );
+            traceException(error);
+          }
+
+          return env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_INTERVAL_MS;
+        })) ?? env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS
+      );
+    }
+
+    return env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS;
+  }
+}

--- a/worker/src/features/batch-project-media-cleaner/index.ts
+++ b/worker/src/features/batch-project-media-cleaner/index.ts
@@ -2,6 +2,7 @@ import { prisma } from "@langfuse/shared/src/db";
 import {
   deleteMediaByProjectId,
   logger,
+  recordIncrement,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
   traceException,
 } from "@langfuse/shared/src/server";
@@ -10,6 +11,8 @@ import { PeriodicExclusiveRunner } from "../../utils/PeriodicExclusiveRunner";
 
 export const BATCH_PROJECT_MEDIA_CLEANER_LOCK_KEY =
   "langfuse:batch-project-media-cleaner";
+
+const METRIC_PREFIX = "langfuse.batch_project_media_cleaner";
 
 export class BatchProjectMediaCleaner extends PeriodicExclusiveRunner {
   protected get defaultIntervalMs(): number {
@@ -34,6 +37,7 @@ export class BatchProjectMediaCleaner extends PeriodicExclusiveRunner {
       intervalMs: env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_INTERVAL_MS,
       sleepOnEmptyMs:
         env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS,
+      projectLimit: env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_PROJECT_LIMIT,
       mediaBatchSize: env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_MEDIA_BATCH_SIZE,
     });
     super.start();
@@ -44,22 +48,24 @@ export class BatchProjectMediaCleaner extends PeriodicExclusiveRunner {
   }
 
   protected async execute(): Promise<number> {
-    const deletedProjects = await prisma.project.findMany({
-      select: { id: true },
-      where: { deletedAt: { not: null } },
-    });
+    const projectsWithMedia = await prisma.$queryRaw<Array<{ id: string }>>`
+      SELECT p.id
+      FROM projects p
+      INNER JOIN media m ON m.project_id = p.id
+      WHERE p.deleted_at IS NOT NULL
+      GROUP BY p.id
+      ORDER BY count(*) DESC
+      LIMIT ${env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_PROJECT_LIMIT}
+    `;
 
-    for (const project of deletedProjects) {
-      const mediaCount = await prisma.media.count({
-        where: { projectId: project.id },
-      });
+    const project = projectsWithMedia.at(0);
+    if (!project) {
+      return env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS;
+    }
 
-      if (mediaCount === 0) {
-        continue;
-      }
-
-      return (
-        (await this.withLock(async () => {
+    return (
+      (await this.withLock(
+        async () => {
           try {
             await deleteMediaByProjectId({
               projectId: project.id,
@@ -92,10 +98,11 @@ export class BatchProjectMediaCleaner extends PeriodicExclusiveRunner {
           }
 
           return env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_INTERVAL_MS;
-        })) ?? env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS
-      );
-    }
-
-    return env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS;
+        },
+        () => {
+          recordIncrement(`${METRIC_PREFIX}.deletion_failures`, 1);
+        },
+      )) ?? env.LANGFUSE_BATCH_PROJECT_MEDIA_CLEANER_SLEEP_ON_EMPTY_MS
+    );
   }
 }

--- a/worker/src/features/media-retention-cleaner/index.ts
+++ b/worker/src/features/media-retention-cleaner/index.ts
@@ -1,10 +1,10 @@
 import { prisma } from "@langfuse/shared/src/db";
 import {
-  getS3MediaStorageClient,
   logger,
   recordGauge,
   recordIncrement,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
+  deleteMediaByProjectId,
   traceException,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
@@ -154,11 +154,34 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
 
   private async processProject(workload: ProjectWorkload): Promise<void> {
     // Delete media files (S3 + PostgreSQL)
-    if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
-      await this.deleteExpiredMedia(
-        workload,
-        env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-      );
+    const pendingItemCount = await prisma.media.count({
+      where: {
+        projectId: workload.projectId,
+        createdAt: { lte: workload.cutoffDate },
+      },
+    });
+
+    // Record gauge for observed work
+    recordGauge(`${METRIC_PREFIX}.pending_items`, pendingItemCount, {
+      projectId: workload.projectId,
+    });
+
+    const deletedCount = await deleteMediaByProjectId({
+      projectId: workload.projectId,
+      cutoffDate: workload.cutoffDate,
+      limit: env.LANGFUSE_MEDIA_RETENTION_CLEANER_ITEM_LIMIT,
+    });
+
+    if (deletedCount > 0) {
+      // Record successful deletion metrics
+      recordIncrement(`${METRIC_PREFIX}.files_deleted`, deletedCount, {
+        projectId: workload.projectId,
+      });
+
+      logger.info(`${this.name}: Media files deleted`, {
+        projectId: workload.projectId,
+        count: deletedCount,
+      });
     }
 
     // Delete blob storage entries (S3 + ClickHouse soft delete)
@@ -172,50 +195,6 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
     logger.info(`${this.name}: Project processed`, {
       projectId: workload.projectId,
       retentionDays: workload.retentionDays,
-    });
-  }
-
-  private async deleteExpiredMedia(
-    workload: ProjectWorkload,
-    bucket: string,
-  ): Promise<void> {
-    const mediaFiles = await prisma.media.findMany({
-      select: { id: true, bucketPath: true },
-      where: {
-        projectId: workload.projectId,
-        createdAt: { lte: workload.cutoffDate },
-      },
-    });
-
-    // Record gauge for observed work
-    recordGauge(`${METRIC_PREFIX}.pending_items`, mediaFiles.length, {
-      projectId: workload.projectId,
-    });
-
-    if (mediaFiles.length === 0) {
-      return;
-    }
-
-    // Delete from S3 first
-    const mediaStorageClient = getS3MediaStorageClient(bucket);
-    await mediaStorageClient.deleteFiles(mediaFiles.map((f) => f.bucketPath));
-
-    // Delete from PostgreSQL (cascades to traceMedia/observationMedia)
-    await prisma.media.deleteMany({
-      where: {
-        id: { in: mediaFiles.map((f) => f.id) },
-        projectId: workload.projectId,
-      },
-    });
-
-    // Record successful deletion metrics
-    recordIncrement(`${METRIC_PREFIX}.files_deleted`, mediaFiles.length, {
-      projectId: workload.projectId,
-    });
-
-    logger.info(`${this.name}: Media files deleted`, {
-      projectId: workload.projectId,
-      count: mediaFiles.length,
     });
   }
 }

--- a/worker/src/features/media-retention-cleaner/index.ts
+++ b/worker/src/features/media-retention-cleaner/index.ts
@@ -154,22 +154,15 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
 
   private async processProject(workload: ProjectWorkload): Promise<void> {
     // Delete media files (S3 + PostgreSQL)
-    const pendingItemCount = await prisma.media.count({
-      where: {
-        projectId: workload.projectId,
-        createdAt: { lte: workload.cutoffDate },
-      },
-    });
-
-    // Record gauge for observed work
-    recordGauge(`${METRIC_PREFIX}.pending_items`, pendingItemCount, {
-      projectId: workload.projectId,
-    });
-
     const deletedCount = await deleteMediaByProjectId({
       projectId: workload.projectId,
       cutoffDate: workload.cutoffDate,
       limit: env.LANGFUSE_MEDIA_RETENTION_CLEANER_ITEM_LIMIT,
+    });
+
+    // Record gauge for observed work in this run
+    recordGauge(`${METRIC_PREFIX}.pending_items`, deletedCount, {
+      projectId: workload.projectId,
     });
 
     if (deletedCount > 0) {

--- a/worker/src/features/traces/processClickhouseTraceDelete.ts
+++ b/worker/src/features/traces/processClickhouseTraceDelete.ts
@@ -5,31 +5,12 @@ import {
   deleteTraces,
   logger,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces,
-  StorageService,
-  StorageServiceFactory,
+  getS3MediaStorageClient,
   traceException,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { prisma } from "@langfuse/shared/src/db";
 import { chunk } from "lodash";
-
-let s3MediaStorageClient: StorageService;
-
-const getS3MediaStorageClient = (bucketName: string): StorageService => {
-  if (!s3MediaStorageClient) {
-    s3MediaStorageClient = StorageServiceFactory.getInstance({
-      bucketName,
-      accessKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID,
-      secretAccessKey: env.LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY,
-      endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
-      region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
-      forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
-      awsSse: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
-      awsSseKmsKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,
-    });
-  }
-  return s3MediaStorageClient;
-};
 
 const deleteMediaItemsForTraces = async (
   projectId: string,

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -9,31 +9,12 @@ import {
   logger,
   QueueName,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
-  StorageService,
-  StorageServiceFactory,
+  deleteMediaByProjectId,
   TQueueJobTypes,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { Prisma } from "@prisma/client";
 import { env } from "../env";
-
-let s3MediaStorageClient: StorageService;
-
-const getS3MediaStorageClient = (bucketName: string): StorageService => {
-  if (!s3MediaStorageClient) {
-    s3MediaStorageClient = StorageServiceFactory.getInstance({
-      bucketName,
-      accessKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID,
-      secretAccessKey: env.LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY,
-      endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
-      region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
-      forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
-      awsSse: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
-      awsSseKmsKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,
-    });
-  }
-  return s3MediaStorageClient;
-};
 
 export const projectDeleteProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.ProjectDelete]>,
@@ -55,28 +36,9 @@ export const projectDeleteProcessor: Processor = async (
 
   logger.info(`Deleting ${projectId} in org ${orgId}`);
 
-  // Delete media data from S3 for project
-  if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
-    logger.info(`Deleting media for ${projectId} in org ${orgId}`);
-    const mediaFilesToDelete = await prisma.media.findMany({
-      select: {
-        id: true,
-        projectId: true,
-        bucketPath: true,
-      },
-      where: {
-        projectId,
-      },
-    });
-    const mediaStorageClient = getS3MediaStorageClient(
-      env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-    );
-    // Delete from Cloud Storage
-    await mediaStorageClient.deleteFiles(
-      mediaFilesToDelete.map((f) => f.bucketPath),
-    );
-    // No need to delete from table as this will be done below via Prisma
-  }
+  // Delete media data (S3 + postgres) for project
+  logger.info(`Deleting media for ${projectId} in org ${orgId}`);
+  await deleteMediaByProjectId({ projectId });
 
   logger.info(
     `Deleting ClickHouse and S3 data for ${projectId} in org ${orgId}`,

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -37,8 +37,10 @@ export const projectDeleteProcessor: Processor = async (
   logger.info(`Deleting ${projectId} in org ${orgId}`);
 
   // Delete media data (S3 + postgres) for project
-  logger.info(`Deleting media for ${projectId} in org ${orgId}`);
-  await deleteMediaByProjectId({ projectId });
+  if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
+    logger.info(`Deleting media for ${projectId} in org ${orgId}`);
+    await deleteMediaByProjectId({ projectId });
+  }
 
   logger.info(
     `Deleting ClickHouse and S3 data for ${projectId} in org ${orgId}`,

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -14,6 +14,7 @@ import {
   batchDataRetentionCleaners,
   mediaRetentionCleaner,
   batchTraceDeletionCleaner,
+  batchProjectMediaCleaner,
 } from "../app";
 
 export const onShutdown: NodeJS.SignalsListener = async (signal) => {
@@ -39,6 +40,9 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
 
   // Stop batch trace deletion cleaner
   batchTraceDeletionCleaner?.stop();
+
+  // Stop batch project media cleaner
+  batchProjectMediaCleaner?.stop();
 
   // Shutdown workers (https://docs.bullmq.io/guide/going-to-production#gracefully-shut-down-workers)
   await WorkerManager.closeWorkers();


### PR DESCRIPTION
### Motivation
- Prevent orphaned S3 media when a project delete job fails by adding a safety-net cleaner for soft-deleted projects. 
- Remove duplicated media-deletion logic across worker processors by centralizing S3+Postgres media deletion in a shared helper. 

### Description
- Added `deleteMediaByProjectId` in `packages/shared/src/server/media-deletion.ts` and exported it from `packages/shared/src/server/index.ts` to encapsulate the pattern: query media → delete S3 (if configured) → delete Postgres rows, returning the deleted count. 
- Refactored existing callers to use the shared helper in `worker/src/features/media-retention-cleaner/index.ts`, `worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts`, and `worker/src/queues/projectDelete.ts`. 
- Removed duplicate local `getS3MediaStorageClient` implementations and switched those modules to import the shared S3 client implementation (`worker/src/queues/projectDelete.ts` and `worker/src/features/traces/processClickhouseTraceDelete.ts`). 
- Implemented `BatchProjectMediaCleaner` at `worker/src/features/batch-project-media-cleaner/index.ts` as a `PeriodicExclusiveRunner` that iterates soft-deleted projects, deletes media in batches, runs blob/ClickHouse cleanup per-project in isolated try/catch blocks, and returns run intervals based on whether work was done. 
- Wired the cleaner into worker lifecycle by adding env vars in `worker/src/env.ts`, starting the cleaner in `worker/src/app.ts`, and stopping it in `worker/src/utils/shutdown.ts`. 
- Added tests `worker/src/__tests__/batchProjectMediaCleaner.test.ts` covering deletion for soft-deleted projects, skipping active projects, failure-isolation between media/blob cleanup, batch-size respect, and interval return behavior. 

### Testing
- Ran `pnpm --filter=@langfuse/shared run build` which failed in this environment due to pre-existing TypeScript/Prisma type issues unrelated to these changes. 
- Ran `pnpm --filter=@langfuse/shared run lint` which completed successfully. 
- Ran `pnpm --filter=worker run lint` which completed successfully after formatting fixes. 
- Ran `pnpm --filter=worker run build` which failed in this environment due to baseline TypeScript/Prisma issues unrelated to this patch. 
- Ran `pnpm run test --filter=worker -- batchProjectMediaCleaner` which failed in this environment because required test environment variables (e.g. ClickHouse / S3 event vars) are not set; the test suite is present and exercises the new cleaner but needs the CI/dev env to provide those vars. 
- Ran `pnpm run test --filter=worker -- mediaRetentionCleaner` which also failed for the same missing-env limitations in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0432972f083238fbdfffaadb04ab8)