### PR TITLE
fix(export): batch export fails when categorical score filter is applied

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -68,13 +68,13 @@ interface BaseScoresAggregationParams {
   level: "observation" | "trace";
   hasScoreAggregationFilters?: boolean;
   /**
-   * Encoding format for categorical scores in the aggregation output.
-   * - "concat" (default): `concat(name, ':', string_value)` — compact but breaks
-   *   when score names contain colons. Suitable for display/filtering only.
-   * - "tuple": `tuple(name, string_value)` — safe for programmatic parsing
-   *   (e.g. batch exports where values must be accurately extracted).
+   * When true, adds an extra `score_categories_tuples` column with
+   * `tuple(name, string_value)` encoding alongside the default concat-encoded
+   * `score_categories`. The tuple column is safe for programmatic parsing
+   * (e.g. batch exports) when score names may contain colons.
+   * The concat column is always present for hasAny filter compatibility.
    */
-  categoricalEncoding?: "concat" | "tuple";
+  includeTupleEncoding?: boolean;
 }
 
 /**
@@ -115,7 +115,7 @@ const buildScoresAggregationCTE = (
         ${primaryKey},
         ${additionalOuterCols.length > 0 ? additionalOuterCols.join(",\n        ") + "," : ""}
         groupArrayIf(tuple(name, avg_value, data_type, string_value), data_type IN ('NUMERIC', 'BOOLEAN')) AS scores_avg,
-        groupArrayIf(${params.categoricalEncoding === "tuple" ? "tuple(name, string_value)" : "concat(name, ':', string_value)"}, data_type = 'CATEGORICAL' AND notEmpty(string_value)) AS score_categories
+        groupArrayIf(concat(name, ':', string_value), data_type = 'CATEGORICAL' AND notEmpty(string_value)) AS score_categories${params.includeTupleEncoding ? `,\n        groupArrayIf(tuple(name, string_value), data_type = 'CATEGORICAL' AND notEmpty(string_value)) AS score_categories_tuples` : ""}
       FROM (
         SELECT
           ${primaryKey},
@@ -147,7 +147,7 @@ const buildScoresAggregationCTE = (
 interface EventsScoresAggregationParams {
   projectId: string;
   startTimeFrom?: string | null;
-  categoricalEncoding?: "concat" | "tuple";
+  includeTupleEncoding?: boolean;
 }
 
 /**
@@ -169,9 +169,9 @@ interface EventsTracesScoresAggregationParams {
   projectId: string;
   startTimeFrom?: string | null;
   hasScoreAggregationFilters?: boolean;
-  // Note: categoricalEncoding is intentionally omitted. This function is only used
+  // Note: includeTupleEncoding is intentionally omitted. This function is only used
   // in UI table queries where score_categories are used for filtering, not programmatic
-  // parsing. If this is ever used in an export path, add categoricalEncoding here and
+  // parsing. If this is ever used in an export path, add includeTupleEncoding here and
   // pass it through to buildScoresAggregationCTE (see EventsScoresAggregationParams).
 }
 

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -136,10 +136,11 @@ export const getEventsStream = async (props: {
     .selectRaw(
       "s.scores_avg as scores_avg",
       "s.score_categories as score_categories",
+      "s.score_categories_tuples as score_categories_tuples",
     )
     .withCTE(
       "scores_agg",
-      eventsScoresAggregation({ projectId, categoricalEncoding: "tuple" }),
+      eventsScoresAggregation({ projectId, includeTupleEncoding: true }),
     )
     .leftJoin(
       "scores_agg s",
@@ -196,6 +197,7 @@ export const getEventsStream = async (props: {
         }[]
       | undefined;
     score_categories: string[] | undefined;
+    score_categories_tuples: [string, string | null][] | undefined;
   };
 
   const asyncGenerator = queryClickhouseStream<EventRow>({
@@ -224,8 +226,8 @@ export const getEventsStream = async (props: {
     }));
 
     // Process categorical scores (tuples from ClickHouse)
-    const categoricalScores = (bufferedRow.score_categories ?? []).map(
-      (cat: any) => ({
+    const categoricalScores = (bufferedRow.score_categories_tuples ?? []).map(
+      (cat) => ({
         name: cat[0],
         value: null,
         dataType: ScoreDataTypeEnum.CATEGORICAL,

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -184,11 +184,16 @@ export const getObservationStream = async (props: {
             tuple(name, avg_value, data_type, string_value),
             data_type IN ('NUMERIC', 'BOOLEAN')
           ) AS scores_avg,
-          -- For categorical scores, use tuples to avoid delimiter issues with names containing colons
+          -- concat encoding for hasAny filter compatibility
+          groupArrayIf(
+            concat(name, ':', string_value),
+            data_type = 'CATEGORICAL' AND notEmpty(string_value)
+          ) AS score_categories,
+          -- tuple encoding for accurate output parsing (names may contain colons)
           groupArrayIf(
             tuple(name, string_value),
             data_type = 'CATEGORICAL' AND notEmpty(string_value)
-          ) AS score_categories
+          ) AS score_categories_tuples
         FROM (
           SELECT
             trace_id,
@@ -253,7 +258,8 @@ export const getObservationStream = async (props: {
         t.timestamp as traceTimestamp,
         t.user_id as userId,
         s.scores_avg as scores_avg,
-        s.score_categories as score_categories
+        s.score_categories as score_categories,
+        s.score_categories_tuples as score_categories_tuples
       FROM observations o
         LEFT JOIN traces t ON t.id = o.trace_id AND t.project_id = o.project_id
         LEFT JOIN scores_agg s ON s.trace_id = o.trace_id AND s.observation_id = o.id
@@ -274,6 +280,7 @@ export const getObservationStream = async (props: {
           }[]
         | undefined;
       score_categories: string[] | undefined;
+      score_categories_tuples: [string, string | null][] | undefined;
     } & {
       traceName: string;
       traceTags: string[];
@@ -315,6 +322,7 @@ export const getObservationStream = async (props: {
         }[]
       | undefined;
     score_categories: string[] | undefined;
+    score_categories_tuples: [string, string | null][] | undefined;
   } & {
     traceName: string;
     traceTags: string[];
@@ -339,8 +347,8 @@ export const getObservationStream = async (props: {
     }));
 
     // Process categorical scores (tuples from ClickHouse)
-    const categoricalScores = (bufferedRow.score_categories ?? []).map(
-      (cat: any) => ({
+    const categoricalScores = (bufferedRow.score_categories_tuples ?? []).map(
+      (cat) => ({
         name: cat[0],
         value: null,
         dataType: ScoreDataTypeEnum.CATEGORICAL,

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -123,11 +123,16 @@ export const getTraceStream = async (props: {
           tuple(name, avg_value, data_type, string_value),
           data_type IN ('NUMERIC', 'BOOLEAN')
         ) AS scores_avg,
-        -- For categorical scores, use tuples to avoid delimiter issues with names containing colons
+        -- concat encoding for hasAny filter compatibility
+        groupArrayIf(
+          concat(name, ':', string_value),
+          data_type = 'CATEGORICAL' AND notEmpty(string_value)
+        ) AS score_categories,
+        -- tuple encoding for accurate output parsing (names may contain colons)
         groupArrayIf(
           tuple(name, string_value),
           data_type = 'CATEGORICAL' AND notEmpty(string_value)
-        ) AS score_categories
+        ) AS score_categories_tuples
       FROM (
         SELECT
           project_id,
@@ -165,7 +170,8 @@ export const getTraceStream = async (props: {
         t.output as output,
         t.metadata as metadata,
         s.scores_avg as scores_avg,
-        s.score_categories as score_categories
+        s.score_categories as score_categories,
+        s.score_categories_tuples as score_categories_tuples
       FROM traces t
         LEFT JOIN scores_agg s ON s.trace_id = t.id AND s.project_id = t.project_id
       WHERE t.project_id = {projectId: String}
@@ -200,6 +206,7 @@ export const getTraceStream = async (props: {
         }[]
       | undefined;
     score_categories: string[] | undefined;
+    score_categories_tuples: [string, string | null][] | undefined;
   }>({
     query,
     params: {
@@ -232,8 +239,8 @@ export const getTraceStream = async (props: {
     }));
 
     // Process categorical scores (tuples from ClickHouse)
-    const categoricalScores = (bufferedRow.score_categories ?? []).map(
-      (cat: any) => ({
+    const categoricalScores = (bufferedRow.score_categories_tuples ?? []).map(
+      (cat: [string, string | null]) => ({
         name: cat[0],
         value: null,
         dataType: ScoreDataTypeEnum.CATEGORICAL,


### PR DESCRIPTION
Regression from #12376 which changed score_categories to tuple encoding in batch export CTEs, breaking hasAny filters that expect Array(String).
