### PR TITLE
fix(web): correct evaluator target filtering

### DIFF
--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -38,6 +38,7 @@ import {
 import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
 import { PeekViewEvaluatorConfigDetail } from "@/src/components/table/peek/peek-evaluator-config-detail";
 import { TablePeekView } from "@/src/components/table/peek";
+import { evalConfigTargetValues } from "@/src/server/api/definitions/evalConfigsTable";
 import {
   DropdownMenu,
   DropdownMenuItem,
@@ -82,7 +83,7 @@ export type EvaluatorDataRow = {
     version: number;
   };
   scoreName: string;
-  target: string; // "trace" or "dataset"
+  target: string;
   filter: FilterState;
   result: {
     level: string;
@@ -156,7 +157,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
 
   const newFilterOptions = {
     status: ["ACTIVE", "INACTIVE"],
-    target: ["trace", "dataset"],
+    target: evalConfigTargetValues,
   };
 
   const queryFilter = useSidebarFilterState(

--- a/web/src/features/evals/eval-config-target-options.clienttest.ts
+++ b/web/src/features/evals/eval-config-target-options.clienttest.ts
@@ -1,0 +1,33 @@
+import { EvalTargetObject } from "@langfuse/shared";
+import { resolveCheckboxOperator } from "@/src/features/filters/hooks/useSidebarFilterState";
+import { evalConfigFilterColumns } from "@/src/server/api/definitions/evalConfigsTable";
+
+describe("eval config target filter options", () => {
+  it("should exclude all non-trace targets when selecting trace", () => {
+    const targetColumn = evalConfigFilterColumns.find(
+      (col) => col.id === "target",
+    );
+    const availableValues =
+      targetColumn?.options?.map((option) => option.value) ?? [];
+
+    expect(availableValues).toEqual(
+      expect.arrayContaining(Object.values(EvalTargetObject)),
+    );
+
+    const result = resolveCheckboxOperator({
+      colType: "stringOptions",
+      existingFilter: undefined,
+      values: [EvalTargetObject.TRACE],
+      availableValues,
+    });
+
+    expect(result).toEqual({
+      finalOperator: "none of",
+      finalValues: expect.arrayContaining([
+        EvalTargetObject.DATASET,
+        EvalTargetObject.EVENT,
+        EvalTargetObject.EXPERIMENT,
+      ]),
+    });
+  });
+});

--- a/web/src/features/evals/eval-config-target-options.clienttest.ts
+++ b/web/src/features/evals/eval-config-target-options.clienttest.ts
@@ -7,8 +7,13 @@ describe("eval config target filter options", () => {
     const targetColumn = evalConfigFilterColumns.find(
       (col) => col.id === "target",
     );
+
+    expect(targetColumn?.type).toBe("stringOptions");
+
     const availableValues =
-      targetColumn?.options?.map((option) => option.value) ?? [];
+      targetColumn?.type === "stringOptions"
+        ? targetColumn.options.map((option) => option.value)
+        : [];
 
     expect(availableValues).toEqual(
       expect.arrayContaining(Object.values(EvalTargetObject)),

--- a/web/src/server/api/definitions/evalConfigsTable.ts
+++ b/web/src/server/api/definitions/evalConfigsTable.ts
@@ -1,4 +1,18 @@
-import { type ColumnDefinition, JobConfigState } from "@langfuse/shared";
+import {
+  EvalTargetObject,
+  type ColumnDefinition,
+  JobConfigState,
+} from "@langfuse/shared";
+
+export const evalConfigTargetOptions = Object.values(EvalTargetObject).map(
+  (value) => ({
+    value,
+  }),
+);
+
+export const evalConfigTargetValues = evalConfigTargetOptions.map(
+  (option) => option.value,
+);
 
 export const evalConfigFilterColumns: ColumnDefinition[] = [
   {
@@ -13,7 +27,7 @@ export const evalConfigFilterColumns: ColumnDefinition[] = [
     id: "target",
     type: "stringOptions",
     internal: 'jc."target_object"',
-    options: [{ value: "trace" }, { value: "dataset" }],
+    options: evalConfigTargetOptions,
   },
 ];
 


### PR DESCRIPTION
## Summary
- include all evaluator target objects in the target filter definition
- reuse the shared target values in the evaluator table filter options so sidebar filtering matches backend values
- add a regression test covering the trace selection case that previously leaked experiment and observation targets

## Impacted packages
- web

## Verification
- pnpm --filter web run lint
- pnpm exec dotenv -e ../.env.test -e ../.env -- jest --runInBand --verbose --selectProjects client --runTestsByPath src/features/evals/eval-config-target-options.clienttest.ts