### PR TITLE
chore: Track v4 beta flag on PostHog person and super property

### DIFF
--- a/web/src/features/events/hooks/useV4Beta.ts
+++ b/web/src/features/events/hooks/useV4Beta.ts
@@ -1,12 +1,20 @@
 import { useSession } from "next-auth/react";
 import { api } from "@/src/utils/api";
 import { useCallback } from "react";
+import posthog from "posthog-js";
+import { V4_BETA_ENABLED_POSTHOG_PROPERTY } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 export function useV4Beta() {
   const { data: session, update: updateSession } = useSession();
 
   const mutation = api.userAccount.setV4BetaEnabled.useMutation({
-    onSuccess: async () => {
+    onSuccess: async ({ v4BetaEnabled }) => {
+      posthog.setPersonProperties({
+        [V4_BETA_ENABLED_POSTHOG_PROPERTY]: v4BetaEnabled,
+      });
+      posthog.register({
+        [V4_BETA_ENABLED_POSTHOG_PROPERTY]: v4BetaEnabled,
+      });
       await updateSession();
     },
   });

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -1,6 +1,8 @@
 import { type CaptureResult, type CaptureOptions } from "posthog-js";
 import { usePostHog } from "posthog-js/react";
 
+export const V4_BETA_ENABLED_POSTHOG_PROPERTY = "v4BetaEnabled";
+
 // resource:action, only use snake_case
 // Exported to silence @typescript-eslint/no-unused-vars v8 warning
 // (used for type extraction via typeof, which is a legitimate pattern)

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -191,7 +191,6 @@ function UserTracking() {
           email: sessionUser.email ?? undefined,
           name: sessionUser.name ?? undefined,
           featureFlags: sessionUser.featureFlags ?? undefined,
-          v4BetaEnabled: sessionUser.v4BetaEnabled ?? false,
           projects:
             sessionUser.organizations.flatMap((org) =>
               org.projects.map((project) => ({

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -77,6 +77,7 @@ import { SupportDrawerProvider } from "@/src/features/support-chat/SupportDrawer
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { ScoreCacheProvider } from "@/src/features/scores/contexts/ScoreCacheContext";
 import { CorrectionCacheProvider } from "@/src/features/corrections/contexts/CorrectionCacheContext";
+import { V4_BETA_ENABLED_POSTHOG_PROPERTY } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 // Check that PostHog is client-side (used to handle Next.js SSR) and that env vars are set
 if (
@@ -184,7 +185,7 @@ function UserTracking() {
     ) {
       lastIdentifiedUser.current = JSON.stringify(sessionUser);
       // PostHog
-      if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST)
+      if (env.NEXT_PUBLIC_POSTHOG_KEY && env.NEXT_PUBLIC_POSTHOG_HOST) {
         posthog.identify(sessionUser.id ?? undefined, {
           environment: process.env.NODE_ENV,
           email: sessionUser.email ?? undefined,
@@ -199,7 +200,14 @@ function UserTracking() {
               })),
             ) ?? undefined,
           LANGFUSE_CLOUD_REGION: region,
+          [V4_BETA_ENABLED_POSTHOG_PROPERTY]:
+            sessionUser.v4BetaEnabled ?? false,
         });
+        posthog.register({
+          [V4_BETA_ENABLED_POSTHOG_PROPERTY]:
+            sessionUser.v4BetaEnabled ?? false,
+        });
+      }
 
       // Sentry
       setUser({
@@ -208,6 +216,7 @@ function UserTracking() {
       });
     } else if (session.status === "unauthenticated") {
       lastIdentifiedUser.current = null;
+      posthog.unregister(V4_BETA_ENABLED_POSTHOG_PROPERTY);
       // Sentry
       setUser(null);
     }


### PR DESCRIPTION
Summary
- persist `v4BetaEnabled` on the PostHog person and super properties when the flag is toggled
- initialize and update the property during user tracking and clear it when unauthenticated
- expose the shared property name constant for reuse

Testing
- Not run (not requested)