### PR TITLE
chore: extract shared media deletion utilities from duplicated worker code.

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -114,6 +114,7 @@ export * from "./otel";
 export * from "./datasets/executeWithDatasetServiceStrategy";
 
 export * from "./data-deletion/ingestionFileDeletion";
+export * from "./media-deletion";
 export * from "./s3";
 
 // dataset run items

--- a/packages/shared/src/server/media-deletion.ts
+++ b/packages/shared/src/server/media-deletion.ts
@@ -1,0 +1,83 @@
+import { prisma } from "../db";
+
+interface MediaFileRef {
+  id: string;
+  bucketPath: string;
+}
+
+/**
+ * Find all media files for a project (for complete project deletion).
+ */
+export async function findAllMediaByProjectId(params: {
+  projectId: string;
+  limit?: number;
+}): Promise<MediaFileRef[]> {
+  return prisma.media.findMany({
+    select: { id: true, bucketPath: true },
+    where: { projectId: params.projectId },
+    ...(params.limit != null && { take: params.limit }),
+  });
+}
+
+/**
+ * Find expired media files for a project (for retention-based cleanup).
+ */
+export async function findExpiredMediaByProjectId(params: {
+  projectId: string;
+  cutoffDate: Date;
+}): Promise<MediaFileRef[]> {
+  return prisma.media.findMany({
+    select: { id: true, bucketPath: true },
+    where: {
+      projectId: params.projectId,
+      createdAt: { lte: params.cutoffDate },
+    },
+  });
+}
+
+export interface StorageClient {
+  deleteFiles: (paths: string[]) => Promise<void>;
+}
+
+/**
+ * Delete media files from S3 first, then from PostgreSQL.
+ * S3 is deleted first to avoid orphaned files if PG deletion succeeds but S3 fails.
+ * Returns the number of media files deleted.
+ */
+export async function deleteMediaFiles(params: {
+  projectId: string;
+  mediaFiles: MediaFileRef[];
+  storageClient: StorageClient;
+}): Promise<number> {
+  const { projectId, mediaFiles, storageClient } = params;
+
+  if (mediaFiles.length === 0) {
+    return 0;
+  }
+
+  // Delete from S3 first
+  await storageClient.deleteFiles(mediaFiles.map((f) => f.bucketPath));
+
+  // Delete from PostgreSQL (cascades to traceMedia/observationMedia)
+  await prisma.media.deleteMany({
+    where: {
+      id: { in: mediaFiles.map((f) => f.id) },
+      projectId,
+    },
+  });
+
+  return mediaFiles.length;
+}
+
+/**
+ * Find projects that have been soft-deleted (deletedAt is set).
+ */
+export async function getDeletedProjects(
+  limit: number,
+): Promise<Array<{ id: string }>> {
+  return prisma.project.findMany({
+    select: { id: true },
+    where: { deletedAt: { not: null } },
+    take: limit,
+  });
+}

--- a/worker/src/__tests__/mediaRetentionCleaner.test.ts
+++ b/worker/src/__tests__/mediaRetentionCleaner.test.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "crypto";
 import {
   createOrgProjectAndApiKey,
   getS3MediaStorageClient,
-  removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { MediaRetentionCleaner } from "../features/media-retention-cleaner";

--- a/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
+++ b/worker/src/ee/dataRetention/handleDataRetentionProcessingJob.ts
@@ -1,10 +1,12 @@
 import {
   deleteEventsOlderThanDays,
+  deleteMediaFiles,
   deleteObservationsOlderThanDays,
   deleteScoresOlderThanDays,
   deleteTracesOlderThanDays,
-  logger,
+  findExpiredMediaByProjectId,
   getS3MediaStorageClient,
+  logger,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
   getCurrentSpan,
 } from "@langfuse/shared/src/server";
@@ -62,36 +64,16 @@ export const handleDataRetentionProcessingJob = async (job: Job) => {
     logger.info(
       `[Data Retention] Deleting media files older than ${currentRetention} days for project ${projectId}`,
     );
-    const mediaFilesToDelete = await prisma.media.findMany({
-      select: {
-        id: true,
-        projectId: true,
-        createdAt: true,
-        bucketPath: true,
-        bucketName: true,
-      },
-      where: {
-        projectId,
-        createdAt: {
-          lte: cutoffDate,
-        },
-      },
+    const mediaFilesToDelete = await findExpiredMediaByProjectId({
+      projectId,
+      cutoffDate,
     });
-    const mediaStorageClient = getS3MediaStorageClient(
-      env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-    );
-    // Delete from Cloud Storage
-    await mediaStorageClient.deleteFiles(
-      mediaFilesToDelete.map((f) => f.bucketPath),
-    );
-    // Delete from postgres. We should automatically remove the corresponding traceMedia and observationMedia
-    await prisma.media.deleteMany({
-      where: {
-        id: {
-          in: mediaFilesToDelete.map((f) => f.id),
-        },
-        projectId,
-      },
+    await deleteMediaFiles({
+      projectId,
+      mediaFiles: mediaFilesToDelete,
+      storageClient: getS3MediaStorageClient(
+        env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+      ),
     });
     logger.info(
       `[Data Retention] Deleted ${mediaFilesToDelete.length} media files for project ${projectId}`,

--- a/worker/src/features/batch-project-cleaner/index.ts
+++ b/worker/src/features/batch-project-cleaner/index.ts
@@ -1,11 +1,11 @@
 import {
+  getDeletedProjects,
   logger,
   queryClickhouse,
   commandClickhouse,
   traceException,
   recordIncrement,
 } from "@langfuse/shared/src/server";
-import { prisma } from "@langfuse/shared/src/db";
 
 export const BATCH_DELETION_TABLES = [
   "traces",
@@ -91,7 +91,9 @@ export class BatchProjectCleaner extends PeriodicExclusiveRunner {
     // Step 1: Query PG for deleted projects (no lock needed)
     let deletedProjects: Array<{ id: string }>;
     try {
-      deletedProjects = await this.getDeletedProjects();
+      deletedProjects = await getDeletedProjects(
+        env.LANGFUSE_BATCH_PROJECT_CLEANER_PROJECT_LIMIT,
+      );
     } catch (error) {
       logger.error(`${this.instanceName}: Failed to query deleted projects`, {
         error,
@@ -192,16 +194,6 @@ export class BatchProjectCleaner extends PeriodicExclusiveRunner {
         },
       )) ?? env.LANGFUSE_BATCH_PROJECT_CLEANER_SLEEP_ON_EMPTY_MS
     );
-  }
-
-  private async getDeletedProjects(): Promise<Array<{ id: string }>> {
-    return prisma.project.findMany({
-      select: { id: true },
-      where: {
-        deletedAt: { not: null },
-      },
-      take: env.LANGFUSE_BATCH_PROJECT_CLEANER_PROJECT_LIMIT,
-    });
   }
 
   private async getProjectCounts(

--- a/worker/src/features/media-retention-cleaner/index.ts
+++ b/worker/src/features/media-retention-cleaner/index.ts
@@ -1,5 +1,7 @@
 import { prisma } from "@langfuse/shared/src/db";
 import {
+  deleteMediaFiles,
+  findExpiredMediaByProjectId,
   getS3MediaStorageClient,
   logger,
   recordGauge,
@@ -155,10 +157,7 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
   private async processProject(workload: ProjectWorkload): Promise<void> {
     // Delete media files (S3 + PostgreSQL)
     if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
-      await this.deleteExpiredMedia(
-        workload,
-        env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-      );
+      await this.deleteExpiredMedia(workload);
     }
 
     // Delete blob storage entries (S3 + ClickHouse soft delete)
@@ -175,16 +174,10 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
     });
   }
 
-  private async deleteExpiredMedia(
-    workload: ProjectWorkload,
-    bucket: string,
-  ): Promise<void> {
-    const mediaFiles = await prisma.media.findMany({
-      select: { id: true, bucketPath: true },
-      where: {
-        projectId: workload.projectId,
-        createdAt: { lte: workload.cutoffDate },
-      },
+  private async deleteExpiredMedia(workload: ProjectWorkload): Promise<void> {
+    const mediaFiles = await findExpiredMediaByProjectId({
+      projectId: workload.projectId,
+      cutoffDate: workload.cutoffDate,
     });
 
     // Record gauge for observed work
@@ -196,16 +189,12 @@ export class MediaRetentionCleaner extends PeriodicExclusiveRunner {
       return;
     }
 
-    // Delete from S3 first
-    const mediaStorageClient = getS3MediaStorageClient(bucket);
-    await mediaStorageClient.deleteFiles(mediaFiles.map((f) => f.bucketPath));
-
-    // Delete from PostgreSQL (cascades to traceMedia/observationMedia)
-    await prisma.media.deleteMany({
-      where: {
-        id: { in: mediaFiles.map((f) => f.id) },
-        projectId: workload.projectId,
-      },
+    await deleteMediaFiles({
+      projectId: workload.projectId,
+      mediaFiles,
+      storageClient: getS3MediaStorageClient(
+        env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET!,
+      ),
     });
 
     // Record successful deletion metrics

--- a/worker/src/features/traces/processClickhouseTraceDelete.ts
+++ b/worker/src/features/traces/processClickhouseTraceDelete.ts
@@ -3,33 +3,14 @@ import {
   deleteObservationsByTraceIds,
   deleteScoresByTraceIds,
   deleteTraces,
+  getS3MediaStorageClient,
   logger,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForTraces,
-  StorageService,
-  StorageServiceFactory,
   traceException,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { prisma } from "@langfuse/shared/src/db";
 import { chunk } from "lodash";
-
-let s3MediaStorageClient: StorageService;
-
-const getS3MediaStorageClient = (bucketName: string): StorageService => {
-  if (!s3MediaStorageClient) {
-    s3MediaStorageClient = StorageServiceFactory.getInstance({
-      bucketName,
-      accessKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID,
-      secretAccessKey: env.LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY,
-      endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
-      region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
-      forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
-      awsSse: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
-      awsSseKmsKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,
-    });
-  }
-  return s3MediaStorageClient;
-};
 
 const deleteMediaItemsForTraces = async (
   projectId: string,

--- a/worker/src/queues/projectDelete.ts
+++ b/worker/src/queues/projectDelete.ts
@@ -1,39 +1,22 @@
 import { Job, Processor } from "bullmq";
 import {
   deleteEventsByProjectId,
+  deleteMediaFiles,
   deleteObservationsByProjectId,
   deleteScoresByProjectId,
   deleteTracesByProjectId,
   deleteDatasetRunItemsByProjectId,
+  findAllMediaByProjectId,
   getCurrentSpan,
+  getS3MediaStorageClient,
   logger,
   QueueName,
   removeIngestionEventsFromS3AndDeleteClickhouseRefsForProject,
-  StorageService,
-  StorageServiceFactory,
   TQueueJobTypes,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { Prisma } from "@prisma/client";
 import { env } from "../env";
-
-let s3MediaStorageClient: StorageService;
-
-const getS3MediaStorageClient = (bucketName: string): StorageService => {
-  if (!s3MediaStorageClient) {
-    s3MediaStorageClient = StorageServiceFactory.getInstance({
-      bucketName,
-      accessKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID,
-      secretAccessKey: env.LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY,
-      endpoint: env.LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT,
-      region: env.LANGFUSE_S3_MEDIA_UPLOAD_REGION,
-      forcePathStyle: env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE === "true",
-      awsSse: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
-      awsSseKmsKeyId: env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,
-    });
-  }
-  return s3MediaStorageClient;
-};
 
 export const projectDeleteProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.ProjectDelete]>,
@@ -55,27 +38,17 @@ export const projectDeleteProcessor: Processor = async (
 
   logger.info(`Deleting ${projectId} in org ${orgId}`);
 
-  // Delete media data from S3 for project
+  // Delete media data from S3 and PG for project
   if (env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET) {
     logger.info(`Deleting media for ${projectId} in org ${orgId}`);
-    const mediaFilesToDelete = await prisma.media.findMany({
-      select: {
-        id: true,
-        projectId: true,
-        bucketPath: true,
-      },
-      where: {
-        projectId,
-      },
+    const mediaFilesToDelete = await findAllMediaByProjectId({ projectId });
+    await deleteMediaFiles({
+      projectId,
+      mediaFiles: mediaFilesToDelete,
+      storageClient: getS3MediaStorageClient(
+        env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
+      ),
     });
-    const mediaStorageClient = getS3MediaStorageClient(
-      env.LANGFUSE_S3_MEDIA_UPLOAD_BUCKET,
-    );
-    // Delete from Cloud Storage
-    await mediaStorageClient.deleteFiles(
-      mediaFilesToDelete.map((f) => f.bucketPath),
-    );
-    // No need to delete from table as this will be done below via Prisma
   }
 
   logger.info(


### PR DESCRIPTION
projectDelete now marks media as deleted immediately. Making it cheaper on
retries.
