### PR TITLE
Feat dataset item metadata

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -32,6 +32,7 @@ export * from "./llm/testModelCall";
 export * from "./llm/getInternalTracingHandler";
 export * from "./utils/DatabaseReadStream";
 export * from "./utils/transforms";
+export * from "./utils/metadata_conversion";
 export * from "./utils/billingCycleHelpers";
 export * from "./utils/compareVersions";
 export * from "./otel/utils";

--- a/packages/shared/src/server/utils/metadata_conversion.ts
+++ b/packages/shared/src/server/utils/metadata_conversion.ts
@@ -1,5 +1,18 @@
 import { parseJsonPrioritised } from "../../utils/json";
 import { MetadataDomain } from "../../domain";
+import { type JsonValue } from "@prisma/client/runtime/library";
+
+/**
+ * Resolves dataset item metadata into a flat Record.
+ */
+export function resolveMetadata(
+  metadata: JsonValue | null | undefined,
+): Record<string, unknown> {
+  if (metadata === null || metadata === undefined) return {};
+  if (Array.isArray(metadata)) return { metadata };
+  if (typeof metadata === "object") return metadata as Record<string, unknown>;
+  return { metadata };
+}
 
 export function parseMetadataCHRecordToDomain(
   metadata: Record<string, string>,

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -8,7 +8,7 @@ import {
   PostDatasetRunItemsV1Body,
   PostDatasetRunItemsV1Response,
 } from "@/src/features/public-api/types/datasets";
-import { type JSONValue, LangfuseNotFoundError } from "@langfuse/shared";
+import { LangfuseNotFoundError } from "@langfuse/shared";
 import { addDatasetRunItemsToEvalQueue } from "@/src/features/evals/server/addDatasetRunItemsToEvalQueue";
 import {
   eventTypes,
@@ -16,6 +16,7 @@ import {
   processEventBatch,
   getObservationById,
   getDatasetItemById,
+  resolveMetadata,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
 import { createOrFetchDatasetRun } from "@/src/features/public-api/server/dataset-runs";
@@ -23,16 +24,6 @@ import {
   generateDatasetRunItemsForPublicApi,
   getDatasetRunItemsCountForPublicApi,
 } from "@/src/features/public-api/server/dataset-run-items";
-
-const resolveMetadata = (metadata: JSONValue): Record<string, unknown> => {
-  if (Array.isArray(metadata)) {
-    return { metadata: metadata };
-  }
-  if (typeof metadata === "object" && metadata !== null) {
-    return metadata as Record<string, unknown>;
-  }
-  return { metadata: metadata };
-};
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({

--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -7,6 +7,7 @@ import { createExperimentJobClickhouse } from "../features/experiments/experimen
 import {
   createDatasetItem,
   createOrgProjectAndApiKey,
+  fetchLLMCompletion,
   logger,
 } from "@langfuse/shared/src/server";
 
@@ -470,6 +471,120 @@ describe("create experiment jobs with placeholders", () => {
 
     // Just verify it doesn't throw and returns success
     expect(result).toEqual({ success: true });
+  });
+});
+
+describe("dataset item metadata in trace sink params", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const setupExperiment = async (itemMetadata: unknown) => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const datasetId = randomUUID();
+    const runId = randomUUID();
+    const promptId = randomUUID();
+
+    await prisma.prompt.create({
+      data: {
+        id: promptId,
+        projectId,
+        name: "Test Prompt",
+        prompt: "Hello {{name}}",
+        type: "text",
+        version: 1,
+        createdBy: "test-user",
+      },
+    });
+    await prisma.dataset.create({
+      data: { id: datasetId, projectId, name: "Test Dataset" },
+    });
+    await prisma.datasetRuns.create({
+      data: {
+        id: runId,
+        name: "Test Run",
+        projectId,
+        datasetId,
+        metadata: {
+          prompt_id: promptId,
+          provider: "openai",
+          model: "gpt-3.5-turbo",
+          model_params: { temperature: 0 },
+        },
+      },
+    });
+    await createDatasetItem({
+      projectId,
+      datasetId,
+      input: { name: "World" },
+      metadata: itemMetadata,
+    });
+    await prisma.llmApiKeys.create({
+      data: {
+        id: randomUUID(),
+        projectId,
+        provider: "openai",
+        adapter: LLMAdapter.OpenAI,
+        displaySecretKey: "test-key",
+        secretKey: encrypt("test-key"),
+      },
+    });
+
+    return { projectId, datasetId, runId };
+  };
+
+  test("includes dataset item object metadata in traceSinkParams", async () => {
+    const { projectId, datasetId, runId } = await setupExperiment({
+      customer_id: "123",
+      variant: "A",
+    });
+
+    await createExperimentJobClickhouse({
+      event: { projectId, datasetId, runId },
+    });
+
+    const call = vi.mocked(fetchLLMCompletion).mock.calls[0][0];
+    expect(call.traceSinkParams?.metadata).toMatchObject({
+      customer_id: "123",
+      variant: "A",
+      dataset_id: datasetId,
+      dataset_item_id: expect.any(String),
+    });
+  });
+
+  test("hardcoded keys are not overwritten by dataset item metadata", async () => {
+    const { projectId, datasetId, runId } = await setupExperiment({
+      dataset_id: "should-not-overwrite",
+      dataset_item_id: "should-not-overwrite",
+      custom_key: "custom_value",
+    });
+
+    await createExperimentJobClickhouse({
+      event: { projectId, datasetId, runId },
+    });
+
+    const call = vi.mocked(fetchLLMCompletion).mock.calls[0][0];
+    expect(call.traceSinkParams?.metadata).toMatchObject({
+      dataset_id: datasetId,
+      dataset_item_id: expect.any(String),
+      custom_key: "custom_value",
+    });
+    expect(call.traceSinkParams?.metadata?.dataset_id).toBe(datasetId);
+  });
+
+  test("includes no extra keys when dataset item has null metadata", async () => {
+    const { projectId, datasetId, runId } = await setupExperiment(null);
+
+    await createExperimentJobClickhouse({
+      event: { projectId, datasetId, runId },
+    });
+
+    const call = vi.mocked(fetchLLMCompletion).mock.calls[0][0];
+    expect(call.traceSinkParams?.metadata).toMatchObject({
+      dataset_id: datasetId,
+      dataset_item_id: expect.any(String),
+    });
+    expect(Object.keys(call.traceSinkParams?.metadata ?? {})).toHaveLength(5); // 5 hardcoded keys
   });
 });
 

--- a/worker/src/__tests__/resolveMetadata.test.ts
+++ b/worker/src/__tests__/resolveMetadata.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { resolveMetadata } from "@langfuse/shared/src/server";
+
+describe("resolveMetadata", () => {
+  it("returns empty object for null", () => {
+    expect(resolveMetadata(null)).toEqual({});
+  });
+
+  it("returns empty object for undefined", () => {
+    expect(resolveMetadata(undefined)).toEqual({});
+  });
+
+  it("returns the object as-is for a JSON object", () => {
+    const input = { foo: "bar", count: 42 };
+    expect(resolveMetadata(input)).toEqual({ foo: "bar", count: 42 });
+  });
+
+  it("wraps an array under a metadata key", () => {
+    const input = [1, 2, 3];
+    expect(resolveMetadata(input)).toEqual({ metadata: [1, 2, 3] });
+  });
+
+  it("wraps a string primitive under a metadata key", () => {
+    expect(resolveMetadata("some-string")).toEqual({
+      metadata: "some-string",
+    });
+  });
+
+  it("wraps a number primitive under a metadata key", () => {
+    expect(resolveMetadata(42)).toEqual({ metadata: 42 });
+  });
+
+  it("wraps a boolean primitive under a metadata key", () => {
+    expect(resolveMetadata(true)).toEqual({ metadata: true });
+  });
+
+  it("handles nested objects", () => {
+    const input = { nested: { deep: "value" }, tags: ["a", "b"] };
+    expect(resolveMetadata(input)).toEqual({
+      nested: { deep: "value" },
+      tags: ["a", "b"],
+    });
+  });
+});

--- a/worker/src/features/experiments/experimentServiceClickhouse.ts
+++ b/worker/src/features/experiments/experimentServiceClickhouse.ts
@@ -15,6 +15,7 @@ import {
   queryClickhouse,
   QueueJobs,
   redis,
+  resolveMetadata,
   TraceSinkParams,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
@@ -194,13 +195,21 @@ async function processLLMCall(
     traceName: `dataset-run-item-${runItemId.slice(0, 5)}`,
     traceId,
     targetProjectId: config.projectId, // ingest to user project
-    metadata: {
-      dataset_id: datasetItem.datasetId,
-      dataset_item_id: datasetItem.id,
-      structured_output_schema: config.structuredOutputSchema,
-      experiment_name: config.experimentName,
-      experiment_run_name: config.experimentRunName,
-    },
+    metadata: (() => {
+      const base = {
+        dataset_id: datasetItem.datasetId,
+        dataset_item_id: datasetItem.id,
+        structured_output_schema: config.structuredOutputSchema,
+        experiment_name: config.experimentName,
+        experiment_run_name: config.experimentRunName,
+      };
+      const itemMetadata = Object.fromEntries(
+        Object.entries(resolveMetadata(datasetItem.metadata)).filter(
+          ([key]) => !(key in base),
+        ),
+      );
+      return { ...base, ...itemMetadata };
+    })(),
     prompt: config.prompt,
     onGenerationComplete: (details) => {
       generationDetails = details;


### PR DESCRIPTION
## What does this PR do?

This refers to what have been discuss here: https://github.com/orgs/langfuse/discussions/12512. When running an experiment we would like to have in the traces the dataset-item metadata, this would allow easy filtering on the traces

Fixes # (issue)

Here is an example, where we can see that the language is correctly set at trace level

<img width="1472" height="137" alt="image" src="https://github.com/user-attachments/assets/5e861efb-16c5-4ef7-add5-35783c06bc0a" />

<img width="620" height="751" alt="image" src="https://github.com/user-attachments/assets/6499a5fb-0191-4601-a2f2-d228121b84ea" />


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
