### PR TITLE
fix(web): lazy load evaluator job execution counts

### DIFF
--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -944,8 +944,8 @@ model EvalTemplate {
   @@map("eval_templates")
 }
 
-// We currently assume in the evalRouter that _all_ job_executions are for EVAL job_configs.
-// If we ever extend this, we need to adjust the filter condition there. ref.: fetchJobExecutionsByStatus.
+// We currently assume in evaluator execution-count queries that _all_ job_executions are for EVAL job_configs.
+// If we ever extend this, we need to adjust the filter condition there. ref.: getEvaluatorExecutionStatusCounts.
 enum JobType {
   EVAL
 }

--- a/packages/shared/src/features/evals/evalConfigBlocking.ts
+++ b/packages/shared/src/features/evals/evalConfigBlocking.ts
@@ -1,4 +1,8 @@
-import { EvaluatorBlockReason, JobConfigState } from "@prisma/client";
+import {
+  EvaluatorBlockReason,
+  JobConfigState,
+  JobExecutionStatus,
+} from "@prisma/client";
 
 export const PausedEvaluatorDisplayState = "PAUSED" as const;
 export type PausedEvaluatorDisplayState = typeof PausedEvaluatorDisplayState;
@@ -7,6 +11,16 @@ export type EvaluatorDisplayState =
   | JobConfigState
   | PausedEvaluatorDisplayState
   | "FINISHED";
+
+export type EvaluatorExecutionStatusCount = {
+  status: JobExecutionStatus;
+  count: number;
+};
+
+export type EvaluatorExecutionCountsByEvaluatorId = Record<
+  string,
+  EvaluatorExecutionStatusCount[]
+>;
 
 type BlockStateLike = {
   status: JobConfigState;
@@ -135,4 +149,26 @@ export function deriveEvaluatorDisplayState(params: {
   }
 
   return JobConfigState.ACTIVE;
+}
+
+export function deriveEvaluatorDisplayStateFromExecutionCounts(params: {
+  status: JobConfigState;
+  blockedAt?: Date | null;
+  timeScope: string[];
+  executionCounts?: EvaluatorExecutionStatusCount[];
+}): EvaluatorDisplayState {
+  const { status, blockedAt, timeScope, executionCounts = [] } = params;
+
+  return deriveEvaluatorDisplayState({
+    status,
+    blockedAt,
+    timeScope,
+    hasPendingJobs: executionCounts.some(
+      (executionCount) => executionCount.status === JobExecutionStatus.PENDING,
+    ),
+    totalJobCount: executionCounts.reduce(
+      (total, executionCount) => total + executionCount.count,
+      0,
+    ),
+  });
 }

--- a/packages/shared/src/server/repositories/index.ts
+++ b/packages/shared/src/server/repositories/index.ts
@@ -19,3 +19,4 @@ export * from "./dataset-run-items";
 export * from "./dataset-items-columns";
 export * from "./dataset-items";
 export * from "./comments";
+export * from "./job-executions";

--- a/packages/shared/src/server/repositories/job-executions.ts
+++ b/packages/shared/src/server/repositories/job-executions.ts
@@ -1,0 +1,68 @@
+import { type PrismaClient } from "@prisma/client";
+import type {
+  EvaluatorExecutionCountsByEvaluatorId,
+  EvaluatorExecutionStatusCount,
+} from "../../features/evals/evalConfigBlocking";
+
+type EvaluatorExecutionStatusCountRecord = EvaluatorExecutionStatusCount & {
+  evaluatorId: string;
+};
+
+export const getEvaluatorExecutionStatusCounts = async ({
+  prisma,
+  projectId,
+  evaluatorIds,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+  evaluatorIds: string[];
+}): Promise<EvaluatorExecutionStatusCountRecord[]> => {
+  if (evaluatorIds.length === 0) {
+    return [];
+  }
+
+  const counts = await prisma.jobExecution.groupBy({
+    where: {
+      // We currently assume every job execution belongs to an evaluator job configuration.
+      jobConfigurationId: { in: evaluatorIds },
+      projectId,
+    },
+    by: ["status", "jobConfigurationId"],
+    _count: true,
+  });
+
+  return counts.map((count) => ({
+    evaluatorId: count.jobConfigurationId,
+    status: count.status,
+    count: count._count,
+  }));
+};
+
+export const getEvaluatorExecutionStatusCountsByEvaluatorId = async ({
+  prisma,
+  projectId,
+  evaluatorIds,
+}: {
+  prisma: PrismaClient;
+  projectId: string;
+  evaluatorIds: string[];
+}): Promise<EvaluatorExecutionCountsByEvaluatorId> => {
+  const counts = await getEvaluatorExecutionStatusCounts({
+    prisma,
+    projectId,
+    evaluatorIds,
+  });
+
+  const countsByEvaluatorId = Object.fromEntries(
+    evaluatorIds.map((evaluatorId) => [
+      evaluatorId,
+      [] as EvaluatorExecutionStatusCount[],
+    ]),
+  ) as EvaluatorExecutionCountsByEvaluatorId;
+
+  for (const { evaluatorId, ...count } of counts) {
+    countsByEvaluatorId[evaluatorId]?.push(count);
+  }
+
+  return countsByEvaluatorId;
+};

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -138,11 +138,11 @@ describe("evals trpc", () => {
         configs: expect.arrayContaining([
           expect.objectContaining({
             id: evalJobConfig1.id,
-            finalStatus: "ACTIVE",
+            displayStatus: "ACTIVE",
           }),
           expect.objectContaining({
             id: evalJobConfig2.id,
-            finalStatus: "ACTIVE",
+            displayStatus: "ACTIVE",
           }),
         ]),
         totalCount: expect.any(Number),
@@ -214,12 +214,12 @@ describe("evals trpc", () => {
       expect(
         response.configs.map((config) => ({
           id: config.id,
-          finalStatus: config.finalStatus,
+          displayStatus: config.displayStatus,
         })),
       ).toEqual([
-        { id: activeEvaluator.id, finalStatus: "ACTIVE" },
-        { id: pausedEvaluator.id, finalStatus: "PAUSED" },
-        { id: inactiveEvaluator.id, finalStatus: "INACTIVE" },
+        { id: activeEvaluator.id, displayStatus: "ACTIVE" },
+        { id: pausedEvaluator.id, displayStatus: "PAUSED" },
+        { id: inactiveEvaluator.id, displayStatus: "INACTIVE" },
       ]);
     });
   });
@@ -289,18 +289,15 @@ describe("evals trpc", () => {
         [evalJobConfig1.id]: expect.arrayContaining([
           expect.objectContaining({
             status: "PENDING",
-            _count: 1,
-            jobConfigurationId: evalJobConfig1.id,
+            count: 1,
           }),
           expect.objectContaining({
             status: "COMPLETED",
-            _count: 1,
-            jobConfigurationId: evalJobConfig1.id,
+            count: 1,
           }),
           expect.objectContaining({
             status: "ERROR",
-            _count: 1,
-            jobConfigurationId: evalJobConfig1.id,
+            count: 1,
           }),
         ]),
         [evalJobConfig2.id]: [],

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -68,7 +68,7 @@ describe("evals trpc", () => {
   });
 
   describe("evals.allConfigs", () => {
-    it("should retrieve all evaluator configurations with execution status counts", async () => {
+    it("should retrieve all evaluator configurations without execution status counts", async () => {
       const { project, caller } = await prepare();
 
       const evalJobConfig1 = await prisma.jobConfiguration.create({
@@ -138,27 +138,11 @@ describe("evals trpc", () => {
         configs: expect.arrayContaining([
           expect.objectContaining({
             id: evalJobConfig1.id,
-            jobExecutionsByState: expect.arrayContaining([
-              expect.objectContaining({
-                status: "PENDING",
-                _count: 1,
-                jobConfigurationId: evalJobConfig1.id,
-              }),
-              expect.objectContaining({
-                status: "COMPLETED",
-                _count: 1,
-                jobConfigurationId: evalJobConfig1.id,
-              }),
-              expect.objectContaining({
-                status: "ERROR",
-                _count: 1,
-                jobConfigurationId: evalJobConfig1.id,
-              }),
-            ]),
+            finalStatus: "ACTIVE",
           }),
           expect.objectContaining({
             id: evalJobConfig2.id,
-            jobExecutionsByState: expect.arrayContaining([]),
+            finalStatus: "ACTIVE",
           }),
         ]),
         totalCount: expect.any(Number),
@@ -237,6 +221,90 @@ describe("evals trpc", () => {
         { id: pausedEvaluator.id, finalStatus: "PAUSED" },
         { id: inactiveEvaluator.id, finalStatus: "INACTIVE" },
       ]);
+    });
+  });
+
+  describe("evals.jobExecutionCountsByEvaluatorIds", () => {
+    it("should lazily retrieve execution status counts grouped by evaluator id", async () => {
+      const { project, caller } = await prepare();
+
+      const evalJobConfig1 = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          scoreName: "test-score",
+          filter: [],
+          targetObject: EvalTargetObject.TRACE,
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+        },
+      });
+
+      await prisma.jobExecution.create({
+        data: {
+          jobConfigurationId: evalJobConfig1.id,
+          status: "PENDING",
+          projectId: project.id,
+        },
+      });
+
+      await prisma.jobExecution.create({
+        data: {
+          jobConfigurationId: evalJobConfig1.id,
+          status: "COMPLETED",
+          projectId: project.id,
+        },
+      });
+
+      await prisma.jobExecution.create({
+        data: {
+          jobConfigurationId: evalJobConfig1.id,
+          status: "ERROR",
+          projectId: project.id,
+        },
+      });
+
+      const evalJobConfig2 = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          scoreName: "test-score-2",
+          filter: [],
+          targetObject: EvalTargetObject.TRACE,
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+        },
+      });
+
+      const response = await caller.evals.jobExecutionCountsByEvaluatorIds({
+        projectId: project.id,
+        evaluatorIds: [evalJobConfig1.id, evalJobConfig2.id],
+      });
+
+      expect(response).toEqual({
+        [evalJobConfig1.id]: expect.arrayContaining([
+          expect.objectContaining({
+            status: "PENDING",
+            _count: 1,
+            jobConfigurationId: evalJobConfig1.id,
+          }),
+          expect.objectContaining({
+            status: "COMPLETED",
+            _count: 1,
+            jobConfigurationId: evalJobConfig1.id,
+          }),
+          expect.objectContaining({
+            status: "ERROR",
+            _count: 1,
+            jobConfigurationId: evalJobConfig1.id,
+          }),
+        ]),
+        [evalJobConfig2.id]: [],
+      });
     });
   });
 

--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -51,7 +51,7 @@ export const PeekViewEvaluatorConfigDetail = ({
           <span className="max-h-fit text-lg font-medium">Configuration</span>
           <div className="flex items-center gap-2">
             <StatusBadge
-              type={evalConfig.finalStatus.toLowerCase()}
+              type={evalConfig.displayStatus.toLowerCase()}
               isLive
               className="max-h-8"
             />
@@ -85,7 +85,7 @@ export const PeekViewEvaluatorConfigDetail = ({
       {evalConfig &&
         evalConfig.targetObject &&
         evalConfig.evalTemplate &&
-        evalConfig.finalStatus === "ACTIVE" && (
+        evalConfig.displayStatus === "ACTIVE" && (
           <LegacyEvalCallout
             projectId={projectId}
             evalConfigId={evalConfig.id}

--- a/web/src/features/evals/components/evaluator-detail.tsx
+++ b/web/src/features/evals/components/evaluator-detail.tsx
@@ -6,22 +6,20 @@ import { StatusBadge } from "@/src/components/layouts/status-badge";
 import { DetailPageNav } from "@/src/features/navigate-detail-pages/DetailPageNav";
 import Page from "@/src/components/layouts/page";
 import { LevelCountsDisplay } from "@/src/components/level-counts-display";
-import {
-  type JobExecutionState,
-  generateJobExecutionCounts,
-} from "@/src/features/evals/utils/job-execution-utils";
+import { generateJobExecutionCounts } from "@/src/features/evals/utils/job-execution-utils";
 import { EvaluatorPausedCallout } from "@/src/features/evals/components/evaluator-paused-callout";
+import { type EvaluatorExecutionStatusCount } from "@langfuse/shared";
 
 const JobExecutionCounts = ({
-  jobExecutionsByState,
+  jobExecutionCounts,
 }: {
-  jobExecutionsByState?: JobExecutionState[];
+  jobExecutionCounts?: EvaluatorExecutionStatusCount[];
 }) => {
-  if (!jobExecutionsByState || jobExecutionsByState.length === 0) {
+  if (!jobExecutionCounts || jobExecutionCounts.length === 0) {
     return null;
   }
 
-  const counts = generateJobExecutionCounts(jobExecutionsByState);
+  const counts = generateJobExecutionCounts(jobExecutionCounts);
   return <LevelCountsDisplay counts={counts} />;
 };
 
@@ -84,15 +82,15 @@ export const EvaluatorDetail = () => {
 
         actionButtonsRight: (
           <>
-            {evaluator.data?.jobExecutionsByState && (
+            {evaluator.data?.jobExecutionCounts && (
               <div className="flex flex-col items-center justify-center rounded-md bg-muted-gray px-2">
                 <JobExecutionCounts
-                  jobExecutionsByState={evaluator.data.jobExecutionsByState}
+                  jobExecutionCounts={evaluator.data.jobExecutionCounts}
                 />
               </div>
             )}
             <StatusBadge
-              type={evaluator.data?.finalStatus.toLowerCase()}
+              type={evaluator.data?.displayStatus.toLowerCase()}
               isLive
               className="max-h-8"
             />

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -13,22 +13,11 @@ import { InlineFilterState } from "@/src/features/filters/components/filter-buil
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
 import { evaluatorFilterConfig } from "@/src/features/filters/config/evaluators-config";
-import { type RouterOutputs, api } from "@/src/utils/api";
-import { safeExtract } from "@/src/utils/map-utils";
-import {
-  type FilterState,
-  type EvaluatorBlockReason,
-  singleFilter,
-} from "@langfuse/shared";
+import { api } from "@/src/utils/api";
 import { createColumnHelper } from "@tanstack/react-table";
 import { useEffect, useState, useMemo } from "react";
 import { useQueryParam, StringParam, withDefault } from "use-query-params";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
-import { z } from "zod/v4";
-import {
-  deriveEvaluatorStatusFromExecutionCounts,
-  generateJobExecutionCounts,
-} from "@/src/features/evals/utils/job-execution-utils";
 import {
   isLegacyEvalTarget,
   isEventTarget,
@@ -64,7 +53,6 @@ import {
 import { EvaluatorForm } from "@/src/features/evals/components/evaluator-form";
 import { useRouter } from "next/router";
 import { DeleteEvalConfigButton } from "@/src/components/deleteButton";
-import { RAGAS_TEMPLATE_PREFIX } from "@/src/features/evals/types";
 import { MaintainerTooltip } from "@/src/features/evals/components/maintainer-tooltip";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { Skeleton } from "@/src/components/ui/skeleton";
@@ -77,35 +65,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/src/components/ui/tooltip";
-
-export type EvaluatorDataRow = {
-  id: string;
-  status: string;
-  createdAt: string;
-  updatedAt: string;
-  maintainer: string;
-  rawStatus: string;
-  template?: {
-    id: string;
-    name: string;
-    version: number;
-  };
-  blockMessage?: string | null;
-  blockReason?: EvaluatorBlockReason | null;
-  scoreName: string;
-  target: string;
-  filter: FilterState;
-  result: {
-    level: string;
-    count: number;
-    symbol: string;
-  }[];
-  isResultLoading: boolean;
-  logs?: string;
-  actions?: string;
-  totalCost?: number | null;
-  isLegacy?: boolean;
-};
+import {
+  type EvaluatorDataRow,
+  useEvaluatorTableData,
+} from "@/src/features/evals/hooks/useEvaluatorTableData";
 
 function LegacyBadgeCell({ status }: { status: string }) {
   return (
@@ -180,15 +143,15 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     },
   );
 
-  const evaluators = api.evals.allConfigs.useQuery({
-    page: paginationState.pageIndex,
-    limit: paginationState.pageSize,
-    projectId,
-    filter: queryFilter.filterState,
-    orderBy: orderByState,
-    searchQuery: searchQuery,
-  });
-  const totalCount = evaluators.data?.totalCount ?? null;
+  const { evaluators, rows, totalCount, hasLegacyEvals } =
+    useEvaluatorTableData({
+      projectId,
+      page: paginationState.pageIndex,
+      limit: paginationState.pageSize,
+      filter: queryFilter.filterState,
+      orderBy: orderByState,
+      searchQuery,
+    });
 
   const existingEvaluator = api.evals.configById.useQuery(
     {
@@ -203,56 +166,6 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
   const hasAccess = useHasProjectAccess({ projectId, scope: "evalJob:CUD" });
 
   const datasets = api.datasets.allDatasetMeta.useQuery({ projectId });
-
-  // Fetch costs for all evaluators
-  const evaluatorIds =
-    evaluators.data?.configs.map((config) => config.id) ?? [];
-  const costs = api.evals.costByEvaluatorIds.useQuery(
-    {
-      projectId,
-      evaluatorIds,
-    },
-    {
-      enabled: evaluators.isSuccess && evaluatorIds.length > 0,
-      meta: {
-        silentHttpCodes: [503],
-      },
-    },
-  );
-  const jobExecutionCounts =
-    api.evals.jobExecutionCountsByEvaluatorIds.useQuery(
-      {
-        projectId,
-        evaluatorIds,
-      },
-      {
-        enabled: evaluators.isSuccess && evaluatorIds.length > 0,
-      },
-    );
-
-  const getEvaluatorStatus = (
-    jobConfig: RouterOutputs["evals"]["allConfigs"]["configs"][number],
-  ) => {
-    const jobExecutionsByState = jobExecutionCounts.data?.[jobConfig.id];
-
-    if (!jobExecutionsByState) {
-      return jobConfig.finalStatus;
-    }
-
-    return deriveEvaluatorStatusFromExecutionCounts({
-      status: jobConfig.status,
-      blockedAt: jobConfig.blockedAt,
-      timeScope: Array.isArray(jobConfig.timeScope) ? jobConfig.timeScope : [],
-      jobExecutionsByState,
-    });
-  };
-
-  const hasLegacyEvals =
-    evaluators.data?.configs?.some(
-      (config) =>
-        getEvaluatorStatus(config) === "ACTIVE" &&
-        isLegacyEvalTarget(config.targetObject),
-    ) ?? false;
 
   useEffect(() => {
     if (evaluators.isSuccess) {
@@ -297,7 +210,9 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       cell: (row) => {
         const totalCost = row.getValue();
 
-        if (!costs.data) return <Skeleton className="h-4 w-16" />;
+        if (row.row.original.isCostLoading) {
+          return <Skeleton className="h-4 w-16" />;
+        }
 
         if (totalCost != null) return usdFormatter(totalCost, 2, 4);
 
@@ -510,45 +425,6 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
     [projectId, peekNavigationProps],
   );
 
-  const convertToTableRow = (
-    jobConfig: RouterOutputs["evals"]["allConfigs"]["configs"][number],
-  ): EvaluatorDataRow => {
-    const jobExecutionsByState = jobExecutionCounts.data?.[jobConfig.id];
-    const result = generateJobExecutionCounts(jobExecutionsByState);
-    const costData = costs.data?.[jobConfig.id];
-
-    return {
-      id: jobConfig.id,
-      status: getEvaluatorStatus(jobConfig),
-      rawStatus: jobConfig.status,
-      createdAt: jobConfig.createdAt.toLocaleString(),
-      updatedAt: jobConfig.updatedAt.toLocaleString(),
-      template: jobConfig.evalTemplate
-        ? {
-            id: jobConfig.evalTemplate.id,
-            name: jobConfig.evalTemplate.name,
-            version: jobConfig.evalTemplate.version,
-          }
-        : undefined,
-      blockMessage: jobConfig.blockMessage,
-      blockReason: jobConfig.blockReason,
-      scoreName: jobConfig.scoreName,
-      target: jobConfig.targetObject,
-      filter: z.array(singleFilter).parse(jobConfig.filter),
-      result: result,
-      isResultLoading: !jobExecutionCounts.data,
-      maintainer: jobConfig.evalTemplate
-        ? jobConfig.evalTemplate.projectId
-          ? "User maintained"
-          : jobConfig.evalTemplate.name.startsWith(RAGAS_TEMPLATE_PREFIX)
-            ? "Langfuse and Ragas maintained"
-            : "Langfuse maintained"
-        : "Not available",
-      totalCost: costData,
-      isLegacy: isLegacyEvalTarget(jobConfig.targetObject),
-    };
-  };
-
   return (
     <DataTableControlsProvider
       tableName={evaluatorFilterConfig.tableName}
@@ -627,9 +503,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
                     : {
                         isLoading: false,
                         isError: false,
-                        data: safeExtract(evaluators.data, "configs", []).map(
-                          (evaluator) => convertToTableRow(evaluator),
-                        ),
+                        data: rows,
                       }
               }
               pagination={{

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -25,7 +25,10 @@ import { useEffect, useState, useMemo } from "react";
 import { useQueryParam, StringParam, withDefault } from "use-query-params";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { z } from "zod/v4";
-import { generateJobExecutionCounts } from "@/src/features/evals/utils/job-execution-utils";
+import {
+  deriveEvaluatorStatusFromExecutionCounts,
+  generateJobExecutionCounts,
+} from "@/src/features/evals/utils/job-execution-utils";
 import {
   isLegacyEvalTarget,
   isEventTarget,
@@ -97,6 +100,7 @@ export type EvaluatorDataRow = {
     count: number;
     symbol: string;
   }[];
+  isResultLoading: boolean;
   logs?: string;
   actions?: string;
   totalCost?: number | null;
@@ -215,15 +219,40 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       },
     },
   );
-
-  const hasLegacyEvals = useMemo(() => {
-    if (!evaluators.data?.configs) return false;
-    return evaluators.data.configs.some(
-      (config) =>
-        config.finalStatus === "ACTIVE" &&
-        isLegacyEvalTarget(config.targetObject),
+  const jobExecutionCounts =
+    api.evals.jobExecutionCountsByEvaluatorIds.useQuery(
+      {
+        projectId,
+        evaluatorIds,
+      },
+      {
+        enabled: evaluators.isSuccess && evaluatorIds.length > 0,
+      },
     );
-  }, [evaluators.data?.configs]);
+
+  const getEvaluatorStatus = (
+    jobConfig: RouterOutputs["evals"]["allConfigs"]["configs"][number],
+  ) => {
+    const jobExecutionsByState = jobExecutionCounts.data?.[jobConfig.id];
+
+    if (!jobExecutionsByState) {
+      return jobConfig.finalStatus;
+    }
+
+    return deriveEvaluatorStatusFromExecutionCounts({
+      status: jobConfig.status,
+      blockedAt: jobConfig.blockedAt,
+      timeScope: Array.isArray(jobConfig.timeScope) ? jobConfig.timeScope : [],
+      jobExecutionsByState,
+    });
+  };
+
+  const hasLegacyEvals =
+    evaluators.data?.configs?.some(
+      (config) =>
+        getEvaluatorStatus(config) === "ACTIVE" &&
+        isLegacyEvalTarget(config.targetObject),
+    ) ?? false;
 
   useEffect(() => {
     if (evaluators.isSuccess) {
@@ -281,7 +310,12 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       size: 150,
       cell: (row) => {
         const result = row.getValue();
-        return <LevelCountsDisplay counts={result} />;
+        return (
+          <LevelCountsDisplay
+            counts={result}
+            isLoading={row.row.original.isResultLoading}
+          />
+        );
       },
     }),
     columnHelper.accessor("logs", {
@@ -479,12 +513,13 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
   const convertToTableRow = (
     jobConfig: RouterOutputs["evals"]["allConfigs"]["configs"][number],
   ): EvaluatorDataRow => {
-    const result = generateJobExecutionCounts(jobConfig.jobExecutionsByState);
+    const jobExecutionsByState = jobExecutionCounts.data?.[jobConfig.id];
+    const result = generateJobExecutionCounts(jobExecutionsByState);
     const costData = costs.data?.[jobConfig.id];
 
     return {
       id: jobConfig.id,
-      status: jobConfig.finalStatus,
+      status: getEvaluatorStatus(jobConfig),
       rawStatus: jobConfig.status,
       createdAt: jobConfig.createdAt.toLocaleString(),
       updatedAt: jobConfig.updatedAt.toLocaleString(),
@@ -501,6 +536,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       target: jobConfig.targetObject,
       filter: z.array(singleFilter).parse(jobConfig.filter),
       result: result,
+      isResultLoading: !jobExecutionCounts.data,
       maintainer: jobConfig.evalTemplate
         ? jobConfig.evalTemplate.projectId
           ? "User maintained"

--- a/web/src/features/evals/hooks/useEvaluatorTableData.ts
+++ b/web/src/features/evals/hooks/useEvaluatorTableData.ts
@@ -1,0 +1,157 @@
+import { useMemo } from "react";
+import { z } from "zod/v4";
+import {
+  deriveEvaluatorDisplayStateFromExecutionCounts,
+  type EvaluatorBlockReason,
+  type FilterState,
+  singleFilter,
+  type OrderByState,
+} from "@langfuse/shared";
+import { api } from "@/src/utils/api";
+import { generateJobExecutionCounts } from "@/src/features/evals/utils/job-execution-utils";
+import { isLegacyEvalTarget } from "@/src/features/evals/utils/typeHelpers";
+import { RAGAS_TEMPLATE_PREFIX } from "@/src/features/evals/types";
+
+export type EvaluatorDataRow = {
+  id: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  maintainer: string;
+  rawStatus: string;
+  template?: {
+    id: string;
+    name: string;
+    version: number;
+  };
+  blockMessage?: string | null;
+  blockReason?: EvaluatorBlockReason | null;
+  scoreName: string;
+  target: string;
+  filter: FilterState;
+  result: {
+    level: string;
+    count: number;
+    symbol: string;
+  }[];
+  isCostLoading: boolean;
+  isResultLoading: boolean;
+  logs?: string;
+  actions?: string;
+  totalCost?: number | null;
+  isLegacy?: boolean;
+};
+
+type UseEvaluatorTableDataParams = {
+  projectId: string;
+  page: number;
+  limit: number;
+  filter: FilterState;
+  orderBy: OrderByState;
+  searchQuery: string | null;
+};
+
+export const useEvaluatorTableData = ({
+  projectId,
+  page,
+  limit,
+  filter,
+  orderBy,
+  searchQuery,
+}: UseEvaluatorTableDataParams) => {
+  const evaluators = api.evals.allConfigs.useQuery({
+    page,
+    limit,
+    projectId,
+    filter,
+    orderBy,
+    searchQuery,
+  });
+
+  const evaluatorIds =
+    evaluators.data?.configs.map((config) => config.id) ?? [];
+
+  const costs = api.evals.costByEvaluatorIds.useQuery(
+    {
+      projectId,
+      evaluatorIds,
+    },
+    {
+      enabled: evaluators.isSuccess && evaluatorIds.length > 0,
+      meta: {
+        silentHttpCodes: [503],
+      },
+    },
+  );
+
+  const jobExecutionCounts =
+    api.evals.jobExecutionCountsByEvaluatorIds.useQuery(
+      {
+        projectId,
+        evaluatorIds,
+      },
+      {
+        enabled: evaluators.isSuccess && evaluatorIds.length > 0,
+      },
+    );
+
+  const rows = useMemo(
+    () =>
+      (evaluators.data?.configs ?? []).map((jobConfig) => {
+        const executionCounts = jobExecutionCounts.data?.[jobConfig.id];
+        const costData = costs.data?.[jobConfig.id];
+        const status = executionCounts
+          ? deriveEvaluatorDisplayStateFromExecutionCounts({
+              status: jobConfig.status,
+              blockedAt: jobConfig.blockedAt,
+              timeScope: Array.isArray(jobConfig.timeScope)
+                ? jobConfig.timeScope
+                : [],
+              executionCounts,
+            })
+          : jobConfig.displayStatus;
+
+        return {
+          id: jobConfig.id,
+          status,
+          rawStatus: jobConfig.status,
+          createdAt: jobConfig.createdAt.toLocaleString(),
+          updatedAt: jobConfig.updatedAt.toLocaleString(),
+          template: jobConfig.evalTemplate
+            ? {
+                id: jobConfig.evalTemplate.id,
+                name: jobConfig.evalTemplate.name,
+                version: jobConfig.evalTemplate.version,
+              }
+            : undefined,
+          blockMessage: jobConfig.blockMessage,
+          blockReason: jobConfig.blockReason,
+          scoreName: jobConfig.scoreName,
+          target: jobConfig.targetObject,
+          filter: z.array(singleFilter).parse(jobConfig.filter),
+          result: generateJobExecutionCounts(executionCounts),
+          isCostLoading: !costs.data,
+          isResultLoading: !jobExecutionCounts.data,
+          maintainer: jobConfig.evalTemplate
+            ? jobConfig.evalTemplate.projectId
+              ? "User maintained"
+              : jobConfig.evalTemplate.name.startsWith(RAGAS_TEMPLATE_PREFIX)
+                ? "Langfuse and Ragas maintained"
+                : "Langfuse maintained"
+            : "Not available",
+          totalCost: costData,
+          isLegacy: isLegacyEvalTarget(jobConfig.targetObject),
+        } satisfies EvaluatorDataRow;
+      }),
+    [costs.data, evaluators.data?.configs, jobExecutionCounts.data],
+  );
+
+  return {
+    evaluators,
+    rows,
+    totalCount: evaluators.data?.totalCount ?? null,
+    hasLegacyEvals: rows.some(
+      (row) => row.status === "ACTIVE" && Boolean(row.isLegacy),
+    ),
+  };
+};

--- a/web/src/features/evals/server/evalConfigState.ts
+++ b/web/src/features/evals/server/evalConfigState.ts
@@ -2,39 +2,14 @@ import { z } from "zod/v4";
 import {
   type JobConfiguration,
   JobConfigState,
-  deriveEvaluatorDisplayState,
   singleFilter,
 } from "@langfuse/shared";
-import { type JobExecutionState } from "@/src/features/evals/utils/job-execution-utils";
 
 export const resetEvalConfigBlockFields = {
   blockedAt: null,
   blockReason: null,
   blockMessage: null,
 } as const;
-
-export const deriveEvaluatorDisplayStatus = (
-  status: string,
-  blockedAt: Date | null,
-  timeScope: string[],
-  jobExecutionsByState: JobExecutionState[],
-): string => {
-  const hasPendingJobs = jobExecutionsByState.some(
-    (jobExecution) => jobExecution.status === "PENDING",
-  );
-  const totalJobCount = jobExecutionsByState.reduce(
-    (count, jobExecution) => count + jobExecution._count,
-    0,
-  );
-
-  return deriveEvaluatorDisplayState({
-    status: status as JobConfigState,
-    blockedAt,
-    timeScope,
-    hasPendingJobs,
-    totalJobCount,
-  });
-};
 
 export const shouldValidateBeforeActivation = ({
   currentStatus,

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -194,6 +194,28 @@ const fetchJobExecutionsByStatus = async ({
   });
 };
 
+type JobExecutionCountsByStatus = Awaited<
+  ReturnType<typeof fetchJobExecutionsByStatus>
+>;
+
+const mapJobExecutionCountsByEvaluatorId = ({
+  evaluatorIds,
+  jobExecutionsByStatus,
+}: {
+  evaluatorIds: string[];
+  jobExecutionsByStatus: JobExecutionCountsByStatus;
+}) => {
+  const countsByEvaluatorId = Object.fromEntries(
+    evaluatorIds.map((evaluatorId) => [evaluatorId, []]),
+  ) as Record<string, JobExecutionCountsByStatus>;
+
+  for (const jobExecution of jobExecutionsByStatus) {
+    countsByEvaluatorId[jobExecution.jobConfigurationId]?.push(jobExecution);
+  }
+
+  return countsByEvaluatorId;
+};
+
 const validateEvalTemplateActivation = async ({
   prisma,
   projectId,
@@ -393,12 +415,6 @@ export const evalRouter = createTRPCRouter({
         ),
       ]);
 
-      const jobExecutionsByState = await fetchJobExecutionsByStatus({
-        prisma: ctx.prisma,
-        projectId: input.projectId,
-        configIds: configs.map((c) => c.id),
-      });
-
       return {
         configs: configs.map((config) => ({
           ...config,
@@ -410,16 +426,11 @@ export const evalRouter = createTRPCRouter({
                 projectId: config.templateProjectId,
               }
             : null,
-          jobExecutionsByState: jobExecutionsByState.filter(
-            (je) => je.jobConfigurationId === config.id,
-          ),
           finalStatus: deriveEvaluatorDisplayStatus(
             config.status,
             config.blockedAt,
             Array.isArray(config.timeScope) ? config.timeScope : [],
-            jobExecutionsByState.filter(
-              (je) => je.jobConfigurationId === config.id,
-            ),
+            [],
           ),
         })),
         totalCount:
@@ -1493,6 +1504,36 @@ export const evalRouter = createTRPCRouter({
       `);
 
       return evaluators;
+    }),
+
+  jobExecutionCountsByEvaluatorIds: protectedProjectProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        evaluatorIds: z.array(z.string()),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "evalJob:read",
+      });
+
+      if (input.evaluatorIds.length === 0) {
+        return {} as Record<string, JobExecutionCountsByStatus>;
+      }
+
+      const jobExecutionsByStatus = await fetchJobExecutionsByStatus({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        configIds: input.evaluatorIds,
+      });
+
+      return mapJobExecutionCountsByEvaluatorId({
+        evaluatorIds: input.evaluatorIds,
+        jobExecutionsByStatus,
+      });
     }),
 
   costByEvaluatorIds: protectedProjectProcedure

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -8,6 +8,7 @@ import { auditLog } from "@/src/features/audit-logs/auditLog";
 import {
   DEFAULT_TRACE_JOB_DELAY,
   ZodModelConfig,
+  deriveEvaluatorDisplayStateFromExecutionCounts,
   type OrderByState,
   singleFilter,
   variableMapping,
@@ -27,6 +28,7 @@ import {
   getQueue,
   getAvgCostByEvaluatorIds,
   getCostByEvaluatorIds,
+  getEvaluatorExecutionStatusCountsByEvaluatorId,
   getScoresByIds,
   logger,
   QueueName,
@@ -51,7 +53,6 @@ import {
 } from "@/src/server/api/definitions/evalConfigsTable";
 import { evalExecutionsFilterCols } from "@/src/server/api/definitions/evalExecutionsTable";
 import {
-  deriveEvaluatorDisplayStatus,
   resetEvalConfigBlockFields,
   selectDatasetEvaluatorsForStatusChange,
   shouldValidateBeforeActivation,
@@ -169,52 +170,6 @@ const UpdateEvalJobSchema = z.object({
   status: z.enum(EvaluatorStatus).optional(),
   timeScope: TimeScopeSchema.optional(),
 });
-
-const fetchJobExecutionsByStatus = async ({
-  prisma,
-  projectId,
-  configIds,
-}: {
-  prisma: PrismaClient;
-  projectId: string;
-  configIds: string[];
-}) => {
-  return prisma.jobExecution.groupBy({
-    where: {
-      // jobConfiguration: {
-      //   projectId: projectId,
-      //   jobType: "EVAL",
-      //   id: { in: configIds },
-      // },
-      jobConfigurationId: { in: configIds },
-      projectId: projectId,
-    },
-    by: ["status", "jobConfigurationId"],
-    _count: true,
-  });
-};
-
-type JobExecutionCountsByStatus = Awaited<
-  ReturnType<typeof fetchJobExecutionsByStatus>
->;
-
-const mapJobExecutionCountsByEvaluatorId = ({
-  evaluatorIds,
-  jobExecutionsByStatus,
-}: {
-  evaluatorIds: string[];
-  jobExecutionsByStatus: JobExecutionCountsByStatus;
-}) => {
-  const countsByEvaluatorId = Object.fromEntries(
-    evaluatorIds.map((evaluatorId) => [evaluatorId, []]),
-  ) as Record<string, JobExecutionCountsByStatus>;
-
-  for (const jobExecution of jobExecutionsByStatus) {
-    countsByEvaluatorId[jobExecution.jobConfigurationId]?.push(jobExecution);
-  }
-
-  return countsByEvaluatorId;
-};
 
 const validateEvalTemplateActivation = async ({
   prisma,
@@ -426,12 +381,12 @@ export const evalRouter = createTRPCRouter({
                 projectId: config.templateProjectId,
               }
             : null,
-          finalStatus: deriveEvaluatorDisplayStatus(
-            config.status,
-            config.blockedAt,
-            Array.isArray(config.timeScope) ? config.timeScope : [],
-            [],
-          ),
+          displayStatus: deriveEvaluatorDisplayStateFromExecutionCounts({
+            status: config.status,
+            blockedAt: config.blockedAt,
+            timeScope: Array.isArray(config.timeScope) ? config.timeScope : [],
+            executionCounts: [],
+          }),
         })),
         totalCount:
           configsCount.length > 0 ? Number(configsCount[0]?.totalCount) : 0,
@@ -464,23 +419,27 @@ export const evalRouter = createTRPCRouter({
 
       if (!config) return null;
 
-      const jobExecutionsByStatus = await fetchJobExecutionsByStatus({
-        prisma: ctx.prisma,
-        projectId: input.projectId,
-        configIds: [config.id],
-      });
+      const jobExecutionCountsByEvaluatorId =
+        await getEvaluatorExecutionStatusCountsByEvaluatorId({
+          prisma: ctx.prisma,
+          projectId: input.projectId,
+          evaluatorIds: [config.id],
+        });
 
-      const finalStatus = deriveEvaluatorDisplayStatus(
-        config.status,
-        config.blockedAt,
-        Array.isArray(config.timeScope) ? config.timeScope : [],
-        jobExecutionsByStatus,
-      );
+      const jobExecutionCounts =
+        jobExecutionCountsByEvaluatorId[config.id] ?? [];
+
+      const displayStatus = deriveEvaluatorDisplayStateFromExecutionCounts({
+        status: config.status,
+        blockedAt: config.blockedAt,
+        timeScope: Array.isArray(config.timeScope) ? config.timeScope : [],
+        executionCounts: jobExecutionCounts,
+      });
 
       return {
         ...config,
-        jobExecutionsByState: jobExecutionsByStatus,
-        finalStatus,
+        jobExecutionCounts,
+        displayStatus,
       };
     }),
 
@@ -1521,18 +1480,13 @@ export const evalRouter = createTRPCRouter({
       });
 
       if (input.evaluatorIds.length === 0) {
-        return {} as Record<string, JobExecutionCountsByStatus>;
+        return {};
       }
 
-      const jobExecutionsByStatus = await fetchJobExecutionsByStatus({
+      return getEvaluatorExecutionStatusCountsByEvaluatorId({
         prisma: ctx.prisma,
         projectId: input.projectId,
-        configIds: input.evaluatorIds,
-      });
-
-      return mapJobExecutionCountsByEvaluatorId({
         evaluatorIds: input.evaluatorIds,
-        jobExecutionsByStatus,
       });
     }),
 

--- a/web/src/features/evals/utils/job-execution-utils.ts
+++ b/web/src/features/evals/utils/job-execution-utils.ts
@@ -1,3 +1,7 @@
+import {
+  deriveEvaluatorDisplayState,
+  type JobConfigState,
+} from "@langfuse/shared";
 import { compactNumberFormatter } from "@/src/utils/numbers";
 
 /**
@@ -38,3 +42,29 @@ export const generateJobExecutionCounts = (
     },
   ];
 };
+
+export const deriveEvaluatorStatusFromExecutionCounts = ({
+  status,
+  blockedAt,
+  timeScope,
+  jobExecutionsByState,
+}: {
+  status: JobConfigState;
+  blockedAt: Date | null;
+  timeScope: string[];
+  jobExecutionsByState?: JobExecutionState[];
+}) =>
+  deriveEvaluatorDisplayState({
+    status,
+    blockedAt,
+    timeScope,
+    hasPendingJobs:
+      jobExecutionsByState?.some(
+        (jobExecution) => jobExecution.status === "PENDING",
+      ) ?? false,
+    totalJobCount:
+      jobExecutionsByState?.reduce(
+        (count, jobExecution) => count + jobExecution._count,
+        0,
+      ) ?? 0,
+  });

--- a/web/src/features/evals/utils/job-execution-utils.ts
+++ b/web/src/features/evals/utils/job-execution-utils.ts
@@ -1,70 +1,42 @@
 import {
-  deriveEvaluatorDisplayState,
-  type JobConfigState,
+  JobExecutionStatus,
+  type EvaluatorExecutionStatusCount,
 } from "@langfuse/shared";
 import { compactNumberFormatter } from "@/src/utils/numbers";
 
-/**
- * Type for job execution state data
- */
-export type JobExecutionState = {
-  status: string;
-  jobConfigurationId: string;
-  _count: number;
-};
-
 export const generateJobExecutionCounts = (
-  jobExecutionsByState?: JobExecutionState[],
+  executionCounts?: EvaluatorExecutionStatusCount[],
 ) => {
   return [
     {
       level: "pending",
       count:
-        jobExecutionsByState?.find((je) => je.status === "PENDING")?._count ||
-        0,
+        executionCounts?.find(
+          (executionCount) =>
+            executionCount.status === JobExecutionStatus.PENDING,
+        )?.count || 0,
       symbol: "🕒",
       customNumberFormatter: compactNumberFormatter,
     },
     {
       level: "error",
       count:
-        jobExecutionsByState?.find((je) => je.status === "ERROR")?._count || 0,
+        executionCounts?.find(
+          (executionCount) =>
+            executionCount.status === JobExecutionStatus.ERROR,
+        )?.count || 0,
       symbol: "❌",
       customNumberFormatter: compactNumberFormatter,
     },
     {
       level: "succeeded",
       count:
-        jobExecutionsByState?.find((je) => je.status === "COMPLETED")?._count ||
-        0,
+        executionCounts?.find(
+          (executionCount) =>
+            executionCount.status === JobExecutionStatus.COMPLETED,
+        )?.count || 0,
       symbol: "✅",
       customNumberFormatter: compactNumberFormatter,
     },
   ];
 };
-
-export const deriveEvaluatorStatusFromExecutionCounts = ({
-  status,
-  blockedAt,
-  timeScope,
-  jobExecutionsByState,
-}: {
-  status: JobConfigState;
-  blockedAt: Date | null;
-  timeScope: string[];
-  jobExecutionsByState?: JobExecutionState[];
-}) =>
-  deriveEvaluatorDisplayState({
-    status,
-    blockedAt,
-    timeScope,
-    hasPendingJobs:
-      jobExecutionsByState?.some(
-        (jobExecution) => jobExecution.status === "PENDING",
-      ) ?? false,
-    totalJobCount:
-      jobExecutionsByState?.reduce(
-        (count, jobExecution) => count + jobExecution._count,
-        0,
-      ) ?? 0,
-  });


### PR DESCRIPTION
## Summary
- remove grouped evaluator execution counts from `evals.allConfigs` and load them lazily through a dedicated query
- move evaluator execution count DTOs and repository access into `@langfuse/shared`
- share evaluator display-status derivation across server and client, and extract evaluator table row shaping into a dedicated hook

## Impacted packages
- web
- @langfuse/shared

## Verification
- `pnpm --filter @langfuse/shared exec eslint src/features/evals/evalConfigBlocking.ts src/server/repositories/index.ts src/server/repositories/job-executions.ts --max-warnings 0`
- `pnpm --filter web exec eslint src/__tests__/server/evals-trpc.servertest.ts src/components/table/peek/peek-evaluator-config-detail.tsx src/features/evals/components/evaluator-detail.tsx src/features/evals/components/evaluator-table.tsx src/features/evals/hooks/useEvaluatorTableData.ts src/features/evals/server/evalConfigState.ts src/features/evals/server/router.ts src/features/evals/utils/job-execution-utils.ts --max-warnings 0`
- `pnpm --filter @langfuse/shared run typecheck`
- `pnpm --filter web run typecheck`
- `pnpm --filter web run test --testPathPatterns="evals-trpc.servertest.ts"` (blocked locally because Postgres at `localhost:5432` and Redis at `127.0.0.1:6379` are not available in this environment)
