### PR TITLE
feat(web): allow members to edit llm tools

### DIFF
--- a/web/src/features/rbac/constants/projectAccessRights.ts
+++ b/web/src/features/rbac/constants/projectAccessRights.ts
@@ -212,6 +212,7 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "evalDefaultModel:CUD",
     "llmApiKeys:read",
     "llmSchemas:read",
+    "llmTools:CUD",
     "llmTools:read",
     "batchExports:create",
     "batchExports:read",

--- a/web/src/features/rbac/utils/checkAccess.clienttest.ts
+++ b/web/src/features/rbac/utils/checkAccess.clienttest.ts
@@ -69,4 +69,13 @@ describe("RBAC access checks", () => {
       }),
     ).toBe(true);
   });
+
+  it("allows members to manage llm tools", () => {
+    expect(
+      hasProjectAccess({
+        role: "MEMBER",
+        scope: "llmTools:CUD",
+      }),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
### Motivation
- Members currently cannot create or edit LLM tools which prevents collaborators from adding tool candidates for playground/experiments (see LFE-8802). 
- The change lifts that restriction so project `MEMBER` role can manage LLM tools without requiring elevated roles.

### Description
- Added `"llmTools:CUD"` to the `MEMBER` entry in `web/src/features/rbac/constants/projectAccessRights.ts` so members gain create/update/delete rights for LLM tools. 
- Added a regression client test in `web/src/features/rbac/utils/checkAccess.clienttest.ts` asserting that `hasProjectAccess({ role: "MEMBER", scope: "llmTools:CUD" })` returns `true`.
- Impacted package: `web`.

### Testing
- Ran `pnpm --filter web run lint` which succeeded. 
- Attempted `pnpm --filter web run test-client --testPathPatterns='checkAccess.clienttest.ts'` but it could not run in this environment due to missing required environment variables (`DATABASE_URL`, `NEXTAUTH_URL`, `SALT`, `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`). 
- The change is a small RBAC config + unit assertion and the added test validates the intended access check logic locally when environment is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a404d70883299590ee8faf99ada6)