### PR TITLE
feat: add unresolved fetches to the v2 prompts API

### DIFF
--- a/fern/apis/server/definition/prompts.yml
+++ b/fern/apis/server/definition/prompts.yml
@@ -26,6 +26,9 @@ service:
           label:
             type: optional<string>
             docs: Label of the prompt to be retrieved. Defaults to "production" if no label or version is set.
+          resolve:
+            type: optional<boolean>
+            docs: Resolve prompt dependencies before returning the prompt. Defaults to `true`. Set to `false` to return the raw stored prompt with dependency tags intact. This bypasses prompt caching and is intended for debugging or one-off jobs, not production runtime fetches.
       response: Prompt
 
     list:
@@ -162,7 +165,7 @@ types:
         docs: Commit message for this prompt version.
       resolutionGraph:
         type: optional<map<string, unknown>>
-        docs: The dependency resolution graph for the current prompt. Null if prompt has no dependencies.
+        docs: The dependency resolution graph for the current prompt. Null if the prompt has no dependencies or if `resolve=false` was used.
 
   ChatMessageWithPlaceholders:
     discriminated: false

--- a/packages/shared/src/features/prompts/types.ts
+++ b/packages/shared/src/features/prompts/types.ts
@@ -92,11 +92,6 @@ export type GetPromptsMetaType = z.infer<typeof GetPromptsMetaSchema>;
 export const GetPromptSchema = z.object({
   name: z.string().transform((v) => decodeURIComponent(v)),
   version: z.coerce.number().int().nullish(),
-  resolve: z
-    .enum(["true", "false"])
-    .nullish()
-    .default("true")
-    .transform((v) => v === "true"), // Optional, defaults to true for backward compatibility
 });
 
 export const GetPromptByNameSchema = z.object({

--- a/packages/shared/src/features/prompts/types.ts
+++ b/packages/shared/src/features/prompts/types.ts
@@ -98,11 +98,6 @@ export const GetPromptByNameSchema = z.object({
   promptName: z.string(),
   version: z.coerce.number().int().nullish(),
   label: z.string().optional(),
-  resolve: z
-    .enum(["true", "false"])
-    .nullish()
-    .default("true")
-    .transform((v) => v === "true"), // Optional, defaults to true for backward compatibility
 });
 
 const BaseTextPromptSchema = z.object({

--- a/packages/shared/src/features/prompts/types.ts
+++ b/packages/shared/src/features/prompts/types.ts
@@ -98,6 +98,11 @@ export const GetPromptByNameSchema = z.object({
   promptName: z.string(),
   version: z.coerce.number().int().nullish(),
   label: z.string().optional(),
+  resolve: z
+    .enum(["true", "false"])
+    .nullish()
+    .default("true")
+    .transform((v) => v === "true"), // Optional, defaults to true for backward compatibility
 });
 
 const BaseTextPromptSchema = z.object({

--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -46,6 +46,10 @@ export class PromptService {
   }
 
   public async getPrompt(params: PromptParams): Promise<PromptResult | null> {
+    if (params.resolve === false) {
+      return this.getRawPrompt(params);
+    }
+
     if (this.cacheEnabled) {
       const cachedPrompt = await this.getCachedPrompt(params);
 
@@ -78,22 +82,39 @@ export class PromptService {
   private async getDbPrompt(
     params: PromptParams,
   ): Promise<PromptResult | null> {
+    return this.resolvePrompt(await this.findPrompt(params));
+  }
+
+  private async getRawPrompt(
+    params: PromptParams,
+  ): Promise<PromptResult | null> {
+    const prompt = await this.findPrompt(params);
+
+    if (!prompt) return null;
+
+    return {
+      ...prompt,
+      resolutionGraph: null,
+      // Compute isActive based on labels (deprecated field in DB)
+      isActive: prompt.labels.includes(PRODUCTION_LABEL),
+    };
+  }
+
+  private async findPrompt(params: PromptParams): Promise<Prompt | null> {
     const { projectId, promptName, version, label } = params;
 
     if (version) {
-      const prompt = await this.prisma.prompt.findFirst({
+      return this.prisma.prompt.findFirst({
         where: {
           projectId,
           name: promptName,
           version,
         },
       });
-
-      return this.resolvePrompt(prompt);
     }
 
     if (label) {
-      const prompt = await this.prisma.prompt.findFirst({
+      return this.prisma.prompt.findFirst({
         where: {
           projectId,
           name: promptName,
@@ -102,8 +123,6 @@ export class PromptService {
           },
         },
       });
-
-      return this.resolvePrompt(prompt);
     }
 
     this.logError("Invalid prompt params", params);

--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -14,7 +14,6 @@ import {
 } from "./types";
 
 import { ParsedPromptDependencyTag } from "../../../features/prompts/parsePromptDependencyTags";
-import { PRODUCTION_LABEL } from "../../../features/prompts/constants";
 
 export const MAX_PROMPT_NESTING_DEPTH = 5;
 
@@ -95,8 +94,6 @@ export class PromptService {
     return {
       ...prompt,
       resolutionGraph: null,
-      // Compute isActive based on labels (deprecated field in DB)
-      isActive: prompt.labels.includes(PRODUCTION_LABEL),
     };
   }
 
@@ -144,8 +141,6 @@ export class PromptService {
       ...prompt,
       prompt: promptGraph.resolvedPrompt,
       resolutionGraph: promptGraph.graph,
-      // Compute isActive based on labels (deprecated field in DB)
-      isActive: prompt.labels.includes(PRODUCTION_LABEL),
     };
   }
 

--- a/packages/shared/src/server/services/PromptService/types.ts
+++ b/packages/shared/src/server/services/PromptService/types.ts
@@ -7,6 +7,7 @@ export type PromptResult = Prompt & {
 export type PromptParams = {
   projectId: string;
   promptName: string;
+  resolve?: boolean;
 } & (
   | { version: number; label: undefined }
   | { version: null | undefined; label: string }

--- a/web/src/__e2e__/api.servertest.ts
+++ b/web/src/__e2e__/api.servertest.ts
@@ -310,6 +310,9 @@ describe("Prompts endpoint", () => {
     if (!redisValue) {
       return;
     }
-    expect(JSON.parse(redisValue)).toEqual(validatedPrompt);
+    expect(JSON.parse(redisValue)).toEqual({
+      ...validatedPrompt,
+      isActive: null, // deprecated isActive is being patched at the endpoint handler level; in Redis it is still null as in DB
+    });
   });
 });

--- a/web/src/__tests__/server/promptCache.servertest.ts
+++ b/web/src/__tests__/server/promptCache.servertest.ts
@@ -96,6 +96,24 @@ describe("PromptService", () => {
         expect.any(Number),
       );
     });
+
+    it("should bypass cache entirely when resolve is false", async () => {
+      mockPrisma.prompt.findFirst.mockResolvedValue(mockPrompt);
+
+      const result = await promptService.getPrompt({
+        projectId: "project1",
+        promptName: "testPrompt",
+        version: 1,
+        label: undefined,
+        resolve: false,
+      });
+
+      expect(result).toEqual(mockPrompt);
+      expect(mockPrisma.prompt.findFirst).toHaveBeenCalled();
+      expect(mockRedis.get).not.toHaveBeenCalled();
+      expect(mockRedis.set).not.toHaveBeenCalled();
+      expect(mockMetricIncrementer).not.toHaveBeenCalled();
+    });
   });
 
   describe("invalidateCache", () => {

--- a/web/src/__tests__/server/prompts.v1.servertest.ts
+++ b/web/src/__tests__/server/prompts.v1.servertest.ts
@@ -72,6 +72,56 @@ describe("/api/public/prompts API Endpoint", () => {
     expect(fetchedObservations.body.tags).toEqual([]);
   });
 
+  it("should ignore resolve=false and still return the resolved prompt", async () => {
+    const childPromptName = `child-prompt-${uuidv4()}`;
+    const parentPromptName = `parent-prompt-${uuidv4()}`;
+
+    await prisma.prompt.create({
+      data: {
+        id: uuidv4(),
+        name: childPromptName,
+        prompt: "child prompt content",
+        labels: ["production"],
+        version: 1,
+        config: {},
+        project: {
+          connect: { id: projectId },
+        },
+        createdBy: "user-1",
+      },
+    });
+
+    await prisma.prompt.create({
+      data: {
+        id: uuidv4(),
+        name: parentPromptName,
+        prompt: `Parent prompt: @@@langfusePrompt:name=${childPromptName}|label=production@@@`,
+        labels: ["production"],
+        version: 1,
+        config: {},
+        project: {
+          connect: { id: projectId },
+        },
+        createdBy: "user-1",
+      },
+    });
+
+    const fetchedObservations = await apiCall(
+      "GET",
+      `/api/public/prompts?name=${encodeURIComponent(parentPromptName)}&version=1&resolve=false`,
+      undefined,
+    );
+
+    expect(fetchedObservations.status).toBe(200);
+
+    if (!isPrompt(fetchedObservations.body)) {
+      throw new Error("Expected body to be a prompt");
+    }
+
+    expect(fetchedObservations.body.prompt).toContain("child prompt content");
+    expect(fetchedObservations.body.prompt).not.toContain("@@@langfusePrompt");
+  });
+
   it("should fetch a prompt with special character", async () => {
     const promptId = uuidv4();
 

--- a/web/src/__tests__/server/prompts.v1.servertest.ts
+++ b/web/src/__tests__/server/prompts.v1.servertest.ts
@@ -72,56 +72,6 @@ describe("/api/public/prompts API Endpoint", () => {
     expect(fetchedObservations.body.tags).toEqual([]);
   });
 
-  it("should ignore resolve=false and still return the resolved prompt", async () => {
-    const childPromptName = `child-prompt-${uuidv4()}`;
-    const parentPromptName = `parent-prompt-${uuidv4()}`;
-
-    await prisma.prompt.create({
-      data: {
-        id: uuidv4(),
-        name: childPromptName,
-        prompt: "child prompt content",
-        labels: ["production"],
-        version: 1,
-        config: {},
-        project: {
-          connect: { id: projectId },
-        },
-        createdBy: "user-1",
-      },
-    });
-
-    await prisma.prompt.create({
-      data: {
-        id: uuidv4(),
-        name: parentPromptName,
-        prompt: `Parent prompt: @@@langfusePrompt:name=${childPromptName}|label=production@@@`,
-        labels: ["production"],
-        version: 1,
-        config: {},
-        project: {
-          connect: { id: projectId },
-        },
-        createdBy: "user-1",
-      },
-    });
-
-    const fetchedObservations = await apiCall(
-      "GET",
-      `/api/public/prompts?name=${encodeURIComponent(parentPromptName)}&version=1&resolve=false`,
-      undefined,
-    );
-
-    expect(fetchedObservations.status).toBe(200);
-
-    if (!isPrompt(fetchedObservations.body)) {
-      throw new Error("Expected body to be a prompt");
-    }
-
-    expect(fetchedObservations.body.prompt).toContain("child prompt content");
-    expect(fetchedObservations.body.prompt).not.toContain("@@@langfusePrompt");
-  });
-
   it("should fetch a prompt with special character", async () => {
     const promptId = uuidv4();
 

--- a/web/src/__tests__/server/prompts.v2.servertest.ts
+++ b/web/src/__tests__/server/prompts.v2.servertest.ts
@@ -1860,6 +1860,37 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       const body = response.body as Prompt;
       expect(body.labels).toContain("production");
       expect(body.prompt).toContain("@@@langfusePrompt");
+      expect(body.resolutionGraph).toBeNull();
+    });
+
+    it("should return the raw prompt when resolve=false even if a dependency is missing", async () => {
+      const { projectId, auth } = await createOrgProjectAndApiKey();
+
+      const parentPromptName = "parent-prompt-" + nanoid();
+      const parentContent =
+        "Parent: @@@langfusePrompt:name=missing-child-prompt|version=1@@@";
+
+      await createPromptInDB({
+        name: parentPromptName,
+        prompt: parentContent,
+        labels: ["production"],
+        version: 1,
+        config: {},
+        projectId,
+        createdBy: "user-1",
+      });
+
+      const response = await makeAPICall(
+        "GET",
+        `${baseURI}/${encodeURIComponent(parentPromptName)}?version=1&resolve=false`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(200);
+      const body = response.body as Prompt;
+      expect(body.prompt).toBe(parentContent);
+      expect(body.resolutionGraph).toBeNull();
     });
   });
 });

--- a/web/src/features/mcp/features/prompts/tools/getPrompt.ts
+++ b/web/src/features/mcp/features/prompts/tools/getPrompt.ts
@@ -5,42 +5,9 @@
  * Read-only operation.
  */
 
-import { z } from "zod/v4";
-import { defineTool } from "../../../core/define-tool";
-import {
-  ParamPromptName,
-  ParamPromptLabel,
-  ParamPromptVersion,
-} from "../validation";
-import { getPromptByName } from "@/src/features/prompts/server/actions/getPromptByName";
-import { UserInputError } from "../../../core/errors";
-import { instrumentAsync } from "@langfuse/shared/src/server";
-import { SpanKind } from "@opentelemetry/api";
+import { createPromptReadTool } from "./promptReadToolFactory";
 
-/**
- * Base schema for JSON Schema generation (without refinements)
- */
-const GetPromptBaseSchema = z.object({
-  name: ParamPromptName,
-  label: ParamPromptLabel,
-  version: ParamPromptVersion,
-});
-
-/**
- * Full input schema with runtime validations
- */
-const GetPromptInputSchema = GetPromptBaseSchema.refine(
-  (data) => !(data.label && data.version),
-  {
-    message:
-      "Cannot specify both label and version - they are mutually exclusive",
-  },
-);
-
-/**
- * getPrompt tool definition and handler
- */
-export const [getPromptTool, handleGetPrompt] = defineTool({
+export const [getPromptTool, handleGetPrompt] = createPromptReadTool({
   name: "getPrompt",
   description: [
     "Fetch a specific prompt by name with optional label or version parameter.",
@@ -52,60 +19,6 @@ export const [getPromptTool, handleGetPrompt] = defineTool({
     "",
     "Note: label and version are mutually exclusive. Returns full prompt content with resolved dependencies.",
   ].join("\n"),
-  baseSchema: GetPromptBaseSchema,
-  inputSchema: GetPromptInputSchema,
-  handler: async (input, context) => {
-    return await instrumentAsync(
-      { name: "mcp.prompts.get", spanKind: SpanKind.INTERNAL },
-      async (span) => {
-        const { name, label, version } = input;
-
-        // Set span attributes for observability
-        span.setAttributes({
-          "langfuse.project.id": context.projectId,
-          "langfuse.org.id": context.orgId,
-          "mcp.api_key_id": context.apiKeyId,
-          "mcp.prompt_name": name,
-        });
-
-        if (label) {
-          span.setAttribute("mcp.prompt_label", label);
-        }
-        if (version) {
-          span.setAttribute("mcp.prompt_version", version);
-        }
-
-        // Fetch prompt using existing service
-        const prompt = await getPromptByName({
-          promptName: name,
-          projectId: context.projectId, // Auto-injected from authenticated API key
-          label,
-          version,
-        });
-
-        if (!prompt) {
-          throw new UserInputError(
-            `Prompt '${name}' not found${label ? ` with label '${label}'` : ""}${version ? ` with version ${version}` : ""}`,
-          );
-        }
-
-        // Return formatted response
-        return {
-          id: prompt.id,
-          name: prompt.name,
-          version: prompt.version,
-          type: prompt.type,
-          prompt: prompt.prompt,
-          labels: prompt.labels,
-          tags: prompt.tags,
-          config: prompt.config,
-          createdAt: prompt.createdAt,
-          updatedAt: prompt.updatedAt,
-          createdBy: prompt.createdBy,
-          projectId: prompt.projectId,
-        };
-      },
-    );
-  },
-  readOnlyHint: true,
+  resolve: true,
+  spanName: "mcp.prompts.get",
 });

--- a/web/src/features/mcp/features/prompts/tools/getPromptUnresolved.ts
+++ b/web/src/features/mcp/features/prompts/tools/getPromptUnresolved.ts
@@ -6,114 +6,26 @@
  * Read-only operation.
  */
 
-import { z } from "zod/v4";
-import { defineTool } from "../../../core/define-tool";
-import {
-  ParamPromptName,
-  ParamPromptLabel,
-  ParamPromptVersion,
-} from "../validation";
-import { UserInputError } from "../../../core/errors";
-import { instrumentAsync } from "@langfuse/shared/src/server";
-import { SpanKind } from "@opentelemetry/api";
-import { getPromptByName } from "@/src/features/prompts/server/actions/getPromptByName";
+import { createPromptReadTool } from "./promptReadToolFactory";
 
-/**
- * Base schema for JSON Schema generation (without refinements)
- */
-const GetPromptUnresolvedBaseSchema = z.object({
-  name: ParamPromptName,
-  label: ParamPromptLabel,
-  version: ParamPromptVersion,
-});
-
-/**
- * Full input schema with runtime validations
- */
-const GetPromptUnresolvedInputSchema = GetPromptUnresolvedBaseSchema.refine(
-  (data) => !(data.label && data.version),
-  {
-    message:
-      "Cannot specify both label and version - they are mutually exclusive",
-  },
-);
-
-/**
- * getPromptUnresolved tool definition and handler
- */
-export const [getPromptUnresolvedTool, handleGetPromptUnresolved] = defineTool({
-  name: "getPromptUnresolved",
-  description: [
-    "Fetch a specific prompt by name with optional label or version parameter WITHOUT resolving dependencies.",
-    "",
-    "Returns the raw prompt content with dependency tags intact. Useful for:",
-    "- Understanding prompt composition/stacking before resolution",
-    "- Debugging prompt dependencies",
-    "- Analyzing the dependency graph structure",
-    "",
-    "Retrieval options:",
-    "- label: Get prompt with specific label (e.g., 'production', 'staging')",
-    "- version: Get specific version number (e.g., 1, 2, 3)",
-    "- neither: Returns 'production' version by default",
-    "",
-    "Note: label and version are mutually exclusive. To get resolved prompts, use the 'getPrompt' tool instead.",
-  ].join("\n"),
-  baseSchema: GetPromptUnresolvedBaseSchema,
-  inputSchema: GetPromptUnresolvedInputSchema,
-  handler: async (input, context) => {
-    return await instrumentAsync(
-      { name: "mcp.prompts.getUnresolved", spanKind: SpanKind.INTERNAL },
-      async (span) => {
-        const { name, label, version } = input;
-
-        // Set span attributes for observability
-        span.setAttributes({
-          "langfuse.project.id": context.projectId,
-          "langfuse.org.id": context.orgId,
-          "mcp.api_key_id": context.apiKeyId,
-          "mcp.prompt_name": name,
-          "mcp.unresolved": true,
-        });
-
-        if (label) {
-          span.setAttribute("mcp.prompt_label", label);
-        }
-        if (version) {
-          span.setAttribute("mcp.prompt_version", version);
-        }
-
-        // Fetch prompt without resolving dependencies using service layer
-        const prompt = await getPromptByName({
-          promptName: name,
-          projectId: context.projectId,
-          version,
-          label,
-          resolve: false, // Fetch raw prompt without resolving dependency tags
-        });
-
-        if (!prompt) {
-          throw new UserInputError(
-            `Prompt '${name}' not found${label ? ` with label '${label}'` : ""}${version ? ` with version ${version}` : ""}`,
-          );
-        }
-
-        // Return formatted response with raw (unresolved) prompt content
-        return {
-          id: prompt.id,
-          name: prompt.name,
-          version: prompt.version,
-          type: prompt.type,
-          prompt: prompt.prompt, // RAW prompt with dependency tags intact
-          labels: prompt.labels,
-          tags: prompt.tags,
-          config: prompt.config,
-          createdAt: prompt.createdAt,
-          updatedAt: prompt.updatedAt,
-          createdBy: prompt.createdBy,
-          projectId: prompt.projectId,
-        };
-      },
-    );
-  },
-  readOnlyHint: true,
-});
+export const [getPromptUnresolvedTool, handleGetPromptUnresolved] =
+  createPromptReadTool({
+    name: "getPromptUnresolved",
+    description: [
+      "Fetch a specific prompt by name with optional label or version parameter WITHOUT resolving dependencies.",
+      "",
+      "Returns the raw prompt content with dependency tags intact. Useful for:",
+      "- Understanding prompt composition/stacking before resolution",
+      "- Debugging prompt dependencies",
+      "- Analyzing the dependency graph structure",
+      "",
+      "Retrieval options:",
+      "- label: Get prompt with specific label (e.g., 'production', 'staging')",
+      "- version: Get specific version number (e.g., 1, 2, 3)",
+      "- neither: Returns 'production' version by default",
+      "",
+      "Note: label and version are mutually exclusive. To get resolved prompts, use the 'getPrompt' tool instead.",
+    ].join("\n"),
+    resolve: false,
+    spanName: "mcp.prompts.getUnresolved",
+  });

--- a/web/src/features/mcp/features/prompts/tools/promptReadToolFactory.ts
+++ b/web/src/features/mcp/features/prompts/tools/promptReadToolFactory.ts
@@ -1,0 +1,119 @@
+import { z } from "zod/v4";
+import { SpanKind } from "@opentelemetry/api";
+import { type Prompt } from "@langfuse/shared";
+import { instrumentAsync } from "@langfuse/shared/src/server";
+
+import { getPromptByName } from "@/src/features/prompts/server/actions/getPromptByName";
+
+import { defineTool } from "../../../core/define-tool";
+import { UserInputError } from "../../../core/errors";
+import {
+  ParamPromptLabel,
+  ParamPromptName,
+  ParamPromptVersion,
+} from "../validation";
+
+export const PromptReadBaseSchema = z.object({
+  name: ParamPromptName,
+  label: ParamPromptLabel,
+  version: ParamPromptVersion,
+});
+
+export const PromptReadInputSchema = PromptReadBaseSchema.refine(
+  (data) => !(data.label && data.version),
+  {
+    message:
+      "Cannot specify both label and version - they are mutually exclusive",
+  },
+);
+
+const formatPromptResponse = (prompt: Prompt) => ({
+  id: prompt.id,
+  name: prompt.name,
+  version: prompt.version,
+  type: prompt.type,
+  prompt: prompt.prompt,
+  labels: prompt.labels,
+  tags: prompt.tags,
+  config: prompt.config,
+  createdAt: prompt.createdAt,
+  updatedAt: prompt.updatedAt,
+  createdBy: prompt.createdBy,
+  projectId: prompt.projectId,
+});
+
+const buildPromptNotFoundMessage = (params: {
+  name: string;
+  label?: string;
+  version?: number | null;
+}) => {
+  const { name, label, version } = params;
+
+  return `Prompt '${name}' not found${label ? ` with label '${label}'` : ""}${version ? ` with version ${version}` : ""}`;
+};
+
+type CreatePromptReadToolOptions = {
+  name: string;
+  description: string;
+  resolve: boolean;
+  spanName: string;
+};
+
+export const createPromptReadTool = (options: CreatePromptReadToolOptions) => {
+  const { name, description, resolve, spanName } = options;
+
+  return defineTool({
+    name,
+    description,
+    baseSchema: PromptReadBaseSchema,
+    inputSchema: PromptReadInputSchema,
+    handler: async (input, context) => {
+      return await instrumentAsync(
+        { name: spanName, spanKind: SpanKind.INTERNAL },
+        async (span) => {
+          const { name, label, version } = input;
+
+          span.setAttributes({
+            "langfuse.project.id": context.projectId,
+            "langfuse.org.id": context.orgId,
+            "mcp.api_key_id": context.apiKeyId,
+            "mcp.prompt_name": name,
+          });
+
+          if (!resolve) {
+            span.setAttribute("mcp.unresolved", true);
+          }
+
+          if (label) {
+            span.setAttribute("mcp.prompt_label", label);
+          }
+
+          if (version) {
+            span.setAttribute("mcp.prompt_version", version);
+          }
+
+          const prompt = await getPromptByName({
+            promptName: name,
+            projectId: context.projectId,
+            label,
+            version,
+            resolve,
+          });
+
+          if (!prompt) {
+            throw new UserInputError(
+              buildPromptNotFoundMessage({
+                name,
+                label,
+                version,
+              }),
+            );
+          }
+
+          return formatPromptResponse(prompt);
+        },
+      );
+    },
+    readOnlyHint: true,
+  });
+};

--- a/web/src/features/prompts/server/actions/getPromptByName.ts
+++ b/web/src/features/prompts/server/actions/getPromptByName.ts
@@ -26,31 +26,6 @@ export const getPromptByName = async (
   if (version && label)
     throw new InvalidRequestError("Cannot specify both version and label");
 
-  // If resolve is false, fetch directly from database without resolving dependencies
-  if (!resolve) {
-    if (version) {
-      return prisma.prompt.findFirst({
-        where: {
-          projectId,
-          name: promptName,
-          version,
-        },
-      });
-    }
-
-    const targetLabel = label ?? PRODUCTION_LABEL;
-    return prisma.prompt.findFirst({
-      where: {
-        projectId,
-        name: promptName,
-        labels: {
-          has: targetLabel,
-        },
-      },
-    });
-  }
-
-  // Default behavior: resolve dependencies using PromptService
   const promptService = new PromptService(prisma, redis, recordIncrement);
 
   if (version)
@@ -59,6 +34,7 @@ export const getPromptByName = async (
       promptName,
       version,
       label: undefined,
+      resolve,
     });
 
   if (label)
@@ -67,6 +43,7 @@ export const getPromptByName = async (
       promptName,
       label,
       version: undefined,
+      resolve,
     });
 
   return promptService.getPrompt({
@@ -74,5 +51,6 @@ export const getPromptByName = async (
     promptName,
     label: PRODUCTION_LABEL,
     version: undefined,
+    resolve,
   });
 };

--- a/web/src/features/prompts/server/handlers/promptNameHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptNameHandler.ts
@@ -28,13 +28,16 @@ const getPromptNameHandler = async (
     return rateLimitCheck.sendRestResponseIfLimited(res);
   }
 
-  const { promptName, version, label } = GetPromptByNameSchema.parse(req.query);
+  const { promptName, version, label, resolve } = GetPromptByNameSchema.parse(
+    req.query,
+  );
 
   const prompt = await getPromptByName({
     promptName: promptName,
     projectId: authCheck.scope.projectId,
     version,
     label,
+    resolve,
   });
 
   if (!prompt) {

--- a/web/src/features/prompts/server/handlers/promptNameHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptNameHandler.ts
@@ -28,16 +28,13 @@ const getPromptNameHandler = async (
     return rateLimitCheck.sendRestResponseIfLimited(res);
   }
 
-  const { promptName, version, label, resolve } = GetPromptByNameSchema.parse(
-    req.query,
-  );
+  const { promptName, version, label } = GetPromptByNameSchema.parse(req.query);
 
   const prompt = await getPromptByName({
     promptName: promptName,
     projectId: authCheck.scope.projectId,
     version,
     label,
-    resolve: resolve ?? true, // Default to true for backward compatibility
   });
 
   if (!prompt) {

--- a/web/src/pages/api/public/prompts.ts
+++ b/web/src/pages/api/public/prompts.ts
@@ -51,7 +51,6 @@ export default async function handler(
       const projectId = authCheck.scope.projectId;
       const promptName = searchParams.name;
       const version = searchParams.version ?? undefined;
-      const shouldResolve = searchParams.resolve ?? true; // Default to true for backward compatibility
 
       const rateLimitCheck =
         await RateLimitService.getInstance().rateLimitRequest(
@@ -67,7 +66,6 @@ export default async function handler(
         promptName,
         projectId,
         version,
-        resolve: shouldResolve,
       });
 
       if (!prompt) throw new LangfuseNotFoundError("Prompt not found");


### PR DESCRIPTION
## Summary
- add `resolve=false` support only to the v2 prompt fetch endpoint and document it in the Fern API spec
- route unresolved reads through `PromptService` while bypassing Redis and dependency resolution
- stop the legacy `/api/public/prompts` route from honoring `resolve`, and add coverage for cache bypass plus v1/v2 behavior

## Impacted packages
- `web`
- `@langfuse/shared`

## Verification
- `pnpm --filter web run test --testPathPatterns="promptCache.servertest"`
- `pnpm --filter web exec eslint src/features/prompts/server/actions/getPromptByName.ts src/pages/api/public/prompts.ts src/__tests__/server/promptCache.servertest.ts src/__tests__/server/prompts.v1.servertest.ts src/__tests__/server/prompts.v2.servertest.ts src/features/prompts/server/handlers/promptNameHandler.ts`
- `pnpm --filter @langfuse/shared run lint`
- `pnpm --filter @langfuse/shared run typecheck`
- `pnpm --filter web run typecheck`

## Notes
- `pnpm --filter web run test --testPathPatterns="promptCache.servertest|prompts.v1.servertest|prompts.v2.servertest"` is still blocked locally because Postgres/Redis are not running.
- Fern regeneration was not run because the `fern` CLI is not installed in this environment.