### PR TITLE
feat(evals): add docs link for backfilling on observation-level LLM-a…

### DIFF
--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -889,7 +889,15 @@ export const InnerEvaluatorForm = (props: {
                         {!field.value && isEventTarget(target) && (
                           <p className="text-xs text-muted-foreground">
                             This evaluator can still be used for batched
-                            evaluation of historic observations.
+                            evaluation of historic observations.{" "}
+                            <a
+                              href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-dark-blue hover:opacity-80"
+                            >
+                              Read the docs
+                            </a>
                           </p>
                         )}
                       </div>


### PR DESCRIPTION
…s-a-judge

## What does this PR do?

Adds link to docs for people who are looking for the backfilling of observation level llm as a judge scores. 
As previously it was a checkbox people are looking for it (Plain issue + github discussion: https://github.com/orgs/langfuse/discussions/12548#discussioncomment-16097803)

<img width="966" height="353" alt="image" src="https://github.com/user-attachments/assets/466ccc5a-cf51-4cbb-a2cf-88e903b9b70f" />


Fixes # (issue)
added docs link

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

