### PR TITLE
fix(api): return 404 instead of 501 for v2 APIs on self-hosted

### DIFF
--- a/web/src/pages/api/public/v2/metrics.ts
+++ b/web/src/pages/api/public/v2/metrics.ts
@@ -6,7 +6,7 @@ import {
   GetMetricsV2Query,
   GetMetricsV2Response,
 } from "@/src/features/public-api/types/metrics";
-import { InvalidRequestError, NotImplementedError } from "@langfuse/shared";
+import { InvalidRequestError, LangfuseNotFoundError } from "@langfuse/shared";
 import {
   executeQuery,
   validateQuery,
@@ -22,7 +22,7 @@ export default withMiddlewares({
     responseSchema: GetMetricsV2Response,
     fn: async ({ query, auth }) => {
       if (env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS !== "true") {
-        throw new NotImplementedError(
+        throw new LangfuseNotFoundError(
           "v2 APIs are currently in beta and only available on Langfuse Cloud",
         );
       }

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -1,5 +1,5 @@
 import { getObservationsV2FromEventsTableForPublicApi } from "@langfuse/shared/src/server";
-import { NotImplementedError } from "@langfuse/shared";
+import { LangfuseNotFoundError } from "@langfuse/shared";
 
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
@@ -18,7 +18,7 @@ export default withMiddlewares({
     responseSchema: GetObservationsV2Response,
     fn: async ({ query, auth }) => {
       if (env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS !== "true") {
-        throw new NotImplementedError(
+        throw new LangfuseNotFoundError(
           "v2 APIs are currently in beta and only available on Langfuse Cloud",
         );
       }


### PR DESCRIPTION
## Summary
- Change v2/observations and v2/metrics endpoints to return 404 (LangfuseNotFoundError) instead of 501 (NotImplementedError) when `LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS` is not enabled
- Prevents false positive 5xx alerts for self-hosted users who monitor HTTP status codes

## Test plan
- [ ] Verify v2/observations returns 404 on self-hosted (without `LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS=true`)
- [ ] Verify v2/metrics returns 404 on self-hosted
- [ ] Verify both endpoints still work correctly on Langfuse Cloud (with flag enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)