### PR TITLE
fix: use created_at for incremental exports to avoid skipping late-arriving data

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1800,11 +1800,12 @@ export const getObservationsForBlobStorageExport = function (
       cost_details,
       completion_start_time,
       prompt_name,
-      prompt_version
+      prompt_version,
+      created_at
     FROM observations FINAL
     WHERE project_id = {projectId: String}
-    AND start_time >= {minTimestamp: DateTime64(3)}
-    AND start_time <= {maxTimestamp: DateTime64(3)}
+    AND created_at >= {minTimestamp: DateTime64(3)}
+    AND created_at <= {maxTimestamp: DateTime64(3)}
   `;
 
   const records = queryClickhouseStream<Record<string, unknown>>({

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1838,11 +1838,12 @@ export const getScoresForBlobStorageExport = function (
       source,
       comment,
       data_type,
-      string_value
+      string_value,
+      created_at
     FROM scores FINAL
     WHERE project_id = {projectId: String}
-    AND timestamp >= {minTimestamp: DateTime64(3)}
-    AND timestamp <= {maxTimestamp: DateTime64(3)}
+    AND created_at >= {minTimestamp: DateTime64(3)}
+    AND created_at <= {maxTimestamp: DateTime64(3)}
     AND data_type IN ({dataTypes: Array(String)})
   `;
 

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1369,11 +1369,12 @@ export const getTracesForBlobStorageExport = function (
       bookmarked as bookmarked,
       tags,
       input as input,
-      output as output
+      output as output,
+      created_at
     FROM ${traceTable} FINAL
     WHERE project_id = {projectId: String}
-    AND timestamp >= {minTimestamp: DateTime64(3)}
-    AND timestamp <= {maxTimestamp: DateTime64(3)}
+    AND created_at >= {minTimestamp: DateTime64(3)}
+    AND created_at <= {maxTimestamp: DateTime64(3)}
   `;
 
   return queryClickhouseStream<Record<string, unknown>>({


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

fixes: #12439

Alter queries for blob export to filter on created_at instead of other timestamp columns in traces, observations, and scores.

Filtering by the business timestamp of these objects can result in data missing from the exports, due to the possibility of late-arriving data, i.e. where `timestamp < created_at`.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->
