### PR TITLE
fix(metadata): write `attributes` to metadata in direct write + S3 `/evals` write for non-langfuse-SDK-spans

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -264,6 +264,9 @@ export class OtelIngestionProcessor {
                     endTimeUnixNano: span.endTimeUnixNano,
                   });
 
+                const isLangfuseSDKSpans =
+                  scopeSpan.scope?.name?.startsWith("langfuse-sdk") ?? false;
+
                 // Extract metadata from different sources
                 const spanMetadata = this.extractMetadata(
                   spanAttributes,
@@ -274,17 +277,18 @@ export class OtelIngestionProcessor {
                   "trace",
                 );
 
-                // Extract input/output (filteredAttributes not needed as metadata.attributes is commented out)
-                // Add filteredAttributes in case spanAttributes are included in the metadata block.
-                const { input, output } = this.extractInputAndOutput({
-                  events: span?.events ?? [],
-                  attributes: spanAttributes,
-                  instrumentationScopeName: scopeSpan?.scope?.name ?? "",
-                });
+                const { input, output, filteredAttributes } =
+                  this.extractInputAndOutput({
+                    events: span?.events ?? [],
+                    attributes: spanAttributes,
+                    instrumentationScopeName: scopeSpan?.scope?.name ?? "",
+                  });
 
                 // Construct metadata object with the specified structure
                 const metadata = {
-                  // attributes: filteredAttributes,
+                  ...(isLangfuseSDKSpans
+                    ? {}
+                    : { attributes: filteredAttributes }),
                   resourceAttributes: resourceAttributes,
                   scopeAttributes: scopeAttributes,
                   ...spanMetadata,


### PR DESCRIPTION
**With otel-dual-write, S3 evals is missing the `attributes` key.** 
This is causing missing metadata for non-Langfuse-SDK-spans. As a result, obsveration-level-llm-as-a-judge is producing inconsistent results in eval execution, when any of these keys are mapped to eval prompt variables. 

**Why is `attributes` key missing?** 
- Dual write only affects the observations → events table flow
- S3 evals upload happens in a parallel code path (lines 391-486)
- That parallel path uses processToEvent() which has attributes commented out

As a result `events_full` table has `attributes` (from dual write via observations table), but S3 doesn't (from processToEvent()).

_Note that Langfuse-SDK-spans do not contain meaningful keys in `attributes`, but serve debugging purposes only._  

**Proposed solution** 
For non-Langfuse-SDK-spans, re-introduce `attributes` key in `processToEvent()` metadata construction to align direct write with dual write behavior. This should produce consistent metadata for the direct write path and S3 eval record upload resulting in corrrect evaluation. 

_Ask: @Steffen911 please confirm this is the desired behaviour for the direct otel write path as well. If not, please provide reasoning + expected behaviour_ 