### PR TITLE
fix(model-prices): add input_text/output_text pricing for Gemini models

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2797,7 +2797,7 @@
     "modelName": "gemini-2.5-flash",
     "matchPattern": "(?i)^(google\/)?(gemini-2.5-flash)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
-    "updatedAt": "2026-03-04T00:00:00.000Z",
+    "updatedAt": "2026-03-17T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "cmcnjkfwn000107l43bf5e8ax_tier_default",
@@ -2814,6 +2814,7 @@
           "input_cached_tokens": 3e-8,
           "cached_content_token_count": 3e-8,
           "output": 0.0000025,
+          "output_text": 0.0000025,
           "output_modality_1": 0.0000025,
           "candidates_token_count": 0.0000025,
           "candidatesTokenCount": 0.0000025,
@@ -2830,7 +2831,7 @@
     "modelName": "gemini-2.5-flash-lite",
     "matchPattern": "(?i)^(google\/)?(gemini-2.5-flash-lite)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
-    "updatedAt": "2026-03-04T00:00:00.000Z",
+    "updatedAt": "2026-03-17T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "cmcnjkrfa000207l4fpnh5mnv_tier_default",
@@ -2847,6 +2848,7 @@
           "input_cached_tokens": 2.5e-8,
           "cached_content_token_count": 2.5e-8,
           "output": 4e-7,
+          "output_text": 4e-7,
           "output_modality_1": 4e-7,
           "candidates_token_count": 4e-7,
           "candidatesTokenCount": 4e-7,
@@ -3363,7 +3365,7 @@
     "modelName": "gemini-2.5-pro",
     "matchPattern": "(?i)^(google\/)?(gemini-2.5-pro)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
-    "updatedAt": "2026-03-04T00:00:00.000Z",
+    "updatedAt": "2026-03-17T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "cmig1hb7i000104l72qrzgc6h_tier_default",
@@ -3380,6 +3382,7 @@
           "input_cached_tokens": 0.125e-6,
           "cached_content_token_count": 0.125e-6,
           "output": 10e-6,
+          "output_text": 10e-6,
           "output_modality_1": 10e-6,
           "candidates_token_count": 10e-6,
           "candidatesTokenCount": 10e-6,
@@ -3410,6 +3413,7 @@
           "input_cached_tokens": 0.25e-6,
           "cached_content_token_count": 0.25e-6,
           "output": 15e-6,
+          "output_text": 15e-6,
           "output_modality_1": 15e-6,
           "candidates_token_count": 15e-6,
           "candidatesTokenCount": 15e-6,
@@ -3425,7 +3429,7 @@
     "modelName": "gemini-3-pro-preview",
     "matchPattern": "(?i)^(google\/)?(gemini-3-pro-preview)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
-    "updatedAt": "2025-12-12T15:00:06.513Z",
+    "updatedAt": "2026-03-17T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "cmig1wmep000404l7fh6q5uog_tier_default",
@@ -3435,12 +3439,14 @@
         "conditions": [],
         "prices": {
           "input": 2e-6,
+          "input_text": 2e-6,
           "input_modality_1": 2e-6,
           "prompt_token_count": 2e-6,
           "promptTokenCount": 2e-6,
           "input_cached_tokens": 0.2e-6,
           "cached_content_token_count": 0.2e-6,
           "output": 12e-6,
+          "output_text": 12e-6,
           "output_modality_1": 12e-6,
           "candidates_token_count": 12e-6,
           "candidatesTokenCount": 12e-6,
@@ -3464,12 +3470,14 @@
         ],
         "prices": {
           "input": 4e-6,
+          "input_text": 4e-6,
           "input_modality_1": 4e-6,
           "prompt_token_count": 4e-6,
           "promptTokenCount": 4e-6,
           "input_cached_tokens": 0.4e-6,
           "cached_content_token_count": 0.4e-6,
           "output": 18e-6,
+          "output_text": 18e-6,
           "output_modality_1": 18e-6,
           "candidates_token_count": 18e-6,
           "candidatesTokenCount": 18e-6,
@@ -3485,7 +3493,7 @@
     "modelName": "gemini-3.1-pro-preview",
     "matchPattern": "(?i)^(google\/)?(gemini-3.1-pro-preview(-customtools)?)$",
     "createdAt": "2026-02-19T00:00:00.000Z",
-    "updatedAt": "2026-02-19T00:00:00.000Z",
+    "updatedAt": "2026-03-17T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "55106bba-a5dd-441b-bc0d-5652582b349d_tier_default",
@@ -3495,12 +3503,14 @@
         "conditions": [],
         "prices": {
           "input": 2e-6,
+          "input_text": 2e-6,
           "input_modality_1": 2e-6,
           "prompt_token_count": 2e-6,
           "promptTokenCount": 2e-6,
           "input_cached_tokens": 0.2e-6,
           "cached_content_token_count": 0.2e-6,
           "output": 12e-6,
+          "output_text": 12e-6,
           "output_modality_1": 12e-6,
           "candidates_token_count": 12e-6,
           "candidatesTokenCount": 12e-6,
@@ -3524,12 +3534,14 @@
         ],
         "prices": {
           "input": 4e-6,
+          "input_text": 4e-6,
           "input_modality_1": 4e-6,
           "prompt_token_count": 4e-6,
           "promptTokenCount": 4e-6,
           "input_cached_tokens": 0.4e-6,
           "cached_content_token_count": 0.4e-6,
           "output": 18e-6,
+          "output_text": 18e-6,
           "output_modality_1": 18e-6,
           "candidates_token_count": 18e-6,
           "candidatesTokenCount": 18e-6,
@@ -3777,7 +3789,7 @@
     "modelName": "gemini-3-flash-preview",
     "matchPattern": "(?i)^(google\/)?(gemini-3-flash-preview)$",
     "createdAt": "2025-12-21T12:01:42.282Z",
-    "updatedAt": "2025-12-21T12:01:42.282Z",
+    "updatedAt": "2026-03-17T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "cmjfoeykl000004l8ffzra8c7_tier_default",
@@ -3787,12 +3799,14 @@
         "conditions": [],
         "prices": {
           "input": 0.5e-6,
+          "input_text": 0.5e-6,
           "input_modality_1": 0.5e-6,
           "prompt_token_count": 0.5e-6,
           "promptTokenCount": 0.5e-6,
           "input_cached_tokens": 0.05e-6,
           "cached_content_token_count": 0.05e-6,
           "output": 3e-6,
+          "output_text": 3e-6,
           "output_modality_1": 3e-6,
           "candidates_token_count": 3e-6,
           "candidatesTokenCount": 3e-6,
@@ -3808,7 +3822,7 @@
     "modelName": "gemini-3.1-flash-lite-preview",
     "matchPattern": "(?i)^(google\/)?(gemini-3.1-flash-lite-preview)$",
     "createdAt": "2026-03-03T00:00:00.000Z",
-    "updatedAt": "2026-03-03T00:00:00.000Z",
+    "updatedAt": "2026-03-17T00:00:00.000Z",
     "pricingTiers": [
       {
         "id": "0707bef8-10c8-46e2-a871-0436f05f0b92_tier_default",
@@ -3818,12 +3832,14 @@
         "conditions": [],
         "prices": {
           "input": 0.25e-6,
+          "input_text": 0.25e-6,
           "input_modality_1": 0.25e-6,
           "prompt_token_count": 0.25e-6,
           "promptTokenCount": 0.25e-6,
           "input_cached_tokens": 0.025e-6,
           "cached_content_token_count": 0.025e-6,
           "output": 1.5e-6,
+          "output_text": 1.5e-6,
           "output_modality_1": 1.5e-6,
           "candidates_token_count": 1.5e-6,
           "candidatesTokenCount": 1.5e-6,


### PR DESCRIPTION
## Summary

Fixes #12601

- **Root cause**: The `@langfuse/langchain` callback handler (via `@langchain/google-common`) breaks down Gemini token usage by modality through `input_token_details` and `output_token_details`. For each modality (e.g., `text`), the count is subtracted from the base `input`/`output` count and added as `input_text`/`output_text` in `usage_details`. This means the server receives `{ input: 0, input_text: 2089, output: 0, output_text: 513, output_reasoning: ... }` instead of `{ input: 2089, output: 513 }`.
- **Why input cost was $0**: The pricing definition for `gemini-3.1-pro-preview` (and other newer Gemini models) had a price for the `input` key but not for `input_text`. Since `input` was 0 after the SDK subtraction, the cost was $0.
- **Fix**: Added `input_text` and `output_text` price entries (at the same per-token rate as `input`/`output`) to all affected Gemini model definitions:
  - `gemini-3-pro-preview` (Standard + Large Context tiers)
  - `gemini-3.1-pro-preview` (Standard + Large Context tiers)
  - `gemini-3-flash-preview`
  - `gemini-3.1-flash-lite-preview`
  - `gemini-2.5-pro` (`output_text` only — `input_text` already existed)
  - `gemini-2.5-flash` (`output_text` only)
  - `gemini-2.5-flash-lite` (`output_text` only)

## Test plan

- [X] Verify JSON is valid and model price upsert succeeds on startup
- [X] Send a Gemini generation via `@langfuse/langchain` with `@langchain/google-webauth` and confirm input cost is no longer $0
- [X] Verify existing `gemini-2.5-pro` traces now show correct output cost breakdown