### PR TITLE
feat(billing): auto-create default spend alerts on new subscriptions

### DIFF
--- a/web/src/__tests__/server/createDefaultSpendAlerts.servertest.ts
+++ b/web/src/__tests__/server/createDefaultSpendAlerts.servertest.ts
@@ -22,7 +22,7 @@ describe("createDefaultSpendAlerts", () => {
 
     expect(alerts).toHaveLength(1);
     expect(alerts[0].threshold.toNumber()).toBe(200);
-    expect(alerts[0].title).toBe("Spend alert ($200)");
+    expect(alerts[0].title).toBe("Default Spend alert ($200)");
   });
 
   it("creates alerts with correct thresholds for pro plan", async () => {

--- a/web/src/__tests__/server/createDefaultSpendAlerts.servertest.ts
+++ b/web/src/__tests__/server/createDefaultSpendAlerts.servertest.ts
@@ -1,0 +1,111 @@
+/** @jest-environment node */
+import { prisma } from "@langfuse/shared/src/db";
+import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import { createDefaultSpendAlerts } from "@/src/ee/features/billing/server/stripeWebhookHandler";
+import { stripeProducts } from "@/src/ee/features/billing/utils/stripeCatalogue";
+
+describe("createDefaultSpendAlerts", () => {
+  it("creates alerts with correct thresholds for core plan", async () => {
+    const { orgId } = await createOrgProjectAndApiKey();
+    const coreProduct = stripeProducts.find(
+      (p) => p.mappedPlan === "cloud:core",
+    )!;
+
+    await createDefaultSpendAlerts({
+      orgId,
+      productId: coreProduct.stripeProductId,
+    });
+
+    const alerts = await prisma.cloudSpendAlert.findMany({
+      where: { orgId },
+    });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].threshold.toNumber()).toBe(200);
+    expect(alerts[0].title).toBe("Spend alert ($200)");
+  });
+
+  it("creates alerts with correct thresholds for pro plan", async () => {
+    const { orgId } = await createOrgProjectAndApiKey();
+    const proProduct = stripeProducts.find(
+      (p) => p.mappedPlan === "cloud:pro",
+    )!;
+
+    await createDefaultSpendAlerts({
+      orgId,
+      productId: proProduct.stripeProductId,
+    });
+
+    const alerts = await prisma.cloudSpendAlert.findMany({
+      where: { orgId },
+    });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].threshold.toNumber()).toBe(1000);
+  });
+
+  it("creates alerts with correct thresholds for enterprise plan", async () => {
+    const { orgId } = await createOrgProjectAndApiKey();
+    const enterpriseProduct = stripeProducts.find(
+      (p) => p.mappedPlan === "cloud:enterprise",
+    )!;
+
+    await createDefaultSpendAlerts({
+      orgId,
+      productId: enterpriseProduct.stripeProductId,
+    });
+
+    const alerts = await prisma.cloudSpendAlert.findMany({
+      where: { orgId },
+    });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].threshold.toNumber()).toBe(2000);
+  });
+
+  it("skips creation if org already has alerts", async () => {
+    const { orgId } = await createOrgProjectAndApiKey();
+
+    // Create an existing alert
+    await prisma.cloudSpendAlert.create({
+      data: {
+        orgId,
+        title: "Existing alert",
+        threshold: 500,
+      },
+    });
+
+    const coreProduct = stripeProducts.find(
+      (p) => p.mappedPlan === "cloud:core",
+    )!;
+
+    await createDefaultSpendAlerts({
+      orgId,
+      productId: coreProduct.stripeProductId,
+    });
+
+    const alerts = await prisma.cloudSpendAlert.findMany({
+      where: { orgId },
+    });
+
+    // Should still have only the original alert
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].title).toBe("Existing alert");
+  });
+
+  it("handles unknown product IDs gracefully", async () => {
+    const { orgId } = await createOrgProjectAndApiKey();
+
+    // Should not throw
+    await createDefaultSpendAlerts({
+      orgId,
+      productId: "prod_unknown_id",
+    });
+
+    const alerts = await prisma.cloudSpendAlert.findMany({
+      where: { orgId },
+    });
+
+    expect(alerts).toHaveLength(0);
+  });
+});

--- a/web/src/ee/features/billing/server/stripeWebhookHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookHandler.ts
@@ -11,6 +11,7 @@ import {
   CloudConfigSchema,
   InternalServerError,
   type Organization,
+  type Plan,
   parseDbOrg,
 } from "@langfuse/shared";
 import {
@@ -21,6 +22,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { type StripeSubscriptionMetadata } from "@/src/ee/features/billing/utils/stripeSubscriptionMetadata";
+import { mapStripeProductIdToPlan } from "@/src/ee/features/billing/utils/stripeCatalogue";
 
 /**
  * Stripe webhook handler for managing subscription events, billing alerts, and invoice notifications.
@@ -373,6 +375,72 @@ export async function updateOrgBillingCycleAnchor(
   });
 }
 
+const DEFAULT_SPEND_ALERT_THRESHOLDS: Partial<Record<Plan, number[]>> = {
+  "cloud:core": [200],
+  "cloud:pro": [1000],
+  "cloud:team": [1000],
+  "cloud:enterprise": [2000],
+};
+
+export async function createDefaultSpendAlerts({
+  orgId,
+  productId,
+}: {
+  orgId: string;
+  productId: string;
+}) {
+  const plan = mapStripeProductIdToPlan(productId);
+  if (!plan) {
+    logger.info(
+      `[Stripe Webhook] createDefaultSpendAlerts: Unknown product ID ${productId}, skipping`,
+    );
+    return;
+  }
+
+  const thresholds = DEFAULT_SPEND_ALERT_THRESHOLDS[plan];
+  if (!thresholds || thresholds.length === 0) {
+    return;
+  }
+
+  // Skip if org already has spend alerts (idempotency / don't overwrite user-configured alerts)
+  const existingAlerts = await prisma.cloudSpendAlert.findFirst({
+    where: { orgId },
+    select: { id: true },
+  });
+  if (existingAlerts) {
+    logger.info(
+      `[Stripe Webhook] createDefaultSpendAlerts: Org ${orgId} already has spend alerts, skipping`,
+    );
+    return;
+  }
+
+  for (const threshold of thresholds) {
+    const alert = await prisma.cloudSpendAlert.create({
+      data: {
+        orgId,
+        title: `Spend alert ($${threshold})`,
+        threshold,
+      },
+    });
+
+    void auditLog({
+      session: {
+        user: { id: "stripe-webhook" },
+        orgId,
+      },
+      orgId,
+      resourceType: "cloudSpendAlert",
+      resourceId: alert.id,
+      action: "create",
+      after: alert,
+    });
+  }
+
+  logger.info(
+    `[Stripe Webhook] createDefaultSpendAlerts: Created ${thresholds.length} default alert(s) for org ${orgId} on plan ${plan}`,
+  );
+}
+
 async function handleSubscriptionChanged(
   subscription: Stripe.Subscription,
   action: "created" | "deleted" | "updated",
@@ -555,6 +623,22 @@ async function handleSubscriptionChanged(
       // Convert unix timestamp (seconds) to Date object
       const anchorDate = new Date(subscription.billing_cycle_anchor * 1000);
       await updateOrgBillingCycleAnchor(parsedOrg.id, anchorDate);
+    }
+
+    // Auto-create default spend alerts for new subscriptions (best-effort)
+    if (action === "created") {
+      try {
+        await createDefaultSpendAlerts({
+          orgId: parsedOrg.id,
+          productId: productId,
+        });
+      } catch (err) {
+        logger.error(
+          "[Stripe Webhook] Failed to create default spend alerts",
+          err,
+        );
+        traceException(err);
+      }
     }
 
     // Invalidate API keys in Redis for it to be updated

--- a/web/src/ee/features/billing/server/stripeWebhookHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookHandler.ts
@@ -375,11 +375,20 @@ export async function updateOrgBillingCycleAnchor(
   });
 }
 
-const DEFAULT_SPEND_ALERT_THRESHOLDS: Partial<Record<Plan, number[]>> = {
-  "cloud:core": [200],
-  "cloud:pro": [1000],
-  "cloud:team": [1000],
-  "cloud:enterprise": [2000],
+type PlanWithoutSpendAlerts =
+  | "oss"
+  | "cloud:hobby"
+  | "self-hosted:pro"
+  | "self-hosted:enterprise";
+
+const DEFAULT_SPEND_ALERT_THRESHOLDS: Record<
+  Exclude<Plan, PlanWithoutSpendAlerts>,
+  number
+> = {
+  "cloud:core": 200,
+  "cloud:pro": 1000,
+  "cloud:team": 1000,
+  "cloud:enterprise": 2000,
 };
 
 export async function createDefaultSpendAlerts({
@@ -389,16 +398,22 @@ export async function createDefaultSpendAlerts({
   orgId: string;
   productId: string;
 }) {
-  const plan = mapStripeProductIdToPlan(productId);
+  const plan = mapStripeProductIdToPlan(productId) as Exclude<
+    Plan,
+    PlanWithoutSpendAlerts
+  >;
   if (!plan) {
-    logger.info(
+    logger.error(
       `[Stripe Webhook] createDefaultSpendAlerts: Unknown product ID ${productId}, skipping`,
     );
     return;
   }
 
-  const thresholds = DEFAULT_SPEND_ALERT_THRESHOLDS[plan];
-  if (!thresholds || thresholds.length === 0) {
+  const threshold = DEFAULT_SPEND_ALERT_THRESHOLDS[plan];
+  if (!threshold) {
+    logger.error(
+      `[Stripe Webhook] createDefaultSpendAlerts: No spend alerts configured for plan ${plan}, skipping`,
+    );
     return;
   }
 
@@ -414,30 +429,28 @@ export async function createDefaultSpendAlerts({
     return;
   }
 
-  for (const threshold of thresholds) {
-    const alert = await prisma.cloudSpendAlert.create({
-      data: {
-        orgId,
-        title: `Spend alert ($${threshold})`,
-        threshold,
-      },
-    });
-
-    void auditLog({
-      session: {
-        user: { id: "stripe-webhook" },
-        orgId,
-      },
+  const alert = await prisma.cloudSpendAlert.create({
+    data: {
       orgId,
-      resourceType: "cloudSpendAlert",
-      resourceId: alert.id,
-      action: "create",
-      after: alert,
-    });
-  }
+      title: `Default Spend alert ($${threshold})`,
+      threshold,
+    },
+  });
+
+  await auditLog({
+    session: {
+      user: { id: "stripe-webhook" },
+      orgId,
+    },
+    orgId,
+    resourceType: "cloudSpendAlert",
+    resourceId: alert.id,
+    action: "create",
+    after: alert,
+  });
 
   logger.info(
-    `[Stripe Webhook] createDefaultSpendAlerts: Created ${thresholds.length} default alert(s) for org ${orgId} on plan ${plan}`,
+    `[Stripe Webhook] createDefaultSpendAlerts: Created default alert over $${threshold} for org ${orgId} on plan ${plan}`,
   );
 }
 


### PR DESCRIPTION
## Summary
- Auto-creates default spend alerts when a new paid subscription is created via Stripe webhook (`customer.subscription.created`)
- Plan-specific thresholds: Core $200, Pro/Team $1,000, Enterprise $2,000
- Idempotent: skips creation if the org already has any spend alerts
- Best-effort: wrapped in try/catch so failures don't break the main subscription flow

Ref: LFE-8154

## Test plan
- [ ] Unit tests verify correct thresholds per plan, idempotency (skips if alerts exist), and graceful handling of unknown product IDs
- [ ] Manual: trigger a `customer.subscription.created` webhook via Stripe CLI and verify alerts appear in billing settings UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)