### PR TITLE
fix(codex): bootstrap env files for new git worktrees

### DIFF
--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -2,38 +2,12 @@
 
 set -euo pipefail
 
-get_primary_worktree_root() {
-  local common_dir
-
-  common_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
-
-  if [ "$(basename "$common_dir")" != ".git" ]; then
-    return 1
-  fi
-
-  dirname "$common_dir"
-}
-
-bootstrap_env_file() {
+ensure_env_file() {
   local target_path="$1"
   local fallback_path="$2"
-  local current_root
-  local primary_root
-  local source_path
 
   if [ -f "$target_path" ]; then
     return 0
-  fi
-
-  current_root="$(pwd -P)"
-
-  if primary_root="$(get_primary_worktree_root)"; then
-    source_path="$primary_root/$target_path"
-
-    if [ "$source_path" != "$current_root/$target_path" ] && [ -f "$source_path" ]; then
-      cp "$source_path" "$target_path"
-      return 0
-    fi
   fi
 
   cp "$fallback_path" "$target_path"
@@ -47,8 +21,8 @@ fi
 corepack enable
 corepack prepare pnpm@9.5.0 --activate
 
-bootstrap_env_file .env .env.dev.example
-bootstrap_env_file .env.test .env.test.example
+ensure_env_file .env .env.dev.example
+ensure_env_file .env.test .env.test.example
 
 pnpm install --frozen-lockfile
 

--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -2,6 +2,43 @@
 
 set -euo pipefail
 
+get_primary_worktree_root() {
+  local common_dir
+
+  common_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+
+  if [ "$(basename "$common_dir")" != ".git" ]; then
+    return 1
+  fi
+
+  dirname "$common_dir"
+}
+
+bootstrap_env_file() {
+  local target_path="$1"
+  local fallback_path="$2"
+  local current_root
+  local primary_root
+  local source_path
+
+  if [ -f "$target_path" ]; then
+    return 0
+  fi
+
+  current_root="$(pwd -P)"
+
+  if primary_root="$(get_primary_worktree_root)"; then
+    source_path="$primary_root/$target_path"
+
+    if [ "$source_path" != "$current_root/$target_path" ] && [ -f "$source_path" ]; then
+      cp "$source_path" "$target_path"
+      return 0
+    fi
+  fi
+
+  cp "$fallback_path" "$target_path"
+}
+
 if ! command -v corepack >/dev/null 2>&1; then
   echo "corepack is required. Use a Codex base environment with Node.js 24 support."
   exit 1
@@ -10,13 +47,8 @@ fi
 corepack enable
 corepack prepare pnpm@9.5.0 --activate
 
-if [ ! -f .env ]; then
-  cp .env.dev.example .env
-fi
-
-if [ ! -f .env.test ]; then
-  cp .env.test.example .env.test
-fi
+bootstrap_env_file .env .env.dev.example
+bootstrap_env_file .env.test .env.test.example
 
 pnpm install --frozen-lockfile
 

--- a/scripts/codex/setup.test.sh
+++ b/scripts/codex/setup.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmpdir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmpdir"
+}
+
+trap cleanup EXIT
+
+primary_root="$tmpdir/primary/langfuse"
+worktree_root="$tmpdir/worktrees/feature/langfuse"
+
+mkdir -p "$tmpdir/bin" "$primary_root/.git" "$worktree_root/scripts/codex"
+
+cp "$repo_root/scripts/codex/setup.sh" "$worktree_root/scripts/codex/setup.sh"
+cp "$repo_root/.env.dev.example" "$worktree_root/.env.dev.example"
+cp "$repo_root/.env.test.example" "$worktree_root/.env.test.example"
+
+chmod +x "$worktree_root/scripts/codex/setup.sh"
+
+cat <<'EOF' > "$tmpdir/bin/corepack"
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat <<'EOF' > "$tmpdir/bin/pnpm"
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat <<EOF > "$tmpdir/bin/git"
+#!/usr/bin/env bash
+if [ "\$1" = "rev-parse" ] && [ "\$2" = "--path-format=absolute" ] && [ "\$3" = "--git-common-dir" ]; then
+  printf '%s\n' "$primary_root/.git"
+  exit 0
+fi
+
+echo "unexpected git invocation: \$*" >&2
+exit 1
+EOF
+
+chmod +x "$tmpdir/bin/corepack" "$tmpdir/bin/pnpm" "$tmpdir/bin/git"
+
+cat <<'EOF' > "$primary_root/.env"
+PRIMARY_ONLY=1
+NEXTAUTH_URL=http://primary.example
+EOF
+
+assert_file_contains() {
+  local file_path="$1"
+  local expected="$2"
+  local message="$3"
+
+  if ! grep -Fqx "$expected" "$file_path"; then
+    echo "$message"
+    echo "missing line: $expected"
+    exit 1
+  fi
+}
+
+run_setup() {
+  (
+    cd "$worktree_root"
+    PATH="$tmpdir/bin:$PATH" bash scripts/codex/setup.sh
+  )
+}
+
+run_setup
+
+if ! cmp -s "$primary_root/.env" "$worktree_root/.env"; then
+  echo ".env should be copied from the primary worktree when missing"
+  exit 1
+fi
+
+if ! cmp -s "$worktree_root/.env.test.example" "$worktree_root/.env.test"; then
+  echo ".env.test should fall back to the checked-in example when the primary worktree has no .env.test"
+  exit 1
+fi
+
+cat <<'EOF' > "$primary_root/.env"
+PRIMARY_ONLY=2
+NEXTAUTH_URL=http://changed.example
+EOF
+
+printf 'WORKTREE_ONLY=keep-me\n' >> "$worktree_root/.env"
+
+run_setup
+
+assert_file_contains \
+  "$worktree_root/.env" \
+  "PRIMARY_ONLY=1" \
+  "setup.sh should not overwrite an existing worktree .env"
+
+assert_file_contains \
+  "$worktree_root/.env" \
+  "WORKTREE_ONLY=keep-me" \
+  "setup.sh should preserve worktree-local env changes on rerun"
+
+echo "setup.sh worktree bootstrap regression test passed"

--- a/scripts/codex/setup.test.sh
+++ b/scripts/codex/setup.test.sh
@@ -11,16 +11,15 @@ cleanup() {
 
 trap cleanup EXIT
 
-primary_root="$tmpdir/primary/langfuse"
-worktree_root="$tmpdir/worktrees/feature/langfuse"
+repo_copy="$tmpdir/repo"
 
-mkdir -p "$tmpdir/bin" "$primary_root/.git" "$worktree_root/scripts/codex"
+mkdir -p "$tmpdir/bin" "$repo_copy/scripts/codex"
 
-cp "$repo_root/scripts/codex/setup.sh" "$worktree_root/scripts/codex/setup.sh"
-cp "$repo_root/.env.dev.example" "$worktree_root/.env.dev.example"
-cp "$repo_root/.env.test.example" "$worktree_root/.env.test.example"
+cp "$repo_root/scripts/codex/setup.sh" "$repo_copy/scripts/codex/setup.sh"
+cp "$repo_root/.env.dev.example" "$repo_copy/.env.dev.example"
+cp "$repo_root/.env.test.example" "$repo_copy/.env.test.example"
 
-chmod +x "$worktree_root/scripts/codex/setup.sh"
+chmod +x "$repo_copy/scripts/codex/setup.sh"
 
 cat <<'EOF' > "$tmpdir/bin/corepack"
 #!/usr/bin/env bash
@@ -32,23 +31,7 @@ cat <<'EOF' > "$tmpdir/bin/pnpm"
 exit 0
 EOF
 
-cat <<EOF > "$tmpdir/bin/git"
-#!/usr/bin/env bash
-if [ "\$1" = "rev-parse" ] && [ "\$2" = "--path-format=absolute" ] && [ "\$3" = "--git-common-dir" ]; then
-  printf '%s\n' "$primary_root/.git"
-  exit 0
-fi
-
-echo "unexpected git invocation: \$*" >&2
-exit 1
-EOF
-
-chmod +x "$tmpdir/bin/corepack" "$tmpdir/bin/pnpm" "$tmpdir/bin/git"
-
-cat <<'EOF' > "$primary_root/.env"
-PRIMARY_ONLY=1
-NEXTAUTH_URL=http://primary.example
-EOF
+chmod +x "$tmpdir/bin/corepack" "$tmpdir/bin/pnpm"
 
 assert_file_contains() {
   local file_path="$1"
@@ -64,40 +47,37 @@ assert_file_contains() {
 
 run_setup() {
   (
-    cd "$worktree_root"
+    cd "$repo_copy"
     PATH="$tmpdir/bin:$PATH" bash scripts/codex/setup.sh
   )
 }
 
 run_setup
 
-if ! cmp -s "$primary_root/.env" "$worktree_root/.env"; then
-  echo ".env should be copied from the primary worktree when missing"
+if ! cmp -s "$repo_copy/.env.dev.example" "$repo_copy/.env"; then
+  echo ".env should be created from .env.dev.example when missing"
   exit 1
 fi
 
-if ! cmp -s "$worktree_root/.env.test.example" "$worktree_root/.env.test"; then
-  echo ".env.test should fall back to the checked-in example when the primary worktree has no .env.test"
+if ! cmp -s "$repo_copy/.env.test.example" "$repo_copy/.env.test"; then
+  echo ".env.test should be created from .env.test.example when missing"
   exit 1
 fi
 
-cat <<'EOF' > "$primary_root/.env"
-PRIMARY_ONLY=2
-NEXTAUTH_URL=http://changed.example
+cat <<'EOF' > "$repo_copy/.env"
+WORKTREE_ONLY=keep-me
 EOF
-
-printf 'WORKTREE_ONLY=keep-me\n' >> "$worktree_root/.env"
 
 run_setup
 
 assert_file_contains \
-  "$worktree_root/.env" \
-  "PRIMARY_ONLY=1" \
-  "setup.sh should not overwrite an existing worktree .env"
+  "$repo_copy/.env" \
+  "WORKTREE_ONLY=keep-me" \
+  "setup.sh should not overwrite an existing .env"
 
 assert_file_contains \
-  "$worktree_root/.env" \
-  "WORKTREE_ONLY=keep-me" \
-  "setup.sh should preserve worktree-local env changes on rerun"
+  "$repo_copy/.env.test" \
+  'DATABASE_URL="postgresql://postgres:postgres@localhost:5432/langfuse_test"' \
+  "setup.sh should preserve the existing .env.test on rerun"
 
-echo "setup.sh worktree bootstrap regression test passed"
+echo "setup.sh example bootstrap regression test passed"


### PR DESCRIPTION
## Summary
- copy missing `.env` from the primary worktree associated with the shared git common dir
- fall back to `.env.dev.example` or `.env.test.example` when the primary worktree does not contain the target env file
- add a shell regression test covering new-worktree bootstrap behavior and rerun safety

## Testing
- Not run (not requested)