### PR TITLE
docs: switch to recommended installation method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ Notes:
 
 1. Install development dependencies:
    - [golang-migrate](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate#migrate-cli) as CLI
-   - [clickhouse binary](https://clickhouse.com/docs/install) on macOS with brew: `brew install --cask clickhouse`
+   - [clickhouse binary](https://clickhouse.com/docs/install) on macOS with brew: `curl https://clickhouse.com/ | sh`
 
 2. Fork the repository and clone it locally
 


### PR DESCRIPTION
## What does this PR do?

Updating the contribution guidelines to the [recommended approach for installing the clickhouse binaries](https://clickhouse.com/docs/install/quick-install-curl).
The current approach is [deprecated](https://clickhouse.com/docs/install/macOS)

<img width="1307" height="203" alt="image" src="https://github.com/user-attachments/assets/f12826f5-04cb-4a84-8ba5-aa3a9d48b8c3" />


Fixes # (issue)

Recommended installation method is breaking

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Chore (refactoring code, technical debt, workflow improvements)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

