### PR TITLE
fix(build): fix cve vulnerabilities in web and worker docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,13 @@ Dockerfile
 node_modules
 npm-debug.log
 README.md
+.pnpm-store
+**/.pnpm-store
+.turbo
+**/.turbo
 **/.next
+**/.next-check
+**/dist
+**/*.tsbuildinfo
 .git
 **/node_modules

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,9 +3,9 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} node:24-alpine AS alpine
 
 # It's important to update the index before installing packages to ensure you're getting the latest versions.
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libc6-compat busybox ssl_client
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libc6-compat busybox ssl_client zlib
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS base
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS build-base
 # Pin turbo to avoid nondeterministic prune output from future patch releases.
 RUN npm install turbo@2.8.20 --global
 ENV PNPM_HOME="/pnpm"
@@ -13,14 +13,19 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 RUN corepack prepare pnpm@9.5.0 --activate
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} base AS pruner
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS runtime-base
+# Remove package managers from the runtime image; only build stages need them.
+RUN rm -rf /usr/local/lib/node_modules/corepack && \
+    rm -f /usr/local/bin/corepack /usr/local/bin/pnpm /usr/local/bin/pnpx /usr/local/bin/yarn /usr/local/bin/yarnpkg
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} build-base AS pruner
 
 WORKDIR /app
 
 COPY . .
 RUN turbo prune --scope=web --docker
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} base AS builder
+FROM --platform=${TARGETPLATFORM:-linux/amd64} build-base AS builder
 
 WORKDIR /app
 
@@ -88,7 +93,7 @@ ENV CI true
 RUN NODE_OPTIONS='--max-old-space-size-percentage=75' turbo run build --filter=web...
 
 # Production image, copy all the files and run next
-FROM --platform=${TARGETPLATFORM:-linux/amd64} base AS runner
+FROM --platform=${TARGETPLATFORM:-linux/amd64} runtime-base AS runner
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -123,6 +128,10 @@ ARG NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
 RUN if [ -n "$NEXT_PUBLIC_LANGFUSE_CLOUD_REGION" ]; then \
     npm install --no-package-lock --no-save dd-trace@5.65.0; \
     fi
+
+# Runtime images do not need npm once explicit runtime tools are installed.
+RUN rm -rf /usr/local/lib/node_modules/npm && \
+    rm -f /usr/local/bin/npm /usr/local/bin/npx
 
 RUN MIGRATE_TARGET_ARCH=$(echo ${TARGETPLATFORM:-linux/amd64} | sed 's/\//-/g') && \
     wget -q -O- https://github.com/golang-migrate/migrate/releases/download/v4.19.1/migrate.$MIGRATE_TARGET_ARCH.tar.gz | tar xvz && \

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -3,9 +3,9 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} node:24-alpine AS alpine
 
 # It's important to update the index before installing packages to ensure you're getting the latest versions.
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libc6-compat busybox ssl_client
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libc6-compat busybox ssl_client zlib
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS base
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS build-base
 # Pin turbo to avoid nondeterministic prune output from future patch releases.
 RUN npm install turbo@2.8.20 --global
 ENV PNPM_HOME="/pnpm"
@@ -13,17 +13,19 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 RUN corepack prepare pnpm@9.5.0 --activate
 
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS runtime-base
+# Remove package managers from the runtime image; only build stages need them.
+RUN rm -rf /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/npm && \
+    rm -f /usr/local/bin/corepack /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/pnpm /usr/local/bin/pnpx /usr/local/bin/yarn /usr/local/bin/yarnpkg
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} base AS pruner
+FROM --platform=${TARGETPLATFORM:-linux/amd64} build-base AS pruner
 
 WORKDIR /app
 
 COPY . .
 RUN turbo prune --scope=worker --docker
 
-
-
-FROM --platform=${TARGETPLATFORM:-linux/amd64} base AS builder
+FROM --platform=${TARGETPLATFORM:-linux/amd64} build-base AS builder
 
 WORKDIR /app
 
@@ -46,7 +48,24 @@ COPY --from=pruner /app/out/full/ .
 
 RUN turbo run build --filter=worker...
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} base AS runner
+FROM --platform=${TARGETPLATFORM:-linux/amd64} builder AS prod-deps
+
+RUN rm -rf /prod && \
+    pnpm --filter worker deploy --prod /prod/worker && \
+    builder_prisma_client_dir="$(find /app/node_modules/.pnpm -path '*/node_modules/@prisma/client' -type d | head -n 1)" && \
+    deployed_prisma_client_dir="$(find /prod/worker/node_modules/.pnpm -path '*/node_modules/@prisma/client' -type d | head -n 1)" && \
+    builder_prisma_runtime_dir="$(dirname "$(dirname "$builder_prisma_client_dir")")/.prisma" && \
+    deployed_prisma_runtime_dir="$(dirname "$(dirname "$deployed_prisma_client_dir")")/.prisma" && \
+    rm -rf "$deployed_prisma_client_dir" "$deployed_prisma_runtime_dir" && \
+    mkdir -p "$(dirname "$deployed_prisma_client_dir")" && \
+    cp -R "$builder_prisma_client_dir" "$deployed_prisma_client_dir" && \
+    cp -R "$builder_prisma_runtime_dir" "$deployed_prisma_runtime_dir" && \
+    # @langfuse/shared currently brings auth-only Next.js packages that the worker never executes.
+    find /prod/worker/node_modules \
+      \( -path '*/node_modules/next' -o -path '*/node_modules/next-auth' -o -path '*/.bin/next' \) \
+      -exec rm -rf {} +
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} runtime-base AS runner
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -66,10 +85,10 @@ ARG UID=1001
 ARG GID=1001
 RUN addgroup --system --gid ${GID} expressjs
 RUN adduser --system --uid ${UID} expressjs
-USER expressjs
-COPY --from=builder --chown=expressjs:expressjs /app .
-COPY --chown=expressjs:expressjs ./worker/entrypoint.sh ./worker/entrypoint.sh
+
+COPY --from=prod-deps --chown=expressjs:expressjs /prod/worker ./worker
 RUN chmod +x ./worker/entrypoint.sh
+USER expressjs
 
 EXPOSE 3030
 ENV PORT=3030


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #[11938](https://github.com/langfuse/langfuse/issues/11938) & #[12721](https://github.com/langfuse/langfuse/issues/12721)

**Implemented**

- [`.dockerignore`](/Users/thor/src/langfuse/langfuse/.dockerignore#L6) now excludes pnpm/turbo/Next/dist caches so Docker build context stays small.
- [`web/Dockerfile`](/Users/thor/src/langfuse/langfuse/web/Dockerfile#L6) now upgrades `zlib` with the other Alpine packages, splits build and runtime bases, and strips package-manager tooling from the final runtime image.
- [`worker/Dockerfile`](/Users/thor/src/langfuse/langfuse/worker/Dockerfile#L16) does the same split, and [`worker/Dockerfile`](/Users/thor/src/langfuse/langfuse/worker/Dockerfile#L51) now assembles the final image from prod-only deployed deps plus built output instead of copying the full workspace. That stage also restores the generated Prisma client/runtime and removes web-only `next`/`next-auth` packages.

**Verified**

- `docker compose --env-file .env.docker -f docker-compose.build.yml up -d --build --wait --wait-timeout 300` now exits `0`.
- `langfuse-web` and `langfuse-worker` both come up healthy in compose.
- Runtime probes show patched Alpine packages in both images: `libcrypto3/libssl3 3.5.5-r0`, `ssl_client/busybox 1.37.0-r30`, `zlib 1.3.2-r0`.
- `pnpm` and `turbo` no longer resolve in the final runtime images, and the worker runtime no longer resolves `vitest` or `jsdom`.
- Targeted `docker scout cves` reruns for the issue-relevant package set now leave one remaining hit in both images: `busybox` `CVE-2025-60876`, with `Fixed version: not fixed`. The OpenSSL, `zlib`, `tar`, `pnpm`, `corepack`, and dev-tooling findings tied to this work are gone from that targeted scan.

**Remaining**

- The last Alpine finding is not fixable with another `apk upgrade` on Alpine 3.23 right now; Scout reports no fixed BusyBox package yet. Getting to zero Alpine findings would mean either waiting for Alpine to ship that fix or moving off the current Alpine base image.


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
