### PR TITLE
fix(dashboards): prevent stale SSE spinner on date range changes

### DIFF
--- a/web/src/__tests__/sse-dashboard-query.clienttest.ts
+++ b/web/src/__tests__/sse-dashboard-query.clienttest.ts
@@ -1,9 +1,12 @@
 /**
  * Tests for the SSE dashboard query hook's parsing and progress logic.
  */
+import { renderHook, waitFor } from "@testing-library/react";
+import { TextDecoder, TextEncoder } from "util";
 import {
   parseSSEBuffer,
   computeMonotonicPercent,
+  useSSEDashboardQuery,
 } from "@/src/hooks/useSSEDashboardQuery";
 
 describe("parseSSEBuffer", () => {
@@ -135,5 +138,190 @@ describe("computeMonotonicPercent", () => {
 
   it("should preserve previous max when current percent is lower", () => {
     expect(computeMonotonicPercent(10, 100, 0.5)).toBe(0.5);
+  });
+});
+
+describe("useSSEDashboardQuery", () => {
+  const originalFetch = global.fetch;
+  const originalTextDecoder = global.TextDecoder;
+
+  const createStreamReader = (chunks: Uint8Array[]) => {
+    let index = 0;
+
+    return {
+      read: jest.fn().mockImplementation(async () => {
+        if (index < chunks.length) {
+          return {
+            done: false,
+            value: chunks[index++],
+          };
+        }
+
+        return {
+          done: true,
+          value: undefined,
+        };
+      }),
+    };
+  };
+
+  const createInput = (fromTimestamp: string, toTimestamp: string) => ({
+    projectId: "project-1",
+    version: "v1" as const,
+    query: {
+      view: "traces" as const,
+      dimensions: [],
+      metrics: [{ measure: "count", aggregation: "count" as const }],
+      filters: [],
+      timeDimension: null,
+      fromTimestamp,
+      toTimestamp,
+      orderBy: null,
+      chartConfig: { type: "BAR_TIME_SERIES" },
+    },
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    global.TextDecoder = originalTextDecoder;
+    jest.restoreAllMocks();
+  });
+
+  it("preserves successful state when disabled after the stream completes", async () => {
+    const encoder = new TextEncoder();
+
+    global.fetch = jest.fn().mockImplementation(async () => ({
+      ok: true,
+      body: {
+        getReader: () =>
+          createStreamReader([
+            encoder.encode(
+              'event: row\ndata: {"count_count":42}\n\n' +
+                "event: done\ndata: {}\n\n",
+            ),
+          ]),
+      },
+    })) as typeof fetch;
+    global.TextDecoder = TextDecoder as typeof global.TextDecoder;
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useSSEDashboardQuery(
+          createInput("2026-03-22T00:00:00.000Z", "2026-03-23T00:00:00.000Z"),
+          {
+            enabled,
+            queryId: "widget-1",
+          },
+        ),
+      {
+        initialProps: { enabled: true },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    rerender({ enabled: false });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.data).toEqual([{ count_count: 42 }]);
+  });
+
+  it("treats a changed input as pending immediately and hides stale results", async () => {
+    const encoder = new TextEncoder();
+    let releaseSecondResponse: (() => void) | null = null;
+
+    global.fetch = jest
+      .fn()
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        body: {
+          getReader: () =>
+            createStreamReader([
+              encoder.encode(
+                'event: row\ndata: {"count_count":42}\n\n' +
+                  "event: done\ndata: {}\n\n",
+              ),
+            ]),
+        },
+      }))
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        body: {
+          getReader: () => {
+            let released = false;
+            const waitForRelease = new Promise<void>((resolve) => {
+              releaseSecondResponse = () => {
+                released = true;
+                resolve();
+              };
+            });
+
+            return {
+              read: jest.fn().mockImplementation(async () => {
+                if (!released) {
+                  await waitForRelease;
+                }
+
+                return {
+                  done: true,
+                  value: undefined,
+                };
+              }),
+            };
+          },
+        },
+      })) as typeof fetch;
+    global.TextDecoder = TextDecoder as typeof global.TextDecoder;
+
+    const firstInput = createInput(
+      "2026-03-22T00:00:00.000Z",
+      "2026-03-23T00:00:00.000Z",
+    );
+    const secondInput = createInput(
+      "2026-03-16T00:00:00.000Z",
+      "2026-03-23T00:00:00.000Z",
+    );
+
+    const { result, rerender } = renderHook(
+      ({ input }) =>
+        useSSEDashboardQuery(input, {
+          enabled: true,
+          queryId: "widget-1",
+        }),
+      {
+        initialProps: { input: firstInput },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    rerender({ input: secondInput });
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isSuccess).toBe(false);
+    expect(result.current.fetchStatus).toBe("fetching");
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.progress).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(releaseSecondResponse).not.toBeNull();
+    });
+
+    releaseSecondResponse?.();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
   });
 });

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -188,6 +188,7 @@ export function DashboardWidget({
       meta: {
         silentHttpCodes: [422],
       },
+      useSSE: true,
       enabled:
         !widget.isPending && Boolean(widget.data) && queryValidation.valid,
     },
@@ -371,7 +372,7 @@ export function DashboardWidget({
             showSpinner={false}
             showHintImmediately={true}
             hintText={queryValidation.reason}
-            className="bg-background/80 absolute inset-0 z-20 backdrop-blur-xs"
+            className="backdrop-blur-xs bg-background/80 absolute inset-0 z-20"
             hintClassName="max-w-sm px-4"
           />
         ) : (
@@ -409,7 +410,7 @@ export function DashboardWidget({
               showSpinner={chartLoadingState.showSpinner}
               showHintImmediately={chartLoadingState.showHintImmediately}
               hintText={chartLoadingState.hintText}
-              className="bg-background/80 absolute inset-0 z-20 backdrop-blur-xs"
+              className="backdrop-blur-xs bg-background/80 absolute inset-0 z-20"
               hintClassName="max-w-sm px-4"
             />
             {queryResult.progress && queryResult.isPending ? (

--- a/web/src/hooks/useSSEDashboardQuery.ts
+++ b/web/src/hooks/useSSEDashboardQuery.ts
@@ -86,6 +86,7 @@ export function useSSEDashboardQuery(
   const [progress, setProgress] = useState<QueryProgress | null>(null);
   const [status, setStatus] = useState<SSEQueryStatus>("idle");
   const [error, setError] = useState<string | null>(null);
+  const [stateInputKey, setStateInputKey] = useState<string | null>(null);
   const maxPercentRef = useRef(0);
   const basePath = env.NEXT_PUBLIC_BASE_PATH ?? "";
 
@@ -94,7 +95,8 @@ export function useSSEDashboardQuery(
   inputRef.current = input;
 
   const runQuery = useCallback(
-    async (signal: AbortSignal) => {
+    async (runInputKey: string, signal: AbortSignal) => {
+      setStateInputKey(runInputKey);
       setStatus("loading");
       setProgress(null);
       setError(null);
@@ -225,28 +227,37 @@ export function useSSEDashboardQuery(
 
   useEffect(() => {
     if (!enabled) {
-      setStatus("idle");
+      setStatus((current) =>
+        current === "success" || current === "error" ? current : "idle",
+      );
       return;
     }
 
     const abortController = new AbortController();
-    void runQuery(abortController.signal);
+    void runQuery(inputKey, abortController.signal);
 
     return () => {
       abortController.abort();
     };
   }, [enabled, inputKey, runQuery]);
 
+  const hasCurrentState = stateInputKey === inputKey;
+  const shouldHidePreviousRunState = enabled && !hasCurrentState;
+  const isPendingForCurrentRun =
+    enabled &&
+    (status === "idle" || status === "loading" || shouldHidePreviousRunState);
+  const effectiveStatus = isPendingForCurrentRun ? "loading" : status;
+
   return {
-    data,
-    progress,
-    status,
-    isLoading: status === "loading",
-    isSuccess: status === "success",
-    isError: status === "error",
-    error,
+    data: shouldHidePreviousRunState ? undefined : data,
+    progress: shouldHidePreviousRunState ? null : progress,
+    status: effectiveStatus,
+    isLoading: effectiveStatus === "loading",
+    isSuccess: effectiveStatus === "success",
+    isError: effectiveStatus === "error",
+    error: shouldHidePreviousRunState ? null : error,
     // Compatibility with existing scheduler expectations
-    fetchStatus: status === "loading" ? "fetching" : "idle",
-    isPending: status === "idle" || status === "loading",
+    fetchStatus: isPendingForCurrentRun ? "fetching" : "idle",
+    isPending: isPendingForCurrentRun,
   };
 }


### PR DESCRIPTION
## Summary
- bind SSE hook state to the current dashboard query input so a date-range change is immediately treated as pending for the new run
- hide stale data/progress/error from the previous run until the new stream owns the state
- add a regression test for changing the dashboard query input while SSE is enabled

## Impacted packages
- web

## Verification
- pnpm --filter web run test-client --testPathPatterns='sse-dashboard-query.clienttest.ts'
- pnpm --filter web run lint
- manual browser repro on http://localhost:3000/project/7a88fb47-b4e2-43b8-a06c-a5ce950dc53a/dashboards/cmawoi7yd00aqad07f3why08w?dateRange=90d by changing 90d -> Past 7 days