### PR TITLE
perf(prisma): add index on job_executions.job_configuration_id

### DIFF
--- a/packages/shared/prisma/migrations/20260324000000_add_job_executions_job_configuration_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20260324000000_add_job_executions_job_configuration_id_idx/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY "job_executions_job_configuration_id_idx" ON "job_executions"("job_configuration_id");

--- a/packages/shared/prisma/migrations/20260324000000_add_job_executions_job_configuration_id_idx/migration.sql
+++ b/packages/shared/prisma/migrations/20260324000000_add_job_executions_job_configuration_id_idx/migration.sql
@@ -1,2 +1,2 @@
 -- CreateIndex
-CREATE INDEX CONCURRENTLY "job_executions_job_configuration_id_idx" ON "job_executions"("job_configuration_id");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "job_executions_job_configuration_id_idx" ON "job_executions"("job_configuration_id");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1025,6 +1025,7 @@ model JobExecution {
 
   @@index([projectId, jobConfigurationId, jobInputTraceId])
   @@index([projectId, jobOutputScoreId])
+  @@index([jobConfigurationId])
   @@map("job_executions")
 }
 


### PR DESCRIPTION
## What does this PR do?

Speeds up slow deletes of LLM-as-a-judge.
Reasoning and context in ticket: https://linear.app/langfuse/issue/LFE-8961/deleting-a-llm-as-a-judge-takes-forever.

The PR addresses the issue by adding an index to the foreign key which is used for the cascading delete when the evaluator is deleted.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

