### PR TITLE
feat: add gzip compression for blob storage exports

### DIFF
--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -96,6 +96,9 @@ types:
       exportStartDate:
         type: optional<datetime>
         docs: Custom start date for exports (required when exportMode is FROM_CUSTOM_DATE)
+      compressed:
+        type: optional<boolean>
+        docs: Enable gzip compression for exported files (.csv.gz, .json.gz, .jsonl.gz). Defaults to true.
 
   BlobStorageIntegrationResponse:
     properties:
@@ -113,6 +116,7 @@ types:
       fileType: BlobStorageIntegrationFileType
       exportMode: BlobStorageExportMode
       exportStartDate: nullable<datetime>
+      compressed: boolean
       nextSyncAt: nullable<datetime>
       lastSyncAt: nullable<datetime>
       lastError: nullable<string>

--- a/packages/shared/prisma/migrations/20260323000000_add_blob_storage_compression/migration.sql
+++ b/packages/shared/prisma/migrations/20260323000000_add_blob_storage_compression/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+-- Backfill existing columns with value false, but use true as the default for newly created rows.
+ALTER TABLE "blob_storage_integrations" ADD COLUMN "compressed" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "blob_storage_integrations" ALTER COLUMN "compressed" SET DEFAULT true;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1112,6 +1112,7 @@ model BlobStorageIntegration {
   exportMode      BlobStorageExportMode            @default(FULL_HISTORY) @map("export_mode")
   exportStartDate DateTime?                        @map("export_start_date")
   exportSource    AnalyticsIntegrationExportSource @default(TRACES_OBSERVATIONS) @map("export_source")
+  compressed      Boolean                          @default(true) @map("compressed")
 
   // Error tracking
   lastError   String?   @map("last_error")

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -29,6 +29,7 @@ const BlobStorageIntegrationResponseSchema = z.object({
   fileType: z.enum(["JSON", "CSV", "JSONL"]),
   exportMode: z.enum(["FULL_HISTORY", "FROM_TODAY", "FROM_CUSTOM_DATE"]),
   exportStartDate: z.coerce.date().nullable(),
+  compressed: z.boolean(),
   nextSyncAt: z.coerce.date().nullable(),
   lastSyncAt: z.coerce.date().nullable(),
   createdAt: z.coerce.date(),
@@ -496,6 +497,49 @@ describe("Blob Storage Integrations API", () => {
 
       // Verify the encrypted value can be decrypted back to the original
       expect(decrypt(savedIntegration!.secretAccessKey!)).toBe(testSecretKey);
+    });
+
+    it("should create integration with compressed=true by default", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+      };
+      // Do not pass compressed — should default to true
+
+      const response = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.compressed).toBe(true);
+    });
+
+    it("should create integration with compressed=false when specified", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        compressed: false,
+      };
+
+      const response = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.compressed).toBe(false);
+
+      const savedIntegration = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      });
+      expect(savedIntegration?.compressed).toBe(false);
     });
   });
 

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -91,6 +91,7 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
             exportMode: rest.exportMode,
             exportStartDate: rest.exportStartDate ?? null,
             exportSource: rest.exportSource,
+            compressed: rest.compressed,
           },
         });
       } catch (e) {

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -24,6 +24,7 @@ type UpsertBlobStorageIntegrationInput = {
   exportMode: BlobStorageExportMode;
   exportStartDate: Date | null;
   exportSource?: AnalyticsIntegrationExportSource;
+  compressed?: boolean;
 };
 
 function resolveExportStartDate(params: {
@@ -81,6 +82,7 @@ export async function upsertBlobStorageIntegration(params: {
     exportMode: data.exportMode,
     exportStartDate: resolvedExportStartDate,
     exportSource: data.exportSource,
+    compressed: data.compressed ?? true,
   };
 
   return prisma.$transaction(async (tx) => {

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -33,6 +33,7 @@ export const blobStorageIntegrationFormSchema = z.object({
   exportSource: z
     .enum(AnalyticsIntegrationExportSource)
     .default(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+  compressed: z.boolean().default(true),
 });
 
 export type BlobStorageIntegrationFormSchema = z.infer<

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -45,6 +45,7 @@ export const CreateBlobStorageIntegrationRequest = z
     fileType: BlobStorageIntegrationFileType,
     exportMode: BlobStorageExportMode,
     exportStartDate: z.coerce.date().nullable().optional(),
+    compressed: z.boolean().optional().default(true),
   })
   .strict()
   .refine(
@@ -74,6 +75,7 @@ export const BlobStorageIntegrationResponse = z
     fileType: BlobStorageIntegrationFileType,
     exportMode: BlobStorageExportMode,
     exportStartDate: z.coerce.date().nullable(),
+    compressed: z.boolean(),
     nextSyncAt: z.coerce.date().nullable(),
     lastSyncAt: z.coerce.date().nullable(),
     lastError: z.string().nullable(),

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -86,6 +86,7 @@ async function handleGetBlobStorageIntegrations(
       fileType: integration.fileType,
       exportMode: integration.exportMode,
       exportStartDate: integration.exportStartDate,
+      compressed: integration.compressed,
       nextSyncAt: integration.nextSyncAt,
       lastSyncAt: integration.lastSyncAt,
       lastError: integration.lastError,
@@ -172,6 +173,7 @@ async function handleUpsertBlobStorageIntegration(
       fileType: validatedData.fileType,
       exportMode: validatedData.exportMode,
       exportStartDate: validatedData.exportStartDate ?? null,
+      compressed: validatedData.compressed,
     },
   });
 
@@ -191,6 +193,7 @@ async function handleUpsertBlobStorageIntegration(
     fileType: integration.fileType,
     exportMode: integration.exportMode,
     exportStartDate: integration.exportStartDate,
+    compressed: integration.compressed,
     nextSyncAt: integration.nextSyncAt,
     lastSyncAt: integration.lastSyncAt,
     lastError: integration.lastError,

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -742,6 +742,27 @@ const BlobStorageIntegrationSettingsForm = ({
 
         <FormField
           control={blobStorageForm.control}
+          name="compressed"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Gzip Compression</FormLabel>
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                  className="mt-1 ml-4"
+                />
+              </FormControl>
+              <FormDescription>
+                Compress exported files with gzip (.csv.gz, .json.gz, .jsonl.gz)
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={blobStorageForm.control}
           name="enabled"
           render={({ field }) => (
             <FormItem>

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -259,6 +259,7 @@ const BlobStorageIntegrationSettingsForm = ({
         (isBetaEnabled
           ? AnalyticsIntegrationExportSource.EVENTS
           : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      compressed: state?.compressed ?? true,
     },
     disabled: isLoading,
   });
@@ -287,6 +288,7 @@ const BlobStorageIntegrationSettingsForm = ({
         (isBetaEnabled
           ? AnalyticsIntegrationExportSource.EVENTS
           : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      compressed: state?.compressed ?? true,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -97,6 +97,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
         enabled: false,
         exportFrequency: "hourly",
+        compressed: false,
       },
     });
 
@@ -137,6 +138,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           exportSource: "TRACES_OBSERVATIONS_EVENTS",
           nextSyncAt: twoHoursAgo,
           lastSyncAt: twoHoursAgo,
+          compressed: false,
         },
       });
 
@@ -282,6 +284,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           enabled: true,
           exportFrequency: "weekly",
           lastSyncAt: oneHourAgo,
+          compressed: false,
         },
       });
 
@@ -348,6 +351,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           enabled: true,
           exportFrequency: "daily",
           lastSyncAt: oneHourAgo,
+          compressed: false,
         },
       });
 
@@ -459,6 +463,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
             exportSource: "TRACES_OBSERVATIONS_EVENTS",
             fileType,
             lastSyncAt: oneHourAgo,
+            compressed: false,
           },
         });
 
@@ -563,6 +568,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
             exportMode: "FULL_HISTORY",
             exportStartDate: null,
             lastSyncAt: null, // First export
+            compressed: false,
           },
         });
 
@@ -639,6 +645,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           exportMode: "FROM_TODAY" as any,
           exportStartDate: new Date(), // Use current date
           lastSyncAt: null, // First export
+          compressed: false,
         },
       });
 
@@ -702,6 +709,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           exportMode: "FROM_CUSTOM_DATE" as any,
           exportStartDate: customDate,
           lastSyncAt: null, // First export
+          compressed: false,
         },
       });
 
@@ -761,6 +769,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
             exportMode: "FULL_HISTORY",
             exportStartDate: null,
             lastSyncAt: null,
+            compressed: false,
           },
         });
 
@@ -837,6 +846,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           enabled: true,
           exportFrequency: "hourly",
           lastSyncAt: twoDaysAgo, // Start from 2 days ago
+          compressed: false,
         },
       });
 
@@ -894,6 +904,7 @@ describe("BlobStorageIntegrationProcessingJob", () => {
           enabled: true,
           exportFrequency: "hourly",
           lastSyncAt: oneHourAgo,
+          compressed: false,
         },
       });
 

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -932,4 +932,172 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       );
     });
   });
+
+  describe("gzip compression", () => {
+    maybeIt(
+      "should produce .csv.gz files when compressed is true",
+      async () => {
+        const { projectId } = await createOrgProjectAndApiKey();
+        s3Prefix = `${projectId}/`;
+        const now = new Date();
+        const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+
+        await prisma.blobStorageIntegration.create({
+          data: {
+            projectId,
+            type: BlobStorageIntegrationType.S3,
+            bucketName,
+            prefix: s3Prefix,
+            accessKeyId: minioAccessKeyId,
+            secretAccessKey: encrypt(minioAccessKeySecret),
+            region: region ? region : "auto",
+            endpoint: minioEndpoint,
+            forcePathStyle:
+              env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+            enabled: true,
+            exportFrequency: "hourly",
+            fileType: BlobStorageIntegrationFileType.CSV,
+            compressed: true,
+            lastSyncAt: oneHourAgo,
+          },
+        });
+
+        const traceId = randomUUID();
+        await createTracesCh([
+          createTrace({
+            id: traceId,
+            project_id: projectId,
+            timestamp: now.getTime() - 40 * 60 * 1000,
+            name: "Compressed Trace",
+          }),
+        ]);
+
+        await handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job);
+
+        const files = await s3StorageService.listFiles(s3Prefix);
+        const projectFiles = files.filter((f) => f.file.includes(projectId));
+
+        expect(projectFiles.length).toBeGreaterThan(0);
+        expect(projectFiles.every((f) => f.file.endsWith(".csv.gz"))).toBe(
+          true,
+        );
+      },
+    );
+
+    maybeIt(
+      "should produce plain .csv files when compressed is false",
+      async () => {
+        const { projectId } = await createOrgProjectAndApiKey();
+        s3Prefix = `${projectId}/`;
+        const now = new Date();
+        const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+
+        await prisma.blobStorageIntegration.create({
+          data: {
+            projectId,
+            type: BlobStorageIntegrationType.S3,
+            bucketName,
+            prefix: s3Prefix,
+            accessKeyId: minioAccessKeyId,
+            secretAccessKey: encrypt(minioAccessKeySecret),
+            region: region ? region : "auto",
+            endpoint: minioEndpoint,
+            forcePathStyle:
+              env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+            enabled: true,
+            exportFrequency: "hourly",
+            fileType: BlobStorageIntegrationFileType.CSV,
+            compressed: false,
+            lastSyncAt: oneHourAgo,
+          },
+        });
+
+        const traceId = randomUUID();
+        await createTracesCh([
+          createTrace({
+            id: traceId,
+            project_id: projectId,
+            timestamp: now.getTime() - 40 * 60 * 1000,
+            name: "Uncompressed Trace",
+          }),
+        ]);
+
+        await handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job);
+
+        const files = await s3StorageService.listFiles(s3Prefix);
+        const projectFiles = files.filter((f) => f.file.includes(projectId));
+
+        expect(projectFiles.length).toBeGreaterThan(0);
+        expect(
+          projectFiles.every(
+            (f) => f.file.endsWith(".csv") && !f.file.endsWith(".csv.gz"),
+          ),
+        ).toBe(true);
+
+        // Verify content is plain text (readable)
+        const traceFile = projectFiles.find((f) => f.file.includes("/traces/"));
+        if (traceFile) {
+          const content = await s3StorageService.download(traceFile.file);
+          expect(content).toContain(traceId);
+          expect(content).toContain("Uncompressed Trace");
+        }
+      },
+    );
+
+    maybeIt(
+      "should produce .jsonl.gz files when compressed with JSONL format",
+      async () => {
+        const { projectId } = await createOrgProjectAndApiKey();
+        s3Prefix = `${projectId}/`;
+        const now = new Date();
+        const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+
+        await prisma.blobStorageIntegration.create({
+          data: {
+            projectId,
+            type: BlobStorageIntegrationType.S3,
+            bucketName,
+            prefix: s3Prefix,
+            accessKeyId: minioAccessKeyId,
+            secretAccessKey: encrypt(minioAccessKeySecret),
+            region: region ? region : "auto",
+            endpoint: minioEndpoint,
+            forcePathStyle:
+              env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+            enabled: true,
+            exportFrequency: "hourly",
+            fileType: BlobStorageIntegrationFileType.JSONL,
+            compressed: true,
+            lastSyncAt: oneHourAgo,
+          },
+        });
+
+        const traceId = randomUUID();
+        await createTracesCh([
+          createTrace({
+            id: traceId,
+            project_id: projectId,
+            timestamp: now.getTime() - 40 * 60 * 1000,
+            name: "JSONL Compressed Trace",
+          }),
+        ]);
+
+        await handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job);
+
+        const files = await s3StorageService.listFiles(s3Prefix);
+        const projectFiles = files.filter((f) => f.file.includes(projectId));
+
+        expect(projectFiles.length).toBeGreaterThan(0);
+        expect(projectFiles.every((f) => f.file.endsWith(".jsonl.gz"))).toBe(
+          true,
+        );
+      },
+    );
+  });
 });

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1,4 +1,5 @@
 import { pipeline } from "stream";
+import { createGzip } from "zlib";
 import { Job } from "bullmq";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -160,6 +161,7 @@ const processBlobStorageExport = async (config: {
   type: BlobStorageIntegrationType;
   table: "traces" | "observations" | "scores" | "observations_v2"; // observations_v2 is the events table
   fileType: BlobStorageIntegrationFileType;
+  compressed: boolean;
 }) => {
   logger.info(
     `[BLOB INTEGRATION] Processing ${config.table} export for project ${config.projectId}`,
@@ -187,7 +189,13 @@ const processBlobStorageExport = async (config: {
       .toISOString()
       .replace(/:/g, "-")
       .substring(0, 19);
-    const filePath = `${config.prefix ?? ""}${config.projectId}/${config.table}/${timestamp}.${blobStorageProps.extension}`;
+    const extension = config.compressed
+      ? `${blobStorageProps.extension}.gz`
+      : blobStorageProps.extension;
+    const filePath = `${config.prefix ?? ""}${config.projectId}/${config.table}/${timestamp}.${extension}`;
+    const uploadContentType = config.compressed
+      ? "application/gzip"
+      : blobStorageProps.contentType;
 
     // Fetch data based on table type
     let dataStream: AsyncGenerator<Record<string, unknown>>;
@@ -225,18 +233,19 @@ const processBlobStorageExport = async (config: {
         throw new Error(`Unsupported table type: ${config.table}`);
     }
 
-    const fileStream = pipeline(
-      dataStream,
-      streamTransformations[config.fileType](),
-      (err) => {
-        if (err) {
-          logger.error(
-            "[BLOB INTEGRATION] Getting data from DB for blob storage integration failed: ",
-            err,
-          );
-        }
-      },
-    );
+    const pipelineCallback = (err: NodeJS.ErrnoException | null) => {
+      if (err) {
+        logger.error(
+          "[BLOB INTEGRATION] Getting data from DB for blob storage integration failed: ",
+          err,
+        );
+      }
+    };
+
+    const formatTransform = streamTransformations[config.fileType]();
+    const fileStream = config.compressed
+      ? pipeline(dataStream, formatTransform, createGzip(), pipelineCallback)
+      : pipeline(dataStream, formatTransform, pipelineCallback);
 
     // Upload the file to cloud storage
     // For CSV exports, use larger part size to handle big files
@@ -245,7 +254,7 @@ const processBlobStorageExport = async (config: {
 
     await storageService.uploadFileBuffered({
       fileName: filePath,
-      fileType: blobStorageProps.contentType,
+      fileType: uploadContentType,
       data: fileStream,
       partSizeBytes: 100 * 1024 * 1024, // 100 MB part size
     });
@@ -355,6 +364,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
       forcePathStyle: blobStorageIntegration.forcePathStyle || undefined,
       type: blobStorageIntegration.type,
       fileType: blobStorageIntegration.fileType,
+      compressed: blobStorageIntegration.compressed,
     };
 
     // Check if this project should only export traces (legacy behavior via env var)


### PR DESCRIPTION
## Summary

- Adds opt-in gzip compression (`createGzip()` stream transform) to the blob storage integration export pipeline
- New `compressed` boolean column on `BlobStorageIntegration` (DB default `true` for new rows, existing rows backfilled as `false`)
- Compressed files use `.csv.gz`/`.json.gz`/`.jsonl.gz` extensions and `application/gzip` content type
- Exposed via UI toggle, tRPC router, and public API
- No changes to the storage layer (`StorageService`, `BufferedStreamUploader`)

Closes LFE-8944
https://linear.app/langfuse/issue/LFE-8944/add-default-on-compression-for-blob-storage-exports

## Impacted packages

- `packages/shared` — Prisma schema + migration
- `web` — UI form, tRPC router, service, public API types/handler
- `worker` — export pipeline gzip transform
- `fern` — API definition

## Verification

- `pnpm run db:generate` — Prisma client regeneration succeeds
- `pnpm --filter web run lint` — clean
- `pnpm --filter worker run lint` — clean
- `pnpm run typecheck` — all packages pass

## Test plan

- [ ] `worker/src/__tests__/blobStorageIntegrationProcessing.test.ts` — new gzip compression tests (compressed `.csv.gz`, uncompressed `.csv`, compressed `.jsonl.gz`)
- [ ] `web/src/__tests__/server/blob-storage-integration-api.servertest.ts` — API tests for `compressed` field default and explicit `false`
- [ ] Manual: configure integration with compression enabled, trigger export, verify `.csv.gz` file decompresses to valid CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)