### PR TITLE
fix(dashboard): restore filter column labels when editing saved widgets

### DIFF
--- a/web/src/features/query/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/query/dashboardUiTableToViewMapping.ts
@@ -282,3 +282,50 @@ export const mapLegacyUiTableFilterToView = (
     return [{ ...filter, column: definition.viewName }];
   });
 };
+
+/**
+ * Reverse mapping: converts persisted view-level filter column names back to
+ * the widget form's filterColumns identifiers so that the filter builder UI
+ * can match them and display the correct column label.
+ *
+ * `targetColumns` is the array of ColumnDefinition objects used by the widget
+ * form's InlineFilterBuilder. A filter column value is remapped when it does
+ * not already match any column `id` or `name` in `targetColumns` but does
+ * match a `viewName` in the view mappings – in which case we look up the
+ * corresponding `uiTableName` and then resolve it to the matching
+ * targetColumn's `id`.
+ */
+export const mapViewFilterToWidgetFormFilter = (
+  view: z.infer<typeof views>,
+  filters: z.infer<typeof FilterArray>,
+  targetColumns: { id: string; name: string }[],
+): z.infer<typeof FilterArray> => {
+  return filters.map((filter) => {
+    // If the column already matches a target column id or name, no mapping needed
+    const alreadyMatched = targetColumns.some(
+      (c) => c.id === filter.column || c.name === filter.column,
+    );
+    if (alreadyMatched) {
+      return filter;
+    }
+
+    // Try to find a view mapping entry where the viewName matches the filter column
+    const definition = viewMappings[view]?.find(
+      (def) => def.viewName === filter.column,
+    );
+    if (!definition) {
+      return filter;
+    }
+
+    // Find the matching target column by uiTableName
+    const targetColumn = targetColumns.find(
+      (c) =>
+        c.name === definition.uiTableName || c.id === definition.uiTableName,
+    );
+    if (!targetColumn) {
+      return filter;
+    }
+
+    return { ...filter, column: targetColumn.name };
+  });
+};

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -12,6 +12,7 @@ import {
   getValidAggregationsForMeasureType,
   type QueryType,
   mapLegacyUiTableFilterToView,
+  mapViewFilterToWidgetFormFilter,
 } from "@/src/features/query";
 import React, { useState, useMemo, useEffect, useRef } from "react";
 import {
@@ -147,6 +148,31 @@ const chartTypes: ChartType[] = [
     icon: Table,
     supportsBreakdown: true,
   },
+];
+
+/**
+ * Static column definitions used by the widget form filter builder.
+ * This is the superset of all possible filter columns across all views.
+ * Used both for rendering the filter builder UI (with dynamic options added)
+ * and for reverse-mapping persisted view-level filter column names back to
+ * the widget form identifiers when loading a saved widget.
+ */
+const WIDGET_FILTER_COLUMNS: { id: string; name: string }[] = [
+  { id: "environment", name: "Environment" },
+  { id: "traceName", name: "Trace Name" },
+  { id: "observationName", name: "Observation Name" },
+  { id: "scoreName", name: "Score Name" },
+  { id: "tags", name: "Tags" },
+  { id: "toolNames", name: "Tool Names" },
+  { id: "user", name: "User" },
+  { id: "session", name: "Session" },
+  { id: "metadata", name: "Metadata" },
+  { id: "release", name: "Release" },
+  { id: "version", name: "Version" },
+  { id: "providedModelName", name: "Model" },
+  { id: "level", name: "Level" },
+  { id: "value", name: "Score Value" },
+  { id: "stringValue", name: "Score String Value" },
 ];
 
 /**
@@ -371,21 +397,13 @@ export function WidgetForm({
     }
   };
   const [userFilterState, setUserFilterState] = useState<FilterState>(
-    initialValues.filters?.map((filter) => {
-      if (filter.column === "name") {
-        // We need to map the generic `name` property to the correct column name for the selected view
-        return {
-          ...filter,
-          column:
-            initialValues.view === "traces"
-              ? "traceName"
-              : initialValues.view === "observations"
-                ? "observationName"
-                : "scoreName",
-        };
-      }
-      return filter;
-    }) ?? [],
+    initialValues.filters
+      ? mapViewFilterToWidgetFormFilter(
+          initialValues.view,
+          initialValues.filters,
+          WIDGET_FILTER_COLUMNS,
+        )
+      : [],
   );
 
   // When beta is toggled on while "traces" is selected (and not editing an


### PR DESCRIPTION
## Summary

Fixes #8282 - When editing a saved dashboard widget, filter column labels (e.g., "User", "Session") were incorrectly displayed as "Column" in the filter builder UI.

**Root cause**: When saving a widget, filter column names are mapped from UI display names to view-level identifiers via `mapLegacyUiTableFilterToView` (e.g., `"User"` -> `"userId"`, `"Session"` -> `"sessionId"`). When loading a saved widget for editing, no reverse mapping was applied. The filter builder could not match the persisted view-level name (e.g., `"userId"`) against the widget form's filter column definitions (which use `id: "user"` and `name: "User"`), so it fell back to showing "Column".

**Fix**: 
- Added `mapViewFilterToWidgetFormFilter` as a reverse mapping function in `dashboardUiTableToViewMapping.ts` that converts persisted view-level column names back to the widget form's filter column display names
- Extracted `WIDGET_FILTER_COLUMNS` as a static lookup table of all filter columns used by the widget form
- Replaced the partial ad-hoc mapping (which only handled the `"name"` column) with the comprehensive reverse mapping function

This affects all filter columns that have different view-level names, including: User, Session, Release (observations view), Version (observations view), Trace Name, Observation Name, and Score Name.

## Test plan

- [ ] Create a widget with a "User" filter on the traces view, save it, then edit -- verify the "User" label is preserved in the filter builder
- [ ] Create a widget with "Session" and "User" filters on the observations view, save and re-edit -- verify both labels are correctly displayed
- [ ] Create a widget with a "Score Value" filter on the scores-numeric view, save and re-edit -- verify the label is preserved
- [ ] Create a widget with "Release" and "Version" filters on the observations view, save and re-edit -- verify labels are correct
- [ ] Verify that creating new widgets and adding filters still works correctly (forward mapping path unchanged)
- [ ] Verify that existing saved widgets with "Environment", "Tags", or "Metadata" filters (which have matching ids) still display correctly