### PR TITLE
feat(web): add run experiment dialog on experiments page

### DIFF
--- a/web/src/pages/project/[projectId]/experiments.tsx
+++ b/web/src/pages/project/[projectId]/experiments.tsx
@@ -67,6 +67,7 @@ export default function Experiments() {
                 projectId={projectId}
                 setFormOpen={setIsCreateExperimentDialogOpen}
                 handleExperimentSuccess={handleExperimentSuccess}
+                showSDKRunInfoPage
               />
             </DialogContent>
           </Dialog>

--- a/web/src/pages/project/[projectId]/experiments.tsx
+++ b/web/src/pages/project/[projectId]/experiments.tsx
@@ -10,6 +10,7 @@ import { ExperimentsTable } from "@/src/features/experiments/components/table";
 import useIsExperimentV4Enabled from "@/src/features/feature-flags/hooks/useIsExperimentV4Enabled";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { api } from "@/src/utils/api";
 import { FlaskConical } from "lucide-react";
 import { useState } from "react";
 import { useRouter } from "next/router";
@@ -20,6 +21,7 @@ export default function Experiments() {
   const [isCreateExperimentDialogOpen, setIsCreateExperimentDialogOpen] =
     useState(false);
   const capture = usePostHogClientCapture();
+  const utils = api.useUtils();
 
   const hasExperimentWriteAccess = useHasProjectAccess({
     projectId,
@@ -27,6 +29,14 @@ export default function Experiments() {
   });
 
   const { isEnabled } = useIsExperimentV4Enabled();
+
+  const handleExperimentSuccess = async () => {
+    setIsCreateExperimentDialogOpen(false);
+    await Promise.all([
+      utils.experiments.all.invalidate(),
+      utils.experiments.countAll.invalidate(),
+    ]);
+  };
 
   return (
     <Page
@@ -56,6 +66,7 @@ export default function Experiments() {
                 key="create-experiment-form-project-experiments"
                 projectId={projectId}
                 setFormOpen={setIsCreateExperimentDialogOpen}
+                handleExperimentSuccess={handleExperimentSuccess}
               />
             </DialogContent>
           </Dialog>

--- a/web/src/pages/project/[projectId]/experiments.tsx
+++ b/web/src/pages/project/[projectId]/experiments.tsx
@@ -1,11 +1,30 @@
 import Page from "@/src/components/layouts/page";
+import { Button } from "@/src/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from "@/src/components/ui/dialog";
+import { CreateExperimentsForm } from "@/src/features/experiments/components/CreateExperimentsForm";
 import { ExperimentsTable } from "@/src/features/experiments/components/table";
 import useIsExperimentV4Enabled from "@/src/features/feature-flags/hooks/useIsExperimentV4Enabled";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { FlaskConical } from "lucide-react";
+import { useState } from "react";
 import { useRouter } from "next/router";
 
 export default function Experiments() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
+  const [isCreateExperimentDialogOpen, setIsCreateExperimentDialogOpen] =
+    useState(false);
+  const capture = usePostHogClientCapture();
+
+  const hasExperimentWriteAccess = useHasProjectAccess({
+    projectId,
+    scope: "promptExperiments:CUD",
+  });
 
   const { isEnabled } = useIsExperimentV4Enabled();
 
@@ -18,6 +37,29 @@ export default function Experiments() {
             "Experiments allow you to compare and analyze different runs of your LLM application. See docs to learn more.",
           href: "https://langfuse.com/docs/datasets/experiments",
         },
+        actionButtonsRight: (
+          <Dialog
+            open={isCreateExperimentDialogOpen}
+            onOpenChange={setIsCreateExperimentDialogOpen}
+          >
+            <DialogTrigger asChild disabled={!hasExperimentWriteAccess}>
+              <Button
+                disabled={!hasExperimentWriteAccess}
+                onClick={() => capture("dataset_run:new_form_open")}
+              >
+                <FlaskConical className="h-4 w-4" />
+                <span className="ml-2 hidden md:block">Run experiment</span>
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+              <CreateExperimentsForm
+                key="create-experiment-form-project-experiments"
+                projectId={projectId}
+                setFormOpen={setIsCreateExperimentDialogOpen}
+              />
+            </DialogContent>
+          </Dialog>
+        ),
       }}
     >
       {isEnabled ? (


### PR DESCRIPTION
### Motivation
- Surface the existing "Run experiment" flow on the Experiments list page so users can start runs from `/project/[projectId]/experiments` without navigating to a dataset or prompt page.
- Keep behavior consistent with existing dataset/prompt places by reusing the same form, RBAC gating, and telemetry.

### Description
- Added a header action button that opens a dialog on the experiments page and renders the existing `CreateExperimentsForm` inside the dialog.
- Introduced local component state and PostHog capture via `usePostHogClientCapture` and an RBAC guard via `useHasProjectAccess` with scope `promptExperiments:CUD` so the button is disabled when the user lacks write access.
- Added imports for `Button`, `Dialog`, `DialogTrigger`, `DialogContent`, `CreateExperimentsForm`, and `FlaskConical`, and wired the `dataset_run:new_form_open` capture event when opening the dialog.
- Changed file: `web/src/pages/project/[projectId]/experiments.tsx`.

### Testing
- Ran `pnpm --filter web exec eslint src/pages/project/[projectId]/experiments.tsx` and the targeted ESLint check passed.
- Started `pnpm --filter web run lint` (full workspace lint) in this environment; validation used the targeted lint above because the full lint run is long-running here.
- Ran the repository `format:check` (Prettier) as part of the formatting checks and it reported that all matched files use Prettier code style.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c3d018a898832bae0ea8357bdb46fb)