### PR TITLE
fix(widgets): simplify dashboard loading states

### DIFF
--- a/web/src/__tests__/chart-loading-state.clienttest.tsx
+++ b/web/src/__tests__/chart-loading-state.clienttest.tsx
@@ -35,7 +35,7 @@ describe("ChartLoadingState", () => {
     expect(screen.getByText(SLOW_QUERY_HINT_TEXT)).toBeInTheDocument();
   });
 
-  test("renders legacy query progress immediately when progress is provided", () => {
+  test("does not render progress details in legacy mode even when progress is provided", () => {
     render(
       <ChartLoadingState
         isLoading={true}
@@ -49,9 +49,11 @@ describe("ChartLoadingState", () => {
       />,
     );
 
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
-    expect(screen.getByText("Loading widget")).toBeInTheDocument();
-    expect(screen.getByText("Reading 1.8B / ~2.9B rows")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(screen.queryByText("Loading widget")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Reading 1.8B / ~2.9B rows"),
+    ).not.toBeInTheDocument();
   });
 
   test("renders spinner immediately, waits 1 second before showing progress, and 3 seconds before showing the hint in minimal mode", () => {

--- a/web/src/__tests__/chart-loading-state.clienttest.tsx
+++ b/web/src/__tests__/chart-loading-state.clienttest.tsx
@@ -13,8 +13,49 @@ describe("ChartLoadingState", () => {
     jest.useRealTimers();
   });
 
-  test("renders spinner immediately, waits 1 second before showing progress, and 3 seconds before showing the hint", () => {
-    render(<ChartLoadingState isLoading={true} />);
+  test("keeps the legacy loader timing by default", () => {
+    const hintDelayMs = 1375;
+
+    render(<ChartLoadingState isLoading={true} hintDelayMs={hintDelayMs} />);
+
+    expect(
+      screen.getByRole("status", { name: "Loading chart data" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(hintDelayMs - 1);
+    });
+    expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(screen.getByText(SLOW_QUERY_HINT_TEXT)).toBeInTheDocument();
+  });
+
+  test("renders legacy query progress immediately when progress is provided", () => {
+    render(
+      <ChartLoadingState
+        isLoading={true}
+        progress={{
+          read_rows: 1_779_300_000,
+          total_rows_to_read: 2_924_500_000,
+          elapsed_ns: 0,
+          read_bytes: 0,
+          percent: 0.6084,
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByText("Loading widget")).toBeInTheDocument();
+    expect(screen.getByText("Reading 1.8B / ~2.9B rows")).toBeInTheDocument();
+  });
+
+  test("renders spinner immediately, waits 1 second before showing progress, and 3 seconds before showing the hint in minimal mode", () => {
+    render(<ChartLoadingState isLoading={true} variant="minimal" />);
 
     expect(
       screen.getByRole("status", { name: "Loading chart data" }),
@@ -46,8 +87,10 @@ describe("ChartLoadingState", () => {
     expect(screen.getByText(SLOW_QUERY_HINT_TEXT)).toBeInTheDocument();
   });
 
-  test("resets delayed progress and hint when loading toggles off and on again", () => {
-    const { rerender } = render(<ChartLoadingState isLoading={true} />);
+  test("resets delayed progress and hint when minimal loading toggles off and on again", () => {
+    const { rerender } = render(
+      <ChartLoadingState isLoading={true} variant="minimal" />,
+    );
 
     act(() => {
       jest.advanceTimersByTime(3000);
@@ -60,7 +103,7 @@ describe("ChartLoadingState", () => {
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
 
-    rerender(<ChartLoadingState isLoading={true} />);
+    rerender(<ChartLoadingState isLoading={true} variant="minimal" />);
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
 
@@ -106,10 +149,11 @@ describe("ChartLoadingState", () => {
     expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
   });
 
-  test("renders query progress details after the progress delay when progress is provided", () => {
+  test("renders query progress details after the progress delay in minimal mode", () => {
     render(
       <ChartLoadingState
         isLoading={true}
+        variant="minimal"
         progress={{
           read_rows: 1_779_300_000,
           total_rows_to_read: 2_924_500_000,
@@ -131,8 +175,10 @@ describe("ChartLoadingState", () => {
     expect(screen.getByText("Reading 1.8B / ~2.9B rows")).toBeInTheDocument();
   });
 
-  test("supports tight layout with the same delayed loader behavior", () => {
-    render(<ChartLoadingState isLoading={true} layout="tight" />);
+  test("supports tight layout with the same delayed minimal loader behavior", () => {
+    render(
+      <ChartLoadingState isLoading={true} variant="minimal" layout="tight" />,
+    );
 
     expect(
       screen.getByRole("status", { name: "Loading chart data" }),

--- a/web/src/__tests__/chart-loading-state.clienttest.tsx
+++ b/web/src/__tests__/chart-loading-state.clienttest.tsx
@@ -13,18 +13,30 @@ describe("ChartLoadingState", () => {
     jest.useRealTimers();
   });
 
-  test("renders spinner immediately and delayed hint after configured delay", () => {
-    const hintDelayMs = 1375;
-
-    render(<ChartLoadingState isLoading={true} hintDelayMs={hintDelayMs} />);
+  test("renders spinner immediately, waits 1 second before showing progress, and 3 seconds before showing the hint", () => {
+    render(<ChartLoadingState isLoading={true} />);
 
     expect(
       screen.getByRole("status", { name: "Loading chart data" }),
     ).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
 
     act(() => {
-      jest.advanceTimersByTime(hintDelayMs - 1);
+      jest.advanceTimersByTime(999);
+    });
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByText("Reading query progress...")).toBeInTheDocument();
+    expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1999);
     });
     expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
 
@@ -34,27 +46,32 @@ describe("ChartLoadingState", () => {
     expect(screen.getByText(SLOW_QUERY_HINT_TEXT)).toBeInTheDocument();
   });
 
-  test("resets delayed hint when loading toggles off and on again", () => {
-    const hintDelayMs = 825;
-
-    const { rerender } = render(
-      <ChartLoadingState isLoading={true} hintDelayMs={hintDelayMs} />,
-    );
+  test("resets delayed progress and hint when loading toggles off and on again", () => {
+    const { rerender } = render(<ChartLoadingState isLoading={true} />);
 
     act(() => {
-      jest.advanceTimersByTime(hintDelayMs);
+      jest.advanceTimersByTime(3000);
     });
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
     expect(screen.getByText(SLOW_QUERY_HINT_TEXT)).toBeInTheDocument();
 
-    rerender(<ChartLoadingState isLoading={false} hintDelayMs={hintDelayMs} />);
+    rerender(<ChartLoadingState isLoading={false} />);
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
 
-    rerender(<ChartLoadingState isLoading={true} hintDelayMs={hintDelayMs} />);
+    rerender(<ChartLoadingState isLoading={true} />);
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
 
     act(() => {
-      jest.advanceTimersByTime(hintDelayMs);
+      jest.advanceTimersByTime(1000);
+    });
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
     });
     expect(screen.getByText(SLOW_QUERY_HINT_TEXT)).toBeInTheDocument();
   });
@@ -69,6 +86,7 @@ describe("ChartLoadingState", () => {
     );
 
     expect(screen.getByText(SLOW_QUERY_HINT_TEXT)).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
     expect(container.querySelector("svg")).not.toBeInTheDocument();
   });
 
@@ -88,7 +106,7 @@ describe("ChartLoadingState", () => {
     expect(screen.queryByText(SLOW_QUERY_HINT_TEXT)).not.toBeInTheDocument();
   });
 
-  test("renders query progress details when progress is provided", () => {
+  test("renders query progress details after the progress delay when progress is provided", () => {
     render(
       <ChartLoadingState
         isLoading={true}
@@ -102,18 +120,29 @@ describe("ChartLoadingState", () => {
       />,
     );
 
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.getByText("Running query...")).toBeInTheDocument();
     expect(screen.getByText("Reading 1.8B / ~2.9B rows")).toBeInTheDocument();
   });
 
-  test("supports tight layout without rendering the default preview chrome", () => {
-    const { container } = render(
-      <ChartLoadingState isLoading={true} layout="tight" />,
-    );
+  test("supports tight layout with the same delayed loader behavior", () => {
+    render(<ChartLoadingState isLoading={true} layout="tight" />);
 
     expect(
       screen.getByRole("status", { name: "Loading chart data" }),
     ).toBeInTheDocument();
-    expect(container.querySelector(".space-y-3")).not.toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 });

--- a/web/src/features/widgets/chart-library/ChartLoadingState.tsx
+++ b/web/src/features/widgets/chart-library/ChartLoadingState.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { SLOW_QUERY_HINT_TEXT } from "@langfuse/shared";
+import { Skeleton } from "@/src/components/ui/skeleton";
 import { type QueryProgress } from "@/src/hooks/useSSEDashboardQuery";
 import { QueryProgressBar } from "@/src/features/widgets/chart-library/QueryProgressBar";
 import { cn } from "@/src/utils/tailwind";
 
+const DEFAULT_LEGACY_HINT_DELAY_MS = 2000;
 const DEFAULT_PROGRESS_DELAY_MS = 1000;
-const DEFAULT_HINT_DELAY_MS = 3000;
+const DEFAULT_MINIMAL_HINT_DELAY_MS = 3000;
 
 type ChartLoadingStateProps = {
   isLoading: boolean;
@@ -15,6 +17,7 @@ type ChartLoadingStateProps = {
   hintClassName?: string;
   spinnerLabel?: string;
   hintText?: string;
+  variant?: "legacy" | "minimal";
   progressDelayMs?: number;
   hintDelayMs?: number;
   showSpinner?: boolean;
@@ -23,6 +26,23 @@ type ChartLoadingStateProps = {
   layout?: "default" | "compact" | "tight";
 };
 
+function ChartLoadingPreview() {
+  return (
+    <div aria-hidden="true" className="space-y-3">
+      <div className="flex items-end gap-2">
+        <Skeleton className="h-12 flex-1 rounded-xl" />
+        <Skeleton className="h-[4.5rem] flex-1 rounded-xl" />
+        <Skeleton className="h-8 flex-1 rounded-xl" />
+        <Skeleton className="h-14 flex-1 rounded-xl" />
+      </div>
+      <div className="flex gap-2">
+        <Skeleton className="h-2 flex-1 rounded-full" />
+        <Skeleton className="h-2 w-[4.5rem] rounded-full" />
+      </div>
+    </div>
+  );
+}
+
 export function ChartLoadingState({
   isLoading,
   className,
@@ -30,13 +50,19 @@ export function ChartLoadingState({
   hintClassName,
   spinnerLabel = "Loading chart data",
   hintText = SLOW_QUERY_HINT_TEXT,
-  progressDelayMs = DEFAULT_PROGRESS_DELAY_MS,
-  hintDelayMs = DEFAULT_HINT_DELAY_MS,
+  variant = "legacy",
+  progressDelayMs,
+  hintDelayMs,
   showSpinner = true,
   showHintImmediately = false,
   progress,
   layout = "default",
 }: ChartLoadingStateProps) {
+  const isMinimal = variant === "minimal";
+  const resolvedProgressDelayMs = progressDelayMs ?? DEFAULT_PROGRESS_DELAY_MS;
+  const resolvedHintDelayMs =
+    hintDelayMs ??
+    (isMinimal ? DEFAULT_MINIMAL_HINT_DELAY_MS : DEFAULT_LEGACY_HINT_DELAY_MS);
   const [showProgress, setShowProgress] = useState(false);
   const [showHint, setShowHint] = useState(false);
 
@@ -50,16 +76,17 @@ export function ChartLoadingState({
     setShowProgress(false);
     setShowHint(false);
 
-    const progressTimeoutId = showSpinner
-      ? window.setTimeout(() => {
-          setShowProgress(true);
-        }, progressDelayMs)
-      : null;
+    const progressTimeoutId =
+      isMinimal && showSpinner
+        ? window.setTimeout(() => {
+            setShowProgress(true);
+          }, resolvedProgressDelayMs)
+        : null;
     const hintTimeoutId = showHintImmediately
       ? null
       : window.setTimeout(() => {
           setShowHint(true);
-        }, hintDelayMs);
+        }, resolvedHintDelayMs);
 
     return () => {
       if (progressTimeoutId !== null) {
@@ -70,9 +97,10 @@ export function ChartLoadingState({
       }
     };
   }, [
-    hintDelayMs,
     isLoading,
-    progressDelayMs,
+    isMinimal,
+    resolvedHintDelayMs,
+    resolvedProgressDelayMs,
     showHintImmediately,
     showSpinner,
   ]);
@@ -81,13 +109,99 @@ export function ChartLoadingState({
     return null;
   }
 
-  const shouldShowProgress = showSpinner && showProgress;
+  const shouldShowProgress = isMinimal ? showSpinner && showProgress : progress;
   const shouldShowHint = showHintImmediately || showHint;
   const isCompact = layout !== "default";
   const isTight = layout === "tight";
   const statusTitle = showSpinner
-    ? "Running query..."
+    ? isMinimal
+      ? "Running query..."
+      : "Loading widget"
     : "Query needs attention";
+
+  if (!isMinimal) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label={spinnerLabel}
+        className={cn(
+          "text-muted-foreground flex h-full min-h-0 w-full flex-col overflow-hidden",
+          className,
+        )}
+      >
+        <div className="m-auto w-full max-w-sm px-4 py-4">
+          <div className={cn("flex flex-col", isCompact ? "gap-3" : "gap-5")}>
+            {!isCompact ? <ChartLoadingPreview /> : null}
+
+            <div
+              className={cn(
+                "flex",
+                isCompact
+                  ? "items-start gap-3 text-left"
+                  : "flex-col items-center gap-3 text-center",
+              )}
+            >
+              <div
+                className={cn(
+                  "bg-background/80 border-border/60 flex shrink-0 items-center justify-center rounded-full border shadow-xs",
+                  isCompact ? "h-9 w-9" : "h-10 w-10",
+                )}
+              >
+                {showSpinner ? (
+                  <Loader2
+                    aria-hidden="true"
+                    className={cn(
+                      isCompact ? "h-4 w-4" : "h-5 w-5",
+                      "animate-spin",
+                      spinnerClassName,
+                    )}
+                  />
+                ) : (
+                  <span
+                    aria-hidden="true"
+                    className="bg-muted-foreground/60 block h-2.5 w-2.5 rounded-full"
+                  />
+                )}
+              </div>
+
+              <div
+                className={cn("space-y-1", isCompact ? "min-w-0 flex-1" : "")}
+              >
+                <p
+                  className={cn(
+                    "text-foreground font-medium",
+                    isTight ? "text-xs" : "text-sm",
+                  )}
+                >
+                  {statusTitle}
+                </p>
+                {shouldShowHint ? (
+                  <p
+                    className={cn(
+                      "animate-in fade-in-0 text-muted-foreground duration-300",
+                      isTight
+                        ? "line-clamp-3 text-[11px] leading-4"
+                        : isCompact
+                          ? "line-clamp-4 text-xs leading-4"
+                          : "line-clamp-3 text-xs leading-5",
+                      hintClassName,
+                    )}
+                  >
+                    {hintText}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+
+            {shouldShowProgress ? (
+              <QueryProgressBar progress={progress} layout={layout} />
+            ) : null}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/web/src/features/widgets/chart-library/ChartLoadingState.tsx
+++ b/web/src/features/widgets/chart-library/ChartLoadingState.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
-import { cn } from "@/src/utils/tailwind";
 import { SLOW_QUERY_HINT_TEXT } from "@langfuse/shared";
-import { Skeleton } from "@/src/components/ui/skeleton";
 import { type QueryProgress } from "@/src/hooks/useSSEDashboardQuery";
 import { QueryProgressBar } from "@/src/features/widgets/chart-library/QueryProgressBar";
+import { cn } from "@/src/utils/tailwind";
 
-const DEFAULT_HINT_DELAY_MS = 2000;
+const DEFAULT_PROGRESS_DELAY_MS = 1000;
+const DEFAULT_HINT_DELAY_MS = 3000;
 
 type ChartLoadingStateProps = {
   isLoading: boolean;
@@ -15,29 +15,13 @@ type ChartLoadingStateProps = {
   hintClassName?: string;
   spinnerLabel?: string;
   hintText?: string;
+  progressDelayMs?: number;
   hintDelayMs?: number;
   showSpinner?: boolean;
   showHintImmediately?: boolean;
   progress?: QueryProgress | null;
   layout?: "default" | "compact" | "tight";
 };
-
-function ChartLoadingPreview() {
-  return (
-    <div aria-hidden="true" className="space-y-3">
-      <div className="flex items-end gap-2">
-        <Skeleton className="h-12 flex-1 rounded-xl" />
-        <Skeleton className="h-[4.5rem] flex-1 rounded-xl" />
-        <Skeleton className="h-8 flex-1 rounded-xl" />
-        <Skeleton className="h-14 flex-1 rounded-xl" />
-      </div>
-      <div className="flex gap-2">
-        <Skeleton className="h-2 flex-1 rounded-full" />
-        <Skeleton className="h-2 w-[4.5rem] rounded-full" />
-      </div>
-    </div>
-  );
-}
 
 export function ChartLoadingState({
   isLoading,
@@ -46,37 +30,64 @@ export function ChartLoadingState({
   hintClassName,
   spinnerLabel = "Loading chart data",
   hintText = SLOW_QUERY_HINT_TEXT,
+  progressDelayMs = DEFAULT_PROGRESS_DELAY_MS,
   hintDelayMs = DEFAULT_HINT_DELAY_MS,
   showSpinner = true,
   showHintImmediately = false,
   progress,
   layout = "default",
 }: ChartLoadingStateProps) {
+  const [showProgress, setShowProgress] = useState(false);
   const [showHint, setShowHint] = useState(false);
 
   useEffect(() => {
     if (!isLoading) {
+      setShowProgress(false);
       setShowHint(false);
       return;
     }
 
-    const timeoutId = window.setTimeout(() => {
-      setShowHint(true);
-    }, hintDelayMs);
+    setShowProgress(false);
+    setShowHint(false);
+
+    const progressTimeoutId = showSpinner
+      ? window.setTimeout(() => {
+          setShowProgress(true);
+        }, progressDelayMs)
+      : null;
+    const hintTimeoutId = showHintImmediately
+      ? null
+      : window.setTimeout(() => {
+          setShowHint(true);
+        }, hintDelayMs);
 
     return () => {
-      window.clearTimeout(timeoutId);
+      if (progressTimeoutId !== null) {
+        window.clearTimeout(progressTimeoutId);
+      }
+      if (hintTimeoutId !== null) {
+        window.clearTimeout(hintTimeoutId);
+      }
     };
-  }, [hintDelayMs, isLoading]);
+  }, [
+    hintDelayMs,
+    isLoading,
+    progressDelayMs,
+    showHintImmediately,
+    showSpinner,
+  ]);
 
   if (!isLoading) {
     return null;
   }
 
+  const shouldShowProgress = showSpinner && showProgress;
   const shouldShowHint = showHintImmediately || showHint;
   const isCompact = layout !== "default";
   const isTight = layout === "tight";
-  const statusTitle = showSpinner ? "Loading widget" : "Query needs attention";
+  const statusTitle = showSpinner
+    ? "Running query..."
+    : "Query needs attention";
 
   return (
     <div
@@ -88,72 +99,58 @@ export function ChartLoadingState({
         className,
       )}
     >
-      <div className="m-auto w-full max-w-sm px-4 py-4">
-        <div className={cn("flex flex-col", isCompact ? "gap-3" : "gap-5")}>
-          {!isCompact ? <ChartLoadingPreview /> : null}
-
-          <div
-            className={cn(
-              "flex",
-              isCompact
-                ? "items-start gap-3 text-left"
-                : "flex-col items-center gap-3 text-center",
-            )}
-          >
-            <div
-              className={cn(
-                "bg-background/80 border-border/60 flex shrink-0 items-center justify-center rounded-full border shadow-xs",
-                isCompact ? "h-9 w-9" : "h-10 w-10",
-              )}
-            >
-              {showSpinner ? (
-                <Loader2
-                  className={cn(
-                    isCompact ? "h-4 w-4" : "h-5 w-5",
-                    "animate-spin",
-                    spinnerClassName,
-                  )}
-                />
-              ) : (
-                <span
-                  className={cn(
-                    "bg-muted-foreground/60 block rounded-full",
-                    "h-2.5 w-2.5",
-                  )}
-                  aria-hidden="true"
-                />
-              )}
-            </div>
-
-            <div className={cn("space-y-1", isCompact ? "min-w-0 flex-1" : "")}>
-              <p
+      <div className="m-auto flex w-full max-w-sm flex-col items-center justify-center px-4 py-6 text-center">
+        <div className={cn("w-full", isCompact ? "space-y-4" : "space-y-5")}>
+          <div className="flex justify-center">
+            {showSpinner ? (
+              <Loader2
+                aria-hidden="true"
                 className={cn(
-                  "text-foreground font-medium",
-                  isTight ? "text-xs" : "text-sm",
+                  "text-muted-foreground animate-spin",
+                  isTight ? "h-4 w-4" : isCompact ? "h-5 w-5" : "h-6 w-6",
+                  spinnerClassName,
                 )}
-              >
-                {statusTitle}
-              </p>
-              {shouldShowHint ? (
-                <p
-                  className={cn(
-                    "animate-in fade-in-0 text-muted-foreground duration-300",
-                    isTight
-                      ? "line-clamp-3 text-[11px] leading-4"
-                      : isCompact
-                        ? "line-clamp-4 text-xs leading-4"
-                        : "line-clamp-3 text-xs leading-5",
-                    hintClassName,
-                  )}
-                >
-                  {hintText}
-                </p>
-              ) : null}
-            </div>
+              />
+            ) : (
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "bg-muted-foreground/60 block rounded-full",
+                  isCompact ? "h-2 w-2" : "h-2.5 w-2.5",
+                )}
+              />
+            )}
           </div>
 
-          {progress ? (
-            <QueryProgressBar progress={progress} layout={layout} />
+          <div className="space-y-1">
+            <p
+              className={cn(
+                "text-foreground font-medium",
+                isTight ? "text-xs" : "text-sm",
+              )}
+            >
+              {statusTitle}
+            </p>
+          </div>
+
+          {shouldShowProgress ? (
+            <QueryProgressBar progress={progress ?? null} layout={layout} />
+          ) : null}
+
+          {shouldShowHint ? (
+            <p
+              className={cn(
+                "animate-in fade-in-0 text-muted-foreground duration-300",
+                isTight
+                  ? "text-[11px] leading-4"
+                  : isCompact
+                    ? "text-xs leading-4"
+                    : "text-xs leading-5",
+                hintClassName,
+              )}
+            >
+              {hintText}
+            </p>
           ) : null}
         </div>
       </div>

--- a/web/src/features/widgets/chart-library/ChartLoadingState.tsx
+++ b/web/src/features/widgets/chart-library/ChartLoadingState.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { SLOW_QUERY_HINT_TEXT } from "@langfuse/shared";
-import { Skeleton } from "@/src/components/ui/skeleton";
 import { type QueryProgress } from "@/src/hooks/useSSEDashboardQuery";
 import { QueryProgressBar } from "@/src/features/widgets/chart-library/QueryProgressBar";
 import { cn } from "@/src/utils/tailwind";
@@ -25,23 +24,6 @@ type ChartLoadingStateProps = {
   progress?: QueryProgress | null;
   layout?: "default" | "compact" | "tight";
 };
-
-function ChartLoadingPreview() {
-  return (
-    <div aria-hidden="true" className="space-y-3">
-      <div className="flex items-end gap-2">
-        <Skeleton className="h-12 flex-1 rounded-xl" />
-        <Skeleton className="h-[4.5rem] flex-1 rounded-xl" />
-        <Skeleton className="h-8 flex-1 rounded-xl" />
-        <Skeleton className="h-14 flex-1 rounded-xl" />
-      </div>
-      <div className="flex gap-2">
-        <Skeleton className="h-2 flex-1 rounded-full" />
-        <Skeleton className="h-2 w-[4.5rem] rounded-full" />
-      </div>
-    </div>
-  );
-}
 
 export function ChartLoadingState({
   isLoading,
@@ -126,79 +108,35 @@ export function ChartLoadingState({
         aria-live="polite"
         aria-label={spinnerLabel}
         className={cn(
-          "text-muted-foreground flex h-full min-h-0 w-full flex-col overflow-hidden",
+          "text-muted-foreground flex h-full min-h-0 w-full flex-col items-center justify-center gap-2 overflow-hidden",
           className,
         )}
       >
-        <div className="m-auto w-full max-w-sm px-4 py-4">
-          <div className={cn("flex flex-col", isCompact ? "gap-3" : "gap-5")}>
-            {!isCompact ? <ChartLoadingPreview /> : null}
-
-            <div
-              className={cn(
-                "flex",
-                isCompact
-                  ? "items-start gap-3 text-left"
-                  : "flex-col items-center gap-3 text-center",
-              )}
-            >
-              <div
-                className={cn(
-                  "bg-background/80 border-border/60 flex shrink-0 items-center justify-center rounded-full border shadow-xs",
-                  isCompact ? "h-9 w-9" : "h-10 w-10",
-                )}
-              >
-                {showSpinner ? (
-                  <Loader2
-                    aria-hidden="true"
-                    className={cn(
-                      isCompact ? "h-4 w-4" : "h-5 w-5",
-                      "animate-spin",
-                      spinnerClassName,
-                    )}
-                  />
-                ) : (
-                  <span
-                    aria-hidden="true"
-                    className="bg-muted-foreground/60 block h-2.5 w-2.5 rounded-full"
-                  />
-                )}
-              </div>
-
-              <div
-                className={cn("space-y-1", isCompact ? "min-w-0 flex-1" : "")}
-              >
-                <p
-                  className={cn(
-                    "text-foreground font-medium",
-                    isTight ? "text-xs" : "text-sm",
-                  )}
-                >
-                  {statusTitle}
-                </p>
-                {shouldShowHint ? (
-                  <p
-                    className={cn(
-                      "animate-in fade-in-0 text-muted-foreground duration-300",
-                      isTight
-                        ? "line-clamp-3 text-[11px] leading-4"
-                        : isCompact
-                          ? "line-clamp-4 text-xs leading-4"
-                          : "line-clamp-3 text-xs leading-5",
-                      hintClassName,
-                    )}
-                  >
-                    {hintText}
-                  </p>
-                ) : null}
-              </div>
-            </div>
-
-            {shouldShowProgress ? (
-              <QueryProgressBar progress={progress} layout={layout} />
-            ) : null}
-          </div>
+        <div
+          className={cn(
+            "flex items-center justify-center",
+            isCompact ? "h-4 w-4" : "h-5 w-5",
+          )}
+        >
+          {showSpinner ? (
+            <Loader2
+              aria-hidden="true"
+              className={cn("h-full w-full animate-spin", spinnerClassName)}
+            />
+          ) : (
+            <span aria-hidden="true" className="h-full w-full" />
+          )}
         </div>
+        {shouldShowHint ? (
+          <p
+            className={cn(
+              "animate-in fade-in-0 max-w-xs text-center text-xs duration-300",
+              hintClassName,
+            )}
+          >
+            {hintText}
+          </p>
+        ) : null}
       </div>
     );
   }

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -25,7 +25,6 @@ import {
   shouldUseWidgetSSE,
 } from "@/src/features/widgets/utils";
 import { ChartLoadingState } from "@/src/features/widgets/chart-library/ChartLoadingState";
-import { QueryStatusFooter } from "@/src/features/widgets/chart-library/QueryStatusFooter";
 import { getChartLoadingStateProps } from "@/src/features/widgets/chart-library/chartLoadingStateUtils";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { type ViewVersion } from "@/src/features/query";
@@ -211,8 +210,21 @@ export function DashboardWidget({
       : placement.x_size <= 4
         ? "compact"
         : "default";
-  const showQueryErrorState =
-    chartLoadingState.isLoading && !queryResult.isPending;
+  const loadingState = !queryValidation.valid
+    ? {
+        showSpinner: false,
+        showHintImmediately: true,
+        hintText: queryValidation.reason,
+        progress: undefined,
+      }
+    : chartLoadingState.isLoading
+      ? {
+          showSpinner: chartLoadingState.showSpinner,
+          showHintImmediately: chartLoadingState.showHintImmediately,
+          hintText: chartLoadingState.hintText,
+          progress: queryResult.isPending ? queryResult.progress : undefined,
+        }
+      : null;
 
   const transformedData = useMemo(() => {
     if (!widget.data || !queryResult.data) {
@@ -364,7 +376,7 @@ export function DashboardWidget({
             </>
           )}
           {/* Download button is available once chart data has loaded */}
-          {!queryResult.isPending ? (
+          {!loadingState ? (
             <DownloadButton
               data={transformedData}
               fileName={widget.data.name}
@@ -379,69 +391,46 @@ export function DashboardWidget({
       >
         {widget.data.description}
       </div>
-      <div className="flex min-h-0 flex-1 flex-col">
-        {!queryValidation.valid ? (
-          <div className="relative min-h-0 flex-1">
-            <ChartLoadingState
-              isLoading={true}
-              showSpinner={false}
-              showHintImmediately={true}
-              hintText={queryValidation.reason}
-              layout={loadingStateLayout}
-              className="bg-background/80 absolute inset-0 z-20 backdrop-blur-xs"
-              hintClassName="max-w-sm px-4"
-            />
-          </div>
+      <div className="min-h-0 flex-1">
+        {loadingState ? (
+          <ChartLoadingState
+            isLoading={true}
+            showSpinner={loadingState.showSpinner}
+            showHintImmediately={loadingState.showHintImmediately}
+            hintText={loadingState.hintText}
+            progress={loadingState.progress}
+            layout={loadingStateLayout}
+            className="h-full"
+            hintClassName="max-w-sm px-4"
+          />
         ) : (
-          <>
-            <div className="relative min-h-0 flex-1">
-              <Chart
-                chartType={widget.data.chartType}
-                data={transformedData}
-                rowLimit={
-                  widget.data.chartConfig.type === "LINE_TIME_SERIES" ||
-                  widget.data.chartConfig.type === "BAR_TIME_SERIES" ||
-                  widget.data.chartConfig.type === "AREA_TIME_SERIES"
-                    ? 100
-                    : (widget.data.chartConfig.row_limit ?? 100)
-                }
-                chartConfig={{
-                  ...widget.data.chartConfig,
-                  // For PIVOT_TABLE, enhance chartConfig with dimensions and metric field names
-                  ...(widget.data.chartType === "PIVOT_TABLE" && {
-                    dimensions: widget.data.dimensions.map((dim) => dim.field),
-                    metrics: widget.data.metrics.map(
-                      (metric) => `${metric.agg}_${metric.measure}`,
-                    ),
-                  }),
-                }}
-                sortState={
-                  widget.data.chartType === "PIVOT_TABLE"
-                    ? sortState
-                    : undefined
-                }
-                onSortChange={
-                  widget.data.chartType === "PIVOT_TABLE"
-                    ? updateSort
-                    : undefined
-                }
-                isLoading={queryResult.isPending}
-              />
-              <ChartLoadingState
-                isLoading={showQueryErrorState}
-                showSpinner={chartLoadingState.showSpinner}
-                showHintImmediately={chartLoadingState.showHintImmediately}
-                hintText={chartLoadingState.hintText}
-                className="bg-background/80 absolute inset-0 z-20 backdrop-blur-xs"
-                hintClassName="max-w-sm px-4"
-              />
-            </div>
-            <QueryStatusFooter
-              isLoading={queryResult.isPending}
-              progress={queryResult.progress}
-              layout={loadingStateLayout}
-            />
-          </>
+          <Chart
+            chartType={widget.data.chartType}
+            data={transformedData}
+            rowLimit={
+              widget.data.chartConfig.type === "LINE_TIME_SERIES" ||
+              widget.data.chartConfig.type === "BAR_TIME_SERIES" ||
+              widget.data.chartConfig.type === "AREA_TIME_SERIES"
+                ? 100
+                : (widget.data.chartConfig.row_limit ?? 100)
+            }
+            chartConfig={{
+              ...widget.data.chartConfig,
+              // For PIVOT_TABLE, enhance chartConfig with dimensions and metric field names
+              ...(widget.data.chartType === "PIVOT_TABLE" && {
+                dimensions: widget.data.dimensions.map((dim) => dim.field),
+                metrics: widget.data.metrics.map(
+                  (metric) => `${metric.agg}_${metric.measure}`,
+                ),
+              }),
+            }}
+            sortState={
+              widget.data.chartType === "PIVOT_TABLE" ? sortState : undefined
+            }
+            onSortChange={
+              widget.data.chartType === "PIVOT_TABLE" ? updateSort : undefined
+            }
+          />
         )}
       </div>
     </div>

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -25,7 +25,6 @@ import {
   shouldUseWidgetSSE,
 } from "@/src/features/widgets/utils";
 import { ChartLoadingState } from "@/src/features/widgets/chart-library/ChartLoadingState";
-import { QueryStatusFooter } from "@/src/features/widgets/chart-library/QueryStatusFooter";
 import { getChartLoadingStateProps } from "@/src/features/widgets/chart-library/chartLoadingStateUtils";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { type ViewVersion } from "@/src/features/query";
@@ -212,8 +211,6 @@ export function DashboardWidget({
         ? "compact"
         : "default";
   const isV4LoadingUi = isBetaEnabled;
-  const showQueryErrorState =
-    chartLoadingState.isLoading && !queryResult.isPending;
   const loadingState =
     isV4LoadingUi && !queryValidation.valid
       ? {
@@ -442,69 +439,59 @@ export function DashboardWidget({
           )}
         </div>
       ) : (
-        <div className="flex min-h-0 flex-1 flex-col">
+        <div className="relative min-h-0 flex-1">
           {!queryValidation.valid ? (
-            <div className="relative min-h-0 flex-1">
+            <ChartLoadingState
+              isLoading={true}
+              showSpinner={false}
+              showHintImmediately={true}
+              hintText={queryValidation.reason}
+              layout={loadingStateLayout}
+              className="bg-background/80 absolute inset-0 z-20 backdrop-blur-xs"
+              hintClassName="max-w-sm px-4"
+            />
+          ) : (
+            <>
+              <Chart
+                chartType={widget.data.chartType}
+                data={transformedData}
+                rowLimit={
+                  widget.data.chartConfig.type === "LINE_TIME_SERIES" ||
+                  widget.data.chartConfig.type === "BAR_TIME_SERIES" ||
+                  widget.data.chartConfig.type === "AREA_TIME_SERIES"
+                    ? 100
+                    : (widget.data.chartConfig.row_limit ?? 100)
+                }
+                chartConfig={{
+                  ...widget.data.chartConfig,
+                  // For PIVOT_TABLE, enhance chartConfig with dimensions and metric field names
+                  ...(widget.data.chartType === "PIVOT_TABLE" && {
+                    dimensions: widget.data.dimensions.map((dim) => dim.field),
+                    metrics: widget.data.metrics.map(
+                      (metric) => `${metric.agg}_${metric.measure}`,
+                    ),
+                  }),
+                }}
+                sortState={
+                  widget.data.chartType === "PIVOT_TABLE"
+                    ? sortState
+                    : undefined
+                }
+                onSortChange={
+                  widget.data.chartType === "PIVOT_TABLE"
+                    ? updateSort
+                    : undefined
+                }
+                isLoading={queryResult.isPending}
+              />
               <ChartLoadingState
-                isLoading={true}
-                showSpinner={false}
-                showHintImmediately={true}
-                hintText={queryValidation.reason}
+                isLoading={chartLoadingState.isLoading}
+                showSpinner={chartLoadingState.showSpinner}
+                showHintImmediately={chartLoadingState.showHintImmediately}
+                hintText={chartLoadingState.hintText}
                 layout={loadingStateLayout}
                 className="bg-background/80 absolute inset-0 z-20 backdrop-blur-xs"
                 hintClassName="max-w-sm px-4"
-              />
-            </div>
-          ) : (
-            <>
-              <div className="relative min-h-0 flex-1">
-                <Chart
-                  chartType={widget.data.chartType}
-                  data={transformedData}
-                  rowLimit={
-                    widget.data.chartConfig.type === "LINE_TIME_SERIES" ||
-                    widget.data.chartConfig.type === "BAR_TIME_SERIES" ||
-                    widget.data.chartConfig.type === "AREA_TIME_SERIES"
-                      ? 100
-                      : (widget.data.chartConfig.row_limit ?? 100)
-                  }
-                  chartConfig={{
-                    ...widget.data.chartConfig,
-                    // For PIVOT_TABLE, enhance chartConfig with dimensions and metric field names
-                    ...(widget.data.chartType === "PIVOT_TABLE" && {
-                      dimensions: widget.data.dimensions.map(
-                        (dim) => dim.field,
-                      ),
-                      metrics: widget.data.metrics.map(
-                        (metric) => `${metric.agg}_${metric.measure}`,
-                      ),
-                    }),
-                  }}
-                  sortState={
-                    widget.data.chartType === "PIVOT_TABLE"
-                      ? sortState
-                      : undefined
-                  }
-                  onSortChange={
-                    widget.data.chartType === "PIVOT_TABLE"
-                      ? updateSort
-                      : undefined
-                  }
-                  isLoading={queryResult.isPending}
-                />
-                <ChartLoadingState
-                  isLoading={showQueryErrorState}
-                  showSpinner={chartLoadingState.showSpinner}
-                  showHintImmediately={chartLoadingState.showHintImmediately}
-                  hintText={chartLoadingState.hintText}
-                  className="bg-background/80 absolute inset-0 z-20 backdrop-blur-xs"
-                  hintClassName="max-w-sm px-4"
-                />
-              </div>
-              <QueryStatusFooter
-                isLoading={queryResult.isPending}
-                progress={queryResult.progress}
-                layout={loadingStateLayout}
               />
             </>
           )}

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -25,6 +25,7 @@ import {
   shouldUseWidgetSSE,
 } from "@/src/features/widgets/utils";
 import { ChartLoadingState } from "@/src/features/widgets/chart-library/ChartLoadingState";
+import { QueryStatusFooter } from "@/src/features/widgets/chart-library/QueryStatusFooter";
 import { getChartLoadingStateProps } from "@/src/features/widgets/chart-library/chartLoadingStateUtils";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { type ViewVersion } from "@/src/features/query";
@@ -210,21 +211,26 @@ export function DashboardWidget({
       : placement.x_size <= 4
         ? "compact"
         : "default";
-  const loadingState = !queryValidation.valid
-    ? {
-        showSpinner: false,
-        showHintImmediately: true,
-        hintText: queryValidation.reason,
-        progress: undefined,
-      }
-    : chartLoadingState.isLoading
+  const isV4LoadingUi = isBetaEnabled;
+  const showQueryErrorState =
+    chartLoadingState.isLoading && !queryResult.isPending;
+  const loadingState =
+    isV4LoadingUi && !queryValidation.valid
       ? {
-          showSpinner: chartLoadingState.showSpinner,
-          showHintImmediately: chartLoadingState.showHintImmediately,
-          hintText: chartLoadingState.hintText,
-          progress: queryResult.isPending ? queryResult.progress : undefined,
+          showSpinner: false,
+          showHintImmediately: true,
+          hintText: queryValidation.reason,
+          progress: undefined,
         }
-      : null;
+      : isV4LoadingUi && chartLoadingState.isLoading
+        ? {
+            showSpinner: chartLoadingState.showSpinner,
+            showHintImmediately: chartLoadingState.showHintImmediately,
+            hintText: chartLoadingState.hintText,
+            progress: queryResult.isPending ? queryResult.progress : undefined,
+          }
+        : null;
+  const canDownload = isV4LoadingUi ? !loadingState : !queryResult.isPending;
 
   const transformedData = useMemo(() => {
     if (!widget.data || !queryResult.data) {
@@ -376,7 +382,7 @@ export function DashboardWidget({
             </>
           )}
           {/* Download button is available once chart data has loaded */}
-          {!loadingState ? (
+          {canDownload ? (
             <DownloadButton
               data={transformedData}
               fileName={widget.data.name}
@@ -391,48 +397,119 @@ export function DashboardWidget({
       >
         {widget.data.description}
       </div>
-      <div className="min-h-0 flex-1">
-        {loadingState ? (
-          <ChartLoadingState
-            isLoading={true}
-            showSpinner={loadingState.showSpinner}
-            showHintImmediately={loadingState.showHintImmediately}
-            hintText={loadingState.hintText}
-            progress={loadingState.progress}
-            layout={loadingStateLayout}
-            className="h-full"
-            hintClassName="max-w-sm px-4"
-          />
-        ) : (
-          <Chart
-            chartType={widget.data.chartType}
-            data={transformedData}
-            rowLimit={
-              widget.data.chartConfig.type === "LINE_TIME_SERIES" ||
-              widget.data.chartConfig.type === "BAR_TIME_SERIES" ||
-              widget.data.chartConfig.type === "AREA_TIME_SERIES"
-                ? 100
-                : (widget.data.chartConfig.row_limit ?? 100)
-            }
-            chartConfig={{
-              ...widget.data.chartConfig,
-              // For PIVOT_TABLE, enhance chartConfig with dimensions and metric field names
-              ...(widget.data.chartType === "PIVOT_TABLE" && {
-                dimensions: widget.data.dimensions.map((dim) => dim.field),
-                metrics: widget.data.metrics.map(
-                  (metric) => `${metric.agg}_${metric.measure}`,
-                ),
-              }),
-            }}
-            sortState={
-              widget.data.chartType === "PIVOT_TABLE" ? sortState : undefined
-            }
-            onSortChange={
-              widget.data.chartType === "PIVOT_TABLE" ? updateSort : undefined
-            }
-          />
-        )}
-      </div>
+      {isV4LoadingUi ? (
+        <div className="min-h-0 flex-1">
+          {loadingState ? (
+            <ChartLoadingState
+              isLoading={true}
+              variant="minimal"
+              showSpinner={loadingState.showSpinner}
+              showHintImmediately={loadingState.showHintImmediately}
+              hintText={loadingState.hintText}
+              progress={loadingState.progress}
+              layout={loadingStateLayout}
+              className="h-full"
+              hintClassName="max-w-sm px-4"
+            />
+          ) : (
+            <Chart
+              chartType={widget.data.chartType}
+              data={transformedData}
+              rowLimit={
+                widget.data.chartConfig.type === "LINE_TIME_SERIES" ||
+                widget.data.chartConfig.type === "BAR_TIME_SERIES" ||
+                widget.data.chartConfig.type === "AREA_TIME_SERIES"
+                  ? 100
+                  : (widget.data.chartConfig.row_limit ?? 100)
+              }
+              chartConfig={{
+                ...widget.data.chartConfig,
+                // For PIVOT_TABLE, enhance chartConfig with dimensions and metric field names
+                ...(widget.data.chartType === "PIVOT_TABLE" && {
+                  dimensions: widget.data.dimensions.map((dim) => dim.field),
+                  metrics: widget.data.metrics.map(
+                    (metric) => `${metric.agg}_${metric.measure}`,
+                  ),
+                }),
+              }}
+              sortState={
+                widget.data.chartType === "PIVOT_TABLE" ? sortState : undefined
+              }
+              onSortChange={
+                widget.data.chartType === "PIVOT_TABLE" ? updateSort : undefined
+              }
+            />
+          )}
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col">
+          {!queryValidation.valid ? (
+            <div className="relative min-h-0 flex-1">
+              <ChartLoadingState
+                isLoading={true}
+                showSpinner={false}
+                showHintImmediately={true}
+                hintText={queryValidation.reason}
+                layout={loadingStateLayout}
+                className="bg-background/80 absolute inset-0 z-20 backdrop-blur-xs"
+                hintClassName="max-w-sm px-4"
+              />
+            </div>
+          ) : (
+            <>
+              <div className="relative min-h-0 flex-1">
+                <Chart
+                  chartType={widget.data.chartType}
+                  data={transformedData}
+                  rowLimit={
+                    widget.data.chartConfig.type === "LINE_TIME_SERIES" ||
+                    widget.data.chartConfig.type === "BAR_TIME_SERIES" ||
+                    widget.data.chartConfig.type === "AREA_TIME_SERIES"
+                      ? 100
+                      : (widget.data.chartConfig.row_limit ?? 100)
+                  }
+                  chartConfig={{
+                    ...widget.data.chartConfig,
+                    // For PIVOT_TABLE, enhance chartConfig with dimensions and metric field names
+                    ...(widget.data.chartType === "PIVOT_TABLE" && {
+                      dimensions: widget.data.dimensions.map(
+                        (dim) => dim.field,
+                      ),
+                      metrics: widget.data.metrics.map(
+                        (metric) => `${metric.agg}_${metric.measure}`,
+                      ),
+                    }),
+                  }}
+                  sortState={
+                    widget.data.chartType === "PIVOT_TABLE"
+                      ? sortState
+                      : undefined
+                  }
+                  onSortChange={
+                    widget.data.chartType === "PIVOT_TABLE"
+                      ? updateSort
+                      : undefined
+                  }
+                  isLoading={queryResult.isPending}
+                />
+                <ChartLoadingState
+                  isLoading={showQueryErrorState}
+                  showSpinner={chartLoadingState.showSpinner}
+                  showHintImmediately={chartLoadingState.showHintImmediately}
+                  hintText={chartLoadingState.hintText}
+                  className="bg-background/80 absolute inset-0 z-20 backdrop-blur-xs"
+                  hintClassName="max-w-sm px-4"
+                />
+              </div>
+              <QueryStatusFooter
+                isLoading={queryResult.isPending}
+                progress={queryResult.progress}
+                layout={loadingStateLayout}
+              />
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the chart preview skeleton with a minimal full-widget loading state
- show the spinner immediately, delay the progress bar by 1 second, and delay the slow-query hint by 3 seconds
- hide the chart until loading completes and remove the footer-based loading treatment
- update widget loading tests to cover the new timing behavior

## Testing
- `pnpm --filter web run test-client --testPathPatterns='chart-loading-state.clienttest.tsx'`
- `pnpm --filter web run lint`