### PR TITLE
feat: allow LLM-as-a-judge to filter by tool names and tool call count

### DIFF
--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -166,7 +166,7 @@ export const observationEvalVariableColumns: ObservationEvalVariableColumn[] = [
 export const availableObservationEvalVariableColumns = [
   ...observationEvalVariableColumns,
   {
-    id: "toolCalls", // Needs to match the `ID` from `mapEventsTable.ts` and `mapObservationsTable.ts`
+    id: "toolCalls", // Needs to match the `ID` from `mapObservationsTable.ts`
     name: "Tool Calls",
     description: "Tool calls",
     internal: "tool_calls",

--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -12,63 +12,68 @@ const flexibleUsageCostSchema = z.record(
   z.coerce.number().nullable(),
 );
 
-export const observationForEvalSchema = z.object({
-  // Identifiers
-  span_id: z.string(),
-  trace_id: z.string(),
-  project_id: z.string(),
-  parent_span_id: z.string().nullish(),
+export const observationForEvalSchema = z
+  .object({
+    // Identifiers
+    span_id: z.string(),
+    trace_id: z.string(),
+    project_id: z.string(),
+    parent_span_id: z.string().nullish(),
 
-  // Core properties
-  type: z.string(),
-  name: z.string(),
-  environment: z.string().default(DEFAULT_TRACE_ENVIRONMENT),
-  version: z.string().nullish(),
-  level: z.string().default(ObservationLevel.DEFAULT),
-  status_message: z.string().nullish(),
+    // Core properties
+    type: z.string(),
+    name: z.string(),
+    environment: z.string().default(DEFAULT_TRACE_ENVIRONMENT),
+    version: z.string().nullish(),
+    level: z.string().default(ObservationLevel.DEFAULT),
+    status_message: z.string().nullish(),
 
-  // Trace-level properties
-  trace_name: z.string().nullish(),
-  user_id: z.string().nullish(),
-  session_id: z.string().nullish(),
-  tags: z.array(z.string()).default([]),
-  release: z.string().nullish(),
+    // Trace-level properties
+    trace_name: z.string().nullish(),
+    user_id: z.string().nullish(),
+    session_id: z.string().nullish(),
+    tags: z.array(z.string()).default([]),
+    release: z.string().nullish(),
 
-  // Model
-  provided_model_name: z.string().nullish(),
-  model_parameters: z.unknown().nullish(),
+    // Model
+    provided_model_name: z.string().nullish(),
+    model_parameters: z.unknown().nullish(),
 
-  // Prompt
-  prompt_id: z.string().nullish(),
-  prompt_name: z.string().nullish(),
-  // Accepts string, number, or any other type from ingestion
-  prompt_version: z.union([z.string().nullish(), z.number().nullish()]),
+    // Prompt
+    prompt_id: z.string().nullish(),
+    prompt_name: z.string().nullish(),
+    // Accepts string, number, or any other type from ingestion
+    prompt_version: z.union([z.string().nullish(), z.number().nullish()]),
 
-  // Usage & Cost - accepts number values directly from ingestion
-  provided_usage_details: flexibleUsageCostSchema,
-  provided_cost_details: flexibleUsageCostSchema,
-  usage_details: flexibleUsageCostSchema,
-  cost_details: flexibleUsageCostSchema,
+    // Usage & Cost - accepts number values directly from ingestion
+    provided_usage_details: flexibleUsageCostSchema,
+    provided_cost_details: flexibleUsageCostSchema,
+    usage_details: flexibleUsageCostSchema,
+    cost_details: flexibleUsageCostSchema,
 
-  // Tool calls
-  tool_definitions: z.record(z.string(), z.unknown()).default({}),
-  tool_calls: z.array(z.unknown()).default([]),
-  tool_call_names: z.array(z.string()).default([]),
+    // Tool calls
+    tool_definitions: z.record(z.string(), z.unknown()).default({}),
+    tool_calls: z.array(z.unknown()).default([]),
+    tool_call_names: z.array(z.string()).default([]),
 
-  // Experiment
-  experiment_id: z.string().nullish(),
-  experiment_name: z.string().nullish(),
-  experiment_description: z.string().nullish(),
-  experiment_dataset_id: z.string().nullish(),
-  experiment_item_id: z.string().nullish(),
-  experiment_item_expected_output: z.string().nullish(),
-  experiment_item_root_span_id: z.string().nullish(),
+    // Experiment
+    experiment_id: z.string().nullish(),
+    experiment_name: z.string().nullish(),
+    experiment_description: z.string().nullish(),
+    experiment_dataset_id: z.string().nullish(),
+    experiment_item_id: z.string().nullish(),
+    experiment_item_expected_output: z.string().nullish(),
+    experiment_item_root_span_id: z.string().nullish(),
 
-  // Data - accepts any type (string, array, object) from different OTEL SDKs
-  input: z.unknown().nullish(),
-  output: z.unknown().nullish(),
-  metadata: z.record(z.string(), z.unknown()).nullish(),
-});
+    // Data - accepts any type (string, array, object) from different OTEL SDKs
+    input: z.unknown().nullish(),
+    output: z.unknown().nullish(),
+    metadata: z.record(z.string(), z.unknown()).nullish(),
+  })
+  .transform((data) => ({
+    ...data,
+    tool_call_count: data.tool_call_names.length,
+  }));
 
 export type ObservationForEval = z.infer<typeof observationForEvalSchema>;
 
@@ -102,6 +107,8 @@ export type ObservationEvalFilterColumnInternal =
     | "experiment_dataset_id"
     | "metadata"
     | "parent_span_id"
+    | "tool_call_names"
+    | "tool_call_count"
   >;
 
 export type ObservationEvalMappingColumnInternal = keyof Pick<
@@ -159,7 +166,7 @@ export const observationEvalVariableColumns: ObservationEvalVariableColumn[] = [
 export const availableObservationEvalVariableColumns = [
   ...observationEvalVariableColumns,
   {
-    id: "toolCalls",
+    id: "toolCalls", // Needs to match the `ID` from `mapEventsTable.ts` and `mapObservationsTable.ts`
     name: "Tool Calls",
     description: "Tool calls",
     internal: "tool_calls",
@@ -290,6 +297,21 @@ export const observationEvalFilterColumns: ObservationEvalColumnDef[] = [
     internal: "parent_span_id",
     nullable: true,
   },
+  {
+    name: "Called Tool Names",
+    id: "calledToolNames",
+    type: "arrayOptions",
+    internal: "tool_call_names",
+    options: [], // to be filled at runtime
+  },
+  {
+    name: "Tool Call Count",
+    id: "toolCalls",
+    type: "number",
+    internal: "tool_call_count",
+    step: 1,
+    min: 0,
+  },
 ];
 
 export const experimentEvalFilterColumns: ObservationEvalColumnDef[] = [
@@ -313,6 +335,7 @@ export type ObservationEvalOptions = {
   tags?: Array<SingleValueOption>;
   traceName?: Array<SingleValueOption>;
   name?: Array<SingleValueOption>;
+  calledToolNames?: Array<SingleValueOption>;
 };
 
 export type ExperimentEvalOptions = {
@@ -335,6 +358,9 @@ export function observationEvalFilterColsWithOptions(
     }
     if (col.id === "name") {
       return formatColumnOptions(col, options?.name ?? []);
+    }
+    if (col.id === "calledToolNames") {
+      return formatColumnOptions(col, options?.calledToolNames ?? []);
     }
     return col;
   });

--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -12,68 +12,64 @@ const flexibleUsageCostSchema = z.record(
   z.coerce.number().nullable(),
 );
 
-export const observationForEvalSchema = z
-  .object({
-    // Identifiers
-    span_id: z.string(),
-    trace_id: z.string(),
-    project_id: z.string(),
-    parent_span_id: z.string().nullish(),
+export const observationForEvalSchema = z.object({
+  // Identifiers
+  span_id: z.string(),
+  trace_id: z.string(),
+  project_id: z.string(),
+  parent_span_id: z.string().nullish(),
 
-    // Core properties
-    type: z.string(),
-    name: z.string(),
-    environment: z.string().default(DEFAULT_TRACE_ENVIRONMENT),
-    version: z.string().nullish(),
-    level: z.string().default(ObservationLevel.DEFAULT),
-    status_message: z.string().nullish(),
+  // Core properties
+  type: z.string(),
+  name: z.string(),
+  environment: z.string().default(DEFAULT_TRACE_ENVIRONMENT),
+  version: z.string().nullish(),
+  level: z.string().default(ObservationLevel.DEFAULT),
+  status_message: z.string().nullish(),
 
-    // Trace-level properties
-    trace_name: z.string().nullish(),
-    user_id: z.string().nullish(),
-    session_id: z.string().nullish(),
-    tags: z.array(z.string()).default([]),
-    release: z.string().nullish(),
+  // Trace-level properties
+  trace_name: z.string().nullish(),
+  user_id: z.string().nullish(),
+  session_id: z.string().nullish(),
+  tags: z.array(z.string()).default([]),
+  release: z.string().nullish(),
 
-    // Model
-    provided_model_name: z.string().nullish(),
-    model_parameters: z.unknown().nullish(),
+  // Model
+  provided_model_name: z.string().nullish(),
+  model_parameters: z.unknown().nullish(),
 
-    // Prompt
-    prompt_id: z.string().nullish(),
-    prompt_name: z.string().nullish(),
-    // Accepts string, number, or any other type from ingestion
-    prompt_version: z.union([z.string().nullish(), z.number().nullish()]),
+  // Prompt
+  prompt_id: z.string().nullish(),
+  prompt_name: z.string().nullish(),
+  // Accepts string, number, or any other type from ingestion
+  prompt_version: z.union([z.string().nullish(), z.number().nullish()]),
 
-    // Usage & Cost - accepts number values directly from ingestion
-    provided_usage_details: flexibleUsageCostSchema,
-    provided_cost_details: flexibleUsageCostSchema,
-    usage_details: flexibleUsageCostSchema,
-    cost_details: flexibleUsageCostSchema,
+  // Usage & Cost - accepts number values directly from ingestion
+  provided_usage_details: flexibleUsageCostSchema,
+  provided_cost_details: flexibleUsageCostSchema,
+  usage_details: flexibleUsageCostSchema,
+  cost_details: flexibleUsageCostSchema,
 
-    // Tool calls
-    tool_definitions: z.record(z.string(), z.unknown()).default({}),
-    tool_calls: z.array(z.unknown()).default([]),
-    tool_call_names: z.array(z.string()).default([]),
+  // Tool calls
+  tool_definitions: z.record(z.string(), z.unknown()).default({}),
+  tool_calls: z.array(z.unknown()).default([]),
+  tool_call_names: z.array(z.string()).default([]),
+  tool_call_count: z.number().default(0),
 
-    // Experiment
-    experiment_id: z.string().nullish(),
-    experiment_name: z.string().nullish(),
-    experiment_description: z.string().nullish(),
-    experiment_dataset_id: z.string().nullish(),
-    experiment_item_id: z.string().nullish(),
-    experiment_item_expected_output: z.string().nullish(),
-    experiment_item_root_span_id: z.string().nullish(),
+  // Experiment
+  experiment_id: z.string().nullish(),
+  experiment_name: z.string().nullish(),
+  experiment_description: z.string().nullish(),
+  experiment_dataset_id: z.string().nullish(),
+  experiment_item_id: z.string().nullish(),
+  experiment_item_expected_output: z.string().nullish(),
+  experiment_item_root_span_id: z.string().nullish(),
 
-    // Data - accepts any type (string, array, object) from different OTEL SDKs
-    input: z.unknown().nullish(),
-    output: z.unknown().nullish(),
-    metadata: z.record(z.string(), z.unknown()).nullish(),
-  })
-  .transform((data) => ({
-    ...data,
-    tool_call_count: data.tool_call_names.length,
-  }));
+  // Data - accepts any type (string, array, object) from different OTEL SDKs
+  input: z.unknown().nullish(),
+  output: z.unknown().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
 
 export type ObservationForEval = z.infer<typeof observationForEvalSchema>;
 
@@ -85,9 +81,11 @@ export function convertEventRecordToObservationForEval(
     record.metadata_values,
   );
 
+  const toolCallNames = record.tool_call_names ?? [];
   return observationForEvalSchema.parse({
     ...record,
     metadata,
+    tool_call_count: toolCallNames.length,
   });
 }
 

--- a/packages/shared/src/tableDefinitions/types.ts
+++ b/packages/shared/src/tableDefinitions/types.ts
@@ -30,6 +30,10 @@ export type ColumnDefinition =
       type: "number" | "string" | "datetime" | "boolean" | "null";
       internal: string;
       nullable?: boolean;
+      /** Step for number inputs (e.g. 1 for integers). Defaults to 0.01 in UI. */
+      step?: number;
+      /** Minimum value for number inputs. */
+      min?: number;
     }
   | {
       name: string;

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -1027,7 +1027,7 @@ export const InnerEvaluatorForm = (props: {
                                 disabled={props.disabled}
                                 columnsWithCustomSelect={
                                   isEventTarget(target) || isTraceTarget(target)
-                                    ? ["tags", "name"]
+                                    ? ["tags", "name", "calledToolNames"]
                                     : undefined
                                 }
                               />

--- a/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
+++ b/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
@@ -106,6 +106,10 @@ export function useEvalConfigFilterOptions({
       name: observationsFilterOptionsResponse.data?.name?.map((n) => ({
         value: n.value,
       })),
+      calledToolNames:
+        observationsFilterOptionsResponse.data?.calledToolNames?.map((t) => ({
+          value: t.value,
+        })),
     };
   }, [
     traceFilterOptionsResponse.data,

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -871,7 +871,13 @@ function FilterBuilderForm({
                           value={filter.value ?? undefined}
                           disabled={disabled}
                           type="number"
-                          step="0.01"
+                          step={
+                            (column && "step" in column && column.step) || 0.01
+                          }
+                          min={
+                            column && "min" in column ? column.min : undefined
+                          }
+                          placeholder="number"
                           lang="en-US"
                           onChange={(e) =>
                             handleFilterChange(

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -872,10 +872,10 @@ function FilterBuilderForm({
                           disabled={disabled}
                           type="number"
                           step={
-                            (column && "step" in column && column.step) || 0.01
+                            (column?.type === "number" && column.step) || 0.01
                           }
                           min={
-                            column && "min" in column ? column.min : undefined
+                            column?.type === "number" ? column.min : undefined
                           }
                           placeholder="number"
                           lang="en-US"

--- a/worker/src/features/batchAction/processBatchedObservationEval.test.ts
+++ b/worker/src/features/batchAction/processBatchedObservationEval.test.ts
@@ -84,4 +84,84 @@ describe("processBatchedObservationEval", () => {
       (prisma.batchAction.update as Mock).mock.calls.length,
     ).toBeGreaterThan(0);
   });
+
+  it("derives tool_call_count from tool_call_names in batch records", async () => {
+    const projectId = "project-1";
+    const batchActionId = "batch-action-2";
+
+    const evaluators: ObservationEvalConfig[] = [
+      {
+        id: "config-1",
+        projectId,
+        filter: [],
+        sampling: { toNumber: () => 1 } as ObservationEvalConfig["sampling"],
+        evalTemplateId: "template-1",
+        scoreName: "quality",
+        targetObject: EvalTargetObject.EVENT,
+        variableMapping: [],
+        status: JobConfigState.ACTIVE,
+        blockedAt: null,
+      },
+    ];
+
+    const rowWithToolCalls: Record<string, unknown> = {
+      span_id: "obs-2",
+      trace_id: "trace-2",
+      project_id: projectId,
+      parent_span_id: null,
+      type: "GENERATION",
+      name: "tool-test",
+      usage_details: {},
+      cost_details: {},
+      provided_usage_details: {},
+      provided_cost_details: {},
+      tags: [],
+      input: "input",
+      output: "output",
+      metadata: {},
+      tool_call_names: ["search", "calculator", "fetch"],
+    };
+
+    const rowWithoutToolCalls: Record<string, unknown> = {
+      span_id: "obs-3",
+      trace_id: "trace-3",
+      project_id: projectId,
+      parent_span_id: null,
+      type: "GENERATION",
+      name: "no-tool-test",
+      usage_details: {},
+      cost_details: {},
+      provided_usage_details: {},
+      provided_cost_details: {},
+      tags: [],
+      input: "input",
+      output: "output",
+      metadata: {},
+    };
+
+    const observationStream = (async function* () {
+      yield rowWithToolCalls;
+      yield rowWithoutToolCalls;
+    })();
+
+    await processBatchedObservationEval({
+      projectId,
+      batchActionId,
+      evaluators,
+      observationStream,
+    });
+
+    expect(scheduleObservationEvals).toHaveBeenCalledTimes(2);
+
+    const firstCall = (scheduleObservationEvals as Mock).mock.calls[0][0];
+    expect(firstCall.observation.tool_call_count).toBe(3);
+    expect(firstCall.observation.tool_call_names).toEqual([
+      "search",
+      "calculator",
+      "fetch",
+    ]);
+
+    const secondCall = (scheduleObservationEvals as Mock).mock.calls[1][0];
+    expect(secondCall.observation.tool_call_count).toBe(0);
+  });
 });

--- a/worker/src/features/batchAction/processBatchedObservationEval.ts
+++ b/worker/src/features/batchAction/processBatchedObservationEval.ts
@@ -44,7 +44,13 @@ export async function processBatchedObservationEval(params: {
     const results = await Promise.allSettled(
       batch.map((record) =>
         limit(async () => {
-          const observation = observationForEvalSchema.parse(record);
+          const toolCallNames = Array.isArray(record.tool_call_names)
+            ? record.tool_call_names
+            : [];
+          const observation = observationForEvalSchema.parse({
+            ...record,
+            tool_call_count: toolCallNames.length,
+          });
           await scheduleObservationEvals({
             observation,
             configs: evaluators,

--- a/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
@@ -43,6 +43,7 @@ describe("extractObservationVariables", () => {
     tool_definitions: { search: '{"description": "Search the web"}' },
     tool_calls: ['{"name": "search", "args": {"query": "test"}}'],
     tool_call_names: ["search"],
+    tool_call_count: 1,
 
     // Usage & Cost
     usage_details: { input: 100, output: 50 },

--- a/worker/src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts
@@ -1184,10 +1184,10 @@ describe("tool_calls computation", () => {
     expect(obs.tool_call_names).toEqual([]);
   });
 
-  it("should derive tool_call_count from tool_call_names length", () => {
+  it("should accept an explicit tool_call_count", () => {
     const obs = observationForEvalSchema.parse({
       ...minimalObs,
-      tool_call_names: ["a", "b", "c"],
+      tool_call_count: 3,
     });
 
     expect(obs.tool_call_count).toBe(3);

--- a/worker/src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts
@@ -6,7 +6,11 @@ import {
   createTestEvalConfig,
   createMockSchedulerDeps,
 } from "./fixtures";
-import { type ObservationForEval, EvalTargetObject } from "@langfuse/shared";
+import {
+  type ObservationForEval,
+  EvalTargetObject,
+  observationForEvalSchema,
+} from "@langfuse/shared";
 
 // Mock logger to avoid noise in tests
 vi.mock("@langfuse/shared/src/server", async () => {
@@ -961,6 +965,75 @@ describe("Filter Evaluation for Observation Evals", () => {
     });
   });
 
+  describe("tool call filters", () => {
+    it("should match when called tool name is in filter list", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        tool_call_names: ["get_weather", "search_web"],
+      });
+
+      const matched = await testFilterMatch(observation, [
+        {
+          column: "calledToolNames",
+          type: "arrayOptions",
+          operator: "any of",
+          value: ["get_weather", "send_email"],
+        },
+      ]);
+
+      expect(matched).toBe(true);
+    });
+
+    it("should not match when no called tool name is in filter list", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        tool_call_names: ["get_weather", "search_web"],
+      });
+
+      const matched = await testFilterMatch(observation, [
+        {
+          column: "calledToolNames",
+          type: "arrayOptions",
+          operator: "any of",
+          value: ["send_email"],
+        },
+      ]);
+
+      expect(matched).toBe(false);
+    });
+
+    it("should match when tool call count meets threshold", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        tool_call_names: ["tool_a", "tool_b", "tool_c"],
+      });
+
+      const matched = await testFilterMatch(observation, [
+        {
+          column: "toolCalls",
+          type: "number",
+          operator: ">=",
+          value: 2,
+        },
+      ]);
+
+      expect(matched).toBe(true);
+    });
+
+    it("should not match when tool call count does not meet threshold", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        tool_call_names: ["tool_a", "tool_b", "tool_c"],
+      });
+
+      const matched = await testFilterMatch(observation, [
+        { column: "toolCalls", type: "number", operator: "=", value: 0 },
+      ]);
+
+      expect(matched).toBe(false);
+    });
+  });
+
   describe("null filters (parentObservationId)", () => {
     it("should match observations where parentObservationId is null (root observations)", async () => {
       const observation = createTestObservation({
@@ -1083,5 +1156,40 @@ describe("Filter Evaluation for Observation Evals", () => {
 
       expect(matched).toBe(false);
     });
+  });
+});
+
+describe("tool_calls computation", () => {
+  const minimalObs = {
+    span_id: "s1",
+    trace_id: "t1",
+    project_id: "p1",
+    type: "GENERATION",
+    name: "test",
+    provided_usage_details: {},
+    provided_cost_details: {},
+    usage_details: {},
+    cost_details: {},
+  };
+
+  it("should default tool_call_count to 0", () => {
+    const obs = observationForEvalSchema.parse(minimalObs);
+
+    expect(obs.tool_call_count).toBe(0);
+  });
+
+  it("should default tool_call_names to empty array", () => {
+    const obs = observationForEvalSchema.parse(minimalObs);
+
+    expect(obs.tool_call_names).toEqual([]);
+  });
+
+  it("should derive tool_call_count from tool_call_names length", () => {
+    const obs = observationForEvalSchema.parse({
+      ...minimalObs,
+      tool_call_names: ["a", "b", "c"],
+    });
+
+    expect(obs.tool_call_count).toBe(3);
   });
 });

--- a/worker/src/features/evaluation/observationEval/__tests__/fixtures.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/fixtures.ts
@@ -20,6 +20,7 @@ import {
 export function createTestObservation(
   overrides: Partial<ObservationForEval> = {},
 ): ObservationForEval {
+  const toolCallNames = overrides.tool_call_names ?? [];
   return {
     // Core identifiers
     span_id: `obs-${randomUUID()}`,
@@ -55,6 +56,7 @@ export function createTestObservation(
     tool_definitions: {},
     tool_calls: [],
     tool_call_names: [],
+    tool_call_count: toolCallNames.length,
 
     // Usage & Cost
     usage_details: { input: 100, output: 50 },

--- a/worker/src/features/evaluation/observationEval/__tests__/observationForEvalSchema.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationForEvalSchema.test.ts
@@ -88,6 +88,7 @@ describe("observationForEvalSchema", () => {
       tool_definitions: { search: '{"description": "Search"}' },
       tool_calls: ['{"name": "search"}'],
       tool_call_names: ["search"],
+      tool_call_count: 1,
       usage_details: { input: 100, output: 50 },
       cost_details: { total: 0.01 },
       provided_usage_details: {},

--- a/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
@@ -51,6 +51,7 @@ describe("scheduleObservationEvals", () => {
     tool_definitions: {},
     tool_calls: [],
     tool_call_names: [],
+    tool_call_count: 0,
 
     // Usage & Cost
     usage_details: { input: 100, output: 50 },

--- a/worker/src/features/experiments/__tests__/scheduleExperimentEvals.test.ts
+++ b/worker/src/features/experiments/__tests__/scheduleExperimentEvals.test.ts
@@ -429,6 +429,7 @@ describe("buildObservationForEval", () => {
       tool_definitions: {},
       tool_calls: [],
       tool_call_names: [],
+      tool_call_count: 0,
     };
   }
 

--- a/worker/src/features/experiments/scheduleExperimentEvals.ts
+++ b/worker/src/features/experiments/scheduleExperimentEvals.ts
@@ -86,6 +86,7 @@ export async function scheduleExperimentObservationEvals(
       tool_definitions: {},
       tool_calls: [],
       tool_call_names: [],
+      tool_call_count: 0,
     };
 
     // 3. Schedule evals

--- a/worker/src/queues/__tests__/otelToObservationForEval.test.ts
+++ b/worker/src/queues/__tests__/otelToObservationForEval.test.ts
@@ -1522,7 +1522,7 @@ describe("OTEL to ObservationForEval Schema Validation", () => {
             spans: [
               {
                 traceId: createBufferId("123456789012345678901234567890ab"),
-                spanId: createBufferId("notool567890ab"),
+                spanId: createBufferId("00b001567890abcd"),
                 name: "no-tools-test",
                 kind: 1,
                 startTimeUnixNano: createNanoTimestamp(

--- a/worker/src/queues/__tests__/otelToObservationForEval.test.ts
+++ b/worker/src/queues/__tests__/otelToObservationForEval.test.ts
@@ -1508,6 +1508,55 @@ describe("OTEL to ObservationForEval Schema Validation", () => {
       expect(obs.tool_definitions).toBeDefined();
       expect(obs.tool_calls).toBeDefined();
       expect(obs.tool_call_names).toBeDefined();
+
+      // tool_call_count is derived from tool_call_names
+      expect(obs.tool_call_count).toBe(obs.tool_call_names.length);
+    });
+
+    it("should set tool_call_count to 0 when no tool calls are present", async () => {
+      const noToolsSpan = {
+        resource: { attributes: [] },
+        scopeSpans: [
+          {
+            scope: { name: "langfuse-sdk", version: "3.0.0" },
+            spans: [
+              {
+                traceId: createBufferId("123456789012345678901234567890ab"),
+                spanId: createBufferId("notool567890ab"),
+                name: "no-tools-test",
+                kind: 1,
+                startTimeUnixNano: createNanoTimestamp(
+                  BigInt(1738242387865000000),
+                ),
+                endTimeUnixNano: createNanoTimestamp(
+                  BigInt(1738242389310000000),
+                ),
+                attributes: [
+                  {
+                    key: "langfuse.observation.type",
+                    value: { stringValue: "generation" },
+                  },
+                  {
+                    key: "langfuse.observation.input",
+                    value: { stringValue: '"Hello"' },
+                  },
+                  {
+                    key: "langfuse.observation.output",
+                    value: { stringValue: '"Hi there"' },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const observations =
+        await processOtelSpanToObservationForEval(noToolsSpan);
+
+      expect(observations).toHaveLength(1);
+      expect(observations[0].tool_call_count).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

- Allow LLM-as-a-judge to filter by used tool names and tool call count
- Tool Call Count is calculated from the length of the tool names
- I didn't do the changes for the "old" traces - in my opinion we shouldn't break the old option but doesn't make sense to add new features to deprecated flows

Fixes https://linear.app/langfuse/issue/LFE-8971/expand-continuous-eval-targeting-options-for-tool-calls

[Loom Video](https://www.loom.com/share/96a31b8d746e4dfeb76bb91df7306d64)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
