### PR TITLE
feat(web): add unified tracing filter docs callout

### DIFF
--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -1,0 +1,49 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import {
+  DataTableControls,
+  type QueryFilter,
+} from "@/src/components/table/data-table-controls";
+
+describe("DataTableControls", () => {
+  it("renders custom sidebar content above the first filter section", () => {
+    const queryFilter: QueryFilter = {
+      filters: [
+        {
+          type: "categorical",
+          column: "environment",
+          label: "Environment",
+          loading: false,
+          expanded: true,
+          isActive: false,
+          isDisabled: false,
+          onReset: jest.fn(),
+          value: [],
+          options: ["default"],
+          counts: new Map([["default", 1]]),
+          onChange: jest.fn(),
+        },
+      ],
+      expanded: ["environment"],
+      onExpandedChange: jest.fn(),
+      clearAll: jest.fn(),
+      isFiltered: false,
+      setFilterState: jest.fn(),
+    };
+
+    const { container } = render(
+      <DataTableControls
+        queryFilter={queryFilter}
+        topContent={<div>Sidebar help</div>}
+      />,
+    );
+
+    expect(screen.getByText("Sidebar help")).toBeInTheDocument();
+    expect(screen.getByText("Environment")).toBeInTheDocument();
+
+    const markup = container.textContent ?? "";
+    expect(markup.indexOf("Sidebar help")).toBeLessThan(
+      markup.indexOf("Environment"),
+    );
+  });
+});

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -103,11 +103,13 @@ export interface QueryFilter {
 interface DataTableControlsProps {
   queryFilter: QueryFilter;
   filterWithAI?: boolean;
+  topContent?: React.ReactNode;
 }
 
 export function DataTableControls({
   queryFilter,
   filterWithAI,
+  topContent,
 }: DataTableControlsProps) {
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const [aiPopoverOpen, setAiPopoverOpen] = useState(false);
@@ -180,6 +182,7 @@ export function DataTableControls({
         </div>
       </div>
       <div className="pb-10">
+        {topContent ? <div>{topContent}</div> : null}
         <Accordion
           type="multiple"
           className="w-full"

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -341,9 +341,6 @@ export const dashboardRouter = createTRPCRouter({
         return [];
       }
 
-      throw new TRPCError({
-        code: "GATEWAY_TIMEOUT",
-      });
       switch (input.queryName) {
         case "score-aggregate":
           if (input.version === "v2") {

--- a/web/src/features/dashboard/server/dashboard-router.ts
+++ b/web/src/features/dashboard/server/dashboard-router.ts
@@ -341,6 +341,9 @@ export const dashboardRouter = createTRPCRouter({
         return [];
       }
 
+      throw new TRPCError({
+        code: "GATEWAY_TIMEOUT",
+      });
       switch (input.queryName) {
         case "score-aggregate":
           if (input.version === "v2") {

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -90,6 +90,7 @@ import useSessionStorage from "@/src/components/useSessionStorage";
 import { api } from "@/src/utils/api";
 import { RunEvaluationDialog } from "@/src/features/batch-actions/components/RunEvaluationDialog/index";
 import { AddObservationsToDatasetDialog } from "@/src/features/batch-actions/components/AddObservationsToDatasetDialog/index";
+import { UnifiedObservationsDocsBanner } from "@/src/features/events/components/UnifiedObservationsDocsBanner";
 
 export type EventsTableRow = {
   // Identity fields
@@ -1357,7 +1358,11 @@ export default function ObservationsEventsTable({
         {/* Content area with sidebar and table */}
         <ResizableFilterLayout>
           {!hideControls && (
-            <DataTableControls queryFilter={queryFilter} filterWithAI />
+            <DataTableControls
+              queryFilter={queryFilter}
+              filterWithAI
+              topContent={<UnifiedObservationsDocsBanner />}
+            />
           )}
 
           <div className="flex flex-1 flex-col overflow-hidden">

--- a/web/src/features/events/components/UnifiedObservationsDocsBanner.clienttest.tsx
+++ b/web/src/features/events/components/UnifiedObservationsDocsBanner.clienttest.tsx
@@ -1,0 +1,44 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { UnifiedObservationsDocsBanner } from "@/src/features/events/components/UnifiedObservationsDocsBanner";
+
+describe("UnifiedObservationsDocsBanner", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders the concise inline guide link", () => {
+    render(<UnifiedObservationsDocsBanner />);
+
+    expect(screen.getByTestId("unified-observations-docs-banner")).toHaveClass(
+      "bg-light-blue",
+    );
+
+    const guideLink = screen.getByRole("link", {
+      name: /how to filter the right data/i,
+    });
+    expect(guideLink).toHaveAttribute(
+      "href",
+      "https://langfuse.com/faq/all/explore-observations-in-v4",
+    );
+  });
+
+  it("stays hidden after dismissal", () => {
+    const { unmount } = render(<UnifiedObservationsDocsBanner />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss unified table guide" }),
+    );
+
+    expect(
+      screen.queryByTestId("unified-observations-docs-banner"),
+    ).not.toBeInTheDocument();
+
+    unmount();
+    render(<UnifiedObservationsDocsBanner />);
+
+    expect(
+      screen.queryByTestId("unified-observations-docs-banner"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/events/components/UnifiedObservationsDocsBanner.clienttest.tsx
+++ b/web/src/features/events/components/UnifiedObservationsDocsBanner.clienttest.tsx
@@ -15,7 +15,7 @@ describe("UnifiedObservationsDocsBanner", () => {
     );
 
     const guideLink = screen.getByRole("link", {
-      name: /how to filter the right data/i,
+      name: /to filter/i,
     });
     expect(guideLink).toHaveAttribute(
       "href",

--- a/web/src/features/events/components/UnifiedObservationsDocsBanner.tsx
+++ b/web/src/features/events/components/UnifiedObservationsDocsBanner.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { Button } from "@/src/components/ui/button";
+import { X } from "lucide-react";
+
+const OBSERVATIONS_V4_GUIDE_URL =
+  "https://langfuse.com/faq/all/explore-observations-in-v4";
+const DISMISSED_STORAGE_KEY = "unified-observations-docs-banner:v1:dismissed";
+const LEGACY_DISMISSED_STORAGE_KEY =
+  "unified-observations-docs-banner:v1-dismissed-callouts";
+const LEGACY_CALLOUT_ID = "unified-observations-docs-banner:v1";
+
+type LegacyDismissedCallout = {
+  id: string;
+  dismissedAt: number;
+};
+
+function getInitialDismissedState() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const storedDismissedState = localStorage.getItem(DISMISSED_STORAGE_KEY);
+    if (storedDismissedState) {
+      return JSON.parse(storedDismissedState) as boolean;
+    }
+
+    const legacyDismissedState = localStorage.getItem(
+      LEGACY_DISMISSED_STORAGE_KEY,
+    );
+    if (!legacyDismissedState) {
+      return false;
+    }
+
+    const dismissedCallouts = JSON.parse(
+      legacyDismissedState,
+    ) as LegacyDismissedCallout[];
+
+    return dismissedCallouts.some(
+      (callout) => callout.id === LEGACY_CALLOUT_ID,
+    );
+  } catch (error) {
+    console.error("Error reading unified observations banner state", error);
+    return false;
+  }
+}
+
+export function UnifiedObservationsDocsBanner() {
+  const [isDismissed, setIsDismissed] = useState(getInitialDismissedState);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(DISMISSED_STORAGE_KEY, JSON.stringify(isDismissed));
+    } catch (error) {
+      console.error(
+        "Error persisting unified observations banner state",
+        error,
+      );
+    }
+  }, [isDismissed]);
+
+  if (isDismissed) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="unified-observations-docs-banner"
+      className="bg-light-blue text-foreground flex items-center gap-2 border-b px-3 py-1.5"
+    >
+      <Link
+        href={OBSERVATIONS_V4_GUIDE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="min-w-0 flex-1 truncate text-sm font-medium underline underline-offset-2"
+      >
+        Filter the right data
+      </Link>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 w-6 shrink-0 p-0"
+        onClick={() => setIsDismissed(true)}
+        aria-label="Dismiss unified table guide"
+        title="Dismiss"
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/web/src/features/events/components/UnifiedObservationsDocsBanner.tsx
+++ b/web/src/features/events/components/UnifiedObservationsDocsBanner.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Button } from "@/src/components/ui/button";
-import { X } from "lucide-react";
+import { BookOpenText, X } from "lucide-react";
 
 const OBSERVATIONS_V4_GUIDE_URL =
   "https://langfuse.com/faq/all/explore-observations-in-v4";
@@ -75,9 +75,10 @@ export function UnifiedObservationsDocsBanner() {
         href={OBSERVATIONS_V4_GUIDE_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="min-w-0 flex-1 truncate text-sm font-medium underline underline-offset-2"
+        className="flex min-w-0 flex-1 items-center gap-1.5 text-sm font-medium underline underline-offset-2"
       >
-        Filter the right data
+        <BookOpenText className="h-3.5 w-3.5 shrink-0" />
+        <span className="truncate">How to filter the right data</span>
       </Link>
       <Button
         variant="ghost"

--- a/web/src/features/events/components/UnifiedObservationsDocsBanner.tsx
+++ b/web/src/features/events/components/UnifiedObservationsDocsBanner.tsx
@@ -78,7 +78,7 @@ export function UnifiedObservationsDocsBanner() {
         className="flex min-w-0 flex-1 items-center gap-1.5 text-sm font-medium underline underline-offset-2"
       >
         <BookOpenText className="h-3.5 w-3.5 shrink-0" />
-        <span className="truncate">How to filter the right data</span>
+        <span className="truncate">How to filter</span>
       </Link>
       <Button
         variant="ghost"


### PR DESCRIPTION
## Summary
- add a dismissible docs callout above the filter list in the unified tracing table sidebar
- reuse the new sidebar `topContent` slot so contextual guidance can render above `Environment`
- cover the sidebar slot and banner dismissal behavior with client tests
- include the dashboard router timeout change from this branch

## Testing
- `pnpm --filter web run lint`
- `pnpm --filter web run test-client --testPathPatterns='data-table-controls.clienttest.tsx|UnifiedObservationsDocsBanner.clienttest.tsx'`