### PR TITLE
feat(events): add nested filter expressions for events queries

### DIFF
--- a/packages/shared/src/interfaces/filters.ts
+++ b/packages/shared/src/interfaces/filters.ts
@@ -121,3 +121,96 @@ export const singleFilter = z.discriminatedUnion("type", [
   nullFilter,
   positionInTraceFilter,
 ]);
+
+export const filterGroupOperator = z.enum(["AND", "OR"]);
+
+type FilterConditionSchema = z.infer<typeof singleFilter>;
+type FilterGroupSchema = {
+  type: "group";
+  operator: z.infer<typeof filterGroupOperator>;
+  conditions: FilterExpressionSchema[];
+};
+type FilterExpressionSchema = FilterConditionSchema | FilterGroupSchema;
+type FilterInputSchema =
+  | FilterConditionSchema[]
+  | FilterExpressionSchema
+  | null
+  | undefined;
+
+export const filterExpression: z.ZodType<FilterExpressionSchema> = z.lazy(() =>
+  z.union([singleFilter, filterGroup]),
+);
+
+export const filterGroup: z.ZodType<FilterGroupSchema> = z.lazy(() =>
+  z.object({
+    type: z.literal("group"),
+    operator: filterGroupOperator,
+    conditions: z.array(filterExpression).min(1),
+  }),
+);
+
+export const filterInput = z.union([z.array(singleFilter), filterExpression]);
+
+export function normalizeFilterExpressionInput(
+  filterInputValue?: FilterInputSchema,
+): FilterExpressionSchema | undefined {
+  if (!filterInputValue) {
+    return undefined;
+  }
+
+  if (Array.isArray(filterInputValue)) {
+    if (filterInputValue.length === 0) {
+      return undefined;
+    }
+
+    return {
+      type: "group",
+      operator: "AND",
+      conditions: filterInputValue,
+    };
+  }
+
+  return filterInputValue;
+}
+
+export function isFilterGroup(
+  filterValue: FilterExpressionSchema,
+): filterValue is FilterGroupSchema {
+  return filterValue.type === "group";
+}
+
+export function getFilterExpressionLeafFilters(
+  filterValue?: FilterExpressionSchema,
+): FilterConditionSchema[] {
+  if (!filterValue) {
+    return [];
+  }
+
+  if (!isFilterGroup(filterValue)) {
+    return [filterValue];
+  }
+
+  return filterValue.conditions.flatMap((condition) =>
+    getFilterExpressionLeafFilters(condition),
+  );
+}
+
+export function getMandatoryFilterExpressionLeafFilters(
+  filterValue?: FilterExpressionSchema,
+): FilterConditionSchema[] {
+  if (!filterValue) {
+    return [];
+  }
+
+  if (!isFilterGroup(filterValue)) {
+    return [filterValue];
+  }
+
+  if (filterValue.operator === "OR") {
+    return [];
+  }
+
+  return filterValue.conditions.flatMap((condition) =>
+    getMandatoryFilterExpressionLeafFilters(condition),
+  );
+}

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -16,6 +16,142 @@ type ClickhouseFilter = {
   params: { [x: string]: any } | {};
 };
 
+export interface CompiledFilterCollection {
+  apply(): ClickhouseFilter;
+  find(predicate: (filter: Filter) => boolean): Filter | undefined;
+  findMandatory(predicate: (filter: Filter) => boolean): Filter | undefined;
+  some(predicate: (filter: Filter) => boolean): boolean;
+  forEach(callback: (filter: Filter) => void): void;
+  length(): number;
+}
+
+type CompiledFilterNode = Filter | FilterGroupNode;
+
+function isFilterGroupNode(node: CompiledFilterNode): node is FilterGroupNode {
+  return node instanceof FilterGroupNode;
+}
+
+function flattenCompiledFilterNode(node: CompiledFilterNode): Filter[] {
+  if (!isFilterGroupNode(node)) {
+    return [node];
+  }
+
+  return node.children.flatMap((child) => flattenCompiledFilterNode(child));
+}
+
+function collectMandatoryCompiledFilters(node: CompiledFilterNode): Filter[] {
+  if (!isFilterGroupNode(node)) {
+    return [node];
+  }
+
+  if (node.operator === "OR") {
+    return [];
+  }
+
+  return node.children.flatMap((child) =>
+    collectMandatoryCompiledFilters(child),
+  );
+}
+
+function applyCompiledFilterNode(node: CompiledFilterNode): ClickhouseFilter {
+  if (!isFilterGroupNode(node)) {
+    return node.apply();
+  }
+
+  const compiledChildren = node.children
+    .map((child) => applyCompiledFilterNode(child))
+    .filter((child) => child.query.trim().length > 0);
+
+  if (compiledChildren.length === 0) {
+    return {
+      query: "",
+      params: {},
+    };
+  }
+
+  if (compiledChildren.length === 1) {
+    return compiledChildren[0];
+  }
+
+  return {
+    query: compiledChildren
+      .map((child) => `(${child.query})`)
+      .join(` ${node.operator} `),
+    params: compiledChildren.reduce(
+      (acc, child) => ({ ...acc, ...child.params }),
+      {} as Record<string, any>,
+    ),
+  };
+}
+
+class FilterGroupNode {
+  constructor(
+    public operator: "AND" | "OR",
+    public children: CompiledFilterNode[],
+  ) {}
+}
+
+export class FilterTree implements CompiledFilterCollection {
+  private leaves: Filter[];
+  private mandatoryLeaves: Filter[];
+
+  constructor(private root: CompiledFilterNode | null = null) {
+    this.leaves = this.root ? flattenCompiledFilterNode(this.root) : [];
+    this.mandatoryLeaves = this.root
+      ? collectMandatoryCompiledFilters(this.root)
+      : [];
+  }
+
+  find(predicate: (filter: Filter) => boolean) {
+    return this.leaves.find(predicate);
+  }
+
+  findMandatory(predicate: (filter: Filter) => boolean) {
+    return this.mandatoryLeaves.find(predicate);
+  }
+
+  some(predicate: (filter: Filter) => boolean) {
+    return this.leaves.some(predicate);
+  }
+
+  forEach(callback: (filter: Filter) => void) {
+    this.leaves.forEach(callback);
+  }
+
+  length() {
+    return this.leaves.length;
+  }
+
+  apply(): ClickhouseFilter {
+    if (!this.root) {
+      return {
+        query: "",
+        params: {},
+      };
+    }
+
+    return applyCompiledFilterNode(this.root);
+  }
+
+  static fromFilter(filter: Filter): FilterTree {
+    return new FilterTree(filter);
+  }
+
+  static fromGroup(
+    operator: "AND" | "OR",
+    children: Array<Filter | FilterTree>,
+  ): FilterTree {
+    return new FilterTree(
+      new FilterGroupNode(
+        operator,
+        children
+          .map((child) => (child instanceof FilterTree ? child.root : child))
+          .filter((child): child is CompiledFilterNode => child !== null),
+      ),
+    );
+  }
+}
+
 export class StringFilter implements Filter {
   public clickhouseTable: string;
   public field: string;
@@ -522,7 +658,7 @@ export class BooleanFilter implements Filter {
   }
 }
 
-export class FilterList {
+export class FilterList implements CompiledFilterCollection {
   private filters: Filter[];
 
   constructor(filters: Filter[] = []) {
@@ -535,6 +671,10 @@ export class FilterList {
 
   find(predicate: (filter: Filter) => boolean) {
     return this.filters.find(predicate);
+  }
+
+  findMandatory(predicate: (filter: Filter) => boolean) {
+    return this.find(predicate);
   }
 
   filter(predicate: (filter: Filter) => boolean) {

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -1,5 +1,8 @@
 import { OBSERVATIONS_TO_TRACE_INTERVAL } from "../../repositories/constants";
-import { FilterList, StringFilter } from "./clickhouse-filter";
+import {
+  type CompiledFilterCollection,
+  StringFilter,
+} from "./clickhouse-filter";
 
 /**
  * Extract the output column alias from a field expression (unquoted).
@@ -398,7 +401,7 @@ abstract class AbstractQueryBuilder {
   }
 
   /**
-   * Add WHERE conditions from FilterList
+   * Add WHERE conditions from a compiled filter collection
    * Strips leading AND/OR and wraps in parentheses
    */
   where(condition: { query: string; params?: Record<string, any> }): this {
@@ -410,10 +413,10 @@ abstract class AbstractQueryBuilder {
   }
 
   /**
-   * Apply filters from a FilterList.
+   * Apply filters from a compiled filter collection.
    * Subclasses can override to add optimizations (e.g., partition pruning).
    */
-  applyFilters(filterList: FilterList): this {
+  applyFilters(filterList: CompiledFilterCollection): this {
     this.where(filterList.apply());
     return this;
   }
@@ -684,8 +687,8 @@ abstract class BaseEventsQueryBuilder<
    * Apply filters with automatic query optimizations.
    * Adds xxHash32 optimization for trace_id equality filters.
    */
-  override applyFilters(filterList: FilterList): this {
-    const traceIdFilter = filterList.find(
+  override applyFilters(filterList: CompiledFilterCollection): this {
+    const traceIdFilter = filterList.findMandatory(
       (f) =>
         f.clickhouseTable.startsWith("events") &&
         f.field === 'e."trace_id"' &&

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -1,6 +1,9 @@
 import z from "zod";
-import { singleFilter } from "../../../interfaces/filters";
-import { FilterCondition } from "../../../types";
+import {
+  normalizeFilterExpressionInput,
+  singleFilter,
+} from "../../../interfaces/filters";
+import { FilterCondition, FilterExpression, FilterInput } from "../../../types";
 import { InvalidRequestError } from "../../../errors";
 import { isValidTableName } from "../../clickhouse/schemaUtils";
 import { logger } from "../../logger";
@@ -20,6 +23,8 @@ import {
   NumberObjectFilter,
   StringObjectFilter,
   NullFilter,
+  FilterTree,
+  type Filter,
 } from "./clickhouse-filter";
 
 export class QueryBuilderError extends Error {
@@ -47,6 +52,125 @@ const COMPATIBLE_FILTER_TYPES: Record<string, string[]> = {
 // This function ensures that the user only selects valid columns from the clickhouse schema.
 // The filter property in this column needs to be zod verified.
 // User input for values (e.g. project_id = <value>) are sent to Clickhouse as parameters to prevent SQL injection
+const createFilterFromCondition = (
+  frontEndFilter: FilterCondition,
+  columnMapping: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
+): Filter => {
+  // checks if the column exists in the clickhouse schema
+  const column = matchAndVerifyTracesUiColumn(frontEndFilter, columnMapping);
+
+  if (columnDefinitions && frontEndFilter.type !== "null") {
+    const colDef = columnDefinitions.find((c) => c.id === column.uiTableId);
+    if (colDef) {
+      const compatible = COMPATIBLE_FILTER_TYPES[colDef.type];
+      if (compatible && !compatible.includes(frontEndFilter.type)) {
+        throw new InvalidRequestError(
+          `Invalid filter type '${frontEndFilter.type}' for column '${frontEndFilter.column}'. Expected filter type '${colDef.type}'.`,
+        );
+      }
+    }
+  }
+
+  switch (frontEndFilter.type) {
+    case "string":
+      return new StringFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        value: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+        emptyEqualsNull: column.emptyEqualsNull,
+      });
+    case "datetime":
+      return new DateTimeFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        value: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+      });
+    case "stringOptions":
+      return new StringOptionsFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        values: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+        emptyEqualsNull: column.emptyEqualsNull,
+      });
+    case "categoryOptions":
+      return new CategoryOptionsFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        key: frontEndFilter.key,
+        values: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+      });
+    case "number":
+      return new NumberFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        value: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+        clickhouseTypeOverwrite: column.clickhouseTypeOverwrite,
+      });
+    case "arrayOptions":
+      return new ArrayOptionsFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        values: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+      });
+    case "boolean":
+      return new BooleanFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        value: frontEndFilter.value,
+        operator: frontEndFilter.operator,
+        tablePrefix: column.queryPrefix,
+      });
+    case "numberObject":
+      return new NumberObjectFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        key: frontEndFilter.key,
+        operator: frontEndFilter.operator,
+        value: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+      });
+    case "stringObject":
+      return new StringObjectFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        key: frontEndFilter.key,
+        value: frontEndFilter.value,
+        tablePrefix: column.queryPrefix,
+      });
+    case "null":
+      return new NullFilter({
+        clickhouseTable: column.clickhouseTableName,
+        field: column.clickhouseSelect,
+        operator: frontEndFilter.operator,
+        tablePrefix: column.queryPrefix,
+        emptyEqualsNull: column.emptyEqualsNull,
+      });
+    case "positionInTrace":
+      throw new QueryBuilderError(
+        "positionInTrace filters must be handled before ClickHouse filter compilation",
+      );
+    default:
+      // eslint-disable-next-line no-case-declarations
+      const exhaustiveCheck: never = frontEndFilter;
+      logger.error(`Invalid filter type: ${JSON.stringify(exhaustiveCheck)}`);
+      throw new QueryBuilderError(`Invalid filter type`);
+  }
+};
+
 export const createFilterFromFilterState = (
   filter: FilterCondition[],
   columnMapping: UiColumnMappings,
@@ -56,116 +180,56 @@ export const createFilterFromFilterState = (
     (frontEndFilter) => frontEndFilter.type !== "positionInTrace",
   );
 
-  return applicableFilters.map((frontEndFilter) => {
-    // checks if the column exists in the clickhouse schema
-    const column = matchAndVerifyTracesUiColumn(frontEndFilter, columnMapping);
+  return applicableFilters.map((frontEndFilter) =>
+    createFilterFromCondition(frontEndFilter, columnMapping, columnDefinitions),
+  );
+};
 
-    if (columnDefinitions && frontEndFilter.type !== "null") {
-      const colDef = columnDefinitions.find((c) => c.id === column.uiTableId);
-      if (colDef) {
-        const compatible = COMPATIBLE_FILTER_TYPES[colDef.type];
-        if (compatible && !compatible.includes(frontEndFilter.type)) {
-          throw new InvalidRequestError(
-            `Invalid filter type '${frontEndFilter.type}' for column '${frontEndFilter.column}'. Expected filter type '${colDef.type}'.`,
-          );
-        }
-      }
-    }
+export const createFilterTreeFromFilterExpression = (
+  filterExpression: FilterExpression | undefined,
+  columnMapping: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
+): FilterTree => {
+  if (!filterExpression) {
+    return new FilterTree();
+  }
 
-    switch (frontEndFilter.type) {
-      case "string":
-        return new StringFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          value: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-          emptyEqualsNull: column.emptyEqualsNull,
-        });
-      case "datetime":
-        return new DateTimeFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          value: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-        });
-      case "stringOptions":
-        return new StringOptionsFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          values: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-          emptyEqualsNull: column.emptyEqualsNull,
-        });
-      case "categoryOptions":
-        return new CategoryOptionsFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          key: frontEndFilter.key,
-          values: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-        });
-      case "number":
-        return new NumberFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          value: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-          clickhouseTypeOverwrite: column.clickhouseTypeOverwrite,
-        });
-      case "arrayOptions":
-        return new ArrayOptionsFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          values: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-        });
-      case "boolean":
-        return new BooleanFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          value: frontEndFilter.value,
-          operator: frontEndFilter.operator,
-          tablePrefix: column.queryPrefix,
-        });
-      case "numberObject":
-        return new NumberObjectFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          key: frontEndFilter.key,
-          operator: frontEndFilter.operator,
-          value: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-        });
-      case "stringObject":
-        return new StringObjectFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          key: frontEndFilter.key,
-          value: frontEndFilter.value,
-          tablePrefix: column.queryPrefix,
-        });
-      case "null":
-        return new NullFilter({
-          clickhouseTable: column.clickhouseTableName,
-          field: column.clickhouseSelect,
-          operator: frontEndFilter.operator,
-          tablePrefix: column.queryPrefix,
-          emptyEqualsNull: column.emptyEqualsNull,
-        });
-      default:
-        // eslint-disable-next-line no-case-declarations
-        const exhaustiveCheck: never = frontEndFilter;
-        logger.error(`Invalid filter type: ${JSON.stringify(exhaustiveCheck)}`);
-        throw new QueryBuilderError(`Invalid filter type`);
-    }
-  });
+  if (filterExpression.type === "group") {
+    return FilterTree.fromGroup(
+      filterExpression.operator,
+      filterExpression.conditions.map((condition) =>
+        createFilterTreeFromFilterExpression(
+          condition,
+          columnMapping,
+          columnDefinitions,
+        ),
+      ),
+    );
+  }
+
+  if (filterExpression.type === "positionInTrace") {
+    return new FilterTree();
+  }
+
+  return FilterTree.fromFilter(
+    createFilterFromCondition(
+      filterExpression,
+      columnMapping,
+      columnDefinitions,
+    ),
+  );
+};
+
+export const createFilterTreeFromFilterInput = (
+  filterInputValue: FilterInput | undefined,
+  columnMapping: UiColumnMappings,
+  columnDefinitions?: ColumnDefinition[],
+): FilterTree => {
+  return createFilterTreeFromFilterExpression(
+    normalizeFilterExpressionInput(filterInputValue),
+    columnMapping,
+    columnDefinitions,
+  );
 };
 
 const matchAndVerifyTracesUiColumn = (

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -6,7 +6,9 @@ export {
 } from "./createGenerationsQuery";
 export {
   type Filter,
+  type CompiledFilterCollection,
   FilterList,
+  FilterTree,
   StringFilter,
   DateTimeFilter,
   StringOptionsFilter,
@@ -23,7 +25,11 @@ export {
   orderByToClickhouseSql,
   orderByToEntries,
 } from "./clickhouse-sql/orderby-factory";
-export { createFilterFromFilterState } from "./clickhouse-sql/factory";
+export {
+  createFilterFromFilterState,
+  createFilterTreeFromFilterExpression,
+  createFilterTreeFromFilterInput,
+} from "./clickhouse-sql/factory";
 export { clickhouseSearchCondition } from "./clickhouse-sql/search";
 export {
   convertApiProvidedFilterToClickhouseFilter,

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1,7 +1,16 @@
 import { prisma } from "../../db";
 import { Observation, EventsObservation, ObservationType } from "../../domain";
 import { env } from "../../env";
-import { InternalServerError, LangfuseNotFoundError } from "../../errors";
+import {
+  InternalServerError,
+  InvalidRequestError,
+  LangfuseNotFoundError,
+} from "../../errors";
+import {
+  getFilterExpressionLeafFilters,
+  getMandatoryFilterExpressionLeafFilters,
+  normalizeFilterExpressionInput,
+} from "../../interfaces/filters";
 import {
   convertDateToClickhouseDateTime,
   PreferredClickhouseService,
@@ -15,7 +24,9 @@ import {
 } from "./traces_converters";
 import {
   DateTimeFilter,
+  type CompiledFilterCollection,
   FilterList,
+  FilterTree,
   FullEventsObservations,
   orderByToClickhouseSql,
   orderByToEntries,
@@ -25,8 +36,11 @@ import {
   type ApiColumnMapping,
   ObservationPriceFields,
 } from "../queries";
-import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
-import type { FilterState } from "../../types";
+import {
+  createFilterFromFilterState,
+  createFilterTreeFromFilterExpression,
+} from "../queries/clickhouse-sql/factory";
+import type { FilterExpression, FilterState } from "../../types";
 import {
   eventsScoresAggregation,
   eventsSessionsAggregation,
@@ -80,6 +94,10 @@ type ObservationsTableQueryResultWitouhtTraceFields = Omit<
   ObservationsTableQueryResult,
   "trace_tags" | "trace_name" | "trace_user_id"
 >;
+
+type EventsObservationTableQuery = Omit<ObservationTableQuery, "filter"> & {
+  filter?: FilterState | FilterExpression;
+};
 
 /**
  * Internal helper: enrich observations with model pricing data
@@ -214,12 +232,12 @@ async function enrichObservationsWithTraceFields(
  * Common pattern: find time filter and convert to ClickHouse DateTime format
  */
 export function extractTimeFilter(
-  filter: FilterList,
+  filter: CompiledFilterCollection,
   tableName: "events_proto" | "traces" = "events_proto",
   fieldName: "start_time" | "timestamp" = "start_time",
   prefix?: "e" | "t",
 ): string | null {
-  const timeFilter = filter.find(
+  const timeFilter = filter.findMandatory(
     (f) =>
       // For events tables, match any events_* prefix (events_proto, events_core, events_full)
       (tableName === "events_proto"
@@ -232,6 +250,50 @@ export function extractTimeFilter(
   return timeFilter
     ? convertDateToClickhouseDateTime((timeFilter as DateTimeFilter).value)
     : null;
+}
+
+function removePositionInTraceFilters(
+  filter?: FilterExpression,
+): FilterExpression | undefined {
+  if (!filter) {
+    return undefined;
+  }
+
+  if (filter.type === "positionInTrace") {
+    return undefined;
+  }
+
+  if (filter.type !== "group") {
+    return filter;
+  }
+
+  const conditions = filter.conditions
+    .map((condition) => removePositionInTraceFilters(condition))
+    .filter((condition): condition is FilterExpression => Boolean(condition));
+
+  if (conditions.length === 0) {
+    return undefined;
+  }
+
+  if (conditions.length === 1) {
+    return conditions[0];
+  }
+
+  return {
+    type: "group",
+    operator: filter.operator,
+    conditions,
+  };
+}
+
+function createEventsFilterCollection(
+  filter?: FilterState | FilterExpression,
+): FilterTree {
+  return createFilterTreeFromFilterExpression(
+    normalizeFilterExpressionInput(filter),
+    eventsTableUiColumnDefinitions,
+    eventsTableCols,
+  );
 }
 
 /**
@@ -355,7 +417,7 @@ export const getObservationsForTraceFromEventsTable = async (params: {
 };
 
 export const getObservationsCountFromEventsTable = async (
-  opts: ObservationTableQuery,
+  opts: EventsObservationTableQuery,
 ) => {
   const count = await getObservationsFromEventsTableInternal<{
     count: string;
@@ -369,7 +431,7 @@ export const getObservationsCountFromEventsTable = async (
 };
 
 export const getObservationsWithModelDataFromEventsTable = async (
-  opts: ObservationTableQuery,
+  opts: EventsObservationTableQuery,
 ): Promise<FullEventsObservations> => {
   const observationRecords =
     await getObservationsFromEventsTableInternal<ObservationsTableQueryResultWitouhtTraceFields>(
@@ -392,7 +454,7 @@ export const getObservationsWithModelDataFromEventsTable = async (
 };
 
 async function getObservationsFromEventsTableInternal<T>(
-  opts: ObservationTableQuery & {
+  opts: EventsObservationTableQuery & {
     select: "count" | "rows";
     tags: Record<string, string>;
   },
@@ -408,24 +470,48 @@ async function getObservationsFromEventsTableInternal<T>(
     clickhouseConfigs,
   } = opts;
 
-  // Extract positionInTrace filter and build baseFilter without it
-  const positionFilter = filter.find((f) => f.type === "positionInTrace");
-  const baseFilter: typeof filter = [
-    ...filter.filter((f) => f.type !== "positionInTrace"),
-  ];
+  const normalizedFilter = normalizeFilterExpressionInput(filter);
+  const allLeafFilters = getFilterExpressionLeafFilters(normalizedFilter);
+  const mandatoryLeafFilters =
+    getMandatoryFilterExpressionLeafFilters(normalizedFilter);
+  const allPositionFilters = allLeafFilters.filter(
+    (
+      leafFilter,
+    ): leafFilter is Extract<
+      FilterState[number],
+      { type: "positionInTrace" }
+    > => leafFilter.type === "positionInTrace",
+  );
+  const mandatoryPositionFilters = mandatoryLeafFilters.filter(
+    (
+      leafFilter,
+    ): leafFilter is Extract<
+      FilterState[number],
+      { type: "positionInTrace" }
+    > => leafFilter.type === "positionInTrace",
+  );
 
-  // Build filter list from baseFilter (without positionInTrace)
-  const observationsFilter = new FilterList(
-    createFilterFromFilterState(
-      baseFilter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
+  if (
+    allPositionFilters.length > 1 ||
+    (allPositionFilters.length === 1 && mandatoryPositionFilters.length !== 1)
+  ) {
+    throw new InvalidRequestError(
+      "Nested or non-conjunctive position-in-trace filters are not supported on events queries.",
+    );
+  }
+
+  const positionFilter = mandatoryPositionFilters[0];
+  const baseFilter = removePositionInTraceFilters(normalizedFilter);
+
+  const observationsFilter = createFilterTreeFromFilterExpression(
+    baseFilter,
+    eventsTableUiColumnDefinitions,
+    eventsTableCols,
   );
 
   const startTimeFrom = extractTimeFilter(observationsFilter);
-  const hasObservationScoresFilter = baseFilter.some((f) => {
-    const column = f.column.toLowerCase();
+  const hasObservationScoresFilter = allLeafFilters.some((leafFilter) => {
+    const column = leafFilter.column.toLowerCase();
     return (
       column === "scores" ||
       column === "scores_avg" ||
@@ -434,8 +520,8 @@ async function getObservationsFromEventsTableInternal<T>(
       column === "scores (categorical)"
     );
   });
-  const hasTraceScoresFilter = baseFilter.some((f) => {
-    const column = f.column.toLowerCase();
+  const hasTraceScoresFilter = allLeafFilters.some((leafFilter) => {
+    const column = leafFilter.column.toLowerCase();
     return (
       column === "trace_scores_avg" ||
       column === "trace_score_categories" ||
@@ -487,12 +573,9 @@ async function getObservationsFromEventsTableInternal<T>(
           ? positionFilter.value
           : 1;
 
-    // Build observation-only filter for CTE (no s.* or t.* references)
-    const nativeFilter = new FilterList(
-      createFilterFromFilterState(
-        baseFilter,
-        eventsTableNativeUiColumnDefinitions,
-      ),
+    const nativeFilter = createFilterTreeFromFilterExpression(
+      baseFilter,
+      eventsTableNativeUiColumnDefinitions,
     );
     const appliedNativeFilter = nativeFilter.apply();
     const qualifyingObsBuilder = new EventsQueryBuilder({ projectId })
@@ -1483,17 +1566,9 @@ export const updateEvents = async (
  */
 export const getEventsGroupedByModel = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -1528,17 +1603,9 @@ export const getEventsGroupedByModel = async (
  */
 export const getEventsGroupedByModelId = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -1571,17 +1638,9 @@ export const getEventsGroupedByModelId = async (
  */
 export const getEventsGroupedByName = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -1614,18 +1673,10 @@ export const getEventsGroupedByName = async (
  */
 export const getEventsGroupedByTraceName = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
   opts?: { extraWhereRaw?: string },
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -1667,18 +1718,10 @@ export const getEventsGroupedByTraceName = async (
  */
 export const getEventsGroupedByTraceTags = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
   opts?: { extraWhereRaw?: string },
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const filteredEventsBuilder = new EventsQueryBuilder({ projectId })
     .selectRaw("e.tags AS tags")
@@ -1729,17 +1772,9 @@ export const getEventsGroupedByTraceTags = async (
  */
 export const getEventsGroupedByPromptName = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -1774,17 +1809,9 @@ export const getEventsGroupedByPromptName = async (
  */
 export const getEventsGroupedByType = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -1817,18 +1844,10 @@ export const getEventsGroupedByType = async (
  */
 export const getEventsGroupedByUserId = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
   opts?: { extraWhereRaw?: string },
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   // We mainly use queries like this to retrieve filter options.
   // Therefore, we can skip final as some inaccuracy in count is acceptable.
@@ -1865,17 +1884,9 @@ export const getEventsGroupedByUserId = async (
  */
 export const getEventsGroupedByVersion = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   // We mainly use queries like this to retrieve filter options.
   // Therefore, we can skip final as some inaccuracy in count is acceptable.
@@ -1910,17 +1921,9 @@ export const getEventsGroupedByVersion = async (
  */
 export const getEventsGroupedBySessionId = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   // We mainly use queries like this to retrieve filter options.
   // Therefore, we can skip final as some inaccuracy in count is acceptable.
@@ -1955,17 +1958,9 @@ export const getEventsGroupedBySessionId = async (
  */
 export const getEventsGroupedByLevel = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   // We mainly use queries like this to retrieve filter options.
   // Therefore, we can skip final as some inaccuracy in count is acceptable.
@@ -2000,17 +1995,9 @@ export const getEventsGroupedByLevel = async (
  */
 export const getEventsGroupedByEnvironment = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   // We mainly use queries like this to retrieve filter options.
   // Therefore, we can skip final as some inaccuracy in count is acceptable.
@@ -2045,17 +2032,9 @@ export const getEventsGroupedByEnvironment = async (
  */
 export const getEventsGroupedByExperimentDatasetId = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -2094,17 +2073,9 @@ export const getEventsGroupedByExperimentDatasetId = async (
  */
 export const getEventsGroupedByExperimentId = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -2137,17 +2108,9 @@ export const getEventsGroupedByExperimentId = async (
  */
 export const getEventsGroupedByExperimentName = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -2180,17 +2143,9 @@ export const getEventsGroupedByExperimentName = async (
  */
 export const getEventsGroupedByHasParentObservation = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -2222,17 +2177,9 @@ export const getEventsGroupedByHasParentObservation = async (
  */
 export const getEventsGroupedByToolName = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,
@@ -2266,17 +2213,9 @@ export const getEventsGroupedByToolName = async (
  */
 export const getEventsGroupedByCalledToolName = async (
   projectId: string,
-  filter: FilterState,
+  filter?: FilterState | FilterExpression,
 ) => {
-  const eventsFilter = new FilterList(
-    createFilterFromFilterState(
-      filter,
-      eventsTableUiColumnDefinitions,
-      eventsTableCols,
-    ),
-  );
-
-  const appliedEventsFilter = eventsFilter.apply();
+  const appliedEventsFilter = createEventsFilterCollection(filter).apply();
 
   const queryBuilder = new EventsAggQueryBuilder({
     projectId,

--- a/packages/shared/src/server/services/commentFilterService.ts
+++ b/packages/shared/src/server/services/commentFilterService.ts
@@ -1,5 +1,9 @@
 import type { PrismaClient } from "../../db";
-import { type singleFilter } from "../../interfaces/filters";
+import {
+  normalizeFilterExpressionInput,
+  type singleFilter,
+} from "../../interfaces/filters";
+import { type FilterExpression, type FilterInput } from "../../types";
 import {
   type CommentObjectType,
   type CommentCountOperator,
@@ -322,5 +326,189 @@ export async function applyCommentFilters({
     ],
     hasNoMatches: false,
     matchingIds: objectIdsFromComments,
+  };
+}
+
+type CommentFilterRewriteResult = {
+  expression?: FilterExpression;
+  hasNoMatches: boolean;
+  matchingIds: string[] | null;
+};
+
+function isCommentFilter(filter: z.infer<typeof singleFilter>): boolean {
+  return (
+    ((filter.type === "number" || filter.type === "datetime") &&
+      filter.column === "commentCount") ||
+    (filter.type === "string" && filter.column === "commentContent")
+  );
+}
+
+async function rewriteCommentFiltersInExpression({
+  filterExpression,
+  prisma,
+  projectId,
+  objectType,
+  idColumn,
+}: {
+  filterExpression?: FilterExpression;
+  prisma: PrismaClient;
+  projectId: string;
+  objectType: CommentObjectType;
+  idColumn: string;
+}): Promise<CommentFilterRewriteResult> {
+  if (!filterExpression) {
+    return {
+      expression: undefined,
+      hasNoMatches: false,
+      matchingIds: null,
+    };
+  }
+
+  if (filterExpression.type !== "group") {
+    if (!isCommentFilter(filterExpression)) {
+      return {
+        expression: filterExpression,
+        hasNoMatches: false,
+        matchingIds: null,
+      };
+    }
+
+    const result = await applyCommentFilters({
+      filterState: [filterExpression],
+      prisma,
+      projectId,
+      objectType,
+      idColumn,
+    });
+
+    return {
+      expression: normalizeFilterExpressionInput(result.filterState),
+      hasNoMatches: result.hasNoMatches,
+      matchingIds: result.matchingIds,
+    };
+  }
+
+  const rewrittenChildren = await Promise.all(
+    filterExpression.conditions.map((condition) =>
+      rewriteCommentFiltersInExpression({
+        filterExpression: condition,
+        prisma,
+        projectId,
+        objectType,
+        idColumn,
+      }),
+    ),
+  );
+
+  if (filterExpression.operator === "AND") {
+    if (rewrittenChildren.some((child) => child.hasNoMatches)) {
+      return {
+        expression: undefined,
+        hasNoMatches: true,
+        matchingIds: [],
+      };
+    }
+
+    const expressions = rewrittenChildren.flatMap((child) =>
+      child.expression ? [child.expression] : [],
+    );
+
+    if (expressions.length === 0) {
+      return {
+        expression: undefined,
+        hasNoMatches: false,
+        matchingIds: null,
+      };
+    }
+
+    if (expressions.length === 1) {
+      return {
+        expression: expressions[0],
+        hasNoMatches: false,
+        matchingIds: null,
+      };
+    }
+
+    return {
+      expression: {
+        type: "group",
+        operator: "AND",
+        conditions: expressions,
+      },
+      hasNoMatches: false,
+      matchingIds: null,
+    };
+  }
+
+  if (
+    rewrittenChildren.some((child) => !child.hasNoMatches && !child.expression)
+  ) {
+    return {
+      expression: undefined,
+      hasNoMatches: false,
+      matchingIds: null,
+    };
+  }
+
+  const expressions = rewrittenChildren.flatMap((child) =>
+    !child.hasNoMatches && child.expression ? [child.expression] : [],
+  );
+
+  if (expressions.length === 0) {
+    return {
+      expression: undefined,
+      hasNoMatches: true,
+      matchingIds: [],
+    };
+  }
+
+  if (expressions.length === 1) {
+    return {
+      expression: expressions[0],
+      hasNoMatches: false,
+      matchingIds: null,
+    };
+  }
+
+  return {
+    expression: {
+      type: "group",
+      operator: "OR",
+      conditions: expressions,
+    },
+    hasNoMatches: false,
+    matchingIds: null,
+  };
+}
+
+export async function applyCommentFiltersToFilterInput({
+  filterState,
+  prisma,
+  projectId,
+  objectType,
+  idColumn = "id",
+}: {
+  filterState: FilterInput | undefined;
+  prisma: PrismaClient;
+  projectId: string;
+  objectType: CommentObjectType;
+  idColumn?: string;
+}): Promise<{
+  filterState: FilterExpression | undefined;
+  hasNoMatches: boolean;
+  matchingIds: string[] | null;
+}> {
+  const result = await rewriteCommentFiltersInExpression({
+    filterExpression: normalizeFilterExpressionInput(filterState),
+    prisma,
+    projectId,
+    objectType,
+    idColumn,
+  });
+
+  return {
+    filterState: result.expression,
+    hasNoMatches: result.hasNoMatches,
+    matchingIds: result.matchingIds,
   };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,10 +1,21 @@
 import { type z } from "zod";
-import { singleFilter, timeFilter } from "./interfaces/filters";
+import {
+  filterExpression,
+  filterGroup,
+  filterGroupOperator,
+  filterInput,
+  singleFilter,
+  timeFilter,
+} from "./interfaces/filters";
 
 // to be sent to the server
 export type TimeFilter = z.infer<typeof timeFilter>;
 export type FilterCondition = z.infer<typeof singleFilter>;
 export type FilterState = FilterCondition[];
+export type FilterGroupOperator = z.infer<typeof filterGroupOperator>;
+export type FilterGroup = z.infer<typeof filterGroup>;
+export type FilterExpression = z.infer<typeof filterExpression>;
+export type FilterInput = z.infer<typeof filterInput>;
 
 // to be used in the client during editing
 export type MakeOptional<T> = {

--- a/web/src/__tests__/server/event-query-builder.servertest.ts
+++ b/web/src/__tests__/server/event-query-builder.servertest.ts
@@ -1,7 +1,11 @@
 import {
   CTEQueryBuilder,
   EventsAggregationQueryBuilder,
+  EventsQueryBuilder,
+  createFilterTreeFromFilterExpression,
+  eventsTableUiColumnDefinitions,
 } from "@langfuse/shared/src/server";
+import { eventsTableCols, type FilterExpression } from "@langfuse/shared";
 
 describe("CTEQueryBuilder", () => {
   it("should compose multiple CTEs with type-safe references", () => {
@@ -119,5 +123,135 @@ describe("CTEQueryBuilder", () => {
     expect(params.param1).toBe("value1");
     expect(params.param2).toBe("value2");
     expect(params.param3).toBe("value3");
+  });
+});
+
+describe("EventsQueryBuilder", () => {
+  it("adds trace hash pruning only for mandatory traceId filters", () => {
+    const filterExpression: FilterExpression = {
+      type: "group",
+      operator: "AND",
+      conditions: [
+        {
+          type: "string",
+          column: "traceId",
+          operator: "=",
+          value: "trace-1",
+        },
+        {
+          type: "group",
+          operator: "OR",
+          conditions: [
+            {
+              type: "string",
+              column: "name",
+              operator: "=",
+              value: "alpha",
+            },
+            {
+              type: "string",
+              column: "name",
+              operator: "=",
+              value: "beta",
+            },
+          ],
+        },
+      ],
+    };
+
+    const compiledFilter = createFilterTreeFromFilterExpression(
+      filterExpression,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    );
+
+    const { query, params } = new EventsQueryBuilder({
+      projectId: "test-project",
+    })
+      .selectFieldSet("count")
+      .applyFilters(compiledFilter)
+      .buildWithParams();
+
+    expect(query).toContain(
+      "xxHash32(trace_id) = xxHash32({traceIdXxHash: String})",
+    );
+    expect(params.traceIdXxHash).toBe("trace-1");
+  });
+
+  it("does not add trace hash pruning for OR-only traceId filters", () => {
+    const filterExpression: FilterExpression = {
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "string",
+          column: "traceId",
+          operator: "=",
+          value: "trace-1",
+        },
+        {
+          type: "string",
+          column: "name",
+          operator: "=",
+          value: "alpha",
+        },
+      ],
+    };
+
+    const compiledFilter = createFilterTreeFromFilterExpression(
+      filterExpression,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    );
+
+    const { query, params } = new EventsQueryBuilder({
+      projectId: "test-project",
+    })
+      .selectFieldSet("count")
+      .applyFilters(compiledFilter)
+      .buildWithParams();
+
+    expect(query).not.toContain("traceIdXxHash");
+    expect(params.traceIdXxHash).toBeUndefined();
+  });
+
+  it("keeps the authorized project filter outside nested OR expressions", () => {
+    const filterExpression: FilterExpression = {
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "string",
+          column: "name",
+          operator: "=",
+          value: "alpha",
+        },
+        {
+          type: "string",
+          column: "type",
+          operator: "=",
+          value: "SPAN",
+        },
+      ],
+    };
+
+    const compiledFilter = createFilterTreeFromFilterExpression(
+      filterExpression,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    );
+
+    const { query, params } = new EventsQueryBuilder({
+      projectId: "authorized-project",
+    })
+      .selectFieldSet("count")
+      .applyFilters(compiledFilter)
+      .buildWithParams();
+
+    expect(query).toContain("WHERE e.project_id = {projectId: String}");
+    expect(query).toMatch(
+      /WHERE e\.project_id = \{projectId: String\}[\s\S]*AND \(\(.+\) OR \(.+\)\)/,
+    );
+    expect(params.projectId).toBe("authorized-project");
   });
 });

--- a/web/src/__tests__/server/events-router.servertest.ts
+++ b/web/src/__tests__/server/events-router.servertest.ts
@@ -1,0 +1,53 @@
+import { addAttributesToSpan } from "@/src/features/events/server/eventsRouter";
+
+describe("eventsRouter addAttributesToSpan", () => {
+  it("sets the resolved project id without throwing", () => {
+    const setAttribute = jest.fn();
+    const span = { setAttribute } as any;
+
+    expect(() =>
+      addAttributesToSpan({
+        span,
+        input: {
+          projectId: "input-project-id",
+          filter: {
+            type: "group",
+            operator: "AND",
+            conditions: [
+              {
+                column: "type",
+                type: "stringOptions",
+                operator: "any of",
+                value: ["GENERATION"],
+              },
+              {
+                column: "startTime",
+                type: "datetime",
+                operator: ">=",
+                value: new Date("2026-03-25T22:15:17.734Z"),
+              },
+              {
+                column: "startTime",
+                type: "datetime",
+                operator: "<=",
+                value: new Date("2026-03-26T22:15:17.734Z"),
+              },
+            ],
+          },
+          page: 1,
+          limit: 1,
+          orderBy: null,
+          searchQuery: null,
+          searchType: [],
+        },
+        orderBy: undefined,
+        resolvedProjectId: "session-project-id",
+      }),
+    ).not.toThrow();
+
+    expect(setAttribute).toHaveBeenCalledWith(
+      "project_id",
+      "session-project-id",
+    );
+  });
+});

--- a/web/src/__tests__/server/filter-expression.servertest.ts
+++ b/web/src/__tests__/server/filter-expression.servertest.ts
@@ -1,0 +1,196 @@
+import {
+  filterExpression,
+  normalizeFilterExpressionInput,
+  type FilterCondition,
+  type FilterExpression,
+  type UiColumnMapping,
+} from "@langfuse/shared";
+import {
+  FilterList,
+  createFilterFromFilterState,
+  createFilterTreeFromFilterExpression,
+  createFilterTreeFromFilterInput,
+} from "@langfuse/shared/src/server";
+
+const testColumnMappings: UiColumnMapping[] = [
+  {
+    uiTableName: "Name",
+    uiTableId: "name",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "name",
+    queryPrefix: "t",
+  },
+  {
+    uiTableName: "Environment",
+    uiTableId: "environment",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "environment",
+    queryPrefix: "t",
+  },
+  {
+    uiTableName: "Type",
+    uiTableId: "type",
+    clickhouseTableName: "traces",
+    clickhouseSelect: "type",
+    queryPrefix: "t",
+  },
+];
+
+const normalizeSql = (query: string) =>
+  query
+    .replace(/[()]/g, "")
+    .replace(/stringFilter\w+/g, "stringFilter")
+    .replace(/\s+/g, " ")
+    .trim();
+
+describe("filter expression helpers", () => {
+  it("normalizes flat filters into a top-level AND group", () => {
+    const flatFilters: FilterCondition[] = [
+      {
+        type: "string",
+        column: "name",
+        operator: "=",
+        value: "alpha",
+      },
+      {
+        type: "string",
+        column: "environment",
+        operator: "=",
+        value: "prod",
+      },
+    ];
+
+    expect(normalizeFilterExpressionInput(flatFilters)).toEqual({
+      type: "group",
+      operator: "AND",
+      conditions: flatFilters,
+    });
+  });
+
+  it("parses nested AND/OR groups", () => {
+    const nestedFilter = {
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "group",
+          operator: "AND",
+          conditions: [
+            {
+              type: "string",
+              column: "name",
+              operator: "=",
+              value: "alpha",
+            },
+            {
+              type: "string",
+              column: "environment",
+              operator: "=",
+              value: "prod",
+            },
+          ],
+        },
+        {
+          type: "string",
+          column: "type",
+          operator: "=",
+          value: "SPAN",
+        },
+      ],
+    } satisfies FilterExpression;
+
+    expect(filterExpression.parse(nestedFilter)).toEqual(nestedFilter);
+  });
+
+  it("rejects empty groups", () => {
+    const result = filterExpression.safeParse({
+      type: "group",
+      operator: "AND",
+      conditions: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("recursive ClickHouse filter compilation", () => {
+  it("compiles nested filters with explicit parentheses and unique params", () => {
+    const expression: FilterExpression = {
+      type: "group",
+      operator: "OR",
+      conditions: [
+        {
+          type: "group",
+          operator: "AND",
+          conditions: [
+            {
+              type: "string",
+              column: "name",
+              operator: "=",
+              value: "alpha",
+            },
+            {
+              type: "string",
+              column: "environment",
+              operator: "=",
+              value: "prod",
+            },
+          ],
+        },
+        {
+          type: "string",
+          column: "type",
+          operator: "=",
+          value: "SPAN",
+        },
+      ],
+    };
+
+    const compiled = createFilterTreeFromFilterExpression(
+      expression,
+      testColumnMappings,
+    ).apply();
+
+    expect(compiled.query).toMatch(
+      /^\(\(t\.name = \{stringFilter\w+: String\}\) AND \(t\.environment = \{stringFilter\w+: String\}\)\) OR \(t\.type = \{stringFilter\w+: String\}\)$/,
+    );
+    expect(Object.keys(compiled.params)).toHaveLength(3);
+    expect(Object.values(compiled.params).sort()).toEqual([
+      "SPAN",
+      "alpha",
+      "prod",
+    ]);
+  });
+
+  it("keeps legacy flat filters equivalent after normalization", () => {
+    const flatFilters: FilterCondition[] = [
+      {
+        type: "string",
+        column: "name",
+        operator: "=",
+        value: "alpha",
+      },
+      {
+        type: "string",
+        column: "environment",
+        operator: "=",
+        value: "prod",
+      },
+    ];
+
+    const legacyCompiled = new FilterList(
+      createFilterFromFilterState(flatFilters, testColumnMappings),
+    ).apply();
+    const treeCompiled = createFilterTreeFromFilterInput(
+      flatFilters,
+      testColumnMappings,
+    ).apply();
+
+    expect(normalizeSql(treeCompiled.query)).toBe(
+      normalizeSql(legacyCompiled.query),
+    );
+    expect(Object.values(treeCompiled.params).sort()).toEqual(
+      Object.values(legacyCompiled.params).sort(),
+    );
+  });
+});

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -1,6 +1,7 @@
 import {
   createEvent,
   createEventsCh,
+  getEventsGroupedByName,
   getObservationsWithModelDataFromEventsTable,
   getObservationsCountFromEventsTable,
   getObservationByIdFromEventsTable,
@@ -13,7 +14,7 @@ import {
 import { prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "crypto";
 import { env } from "@/src/env.mjs";
-import { type FilterCondition } from "@langfuse/shared";
+import { type FilterCondition, type FilterExpression } from "@langfuse/shared";
 import waitForExpect from "wait-for-expect";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
@@ -345,6 +346,198 @@ describe("Clickhouse Events Repository Test", () => {
 
       expect(count).toBe(5);
       expect(observations.length).toBe(5);
+    });
+  });
+
+  maybe("Nested Filter Expression", () => {
+    it("supports nested AND/OR filters for list and count queries", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const matchingSpanId = randomUUID();
+      const matchingGenerationId = randomUUID();
+      const nonMatchingId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: matchingSpanId,
+          span_id: matchingSpanId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "alpha-span",
+          environment: "prod",
+        }),
+        createEvent({
+          id: matchingGenerationId,
+          span_id: matchingGenerationId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "GENERATION",
+          name: "beta-generation",
+          environment: "staging",
+        }),
+        createEvent({
+          id: nonMatchingId,
+          span_id: nonMatchingId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "beta-generation",
+          environment: "staging",
+        }),
+      ]);
+
+      const filter: FilterExpression = {
+        type: "group",
+        operator: "OR",
+        conditions: [
+          {
+            type: "group",
+            operator: "AND",
+            conditions: [
+              {
+                type: "string",
+                column: "type",
+                operator: "=",
+                value: "SPAN",
+              },
+              {
+                type: "string",
+                column: "environment",
+                operator: "=",
+                value: "prod",
+              },
+            ],
+          },
+          {
+            type: "group",
+            operator: "AND",
+            conditions: [
+              {
+                type: "string",
+                column: "type",
+                operator: "=",
+                value: "GENERATION",
+              },
+              {
+                type: "string",
+                column: "name",
+                operator: "=",
+                value: "beta-generation",
+              },
+            ],
+          },
+        ],
+      };
+
+      const [observations, count] = await Promise.all([
+        getObservationsWithModelDataFromEventsTable({
+          projectId: uniqueProjectId,
+          filter,
+          limit: 100,
+          offset: 0,
+        }),
+        getObservationsCountFromEventsTable({
+          projectId: uniqueProjectId,
+          filter,
+        }),
+      ]);
+
+      expect(count).toBe(2);
+      expect(observations).toHaveLength(2);
+      expect(observations.map((observation) => observation.id).sort()).toEqual(
+        [matchingGenerationId, matchingSpanId].sort(),
+      );
+    });
+
+    it("applies nested filters to grouped filter-option queries", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "alpha-span",
+          environment: "prod",
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "GENERATION",
+          name: "beta-generation",
+          environment: "staging",
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "beta-generation",
+          environment: "staging",
+        }),
+      ]);
+
+      const filter: FilterExpression = {
+        type: "group",
+        operator: "OR",
+        conditions: [
+          {
+            type: "group",
+            operator: "AND",
+            conditions: [
+              {
+                type: "string",
+                column: "type",
+                operator: "=",
+                value: "SPAN",
+              },
+              {
+                type: "string",
+                column: "environment",
+                operator: "=",
+                value: "prod",
+              },
+            ],
+          },
+          {
+            type: "group",
+            operator: "AND",
+            conditions: [
+              {
+                type: "string",
+                column: "type",
+                operator: "=",
+                value: "GENERATION",
+              },
+              {
+                type: "string",
+                column: "name",
+                operator: "=",
+                value: "beta-generation",
+              },
+            ],
+          },
+        ],
+      };
+
+      const groupedNames = await getEventsGroupedByName(
+        uniqueProjectId,
+        filter,
+      );
+      const countsByName = new Map(
+        groupedNames.map((row) => [row.name, row.count] as const),
+      );
+
+      expect(countsByName.get("alpha-span")).toBe(1);
+      expect(countsByName.get("beta-generation")).toBe(1);
+      expect(countsByName.size).toBe(2);
     });
   });
 

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -1,10 +1,13 @@
 import { api } from "@/src/utils/api";
 import { useMemo } from "react";
-import { type FilterState, type TimeFilter } from "@langfuse/shared";
+import {
+  normalizeFilterExpressionInput,
+  type FilterInput,
+} from "@langfuse/shared";
 
 type UseEventsFilterOptionsParams = {
   projectId: string;
-  oldFilterState: FilterState;
+  oldFilterState: FilterInput;
   hasParentObservation?: boolean;
 };
 
@@ -13,22 +16,40 @@ export function useEventsFilterOptions({
   oldFilterState,
   hasParentObservation,
 }: UseEventsFilterOptionsParams) {
-  // Extract start time filters for filter options query
-  const startTimeFilters = useMemo(() => {
-    return oldFilterState.filter(
-      (f) =>
-        (f.column === "Start Time" || f.column === "startTime") &&
-        f.type === "datetime",
-    ) as TimeFilter[];
-  }, [oldFilterState]);
+  const filter = useMemo(() => {
+    const normalizedFilter = normalizeFilterExpressionInput(oldFilterState);
+
+    if (hasParentObservation === undefined) {
+      return normalizedFilter;
+    }
+
+    const hasParentObservationFilter = {
+      column: "hasParentObservation",
+      type: "boolean" as const,
+      operator: "=" as const,
+      value: hasParentObservation,
+    };
+
+    if (!normalizedFilter) {
+      return {
+        type: "group" as const,
+        operator: "AND" as const,
+        conditions: [hasParentObservationFilter],
+      };
+    }
+
+    return {
+      type: "group" as const,
+      operator: "AND" as const,
+      conditions: [normalizedFilter, hasParentObservationFilter],
+    };
+  }, [oldFilterState, hasParentObservation]);
 
   // Fetch filter options
   const filterOptions = api.events.filterOptions.useQuery(
     {
       projectId,
-      startTimeFilter:
-        startTimeFilters.length > 0 ? startTimeFilters : undefined,
-      hasParentObservation,
+      filter,
     },
     {
       trpc: {

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -5,11 +5,13 @@ import {
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
 import {
+  getFilterExpressionLeafFilters,
+  filterInput,
   type Observation,
   type OrderByState,
+  normalizeFilterExpressionInput,
   normalizeOrderByForTable,
   paginationZod,
-  timeFilter,
 } from "@langfuse/shared";
 import { EventsTableOptions } from "./types";
 import {
@@ -25,7 +27,7 @@ import {
   getAgentGraphDataFromEventsTable,
   getObservationsForTraceFromEventsTable,
   MAX_OBSERVATIONS_PER_TRACE,
-  applyCommentFilters,
+  applyCommentFiltersToFilterInput,
 } from "@langfuse/shared/src/server";
 
 import {
@@ -47,7 +49,7 @@ export type GetAllEventsInput = z.infer<typeof GetAllEventsInput>;
 
 const GetEventFilterOptionsInput = zodSchema.object({
   projectId: zodSchema.string(),
-  startTimeFilter: zodSchema.array(timeFilter).optional(),
+  filter: filterInput.optional(),
 });
 
 export type GetEventFilterOptionsInput = z.infer<
@@ -73,13 +75,13 @@ export const eventsRouter = createTRPCRouter({
   all: protectedProjectProcedure
     .input(GetAllEventsInput)
     .query(async ({ input, ctx }) => {
-      const { filterState, hasNoMatches } = await applyCommentFilters({
-        filterState: input.filter ?? [],
-        prisma: ctx.prisma,
-        projectId: ctx.session.projectId,
-        objectType: "OBSERVATION",
-      });
-
+      const { filterState, hasNoMatches } =
+        await applyCommentFiltersToFilterInput({
+          filterState: input.filter,
+          prisma: ctx.prisma,
+          projectId: ctx.session.projectId,
+          objectType: "OBSERVATION",
+        });
       if (hasNoMatches) {
         return { observations: [] };
       }
@@ -93,7 +95,12 @@ export const eventsRouter = createTRPCRouter({
             orderBy: input.orderBy,
             expectedTimeColumn: "startTime",
           });
-          addAttributesToSpan({ span, input, orderBy: normalizedOrderBy });
+          addAttributesToSpan({
+            span,
+            input,
+            orderBy: normalizedOrderBy,
+            resolvedProjectId: ctx.session.projectId,
+          });
 
           return getEventList({
             projectId: ctx.session.projectId,
@@ -110,12 +117,13 @@ export const eventsRouter = createTRPCRouter({
   countAll: protectedProjectProcedure
     .input(GetAllEventsInput)
     .query(async ({ input, ctx }) => {
-      const { filterState, hasNoMatches } = await applyCommentFilters({
-        filterState: input.filter ?? [],
-        prisma: ctx.prisma,
-        projectId: ctx.session.projectId,
-        objectType: "OBSERVATION",
-      });
+      const { filterState, hasNoMatches } =
+        await applyCommentFiltersToFilterInput({
+          filterState: input.filter,
+          prisma: ctx.prisma,
+          projectId: ctx.session.projectId,
+          objectType: "OBSERVATION",
+        });
 
       if (hasNoMatches) {
         return { totalCount: 0 };
@@ -130,7 +138,13 @@ export const eventsRouter = createTRPCRouter({
             orderBy: input.orderBy,
             expectedTimeColumn: "startTime",
           });
-          addAttributesToSpan({ span, input, orderBy: normalizedOrderBy });
+          addAttributesToSpan({
+            span,
+            input,
+            orderBy: normalizedOrderBy,
+            resolvedProjectId: ctx.session.projectId,
+          });
+
           return getEventCount({
             projectId: ctx.session.projectId,
             filter: filterState,
@@ -142,25 +156,23 @@ export const eventsRouter = createTRPCRouter({
       );
     }),
   filterOptions: protectedProjectProcedure
-    .input(
-      zodSchema.object({
-        projectId: zodSchema.string(),
-        startTimeFilter: zodSchema.array(timeFilter).optional(),
-        hasParentObservation: zodSchema.boolean().optional(),
-      }),
-    )
-    .query(async ({ input }) => {
+    .input(GetEventFilterOptionsInput)
+    .query(async ({ input, ctx }) => {
       return instrumentAsync(
         {
           name: "get-event-filter-options-trpc",
         },
 
         async (span) => {
-          addAttributesToSpan({ span, input, orderBy: undefined });
+          addAttributesToSpan({
+            span,
+            input,
+            orderBy: undefined,
+            resolvedProjectId: ctx.session.projectId,
+          });
           return getEventFilterOptions({
-            projectId: input.projectId,
-            startTimeFilter: input.startTimeFilter,
-            hasParentObservation: input.hasParentObservation,
+            projectId: ctx.session.projectId,
+            filter: input.filter,
           });
         },
       );
@@ -171,7 +183,7 @@ export const eventsRouter = createTRPCRouter({
       return instrumentAsync(
         { name: "get-event-batch-io-trpc" },
         async (span) => {
-          span.setAttribute("project_id", input.projectId);
+          span.setAttribute("project_id", ctx.session.projectId);
           span.setAttribute("observation_count", input.observations.length);
 
           return getEventBatchIO({
@@ -200,7 +212,7 @@ export const eventsRouter = createTRPCRouter({
       return instrumentAsync(
         { name: "get-events-scores-for-trace-trpc" },
         async (span) => {
-          span.setAttribute("project_id", input.projectId);
+          span.setAttribute("project_id", ctx.session.projectId);
           span.setAttribute("trace_id", input.traceId);
 
           return getScoresAndCorrectionsForTraces({
@@ -265,7 +277,7 @@ export const eventsRouter = createTRPCRouter({
         return instrumentAsync(
           { name: "get-events-agent-graph-data-trpc" },
           async (span) => {
-            span.setAttribute("project_id", input.projectId);
+            span.setAttribute("project_id", ctx.session.projectId);
             span.setAttribute("trace_id", input.traceId);
 
             const { traceId, minStartTime, maxStartTime } = input;
@@ -341,15 +353,19 @@ export const addAttributesToSpan = ({
   span: opentelemetry.Span;
   input: GetAllEventsInput | GetEventFilterOptionsInput;
   orderBy?: OrderByState;
+  resolvedProjectId: string;
 }) => {
-  span.setAttribute("project_id", input.projectId);
+  span.setAttribute("project_id", resolvedProjectId);
 
   // Only process filter if it exists (not present in GetEventFilterOptionsInput)
   if ("filter" in input && input.filter) {
-    const startTimeFilter = input.filter.find(
+    const filterLeaves = getFilterExpressionLeafFilters(
+      normalizeFilterExpressionInput(input.filter),
+    );
+    const startTimeFilter = filterLeaves.find(
       (f) => f.column === "startTime" && f.type === "datetime",
     );
-    const endTimeFilter = input.filter.find(
+    const endTimeFilter = filterLeaves.find(
       (f) => f.column === "endTime" && f.type === "datetime",
     );
 
@@ -362,7 +378,7 @@ export const addAttributesToSpan = ({
       span.setAttribute("duration_minutes", durationMs / 60000);
     }
 
-    input.filter.forEach((f) => {
+    filterLeaves.forEach((f) => {
       if (f.value !== undefined) {
         span.setAttribute(f.column, String(f.value));
       }

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -349,6 +349,7 @@ export const addAttributesToSpan = ({
   span,
   input,
   orderBy,
+  resolvedProjectId,
 }: {
   span: opentelemetry.Span;
   input: GetAllEventsInput | GetEventFilterOptionsInput;

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -1,7 +1,10 @@
-import { type z } from "zod";
 import {
   AGGREGATABLE_SCORE_TYPES,
   type FilterCondition,
+  getMandatoryFilterExpressionLeafFilters,
+  normalizeFilterExpressionInput,
+  type FilterExpression,
+  type FilterInput,
   filterAndValidateDbScoreList,
 } from "@langfuse/shared";
 import {
@@ -33,11 +36,8 @@ import {
   getScoresForTraces,
   traceException,
 } from "@langfuse/shared/src/server";
-import { type timeFilter, type FilterState } from "@langfuse/shared";
 import { type EventBatchIOOutput } from "@/src/features/events/server/eventsRouter";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
-
-type TimeFilter = z.infer<typeof timeFilter>;
 
 const TRACE_SCORE_SCOPE_FILTER: FilterCondition[] = [
   {
@@ -56,7 +56,7 @@ const TRACE_SCORE_SCOPE_FILTER: FilterCondition[] = [
 
 interface GetObservationsListParams {
   projectId: string;
-  filter: any[];
+  filter?: FilterExpression;
   searchQuery?: string;
   searchType: any[];
   orderBy: any;
@@ -66,7 +66,7 @@ interface GetObservationsListParams {
 
 interface GetObservationsCountParams {
   projectId: string;
-  filter: any[];
+  filter?: FilterExpression;
   searchQuery?: string;
   searchType: any[];
   orderBy: any;
@@ -74,8 +74,7 @@ interface GetObservationsCountParams {
 
 interface GetObservationsFilterOptionsParams {
   projectId: string;
-  startTimeFilter?: TimeFilter[];
-  hasParentObservation?: boolean;
+  filter?: FilterInput;
 }
 
 /**
@@ -204,42 +203,28 @@ export async function getEventCount(params: GetObservationsCountParams) {
 export async function getEventFilterOptions(
   params: GetObservationsFilterOptionsParams,
 ) {
-  const { projectId, startTimeFilter, hasParentObservation } = params;
+  const { projectId } = params;
+  const normalizedFilter = normalizeFilterExpressionInput(params.filter);
 
-  // Build filter with optional hasParentObservation for scoping filter options
-  const eventsFilter: FilterState = [
-    ...(startTimeFilter ?? []),
-    ...(hasParentObservation !== undefined
-      ? [
-          {
-            column: "hasParentObservation" as const,
-            type: "boolean" as const,
-            operator: "=" as const,
-            value: hasParentObservation,
-          },
-        ]
-      : []),
-  ];
+  const mandatoryStartTimeFilters = getMandatoryFilterExpressionLeafFilters(
+    normalizedFilter,
+  ).filter(
+    (filter) => filter.type === "datetime" && filter.column === "startTime",
+  );
 
-  // Map startTimeFilter to Timestamp column for trace queries
-  const traceTimestampFilters =
-    startTimeFilter && startTimeFilter.length > 0
-      ? startTimeFilter.map((f) => ({
-          column: "Timestamp" as const,
-          operator: f.operator,
-          value: f.value,
-          type: "datetime" as const,
-        }))
-      : [];
+  const traceTimestampFilters = mandatoryStartTimeFilters.map((filter) => ({
+    column: "Timestamp" as const,
+    operator: filter.operator,
+    value: filter.value,
+    type: "datetime" as const,
+  }));
   const traceScoreTimestampFilters: FilterCondition[] =
-    startTimeFilter && startTimeFilter.length > 0
-      ? startTimeFilter.map((f) => ({
-          column: "timestamp",
-          operator: f.operator,
-          value: f.value,
-          type: "datetime",
-        }))
-      : [];
+    mandatoryStartTimeFilters.map((filter) => ({
+      column: "timestamp",
+      operator: filter.operator,
+      value: filter.value,
+      type: "datetime",
+    }));
 
   const [
     numericScoreNames,
@@ -270,24 +255,24 @@ export async function getEventFilterOptions(
       projectId,
       filter: [...TRACE_SCORE_SCOPE_FILTER, ...traceScoreTimestampFilters],
     }),
-    getEventsGroupedByModel(projectId, eventsFilter),
-    getEventsGroupedByName(projectId, eventsFilter),
-    getEventsGroupedByPromptName(projectId, eventsFilter),
-    getEventsGroupedByTraceTags(projectId, eventsFilter),
-    getEventsGroupedByTraceName(projectId, eventsFilter),
-    getEventsGroupedByModelId(projectId, eventsFilter),
-    getEventsGroupedByType(projectId, eventsFilter),
-    getEventsGroupedByUserId(projectId, eventsFilter),
-    getEventsGroupedByVersion(projectId, eventsFilter),
-    getEventsGroupedBySessionId(projectId, eventsFilter),
-    getEventsGroupedByLevel(projectId, eventsFilter),
-    getEventsGroupedByEnvironment(projectId, eventsFilter),
-    getEventsGroupedByExperimentDatasetId(projectId, eventsFilter),
-    getEventsGroupedByExperimentId(projectId, eventsFilter),
-    getEventsGroupedByExperimentName(projectId, eventsFilter),
-    getEventsGroupedByHasParentObservation(projectId, eventsFilter),
-    getEventsGroupedByToolName(projectId, eventsFilter),
-    getEventsGroupedByCalledToolName(projectId, eventsFilter),
+    getEventsGroupedByModel(projectId, normalizedFilter),
+    getEventsGroupedByName(projectId, normalizedFilter),
+    getEventsGroupedByPromptName(projectId, normalizedFilter),
+    getEventsGroupedByTraceTags(projectId, normalizedFilter),
+    getEventsGroupedByTraceName(projectId, normalizedFilter),
+    getEventsGroupedByModelId(projectId, normalizedFilter),
+    getEventsGroupedByType(projectId, normalizedFilter),
+    getEventsGroupedByUserId(projectId, normalizedFilter),
+    getEventsGroupedByVersion(projectId, normalizedFilter),
+    getEventsGroupedBySessionId(projectId, normalizedFilter),
+    getEventsGroupedByLevel(projectId, normalizedFilter),
+    getEventsGroupedByEnvironment(projectId, normalizedFilter),
+    getEventsGroupedByExperimentDatasetId(projectId, normalizedFilter),
+    getEventsGroupedByExperimentId(projectId, normalizedFilter),
+    getEventsGroupedByExperimentName(projectId, normalizedFilter),
+    getEventsGroupedByHasParentObservation(projectId, normalizedFilter),
+    getEventsGroupedByToolName(projectId, normalizedFilter),
+    getEventsGroupedByCalledToolName(projectId, normalizedFilter),
   ]);
   const traceNumericScoreNames = Array.from(
     new Set(

--- a/web/src/features/events/server/types.ts
+++ b/web/src/features/events/server/types.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import { singleFilter, TracingSearchType, orderBy } from "@langfuse/shared";
+import { filterInput, TracingSearchType, orderBy } from "@langfuse/shared";
 
 export const EventsTableOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure
-  filter: z.array(singleFilter),
+  filter: filterInput,
   searchQuery: z.string().nullable(),
   searchType: z.array(TracingSearchType),
   orderBy: orderBy,


### PR DESCRIPTION
## Summary
- add a shared recursive filter expression model with normalization from legacy flat filter arrays
- compile nested `AND`/`OR` filter trees into parenthesized ClickHouse predicates for events queries
- update the events router, service, repository, and filter-options hook to use the normalized expression path
- preserve tenant isolation by keeping `project_id` enforced outside user-controlled filter logic and routing events queries through `ctx.session.projectId`
- add recursive comment-filter rewriting and guard unsupported nested `positionInTrace` cases
- add regression coverage for filter normalization, query-builder behavior, and nested events repository filters

## Testing
- `pnpm --filter @langfuse/shared run lint`
- `pnpm --filter web run lint`
- `pnpm --filter @langfuse/shared exec dotenv -e ../../.env.dev.example -- npx prisma generate`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter web exec dotenv -e ../.env.test.example -e ../.env.dev.example -- jest src/__tests__/server/filter-expression.servertest.ts src/__tests__/server/event-query-builder.servertest.ts --runInBand`
- `pnpm --filter web exec dotenv -e ../.env.test.example -e ../.env.dev.example -- jest src/__tests__/server/repositories/event-repository.servertest.ts --runInBand -t "Nested Filter Expression"`