### PR TITLE
docs: update telemetry docs in localized READMEs

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -348,9 +348,9 @@ _[Langfuse 中的公共示例追踪](https://cloud.langfuse.com/project/cloramnk
 1. 了解 Langfuse 的使用情况，并改进最关键的功能。
 2. 跟踪整体使用数据，以便内部及外部（例如筹款）报告。
 
-所有数据均不会与第三方共享，也不包含任何敏感信息。我们对这一过程保持高度透明，你可以在 [此处](/web/src/features/telemetry/index.ts) 查看我们收集的具体数据。
+遥测数据不包括原始 traces、prompts、observations、scores 或数据集内容。我们在[遥测文档](https://langfuse.com/self-hosting/security/telemetry)中记录了收集的确切字段、这些数据会被发送到哪里，以及相关实现说明。
 
-你可以通过设置 `TELEMETRY_ENABLED=false` 来选择退出。
+对于 Langfuse OSS，你可以通过设置 `TELEMETRY_ENABLED=false` 来选择退出。
 
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -353,7 +353,6 @@ Langfuseを利用している主要なオープンソースPythonプロジェク
 1. Langfuseの利用状況を把握し、最も重要な機能の改善に役立てる
 2. 内部および外部（例：資金調達）のレポートのために全体の利用状況を追跡する
 
-収集されたデータは第三者と共有されず、機微な情報は一切含まれていません。  
-当社はこの点について極力透明性を保っており、収集される具体的なデータの詳細は[こちら](/web/src/features/telemetry/index.ts)で確認できます。
+テレメトリーには、生の traces、prompts、observations、scores、またはデータセットの内容は含まれません。収集される正確な項目、それらの送信先、および実装上の参照先については、[テレメトリードキュメント](https://langfuse.com/self-hosting/security/telemetry)に記載しています。
 
-`TELEMETRY_ENABLED=false` を設定することで、テレメトリーの報告をオプトアウトできます.
+Langfuse OSS では、`TELEMETRY_ENABLED=false` を設定することで、テレメトリーの報告をオプトアウトできます.

--- a/README.kr.md
+++ b/README.kr.md
@@ -336,6 +336,6 @@ _[Langfuse의 공개 예제 trace](https://cloud.langfuse.com/project/cloramnkj0
 1. Langfuse가 어떻게 사용되는지 이해하고, 가장 관련성 높은 기능을 개선할 수 있습니다.
 2. 내부 및 외부(예: 자금 조달) 보고를 위한 전체 사용량을 추적할 수 있습니다.
 
-수집된 데이터는 제3자와 공유되지 않으며 민감한 정보를 포함하지 않습니다. 이에 대해 매우 투명하게 공개하고 있으며, 수집되는 정확한 데이터는 [여기](/web/src/features/telemetry/index.ts)에서 확인할 수 있습니다.
+텔레메트리에는 원시 traces, prompts, observations, scores 또는 데이터셋 내용이 포함되지 않습니다. 수집되는 정확한 필드, 전송 대상, 그리고 구현 참조는 [텔레메트리 문서](https://langfuse.com/self-hosting/security/telemetry)에 문서화되어 있습니다.
 
-환경 변수 `TELEMETRY_ENABLED=false`를 설정하여 옵트아웃할 수 있습니다.
+Langfuse OSS에서는 환경 변수 `TELEMETRY_ENABLED=false`를 설정하여 옵트아웃할 수 있습니다.

--- a/web/src/features/telemetry/README.md
+++ b/web/src/features/telemetry/README.md
@@ -7,6 +7,6 @@ This helps us to:
 1. Understand how Langfuse is used and improve the most relevant features.
 2. Track overall usage for internal and external (e.g. fundraising) reporting.
 
-None of the data is shared with third parties and does not include any sensitive information. We want to be super transparent about this and you can find the exact data we collect [here](/src/features/telemetry/index.ts).
+The telemetry does not include raw traces, prompts, observations, scores, or dataset contents. We document the exact fields that are collected, where they are sent, and the implementation reference in our [telemetry docs](https://langfuse.com/self-hosting/security/telemetry).
 
-You can opt-out by setting `TELEMETRY_ENABLED=false`.
+For Langfuse OSS, you can opt out by setting `TELEMETRY_ENABLED=false`.


### PR DESCRIPTION
## Summary
- update the telemetry section in `README.cn.md`, `README.ja.md`, and `README.kr.md` to match the current English README
- replace stale internal telemetry file links with the external telemetry docs URL
- add the `For Langfuse OSS` qualifier to the telemetry opt-out instruction
- align `web/src/features/telemetry/README.md` with the current telemetry wording

## Testing
- Not run (not requested)