### PR TITLE
fix(dashboard): restrict aggregations for uniqueness measures

### DIFF
--- a/web/src/__tests__/server/queryBuilder.servertest.ts
+++ b/web/src/__tests__/server/queryBuilder.servertest.ts
@@ -4355,6 +4355,8 @@ describe("getValidAggregationsForMeasureType", () => {
     ["integer", allAggs],
     ["decimal", allAggs],
     ["number", allAggs],
+    // uniqueCount → all aggregations except count
+    ["uniqueCount", allAggs - 1],
     // Non-numeric / missing → restricted
     ["string", restricted.length],
     ["boolean", restricted.length],
@@ -4366,6 +4368,13 @@ describe("getValidAggregationsForMeasureType", () => {
 
   it("restricted set contains only count and uniq", () => {
     expect(getValidAggregationsForMeasureType("string")).toEqual(restricted);
+  });
+
+  it("uniqueCount excludes count but includes sum and uniq", () => {
+    const valid = getValidAggregationsForMeasureType("uniqueCount");
+    expect(valid).not.toContain("count");
+    expect(valid).toContain("sum");
+    expect(valid).toContain("uniq");
   });
 });
 

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -98,14 +98,14 @@ export const traceView: ViewDeclarationType = {
     uniqueUserIds: {
       sql: "uniq(traces.user_id)",
       alias: "uniqueUserIds",
-      type: "integer",
+      type: "uniqueCount",
       description: "Count of unique userIds.",
       unit: "users",
     },
     uniqueSessionIds: {
       sql: "uniq(traces.session_id)",
       alias: "uniqueSessionIds",
-      type: "integer",
+      type: "uniqueCount",
       description: "Count of unique sessionIds.",
       unit: "sessions",
     },
@@ -268,7 +268,7 @@ export const eventsTracesView: ViewDeclarationType = {
       sql: "@@AGG@@(nullIf(events_traces.user_id, ''))",
       aggs: { agg: "any" },
       alias: "uniqueUserIds",
-      type: "string",
+      type: "uniqueCount",
       description:
         "User identifier; apply uniq aggregation to count distinct users.",
       unit: "users",
@@ -277,7 +277,7 @@ export const eventsTracesView: ViewDeclarationType = {
       sql: "@@AGG@@(nullIf(events_traces.session_id, ''))",
       aggs: { agg: "any" },
       alias: "uniqueSessionIds",
-      type: "string",
+      type: "uniqueCount",
       description:
         "Session identifier; apply uniq aggregation to count distinct sessions.",
       unit: "sessions",
@@ -1168,7 +1168,7 @@ export const eventsObservationsView: ViewDeclarationType = {
       sql: "@@AGG@@(nullIf(events_observations.user_id, ''))",
       aggs: { agg: "any" },
       alias: "uniqueUserIds",
-      type: "string",
+      type: "uniqueCount",
       description:
         "User identifier; apply uniq aggregation to count distinct users.",
       unit: "users",
@@ -1177,7 +1177,7 @@ export const eventsObservationsView: ViewDeclarationType = {
       sql: "@@AGG@@(nullIf(events_observations.session_id, ''))",
       aggs: { agg: "any" },
       alias: "uniqueSessionIds",
-      type: "string",
+      type: "uniqueCount",
       description:
         "Session identifier; apply uniq aggregation to count distinct sessions.",
       unit: "sessions",

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -124,6 +124,12 @@ export const metricAggregations = z.enum([
  * Returns the subset of aggregations that are valid for a given measure type.
  * Whitelists known numeric types; unknown or missing types default to the
  * restrictive count/uniq set to surface missing type annotations early.
+ *
+ * "uniqueCount" is used for measures that already compute a unique count
+ * (e.g. uniq(user_id)). The inner query produces a per-group integer, so
+ * numeric aggregations like sum/avg/max/min are fine for the outer query,
+ * but "count" is excluded because it would count *rows* rather than summing
+ * the unique counts – which is the bug described in #12273.
  */
 export function getValidAggregationsForMeasureType(
   measureType: string | undefined,
@@ -134,6 +140,9 @@ export function getValidAggregationsForMeasureType(
     measureType === "number"
   ) {
     return [...metricAggregations.options];
+  }
+  if (measureType === "uniqueCount") {
+    return metricAggregations.options.filter((a) => a !== "count");
   }
   return ["count", "uniq"];
 }


### PR DESCRIPTION
## Summary

Fixes #12273.

Dashboard widgets using "Unique User Ids" or "Unique Session Ids" with "Count" aggregation display total trace count instead of the actual distinct count. This happens because the inner query already computes `uniq(user_id)` per group (always yielding an integer), and wrapping that with `count()` in the outer query just counts rows.

The fix introduces a `uniqueCount` measure type that permits all numeric aggregations (sum, avg, max, min, percentiles, etc.) except `count`, which is semantically incorrect for pre-aggregated uniqueness measures. This type is applied to all `uniqueUserIds` and `uniqueSessionIds` measures across both v1 and v2 view definitions.

## Changes

- Add `uniqueCount` branch to `getValidAggregationsForMeasureType` in `types.ts` that filters out `count`
- Change measure type from `integer`/`string` to `uniqueCount` for `uniqueUserIds` and `uniqueSessionIds` in all views (`traceView`, `eventsTracesView`, `eventsObservationsView`)
- Add test coverage for the new type in `queryBuilder.servertest.ts`

## Impacted packages

- `web`