### PR TITLE
style(web): consistent button cursor behavior

### DIFF
--- a/web/src/components/onboarding/DatasetItemsOnboarding.tsx
+++ b/web/src/components/onboarding/DatasetItemsOnboarding.tsx
@@ -43,6 +43,7 @@ const DatasetItemEntryPointRow = ({
     <div
       role="button"
       tabIndex={0}
+      aria-disabled={disabled}
       className={cn(
         "border-border flex h-20 items-center gap-4 rounded-lg border p-4 transition-colors",
         disabled

--- a/web/src/components/onboarding/DatasetItemsOnboarding.tsx
+++ b/web/src/components/onboarding/DatasetItemsOnboarding.tsx
@@ -51,6 +51,16 @@ const DatasetItemEntryPointRow = ({
           : "bg-card hover:bg-accent/50 cursor-pointer",
       )}
       onClick={!disabled ? onClick : undefined}
+      onKeyDown={
+        !disabled
+          ? (event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onClick?.();
+              }
+            }
+          : undefined
+      }
       title={
         !hasAccess
           ? "You don't have access to this feature, please contact your administrator"

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -317,6 +317,11 @@
     @apply border-border;
   }
 
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+
   html,
   body {
     /* Prevent pull-to-refresh and rubber-banding on the page level only */

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -317,7 +317,7 @@
     @apply border-border;
   }
 
-  button:not(:disabled),
+  button:not(:disabled):not([aria-disabled="true"]),
   [role="button"]:not([aria-disabled="true"]) {
     cursor: pointer;
   }


### PR DESCRIPTION
### Motivation
- Many interactive elements in the UI did not show a pointer cursor which made clickable controls less discoverable, so add a centralized style to consistently indicate clickability for enabled buttons and button-like elements.


⚠️ This PR makes thing consistent. Note though that the default behavior on mac is to have no pointer cursor. E.g. Linear hence has a setting to configure this.

<img width="688" height="93" alt="image" src="https://github.com/user-attachments/assets/6202ad0d-3efe-47fe-ab38-85c25f8e011d" />

### Description

- Fixes: [Linear](https://linear.app/langfuse/issue/LFE-9016/many-buttons-are-not-treated-as-buttons)
------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c52e5c117883278028bf641149021b)