### PR TITLE
fix(web): left-align wrapped sidebar filter labels

### DIFF
--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -407,7 +407,7 @@ const FilterAccordionTrigger = ({
   <AccordionPrimitive.Header className="bg-background sticky top-10 z-10 flex">
     <AccordionPrimitive.Trigger
       className={cn(
-        "flex flex-1 items-center justify-between font-medium hover:underline [&[data-state=open]>svg]:rotate-180",
+        "flex flex-1 items-center justify-between text-left font-medium hover:underline [&[data-state=open]>svg]:rotate-180",
         className,
       )}
       {...props}


### PR DESCRIPTION
### Motivation
- The sidebar filter accordion trigger centered multi-line labels (such as the Trace categorical score filter), causing wrapped text to appear center-aligned instead of left-aligned.

### Description
- Add the `text-left` utility to the accordion trigger in `web/src/components/table/data-table-controls.tsx` so wrapped filter labels are left-aligned in the sidebar (impacts the `web` package).

### Testing
- Ran `pnpm --filter web run lint` and the lint step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c53d37bffc832b9163465af41ffa36)