### PR TITLE
fix(web): prevent DataTable onRowClick when clicking interactive elements

### DIFF
--- a/web/src/__tests__/data-table-row-click.clienttest.ts
+++ b/web/src/__tests__/data-table-row-click.clienttest.ts
@@ -1,0 +1,25 @@
+import { shouldIgnoreRowClickTarget } from "@/src/components/table/data-table";
+
+describe("shouldIgnoreRowClickTarget", () => {
+  it("returns true for button descendants", () => {
+    const button = document.createElement("button");
+    const icon = document.createElement("span");
+    button.appendChild(icon);
+
+    expect(shouldIgnoreRowClickTarget(icon)).toBe(true);
+  });
+
+  it("returns true for link descendants", () => {
+    const link = document.createElement("a");
+    const child = document.createElement("div");
+    link.appendChild(child);
+
+    expect(shouldIgnoreRowClickTarget(child)).toBe(true);
+  });
+
+  it("returns false for non-interactive elements", () => {
+    const div = document.createElement("div");
+
+    expect(shouldIgnoreRowClickTarget(div)).toBe(false);
+  });
+});

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -110,6 +110,15 @@ function isValidCssVariableName({
   return regex.test(name);
 }
 
+const INTERACTIVE_ROW_CLICK_SELECTOR =
+  "a, button, input, select, textarea, summary, [role='button'], [role='link']";
+
+export const shouldIgnoreRowClickTarget = (target: EventTarget | null) => {
+  if (!(target instanceof Element)) return false;
+
+  return Boolean(target.closest(INTERACTIVE_ROW_CLICK_SELECTOR));
+};
+
 // These are the important styles to make sticky column pinning work!
 const getCommonPinningStyles = <TData,>(
   column: Column<TData>,
@@ -499,7 +508,10 @@ function TableRowComponent<TData>({
   return (
     <TableRow
       data-row-index={row.index}
-      onClick={(e) => onRowClick?.(row.original, e)}
+      onClick={(e) => {
+        if (shouldIgnoreRowClickTarget(e.target)) return;
+        onRowClick?.(row.original, e);
+      }}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
           onRowClick?.(row.original);


### PR DESCRIPTION
### Motivation
- Prevent `DataTable` row click handlers from firing when the user interacts with buttons/links or other interactive controls inside a table cell without requiring changes to those buttons or links.

### Description
- Added `INTERACTIVE_ROW_CLICK_SELECTOR` and exported `shouldIgnoreRowClickTarget` which returns true when the event target is inside an interactive element via `Element.closest`.
- Guarded the row `onClick` in `TableRowComponent` to return early when `shouldIgnoreRowClickTarget(e.target)` is true so `onRowClick` is not invoked for button/link interactions.
- Added a targeted client test `web/src/__tests__/data-table-row-click.clienttest.ts` that verifies the new `shouldIgnoreRowClickTarget` behavior for button descendants, link descendants, and non-interactive elements.

### Testing
- Ran `pnpm --filter web run lint` and the lint step completed successfully.
- Ran the targeted client tests with `pnpm --filter web run test-client --testPathPatterns='data-table-row-click.clienttest.ts'` (with required env vars) and the test suite passed (3 tests, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c3e85228ec832bbab9ddb16420b3e7)