### PR TITLE
feat: introduce `TEXT` scores

### DIFF
--- a/packages/shared/prisma/migrations/20260327000000_add_free_form_score_config_data_type/migration.sql
+++ b/packages/shared/prisma/migrations/20260327000000_add_free_form_score_config_data_type/migration.sql
@@ -1,2 +1,2 @@
 -- AlterEnum
-ALTER TYPE "ScoreConfigDataType" ADD VALUE 'FREE_FORM';
+ALTER TYPE "ScoreConfigDataType" ADD VALUE 'TEXT';

--- a/packages/shared/prisma/migrations/20260327000000_add_free_form_score_config_data_type/migration.sql
+++ b/packages/shared/prisma/migrations/20260327000000_add_free_form_score_config_data_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ScoreConfigDataType" ADD VALUE 'FREE_FORM';

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -495,7 +495,7 @@ enum ScoreConfigDataType {
   CATEGORICAL
   NUMERIC
   BOOLEAN
-  FREE_FORM
+  TEXT
 }
 
 model AnnotationQueue {
@@ -925,7 +925,7 @@ model EvalTemplate {
   provider         String?
   modelParams      Json?              @map("model_params")
   vars             String[]           @default([])
-  outputDefinition     Json               @map("output_schema")
+  outputDefinition Json               @map("output_schema")
   JobConfiguration JobConfiguration[]
   JobExecution     JobExecution[]
 

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -495,6 +495,7 @@ enum ScoreConfigDataType {
   CATEGORICAL
   NUMERIC
   BOOLEAN
+  FREE_FORM
 }
 
 model AnnotationQueue {

--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -969,7 +969,7 @@ async function generateConfigs(project: Project) {
       id: `config-${v4()}`,
       projectId: project.id,
       name: "Feedback",
-      dataType: ScoreDataTypeEnum.FREE_FORM,
+      dataType: ScoreDataTypeEnum.TEXT,
       description: "Free-form text feedback on the output quality.",
       isArchived: false,
     },

--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -965,6 +965,14 @@ async function generateConfigs(project: Project) {
         "Used to indicate if text was harmful or offensive in nature.",
       isArchived: false,
     },
+    {
+      id: `config-${v4()}`,
+      projectId: project.id,
+      name: "Feedback",
+      dataType: ScoreDataTypeEnum.FREE_FORM,
+      description: "Free-form text feedback on the output quality.",
+      isArchived: false,
+    },
   ];
 
   for (const config of configs) {

--- a/packages/shared/src/domain/score-configs.ts
+++ b/packages/shared/src/domain/score-configs.ts
@@ -72,10 +72,10 @@ export const CategoricalConfigFields = z.object({
   categories: z.array(ScoreConfigCategory).superRefine(validateCategories),
 });
 
-export const FreeFormConfigFields = z.object({
+export const TextConfigFields = z.object({
   maxValue: z.undefined().nullish(),
   minValue: z.undefined().nullish(),
-  dataType: z.literal("FREE_FORM"),
+  dataType: z.literal("TEXT"),
   categories: z.undefined().nullish(),
 });
 
@@ -123,7 +123,7 @@ export const ScoreConfigSchema = z
     }),
     z.object({
       ...ScoreConfigBase.shape,
-      ...FreeFormConfigFields.shape,
+      ...TextConfigFields.shape,
     }),
   ])
   .superRefine(validateNumericRangeFields);

--- a/packages/shared/src/domain/score-configs.ts
+++ b/packages/shared/src/domain/score-configs.ts
@@ -72,6 +72,13 @@ export const CategoricalConfigFields = z.object({
   categories: z.array(ScoreConfigCategory).superRefine(validateCategories),
 });
 
+export const FreeFormConfigFields = z.object({
+  maxValue: z.undefined().nullish(),
+  minValue: z.undefined().nullish(),
+  dataType: z.literal("FREE_FORM"),
+  categories: z.undefined().nullish(),
+});
+
 const ScoreConfigBase = z.object({
   id: z.string(),
   name: z.string().min(1).max(35),
@@ -113,6 +120,10 @@ export const ScoreConfigSchema = z
     z.object({
       ...ScoreConfigBase.shape,
       ...BooleanConfigFields.shape,
+    }),
+    z.object({
+      ...ScoreConfigBase.shape,
+      ...FreeFormConfigFields.shape,
     }),
   ])
   .superRefine(validateNumericRangeFields);

--- a/packages/shared/src/domain/scores.ts
+++ b/packages/shared/src/domain/scores.ts
@@ -17,14 +17,14 @@ export const ScoreDataTypeArray = [
   "CATEGORICAL",
   "BOOLEAN",
   "CORRECTION",
-  "FREE_FORM",
+  "TEXT",
 ] as const;
 export const ScoreDataTypeEnum = {
   NUMERIC: "NUMERIC",
   CATEGORICAL: "CATEGORICAL",
   BOOLEAN: "BOOLEAN",
   CORRECTION: "CORRECTION",
-  FREE_FORM: "FREE_FORM",
+  TEXT: "TEXT",
 } as const;
 export const ScoreDataTypeDomain = z.enum(ScoreDataTypeArray);
 export type ScoreDataTypeType = z.infer<typeof ScoreDataTypeDomain>;
@@ -49,9 +49,9 @@ const CorrectionData = z.object({
   dataType: z.literal("CORRECTION"),
 });
 
-export const FreeFormData = z.object({
+export const TextData = z.object({
   stringValue: z.string().min(1).max(500),
-  dataType: z.literal("FREE_FORM"),
+  dataType: z.literal("TEXT"),
 });
 
 // Only used for backwards compatibility with old score API schemas
@@ -96,7 +96,7 @@ export const ScoreSchema = ScoreFoundationSchema.and(
     CategoricalData,
     BooleanData,
     CorrectionData,
-    FreeFormData,
+    TextData,
   ]),
 );
 

--- a/packages/shared/src/domain/scores.ts
+++ b/packages/shared/src/domain/scores.ts
@@ -17,12 +17,14 @@ export const ScoreDataTypeArray = [
   "CATEGORICAL",
   "BOOLEAN",
   "CORRECTION",
+  "FREE_FORM",
 ] as const;
 export const ScoreDataTypeEnum = {
   NUMERIC: "NUMERIC",
   CATEGORICAL: "CATEGORICAL",
   BOOLEAN: "BOOLEAN",
   CORRECTION: "CORRECTION",
+  FREE_FORM: "FREE_FORM",
 } as const;
 export const ScoreDataTypeDomain = z.enum(ScoreDataTypeArray);
 export type ScoreDataTypeType = z.infer<typeof ScoreDataTypeDomain>;
@@ -45,6 +47,11 @@ export const BooleanData = z.object({
 const CorrectionData = z.object({
   stringValue: z.null(),
   dataType: z.literal("CORRECTION"),
+});
+
+export const FreeFormData = z.object({
+  stringValue: z.string().min(1).max(500),
+  dataType: z.literal("FREE_FORM"),
 });
 
 // Only used for backwards compatibility with old score API schemas
@@ -89,6 +96,7 @@ export const ScoreSchema = ScoreFoundationSchema.and(
     CategoricalData,
     BooleanData,
     CorrectionData,
+    FreeFormData,
   ]),
 );
 
@@ -115,6 +123,11 @@ export const AGGREGATABLE_SCORE_TYPES = [
 export type AggregatableScoreDataType =
   (typeof AGGREGATABLE_SCORE_TYPES)[number];
 
+export const LISTABLE_SCORE_TYPES = ScoreDataTypeArray.filter(
+  (type) => type !== "CORRECTION",
+) satisfies readonly ScoreDataTypeType[];
+
+export type ListableScore = ScoresByDataTypes<typeof LISTABLE_SCORE_TYPES>;
 // Type helper for functions that return only aggregatable scores
 export type AggregatableScore = ScoresByDataTypes<
   typeof AGGREGATABLE_SCORE_TYPES

--- a/packages/shared/src/domain/scores.ts
+++ b/packages/shared/src/domain/scores.ts
@@ -123,12 +123,14 @@ export const AGGREGATABLE_SCORE_TYPES = [
 export type AggregatableScoreDataType =
   (typeof AGGREGATABLE_SCORE_TYPES)[number];
 
-export const LISTABLE_SCORE_TYPES = ScoreDataTypeArray.filter(
-  (type) => type !== "CORRECTION",
-) satisfies readonly ScoreDataTypeType[];
-
-export type ListableScore = ScoresByDataTypes<typeof LISTABLE_SCORE_TYPES>;
 // Type helper for functions that return only aggregatable scores
 export type AggregatableScore = ScoresByDataTypes<
   typeof AGGREGATABLE_SCORE_TYPES
 >;
+
+export const LISTABLE_SCORE_TYPES = ScoreDataTypeArray.filter(
+  (type) => type !== "CORRECTION",
+) satisfies readonly ScoreDataTypeType[];
+
+export type ListableScoreDataType = (typeof LISTABLE_SCORE_TYPES)[number];
+export type ListableScore = ScoresByDataTypes<typeof LISTABLE_SCORE_TYPES>;

--- a/packages/shared/src/features/annotation/types.ts
+++ b/packages/shared/src/features/annotation/types.ts
@@ -3,7 +3,7 @@ import { StringNoHTML, StringNoHTMLNonEmpty } from "../../utils/zod";
 import {
   BooleanData,
   CategoricalData,
-  FreeFormData,
+  TextData,
   NumericData,
 } from "../../domain";
 
@@ -54,7 +54,7 @@ export const CreateAnnotationScoreData = CreateAnnotationScoreBase.and(
     NumericData,
     CategoricalData,
     BooleanData,
-    FreeFormData,
+    TextData,
   ]),
 );
 
@@ -71,7 +71,7 @@ export const UpdateAnnotationScoreData = UpdateAnnotationScoreBase.and(
     NumericData,
     CategoricalData,
     BooleanData,
-    FreeFormData,
+    TextData,
   ]),
 );
 

--- a/packages/shared/src/features/annotation/types.ts
+++ b/packages/shared/src/features/annotation/types.ts
@@ -1,6 +1,11 @@
 import z from "zod";
 import { StringNoHTML, StringNoHTMLNonEmpty } from "../../utils/zod";
-import { BooleanData, CategoricalData, NumericData } from "../../domain";
+import {
+  BooleanData,
+  CategoricalData,
+  FreeFormData,
+  NumericData,
+} from "../../domain";
 
 const ScoreTargetTrace = z.object({
   type: z.literal("trace"),
@@ -45,7 +50,12 @@ const UpdateAnnotationScoreBase = CreateAnnotationScoreBase.extend({
  * For langfuse score types please refer to `web/src/features/public-api/types/scores.ts`
  */
 export const CreateAnnotationScoreData = CreateAnnotationScoreBase.and(
-  z.discriminatedUnion("dataType", [NumericData, CategoricalData, BooleanData]),
+  z.discriminatedUnion("dataType", [
+    NumericData,
+    CategoricalData,
+    BooleanData,
+    FreeFormData,
+  ]),
 );
 
 export type CreateAnnotationScoreData = z.infer<
@@ -57,7 +67,12 @@ export type CreateAnnotationScoreData = z.infer<
  * For langfuse score types please refer to `web/src/features/public-api/types/scores.ts`
  */
 export const UpdateAnnotationScoreData = UpdateAnnotationScoreBase.and(
-  z.discriminatedUnion("dataType", [NumericData, CategoricalData, BooleanData]),
+  z.discriminatedUnion("dataType", [
+    NumericData,
+    CategoricalData,
+    BooleanData,
+    FreeFormData,
+  ]),
 );
 
 export type UpdateAnnotationScoreData = z.infer<

--- a/packages/shared/src/features/scores/interfaces/ingestion/validation.ts
+++ b/packages/shared/src/features/scores/interfaces/ingestion/validation.ts
@@ -83,6 +83,6 @@ export const ScorePropsAgainstConfig = z.union([
   }),
   z.object({
     value: z.string().min(1).max(500),
-    dataType: z.literal("FREE_FORM"),
+    dataType: z.literal("TEXT"),
   }),
 ]);

--- a/packages/shared/src/features/scores/interfaces/ingestion/validation.ts
+++ b/packages/shared/src/features/scores/interfaces/ingestion/validation.ts
@@ -81,4 +81,8 @@ export const ScorePropsAgainstConfig = z.union([
     }),
     dataType: z.literal("BOOLEAN"),
   }),
+  z.object({
+    value: z.string().min(1).max(500),
+    dataType: z.literal("FREE_FORM"),
+  }),
 ]);

--- a/packages/shared/src/features/scores/interfaces/ui/types.ts
+++ b/packages/shared/src/features/scores/interfaces/ui/types.ts
@@ -23,7 +23,15 @@ export type NumericAggregate = BaseAggregate & {
   average: number;
 };
 
-export type AggregatedScoreData = CategoricalAggregate | NumericAggregate;
+export type TextAggregate = BaseAggregate & {
+  type: "TEXT";
+  values: string[];
+};
+
+export type AggregatedScoreData =
+  | CategoricalAggregate
+  | NumericAggregate
+  | TextAggregate;
 
 export type ScoreAggregate = Record<string, AggregatedScoreData>;
 

--- a/packages/shared/src/features/scores/interfaces/ui/types.ts
+++ b/packages/shared/src/features/scores/interfaces/ui/types.ts
@@ -26,6 +26,7 @@ export type NumericAggregate = BaseAggregate & {
 export type TextAggregate = BaseAggregate & {
   type: "TEXT";
   values: string[];
+  valueCounts: { value: string; count: number }[];
 };
 
 export type AggregatedScoreData =

--- a/packages/shared/src/server/ingestion/validateAndInflateScore.ts
+++ b/packages/shared/src/server/ingestion/validateAndInflateScore.ts
@@ -173,7 +173,7 @@ function resolveScoreValueAnnotation(
     case ScoreDataTypeEnum.BOOLEAN:
       return body.value;
     case ScoreDataTypeEnum.CATEGORICAL:
-    case ScoreDataTypeEnum.FREE_FORM:
+    case ScoreDataTypeEnum.TEXT:
       return body.stringValue;
     case ScoreDataTypeEnum.CORRECTION:
       throw new Error("CORRECTION type not supported in annotation drawer");

--- a/packages/shared/src/server/ingestion/validateAndInflateScore.ts
+++ b/packages/shared/src/server/ingestion/validateAndInflateScore.ts
@@ -173,6 +173,7 @@ function resolveScoreValueAnnotation(
     case ScoreDataTypeEnum.BOOLEAN:
       return body.value;
     case ScoreDataTypeEnum.CATEGORICAL:
+    case ScoreDataTypeEnum.FREE_FORM:
       return body.stringValue;
     case ScoreDataTypeEnum.CORRECTION:
       throw new Error("CORRECTION type not supported in annotation drawer");

--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -120,7 +120,7 @@ export const buildScoresAggregationCTE = (
         ${primaryKey},
         ${additionalOuterCols.length > 0 ? additionalOuterCols.join(",\n        ") + "," : ""}
         groupArrayIf(tuple(name, avg_value, data_type, string_value), data_type IN ('NUMERIC', 'BOOLEAN')) AS scores_avg,
-        groupArrayIf(concat(name, ':', string_value), data_type = 'CATEGORICAL' AND notEmpty(string_value)) AS score_categories${params.includeTupleEncoding ? `,\n        groupArrayIf(tuple(name, string_value), data_type = 'CATEGORICAL' AND notEmpty(string_value)) AS score_categories_tuples` : ""}
+        groupArrayIf(concat(name, ':', string_value), data_type IN ('CATEGORICAL', 'TEXT') AND notEmpty(string_value)) AS score_categories${params.includeTupleEncoding ? `,\n        groupArrayIf(tuple(name, string_value), data_type IN ('CATEGORICAL', 'TEXT') AND notEmpty(string_value)) AS score_categories_tuples` : ""}
       FROM (
         SELECT
           ${primaryKey},

--- a/packages/shared/src/server/repositories/environments.ts
+++ b/packages/shared/src/server/repositories/environments.ts
@@ -1,4 +1,4 @@
-import { AGGREGATABLE_SCORE_TYPES } from "../../domain/scores";
+import { LISTABLE_SCORE_TYPES } from "../../domain/scores";
 import { queryClickhouse } from "./clickhouse";
 
 export type EnvironmentFilterProps = {
@@ -38,7 +38,7 @@ export const getEnvironmentsForProject = async (
     params: {
       projectId,
       fromTimestamp,
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
     },
     tags: {
       feature: "tracing",

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -5,6 +5,7 @@ import {
   AGGREGATABLE_SCORE_TYPES,
   AggregatableScoreDataType,
   ScoreByDataType,
+  LISTABLE_SCORE_TYPES,
 } from "../../domain/scores";
 import {
   commandClickhouse,
@@ -131,7 +132,7 @@ export const getScoresByIds = async (
     scoreId,
     source,
     scoreScope: "all",
-    dataTypes: AGGREGATABLE_SCORE_TYPES,
+    dataTypes: LISTABLE_SCORE_TYPES,
   });
 };
 
@@ -248,7 +249,7 @@ export const getScoresForSessions = async <
       sessionIds,
       limit,
       offset,
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
     },
     tags: {
       feature: "sessions",
@@ -585,7 +586,7 @@ export const getScoresForTraces = async <
 ) => {
   return getScoresForTracesInternal({
     ...props,
-    dataTypes: AGGREGATABLE_SCORE_TYPES,
+    dataTypes: LISTABLE_SCORE_TYPES,
   });
 };
 
@@ -664,7 +665,7 @@ export const getScoresForObservations = async <
     params: {
       projectId: projectId,
       observationIds: observationIds,
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
       limit: limit,
       offset: offset,
     },
@@ -1182,7 +1183,7 @@ const getScoresUiGeneric = async <T>(props: {
     input: {
       params: {
         projectId: projectId,
-        dataTypes: AGGREGATABLE_SCORE_TYPES,
+        dataTypes: LISTABLE_SCORE_TYPES,
         ...(scoresFilterRes ? scoresFilterRes.params : {}),
         limit: limit,
         offset: offset,
@@ -1386,7 +1387,7 @@ const getScoresUiGenericFromEvents = async <T>(props: {
     input: {
       params: {
         projectId,
-        dataTypes: AGGREGATABLE_SCORE_TYPES,
+        dataTypes: LISTABLE_SCORE_TYPES,
         ...(scoreOnlyFilterRes ? scoreOnlyFilterRes.params : {}),
         ...tracesCTEParams,
         limit,
@@ -1528,7 +1529,7 @@ export const getScoreNames = async (
     params: {
       projectId: projectId,
       ...(timestampFilterRes ? timestampFilterRes.params : {}),
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
     },
     tags: {
       feature: "tracing",
@@ -1557,6 +1558,8 @@ export const getScoreStringValues = async (
   );
   const timestampFilterRes = chFilter.apply();
 
+  // exclude FREE_FORM scores as they are arbitrary by nature and hence have high cardinality
+  // which in turn can lead to performance issues
   const query = `
       select
         string_value,
@@ -1565,6 +1568,7 @@ export const getScoreStringValues = async (
       WHERE s.project_id = {projectId: String}
       AND string_value IS NOT NULL
       AND string_value != ''
+      AND s.data_type != 'FREE_FORM'
       ${timestampFilterRes?.query ? `AND ${timestampFilterRes.query}` : ""}
       GROUP BY string_value
       ORDER BY count() desc
@@ -1871,7 +1875,7 @@ export const getScoreCountsByProjectInCreationInterval = async ({
     params: {
       start: convertDateToClickhouseDateTime(start),
       end: convertDateToClickhouseDateTime(end),
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
     },
     clickhouseConfigs: {
       request_timeout: 120000, // 2 minutes timeout
@@ -1950,7 +1954,7 @@ export const getDistinctScoreNames = async (p: {
     params: {
       projectId,
       cutoffCreatedAt: convertDateToClickhouseDateTime(cutoffCreatedAt),
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
       ...(scoreTimestampFilter
         ? {
             filterTimestamp: convertDateToClickhouseDateTime(
@@ -2005,7 +2009,7 @@ export const getScoresForBlobStorageExport = function (
       projectId,
       minTimestamp: convertDateToClickhouseDateTime(minTimestamp),
       maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
     },
     tags: {
       feature: "blobstorage",
@@ -2251,7 +2255,7 @@ export const getScoreCountsByProjectAndDay = async ({
     params: {
       startDate: convertDateToClickhouseDateTime(startDate),
       endDate: convertDateToClickhouseDateTime(endDate),
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
     },
     tags: {
       feature: "tracing",

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1835,7 +1835,7 @@ export const getAggregatedScoresForPrompts = async (
     params: {
       projectId,
       promptIds,
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
     },
     tags: {
       feature: "tracing",
@@ -1954,7 +1954,7 @@ export const getDistinctScoreNames = async (p: {
     params: {
       projectId,
       cutoffCreatedAt: convertDateToClickhouseDateTime(cutoffCreatedAt),
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
       ...(scoreTimestampFilter
         ? {
             filterTimestamp: convertDateToClickhouseDateTime(
@@ -2082,7 +2082,7 @@ export const getScoresForAnalyticsIntegrations = async function* (
       projectId,
       minTimestamp: convertDateToClickhouseDateTime(minTimestamp),
       maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
     },
     tags: {
       feature: "posthog",

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -801,7 +801,7 @@ export const getScoresGroupedByNameSourceType = async ({
     query: query,
     params: {
       projectId: projectId,
-      dataTypes: AGGREGATABLE_SCORE_TYPES,
+      dataTypes: LISTABLE_SCORE_TYPES,
       ...(fromTimestamp
         ? { fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp) }
         : {}),
@@ -1954,7 +1954,7 @@ export const getDistinctScoreNames = async (p: {
     params: {
       projectId,
       cutoffCreatedAt: convertDateToClickhouseDateTime(cutoffCreatedAt),
-      dataTypes: LISTABLE_SCORE_TYPES,
+      dataTypes: AGGREGATABLE_SCORE_TYPES,
       ...(scoreTimestampFilter
         ? {
             filterTimestamp: convertDateToClickhouseDateTime(

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1558,7 +1558,7 @@ export const getScoreStringValues = async (
   );
   const timestampFilterRes = chFilter.apply();
 
-  // exclude FREE_FORM scores as they are arbitrary by nature and hence have high cardinality
+  // exclude TEXT scores as they are arbitrary by nature and hence have high cardinality
   // which in turn can lead to performance issues
   const query = `
       select
@@ -1568,7 +1568,7 @@ export const getScoreStringValues = async (
       WHERE s.project_id = {projectId: String}
       AND string_value IS NOT NULL
       AND string_value != ''
-      AND s.data_type != 'FREE_FORM'
+      AND s.data_type != 'TEXT'
       ${timestampFilterRes?.query ? `AND ${timestampFilterRes.query}` : ""}
       GROUP BY string_value
       ORDER BY count() desc

--- a/web/src/__tests__/server/repositories/score-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/score-repository.servertest.ts
@@ -804,8 +804,8 @@ describe("Clickhouse Scores Repository Test", () => {
     });
   });
 
-  describe("FREE_FORM scores", () => {
-    it("should round-trip a FREE_FORM score through ClickHouse", async () => {
+  describe("TEXT scores", () => {
+    it("should round-trip a TEXT score through ClickHouse", async () => {
       const scoreId = v4();
       const traceId = v4();
 
@@ -816,7 +816,7 @@ describe("Clickhouse Scores Repository Test", () => {
         name: "free-form-score",
         value: 0,
         string_value: "This is free text feedback",
-        data_type: "FREE_FORM",
+        data_type: "TEXT",
         source: "ANNOTATION",
       });
 
@@ -824,13 +824,13 @@ describe("Clickhouse Scores Repository Test", () => {
 
       const result = await getScoreById({ projectId, scoreId });
       expect(result).toBeDefined();
-      expect(result!.dataType).toBe("FREE_FORM");
+      expect(result!.dataType).toBe("TEXT");
       expect(result!.stringValue).toBe("This is free text feedback");
       expect(result!.value).toBe(0);
       expect(result!.source).toBe("ANNOTATION");
     });
 
-    it("should exclude FREE_FORM scores from getScoresGroupedByNameSourceType", async () => {
+    it("should exclude TEXT scores from getScoresGroupedByNameSourceType", async () => {
       const isolatedProjectId = v4();
       const traceId = v4();
 
@@ -843,24 +843,24 @@ describe("Clickhouse Scores Repository Test", () => {
         source: "API",
       });
 
-      const freeFormScore = createTraceScore({
+      const TextScore = createTraceScore({
         project_id: isolatedProjectId,
         trace_id: traceId,
         name: "free-form-score",
-        data_type: "FREE_FORM",
+        data_type: "TEXT",
         value: 0,
         string_value: "Some feedback text",
         source: "ANNOTATION",
       });
 
-      await createScoresCh([numericScore, freeFormScore]);
+      await createScoresCh([numericScore, TextScore]);
 
       const result = await getScoresGroupedByNameSourceType({
         projectId: isolatedProjectId,
         filter: [],
       });
 
-      // Only NUMERIC should appear (FREE_FORM excluded by AGGREGATABLE_SCORE_TYPES)
+      // Only NUMERIC should appear (TEXT excluded by AGGREGATABLE_SCORE_TYPES)
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
         name: "numeric-score",
@@ -869,7 +869,7 @@ describe("Clickhouse Scores Repository Test", () => {
       });
     });
 
-    it("should exclude FREE_FORM string values from getScoreStringValues", async () => {
+    it("should exclude TEXT string values from getScoreStringValues", async () => {
       const isolatedProjectId = v4();
       const traceId = v4();
 
@@ -883,17 +883,17 @@ describe("Clickhouse Scores Repository Test", () => {
         source: "API",
       });
 
-      const freeFormScore = createTraceScore({
+      const TextScore = createTraceScore({
         project_id: isolatedProjectId,
         trace_id: traceId,
         name: "free-text-score",
-        data_type: "FREE_FORM",
+        data_type: "TEXT",
         value: 0,
         string_value: "This should not appear in filter options",
         source: "ANNOTATION",
       });
 
-      await createScoresCh([categoricalScore, freeFormScore]);
+      await createScoresCh([categoricalScore, TextScore]);
 
       const result = await getScoreStringValues(isolatedProjectId, []);
 
@@ -965,7 +965,7 @@ describe("Clickhouse Scores Repository Test", () => {
           trace_id: traceId,
           observation_id: observationId,
           name: "free-form",
-          data_type: "FREE_FORM",
+          data_type: "TEXT",
           value: 0,
           string_value: "Some feedback",
           source: "ANNOTATION",
@@ -987,7 +987,7 @@ describe("Clickhouse Scores Repository Test", () => {
           project_id: isolatedProjectId,
           session_id: sessionId,
           name: "session-free-form",
-          data_type: "FREE_FORM",
+          data_type: "TEXT",
           value: 0,
           string_value: "Session feedback",
           source: "ANNOTATION",
@@ -1044,10 +1044,10 @@ describe("Clickhouse Scores Repository Test", () => {
       expect(dataTypes).toContain("NUMERIC");
       expect(dataTypes).toContain("CATEGORICAL");
       expect(dataTypes).toContain("BOOLEAN");
-      expect(dataTypes).not.toContain("FREE_FORM");
+      expect(dataTypes).not.toContain("TEXT");
     });
 
-    it("getScoresForExperiments should exclude FREE_FORM scores", async () => {
+    it("getScoresForExperiments should exclude TEXT scores", async () => {
       const dataset = await prisma.dataset.create({
         data: { projectId: isolatedProjectId, name: v4() },
       });
@@ -1071,7 +1071,7 @@ describe("Clickhouse Scores Repository Test", () => {
           project_id: isolatedProjectId,
           dataset_run_id: datasetRun.id,
           name: "run-free-form",
-          data_type: "FREE_FORM",
+          data_type: "TEXT",
           value: 0,
           string_value: "Should be excluded",
         }),
@@ -1087,7 +1087,7 @@ describe("Clickhouse Scores Repository Test", () => {
       expect(result[0].dataType).toBe("NUMERIC");
     });
 
-    it("getTraceScoresForDatasetRuns should exclude FREE_FORM scores", async () => {
+    it("getTraceScoresForDatasetRuns should exclude TEXT scores", async () => {
       const dataset = await prisma.dataset.create({
         data: { projectId: isolatedProjectId, name: v4() },
       });
@@ -1128,7 +1128,7 @@ describe("Clickhouse Scores Repository Test", () => {
           project_id: isolatedProjectId,
           trace_id: runTraceId,
           name: "trace-free-form",
-          data_type: "FREE_FORM",
+          data_type: "TEXT",
           value: 0,
           string_value: "Should be excluded",
         }),

--- a/web/src/__tests__/server/repositories/score-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/score-repository.servertest.ts
@@ -2,11 +2,15 @@ import { prisma } from "@langfuse/shared/src/db";
 import {
   createScoresCh,
   getScoreById,
+  getScoresByIds,
   getScoresGroupedByNameSourceType,
   getScoresUiTable,
   getScoresForTraces,
   getScoresForObservations,
   getScoresForSessions,
+  getScoresForExperiments,
+  getTraceScoresForDatasetRuns,
+  getScoreNames,
   createTracesCh,
   createObservationsCh,
   createTrace,
@@ -17,6 +21,7 @@ import {
   createDatasetRunScore,
   createSessionScore,
   createOrgProjectAndApiKey,
+  getScoreStringValues,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
 
@@ -796,6 +801,346 @@ describe("Clickhouse Scores Repository Test", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].metadata).toEqual({});
+    });
+  });
+
+  describe("FREE_FORM scores", () => {
+    it("should round-trip a FREE_FORM score through ClickHouse", async () => {
+      const scoreId = v4();
+      const traceId = v4();
+
+      const score = createTraceScore({
+        id: scoreId,
+        project_id: projectId,
+        trace_id: traceId,
+        name: "free-form-score",
+        value: 0,
+        string_value: "This is free text feedback",
+        data_type: "FREE_FORM",
+        source: "ANNOTATION",
+      });
+
+      await createScoresCh([score]);
+
+      const result = await getScoreById({ projectId, scoreId });
+      expect(result).toBeDefined();
+      expect(result!.dataType).toBe("FREE_FORM");
+      expect(result!.stringValue).toBe("This is free text feedback");
+      expect(result!.value).toBe(0);
+      expect(result!.source).toBe("ANNOTATION");
+    });
+
+    it("should exclude FREE_FORM scores from getScoresGroupedByNameSourceType", async () => {
+      const isolatedProjectId = v4();
+      const traceId = v4();
+
+      const numericScore = createTraceScore({
+        project_id: isolatedProjectId,
+        trace_id: traceId,
+        name: "numeric-score",
+        data_type: "NUMERIC",
+        value: 42,
+        source: "API",
+      });
+
+      const freeFormScore = createTraceScore({
+        project_id: isolatedProjectId,
+        trace_id: traceId,
+        name: "free-form-score",
+        data_type: "FREE_FORM",
+        value: 0,
+        string_value: "Some feedback text",
+        source: "ANNOTATION",
+      });
+
+      await createScoresCh([numericScore, freeFormScore]);
+
+      const result = await getScoresGroupedByNameSourceType({
+        projectId: isolatedProjectId,
+        filter: [],
+      });
+
+      // Only NUMERIC should appear (FREE_FORM excluded by AGGREGATABLE_SCORE_TYPES)
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        name: "numeric-score",
+        source: "API",
+        dataType: "NUMERIC",
+      });
+    });
+
+    it("should exclude FREE_FORM string values from getScoreStringValues", async () => {
+      const isolatedProjectId = v4();
+      const traceId = v4();
+
+      const categoricalScore = createTraceScore({
+        project_id: isolatedProjectId,
+        trace_id: traceId,
+        name: "cat-score",
+        data_type: "CATEGORICAL",
+        value: 1,
+        string_value: "Good",
+        source: "API",
+      });
+
+      const freeFormScore = createTraceScore({
+        project_id: isolatedProjectId,
+        trace_id: traceId,
+        name: "free-text-score",
+        data_type: "FREE_FORM",
+        value: 0,
+        string_value: "This should not appear in filter options",
+        source: "ANNOTATION",
+      });
+
+      await createScoresCh([categoricalScore, freeFormScore]);
+
+      const result = await getScoreStringValues(isolatedProjectId, []);
+
+      const stringValues = result.map((r) => r.value);
+      expect(stringValues).toContain("Good");
+      expect(stringValues).not.toContain(
+        "This should not appear in filter options",
+      );
+    });
+  });
+
+  describe("score data type coverage", () => {
+    let isolatedProjectId: string;
+    const traceId = v4();
+    const observationId = v4();
+    const sessionId = v4();
+    const scoreIds: string[] = [];
+
+    beforeAll(async () => {
+      const { projectId: pid } = await createOrgProjectAndApiKey();
+      isolatedProjectId = pid;
+
+      const trace = createTrace({
+        id: traceId,
+        project_id: isolatedProjectId,
+        session_id: sessionId,
+      });
+      await createTracesCh([trace]);
+
+      const obs = createObservation({
+        id: observationId,
+        trace_id: traceId,
+        project_id: isolatedProjectId,
+      });
+      await createObservationsCh([obs]);
+
+      const scores = [
+        createTraceScore({
+          project_id: isolatedProjectId,
+          trace_id: traceId,
+          observation_id: observationId,
+          name: "numeric",
+          data_type: "NUMERIC",
+          value: 1,
+          source: "API",
+        }),
+        createTraceScore({
+          project_id: isolatedProjectId,
+          trace_id: traceId,
+          observation_id: observationId,
+          name: "categorical",
+          data_type: "CATEGORICAL",
+          value: 0,
+          string_value: "Good",
+          source: "API",
+        }),
+        createTraceScore({
+          project_id: isolatedProjectId,
+          trace_id: traceId,
+          observation_id: observationId,
+          name: "boolean",
+          data_type: "BOOLEAN",
+          value: 1,
+          string_value: "True",
+          source: "API",
+        }),
+        createTraceScore({
+          project_id: isolatedProjectId,
+          trace_id: traceId,
+          observation_id: observationId,
+          name: "free-form",
+          data_type: "FREE_FORM",
+          value: 0,
+          string_value: "Some feedback",
+          source: "ANNOTATION",
+        }),
+      ];
+
+      scoreIds.push(...scores.map((s) => s.id));
+
+      const sessionScores = [
+        createSessionScore({
+          project_id: isolatedProjectId,
+          session_id: sessionId,
+          name: "session-numeric",
+          data_type: "NUMERIC",
+          value: 5,
+          source: "API",
+        }),
+        createSessionScore({
+          project_id: isolatedProjectId,
+          session_id: sessionId,
+          name: "session-free-form",
+          data_type: "FREE_FORM",
+          value: 0,
+          string_value: "Session feedback",
+          source: "ANNOTATION",
+        }),
+      ];
+
+      await createScoresCh([...scores, ...sessionScores]);
+    });
+
+    it("getScoresByIds should return all non-CORRECTION types", async () => {
+      const result = await getScoresByIds(isolatedProjectId, scoreIds);
+      expect(result).toHaveLength(4);
+    });
+
+    it("getScoresForTraces should return all non-CORRECTION types", async () => {
+      const result = await getScoresForTraces({
+        projectId: isolatedProjectId,
+        traceIds: [traceId],
+      });
+      expect(result).toHaveLength(4);
+    });
+
+    it("getScoresForObservations should return all non-CORRECTION types", async () => {
+      const result = await getScoresForObservations({
+        projectId: isolatedProjectId,
+        observationIds: [observationId],
+      });
+      expect(result).toHaveLength(4);
+    });
+
+    it("getScoresForSessions should return all non-CORRECTION types", async () => {
+      const result = await getScoresForSessions({
+        projectId: isolatedProjectId,
+        sessionIds: [sessionId],
+      });
+      expect(result).toHaveLength(2);
+    });
+
+    it("getScoreNames should return names of all non-CORRECTION types", async () => {
+      const result = await getScoreNames(isolatedProjectId, []);
+      const names = result.map((r) => r.name);
+      expect(names).toContain("numeric");
+      expect(names).toContain("categorical");
+      expect(names).toContain("boolean");
+      expect(names).toContain("free-form");
+    });
+
+    it("getScoresGroupedByNameSourceType should only return aggregatable types", async () => {
+      const result = await getScoresGroupedByNameSourceType({
+        projectId: isolatedProjectId,
+        filter: [],
+      });
+      const dataTypes = result.map((r) => r.dataType);
+      expect(dataTypes).toContain("NUMERIC");
+      expect(dataTypes).toContain("CATEGORICAL");
+      expect(dataTypes).toContain("BOOLEAN");
+      expect(dataTypes).not.toContain("FREE_FORM");
+    });
+
+    it("getScoresForExperiments should exclude FREE_FORM scores", async () => {
+      const dataset = await prisma.dataset.create({
+        data: { projectId: isolatedProjectId, name: v4() },
+      });
+      const datasetRun = await prisma.datasetRuns.create({
+        data: {
+          projectId: isolatedProjectId,
+          name: v4(),
+          datasetId: dataset.id,
+        },
+      });
+
+      const scores = [
+        createDatasetRunScore({
+          project_id: isolatedProjectId,
+          dataset_run_id: datasetRun.id,
+          name: "run-numeric",
+          data_type: "NUMERIC",
+          value: 1,
+        }),
+        createDatasetRunScore({
+          project_id: isolatedProjectId,
+          dataset_run_id: datasetRun.id,
+          name: "run-free-form",
+          data_type: "FREE_FORM",
+          value: 0,
+          string_value: "Should be excluded",
+        }),
+      ];
+      await createScoresCh(scores);
+
+      const result = await getScoresForExperiments({
+        projectId: isolatedProjectId,
+        runIds: [datasetRun.id],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].dataType).toBe("NUMERIC");
+    });
+
+    it("getTraceScoresForDatasetRuns should exclude FREE_FORM scores", async () => {
+      const dataset = await prisma.dataset.create({
+        data: { projectId: isolatedProjectId, name: v4() },
+      });
+      const datasetRun = await prisma.datasetRuns.create({
+        data: {
+          projectId: isolatedProjectId,
+          name: v4(),
+          datasetId: dataset.id,
+        },
+      });
+      const runTraceId = v4();
+      const runTrace = createTrace({
+        id: runTraceId,
+        project_id: isolatedProjectId,
+      });
+      await createTracesCh([runTrace]);
+
+      const datasetRunItem = createDatasetRunItem({
+        project_id: isolatedProjectId,
+        dataset_run_id: datasetRun.id,
+        dataset_id: dataset.id,
+        dataset_run_name: datasetRun.name,
+        dataset_item_id: v4(),
+        trace_id: runTraceId,
+      });
+      await createDatasetRunItemsCh([datasetRunItem]);
+
+      const scores = [
+        createTraceScore({
+          project_id: isolatedProjectId,
+          trace_id: runTraceId,
+          name: "trace-boolean",
+          data_type: "BOOLEAN",
+          value: 1,
+          string_value: "True",
+        }),
+        createTraceScore({
+          project_id: isolatedProjectId,
+          trace_id: runTraceId,
+          name: "trace-free-form",
+          data_type: "FREE_FORM",
+          value: 0,
+          string_value: "Should be excluded",
+        }),
+      ];
+      await createScoresCh(scores);
+
+      const result = await getTraceScoresForDatasetRuns(isolatedProjectId, [
+        datasetRun.id,
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].dataType).toBe("BOOLEAN");
     });
   });
 });

--- a/web/src/__tests__/server/validate-config-against-body.servertest.ts
+++ b/web/src/__tests__/server/validate-config-against-body.servertest.ts
@@ -6,10 +6,10 @@ import {
   type ScoreDomain,
 } from "@langfuse/shared/src/server";
 
-const baseFreeFormConfig: ScoreConfigDomain = {
+const baseTextConfig: ScoreConfigDomain = {
   id: "config-1",
   name: "free-text-config",
-  dataType: "FREE_FORM",
+  dataType: "TEXT",
   isArchived: false,
   description: null,
   createdAt: new Date(),
@@ -20,13 +20,13 @@ const baseFreeFormConfig: ScoreConfigDomain = {
   categories: undefined,
 };
 
-const baseFreeFormScore: ScoreDomain = {
+const baseTextScore: ScoreDomain = {
   id: "score-1",
   projectId: "project-1",
   name: "free-text-config",
   value: 0,
   stringValue: "Some valid free text",
-  dataType: "FREE_FORM",
+  dataType: "TEXT",
   source: "ANNOTATION",
   comment: null,
   metadata: {},
@@ -45,57 +45,57 @@ const baseFreeFormScore: ScoreDomain = {
   longStringValue: "",
 };
 
-describe("validateConfigAgainstBody for FREE_FORM scores", () => {
-  it("should succeed with valid FREE_FORM annotation score", () => {
+describe("validateConfigAgainstBody for TEXT scores", () => {
+  it("should succeed with valid TEXT annotation score", () => {
     expect(() =>
       validateConfigAgainstBody({
-        body: baseFreeFormScore,
-        config: baseFreeFormConfig,
+        body: baseTextScore,
+        config: baseTextConfig,
         context: "ANNOTATION",
       }),
     ).not.toThrow();
   });
 
-  it("should reject empty FREE_FORM text", () => {
+  it("should reject empty TEXT text", () => {
     const emptyScore: ScoreDomain = {
-      ...baseFreeFormScore,
+      ...baseTextScore,
       stringValue: "",
     };
 
     expect(() =>
       validateConfigAgainstBody({
         body: emptyScore,
-        config: baseFreeFormConfig,
+        config: baseTextConfig,
         context: "ANNOTATION",
       }),
     ).toThrow();
   });
 
-  it("should reject FREE_FORM text exceeding 500 characters", () => {
+  it("should reject TEXT text exceeding 500 characters", () => {
     const longScore: ScoreDomain = {
-      ...baseFreeFormScore,
+      ...baseTextScore,
       stringValue: "a".repeat(501),
     };
 
     expect(() =>
       validateConfigAgainstBody({
         body: longScore,
-        config: baseFreeFormConfig,
+        config: baseTextConfig,
         context: "ANNOTATION",
       }),
     ).toThrow();
   });
 
-  it("should accept FREE_FORM text at exactly 500 characters", () => {
+  it("should accept TEXT text at exactly 500 characters", () => {
     const maxLengthScore: ScoreDomain = {
-      ...baseFreeFormScore,
+      ...baseTextScore,
       stringValue: "a".repeat(500),
     };
 
     expect(() =>
       validateConfigAgainstBody({
         body: maxLengthScore,
-        config: baseFreeFormConfig,
+        config: baseTextConfig,
         context: "ANNOTATION",
       }),
     ).not.toThrow();
@@ -103,13 +103,13 @@ describe("validateConfigAgainstBody for FREE_FORM scores", () => {
 
   it("should reject archived config", () => {
     const archivedConfig: ScoreConfigDomain = {
-      ...baseFreeFormConfig,
+      ...baseTextConfig,
       isArchived: true,
     };
 
     expect(() =>
       validateConfigAgainstBody({
-        body: baseFreeFormScore,
+        body: baseTextScore,
         config: archivedConfig,
         context: "ANNOTATION",
       }),
@@ -118,14 +118,14 @@ describe("validateConfigAgainstBody for FREE_FORM scores", () => {
 
   it("should reject name mismatch", () => {
     const mismatchedScore: ScoreDomain = {
-      ...baseFreeFormScore,
+      ...baseTextScore,
       name: "different-name",
     };
 
     expect(() =>
       validateConfigAgainstBody({
         body: mismatchedScore,
-        config: baseFreeFormConfig,
+        config: baseTextConfig,
         context: "ANNOTATION",
       }),
     ).toThrow("Name mismatch");

--- a/web/src/__tests__/server/validate-config-against-body.servertest.ts
+++ b/web/src/__tests__/server/validate-config-against-body.servertest.ts
@@ -1,0 +1,133 @@
+/** @jest-environment node */
+
+import {
+  validateConfigAgainstBody,
+  type ScoreConfigDomain,
+  type ScoreDomain,
+} from "@langfuse/shared/src/server";
+
+const baseFreeFormConfig: ScoreConfigDomain = {
+  id: "config-1",
+  name: "free-text-config",
+  dataType: "FREE_FORM",
+  isArchived: false,
+  description: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  projectId: "project-1",
+  maxValue: undefined,
+  minValue: undefined,
+  categories: undefined,
+};
+
+const baseFreeFormScore: ScoreDomain = {
+  id: "score-1",
+  projectId: "project-1",
+  name: "free-text-config",
+  value: 0,
+  stringValue: "Some valid free text",
+  dataType: "FREE_FORM",
+  source: "ANNOTATION",
+  comment: null,
+  metadata: {},
+  configId: "config-1",
+  queueId: null,
+  executionTraceId: null,
+  authorUserId: null,
+  environment: "default",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  timestamp: new Date(),
+  traceId: "trace-1",
+  sessionId: null,
+  observationId: null,
+  datasetRunId: null,
+  longStringValue: "",
+};
+
+describe("validateConfigAgainstBody for FREE_FORM scores", () => {
+  it("should succeed with valid FREE_FORM annotation score", () => {
+    expect(() =>
+      validateConfigAgainstBody({
+        body: baseFreeFormScore,
+        config: baseFreeFormConfig,
+        context: "ANNOTATION",
+      }),
+    ).not.toThrow();
+  });
+
+  it("should reject empty FREE_FORM text", () => {
+    const emptyScore: ScoreDomain = {
+      ...baseFreeFormScore,
+      stringValue: "",
+    };
+
+    expect(() =>
+      validateConfigAgainstBody({
+        body: emptyScore,
+        config: baseFreeFormConfig,
+        context: "ANNOTATION",
+      }),
+    ).toThrow();
+  });
+
+  it("should reject FREE_FORM text exceeding 500 characters", () => {
+    const longScore: ScoreDomain = {
+      ...baseFreeFormScore,
+      stringValue: "a".repeat(501),
+    };
+
+    expect(() =>
+      validateConfigAgainstBody({
+        body: longScore,
+        config: baseFreeFormConfig,
+        context: "ANNOTATION",
+      }),
+    ).toThrow();
+  });
+
+  it("should accept FREE_FORM text at exactly 500 characters", () => {
+    const maxLengthScore: ScoreDomain = {
+      ...baseFreeFormScore,
+      stringValue: "a".repeat(500),
+    };
+
+    expect(() =>
+      validateConfigAgainstBody({
+        body: maxLengthScore,
+        config: baseFreeFormConfig,
+        context: "ANNOTATION",
+      }),
+    ).not.toThrow();
+  });
+
+  it("should reject archived config", () => {
+    const archivedConfig: ScoreConfigDomain = {
+      ...baseFreeFormConfig,
+      isArchived: true,
+    };
+
+    expect(() =>
+      validateConfigAgainstBody({
+        body: baseFreeFormScore,
+        config: archivedConfig,
+        context: "ANNOTATION",
+      }),
+    ).toThrow("Config is archived");
+  });
+
+  it("should reject name mismatch", () => {
+    const mismatchedScore: ScoreDomain = {
+      ...baseFreeFormScore,
+      name: "different-name",
+    };
+
+    expect(() =>
+      validateConfigAgainstBody({
+        body: mismatchedScore,
+        config: baseFreeFormConfig,
+        context: "ANNOTATION",
+      }),
+    ).toThrow("Name mismatch");
+  });
+});

--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -65,24 +65,26 @@ const ScoreGroupBadge = <
     <Badge
       variant="tertiary"
       key={name}
-      className={`flex items-center gap-1 ${compact ? "px-1.5 leading-tight" : "px-2.5"} text-xs font-normal${badgeClassName ? " " + badgeClassName : ""}`}
+      className={`flex max-w-full min-w-0 items-center gap-1 ${compact ? "px-1.5 leading-tight" : "px-2.5"} text-xs font-normal${badgeClassName ? " " + badgeClassName : ""}`}
     >
       <div
-        className={`w-fit max-w-20 truncate ${compact ? "leading-tight" : ""}`}
+        className={`w-fit max-w-20 shrink-0 truncate ${compact ? "leading-tight" : ""}`}
         title={name}
       >
         {name}:
       </div>
-      <div className="flex items-center gap-1 text-nowrap">
+      <div className="flex min-w-0 items-center gap-1 text-nowrap">
         {scores.map((s, i) => (
           <span
             key={i}
-            className="group/score ml-1 flex items-center gap-1 rounded-sm first:ml-0"
+            className="group/score ml-1 flex min-w-0 items-center gap-1 rounded-sm first:ml-0"
           >
-            {s.stringValue ?? s.value?.toFixed(2) ?? ""}
+            <span className="truncate">
+              {s.stringValue ?? s.value?.toFixed(2) ?? ""}
+            </span>
             {s.comment && (
               <HoverCard>
-                <HoverCardTrigger className="inline-block">
+                <HoverCardTrigger className="inline-block shrink-0">
                   <MessageCircleMoreIcon className="mb-0.25 size-3!" />
                 </HoverCardTrigger>
                 <HoverCardContent className="max-h-[50dvh] overflow-y-auto text-xs break-normal whitespace-normal">
@@ -104,7 +106,7 @@ const ScoreGroupBadge = <
             )}
             {hasMetadata(s) && (
               <HoverCard>
-                <HoverCardTrigger className="inline-block">
+                <HoverCardTrigger className="inline-block shrink-0">
                   <BracesIcon className="mb-0.25 size-3!" />
                 </HoverCardTrigger>
                 <HoverCardContent className="max-h-[50dvh] overflow-y-auto rounded-md border-none p-0 text-xs break-normal whitespace-normal">

--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -74,12 +74,15 @@ export const ScoresTableCell = ({
 
     return (
       <span
-        className={cn("flex flex-row gap-0.5 rounded-sm", COLOR_MAP.get(value))}
+        className={cn(
+          "flex min-w-0 flex-row gap-0.5 rounded-sm",
+          COLOR_MAP.get(value),
+        )}
       >
-        {value}
+        <span className="truncate">{value}</span>
         {aggregate.comment && (
           <HoverCard>
-            <HoverCardTrigger className="inline-block cursor-pointer">
+            <HoverCardTrigger className="inline-block shrink-0 cursor-pointer">
               <MessageCircleMore size={12} />
             </HoverCardTrigger>
             <HoverCardContent className="flex flex-col p-0 text-xs break-normal whitespace-normal">

--- a/web/src/components/scores-table-cell.tsx
+++ b/web/src/components/scores-table-cell.tsx
@@ -123,6 +123,10 @@ export const ScoresTableCell = ({
     );
   }
 
+  if (aggregate.type === "TEXT") {
+    return <span className="truncate">{aggregate.values.join("; ")}</span>;
+  }
+
   return (
     <div className="group">
       {aggregate.valueCounts.length > COLLAPSE_CATEGORICAL_SCORES_AFTER ? (

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -29,6 +29,7 @@ import {
   isPresent,
   type FilterState,
   type ScoreDataTypeType,
+  LISTABLE_SCORE_TYPES,
   BatchExportTableName,
   BatchActionType,
   TableViewPresetTableName,
@@ -263,7 +264,7 @@ export default function ScoresTable({
           count: n.count !== undefined ? Number(n.count) : undefined,
         })) ?? undefined,
       source: ["ANNOTATION", "API", "EVAL"],
-      dataType: ["NUMERIC", "CATEGORICAL", "BOOLEAN"],
+      dataType: [...LISTABLE_SCORE_TYPES],
       value: [],
       stringValue:
         filterOptions.data?.stringValue?.map((sv) => ({

--- a/web/src/features/events/hooks/useEventsTraceData.ts
+++ b/web/src/features/events/hooks/useEventsTraceData.ts
@@ -6,7 +6,7 @@ import {
 } from "@/src/features/events/lib/eventsToTraceAdapter";
 import {
   filterAndValidateDbScoreList,
-  AGGREGATABLE_SCORE_TYPES,
+  ScoreDataTypeArray,
   ScoreDataTypeEnum,
   type ScoreDomain,
 } from "@langfuse/shared";
@@ -123,7 +123,7 @@ export function useEventsTraceData(
     // Validate and partition scores
     const validatedScores = filterAndValidateDbScoreList({
       scores: scoresQuery.data ?? [],
-      dataTypes: [...AGGREGATABLE_SCORE_TYPES, ScoreDataTypeEnum.CORRECTION],
+      dataTypes: [...ScoreDataTypeArray],
       onParseError: (e) => {
         console.error("[useEventsTraceData] Score validation error:", e);
       },

--- a/web/src/features/events/hooks/useEventsTraceData.ts
+++ b/web/src/features/events/hooks/useEventsTraceData.ts
@@ -5,8 +5,8 @@ import {
   type AdaptedTraceData,
 } from "@/src/features/events/lib/eventsToTraceAdapter";
 import {
+  AGGREGATABLE_SCORE_TYPES,
   filterAndValidateDbScoreList,
-  ScoreDataTypeArray,
   ScoreDataTypeEnum,
   type ScoreDomain,
 } from "@langfuse/shared";
@@ -123,7 +123,7 @@ export function useEventsTraceData(
     // Validate and partition scores
     const validatedScores = filterAndValidateDbScoreList({
       scores: scoresQuery.data ?? [],
-      dataTypes: [...ScoreDataTypeArray],
+      dataTypes: [...AGGREGATABLE_SCORE_TYPES, ScoreDataTypeEnum.CORRECTION],
       onParseError: (e) => {
         console.error("[useEventsTraceData] Score validation error:", e);
       },

--- a/web/src/features/events/hooks/useEventsTraceData.ts
+++ b/web/src/features/events/hooks/useEventsTraceData.ts
@@ -5,8 +5,8 @@ import {
   type AdaptedTraceData,
 } from "@/src/features/events/lib/eventsToTraceAdapter";
 import {
-  AGGREGATABLE_SCORE_TYPES,
   filterAndValidateDbScoreList,
+  ScoreDataTypeArray,
   ScoreDataTypeEnum,
   type ScoreDomain,
 } from "@langfuse/shared";
@@ -123,7 +123,7 @@ export function useEventsTraceData(
     // Validate and partition scores
     const validatedScores = filterAndValidateDbScoreList({
       scores: scoresQuery.data ?? [],
-      dataTypes: [...AGGREGATABLE_SCORE_TYPES, ScoreDataTypeEnum.CORRECTION],
+      dataTypes: [...ScoreDataTypeArray],
       onParseError: (e) => {
         console.error("[useEventsTraceData] Score validation error:", e);
       },

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -1,7 +1,7 @@
 import { type z } from "zod";
 import {
-  AGGREGATABLE_SCORE_TYPES,
   type FilterCondition,
+  LISTABLE_SCORE_TYPES,
   filterAndValidateDbScoreList,
 } from "@langfuse/shared";
 import {
@@ -128,13 +128,13 @@ export async function getEventList(params: GetObservationsListParams) {
 
   const validatedScores = filterAndValidateDbScoreList({
     scores,
-    dataTypes: AGGREGATABLE_SCORE_TYPES,
+    dataTypes: LISTABLE_SCORE_TYPES,
     includeHasMetadata: true,
     onParseError: traceException,
   });
   const validatedTraceScores = filterAndValidateDbScoreList({
     scores: traceScores,
-    dataTypes: AGGREGATABLE_SCORE_TYPES,
+    dataTypes: LISTABLE_SCORE_TYPES,
     includeHasMetadata: true,
     onParseError: traceException,
   });

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -13,7 +13,7 @@ import {
   shouldSkipObservationsFinal,
 } from "@langfuse/shared/src/server";
 import {
-  AGGREGATABLE_SCORE_TYPES,
+  LISTABLE_SCORE_TYPES,
   type OrderByState,
   tracesTableCols,
 } from "@langfuse/shared";
@@ -376,7 +376,7 @@ async function buildTracesBaseQuery(
     ...appliedEnvironmentFilter.params,
     ...appliedFilter.params,
     projectId: props.projectId,
-    dataTypes: AGGREGATABLE_SCORE_TYPES,
+    dataTypes: LISTABLE_SCORE_TYPES,
     ...(props.limit !== undefined ? { limit: props.limit } : {}),
     ...(props.page !== undefined
       ? { offset: (props.page - 1) * props.limit }

--- a/web/src/features/public-api/types/score-configs.ts
+++ b/web/src/features/public-api/types/score-configs.ts
@@ -1,7 +1,7 @@
 import {
   BooleanConfigFields,
   CategoricalConfigFields,
-  FreeFormConfigFields,
+  TextConfigFields,
   jsonSchema,
   NumericConfigFields,
   paginationMetaResponseZod,
@@ -56,7 +56,7 @@ const APIScoreConfig = z
     }),
     z.object({
       ...ScoreConfigBase.shape,
-      ...FreeFormConfigFields.shape,
+      ...TextConfigFields.shape,
     }),
   ])
   .superRefine(validateNumericRangeFields);

--- a/web/src/features/public-api/types/score-configs.ts
+++ b/web/src/features/public-api/types/score-configs.ts
@@ -1,6 +1,7 @@
 import {
   BooleanConfigFields,
   CategoricalConfigFields,
+  FreeFormConfigFields,
   jsonSchema,
   NumericConfigFields,
   paginationMetaResponseZod,
@@ -52,6 +53,10 @@ const APIScoreConfig = z
     z.object({
       ...ScoreConfigBase.shape,
       ...BooleanConfigFields.shape,
+    }),
+    z.object({
+      ...ScoreConfigBase.shape,
+      ...FreeFormConfigFields.shape,
     }),
   ])
   .superRefine(validateNumericRangeFields);

--- a/web/src/features/score-configs/components/UpsertScoreConfigDialog.tsx
+++ b/web/src/features/score-configs/components/UpsertScoreConfigDialog.tsx
@@ -34,7 +34,7 @@ import { Textarea } from "@/src/components/ui/textarea";
 import {
   isBooleanDataType,
   isCategoricalDataType,
-  isFreeFormDataType,
+  isTextDataType,
   isNumericDataType,
 } from "@/src/features/scores/lib/helpers";
 import DocPopup from "@/src/components/layouts/doc-popup";
@@ -198,7 +198,7 @@ export function UpsertScoreConfigDialog({
                           form.clearErrors();
                           if (isNumericDataType(dt)) {
                             form.setValue("categories", undefined);
-                          } else if (isFreeFormDataType(dt)) {
+                          } else if (isTextDataType(dt)) {
                             form.setValue("categories", undefined);
                             form.setValue("minValue", undefined);
                             form.setValue("maxValue", undefined);
@@ -286,7 +286,7 @@ export function UpsertScoreConfigDialog({
                       )}
                     />
                   </>
-                ) : isFreeFormDataType(form.getValues("dataType")) ? null : (
+                ) : isTextDataType(form.getValues("dataType")) ? null : (
                   <div className="grid grid-flow-row gap-2">
                     <FormField
                       control={form.control}

--- a/web/src/features/score-configs/components/UpsertScoreConfigDialog.tsx
+++ b/web/src/features/score-configs/components/UpsertScoreConfigDialog.tsx
@@ -34,6 +34,7 @@ import { Textarea } from "@/src/components/ui/textarea";
 import {
   isBooleanDataType,
   isCategoricalDataType,
+  isFreeFormDataType,
   isNumericDataType,
 } from "@/src/features/scores/lib/helpers";
 import DocPopup from "@/src/components/layouts/doc-popup";
@@ -192,16 +193,19 @@ export function UpsertScoreConfigDialog({
                         disabled={!!id}
                         defaultValue={field.value}
                         onValueChange={(value) => {
-                          field.onChange(value as ScoreConfigDataType);
+                          const dt = value as ScoreConfigDataType;
+                          field.onChange(dt);
                           form.clearErrors();
-                          if (isNumericDataType(value as ScoreConfigDataType)) {
+                          if (isNumericDataType(dt)) {
                             form.setValue("categories", undefined);
+                          } else if (isFreeFormDataType(dt)) {
+                            form.setValue("categories", undefined);
+                            form.setValue("minValue", undefined);
+                            form.setValue("maxValue", undefined);
                           } else {
                             form.setValue("minValue", undefined);
                             form.setValue("maxValue", undefined);
-                            if (
-                              isBooleanDataType(value as ScoreConfigDataType)
-                            ) {
+                            if (isBooleanDataType(dt)) {
                               replace([
                                 { label: "True", value: 1 },
                                 { label: "False", value: 0 },
@@ -282,7 +286,7 @@ export function UpsertScoreConfigDialog({
                       )}
                     />
                   </>
-                ) : (
+                ) : isFreeFormDataType(form.getValues("dataType")) ? null : (
                   <div className="grid grid-flow-row gap-2">
                     <FormField
                       control={form.control}

--- a/web/src/features/score-configs/lib/upsertFormTypes.ts
+++ b/web/src/features/score-configs/lib/upsertFormTypes.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 export const createConfigSchema = z.object({
   name: z.string().min(1).max(35),
   description: z.string().optional(),
-  dataType: z.enum(["CATEGORICAL", "NUMERIC", "BOOLEAN", "FREE_FORM"]),
+  dataType: z.enum(["CATEGORICAL", "NUMERIC", "BOOLEAN", "TEXT"]),
   minValue: z.coerce.number().optional(),
   maxValue: z.coerce.number().optional(),
   categories: z.array(ScoreConfigCategory).optional(),

--- a/web/src/features/score-configs/lib/upsertFormTypes.ts
+++ b/web/src/features/score-configs/lib/upsertFormTypes.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 export const createConfigSchema = z.object({
   name: z.string().min(1).max(35),
   description: z.string().optional(),
-  dataType: z.enum(["CATEGORICAL", "NUMERIC", "BOOLEAN"]),
+  dataType: z.enum(["CATEGORICAL", "NUMERIC", "BOOLEAN", "FREE_FORM"]),
   minValue: z.coerce.number().optional(),
   maxValue: z.coerce.number().optional(),
   categories: z.array(ScoreConfigCategory).optional(),

--- a/web/src/features/score-configs/lib/validateScoreConfigUpsertFormInput.ts
+++ b/web/src/features/score-configs/lib/validateScoreConfigUpsertFormInput.ts
@@ -2,7 +2,7 @@ import {
   NumericConfigFields,
   CategoricalConfigFields,
   BooleanConfigFields,
-  FreeFormConfigFields,
+  TextConfigFields,
   validateNumericRangeFields,
 } from "@langfuse/shared";
 import { z } from "zod";
@@ -20,7 +20,7 @@ const ScoreConfigValidationSchema = ScoreConfigBaseSchema.and(
       NumericConfigFields,
       CategoricalConfigFields,
       BooleanConfigFields,
-      FreeFormConfigFields,
+      TextConfigFields,
     ])
     .superRefine(validateNumericRangeFields),
 );

--- a/web/src/features/score-configs/lib/validateScoreConfigUpsertFormInput.ts
+++ b/web/src/features/score-configs/lib/validateScoreConfigUpsertFormInput.ts
@@ -2,6 +2,7 @@ import {
   NumericConfigFields,
   CategoricalConfigFields,
   BooleanConfigFields,
+  FreeFormConfigFields,
   validateNumericRangeFields,
 } from "@langfuse/shared";
 import { z } from "zod";
@@ -19,6 +20,7 @@ const ScoreConfigValidationSchema = ScoreConfigBaseSchema.and(
       NumericConfigFields,
       CategoricalConfigFields,
       BooleanConfigFields,
+      FreeFormConfigFields,
     ])
     .superRefine(validateNumericRangeFields),
 );

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -39,7 +39,7 @@ import { HoverCardContent } from "@radix-ui/react-hover-card";
 import { HoverCard, HoverCardTrigger } from "@/src/components/ui/hover-card";
 import {
   formatAnnotateDescription,
-  isFreeFormDataType,
+  isTextDataType,
   isNumericDataType,
   isScoreUnsaved,
 } from "@/src/features/scores/lib/helpers";
@@ -488,7 +488,7 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     handleUpsert(index, numericCategoryValue, stringValue);
   };
 
-  const handleFreeFormUpsert = (index: number) => {
+  const handleTextUpsert = (index: number) => {
     const field = controlledFields[index];
     const config = configs.find((c) => c.id === field.configId);
 
@@ -692,7 +692,7 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
                           </Popover>
                         </div>
                         <div className="grid grid-cols-[11fr_1fr] items-center py-1">
-                          {isFreeFormDataType(score.dataType) ? (
+                          {isTextDataType(score.dataType) ? (
                             <FormField
                               control={form.control}
                               name={`scoreData.${index}.stringValue`}
@@ -706,7 +706,7 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
                                       className="text-xs"
                                       disabled={isInputDisabled(config)}
                                       placeholder="Enter free form text..."
-                                      onBlur={() => handleFreeFormUpsert(index)}
+                                      onBlur={() => handleTextUpsert(index)}
                                     />
                                   </FormControl>
                                   <FormMessage className="text-xs" />

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -39,6 +39,7 @@ import { HoverCardContent } from "@radix-ui/react-hover-card";
 import { HoverCard, HoverCardTrigger } from "@/src/components/ui/hover-card";
 import {
   formatAnnotateDescription,
+  isFreeFormDataType,
   isNumericDataType,
   isScoreUnsaved,
 } from "@/src/features/scores/lib/helpers";
@@ -487,6 +488,16 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     handleUpsert(index, numericCategoryValue, stringValue);
   };
 
+  const handleFreeFormUpsert = (index: number) => {
+    const field = controlledFields[index];
+    const config = configs.find((c) => c.id === field.configId);
+
+    if (!config || !field) return;
+    if (!field.stringValue) return;
+
+    handleUpsert(index, 0, field.stringValue);
+  };
+
   const rollbackCommentError = (
     index: number,
     field: (typeof controlledFields)[number],
@@ -676,7 +687,28 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
                           </Popover>
                         </div>
                         <div className="grid grid-cols-[11fr_1fr] items-center py-1">
-                          {isNumericDataType(score.dataType) ? (
+                          {isFreeFormDataType(score.dataType) ? (
+                            <FormField
+                              control={form.control}
+                              name={`scoreData.${index}.stringValue`}
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormControl>
+                                    <Textarea
+                                      {...field}
+                                      value={field.value ?? ""}
+                                      maxLength={500}
+                                      className="text-xs"
+                                      disabled={isInputDisabled(config)}
+                                      placeholder="Enter free form text..."
+                                      onBlur={() => handleFreeFormUpsert(index)}
+                                    />
+                                  </FormControl>
+                                  <FormMessage className="text-xs" />
+                                </FormItem>
+                              )}
+                            />
+                          ) : isNumericDataType(score.dataType) ? (
                             <FormField
                               control={form.control}
                               name={`scoreData.${index}.value`}

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -493,7 +493,12 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     const config = configs.find((c) => c.id === field.configId);
 
     if (!config || !field) return;
-    if (!field.stringValue) return;
+    if (!field.stringValue) {
+      if (field.id) {
+        handleDeleteScore(index);
+      }
+      return;
+    }
 
     handleUpsert(index, 0, field.stringValue);
   };

--- a/web/src/features/scores/lib/aggregateScores.ts
+++ b/web/src/features/scores/lib/aggregateScores.ts
@@ -5,6 +5,7 @@ import {
   type ScoreSourceType,
   type ScoreDomain,
   type AggregatableScoreDataType,
+  type ScoreDataTypeType,
 } from "@langfuse/shared";
 
 /**
@@ -22,7 +23,7 @@ export const composeAggregateScoreKey = ({
 }: {
   name: string;
   source: ScoreSourceType;
-  dataType: AggregatableScoreDataType;
+  dataType: ScoreDataTypeType;
   keyPrefix?: string;
 }): string => {
   const formattedName = normalizeScoreName(name);
@@ -34,13 +35,13 @@ export const decomposeAggregateScoreKey = (
 ): {
   name: string;
   source: ScoreSourceType;
-  dataType: AggregatableScoreDataType;
+  dataType: ScoreDataTypeType;
 } => {
   const [name, source, dataType] = key.split("-");
   return {
     name,
     source: source as ScoreSourceType,
-    dataType: dataType as AggregatableScoreDataType,
+    dataType: dataType as ScoreDataTypeType,
   };
 };
 

--- a/web/src/features/scores/lib/aggregateScores.ts
+++ b/web/src/features/scores/lib/aggregateScores.ts
@@ -6,7 +6,10 @@ import {
   type ScoreDomain,
   type AggregatableScoreDataType,
   type ScoreDataTypeType,
+  type ListableScore,
+  type ListableScoreDataType,
 } from "@langfuse/shared";
+import { List } from "lodash";
 
 /**
  * Normalizes score names for comparison by converting - and . to _
@@ -52,7 +55,7 @@ export const getScoreLabelFromKey = (key: string): string => {
 
 export type ScoreToAggregate =
   | (Omit<ScoreDomain, "dataType"> & {
-      dataType: AggregatableScoreDataType;
+      dataType: ListableScore["dataType"];
       hasMetadata?: boolean;
     })
   | (ScoreSimplified & {
@@ -65,8 +68,8 @@ export type ScoreToAggregate =
  * aggregation logic (value counting vs numeric averaging).
  */
 export const resolveAggregateType = (
-  dataType: AggregatableScoreDataType,
-): "NUMERIC" | "CATEGORICAL" => {
+  dataType: ListableScoreDataType,
+): "NUMERIC" | "CATEGORICAL" | "TEXT" => {
   return dataType === "BOOLEAN" ? "CATEGORICAL" : dataType;
 };
 

--- a/web/src/features/scores/lib/aggregateScores.ts
+++ b/web/src/features/scores/lib/aggregateScores.ts
@@ -4,12 +4,10 @@ import {
   type ScoreSimplified,
   type ScoreSourceType,
   type ScoreDomain,
-  type AggregatableScoreDataType,
   type ScoreDataTypeType,
   type ListableScore,
   type ListableScoreDataType,
 } from "@langfuse/shared";
-import { List } from "lodash";
 
 /**
  * Normalizes score names for comparison by converting - and . to _

--- a/web/src/features/scores/lib/helpers.ts
+++ b/web/src/features/scores/lib/helpers.ts
@@ -16,8 +16,8 @@ export const isCategoricalDataType = (dataType: ScoreDataTypeType) =>
 export const isBooleanDataType = (dataType: ScoreDataTypeType) =>
   dataType === ScoreDataTypeEnum.BOOLEAN;
 
-export const isFreeFormDataType = (dataType: ScoreDataTypeType) =>
-  dataType === ScoreDataTypeEnum.FREE_FORM;
+export const isTextDataType = (dataType: ScoreDataTypeType) =>
+  dataType === ScoreDataTypeEnum.TEXT;
 
 export const isScoreUnsaved = (scoreId?: string | null): boolean => !scoreId;
 

--- a/web/src/features/scores/lib/helpers.ts
+++ b/web/src/features/scores/lib/helpers.ts
@@ -16,6 +16,9 @@ export const isCategoricalDataType = (dataType: ScoreDataTypeType) =>
 export const isBooleanDataType = (dataType: ScoreDataTypeType) =>
   dataType === ScoreDataTypeEnum.BOOLEAN;
 
+export const isFreeFormDataType = (dataType: ScoreDataTypeType) =>
+  dataType === ScoreDataTypeEnum.FREE_FORM;
+
 export const isScoreUnsaved = (scoreId?: string | null): boolean => !scoreId;
 
 export const toOrderedScoresList = (list: ScoreData[]): ScoreData[] =>

--- a/web/src/features/scores/lib/scoreColumns.ts
+++ b/web/src/features/scores/lib/scoreColumns.ts
@@ -143,7 +143,7 @@ export const getScoreDataTypeIcon = (dataType: ScoreDataTypeType): string => {
       return "Ⓑ";
     case "CORRECTION":
       return "";
-    case "FREE_FORM":
+    case "TEXT":
       return "Aa";
   }
 };

--- a/web/src/features/scores/lib/scoreColumns.ts
+++ b/web/src/features/scores/lib/scoreColumns.ts
@@ -143,6 +143,8 @@ export const getScoreDataTypeIcon = (dataType: ScoreDataTypeType): string => {
       return "Ⓑ";
     case "CORRECTION":
       return "";
+    case "FREE_FORM":
+      return "Aa";
   }
 };
 

--- a/web/src/features/scores/lib/transformScores.ts
+++ b/web/src/features/scores/lib/transformScores.ts
@@ -109,11 +109,17 @@ function transformAggregates(
   const scores: AnnotationScore[] = [];
 
   Object.entries(mergedAggregates).forEach(([key, aggregate]) => {
-    const { name, source, dataType } = decomposeAggregateScoreKey(key);
+    const {
+      name,
+      source,
+      dataType: rawDataType,
+    } = decomposeAggregateScoreKey(key);
 
     // Only ANNOTATION source can be edited, and must have single ID
     // Multi-value aggregates (no id) are child observation scores - skip them
     if (source !== "ANNOTATION" || !aggregate.id) return;
+
+    const dataType = rawDataType as AnnotationScoreDataType;
 
     const config = configs.find(
       (c) => normalizeScoreName(c.name) === name && c.dataType === dataType,

--- a/web/src/features/scores/types.ts
+++ b/web/src/features/scores/types.ts
@@ -8,7 +8,6 @@ import {
   type ScoreAggregate,
   type ScoreConfigDomain,
   type ScoreDomain,
-  type AggregatableScoreDataType,
   ScoreConfigDataType,
 } from "@langfuse/shared";
 import { type z } from "zod";
@@ -106,7 +105,7 @@ export type ScoreColumn = {
   key: string;
   name: string;
   source: ScoreSourceType;
-  dataType: AggregatableScoreDataType;
+  dataType: AnnotationScoreDataType;
 };
 
 export type ScoreConfigSelection =

--- a/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
+++ b/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
@@ -1,7 +1,6 @@
 import { env } from "@/src/env.mjs";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 import {
-  AGGREGATABLE_SCORE_TYPES,
   filterAndValidateDbScoreList,
   LISTABLE_SCORE_TYPES,
 } from "@langfuse/shared";

--- a/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
+++ b/web/src/server/api/routers/generations/db/getAllGenerationsSqlQuery.ts
@@ -3,6 +3,7 @@ import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 import {
   AGGREGATABLE_SCORE_TYPES,
   filterAndValidateDbScoreList,
+  LISTABLE_SCORE_TYPES,
 } from "@langfuse/shared";
 import {
   getObservationsTableWithModelData,
@@ -43,7 +44,7 @@ export async function getAllGenerations({
 
   const validatedScores = filterAndValidateDbScoreList({
     scores,
-    dataTypes: AGGREGATABLE_SCORE_TYPES,
+    dataTypes: LISTABLE_SCORE_TYPES,
     includeHasMetadata: true,
     onParseError: traceException,
   });

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -128,7 +128,7 @@ const handleGetSessionById = async (input: {
 
   const validatedScores = filterAndValidateDbScoreList({
     scores,
-    dataTypes: AGGREGATABLE_SCORE_TYPES,
+    dataTypes: [...LISTABLE_SCORE_TYPES],
     onParseError: traceException,
   });
 

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -20,6 +20,7 @@ import {
   type SessionOptions,
   type ScoreDomain,
   AGGREGATABLE_SCORE_TYPES,
+  LISTABLE_SCORE_TYPES,
 } from "@langfuse/shared";
 import { Prisma } from "@langfuse/shared/src/db";
 import { TRPCError } from "@trpc/server";
@@ -657,7 +658,7 @@ export const sessionRouter = createTRPCRouter({
 
       const validatedScores: ScoreDomain[] = filterAndValidateDbScoreList({
         scores,
-        dataTypes: AGGREGATABLE_SCORE_TYPES,
+        dataTypes: [...LISTABLE_SCORE_TYPES],
         onParseError: traceException,
       });
 
@@ -701,7 +702,7 @@ export const sessionRouter = createTRPCRouter({
 
       const validatedScores: ScoreDomain[] = filterAndValidateDbScoreList({
         scores,
-        dataTypes: AGGREGATABLE_SCORE_TYPES,
+        dataTypes: [...LISTABLE_SCORE_TYPES],
         onParseError: traceException,
       });
 

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -19,7 +19,6 @@ import {
   timeFilter,
   type SessionOptions,
   type ScoreDomain,
-  AGGREGATABLE_SCORE_TYPES,
   LISTABLE_SCORE_TYPES,
 } from "@langfuse/shared";
 import { Prisma } from "@langfuse/shared/src/db";
@@ -406,7 +405,7 @@ export const sessionRouter = createTRPCRouter({
 
       const validatedScores = filterAndValidateDbScoreList({
         scores,
-        dataTypes: AGGREGATABLE_SCORE_TYPES,
+        dataTypes: LISTABLE_SCORE_TYPES,
         onParseError: traceException,
       });
 
@@ -475,7 +474,7 @@ export const sessionRouter = createTRPCRouter({
 
       const validatedScores = filterAndValidateDbScoreList({
         scores,
-        dataTypes: AGGREGATABLE_SCORE_TYPES,
+        dataTypes: LISTABLE_SCORE_TYPES,
         onParseError: traceException,
       });
 

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -748,7 +748,7 @@ export const sessionRouter = createTRPCRouter({
 
       const validatedScores = filterAndValidateDbScoreList({
         scores,
-        dataTypes: AGGREGATABLE_SCORE_TYPES,
+        dataTypes: [...LISTABLE_SCORE_TYPES],
         onParseError: traceException,
       });
 

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -23,6 +23,7 @@ import {
   TracingSearchType,
   type ScoreDomain,
   AGGREGATABLE_SCORE_TYPES,
+  ScoreDataTypeArray,
   ScoreDataTypeEnum,
 } from "@langfuse/shared";
 import {
@@ -371,7 +372,7 @@ export const traceRouter = createTRPCRouter({
 
       const validatedScores = filterAndValidateDbScoreList({
         scores: traceScores,
-        dataTypes: [...AGGREGATABLE_SCORE_TYPES, ScoreDataTypeEnum.CORRECTION],
+        dataTypes: [...ScoreDataTypeArray],
         onParseError: traceException,
       });
 

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -22,9 +22,9 @@ import {
   type Observation,
   TracingSearchType,
   type ScoreDomain,
-  AGGREGATABLE_SCORE_TYPES,
   ScoreDataTypeArray,
   ScoreDataTypeEnum,
+  LISTABLE_SCORE_TYPES,
 } from "@langfuse/shared";
 import {
   traceException,
@@ -244,7 +244,7 @@ export const traceRouter = createTRPCRouter({
 
       const validatedScores = filterAndValidateDbScoreList({
         scores: traceScores,
-        dataTypes: AGGREGATABLE_SCORE_TYPES,
+        dataTypes: LISTABLE_SCORE_TYPES,
         includeHasMetadata: true,
         onParseError: traceException,
       });

--- a/worker/src/features/database-read-stream/observation-stream.ts
+++ b/worker/src/features/database-read-stream/observation-stream.ts
@@ -187,12 +187,12 @@ export const getObservationStream = async (props: {
           -- concat encoding for hasAny filter compatibility
           groupArrayIf(
             concat(name, ':', string_value),
-            data_type = 'CATEGORICAL' AND notEmpty(string_value)
+            data_type IN ('CATEGORICAL', 'TEXT') AND notEmpty(string_value)
           ) AS score_categories,
           -- tuple encoding for accurate output parsing (names may contain colons)
           groupArrayIf(
             tuple(name, string_value),
-            data_type = 'CATEGORICAL' AND notEmpty(string_value)
+            data_type IN ('CATEGORICAL', 'TEXT') AND notEmpty(string_value)
           ) AS score_categories_tuples
         FROM (
           SELECT

--- a/worker/src/features/database-read-stream/trace-stream.ts
+++ b/worker/src/features/database-read-stream/trace-stream.ts
@@ -126,12 +126,12 @@ export const getTraceStream = async (props: {
         -- concat encoding for hasAny filter compatibility
         groupArrayIf(
           concat(name, ':', string_value),
-          data_type = 'CATEGORICAL' AND notEmpty(string_value)
+          data_type IN ('CATEGORICAL', 'TEXT') AND notEmpty(string_value)
         ) AS score_categories,
         -- tuple encoding for accurate output parsing (names may contain colons)
         groupArrayIf(
           tuple(name, string_value),
-          data_type = 'CATEGORICAL' AND notEmpty(string_value)
+          data_type IN ('CATEGORICAL', 'TEXT') AND notEmpty(string_value)
         ) AS score_categories_tuples
       FROM (
         SELECT
@@ -238,7 +238,7 @@ export const getTraceStream = async (props: {
       stringValue: score[3],
     }));
 
-    // Process categorical scores (tuples from ClickHouse)
+    // Process categorical / text scores (tuples from ClickHouse)
     const categoricalScores = (bufferedRow.score_categories_tuples ?? []).map(
       (cat: [string, string | null]) => ({
         name: cat[0],


### PR DESCRIPTION
## What does this PR do?

- introduce `TEXT` scores for annotations
- purposefully excluded from
  - analytics
  - dataset / experiment runs
  - evaluations

Note that public API changes / SDK changes / doc changes will be shipped as separate PR

Fixes #[LFE-9037](https://linear.app/langfuse/issue/LFE-9037/implement-internal-changes-for-free-form-scores)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
