### PR TITLE
fix(ui): use friendly file extension labels for media cards

### DIFF
--- a/web/src/components/ui/LangfuseMediaView.tsx
+++ b/web/src/components/ui/LangfuseMediaView.tsx
@@ -14,6 +14,7 @@ import {
   type MediaContentType,
   type MediaReturnType,
 } from "@/src/features/media/validation";
+import { getFileExtensionLabel } from "@/src/features/media/getFileExtensionLabel";
 import {
   ExternalLink,
   File,
@@ -121,7 +122,7 @@ function FileViewer({
 
   const fileName = src.split("/").pop()?.split("?")[0] || "";
   const fileType = mimeType.split("/")[0];
-  const fileExtension = mimeType.split("/")[1]?.toUpperCase() || "FILE";
+  const fileExtension = getFileExtensionLabel(mimeType);
   const isImage = fileType === "image";
   const isAudio = fileType === "audio";
   const isVideo = fileType === "video";

--- a/web/src/features/media/getFileExtensionLabel.clienttest.ts
+++ b/web/src/features/media/getFileExtensionLabel.clienttest.ts
@@ -1,0 +1,138 @@
+import { getFileExtensionLabel } from "./getFileExtensionLabel";
+import { MediaContentType } from "./validation";
+
+describe("getFileExtensionLabel", () => {
+  describe("image content types", () => {
+    it.each([
+      [MediaContentType.PNG, "PNG"],
+      [MediaContentType.JPEG, "JPEG"],
+      [MediaContentType.JPG, "JPG"],
+      [MediaContentType.WEBP, "WEBP"],
+      [MediaContentType.GIF, "GIF"],
+      [MediaContentType.SVG, "SVG"],
+      [MediaContentType.TIFF, "TIFF"],
+      [MediaContentType.BMP, "BMP"],
+      [MediaContentType.AVIF, "AVIF"],
+      [MediaContentType.HEIC, "HEIC"],
+    ])("should return correct label for %s", (contentType, expected) => {
+      expect(getFileExtensionLabel(contentType)).toBe(expected);
+    });
+  });
+
+  describe("audio content types", () => {
+    it.each([
+      [MediaContentType.MP3, "MP3"],
+      [MediaContentType.MP3_LEGACY, "MP3"],
+      [MediaContentType.WAV, "WAV"],
+      [MediaContentType.OGG, "OGG"],
+      [MediaContentType.OGA, "OGA"],
+      [MediaContentType.AAC, "AAC"],
+      [MediaContentType.M4A, "M4A"],
+      [MediaContentType.FLAC, "FLAC"],
+      [MediaContentType.OPUS, "OPUS"],
+      [MediaContentType.WEBA, "WEBA"],
+    ])("should return correct label for %s", (contentType, expected) => {
+      expect(getFileExtensionLabel(contentType)).toBe(expected);
+    });
+  });
+
+  describe("video content types", () => {
+    it.each([
+      [MediaContentType.MP4, "MP4"],
+      [MediaContentType.WEBM, "WEBM"],
+      [MediaContentType.VIDEO_OGG, "OGV"],
+      [MediaContentType.MPEG, "MPEG"],
+      [MediaContentType.MOV, "MOV"],
+      [MediaContentType.AVI, "AVI"],
+      [MediaContentType.MKV, "MKV"],
+    ])("should return correct label for %s", (contentType, expected) => {
+      expect(getFileExtensionLabel(contentType)).toBe(expected);
+    });
+  });
+
+  describe("text content types", () => {
+    it.each([
+      [MediaContentType.TXT, "TXT"],
+      [MediaContentType.HTML, "HTML"],
+      [MediaContentType.CSS, "CSS"],
+      [MediaContentType.CSV, "CSV"],
+      [MediaContentType.MARKDOWN, "MD"],
+      [MediaContentType.PYTHON, "PY"],
+      [MediaContentType.JAVASCRIPT, "JS"],
+      [MediaContentType.TYPESCRIPT, "TS"],
+    ])("should return correct label for %s", (contentType, expected) => {
+      expect(getFileExtensionLabel(contentType)).toBe(expected);
+    });
+  });
+
+  describe("document and application content types", () => {
+    it.each([
+      [MediaContentType.PDF, "PDF"],
+      [MediaContentType.DOC, "DOC"],
+      [MediaContentType.DOCX, "DOCX"],
+      [MediaContentType.XLS, "XLS"],
+      [MediaContentType.XLSX, "XLSX"],
+      [MediaContentType.PPTX, "PPTX"],
+      [MediaContentType.RTF, "RTF"],
+      [MediaContentType.JSON, "JSON"],
+      [MediaContentType.JSONL, "JSONL"],
+      [MediaContentType.XML, "XML"],
+      [MediaContentType.YAML, "YAML"],
+      [MediaContentType.PARQUET, "PARQUET"],
+    ])("should return correct label for %s", (contentType, expected) => {
+      expect(getFileExtensionLabel(contentType)).toBe(expected);
+    });
+  });
+
+  describe("archive and binary content types", () => {
+    it.each([
+      [MediaContentType.ZIP, "ZIP"],
+      [MediaContentType.GZIP, "GZ"],
+      [MediaContentType.TAR, "TAR"],
+      [MediaContentType.SEVEN_Z, "7Z"],
+      [MediaContentType.BIN, "BIN"],
+    ])("should return correct label for %s", (contentType, expected) => {
+      expect(getFileExtensionLabel(contentType)).toBe(expected);
+    });
+  });
+
+  describe("fallback for unknown MIME types", () => {
+    it("should strip vendor prefix and return last segment", () => {
+      expect(
+        getFileExtensionLabel(
+          "application/vnd.custom-vendor.spreadsheet.format",
+        ),
+      ).toBe("FORMAT");
+    });
+
+    it("should strip x- prefix from unknown types", () => {
+      expect(getFileExtensionLabel("application/x-custom")).toBe("CUSTOM");
+    });
+
+    it("should handle simple unknown subtypes", () => {
+      expect(getFileExtensionLabel("application/foobar")).toBe("FOOBAR");
+    });
+
+    it("should handle unknown image subtypes", () => {
+      expect(getFileExtensionLabel("image/x-icon")).toBe("ICON");
+    });
+
+    it("should return FILE when subtype is missing", () => {
+      expect(getFileExtensionLabel("application")).toBe("FILE");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should return FILE for an empty string", () => {
+      expect(getFileExtensionLabel("")).toBe("FILE");
+    });
+
+    it("should handle a slash with no subtype", () => {
+      expect(getFileExtensionLabel("image/")).toBe("");
+    });
+
+    it("should handle content type with extra segments after slash", () => {
+      expect(getFileExtensionLabel("type/sub.part")).toBe("PART");
+    });
+  });
+});

--- a/web/src/features/media/getFileExtensionLabel.ts
+++ b/web/src/features/media/getFileExtensionLabel.ts
@@ -1,0 +1,79 @@
+import { MediaContentType, MediaFileExtension } from "./validation";
+
+const mimeToExtension: Record<string, string> = {
+  [MediaContentType.PNG]: MediaFileExtension.PNG,
+  [MediaContentType.JPEG]: MediaFileExtension.JPEG,
+  [MediaContentType.JPG]: MediaFileExtension.JPG,
+  [MediaContentType.WEBP]: MediaFileExtension.WEBP,
+  [MediaContentType.GIF]: MediaFileExtension.GIF,
+  [MediaContentType.SVG]: MediaFileExtension.SVG,
+  [MediaContentType.TIFF]: MediaFileExtension.TIFF,
+  [MediaContentType.BMP]: MediaFileExtension.BMP,
+  [MediaContentType.AVIF]: MediaFileExtension.AVIF,
+  [MediaContentType.HEIC]: MediaFileExtension.HEIC,
+  [MediaContentType.MP3]: MediaFileExtension.MP3,
+  [MediaContentType.MP3_LEGACY]: MediaFileExtension.MP3,
+  [MediaContentType.WAV]: MediaFileExtension.WAV,
+  [MediaContentType.OGG]: MediaFileExtension.OGG,
+  [MediaContentType.OGA]: MediaFileExtension.OGA,
+  [MediaContentType.AAC]: MediaFileExtension.AAC,
+  [MediaContentType.M4A]: MediaFileExtension.M4A,
+  [MediaContentType.FLAC]: MediaFileExtension.FLAC,
+  [MediaContentType.OPUS]: MediaFileExtension.OPUS,
+  [MediaContentType.WEBA]: MediaFileExtension.WEBA,
+  [MediaContentType.MP4]: MediaFileExtension.MP4,
+  [MediaContentType.WEBM]: MediaFileExtension.WEBM,
+  [MediaContentType.VIDEO_OGG]: MediaFileExtension.OGV,
+  [MediaContentType.MPEG]: MediaFileExtension.MPEG,
+  [MediaContentType.MOV]: MediaFileExtension.MOV,
+  [MediaContentType.AVI]: MediaFileExtension.AVI,
+  [MediaContentType.MKV]: MediaFileExtension.MKV,
+  [MediaContentType.TXT]: MediaFileExtension.TXT,
+  [MediaContentType.HTML]: MediaFileExtension.HTML,
+  [MediaContentType.CSS]: MediaFileExtension.CSS,
+  [MediaContentType.CSV]: MediaFileExtension.CSV,
+  [MediaContentType.MARKDOWN]: MediaFileExtension.MD,
+  [MediaContentType.PYTHON]: MediaFileExtension.PY,
+  [MediaContentType.JAVASCRIPT]: MediaFileExtension.JS,
+  [MediaContentType.TYPESCRIPT]: MediaFileExtension.TS,
+  [MediaContentType.YAML]: MediaFileExtension.YAML,
+  [MediaContentType.PDF]: MediaFileExtension.PDF,
+  [MediaContentType.DOC]: MediaFileExtension.DOC,
+  [MediaContentType.XLS]: MediaFileExtension.XLS,
+  [MediaContentType.XLSX]: MediaFileExtension.XLSX,
+  [MediaContentType.ZIP]: MediaFileExtension.ZIP,
+  [MediaContentType.JSON]: MediaFileExtension.JSON,
+  [MediaContentType.XML]: MediaFileExtension.XML,
+  [MediaContentType.BIN]: MediaFileExtension.BIN,
+  [MediaContentType.DOCX]: MediaFileExtension.DOCX,
+  [MediaContentType.PPTX]: MediaFileExtension.PPTX,
+  [MediaContentType.RTF]: MediaFileExtension.RTF,
+  [MediaContentType.JSONL]: MediaFileExtension.JSONL,
+  [MediaContentType.PARQUET]: MediaFileExtension.PARQUET,
+  [MediaContentType.GZIP]: MediaFileExtension.GZ,
+  [MediaContentType.TAR]: MediaFileExtension.TAR,
+  [MediaContentType.SEVEN_Z]: MediaFileExtension.SEVEN_Z,
+};
+
+/**
+ * Returns a short, human-friendly file extension label for a given MIME content type.
+ * Falls back to the MIME subtype (the part after '/') when the content type is not
+ * in the known mapping, avoiding verbose labels like
+ * "VND.OPENXMLFORMATS-OFFICEDOCUMENT.WORDPROCESSINGML.DOCUMENT".
+ */
+export function getFileExtensionLabel(contentType: string): string {
+  const mapped = mimeToExtension[contentType];
+  if (mapped) {
+    return mapped.toUpperCase();
+  }
+
+  // Fallback: use MIME subtype but strip vendor/x- prefixes for readability
+  const subtype = contentType.split("/")[1] ?? "FILE";
+  return (
+    subtype
+      .replace(/^(vnd\.|x-)/i, "")
+      .split(".")
+      .pop()
+      ?.toUpperCase() ?? "FILE"
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Fixes media card label overflow for verbose MIME types (e.g. Office formats like `.docx`, `.xlsx`, `.pptx`).

Adds a client-safe `getFileExtensionLabel()` utility that maps MIME content types to short, human-friendly extension labels (e.g. `DOCX` instead of `VND.OPENXMLFORMATS-OFFICEDOCUMENT.WORDPROCESSINGML.DOCUMENT`). Reuses existing `MediaContentType` and `MediaFileExtension` enums from `web/src/features/media/validation.ts`. Falls back gracefully for unknown MIME types by stripping vendor/x- prefixes.

Fixes #12855

### Changes

- **`web/src/features/media/getFileExtensionLabel.ts`** (new): Client-safe utility with complete MIME-to-extension mapping and smart fallback
- **`web/src/components/ui/LangfuseMediaView.tsx`**: Replace naive `mimeType.split("/")[1]?.toUpperCase()` with `getFileExtensionLabel(mimeType)`
- **`web/src/features/media/getFileExtensionLabel.clienttest.ts`** (new): 60 unit tests covering all mapped content types, fallback behavior, and edge cases

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] My changes generate no new warnings (`pnpm --filter web run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes