### PR TITLE
fix(web): show trace-level scores in observation detail table

### DIFF
--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -100,6 +100,7 @@ export default function ScoresTable({
   userId,
   traceId,
   observationId,
+  includeTraceLevelScores = false,
   hiddenColumns = [],
   localStorageSuffix = "",
   disableUrlPersistence = false,
@@ -108,6 +109,7 @@ export default function ScoresTable({
   userId?: string;
   traceId?: string;
   observationId?: string;
+  includeTraceLevelScores?: boolean;
   omittedFilter?: string[];
   hiddenColumns?: string[];
   localStorageSuffix?: string;
@@ -312,7 +314,7 @@ export default function ScoresTable({
     [
       ...(userId ? [{ key: "User ID", value: userId }] : []),
       ...(traceId ? [{ key: "Trace ID", value: traceId }] : []),
-      ...(observationId
+      ...(observationId && !includeTraceLevelScores
         ? [{ key: "Observation ID", value: observationId }]
         : []),
     ],

--- a/web/src/components/trace2/ObservationPreview.tsx
+++ b/web/src/components/trace2/ObservationPreview.tsx
@@ -596,6 +596,7 @@ export const ObservationPreview = ({
                   traceId={traceId}
                   omittedFilter={["Observation ID"]}
                   observationId={preloadedObservation.id}
+                  includeTraceLevelScores
                   hiddenColumns={[
                     "traceId",
                     "observationId",

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -472,6 +472,7 @@ export function ObservationDetailView({
               projectId={projectId}
               traceId={traceId}
               observationId={observation.id}
+              includeTraceLevelScores
               hiddenColumns={[
                 "traceId",
                 "observationId",


### PR DESCRIPTION
### Motivation
- Observation Scores tables in observation-detail/preview views were excluding trace-level scores because an `Observation ID` filter was always applied, which hid trace-level rows for dual-written or v4 (events-backed) traces.

### Description
- Add an optional `includeTraceLevelScores?: boolean` prop to `ScoresTable` (default `false`).
- When `includeTraceLevelScores` is true, skip adding the backend `Observation ID` filter so trace-level score rows are included in the query results.
- Enable `includeTraceLevelScores` in `ObservationPreview` and `ObservationDetailView` so the Scores tab shows both observation- and trace-level scores.

### Testing
- Ran `pnpm --filter web run lint` successfully.
- Attempted `pnpm --filter web run test-client --testPathPatterns="mergeScoresWithCache|transformScores"`, but the test run failed in this environment due to missing required environment variables (`DATABASE_URL`, `NEXTAUTH_URL`, `SALT`, `CLICKHOUSE_URL`, `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca40563bbc832e83a2f20a9cabe48e)