### PR TITLE
feat(billing): add universal $4K default spend alert for all cloud plans

### DIFF
--- a/web/src/__tests__/server/createDefaultSpendAlerts.servertest.ts
+++ b/web/src/__tests__/server/createDefaultSpendAlerts.servertest.ts
@@ -18,11 +18,14 @@ describe("createDefaultSpendAlerts", () => {
 
     const alerts = await prisma.cloudSpendAlert.findMany({
       where: { orgId },
+      orderBy: { threshold: "asc" },
     });
 
-    expect(alerts).toHaveLength(1);
+    expect(alerts).toHaveLength(2);
     expect(alerts[0].threshold.toNumber()).toBe(200);
     expect(alerts[0].title).toBe("Default Spend alert ($200)");
+    expect(alerts[1].threshold.toNumber()).toBe(4000);
+    expect(alerts[1].title).toBe("Default Spend alert ($4000)");
   });
 
   it("creates alerts with correct thresholds for pro plan", async () => {
@@ -38,10 +41,12 @@ describe("createDefaultSpendAlerts", () => {
 
     const alerts = await prisma.cloudSpendAlert.findMany({
       where: { orgId },
+      orderBy: { threshold: "asc" },
     });
 
-    expect(alerts).toHaveLength(1);
+    expect(alerts).toHaveLength(2);
     expect(alerts[0].threshold.toNumber()).toBe(1000);
+    expect(alerts[1].threshold.toNumber()).toBe(4000);
   });
 
   it("creates alerts with correct thresholds for enterprise plan", async () => {
@@ -57,10 +62,12 @@ describe("createDefaultSpendAlerts", () => {
 
     const alerts = await prisma.cloudSpendAlert.findMany({
       where: { orgId },
+      orderBy: { threshold: "asc" },
     });
 
-    expect(alerts).toHaveLength(1);
+    expect(alerts).toHaveLength(2);
     expect(alerts[0].threshold.toNumber()).toBe(2000);
+    expect(alerts[1].threshold.toNumber()).toBe(4000);
   });
 
   it("skips creation if org already has alerts", async () => {

--- a/web/src/ee/features/billing/server/stripeWebhookHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookHandler.ts
@@ -391,6 +391,9 @@ const DEFAULT_SPEND_ALERT_THRESHOLDS: Record<
   "cloud:enterprise": 2000,
 };
 
+// Universal threshold applied to all plans in addition to the plan-specific threshold
+const UNIVERSAL_SPEND_ALERT_THRESHOLD = 4000;
+
 export async function createDefaultSpendAlerts({
   orgId,
   productId,
@@ -409,8 +412,8 @@ export async function createDefaultSpendAlerts({
     return;
   }
 
-  const threshold = DEFAULT_SPEND_ALERT_THRESHOLDS[plan];
-  if (!threshold) {
+  const planThreshold = DEFAULT_SPEND_ALERT_THRESHOLDS[plan];
+  if (!planThreshold) {
     logger.error(
       `[Stripe Webhook] createDefaultSpendAlerts: No spend alerts configured for plan ${plan}, skipping`,
     );
@@ -429,29 +432,36 @@ export async function createDefaultSpendAlerts({
     return;
   }
 
-  const alert = await prisma.cloudSpendAlert.create({
-    data: {
-      orgId,
-      title: `Default Spend alert ($${threshold})`,
-      threshold,
-    },
-  });
+  // Create plan-specific alert plus the universal $4K alert (deduplicated)
+  const thresholds = [
+    ...new Set([planThreshold, UNIVERSAL_SPEND_ALERT_THRESHOLD]),
+  ];
 
-  await auditLog({
-    session: {
-      user: { id: "stripe-webhook" },
-      orgId,
-    },
-    orgId,
-    resourceType: "cloudSpendAlert",
-    resourceId: alert.id,
-    action: "create",
-    after: alert,
-  });
+  for (const threshold of thresholds) {
+    const alert = await prisma.cloudSpendAlert.create({
+      data: {
+        orgId,
+        title: `Default Spend alert ($${threshold})`,
+        threshold,
+      },
+    });
 
-  logger.info(
-    `[Stripe Webhook] createDefaultSpendAlerts: Created default alert over $${threshold} for org ${orgId} on plan ${plan}`,
-  );
+    await auditLog({
+      session: {
+        user: { id: "stripe-webhook" },
+        orgId,
+      },
+      orgId,
+      resourceType: "cloudSpendAlert",
+      resourceId: alert.id,
+      action: "create",
+      after: alert,
+    });
+
+    logger.info(
+      `[Stripe Webhook] createDefaultSpendAlerts: Created default alert over $${threshold} for org ${orgId} on plan ${plan}`,
+    );
+  }
 }
 
 async function handleSubscriptionChanged(


### PR DESCRIPTION
Adds a $4000 spend alert on top of the existing plan-specific default alerts on new subscriptions, as requested in LFE-8154 to help catch unintentional high-spend loads across all plan tiers.
