### PR TITLE
fix(ui): shorten environment filter empty state help text

### DIFF
--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -805,8 +805,6 @@ export function CategoricalFacet({
                 options.length === 1 &&
                 options[0]?.toLowerCase() === "default" ? (
                   <div className="text-muted-foreground mt-2 px-2 text-xs">
-                    Environments help you separate traces from different
-                    contexts (e.g. production, staging).{" "}
                     <a
                       href="https://langfuse.com/docs/observability/features/environments"
                       target="_blank"


### PR DESCRIPTION
Shortened the environment filter empty state text from "Environments help you separate traces from different contexts (e.g. production, staging). See docs on how to add environments to your traces." to just "See docs on how to add environments to your traces."
<img width="183" height="150" alt="image" src="https://github.com/user-attachments/assets/9065293b-27d2-461d-8c37-5c23576d74a1" />
