### PR TITLE
feat(scores):  make `TEXT` scores available via public API

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -431,6 +431,12 @@ types:
       stringValue:
         type: string
         docs: The string representation of the score value. If no config is linked, can be any string. Otherwise, must map to a config category
+  TextScoreV1:
+    extends: BaseScoreV1
+    properties:
+      stringValue:
+        type: string
+        docs: The text content of the score (1-500 characters)
   ScoreV1:
     discriminant: "dataType"
     union:
@@ -443,6 +449,9 @@ types:
       BOOLEAN:
         type: BooleanScoreV1
         docs: "Score with BOOLEAN data type"
+      TEXT:
+        type: TextScoreV1
+        docs: "Score with TEXT data type"
 
   # Source: packages/shared/src/features/scores/interfaces/api/v2/schemas.ts - APIScoreSchemaV2
   BaseScore:
@@ -950,14 +959,6 @@ types:
       - CATEGORICAL
       - CORRECTION
       - TEXT
-
-  # v1 POST /scores does not support TEXT — use this enum for the v1 create endpoint
-  CreateScoreDataTypeV1:
-    enum:
-      - NUMERIC
-      - BOOLEAN
-      - CATEGORICAL
-      - CORRECTION
 
 errors:
   Error:

--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -951,6 +951,14 @@ types:
       - CORRECTION
       - TEXT
 
+  # v1 POST /scores does not support TEXT — use this enum for the v1 create endpoint
+  CreateScoreDataTypeV1:
+    enum:
+      - NUMERIC
+      - BOOLEAN
+      - CATEGORICAL
+      - CORRECTION
+
 errors:
   Error:
     status-code: 400

--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -555,7 +555,7 @@ types:
     union:
       - double
       - string
-    docs: The value of the score. Must be passed as string for categorical scores, and numeric for boolean and numeric scores
+    docs: The value of the score. Must be passed as string for categorical and text scores, and numeric for boolean and numeric scores
 
   # Source: web/src/features/public-api/types/comments.ts - APIComment
   Comment:

--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -516,6 +516,12 @@ types:
       stringValue:
         type: string
         docs: The string representation of the correction content
+  TextScore:
+    extends: BaseScore
+    properties:
+      stringValue:
+        type: string
+        docs: The text content of the score (1-500 characters)
   Score:
     discriminant: "dataType"
     union:
@@ -531,6 +537,9 @@ types:
       CORRECTION:
         type: CorrectionScore
         docs: "Score with CORRECTION data type"
+      TEXT:
+        type: TextScore
+        docs: "Score with TEXT data type"
 
   CreateScoreValue:
     discriminated: false
@@ -932,6 +941,7 @@ types:
       - NUMERIC
       - BOOLEAN
       - CATEGORICAL
+      - TEXT
 
   ScoreDataType:
     enum:
@@ -939,6 +949,7 @@ types:
       - BOOLEAN
       - CATEGORICAL
       - CORRECTION
+      - TEXT
 
 errors:
   Error:

--- a/fern/apis/server/definition/ingestion.yml
+++ b/fern/apis/server/definition/ingestion.yml
@@ -287,7 +287,7 @@ types:
         docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
       value:
         type: commons.CreateScoreValue
-        docs: The value of the score. Must be passed as string for categorical scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false)
+        docs: The value of the score. Must be passed as string for categorical and text scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false). Text score values must be between 1 and 500 characters.
       comment: optional<string>
       metadata: optional<unknown>
       dataType:

--- a/fern/apis/server/definition/legacy/score-v1.yml
+++ b/fern/apis/server/definition/legacy/score-v1.yml
@@ -85,11 +85,6 @@ types:
           dataType: "BOOLEAN"
           configId: "1234-5678-90ab-cdef"
           traceId: "cdef-1234-5678-90ab"
-      - value:
-          name: "feedback"
-          value: "Great explanation of the concept"
-          dataType: "TEXT"
-          traceId: "cdef-1234-5678-90ab"
   CreateScoreResponse:
     properties:
       id:

--- a/fern/apis/server/definition/legacy/score-v1.yml
+++ b/fern/apis/server/definition/legacy/score-v1.yml
@@ -85,6 +85,11 @@ types:
           dataType: "BOOLEAN"
           configId: "1234-5678-90ab-cdef"
           traceId: "cdef-1234-5678-90ab"
+      - value:
+          name: "feedback"
+          value: "Great explanation of the concept"
+          dataType: "TEXT"
+          traceId: "cdef-1234-5678-90ab"
   CreateScoreResponse:
     properties:
       id:

--- a/fern/apis/server/definition/legacy/score-v1.yml
+++ b/fern/apis/server/definition/legacy/score-v1.yml
@@ -41,7 +41,7 @@ types:
         type: optional<string>
         docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
       dataType:
-        type: optional<commons.CreateScoreDataTypeV1>
+        type: optional<commons.ScoreDataType>
         docs: The data type of the score. When passing a configId this field is inferred. Otherwise, this field must be passed or will default to numeric.
       configId:
         type: optional<string>
@@ -84,6 +84,11 @@ types:
           value: 1
           dataType: "BOOLEAN"
           configId: "1234-5678-90ab-cdef"
+          traceId: "cdef-1234-5678-90ab"
+      - value:
+          name: "feedback"
+          value: "Great explanation of the concept"
+          dataType: "TEXT"
           traceId: "cdef-1234-5678-90ab"
   CreateScoreResponse:
     properties:

--- a/fern/apis/server/definition/legacy/score-v1.yml
+++ b/fern/apis/server/definition/legacy/score-v1.yml
@@ -31,7 +31,7 @@ types:
       name: string
       value:
         type: commons.CreateScoreValue
-        docs: The value of the score. Must be passed as string for categorical scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false)
+        docs: The value of the score. Must be passed as string for categorical and text scores, and numeric for boolean and numeric scores. Boolean score values must equal either 1 or 0 (true or false). Text score values must be between 1 and 500 characters.
       comment: optional<string>
       metadata: optional<map<string, unknown>>
       environment:

--- a/fern/apis/server/definition/legacy/score-v1.yml
+++ b/fern/apis/server/definition/legacy/score-v1.yml
@@ -41,7 +41,7 @@ types:
         type: optional<string>
         docs: The annotation queue referenced by the score. Indicates if score was initially created while processing annotation queue.
       dataType:
-        type: optional<commons.ScoreDataType>
+        type: optional<commons.CreateScoreDataTypeV1>
         docs: The data type of the score. When passing a configId this field is inferred. Otherwise, this field must be passed or will default to numeric.
       configId:
         type: optional<string>

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -130,6 +130,11 @@ types:
     properties:
       trace: optional<GetScoresResponseTraceData>
 
+  GetScoresResponseDataText:
+    extends: commons.TextScore
+    properties:
+      trace: optional<GetScoresResponseTraceData>
+
   GetScoresResponseData:
     discriminant: dataType
     union:
@@ -137,6 +142,7 @@ types:
       CATEGORICAL: GetScoresResponseDataCategorical
       BOOLEAN: GetScoresResponseDataBoolean
       CORRECTION: GetScoresResponseDataCorrection
+      TEXT: GetScoresResponseDataText
 
   GetScoresResponse:
     properties:

--- a/packages/shared/src/domain/scores.ts
+++ b/packages/shared/src/domain/scores.ts
@@ -130,9 +130,12 @@ export type AggregatableScore = ScoresByDataTypes<
   typeof AGGREGATABLE_SCORE_TYPES
 >;
 
-export const LISTABLE_SCORE_TYPES = ScoreDataTypeArray.filter(
-  (type) => type !== "CORRECTION",
-) satisfies readonly ScoreDataTypeType[];
+export const LISTABLE_SCORE_TYPES = [
+  "NUMERIC",
+  "BOOLEAN",
+  "CATEGORICAL",
+  "TEXT",
+] as const satisfies readonly ScoreDataTypeType[];
 
 export type ListableScoreDataType = (typeof LISTABLE_SCORE_TYPES)[number];
 export type ListableScore = ScoresByDataTypes<typeof LISTABLE_SCORE_TYPES>;

--- a/packages/shared/src/features/scores/interfaces/api/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/api/shared.ts
@@ -111,7 +111,7 @@ const InferredScoreBody = z.object({
   configId: z.string().nullish(),
 });
 
-// v1: excludes TEXT (TEXT scores are only available via v2)
+// v1: excludes TEXT (TEXT scores can only be created via the ingestion API)
 export const PostScoresBodyV1 = applyScoreValidation(
   PostScoreBodyFoundationSchema.and(
     z.discriminatedUnion("dataType", [

--- a/packages/shared/src/features/scores/interfaces/api/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/api/shared.ts
@@ -74,46 +74,66 @@ export const GetScoresQuery = z.object({
 });
 
 // POST /scores
-// Please note that the POST /scores endpoint supports all score types (trace, session, dataset run) across v1 and v2.
 /**
  * PostScoresBody is copied for the ingestion API as `ScoreBody`. Please copy any changes here in `packages/shared/src/features/ingestion/types.ts`
  */
+const NumericScoreBody = z.object({
+  value: z.number(),
+  dataType: z.literal("NUMERIC"),
+  configId: z.string().nullish(),
+});
+const CategoricalScoreBody = z.object({
+  value: z.string(),
+  dataType: z.literal("CATEGORICAL"),
+  configId: z.string().nullish(),
+});
+const BooleanScoreBody = z.object({
+  value: z.number().refine((value) => value === 0 || value === 1, {
+    message:
+      "Value must be a number equal to either 0 or 1 for data type BOOLEAN",
+  }),
+  dataType: z.literal("BOOLEAN"),
+  configId: z.string().nullish(),
+});
+const CorrectionScoreBody = z.object({
+  value: z.string(), // Corrected output text
+  dataType: z.literal("CORRECTION"),
+  configId: z.undefined().nullish(), // Cannot have config
+});
+const TextScoreBody = z.object({
+  value: z.string().min(1).max(500),
+  dataType: z.literal("TEXT"),
+  configId: z.string().nullish(),
+});
+const InferredScoreBody = z.object({
+  value: z.union([z.string(), z.number()]),
+  dataType: z.undefined(),
+  configId: z.string().nullish(),
+});
+
+// v1: excludes TEXT (TEXT scores are only available via v2)
+export const PostScoresBodyV1 = applyScoreValidation(
+  PostScoreBodyFoundationSchema.and(
+    z.discriminatedUnion("dataType", [
+      NumericScoreBody,
+      CategoricalScoreBody,
+      BooleanScoreBody,
+      CorrectionScoreBody,
+      InferredScoreBody,
+    ]),
+  ),
+);
+
+// v2 / ingestion: includes TEXT
 export const PostScoresBody = applyScoreValidation(
   PostScoreBodyFoundationSchema.and(
     z.discriminatedUnion("dataType", [
-      z.object({
-        value: z.number(),
-        dataType: z.literal("NUMERIC"),
-        configId: z.string().nullish(),
-      }),
-      z.object({
-        value: z.string(),
-        dataType: z.literal("CATEGORICAL"),
-        configId: z.string().nullish(),
-      }),
-      z.object({
-        value: z.number().refine((value) => value === 0 || value === 1, {
-          message:
-            "Value must be a number equal to either 0 or 1 for data type BOOLEAN",
-        }),
-        dataType: z.literal("BOOLEAN"),
-        configId: z.string().nullish(),
-      }),
-      z.object({
-        value: z.string(), // Corrected output text
-        dataType: z.literal("CORRECTION"),
-        configId: z.undefined().nullish(), // Cannot have config
-      }),
-      z.object({
-        value: z.string().min(1).max(500),
-        dataType: z.literal("TEXT"),
-        configId: z.string().nullish(),
-      }),
-      z.object({
-        value: z.union([z.string(), z.number()]),
-        dataType: z.undefined(),
-        configId: z.string().nullish(),
-      }),
+      NumericScoreBody,
+      CategoricalScoreBody,
+      BooleanScoreBody,
+      CorrectionScoreBody,
+      TextScoreBody,
+      InferredScoreBody,
     ]),
   ),
 );

--- a/packages/shared/src/features/scores/interfaces/api/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/api/shared.ts
@@ -105,6 +105,11 @@ export const PostScoresBody = applyScoreValidation(
         configId: z.undefined().nullish(), // Cannot have config
       }),
       z.object({
+        value: z.string().min(1).max(500),
+        dataType: z.literal("TEXT"),
+        configId: z.string().nullish(),
+      }),
+      z.object({
         value: z.union([z.string(), z.number()]),
         dataType: z.undefined(),
         configId: z.string().nullish(),

--- a/packages/shared/src/features/scores/interfaces/api/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/api/shared.ts
@@ -77,63 +77,42 @@ export const GetScoresQuery = z.object({
 /**
  * PostScoresBody is copied for the ingestion API as `ScoreBody`. Please copy any changes here in `packages/shared/src/features/ingestion/types.ts`
  */
-const NumericScoreBody = z.object({
-  value: z.number(),
-  dataType: z.literal("NUMERIC"),
-  configId: z.string().nullish(),
-});
-const CategoricalScoreBody = z.object({
-  value: z.string(),
-  dataType: z.literal("CATEGORICAL"),
-  configId: z.string().nullish(),
-});
-const BooleanScoreBody = z.object({
-  value: z.number().refine((value) => value === 0 || value === 1, {
-    message:
-      "Value must be a number equal to either 0 or 1 for data type BOOLEAN",
-  }),
-  dataType: z.literal("BOOLEAN"),
-  configId: z.string().nullish(),
-});
-const CorrectionScoreBody = z.object({
-  value: z.string(), // Corrected output text
-  dataType: z.literal("CORRECTION"),
-  configId: z.undefined().nullish(), // Cannot have config
-});
-const TextScoreBody = z.object({
-  value: z.string().min(1).max(500),
-  dataType: z.literal("TEXT"),
-  configId: z.string().nullish(),
-});
-const InferredScoreBody = z.object({
-  value: z.union([z.string(), z.number()]),
-  dataType: z.undefined(),
-  configId: z.string().nullish(),
-});
-
-// v1: excludes TEXT (TEXT scores can only be created via the ingestion API)
-export const PostScoresBodyV1 = applyScoreValidation(
-  PostScoreBodyFoundationSchema.and(
-    z.discriminatedUnion("dataType", [
-      NumericScoreBody,
-      CategoricalScoreBody,
-      BooleanScoreBody,
-      CorrectionScoreBody,
-      InferredScoreBody,
-    ]),
-  ),
-);
-
-// v2 / ingestion: includes TEXT
 export const PostScoresBody = applyScoreValidation(
   PostScoreBodyFoundationSchema.and(
     z.discriminatedUnion("dataType", [
-      NumericScoreBody,
-      CategoricalScoreBody,
-      BooleanScoreBody,
-      CorrectionScoreBody,
-      TextScoreBody,
-      InferredScoreBody,
+      z.object({
+        value: z.number(),
+        dataType: z.literal("NUMERIC"),
+        configId: z.string().nullish(),
+      }),
+      z.object({
+        value: z.string(),
+        dataType: z.literal("CATEGORICAL"),
+        configId: z.string().nullish(),
+      }),
+      z.object({
+        value: z.number().refine((value) => value === 0 || value === 1, {
+          message:
+            "Value must be a number equal to either 0 or 1 for data type BOOLEAN",
+        }),
+        dataType: z.literal("BOOLEAN"),
+        configId: z.string().nullish(),
+      }),
+      z.object({
+        value: z.string(), // Corrected output text
+        dataType: z.literal("CORRECTION"),
+        configId: z.undefined().nullish(), // Cannot have config
+      }),
+      z.object({
+        value: z.string().min(1).max(500),
+        dataType: z.literal("TEXT"),
+        configId: z.string().nullish(),
+      }),
+      z.object({
+        value: z.union([z.string(), z.number()]),
+        dataType: z.undefined(),
+        configId: z.string().nullish(),
+      }),
     ]),
   ),
 );

--- a/packages/shared/src/features/scores/interfaces/api/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/api/shared.ts
@@ -6,6 +6,7 @@ import { PostScoreBodyFoundationSchema } from "../shared";
 import {
   ScoreDataTypeDomain,
   ScoreSourceDomain,
+  TEXT_SCORE_MAX_LENGTH,
 } from "../../../../domain/scores";
 import { singleFilter } from "../../../../interfaces/filters";
 import { InvalidRequestError } from "../../../../errors";
@@ -104,7 +105,7 @@ export const PostScoresBody = applyScoreValidation(
         configId: z.undefined().nullish(), // Cannot have config
       }),
       z.object({
-        value: z.string().min(1).max(500),
+        value: z.string().min(1).max(TEXT_SCORE_MAX_LENGTH),
         dataType: z.literal("TEXT"),
         configId: z.string().nullish(),
       }),

--- a/packages/shared/src/features/scores/interfaces/api/v1/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v1/endpoints.ts
@@ -5,7 +5,7 @@ import {
   DeleteScoreResponse,
   GetScoreQuery,
   GetScoresQuery,
-  PostScoresBody,
+  PostScoresBodyV1 as PostScoresBodyV1Shared,
   PostScoresResponse,
 } from "../shared";
 import { APIScoreSchemaV1 } from "./schemas";
@@ -38,7 +38,7 @@ export const GetScoresResponseV1 = z.object({
   meta: paginationMetaResponseZod,
 });
 
-// POST /scores
-export const PostScoresBodyV1 = PostScoresBody;
+// POST /scores (v1 excludes TEXT scores)
+export const PostScoresBodyV1 = PostScoresBodyV1Shared;
 
 export const PostScoresResponseV1 = PostScoresResponse;

--- a/packages/shared/src/features/scores/interfaces/api/v1/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v1/endpoints.ts
@@ -5,7 +5,7 @@ import {
   DeleteScoreResponse,
   GetScoreQuery,
   GetScoresQuery,
-  PostScoresBodyV1 as PostScoresBodyV1Shared,
+  PostScoresBody,
   PostScoresResponse,
 } from "../shared";
 import { APIScoreSchemaV1 } from "./schemas";
@@ -38,7 +38,7 @@ export const GetScoresResponseV1 = z.object({
   meta: paginationMetaResponseZod,
 });
 
-// POST /scores (v1 excludes TEXT scores)
-export const PostScoresBodyV1 = PostScoresBodyV1Shared;
+// POST /scores
+export const PostScoresBodyV1 = PostScoresBody;
 
 export const PostScoresResponseV1 = PostScoresResponse;

--- a/packages/shared/src/features/scores/interfaces/api/v1/schemas.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v1/schemas.ts
@@ -9,7 +9,7 @@ import {
 /**
  * Foundation schema for scores API v1 i.e. trace and observation scores ONLY
  *
- * Must be extended with score data specific schema (numeric, categorical, boolean)
+ * Must be extended with score data specific schema (numeric, categorical, boolean, text)
  * @see {@link NumericData}, {@link CategoricalData}, {@link BooleanData}
  */
 const ScoreFoundationSchemaV1 = ScoreSchemaExclReferencesAndDates.extend({
@@ -22,8 +22,17 @@ const ScoreFoundationSchemaV1 = ScoreSchemaExclReferencesAndDates.extend({
   observationId: z.string().nullish(),
 });
 
-export const APIScoreSchemaV1 = ScoreFoundationSchemaV1.and(
-  z.discriminatedUnion("dataType", [NumericData, CategoricalData, BooleanData]),
-);
+// Response-only schema without input validation constraints (e.g. length limits)
+const TextData = z.object({
+  stringValue: z.string(),
+  dataType: z.literal("TEXT"),
+});
+
+export const APIScoreSchemaV1 = z.discriminatedUnion("dataType", [
+  ScoreFoundationSchemaV1.extend(NumericData.shape),
+  ScoreFoundationSchemaV1.extend(CategoricalData.shape),
+  ScoreFoundationSchemaV1.extend(BooleanData.shape),
+  ScoreFoundationSchemaV1.omit({ value: true }).extend(TextData.shape),
+]);
 
 export type APIScoreV1 = z.infer<typeof APIScoreSchemaV1>;

--- a/packages/shared/src/features/scores/interfaces/api/v2/schemas.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v2/schemas.ts
@@ -2,6 +2,7 @@ import {
   BooleanData,
   CategoricalData,
   NumericData,
+  TextData,
   ScoreSchemaExclReferencesAndDates,
 } from "../../../../../domain";
 import z from "zod";
@@ -27,6 +28,8 @@ const ScoreFoundationSchemaV2 = ScoreSchemaExclReferencesAndDates.extend({
   observationId: z.string().nullish(),
   sessionId: z.string().nullish(),
   datasetRunId: z.string().nullish(),
+  // Optional for TEXT scores where value is always 0 and stripped from the API response
+  value: z.number().optional(),
 });
 
 export const APIScoreSchemaV2 = ScoreFoundationSchemaV2.and(
@@ -35,6 +38,7 @@ export const APIScoreSchemaV2 = ScoreFoundationSchemaV2.and(
     CategoricalData,
     BooleanData,
     CorrectionData,
+    TextData,
   ]),
 );
 

--- a/packages/shared/src/features/scores/interfaces/api/v2/schemas.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v2/schemas.ts
@@ -2,14 +2,20 @@ import {
   BooleanData,
   CategoricalData,
   NumericData,
-  TextData,
   ScoreSchemaExclReferencesAndDates,
 } from "../../../../../domain";
 import z from "zod";
 
+// Response-only schemas without input validation constraints (e.g. length limits).
+// Input constraints are enforced at write time; response schemas must accept any stored value.
 const CorrectionData = z.object({
   stringValue: z.string(),
   dataType: z.literal("CORRECTION"),
+});
+
+const TextData = z.object({
+  stringValue: z.string(),
+  dataType: z.literal("TEXT"),
 });
 
 /**

--- a/packages/shared/src/features/scores/interfaces/api/v2/schemas.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v2/schemas.ts
@@ -28,18 +28,15 @@ const ScoreFoundationSchemaV2 = ScoreSchemaExclReferencesAndDates.extend({
   observationId: z.string().nullish(),
   sessionId: z.string().nullish(),
   datasetRunId: z.string().nullish(),
-  // Optional for TEXT scores where value is always 0 and stripped from the API response
-  value: z.number().optional(),
 });
 
-export const APIScoreSchemaV2 = ScoreFoundationSchemaV2.and(
-  z.discriminatedUnion("dataType", [
-    NumericData,
-    CategoricalData,
-    BooleanData,
-    CorrectionData,
-    TextData,
-  ]),
-);
+export const APIScoreSchemaV2 = z.discriminatedUnion("dataType", [
+  ScoreFoundationSchemaV2.extend(NumericData.shape),
+  ScoreFoundationSchemaV2.extend(CategoricalData.shape),
+  ScoreFoundationSchemaV2.extend(BooleanData.shape),
+  ScoreFoundationSchemaV2.extend(CorrectionData.shape),
+  // a numeric value does not make sense for TEXT scores, so we omit the property
+  ScoreFoundationSchemaV2.omit({ value: true }).extend(TextData.shape),
+]);
 
 export type APIScoreV2 = z.infer<typeof APIScoreSchemaV2>;

--- a/packages/shared/src/features/scores/interfaces/ingestion/validation.ts
+++ b/packages/shared/src/features/scores/interfaces/ingestion/validation.ts
@@ -35,7 +35,7 @@ export const ScoreBodyWithoutConfig = applyScoreValidation(
     ),
     PostScoreBodyFoundationSchema.extend(
       z.object({
-        value: z.string().min(1).max(500),
+        value: z.string().min(1).max(TEXT_SCORE_MAX_LENGTH),
         dataType: z.literal("TEXT"),
       }).shape,
     ),

--- a/packages/shared/src/features/scores/interfaces/ingestion/validation.ts
+++ b/packages/shared/src/features/scores/interfaces/ingestion/validation.ts
@@ -7,31 +7,37 @@ import { TEXT_SCORE_MAX_LENGTH } from "../../../../domain/scores";
 
 export const ScoreBodyWithoutConfig = applyScoreValidation(
   z.discriminatedUnion("dataType", [
-    PostScoreBodyFoundationSchema.merge(
+    PostScoreBodyFoundationSchema.extend(
       z.object({
         value: z.number(),
         dataType: z.literal("NUMERIC"),
-      }),
+      }).shape,
     ),
-    PostScoreBodyFoundationSchema.merge(
+    PostScoreBodyFoundationSchema.extend(
       z.object({
         value: z.string(),
         dataType: z.literal("CATEGORICAL"),
-      }),
+      }).shape,
     ),
-    PostScoreBodyFoundationSchema.merge(
+    PostScoreBodyFoundationSchema.extend(
       z.object({
         value: z.string(),
         dataType: z.literal("CORRECTION"),
-      }),
+      }).shape,
     ),
-    PostScoreBodyFoundationSchema.merge(
+    PostScoreBodyFoundationSchema.extend(
       z.object({
         value: z.number().refine((val) => val === 0 || val === 1, {
           message: "Value must be either 0 or 1",
         }),
         dataType: z.literal("BOOLEAN"),
-      }),
+      }).shape,
+    ),
+    PostScoreBodyFoundationSchema.extend(
+      z.object({
+        value: z.string().min(1).max(500),
+        dataType: z.literal("TEXT"),
+      }).shape,
     ),
   ]),
 );

--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { NonEmptyString, jsonSchema } from "../../utils/zod";
 import { ModelUsageUnit } from "../../constants";
 import { ScoreSourceType } from "../../domain";
+import { TEXT_SCORE_MAX_LENGTH } from "../../domain/scores";
 import { applyScoreValidation } from "../../utils/scores";
 
 export const idSchema = z
@@ -559,7 +560,7 @@ const createAllIngestionSchemas = ({
       ),
       BaseScoreBody.extend(
         z.object({
-          value: z.string().min(1).max(500),
+          value: z.string().min(1).max(TEXT_SCORE_MAX_LENGTH),
           dataType: z.literal("TEXT"),
           configId: z.string().nullish(),
         }).shape,

--- a/packages/shared/src/server/ingestion/types.ts
+++ b/packages/shared/src/server/ingestion/types.ts
@@ -526,21 +526,21 @@ const createAllIngestionSchemas = ({
 
   const ScoreBody = applyScoreValidation(
     z.discriminatedUnion("dataType", [
-      BaseScoreBody.merge(
+      BaseScoreBody.extend(
         z.object({
           value: z.number(),
           dataType: z.literal("NUMERIC"),
           configId: z.string().nullish(),
-        }),
+        }).shape,
       ),
-      BaseScoreBody.merge(
+      BaseScoreBody.extend(
         z.object({
           value: z.string(),
           dataType: z.literal("CATEGORICAL"),
           configId: z.string().nullish(),
-        }),
+        }).shape,
       ),
-      BaseScoreBody.merge(
+      BaseScoreBody.extend(
         z.object({
           value: z.number().refine((value) => value === 0 || value === 1, {
             message:
@@ -548,21 +548,28 @@ const createAllIngestionSchemas = ({
           }),
           dataType: z.literal("BOOLEAN"),
           configId: z.string().nullish(),
-        }),
+        }).shape,
       ),
-      BaseScoreBody.merge(
+      BaseScoreBody.extend(
         z.object({
           value: z.string(),
           dataType: z.literal("CORRECTION"),
           configId: z.undefined().nullish(), // Cannot have config
-        }),
+        }).shape,
       ),
-      BaseScoreBody.merge(
+      BaseScoreBody.extend(
+        z.object({
+          value: z.string().min(1).max(500),
+          dataType: z.literal("TEXT"),
+          configId: z.string().nullish(),
+        }).shape,
+      ),
+      BaseScoreBody.extend(
         z.object({
           value: z.union([z.string(), z.number()]),
           dataType: z.undefined(),
           configId: z.string().nullish(),
-        }),
+        }).shape,
       ),
     ]),
   );

--- a/packages/shared/src/server/ingestion/validateAndInflateScore.ts
+++ b/packages/shared/src/server/ingestion/validateAndInflateScore.ts
@@ -64,7 +64,7 @@ export async function validateAndInflateScore(
 
   if (!validation.success) {
     throw new InvalidRequestError(
-      `Ingested score value type not valid against provided data type. Provide numeric values for numeric and boolean scores, and string values for categorical scores.`,
+      `Ingested score value type not valid against provided data type. Provide numeric values for numeric and boolean scores, string values for categorical scores, and string values of 1-500 characters for text scores.`,
     );
   }
 

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -6353,6 +6353,12 @@ components:
           description: >-
             Custom start date for exports (required when exportMode is
             FROM_CUSTOM_DATE)
+        compressed:
+          type: boolean
+          nullable: true
+          description: >-
+            Enable gzip compression for exported files (.csv.gz, .json.gz,
+            .jsonl.gz). Defaults to true.
       required:
         - projectId
         - type
@@ -6399,6 +6405,8 @@ components:
           type: string
           format: date-time
           nullable: true
+        compressed:
+          type: boolean
         nextSyncAt:
           type: string
           format: date-time
@@ -6432,6 +6440,7 @@ components:
         - forcePathStyle
         - fileType
         - exportMode
+        - compressed
         - createdAt
         - updatedAt
     BlobStorageIntegrationsResponse:
@@ -7460,6 +7469,17 @@ components:
         - stringValue
       allOf:
         - $ref: '#/components/schemas/BaseScore'
+    TextScore:
+      title: TextScore
+      type: object
+      properties:
+        stringValue:
+          type: string
+          description: The text content of the score (1-500 characters)
+      required:
+        - stringValue
+      allOf:
+        - $ref: '#/components/schemas/BaseScore'
     Score:
       title: Score
       oneOf:
@@ -7505,6 +7525,17 @@ components:
                   enum:
                     - CORRECTION
             - $ref: '#/components/schemas/CorrectionScore'
+          required:
+            - dataType
+        - type: object
+          allOf:
+            - type: object
+              properties:
+                dataType:
+                  type: string
+                  enum:
+                    - TEXT
+            - $ref: '#/components/schemas/TextScore'
           required:
             - dataType
     CreateScoreValue:
@@ -8235,6 +8266,7 @@ components:
         - NUMERIC
         - BOOLEAN
         - CATEGORICAL
+        - TEXT
     ScoreDataType:
       title: ScoreDataType
       type: string
@@ -8243,6 +8275,7 @@ components:
         - BOOLEAN
         - CATEGORICAL
         - CORRECTION
+        - TEXT
     DeleteDatasetItemResponse:
       title: DeleteDatasetItemResponse
       type: object
@@ -10821,6 +10854,15 @@ components:
           nullable: true
       allOf:
         - $ref: '#/components/schemas/CorrectionScore'
+    GetScoresResponseDataText:
+      title: GetScoresResponseDataText
+      type: object
+      properties:
+        trace:
+          $ref: '#/components/schemas/GetScoresResponseTraceData'
+          nullable: true
+      allOf:
+        - $ref: '#/components/schemas/TextScore'
     GetScoresResponseData:
       title: GetScoresResponseData
       oneOf:
@@ -10866,6 +10908,17 @@ components:
                   enum:
                     - CORRECTION
             - $ref: '#/components/schemas/GetScoresResponseDataCorrection'
+          required:
+            - dataType
+        - type: object
+          allOf:
+            - type: object
+              properties:
+                dataType:
+                  type: string
+                  enum:
+                    - TEXT
+            - $ref: '#/components/schemas/GetScoresResponseDataText'
           required:
             - dataType
     GetScoresResponse:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8276,6 +8276,14 @@ components:
         - CATEGORICAL
         - CORRECTION
         - TEXT
+    CreateScoreDataTypeV1:
+      title: CreateScoreDataTypeV1
+      type: string
+      enum:
+        - NUMERIC
+        - BOOLEAN
+        - CATEGORICAL
+        - CORRECTION
     DeleteDatasetItemResponse:
       title: DeleteDatasetItemResponse
       type: object
@@ -9245,7 +9253,7 @@ components:
             The annotation queue referenced by the score. Indicates if score was
             initially created while processing annotation queue.
         dataType:
-          $ref: '#/components/schemas/ScoreDataType'
+          $ref: '#/components/schemas/CreateScoreDataTypeV1'
           nullable: true
           description: >-
             The data type of the score. When passing a configId this field is

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8924,9 +8924,10 @@ components:
         value:
           $ref: '#/components/schemas/CreateScoreValue'
           description: >-
-            The value of the score. Must be passed as string for categorical
-            scores, and numeric for boolean and numeric scores. Boolean score
-            values must equal either 1 or 0 (true or false)
+            The value of the score. Must be passed as string for categorical and
+            text scores, and numeric for boolean and numeric scores. Boolean
+            score values must equal either 1 or 0 (true or false). Text score
+            values must be between 1 and 500 characters.
         comment:
           type: string
           nullable: true
@@ -9243,9 +9244,10 @@ components:
         value:
           $ref: '#/components/schemas/CreateScoreValue'
           description: >-
-            The value of the score. Must be passed as string for categorical
-            scores, and numeric for boolean and numeric scores. Boolean score
-            values must equal either 1 or 0 (true or false)
+            The value of the score. Must be passed as string for categorical and
+            text scores, and numeric for boolean and numeric scores. Boolean
+            score values must equal either 1 or 0 (true or false). Text score
+            values must be between 1 and 500 characters.
         comment:
           type: string
           nullable: true

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7567,8 +7567,8 @@ components:
           format: double
         - type: string
       description: >-
-        The value of the score. Must be passed as string for categorical scores,
-        and numeric for boolean and numeric scores
+        The value of the score. Must be passed as string for categorical and
+        text scores, and numeric for boolean and numeric scores
     Comment:
       title: Comment
       type: object

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7292,6 +7292,17 @@ components:
         - stringValue
       allOf:
         - $ref: '#/components/schemas/BaseScoreV1'
+    TextScoreV1:
+      title: TextScoreV1
+      type: object
+      properties:
+        stringValue:
+          type: string
+          description: The text content of the score (1-500 characters)
+      required:
+        - stringValue
+      allOf:
+        - $ref: '#/components/schemas/BaseScoreV1'
     ScoreV1:
       title: ScoreV1
       oneOf:
@@ -7326,6 +7337,17 @@ components:
                   enum:
                     - BOOLEAN
             - $ref: '#/components/schemas/BooleanScoreV1'
+          required:
+            - dataType
+        - type: object
+          allOf:
+            - type: object
+              properties:
+                dataType:
+                  type: string
+                  enum:
+                    - TEXT
+            - $ref: '#/components/schemas/TextScoreV1'
           required:
             - dataType
     BaseScore:
@@ -8276,14 +8298,6 @@ components:
         - CATEGORICAL
         - CORRECTION
         - TEXT
-    CreateScoreDataTypeV1:
-      title: CreateScoreDataTypeV1
-      type: string
-      enum:
-        - NUMERIC
-        - BOOLEAN
-        - CATEGORICAL
-        - CORRECTION
     DeleteDatasetItemResponse:
       title: DeleteDatasetItemResponse
       type: object
@@ -9253,7 +9267,7 @@ components:
             The annotation queue referenced by the score. Indicates if score was
             initially created while processing annotation queue.
         dataType:
-          $ref: '#/components/schemas/CreateScoreDataTypeV1'
+          $ref: '#/components/schemas/ScoreDataType'
           nullable: true
           description: >-
             The data type of the score. When passing a configId this field is

--- a/web/src/__tests__/server/score-configs.servertest.ts
+++ b/web/src/__tests__/server/score-configs.servertest.ts
@@ -257,6 +257,34 @@ describe("/api/public/score-configs API Endpoint", () => {
     ]);
   });
 
+  it("should POST a text score config", async () => {
+    const postScoreConfig = await makeZodVerifiedAPICall(
+      PostScoreConfigResponse,
+      "POST",
+      "/api/public/score-configs",
+      {
+        name: "text-config-name",
+        dataType: "TEXT",
+      },
+      auth,
+    );
+
+    const scoreConfig = await makeZodVerifiedAPICall(
+      GetScoreConfigResponse,
+      "GET",
+      `/api/public/score-configs/${postScoreConfig.body.id}`,
+      undefined,
+      auth,
+    );
+
+    expect(postScoreConfig.status).toBe(200);
+    expect(scoreConfig.body.name).toBe("text-config-name");
+    expect(scoreConfig.body.dataType).toBe("TEXT");
+    expect(scoreConfig.body.categories).toBeFalsy();
+    expect(scoreConfig.body.maxValue).toBeFalsy();
+    expect(scoreConfig.body.minValue).toBeFalsy();
+  });
+
   it("should fail POST of numeric score config with invalid range", async () => {
     try {
       await makeZodVerifiedAPICall(

--- a/web/src/__tests__/server/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v1.servertest.ts
@@ -75,6 +75,51 @@ describe("/api/public/scores API Endpoint", () => {
       });
     });
 
+    it("should GET a text score", async () => {
+      const { projectId, auth } = await createOrgProjectAndApiKey();
+
+      const scoreId = v4();
+      const traceId = v4();
+      const score = createTraceScore({
+        id: scoreId,
+        project_id: projectId,
+        trace_id: traceId,
+        name: "Text Score",
+        timestamp: Date.now(),
+        value: 0,
+        string_value: "Great explanation",
+        source: "API",
+        comment: "comment",
+        data_type: "TEXT" as const,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+        event_ts: Date.now(),
+        is_deleted: 0,
+      });
+
+      await createScoresCh([score]);
+
+      const getScore = await makeZodVerifiedAPICall(
+        GetScoreResponseV1,
+        "GET",
+        `/api/public/scores/${scoreId}`,
+        undefined,
+        auth,
+      );
+
+      expect(getScore.status).toBe(200);
+      expect(getScore.body).toMatchObject({
+        id: scoreId,
+        name: "Text Score",
+        stringValue: "Great explanation",
+        comment: "comment",
+        source: "API",
+        traceId,
+        dataType: "TEXT",
+      });
+      expect(getScore.body).not.toHaveProperty("value");
+    });
+
     it("should GET score with minimal score data and minimal trace data", async () => {
       const { projectId, auth } = await createOrgProjectAndApiKey();
 
@@ -422,6 +467,8 @@ describe("/api/public/scores API Endpoint", () => {
       const scoreId_5 = v4();
       const scoreId_6 = v4();
       const scoreId_7 = v4();
+      const textScoreId_1 = v4();
+      const textScoreId_2 = v4();
       let authentication: string;
       let newProjectId: string;
 
@@ -530,6 +577,26 @@ describe("/api/public/scores API Endpoint", () => {
           environment: "production",
         });
 
+        const textScore1 = createTraceScore({
+          id: textScoreId_1,
+          project_id: newProjectId,
+          trace_id: traceId_2,
+          name: "text-score-name",
+          data_type: "TEXT",
+          string_value: "text-value-1",
+          value: 0,
+        });
+
+        const textScore2 = createTraceScore({
+          id: textScoreId_2,
+          project_id: newProjectId,
+          trace_id: traceId_3,
+          name: "text-score-name",
+          data_type: "TEXT",
+          string_value: "text-value-2",
+          value: 0,
+        });
+
         const sessionScore1 = createSessionScore({
           id: scoreId_6,
           project_id: newProjectId,
@@ -554,6 +621,8 @@ describe("/api/public/scores API Endpoint", () => {
           score3,
           score4,
           score5,
+          textScore1,
+          textScore2,
           sessionScore1,
           sessionScore2,
         ]);
@@ -571,7 +640,7 @@ describe("/api/public/scores API Endpoint", () => {
         expect(getAllScore.body.meta).toMatchObject({
           page: 1,
           limit: 50,
-          totalItems: 5, // 7 scores in total, but only 5 are trace scores
+          totalItems: 7, // 9 scores in total, but only 7 are trace scores
           totalPages: 1,
         });
         for (const val of getAllScore.body.data) {
@@ -628,6 +697,31 @@ describe("/api/public/scores API Endpoint", () => {
             observationId: generationId,
             dataType: "NUMERIC",
           });
+        }
+      });
+
+      it("get all scores for text data type", async () => {
+        const getAllScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV1,
+          "GET",
+          `/api/public/scores?dataType=TEXT`,
+          undefined,
+          authentication,
+        );
+
+        expect(getAllScore.status).toBe(200);
+        expect(getAllScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 2,
+          totalPages: 1,
+        });
+        for (const val of getAllScore.body.data) {
+          expect(val).toMatchObject({
+            dataType: "TEXT",
+            name: "text-score-name",
+          });
+          expect(val.stringValue).toContain("text-value");
         }
       });
 
@@ -696,7 +790,7 @@ describe("/api/public/scores API Endpoint", () => {
         expect(getAllScore.body.meta).toMatchObject({
           page: 1,
           limit: 50,
-          totalItems: 1,
+          totalItems: 2,
           totalPages: 1,
         });
         for (const val of getAllScore.body.data) {

--- a/web/src/__tests__/server/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v2.servertest.ts
@@ -190,6 +190,51 @@ describe("/api/public/v2/scores API Endpoint", () => {
         dataType: "NUMERIC",
       });
     });
+
+    it("should GET a text score", async () => {
+      const { projectId, auth } = await createOrgProjectAndApiKey();
+
+      const scoreId = v4();
+      const traceId = v4();
+      const score = createTraceScore({
+        id: scoreId,
+        project_id: projectId,
+        trace_id: traceId,
+        name: "Text Score",
+        timestamp: Date.now(),
+        value: 0,
+        string_value: "Great explanation",
+        source: "API",
+        comment: "comment",
+        data_type: "TEXT" as const,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+        event_ts: Date.now(),
+        is_deleted: 0,
+      });
+
+      await createScoresCh([score]);
+
+      const getScore = await makeZodVerifiedAPICall(
+        GetScoreResponseV2,
+        "GET",
+        `/api/public/v2/scores/${scoreId}`,
+        undefined,
+        auth,
+      );
+
+      expect(getScore.status).toBe(200);
+      expect(getScore.body).toMatchObject({
+        id: scoreId,
+        name: "Text Score",
+        stringValue: "Great explanation",
+        comment: "comment",
+        source: "API",
+        traceId,
+        dataType: "TEXT",
+      });
+      expect(getScore.body).not.toHaveProperty("value");
+    });
   });
 
   describe("GET /api/public/scores", () => {
@@ -217,6 +262,8 @@ describe("/api/public/v2/scores API Endpoint", () => {
       const scoreId_9 = v4();
       const correctionScoreId_1 = v4();
       const correctionScoreId_2 = v4();
+      const textScoreId_1 = v4();
+      const textScoreId_2 = v4();
       let authentication: string;
       let newProjectId: string;
       let executionTraceId: string;
@@ -348,6 +395,26 @@ describe("/api/public/v2/scores API Endpoint", () => {
           environment: "annotation",
         });
 
+        const textScore1 = createTraceScore({
+          id: textScoreId_1,
+          project_id: newProjectId,
+          trace_id: traceId_2,
+          name: "text-score-name",
+          data_type: "TEXT",
+          string_value: "text-value-1",
+          value: 0,
+        });
+
+        const textScore2 = createTraceScore({
+          id: textScoreId_2,
+          project_id: newProjectId,
+          trace_id: traceId_3,
+          name: "text-score-name",
+          data_type: "TEXT",
+          string_value: "text-value-2",
+          value: 0,
+        });
+
         const sessionScore1 = createSessionScore({
           id: scoreId_6,
           project_id: newProjectId,
@@ -396,6 +463,8 @@ describe("/api/public/v2/scores API Endpoint", () => {
           runScore2,
           correction1,
           correction2,
+          textScore1,
+          textScore2,
         ]);
       });
 
@@ -411,7 +480,7 @@ describe("/api/public/v2/scores API Endpoint", () => {
         expect(getAllScore.body.meta).toMatchObject({
           page: 1,
           limit: 50,
-          totalItems: 11,
+          totalItems: 13,
           totalPages: 1,
         });
         for (const val of getAllScore.body.data) {
@@ -514,6 +583,31 @@ describe("/api/public/v2/scores API Endpoint", () => {
             name: "output",
           });
           expect(val.stringValue).toContain("correction-value");
+        }
+      });
+
+      it("get all scores for text data type", async () => {
+        const getAllScore = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?dataType=TEXT`,
+          undefined,
+          authentication,
+        );
+
+        expect(getAllScore.status).toBe(200);
+        expect(getAllScore.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 2,
+          totalPages: 1,
+        });
+        for (const val of getAllScore.body.data) {
+          expect(val).toMatchObject({
+            dataType: "TEXT",
+            name: "text-score-name",
+          });
+          expect(val.stringValue).toContain("text-value");
         }
       });
 
@@ -737,7 +831,7 @@ describe("/api/public/v2/scores API Endpoint", () => {
         expect(getAllScore.body.meta).toMatchObject({
           page: 1,
           limit: 50,
-          totalItems: 2,
+          totalItems: 3,
           totalPages: 1,
         });
         for (const val of getAllScore.body.data) {

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -264,7 +264,7 @@ export default function ScoresTable({
           count: n.count !== undefined ? Number(n.count) : undefined,
         })) ?? undefined,
       source: ["ANNOTATION", "API", "EVAL"],
-      dataType: LISTABLE_SCORE_TYPES,
+      dataType: [...LISTABLE_SCORE_TYPES],
       value: [],
       stringValue:
         filterOptions.data?.stringValue?.map((sv) => ({

--- a/web/src/features/public-api/server/scores-api-service.ts
+++ b/web/src/features/public-api/server/scores-api-service.ts
@@ -4,10 +4,7 @@ import {
   convertScoreToPublicApi,
   type ScoreQueryType,
 } from "@/src/features/public-api/server/scores";
-import {
-  AGGREGATABLE_SCORE_TYPES,
-  type ScoreSourceType,
-} from "@langfuse/shared";
+import { LISTABLE_SCORE_TYPES, type ScoreSourceType } from "@langfuse/shared";
 import { _handleGetScoreById } from "@langfuse/shared/src/server";
 
 export class ScoresApiService {
@@ -15,7 +12,7 @@ export class ScoresApiService {
 
   /**
    * Get a specific score by ID
-   * v1: Only returns aggregatable scores (NUMERIC, BOOLEAN, CATEGORICAL) - excludes CORRECTION and TEXT
+   * v1: Returns listable scores (NUMERIC, BOOLEAN, CATEGORICAL, TEXT) - excludes CORRECTION
    * v2: Returns all score types including CORRECTION and TEXT
    */
   async getScoreById({
@@ -33,7 +30,7 @@ export class ScoresApiService {
       source,
       scoreScope: this.apiVersion === "v1" ? "traces_only" : "all",
       scoreDataTypes:
-        this.apiVersion === "v1" ? AGGREGATABLE_SCORE_TYPES : undefined,
+        this.apiVersion === "v1" ? LISTABLE_SCORE_TYPES : undefined,
       preferredClickhouseService: "ReadOnly",
     });
 
@@ -46,7 +43,7 @@ export class ScoresApiService {
 
   /**
    * Get list of scores with version-aware filtering
-   * v1: Only returns aggregatable scores (NUMERIC, BOOLEAN, CATEGORICAL) - excludes CORRECTION and TEXT
+   * v1: Returns listable scores (NUMERIC, BOOLEAN, CATEGORICAL, TEXT) - excludes CORRECTION
    * v2: Returns all score types including CORRECTION and TEXT
    */
   async generateScoresForPublicApi(props: ScoreQueryType) {
@@ -54,13 +51,13 @@ export class ScoresApiService {
       props,
       scoreScope: this.apiVersion === "v1" ? "traces_only" : "all",
       scoreDataTypes:
-        this.apiVersion === "v1" ? AGGREGATABLE_SCORE_TYPES : undefined,
+        this.apiVersion === "v1" ? LISTABLE_SCORE_TYPES : undefined,
     });
   }
 
   /**
    * Get count of scores with version-aware filtering
-   * v1: Only counts aggregatable scores (NUMERIC, BOOLEAN, CATEGORICAL) - excludes CORRECTION and TEXT
+   * v1: Only counts listable scores (NUMERIC, BOOLEAN, CATEGORICAL, TEXT) - excludes CORRECTION
    * v2: Counts all score types including CORRECTION and TEXT
    */
   async getScoresCountForPublicApi(props: ScoreQueryType) {
@@ -68,7 +65,7 @@ export class ScoresApiService {
       props,
       scoreScope: this.apiVersion === "v1" ? "traces_only" : "all",
       scoreDataTypes:
-        this.apiVersion === "v1" ? AGGREGATABLE_SCORE_TYPES : undefined,
+        this.apiVersion === "v1" ? LISTABLE_SCORE_TYPES : undefined,
     });
   }
 }

--- a/web/src/features/public-api/server/scores-api-service.ts
+++ b/web/src/features/public-api/server/scores-api-service.ts
@@ -15,8 +15,8 @@ export class ScoresApiService {
 
   /**
    * Get a specific score by ID
-   * v1: Only returns aggregatable scores (NUMERIC, BOOLEAN, CATEGORICAL) - excludes CORRECTION
-   * v2: Returns all score types including CORRECTION
+   * v1: Only returns aggregatable scores (NUMERIC, BOOLEAN, CATEGORICAL) - excludes CORRECTION and TEXT
+   * v2: Returns all score types including CORRECTION and TEXT
    */
   async getScoreById({
     projectId,
@@ -46,8 +46,8 @@ export class ScoresApiService {
 
   /**
    * Get list of scores with version-aware filtering
-   * v1: Only returns aggregatable scores (NUMERIC, BOOLEAN, CATEGORICAL) - excludes CORRECTION
-   * v2: Returns all score types including CORRECTION
+   * v1: Only returns aggregatable scores (NUMERIC, BOOLEAN, CATEGORICAL) - excludes CORRECTION and TEXT
+   * v2: Returns all score types including CORRECTION and TEXT
    */
   async generateScoresForPublicApi(props: ScoreQueryType) {
     return _handleGenerateScoresForPublicApi({
@@ -60,8 +60,8 @@ export class ScoresApiService {
 
   /**
    * Get count of scores with version-aware filtering
-   * v1: Only counts aggregatable scores (NUMERIC, BOOLEAN, CATEGORICAL) - excludes CORRECTION
-   * v2: Counts all score types including CORRECTION
+   * v1: Only counts aggregatable scores (NUMERIC, BOOLEAN, CATEGORICAL) - excludes CORRECTION and TEXT
+   * v2: Counts all score types including CORRECTION and TEXT
    */
   async getScoresCountForPublicApi(props: ScoreQueryType) {
     return _handleGetScoresCountForPublicApi({

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -21,17 +21,25 @@ import {
 /**
  * Converts a ScoreDomain object to API format.
  * For CORRECTION scores, moves longStringValue to stringValue for API compatibility.
+ * For TEXT scores, removes longStringValue and value (always 0, not meaningful).
  * For other score types, removes longStringValue.
  */
-export const convertScoreToPublicApi = <T extends ScoreDomain>(
-  score: T,
-): Omit<T, "longStringValue"> & { stringValue?: string | null } => {
+export const convertScoreToPublicApi = (
+  score: ScoreDomain,
+): Omit<ScoreDomain, "longStringValue" | "value"> & {
+  stringValue?: string | null;
+  value?: number;
+} => {
   if (score.dataType === ScoreDataTypeEnum.CORRECTION) {
     const { longStringValue, ...rest } = score;
     return {
       ...rest,
       stringValue: longStringValue,
     };
+  }
+
+  if (score.dataType === ScoreDataTypeEnum.TEXT) {
+    return removeObjectKeys(score, ["longStringValue", "value"]);
   }
 
   return removeObjectKeys(score, ["longStringValue"]);

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -18,18 +18,26 @@ import {
   type FilterState,
 } from "@langfuse/shared";
 
+type ScoreApiResult = Omit<ScoreDomain, "longStringValue"> & {
+  stringValue?: string | null;
+};
+type TextScoreApiResult = Omit<ScoreDomain, "longStringValue" | "value"> & {
+  stringValue?: string | null;
+};
+
 /**
  * Converts a ScoreDomain object to API format.
  * For CORRECTION scores, moves longStringValue to stringValue for API compatibility.
  * For TEXT scores, removes longStringValue and value (always 0, not meaningful).
  * For other score types, removes longStringValue.
  */
-export const convertScoreToPublicApi = (
+export function convertScoreToPublicApi(
+  score: ScoreDomain & { dataType: "TEXT" },
+): TextScoreApiResult;
+export function convertScoreToPublicApi(score: ScoreDomain): ScoreApiResult;
+export function convertScoreToPublicApi(
   score: ScoreDomain,
-): Omit<ScoreDomain, "longStringValue" | "value"> & {
-  stringValue?: string | null;
-  value?: number;
-} => {
+): ScoreApiResult | TextScoreApiResult {
   if (score.dataType === ScoreDataTypeEnum.CORRECTION) {
     const { longStringValue, ...rest } = score;
     return {
@@ -43,7 +51,7 @@ export const convertScoreToPublicApi = (
   }
 
   return removeObjectKeys(score, ["longStringValue"]);
-};
+}
 
 export type ScoreQueryType = {
   page: number;

--- a/web/src/features/public-api/types/score-configs.ts
+++ b/web/src/features/public-api/types/score-configs.ts
@@ -97,6 +97,15 @@ export const PostScoreConfigBody = z
         categories: z.undefined(),
       }).shape,
     }),
+    z.object({
+      ...PostScoreConfigBase.shape,
+      ...z.object({
+        dataType: z.literal("TEXT"),
+        categories: z.undefined(),
+        maxValue: z.undefined().nullish(),
+        minValue: z.undefined().nullish(),
+      }).shape,
+    }),
   ])
   .superRefine(validateNumericRangeFields);
 

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -297,7 +297,10 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     form.setValue(`scoreData.${index}.stringValue`, previousScore.stringValue);
     form.setValue(`scoreData.${index}.comment`, previousScore.comment);
     form.setValue(`scoreData.${index}.timestamp`, previousScore.timestamp);
-    form.setError(`scoreData.${index}.value`, {
+    const errorField = isTextDataType(field.dataType)
+      ? `scoreData.${index}.stringValue`
+      : `scoreData.${index}.value`;
+    form.setError(errorField, {
       type: "server",
       message: "Failed to delete score",
     });
@@ -316,7 +319,10 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     };
 
     // Optimistically clear form
-    form.clearErrors(`scoreData.${index}.value`);
+    const clearField = isTextDataType(field.dataType)
+      ? `scoreData.${index}.stringValue`
+      : `scoreData.${index}.value`;
+    form.clearErrors(clearField);
     update(index, {
       name: field.name,
       dataType: field.dataType,
@@ -351,7 +357,10 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
   ) => {
     form.setValue(`scoreData.${index}.value`, previousValue);
     form.setValue(`scoreData.${index}.stringValue`, previousStringValue);
-    form.setError(`scoreData.${index}.value`, {
+    const errorField = isTextDataType(controlledFields[index]?.dataType)
+      ? `scoreData.${index}.stringValue`
+      : `scoreData.${index}.value`;
+    form.setError(errorField, {
       type: "server",
       message: "Failed to update score",
     });
@@ -368,7 +377,10 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     form.setValue(`scoreData.${index}.timestamp`, previousTimestamp);
     form.setValue(`scoreData.${index}.value`, previousValue);
     form.setValue(`scoreData.${index}.stringValue`, previousStringValue);
-    form.setError(`scoreData.${index}.value`, {
+    const errorField = isTextDataType(controlledFields[index]?.dataType)
+      ? `scoreData.${index}.stringValue`
+      : `scoreData.${index}.value`;
+    form.setError(errorField, {
       type: "server",
       message: "Failed to create score",
     });

--- a/web/src/features/scores/components/AnnotationForm.tsx
+++ b/web/src/features/scores/components/AnnotationForm.tsx
@@ -297,13 +297,17 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     form.setValue(`scoreData.${index}.stringValue`, previousScore.stringValue);
     form.setValue(`scoreData.${index}.comment`, previousScore.comment);
     form.setValue(`scoreData.${index}.timestamp`, previousScore.timestamp);
-    const errorField = isTextDataType(field.dataType)
-      ? `scoreData.${index}.stringValue`
-      : `scoreData.${index}.value`;
-    form.setError(errorField, {
-      type: "server",
-      message: "Failed to delete score",
-    });
+    if (isTextDataType(field.dataType)) {
+      form.setError(`scoreData.${index}.stringValue`, {
+        type: "server",
+        message: "Failed to delete score",
+      });
+    } else {
+      form.setError(`scoreData.${index}.value`, {
+        type: "server",
+        message: "Failed to delete score",
+      });
+    }
   };
 
   const handleDeleteScore = (index: number) => {
@@ -319,10 +323,11 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     };
 
     // Optimistically clear form
-    const clearField = isTextDataType(field.dataType)
-      ? `scoreData.${index}.stringValue`
-      : `scoreData.${index}.value`;
-    form.clearErrors(clearField);
+    if (isTextDataType(field.dataType)) {
+      form.clearErrors(`scoreData.${index}.stringValue`);
+    } else {
+      form.clearErrors(`scoreData.${index}.value`);
+    }
     update(index, {
       name: field.name,
       dataType: field.dataType,
@@ -357,13 +362,17 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
   ) => {
     form.setValue(`scoreData.${index}.value`, previousValue);
     form.setValue(`scoreData.${index}.stringValue`, previousStringValue);
-    const errorField = isTextDataType(controlledFields[index]?.dataType)
-      ? `scoreData.${index}.stringValue`
-      : `scoreData.${index}.value`;
-    form.setError(errorField, {
-      type: "server",
-      message: "Failed to update score",
-    });
+    if (isTextDataType(controlledFields[index]?.dataType)) {
+      form.setError(`scoreData.${index}.stringValue`, {
+        type: "server",
+        message: "Failed to update score",
+      });
+    } else {
+      form.setError(`scoreData.${index}.value`, {
+        type: "server",
+        message: "Failed to update score",
+      });
+    }
   };
 
   const rollbackCreateError = (
@@ -377,13 +386,17 @@ function InnerAnnotationForm<Target extends ScoreTarget>({
     form.setValue(`scoreData.${index}.timestamp`, previousTimestamp);
     form.setValue(`scoreData.${index}.value`, previousValue);
     form.setValue(`scoreData.${index}.stringValue`, previousStringValue);
-    const errorField = isTextDataType(controlledFields[index]?.dataType)
-      ? `scoreData.${index}.stringValue`
-      : `scoreData.${index}.value`;
-    form.setError(errorField, {
-      type: "server",
-      message: "Failed to create score",
-    });
+    if (isTextDataType(controlledFields[index]?.dataType)) {
+      form.setError(`scoreData.${index}.stringValue`, {
+        type: "server",
+        message: "Failed to create score",
+      });
+    } else {
+      form.setError(`scoreData.${index}.value`, {
+        type: "server",
+        message: "Failed to create score",
+      });
+    }
   };
 
   const handleUpsert = (

--- a/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
+++ b/worker/src/services/IngestionService/tests/IngestionService.integration.test.ts
@@ -624,6 +624,69 @@ describe("Ingestion end-to-end tests", () => {
     }, 10_000);
   });
 
+  it("should correctly ingest a TEXT score", async () => {
+    const traceId = randomUUID();
+    const scoreId = randomUUID();
+
+    const traceEventList: TraceEventType[] = [
+      {
+        type: "trace-create",
+        id: traceId,
+        timestamp: new Date().toISOString(),
+        body: {
+          name: "trace-for-text-score",
+          timestamp: new Date().toISOString(),
+          environment,
+        },
+      },
+    ];
+
+    const scoreEventList: ScoreEventType[] = [
+      {
+        id: randomUUID(),
+        type: "score-create",
+        timestamp: new Date().toISOString(),
+        body: {
+          id: scoreId,
+          dataType: "TEXT",
+          name: "text-score",
+          value: "Great explanation of the concept",
+          source: ScoreSourceEnum.API,
+          traceId: traceId,
+          environment,
+        },
+      },
+    ];
+
+    await Promise.all([
+      ingestionService.processTraceEventList({
+        projectId,
+        entityId: traceId,
+        createdAtTimestamp: new Date(),
+        traceEventList,
+      }),
+      ingestionService.processScoreEventList({
+        projectId,
+        entityId: scoreId,
+        createdAtTimestamp: new Date(),
+        scoreEventList,
+      }),
+    ]);
+
+    await clickhouseWriter.flushAll(true);
+
+    const score = await getClickhouseRecord(TableName.Scores, scoreId);
+
+    expect(score.id).toBe(scoreId);
+    expect(score.trace_id).toBe(traceId);
+    expect(score.name).toBe("text-score");
+    expect(score.data_type).toBe("TEXT");
+    expect(score.string_value).toBe("Great explanation of the concept");
+    expect(score.value).toBe(0);
+    expect(score.source).toBe(ScoreSourceEnum.API);
+    expect(score.project_id).toBe(projectId);
+  }, 10_000);
+
   [
     {
       observationExternalModel: "gpt-3.5",


### PR DESCRIPTION
## What does this PR do?

- make `TEXT` scores available via public v1 && v2 API

Fixes [#LFE-9037](https://linear.app/langfuse/issue/LFE-9038/implement-public-api-for-text-scores)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

