### PR TITLE
fix(web): Improve v4 promo banner styling on small displays

### DIFF
--- a/web/src/features/events/components/V4BetaPromoBanner.tsx
+++ b/web/src/features/events/components/V4BetaPromoBanner.tsx
@@ -92,40 +92,49 @@ export function V4BetaPromoBanner() {
     >
       <div className="flex items-center gap-2 py-1.5 pl-3">
         <ZapIcon className="h-4 w-4 shrink-0" />
-        <p className="flex flex-1 flex-row gap-1 text-sm">
-          <span className="font-semibold">{pageMessage}</span> Enable the{" "}
-          <button
-            className="inline cursor-pointer font-semibold underline underline-offset-2"
-            onClick={() => {
-              enableWithIntro({
-                onSuccess: () => {
-                  capture("sidebar:v4_beta_toggled", { enabled: true });
-                },
-              });
-            }}
-            disabled={isLoading}
-          >
-            Fast (Preview)
-          </button>{" "}
-          toggle for a more performant experience.{" "}
+        <p
+          className="flex flex-1 gap-1 overflow-hidden text-sm"
+          title="Enable the Fast (Preview) toggle for a more performant experience."
+        >
+          <span className="truncate">
+            <span className="hidden font-semibold md:inline">
+              {pageMessage}
+            </span>{" "}
+            Enable the{" "}
+            <button
+              className="inline cursor-pointer font-semibold underline underline-offset-2"
+              onClick={() => {
+                enableWithIntro({
+                  onSuccess: () => {
+                    capture("sidebar:v4_beta_toggled", { enabled: true });
+                  },
+                });
+              }}
+              disabled={isLoading}
+            >
+              Fast (Preview)
+            </button>{" "}
+            toggle for a more performant experience.{" "}
+          </span>
+
           <Link
             href={CHANGELOG_URL}
             target="_blank"
-            className="flex flex-row items-center gap-1 underline underline-offset-2"
+            className="flex flex-row items-center gap-1 whitespace-nowrap underline underline-offset-2"
           >
             Learn more
-            <ExternalLink className="h-3 w-3" />
+            <ExternalLink className="h-3 w-3 shrink-0" />
           </Link>
         </p>
         <Button
           variant="ghost"
           size="sm"
-          className="h-6 w-6 p-0"
+          className="h-6 w-6 shrink-0 p-0"
           onClick={() => setIsDismissed(true)}
           aria-label="Dismiss banner"
           title="Dismiss"
         >
-          <X className="h-4 w-4" />
+          <X className="h-4 w-4 shrink-0" />
         </Button>
       </div>
       <V4BetaIntroDialog

--- a/web/src/features/events/components/V4BetaPromoBanner.tsx
+++ b/web/src/features/events/components/V4BetaPromoBanner.tsx
@@ -94,7 +94,7 @@ export function V4BetaPromoBanner() {
         <ZapIcon className="h-4 w-4 shrink-0" />
         <p
           className="flex flex-1 gap-1 overflow-hidden text-sm"
-          title="Enable the Fast (Preview) toggle for a more performant experience."
+          title={`${pageMessage} Enable the Fast (Preview) toggle for a more performant experience.`}
         >
           <span className="truncate">
             <span className="hidden font-semibold md:inline">


### PR DESCRIPTION
## What does this PR do?

This PR improves the styling of the v4 promo banner (`V4BetaPromoBanner.tsx`) for smaller screens.

Before:
<img width="1382" height="195" alt="Before" src="https://github.com/user-attachments/assets/5c88bcb7-2c6d-4b50-b411-4b6db1c5277f" />

After:
<img width="2050" height="584" alt="1" src="https://github.com/user-attachments/assets/072291d8-867a-4b89-a710-cde70d0f5998" />
<img width="1538" height="606" alt="2" src="https://github.com/user-attachments/assets/46728a2c-8bdd-4675-b6c0-7d6329f43013" />
<img width="1362" height="342" alt="3" src="https://github.com/user-attachments/assets/9a73316b-97a9-4d8a-9149-42cc20fa8a55" />
<img width="1206" height="433" alt="4" src="https://github.com/user-attachments/assets/8d3540d7-c17d-4fc8-8e30-a9ce9e86f739" />

It also sets the `title` attribute, so that truncated text can be read by hovering over it:
<img width="539" height="95" alt="Screenshot 2026-04-01 at 14 47 19" src="https://github.com/user-attachments/assets/e3b72f5e-3665-40b9-afa9-ad4ffea95f07" />

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
