### PR TITLE
fix(worker): add ClickHouse request timeout for experiment backfill query

### DIFF
--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -155,6 +155,9 @@ export async function getDatasetRunItemsSinceLastRun(
       lastRun: convertDateToClickhouseDateTime(lastRun),
       upperBound: convertDateToClickhouseDateTime(upperBound),
     },
+    clickhouseConfigs: {
+      request_timeout: 120000, // 2 minutes timeout
+    },
     tags: {
       feature: "experiment-backfill",
       operation_name: "getDatasetRunItemsSinceLastRun",


### PR DESCRIPTION
Adds a 2-minute request timeout to the getDatasetRunItemsSinceLastRun ClickHouse query to prevent long-running queries from hanging indefinitely.
