### PR TITLE
fix(worker): cap experiment backfill to 8-hour windows

### DIFF
--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -751,12 +751,21 @@ export async function runExperimentBackfill(): Promise<void> {
     // This ensures we don't process items that might still be receiving data
     const upperBound = new Date(Date.now() - 30 * 1000);
 
-    // Execute backfill
-    logger.info("[EXPERIMENT BACKFILL] Starting backfill process");
-    await processExperimentBackfill(lastRun, upperBound);
+    // Cap each execution to an 8-hour window. The scheduler runs frequently
+    // enough that consecutive jobs will catch up on any larger gap.
+    const maxChunkMs = 8 * 60 * 60 * 1000;
+    const chunkEnd = new Date(
+      Math.min(lastRun.getTime() + maxChunkMs, upperBound.getTime()),
+    );
 
-    // Update timestamp with the upper bound we processed up to
-    await updateBackfillTimestamp(upperBound);
+    logger.info(
+      `[EXPERIMENT BACKFILL] Processing chunk from ${lastRun.toISOString()} to ${chunkEnd.toISOString()}`,
+    );
+    await processExperimentBackfill(lastRun, chunkEnd);
+
+    // Advance the persisted timestamp after successful processing
+    await updateBackfillTimestamp(chunkEnd);
+
     logger.info("[EXPERIMENT BACKFILL] Backfill completed successfully");
   } catch (error) {
     logger.error("[EXPERIMENT BACKFILL] Failed to run backfill", error);

--- a/worker/src/queues/eventPropagationQueue.ts
+++ b/worker/src/queues/eventPropagationQueue.ts
@@ -5,7 +5,7 @@ import {
   instrumentAsync,
 } from "@langfuse/shared/src/server";
 import { handleEventPropagationJob } from "../features/eventPropagation/handleEventPropagationJob";
-// import { runExperimentBackfill } from "../features/eventPropagation/handleExperimentBackfill";
+import { runExperimentBackfill } from "../features/eventPropagation/handleExperimentBackfill";
 import { SpanKind } from "@opentelemetry/api";
 
 export const eventPropagationProcessor: Processor = async (job) => {
@@ -22,7 +22,7 @@ export const eventPropagationProcessor: Processor = async (job) => {
           // Step 1: Execute the main partition processing
           await handleEventPropagationJob(job);
           // Step 2: Execute experiment backfill with 5-minute throttle
-          // await runExperimentBackfill();
+          await runExperimentBackfill();
         } catch (error) {
           logger.error("Error executing EventPropagationJob", error);
           throw error;

--- a/worker/src/queues/eventPropagationQueue.ts
+++ b/worker/src/queues/eventPropagationQueue.ts
@@ -5,7 +5,7 @@ import {
   instrumentAsync,
 } from "@langfuse/shared/src/server";
 import { handleEventPropagationJob } from "../features/eventPropagation/handleEventPropagationJob";
-import { runExperimentBackfill } from "../features/eventPropagation/handleExperimentBackfill";
+// import { runExperimentBackfill } from "../features/eventPropagation/handleExperimentBackfill";
 import { SpanKind } from "@opentelemetry/api";
 
 export const eventPropagationProcessor: Processor = async (job) => {
@@ -22,7 +22,7 @@ export const eventPropagationProcessor: Processor = async (job) => {
           // Step 1: Execute the main partition processing
           await handleEventPropagationJob(job);
           // Step 2: Execute experiment backfill with 5-minute throttle
-          await runExperimentBackfill();
+          // await runExperimentBackfill();
         } catch (error) {
           logger.error("Error executing EventPropagationJob", error);
           throw error;


### PR DESCRIPTION
## Summary
- Temporarily disables the experiment backfill step in the event propagation processor to address performance issues.

## Test plan
- [ ] Verify event propagation queue processes jobs without the backfill step
- [ ] Monitor for improved queue performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)