### PR TITLE
perf(worker): optimize experiment backfill query and add delay metrics

### DIFF
--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -177,6 +177,7 @@ export async function getRelevantObservations(
   projectIds: string[],
   traceIds: string[],
   minTime: Date,
+  maxTime: Date,
 ): Promise<SpanRecord[]> {
   if (projectIds.length === 0 || traceIds.length === 0) {
     return [];
@@ -231,6 +232,7 @@ export async function getRelevantObservations(
     WHERE o.project_id IN {projectIds: Array(String)}
       AND o.trace_id IN {traceIds: Array(String)}
       AND o.start_time >= {minTime: DateTime64(3)} - interval 4 hour
+      AND o.start_time <= {maxTime: DateTime64(3)} + interval 7 day
     ORDER BY o.event_ts DESC
     LIMIT 1 BY o.project_id, o.id
   `;
@@ -241,6 +243,7 @@ export async function getRelevantObservations(
       projectIds,
       traceIds,
       minTime: convertDateToClickhouseDateTime(minTime),
+      maxTime: convertDateToClickhouseDateTime(maxTime),
     },
     tags: {
       feature: "experiment-backfill",
@@ -256,6 +259,7 @@ export async function getRelevantTraces(
   projectIds: string[],
   traceIds: string[],
   minTime: Date,
+  maxTime: Date,
 ): Promise<SpanRecord[]> {
   if (projectIds.length === 0 || traceIds.length === 0) {
     return [];
@@ -305,6 +309,7 @@ export async function getRelevantTraces(
     WHERE t.project_id IN {projectIds: Array(String)}
       AND t.id IN {traceIds: Array(String)}
       AND t.timestamp >= {minTime: DateTime64(3)} - interval 4 hour
+      AND t.timestamp <= {maxTime: DateTime64(3)} + interval 7 day
     ORDER BY t.event_ts DESC
     LIMIT 1 BY t.project_id, t.id
   `;
@@ -315,6 +320,7 @@ export async function getRelevantTraces(
       projectIds,
       traceIds,
       minTime: convertDateToClickhouseDateTime(minTime),
+      maxTime: convertDateToClickhouseDateTime(maxTime),
     },
     tags: {
       feature: "experiment-backfill",
@@ -830,8 +836,8 @@ async function processExperimentBackfill(
 
     // Fetch observations and traces
     const [observations, traces] = await Promise.all([
-      getRelevantObservations(projectIds, traceIds, lastRun),
-      getRelevantTraces(projectIds, traceIds, lastRun),
+      getRelevantObservations(projectIds, traceIds, lastRun, upperBound),
+      getRelevantTraces(projectIds, traceIds, lastRun, upperBound),
     ]);
 
     logger.info(

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -5,6 +5,7 @@ import {
   convertDateToClickhouseDateTime,
   clickhouseClient,
   flattenJsonToPathArrays,
+  recordGauge,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 import { ClickhouseWriter } from "../../services/ClickhouseWriter";
@@ -113,15 +114,12 @@ export async function getDatasetRunItemsSinceLastRun(
   upperBound: Date,
 ): Promise<DatasetRunItem[]> {
   const query = `
-    WITH prefiltered_events as (
-      select distinct project_id, trace_id
-      from events_core
-      where start_time > {lastRun: DateTime64(3)} - interval 1 day
-      and project_id in (
-        select distinct project_id
-        from dataset_run_items_rmt
-        where created_at > {lastRun: DateTime64(3)}
-      )
+    WITH candidate_dris AS (
+      SELECT project_id, trace_id
+      FROM dataset_run_items_rmt
+      WHERE created_at > {lastRun: DateTime64(3)}
+        AND created_at <= {upperBound: DateTime64(3)}
+      GROUP BY project_id, trace_id
     )
 
     SELECT
@@ -140,11 +138,12 @@ export async function getDatasetRunItemsSinceLastRun(
       dri.dataset_item_metadata,
       dri.created_at
     FROM dataset_run_items_rmt AS dri
-    LEFT ANTI JOIN prefiltered_events AS pe
-    ON dri.project_id = pe.project_id
-      AND dri.trace_id = pe.trace_id
+    LEFT ANTI JOIN events_core AS ec
+      ON dri.project_id = ec.project_id
+      AND dri.trace_id = ec.trace_id
     WHERE dri.created_at > {lastRun: DateTime64(3)}
       AND dri.created_at <= {upperBound: DateTime64(3)}
+      AND (dri.project_id, dri.trace_id) IN (SELECT project_id, trace_id FROM candidate_dris)
     ORDER BY dri.created_at DESC
     LIMIT 1 BY dri.project_id, dri.trace_id, coalesce(dri.observation_id, '')
   `;
@@ -741,6 +740,13 @@ export async function runExperimentBackfill(): Promise<void> {
     // Initialize cutoff timestamp (first-run protection)
     const lastRun = await initializeBackfillCutoff();
 
+    // Track how far behind the backfill cursor is, even if we skip due to throttle
+    const lastRunDelaySeconds = (Date.now() - lastRun.getTime()) / 1000;
+    recordGauge(
+      "langfuse.experiment_backfill.last_run_delay_seconds",
+      lastRunDelaySeconds,
+    );
+
     // Check 5-minute throttle
     if (!(await shouldRunBackfill(lastRun))) {
       logger.debug("[EXPERIMENT BACKFILL] Skipping due to throttle");
@@ -765,6 +771,13 @@ export async function runExperimentBackfill(): Promise<void> {
 
     // Advance the persisted timestamp after successful processing
     await updateBackfillTimestamp(chunkEnd);
+
+    // Track remaining delay after processing this chunk
+    const remainingDelaySeconds = (Date.now() - chunkEnd.getTime()) / 1000;
+    recordGauge(
+      "langfuse.experiment_backfill.remaining_delay_seconds",
+      remainingDelaySeconds,
+    );
 
     logger.info("[EXPERIMENT BACKFILL] Backfill completed successfully");
   } catch (error) {


### PR DESCRIPTION
## Summary
- Replaces the broad `events_core` table scan in `getDatasetRunItemsSinceLastRun` with a CTE that first identifies candidate DRIs in the time window, then drives the anti-join from that small set — avoids scanning the full events history
- Adds two delay gauges (`last_run_delay_seconds`, `remaining_delay_seconds`) so backfill cursor drift is detected early via monitoring instead of accumulating silently

## Test plan
- [ ] Verify the optimized query returns the same results as the previous version
- [ ] Confirm both gauges are emitted in monitoring (even on throttled skips for the `last_run` gauge)
- [ ] Monitor ClickHouse query performance improvement for the DRI lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)