### PR TITLE
chore(clickhouse): add langfuse user-agent header to all ClickHouse requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
       "@release-it/bumper": {
         "out": [
           {
+            "file": "./packages/shared/src/constants/VERSION.ts",
+            "type": "application/typescript"
+          },
+          {
             "file": "./web/src/constants/VERSION.ts",
             "type": "application/typescript"
           },

--- a/packages/shared/src/constants/VERSION.ts
+++ b/packages/shared/src/constants/VERSION.ts
@@ -1,0 +1,1 @@
+export const VERSION = "v3.163.0";

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@clickhouse/client";
 import { env } from "../../env";
+import { VERSION } from "../../constants/VERSION";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
 import { getCurrentSpan } from "../instrumentation";
 import { propagation, context } from "@opentelemetry/api";
@@ -117,6 +118,7 @@ export class ClickHouseClientManager {
       const client = createClient({
         ...opts,
         ...settings,
+        application: `langfuse/${VERSION.replace("v", "")}`,
         keep_alive: {
           idle_socket_ttl: env.CLICKHOUSE_KEEP_ALIVE_IDLE_SOCKET_TTL,
         },


### PR DESCRIPTION
## What does this PR do?

Adds a `langfuse/{version}` product token to the User-Agent header sent on every ClickHouse request, using the `application` option in `createClient()`.

Closes [LFE-9069](https://linear.app/langfuse/issue/LFE-9069/add-user-agent-header-to-all-requests-that-langfuse-makes-to)

### Motivation

ClickHouse records the `http_user_agent` field in `system.query_log` for every inbound request. Without a product token, all Langfuse queries are indistinguishable from generic `clickhouse-js` traffic, making it harder to attribute query load, debug issues, and support self-hosters.

### How it works

The `@clickhouse/client` library exposes an `application` config option in `createClient()` that **prepends** the supplied string to its default User-Agent, preserving the library and runtime info:

```
langfuse/3.163.0 clickhouse-js/1.13.0 (lv:nodejs/v20.x.x; os:linux)
```

All ClickHouse clients in this repo are created through the single `ClickHouseClientManager.getClient()` path in `packages/shared`, so this one-line change covers every query made by both `web` and `worker`.

The version string is sourced from a new `packages/shared/src/constants/VERSION.ts` constant — the same file format already used by `web` and `worker` — and is now included in the `@release-it/bumper` output list so it stays in sync automatically on every release.

### Changes

- `packages/shared/src/constants/VERSION.ts` — new file, same format as `web` and `worker` equivalents
- `packages/shared/src/server/clickhouse/client.ts` — adds `application: "langfuse/${VERSION.replace("v", "")}"` to `createClient()`
- `package.json` — adds the new `VERSION.ts` to the `@release-it/bumper` output list

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked that my changes generate no new warnings (`pnpm run lint`)
- [x] New and existing unit tests pass locally with my changes