### PR TITLE
fix(trace-table): Only disable URL persistence for `ScoresTable` in peek mode

### DIFF
--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -129,6 +129,7 @@ export function ObservationDetailView({
     setJsonViewPreference,
     jsonBetaEnabled,
     setJsonBetaEnabled,
+    isPeekMode,
   } = useViewPreferences();
 
   // Map jsonViewPreference to currentView format expected by child components
@@ -480,7 +481,7 @@ export function ObservationDetailView({
                 "userId",
               ]}
               localStorageSuffix="ObservationPreview"
-              disableUrlPersistence
+              disableUrlPersistence={isPeekMode}
             />
           </div>
         </TabsBarContent>

--- a/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
@@ -93,6 +93,7 @@ export function TraceDetailView({
     setJsonViewPreference,
     jsonBetaEnabled,
     setJsonBetaEnabled,
+    isPeekMode,
   } = useViewPreferences();
 
   // Map jsonViewPreference to currentView format expected by child components
@@ -421,7 +422,7 @@ export function TraceDetailView({
                 traceId={trace.id}
                 hiddenColumns={["traceName", "jobConfigurationId", "userId"]}
                 localStorageSuffix="TracePreview"
-                disableUrlPersistence
+                disableUrlPersistence={isPeekMode}
               />
             </div>
           </TabsBarContent>


### PR DESCRIPTION
## What does this PR do?

The `ScoresTable` filtering in the `TraceDetailView` was not working because the sidebar filter state was not persisted to the URL, as `disableUrlPersistence` was enabled ([see relevant code](https://github.com/langfuse/langfuse/blob/1793101288e09c2420b7c027744894ca04919892/web/src/components/table/use-cases/scores.tsx#L294)).
This PR ensures that `disableUrlPersistence` is only set to true when the `ScoresTable` is in peek mode, and not for fullscreen pages such as `TraceDetailView`.

Loom Video: https://www.loom.com/share/4bbc55658a2a4bfd919e1a5ad3516f58

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
