### PR TITLE
feat(worker): add env var to exclude project IDs from experiment backfill

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -271,6 +271,12 @@ const EnvSchema = z.object({
     .positive()
     .default(5 * 60 * 1000), // 5 minutes
 
+  // Comma-separated list of project IDs to exclude from experiment backfill processing
+  LANGFUSE_EXPERIMENT_BACKFILL_EXCLUDE_PROJECT_IDS: z
+    .string()
+    .optional()
+    .transform((s) => (s ? s.split(",").map((id) => id.trim()) : [])),
+
   // Core data S3 upload - Langfuse Cloud
   LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z
     .enum(["true", "false"])

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -809,7 +809,26 @@ async function processExperimentBackfill(
     upperBound,
   );
 
-  if (allDatasetRunItems.length === 0) {
+  // Filter out excluded project IDs
+  const excludeProjectIds =
+    env.LANGFUSE_EXPERIMENT_BACKFILL_EXCLUDE_PROJECT_IDS;
+  const datasetRunItems =
+    excludeProjectIds && excludeProjectIds.length > 0
+      ? allDatasetRunItems.filter(
+          (dri) => !excludeProjectIds.includes(dri.project_id),
+        )
+      : allDatasetRunItems;
+
+  if (excludeProjectIds && excludeProjectIds.length > 0) {
+    const excludedCount = allDatasetRunItems.length - datasetRunItems.length;
+    if (excludedCount > 0) {
+      logger.info(
+        `[EXPERIMENT BACKFILL] Excluded ${excludedCount} items from ${excludeProjectIds.length} excluded project(s)`,
+      );
+    }
+  }
+
+  if (datasetRunItems.length === 0) {
     logger.info(
       "[EXPERIMENT BACKFILL] No dataset run items to process, skipping",
     );
@@ -818,10 +837,10 @@ async function processExperimentBackfill(
 
   // Step 2: Process in chunks
   const chunkSize = env.LANGFUSE_DATASET_RUN_BACKFILL_CHUNK_SIZE;
-  const chunks = chunk(allDatasetRunItems, chunkSize);
+  const chunks = chunk(datasetRunItems, chunkSize);
 
   logger.info(
-    `[EXPERIMENT BACKFILL] Processing ${allDatasetRunItems.length} items in ${chunks.length} chunks of ${chunkSize}`,
+    `[EXPERIMENT BACKFILL] Processing ${datasetRunItems.length} items in ${chunks.length} chunks of ${chunkSize}`,
   );
 
   for (let i = 0; i < chunks.length; i++) {
@@ -919,6 +938,6 @@ async function processExperimentBackfill(
   }
 
   logger.info(
-    `[EXPERIMENT BACKFILL] Completed backfill process for ${allDatasetRunItems.length} items`,
+    `[EXPERIMENT BACKFILL] Completed backfill process for ${datasetRunItems.length} items`,
   );
 }


### PR DESCRIPTION
## Summary
- Adds `LANGFUSE_EXPERIMENT_BACKFILL_EXCLUDE_PROJECT_IDS` env var (comma-separated list) to allow excluding specific project IDs from the experiment dual-write backfill processing
- After fetching eligible dataset run items, items belonging to excluded projects are filtered out before chunk processing
- Follows existing pattern used by `LANGFUSE_BLOB_STORAGE_EXPORT_TRACE_ONLY_PROJECT_IDS`

Resolves https://linear.app/langfuse/issue/LFE-9149/handle-experiment-dual-write-backlog

## Test plan
- [ ] Deploy with env var unset — backfill processes all projects as before
- [ ] Deploy with `LANGFUSE_EXPERIMENT_BACKFILL_EXCLUDE_PROJECT_IDS=proj1,proj2` — verify excluded projects are skipped and logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>