### PR TITLE
perf(worker): skip redundant IngestionService enrichment in experiment backfill

### DIFF
--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -937,7 +937,7 @@ async function processExperimentBackfill(
 
     // Write enriched spans to events_full table
     if (allEnrichedSpans.length > 0) {
-      await writeEnrichedSpans(allEnrichedSpans);
+      writeEnrichedSpans(allEnrichedSpans);
     }
   }
 

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -3,14 +3,12 @@ import {
   queryClickhouse,
   redis,
   convertDateToClickhouseDateTime,
-  clickhouseClient,
   flattenJsonToPathArrays,
   recordGauge,
+  type EventRecordInsertType,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
-import { ClickhouseWriter } from "../../services/ClickhouseWriter";
-import { IngestionService } from "../../services/IngestionService";
-import { prisma } from "@langfuse/shared/src/db";
+import { ClickhouseWriter, TableName } from "../../services/ClickhouseWriter";
 import { chunk } from "lodash";
 
 const EXPERIMENT_BACKFILL_TIMESTAMP_KEY =
@@ -483,114 +481,120 @@ export function enrichSpansWithExperiment(
 }
 
 /**
- * Write enriched spans to the events_full table using IngestionService.writeEventRecord().
- * Converts EnrichedSpan to EventInput format.
+ * Write enriched spans directly to the events_full table.
+ * Spans already have model match, usage, and cost details from ClickHouse,
+ * so we skip IngestionService enrichment and write EventRecordInsertType directly.
  */
-export async function writeEnrichedSpans(spans: EnrichedSpan[]): Promise<void> {
+export function writeEnrichedSpans(spans: EnrichedSpan[]): void {
   if (spans.length === 0) {
     return;
   }
 
-  // Ensure required dependencies are available
-  if (!redis) throw new Error("Redis not available");
-  if (!prisma) throw new Error("Prisma not available");
-
-  const ingestionService = new IngestionService(
-    redis,
-    prisma,
-    ClickhouseWriter.getInstance(),
-    clickhouseClient(),
-  );
+  const clickhouseWriter = ClickhouseWriter.getInstance();
+  const now = Date.now() * 1000; // microseconds
 
   for (const span of spans) {
-    // Convert EnrichedSpan to EventInput format
-    const eventInput = {
-      // Required identifiers
-      projectId: span.project_id,
-      traceId: span.trace_id,
-      spanId: span.span_id,
-      startTimeISO: span.start_time,
-      endTimeISO: span.end_time || span.start_time, // Required field, use start_time as fallback
+    // Flatten metadata for ClickHouse Array(String) columns
+    const flattened = span.metadata
+      ? flattenJsonToPathArrays(span.metadata)
+      : { names: [], values: [] };
 
-      // Optional identifiers
-      parentSpanId: span.parent_span_id || undefined,
+    const promptVersion = span.prompt_version
+      ? parseInt(span.prompt_version, 10)
+      : undefined;
 
-      // Core properties
+    const eventRecord: EventRecordInsertType = {
+      id: span.span_id,
+      project_id: span.project_id,
+      trace_id: span.trace_id,
+      span_id: span.span_id,
+      parent_span_id: span.parent_span_id || undefined,
+
       name: span.name,
       type: span.type,
-      environment: span.environment || undefined,
+      environment: span.environment || "default",
       version: span.version || undefined,
       release: span.release || undefined,
+
       tags: span.tags || [],
       bookmarked: span.bookmarked || false,
       public: span.public || false,
-      completionStartTime: span.completion_start_time || undefined,
 
-      // User/session
-      traceName: span.trace_name || undefined,
-      userId: span.user_id || undefined,
-      sessionId: span.session_id || undefined,
-      level: span.level || undefined,
-      statusMessage: span.status_message || undefined,
+      trace_name: span.trace_name || undefined,
+      user_id: span.user_id || undefined,
+      session_id: span.session_id || undefined,
 
-      // Prompt
-      promptId: span.prompt_id || undefined,
-      promptName: span.prompt_name || undefined,
-      promptVersion: span.prompt_version || undefined,
+      level: span.level || "DEFAULT",
+      status_message: span.status_message || undefined,
 
-      // Model
-      modelName: span.provided_model_name || undefined,
-      modelParameters: span.model_parameters || undefined,
+      start_time: new Date(span.start_time).getTime() * 1000,
+      end_time: span.end_time ? new Date(span.end_time).getTime() * 1000 : null,
+      completion_start_time: span.completion_start_time
+        ? new Date(span.completion_start_time).getTime() * 1000
+        : null,
 
-      // Usage & Cost
-      providedUsageDetails: span.provided_usage_details || undefined,
-      usageDetails: span.usage_details || undefined,
-      providedCostDetails: span.provided_cost_details || undefined,
-      costDetails: span.cost_details || undefined,
-      totalCost: span.total_cost || undefined,
+      prompt_id: span.prompt_id || "",
+      prompt_name: span.prompt_name || undefined,
+      prompt_version:
+        promptVersion != null &&
+        Number.isInteger(promptVersion) &&
+        promptVersion >= 0 &&
+        promptVersion <= 65535
+          ? promptVersion
+          : undefined,
 
-      // Tool calls
-      toolDefinitions: span.tool_definitions || {},
-      toolCalls: span.tool_calls || [],
-      toolCallNames: span.tool_call_names || [],
+      model_id: span.model_id || "",
+      provided_model_name: span.provided_model_name || undefined,
+      model_parameters: span.model_parameters || undefined,
 
-      usagePricingTierId: span.usage_pricing_tier_id || undefined,
-      usagePricingTierName: span.usage_pricing_tier_name || undefined,
+      provided_usage_details: span.provided_usage_details ?? {},
+      usage_details: span.usage_details ?? {},
+      provided_cost_details: span.provided_cost_details ?? {},
+      cost_details: span.cost_details ?? {},
 
-      // I/O
+      usage_pricing_tier_id: span.usage_pricing_tier_id || undefined,
+      usage_pricing_tier_name: span.usage_pricing_tier_name || undefined,
+
+      tool_definitions: span.tool_definitions || {},
+      tool_calls: span.tool_calls || [],
+      tool_call_names: span.tool_call_names || [],
+
       input: span.input || undefined,
       output: span.output || undefined,
 
-      // Metadata
-      metadata: span.metadata,
+      metadata_names: flattened.names,
+      metadata_values: flattened.values.map((v) => v ?? ""),
 
-      // Source/instrumentation
       source: span.source,
 
-      // Experiment fields
-      experimentId: span.experiment_id,
-      experimentName: span.experiment_name,
-      experimentMetadataNames: span.experiment_metadata_names,
-      experimentMetadataValues: span.experiment_metadata_values,
-      experimentDescription: span.experiment_description,
-      experimentDatasetId: span.experiment_dataset_id,
-      experimentItemId: span.experiment_item_id,
-      experimentItemVersion: span.experiment_item_version || undefined,
-      experimentItemRootSpanId: span.experiment_item_root_span_id,
-      experimentItemExpectedOutput: span.experiment_item_expected_output,
-      experimentItemMetadataNames: span.experiment_item_metadata_names,
-      experimentItemMetadataValues: span.experiment_item_metadata_values,
+      blob_storage_file_path: "",
+      event_bytes: 0,
+      is_deleted: 0,
+
+      experiment_id: span.experiment_id,
+      experiment_name: span.experiment_name,
+      experiment_metadata_names: span.experiment_metadata_names || [],
+      experiment_metadata_values: span.experiment_metadata_values || [],
+      experiment_description: span.experiment_description,
+      experiment_dataset_id: span.experiment_dataset_id,
+      experiment_item_id: span.experiment_item_id,
+      experiment_item_version: span.experiment_item_version || undefined,
+      experiment_item_root_span_id: span.experiment_item_root_span_id,
+      experiment_item_expected_output: span.experiment_item_expected_output,
+      experiment_item_metadata_names: span.experiment_item_metadata_names || [],
+      experiment_item_metadata_values:
+        span.experiment_item_metadata_values || [],
+
+      created_at: now,
+      updated_at: now,
+      event_ts: now,
     };
 
-    const eventRecord = await ingestionService.createEventRecord(
-      eventInput,
-      "",
-    ); // Empty fileKey since we're not storing raw events
-    ingestionService.writeEventRecord(eventRecord);
+    clickhouseWriter.addToQueue(TableName.EventsFull, eventRecord);
   }
 
   logger.info(
-    `[EXPERIMENT BACKFILL] Wrote ${spans.length} enriched spans to events_full table via IngestionService`,
+    `[EXPERIMENT BACKFILL] Wrote ${spans.length} enriched spans to events_full table`,
   );
 }
 


### PR DESCRIPTION
## Summary
- Spans processed by the experiment backfill already have model match, usage details, cost details, and pricing tier data from ClickHouse
- Running them through `IngestionService.createEventRecord()` redundantly re-does model matching (Redis + Postgres), tokenization, and cost calculation
- This PR converts `EnrichedSpan` directly to `EventRecordInsertType` and writes to ClickHouse via `ClickhouseWriter.addToQueue()`, removing the `IngestionService` and `prisma` dependencies from `writeEnrichedSpans`

Refs: https://linear.app/langfuse/issue/LFE-9149/handle-experiment-dual-write-backlog

## Test plan
- [ ] Verify experiment backfill writes correct event records to `events_full`
- [ ] Confirm usage/cost/model fields match the source observations
- [ ] Monitor backfill latency improvement in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)