### PR TITLE
perf(worker): advance experiment backfill cursor per chunk

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -265,7 +265,7 @@ const EnvSchema = z.object({
   LANGFUSE_DATASET_RUN_BACKFILL_CHUNK_SIZE: z.coerce
     .number()
     .positive()
-    .default(200),
+    .default(100),
   LANGFUSE_EXPERIMENT_BACKFILL_THROTTLE_MS: z.coerce
     .number()
     .positive()

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -142,7 +142,7 @@ export async function getDatasetRunItemsSinceLastRun(
     WHERE dri.created_at > {lastRun: DateTime64(3)}
       AND dri.created_at <= {upperBound: DateTime64(3)}
       AND (dri.project_id, dri.trace_id) IN (SELECT project_id, trace_id FROM candidate_dris)
-    ORDER BY dri.created_at DESC
+    ORDER BY dri.created_at ASC
     LIMIT 1 BY dri.project_id, dri.trace_id, coalesce(dri.observation_id, '')
   `;
 
@@ -243,6 +243,9 @@ export async function getRelevantObservations(
       minTime: convertDateToClickhouseDateTime(minTime),
       maxTime: convertDateToClickhouseDateTime(maxTime),
     },
+    clickhouseConfigs: {
+      request_timeout: 60_000,
+    },
     tags: {
       feature: "experiment-backfill",
       operation_name: "getRelevantObservations",
@@ -319,6 +322,9 @@ export async function getRelevantTraces(
       traceIds,
       minTime: convertDateToClickhouseDateTime(minTime),
       maxTime: convertDateToClickhouseDateTime(maxTime),
+    },
+    clickhouseConfigs: {
+      request_timeout: 60_000,
     },
     tags: {
       feature: "experiment-backfill",
@@ -779,9 +785,6 @@ export async function runExperimentBackfill(): Promise<void> {
     );
     await processExperimentBackfill(lastRun, chunkEnd);
 
-    // Advance the persisted timestamp after successful processing
-    await updateBackfillTimestamp(chunkEnd);
-
     // Track remaining delay after processing this chunk
     const remainingDelaySeconds = (Date.now() - chunkEnd.getTime()) / 1000;
     recordGauge(
@@ -939,6 +942,14 @@ async function processExperimentBackfill(
     if (allEnrichedSpans.length > 0) {
       writeEnrichedSpans(allEnrichedSpans);
     }
+
+    // Advance cursor after each successful chunk (items are ASC ordered by created_at)
+    const lastItemInChunk = driChunk[driChunk.length - 1];
+    const chunkCursor =
+      i === chunks.length - 1
+        ? upperBound // Final chunk: advance past the entire window
+        : new Date(lastItemInChunk.created_at);
+    await updateBackfillTimestamp(chunkCursor);
   }
 
   logger.info(


### PR DESCRIPTION
## Summary
- Advance the backfill cursor after each successful chunk instead of only after all chunks complete, so failures on chunk N don't cause chunks 1..N-1 to be re-processed on retry
- Order dataset run items ASC by `created_at` (was DESC) to enable safe per-chunk cursor advancement
- Add explicit 60s query timeouts to `getRelevantObservations` and `getRelevantTraces`
- Reduce default chunk size from 200 → 100 for smaller blast radius

## Test plan
- [ ] Deploy to staging and verify backfill logs show cursor advancing after each chunk
- [ ] Verify that if a chunk fails, the next run resumes from the last successful chunk rather than restarting

🤖 Generated with [Claude Code](https://claude.com/claude-code)