### PR TITLE
fix(auth): guard GitHub Enterprise email lookup against empty responses and network errors

### DIFF
--- a/packages/shared/src/server/auth/gitHubEnterpriseProvider.ts
+++ b/packages/shared/src/server/auth/gitHubEnterpriseProvider.ts
@@ -43,10 +43,11 @@ export function GitHubEnterpriseProvider<P extends GithubProfile>(
                   undefined;
               }
             }
-          } catch {
+          } catch (_e) {
             // Network errors should not block login entirely; the profile
             // will proceed with email undefined and NextAuth will surface
             // a sign-in error if an email is required by the adapter.
+            void _e;
           }
         }
 

--- a/packages/shared/src/server/auth/gitHubEnterpriseProvider.ts
+++ b/packages/shared/src/server/auth/gitHubEnterpriseProvider.ts
@@ -30,13 +30,23 @@ export function GitHubEnterpriseProvider<P extends GithubProfile>(
         if (!profile.email) {
           // If the user does not have a public email, get another via the GitHub API
           // See https://docs.github.com/en/rest/users/emails#list-email-addresses-for-the-authenticated-user
-          const res = await fetch(`${apiBaseUrl}/user/emails`, {
-            headers: { Authorization: `token ${tokens.access_token}` },
-          });
+          try {
+            const res = await fetch(`${apiBaseUrl}/user/emails`, {
+              headers: { Authorization: `token ${tokens.access_token}` },
+            });
 
-          if (res.ok) {
-            const emails = (await res.json()) as GithubEmail[];
-            profile.email = (emails.find((e) => e.primary) ?? emails[0]).email;
+            if (res.ok) {
+              const emails = (await res.json()) as GithubEmail[];
+              if (Array.isArray(emails) && emails.length > 0) {
+                profile.email =
+                  (emails.find((e) => e.primary) ?? emails[0])?.email ??
+                  undefined;
+              }
+            }
+          } catch {
+            // Network errors should not block login entirely; the profile
+            // will proceed with email undefined and NextAuth will surface
+            // a sign-in error if an email is required by the adapter.
           }
         }
 


### PR DESCRIPTION
Ran into this while setting up Langfuse with GitHub Enterprise SSO on an internal instance. Users whose GitHub profiles have no public email hit a crash during OAuth login.

### The problem

In `gitHubEnterpriseProvider.ts`, when a user has no public email, the provider fetches `/user/emails` from the GitHub API. Three failure modes exist on that path:

1. **Empty email list**: If the API returns an empty array (e.g., the user hasn't verified any email), `emails[0]` is `undefined` and accessing `.email` on it throws `TypeError: Cannot read properties of undefined (reading 'email')`.

2. **Network failure**: The `fetch` call has no try-catch. On self-hosted GitHub Enterprise instances, DNS resolution failures, firewall rules, or TLS issues cause an unhandled exception that crashes the entire OAuth callback.

3. **Non-array response**: If the API returns an error object with a 200 status (some proxies do this), calling `.find()` on a non-array throws.

Reproduction:
```js
const emails = [];  // empty response from /user/emails
(emails.find(e => e.primary) ?? emails[0]).email
// => TypeError: Cannot read properties of undefined (reading 'email')
```

### The fix

- Wrap the `/user/emails` fetch in try-catch so network errors degrade gracefully instead of crashing
- Check `Array.isArray(emails) && emails.length > 0` before accessing elements
- Use optional chaining on the email access as a final guard

The profile proceeds with `email: undefined` on failure — NextAuth will handle missing email at the adapter level (showing a sign-in error) rather than the whole callback crashing with a 500.

### Before
Login crashes with `TypeError` when GitHub Enterprise returns no emails or the API is unreachable.

### After
Login degrades gracefully — users without a resolvable email see a clear sign-in error instead of a server crash.