### PR TITLE
Fix #12944: bug: v3.163.0 self-hosted Redis/BullMQ regression after #...

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -8,7 +8,6 @@ const defaultRedisOptions: Partial<RedisOptions> = {
   maxRetriesPerRequest: null,
   enableAutoPipelining: env.REDIS_ENABLE_AUTO_PIPELINING === "true",
   keepAlive: 10000, // 10s — prevents middleboxes from killing idle connections
-  socketTimeout: 30000, // 30s — forces reconnect if no data received, prevents hung moveToCompleted() from blocking concurrency slots forever
 };
 
 const REDIS_SCAN_COUNT = 1000;


### PR DESCRIPTION
Closes #12944

## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty redis socketTimeout regression`.

Removes `socketTimeout: 30000` from `defaultRedisOptions` in `packages/shared/src/server/redis/redis.ts`, reverting the regression introduced by #12574 that shipped in v3.163.0.

Fixes # (issue)

The `socketTimeout` option was added to the shared `defaultRedisOptions` object (used by all Redis connections, including BullMQ queue/worker connections) as a fail-fast measure during outages. However, BullMQ worker connections use long-lived blocking commands (`bzpopmin` via `Worker.waitForJob`). With `socketTimeout: 30000` set, ioredis closes and reconnects the socket every 30 seconds of inactivity on an idle queue. Because the BullMQ connections also have `enableOfflineQueue: false`, any in-flight or re-issued command during the reconnect window immediately throws `Stream isn't writeable and enableOfflineQueue options is false`, causing a continuous error loop in both web and worker processes even against a fully healthy Redis instance.

The specific line removed:

```
socketTimeout: 30000, // 30s — forces reconnect if no data received, prevents hung moveToCompleted() from blocking concurrency slots forever
```

This was already reverted on `main` in commit `21210296` (#12930) shortly after the original merge, but no patch release had been cut before users upgraded to v3.163.0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*