### PR TITLE
feat(llm): add first-class GigaChat provider support

### DIFF
--- a/gigachat-integration.md
+++ b/gigachat-integration.md
@@ -1,0 +1,192 @@
+# GigaChat Integration Notes (Thread Summary)
+
+## Goal
+
+Add first-class GigaChat provider support to Langfuse (not only OpenAI-compatible custom base URL usage), and document pricing assumptions for now.
+
+## Integration Approach Chosen
+
+- Implemented as dedicated adapter: `LLMAdapter.GigaChat` (`"gigachat"`).
+- Added provider-specific config and defaults:
+  - `GIGACHAT_DEFAULT_SCOPE = "GIGACHAT_API_PERS"`
+  - `GIGACHAT_DEFAULT_BASE_URL = "https://gigachat.devices.sberbank.ru/api/v1/"`
+- For generic completions/tool-calls, still uses OpenAI-compatible model invocation path after OAuth token exchange.
+- For evaluator structured output (LLMAJ), now uses a dedicated native GigaChat function-calling request path (`functions` + forced `function_call`).
+
+## Inputs Provided During Thread
+
+- LLM connection secret semantics:
+  - `GIGACHAT_CREDENTIALS`
+  - `GIGACHAT_SCOPE` (default `GIGACHAT_API_PERS`)
+  - `GIGACHAT_BASE_URL` (default `https://gigachat.devices.sberbank.ru/api/v1/`)
+- Structured output compatibility:
+  - GigaChat structured output is compatible.
+  - Default method is function calling; json mode exists as well.
+- Source links:
+  - Models endpoint: `https://gigachat.devices.sberbank.ru/api/v1/models`
+  - Pricing page: `https://developers.sber.ru/docs/ru/gigachat/tariffs/individual-tariffs#platnye-pakety`
+
+## Files Changed
+
+### Shared (`packages/shared`)
+
+- `packages/shared/src/interfaces/customLLMProviderConfigSchemas.ts`
+  - Added `GigaChatConfigSchema`.
+  - Added `GIGACHAT_DEFAULT_SCOPE`.
+  - Added `GIGACHAT_DEFAULT_BASE_URL`.
+
+- `packages/shared/src/server/llm/types.ts`
+  - Added `LLMAdapter.GigaChat`.
+  - Added `gigaChatModels`:
+    - `GigaChat-2`
+    - `GigaChat-2-Max`
+    - `GigaChat-2-Pro`
+    - `GigaChat-2-Lite`
+  - Added GigaChat to `supportedModels`.
+  - Extended `LLMApiKeySchema.config` union with `GigaChatConfigSchema`.
+
+- `packages/shared/src/server/llm/fetchLLMCompletion.ts`
+  - Added GigaChat execution branch.
+  - Added OAuth token exchange helper:
+    - POST to `/api/v2/oauth`
+    - `Authorization: Basic <credentials>`
+    - body includes `scope`
+    - includes `RqUID` header
+  - Uses returned access token for chat completion via OpenAI-compatible `ChatOpenAI`.
+  - Added GigaChat-native structured-output path for LLMAJ:
+    - Sends `POST /chat/completions` with `functions` and forced `function_call`.
+    - Converts eval Zod schema to JSON schema for function `parameters`.
+    - Parses response from `choices[0].message.function_call.arguments` (with content fallback).
+  - Added GigaChat OAuth token cache + in-flight dedupe:
+    - Reuses token until near expiry.
+    - Prevents many parallel eval jobs from requesting a new token simultaneously.
+    - Handles `expires_at` / `expires_in` when present; otherwise uses safe fallback TTL.
+
+### Web (`web`)
+
+- `web/src/features/llm-api-key/types.ts`
+  - Added GigaChat config schema to connection payload union.
+
+- `web/src/features/llm-api-key/server/router.ts`
+  - Extended `testLLMConnection` config parsing for GigaChat (`scope`).
+
+- `web/src/features/public-api/types/llm-connections.ts`
+  - Added GigaChat config validation in `PutLlmConnectionV1Body`.
+  - Allows optional GigaChat config (`{ scope: string }`).
+
+- `web/src/features/public-api/components/CreateLLMApiKeyForm.tsx`
+  - Added GigaChat-aware form behavior:
+    - Base URL default and required validation.
+    - Scope field in advanced settings.
+    - Secret label changed to `GigaChat Credentials` for this adapter.
+    - Help text: credentials can be provided with or without `Basic ` prefix.
+  - Included adapter in advanced settings handling.
+
+- `web/src/features/playground/page/hooks/useModelParams.ts`
+  - Added default parameter branch for `LLMAdapter.GigaChat`.
+
+- `web/src/__tests__/server/llm-connections-api.servertest.ts`
+  - Added GigaChat in "all adapters" coverage.
+  - Added config validation case for GigaChat.
+
+### Worker (`worker`)
+
+- `worker/src/__tests__/llmConnections.test.ts`
+  - Added GigaChat integration test scaffold and env var docs.
+  - Added GigaChat evaluator structured-output coverage via shared eval test helper.
+
+- `worker/src/constants/default-model-prices.json`
+  - Added approximate USD pricing entries for:
+    - `gigachat-2` (also matches `gigachat`)
+    - `gigachat-2-lite`
+    - `gigachat-2-pro` (also matches legacy `gigachat-pro`)
+    - `gigachat-2-max` (also matches legacy `gigachat-max`)
+
+## Pricing Assumptions Used
+
+Pricing source is package pricing in RUB, not split by input/output. To make defaults usable in Langfuse's USD/token format, approximate conversion was used for this date:
+
+- Assumed FX: `1 USD = 90 RUB`
+- Conversion from package RUB to USD/token:
+  - Lite (`1300 RUB / 20,000,000`) -> `0.7222e-6`
+  - Pro (`1500 RUB / 3,000,000`) -> `5.5556e-6`
+  - Max (`1950 RUB / 3,000,000`) -> `7.2222e-6`
+- Applied same value for `input` and `output` due to package-level pricing format.
+
+## Validation Run Results
+
+Passed:
+
+- `pnpm --filter @langfuse/shared run lint`
+- `pnpm --filter @langfuse/shared run typecheck`
+- `pnpm --filter @langfuse/shared run build`
+- `pnpm --filter web run lint`
+- `pnpm --filter web run typecheck`
+- `pnpm --filter worker run lint`
+- `pnpm --filter worker run typecheck`
+- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
+- Regex tests for new GigaChat price match patterns via helper script.
+
+## Test Failure Clarification from Thread
+
+`web` test `llm-connections-api.servertest` failing with `TypeError: fetch failed` is not due to GigaChat credentials.
+
+Reason:
+
+- Test helper targets `http://localhost:3000` directly.
+- If web app is not reachable at port 3000, all tests in that suite fail with `fetch failed`.
+
+How to run properly:
+
+1. Start app stack (`pnpm run dev` or at least web + required infra).
+2. Run:
+   - `pnpm --filter web run test --testPathPatterns="llm-connections-api\.servertest"`
+
+## LLMAJ Runtime Issues and Fixes (Latest)
+
+Observed during dataset LLMAJ runs:
+
+- Initial failure: `Model configuration not valid for evaluation. 400 status code (no body)`.
+- Root cause: GigaChat structured output via generic OpenAI-style path was not reliable for evaluator schema calls.
+- Fix applied: native GigaChat function-calling structured-output branch in `fetchLLMCompletion`.
+
+Subsequent failure:
+
+- `429 status code` with LangChain rate-limit wrapper message.
+- Worker logs show concrete source:
+  - `GigaChat auth failed with status 429 ...` from OAuth token endpoint (`/api/v2/oauth`), not from score schema parsing.
+- Fix applied: OAuth token caching + in-flight request deduplication to reduce auth request burst load.
+
+Current expected behavior:
+
+- LLMAJ retries still happen via existing queue retry logic on retryable LLM errors.
+- Auth 429 frequency should be significantly reduced because token is reused for ~token lifetime instead of per-call auth requests.
+
+## Environment Variables of Interest
+
+### For runtime GigaChat integration
+
+- `GIGACHAT_CREDENTIALS` (used as LLM connection secret in UI/API)
+- `GIGACHAT_SCOPE` (default `GIGACHAT_API_PERS`)
+- `GIGACHAT_BASE_URL` (default `https://gigachat.devices.sberbank.ru/api/v1/`)
+
+### For worker integration tests (if executing live)
+
+- `LANGFUSE_LLM_CONNECTION_GIGACHAT_CREDENTIALS`
+- `LANGFUSE_LLM_CONNECTION_GIGACHAT_BASE_URL`
+- `LANGFUSE_LLM_CONNECTION_GIGACHAT_SCOPE` (optional; defaulted in test)
+
+## Open Follow-Ups (Optional)
+
+- Add explicit docs section in user-facing setup docs for GigaChat credentials format and defaults.
+- Revisit pricing entries with a fixed FX policy or official USD-equivalent source if available.
+- Decide whether to add tokenizer mapping once an appropriate tokenizer strategy is chosen for GigaChat models.
+
+## Reference Links
+
+- Langfuse contributing guideline:
+  - https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md
+- GigaChat models:
+  - https://gigachat.devices.sberbank.ru/api/v1/models
+- GigaChat tariffs:
+  - https://developers.sber.ru/docs/ru/gigachat/tariffs/individual-tariffs#platnye-pakety

--- a/packages/shared/src/interfaces/customLLMProviderConfigSchemas.ts
+++ b/packages/shared/src/interfaces/customLLMProviderConfigSchemas.ts
@@ -27,6 +27,19 @@ export const VertexAIConfigSchema = z
 
 export type VertexAIConfig = z.infer<typeof VertexAIConfigSchema>;
 
+export const GIGACHAT_DEFAULT_SCOPE = "GIGACHAT_API_PERS";
+export const GIGACHAT_DEFAULT_BASE_URL =
+  "https://gigachat.devices.sberbank.ru/api/v1/";
+export const GIGACHAT_DEFAULT_OAUTH_URL =
+  "https://ngw.devices.sberbank.ru:9443/api/v2/oauth";
+
+export const GigaChatConfigSchema = z
+  .object({
+    scope: z.string().default(GIGACHAT_DEFAULT_SCOPE),
+  })
+  .strict();
+export type GigaChatConfig = z.infer<typeof GigaChatConfigSchema>;
+
 export const GCPServiceAccountKeySchema = z.object({
   type: z.literal("service_account"),
   project_id: z.string(),

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -1,4 +1,5 @@
 import { type ZodSchema, z } from "zod";
+import { randomUUID } from "crypto";
 
 import { ChatAnthropic, ChatAnthropicInput } from "@langchain/anthropic";
 import { ChatVertexAI } from "@langchain/google-vertexai";
@@ -21,6 +22,9 @@ import { env } from "../../env";
 import GCPServiceAccountKeySchema, {
   BedrockConfigSchema,
   BedrockCredentialSchema,
+  GIGACHAT_DEFAULT_BASE_URL,
+  GIGACHAT_DEFAULT_OAUTH_URL,
+  GigaChatConfigSchema,
   VertexAIConfigSchema,
   BEDROCK_USE_DEFAULT_CREDENTIALS,
   VERTEXAI_USE_DEFAULT_CREDENTIALS,
@@ -40,7 +44,7 @@ import {
   TraceSinkParams,
 } from "./types";
 import type { BaseCallbackHandler } from "@langchain/core/callbacks/base";
-import { ProxyAgent } from "undici";
+import { Agent, ProxyAgent } from "undici";
 import { getInternalTracingHandler } from "./getInternalTracingHandler";
 import { decrypt } from "../../encryption";
 import { decryptAndParseExtraHeaders } from "./utils";
@@ -57,6 +61,22 @@ const THINKING_BLOCK_TYPES: Partial<Record<LLMAdapter, Set<string>>> = {
   [LLMAdapter.VertexAI]: new Set(["reasoning"]),
   [LLMAdapter.GoogleAIStudio]: new Set(["reasoning"]),
 };
+
+// Some adapters reject native JSON-schema response format but accept function-calling.
+const STRUCTURED_OUTPUT_FUNCTION_CALLING_ADAPTERS = new Set<LLMAdapter>([
+  LLMAdapter.GigaChat,
+]);
+
+const GIGACHAT_TOKEN_DEFAULT_TTL_MS = 25 * 60 * 1000;
+const GIGACHAT_TOKEN_EXPIRY_SAFETY_WINDOW_MS = 60 * 1000;
+const GIGACHAT_OAUTH_MAX_ATTEMPTS = 3;
+const GIGACHAT_OAUTH_BASE_RETRY_DELAY_MS = 750;
+
+const gigaChatTokenCache = new Map<
+  string,
+  { accessToken: string; expiresAtMs: number }
+>();
+const gigaChatTokenInflightRequests = new Map<string, Promise<string>>();
 
 function getThinkingBlockTypes(adapter: LLMAdapter): Set<string> | undefined {
   return THINKING_BLOCK_TYPES[adapter];
@@ -245,6 +265,13 @@ export async function fetchLLMCompletion(
   const proxyUrl = env.HTTPS_PROXY;
   const proxyDispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
   const timeoutMs = env.LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS;
+  let gigaChatRuntime:
+    | {
+        baseURL: string;
+        accessToken: string;
+        dispatcher: Agent | ProxyAgent;
+      }
+    | undefined;
 
   let chatModel:
     | ChatOpenAI
@@ -326,6 +353,44 @@ export async function fetchLLMCompletion(
         ...(proxyDispatcher && {
           fetchOptions: { dispatcher: proxyDispatcher },
         }),
+      },
+      modelKwargs: modelParams.providerOptions,
+      timeout: timeoutMs,
+    });
+  } else if (modelParams.adapter === LLMAdapter.GigaChat) {
+    const gigaChatConfig = GigaChatConfigSchema.parse(config ?? {});
+    const gigaChatBaseURL = baseURL ?? GIGACHAT_DEFAULT_BASE_URL;
+    const gigaChatDispatcher = getGigaChatDispatcher(proxyDispatcher);
+    const gigaChatAccessToken = await fetchGigaChatAccessToken({
+      credentials: apiKey,
+      scope: gigaChatConfig.scope,
+      baseURL: gigaChatBaseURL,
+      timeoutMs,
+      dispatcher: gigaChatDispatcher,
+    });
+    gigaChatRuntime = {
+      baseURL: gigaChatBaseURL,
+      accessToken: gigaChatAccessToken,
+      dispatcher: gigaChatDispatcher,
+    };
+
+    chatModel = new ChatOpenAI({
+      apiKey: gigaChatAccessToken,
+      model: modelParams.model,
+      temperature: modelParams.temperature,
+      maxTokens: modelParams.max_tokens,
+      topP: modelParams.top_p,
+      streamUsage: false,
+      callbacks: finalCallbacks,
+      maxRetries,
+      configuration: {
+        baseURL: processOpenAIBaseURL({
+          url: gigaChatBaseURL,
+          modelName: modelParams.model,
+        }),
+        timeout: timeoutMs,
+        defaultHeaders: extraHeaders,
+        fetchOptions: { dispatcher: gigaChatDispatcher },
       },
       modelKwargs: modelParams.providerOptions,
       timeout: timeoutMs,
@@ -458,12 +523,30 @@ export async function fetchLLMCompletion(
   try {
     // Important: await all generations in the try block as otherwise `processTracedEvents` will run too early in finally block
     if (params.structuredOutputSchema) {
+      // GigaChat structured output is more reliable via native function calling payload.
+      if (
+        modelParams.adapter === LLMAdapter.GigaChat &&
+        gigaChatRuntime &&
+        !streaming
+      ) {
+        return await fetchGigaChatStructuredOutput({
+          messages,
+          modelParams,
+          structuredOutputSchema: params.structuredOutputSchema,
+          runtime: gigaChatRuntime,
+          extraHeaders,
+          timeoutMs,
+        });
+      }
+
       // Thinking-capable adapters may produce reasoning blocks that corrupt JSON schema
       // parsing. Force function calling so the parser reads from tool_calls instead.
-      const structuredOutputConfig =
-        thinkingTypes != null
-          ? { method: "functionCalling" as const }
-          : undefined;
+      const shouldUseFunctionCallingForStructuredOutput =
+        thinkingTypes != null ||
+        STRUCTURED_OUTPUT_FUNCTION_CALLING_ADAPTERS.has(modelParams.adapter);
+      const structuredOutputConfig = shouldUseFunctionCallingForStructuredOutput
+        ? { method: "functionCalling" as const }
+        : undefined;
 
       const structuredOutput = await (chatModel as ChatOpenAI)
         .withStructuredOutput(
@@ -649,6 +732,149 @@ function processOpenAIBaseURL(params: {
   return url.replace("{model}", modelName);
 }
 
+function getGigaChatDispatcher(
+  proxyDispatcher?: ProxyAgent,
+): Agent | ProxyAgent {
+  if (proxyDispatcher) {
+    return proxyDispatcher;
+  }
+
+  // GigaChat may require additional trusted root certs (MinTsifry).
+  // To keep setup simple, default to TLS certificate verification disabled.
+  return new Agent({
+    connect: {
+      rejectUnauthorized: false,
+    },
+  });
+}
+
+async function fetchGigaChatAccessToken(params: {
+  credentials: string;
+  scope: string;
+  baseURL: string;
+  timeoutMs: number;
+  dispatcher: Agent | ProxyAgent;
+}): Promise<string> {
+  const { credentials, scope, baseURL, timeoutMs, dispatcher } = params;
+  const tokenUrl = getGigaChatOAuthUrl(baseURL);
+  const basicCredentials = credentials.startsWith("Basic ")
+    ? credentials.slice(6).trim()
+    : credentials.trim();
+  const cacheKey = `${tokenUrl}|${scope}|${basicCredentials}`;
+
+  const cachedToken = gigaChatTokenCache.get(cacheKey);
+  if (
+    cachedToken &&
+    cachedToken.expiresAtMs - GIGACHAT_TOKEN_EXPIRY_SAFETY_WINDOW_MS >
+      Date.now()
+  ) {
+    return cachedToken.accessToken;
+  }
+
+  const inflightRequest = gigaChatTokenInflightRequests.get(cacheKey);
+  if (inflightRequest) {
+    return inflightRequest;
+  }
+
+  const accessTokenPromise = (async () => {
+    let response: Response | null = null;
+    let responseText = "";
+
+    for (let attempt = 1; attempt <= GIGACHAT_OAUTH_MAX_ATTEMPTS; attempt++) {
+      response = await fetch(tokenUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${basicCredentials}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+          RqUID: randomUUID(),
+        },
+        body: new URLSearchParams({ scope }).toString(),
+        signal: AbortSignal.timeout(timeoutMs),
+        ...(dispatcher ? ({ dispatcher } as any) : {}),
+      });
+
+      if (response.ok) {
+        break;
+      }
+
+      responseText = await response.text();
+      const isRetryableStatus =
+        response.status === 429 || response.status >= 500;
+      const shouldRetry =
+        isRetryableStatus && attempt < GIGACHAT_OAUTH_MAX_ATTEMPTS;
+
+      if (!shouldRetry) {
+        throw createGigaChatRequestError({
+          message: `GigaChat auth failed with status ${response.status}: ${responseText}`,
+          status: response.status,
+        });
+      }
+
+      const retryDelayMs = getRetryDelayMs({
+        attempt,
+        retryAfterHeader: response.headers.get("retry-after"),
+      });
+      logger.warn(
+        `GigaChat auth attempt ${attempt}/${GIGACHAT_OAUTH_MAX_ATTEMPTS} failed with ${response.status}. Retrying in ${retryDelayMs}ms`,
+      );
+      await sleep(retryDelayMs);
+    }
+
+    if (!response || !response.ok) {
+      throw createGigaChatRequestError({
+        message: `GigaChat auth failed without a successful response${
+          responseText ? `: ${responseText}` : ""
+        }`,
+      });
+    }
+
+    const tokenPayload = z
+      .object({
+        access_token: z.string(),
+        // API may return either absolute expiry timestamp or lifetime.
+        expires_at: z.union([z.number(), z.string()]).optional(),
+        expires_in: z.union([z.number(), z.string()]).optional(),
+      })
+      .passthrough()
+      .parse(await response.json());
+
+    const now = Date.now();
+    const expiresAtMs = resolveGigaChatTokenExpiryMs({
+      nowMs: now,
+      expiresAtRaw: tokenPayload.expires_at,
+      expiresInRaw: tokenPayload.expires_in,
+    });
+
+    gigaChatTokenCache.set(cacheKey, {
+      accessToken: tokenPayload.access_token,
+      expiresAtMs,
+    });
+
+    return tokenPayload.access_token;
+  })();
+
+  gigaChatTokenInflightRequests.set(cacheKey, accessTokenPromise);
+  try {
+    return await accessTokenPromise;
+  } finally {
+    gigaChatTokenInflightRequests.delete(cacheKey);
+  }
+}
+
+function getGigaChatOAuthUrl(baseURL: string): string {
+  try {
+    const parsed = new URL(baseURL);
+    if (parsed.hostname === "gigachat.devices.sberbank.ru") {
+      return GIGACHAT_DEFAULT_OAUTH_URL;
+    }
+  } catch {
+    // Fallback to default endpoint below.
+  }
+
+  return GIGACHAT_DEFAULT_OAUTH_URL;
+}
+
 function extractCleanErrorMessage(rawMessage: string): string {
   // Try to parse JSON error format (common in Google/Vertex AI errors)
   // Example: '[{"error":{"code":404,"message":"Model not found..."}}]'
@@ -678,4 +904,287 @@ function extractCleanErrorMessage(rawMessage: string): string {
   }
 
   return rawMessage;
+}
+
+function resolveGigaChatTokenExpiryMs(params: {
+  nowMs: number;
+  expiresAtRaw?: number | string;
+  expiresInRaw?: number | string;
+}) {
+  const { nowMs, expiresAtRaw, expiresInRaw } = params;
+
+  const expiresAtNumber =
+    typeof expiresAtRaw === "string" ? Number(expiresAtRaw) : expiresAtRaw;
+  if (typeof expiresAtNumber === "number" && Number.isFinite(expiresAtNumber)) {
+    // Some APIs return seconds, others milliseconds.
+    return expiresAtNumber > 1e12 ? expiresAtNumber : expiresAtNumber * 1000;
+  }
+
+  const expiresInNumber =
+    typeof expiresInRaw === "string" ? Number(expiresInRaw) : expiresInRaw;
+  if (typeof expiresInNumber === "number" && Number.isFinite(expiresInNumber)) {
+    return nowMs + expiresInNumber * 1000;
+  }
+
+  return nowMs + GIGACHAT_TOKEN_DEFAULT_TTL_MS;
+}
+
+function toGigaChatMessages(messages: ChatMessage[]) {
+  return messages
+    .filter((message) => message.content !== "")
+    .map((message) => {
+      const content =
+        typeof message.content === "string"
+          ? message.content
+          : JSON.stringify(message.content);
+
+      if (message.type === ChatMessageType.ToolResult) {
+        return {
+          role: "function",
+          content,
+        };
+      }
+
+      if (message.role === ChatMessageRole.System) {
+        return {
+          role: "system",
+          content,
+        };
+      }
+
+      if (message.role === ChatMessageRole.User) {
+        return {
+          role: "user",
+          content,
+        };
+      }
+
+      return {
+        role: "assistant",
+        content,
+      };
+    });
+}
+
+function buildGigaChatFunctionParameters(
+  schema: ZodSchema | LLMJSONSchema,
+): Record<string, unknown> {
+  if (
+    typeof schema === "object" &&
+    schema !== null &&
+    "type" in schema &&
+    "properties" in schema
+  ) {
+    return schema as Record<string, unknown>;
+  }
+
+  if (schema instanceof z.ZodObject) {
+    return zodObjectToJsonSchema(schema);
+  }
+
+  throw new Error(
+    "Unsupported structured output schema for GigaChat. Expected a JSON schema object or a Zod object schema.",
+  );
+}
+
+function zodObjectToJsonSchema(
+  schema: z.ZodObject<Record<string, z.ZodTypeAny>>,
+): Record<string, unknown> {
+  const shape = schema.shape;
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+
+  for (const [key, value] of Object.entries(shape)) {
+    properties[key] = zodTypeToJsonSchema(value);
+    if (!isZodOptional(value)) {
+      required.push(key);
+    }
+  }
+
+  const description = getZodDescription(schema);
+
+  return {
+    type: "object",
+    properties,
+    ...(required.length ? { required } : {}),
+    ...(description ? { description } : {}),
+    additionalProperties: false,
+  };
+}
+
+function isZodOptional(value: z.ZodTypeAny): boolean {
+  return value instanceof z.ZodOptional || value instanceof z.ZodDefault;
+}
+
+function zodTypeToJsonSchema(schema: z.ZodTypeAny): Record<string, unknown> {
+  const description = getZodDescription(schema);
+
+  if (schema instanceof z.ZodOptional || schema instanceof z.ZodDefault) {
+    return zodTypeToJsonSchema(schema.unwrap() as any);
+  }
+
+  if (schema instanceof z.ZodNullable) {
+    const innerSchema = zodTypeToJsonSchema(schema.unwrap() as any);
+    return {
+      anyOf: [innerSchema, { type: "null" }],
+      ...(description ? { description } : {}),
+    };
+  }
+
+  if (schema instanceof z.ZodString) {
+    return { type: "string", ...(description ? { description } : {}) };
+  }
+  if (schema instanceof z.ZodNumber) {
+    return { type: "number", ...(description ? { description } : {}) };
+  }
+  if (schema instanceof z.ZodBoolean) {
+    return { type: "boolean", ...(description ? { description } : {}) };
+  }
+  if (schema instanceof z.ZodEnum) {
+    return {
+      type: "string",
+      enum: schema.options,
+      ...(description ? { description } : {}),
+    };
+  }
+  if (schema instanceof z.ZodArray) {
+    return {
+      type: "array",
+      items: zodTypeToJsonSchema(schema.element as any),
+      ...(description ? { description } : {}),
+    };
+  }
+  if (schema instanceof z.ZodObject) {
+    const objectSchema = zodObjectToJsonSchema(schema);
+    return {
+      ...objectSchema,
+      ...(description ? { description } : {}),
+    };
+  }
+
+  throw new Error("Unsupported Zod type for GigaChat structured output.");
+}
+
+function getZodDescription(schema: z.ZodTypeAny): string | undefined {
+  const description =
+    (schema as any)?._def?.description ??
+    (schema as any)?._def?.meta?.description ??
+    (schema as any)?.description;
+
+  return typeof description === "string" && description.length > 0
+    ? description
+    : undefined;
+}
+
+function getRetryDelayMs(params: {
+  attempt: number;
+  retryAfterHeader: string | null;
+}): number {
+  const { attempt, retryAfterHeader } = params;
+  const retryAfterSeconds = retryAfterHeader
+    ? Number.parseInt(retryAfterHeader, 10)
+    : NaN;
+
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+    return retryAfterSeconds * 1000;
+  }
+
+  return GIGACHAT_OAUTH_BASE_RETRY_DELAY_MS * Math.pow(2, attempt - 1);
+}
+
+function createGigaChatRequestError(params: {
+  message: string;
+  status?: number;
+}) {
+  const error = new Error(params.message) as Error & { status?: number };
+  if (typeof params.status === "number") {
+    error.status = params.status;
+  }
+  return error;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchGigaChatStructuredOutput(params: {
+  messages: ChatMessage[];
+  modelParams: ModelParams;
+  structuredOutputSchema: ZodSchema | LLMJSONSchema;
+  runtime: {
+    baseURL: string;
+    accessToken: string;
+    dispatcher: Agent | ProxyAgent;
+  };
+  extraHeaders?: Record<string, string>;
+  timeoutMs: number;
+}): Promise<Record<string, unknown>> {
+  const functionName = "structured_output";
+  const functionParameters = buildGigaChatFunctionParameters(
+    params.structuredOutputSchema,
+  );
+
+  const response = await fetch(
+    new URL("chat/completions", params.runtime.baseURL).toString(),
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${params.runtime.accessToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...(params.extraHeaders ?? {}),
+      },
+      body: JSON.stringify({
+        model: params.modelParams.model,
+        messages: toGigaChatMessages(params.messages),
+        functions: [
+          {
+            name: functionName,
+            description:
+              "Return the evaluation result in the required structured format.",
+            parameters: functionParameters,
+          },
+        ],
+        function_call: { name: functionName },
+        temperature: params.modelParams.temperature,
+        max_tokens: params.modelParams.max_tokens,
+        top_p: params.modelParams.top_p,
+        ...(params.modelParams.providerOptions ?? {}),
+      }),
+      signal: AbortSignal.timeout(params.timeoutMs),
+      ...(params.runtime.dispatcher
+        ? ({ dispatcher: params.runtime.dispatcher } as any)
+        : {}),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `GigaChat completion failed with status ${response.status}: ${await response.text()}`,
+    );
+  }
+
+  const payload = (await response.json()) as {
+    choices?: Array<{
+      message?: {
+        function_call?: { arguments?: unknown };
+        content?: unknown;
+      };
+    }>;
+  };
+
+  const rawArguments = payload.choices?.[0]?.message?.function_call?.arguments;
+  if (rawArguments && typeof rawArguments === "object") {
+    return rawArguments as Record<string, unknown>;
+  }
+  if (typeof rawArguments === "string") {
+    return JSON.parse(rawArguments) as Record<string, unknown>;
+  }
+
+  const content = payload.choices?.[0]?.message?.content;
+  if (typeof content === "string") {
+    return JSON.parse(content) as Record<string, unknown>;
+  }
+
+  throw new Error("GigaChat did not return structured output arguments.");
 }

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -2,6 +2,7 @@ import { LlmApiKeys } from "@prisma/client";
 import z from "zod";
 import {
   BedrockConfigSchema,
+  GigaChatConfigSchema,
   VertexAIConfigSchema,
 } from "../../interfaces/customLLMProviderConfigSchemas";
 import { JSONObjectSchema } from "../../utils/zod";
@@ -252,6 +253,7 @@ export enum LLMAdapter {
   Bedrock = "bedrock",
   VertexAI = "google-vertex-ai",
   GoogleAIStudio = "google-ai-studio",
+  GigaChat = "gigachat",
 }
 
 export const TextPromptContentSchema = z.string().min(1, "Enter a prompt");
@@ -485,6 +487,14 @@ export const googleAIStudioModels = [
   "gemini-1.5-flash-8b",
 ] as const;
 
+// WARNING: The first entry in the array is chosen as the default model to add LLM API keys
+export const gigaChatModels = [
+  "GigaChat-2",
+  "GigaChat-2-Max",
+  "GigaChat-2-Pro",
+  "GigaChat-2-Lite",
+] as const;
+
 export type AnthropicModel = (typeof anthropicModels)[number];
 export type VertexAIModel = (typeof vertexAIModels)[number];
 export const supportedModels = {
@@ -492,6 +502,7 @@ export const supportedModels = {
   [LLMAdapter.OpenAI]: openAIModels,
   [LLMAdapter.VertexAI]: vertexAIModels,
   [LLMAdapter.GoogleAIStudio]: googleAIStudioModels,
+  [LLMAdapter.GigaChat]: gigaChatModels,
   [LLMAdapter.Azure]: [],
   [LLMAdapter.Bedrock]: [],
 } as const;
@@ -517,7 +528,9 @@ export const LLMApiKeySchema = z
     baseURL: z.string().nullable(),
     customModels: z.array(z.string()),
     withDefaultModels: z.boolean(),
-    config: z.union([BedrockConfigSchema, VertexAIConfigSchema]).nullish(), // Bedrock and VertexAI have additional config
+    config: z
+      .union([BedrockConfigSchema, VertexAIConfigSchema, GigaChatConfigSchema])
+      .nullish(), // Bedrock, VertexAI and GigaChat have additional config
   })
   // strict mode to prevent extra keys. Thorws error otherwise
   // https://github.com/colinhacks/zod?tab=readme-ov-file#strict

--- a/web/src/__tests__/server/llm-connections-api.servertest.ts
+++ b/web/src/__tests__/server/llm-connections-api.servertest.ts
@@ -515,6 +515,10 @@ describe("/api/public/llm-connections API Endpoints", () => {
           adapter: LLMAdapter.GoogleAIStudio,
           provider: generateUniqueProvider("test-studio"),
         },
+        {
+          adapter: LLMAdapter.GigaChat,
+          provider: generateUniqueProvider("test-gigachat"),
+        },
       ];
 
       for (const { adapter, provider } of adaptersWithoutConfig) {
@@ -588,6 +592,25 @@ describe("/api/public/llm-connections API Endpoints", () => {
       expect(vertexResponse.status).toBe(201);
       expect(vertexResponse.body.adapter).toBe(LLMAdapter.VertexAI);
       expect(vertexResponse.body.config).toBeNull();
+
+      const gigachatResponse = await makeZodVerifiedAPICall(
+        PutLlmConnectionV1Response,
+        "PUT",
+        "/api/public/llm-connections",
+        {
+          provider: generateUniqueProvider("test-gigachat-config"),
+          adapter: LLMAdapter.GigaChat,
+          secretKey: "credentials-value",
+          config: { scope: "GIGACHAT_API_PERS" },
+        },
+        auth,
+        201,
+      );
+      expect(gigachatResponse.status).toBe(201);
+      expect(gigachatResponse.body.adapter).toBe(LLMAdapter.GigaChat);
+      expect(gigachatResponse.body.config).toEqual({
+        scope: "GIGACHAT_API_PERS",
+      });
     });
 
     it("should handle optional fields correctly", async () => {

--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -17,6 +17,7 @@ import {
   supportedModels,
   GCPServiceAccountKeySchema,
   BedrockConfigSchema,
+  GigaChatConfigSchema,
   VertexAIConfigSchema,
   BEDROCK_USE_DEFAULT_CREDENTIALS,
   VERTEXAI_USE_DEFAULT_CREDENTIALS,
@@ -99,6 +100,9 @@ async function testLLMConnection(
       parsedConfig = vertexAIConfig.location
         ? { location: vertexAIConfig.location }
         : null;
+    } else if (params.adapter === LLMAdapter.GigaChat) {
+      const gigaChatConfig = GigaChatConfigSchema.parse(params.config ?? {});
+      parsedConfig = { scope: gigaChatConfig.scope };
     }
 
     await fetchLLMCompletion({

--- a/web/src/features/llm-api-key/types.ts
+++ b/web/src/features/llm-api-key/types.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import {
-  LLMAdapter,
   BedrockConfigSchema,
+  GigaChatConfigSchema,
+  LLMAdapter,
   VertexAIConfigSchema,
 } from "@langfuse/shared";
 
@@ -15,7 +16,9 @@ export const LlmApiKeySchema = z.object({
   baseURL: z.string().url().optional(),
   withDefaultModels: z.boolean().optional(),
   customModels: z.array(z.string().min(1)).optional(),
-  config: z.union([VertexAIConfigSchema, BedrockConfigSchema]).optional(),
+  config: z
+    .union([VertexAIConfigSchema, BedrockConfigSchema, GigaChatConfigSchema])
+    .optional(),
   extraHeaders: z.record(z.string(), z.string()).optional(),
 });
 

--- a/web/src/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/features/playground/page/hooks/useModelParams.ts
@@ -306,5 +306,19 @@ function getDefaultAdapterParams(
         maxReasoningTokens: { value: 0, enabled: false },
         providerOptions: { value: {}, enabled: false },
       };
+
+    case LLMAdapter.GigaChat:
+      return {
+        adapter: {
+          value: adapter,
+          enabled: true,
+        },
+        temperature: { value: 0, enabled: false },
+        maxTemperature: { value: 2, enabled: false },
+        max_tokens: { value: 4096, enabled: false },
+        top_p: { value: 1, enabled: false },
+        maxReasoningTokens: { value: 0, enabled: false },
+        providerOptions: { value: {}, enabled: false },
+      };
   }
 }

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -4,6 +4,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import {
   type BedrockConfig,
   type BedrockCredential,
+  GIGACHAT_DEFAULT_BASE_URL,
+  GIGACHAT_DEFAULT_SCOPE,
+  type GigaChatConfig,
   type VertexAIConfig,
   LLMAdapter,
   type LlmApiKeys,
@@ -63,6 +66,7 @@ const createFormSchema = (mode: "create" | "update") =>
       awsSecretAccessKey: z.string().optional(),
       awsRegion: z.string().optional(),
       vertexAILocation: z.string().optional(),
+      gigachatScope: z.string().optional(),
       extraHeaders: z.array(
         z.object({
           key: z.string().min(1),
@@ -159,11 +163,12 @@ const createFormSchema = (mode: "create" | "update") =>
     )
     .refine(
       (data) => {
-        if (data.adapter !== LLMAdapter.Azure) return true;
+        if (![LLMAdapter.Azure, LLMAdapter.GigaChat].includes(data.adapter))
+          return true;
         return data.baseURL && data.baseURL.trim() !== "";
       },
       {
-        message: "API Base URL is required for Azure connections.",
+        message: "API Base URL is required for Azure and GigaChat connections.",
         path: ["baseURL"],
       },
     );
@@ -217,6 +222,8 @@ export function CreateLLMApiKeyForm({
         return customization?.defaultBaseUrlAzure ?? "";
       case LLMAdapter.Anthropic:
         return customization?.defaultBaseUrlAnthropic ?? "";
+      case LLMAdapter.GigaChat:
+        return GIGACHAT_DEFAULT_BASE_URL;
       default:
         return "";
     }
@@ -252,6 +259,11 @@ export function CreateLLMApiKeyForm({
               existingKey.adapter === LLMAdapter.Bedrock && existingKey.config
                 ? ((existingKey.config as BedrockConfig).region ?? "")
                 : "",
+            gigachatScope:
+              existingKey.adapter === LLMAdapter.GigaChat && existingKey.config
+                ? ((existingKey.config as GigaChatConfig).scope ??
+                  GIGACHAT_DEFAULT_SCOPE)
+                : GIGACHAT_DEFAULT_SCOPE,
             awsAccessKeyId: "",
             awsSecretAccessKey: "",
           }
@@ -265,6 +277,7 @@ export function CreateLLMApiKeyForm({
             extraHeaders: [],
             vertexAILocation: "global",
             awsRegion: "",
+            gigachatScope: GIGACHAT_DEFAULT_SCOPE,
             awsAccessKeyId: "",
             awsSecretAccessKey: "",
           },
@@ -276,7 +289,8 @@ export function CreateLLMApiKeyForm({
     adapter === LLMAdapter.OpenAI ||
     adapter === LLMAdapter.Anthropic ||
     adapter === LLMAdapter.VertexAI ||
-    adapter === LLMAdapter.GoogleAIStudio;
+    adapter === LLMAdapter.GoogleAIStudio ||
+    adapter === LLMAdapter.GigaChat;
 
   const { fields, append, remove } = useFieldArray({
     control: form.control,
@@ -431,7 +445,7 @@ export function CreateLLMApiKeyForm({
     }
 
     let secretKey = values.secretKey;
-    let config: BedrockConfig | VertexAIConfig | undefined;
+    let config: BedrockConfig | VertexAIConfig | GigaChatConfig | undefined;
 
     if (currentAdapter === LLMAdapter.Bedrock) {
       // In update mode, only update credentials if provided
@@ -489,6 +503,10 @@ export function CreateLLMApiKeyForm({
       if (Object.keys(config).length === 0) {
         config = undefined;
       }
+    } else if (currentAdapter === LLMAdapter.GigaChat) {
+      config = {
+        scope: values.gigachatScope?.trim() || GIGACHAT_DEFAULT_SCOPE,
+      };
     }
 
     const extraHeaders =
@@ -894,12 +912,23 @@ export function CreateLLMApiKeyForm({
               name="secretKey"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>API Key</FormLabel>
+                  <FormLabel>
+                    {currentAdapter === LLMAdapter.GigaChat
+                      ? "GigaChat Credentials"
+                      : "API Key"}
+                  </FormLabel>
                   <FormDescription>
                     {isLangfuseCloud
                       ? "Your API keys are stored encrypted on our servers."
                       : "Your API keys are stored encrypted in your database."}
                   </FormDescription>
+                  {currentAdapter === LLMAdapter.GigaChat && (
+                    <FormDescription className="text-dark-yellow">
+                      Use the value of <code>GIGACHAT_CREDENTIALS</code> (Basic
+                      auth credentials from Sber). You can provide it with or
+                      without the <code>Basic </code> prefix.
+                    </FormDescription>
+                  )}
                   <FormControl>
                     <Input
                       {...field}
@@ -920,7 +949,7 @@ export function CreateLLMApiKeyForm({
           )}
 
           {/* Azure Base URL - Always required for Azure */}
-          {currentAdapter === LLMAdapter.Azure && (
+          {[LLMAdapter.Azure, LLMAdapter.GigaChat].includes(currentAdapter) && (
             <FormField
               control={form.control}
               name="baseURL"
@@ -928,15 +957,43 @@ export function CreateLLMApiKeyForm({
                 <FormItem>
                   <FormLabel>API Base URL</FormLabel>
                   <FormDescription>
-                    Please add the base URL in the following format (or
-                    compatible API):
-                    https://&#123;instanceName&#125;.openai.azure.com/openai/deployments
+                    {currentAdapter === LLMAdapter.Azure
+                      ? "Please add the base URL in the following format (or compatible API): https://{instanceName}.openai.azure.com/openai/deployments"
+                      : `Default GigaChat base URL: ${GIGACHAT_DEFAULT_BASE_URL}`}
                   </FormDescription>
                   <FormControl>
                     <Input
                       {...field}
-                      placeholder="https://your-instance.openai.azure.com/openai/deployments"
+                      placeholder={
+                        currentAdapter === LLMAdapter.Azure
+                          ? "https://your-instance.openai.azure.com/openai/deployments"
+                          : GIGACHAT_DEFAULT_BASE_URL
+                      }
                     />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+
+          {/* GigaChat Scope - main section */}
+          {currentAdapter === LLMAdapter.GigaChat && (
+            <FormField
+              control={form.control}
+              name="gigachatScope"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Scope</FormLabel>
+                  <FormDescription>
+                    OAuth scope for GigaChat token exchange. Defaults to{" "}
+                    <span className="font-medium">
+                      {GIGACHAT_DEFAULT_SCOPE}
+                    </span>
+                    .
+                  </FormDescription>
+                  <FormControl>
+                    <Input {...field} placeholder={GIGACHAT_DEFAULT_SCOPE} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -974,34 +1031,36 @@ export function CreateLLMApiKeyForm({
           {hasAdvancedSettings(currentAdapter) && showAdvancedSettings && (
             <div className="space-y-4 border-t pt-4">
               {/* baseURL */}
-              <FormField
-                control={form.control}
-                name="baseURL"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>API Base URL</FormLabel>
-                    <FormDescription>
-                      Leave blank to use the default base URL for the given LLM
-                      adapter.{" "}
-                      {currentAdapter === LLMAdapter.OpenAI && (
-                        <span>OpenAI default: https://api.openai.com/v1</span>
-                      )}
-                      {currentAdapter === LLMAdapter.Anthropic && (
-                        <span>
-                          Anthropic default: https://api.anthropic.com
-                          (excluding /v1/messages)
-                        </span>
-                      )}
-                    </FormDescription>
+              {currentAdapter !== LLMAdapter.GigaChat && (
+                <FormField
+                  control={form.control}
+                  name="baseURL"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>API Base URL</FormLabel>
+                      <FormDescription>
+                        Leave blank to use the default base URL for the given
+                        LLM adapter.{" "}
+                        {currentAdapter === LLMAdapter.OpenAI && (
+                          <span>OpenAI default: https://api.openai.com/v1</span>
+                        )}
+                        {currentAdapter === LLMAdapter.Anthropic && (
+                          <span>
+                            Anthropic default: https://api.anthropic.com
+                            (excluding /v1/messages)
+                          </span>
+                        )}
+                      </FormDescription>
 
-                    <FormControl>
-                      <Input {...field} placeholder="default" />
-                    </FormControl>
+                      <FormControl>
+                        <Input {...field} placeholder="default" />
+                      </FormControl>
 
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
 
               {/* VertexAI Location */}
               {currentAdapter === LLMAdapter.VertexAI && (

--- a/web/src/features/public-api/types/llm-connections.ts
+++ b/web/src/features/public-api/types/llm-connections.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { paginationZod, LLMAdapter, type JSONValue } from "@langfuse/shared";
-import { BedrockConfigSchema, VertexAIConfigSchema } from "@langfuse/shared";
+import {
+  BedrockConfigSchema,
+  GigaChatConfigSchema,
+  VertexAIConfigSchema,
+} from "@langfuse/shared";
 
 // Base LLM connection response schema - strict to prevent secret leakage
 export const LlmConnectionResponse = z
@@ -83,6 +87,18 @@ export const PutLlmConnectionV1Body = PutLlmConnectionV1BodyBase.superRefine(
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: `Invalid VertexAI config: ${result.error.issues.map((e) => e.message).join(", ")}. Expected: { location: string }`,
+            path: ["config"],
+          });
+        }
+      }
+    } else if (adapter === LLMAdapter.GigaChat) {
+      // GigaChat config is optional, but if provided must be valid
+      if (config) {
+        const result = GigaChatConfigSchema.safeParse(config);
+        if (!result.success) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Invalid GigaChat config: ${result.error.issues.map((e) => e.message).join(", ")}. Expected: { scope: string }`,
             path: ["config"],
           });
         }

--- a/worker/src/__tests__/llmConnections.test.ts
+++ b/worker/src/__tests__/llmConnections.test.ts
@@ -37,6 +37,9 @@ import { z } from "zod";
  * - LANGFUSE_LLM_CONNECTION_BEDROCK_REGION
  * - LANGFUSE_LLM_CONNECTION_VERTEXAI_KEY
  * - LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY
+ * - LANGFUSE_LLM_CONNECTION_GIGACHAT_CREDENTIALS
+ * - LANGFUSE_LLM_CONNECTION_GIGACHAT_BASE_URL
+ * - LANGFUSE_LLM_CONNECTION_GIGACHAT_SCOPE
  */
 
 type TestLLMConnection = {
@@ -1114,5 +1117,83 @@ describe("LLM Connection Tests", () => {
       expect(typeof completion).toBe("object");
       expect((completion as CompletionWithReasoning).text).toContain("4");
     }, 30_000);
+  });
+
+  describe("GigaChat", () => {
+    const MODEL = "GigaChat-2-Max";
+
+    const checkEnvVars = () => {
+      if (!process.env.LANGFUSE_LLM_CONNECTION_GIGACHAT_CREDENTIALS) {
+        throw new Error(
+          "LANGFUSE_LLM_CONNECTION_GIGACHAT_CREDENTIALS not set. " +
+            "This test requires GigaChat credentials to verify the LLM connection. " +
+            "Set the environment variable to run this test.",
+        );
+      }
+      if (!process.env.LANGFUSE_LLM_CONNECTION_GIGACHAT_BASE_URL) {
+        throw new Error(
+          "LANGFUSE_LLM_CONNECTION_GIGACHAT_BASE_URL not set. " +
+            "This test requires the GigaChat base URL to verify the LLM connection. " +
+            "Set the environment variable to run this test.",
+        );
+      }
+    };
+
+    const getConfig = () => ({
+      scope:
+        process.env.LANGFUSE_LLM_CONNECTION_GIGACHAT_SCOPE ??
+        "GIGACHAT_API_PERS",
+    });
+
+    test("simple completion", async () => {
+      checkEnvVars();
+
+      const completion = await fetchLLMCompletion({
+        streaming: false,
+        messages: [
+          {
+            role: "user",
+            content: "What is 2+2? Answer only with the number.",
+            type: ChatMessageType.PublicAPICreated,
+          },
+        ],
+        modelParams: {
+          provider: "gigachat",
+          adapter: LLMAdapter.GigaChat,
+          model: MODEL,
+          temperature: 0,
+          max_tokens: 10,
+        },
+        llmConnection: {
+          secretKey: encrypt(
+            process.env.LANGFUSE_LLM_CONNECTION_GIGACHAT_CREDENTIALS!,
+          ),
+          baseURL: process.env.LANGFUSE_LLM_CONNECTION_GIGACHAT_BASE_URL!,
+          config: getConfig(),
+        },
+      });
+
+      expect(typeof completion).toBe("string");
+      expect(completion).toContain("4");
+    }, 30_000);
+
+    registerEvalStructuredOutputTests({
+      checkEnv: checkEnvVars,
+      getModelParams: () => ({
+        provider: "gigachat",
+        adapter: LLMAdapter.GigaChat,
+        model: MODEL,
+        temperature: 0,
+        max_tokens: 200,
+      }),
+      getLLMConnection: () => ({
+        secretKey: encrypt(
+          process.env.LANGFUSE_LLM_CONNECTION_GIGACHAT_CREDENTIALS!,
+        ),
+        baseURL: process.env.LANGFUSE_LLM_CONNECTION_GIGACHAT_BASE_URL!,
+        config: getConfig(),
+      }),
+      timeoutMs: 30_000,
+    });
   });
 });

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3987,5 +3987,93 @@
         }
       }
     ]
+  },
+  {
+    "id": "fd621db1-de6f-4d90-95fe-7cf6db118405",
+    "modelName": "gigachat-2",
+    "matchPattern": "(?i)^(sber\\/)?(gigachat|gigachat-2)$",
+    "createdAt": "2026-04-02T00:00:00.000Z",
+    "updatedAt": "2026-04-02T00:00:00.000Z",
+    "tokenizerConfig": null,
+    "tokenizerId": null,
+    "pricingTiers": [
+      {
+        "id": "fd621db1-de6f-4d90-95fe-7cf6db118405_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 0.7222e-6,
+          "output": 0.7222e-6
+        }
+      }
+    ]
+  },
+  {
+    "id": "9e6200e5-4c46-493c-9ed6-afeb790bce9f",
+    "modelName": "gigachat-2-lite",
+    "matchPattern": "(?i)^(sber\\/)?(gigachat-2-lite)$",
+    "createdAt": "2026-04-02T00:00:00.000Z",
+    "updatedAt": "2026-04-02T00:00:00.000Z",
+    "tokenizerConfig": null,
+    "tokenizerId": null,
+    "pricingTiers": [
+      {
+        "id": "9e6200e5-4c46-493c-9ed6-afeb790bce9f_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 0.7222e-6,
+          "output": 0.7222e-6
+        }
+      }
+    ]
+  },
+  {
+    "id": "65bba53b-c718-4c7a-9dad-0e4a7e624b5f",
+    "modelName": "gigachat-2-pro",
+    "matchPattern": "(?i)^(sber\\/)?(gigachat-pro|gigachat-2-pro)$",
+    "createdAt": "2026-04-02T00:00:00.000Z",
+    "updatedAt": "2026-04-02T00:00:00.000Z",
+    "tokenizerConfig": null,
+    "tokenizerId": null,
+    "pricingTiers": [
+      {
+        "id": "65bba53b-c718-4c7a-9dad-0e4a7e624b5f_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 5.5556e-6,
+          "output": 5.5556e-6
+        }
+      }
+    ]
+  },
+  {
+    "id": "fd3f7b3d-6663-4b3b-a90a-ca0068c2eb4d",
+    "modelName": "gigachat-2-max",
+    "matchPattern": "(?i)^(sber\\/)?(gigachat-max|gigachat-2-max)$",
+    "createdAt": "2026-04-02T00:00:00.000Z",
+    "updatedAt": "2026-04-02T00:00:00.000Z",
+    "tokenizerConfig": null,
+    "tokenizerId": null,
+    "pricingTiers": [
+      {
+        "id": "fd3f7b3d-6663-4b3b-a90a-ca0068c2eb4d_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 7.2222e-6,
+          "output": 7.2222e-6
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

This PR adds first-class GigaChat support across Langfuse runtime, API contracts, UI configuration, and pricing defaults.

### What changed

- Added dedicated adapter support:
  - `LLMAdapter.GigaChat` (`gigachat`)
  - default model set: `GigaChat-2`, `GigaChat-2-Max`, `GigaChat-2-Pro`, `GigaChat-2-Lite`
- Added GigaChat provider config schema and defaults:
  - `scope` config with default `GIGACHAT_API_PERS`
  - default base URL and OAuth URL constants
- Implemented runtime auth flow for GigaChat:
  - OAuth token exchange (`Basic` credentials -> bearer token)
  - retry logic for retryable auth statuses
  - token cache + in-flight deduplication to reduce auth bursts
- Added dedicated GigaChat structured-output path for evaluator use cases:
  - native function-calling request shape
  - schema conversion from Zod/JSON schema
  - robust function arguments parsing fallback
- Extended Web/API support:
  - API validation for optional GigaChat config
  - LLM connection handling and config parsing for GigaChat
  - Create LLM API Key form updates (credentials label/help, base URL handling, scope input)
  - playground model default params for GigaChat
- Added/updated tests in `web` and `worker`
- Added GigaChat default pricing entries in `worker/src/constants/default-model-prices.json`

## Linked issue

Closes #12989 

## Impacted packages

- `packages/shared`
- `web`
- `worker`

## Validation

- `pnpm --filter @langfuse/shared run lint`
- `pnpm --filter @langfuse/shared run typecheck`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter web run lint`
- `pnpm --filter web run typecheck`
- `pnpm --filter worker run lint`
- `pnpm --filter worker run typecheck`
- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
- Targeted GigaChat-related tests (web + worker)

## Notes

- GigaChat pricing entries are based on package-level RUB tariffs converted to USD/token using a documented approximation, with equal input/output unit pricing.
- Structured evaluator output for GigaChat now uses a native function-calling path to improve reliability.