### PR TITLE
fix(web): Add hint about secrets when copying .env in api key settings

### DIFF
--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -217,15 +217,14 @@ export function CodeView(props: {
   defaultCollapsed?: boolean;
   title?: string;
   scrollable?: boolean;
-  /** Message to display after the content was successfully copied to the clipboard */
-  clipboardMessage?: string;
+  copiedToClipboardMessage?: string;
 }) {
-  const { clipboardMessage } = props;
+  const { copiedToClipboardMessage } = props;
 
   const [isCopied, setIsCopied] = useState(false);
   const [isCollapsed, setCollapsed] = useState(props.defaultCollapsed);
 
-  const copySuccessStateDuration = clipboardMessage ? 3_000 : 1_000;
+  const copySuccessStateDuration = copiedToClipboardMessage ? 3_000 : 1_000;
   const copySuccessTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -256,14 +255,14 @@ export function CodeView(props: {
     return (
       <div className="animate-appear relative h-3">
         <Check className="h-3 w-3" />
-        {clipboardMessage && (
+        {copiedToClipboardMessage && (
           <div className="text-secondary-foreground absolute top-0 right-0 mr-6 h-full max-w-[60vw] transform truncate overflow-hidden text-right text-sm leading-none whitespace-nowrap">
-            {clipboardMessage}
+            {copiedToClipboardMessage}
           </div>
         )}
       </div>
     );
-  }, [clipboardMessage]);
+  }, [copiedToClipboardMessage]);
 
   return (
     <div

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -217,9 +217,15 @@ export function CodeView(props: {
   defaultCollapsed?: boolean;
   title?: string;
   scrollable?: boolean;
+  /** Message to display after the content was successfully copied to the clipboard */
+  clipboardMessage?: string;
 }) {
+  const { clipboardMessage } = props;
+
   const [isCopied, setIsCopied] = useState(false);
   const [isCollapsed, setCollapsed] = useState(props.defaultCollapsed);
+
+  const copySuccessStateDuration = clipboardMessage ? 2_000 : 1_000;
 
   const handleCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -230,13 +236,26 @@ export function CodeView(props: {
         ? props.content
         : (props.content?.join("\n") ?? ""));
     void copyTextToClipboard(content);
-    setTimeout(() => setIsCopied(false), 1000);
+    setTimeout(() => setIsCopied(false), copySuccessStateDuration);
 
     // Keep focus on the copy button to prevent focus shifting
     event.currentTarget.focus();
   };
 
   const handleShowAll = () => setCollapsed(!isCollapsed);
+
+  const CopySuccessIcon = useMemo(() => {
+    return (
+      <div className="animate-appear relative h-3">
+        <Check className="h-3 w-3" />
+        {clipboardMessage && (
+          <div className="text-secondary-foreground absolute top-0 right-0 mr-6 h-full max-w-[60vw] transform truncate overflow-hidden text-right text-sm leading-none whitespace-nowrap">
+            {clipboardMessage}
+          </div>
+        )}
+      </div>
+    );
+  }, [clipboardMessage]);
 
   return (
     <div
@@ -256,11 +275,7 @@ export function CodeView(props: {
               onClick={handleCopy}
               className=""
             >
-              {isCopied ? (
-                <Check className="h-3 w-3" />
-              ) : (
-                <Copy className="h-3 w-3" />
-              )}
+              {isCopied ? CopySuccessIcon : <Copy className="h-3 w-3" />}
             </Button>
           </div>
         ) : undefined}
@@ -278,11 +293,7 @@ export function CodeView(props: {
             onClick={handleCopy}
             className="absolute top-2 right-2 z-10"
           >
-            {isCopied ? (
-              <Check className="h-3 w-3" />
-            ) : (
-              <Copy className="h-3 w-3" />
-            )}
+            {isCopied ? CopySuccessIcon : <Copy className="h-3 w-3" />}
           </Button>
         )}
         <code

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import {
   Check,
@@ -225,7 +225,10 @@ export function CodeView(props: {
   const [isCopied, setIsCopied] = useState(false);
   const [isCollapsed, setCollapsed] = useState(props.defaultCollapsed);
 
-  const copySuccessStateDuration = clipboardMessage ? 2_000 : 1_000;
+  const copySuccessStateDuration = clipboardMessage ? 3_000 : 1_000;
+  const copySuccessTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   const handleCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -236,7 +239,12 @@ export function CodeView(props: {
         ? props.content
         : (props.content?.join("\n") ?? ""));
     void copyTextToClipboard(content);
-    setTimeout(() => setIsCopied(false), copySuccessStateDuration);
+    if (copySuccessTimeoutRef.current)
+      clearTimeout(copySuccessTimeoutRef.current);
+    copySuccessTimeoutRef.current = setTimeout(
+      () => setIsCopied(false),
+      copySuccessStateDuration,
+    );
 
     // Keep focus on the copy button to prevent focus shifting
     event.currentTarget.focus();

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -98,7 +98,7 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
       <CodeView
         content={envCode}
         title=".env"
-        clipboardMessage="Note: secrets are not shown here. Create a new key to copy them."
+        copiedToClipboardMessage="Secrets are not included, create a new key to copy them."
       />
       <Card className="mb-4 overflow-hidden">
         <Table>

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -98,7 +98,7 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
       <CodeView
         content={envCode}
         title=".env"
-        clipboardMessage="Secrets could not be copied in full. Please create a new key to copy them."
+        clipboardMessage="Note: secrets are not shown here. Create a new key to copy them."
       />
       <Card className="mb-4 overflow-hidden">
         <Table>

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -95,7 +95,11 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
         }}
         actionButtons={<CreateApiKeyButton entityId={entityId} scope={scope} />}
       />
-      <CodeView content={envCode} title=".env" />
+      <CodeView
+        content={envCode}
+        title=".env"
+        clipboardMessage="Secrets could not be copied in full. Please create a new key to copy them."
+      />
       <Card className="mb-4 overflow-hidden">
         <Table>
           <TableHeader>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -77,6 +77,7 @@
   --animate-rainbow: rainbow var(--speed, 2s) infinite linear;
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
+  --animate-appear: appear 0.2s ease-out forwards;
 
   @keyframes rainbow {
     0% {
@@ -105,6 +106,16 @@
 
     to {
       height: 0;
+    }
+  }
+
+  @keyframes appear {
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds a small hint message indicating that the `.env` content copied in the API key settings does not contain any secrets. The hint is displayed after copying and disappears after 3 seconds.

Loom Video: https://www.loom.com/share/9d00ac363657416e8703d6058e968024

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.