### PR TITLE
ci: add cla-assistant workflow to retrigger stuck CLA checks

### DIFF
--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -1,0 +1,20 @@
+# Workaround for a known cla-assistant bug where the CLA check gets stuck and
+# never re-runs after a contributor signs the CLA.
+# See: https://github.com/cla-assistant/cla-assistant/issues/528
+#
+# Usage: comment `/check-cla` on any PR to manually retrigger the CLA check.
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  retrigger_cla:
+    # Only run on PR comments (not issue comments) with the /check-cla command
+    if: github.event.issue.pull_request && github.event.comment.body == '/check-cla'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrigger CLA check
+        run: |
+          curl -s "https://cla-assistant.io/check/langfuse/langfuse?pullRequest=${{ github.event.issue.number }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -510,3 +510,5 @@ npx fern-api generate --api organizations  # for the organizations API
 Langfuse is MIT licensed, except for `ee/` folder. See [LICENSE](LICENSE) and [docs](https://langfuse.com/docs/open-source) for more details.
 
 When contributing to the Langfuse codebase, you need to agree to the [Contributor License Agreement](https://cla-assistant.io/langfuse/langfuse). You only need to do this once and the CLA bot will remind you if you haven't signed it yet.
+
+If the CLA check gets stuck after signing (a [known cla-assistant bug](https://github.com/cla-assistant/cla-assistant/issues/520)), comment `/check-cla` on your PR to retrigger it.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cla-assistant.yml` to manually retrigger stuck CLA checks
- Comment `/check-cla` on any PR to trigger the check via cla-assistant.io
- Workaround for a known cla-assistant bug: https://github.com/cla-assistant/cla-assistant/issues/520, https://github.com/cla-assistant/cla-assistant/issues/528

## Test plan

- [ ] Comment `/check-cla` on a PR and verify the CLA check is retriggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)