### PR TITLE
fix(api): return archived item when getting dataset item by ID

### DIFF
--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -320,21 +320,17 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     ).toBe(true);
   });
 
-  it("should return 404 when getting an ARCHIVED dataset item by id", async () => {
+  it("should return archived dataset item when getting by id", async () => {
     const datasetName = `dataset-archived-by-id-${v4()}`;
 
-    // Create dataset
     await makeZodVerifiedAPICall(
       PostDatasetsV1Response,
       "POST",
       "/api/public/datasets",
-      {
-        name: datasetName,
-      },
+      { name: datasetName },
       auth,
     );
 
-    // Create an archived dataset item
     const archivedItem = await makeZodVerifiedAPICall(
       PostDatasetItemsV1Response,
       "POST",
@@ -350,16 +346,29 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     expect(archivedItem.status).toBe(200);
     expect(archivedItem.body.status).toBe("ARCHIVED");
 
-    // Try to get the archived item by id - should return 404
-    const getArchivedItem = await makeAPICall(
+    const getArchivedItem = await makeZodVerifiedAPICall(
+      GetDatasetItemV1Response,
       "GET",
       `/api/public/dataset-items/archived-item-by-id`,
       undefined,
       auth,
     );
-    expect(getArchivedItem.status).toBe(404);
+    expect(getArchivedItem.status).toBe(200);
+    expect(getArchivedItem.body.id).toBe("archived-item-by-id");
+    expect(getArchivedItem.body.status).toBe("ARCHIVED");
+  });
 
-    // Create an active item to verify GET still works for active items
+  it("should return active dataset item when getting by id", async () => {
+    const datasetName = `dataset-active-by-id-${v4()}`;
+
+    await makeZodVerifiedAPICall(
+      PostDatasetsV1Response,
+      "POST",
+      "/api/public/datasets",
+      { name: datasetName },
+      auth,
+    );
+
     const activeItem = await makeZodVerifiedAPICall(
       PostDatasetItemsV1Response,
       "POST",
@@ -374,7 +383,6 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     );
     expect(activeItem.status).toBe(200);
 
-    // Get the active item by id - should succeed
     const getActiveItem = await makeZodVerifiedAPICall(
       GetDatasetItemV1Response,
       "GET",

--- a/web/src/pages/api/public/dataset-items/[datasetItemId].ts
+++ b/web/src/pages/api/public/dataset-items/[datasetItemId].ts
@@ -27,10 +27,9 @@ export default withMiddlewares({
       const datasetItem = await getDatasetItemById({
         projectId: auth.scope.projectId,
         datasetItemId: datasetItemId,
-        status: "ACTIVE",
       });
       if (!datasetItem) {
-        throw new LangfuseNotFoundError("Dataset item not found or archived");
+        throw new LangfuseNotFoundError("Dataset item not found");
       }
 
       const dataset = await prisma.dataset.findUnique({


### PR DESCRIPTION
## What does this PR do?

Previously GET /api/public/dataset-items/{id} returned 404 for archived items. Now it returns them with their status - changing this as that's more intuitive behavior. `404` should really just be returned when no item with that ID exists.


## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

