### PR TITLE
chore: optional docker setup in Codex setup/maintenance scripts

### DIFF
--- a/scripts/codex/maintenance.sh
+++ b/scripts/codex/maintenance.sh
@@ -14,3 +14,29 @@ pnpm install --frozen-lockfile
 
 # Keep generated Prisma artifacts aligned after dependency or schema updates.
 pnpm run db:generate
+
+if [ "${CODEX_ENABLE_DOCKER_DEV_INFRA:-0}" = "1" ]; then
+  # Opt-in path for Codex cloud environments that include Docker support.
+  # This keeps infra containers healthy across recurring maintenance runs.
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "CODEX_ENABLE_DOCKER_DEV_INFRA=1 is set, but Docker is unavailable in this environment."
+    exit 1
+  fi
+
+  # Recreate local infra containers during maintenance so refreshed images and
+  # compose configuration changes are applied deterministically.
+  pnpm run infra:dev:down
+  pnpm run infra:dev:up --pull always
+
+  # Reapply committed Prisma migrations after container recreation.
+  pnpm --filter=shared run db:deploy
+
+  # Setup installs golang-migrate for Docker-enabled environments. Fail fast
+  # if it is unexpectedly missing so infra maintenance does not silently drift.
+  if ! command -v migrate >/dev/null 2>&1; then
+    echo "golang-migrate is required for ClickHouse migrations. Re-run bash scripts/codex/setup.sh."
+    exit 1
+  fi
+
+  pnpm --filter=shared run ch:up
+fi

--- a/scripts/codex/maintenance.sh
+++ b/scripts/codex/maintenance.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+# setup.sh installs golang-migrate into ~/.local/bin for non-root environments.
+# Ensure the same location is on PATH when maintenance runs in non-interactive
+# shells (where profile PATH mutations may not be loaded).
+export PATH="${HOME}/.local/bin:${PATH}"
+
 if ! command -v corepack >/dev/null 2>&1; then
   echo "corepack is required. Use a Codex base environment with Node.js 24 support."
   exit 1

--- a/scripts/codex/maintenance.sh
+++ b/scripts/codex/maintenance.sh
@@ -39,7 +39,7 @@ if [ "${CODEX_ENABLE_DOCKER_DEV_INFRA:-0}" = "1" ]; then
   # Setup installs golang-migrate for Docker-enabled environments. Fail fast
   # if it is unexpectedly missing so infra maintenance does not silently drift.
   if ! command -v migrate >/dev/null 2>&1; then
-    echo "golang-migrate is required for ClickHouse migrations. Re-run bash scripts/codex/setup.sh."
+    echo "golang-migrate is required for ClickHouse migrations. Re-run CODEX_ENABLE_DOCKER_DEV_INFRA=1 bash scripts/codex/setup.sh."
     exit 1
   fi
 

--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -14,6 +14,14 @@ install_golang_migrate() {
   os="$(uname -s | tr '[:upper:]' '[:lower:]')"
   arch="$(uname -m)"
 
+  case "$os" in
+    linux|darwin) ;;
+    *)
+      echo "Unsupported operating system for golang-migrate auto-install: $os"
+      exit 1
+      ;;
+  esac
+
   case "$arch" in
     x86_64) arch="amd64" ;;
     aarch64|arm64) arch="arm64" ;;

--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# Keep user-level tooling installs discoverable in non-interactive shells.
+# setup/maintenance rely on this for golang-migrate when Docker infra is enabled.
+export PATH="${HOME}/.local/bin:${PATH}"
+
 install_golang_migrate() {
   local version="v4.19.1"
   local arch

--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -2,6 +2,34 @@
 
 set -euo pipefail
 
+install_golang_migrate() {
+  local version="v4.19.1"
+  local arch
+  local os
+
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+
+  case "$arch" in
+    x86_64) arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *)
+      echo "Unsupported architecture for golang-migrate auto-install: $arch"
+      exit 1
+      ;;
+  esac
+
+  local tarball="migrate.${os}-${arch}.tar.gz"
+  local url="https://github.com/golang-migrate/migrate/releases/download/${version}/${tarball}"
+  local install_dir="${HOME}/.local/bin"
+
+  mkdir -p "$install_dir"
+  curl -fsSL "$url" | tar xz migrate
+  mv migrate "${install_dir}/migrate"
+  chmod +x "${install_dir}/migrate"
+  export PATH="${install_dir}:${PATH}"
+}
+
 ensure_env_file() {
   local target_path="$1"
   local fallback_path="$2"
@@ -36,3 +64,33 @@ pnpm --filter=shared run db:generate
 
 # Prisma client generation is needed for typecheck/build tasks in Codex.
 pnpm run db:generate
+
+if [ "${CODEX_ENABLE_DOCKER_DEV_INFRA:-0}" = "1" ]; then
+  # Opt-in path for Codex cloud environments that include Docker support.
+  # This mirrors local docker-compose.dev.yml infrastructure usage.
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "CODEX_ENABLE_DOCKER_DEV_INFRA=1 is set, but Docker is unavailable in this environment."
+    exit 1
+  fi
+
+  # Start local infra containers used by the default .env configuration
+  # (Postgres, ClickHouse, Redis, etc).
+  pnpm run infra:dev:up
+
+  # Apply committed Prisma migrations to ensure schema compatibility before
+  # running app tasks in this environment.
+  pnpm --filter=shared run db:deploy
+
+  # CI installs golang-migrate before applying ClickHouse migrations. Mirror
+  # that behavior in Codex setup for Docker-enabled environments.
+  if ! command -v migrate >/dev/null 2>&1; then
+    install_golang_migrate
+  fi
+
+  if ! command -v migrate >/dev/null 2>&1; then
+    echo "golang-migrate installation failed; cannot run ClickHouse migrations."
+    exit 1
+  fi
+
+  pnpm --filter=shared run ch:up
+fi

--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -26,12 +26,42 @@ install_golang_migrate() {
   local tarball="migrate.${os}-${arch}.tar.gz"
   local url="https://github.com/golang-migrate/migrate/releases/download/${version}/${tarball}"
   local install_dir="${HOME}/.local/bin"
+  local tmpdir
+  local archive_path
+  local checksum_path
+  local expected_sha
+  local actual_sha
+
+  tmpdir="$(mktemp -d)"
+  archive_path="${tmpdir}/${tarball}"
+  checksum_path="${tmpdir}/${tarball}.sha256"
+
+  curl -fsSL -o "$archive_path" "$url"
+  curl -fsSL -o "$checksum_path" "${url}.sha256"
+
+  expected_sha="$(awk '{print $1}' "$checksum_path")"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha="$(sha256sum "$archive_path" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual_sha="$(shasum -a 256 "$archive_path" | awk '{print $1}')"
+  else
+    echo "Neither sha256sum nor shasum is available to verify golang-migrate checksum."
+    rm -rf "$tmpdir"
+    exit 1
+  fi
+
+  if [ "$expected_sha" != "$actual_sha" ]; then
+    echo "golang-migrate checksum verification failed."
+    rm -rf "$tmpdir"
+    exit 1
+  fi
 
   mkdir -p "$install_dir"
-  curl -fsSL "$url" | tar xz migrate
-  mv migrate "${install_dir}/migrate"
+  tar xzf "$archive_path" -C "$tmpdir" migrate
+  mv "${tmpdir}/migrate" "${install_dir}/migrate"
   chmod +x "${install_dir}/migrate"
   export PATH="${install_dir}:${PATH}"
+  rm -rf "$tmpdir"
 }
 
 ensure_env_file() {


### PR DESCRIPTION
### Motivation

- Provide an opt-in path to manage and refresh local Docker-based development infrastructure during bootstrap and recurring maintenance runs via `CODEX_ENABLE_DOCKER_DEV_INFRA`.
- Ensure Prisma and ClickHouse migrations are applied reliably in Docker-enabled environments by validating or installing the `golang-migrate` tool and failing fast if prerequisites are missing.

### Description

- Add a `CODEX_ENABLE_DOCKER_DEV_INFRA` conditional branch to `scripts/codex/maintenance.sh` that checks for `docker`, tears down and recreates infra with `pnpm run infra:dev:down` and `pnpm run infra:dev:up --pull always`, runs `pnpm --filter=shared run db:deploy`, verifies `migrate` is present, and runs `pnpm --filter=shared run ch:up`.
- Add an `install_golang_migrate()` helper to `scripts/codex/setup.sh` which downloads the appropriate `migrate` binary for the host OS/arch into `~/.local/bin` and updates `PATH`.
- Extend `scripts/codex/setup.sh` to opt-in start infra with `pnpm run infra:dev:up`, apply Prisma migrations with `pnpm --filter=shared run db:deploy`, auto-install `golang-migrate` if missing, verify the installation, and run ClickHouse migrations with `pnpm --filter=shared run ch:up`.
- Add explicit fail-fast messages when `corepack`, `docker`, or `migrate` are required but unavailable to avoid silent drift.

### Testing

- No automated tests were added or run for these script changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d65874280c8323b8c822ccfe90081e)