### PR TITLE
fix(web): Inconsistent search results between editor and controller

### DIFF
--- a/web/src/components/ChatMessages/messageSearch/controller.clienttest.ts
+++ b/web/src/components/ChatMessages/messageSearch/controller.clienttest.ts
@@ -1,0 +1,126 @@
+import { ChatMessageRole, ChatMessageType } from "@langfuse/shared";
+
+import { createMessageSearchController } from "./controller";
+
+describe("message search controller", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const commitQuery = (
+    controller: ReturnType<typeof createMessageSearchController>,
+    query: string,
+  ) => {
+    controller.setQueryInput(query);
+    jest.runAllTimers();
+    return controller.getSnapshot().matches;
+  };
+
+  it("finds all occurrences of a query", () => {
+    const controller = createMessageSearchController(["page-1"]);
+
+    controller.registerPageMessages("page-1", [
+      {
+        id: "message-1",
+        type: ChatMessageType.System,
+        role: ChatMessageRole.System,
+        content:
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ",
+      },
+      {
+        id: "message-2",
+        type: ChatMessageType.User,
+        role: ChatMessageRole.User,
+        content:
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ",
+      },
+    ]);
+
+    expect(commitQuery(controller, "Lorem")).toEqual([
+      expect.objectContaining({
+        messageId: "message-1",
+        from: 0,
+        to: 5,
+      }),
+      expect.objectContaining({
+        messageId: "message-2",
+        from: 0,
+        to: 5,
+      }),
+    ]);
+
+    expect(commitQuery(controller, "dolor")).toEqual([
+      expect.objectContaining({
+        messageId: "message-1",
+        from: 12,
+        to: 17,
+      }),
+      expect.objectContaining({
+        messageId: "message-1",
+        from: 103,
+        to: 108,
+      }),
+      expect.objectContaining({
+        messageId: "message-2",
+        from: 12,
+        to: 17,
+      }),
+      expect.objectContaining({
+        messageId: "message-2",
+        from: 103,
+        to: 108,
+      }),
+    ]);
+  });
+
+  // Regression test for https://github.com/langfuse/langfuse/issues/13002
+  it("matches fullwidth and halfwidth variants consistently", () => {
+    const controller = createMessageSearchController(["page-1"]);
+
+    controller.registerPageMessages("page-1", [
+      {
+        id: "message-1",
+        type: ChatMessageType.System,
+        role: ChatMessageRole.System,
+        content:
+          "Langfuse is an LLM observability platform. Ｌａｎｇｆｕｓｅ is also great.",
+      },
+    ]);
+
+    expect(commitQuery(controller, "Ｌａｎｇｆｕｓｅ")).toEqual([
+      expect.objectContaining({ from: 0, to: 8 }),
+      expect.objectContaining({ from: 43, to: 51 }),
+    ]);
+    expect(commitQuery(controller, "Langfuse")).toEqual([
+      expect.objectContaining({ from: 0, to: 8 }),
+      expect.objectContaining({ from: 43, to: 51 }),
+    ]);
+    expect(commitQuery(controller, "langfuse")).toEqual([
+      expect.objectContaining({ from: 0, to: 8 }),
+      expect.objectContaining({ from: 43, to: 51 }),
+    ]);
+  });
+
+  // Regression test for https://github.com/langfuse/langfuse/issues/13002
+  it("returns original document offsets for compatibility character matches", () => {
+    const controller = createMessageSearchController(["page-1"]);
+
+    controller.registerPageMessages("page-1", [
+      {
+        id: "message-1",
+        type: ChatMessageType.System,
+        role: ChatMessageRole.System,
+        content: "高さ180㌢の棚",
+      },
+    ]);
+
+    expect(commitQuery(controller, "センチ")).toEqual([
+      expect.objectContaining({ from: 5, to: 6 }),
+    ]);
+  });
+});

--- a/web/src/components/ChatMessages/messageSearch/controller.ts
+++ b/web/src/components/ChatMessages/messageSearch/controller.ts
@@ -3,6 +3,8 @@
 import capitalize from "lodash/capitalize";
 import { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { ChatMessageType, type ChatMessageWithId } from "@langfuse/shared";
+import { EditorState } from "@codemirror/state";
+import { SearchQuery } from "@codemirror/search";
 import { type RefObject } from "react";
 
 import {
@@ -137,7 +139,11 @@ function buildMatches(state: MessageSearchState) {
     return [];
   }
 
-  const lowerQuery = searchQuery.toLocaleLowerCase();
+  const codeMirrorSearchQuery = new SearchQuery({
+    search: searchQuery,
+    caseSensitive: false,
+    literal: true,
+  });
   const allMatches: MessageSearchMatch[] = [];
 
   for (const [pageIndex, pageId] of state.pageIds.entries()) {
@@ -152,10 +158,13 @@ function buildMatches(state: MessageSearchState) {
         continue;
       }
 
-      const lowerText = text.toLocaleLowerCase();
-      let from = lowerText.indexOf(lowerQuery);
+      const cursor = codeMirrorSearchQuery.getCursor(
+        EditorState.create({ doc: text }),
+      );
+      let match = cursor.next();
 
-      while (from !== -1) {
+      while (!match.done) {
+        const { from, to } = match.value;
         const label = getMessageSearchLabel(message, messageIndex);
         const pageLabel = state.getPageLabel?.(pageId, pageIndex);
         const matchWithoutKey = {
@@ -164,7 +173,7 @@ function buildMatches(state: MessageSearchState) {
           label,
           locationLabel: pageLabel ? `${pageLabel} · ${label}` : label,
           from,
-          to: from + searchQuery.length,
+          to,
           text,
         };
 
@@ -173,10 +182,7 @@ function buildMatches(state: MessageSearchState) {
           ...matchWithoutKey,
         });
 
-        from = lowerText.indexOf(
-          lowerQuery,
-          from + Math.max(1, lowerQuery.length),
-        );
+        match = cursor.next();
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

This PR fixes an inconsistency in chat message search within Playground and Prompt Management (chat mode), where the match counter and editor highlights could become out of sync.

Previously, the controller used `toLocaleLowerCase()` with `indexOf()`, while the editor relied on CodeMirror’s search logic. This mismatch led to cases where certain matches—such as fullwidth vs. halfwidth text (`Ｌａｎｇｆｕｓｅ` vs `Langfuse`) were highlighted in the editor but not counted.

This PR updates the message search controller to use CodeMirror’s `SearchQuery.getCursor()`, ensuring both the counter and highlights rely on the same matching logic.

Fixes #13002

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
