### PR TITLE
fix(v4-add-to-dataset): Allow non-string JSON prefill values for new dataset items

### DIFF
--- a/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
@@ -56,7 +56,7 @@ export const NewDatasetItemFromExistingObject = (props: {
 
     if (typeof value === "string") {
       const parsed = parseJsonPrioritised(value);
-      return parsed ?? value;
+      return parsed !== undefined ? parsed : value;
     }
 
     return value;

--- a/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
@@ -24,6 +24,7 @@ import { useIsAuthenticatedAndProjectMember } from "@/src/features/auth/hooks";
 import { parseJsonPrioritised } from "@langfuse/shared";
 import { ActionButton } from "@/src/components/ActionButton";
 import { type MetadataDomainClient } from "@/src/utils/clientSideDomainTypes";
+import { type Prisma } from "@langfuse/shared";
 
 /**
  * Component for creating a new dataset item from an existing object.
@@ -39,22 +40,30 @@ export const NewDatasetItemFromExistingObject = (props: {
   traceId?: string;
   observationId?: string;
   fromDatasetId?: string;
-  input: string | null;
-  output: string | null;
+  input: Prisma.JsonValue | null;
+  output: Prisma.JsonValue | null;
   metadata: MetadataDomainClient;
   isCopyItem?: boolean;
   buttonVariant?: ButtonProps["variant"];
   size?: ButtonProps["size"];
 }) => {
-  const parsedInput =
-    props.input && typeof props.input === "string"
-      ? (parseJsonPrioritised(props.input) ?? null)
-      : null;
+  const normalizePrefillValue = (
+    value: Prisma.JsonValue | null,
+  ): Prisma.JsonValue | null => {
+    if (value === null || value === undefined) {
+      return null;
+    }
 
-  const parsedOutput =
-    props.output && typeof props.output === "string"
-      ? (parseJsonPrioritised(props.output) ?? null)
-      : null;
+    if (typeof value === "string") {
+      const parsed = parseJsonPrioritised(value);
+      return parsed ?? value;
+    }
+
+    return value;
+  };
+
+  const parsedInput = normalizePrefillValue(props.input);
+  const parsedOutput = normalizePrefillValue(props.output);
 
   const [isFormOpen, setIsFormOpen] = useState(false);
   const isAuthenticatedAndProjectMember = useIsAuthenticatedAndProjectMember(


### PR DESCRIPTION
### Motivation
- The component previously assumed `input` and `output` props were strings and attempted to parse them, which broke cases where prefill data is already a structured JSON value.
- Accepting richer JSON types enables creating dataset items from existing objects without forcing serialization to strings.

### Description
- Change `input` and `output` prop types from `string | null` to `Prisma.JsonValue | null` in `NewDatasetItemFromExistingObject.tsx`.
- Add `Prisma` import from `@langfuse/shared` and remove the old string-only parsing branches.
- Introduce `normalizePrefillValue` helper that accepts `Prisma.JsonValue | null`, parses string values with `parseJsonPrioritised`, and returns either the parsed value or the original value, preserving non-string JSON values.
- Replace previous `parsedInput`/`parsedOutput` logic with calls to `normalizePrefillValue`.

### Testing
- Ran TypeScript typecheck / build which succeeded without errors.
- Ran the project's automated unit test suite which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d5199ba03c832b8d3cecac05dfad4b)