### PR TITLE
fix(web): Create new `TableCellWithCopyButton` for `ApiKeyList`

### DIFF
--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import {
   Check,
@@ -24,6 +24,7 @@ import {
   usePromptReferenceProjectId,
 } from "@/src/components/ui/PromptReferences";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
+import { useCopyToClipboard } from "@/src/hooks/useCopyToClipboard";
 
 export const IO_TABLE_CHAR_LIMIT = 10000;
 
@@ -221,32 +222,27 @@ export function CodeView(props: {
 }) {
   const { copiedToClipboardMessage } = props;
 
-  const [isCopied, setIsCopied] = useState(false);
   const [isCollapsed, setCollapsed] = useState(props.defaultCollapsed);
 
-  const copySuccessStateDuration = copiedToClipboardMessage ? 3_000 : 1_000;
-  const copySuccessTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
+  const { copy, isCopied } = useCopyToClipboard({
+    successDuration: copiedToClipboardMessage ? 3_000 : 1_000,
+  });
 
-  const handleCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleCopy = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    setIsCopied(true);
     const content =
       props.originalContent ??
       (typeof props.content === "string"
         ? props.content
         : (props.content?.join("\n") ?? ""));
-    void copyTextToClipboard(content);
-    if (copySuccessTimeoutRef.current)
-      clearTimeout(copySuccessTimeoutRef.current);
-    copySuccessTimeoutRef.current = setTimeout(
-      () => setIsCopied(false),
-      copySuccessStateDuration,
-    );
 
-    // Keep focus on the copy button to prevent focus shifting
-    event.currentTarget.focus();
+    await copy(content);
+
+    if (event.currentTarget) {
+      // Keep focus on the copy button to prevent focus shifting
+      // Note: The currentTarget might no longer be in the DOM since React might have re-rendered the component after the state update.
+      event.currentTarget.focus();
+    }
   };
 
   const handleShowAll = () => setCollapsed(!isCollapsed);

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -237,7 +237,11 @@ export function CodeView(props: {
         ? props.content
         : (props.content?.join("\n") ?? ""));
 
-    await copy(content);
+    try {
+      await copy(content);
+    } catch {
+      // Clipboard writes can be rejected when the browser denies permission.
+    }
 
     if (button) {
       // Keep focus on the copy button to prevent focus shifting

--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -230,6 +230,7 @@ export function CodeView(props: {
 
   const handleCopy = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
+    const button = event.currentTarget;
     const content =
       props.originalContent ??
       (typeof props.content === "string"
@@ -238,10 +239,10 @@ export function CodeView(props: {
 
     await copy(content);
 
-    if (event.currentTarget) {
+    if (button) {
       // Keep focus on the copy button to prevent focus shifting
-      // Note: The currentTarget might no longer be in the DOM since React might have re-rendered the component after the state update.
-      event.currentTarget.focus();
+      // Note: the original button might no longer be in the DOM if React re-rendered the component after the state update.
+      button.focus();
     }
   };
 

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -133,11 +133,12 @@ const TableCellWithCopyButton = React.forwardRef<
         aria-label={copyButtonLabel ?? "Copy to clipboard"}
         onClick={async (event) => {
           event.preventDefault();
+          const button = event.currentTarget;
           await copy(text);
 
-          if (event.currentTarget) {
-            // The currentTarget might no longer be in the DOM since React might have re-rendered the component after the state update.
-            event.currentTarget.focus();
+          if (button) {
+            // The original button might no longer be in the DOM if React re-rendered the component after the state update.
+            button.focus();
           }
         }}
       >

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -134,7 +134,11 @@ const TableCellWithCopyButton = React.forwardRef<
         onClick={async (event) => {
           event.preventDefault();
           const button = event.currentTarget;
-          await copy(text);
+          try {
+            await copy(text);
+          } catch {
+            // Clipboard writes can be rejected when the browser denies permission.
+          }
 
           if (button) {
             // The original button might no longer be in the DOM if React re-rendered the component after the state update.

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 
+import { Button } from "@/src/components/ui/button";
+import { useCopyToClipboard } from "@/src/hooks/useCopyToClipboard";
 import { cn } from "@/src/utils/tailwind";
+import { Check, Copy } from "lucide-react";
 
 type TableDensity = "compact" | "comfortable";
 
@@ -101,6 +104,54 @@ const TableCell = React.forwardRef<
 ));
 TableCell.displayName = "TableCell";
 
+type TableCellWithCopyButtonProps =
+  React.TdHTMLAttributes<HTMLTableCellElement> & {
+    text: string;
+    density?: TableDensity;
+    copyButtonLabel?: string;
+  };
+
+const TableCellWithCopyButton = React.forwardRef<
+  HTMLTableCellElement,
+  TableCellWithCopyButtonProps
+>(({ text, copyButtonLabel, className, ...props }, ref) => {
+  const { copy, isCopied } = useCopyToClipboard();
+
+  return (
+    <TableCell
+      ref={ref}
+      className={cn("relative min-w-0 pr-10", className)}
+      title={text}
+      {...props}
+    >
+      {text}
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        className="absolute top-1/2 right-2 -translate-y-1/2"
+        title={copyButtonLabel ?? "Copy to clipboard"}
+        aria-label={copyButtonLabel ?? "Copy to clipboard"}
+        onClick={async (event) => {
+          event.preventDefault();
+          await copy(text);
+
+          if (event.currentTarget) {
+            // The currentTarget might no longer be in the DOM since React might have re-rendered the component after the state update.
+            event.currentTarget.focus();
+          }
+        }}
+      >
+        {isCopied ? (
+          <Check className="h-3 w-3" />
+        ) : (
+          <Copy className="h-3 w-3" />
+        )}
+      </Button>
+    </TableCell>
+  );
+});
+TableCellWithCopyButton.displayName = "TableCellWithCopyButton";
+
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
   React.HTMLAttributes<HTMLTableCaptionElement>
@@ -121,5 +172,6 @@ export {
   TableHead,
   TableRow,
   TableCell,
+  TableCellWithCopyButton,
   TableCaption,
 };

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -15,6 +15,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableCellWithCopyButton,
   TableHead,
   TableHeader,
   TableRow,
@@ -144,12 +145,11 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
                       scope={scope}
                     />
                   </TableCell>
-                  <TableCell density="comfortable" className="font-mono">
-                    <CodeView
-                      className="inline-block text-xs"
-                      content={apiKey.publicKey}
-                    />
-                  </TableCell>
+                  <TableCellWithCopyButton
+                    density="comfortable"
+                    text={apiKey.publicKey}
+                    className="truncate font-mono"
+                  />
                   <TableCell density="comfortable" className="font-mono">
                     {apiKey.displaySecretKey}
                   </TableCell>

--- a/web/src/hooks/useCopyToClipboard.clienttest.ts
+++ b/web/src/hooks/useCopyToClipboard.clienttest.ts
@@ -1,0 +1,112 @@
+import { act, renderHook } from "@testing-library/react";
+import { useCopyToClipboard } from "@/src/hooks/useCopyToClipboard";
+
+describe("useCopyToClipboard", () => {
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+  });
+
+  it("copies the provided text and exposes a temporary success state", async () => {
+    const { result } = renderHook(() =>
+      useCopyToClipboard({ successDuration: 500 }),
+    );
+
+    expect(result.current.isCopied).toBe(false);
+
+    await act(async () => {
+      await result.current.copy("pk-lf-test");
+    });
+
+    expect(result.current.isCopied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(499);
+    });
+
+    expect(result.current.isCopied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(result.current.isCopied).toBe(false);
+  });
+
+  it("resets the success timeout when copy is triggered again", async () => {
+    const { result } = renderHook(() =>
+      useCopyToClipboard({ successDuration: 500 }),
+    );
+
+    await act(async () => {
+      await result.current.copy("first");
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await act(async () => {
+      await result.current.copy("second");
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(499);
+    });
+
+    expect(result.current.isCopied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(result.current.isCopied).toBe(false);
+  });
+
+  it("keeps the active copied state across rerenders and preserves the original timeout", async () => {
+    const { result, rerender } = renderHook(
+      ({ successDuration }) => useCopyToClipboard({ successDuration }),
+      {
+        initialProps: { successDuration: 500 },
+      },
+    );
+
+    await act(async () => {
+      await result.current.copy("first");
+    });
+
+    expect(result.current.isCopied).toBe(true);
+
+    rerender({ successDuration: 2_000 });
+
+    expect(result.current.isCopied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(499);
+    });
+
+    expect(result.current.isCopied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(result.current.isCopied).toBe(false);
+  });
+});

--- a/web/src/hooks/useCopyToClipboard.clienttest.ts
+++ b/web/src/hooks/useCopyToClipboard.clienttest.ts
@@ -79,6 +79,35 @@ describe("useCopyToClipboard", () => {
     expect(result.current.isCopied).toBe(false);
   });
 
+  it("resets copied state after a failed clipboard write", async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error("NotAllowedError"));
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText,
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useCopyToClipboard({ successDuration: 500 }),
+    );
+
+    await act(async () => {
+      await expect(result.current.copy("pk-lf-test")).rejects.toThrow(
+        "NotAllowedError",
+      );
+    });
+
+    expect(result.current.isCopied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current.isCopied).toBe(false);
+  });
+
   it("keeps the active copied state across rerenders and preserves the original timeout", async () => {
     const { result, rerender } = renderHook(
       ({ successDuration }) => useCopyToClipboard({ successDuration }),

--- a/web/src/hooks/useCopyToClipboard.clienttest.ts
+++ b/web/src/hooks/useCopyToClipboard.clienttest.ts
@@ -47,65 +47,12 @@ describe("useCopyToClipboard", () => {
     });
 
     expect(result.current.isCopied).toBe(false);
-  });
-
-  it("resets the success timeout when copy is triggered again", async () => {
-    const { result } = renderHook(() =>
-      useCopyToClipboard({ successDuration: 500 }),
-    );
 
     await act(async () => {
-      await result.current.copy("first");
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(300);
-    });
-
-    await act(async () => {
-      await result.current.copy("second");
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(499);
+      await result.current.copy("pk-lf-test");
     });
 
     expect(result.current.isCopied).toBe(true);
-
-    act(() => {
-      jest.advanceTimersByTime(1);
-    });
-
-    expect(result.current.isCopied).toBe(false);
-  });
-
-  it("resets copied state after a failed clipboard write", async () => {
-    const writeText = jest.fn().mockRejectedValue(new Error("NotAllowedError"));
-
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: {
-        writeText,
-      },
-    });
-
-    const { result } = renderHook(() =>
-      useCopyToClipboard({ successDuration: 500 }),
-    );
-
-    await act(async () => {
-      await expect(result.current.copy("pk-lf-test")).rejects.toThrow(
-        "NotAllowedError",
-      );
-    });
-
-    expect(result.current.isCopied).toBe(true);
-
-    act(() => {
-      jest.advanceTimersByTime(500);
-    });
-
-    expect(result.current.isCopied).toBe(false);
   });
 
   it("keeps the active copied state across rerenders and preserves the original timeout", async () => {

--- a/web/src/hooks/useCopyToClipboard.ts
+++ b/web/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from "react";
+import { copyTextToClipboard } from "@/src/utils/clipboard";
+
+/**
+ * Copies text to the clipboard and exposes a temporary success state for UI feedback.
+ */
+export function useCopyToClipboard({
+  successDuration = 1_000,
+}: {
+  successDuration?: number;
+} = {}) {
+  const [isCopied, setIsCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const copy = async (text: string) => {
+    setIsCopied(true);
+    await copyTextToClipboard(text);
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      setIsCopied(false);
+    }, successDuration);
+  };
+
+  return { copy, isCopied };
+}

--- a/web/src/hooks/useCopyToClipboard.ts
+++ b/web/src/hooks/useCopyToClipboard.ts
@@ -22,15 +22,17 @@ export function useCopyToClipboard({
 
   const copy = async (text: string) => {
     setIsCopied(true);
-    await copyTextToClipboard(text);
+    try {
+      await copyTextToClipboard(text);
+    } finally {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
 
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        setIsCopied(false);
+      }, successDuration);
     }
-
-    timeoutRef.current = setTimeout(() => {
-      setIsCopied(false);
-    }, successDuration);
   };
 
   return { copy, isCopied };


### PR DESCRIPTION
## What does this PR do?

This PR improves the API key table in the web app by introducing a dedicated `TableCellWithCopyButton` component. Instead of rendering the public key through `CodeView`, the table now uses a purpose-built table cell with an inline copy action, which is a better fit for truncated table content and preserves focus correctly after copy interactions.

To support this, the PR also extracts copy-state handling into a reusable `useCopyToClipboard` hook and updates `CodeJsonViewer` to use the same shared logic. The new hook is covered by client tests for temporary success state handling, timeout resets, and rerender behavior.

<img width="1012" height="420" alt="Screenshot 2026-04-09 at 13 39 19" src="https://github.com/user-attachments/assets/1ff01663-93b7-4913-80e1-d521265e26e6" />

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
