### PR TITLE
fix(annotation): Wait for session to load before rendering annotation queue items

### DIFF
--- a/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
@@ -149,7 +149,8 @@ export const AnnotationQueueItemPage: React.FC<{
     (seenItemData.isPending && itemId) ||
     (fetchAndLockNextMutation.isPending && !itemId) ||
     unseenPendingItemCount.isPending ||
-    objectData.isLoading
+    objectData.isLoading ||
+    (!sessionLoaded && !isSingleItem)
   ) {
     return <Skeleton className="h-full w-full" />;
   }


### PR DESCRIPTION
### Motivation
- Prevent the annotation queue page from rendering item content before the user session is available for multi-item views so session-dependent logic doesn't run on incomplete state.

### Description
- Update the loading condition in `web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx` to include `(!sessionLoaded && !isSingleItem)`, causing the component to render `<Skeleton />` until the session is loaded for non-single-item queues.

### Testing
- Ran TypeScript typecheck and existing unit tests locally, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d7874b9040832b9e3ad2d4356baa80)