### PR TITLE
chore(experiments): Link dataset cell in Experiments table to dataset page and show display name

### DIFF
--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -301,11 +301,29 @@ export default function ExperimentsTable({
       header: getExperimentsColumnName("experimentDatasetId"),
       size: 150,
       cell: ({ row }) => {
-        const key: string | undefined = row.getValue("datasetId");
-        const value = filterOptions.experimentDatasetId?.find(
-          (d) => d.value === key,
+        const datasetId: string | undefined = row.getValue("datasetId");
+        const datasetName = filterOptions.experimentDatasetId?.find(
+          (d) => d.value === datasetId,
         )?.displayValue;
-        return value ? <TableIdOrName value={value} /> : undefined;
+
+        if (!datasetId || !datasetName) {
+          return undefined;
+        }
+
+        return (
+          <Link
+            href={`/project/${projectId}/datasets/${encodeURIComponent(datasetId)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Badge
+              variant="secondary"
+              className="hover:bg-secondary/80 max-w-full cursor-pointer"
+            >
+              {datasetName}
+            </Badge>
+          </Link>
+        );
       },
     },
     {


### PR DESCRIPTION
### Motivation
- Improve usability of the Experiments table by showing the dataset display name instead of the raw id and making the dataset cell navigable to the dataset detail page.
- Ensure the dataset link opens safely in a new tab and only renders when both id and display name are available.

### Description
- Replace the previous `TableIdOrName` rendering for the `datasetId` column with a lookup of `filterOptions.experimentDatasetId` to extract the dataset display name.
- Add guards to return `undefined` if `datasetId` or `datasetName` are missing to avoid rendering broken links.
- Render a `Link` to `/project/${projectId}/datasets/${encodeURIComponent(datasetId)}` wrapping a `Badge` when both values exist, and set `target="_blank"` and `rel="noopener noreferrer"` for safe external navigation.
- Rename local variables for clarity from `key`/`value` to `datasetId`/`datasetName` and adjust styling classes on the `Badge`.

### Testing
- Ran the test suite with `yarn test` and all unit tests completed successfully. 
- Performed a TypeScript/webpack build with `yarn build` and the build succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d7799b05ec832b8f14366faec7a287)