### PR TITLE
fix(web): Table padding issues

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -77,6 +77,7 @@ interface DataTableProps<TData, TValue> {
   tableName: string;
   getRowClassName?: (row: TData) => string;
   topAlignCells?: boolean;
+  cellPadding?: "compact" | "comfortable";
 }
 
 export interface AsyncTableData<T> {
@@ -165,6 +166,7 @@ export function DataTable<TData extends object, TValue>({
   tableName,
   getRowClassName,
   topAlignCells = false,
+  cellPadding = "compact",
 }: DataTableProps<TData, TValue>) {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const rowheighttw = getRowHeightTailwindClass(rowHeight, customRowHeights);
@@ -416,6 +418,7 @@ export function DataTable<TData extends object, TValue>({
                 onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
                 getRowClassName={getRowClassName}
                 topAlignCells={topAlignCells}
+                cellPadding={cellPadding}
                 tableSnapshot={{
                   columnVisibility,
                   columnOrder,
@@ -434,6 +437,7 @@ export function DataTable<TData extends object, TValue>({
                 onRowClick={hasRowClickAction ? handleOnRowClick : undefined}
                 getRowClassName={getRowClassName}
                 topAlignCells={topAlignCells}
+                cellPadding={cellPadding}
               />
             )}
           </Table>
@@ -480,6 +484,7 @@ interface TableBodyComponentProps<TData> {
   onRowClick?: (row: TData, event?: React.MouseEvent) => void;
   getRowClassName?: (row: TData) => string;
   topAlignCells?: boolean;
+  cellPadding?: "compact" | "comfortable";
   tableSnapshot?: {
     columnVisibility?: VisibilityState;
     columnOrder?: ColumnOrderState;
@@ -533,6 +538,7 @@ function TableBodyComponent<TData>({
   onRowClick,
   getRowClassName,
   topAlignCells = false,
+  cellPadding = "compact",
 }: TableBodyComponentProps<TData>) {
   return (
     <TableBody>
@@ -562,7 +568,8 @@ function TableBodyComponent<TData>({
                 <TableCell
                   key={cell.id}
                   className={cn(
-                    "overflow-hidden border-b px-1 text-xs first:pl-2",
+                    "overflow-hidden border-b text-xs first:pl-2",
+                    cellPadding === "comfortable" ? "p-1" : "px-1",
                     isSmallRowHeight && "whitespace-nowrap",
                     getPinningClasses(cell.column),
                   )}

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -661,6 +661,7 @@ const MemoizedTableBody = React.memo(TableBodyComponent, (prev, next) => {
   if (prev.data.isLoading !== next.data.isLoading) return false;
   if (prev.rowheighttw !== next.rowheighttw) return false;
   if (prev.rowHeight !== next.rowHeight) return false;
+  if (prev.cellPadding !== next.cellPadding) return false;
 
   // Then do more expensive deep equality checks
   if (

--- a/web/src/components/table/use-cases/models.tsx
+++ b/web/src/components/table/use-cases/models.tsx
@@ -358,6 +358,7 @@ export default function ModelTable({ projectId }: { projectId: string }) {
           columnOrder={columnOrder}
           onColumnOrderChange={setColumnOrder}
           rowHeight={rowHeight}
+          cellPadding="comfortable"
           onRowClick={(row) => {
             router.push(`/project/${projectId}/settings/models/${row.modelId}`);
           }}

--- a/web/src/components/table/use-cases/score-configs.tsx
+++ b/web/src/components/table/use-cases/score-configs.tsx
@@ -284,6 +284,7 @@ export function ScoreConfigsTable({ projectId }: { projectId: string }) {
           columnOrder={columnOrder}
           onColumnOrderChange={setColumnOrder}
           rowHeight={rowHeight}
+          cellPadding="comfortable"
           className="gap-2"
         />
       </SettingsTableCard>

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 
 import { cn } from "@/src/utils/tailwind";
 
+type TableDensity = "compact" | "comfortable";
+
 const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
@@ -74,7 +76,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "bg-background text-muted-foreground relative h-10 border-b px-4 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
+      "bg-background text-muted-foreground relative h-10 border-b px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
       className,
     )}
     {...props}
@@ -84,12 +86,13 @@ TableHead.displayName = "TableHead";
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
-  React.TdHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
+  React.TdHTMLAttributes<HTMLTableCellElement> & { density?: TableDensity }
+>(({ className, density = "compact", ...props }, ref) => (
   <td
     ref={ref}
     className={cn(
-      "h-full px-2 py-0 align-middle [&:has([role=checkbox])]:pr-0",
+      "h-full align-middle [&:has([role=checkbox])]:pr-0",
+      density === "comfortable" ? "p-2" : "px-2 py-0",
       "border-b [:last-child_>_&]:border-b-0",
       className,
     )}

--- a/web/src/ee/features/audit-log-viewer/AuditLogsTable.tsx
+++ b/web/src/ee/features/audit-log-viewer/AuditLogsTable.tsx
@@ -187,6 +187,7 @@ export function AuditLogsTable(props: AuditLogsTableProps) {
             state: paginationState,
           }}
           rowHeight={rowHeight}
+          cellPadding="comfortable"
         />
       </SettingsTableCard>
     </>

--- a/web/src/features/dashboard/components/SelectDashboardDialog.tsx
+++ b/web/src/features/dashboard/components/SelectDashboardDialog.tsx
@@ -102,11 +102,20 @@ export function SelectDashboardDialog({
                           selectedDashboardId === d.id ? "bg-muted" : ""
                         }`}
                       >
-                        <TableCell className="font-medium">{d.name}</TableCell>
-                        <TableCell className="truncate" title={d.description}>
+                        <TableCell
+                          density="comfortable"
+                          className="font-medium"
+                        >
+                          {d.name}
+                        </TableCell>
+                        <TableCell
+                          density="comfortable"
+                          className="truncate"
+                          title={d.description}
+                        >
                           {d.description}
                         </TableCell>
-                        <TableCell>
+                        <TableCell density="comfortable">
                           {new Date(d.updatedAt).toLocaleString()}
                         </TableCell>
                       </TableRow>

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -117,7 +117,11 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
           <TableBody className="text-muted-foreground">
             {apiKeysQuery.data?.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={5} className="text-center">
+                <TableCell
+                  density="comfortable"
+                  colSpan={5}
+                  className="text-center"
+                >
                   None
                 </TableCell>
               </TableRow>
@@ -127,29 +131,32 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
                   key={apiKey.id}
                   className="hover:bg-primary-foreground"
                 >
-                  <TableCell className="hidden md:table-cell">
+                  <TableCell
+                    density="comfortable"
+                    className="hidden md:table-cell"
+                  >
                     {apiKey.createdAt.toLocaleDateString()}
                   </TableCell>
-                  <TableCell>
+                  <TableCell density="comfortable">
                     <ApiKeyNote
                       apiKey={apiKey}
                       entityId={entityId}
                       scope={scope}
                     />
                   </TableCell>
-                  <TableCell className="font-mono">
+                  <TableCell density="comfortable" className="font-mono">
                     <CodeView
                       className="inline-block text-xs"
                       content={apiKey.publicKey}
                     />
                   </TableCell>
-                  <TableCell className="font-mono">
+                  <TableCell density="comfortable" className="font-mono">
                     {apiKey.displaySecretKey}
                   </TableCell>
                   {/* <TableCell>
                   {apiKey.lastUsedAt?.toLocaleDateString() ?? "Never"}
                 </TableCell> */}
-                  <TableCell>
+                  <TableCell density="comfortable">
                     <DeleteApiKeyButton
                       entityId={entityId}
                       apiKeyId={apiKey.id}

--- a/web/src/features/public-api/components/LLMApiKeyList.tsx
+++ b/web/src/features/public-api/components/LLMApiKeyList.tsx
@@ -93,7 +93,11 @@ export function LlmApiKeyList(props: { projectId: string }) {
           <TableBody className="text-muted-foreground">
             {apiKeys.data?.data.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={6} className="text-center">
+                <TableCell
+                  density="comfortable"
+                  colSpan={6}
+                  className="text-center"
+                >
                   None
                 </TableCell>
               </TableRow>
@@ -104,18 +108,28 @@ export function LlmApiKeyList(props: { projectId: string }) {
                   className="hover:bg-primary-foreground cursor-default"
                   onClick={() => setEditingKeyId(apiKey.id)}
                 >
-                  <TableCell className="font-mono">{apiKey.provider}</TableCell>
-                  <TableCell className="font-mono">{apiKey.adapter}</TableCell>
-                  <TableCell className="max-w-md overflow-auto font-mono">
+                  <TableCell density="comfortable" className="font-mono">
+                    {apiKey.provider}
+                  </TableCell>
+                  <TableCell density="comfortable" className="font-mono">
+                    {apiKey.adapter}
+                  </TableCell>
+                  <TableCell
+                    density="comfortable"
+                    className="max-w-md overflow-auto font-mono"
+                  >
                     {apiKey.baseURL ?? "default"}
                   </TableCell>
-                  <TableCell className="font-mono">
+                  <TableCell density="comfortable" className="font-mono">
                     {apiKey.displaySecretKey}
                   </TableCell>
                   {hasExtraHeaderKeys ? (
-                    <TableCell> {apiKey.extraHeaderKeys.join(", ")} </TableCell>
+                    <TableCell density="comfortable">
+                      {" "}
+                      {apiKey.extraHeaderKeys.join(", ")}{" "}
+                    </TableCell>
                   ) : null}
-                  <TableCell className="text-right">
+                  <TableCell density="comfortable" className="text-right">
                     <div
                       className="flex justify-end space-x-2"
                       onClick={(e) => e.stopPropagation()}

--- a/web/src/features/rbac/components/MembersTable.tsx
+++ b/web/src/features/rbac/components/MembersTable.tsx
@@ -432,6 +432,7 @@ export function MembersTable({
             onColumnVisibilityChange={setColumnVisibility}
             columnOrder={columnOrder}
             onColumnOrderChange={setColumnOrder}
+            cellPadding="comfortable"
           />
         </SettingsTableCard>
       ) : (

--- a/web/src/features/rbac/components/MembersTable.tsx
+++ b/web/src/features/rbac/components/MembersTable.tsx
@@ -465,6 +465,7 @@ export function MembersTable({
           onColumnVisibilityChange={setColumnVisibility}
           columnOrder={columnOrder}
           onColumnOrderChange={setColumnOrder}
+          cellPadding="comfortable"
         />
       )}
     </>

--- a/web/src/features/widgets/components/SelectWidgetDialog.tsx
+++ b/web/src/features/widgets/components/SelectWidgetDialog.tsx
@@ -119,19 +119,20 @@ export function SelectWidgetDialog({
                         selectedWidgetId === widget.id ? "bg-muted" : ""
                       }`}
                     >
-                      <TableCell className="font-medium">
+                      <TableCell density="comfortable" className="font-medium">
                         {widget.name}
                       </TableCell>
                       <TableCell
+                        density="comfortable"
                         className="truncate"
                         title={widget.description}
                       >
                         {widget.description}
                       </TableCell>
-                      <TableCell>
+                      <TableCell density="comfortable">
                         {startCase(widget.view.toLowerCase())}
                       </TableCell>
-                      <TableCell>
+                      <TableCell density="comfortable">
                         {getChartTypeDisplayName(
                           widget.chartType as DashboardWidgetChartType,
                         )}


### PR DESCRIPTION
## What does this PR do?

Fixes the table padding regression introduced in #10942 (I checked out the code before this commit was merged to verify the tables were looking fine before) so settings tables regain appropriate spacing around inputs, selects, and action buttons, while dense product tables keep their compact layout.

This change:

- adds an explicit `cellPadding` option to `DataTable` so settings-focused tables can opt into more comfortable cell spacing
- adds an explicit `density` prop to primitive `TableCell` usage for the API key settings tables
- applies the comfortable spacing only to settings-related tables such as API keys, members, models, score configs, and audit logs
- preserves the reduced padding and border behavior for dense non-settings tables such as traces, sessions, and scores

## Screenshots

API Key Settings (After)
<img width="1023" height="318" alt="Screenshot 2026-04-09 at 13 08 28" src="https://github.com/user-attachments/assets/45268781-b0dc-4a49-b23a-eb275180e7c6" />

Team Settings (After)
<img width="1029" height="371" alt="Screenshot 2026-04-09 at 13 08 21" src="https://github.com/user-attachments/assets/e1b1e437-cad6-4238-a1f3-fbe464f16f3e" />

Traces Table (After) _note: no expected change_
<img width="1280" height="823" alt="Screenshot 2026-04-09 at 13 09 18" src="https://github.com/user-attachments/assets/aa40bdf5-1f66-4e05-8b45-38dd6fa7a69b" />

Api Key Settings 
<img width="1019" height="318" alt="Screenshot 2026-04-09 at 13 33 03" src="https://github.com/user-attachments/assets/f1b231af-315d-42d8-8514-9c1ef17d983c" />
(Before)

Team Settings (Before)
<img width="1023" height="294" alt="Screenshot 2026-04-09 at 13 33 09" src="https://github.com/user-attachments/assets/92fbde47-5b3b-4314-b819-a8ebd67b4167" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
