### PR TITLE
fix(web): Prevent toast error when toggling v4 with selected saved view

### DIFF
--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -6,7 +6,6 @@ import {
   type TableViewPresetState,
   type ColumnDefinition,
 } from "@langfuse/shared";
-import { type DefaultViewScope } from "@langfuse/shared/src/server";
 import { useRouter } from "next/router";
 import { useEffect, useCallback, useState, useRef } from "react";
 import { type VisibilityState } from "@tanstack/react-table";
@@ -31,6 +30,7 @@ interface TableStateUpdaters {
 interface UseTableStateProps {
   tableName: TableViewPresetTableName;
   projectId: string;
+  viewPersistenceKey?: string;
   stateUpdaters: TableStateUpdaters;
   validationContext?: {
     columns?: LangfuseColumnDef<any, any>[];
@@ -46,6 +46,7 @@ interface UseTableStateProps {
 export function useTableViewManager({
   projectId,
   tableName,
+  viewPersistenceKey,
   stateUpdaters,
   validationContext = {},
   currentFilterState,
@@ -58,9 +59,14 @@ export function useTableViewManager({
   const capture = usePostHogClientCapture();
   const pendingFiltersRef = useRef<FilterState | null>(null);
   const pendingFiltersPreviousStateRef = useRef<FilterState | null>(null);
+  // Session storage needs a mode-specific key because the same tableName can be
+  // rendered by different route variants (for example legacy vs v4 pages) with
+  // distinct saved-view IDs. Reusing tableName would restore stale IDs across
+  // modes and boot the user into an incompatible saved view.
+  const resolvedViewPersistenceKey = viewPersistenceKey ?? tableName;
 
   const [storedViewId, setStoredViewId] = useSessionStorage<string | null>(
-    `${tableName}-${projectId}-viewId`,
+    `${resolvedViewPersistenceKey}-${projectId}-viewId`,
     null,
   );
   const [selectedViewIdParam, setSelectedViewId] = useQueryParam(
@@ -288,6 +294,10 @@ export function useTableViewManager({
     if (isInitializedRef.current) return;
     if (selectedViewIdRef.current !== requestedViewId) return;
     if (selectedViewData.id !== requestedViewId) return;
+    if (selectedViewData.tableName !== tableName) {
+      handleSetViewId(null);
+      return;
+    }
 
     // Track permalink visit
     capture("saved_views:permalink_visit", {
@@ -304,6 +314,7 @@ export function useTableViewManager({
     isSelectedViewSuccess,
     selectedViewData,
     selectedViewId,
+    handleSetViewId,
     capture,
     tableName,
     applyViewState,
@@ -368,6 +379,6 @@ export function useTableViewManager({
     applyViewState,
     handleSetViewId,
     selectedViewId,
-    defaultViewScope: resolvedDefault?.scope as DefaultViewScope | null,
+    defaultViewScope: resolvedDefault?.scope ?? null,
   };
 }

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -137,6 +137,7 @@ export type ObservationsTableProps = {
   omittedFilter?: string[];
   // External control props for embedded preview tables
   hideControls?: boolean;
+  viewPersistenceKey?: string;
   externalFilterState?: FilterState;
   externalDateRange?: TableDateRange;
   limitRows?: number;
@@ -148,6 +149,7 @@ export default function ObservationsTable({
   promptVersion,
   modelId,
   hideControls = false,
+  viewPersistenceKey,
   externalFilterState,
   externalDateRange,
   limitRows,
@@ -1215,6 +1217,7 @@ export default function ObservationsTable({
   const { isLoading: isViewLoading, ...viewControllers } = useTableViewManager({
     tableName: TableViewPresetTableName.Observations,
     projectId,
+    viewPersistenceKey,
     stateUpdaters: {
       setOrderBy: setOrderByState,
       setFilters: setFiltersWrapper,

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -137,6 +137,7 @@ export type TracesTableProps = {
   userId?: string;
   omittedFilter?: string[];
   hideControls?: boolean;
+  viewPersistenceKey?: string;
   externalFilterState?: FilterState;
   externalDateRange?: TableDateRange;
   limitRows?: number;
@@ -147,6 +148,7 @@ export default function TracesTable({
   userId,
   omittedFilter = [],
   hideControls = false,
+  viewPersistenceKey,
   externalFilterState,
   externalDateRange,
   limitRows,
@@ -1240,6 +1242,7 @@ export default function TracesTable({
   const { isLoading: isViewLoading, ...viewControllers } = useTableViewManager({
     tableName: TableViewPresetTableName.Traces,
     projectId,
+    viewPersistenceKey,
     stateUpdaters: {
       setOrderBy: setOrderByState,
       setFilters: setFiltersWrapper,

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -166,6 +166,7 @@ export type EventsTableProps = {
   projectId: string;
   userId?: string;
   hideControls?: boolean;
+  viewPersistenceKey?: string;
   // External control props for embedded preview tables
   externalFilterState?: FilterState;
   externalDateRange?: TableDateRange;
@@ -177,6 +178,7 @@ export default function ObservationsEventsTable({
   projectId,
   userId,
   hideControls = false,
+  viewPersistenceKey,
   externalFilterState,
   externalDateRange,
   limitRows,
@@ -1146,6 +1148,7 @@ export default function ObservationsEventsTable({
   const { isLoading: isViewLoading, ...viewControllers } = useTableViewManager({
     tableName: TableViewPresetTableName.Observations,
     projectId,
+    viewPersistenceKey,
     stateUpdaters: {
       setOrderBy: setOrderByState,
       setFilters: setFiltersWrapper,

--- a/web/src/features/events/hooks/useV4Beta.ts
+++ b/web/src/features/events/hooks/useV4Beta.ts
@@ -11,11 +11,16 @@ type SetV4BetaEnabledOptions = {
 const INTRO_DIALOG_SEEN_KEY = "v4-beta-intro-dialog-seen";
 
 export function useV4Beta() {
-  const { data: session, update: updateSession } = useSession();
+  const {
+    data: session,
+    update: updateSession,
+    status: sessionStatus,
+  } = useSession();
 
   const mutation = api.userAccount.setV4BetaEnabled.useMutation();
 
   const isBetaEnabled = session?.user?.v4BetaEnabled ?? false;
+  const isInitializing = sessionStatus === "loading";
   const [showIntroDialog, setShowIntroDialog] = useState(false);
   const [pendingOnSuccess, setPendingOnSuccess] =
     useState<SetV4BetaEnabledOptions["onSuccess"]>();
@@ -71,6 +76,7 @@ export function useV4Beta() {
 
   return {
     isBetaEnabled,
+    isInitializing,
     setBetaEnabled,
     enableWithIntro,
     showIntroDialog,

--- a/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
+++ b/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
@@ -80,7 +80,7 @@ jest.mock("use-query-params", () => {
   const React = require("react");
   const actual = jest.requireActual("use-query-params");
 
-  const StringParam = { __type: "string" };
+  const StringParam = { __type: "string" } as const;
   const withDefault = (param: unknown, defaultValue: unknown) => ({
     ...(typeof param === "object" && param !== null ? param : {}),
     __default: defaultValue,

--- a/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
+++ b/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
@@ -19,6 +19,19 @@ const mockGetByIdUseQuery = jest.fn();
 
 const queryParamStore = new Map<string, unknown>();
 
+type MockViewQueryResult = {
+  data?: unknown;
+  error?: unknown;
+  isSuccess?: boolean;
+  isError?: boolean;
+};
+
+const hasDefaultValue = (value: unknown): value is { __default: unknown } =>
+  typeof value === "object" && value !== null && "__default" in value;
+
+const isMockViewQueryResult = (value: unknown): value is MockViewQueryResult =>
+  typeof value === "object" && value !== null;
+
 jest.mock("next/router", () => ({
   useRouter: () => mockUseRouter(),
 }));
@@ -44,20 +57,18 @@ jest.mock("../../utils/api", () => ({
       },
       getById: {
         useQuery: (...args: unknown[]) => {
-          const result = mockGetByIdUseQuery(...args) as
-            | {
-                data?: unknown;
-                error?: unknown;
-                isSuccess?: boolean;
-                isError?: boolean;
-              }
-            | undefined;
+          const result = mockGetByIdUseQuery(...args);
+          const normalizedResult = isMockViewQueryResult(result)
+            ? result
+            : undefined;
 
           return {
-            data: result?.data,
-            error: result?.error ?? null,
-            isSuccess: result?.isSuccess ?? result?.data !== undefined,
-            isError: result?.isError ?? !!result?.error,
+            data: normalizedResult?.data,
+            error: normalizedResult?.error ?? null,
+            isSuccess:
+              normalizedResult?.isSuccess ??
+              normalizedResult?.data !== undefined,
+            isError: normalizedResult?.isError ?? !!normalizedResult?.error,
           };
         },
       },
@@ -69,19 +80,14 @@ jest.mock("use-query-params", () => {
   const React = require("react");
   const actual = jest.requireActual("use-query-params");
 
-  const StringParam = { __type: "string" } as const;
+  const StringParam = { __type: "string" };
   const withDefault = (param: unknown, defaultValue: unknown) => ({
     ...(typeof param === "object" && param !== null ? param : {}),
     __default: defaultValue,
   });
 
   const readDefault = (config: unknown) =>
-    typeof config === "object" &&
-    config !== null &&
-    "__default" in config &&
-    (config as { __default?: unknown }).__default !== undefined
-      ? (config as { __default: unknown }).__default
-      : null;
+    hasDefaultValue(config) ? config.__default : null;
 
   return {
     ...actual,
@@ -204,10 +210,16 @@ function SavedViewHarness() {
   );
 }
 
-function ViewSelectionHarness() {
+function ViewSelectionHarness({
+  tableName = TableViewPresetTableName.Traces,
+  viewPersistenceKey,
+}: {
+  tableName?: TableViewPresetTableName;
+  viewPersistenceKey?: string;
+}) {
   const [appliedFilters, setAppliedFilters] = useState<FilterState>([]);
   const { selectedViewId, handleSetViewId } = useTableViewManager({
-    tableName: TableViewPresetTableName.Traces,
+    tableName,
     projectId: "project-1",
     stateUpdaters: {
       setFilters: setAppliedFilters,
@@ -219,6 +231,7 @@ function ViewSelectionHarness() {
       filterColumnDefinition: TEST_FILTER_CONFIG.columnDefinitions,
     },
     currentFilterState: appliedFilters,
+    viewPersistenceKey,
   });
 
   return (
@@ -421,5 +434,70 @@ describe("Saved view restore with implicit environment defaults", () => {
       expect(screen.getByTestId("selected-view-id").textContent).toBe("null");
       expect(screen.getByTestId("applied-filter-count").textContent).toBe("0");
     });
+  });
+
+  it("clears a permalink when the fetched saved view belongs to a different table", async () => {
+    mockGetByIdUseQuery.mockReturnValue({
+      data: {
+        id: "view-1",
+        name: "Traces saved view",
+        tableName: TableViewPresetTableName.Traces,
+        projectId: "project-1",
+        orderBy: null,
+        filters: OLD_SAVED_VIEW_FILTERS,
+        columnOrder: null,
+        columnVisibility: null,
+        searchQuery: "",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        createdBy: "user-1",
+        createdByUser: null,
+      },
+      error: null,
+    });
+
+    render(
+      <ViewSelectionHarness
+        tableName={TableViewPresetTableName.Observations}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-view-id").textContent).toBe("null");
+    });
+
+    expect(screen.getByTestId("applied-filter-count").textContent).toBe("0");
+    expect(queryParamStore.has("viewId")).toBe(false);
+  });
+
+  it("does not restore a stored saved view from another mode's persistence key", async () => {
+    queryParamStore.delete("viewId");
+    mockUseRouter.mockReturnValue({
+      isReady: true,
+      query: {},
+    });
+
+    sessionStorage.setItem(
+      "observations-v3-project-1-viewId",
+      JSON.stringify("view-1"),
+    );
+
+    render(
+      <ViewSelectionHarness
+        tableName={TableViewPresetTableName.Observations}
+        viewPersistenceKey="observations-v4"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected-view-id").textContent).toBe("null");
+    });
+
+    expect(screen.getByTestId("applied-filter-count").textContent).toBe("0");
+    expect(mockGetByIdUseQuery).toHaveBeenCalled();
+    expect(mockGetByIdUseQuery).toHaveBeenCalledWith(
+      { projectId: "project-1", viewId: null },
+      expect.objectContaining({ enabled: false }),
+    );
   });
 });

--- a/web/src/pages/project/[projectId]/observations.tsx
+++ b/web/src/pages/project/[projectId]/observations.tsx
@@ -72,18 +72,26 @@ export default function Generations() {
             "An observation captures a single function call in an application. See docs to learn more.",
           href: "https://langfuse.com/docs/observability/data-model",
         },
-        tabsProps: isBetaEnabled
-          ? undefined
-          : {
-              tabs: getTracingTabs(projectId),
-              activeTab: TRACING_TABS.OBSERVATIONS,
-            },
+        tabsProps:
+          isBetaEnabled || isInitializing
+            ? undefined
+            : {
+                tabs: getTracingTabs(projectId),
+                activeTab: TRACING_TABS.OBSERVATIONS,
+              },
       }}
       scrollable={showOnboarding}
     >
       {/* Show onboarding screen if user has no traces */}
       {showOnboarding ? (
         <TracesOnboarding projectId={projectId} />
+      ) : isInitializing ? (
+        <>
+          {/* Wait for the beta flag before mounting either table. Otherwise the
+              legacy table can briefly mount, restore a v3 saved view, and
+              promote its viewId into the URL before the correct mode
+              resolves. */}
+        </>
       ) : isBetaEnabled ? (
         <ObservationsEventsTable
           projectId={projectId}

--- a/web/src/pages/project/[projectId]/observations.tsx
+++ b/web/src/pages/project/[projectId]/observations.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { useRouter } from "next/router";
+import { useQueryParams, StringParam } from "use-query-params";
 import ObservationsTable from "@/src/components/table/use-cases/observations";
 import Page from "@/src/components/layouts/page";
 import { api } from "@/src/utils/api";
@@ -15,8 +16,32 @@ import { useQueryProject } from "@/src/features/projects/hooks";
 export default function Generations() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
-  const { isBetaEnabled } = useV4Beta();
+  const { isBetaEnabled, isInitializing } = useV4Beta();
+  const [, setQueryParams] = useQueryParams({ viewId: StringParam });
   const { project } = useQueryProject();
+  const previousBetaEnabledRef = useRef<boolean | null>(null);
+  const viewPersistenceKey = isBetaEnabled
+    ? "observations-v4"
+    : "observations-v3";
+
+  // Clear viewId when switching between table modes
+  useEffect(() => {
+    if (isInitializing) {
+      return;
+    }
+
+    const previousIsBetaEnabled = previousBetaEnabledRef.current;
+    previousBetaEnabledRef.current = isBetaEnabled;
+
+    const didTableModeChange =
+      previousIsBetaEnabled !== null && previousIsBetaEnabled !== isBetaEnabled;
+
+    if (!didTableModeChange) {
+      return;
+    }
+
+    setQueryParams({ viewId: undefined });
+  }, [isBetaEnabled, isInitializing, setQueryParams]);
 
   // Check if the user has tracing configured
   // Skip polling entirely if the project flag is already set in the session
@@ -60,9 +85,15 @@ export default function Generations() {
       {showOnboarding ? (
         <TracesOnboarding projectId={projectId} />
       ) : isBetaEnabled ? (
-        <ObservationsEventsTable projectId={projectId} />
+        <ObservationsEventsTable
+          projectId={projectId}
+          viewPersistenceKey={viewPersistenceKey}
+        />
       ) : (
-        <ObservationsTable projectId={projectId} />
+        <ObservationsTable
+          projectId={projectId}
+          viewPersistenceKey={viewPersistenceKey}
+        />
       )}
     </Page>
   );

--- a/web/src/pages/project/[projectId]/traces.tsx
+++ b/web/src/pages/project/[projectId]/traces.tsx
@@ -113,15 +113,23 @@ export default function Traces() {
           ),
           href: "https://langfuse.com/docs/observability/data-model",
         },
-        tabsProps: isBetaEnabled
-          ? undefined
-          : {
-              tabs: getTracingTabs(projectId),
-              activeTab: TRACING_TABS.TRACES,
-            },
+        tabsProps:
+          isBetaEnabled || isInitializing
+            ? undefined
+            : {
+                tabs: getTracingTabs(projectId),
+                activeTab: TRACING_TABS.TRACES,
+              },
       }}
     >
-      {isBetaEnabled ? (
+      {isInitializing ? (
+        <>
+          {/* Wait for the beta flag before mounting either table. Otherwise the
+              legacy table can briefly mount, restore a v3 saved view, and
+              promote its viewId into the URL before the correct mode
+              resolves. */}
+        </>
+      ) : isBetaEnabled ? (
         <ObservationsEventsTable
           projectId={projectId}
           viewPersistenceKey={viewPersistenceKey}

--- a/web/src/pages/project/[projectId]/traces.tsx
+++ b/web/src/pages/project/[projectId]/traces.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import { useQueryParams, StringParam } from "use-query-params";
 import TracesTable from "@/src/components/table/use-cases/traces";
@@ -16,16 +16,41 @@ import { useQueryProject } from "@/src/features/projects/hooks";
 export default function Traces() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
-  const { isBetaEnabled } = useV4Beta();
-  const [, setQueryParams] = useQueryParams({ viewMode: StringParam });
+  const { isBetaEnabled, isInitializing } = useV4Beta();
+  const [, setQueryParams] = useQueryParams({
+    viewId: StringParam,
+    viewMode: StringParam,
+  });
   const { project } = useQueryProject();
+  const previousBetaEnabledRef = useRef<boolean | null>(null);
+  const viewPersistenceKey = isBetaEnabled ? "traces-v4" : "traces-v3";
 
-  // Clear viewMode query when beta is turned off (e.g. from sidebar)
+  // Clear mode-specific query state when switching table modes
   useEffect(() => {
-    if (!isBetaEnabled) {
-      setQueryParams({ viewMode: undefined });
+    if (isInitializing) {
+      return;
     }
-  }, [isBetaEnabled, setQueryParams]);
+
+    const previousIsBetaEnabled = previousBetaEnabledRef.current;
+    previousBetaEnabledRef.current = isBetaEnabled;
+
+    if (previousIsBetaEnabled === null) {
+      if (!isBetaEnabled) {
+        setQueryParams({ viewMode: undefined });
+      }
+      return;
+    }
+
+    if (previousIsBetaEnabled === isBetaEnabled) {
+      return;
+    }
+
+    if (!isBetaEnabled) {
+      setQueryParams({ viewId: undefined, viewMode: undefined });
+    } else {
+      setQueryParams({ viewId: undefined });
+    }
+  }, [isBetaEnabled, isInitializing, setQueryParams]);
 
   // Check if the user has tracing configured
   // Skip polling entirely if the project flag is already set in the session
@@ -97,9 +122,15 @@ export default function Traces() {
       }}
     >
       {isBetaEnabled ? (
-        <ObservationsEventsTable projectId={projectId} />
+        <ObservationsEventsTable
+          projectId={projectId}
+          viewPersistenceKey={viewPersistenceKey}
+        />
       ) : (
-        <TracesTable projectId={projectId} />
+        <TracesTable
+          projectId={projectId}
+          viewPersistenceKey={viewPersistenceKey}
+        />
       )}
     </Page>
   );


### PR DESCRIPTION
## What does this PR do?

This PR fixes saved view restoration when switching between the legacy traces/observations tables and the v4 events-backed views.

Previously, both modes reused the same saved-view session storage keys and could carry a `viewId` permalink across mode switches. That allowed stale or incompatible saved-view IDs to be restored after toggling between table modes.

This change:
- uses mode-specific persistence keys for traces and observations saved views
- clears `viewId` when switching between table modes so stale permalinks are not reused
- rejects permalinks that resolve to a saved view from the wrong table
- adds regression coverage for cross-mode saved-view restoration and invalid table/view combinations
- simplifies the surrounding mode-switch logic and removes avoidable type casts in the touched code

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

