### PR TITLE
fix: validate Azure blob storage container names

### DIFF
--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -68,7 +68,7 @@ types:
       type: BlobStorageIntegrationType
       bucketName:
         type: string
-        docs: Name of the storage bucket
+        docs: Name of the storage bucket. For AZURE_BLOB_STORAGE, must be a valid Azure container name (3-63 chars, lowercase letters, numbers, and hyphens only, must start and end with a letter or number, no consecutive hyphens).
       endpoint:
         type: optional<string>
         docs: Custom endpoint URL (required for S3_COMPATIBLE type)

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -6325,7 +6325,11 @@ components:
           $ref: '#/components/schemas/BlobStorageIntegrationType'
         bucketName:
           type: string
-          description: Name of the storage bucket
+          description: >-
+            Name of the storage bucket. For AZURE_BLOB_STORAGE, must be a valid
+            Azure container name (3-63 chars, lowercase letters, numbers, and
+            hyphens only, must start and end with a letter or number, no
+            consecutive hyphens).
         endpoint:
           type: string
           nullable: true

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -445,6 +445,24 @@ describe("Blob Storage Integrations API", () => {
       );
     });
 
+    it("should reject invalid Azure container names", async () => {
+      const azureConfig = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        type: "AZURE_BLOB_STORAGE" as const,
+        endpoint: "https://myaccount.blob.core.windows.net",
+        bucketName: "Feedback N8N Bot",
+      };
+
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        azureConfig,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(400);
+    });
+
     it("should handle export modes with dates", async () => {
       const customDateConfig = {
         ...validBlobStorageConfig,

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -6,7 +6,8 @@ import {
   createTRPCRouter,
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
-import { blobStorageIntegrationFormSchema } from "@/src/features/blobstorage-integration/types";
+import { blobStorageIntegrationFormSchemaBase } from "@/src/features/blobstorage-integration/types";
+import { validateAzureContainerName } from "@/src/features/blobstorage-integration/validation";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { TRPCError } from "@trpc/server";
 import {
@@ -56,7 +57,11 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
     }),
 
   update: protectedProjectProcedure
-    .input(blobStorageIntegrationFormSchema.extend({ projectId: z.string() }))
+    .input(
+      blobStorageIntegrationFormSchemaBase
+        .extend({ projectId: z.string() })
+        .superRefine(validateAzureContainerName),
+    )
     .mutation(async ({ input, ctx }) => {
       try {
         throwIfNoProjectAccess({

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -5,8 +5,9 @@ import {
   BlobStorageExportMode,
   AnalyticsIntegrationExportSource,
 } from "@langfuse/shared";
+import { validateAzureContainerName } from "@/src/features/blobstorage-integration/validation";
 
-export const blobStorageIntegrationFormSchema = z.object({
+export const blobStorageIntegrationFormSchemaBase = z.object({
   type: z.enum(BlobStorageIntegrationType),
   bucketName: z.string().min(1, { message: "Bucket name is required" }),
   endpoint: z.string().url().optional().nullable(),
@@ -35,6 +36,9 @@ export const blobStorageIntegrationFormSchema = z.object({
     .default(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
   compressed: z.boolean().default(true),
 });
+
+export const blobStorageIntegrationFormSchema =
+  blobStorageIntegrationFormSchemaBase.superRefine(validateAzureContainerName);
 
 export type BlobStorageIntegrationFormSchema = z.infer<
   typeof blobStorageIntegrationFormSchema

--- a/web/src/features/blobstorage-integration/validation.clienttest.ts
+++ b/web/src/features/blobstorage-integration/validation.clienttest.ts
@@ -1,0 +1,74 @@
+import {
+  AZURE_CONTAINER_NAME_REGEX,
+  validateAzureContainerName,
+} from "./validation";
+import { z } from "zod";
+
+describe("AZURE_CONTAINER_NAME_REGEX", () => {
+  const valid = [
+    "abc",
+    "my-container",
+    "a1b2c3",
+    "123",
+    "a-b",
+    "a".repeat(63),
+    "container-name-1",
+  ];
+
+  const invalid = [
+    "ab", // too short
+    "a", // too short
+    "a".repeat(64), // too long
+    "ABC", // uppercase
+    "My-Container", // mixed case
+    "-abc", // starts with hyphen
+    "abc-", // ends with hyphen
+    "my--container", // consecutive hyphens
+    "has space", // spaces
+    "has.dot", // dots
+    "has/slash", // slashes
+    "Feedback N8N Bot", // the original issue
+    "", // empty
+  ];
+
+  it.each(valid)("accepts valid name: %s", (name) => {
+    expect(AZURE_CONTAINER_NAME_REGEX.test(name)).toBe(true);
+  });
+
+  it.each(invalid)("rejects invalid name: %s", (name) => {
+    expect(AZURE_CONTAINER_NAME_REGEX.test(name)).toBe(false);
+  });
+});
+
+describe("validateAzureContainerName via schema", () => {
+  const schema = z
+    .object({ type: z.string(), bucketName: z.string() })
+    .superRefine(validateAzureContainerName);
+
+  it("rejects invalid Azure container name", () => {
+    const result = schema.safeParse({
+      type: "AZURE_BLOB_STORAGE",
+      bucketName: "Feedback N8N Bot",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["bucketName"]);
+    }
+  });
+
+  it("allows invalid container name for S3 type", () => {
+    const result = schema.safeParse({
+      type: "S3",
+      bucketName: "Feedback N8N Bot",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows valid Azure container name", () => {
+    const result = schema.safeParse({
+      type: "AZURE_BLOB_STORAGE",
+      bucketName: "valid-container",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/web/src/features/blobstorage-integration/validation.clienttest.ts
+++ b/web/src/features/blobstorage-integration/validation.clienttest.ts
@@ -71,4 +71,13 @@ describe("validateAzureContainerName via schema", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("skips Azure validation when bucketName is empty", () => {
+    const result = schema.safeParse({
+      type: "AZURE_BLOB_STORAGE",
+      bucketName: "",
+    });
+    // Should pass superRefine (empty guard), letting .min(1) handle it upstream
+    expect(result.success).toBe(true);
+  });
 });

--- a/web/src/features/blobstorage-integration/validation.ts
+++ b/web/src/features/blobstorage-integration/validation.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/**
+ * Azure container names must be 3-63 characters, lowercase letters, numbers,
+ * and hyphens only. Must start and end with a letter or number. No consecutive
+ * hyphens.
+ *
+ * @see https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names
+ */
+export const AZURE_CONTAINER_NAME_REGEX =
+  /^[a-z0-9](?!.*--)[a-z0-9-]{1,61}[a-z0-9]$/;
+
+export const AZURE_CONTAINER_NAME_ERROR =
+  "Azure container names must be 3-63 characters, lowercase letters, numbers, and hyphens only. Must start and end with a letter or number, no consecutive hyphens.";
+
+export function validateAzureContainerName(
+  data: { type: string; bucketName: string },
+  ctx: z.RefinementCtx,
+) {
+  if (
+    data.type === "AZURE_BLOB_STORAGE" &&
+    !AZURE_CONTAINER_NAME_REGEX.test(data.bucketName)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: AZURE_CONTAINER_NAME_ERROR,
+      path: ["bucketName"],
+    });
+  }
+}

--- a/web/src/features/blobstorage-integration/validation.ts
+++ b/web/src/features/blobstorage-integration/validation.ts
@@ -17,6 +17,7 @@ export function validateAzureContainerName(
   data: { type: string; bucketName: string },
   ctx: z.RefinementCtx,
 ) {
+  if (!data.bucketName) return;
   if (
     data.type === "AZURE_BLOB_STORAGE" &&
     !AZURE_CONTAINER_NAME_REGEX.test(data.bucketName)

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { validateAzureContainerName } from "@/src/features/blobstorage-integration/validation";
 
 /**
  * Enums
@@ -57,7 +58,8 @@ export const CreateBlobStorageIntegrationRequest = z
         "exportStartDate is required when exportMode is FROM_CUSTOM_DATE",
       path: ["exportStartDate"],
     },
-  );
+  )
+  .superRefine(validateAzureContainerName);
 
 export const BlobStorageIntegrationResponse = z
   .object({

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -27,7 +27,7 @@ export const CreateBlobStorageIntegrationRequest = z
   .object({
     projectId: z.string(),
     type: BlobStorageIntegrationType,
-    bucketName: z.string(),
+    bucketName: z.string().min(1),
     endpoint: z.string().nullable().optional(),
     region: z.string(),
     accessKeyId: z.string().nullable().optional(),

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -392,7 +392,7 @@ const BlobStorageIntegrationSettingsForm = ({
               </FormControl>
               <FormDescription>
                 {integrationType === "AZURE_BLOB_STORAGE"
-                  ? "The Azure storage container name"
+                  ? "Azure container name (3-63 chars, lowercase letters, numbers, and hyphens only)"
                   : "The S3 bucket name"}
               </FormDescription>
               <FormMessage />


### PR DESCRIPTION
Azure requires container names to be 3-63 chars, lowercase alphanumeric
and hyphens only. Add Zod superRefine validation to the form schema,
tRPC router, and public API schema so invalid names like "Foobar Banana"
are rejected at submission time with a clear error message.
