### PR TITLE
fix(codex): run clickhouse server as clickhouse user

### DIFF
--- a/scripts/codex/cloud_services.sh
+++ b/scripts/codex/cloud_services.sh
@@ -359,14 +359,18 @@ ensure_clickhouse_running() {
   local clickhouse_log="$clickhouse_root/clickhouse.log"
   local clickhouse_err="$clickhouse_root/clickhouse.err.log"
   local clickhouse_pid="$clickhouse_root/clickhouse.pid"
+  local -a clickhouse_runner
 
   mkdir -p "$clickhouse_data"
   if [ "${EUID:-$(id -u)}" -eq 0 ] && id -u clickhouse >/dev/null 2>&1; then
     chown -R clickhouse:clickhouse "$clickhouse_root"
+    clickhouse_runner=(runuser -u clickhouse --)
+  else
+    clickhouse_runner=()
   fi
 
   if ! wait_for_http "http://127.0.0.1:$CLICKHOUSE_HTTP_PORT/ping" 1; then
-    clickhouse-server \
+    "${clickhouse_runner[@]}" clickhouse-server \
       --daemon \
       --config-file=/etc/clickhouse-server/config.xml \
       --pid-file="$clickhouse_pid" \
@@ -389,7 +393,9 @@ ensure_clickhouse_running() {
   clickhouse_user_identifier="$(escape_clickhouse_identifier "$CLICKHOUSE_USER")"
 
   clickhouse-client --host 127.0.0.1 --port "$CLICKHOUSE_NATIVE_PORT" -q "CREATE USER IF NOT EXISTS $clickhouse_user_identifier IDENTIFIED WITH plaintext_password BY '$clickhouse_password_sql'"
-  clickhouse-client --host 127.0.0.1 --port "$CLICKHOUSE_NATIVE_PORT" -q "GRANT ALL ON *.* TO $clickhouse_user_identifier WITH GRANT OPTION"
+  if ! clickhouse-client --host 127.0.0.1 --port "$CLICKHOUSE_NATIVE_PORT" -q "GRANT CURRENT GRANTS ON *.* TO $clickhouse_user_identifier" >/dev/null 2>&1; then
+    clickhouse-client --host 127.0.0.1 --port "$CLICKHOUSE_NATIVE_PORT" -q "GRANT ALL ON *.* TO $clickhouse_user_identifier WITH GRANT OPTION"
+  fi
 }
 
 ensure_minio_running() {


### PR DESCRIPTION
## Summary
- run ClickHouse daemon launch as the `clickhouse` OS user when executing as root, matching ownership requirements of the data directory
- retain root-mode ownership normalization for the workspace-scoped ClickHouse data/log/pid tree under `CODEX_SERVICES_ROOT`
- update grant bootstrapping to prefer `GRANT CURRENT GRANTS ON *.*` (with fallback to previous statement) to avoid permission errors on newer ClickHouse defaults

## Impacted packages
- root scripts (`scripts/codex/cloud_services.sh`)

## Verification
- `bash -n scripts/codex/cloud_services.sh scripts/codex/setup_cloud.sh scripts/codex/maintenance_cloud.sh`
- `bash scripts/codex/setup.test.sh`
- `bash -lc 'source scripts/codex/cloud_services.sh; ensure_clickhouse_running'`
- `git commit` hooks (`pnpm format:check`, `pnpm lint`)


------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d769c93d7c8323a71347b1e401db08)