### PR TITLE
chore: Initialize local databases during cloud setup and maintenance scripts

### DIFF
--- a/scripts/codex/cloud_services.sh
+++ b/scripts/codex/cloud_services.sh
@@ -29,6 +29,7 @@ MINIO_SHA256_AMD64="${MINIO_SHA256_AMD64:-7c5bd8512c6e966455b1d198209358b2d191c7
 MINIO_SHA256_ARM64="${MINIO_SHA256_ARM64:-5c83cd2cf151717ba0243f73e1c7802ff36e272b67144bdd7f1f7d684fd6f03d}"
 MC_SHA256_AMD64="${MC_SHA256_AMD64:-01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891}"
 MC_SHA256_ARM64="${MC_SHA256_ARM64:-14c8c9616cfce4636add161304353244e8de383b2e2752c0e9dad01d4c27c12c}"
+MIGRATE_RELEASE_TAG="${MIGRATE_RELEASE_TAG:-v4.19.1}"
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -112,6 +113,45 @@ ensure_clickhouse_binaries() {
   ensure_clickhouse_repo
   apt-get install -y clickhouse-server clickhouse-client
   stop_service_if_running clickhouse-server
+}
+
+detect_migrate_arch() {
+  local machine_arch
+  machine_arch="$(uname -m)"
+
+  case "$machine_arch" in
+    x86_64|amd64)
+      echo "amd64"
+      ;;
+    aarch64|arm64)
+      echo "arm64"
+      ;;
+    *)
+      echo "Unsupported architecture for golang-migrate binary: $machine_arch" >&2
+      exit 1
+      ;;
+  esac
+}
+
+ensure_migrate_binary() {
+  if command -v migrate >/dev/null 2>&1; then
+    return 0
+  fi
+
+  ensure_apt_package ca-certificates
+  ensure_apt_package curl
+
+  local migrate_arch
+  local tmp_dir
+  migrate_arch="$(detect_migrate_arch)"
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' RETURN
+
+  curl -fsSL "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_RELEASE_TAG}/migrate.linux-${migrate_arch}.tar.gz" \
+    | tar -xz -C "$tmp_dir" migrate
+  install -m 0755 "$tmp_dir/migrate" /usr/local/bin/migrate
+
+  trap - RETURN
 }
 
 detect_minio_arch() {
@@ -454,6 +494,7 @@ ensure_minio_running() {
 ensure_cloud_dependencies() {
   mkdir -p "$CODEX_SERVICES_ROOT"
 
+  ensure_migrate_binary
   ensure_postgres_running
   ensure_redis_running
   ensure_clickhouse_running

--- a/scripts/codex/cloud_services.sh
+++ b/scripts/codex/cloud_services.sh
@@ -30,6 +30,8 @@ MINIO_SHA256_ARM64="${MINIO_SHA256_ARM64:-5c83cd2cf151717ba0243f73e1c7802ff36e27
 MC_SHA256_AMD64="${MC_SHA256_AMD64:-01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891}"
 MC_SHA256_ARM64="${MC_SHA256_ARM64:-14c8c9616cfce4636add161304353244e8de383b2e2752c0e9dad01d4c27c12c}"
 MIGRATE_RELEASE_TAG="${MIGRATE_RELEASE_TAG:-v4.19.1}"
+MIGRATE_SHA256_AMD64="${MIGRATE_SHA256_AMD64:-2ac648fbd1b127b69ab5a7b33cf96212178f71e22379fc50573630c6f4c7ce18}"
+MIGRATE_SHA256_ARM64="${MIGRATE_SHA256_ARM64:-2fea2455c0f3f07cc3f4b98471c951ad1a716059574b20b6416bd1e9058751c5}"
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -142,16 +144,26 @@ ensure_migrate_binary() {
   ensure_apt_package curl
 
   local migrate_arch
+  local migrate_sha256
   local tmp_dir
   migrate_arch="$(detect_migrate_arch)"
+  case "$migrate_arch" in
+    amd64)
+      migrate_sha256="$MIGRATE_SHA256_AMD64"
+      ;;
+    arm64)
+      migrate_sha256="$MIGRATE_SHA256_ARM64"
+      ;;
+  esac
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "$tmp_dir"' RETURN
 
-  curl -fsSL "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_RELEASE_TAG}/migrate.linux-${migrate_arch}.tar.gz" \
-    | tar -xz -C "$tmp_dir" migrate
+  download_and_verify_sha256 \
+    "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_RELEASE_TAG}/migrate.linux-${migrate_arch}.tar.gz" \
+    "$tmp_dir/migrate.tar.gz" \
+    "$migrate_sha256"
+  tar -xzf "$tmp_dir/migrate.tar.gz" -C "$tmp_dir" migrate
   install -m 0755 "$tmp_dir/migrate" /usr/local/bin/migrate
-
-  trap - RETURN
 }
 
 detect_minio_arch() {

--- a/scripts/codex/maintenance_cloud.sh
+++ b/scripts/codex/maintenance_cloud.sh
@@ -18,3 +18,9 @@ pnpm install --frozen-lockfile
 
 # Keep generated Prisma artifacts aligned after dependency or schema updates.
 pnpm run db:generate
+
+# Keep local databases initialized for worker/web tests during maintenance runs.
+pnpm --filter=shared run db:reset:test
+pnpm --filter=shared run db:reset -f
+SKIP_CONFIRM=1 pnpm --filter=shared run ch:reset
+pnpm --filter=shared run db:seed:examples

--- a/scripts/codex/setup_cloud.sh
+++ b/scripts/codex/setup_cloud.sh
@@ -40,3 +40,10 @@ pnpm --filter=shared run db:generate
 
 # Prisma client generation is needed for typecheck/build tasks in Codex.
 pnpm run db:generate
+
+# Initialize local databases so worker/web tests can run immediately after
+# bootstrap without "table does not exist" failures.
+pnpm --filter=shared run db:reset:test
+pnpm --filter=shared run db:reset -f
+SKIP_CONFIRM=1 pnpm --filter=shared run ch:reset
+pnpm --filter=shared run db:seed:examples


### PR DESCRIPTION
### Motivation
- Ensure local databases are initialized during bootstrap and maintenance so worker/web tests do not fail with "table does not exist" errors.
- Make Prisma artifacts and example data available immediately after dependency installation to speed up test and development workflows.

### Description
- Added runs of `pnpm --filter=shared run db:reset:test`, `pnpm --filter=shared run db:reset -f`, `SKIP_CONFIRM=1 pnpm --filter=shared run ch:reset`, and `pnpm --filter=shared run db:seed:examples` to both `scripts/codex/setup_cloud.sh` and `scripts/codex/maintenance_cloud.sh` after dependency install and Prisma generation.
- Kept existing `pnpm run db:generate` steps and Playwright install in `setup_cloud.sh` to preserve artifact generation and browser setup.
- Added brief comments explaining why local DB initialization is required for tests.

### Testing
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d902d790e48323820fb4c64935211c)