### PR TITLE
fix(worker): advance experiment backfill cursor when no items to process

### DIFF
--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -837,8 +837,9 @@ async function processExperimentBackfill(
 
   if (datasetRunItems.length === 0) {
     logger.info(
-      "[EXPERIMENT BACKFILL] No dataset run items to process, skipping",
+      "[EXPERIMENT BACKFILL] No dataset run items to process, advancing cursor",
     );
+    await updateBackfillTimestamp(upperBound);
     return;
   }
 


### PR DESCRIPTION
## Summary
- The experiment backfill cursor (`langfuse:event-propagation:experiment-backfill:last-run` in Redis) was only advanced inside the chunk-processing loop in `processExperimentBackfill`, which is never reached when the ClickHouse query returns zero dataset run items.
- This caused `langfuse.experiment_backfill.last_run_delay_seconds` to grow indefinitely in environments with no recent experiment activity, making the metric appear stuck (e.g. on April 7th).
- Fix: call `updateBackfillTimestamp(upperBound)` before the early return so the cursor advances even when there is no work to do.

## Test plan
- [ ] Deploy to affected environment and verify `last_run_delay_seconds` drops back to near-zero on the next backfill cycle
- [ ] Confirm that environments with active experiments continue to process items normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)