### PR TITLE
fix(auth): add issuer to GitHubProvider & GitHubEnterpriseProvider for RFC 9207

### DIFF
--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -353,6 +353,7 @@ if (env.AUTH_GITHUB_CLIENT_ID && env.AUTH_GITHUB_CLIENT_SECRET)
     GitHubProvider({
       clientId: env.AUTH_GITHUB_CLIENT_ID,
       clientSecret: env.AUTH_GITHUB_CLIENT_SECRET,
+      issuer: "https://github.com/login/oauth",
       allowDangerousEmailAccountLinking:
         env.AUTH_GITHUB_ALLOW_ACCOUNT_LINKING === "true",
       client: {
@@ -372,6 +373,7 @@ if (
       clientId: env.AUTH_GITHUB_ENTERPRISE_CLIENT_ID,
       clientSecret: env.AUTH_GITHUB_ENTERPRISE_CLIENT_SECRET,
       enterprise: { baseUrl: env.AUTH_GITHUB_ENTERPRISE_BASE_URL },
+      issuer: `${env.AUTH_GITHUB_ENTERPRISE_BASE_URL}/login/oauth`,
       allowDangerousEmailAccountLinking:
         env.AUTH_GITHUB_ENTERPRISE_ALLOW_ACCOUNT_LINKING === "true",
       client: {


### PR DESCRIPTION
## Summary

Complements #13093 by adding the `issuer` field to **both** `GitHubProvider` and `GitHubEnterpriseProvider` in `web/src/server/auth.ts`.

GitHub recently started returning an `iss` parameter in OAuth callback responses, implementing [RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207). `openid-client` (used by NextAuth v4) validates this unconditionally — if `issuer` is not configured on the provider, it throws:

```
issuer must be configured on the issuer
```

This completely breaks GitHub OAuth sign-in for all self-hosted Langfuse deployments.

## Changes

| Provider | `issuer` value |
|----------|---------------|
| `GitHubProvider` | `"https://github.com/login/oauth"` |
| `GitHubEnterpriseProvider` | `` `${env.AUTH_GITHUB_ENTERPRISE_BASE_URL}/login/oauth` `` |

**Diff: 2 lines added, 0 removed.**

## Why this PR in addition to #13093

PR #13093 (by @Marie673) correctly fixes `GitHubProvider` but intentionally skips `GitHubEnterpriseProvider`. This PR covers both providers so that GHES deployments are also protected when GitHub Enterprise Server rolls out RFC 9207.

## Context

I independently hit this exact bug in my own Next.js + NextAuth v4 project. After debugging the `openid-client` source code and tracing the `iss` parameter in callback URLs, I fixed it in my project first, then found the same bug here and decided to contribute the fix upstream.

## Test Plan

- [ ] Self-hosted Langfuse with `AUTH_GITHUB_CLIENT_ID` + `AUTH_GITHUB_CLIENT_SECRET` → GitHub OAuth sign-in succeeds
- [ ] Self-hosted Langfuse with GitHub Enterprise Server (`AUTH_GITHUB_ENTERPRISE_BASE_URL`) → GHES OAuth sign-in succeeds
- [ ] Existing sign-in flows (credentials, GitLab, Okta, etc.) are unaffected

Fixes #13091

cc @marcklingen @maxdeichmann @Steffen911 @hassiebp @Marie673