### PR TITLE
fix(dashboard): convert latency from ms to seconds in custom widgets

### DIFF
--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -227,6 +227,15 @@ export function DashboardWidget({
     setRetryCount((current) => current + 1);
   }, []);
 
+  const isLatencyMetric = useMemo(() => {
+    const firstMetric = widget.data?.metrics[0];
+    if (!firstMetric) return false;
+    return (
+      firstMetric.measure === "latency" ||
+      firstMetric.measure === "streamingLatency"
+    );
+  }, [widget.data?.metrics]);
+
   const transformedData = useMemo(() => {
     if (!widget.data || !queryResult.data) {
       return [];
@@ -254,7 +263,13 @@ export function DashboardWidget({
         agg: "count",
       };
       const metricField = `${metric.agg}_${metric.measure}`;
-      const metricValue = item[metricField];
+      const rawMetricValue = item[metricField];
+      // Latency measures are stored in milliseconds in ClickHouse,
+      // convert to seconds for display consistency with built-in dashboards
+      const metricValue =
+        isLatencyMetric && typeof rawMetricValue === "number"
+          ? rawMetricValue / 1000
+          : rawMetricValue;
 
       const dimensionField =
         widget.data.dimensions.slice().shift()?.field ?? "none";
@@ -433,6 +448,12 @@ export function DashboardWidget({
                 widget.data.chartType === "PIVOT_TABLE" ? updateSort : undefined
               }
               isLoading={queryResult.isPending}
+              valueFormatter={
+                isLatencyMetric
+                  ? (seconds: number) =>
+                      `${Intl.NumberFormat("en-US", { notation: "compact", minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(seconds)}s`
+                  : undefined
+              }
             />
             <ChartLoadingState
               isLoading={chartLoadingState.isLoading}

--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -292,7 +292,7 @@ export function DashboardWidget({
         time_dimension: item["time_dimension"],
       };
     });
-  }, [queryResult.data, widget.data]);
+  }, [queryResult.data, widget.data, isLatencyMetric]);
 
   const handleEdit = () => {
     router.push(


### PR DESCRIPTION
## Summary

Custom dashboard widgets display raw millisecond values for latency metrics (e.g., "9.3K" instead of "9.3s"), while built-in dashboard components correctly show seconds.

**Root cause:** `DashboardWidget.tsx` passes raw ClickHouse query results (which use `date_diff('millisecond', ...)`) directly to chart components without converting to seconds. The built-in components (`LatencyTables.tsx`, `LatencyChart.tsx`) already handle this conversion via `latencyFormatter`.

**Fix:**
- Detects when a widget metric is `latency` or `streamingLatency`
- Converts millisecond values to seconds in `transformedData` (fixes BigNumber, all chart types)
- Adds a `valueFormatter` that appends "s" suffix to chart axes/tooltips

Fixes #13111
Related: #11051, #11208

## Test plan

- [ ] Create a custom dashboard widget with View=Observations, Metric=Latency (Avg), Breakdown=Name
- [ ] Verify values display in seconds (e.g., "9.3s") instead of raw milliseconds ("9.3K")
- [ ] Verify BigNumber widget type also shows seconds
- [ ] Verify built-in dashboard components still work correctly
- [ ] Verify non-latency metrics are unaffected