### PR TITLE
fix(shared): treat end-of-life model errors as non-retryable

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -632,7 +632,11 @@ export async function fetchLLMCompletion(
     return completion;
   } catch (e) {
     const responseStatusCode =
-      (e as any)?.response?.status ?? (e as any)?.status ?? 500;
+      (e as any)?.response?.status ??
+      (e as any)?.status ??
+      // Bedrock errors have status code in $metadata.httpStatusCode
+      (e as any)?.$metadata?.httpStatusCode ??
+      500;
     const rawMessage = e instanceof Error ? e.message : String(e);
     const message = extractCleanErrorMessage(rawMessage);
 

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -62,12 +62,6 @@ const NON_RETRYABLE_LLM_ERROR_PATTERNS = [
   "reached the end of its life",
 ] as const;
 
-export function isNonRetryableLLMErrorMessage(message: string): boolean {
-  return NON_RETRYABLE_LLM_ERROR_PATTERNS.some((pattern) =>
-    message.includes(pattern),
-  );
-}
-
 const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
 // Maps adapters to the content block types that represent "thinking".
@@ -643,7 +637,9 @@ export async function fetchLLMCompletion(
     const message = extractCleanErrorMessage(rawMessage);
 
     // Check for non-retryable error patterns in message
-    const hasNonRetryablePattern = isNonRetryableLLMErrorMessage(message);
+    const hasNonRetryablePattern = NON_RETRYABLE_LLM_ERROR_PATTERNS.some(
+      (pattern) => message.includes(pattern),
+    );
 
     // Determine retryability:
     // - 429 (rate limit): retryable with custom delay

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -54,6 +54,20 @@ import { LLMCompletionError } from "./errors";
 
 export type CompletionWithReasoning = { text: string; reasoning?: string };
 
+const NON_RETRYABLE_LLM_ERROR_PATTERNS = [
+  "Request timed out",
+  "is not valid JSON",
+  "Unterminated string in JSON at position",
+  "TypeError",
+  "reached the end of its life",
+] as const;
+
+export function isNonRetryableLLMErrorMessage(message: string): boolean {
+  return NON_RETRYABLE_LLM_ERROR_PATTERNS.some((pattern) =>
+    message.includes(pattern),
+  );
+}
+
 const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
 // Maps adapters to the content block types that represent "thinking".
@@ -629,16 +643,7 @@ export async function fetchLLMCompletion(
     const message = extractCleanErrorMessage(rawMessage);
 
     // Check for non-retryable error patterns in message
-    const nonRetryablePatterns = [
-      "Request timed out",
-      "is not valid JSON",
-      "Unterminated string in JSON at position",
-      "TypeError",
-    ];
-
-    const hasNonRetryablePattern = nonRetryablePatterns.some((pattern) =>
-      message.includes(pattern),
-    );
+    const hasNonRetryablePattern = isNonRetryableLLMErrorMessage(message);
 
     // Determine retryability:
     // - 429 (rate limit): retryable with custom delay

--- a/worker/src/__tests__/fetchLLMCompletionTimeout.test.ts
+++ b/worker/src/__tests__/fetchLLMCompletionTimeout.test.ts
@@ -2,12 +2,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const invokeMock = vi.fn();
 const streamMock = vi.fn();
-const chatVertexAIConstructorMock = vi.fn().mockImplementation(() => ({
-  invoke: invokeMock,
-  pipe: vi.fn().mockReturnValue({
-    stream: streamMock,
-  }),
-}));
+const bedrockInvokeMock = vi.fn();
+const chatVertexAIConstructorMock = vi.fn().mockImplementation(function () {
+  return {
+    invoke: invokeMock,
+    pipe: vi.fn().mockReturnValue({
+      stream: streamMock,
+    }),
+  };
+});
+const chatBedrockConverseConstructorMock = vi
+  .fn()
+  .mockImplementation(function () {
+    return {
+      invoke: bedrockInvokeMock,
+      pipe: vi.fn().mockReturnValue({
+        invoke: bedrockInvokeMock,
+        stream: streamMock,
+      }),
+    };
+  });
 const VERTEXAI_USE_DEFAULT_CREDENTIALS = "__VERTEXAI_DEFAULT_CREDENTIALS__";
 
 process.env.CLICKHOUSE_URL ??= "http://localhost:8123";
@@ -159,5 +173,83 @@ describe("fetchLLMCompletion runtime timeouts", () => {
 
     await vi.runOnlyPendingTimersAsync();
     await completionRejection;
+  });
+});
+
+describe("fetchLLMCompletion end of model lifetime", () => {
+  let originalCloudRegion: string | undefined;
+  let encrypt: typeof import("../../../packages/shared/src/encryption").encrypt;
+  let fetchLLMCompletion: typeof import("../../../packages/shared/src/server/llm/fetchLLMCompletion").fetchLLMCompletion;
+
+  beforeEach(async () => {
+    invokeMock.mockReset();
+    streamMock.mockReset();
+    bedrockInvokeMock.mockReset();
+    chatBedrockConverseConstructorMock.mockClear();
+    vi.resetModules();
+    originalCloudRegion = process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    delete process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    // @langchain/aws is a dependency of @langfuse/shared, not worker — a bare
+    // specifier can't resolve from this test file under pnpm strict isolation.
+    vi.doMock("../../../packages/shared/node_modules/@langchain/aws", () => ({
+      ChatBedrockConverse: chatBedrockConverseConstructorMock,
+    }));
+    vi.doMock("../../../packages/shared/src/server/llm/errors", () => ({
+      LLMCompletionError: MockLLMCompletionError,
+    }));
+
+    ({ encrypt } = await import("../../../packages/shared/src/encryption"));
+    ({ fetchLLMCompletion } =
+      await import("../../../packages/shared/src/server/llm/fetchLLMCompletion"));
+  });
+
+  afterEach(() => {
+    if (originalCloudRegion === undefined) {
+      delete process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    } else {
+      process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+    }
+  });
+
+  it("treats end-of-life model errors as non-retryable", async () => {
+    const endOfLifeError = new Error(
+      "This model version has reached the end of its life. Please refer to the AWS documentation for more details.",
+    ) as Error & { status: number };
+    endOfLifeError.status = 404;
+    bedrockInvokeMock.mockRejectedValue(endOfLifeError);
+
+    const completionPromise = fetchLLMCompletion({
+      streaming: false,
+      messages: [
+        {
+          role: "user",
+          content: "What is 2+2? Answer only with the number.",
+          type: "public-api-created",
+        },
+      ],
+      modelParams: {
+        provider: "bedrock",
+        adapter: "bedrock",
+        model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        temperature: 0,
+        max_tokens: 10,
+      },
+      llmConnection: {
+        secretKey: encrypt(JSON.stringify({ apiKey: "test-api-key" })),
+        config: {
+          region: "us-east-1",
+        },
+      },
+    });
+
+    expect(chatBedrockConverseConstructorMock).toHaveBeenCalled();
+
+    await expect(completionPromise).rejects.toMatchObject({
+      name: "LLMCompletionError",
+      message:
+        "This model version has reached the end of its life. Please refer to the AWS documentation for more details.",
+      responseStatusCode: 404,
+      isRetryable: false,
+    });
   });
 });

--- a/worker/src/__tests__/fetchLLMCompletionTimeout.test.ts
+++ b/worker/src/__tests__/fetchLLMCompletionTimeout.test.ts
@@ -212,10 +212,12 @@ describe("fetchLLMCompletion end of model lifetime", () => {
   });
 
   it("treats end-of-life model errors as non-retryable", async () => {
+    // Mirror real AWS SDK error shape: status code lives on $metadata.httpStatusCode
     const endOfLifeError = new Error(
       "This model version has reached the end of its life. Please refer to the AWS documentation for more details.",
-    ) as Error & { status: number };
-    endOfLifeError.status = 404;
+    ) as Error & { $metadata: { httpStatusCode: number } };
+    endOfLifeError.name = "ResourceNotFoundException";
+    endOfLifeError.$metadata = { httpStatusCode: 404 };
     bedrockInvokeMock.mockRejectedValue(endOfLifeError);
 
     const completionPromise = fetchLLMCompletion({

--- a/worker/src/__tests__/fetchLLMCompletionTimeout.test.ts
+++ b/worker/src/__tests__/fetchLLMCompletionTimeout.test.ts
@@ -180,6 +180,7 @@ describe("fetchLLMCompletion end of model lifetime", () => {
   let originalCloudRegion: string | undefined;
   let encrypt: typeof import("../../../packages/shared/src/encryption").encrypt;
   let fetchLLMCompletion: typeof import("../../../packages/shared/src/server/llm/fetchLLMCompletion").fetchLLMCompletion;
+  let ResourceNotFoundException: any;
 
   beforeEach(async () => {
     invokeMock.mockReset();
@@ -201,6 +202,16 @@ describe("fetchLLMCompletion end of model lifetime", () => {
     ({ encrypt } = await import("../../../packages/shared/src/encryption"));
     ({ fetchLLMCompletion } =
       await import("../../../packages/shared/src/server/llm/fetchLLMCompletion"));
+
+    // Resolve the real AWS SDK exception via @langchain/aws's dependency tree.
+    const awsModulePath = require.resolve("@langchain/aws", {
+      paths: [require("path").resolve(__dirname, "../../../packages/shared")],
+    });
+    ({ ResourceNotFoundException } = await import(
+      require.resolve("@aws-sdk/client-bedrock-runtime", {
+        paths: [require("path").dirname(awsModulePath)],
+      })
+    ));
   });
 
   afterEach(() => {
@@ -212,12 +223,11 @@ describe("fetchLLMCompletion end of model lifetime", () => {
   });
 
   it("treats end-of-life model errors as non-retryable", async () => {
-    // Mirror real AWS SDK error shape: status code lives on $metadata.httpStatusCode
-    const endOfLifeError = new Error(
-      "This model version has reached the end of its life. Please refer to the AWS documentation for more details.",
-    ) as Error & { $metadata: { httpStatusCode: number } };
-    endOfLifeError.name = "ResourceNotFoundException";
-    endOfLifeError.$metadata = { httpStatusCode: 404 };
+    const endOfLifeError = new ResourceNotFoundException({
+      message:
+        "This model version has reached the end of its life. Please refer to the AWS documentation for more details.",
+      $metadata: { httpStatusCode: 404 },
+    });
     bedrockInvokeMock.mockRejectedValue(endOfLifeError);
 
     const completionPromise = fetchLLMCompletion({


### PR DESCRIPTION
## Summary
- correctly identify and handle Bedrock end of lifetime errors

## Test plan
- [x] `pnpm --filter worker run test -- --run worker/src/__tests__/fetchLLMCompletionTimeout.test.ts` — all 3 tests pass (timeout + streaming timeout + end-of-life)
- [x] `pnpm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)