### PR TITLE
feat(ui): remove tier from pylon issue field and change warning message

### DIFF
--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -199,12 +199,12 @@ export function SupportFormSection({
       setFiles(undefined);
       if (data.pylonIssueFailed) {
         showErrorToast(
-          "Pylon Sync Failed",
-          "The support ticket was created but failed to sync to Pylon. Check server logs for details.",
-          "WARNING",
+          "Support request was not sent",
+          "Please contact support@langfuse.com",
         );
+      } else {
+        onSuccess();
       }
-      onSuccess();
     },
     onSettled: () => setIsSubmittingLocal(false),
   });

--- a/web/src/features/support-chat/trpc/plainRouter.ts
+++ b/web/src/features/support-chat/trpc/plainRouter.ts
@@ -343,14 +343,6 @@ export const plainRouter = createTRPCRouter({
                   ]
                 : []),
               { slug: "langfuse_metadata", value: pylonMetadata },
-              ...(pylonCustomerTier
-                ? [
-                    {
-                      slug: "langfuse_customer_tier",
-                      value: pylonCustomerTier,
-                    },
-                  ]
-                : []),
               {
                 slug: "case_severity",
                 value: mapToPylonCaseSeverity({


### PR DESCRIPTION
- Only writes langfuse tier to pylon account field and not the issue field
- Improve the warning message when issue creation fails