### PR TITLE
feat(slack): show change author in Slack prompt notification

### DIFF
--- a/worker/src/__tests__/promptVersionProcessor.test.ts
+++ b/worker/src/__tests__/promptVersionProcessor.test.ts
@@ -157,6 +157,11 @@ describe("promptVersionChangeWorker", () => {
           updatedAt: new Date(),
           commitMessage: null,
         },
+        user: {
+          id: "test-user",
+          name: "Test User",
+          email: "test@example.com",
+        },
       };
 
       await promptVersionProcessor(event);

--- a/worker/src/__tests__/slack-message-builder.test.ts
+++ b/worker/src/__tests__/slack-message-builder.test.ts
@@ -22,6 +22,11 @@ describe("SlackMessageBuilder", () => {
       prompt: { text: "Hello {{name}}" },
       config: { temperature: 0.7 },
     },
+    user: {
+      id: "user-123",
+      name: "Test User",
+      email: "test@example.com",
+    },
   };
 
   describe("buildPromptVersionMessage", () => {
@@ -54,6 +59,10 @@ describe("SlackMessageBuilder", () => {
       expect(blocks[2]).toMatchObject({
         type: "section",
         fields: [
+          {
+            type: "mrkdwn",
+            text: "*Change author:*\nTest User",
+          },
           {
             type: "mrkdwn",
             text: "*Type:*\ntext",
@@ -133,6 +142,11 @@ describe("SlackMessageBuilder", () => {
           prompt: null,
           config: null,
         },
+        user: {
+          id: "user-123",
+          name: null,
+          email: "test@example.com",
+        },
       };
 
       const blocks =
@@ -140,15 +154,35 @@ describe("SlackMessageBuilder", () => {
 
       expect(blocks).toHaveLength(5); // No commit message section
 
-      // Check labels and tags show "None"
+      // Check "Change author" falls back to email when name is null
       const detailsSection = blocks[2];
-      expect(detailsSection.fields[2].text).toBe("*Labels:*\nNone");
-      expect(detailsSection.fields[3].text).toBe("*Tags:*\nNone");
+      expect(detailsSection.fields[0].text).toBe(
+        "*Change author:*\ntest@example.com",
+      );
+
+      // Check labels and tags show "None"
+      expect(detailsSection.fields[3].text).toBe("*Labels:*\nNone");
+      expect(detailsSection.fields[4].text).toBe("*Tags:*\nNone");
 
       // Ensure no commit message section
       expect(
         blocks.find((block) => block.text?.text?.includes("*Commit Message:*")),
       ).toBeUndefined();
+    });
+
+    it("should show 'API User' when user is not provided", () => {
+      const apiPayload: WebhookInput["payload"] = {
+        action: "created",
+        type: "prompt-version",
+        prompt: {
+          ...mockPromptPayload.prompt,
+        },
+      };
+
+      const blocks = SlackMessageBuilder.buildPromptVersionMessage(apiPayload);
+
+      const detailsSection = blocks[2];
+      expect(detailsSection.fields[0].text).toBe("*Change author:*\nAPI User");
     });
 
     it("should generate correct action emojis for different actions", () => {

--- a/worker/src/__tests__/slack-message-builder.test.ts
+++ b/worker/src/__tests__/slack-message-builder.test.ts
@@ -185,6 +185,48 @@ describe("SlackMessageBuilder", () => {
       expect(detailsSection.fields[0].text).toBe("*Change author:*\nAPI User");
     });
 
+    it("should escape Slack mrkdwn special characters in user name", () => {
+      const injectionPayload: WebhookInput["payload"] = {
+        action: "created",
+        type: "prompt-version",
+        prompt: { ...mockPromptPayload.prompt },
+        user: {
+          id: "user-123",
+          name: "<!channel>",
+          email: "attacker@example.com",
+        },
+      };
+
+      const blocks =
+        SlackMessageBuilder.buildPromptVersionMessage(injectionPayload);
+
+      const detailsSection = blocks[2];
+      expect(detailsSection.fields[0].text).toBe(
+        "*Change author:*\n&lt;!channel&gt;",
+      );
+    });
+
+    it("should fall back to email when name is empty string", () => {
+      const emptyNamePayload: WebhookInput["payload"] = {
+        action: "created",
+        type: "prompt-version",
+        prompt: { ...mockPromptPayload.prompt },
+        user: {
+          id: "user-123",
+          name: "",
+          email: "alice@example.com",
+        },
+      };
+
+      const blocks =
+        SlackMessageBuilder.buildPromptVersionMessage(emptyNamePayload);
+
+      const detailsSection = blocks[2];
+      expect(detailsSection.fields[0].text).toBe(
+        "*Change author:*\nalice@example.com",
+      );
+    });
+
     it("should generate correct action emojis for different actions", () => {
       const testCases = [
         { action: "created", expectedEmoji: "✨" },

--- a/worker/src/__tests__/slack-processor.test.ts
+++ b/worker/src/__tests__/slack-processor.test.ts
@@ -160,6 +160,11 @@ describe("Slack Processor", () => {
           prompt: fullPrompt as PromptDomain,
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -214,6 +219,11 @@ describe("Slack Processor", () => {
           prompt: { id: promptId } as PromptDomain,
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -265,6 +275,11 @@ describe("Slack Processor", () => {
           prompt: fullPrompt as any,
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -320,6 +335,11 @@ describe("Slack Processor", () => {
           prompt: fullPrompt as PromptDomain,
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -395,6 +415,11 @@ describe("Slack Processor", () => {
             prompt: fullPrompt as PromptDomain,
             action: "created",
             type: "prompt-version",
+            user: {
+              id: "user-123",
+              name: "Test User",
+              email: "test@example.com",
+            },
           },
         };
 
@@ -436,6 +461,11 @@ describe("Slack Processor", () => {
           prompt: fullPrompt as PromptDomain,
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 

--- a/worker/src/__tests__/webhooks.test.ts
+++ b/worker/src/__tests__/webhooks.test.ts
@@ -213,6 +213,11 @@ describe("Webhook Integration Tests", () => {
           prompt: PromptDomainSchema.parse(fullPrompt),
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -349,6 +354,11 @@ describe("Webhook Integration Tests", () => {
           prompt: PromptDomainSchema.parse(fullPrompt),
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -416,6 +426,11 @@ describe("Webhook Integration Tests", () => {
           prompt: PromptDomainSchema.parse(fullPrompt),
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -489,6 +504,11 @@ describe("Webhook Integration Tests", () => {
           prompt: PromptDomainSchema.parse(fullPrompt),
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -563,6 +583,11 @@ describe("Webhook Integration Tests", () => {
             prompt: PromptDomainSchema.parse(fullPrompt),
             action: "created",
             type: "prompt-version",
+            user: {
+              id: "user-123",
+              name: "Test User",
+              email: "test@example.com",
+            },
           },
         };
 
@@ -643,6 +668,11 @@ describe("Webhook Integration Tests", () => {
           prompt: PromptDomainSchema.parse(fullPrompt),
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -734,6 +764,11 @@ describe("Webhook Integration Tests", () => {
           prompt: PromptDomainSchema.parse(fullPrompt),
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -813,6 +848,11 @@ describe("Webhook Integration Tests", () => {
           prompt: PromptDomainSchema.parse(fullPrompt),
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -897,6 +937,11 @@ describe("Webhook Integration Tests", () => {
           prompt: PromptDomainSchema.parse(fullPrompt),
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -980,6 +1025,11 @@ describe("Webhook Integration Tests", () => {
           prompt: PromptDomainSchema.parse(fullPrompt),
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 
@@ -1034,6 +1084,11 @@ describe("Webhook Integration Tests", () => {
           prompt: PromptDomainSchema.parse(fullPrompt),
           action: "created",
           type: "prompt-version",
+          user: {
+            id: "user-123",
+            name: "Test User",
+            email: "test@example.com",
+          },
         },
       };
 

--- a/worker/src/features/slack/slackMessageBuilder.ts
+++ b/worker/src/features/slack/slackMessageBuilder.ts
@@ -40,6 +40,10 @@ export class SlackMessageBuilder {
         fields: [
           {
             type: "mrkdwn",
+            text: `*Change author:*\n${payload.user?.name ?? payload.user?.email ?? "API User"}`,
+          },
+          {
+            type: "mrkdwn",
             text: `*Type:*\n${prompt.type}`,
           },
           {

--- a/worker/src/features/slack/slackMessageBuilder.ts
+++ b/worker/src/features/slack/slackMessageBuilder.ts
@@ -2,6 +2,15 @@ import { logger } from "@langfuse/shared/src/server";
 import type { WebhookInput } from "@langfuse/shared/src/server";
 import { env } from "../../env";
 
+/** Escape Slack mrkdwn special characters to prevent injection (e.g. <!channel>)
+ * @see https://docs.slack.dev/messaging/formatting-message-text/#escaping */
+function escapeSlackMrkdwn(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 /**
  * Builds Slack Block Kit messages for different Langfuse event types
  */
@@ -40,7 +49,7 @@ export class SlackMessageBuilder {
         fields: [
           {
             type: "mrkdwn",
-            text: `*Change author:*\n${payload.user?.name ?? payload.user?.email ?? "API User"}`,
+            text: `*Change author:*\n${escapeSlackMrkdwn(payload.user?.name || payload.user?.email || "API User")}`,
           },
           {
             type: "mrkdwn",

--- a/worker/src/features/slack/slackMessageBuilder.ts
+++ b/worker/src/features/slack/slackMessageBuilder.ts
@@ -40,7 +40,7 @@ export class SlackMessageBuilder {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `*${prompt.name}* (version ${prompt.version}) has been *${action}*`,
+          text: `*${escapeSlackMrkdwn(prompt.name)}* (version ${prompt.version}) has been *${action}*`,
         },
       },
       // Details section with key information
@@ -65,7 +65,7 @@ export class SlackMessageBuilder {
           },
           {
             type: "mrkdwn",
-            text: `*Tags:*\n${prompt.tags.length > 0 ? prompt.tags.join(", ") : "None"}`,
+            text: `*Tags:*\n${prompt.tags.length > 0 ? prompt.tags.map(escapeSlackMrkdwn).join(", ") : "None"}`,
           },
         ],
       },
@@ -76,7 +76,7 @@ export class SlackMessageBuilder {
               type: "section",
               text: {
                 type: "mrkdwn",
-                text: `*Commit Message:*\n> ${prompt.commitMessage}`,
+                text: `*Commit Message:*\n> ${escapeSlackMrkdwn(prompt.commitMessage)}`,
               },
             },
           ]


### PR DESCRIPTION
## Summary
- add name of the author to Slack message for prompt updates
- in case no user is shown wie show "API user" (as that change was then made through the public API)