### PR TITLE
fix(worker): sync managed evaluator vars on template updates

### DIFF
--- a/worker/src/constants/managed-evaluators.json
+++ b/worker/src/constants/managed-evaluators.json
@@ -202,7 +202,7 @@
   {
     "id": "cmal6wart010lynrdtpv6olai",
     "created_at": "2025-05-20T18:16:12.000Z",
-    "updated_at": "2026-04-14T00:00:00.000Z",
+    "updated_at": "2026-04-13T18:16:12.000Z",
     "name": "SQL Semantic Equivalence",
     "partner": "ragas",
     "version": 1,

--- a/worker/src/constants/managed-evaluators.json
+++ b/worker/src/constants/managed-evaluators.json
@@ -202,7 +202,7 @@
   {
     "id": "cmal6wart010lynrdtpv6olai",
     "created_at": "2025-05-20T18:16:12.000Z",
-    "updated_at": "2025-05-25T18:16:12.000Z",
+    "updated_at": "2026-04-14T00:00:00.000Z",
     "name": "SQL Semantic Equivalence",
     "partner": "ragas",
     "version": 1,

--- a/worker/src/scripts/upsertManagedEvaluators.ts
+++ b/worker/src/scripts/upsertManagedEvaluators.ts
@@ -75,7 +75,7 @@ export const upsertManagedEvaluators = async (force = false) => {
 
       return prisma.evalTemplate
         .upsert({
-          where: { id: evaluator.id },
+          where: { id: evaluator.id, projectId: null },
           update: {
             ...baseEvaluator,
           },

--- a/worker/src/scripts/upsertManagedEvaluators.ts
+++ b/worker/src/scripts/upsertManagedEvaluators.ts
@@ -75,7 +75,7 @@ export const upsertManagedEvaluators = async (force = false) => {
 
       return prisma.evalTemplate
         .upsert({
-          where: { id: evaluator.id, projectId: null },
+          where: { id: evaluator.id },
           update: {
             ...baseEvaluator,
           },

--- a/worker/src/scripts/upsertManagedEvaluators.ts
+++ b/worker/src/scripts/upsertManagedEvaluators.ts
@@ -69,6 +69,7 @@ export const upsertManagedEvaluators = async (force = false) => {
         version: evaluator.version,
         outputDefinition: evaluator.outputDefinition,
         prompt: evaluator.prompt,
+        vars: parsePromptVariables(evaluator.prompt),
         updatedAt: evaluator.updated_at,
       };
 
@@ -83,7 +84,6 @@ export const upsertManagedEvaluators = async (force = false) => {
             id: evaluator.id,
             projectId: null,
             updatedAt: evaluator.updated_at,
-            vars: parsePromptVariables(evaluator.prompt),
           },
         })
         .then(() =>

--- a/worker/src/scripts/upsertManagedEvaluators.ts
+++ b/worker/src/scripts/upsertManagedEvaluators.ts
@@ -99,7 +99,7 @@ export const upsertManagedEvaluators = async (force = false) => {
 
     await Promise.all(upsertPromises);
     logger.info(
-      `Finished upserting Langfuse dashboards and widgets in ${Date.now() - startTime}ms`,
+      `Finished upserting Langfuse evaluators in ${Date.now() - startTime}ms`,
     );
   } catch (error) {
     logger.error(


### PR DESCRIPTION
### Motivation
- Cloud instances showed stale evaluator variables because managed evaluator sync populated `vars` only on create, so prompt changes (new placeholders) did not propagate to existing eval template rows.
- The Ragas "SQL Semantic Equivalence" template was affected (UI only displayed `database_schema` instead of also `question_one` / `question_two`).

### Description
- Recalculate and include `vars` derived from the prompt in the upsert path so both **update** and **create** write the current variables by calling `parsePromptVariables(evaluator.prompt)` and adding `vars` to the base evaluator object in `worker/src/scripts/upsertManagedEvaluators.ts`.
- Remove duplicate `parsePromptVariables` call in the `create` block by reusing the base evaluator that already contains `vars`.
- Bump `updated_at` for the Ragas `SQL Semantic Equivalence` entry in `worker/src/constants/managed-evaluators.json` so environments with an existing row will be refreshed on the next sync.

### Testing
- Ran `pnpm --filter worker run lint` (and repo pre-commit format checks) which completed successfully. 
- Attempted to run a focused unit test of the upsert script in this environment but the test invocation failed due to local module resolution / environment constraints, so the unit test could not be executed here. 
- No other automated test failures were introduced by the lint/format checks that ran.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de1835b8fc832ba874ef5f97a32f3c)