### PR TITLE
fix(experiments): keep referenced prompts single-row in compact density

### DIFF
--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -335,13 +335,20 @@ export default function ExperimentsTable({
       cell: ({ row }) => {
         const value: Array<[string, number | null]> = row.getValue("prompts");
         return (
-          <div className="flex flex-wrap gap-1">
+          <div
+            className={
+              rowHeight === "s"
+                ? "flex max-w-full flex-nowrap gap-1 overflow-x-auto py-0.5 whitespace-nowrap"
+                : "flex flex-wrap gap-1"
+            }
+          >
             {value.map(([name, version]) => (
               <Link
                 key={`${name}-${version}`}
                 href={`/project/${projectId}/prompts/${encodeURIComponent(name)}?version=${version}`}
                 target="_blank"
                 rel="noopener noreferrer"
+                className="shrink-0"
               >
                 <Badge
                   variant="secondary"


### PR DESCRIPTION
### Motivation
- Fix formatting of referenced prompts in the experiments list so badges stay on a single row and can be scrolled horizontally when the table is in compact (`s`) density.

### Description
- Updated `web/src/features/experiments/components/table/ExperimentsTable.tsx` to render the prompts container with no-wrap and horizontal scrolling when `rowHeight === "s"` and preserve existing wrapping behavior for other densities, and added `className="shrink-0"` to each prompt link so badges do not collapse when overflowing.

### Testing
- Ran `pnpm --filter web run lint` which completed successfully.
- Pre-commit checks executed during `git commit` (including `pnpm format:check` and `pnpm lint`) and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de3be86d24832ba7dd12d7780dd413)