### PR TITLE
fix(self-hosting): URL-encode credentials when constructing DATABASE_URL

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -1,12 +1,19 @@
 #!/bin/sh
 
+# URL-encode a string for use in a connection URI.
+# Only called when constructing DATABASE_URL from individual env vars,
+# so it cannot affect setups that provide DATABASE_URL directly.
+urlencode() {
+    node -p "encodeURIComponent(process.argv[1])" -- "$1"
+}
+
 # Run cleanup script before running migrations
 # Check if DATABASE_URL is not set
 if [ -z "$DATABASE_URL" ]; then
     # Check if all required variables are provided
     if [ -n "$DATABASE_HOST" ] && [ -n "$DATABASE_USERNAME" ] && [ -n "$DATABASE_PASSWORD" ]  && [ -n "$DATABASE_NAME" ]; then
         # Construct DATABASE_URL from the provided variables
-        DATABASE_URL="postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}"
+        DATABASE_URL="postgresql://$(urlencode "$DATABASE_USERNAME"):$(urlencode "$DATABASE_PASSWORD")@${DATABASE_HOST}/${DATABASE_NAME}"
         export DATABASE_URL
     else
         echo "Error: Required database environment variables are not set. Provide a postgres url for DATABASE_URL."

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -1,12 +1,19 @@
 #!/bin/sh
 
+# URL-encode a string for use in a connection URI.
+# Only called when constructing DATABASE_URL from individual env vars,
+# so it cannot affect setups that provide DATABASE_URL directly.
+urlencode() {
+    node -p "encodeURIComponent(process.argv[1])" -- "$1"
+}
+
 # Run cleanup script before running migrations
 # Check if DATABASE_URL is not set
 if [ -z "$DATABASE_URL" ]; then
     # Check if all required variables are provided
     if [ -n "$DATABASE_HOST" ] && [ -n "$DATABASE_USERNAME" ] && [ -n "$DATABASE_PASSWORD" ]  && [ -n "$DATABASE_NAME" ]; then
         # Construct DATABASE_URL from the provided variables
-        DATABASE_URL="postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}"
+        DATABASE_URL="postgresql://$(urlencode "$DATABASE_USERNAME"):$(urlencode "$DATABASE_PASSWORD")@${DATABASE_HOST}/${DATABASE_NAME}"
         export DATABASE_URL
     else
         echo "Error: Required database environment variables are not set. Provide a postgres url for DATABASE_URL."


### PR DESCRIPTION
Fixes #3923.

## Problem

When users provide `DATABASE_USERNAME` or `DATABASE_PASSWORD` containing special characters (e.g. `@`, `:`, `#`, `%`), the constructed `DATABASE_URL` breaks because those characters have meaning in URI syntax. This causes Prisma to throw `P1013: The provided database string is invalid`.

## Solution

Add a `urlencode()` helper to both `web/entrypoint.sh` and `worker/entrypoint.sh` that encodes credentials via Node's `encodeURIComponent` before interpolation.

```sh
urlencode() {
    node -p "encodeURIComponent(process.argv[1])" -- "$1"
}
```

## Backwards compatibility

This is the main concern raised by @Steffen911 in [this comment](https://github.com/langfuse/langfuse/issues/3923#issuecomment-2896831134).

The encoding is **only applied when constructing `DATABASE_URL` from individual env vars** (`DATABASE_HOST`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`, `DATABASE_NAME`). If `DATABASE_URL` is provided directly, this code path is never reached — see the `if [ -z "$DATABASE_URL" ]` guard.

This means:
- Setups providing `DATABASE_URL` directly → **zero change in behavior**
- Setups with simple credentials (no special chars) → `encodeURIComponent("admin")` returns `"admin"` → **zero change**
- Setups with special characters → **fixed** (the only "broken" setups, per Steffen's requirement)

No new dependencies — `node` is already available in both containers.

## Diff

2 files changed, 14 insertions, 2 deletions.