### PR TITLE
fix(self-hosting): respect DATABASE_PORT env var in entrypoint

### DIFF
--- a/web/entrypoint.sh
+++ b/web/entrypoint.sh
@@ -6,7 +6,7 @@ if [ -z "$DATABASE_URL" ]; then
     # Check if all required variables are provided
     if [ -n "$DATABASE_HOST" ] && [ -n "$DATABASE_USERNAME" ] && [ -n "$DATABASE_PASSWORD" ]  && [ -n "$DATABASE_NAME" ]; then
         # Construct DATABASE_URL from the provided variables
-        DATABASE_URL="postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}"
+        DATABASE_URL="postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT:-5432}/${DATABASE_NAME}"
         export DATABASE_URL
     else
         echo "Error: Required database environment variables are not set. Provide a postgres url for DATABASE_URL."

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -6,7 +6,7 @@ if [ -z "$DATABASE_URL" ]; then
     # Check if all required variables are provided
     if [ -n "$DATABASE_HOST" ] && [ -n "$DATABASE_USERNAME" ] && [ -n "$DATABASE_PASSWORD" ]  && [ -n "$DATABASE_NAME" ]; then
         # Construct DATABASE_URL from the provided variables
-        DATABASE_URL="postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}"
+        DATABASE_URL="postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT:-5432}/${DATABASE_NAME}"
         export DATABASE_URL
     else
         echo "Error: Required database environment variables are not set. Provide a postgres url for DATABASE_URL."


### PR DESCRIPTION
Fixes #11240.

## Problem

The `entrypoint.sh` scripts in both `web/` and `worker/` construct `DATABASE_URL` from individual env vars but ignore `DATABASE_PORT`, hardcoding the default PostgreSQL port behavior. Users running PostgreSQL on a non-standard port have no way to configure this without providing the full `DATABASE_URL`.

## Solution

Insert `${DATABASE_PORT:-5432}` into the connection string construction:

```sh
DATABASE_URL="postgresql://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT:-5432}/${DATABASE_NAME}"
```

The `:-5432` default means existing setups that don't set `DATABASE_PORT` get the standard PostgreSQL port — **zero change in behavior**.

## Diff

2 files changed, 2 insertions, 2 deletions.