### PR TITLE
feat(blob-export): add author_user_id and metadata to scores export

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2050,6 +2050,8 @@ export const getScoresForAnalyticsIntegrations = async function* (
       s.name as name,
       s.value as value,
       s.string_value as string_value,
+      s.author_user_id as author_user_id,
+      s.metadata as metadata,
       s.data_type as data_type,
       s.comment as comment,
       s.environment as environment,


### PR DESCRIPTION
## What does this PR do?

  Adds author_user_id and metadata to the fields exported in the blob storage scores export.

  Both columns exist in the ClickHouse scores table but were omitted from the SELECT in
  getScoresForBlobStorageExport, making them unavailable to downstream consumers of the blob export.
  Follows the same pattern as #12792 and #12789.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- I haven't run pnpm run format — this is a two-line SQL SELECT addition, please flag if CI catches
   anything
- I haven't commented my code — no hard-to-understand areas in this change
- I haven't checked if my changes generate no new warnings (npm run lint) — please flag if CI
  catches anything
- I haven't added tests — this is a read-only SQL column addition with no logic; verified the
  columns exist in the ClickHouse scores table schema
- I haven't checked if new and existing unit tests pass locally