### PR TITLE
chore(ci): remove GitHub Actions that rely on Node 20

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,10 +30,28 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      # Replaces fkirc/skip-duplicate-actions — skips runs whose git tree
+      # was already tested in a prior successful run of this workflow.
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5
-        with:
-          do_not_skip: '["workflow_dispatch"]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CURRENT_TREE=$(gh api "repos/${{ github.repository }}/git/commits/${{ github.sha }}" --jq '.tree.sha')
+
+          MATCH=$(gh api "repos/${{ github.repository }}/actions/workflows/pipeline.yml/runs?status=success&per_page=20" \
+            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }} and .head_commit.tree_id == \"$CURRENT_TREE\")] | first | .head_sha // empty")
+
+          if [[ -n "$MATCH" ]]; then
+            echo "::notice::Tree $CURRENT_TREE already tested in a prior successful run (commit $MATCH) — skipping"
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Recommended for paths-filter action

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -660,13 +660,53 @@ jobs:
         run: exit 1
         working-directory: .
       - name: Notify Slack
-        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
-        if: always() && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        if: failure() && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
-          status: ${{ job.status }}
-          notify_when: "failure"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "❌ CI failed on ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "❌ CI Failed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch/Tag:*\n`${{ github.ref_name }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n${{ github.actor }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow Logs",
+                        "emoji": true
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "style": "danger"
+                    }
+                  ]
+                }
+              ]
+            }
       - name: Output job results
         run: |
           echo "Job results: ${STEPS_SET_SUCCESS_OUTPUT_OUTPUTS_SUCCESS}"
@@ -939,10 +979,50 @@ jobs:
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1
       - name: Notify Slack
-        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2
-        if: always()
+        if: failure()
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
-          status: ${{ job.status }}
-          notify_when: "failure"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "❌ Docker release failed on ${{ github.ref_name }}",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "❌ Docker Release Failed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Tag:*\n`${{ github.ref_name }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Triggered by:*\n${{ github.actor }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow Logs",
+                        "emoji": true
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "style": "danger"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -17,7 +17,5 @@ rules:
         - LANGFUSE_LLM_CONNECTION_BEDROCK_REGION
         - LANGFUSE_LLM_CONNECTION_VERTEXAI_KEY
         - LANGFUSE_LLM_CONNECTION_GOOGLEAISTUDIO_KEY
-        # Shared CI notification secret, not tied to a deployment environment.
-        - SLACK_WEBHOOK_URL
         # Fern token is generation-only; GitHub write actions are handled by GH_ACCESS_TOKEN in a protected environment.
         - FERN_TOKEN


### PR DESCRIPTION
## Summary

- Replace `fkirc/skip-duplicate-actions` (Node 20) with an inline `gh api` script that replicates the tree-hash deduplication logic in ~15 lines of shell
- Replace `ravsamhq/notify-slack-action` (Node 20) with the official `slackapi/slack-github-action@v3.0.1` (Node 24), using Block Kit payloads for richer failure notifications
- Clean up the `zizmor.yml` secrets-outside-env allowlist (webhook is now passed via action input, not env var)
- fix https://linear.app/langfuse/issue/LFE-9250/look-at-npm-20-runner-warnings

## Motivation

Both removed actions depend on Node 20 which is approaching EOL. This removes them in favor of either built-in tooling (`gh` CLI) or the official Slack action.

## Test plan

- [x] CI pipeline runs successfully on this PR (skip-duplicate logic is exercised)
- [x] Trigger a test failure on a `main`/tag push to verify Slack notifications render correctly (Block Kit format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR replaces two Node 20-dependent GitHub Actions with Node 20-free alternatives: `fkirc/skip-duplicate-actions` is swapped for an inline `gh api` shell script that replicates tree-hash deduplication, and `ravsamhq/notify-slack-action` is replaced by `slackapi/slack-github-action@v3.0.1` with Block Kit payloads. The zizmor allowlist is also cleaned up to drop `SLACK_WEBHOOK_URL`, which is now correctly passed as an action input instead of an env var.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both replacements are functionally equivalent and the only finding is a minor look-back window limitation in the skip check.

All findings are P2. The Slack notification replacement is a clean drop-in with equivalent failure semantics. The skip-check script is logically correct; the per_page=20 window is a minor regression that causes unnecessary re-runs at worst, never incorrect results. The zizmor cleanup is correct.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pipeline.yml | Replaces `fkirc/skip-duplicate-actions` with inline `gh api` shell script (limited to 20 runs) and replaces `ravsamhq/notify-slack-action` with `slackapi/slack-github-action@v3.0.1` using Block Kit payloads; both are functionally equivalent but the skip check has a narrower look-back window. |
| .github/zizmor.yml | Removes `SLACK_WEBHOOK_URL` from the `secrets-outside-env` allowlist; correct cleanup since the secret is now passed via the action's `with:` input rather than an `env:` block. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger: push / PR / merge_group / workflow_dispatch] --> B{event == workflow_dispatch?}
    B -- yes --> C[should_skip=false]
    B -- no --> D[Fetch current tree SHA via gh api]
    D --> E[Query last 20 successful pipeline runs]
    E --> F{Prior run found\nwith same tree SHA?}
    F -- yes --> G[should_skip=true\nprint notice]
    F -- no --> C
    C --> H[Run all CI jobs]
    G --> I[Skip downstream jobs]
    H --> J{CI result?}
    J -- failure on main/tag push --> K[slackapi/slack-github-action\nBlock Kit payload to Slack]
    J -- success --> L[all-ci-passed]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/pipeline.yml
Line: 46-47

Comment:
**`per_page=20` may miss valid skip opportunities**

The API query fetches only the 20 most recent successful pipeline runs. If more than 20 successful runs have been triggered since the last time this exact git tree was tested (e.g., after a fast-merge burst on `main`), the deduplication will silently fall through and re-run an already-tested tree. This is a minor regression from `fkirc/skip-duplicate-actions`, which used a broader window. Consider bumping to `per_page=100` (GitHub API maximum) to reduce the miss rate.

```suggestion
          MATCH=$(gh api "repos/${{ github.repository }}/actions/workflows/pipeline.yml/runs?status=success&per_page=100" \
            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }} and .head_commit.tree_id == \"$CURRENT_TREE\")] | first | .head_sha // empty")
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): replace ravsamhq/notify-slack..."](https://github.com/langfuse/langfuse/commit/c6dd0b2ea0433d3880dca0ffd720225a22addce6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28621450)</sub>

<!-- /greptile_comment -->