### PR TITLE
fix(evals): return full JSONPath slice result and deduplicate eval JSONPath logic

### DIFF
--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -53,14 +53,23 @@ function parseMultiEncodedJson(value: unknown): unknown {
 }
 
 function parseJsonDefault(selectedColumn: unknown, jsonSelector: string) {
-  // selectedColumn should already be preprocessed by preprocessObjectWithJsonFields
-  // so we can directly use it with JSONPath
+  // JSONPath can only query objects/arrays — return primitives as-is
+  if (typeof selectedColumn !== "object" || selectedColumn === null) {
+    return selectedColumn;
+  }
+
   const result = JSONPath({
     path: jsonSelector,
     json: selectedColumn as any, // JSONPath accepts unknown but types are strict
   });
 
-  return Array.isArray(result) && result.length > 0 ? result[0] : undefined;
+  if (!Array.isArray(result) || result.length === 0) {
+    return undefined;
+  }
+
+  // For single-match queries (e.g. $.name), return the unwrapped value.
+  // For multi-match queries (e.g. $[1:], $[*].name), return the full array.
+  return result.length === 1 ? result[0] : result;
 }
 
 export function extractValueFromObject(

--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -78,12 +78,7 @@ export function extractValueFromObject(
   jsonSelector?: string,
   parseJson?: (selectedColumn: unknown, jsonSelector: string) => unknown,
 ): { value: string; error: Error | null } {
-  let selectedColumn = obj[selectedColumnId];
-
-  // Simple preprocessing: attempt to parse to valid JSON object
-  if (typeof selectedColumn === "string") {
-    selectedColumn = parseMultiEncodedJson(selectedColumn);
-  }
+  const selectedColumn = obj[selectedColumnId];
 
   const jsonParser = parseJson || parseJsonDefault;
 
@@ -91,14 +86,21 @@ export function extractValueFromObject(
   let error: Error | null = null;
 
   if (jsonSelector && selectedColumn) {
+    // Only parse multi-encoded JSON when a selector is present — avoids
+    // mutating formatting (e.g. whitespace) for the no-selector passthrough.
+    const parsed =
+      typeof selectedColumn === "string"
+        ? parseMultiEncodedJson(selectedColumn)
+        : selectedColumn;
+
     try {
-      jsonSelectedColumn = jsonParser(selectedColumn, jsonSelector);
+      jsonSelectedColumn = jsonParser(parsed, jsonSelector);
     } catch (err) {
       error =
         err instanceof Error
           ? err
           : new Error("There was an unknown error parsing the JSON");
-      jsonSelectedColumn = selectedColumn; // Fallback to original value
+      jsonSelectedColumn = selectedColumn; // Fallback to raw original value
     }
   } else {
     jsonSelectedColumn = selectedColumn;

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -2940,7 +2940,7 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
       expect(resultInput).toEqual([
         {
-          value: '["Hello world"]',
+          value: "Hello world",
           var: "user_message",
         },
       ]);
@@ -2965,7 +2965,7 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
       expect(resultOutput).toEqual([
         {
-          value: '["positive"]',
+          value: "positive",
           var: "expected_label",
         },
       ]);
@@ -3015,12 +3015,12 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
       expect(result).toEqual([
         {
-          value: '["What is the weather?"]',
+          value: "What is the weather?",
           var: "user_input",
           environment: "production",
         },
         {
-          value: '["It is sunny"]',
+          value: "It is sunny",
           var: "response_text",
           environment: "production",
         },

--- a/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
+++ b/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { extractValueFromObject } from "../../../../../packages/shared/src/features/evals/utilities";
+
+describe("extractValueFromObject", () => {
+  describe("JSONPath slice expressions returning multiple elements", () => {
+    it("should return full slice result for $[1:]", () => {
+      const obj = {
+        data: JSON.stringify([
+          { role: "human" },
+          { role: "ai" },
+          { role: "human" },
+        ]),
+      };
+
+      const result = extractValueFromObject(obj, "data", "$[1:]");
+      expect(result.value).toBe(
+        JSON.stringify([{ role: "ai" }, { role: "human" }]),
+      );
+      expect(result.error).toBeNull();
+    });
+
+    it("should return full result for $[*].role (wildcard multi-match)", () => {
+      const obj = {
+        data: JSON.stringify([
+          { role: "human" },
+          { role: "ai" },
+          { role: "human" },
+        ]),
+      };
+
+      const result = extractValueFromObject(obj, "data", "$[*].role");
+      expect(result.value).toBe(JSON.stringify(["human", "ai", "human"]));
+      expect(result.error).toBeNull();
+    });
+
+    it("should return full slice for $[0:2]", () => {
+      const obj = {
+        data: JSON.stringify(["a", "b", "c", "d"]),
+      };
+
+      const result = extractValueFromObject(obj, "data", "$[0:2]");
+      expect(result.value).toBe(JSON.stringify(["a", "b"]));
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe("JSONPath single element access (backward compat)", () => {
+    it("should return unwrapped value for $[0]", () => {
+      const obj = {
+        data: JSON.stringify(["first", "second", "third"]),
+      };
+
+      const result = extractValueFromObject(obj, "data", "$[0]");
+      expect(result.value).toBe("first");
+      expect(result.error).toBeNull();
+    });
+
+    it("should return unwrapped value for $.name", () => {
+      const obj = {
+        data: JSON.stringify({ name: "Alice", age: 30 }),
+      };
+
+      const result = extractValueFromObject(obj, "data", "$.name");
+      expect(result.value).toBe("Alice");
+      expect(result.error).toBeNull();
+    });
+
+    it("should return unwrapped nested object for $.nested", () => {
+      const obj = {
+        data: JSON.stringify({ nested: { key: "value" } }),
+      };
+
+      const result = extractValueFromObject(obj, "data", "$.nested");
+      expect(result.value).toBe(JSON.stringify({ key: "value" }));
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe("empty result handling", () => {
+    it("should return empty string for non-matching JSONPath", () => {
+      const obj = {
+        data: JSON.stringify({ name: "Alice" }),
+      };
+
+      const result = extractValueFromObject(obj, "data", "$.nonexistent");
+      expect(result.value).toBe("");
+      expect(result.error).toBeNull();
+    });
+
+    it("should return empty string when column does not exist", () => {
+      const obj = { other: "value" };
+
+      const result = extractValueFromObject(obj, "missing");
+      expect(result.value).toBe("");
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe("primitive value with JSON selector", () => {
+    it("should return primitive string as-is when selector is applied", () => {
+      const obj = {
+        data: "plain text, not JSON",
+      };
+
+      const result = extractValueFromObject(obj, "data", "$.field");
+      expect(result.value).toBe("plain text, not JSON");
+      expect(result.error).toBeNull();
+    });
+
+    it("should return number as-is when selector is applied", () => {
+      const obj = { data: 42 };
+
+      const result = extractValueFromObject(obj, "data", "$.field");
+      expect(result.value).toBe("42");
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe("no JSON selector", () => {
+    it("should return stringified object when no selector is provided", () => {
+      const obj = {
+        data: { key: "value" },
+      };
+
+      const result = extractValueFromObject(obj, "data");
+      expect(result.value).toBe(JSON.stringify({ key: "value" }));
+      expect(result.error).toBeNull();
+    });
+
+    it("should return primitive string directly", () => {
+      const obj = { data: "simple string" };
+
+      const result = extractValueFromObject(obj, "data");
+      expect(result.value).toBe("simple string");
+      expect(result.error).toBeNull();
+    });
+
+    it("should return number as string", () => {
+      const obj = { data: 42 };
+
+      const result = extractValueFromObject(obj, "data");
+      expect(result.value).toBe("42");
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe("multi-encoded JSON strings", () => {
+    it("should handle double-encoded JSON with selector", () => {
+      const inner = { name: "Alice" };
+      const obj = {
+        data: JSON.stringify(JSON.stringify(inner)),
+      };
+
+      const result = extractValueFromObject(obj, "data", "$.name");
+      expect(result.value).toBe("Alice");
+      expect(result.error).toBeNull();
+    });
+  });
+});

--- a/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
+++ b/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractValueFromObject } from "../../../../../packages/shared/src/features/evals/utilities";
+import { extractValueFromObject } from "@langfuse/shared";
 
 describe("extractValueFromObject", () => {
   describe("JSONPath slice expressions returning multiple elements", () => {

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -59,10 +59,10 @@ import {
   PersistedEvalOutputDefinitionSchema,
   ScoreDataTypeEnum,
   validateEvalOutputResult,
+  extractValueFromObject,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import { createW3CTraceId } from "../utils";
-import { JSONPath } from "jsonpath-plus";
 import { UnrecoverableError } from "../../errors/UnrecoverableError";
 import { ObservationNotFoundError } from "../../errors/ObservationNotFoundError";
 import {
@@ -1323,7 +1323,6 @@ const snakeToCamel = (s: string) =>
 
 export const parseDatabaseRowToString = (
   dbRow: Record<string, unknown>,
-
   mapping: z.infer<typeof variableMapping>,
 ): string => {
   // Prisma returns camelCase keys, but selectedColumnId may be snake_case
@@ -1331,38 +1330,26 @@ export const parseDatabaseRowToString = (
     dbRow[mapping.selectedColumnId] ??
     dbRow[snakeToCamel(mapping.selectedColumnId)];
 
-  let jsonSelectedColumn;
-
-  if (mapping.jsonSelector) {
-    if (logger.isLevelEnabled("debug")) {
-      logger.debug(
-        `Parsing JSON for json selector ${mapping.jsonSelector} from ${JSON.stringify(selectedColumn)}`,
-      );
-    }
-
-    try {
-      jsonSelectedColumn = JSONPath({
-        path: mapping.jsonSelector,
-
-        json:
-          typeof selectedColumn === "string"
-            ? JSON.parse(selectedColumn)
-            : selectedColumn,
-      });
-    } catch (error) {
-      logger.error(
-        `Error parsing JSON for json selector ${mapping.jsonSelector}. Falling back to original value.`,
-
-        error,
-      );
-
-      jsonSelectedColumn = selectedColumn;
-    }
-  } else {
-    jsonSelectedColumn = selectedColumn;
+  if (logger.isLevelEnabled("debug") && mapping.jsonSelector) {
+    logger.debug(
+      `Parsing JSON for json selector ${mapping.jsonSelector} from ${JSON.stringify(selectedColumn)}`,
+    );
   }
 
-  return parseUnknownToString(jsonSelectedColumn);
+  const { value, error } = extractValueFromObject(
+    { [mapping.selectedColumnId]: selectedColumn },
+    mapping.selectedColumnId,
+    mapping.jsonSelector ?? undefined,
+  );
+
+  if (error) {
+    logger.error(
+      `Error parsing JSON for json selector ${mapping.jsonSelector}. Falling back to original value.`,
+      error,
+    );
+  }
+
+  return value;
 };
 
 export const parseUnknownToString = (value: unknown): string => {

--- a/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
@@ -457,6 +457,61 @@ describe("extractObservationVariables", () => {
       expect(result[0].value).toBe("[]");
     });
 
+    it("should return full slice result for $[1:] on an array input", () => {
+      const observationWithArray: ObservationForEval = {
+        ...mockObservation,
+        input: JSON.stringify([
+          { role: "human" },
+          { role: "ai" },
+          { role: "human" },
+        ]),
+      };
+
+      const variableMapping: ObservationVariableMapping[] = [
+        {
+          templateVariable: "sliced",
+          selectedColumnId: "input",
+          jsonSelector: "$[1:]",
+        },
+      ];
+
+      const result = extractObservationVariables({
+        observation: observationWithArray,
+        variableMapping,
+      });
+
+      expect(result[0].value).toBe(
+        JSON.stringify([{ role: "ai" }, { role: "human" }]),
+      );
+    });
+
+    it("should return single element for $[0] on an array input", () => {
+      const observationWithArray: ObservationForEval = {
+        ...mockObservation,
+        input: JSON.stringify([
+          { role: "human" },
+          { role: "ai" },
+          { role: "human" },
+        ]),
+      };
+
+      const variableMapping: ObservationVariableMapping[] = [
+        {
+          templateVariable: "first",
+          selectedColumnId: "input",
+          jsonSelector: "$[0]",
+        },
+      ];
+
+      const result = extractObservationVariables({
+        observation: observationWithArray,
+        variableMapping,
+      });
+
+      // Single-element results are unwrapped
+      expect(result[0].value).toBe(JSON.stringify({ role: "human" }));
+    });
+
     it("should handle non-JSON string column with JSON selector", () => {
       const observationWithPlainText: ObservationForEval = {
         ...mockObservation,

--- a/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
@@ -458,61 +458,6 @@ describe("extractObservationVariables", () => {
       expect(result[0].value).toBe("");
     });
 
-    it("should return full slice result for $[1:] on an array input", () => {
-      const observationWithArray: ObservationForEval = {
-        ...mockObservation,
-        input: JSON.stringify([
-          { role: "human" },
-          { role: "ai" },
-          { role: "human" },
-        ]),
-      };
-
-      const variableMapping: ObservationVariableMapping[] = [
-        {
-          templateVariable: "sliced",
-          selectedColumnId: "input",
-          jsonSelector: "$[1:]",
-        },
-      ];
-
-      const result = extractObservationVariables({
-        observation: observationWithArray,
-        variableMapping,
-      });
-
-      expect(result[0].value).toBe(
-        JSON.stringify([{ role: "ai" }, { role: "human" }]),
-      );
-    });
-
-    it("should return single element for $[0] on an array input", () => {
-      const observationWithArray: ObservationForEval = {
-        ...mockObservation,
-        input: JSON.stringify([
-          { role: "human" },
-          { role: "ai" },
-          { role: "human" },
-        ]),
-      };
-
-      const variableMapping: ObservationVariableMapping[] = [
-        {
-          templateVariable: "first",
-          selectedColumnId: "input",
-          jsonSelector: "$[0]",
-        },
-      ];
-
-      const result = extractObservationVariables({
-        observation: observationWithArray,
-        variableMapping,
-      });
-
-      // Single-element results are unwrapped
-      expect(result[0].value).toBe(JSON.stringify({ role: "human" }));
-    });
-
     it("should handle non-JSON string column with JSON selector", () => {
       const observationWithPlainText: ObservationForEval = {
         ...mockObservation,

--- a/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
@@ -311,8 +311,8 @@ describe("extractObservationVariables", () => {
         variableMapping,
       });
 
-      // JSONPath returns an array, which gets JSON-stringified
-      expect(result[0].value).toBe(JSON.stringify(["Hello, how are you?"]));
+      // Single-match results are unwrapped
+      expect(result[0].value).toBe("Hello, how are you?");
     });
 
     it("should apply JSON selector to extract nested field from output", () => {
@@ -332,7 +332,8 @@ describe("extractObservationVariables", () => {
         availableObservationEvalVariableColumns as ObservationEvalVariableColumn[],
       );
 
-      expect(result[0].value).toBe(JSON.stringify(["I am fine, thank you!"]));
+      // Single-match results are unwrapped
+      expect(result[0].value).toBe("I am fine, thank you!");
     });
 
     // OTel ingestion stringifies metadata.attributes.* values; ingestion stringifies the whole metadata.attributes object
@@ -453,8 +454,8 @@ describe("extractObservationVariables", () => {
         availableObservationEvalVariableColumns as ObservationEvalVariableColumn[],
       );
 
-      // JSONPath returns empty array for non-matching paths
-      expect(result[0].value).toBe("[]");
+      // Non-matching JSONPath returns empty string
+      expect(result[0].value).toBe("");
     });
 
     it("should return full slice result for $[1:] on an array input", () => {

--- a/worker/src/features/evaluation/observationEval/extractObservationVariables.ts
+++ b/worker/src/features/evaluation/observationEval/extractObservationVariables.ts
@@ -88,11 +88,18 @@ export function extractObservationVariables(
       : observation[internal];
 
     // Build a single-key object so extractValueFromObject can look it up
-    const { value } = extractValueFromObject(
+    const { value, error } = extractValueFromObject(
       { [mapping.selectedColumnId]: fieldValue },
       mapping.selectedColumnId,
       mapping.jsonSelector ?? undefined,
     );
+
+    if (error) {
+      logger.debug(
+        `Error applying JSON selector "${mapping.jsonSelector}" for variable "${mapping.templateVariable}". Falling back to original value.`,
+        { error },
+      );
+    }
 
     variables.push({
       var: mapping.templateVariable,

--- a/worker/src/features/evaluation/observationEval/extractObservationVariables.ts
+++ b/worker/src/features/evaluation/observationEval/extractObservationVariables.ts
@@ -3,8 +3,8 @@ import {
   observationEvalVariableColumns,
   type ObservationVariableMapping,
   deepParseJson,
+  extractValueFromObject,
 } from "@langfuse/shared";
-import { JSONPath } from "jsonpath-plus";
 import { logger } from "@langfuse/shared/src/server";
 
 /**
@@ -87,78 +87,18 @@ export function extractObservationVariables(
       ? parsedFields.get(mapping.selectedColumnId)
       : observation[internal];
 
-    const extractedValue = mapping.jsonSelector
-      ? applyJsonSelector({
-          value: fieldValue,
-          selector: mapping.jsonSelector,
-        })
-      : fieldValue;
+    // Build a single-key object so extractValueFromObject can look it up
+    const { value } = extractValueFromObject(
+      { [mapping.selectedColumnId]: fieldValue },
+      mapping.selectedColumnId,
+      mapping.jsonSelector ?? undefined,
+    );
 
     variables.push({
       var: mapping.templateVariable,
-      value: parseUnknownToString(extractedValue),
+      value,
     });
   }
 
   return variables;
-}
-
-interface ApplyJsonSelectorParams {
-  value: unknown;
-  selector: string;
-}
-
-/**
- * Applies a JSONPath selector to extract a nested value.
- * Assumes value is already parsed via deepParseJson.
- */
-function applyJsonSelector(params: ApplyJsonSelectorParams): unknown {
-  const { value, selector } = params;
-
-  if (value === null || value === undefined) {
-    return value;
-  }
-
-  if (typeof value !== "object") {
-    logger.debug(
-      `Can't apply JSONPath to primitive value for selector "${selector}". Falling back to original value.`,
-    );
-    return value; // Can't apply JSONPath to primitives
-  }
-
-  try {
-    return JSONPath({
-      path: selector,
-      json: value,
-    });
-  } catch (error) {
-    logger.debug(
-      `Error applying JSON selector "${selector}". Falling back to original value.`,
-      { error },
-    );
-    return value;
-  }
-}
-
-/**
- * Converts an unknown value to a string for use in prompt templates.
- */
-function parseUnknownToString(value: unknown): string {
-  if (value === null || value === undefined) {
-    return "";
-  }
-
-  if (
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return value.toString();
-  }
-
-  if (typeof value === "object") {
-    return JSON.stringify(value);
-  }
-
-  return "";
 }


### PR DESCRIPTION
## Summary
- Fix `parseJsonDefault` in `packages/shared` to return the full array for multi-match JSONPath queries (slices like `$[1:]`, wildcards like `$[*].role`) instead of only `result[0]`. Single-match queries remain unwrapped for backward compatibility.
- Add primitive guard to `parseJsonDefault` — return primitives as-is instead of passing them to JSONPath (which returns `[]` for non-objects).
- Deduplicate JSONPath evaluation: the worker's `parseDatabaseRowToString` and `extractObservationVariables` now delegate to the shared `extractValueFromObject` instead of maintaining separate JSONPath + stringify logic.
- `snakeToCamel` column ID fallback and `parseUnknownToString` remain in the worker as database-specific concerns.

## Impacted packages
- `packages/shared` — `parseJsonDefault` fix + primitive guard
- `worker` — deduplication of `parseDatabaseRowToString` and `extractObservationVariables`

## Verification
- `pnpm --filter @langfuse/shared run lint` ✅
- `pnpm --filter worker run lint` ✅
- `vitest run extractValueFromObject.test.ts` — 14/14 passed ✅

## Test plan
- [x] JSONPath slice `$[1:]` returns full array, not just first element
- [x] Single-match `$.name` / `$[0]` still returns unwrapped value
- [x] Primitive values with JSON selector return as-is (not empty)
- [x] Non-matching JSONPath returns empty string
- [x] Multi-encoded JSON strings are handled correctly
- [x] Error logging preserved in `parseDatabaseRowToString`

Closes LFE-8416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes `parseJsonDefault` to return full arrays for multi-match JSONPath queries, adds a primitive guard, and deduplicates JSONPath logic across `parseDatabaseRowToString` and `extractObservationVariables` by delegating to `extractValueFromObject`.

- **Existing tests will fail**: The PR only verified `extractValueFromObject.test.ts` (14/14). At least three existing tests in `extractObservationVariables.test.ts` expect the old array-wrapped behaviour (e.g. `$.prompt` returning `JSON.stringify([\"Hello, how are you?\"])`) that `parseJsonDefault` now changes — these tests were not updated to reflect the intentional unwrapping for single-match and `\"\"` for empty results.
- **Silent error drop in `extractObservationVariables`**: The `error` field from `extractValueFromObject` is destructured away without logging, removing the `debug`-level error visibility that the old `applyJsonSelector` provided.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until stale tests in `extractObservationVariables.test.ts` are updated to match the new unwrapped/empty-string behaviour.

The core logic fix in `parseJsonDefault` and the `evalService` refactor are correct. The blocking concern is that the full test suite was not run — three pre-existing tests now assert the old array-wrapped result format and will fail in CI.

`worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts` — three test assertions need updating for the new single-match unwrapping and empty-result `""` behaviour.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/shared/src/features/evals/utilities.ts | Adds primitive guard to `parseJsonDefault` and changes multi-match vs single-match unwrapping logic; core fix is correct but behaviour change breaks existing tests. |
| worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts | New test suite covers the shared utility well; uses a fragile deep-relative import path instead of `@langfuse/shared`. |
| worker/src/features/evaluation/evalService.ts | Clean deduplication of `parseDatabaseRowToString`; `snakeToCamel` fallback correctly resolved before wrapping, error logging preserved. |
| worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts | New tests for slice/single-element cases are correct, but three pre-existing tests expect old array-wrapped results and will fail with the refactored code. |
| worker/src/features/evaluation/observationEval/extractObservationVariables.ts | Good deduplication; error from `extractValueFromObject` is silently dropped without logging, losing the debug observability that `applyJsonSelector` provided. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DB row or Observation field] --> B{Has jsonSelector?}
    B -- No --> C[parseMultiEncodedJson]
    C --> D[parseUnknownToString returns value]
    B -- Yes --> E[parseMultiEncodedJson]
    E --> F[parseJsonDefault via extractValueFromObject]
    F --> G{JSONPath result length}
    G -- 0 --> H[return undefined, value is empty string]
    G -- 1 --> I[unwrap result at index 0]
    G -- more than 1 --> J[return full array, JSON.stringify]
    I --> K[Caller gets final string value]
    J --> K
    H --> K
    D --> K
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts`, line 314-316 ([link](https://github.com/langfuse/langfuse/blob/cbffe3231cac186a09634a5a5ce6014ab3a49808/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts#L314-L316)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Existing tests expect old array-wrapped behavior that new code breaks**

   The old `applyJsonSelector` returned the raw JSONPath result array (e.g., `["Hello, how are you?"]`), but `parseJsonDefault` now unwraps single-match results. At least three existing tests will fail:

   - Line 315: `$.prompt` single-match — expects `JSON.stringify(["Hello, how are you?"])`, will receive `"Hello, how are you?"`
   - Line 335: `$.response` single-match — expects `JSON.stringify(["I am fine, thank you!"])`, will receive `"I am fine, thank you!"`
   - Line 457: non-matching path `$.nonexistent.deeply.nested` — expects `"[]"`, will receive `""` (because `parseJsonDefault` now returns `undefined` → `""` for empty results)

   The PR's verification only ran `vitest run extractValueFromObject.test.ts`, so these regressions were not caught. The existing tests need to be updated to reflect the intentional behavior change.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
   Line: 314-316

   Comment:
   **Existing tests expect old array-wrapped behavior that new code breaks**

   The old `applyJsonSelector` returned the raw JSONPath result array (e.g., `["Hello, how are you?"]`), but `parseJsonDefault` now unwraps single-match results. At least three existing tests will fail:

   - Line 315: `$.prompt` single-match — expects `JSON.stringify(["Hello, how are you?"])`, will receive `"Hello, how are you?"`
   - Line 335: `$.response` single-match — expects `JSON.stringify(["I am fine, thank you!"])`, will receive `"I am fine, thank you!"`
   - Line 457: non-matching path `$.nonexistent.deeply.nested` — expects `"[]"`, will receive `""` (because `parseJsonDefault` now returns `undefined` → `""` for empty results)

   The PR's verification only ran `vitest run extractValueFromObject.test.ts`, so these regressions were not caught. The existing tests need to be updated to reflect the intentional behavior change.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
Line: 314-316

Comment:
**Existing tests expect old array-wrapped behavior that new code breaks**

The old `applyJsonSelector` returned the raw JSONPath result array (e.g., `["Hello, how are you?"]`), but `parseJsonDefault` now unwraps single-match results. At least three existing tests will fail:

- Line 315: `$.prompt` single-match — expects `JSON.stringify(["Hello, how are you?"])`, will receive `"Hello, how are you?"`
- Line 335: `$.response` single-match — expects `JSON.stringify(["I am fine, thank you!"])`, will receive `"I am fine, thank you!"`
- Line 457: non-matching path `$.nonexistent.deeply.nested` — expects `"[]"`, will receive `""` (because `parseJsonDefault` now returns `undefined` → `""` for empty results)

The PR's verification only ran `vitest run extractValueFromObject.test.ts`, so these regressions were not caught. The existing tests need to be updated to reflect the intentional behavior change.

```suggestion
      // Single-match results are now unwrapped (not array-wrapped)
      expect(result[0].value).toBe("Hello, how are you?");
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: worker/src/features/evaluation/observationEval/extractObservationVariables.ts
Line: 91-95

Comment:
**Errors from `extractValueFromObject` silently dropped**

The old `applyJsonSelector` logged a `debug` message when JSONPath threw an error. The new code destructures only `value`, silently discarding `error`. Any JSON selector parse failure in `extractObservationVariables` will produce a silent fallback with no observability.

```suggestion
    const { value, error } = extractValueFromObject(
      { [mapping.selectedColumnId]: fieldValue },
      mapping.selectedColumnId,
      mapping.jsonSelector ?? undefined,
    );
    if (error) {
      logger.debug(
        `Error applying JSON selector "${mapping.jsonSelector}" for variable "${mapping.templateVariable}". Falling back to original value.`,
        { error },
      );
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
Line: 2

Comment:
**Prefer package import over deep relative path**

This test imports directly from the file path via a 5-level relative traversal. Other test files in this package (e.g., `extractObservationVariables.test.ts`) import via the workspace package name, which is less fragile if the internal file structure changes.

```suggestion
import { extractValueFromObject } from "@langfuse/shared";
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): return full JSONPath slice r..."](https://github.com/langfuse/langfuse/commit/cbffe3231cac186a09634a5a5ce6014ab3a49808) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28621546)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->