### PR TITLE
fix(otel): prevent prototype pollution in OTel attribute key parsing

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1315,18 +1315,25 @@ export class OtelIngestionProcessor {
     const keys = Object.keys(input).map((key) => key.replace(`${prefix}.`, ""));
     const useArray = keys.some((key) => key.match(/^\d+\./));
 
+    // Blocklist to prevent prototype pollution via crafted OTel attribute keys
+    const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
     // Helper function to set a value at a nested path
     const setNestedValue = (obj: any, path: string[], value: unknown): void => {
       let current = obj;
       for (let i = 0; i < path.length - 1; i++) {
         const key = path[i];
+        if (DANGEROUS_KEYS.has(key)) return;
         if (!(key in current)) {
           // Check if next key is a number to decide if we need an array or object
           current[key] = /^\d+$/.test(path[i + 1]) ? [] : {};
         }
         current = current[key];
       }
-      current[path[path.length - 1]] = value;
+      const finalKey = path[path.length - 1];
+      if (!DANGEROUS_KEYS.has(finalKey)) {
+        current[finalKey] = value;
+      }
     };
 
     if (useArray) {
@@ -1335,7 +1342,7 @@ export class OtelIngestionProcessor {
         const pathParts = key.split(".");
         const index = parseInt(pathParts[0], 10);
         if (!result[index]) {
-          result[index] = {};
+          result[index] = Object.create(null);
         }
         if (pathParts.length === 2) {
           // Simple case: 0.content -> result[0].content
@@ -1351,7 +1358,7 @@ export class OtelIngestionProcessor {
       }
       return result;
     } else {
-      const result: Record<string, unknown> = {};
+      const result: Record<string, unknown> = Object.create(null);
       for (const key of keys) {
         const pathParts = key.split(".");
         if (pathParts.length === 1) {

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -7465,4 +7465,73 @@ describe("OTel Resource Span Mapping", () => {
       );
     });
   });
+
+  describe("Prototype pollution protection", () => {
+    const publicKey = "pk-lf-1234567890";
+
+    it("should not pollute Object.prototype via __proto__ in gen_ai.prompt attributes", async () => {
+      const traceId = "abcdef1234567890abcdef1234567890";
+      const spanId = "abcdef1234567890";
+
+      const resourceSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "langfuse-sdk",
+              version: "2.0.0",
+              attributes: [
+                {
+                  key: "public_key",
+                  value: { stringValue: publicKey },
+                },
+              ],
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex").toJSON(),
+                spanId: Buffer.from(spanId, "hex").toJSON(),
+                name: "pollution-test",
+                kind: 1,
+                startTimeUnixNano: { low: 1000000000, high: 0, unsigned: true },
+                endTimeUnixNano: { low: 2000000000, high: 0, unsigned: true },
+                attributes: [
+                  {
+                    key: "gen_ai.prompt.role",
+                    value: { stringValue: "user" },
+                  },
+                  {
+                    key: "gen_ai.prompt.content",
+                    value: { stringValue: "hello" },
+                  },
+                  {
+                    key: "gen_ai.prompt.__proto__.POLLUTED",
+                    value: { stringValue: "SUCCESS" },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set([traceId]),
+        publicKey,
+      );
+
+      // Verify Object.prototype was NOT polluted
+      expect(({} as any).POLLUTED).toBeUndefined();
+      expect(Object.prototype.hasOwnProperty("POLLUTED" as any)).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Prevent prototype pollution via crafted OTel attribute keys (e.g. `gen_ai.prompt.__proto__.POLLUTED`) in `convertKeyPathToNestedObject`
- Add `DANGEROUS_KEYS` blocklist (`__proto__`, `constructor`, `prototype`) to guard both intermediate and final keys in nested path construction
- Use `Object.create(null)` for result objects so they have no prototype chain

## Impacted packages
- `packages/shared` — `OtelIngestionProcessor.ts`
- `web` — server test for prototype pollution

## Test plan
- [x] Added server test verifying `Object.prototype` is not polluted when `__proto__` keys are sent via OTel attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR patches a prototype pollution vulnerability in `convertKeyPathToNestedObject` where crafted OTel attribute keys like `gen_ai.prompt.__proto__.POLLUTED` could contaminate `Object.prototype`. The fix adds a `DANGEROUS_KEYS` blocklist and switches result objects to `Object.create(null)`.

The core security fix is correct: the blocklist guards both intermediate and final keys in `setNestedValue`, and null-prototype objects make the remaining unguarded cases (single-segment keys and the `pathParts.length === 2` fast path) inherently safe. One P2 concern remains around placing the constant inside the function and a defense-in-depth gap in two fast-path branches.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the prototype pollution vulnerability is correctly fixed and both fast paths are safe via null-prototype objects.

All remaining findings are P2 style/defense-in-depth suggestions. The core fix (DANGEROUS_KEYS blocklist + Object.create(null)) is correct and the test covers the primary exploit vector. No P0 or P1 issues found.

No files require special attention, but OtelIngestionProcessor.ts has two minor defense-in-depth gaps in fast-path branches.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/otel/OtelIngestionProcessor.ts | Adds DANGEROUS_KEYS blocklist and Object.create(null) to block prototype pollution; two fast-path branches skip the blocklist check but are safe due to null-prototype objects; DANGEROUS_KEYS is recreated on every call. |
| web/src/__tests__/server/api/otel/otelMapping.servertest.ts | Adds a new test verifying prototype pollution is blocked for __proto__ in the non-array path; no test for the array-indexed path (e.g. gen_ai.completion.0.__proto__). |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["OTel attribute key"] --> B["convertKeyPathToNestedObject"]
    B --> C["Strip prefix, split into pathParts"]
    C --> D{useArray}
    D -- No --> E["result = Object.create(null)"]
    D -- Yes --> F["result = Array"]
    E --> G{pathParts.length == 1}
    G -- Yes --> H["result[key] = value\nsafe: null-proto obj"]
    G -- No --> I["setNestedValue(result, pathParts, value)"]
    F --> J{pathParts.length == 2}
    J -- Yes --> K["result[index][pathParts[1]] = value\nsafe via null-proto, no DANGEROUS_KEYS guard"]
    J -- No --> I
    I --> L{intermediate key in DANGEROUS_KEYS}
    L -- Yes --> M["return early - blocked"]
    L -- No --> N["traverse or create nested obj"]
    N --> O{final key in DANGEROUS_KEYS}
    O -- Yes --> P["skip write - blocked"]
    O -- No --> Q["current[finalKey] = value"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/shared/src/server/otel/OtelIngestionProcessor.ts
Line: 1318-1319

Comment:
**Module-level constant preferred over per-call allocation**

`DANGEROUS_KEYS` is a fixed set that never changes, but it is reconstructated into a new `Set` object on every invocation of `convertKeyPathToNestedObject`. Moving it to module scope avoids the repeated allocation and makes the intent (a compile-time constant) more obvious.

```suggestion
// Blocklist to prevent prototype pollution via crafted OTel attribute keys
const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
```

(Move this line outside the method, at module/class level, and remove it from inside the function.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/shared/src/server/otel/OtelIngestionProcessor.ts
Line: 1347-1350

Comment:
**Defense-in-depth: fast path skips DANGEROUS_KEYS check**

The `pathParts.length === 2` fast path writes directly to `result[index]` without consulting `DANGEROUS_KEYS`. This is **currently safe** because `result[index]` is `Object.create(null)` (so setting `__proto__` just creates a regular own property), but it is inconsistent with the general `setNestedValue` path and could silently regress if the initialisation of `result[index]` ever changes back to `{}`.

```suggestion
        if (pathParts.length === 2) {
          // Simple case: 0.content -> result[0].content
          if (!DANGEROUS_KEYS.has(pathParts[1])) {
            result[index][pathParts[1]] = input[`${prefix}.${key}`];
          }
        } else {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): prevent prototype pollution i..."](https://github.com/langfuse/langfuse/commit/d0737f557ee34536ccb1817a23eb6f520d9e15d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28625634)</sub>

<!-- /greptile_comment -->