### PR TITLE
fix: prevent ip validation bypass for image URL validation

### DIFF
--- a/web/src/server/api/routers/utilities.ts
+++ b/web/src/server/api/routers/utilities.ts
@@ -79,10 +79,11 @@ const isValidAndSecureUrl = async (urlString: string): Promise<boolean> => {
 
     // Consider unresolvable or private hostnames as invalid/unsafe
     return (
-      (Boolean(ipAddresses.addresses4.length) &&
-        ipAddresses.addresses4.every((ip) => !isPrivateIp(ip))) ||
-      (Boolean(ipAddresses.addresses6.length) &&
-        ipAddresses.addresses6.every((ip) => !isPrivateIp(ip)))
+      (ipAddresses.addresses4.length === 0 ||
+        ipAddresses.addresses4.every((ip) => !isPrivateIp(ip))) &&
+      (ipAddresses.addresses6.length === 0 ||
+        ipAddresses.addresses6.every((ip) => !isPrivateIp(ip))) &&
+      (ipAddresses.addresses4.length > 0 || ipAddresses.addresses6.length > 0)
     );
   } catch (error) {
     logger.info("Invalid URL:", error);


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes an SSRF IP validation bypass in `isValidAndSecureUrl` where the old `||` operator allowed a hostname that resolved to a public IPv4 address **and** a private IPv6 address (e.g. `::1`) to pass the SSRF check. The new `&&` logic correctly requires all resolved addresses across both families to be non-private, plus at least one address must resolve (to block unresolvable hostnames).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core SSRF bypass is correctly fixed; remaining finding is a pre-existing gap in IPv6 range coverage, not introduced by this PR.

The boolean logic change is mathematically correct and completely closes the described bypass. The single remaining comment is a P2 hardening suggestion about IPv6 ULA/IPv4-mapped ranges that predates this PR and is out of scope of the fix.

No files require special attention for merge; the IPv6 range hardening note in isPrivateIp is a follow-up opportunity.

<details open><summary><h3>Security Review</h3></summary>

- **IPv6 ULA not blocked** (`web/src/server/api/routers/utilities.ts`, `isPrivateIp`): Unique Local Addresses (`fc00::/7`) and IPv4-mapped private addresses (`::ffff:x.x.x.x/96`) are not detected as private in the IPv6 branch, leaving a residual SSRF path via AAAA records pointing to internal ULA space.
- No new secrets or credentials exposed; no SQL/XSS/injection vectors introduced. The core logic fix (OR → AND) is correct and closes the described bypass.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/server/api/routers/utilities.ts | Fixes SSRF bypass: replaces OR logic with AND to require all resolved addresses (IPv4 and IPv6) to be non-private; logic is mathematically correct and the third condition correctly rejects unresolvable hostnames. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["isValidAndSecureUrl(urlString)"] --> B{protocol === 'https:'?}
    B -- No --> Z1["return false"]
    B -- Yes --> C["resolveHostname(hostname)"]
    C --> D["dns.resolve4 → addresses4"]
    C --> E["dns.resolve6 → addresses6"]
    D & E --> F{addresses4.length > 0 OR addresses6.length > 0?}
    F -- No --> Z2["return false (unresolvable host)"]
    F -- Yes --> G{all addresses4 non-private?}
    G -- No --> Z3["return false (private IPv4 found)"]
    G -- Yes --> H{all addresses6 non-private?}
    H -- No --> Z4["return false (private IPv6 found)"]
    H -- Yes --> Z5["return true (safe URL)"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/server/api/routers/utilities.ts
Line: 27-31

Comment:
**IPv6 ULA and IPv4-mapped addresses not covered**

`isPrivateIp` only blocks IPv6 link-local (`fe80::/10`) and loopback (`::1`). Unique Local Addresses (`fc00::/7`, e.g. `fd12::1`) and IPv4-mapped private addresses (`::ffff:10.0.0.1`, `::ffff:192.168.x.x`) would not be detected as private, so a hostname whose AAAA record points to a ULA or IPv4-mapped private address would pass the SSRF check even after this PR. Consider extending the IPv6 branch to cover these ranges, e.g.:

```typescript
const isValidAddress6 =
  address.isLinkLocal() ||
  address.isLoopback() ||
  address.isInSubnet(new Address6("fc00::/7")) ||   // ULA
  address.isInSubnet(new Address6("::ffff:0:0/96")); // IPv4-mapped
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent ip validation bypass for UR..."](https://github.com/langfuse/langfuse/commit/4a99be5cf0c6960993439616225139ede182a43f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28631557)</sub>

<!-- /greptile_comment -->