### PR TITLE
chore(trpc): handling of errors with body parse issues

### DIFF
--- a/web/src/utils/trpcErrorToast.tsx
+++ b/web/src/utils/trpcErrorToast.tsx
@@ -3,6 +3,15 @@ import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 
 // Catch network level errors, e.g. by proxy rate-limiting
 
+/**
+ * Check if error was caused by a response parsing failure.
+ * This happens when infrastructure (nginx, cloudflare, etc.) returns a non-JSON
+ * response body (e.g., empty body on 431, HTML error page on 502/503/504).
+ */
+const isResponseParseError = (error: TRPCClientError<any>): boolean => {
+  return error.cause instanceof SyntaxError;
+};
+
 const httpStatusOverride: Record<number, keyof typeof errorTitleMap> = {
   429: "TOO_MANY_REQUESTS",
   524: "TIMEOUT",
@@ -61,6 +70,17 @@ const getErrorDescription = (httpStatus: number) => {
 
 export const trpcErrorToast = (error: unknown) => {
   if (error instanceof TRPCClientError) {
+    // Handle infrastructure-level errors that return non-JSON responses
+    // (e.g., 431 with empty body, 502/503/504 with HTML error pages)
+    if (isResponseParseError(error)) {
+      showErrorToast(
+        "Unexpected Response",
+        "The request could not be completed. We've been notified and are looking into it. Please try again or contact support if this persists.",
+        "WARNING",
+      );
+      return;
+    }
+
     const { errorTitle, httpStatus } = getErrorTitleAndHttpCode(error);
 
     const path = error.data?.path;


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds an early-exit path in `trpcErrorToast` for infrastructure-level parse errors — cases where a proxy (nginx, Cloudflare, etc.) returns a non-JSON body (e.g., empty body on 431, HTML on 502/503/504) causing tRPC's JSON parser to throw a `SyntaxError`, which then surfaces as `TRPCClientError.cause`. The existing error-handling code would fall through to `getErrorTitleAndHttpCode`, which reads `error.data?.httpStatus` — data that is unavailable when JSON parsing failed entirely — so the early return with a dedicated user-facing message is the right call.

<h3>Confidence Score: 5/5</h3>

Safe to merge — small, focused fix with no logic regressions.

The only changed behaviour is an additional early-exit guard that fires when `error.cause` is a `SyntaxError`. All other existing paths are untouched. The guard is correctly placed before the code that reads `error.data`, which would be unavailable in parse-failure scenarios. No P0/P1 issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/utils/trpcErrorToast.tsx | Adds `isResponseParseError` guard that detects body-parse failures via `error.cause instanceof SyntaxError` and returns an "Unexpected Response" toast early, preventing a broken fallback through `getErrorTitleAndHttpCode` when `error.data` is absent. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[trpcErrorToast called] --> B{instanceof TRPCClientError?}
    B -- No --> C[showErrorToast: Unexpected Error / ERROR]
    B -- Yes --> D{isResponseParseError?\nerror.cause instanceof SyntaxError}
    D -- Yes --> E[showErrorToast: Unexpected Response / WARNING\nearly return]
    D -- No --> F[getErrorTitleAndHttpCode\nread error.data.httpStatus & code]
    F --> G[getErrorDescription\nhttpStatus-based message]
    G --> H{httpStatus >= 500?}
    H -- Yes --> I[showErrorToast: errorTitle / ERROR]
    H -- No --> J[showErrorToast: errorTitle / WARNING]
```

<sub>Reviews (1): Last reviewed commit: ["chore(trpc): handling of errors with bod..."](https://github.com/langfuse/langfuse/commit/bdb5fdf861521698168cf08ce215e77906c1694b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28641116)</sub>

<!-- /greptile_comment -->