### PR TITLE
fix(security): close SSRF TOCTOU gap with DNS pinning

### DIFF
--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -83,6 +83,7 @@ export * from "./redis/notificationQueue";
 export * from "./webhooks/validation";
 export * from "./webhooks/ipBlocking";
 export * from "./webhooks/redirectHandler";
+export * from "./webhooks/pinnedAgent";
 export * from "./redis/experimentCreateQueue";
 export * from "./redis/dlqRetryQueue";
 export * from "./redis/entityChangeQueue";

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -83,6 +83,8 @@ export * from "./redis/meteringDataPostgresExportQueue";
 export * from "./redis/notificationQueue";
 export * from "./webhooks/validation";
 export * from "./webhooks/ipBlocking";
+export * from "./webhooks/redirectHandler";
+export * from "./webhooks/pinnedAgent";
 export * from "./redis/experimentCreateQueue";
 export * from "./redis/dlqRetryQueue";
 export * from "./redis/entityChangeQueue";

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -83,7 +83,6 @@ export * from "./redis/meteringDataPostgresExportQueue";
 export * from "./redis/notificationQueue";
 export * from "./webhooks/validation";
 export * from "./webhooks/ipBlocking";
-export * from "./webhooks/redirectHandler";
 export * from "./webhooks/pinnedAgent";
 export * from "./redis/experimentCreateQueue";
 export * from "./redis/dlqRetryQueue";

--- a/packages/shared/src/server/llm/baseUrlValidation.ts
+++ b/packages/shared/src/server/llm/baseUrlValidation.ts
@@ -33,7 +33,7 @@ export function llmBaseUrlWhitelistFromEnv(): LlmBaseUrlValidationWhitelist {
 export async function validateLlmConnectionBaseURL(
   urlString: string,
   whitelist: LlmBaseUrlValidationWhitelist = llmBaseUrlWhitelistFromEnv(),
-): Promise<void> {
+): Promise<string[]> {
   const effectiveWhitelist = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
     ? {
         hosts: [],
@@ -56,7 +56,15 @@ export async function validateLlmConnectionBaseURL(
   const hostname = normalizeHostname(url.hostname);
 
   if (effectiveWhitelist.hosts.includes(hostname)) {
-    return;
+    // Whitelisted host — skip blocking checks but still resolve for IP pinning
+    if (isIPAddress(hostname)) {
+      return [hostname];
+    }
+    try {
+      return await resolveHost(hostname);
+    } catch {
+      return [];
+    }
   }
 
   if (isHostnameBlocked(hostname)) {
@@ -81,7 +89,7 @@ export async function validateLlmConnectionBaseURL(
       throw new Error("Blocked IP address detected");
     }
 
-    return;
+    return [hostname];
   }
 
   let ips: string[];
@@ -89,7 +97,7 @@ export async function validateLlmConnectionBaseURL(
     ips = await resolveHost(hostname);
   } catch {
     // DNS resolution is best-effort here so valid custom gateways do not fail at write time.
-    return;
+    return [];
   }
 
   for (const ip of ips) {
@@ -100,6 +108,7 @@ export async function validateLlmConnectionBaseURL(
       throw new Error("Blocked IP address detected");
     }
   }
+  return ips;
 }
 
 function normalizeURL(urlString: string): string {

--- a/packages/shared/src/server/llm/baseUrlValidation.ts
+++ b/packages/shared/src/server/llm/baseUrlValidation.ts
@@ -26,7 +26,7 @@ export function llmBaseUrlWhitelistFromEnv(): LlmBaseUrlValidationWhitelist {
 export async function validateLlmConnectionBaseURL(
   urlString: string,
   whitelist: LlmBaseUrlValidationWhitelist = llmBaseUrlWhitelistFromEnv(),
-): Promise<void> {
+): Promise<string[]> {
   const effectiveWhitelist = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
     ? {
         hosts: [],
@@ -41,7 +41,7 @@ export async function validateLlmConnectionBaseURL(
     throw new Error("Only HTTP and HTTPS protocols are allowed");
   }
 
-  await validateOutboundUrlHost({
+  const ips = await validateOutboundUrlHost({
     url,
     whitelist: effectiveWhitelist,
     logContext: "LLM base URL",
@@ -53,4 +53,6 @@ export async function validateLlmConnectionBaseURL(
   if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION && url.protocol !== "https:") {
     throw new Error("Only HTTPS base URLs are allowed on Langfuse Cloud");
   }
+
+  return ips;
 }

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -697,8 +697,9 @@ export async function fetchLLMCompletion(
     await processTracedEvents();
     // Close the single-use pinned agent to release its connection pool.
     // ProxyAgent also extends Agent, so this handles both cases.
+    // Swallow close errors so they can't mask the original completion error.
     if (llmDispatcher && !proxyUrl) {
-      await llmDispatcher.close();
+      await llmDispatcher.close().catch(() => undefined);
     }
   }
 }

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -41,7 +41,8 @@ import {
   TraceSinkParams,
 } from "./types";
 import type { BaseCallbackHandler } from "@langchain/core/callbacks/base";
-import { ProxyAgent } from "undici";
+import { type Agent, ProxyAgent } from "undici";
+import { createPinnedAgent } from "../webhooks/pinnedAgent";
 import { getInternalTracingHandler } from "./getInternalTracingHandler";
 import { decrypt } from "../../encryption";
 import {
@@ -51,6 +52,7 @@ import {
 } from "./utils";
 import { logger } from "../logger";
 import { LLMCompletionError } from "./errors";
+import { validateLlmConnectionBaseURL } from "./baseUrlValidation";
 
 export type CompletionWithReasoning = { text: string; reasoning?: string };
 
@@ -216,6 +218,14 @@ export async function fetchLLMCompletion(
   } = params;
 
   const { baseURL, config } = llmConnection;
+
+  // Re-validate user-configured base URL at call time and obtain resolved IPs.
+  // The URL was already validated when saved, but DNS may have changed since.
+  let baseURLResolvedIPs: string[] = [];
+  if (baseURL) {
+    baseURLResolvedIPs = await validateLlmConnectionBaseURL(baseURL);
+  }
+
   const apiKey = decrypt(llmConnection.secretKey); // the apiKey must never be printed to the console
   const extraHeaders = decryptAndParseExtraHeaders(llmConnection.extraHeaders);
 
@@ -300,9 +310,16 @@ export async function fetchLLMCompletion(
     (m) => m.content.length > 0 || "tool_calls" in m,
   );
 
-  // Common proxy configuration for all adapters
+  // Dispatcher for outbound LLM SDK requests.
+  // When HTTPS_PROXY is set the proxy handles DNS + routing.
+  // Otherwise, if we resolved IPs for a user-configured base URL,
+  // pin DNS so the SDK connects to the already-validated addresses.
   const proxyUrl = env.HTTPS_PROXY;
-  const proxyDispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
+  const llmDispatcher: Agent | ProxyAgent | undefined = proxyUrl
+    ? new ProxyAgent(proxyUrl)
+    : baseURLResolvedIPs.length > 0
+      ? createPinnedAgent(baseURLResolvedIPs)
+      : undefined;
   const timeoutMs = env.LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS;
 
   let chatModel:
@@ -329,8 +346,8 @@ export async function fetchLLMCompletion(
         maxRetries,
         defaultHeaders: extraHeaders,
         timeout: timeoutMs,
-        ...(proxyDispatcher && {
-          fetchOptions: { dispatcher: proxyDispatcher },
+        ...(llmDispatcher && {
+          fetchOptions: { dispatcher: llmDispatcher },
         }),
       },
       temperature: modelParams.temperature,
@@ -382,8 +399,8 @@ export async function fetchLLMCompletion(
         baseURL: processedBaseURL,
         timeout: timeoutMs,
         defaultHeaders: extraHeaders,
-        ...(proxyDispatcher && {
-          fetchOptions: { dispatcher: proxyDispatcher },
+        ...(llmDispatcher && {
+          fetchOptions: { dispatcher: llmDispatcher },
         }),
       },
       modelKwargs: modelParams.providerOptions,
@@ -404,8 +421,8 @@ export async function fetchLLMCompletion(
       configuration: {
         timeout: timeoutMs,
         defaultHeaders: extraHeaders,
-        ...(proxyDispatcher && {
-          fetchOptions: { dispatcher: proxyDispatcher },
+        ...(llmDispatcher && {
+          fetchOptions: { dispatcher: llmDispatcher },
         }),
       },
       modelKwargs: modelParams.providerOptions,
@@ -678,6 +695,11 @@ export async function fetchLLMCompletion(
     });
   } finally {
     await processTracedEvents();
+    // Close the single-use pinned agent to release its connection pool.
+    // ProxyAgent also extends Agent, so this handles both cases.
+    if (llmDispatcher && !proxyUrl) {
+      await llmDispatcher.close();
+    }
   }
 }
 

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -698,7 +698,7 @@ export async function fetchLLMCompletion(
     // Close the single-use pinned agent to release its connection pool.
     // ProxyAgent also extends Agent, so this handles both cases.
     // Swallow close errors so they can't mask the original completion error.
-    if (llmDispatcher && !proxyUrl) {
+    if (llmDispatcher) {
       await llmDispatcher.close().catch(() => undefined);
     }
   }

--- a/packages/shared/src/server/outbound-url/fetch.ts
+++ b/packages/shared/src/server/outbound-url/fetch.ts
@@ -265,10 +265,11 @@ export async function fetchWithSecureRedirects(
         // while image URLs require HTTPS. Keep the fetch helper generic and
         // require callers to pass the validator that matches their flow.
         // The validator returns the resolved IPs so the next hop can pin DNS.
-        const resolvedIPs = await redirectOptions.redirectValidation.validateUrl(
-          redirectUrl,
-          redirectOptions.redirectValidation.whitelist,
-        );
+        const resolvedIPs =
+          await redirectOptions.redirectValidation.validateUrl(
+            redirectUrl,
+            redirectOptions.redirectValidation.whitelist,
+          );
         currentResolvedIPs = useIPPinning ? resolvedIPs : undefined;
       } catch (error) {
         logger.warn("Redirect validation failed", {

--- a/packages/shared/src/server/outbound-url/fetch.ts
+++ b/packages/shared/src/server/outbound-url/fetch.ts
@@ -190,7 +190,9 @@ export async function fetchWithSecureRedirects(
       response = await fetch(currentUrl, perRequestFetchOptions);
     } finally {
       // Close the single-use agent to release its connection pool.
-      await agent?.close();
+      // Swallow close errors so they can't replace a fetch error or mask
+      // the response on the happy path.
+      await agent?.close().catch(() => undefined);
     }
 
     // Check if this is a redirect response (3xx status codes)

--- a/packages/shared/src/server/outbound-url/fetch.ts
+++ b/packages/shared/src/server/outbound-url/fetch.ts
@@ -1,5 +1,8 @@
 import type { OutboundUrlValidationWhitelist } from "./validation";
 import { logger } from "../logger";
+import { env } from "../../env";
+import { createPinnedAgent } from "../webhooks/pinnedAgent";
+import { type Agent } from "undici";
 
 const SENSITIVE_REDIRECT_HEADERS = new Set([
   "authorization",
@@ -58,10 +61,15 @@ export interface RedirectResult {
   finalUrl: string;
 }
 
+/**
+ * Validates a redirect target URL and returns the resolved IPs so the next-hop
+ * fetch can pin DNS to those addresses. Validators that do not need pinning
+ * may return an empty array.
+ */
 export type RedirectUrlValidator = (
   url: string,
   whitelist?: OutboundUrlValidationWhitelist,
-) => Promise<void>;
+) => Promise<string[]>;
 
 interface BaseRedirectOptions {
   maxRedirects: number;
@@ -71,6 +79,12 @@ interface BaseRedirectOptions {
 interface RedirectValidationOptions {
   validateUrl: RedirectUrlValidator;
   whitelist?: OutboundUrlValidationWhitelist;
+  /**
+   * Pre-resolved IPs for the initial URL (typically returned by the same
+   * validator the caller already invoked). When provided, the first hop pins
+   * DNS to these IPs to close the TOCTOU gap between validation and fetch.
+   */
+  initialResolvedIPs?: string[];
 }
 
 /**
@@ -93,6 +107,11 @@ export type RedirectOptions =
  * target before following it. Callers provide validation so each outbound flow
  * can enforce its own protocol, port, and whitelist rules.
  *
+ * When validators return resolved IPs, fetch pins DNS to those addresses via
+ * an undici Agent to close the TOCTOU gap between validation and connect.
+ * Pinning is skipped automatically when HTTPS_PROXY is configured because the
+ * proxy handles DNS + connection routing.
+ *
  * @param url - The initial URL to fetch
  * @param options - Fetch options (method, body, headers, signal, etc.)
  * @param redirectOptions - Configuration for redirect handling (maxRedirects, validation, whitelist)
@@ -108,7 +127,10 @@ export type RedirectOptions =
  *   { method: "POST", body: payload, headers, signal },
  *   {
  *     maxRedirects: 10,
- *     redirectValidation: { validateUrl: validateWebhookURL },
+ *     redirectValidation: {
+ *       validateUrl: validateWebhookURLAndGetIPs,
+ *       initialResolvedIPs,
+ *     },
  *   }
  * );
  * console.log(`Final URL: ${result.finalUrl}`);
@@ -126,10 +148,20 @@ export async function fetchWithSecureRedirects(
     ...additionalSensitiveHeaders.map((headerName) => headerName.toLowerCase()),
   ]);
 
+  // When HTTPS_PROXY is configured the proxy handles DNS + connection routing,
+  // so we skip our own IP pinning to avoid conflicts.
+  const useIPPinning = !env.HTTPS_PROXY;
+
   // Track redirect chain for loop detection and logging
   const redirectChain: string[] = [];
   let currentUrl = url;
   let redirectDepth = 0;
+  let currentResolvedIPs: string[] | undefined =
+    redirectOptions.skipValidation === true
+      ? undefined
+      : useIPPinning
+        ? redirectOptions.redirectValidation.initialResolvedIPs
+        : undefined;
 
   // Force manual redirect handling to prevent automatic following.
   let fetchOptions: RequestInit = {
@@ -144,8 +176,22 @@ export async function fetchWithSecureRedirects(
       maxRedirects,
     });
 
-    // Fetch the current URL
-    const response = await fetch(currentUrl, fetchOptions);
+    // Build per-request fetch options, pinning DNS when we have validated IPs.
+    let agent: Agent | undefined;
+    const perRequestFetchOptions: RequestInit = { ...fetchOptions };
+    if (currentResolvedIPs?.length) {
+      agent = createPinnedAgent(currentResolvedIPs);
+      // Node.js global fetch (undici) supports the dispatcher option at runtime.
+      (perRequestFetchOptions as Record<string, unknown>).dispatcher = agent;
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(currentUrl, perRequestFetchOptions);
+    } finally {
+      // Close the single-use agent to release its connection pool.
+      await agent?.close();
+    }
 
     // Check if this is a redirect response (3xx status codes)
     const isRedirect =
@@ -216,10 +262,12 @@ export async function fetchWithSecureRedirects(
         // Redirect safety is domain-specific: webhooks allow HTTP(S) on 80/443,
         // while image URLs require HTTPS. Keep the fetch helper generic and
         // require callers to pass the validator that matches their flow.
-        await redirectOptions.redirectValidation.validateUrl(
+        // The validator returns the resolved IPs so the next hop can pin DNS.
+        const resolvedIPs = await redirectOptions.redirectValidation.validateUrl(
           redirectUrl,
           redirectOptions.redirectValidation.whitelist,
         );
+        currentResolvedIPs = useIPPinning ? resolvedIPs : undefined;
       } catch (error) {
         logger.warn("Redirect validation failed", {
           from: currentUrl,
@@ -234,6 +282,8 @@ export async function fetchWithSecureRedirects(
           redirectDepth,
         );
       }
+    } else {
+      currentResolvedIPs = undefined;
     }
 
     const currentOrigin = new URL(currentUrl).origin;

--- a/packages/shared/src/server/outbound-url/validation.ts
+++ b/packages/shared/src/server/outbound-url/validation.ts
@@ -79,13 +79,21 @@ export async function validateOutboundUrlHost({
   whitelist,
   logContext,
   shouldSkipDnsCheckForLiteralIps,
-}: ValidateOutboundUrlHostOptions): Promise<void> {
+}: ValidateOutboundUrlHostOptions): Promise<string[]> {
   // WHATWG URL parsing already lowercases and punycodes HTTP(S) hostnames, so
   // host safety checks stay tied to the parsed URL component.
   const hostname = url.hostname;
 
   if (whitelist.hosts.includes(hostname)) {
-    return;
+    // Whitelisted host — skip blocking checks but still resolve for IP pinning.
+    // DNS resolution is best-effort: a transient failure should not block a
+    // whitelisted destination, so callers fall back to unpinned delivery.
+    if (isIPAddress(hostname)) return [hostname];
+    try {
+      return await resolveHost(hostname);
+    } catch {
+      return [];
+    }
   }
 
   if (isHostnameBlocked(hostname)) {
@@ -100,7 +108,7 @@ export async function validateOutboundUrlHost({
       throw new Error("Blocked IP address detected");
     }
 
-    if (shouldSkipDnsCheckForLiteralIps) return;
+    if (shouldSkipDnsCheckForLiteralIps) return [hostname];
   }
 
   // DNS-resolution failure is treated as a hard validation error: silently
@@ -117,6 +125,8 @@ export async function validateOutboundUrlHost({
       throw new Error("Blocked IP address detected");
     }
   }
+
+  return ips;
 }
 
 function assertValidUrlEncoding(urlString: string): void {

--- a/packages/shared/src/server/webhooks/pinnedAgent.ts
+++ b/packages/shared/src/server/webhooks/pinnedAgent.ts
@@ -1,0 +1,27 @@
+import { Agent } from "undici";
+
+/**
+ * Creates an undici Agent that pins DNS resolution to the given IPs,
+ * preventing TOCTOU races between validation and the actual connection.
+ * The Agent's lookup override returns a pre-validated IP so the HTTP
+ * client never re-resolves the hostname independently.
+ */
+export function createPinnedAgent(resolvedIPs: string[]): Agent {
+  const ip = resolvedIPs[0];
+  const family = ip.includes(":") ? 6 : 4;
+  return new Agent({
+    connect: {
+      lookup: (
+        _hostname: string,
+        _options: unknown,
+        callback: (
+          err: NodeJS.ErrnoException | null,
+          address: string,
+          family: number,
+        ) => void,
+      ) => {
+        callback(null, ip, family);
+      },
+    },
+  });
+}

--- a/packages/shared/src/server/webhooks/pinnedAgent.ts
+++ b/packages/shared/src/server/webhooks/pinnedAgent.ts
@@ -7,6 +7,9 @@ import { Agent } from "undici";
  * client never re-resolves the hostname independently.
  */
 export function createPinnedAgent(resolvedIPs: string[]): Agent {
+  // Deliberately pin to a single validated IP. Cycling through alternates on
+  // connection failure could re-open the TOCTOU gap by allowing a DNS-rebinding
+  // attacker to smuggle a malicious IP into the retry path.
   const ip = resolvedIPs[0];
   const family = ip.includes(":") ? 6 : 4;
   return new Agent({

--- a/packages/shared/src/server/webhooks/redirectHandler.ts
+++ b/packages/shared/src/server/webhooks/redirectHandler.ts
@@ -1,6 +1,9 @@
-import { validateWebhookURL } from "./validation";
+import { validateWebhookURLAndGetIPs } from "./validation";
 import type { WebhookValidationWhitelist } from "./validation";
+import { createPinnedAgent } from "./pinnedAgent";
+import { env } from "../../env";
 import { logger } from "../logger";
+import { type Agent } from "undici";
 
 /**
  * Custom error for redirect validation failures
@@ -59,6 +62,8 @@ export interface RedirectOptions {
   maxRedirects: number;
   skipValidation?: boolean;
   whitelist?: WebhookValidationWhitelist;
+  /** Pre-resolved IPs from validateWebhookURL for the initial URL. */
+  initialResolvedIPs?: string[];
 }
 
 /**
@@ -92,15 +97,25 @@ export async function fetchWithSecureRedirects(
   options: RequestInit,
   redirectOptions: RedirectOptions,
 ): Promise<RedirectResult> {
-  const { maxRedirects, skipValidation = false, whitelist } = redirectOptions;
+  const {
+    maxRedirects,
+    skipValidation = false,
+    whitelist,
+    initialResolvedIPs,
+  } = redirectOptions;
 
   // Track redirect chain for loop detection and logging
   const redirectChain: string[] = [];
   let currentUrl = url;
   let redirectDepth = 0;
+  // IPs validated by the caller (or by redirect-hop validation below).
+  // When an HTTPS_PROXY is configured the proxy handles DNS + connection
+  // routing, so we skip our own IP pinning to avoid conflicts.
+  const useIPPinning = !env.HTTPS_PROXY;
+  let currentResolvedIPs = useIPPinning ? initialResolvedIPs : undefined;
 
   // Force manual redirect handling to prevent automatic following
-  const fetchOptions: RequestInit = {
+  const baseFetchOptions: RequestInit = {
     ...options,
     redirect: "manual",
   };
@@ -112,8 +127,22 @@ export async function fetchWithSecureRedirects(
       maxRedirects,
     });
 
-    // Fetch the current URL
-    const response = await fetch(currentUrl, fetchOptions);
+    // Build per-request fetch options, pinning DNS when we have validated IPs
+    let agent: Agent | undefined;
+    const fetchOptions = { ...baseFetchOptions };
+    if (currentResolvedIPs?.length) {
+      agent = createPinnedAgent(currentResolvedIPs);
+      // Node.js global fetch (undici) supports the dispatcher option at runtime
+      (fetchOptions as Record<string, unknown>).dispatcher = agent;
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(currentUrl, fetchOptions);
+    } finally {
+      // Close the single-use agent to release its connection pool
+      await agent?.close();
+    }
 
     // Check if this is a redirect response (3xx status codes)
     const isRedirect =
@@ -179,10 +208,14 @@ export async function fetchWithSecureRedirects(
       ]);
     }
 
-    // Validate the redirect target URL before following
+    // Validate the redirect target URL and obtain pinned IPs for the next hop
     if (!skipValidation) {
       try {
-        await validateWebhookURL(redirectUrl, whitelist);
+        const resolvedIPs = await validateWebhookURLAndGetIPs(
+          redirectUrl,
+          whitelist,
+        );
+        currentResolvedIPs = useIPPinning ? resolvedIPs : undefined;
       } catch (error) {
         logger.warn("Redirect validation failed", {
           from: currentUrl,
@@ -197,6 +230,8 @@ export async function fetchWithSecureRedirects(
           redirectDepth,
         );
       }
+    } else {
+      currentResolvedIPs = undefined;
     }
 
     // Follow the redirect

--- a/packages/shared/src/server/webhooks/redirectHandler.ts
+++ b/packages/shared/src/server/webhooks/redirectHandler.ts
@@ -140,8 +140,10 @@ export async function fetchWithSecureRedirects(
     try {
       response = await fetch(currentUrl, fetchOptions);
     } finally {
-      // Close the single-use agent to release its connection pool
-      await agent?.close();
+      // Close the single-use agent to release its connection pool.
+      // Swallow close errors so they can't replace a fetch error or mask
+      // the response on the happy path.
+      await agent?.close().catch(() => undefined);
     }
 
     // Check if this is a redirect response (3xx status codes)

--- a/packages/shared/src/server/webhooks/validation.ts
+++ b/packages/shared/src/server/webhooks/validation.ts
@@ -43,17 +43,16 @@ export function whitelistFromEnv(): WebhookValidationWhitelist {
 }
 
 /**
- * Validates a webhook URL to prevent SSRF attacks by blocking internal/private IP addresses
- * Should be called when saving webhook URLs and before sending webhooks
+ * Validates a webhook URL to prevent SSRF attacks by blocking internal/private IP addresses.
+ * Returns the resolved IP addresses so callers can pin DNS and avoid TOCTOU races
+ * between validation and the actual HTTP request.
  *
- * Security Note: This validation has a Time-of-Check-Time-of-Use (TOCTOU) vulnerability
- * where DNS can change between validation and actual HTTP request. For maximum security,
- * the HTTP client should also implement IP blocking at connection time.
+ * Should be called when saving webhook URLs and before sending webhooks.
  */
-export async function validateWebhookURL(
+export async function validateWebhookURLAndGetIPs(
   urlString: string,
   whitelist: WebhookValidationWhitelist = whitelistFromEnv(),
-): Promise<void> {
+): Promise<string[]> {
   // Step 1: Basic URL parsing and normalization
   let url: URL;
   try {
@@ -77,8 +76,11 @@ export async function validateWebhookURL(
   const hostname = normalizeHostname(url.hostname);
 
   if (whitelist.hosts.includes(hostname)) {
-    // skip further checks if hostname is whitelisted
-    return;
+    // Whitelisted host — skip blocking checks but still resolve for IP pinning
+    if (isIPAddress(hostname)) {
+      return [hostname];
+    }
+    return resolveHost(hostname);
   }
 
   // Block obviously dangerous hostnames
@@ -96,6 +98,7 @@ export async function validateWebhookURL(
       // Throw generic error to user to prevent IP leakage
       throw new Error("Blocked IP address detected");
     }
+    return [hostname];
   }
 
   // Step 5: DNS resolution and validation
@@ -110,6 +113,7 @@ export async function validateWebhookURL(
       throw new Error("Blocked IP address detected");
     }
   }
+  return ips;
 }
 
 /**

--- a/packages/shared/src/server/webhooks/validation.ts
+++ b/packages/shared/src/server/webhooks/validation.ts
@@ -76,11 +76,17 @@ export async function validateWebhookURLAndGetIPs(
   const hostname = normalizeHostname(url.hostname);
 
   if (whitelist.hosts.includes(hostname)) {
-    // Whitelisted host — skip blocking checks but still resolve for IP pinning
+    // Whitelisted host — skip blocking checks but still resolve for IP pinning.
+    // DNS resolution is best-effort: a transient failure should not block a
+    // whitelisted webhook; returning [] lets the caller fall back to unpinned delivery.
     if (isIPAddress(hostname)) {
       return [hostname];
     }
-    return resolveHost(hostname);
+    try {
+      return await resolveHost(hostname);
+    } catch {
+      return [];
+    }
   }
 
   // Block obviously dangerous hostnames

--- a/packages/shared/src/server/webhooks/validation.ts
+++ b/packages/shared/src/server/webhooks/validation.ts
@@ -18,17 +18,16 @@ export function whitelistFromEnv(): WebhookValidationWhitelist {
 }
 
 /**
- * Validates a webhook URL to prevent SSRF attacks by blocking internal/private IP addresses
- * Should be called when saving webhook URLs and before sending webhooks
+ * Validates a webhook URL to prevent SSRF attacks by blocking internal/private IP addresses.
+ * Returns the resolved IP addresses so callers can pin DNS and avoid TOCTOU races
+ * between validation and the actual HTTP request.
  *
- * Security Note: This validation has a Time-of-Check-Time-of-Use (TOCTOU) vulnerability
- * where DNS can change between validation and actual HTTP request. For maximum security,
- * the HTTP client should also implement IP blocking at connection time.
+ * Should be called when saving webhook URLs and before sending webhooks.
  */
-export async function validateWebhookURL(
+export async function validateWebhookURLAndGetIPs(
   urlString: string,
   whitelist: WebhookValidationWhitelist = whitelistFromEnv(),
-): Promise<void> {
+): Promise<string[]> {
   const url = parseOutboundUrl(urlString);
 
   if (!["https:", "http:"].includes(url.protocol)) {
@@ -39,7 +38,7 @@ export async function validateWebhookURL(
     throw new Error("Only ports 80 and 443 are allowed");
   }
 
-  await validateOutboundUrlHost({
+  return await validateOutboundUrlHost({
     url,
     whitelist,
     logContext: "Webhook",

--- a/web/src/features/automations/server/githubDispatchHelpers.ts
+++ b/web/src/features/automations/server/githubDispatchHelpers.ts
@@ -8,7 +8,7 @@ import {
 } from "@langfuse/shared";
 import {
   getActionByIdWithSecrets,
-  validateWebhookURL,
+  validateWebhookURLAndGetIPs,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 
@@ -60,7 +60,7 @@ export async function processGitHubDispatchActionConfig({
   }
 
   try {
-    await validateWebhookURL(urlToUse);
+    await validateWebhookURLAndGetIPs(urlToUse);
   } catch (error) {
     throw new TRPCError({
       code: "BAD_REQUEST",

--- a/web/src/features/automations/server/webhookHelpers.ts
+++ b/web/src/features/automations/server/webhookHelpers.ts
@@ -15,7 +15,7 @@ import {
   mergeHeaders,
   createDisplayHeaders,
   encryptSecretHeaders,
-  validateWebhookURL,
+  validateWebhookURLAndGetIPs,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 
@@ -55,7 +55,7 @@ export async function processWebhookActionConfig({
   }
 
   try {
-    await validateWebhookURL(actionConfig.url);
+    await validateWebhookURLAndGetIPs(actionConfig.url);
   } catch (error) {
     throw new TRPCError({
       code: "BAD_REQUEST",

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -41,7 +41,7 @@ import {
   getCategoricalScoresGroupedByName,
   getDatasetRunsTableRowsCh,
   getDatasetRunsTableCountCh,
-  validateWebhookURL,
+  validateWebhookURLAndGetIPs,
   getDatasetRunItemsWithoutIOByItemIds,
   getDatasetItemsWithRunDataCount,
   getDatasetItemIdsWithRunData,
@@ -1745,7 +1745,7 @@ export const datasetRouter = createTRPCRouter({
       }
 
       try {
-        await validateWebhookURL(dataset.remoteExperimentUrl);
+        await validateWebhookURLAndGetIPs(dataset.remoteExperimentUrl);
       } catch (error) {
         throw new TRPCError({
           code: "BAD_REQUEST",

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1795,8 +1795,11 @@ export const datasetRouter = createTRPCRouter({
           },
           {
             maxRedirects: 5,
-            whitelist: whitelistFromEnv(),
-            initialResolvedIPs: resolvedIPs,
+            redirectValidation: {
+              validateUrl: validateWebhookURLAndGetIPs,
+              whitelist: whitelistFromEnv(),
+              initialResolvedIPs: resolvedIPs,
+            },
           },
         );
         const response = redirectResult.response;

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -41,7 +41,7 @@ import {
   getCategoricalScoresGroupedByName,
   getDatasetRunsTableRowsCh,
   getDatasetRunsTableCountCh,
-  validateWebhookURL,
+  validateWebhookURLAndGetIPs,
   getDatasetRunItemsWithoutIOByItemIds,
   getDatasetItemsWithRunDataCount,
   getDatasetItemIdsWithRunData,
@@ -1764,7 +1764,7 @@ export const datasetRouter = createTRPCRouter({
       }
 
       try {
-        await validateWebhookURL(dataset.remoteExperimentUrl);
+        await validateWebhookURLAndGetIPs(dataset.remoteExperimentUrl);
       } catch (error) {
         throw new TRPCError({
           code: "BAD_REQUEST",

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -42,6 +42,8 @@ import {
   getDatasetRunsTableRowsCh,
   getDatasetRunsTableCountCh,
   validateWebhookURLAndGetIPs,
+  fetchWithSecureRedirects,
+  whitelistFromEnv,
   getDatasetRunItemsWithoutIOByItemIds,
   getDatasetItemsWithRunDataCount,
   getDatasetItemIdsWithRunData,
@@ -1763,8 +1765,11 @@ export const datasetRouter = createTRPCRouter({
         };
       }
 
+      let resolvedIPs: string[];
       try {
-        await validateWebhookURLAndGetIPs(dataset.remoteExperimentUrl);
+        resolvedIPs = await validateWebhookURLAndGetIPs(
+          dataset.remoteExperimentUrl,
+        );
       } catch (error) {
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -1773,19 +1778,28 @@ export const datasetRouter = createTRPCRouter({
       }
 
       try {
-        const response = await fetch(dataset.remoteExperimentUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
+        const redirectResult = await fetchWithSecureRedirects(
+          dataset.remoteExperimentUrl,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              projectId: input.projectId,
+              datasetId: input.datasetId,
+              datasetName: dataset.name,
+              payload: input.payload ?? dataset.remoteExperimentPayload,
+            }),
+            signal: AbortSignal.timeout(20000), // 20 second timeout
           },
-          body: JSON.stringify({
-            projectId: input.projectId,
-            datasetId: input.datasetId,
-            datasetName: dataset.name,
-            payload: input.payload ?? dataset.remoteExperimentPayload,
-          }),
-          signal: AbortSignal.timeout(20000), // 20 second timeout
-        });
+          {
+            maxRedirects: 5,
+            whitelist: whitelistFromEnv(),
+            initialResolvedIPs: resolvedIPs,
+          },
+        );
+        const response = redirectResult.response;
 
         if (!response.ok) {
           logger.info(`Remote server returned error (${response.status})`);

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -10,7 +10,7 @@ import { decrypt, encrypt } from "@langfuse/shared/encryption";
 import { posthogIntegrationFormSchema } from "@/src/features/posthog-integration/types";
 import { TRPCError } from "@trpc/server";
 import { env } from "@/src/env.mjs";
-import { validateWebhookURL } from "@langfuse/shared/src/server";
+import { validateWebhookURLAndGetIPs } from "@langfuse/shared/src/server";
 
 export const posthogIntegrationRouter = createTRPCRouter({
   get: protectedProjectProcedure
@@ -72,7 +72,7 @@ export const posthogIntegrationRouter = createTRPCRouter({
 
       // Validate PostHog hostname to prevent SSRF attacks
       try {
-        await validateWebhookURL(input.posthogHostname);
+        await validateWebhookURLAndGetIPs(input.posthogHostname);
       } catch (error) {
         throw new TRPCError({
           code: "BAD_REQUEST",

--- a/web/src/server/api/routers/utilities.ts
+++ b/web/src/server/api/routers/utilities.ts
@@ -84,6 +84,9 @@ const fetchImageUrlWithSecureRedirects = async (
             "Image URL redirect target failed security validation",
           );
         }
+        // Image URL fetches do not pin DNS today; return [] to disable pinning
+        // while preserving the generic validator contract.
+        return [];
       },
     },
   });

--- a/worker/src/__tests__/url-normalization.test.ts
+++ b/worker/src/__tests__/url-normalization.test.ts
@@ -1,19 +1,21 @@
 import { describe, it, expect } from "vitest";
-import { validateWebhookURL } from "@langfuse/shared/src/server";
+import { validateWebhookURLAndGetIPs } from "@langfuse/shared/src/server";
 
 describe("URL Normalization and Edge Cases", () => {
   describe("URL encoding bypass attempts", () => {
     it("should reject URL-encoded localhost", async () => {
       // %6C%6F%63%61%6C%68%6F%73%74 = "localhost"
       await expect(
-        validateWebhookURL("http://%6C%6F%63%61%6C%68%6F%73%74/webhook"),
+        validateWebhookURLAndGetIPs(
+          "http://%6C%6F%63%61%6C%68%6F%73%74/webhook",
+        ),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should reject double-encoded URLs", async () => {
       // Double encoding of "localhost"
       await expect(
-        validateWebhookURL(
+        validateWebhookURLAndGetIPs(
           "http://%256C%256F%2563%2561%256C%2568%256F%2573%2574/webhook",
         ),
       ).rejects.toThrow(/Invalid URL|Blocked hostname detected/);
@@ -22,21 +24,25 @@ describe("URL Normalization and Edge Cases", () => {
     it("should reject mixed case encoding", async () => {
       // Mixed case: %6c%6f%63%61%6c%68%6f%73%74 = "localhost"
       await expect(
-        validateWebhookURL("http://%6c%6f%63%61%6c%68%6f%73%74/webhook"),
+        validateWebhookURLAndGetIPs(
+          "http://%6c%6f%63%61%6c%68%6f%73%74/webhook",
+        ),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should handle partial URL encoding", async () => {
       // Partially encoded: local%68ost = "localhost"
       await expect(
-        validateWebhookURL("http://local%68ost/webhook"),
+        validateWebhookURLAndGetIPs("http://local%68ost/webhook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should reject encoded private IPs", async () => {
       // %31%39%32%2E%31%36%38%2E%31%2E%31 = "192.168.1.1"
       await expect(
-        validateWebhookURL("http://%31%39%32%2E%31%36%38%2E%31%2E%31/webhook"),
+        validateWebhookURLAndGetIPs(
+          "http://%31%39%32%2E%31%36%38%2E%31%2E%31/webhook",
+        ),
       ).rejects.toThrow("Blocked IP address detected");
     });
   });
@@ -45,7 +51,7 @@ describe("URL Normalization and Edge Cases", () => {
     it("should handle unicode domains properly", async () => {
       // These should be converted to punycode and validated
       await expect(
-        validateWebhookURL("http://тест.example.com/webhook"),
+        validateWebhookURLAndGetIPs("http://тест.example.com/webhook"),
       ).rejects.toThrow(/DNS lookup failed|Invalid URL/);
     });
 
@@ -58,7 +64,7 @@ describe("URL Normalization and Edge Cases", () => {
       ];
 
       for (const url of unicodeVariations) {
-        await expect(validateWebhookURL(url)).rejects.toThrow(
+        await expect(validateWebhookURLAndGetIPs(url)).rejects.toThrow(
           /Blocked hostname detected|Invalid URL|DNS lookup failed/,
         );
       }
@@ -66,7 +72,7 @@ describe("URL Normalization and Edge Cases", () => {
 
     it("should handle homograph attacks", async () => {
       // Cyrillic characters that look like Latin
-      await expect(validateWebhookURL("http://ӏocalhost/webhook")) // Cyrillic і that looks like l
+      await expect(validateWebhookURLAndGetIPs("http://ӏocalhost/webhook")) // Cyrillic і that looks like l
         .rejects.toThrow(/Blocked hostname detected|DNS lookup failed/);
     });
   });
@@ -74,23 +80,23 @@ describe("URL Normalization and Edge Cases", () => {
   describe("Whitespace and special character handling", () => {
     it("should trim whitespace from URLs", async () => {
       await expect(
-        validateWebhookURL("  http://localhost/webhook  "),
+        validateWebhookURLAndGetIPs("  http://localhost/webhook  "),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should handle newlines and tabs", async () => {
       await expect(
-        validateWebhookURL("http://localhost/webhook\n"),
+        validateWebhookURLAndGetIPs("http://localhost/webhook\n"),
       ).rejects.toThrow("Blocked hostname detected");
 
       await expect(
-        validateWebhookURL("http://localhost/webhook\t"),
+        validateWebhookURLAndGetIPs("http://localhost/webhook\t"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should handle URLs with unusual characters", async () => {
       await expect(
-        validateWebhookURL("http://localhost:80/../webhook"),
+        validateWebhookURLAndGetIPs("http://localhost:80/../webhook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
   });
@@ -98,55 +104,55 @@ describe("URL Normalization and Edge Cases", () => {
   describe("Protocol and port edge cases", () => {
     it("should reject case variations of protocols", async () => {
       await expect(
-        validateWebhookURL("HTTP://localhost/webhook"),
+        validateWebhookURLAndGetIPs("HTTP://localhost/webhook"),
       ).rejects.toThrow("Blocked hostname detected");
 
       await expect(
-        validateWebhookURL("hTTp://localhost/webhook"),
+        validateWebhookURLAndGetIPs("hTTp://localhost/webhook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should handle implicit ports correctly", async () => {
       // These should not be rejected for port reasons, but for hostname
       await expect(
-        validateWebhookURL("http://localhost/webhook"),
+        validateWebhookURLAndGetIPs("http://localhost/webhook"),
       ).rejects.toThrow("Blocked hostname detected");
 
       await expect(
-        validateWebhookURL("https://localhost/webhook"),
+        validateWebhookURLAndGetIPs("https://localhost/webhook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should reject non-standard port formats", async () => {
       await expect(
-        validateWebhookURL("http://example.com:08080/webhook"),
+        validateWebhookURLAndGetIPs("http://example.com:08080/webhook"),
       ).rejects.toThrow("Only ports 80 and 443 are allowed");
     });
   });
 
   describe("IPv6 edge cases", () => {
     it("should handle IPv6 with brackets", async () => {
-      await expect(validateWebhookURL("http://[::1]/webhook")).rejects.toThrow(
-        /Blocked IP address detected|ipaddr:/,
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http://[::1]/webhook"),
+      ).rejects.toThrow(/Blocked IP address detected|ipaddr:/);
     });
 
     it("should handle IPv6 without brackets in URL context", async () => {
       // This should fail URL parsing
-      await expect(validateWebhookURL("http://::1/webhook")).rejects.toThrow(
-        "Invalid URL syntax",
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http://::1/webhook"),
+      ).rejects.toThrow("Invalid URL syntax");
     });
 
     it("should handle compressed IPv6 addresses", async () => {
       await expect(
-        validateWebhookURL("http://[2001:db8::1]/webhook"),
+        validateWebhookURLAndGetIPs("http://[2001:db8::1]/webhook"),
       ).rejects.toThrow(/Blocked IP address detected|ipaddr:/);
     });
 
     it("should handle IPv4-mapped IPv6 addresses", async () => {
       await expect(
-        validateWebhookURL("http://[::ffff:192.168.1.1]/webhook"),
+        validateWebhookURLAndGetIPs("http://[::ffff:192.168.1.1]/webhook"),
       ).rejects.toThrow(/Blocked IP address detected|ipaddr:/);
     });
   });
@@ -173,14 +179,14 @@ describe("URL Normalization and Edge Cases", () => {
 
       // Test URLs that fail at parsing
       for (const url of invalidSyntaxUrls) {
-        await expect(validateWebhookURL(url)).rejects.toThrow(
+        await expect(validateWebhookURLAndGetIPs(url)).rejects.toThrow(
           /Invalid URL syntax/,
         );
       }
 
       // Test URLs that fail at DNS resolution
       for (const url of invalidDnsUrls) {
-        await expect(validateWebhookURL(url)).rejects.toThrow(
+        await expect(validateWebhookURLAndGetIPs(url)).rejects.toThrow(
           /DNS lookup failed/,
         );
       }
@@ -194,7 +200,7 @@ describe("URL Normalization and Edge Cases", () => {
       ];
 
       for (const url of invalidEncodedUrls) {
-        await expect(validateWebhookURL(url)).rejects.toThrow(
+        await expect(validateWebhookURLAndGetIPs(url)).rejects.toThrow(
           /Invalid URL|DNS lookup failed/,
         );
       }
@@ -205,30 +211,30 @@ describe("URL Normalization and Edge Cases", () => {
     it("should handle very long URLs", async () => {
       const longHostname = "a".repeat(253) + ".com"; // Max hostname length
       await expect(
-        validateWebhookURL(`https://${longHostname}/webhook`),
+        validateWebhookURLAndGetIPs(`https://${longHostname}/webhook`),
       ).rejects.toThrow(/DNS lookup failed/);
     });
 
     it("should handle URLs with many subdomains", async () => {
       const manySubdomains = Array(50).fill("sub").join(".") + ".example.com";
       await expect(
-        validateWebhookURL(`https://${manySubdomains}/webhook`),
+        validateWebhookURLAndGetIPs(`https://${manySubdomains}/webhook`),
       ).rejects.toThrow(/DNS lookup failed/);
     }, 10000);
 
     it("should handle empty hostname", async () => {
       // This URL is parsed as hostname="webhook" by URL constructor
       // so it fails during DNS resolution, not URL parsing
-      await expect(validateWebhookURL("http:///webhook")).rejects.toThrow(
-        "DNS lookup failed for webhook",
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http:///webhook"),
+      ).rejects.toThrow("DNS lookup failed for webhook");
     });
   });
 
   describe("Path and query parameter edge cases", () => {
     it("should validate hostname regardless of path", async () => {
       await expect(
-        validateWebhookURL(
+        validateWebhookURLAndGetIPs(
           "http://localhost/very/long/path/with/many/segments",
         ),
       ).rejects.toThrow("Blocked hostname detected");
@@ -236,19 +242,21 @@ describe("URL Normalization and Edge Cases", () => {
 
     it("should validate hostname regardless of query parameters", async () => {
       await expect(
-        validateWebhookURL("http://localhost/webhook?param=value&other=test"),
+        validateWebhookURLAndGetIPs(
+          "http://localhost/webhook?param=value&other=test",
+        ),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should validate hostname regardless of fragment", async () => {
       await expect(
-        validateWebhookURL("http://localhost/webhook#fragment"),
+        validateWebhookURLAndGetIPs("http://localhost/webhook#fragment"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should handle encoded path components", async () => {
       await expect(
-        validateWebhookURL("http://localhost/web%20hook"),
+        validateWebhookURLAndGetIPs("http://localhost/web%20hook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
   });
@@ -264,7 +272,7 @@ describe("URL Normalization and Edge Cases", () => {
       ];
 
       for (const url of metadataAttempts) {
-        await expect(validateWebhookURL(url)).rejects.toThrow(
+        await expect(validateWebhookURLAndGetIPs(url)).rejects.toThrow(
           /Blocked|DNS lookup failed/,
         );
       }
@@ -280,7 +288,7 @@ describe("URL Normalization and Edge Cases", () => {
       ];
 
       for (const url of internalAttempts) {
-        await expect(validateWebhookURL(url)).rejects.toThrow(
+        await expect(validateWebhookURLAndGetIPs(url)).rejects.toThrow(
           /Blocked|Only ports 80 and 443 are allowed/,
         );
       }

--- a/worker/src/__tests__/webhook-redirect.test.ts
+++ b/worker/src/__tests__/webhook-redirect.test.ts
@@ -24,7 +24,7 @@ import { randomUUID } from "crypto";
  *
  * The redirect validation implementation is in:
  * - packages/shared/src/server/outbound-url/fetch.ts (fetchWithSecureRedirects)
- * - packages/shared/src/server/webhooks/validation.ts (validateWebhookURL)
+ * - packages/shared/src/server/webhooks/validation.ts (validateWebhookURLAndGetIPs)
  */
 
 // Mock server to handle HTTP redirects

--- a/worker/src/__tests__/webhook-validation.test.ts
+++ b/worker/src/__tests__/webhook-validation.test.ts
@@ -1,115 +1,115 @@
 import { describe, it, expect } from "vitest";
-import { validateWebhookURL } from "@langfuse/shared/src/server";
+import { validateWebhookURLAndGetIPs } from "@langfuse/shared/src/server";
 
 describe("Webhook URL Validation", () => {
   describe("validateWebhookURL", () => {
     it("should accept valid public HTTPS URLs", async () => {
       await expect(
-        validateWebhookURL("https://httpbin.org/post"),
+        validateWebhookURLAndGetIPs("https://httpbin.org/post"),
       ).resolves.not.toThrow();
     });
 
     it("should accept valid public HTTP URLs", async () => {
       await expect(
-        validateWebhookURL("http://httpbin.org/post"),
+        validateWebhookURLAndGetIPs("http://httpbin.org/post"),
       ).resolves.not.toThrow();
     });
 
     it("should reject invalid URL syntax", async () => {
-      await expect(validateWebhookURL("not-a-url")).rejects.toThrow(
+      await expect(validateWebhookURLAndGetIPs("not-a-url")).rejects.toThrow(
         "Invalid URL syntax",
       );
     });
 
     it("should reject non-HTTP/HTTPS protocols", async () => {
-      await expect(validateWebhookURL("ftp://example.com")).rejects.toThrow(
-        "Only HTTP and HTTPS protocols are allowed",
-      );
-      await expect(validateWebhookURL("file:///etc/passwd")).rejects.toThrow(
-        "Only HTTP and HTTPS protocols are allowed",
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("ftp://example.com"),
+      ).rejects.toThrow("Only HTTP and HTTPS protocols are allowed");
+      await expect(
+        validateWebhookURLAndGetIPs("file:///etc/passwd"),
+      ).rejects.toThrow("Only HTTP and HTTPS protocols are allowed");
     });
 
     it("should reject disallowed ports", async () => {
       await expect(
-        validateWebhookURL("https://example.com:8080/hook"),
+        validateWebhookURLAndGetIPs("https://example.com:8080/hook"),
       ).rejects.toThrow("Only ports 80 and 443 are allowed");
       await expect(
-        validateWebhookURL("http://example.com:3000/hook"),
+        validateWebhookURLAndGetIPs("http://example.com:3000/hook"),
       ).rejects.toThrow("Only ports 80 and 443 are allowed");
     });
 
     it("should allow standard ports", async () => {
       await expect(
-        validateWebhookURL("https://httpbin.org:443/post"),
+        validateWebhookURLAndGetIPs("https://httpbin.org:443/post"),
       ).resolves.not.toThrow();
       await expect(
-        validateWebhookURL("http://httpbin.org:80/post"),
+        validateWebhookURLAndGetIPs("http://httpbin.org:80/post"),
       ).resolves.not.toThrow();
     });
 
     it("should reject localhost URLs", async () => {
-      await expect(validateWebhookURL("http://localhost/hook")).rejects.toThrow(
-        "Blocked hostname detected",
-      );
       await expect(
-        validateWebhookURL("http://test.localhost/hook"),
+        validateWebhookURLAndGetIPs("http://localhost/hook"),
+      ).rejects.toThrow("Blocked hostname detected");
+      await expect(
+        validateWebhookURLAndGetIPs("http://test.localhost/hook"),
       ).rejects.toThrow("Blocked hostname detected");
       // Generic error message without IP address
       await expect(
-        validateWebhookURL("https://127.0.0.1/hook"),
+        validateWebhookURLAndGetIPs("https://127.0.0.1/hook"),
       ).rejects.toThrow("Blocked IP address detected");
-      await expect(validateWebhookURL("http://[::1]/hook")).rejects.toThrow(
-        /Blocked IP address detected|ipaddr:/,
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http://[::1]/hook"),
+      ).rejects.toThrow(/Blocked IP address detected|ipaddr:/);
     });
 
     it("should reject private network URLs", async () => {
       // Generic error messages without exposing IP addresses
       await expect(
-        validateWebhookURL("http://192.168.1.1/hook"),
+        validateWebhookURLAndGetIPs("http://192.168.1.1/hook"),
       ).rejects.toThrow("Blocked IP address detected");
-      await expect(validateWebhookURL("http://10.0.0.1/hook")).rejects.toThrow(
-        "Blocked IP address detected",
-      );
       await expect(
-        validateWebhookURL("http://172.16.0.1/hook"),
+        validateWebhookURLAndGetIPs("http://10.0.0.1/hook"),
+      ).rejects.toThrow("Blocked IP address detected");
+      await expect(
+        validateWebhookURLAndGetIPs("http://172.16.0.1/hook"),
       ).rejects.toThrow("Blocked IP address detected");
     });
 
     it("should reject link-local addresses", async () => {
       await expect(
-        validateWebhookURL("http://169.254.169.254/hook"),
+        validateWebhookURLAndGetIPs("http://169.254.169.254/hook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should reject multicast addresses", async () => {
       // Generic error message without exposing IP address
-      await expect(validateWebhookURL("http://224.0.0.1/hook")).rejects.toThrow(
-        "Blocked IP address detected",
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http://224.0.0.1/hook"),
+      ).rejects.toThrow("Blocked IP address detected");
     });
 
     it("should reject broadcast addresses", async () => {
       // Generic error message without exposing IP address
       await expect(
-        validateWebhookURL("http://255.255.255.255/hook"),
+        validateWebhookURLAndGetIPs("http://255.255.255.255/hook"),
       ).rejects.toThrow("Blocked IP address detected");
     });
 
     it("should reject IPv6 private addresses", async () => {
       // Generic error messages without exposing IP addresses
-      await expect(validateWebhookURL("http://[fc00::1]/hook")).rejects.toThrow(
-        /Blocked IP address detected|ipaddr:/,
-      );
-      await expect(validateWebhookURL("http://[fe80::1]/hook")).rejects.toThrow(
-        /Blocked IP address detected|ipaddr:/,
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http://[fc00::1]/hook"),
+      ).rejects.toThrow(/Blocked IP address detected|ipaddr:/);
+      await expect(
+        validateWebhookURLAndGetIPs("http://[fe80::1]/hook"),
+      ).rejects.toThrow(/Blocked IP address detected|ipaddr:/);
     });
 
     it("should handle DNS resolution failures gracefully", async () => {
       await expect(
-        validateWebhookURL(
+        validateWebhookURLAndGetIPs(
           "https://this-domain-definitely-does-not-exist-12345.com/hook",
         ),
       ).rejects.toThrow("DNS lookup failed");
@@ -118,7 +118,7 @@ describe("Webhook URL Validation", () => {
     it("should reject URL-encoded localhost bypass attempts", async () => {
       // %6C%6F%63%61%6C%68%6F%73%74 decodes to "localhost" but fails on port check first
       await expect(
-        validateWebhookURL("http://%6C%6F%63%61%6C%68%6F%73%74/hook"),
+        validateWebhookURLAndGetIPs("http://%6C%6F%63%61%6C%68%6F%73%74/hook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
@@ -126,31 +126,31 @@ describe("Webhook URL Validation", () => {
       // Note: "internal.company.com" would require DNS resolution which can timeout
       // Using domains that match blocked patterns directly for faster tests
       await expect(
-        validateWebhookURL("http://service.internal/hook"),
+        validateWebhookURLAndGetIPs("http://service.internal/hook"),
       ).rejects.toThrow("Blocked hostname detected");
       await expect(
-        validateWebhookURL("http://app.internal/hook"),
+        validateWebhookURLAndGetIPs("http://app.internal/hook"),
       ).rejects.toThrow("Blocked hostname detected");
-      await expect(validateWebhookURL("http://intranet/hook")).rejects.toThrow(
-        "Blocked hostname detected",
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http://intranet/hook"),
+      ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should reject docker internal hostnames", async () => {
       await expect(
-        validateWebhookURL("http://host.docker.internal/hook"),
+        validateWebhookURLAndGetIPs("http://host.docker.internal/hook"),
       ).rejects.toThrow("Blocked hostname detected");
       await expect(
-        validateWebhookURL("http://gateway.docker.internal/hook"),
+        validateWebhookURLAndGetIPs("http://gateway.docker.internal/hook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should reject cloud metadata endpoints", async () => {
       await expect(
-        validateWebhookURL("http://metadata.google.internal/hook"),
+        validateWebhookURLAndGetIPs("http://metadata.google.internal/hook"),
       ).rejects.toThrow("Blocked hostname detected");
       await expect(
-        validateWebhookURL("http://[fd00:ec2::254]/hook"),
+        validateWebhookURLAndGetIPs("http://[fd00:ec2::254]/hook"),
       ).rejects.toThrow(
         /Blocked hostname detected|Blocked IP address detected/,
       );
@@ -158,27 +158,27 @@ describe("Webhook URL Validation", () => {
 
     it("should handle malformed URL encoding", async () => {
       await expect(
-        validateWebhookURL("http://exam%ple.com/hook"),
+        validateWebhookURLAndGetIPs("http://exam%ple.com/hook"),
       ).rejects.toThrow(/Invalid URL encoding|Invalid URL syntax/);
     });
 
     it("should allow local hostname, if it is included in the whitelist", async () => {
       await expect(
-        validateWebhookURL("http://internal.company.com/hook", {
+        validateWebhookURLAndGetIPs("http://internal.company.com/hook", {
           hosts: ["internal.company.com"],
           ips: [],
           ip_ranges: [],
         }),
       ).resolves.not.toThrow();
       await expect(
-        validateWebhookURL("http://app.internal/hook", {
+        validateWebhookURLAndGetIPs("http://app.internal/hook", {
           hosts: ["app.internal"],
           ips: [],
           ip_ranges: [],
         }),
       ).resolves.not.toThrow();
       await expect(
-        validateWebhookURL("http://intranet/hook", {
+        validateWebhookURLAndGetIPs("http://intranet/hook", {
           hosts: ["intranet"],
           ips: [],
           ip_ranges: [],

--- a/worker/src/__tests__/webhook-validation.test.ts
+++ b/worker/src/__tests__/webhook-validation.test.ts
@@ -23,7 +23,7 @@ vi.mock("node:dns/promises", () => ({
   lookup: lookupMock,
 }));
 
-import { validateWebhookURL } from "../../../packages/shared/src/server/webhooks/validation";
+import { validateWebhookURLAndGetIPs } from "@langfuse/shared/src/server";
 
 const nonexistentDomain = "this-domain-definitely-does-not-exist-12345.com";
 
@@ -54,111 +54,111 @@ describe("Webhook URL Validation", () => {
   describe("validateWebhookURL", () => {
     it("should accept valid public HTTPS URLs", async () => {
       await expect(
-        validateWebhookURL("https://httpbin.org/post"),
+        validateWebhookURLAndGetIPs("https://httpbin.org/post"),
       ).resolves.not.toThrow();
     });
 
     it("should accept valid public HTTP URLs", async () => {
       await expect(
-        validateWebhookURL("http://httpbin.org/post"),
+        validateWebhookURLAndGetIPs("http://httpbin.org/post"),
       ).resolves.not.toThrow();
     });
 
     it("should reject invalid URL syntax", async () => {
-      await expect(validateWebhookURL("not-a-url")).rejects.toThrow(
+      await expect(validateWebhookURLAndGetIPs("not-a-url")).rejects.toThrow(
         "Invalid URL syntax",
       );
     });
 
     it("should reject non-HTTP/HTTPS protocols", async () => {
-      await expect(validateWebhookURL("ftp://example.com")).rejects.toThrow(
-        "Only HTTP and HTTPS protocols are allowed",
-      );
-      await expect(validateWebhookURL("file:///etc/passwd")).rejects.toThrow(
-        "Only HTTP and HTTPS protocols are allowed",
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("ftp://example.com"),
+      ).rejects.toThrow("Only HTTP and HTTPS protocols are allowed");
+      await expect(
+        validateWebhookURLAndGetIPs("file:///etc/passwd"),
+      ).rejects.toThrow("Only HTTP and HTTPS protocols are allowed");
     });
 
     it("should reject disallowed ports", async () => {
       await expect(
-        validateWebhookURL("https://example.com:8080/hook"),
+        validateWebhookURLAndGetIPs("https://example.com:8080/hook"),
       ).rejects.toThrow("Only ports 80 and 443 are allowed");
       await expect(
-        validateWebhookURL("http://example.com:3000/hook"),
+        validateWebhookURLAndGetIPs("http://example.com:3000/hook"),
       ).rejects.toThrow("Only ports 80 and 443 are allowed");
     });
 
     it("should allow standard ports", async () => {
       await expect(
-        validateWebhookURL("https://httpbin.org:443/post"),
+        validateWebhookURLAndGetIPs("https://httpbin.org:443/post"),
       ).resolves.not.toThrow();
       await expect(
-        validateWebhookURL("http://httpbin.org:80/post"),
+        validateWebhookURLAndGetIPs("http://httpbin.org:80/post"),
       ).resolves.not.toThrow();
     });
 
     it("should reject localhost URLs", async () => {
-      await expect(validateWebhookURL("http://localhost/hook")).rejects.toThrow(
-        "Blocked hostname detected",
-      );
       await expect(
-        validateWebhookURL("http://test.localhost/hook"),
+        validateWebhookURLAndGetIPs("http://localhost/hook"),
+      ).rejects.toThrow("Blocked hostname detected");
+      await expect(
+        validateWebhookURLAndGetIPs("http://test.localhost/hook"),
       ).rejects.toThrow("Blocked hostname detected");
       // Generic error message without IP address
       await expect(
-        validateWebhookURL("https://127.0.0.1/hook"),
+        validateWebhookURLAndGetIPs("https://127.0.0.1/hook"),
       ).rejects.toThrow("Blocked IP address detected");
-      await expect(validateWebhookURL("http://[::1]/hook")).rejects.toThrow(
-        /Blocked IP address detected|ipaddr:/,
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http://[::1]/hook"),
+      ).rejects.toThrow(/Blocked IP address detected|ipaddr:/);
     });
 
     it("should reject private network URLs", async () => {
       // Generic error messages without exposing IP addresses
       await expect(
-        validateWebhookURL("http://192.168.1.1/hook"),
+        validateWebhookURLAndGetIPs("http://192.168.1.1/hook"),
       ).rejects.toThrow("Blocked IP address detected");
-      await expect(validateWebhookURL("http://10.0.0.1/hook")).rejects.toThrow(
-        "Blocked IP address detected",
-      );
       await expect(
-        validateWebhookURL("http://172.16.0.1/hook"),
+        validateWebhookURLAndGetIPs("http://10.0.0.1/hook"),
+      ).rejects.toThrow("Blocked IP address detected");
+      await expect(
+        validateWebhookURLAndGetIPs("http://172.16.0.1/hook"),
       ).rejects.toThrow("Blocked IP address detected");
     });
 
     it("should reject link-local addresses", async () => {
       await expect(
-        validateWebhookURL("http://169.254.169.254/hook"),
+        validateWebhookURLAndGetIPs("http://169.254.169.254/hook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should reject multicast addresses", async () => {
       // Generic error message without exposing IP address
-      await expect(validateWebhookURL("http://224.0.0.1/hook")).rejects.toThrow(
-        "Blocked IP address detected",
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http://224.0.0.1/hook"),
+      ).rejects.toThrow("Blocked IP address detected");
     });
 
     it("should reject broadcast addresses", async () => {
       // Generic error message without exposing IP address
       await expect(
-        validateWebhookURL("http://255.255.255.255/hook"),
+        validateWebhookURLAndGetIPs("http://255.255.255.255/hook"),
       ).rejects.toThrow("Blocked IP address detected");
     });
 
     it("should reject IPv6 private addresses", async () => {
       // Generic error messages without exposing IP addresses
-      await expect(validateWebhookURL("http://[fc00::1]/hook")).rejects.toThrow(
-        /Blocked IP address detected|ipaddr:/,
-      );
-      await expect(validateWebhookURL("http://[fe80::1]/hook")).rejects.toThrow(
-        /Blocked IP address detected|ipaddr:/,
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http://[fc00::1]/hook"),
+      ).rejects.toThrow(/Blocked IP address detected|ipaddr:/);
+      await expect(
+        validateWebhookURLAndGetIPs("http://[fe80::1]/hook"),
+      ).rejects.toThrow(/Blocked IP address detected|ipaddr:/);
     });
 
     it("should handle DNS resolution failures gracefully", async () => {
       await expect(
-        validateWebhookURL(`https://${nonexistentDomain}/hook`),
+        validateWebhookURLAndGetIPs(`https://${nonexistentDomain}/hook`),
       ).rejects.toThrow("DNS lookup failed");
       expect(resolve4Mock).toHaveBeenCalledWith(nonexistentDomain);
       expect(resolve6Mock).toHaveBeenCalledWith(nonexistentDomain);
@@ -170,7 +170,7 @@ describe("Webhook URL Validation", () => {
     it("should reject URL-encoded localhost bypass attempts", async () => {
       // %6C%6F%63%61%6C%68%6F%73%74 decodes to "localhost" but fails on port check first
       await expect(
-        validateWebhookURL("http://%6C%6F%63%61%6C%68%6F%73%74/hook"),
+        validateWebhookURLAndGetIPs("http://%6C%6F%63%61%6C%68%6F%73%74/hook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
@@ -213,31 +213,31 @@ describe("Webhook URL Validation", () => {
       // Note: "internal.company.com" would require DNS resolution which can timeout
       // Using domains that match blocked patterns directly for faster tests
       await expect(
-        validateWebhookURL("http://service.internal/hook"),
+        validateWebhookURLAndGetIPs("http://service.internal/hook"),
       ).rejects.toThrow("Blocked hostname detected");
       await expect(
-        validateWebhookURL("http://app.internal/hook"),
+        validateWebhookURLAndGetIPs("http://app.internal/hook"),
       ).rejects.toThrow("Blocked hostname detected");
-      await expect(validateWebhookURL("http://intranet/hook")).rejects.toThrow(
-        "Blocked hostname detected",
-      );
+      await expect(
+        validateWebhookURLAndGetIPs("http://intranet/hook"),
+      ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should reject docker internal hostnames", async () => {
       await expect(
-        validateWebhookURL("http://host.docker.internal/hook"),
+        validateWebhookURLAndGetIPs("http://host.docker.internal/hook"),
       ).rejects.toThrow("Blocked hostname detected");
       await expect(
-        validateWebhookURL("http://gateway.docker.internal/hook"),
+        validateWebhookURLAndGetIPs("http://gateway.docker.internal/hook"),
       ).rejects.toThrow("Blocked hostname detected");
     });
 
     it("should reject cloud metadata endpoints", async () => {
       await expect(
-        validateWebhookURL("http://metadata.google.internal/hook"),
+        validateWebhookURLAndGetIPs("http://metadata.google.internal/hook"),
       ).rejects.toThrow("Blocked hostname detected");
       await expect(
-        validateWebhookURL("http://[fd00:ec2::254]/hook"),
+        validateWebhookURLAndGetIPs("http://[fd00:ec2::254]/hook"),
       ).rejects.toThrow(
         /Blocked hostname detected|Blocked IP address detected/,
       );
@@ -245,27 +245,27 @@ describe("Webhook URL Validation", () => {
 
     it("should handle malformed URL encoding", async () => {
       await expect(
-        validateWebhookURL("http://exam%ple.com/hook"),
+        validateWebhookURLAndGetIPs("http://exam%ple.com/hook"),
       ).rejects.toThrow(/Invalid URL encoding|Invalid URL syntax/);
     });
 
     it("should allow local hostname, if it is included in the whitelist", async () => {
       await expect(
-        validateWebhookURL("http://internal.company.com/hook", {
+        validateWebhookURLAndGetIPs("http://internal.company.com/hook", {
           hosts: ["internal.company.com"],
           ips: [],
           ip_ranges: [],
         }),
       ).resolves.not.toThrow();
       await expect(
-        validateWebhookURL("http://app.internal/hook", {
+        validateWebhookURLAndGetIPs("http://app.internal/hook", {
           hosts: ["app.internal"],
           ips: [],
           ip_ranges: [],
         }),
       ).resolves.not.toThrow();
       await expect(
-        validateWebhookURL("http://intranet/hook", {
+        validateWebhookURLAndGetIPs("http://intranet/hook", {
           hosts: ["intranet"],
           ips: [],
           ip_ranges: [],

--- a/worker/src/__tests__/webhook-validation.test.ts
+++ b/worker/src/__tests__/webhook-validation.test.ts
@@ -23,7 +23,7 @@ vi.mock("node:dns/promises", () => ({
   lookup: lookupMock,
 }));
 
-import { validateWebhookURLAndGetIPs } from "@langfuse/shared/src/server";
+import { validateWebhookURLAndGetIPs } from "../../../packages/shared/src/server/webhooks/validation";
 
 const nonexistentDomain = "this-domain-definitely-does-not-exist-12345.com";
 

--- a/worker/src/__tests__/webhook-validation.test.ts
+++ b/worker/src/__tests__/webhook-validation.test.ts
@@ -182,7 +182,9 @@ describe("Webhook URL Validation", () => {
 
       for (const delimiter of encodedDelimiters) {
         await expect(
-          validateWebhookURL(`http://example.com${delimiter}@127.0.0.1/hook`),
+          validateWebhookURLAndGetIPs(
+            `http://example.com${delimiter}@127.0.0.1/hook`,
+          ),
         ).rejects.toThrow(
           "URL credentials are not allowed. Use authentication headers instead.",
         );
@@ -191,7 +193,7 @@ describe("Webhook URL Validation", () => {
 
     it("should reject URLs with embedded credentials", async () => {
       await expect(
-        validateWebhookURL("https://user:pass@example.com/hook"),
+        validateWebhookURLAndGetIPs("https://user:pass@example.com/hook"),
       ).rejects.toThrow(
         "URL credentials are not allowed. Use authentication headers instead.",
       );
@@ -199,7 +201,7 @@ describe("Webhook URL Validation", () => {
 
     it("should validate IDN hostnames using their punycoded hostname", async () => {
       await expect(
-        validateWebhookURL("http://тест.example.com/hook"),
+        validateWebhookURLAndGetIPs("http://тест.example.com/hook"),
       ).resolves.not.toThrow();
 
       expect(resolve4Mock).toHaveBeenCalledWith("xn--e1aybc.example.com");

--- a/worker/src/__tests__/webhooks.test.ts
+++ b/worker/src/__tests__/webhooks.test.ts
@@ -524,7 +524,6 @@ describe("Webhook Integration Tests", () => {
       );
       expect(execution?.output).toMatchObject({
         httpStatus: 500,
-        responseBody: '{"error":"Internal Server Error"}',
       });
     });
 

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -9,7 +9,7 @@ import {
   getScoresForAnalyticsIntegrations,
   getEventsForAnalyticsIntegrations,
   getCurrentSpan,
-  validateWebhookURL,
+  validateWebhookURLAndGetIPs,
 } from "@langfuse/shared/src/server";
 import {
   transformTraceForPostHog,
@@ -264,7 +264,7 @@ export const handlePostHogIntegrationProjectJob = async (
 
   // Validate PostHog hostname to prevent SSRF attacks before sending data
   try {
-    await validateWebhookURL(postHogIntegration.posthogHostName);
+    await validateWebhookURLAndGetIPs(postHogIntegration.posthogHostName);
   } catch (error) {
     logger.error(
       `[POSTHOG] PostHog integration for project ${projectId} has invalid hostname: ${postHogIntegration.posthogHostName}. Error: ${error instanceof Error ? error.message : String(error)}`,

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -9,7 +9,7 @@ import {
   getScoresForAnalyticsIntegrations,
   getEventsForAnalyticsIntegrations,
   getCurrentSpan,
-  validateWebhookURL,
+  validateWebhookURLAndGetIPs,
 } from "@langfuse/shared/src/server";
 import {
   transformTraceForPostHog,
@@ -271,7 +271,7 @@ export const handlePostHogIntegrationProjectJob = async (
 
   // Validate PostHog hostname to prevent SSRF attacks before sending data
   try {
-    await validateWebhookURL(postHogIntegration.posthogHostName);
+    await validateWebhookURLAndGetIPs(postHogIntegration.posthogHostName);
   } catch (error) {
     logger.error(
       `[POSTHOG] PostHog integration for project ${projectId} has invalid hostname: ${postHogIntegration.posthogHostName}. Error: ${error instanceof Error ? error.message : String(error)}`,

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -269,7 +269,12 @@ export const handlePostHogIntegrationProjectJob = async (
     return;
   }
 
-  // Validate PostHog hostname to prevent SSRF attacks before sending data
+  // Validate PostHog hostname to prevent SSRF attacks before sending data.
+  // The resolved IPs returned here are intentionally unused: posthog-node does
+  // not expose a custom DNS resolver or undici dispatcher, so DNS pinning would
+  // require replacing the SDK calls with raw fetch + createPinnedAgent.
+  // A small TOCTOU window between this check and the SDK's own DNS lookup
+  // remains and is a known limitation of the PostHog SDK dependency.
   try {
     await validateWebhookURLAndGetIPs(postHogIntegration.posthogHostName);
   } catch (error) {

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -258,12 +258,10 @@ async function executeHttpAction({
           startedAt: executionStart,
           finishedAt: new Date(),
           error: error instanceof Error ? error.message : "Unknown error",
-          output: httpStatus
-            ? {
-                httpStatus,
-                responseBody: responseBody?.substring(0, 1000),
-              }
-            : undefined,
+          // Do not persist the external response body: a hostile endpoint could
+          // echo data from an internal service reached via SSRF before a
+          // redirect is blocked, turning this column into an exfiltration channel.
+          output: httpStatus ? { httpStatus } : undefined,
         },
       });
 

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -14,7 +14,7 @@ import {
 import { decrypt, createSignatureHeader } from "@langfuse/shared/encryption";
 import { prisma } from "@langfuse/shared/src/db";
 import {
-  validateWebhookURL,
+  validateWebhookURLAndGetIPs,
   whitelistFromEnv,
   fetchWithSecureRedirects,
 } from "@langfuse/shared/src/server";
@@ -144,9 +144,10 @@ async function executeHttpAction({
         }, env.LANGFUSE_WEBHOOK_TIMEOUT_MS);
 
         try {
-          // Skip validation when flag is set (for tests with MSW mocking)
+          // Validate URL and obtain resolved IPs for DNS pinning
+          let resolvedIPs: string[] | undefined;
           if (!skipValidation) {
-            await validateWebhookURL(url);
+            resolvedIPs = await validateWebhookURLAndGetIPs(url);
           }
 
           const redirectResult = await fetchWithSecureRedirects(
@@ -161,6 +162,7 @@ async function executeHttpAction({
               maxRedirects: env.LANGFUSE_WEBHOOK_MAX_REDIRECTS,
               skipValidation,
               whitelist: whitelistFromEnv(),
+              initialResolvedIPs: resolvedIPs,
             },
           );
 

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -14,7 +14,7 @@ import {
 import { decrypt, createSignatureHeader } from "@langfuse/shared/encryption";
 import { Prisma, prisma } from "@langfuse/shared/src/db";
 import {
-  validateWebhookURL,
+  validateWebhookURLAndGetIPs,
   whitelistFromEnv,
   fetchWithSecureRedirects,
 } from "@langfuse/shared/src/server";
@@ -148,9 +148,11 @@ async function executeHttpAction({
         try {
           const whitelist = whitelistFromEnv();
 
-          // Skip validation when flag is set (for tests with MSW mocking)
+          // Validate URL and obtain resolved IPs for DNS pinning. Skipped in
+          // tests where the URL is mocked via MSW.
+          let resolvedIPs: string[] | undefined;
           if (!skipValidation) {
-            await validateWebhookURL(url, whitelist);
+            resolvedIPs = await validateWebhookURLAndGetIPs(url, whitelist);
           }
 
           const redirectOptions = skipValidation
@@ -162,8 +164,9 @@ async function executeHttpAction({
             : {
                 maxRedirects: env.LANGFUSE_WEBHOOK_MAX_REDIRECTS,
                 redirectValidation: {
-                  validateUrl: validateWebhookURL,
+                  validateUrl: validateWebhookURLAndGetIPs,
                   whitelist,
+                  initialResolvedIPs: resolvedIPs,
                 },
                 additionalSensitiveHeaders,
               };

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -274,12 +274,10 @@ async function executeHttpAction({
           startedAt: executionStart,
           finishedAt: new Date(),
           error: error instanceof Error ? error.message : "Unknown error",
-          output: httpStatus
-            ? {
-                httpStatus,
-                responseBody: responseBody?.substring(0, 1000),
-              }
-            : undefined,
+          // Do not persist the external response body: a hostile endpoint could
+          // echo data from an internal service reached via SSRF before a
+          // redirect is blocked, turning this column into an exfiltration channel.
+          output: httpStatus ? { httpStatus } : undefined,
         },
       });
 


### PR DESCRIPTION
## Summary

- **Pin DNS resolution** between SSRF validation and HTTP requests using a custom undici `Agent` with a `lookup` override, preventing DNS rebinding attacks
- **Strip response bodies** from webhook error output (`automationExecution.output`) to close the exfiltration channel
- **Re-validate LLM base URLs at call time**, not just save time, and pin DNS on SDK dispatchers (Anthropic, OpenAI, Azure)
- Skip IP pinning when `HTTPS_PROXY` is configured (proxy handles routing)

### Impacted packages
- `@langfuse/shared` — `webhooks/validation.ts`, `webhooks/redirectHandler.ts`, `webhooks/pinnedAgent.ts` (new), `llm/baseUrlValidation.ts`, `llm/fetchLLMCompletion.ts`
- `worker` — `queues/webhooks.ts`
- `web` — callers of renamed `validateWebhookURLAndGetIPs`

### Verification
- `pnpm --filter @langfuse/shared run lint` ✅
- `pnpm --filter worker run lint` ✅
- `pnpm --filter web run lint` ✅
- Pre-commit hooks (format + turbo lint) ✅

## Test plan

- [ ] Verify webhook delivery still works on staging (happy path)
- [ ] Verify LLM-as-a-judge evaluations still complete against custom base URLs
- [ ] Verify webhook error executions no longer contain `responseBody` in output
- [ ] Verify PostHog integration and dataset remote experiments still function
- [ ] Confirm no regressions when `HTTPS_PROXY` is set (pinning should be skipped)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR closes the SSRF TOCTOU gap by pinning DNS resolution between validation and the actual HTTP request: `validateWebhookURL` is renamed to `validateWebhookURLAndGetIPs` and now returns resolved IPs, a new `createPinnedAgent` utility locks the undici dispatcher to those IPs, and LLM base URLs are re-validated at call time. Two issues need attention before merge:

- **Missing try-catch in `validation.ts`** (line 83): calling `resolveHost(hostname)` without error handling for whitelisted hosts is a regression — transient DNS failures now block webhook delivery to hosts that previously always passed. `baseUrlValidation.ts` already handles the equivalent case with `catch { return []; }`.
- **`responseBody` still persisted in `automationExecution.output`**: the PR description promises this exfiltration channel is closed, but `worker/src/queues/webhooks.ts` still writes up to 1 000 chars of the external server's response body on error.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the whitelisted-host try-catch regression and verifying the response-body stripping is either implemented or intentionally deferred.

Two P1 findings: the missing try-catch in validation.ts is a behavioral regression for whitelisted hosts, and responseBody still being written to automationExecution.output contradicts the stated security fix. The core DNS-pinning mechanism is well-implemented and the TOCTOU gap is genuinely closed for the non-whitelisted path.

packages/shared/src/server/webhooks/validation.ts (line 83) and worker/src/queues/webhooks.ts (lines 261–265)

<details open><summary><h3>Security Review</h3></summary>

- **Exfiltration channel not closed** (`worker/src/queues/webhooks.ts` lines 261–265): up to 1 000 chars of the HTTP response body from the external server are persisted in `automationExecution.output` on webhook failure. An attacker controlling a redirect destination could echo back data from an internal service reached before the redirect is blocked.
- **DNS pinning gap for whitelisted hosts** (`packages/shared/src/server/webhooks/validation.ts` line 83): if DNS resolution throws for a whitelisted hostname, the validation error propagates rather than falling back to unpinned delivery. This is a correctness regression, not an active bypass, but it reduces the reliability of the security layer for users relying on the whitelist.
- The core TOCTOU fix (DNS pinning via undici dispatcher) is sound; no bypass of the blocking checks was introduced.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/shared/src/server/webhooks/validation.ts | Renamed to `validateWebhookURLAndGetIPs` and now returns resolved IPs; whitelisted-host DNS resolution on line 83 is missing a try-catch, introducing a regression where transient DNS failures break previously-whitelisted webhooks. |
| worker/src/queues/webhooks.ts | Passes resolved IPs to fetchWithSecureRedirects for pinning; however `responseBody` is still persisted in `automationExecution.output` on error, contradicting the PR description's claim of stripping it. |
| packages/shared/src/server/webhooks/pinnedAgent.ts | New utility that pins DNS by returning a pre-validated IP from the lookup callback; only uses the first IP in the array (by design). |
| packages/shared/src/server/webhooks/redirectHandler.ts | DNS pinning applied per redirect hop using validated IPs; minor concern about `agent.close()` in finally possibly masking fetch errors. |
| packages/shared/src/server/llm/baseUrlValidation.ts | Correctly returns resolved IPs for pinning; whitelisted-host DNS failures handled with try-catch returning `[]`, consistent with best-effort semantics. |
| packages/shared/src/server/llm/fetchLLMCompletion.ts | Re-validates base URL at call time and creates pinned dispatcher; properly closes pinned agent in finally; proxy case correctly bypasses pinning. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant validateWebhookURLAndGetIPs
    participant DNS
    participant createPinnedAgent
    participant fetchWithSecureRedirects
    participant ExternalServer

    Caller->>validateWebhookURLAndGetIPs: url
    validateWebhookURLAndGetIPs->>DNS: resolve(hostname)
    DNS-->>validateWebhookURLAndGetIPs: [ip1, ip2, ...]
    validateWebhookURLAndGetIPs->>validateWebhookURLAndGetIPs: check each IP against blocklist
    validateWebhookURLAndGetIPs-->>Caller: resolvedIPs[]

    Caller->>createPinnedAgent: resolvedIPs[0]
    createPinnedAgent-->>Caller: Agent (lookup → fixed IP)

    Caller->>fetchWithSecureRedirects: url + initialResolvedIPs
    loop Each hop (incl. redirects)
        fetchWithSecureRedirects->>createPinnedAgent: currentResolvedIPs[0]
        createPinnedAgent-->>fetchWithSecureRedirects: pinnedAgent
        fetchWithSecureRedirects->>ExternalServer: fetch(url, dispatcher=pinnedAgent)
        ExternalServer-->>fetchWithSecureRedirects: response
        fetchWithSecureRedirects->>fetchWithSecureRedirects: agent.close()
        alt 3xx redirect
            fetchWithSecureRedirects->>validateWebhookURLAndGetIPs: redirectUrl
            validateWebhookURLAndGetIPs->>DNS: resolve(redirectHostname)
            DNS-->>validateWebhookURLAndGetIPs: [newIPs]
            validateWebhookURLAndGetIPs-->>fetchWithSecureRedirects: newResolvedIPs
        end
    end
    fetchWithSecureRedirects-->>Caller: RedirectResult
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `worker/src/queues/webhooks.ts`, line 261-265 ([link](https://github.com/langfuse/langfuse/blob/e1675299dc9dd8ee39eaf15345b019f630a66f1f/worker/src/queues/webhooks.ts#L261-L265)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **Response body still written to `automationExecution.output`**

   The PR description lists "Strip response bodies from webhook error output to close the exfiltration channel" as a delivered change, but `responseBody` (up to 1 000 chars of the external server's response) is still persisted in the `output` column on failure. An attacker who controls a webhook endpoint can use this to exfiltrate data from internal services that SSRF reaches before a redirect is blocked. The stripping fix described in the PR summary appears to have been left out.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: worker/src/queues/webhooks.ts
   Line: 261-265

   Comment:
   **Response body still written to `automationExecution.output`**

   The PR description lists "Strip response bodies from webhook error output to close the exfiltration channel" as a delivered change, but `responseBody` (up to 1 000 chars of the external server's response) is still persisted in the `output` column on failure. An attacker who controls a webhook endpoint can use this to exfiltrate data from internal services that SSRF reaches before a redirect is blocked. The stripping fix described in the PR summary appears to have been left out.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/shared/src/server/webhooks/validation.ts
Line: 83

Comment:
**Missing try-catch for whitelisted host DNS resolution**

`resolveHost(hostname)` can throw `"DNS lookup failed for <hostname>"` when both A and AAAA queries fail. Before this PR, a whitelisted host always passed validation immediately (no DNS call). Now, a transient DNS failure on a whitelisted hostname blocks the webhook entirely — a regression. `baseUrlValidation.ts` handles the same case with a silent `catch { return []; }`, but this path does not.

```suggestion
    return resolveHost(hostname).catch(() => []);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: worker/src/queues/webhooks.ts
Line: 261-265

Comment:
**Response body still written to `automationExecution.output`**

The PR description lists "Strip response bodies from webhook error output to close the exfiltration channel" as a delivered change, but `responseBody` (up to 1 000 chars of the external server's response) is still persisted in the `output` column on failure. An attacker who controls a webhook endpoint can use this to exfiltrate data from internal services that SSRF reaches before a redirect is blocked. The stripping fix described in the PR summary appears to have been left out.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/shared/src/server/webhooks/pinnedAgent.ts
Line: 10

Comment:
**Only first resolved IP is used; others are silently discarded**

`resolvedIPs[0]` is chosen arbitrarily. When a hostname resolves to multiple IPs and the first is momentarily unreachable, the request fails without trying the alternatives. This is a deliberate security tradeoff (trying multiple IPs could be abused in a multi-step SSRF), but it should be documented in a comment so future maintainers don't "fix" it accidentally.

```suggestion
  // Deliberately use only the first validated IP.
  // Cycling through alternates could allow a DNS-rebinding attacker to
  // smuggle a malicious IP into the retry path, so we pin to one address.
  const ip = resolvedIPs[0];
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/shared/src/server/webhooks/redirectHandler.ts
Line: 139-145

Comment:
**`finally` close can mask fetch errors or silently drop a successful response**

If `agent?.close()` rejects in the `finally` block, its error replaces any error thrown by `fetch` and the successful `response` assignment is also lost. In practice undici `Agent.close()` is unlikely to throw, but adding a `catch` is defensive:

```suggestion
    let response: Response;
    try {
      response = await fetch(currentUrl, fetchOptions);
    } finally {
      await agent?.close().catch(() => undefined);
    }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): close SSRF TOCTOU gap wit..."](https://github.com/langfuse/langfuse/commit/e1675299dc9dd8ee39eaf15345b019f630a66f1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28649510)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->