### PR TITLE
fix: block private IPv6 variants in image URL validation

### DIFF
--- a/web/src/__tests__/server/utilities-router.servertest.ts
+++ b/web/src/__tests__/server/utilities-router.servertest.ts
@@ -1,0 +1,67 @@
+/** @jest-environment node */
+
+jest.mock("dns", () => ({
+  promises: {
+    resolve4: jest.fn(),
+    resolve6: jest.fn(),
+  },
+}));
+
+import { promises as dns } from "dns";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+
+const mockedResolve4 = jest.mocked(dns.resolve4);
+const mockedResolve6 = jest.mocked(dns.resolve6);
+
+describe("utilities.validateImgUrl", () => {
+  const caller = appRouter.createCaller(
+    createInnerTRPCContext({
+      session: {
+        expires: "1",
+        user: {
+          id: "user-1",
+          organizations: [],
+          featureFlags: {},
+          admin: false,
+        },
+      } as any,
+      headers: {},
+    }),
+  );
+
+  beforeEach(() => {
+    mockedResolve4.mockReset();
+    mockedResolve6.mockReset();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-type" ? "image/png" : null,
+      },
+    }) as any;
+  });
+
+  it("should reject hostnames that resolve to an IPv6 unique local address", async () => {
+    mockedResolve4.mockResolvedValue([]);
+    mockedResolve6.mockResolvedValue(["fd12::1"]);
+
+    await expect(
+      caller.utilities.validateImgUrl(
+        "https://ula-only.example.test/image.png",
+      ),
+    ).resolves.toEqual({ isValid: false });
+  });
+
+  it("should reject hostnames that resolve to an IPv4-mapped private IPv6 address", async () => {
+    mockedResolve4.mockResolvedValue([]);
+    mockedResolve6.mockResolvedValue(["::ffff:10.0.0.1"]);
+
+    await expect(
+      caller.utilities.validateImgUrl(
+        "https://mapped-private.example.test/image.png",
+      ),
+    ).resolves.toEqual({ isValid: false });
+  });
+});

--- a/web/src/server/api/routers/utilities.ts
+++ b/web/src/server/api/routers/utilities.ts
@@ -12,6 +12,7 @@ const IP_4_LINK_LOCAL_SUBNET = "169.254.0.0/16";
 const IP_4_PRIVATE_A_SUBNET = "10.0.0.0/8";
 const IP_4_PRIVATE_B_SUBNET = "172.16.0.0/12";
 const IP_4_PRIVATE_C_SUBNET = "192.168.0.0/16";
+const IP_6_UNIQUE_LOCAL_SUBNET = "fc00::/7";
 
 /**
  * Check if the ipAddress is a private IP address
@@ -26,7 +27,16 @@ const isPrivateIp = (ipAddress: string): boolean => {
   try {
     if (Address6.isValid(ipAddress)) {
       const address = new Address6(ipAddress);
-      const isValidAddress6 = address.isLinkLocal() || address.isLoopback();
+      const isUniqueLocalAddress = address.isInSubnet(
+        new Address6(IP_6_UNIQUE_LOCAL_SUBNET),
+      );
+      const isPrivateMappedIpv4Address =
+        address.is4() && isPrivateIp(address.to4().correctForm());
+      const isValidAddress6 =
+        address.isLinkLocal() ||
+        address.isLoopback() ||
+        isUniqueLocalAddress ||
+        isPrivateMappedIpv4Address;
       if (isValidAddress6) return true;
     }
     if (Address4.isValid(ipAddress)) {


### PR DESCRIPTION
Fixes #13213

## Summary
- block IPv6 Unique Local Addresses (`fc00::/7`) in `validateImgUrl`
- block IPv4-mapped private IPv6 addresses by reusing the existing IPv4 private-range checks
- add focused server regressions for both missed cases

## Why this scope
Recent accepted security fixes in this area were merged as small, tightly scoped patches with direct tests (for example `#13207`). I kept this change limited to the existing `validateImgUrl` security boundary instead of refactoring the broader URL-validation flow.

## Impacted packages
- `web` — `utilities.ts` image URL validation and targeted server regression tests

## Test plan
- `pnpm --filter @langfuse/shared run db:generate`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter web run test --testPathPatterns='utilities-router.servertest.ts'`
- `pnpm --filter web exec dotenv -e ../.env -- eslint src/server/api/routers/utilities.ts src/__tests__/server/utilities-router.servertest.ts --max-warnings 0`

## Notes
- The targeted test run in my local environment logs a missing local Postgres instance during the shared Jest setup/teardown path, but the focused test body still runs and passes.
- This PR intentionally does not revisit the already-fixed dual-stack bypass from `#13207`; it only closes the remaining IPv6 private-address gap.
