### PR TITLE
fix: update managed ragas-faithfulness-evaluator with proper scoring and prompt details

### DIFF
--- a/worker/src/constants/managed-evaluators.json
+++ b/worker/src/constants/managed-evaluators.json
@@ -163,15 +163,15 @@
   {
     "id": "cmal6wart010lynrdtpv6olaf",
     "created_at": "2025-05-20T18:16:12.000Z",
-    "updated_at": "2025-05-20T18:16:12.000Z",
+    "updated_at": "2026-04-16T18:16:12.000Z",
     "name": "Faithfulness",
     "partner": "ragas",
     "version": 1,
     "outputDefinition": {
-      "score": "Score between 0 and 1. Score 0 if false or negative and 1 if true or positive",
+      "score": "Based on the claim analysis provided, give a single score from 0 to 1 (where 1 is perfectly faithful and 0 is entirely unsupported) representing the overall proportion of the answer that is grounded in the context. Output only the number",
       "reasoning": "One sentence reasoning for the score"
     },
-    "prompt": "Given a question and an answer, analyze the complexity of each sentence in the answer. Break down each sentence into one or more fully understandable statements. Ensure that no pronouns are used in any statement.\nQuestion: {{question}}\nAnswer: {{answer}}"
+    "prompt": "You are an expert evaluator. Your task is to determine the Faithfulness of a generated answer based on a provided context.\n\nFollow these steps exactly:\n1. Deconstruction: Break the \"Answer\" down into a list of atomic, self-contained statements. Do not use pronouns; replace them with the actual subjects.\n2. Verification: For each statement, check if it is supported by the \"Context.\"\n3. Verdict: Assign a 1 if the statement is directly supported by the context, or a 0 if it is not supported or contradicted. Provide a brief reason for each.\n4. Calculation: Calculate the final faithfulness score as: Total Verdicts of 1 divided by Total Number of Statements.\n\nInput Data:\nContext: {{context}}\nAnswer: {{answer}}"
   },
   {
     "id": "cmal6wart010lynrdtpv6olag",

--- a/worker/src/constants/managed-evaluators.json
+++ b/worker/src/constants/managed-evaluators.json
@@ -163,10 +163,23 @@
   {
     "id": "cmal6wart010lynrdtpv6olaf",
     "created_at": "2025-05-20T18:16:12.000Z",
-    "updated_at": "2026-04-16T18:16:12.000Z",
+    "updated_at": "2025-05-20T18:16:12.000Z",
     "name": "Faithfulness",
     "partner": "ragas",
     "version": 1,
+    "outputDefinition": {
+      "score": "Score between 0 and 1. Score 0 if false or negative and 1 if true or positive",
+      "reasoning": "One sentence reasoning for the score"
+    },
+    "prompt": "Given a question and an answer, analyze the complexity of each sentence in the answer. Break down each sentence into one or more fully understandable statements. Ensure that no pronouns are used in any statement.\nQuestion: {{question}}\nAnswer: {{answer}}"
+  },
+  {
+    "id": "cmal6wart010lynrdtpv6olfv2",
+    "created_at": "2026-04-17T10:00:00.000Z",
+    "updated_at": "2026-04-17T10:00:00.000Z",
+    "name": "Faithfulness",
+    "partner": "ragas",
+    "version": 2,
     "outputDefinition": {
       "score": "Based on the claim analysis provided, give a single score from 0 to 1 (where 1 is perfectly faithful and 0 is entirely unsupported) representing the overall proportion of the answer that is grounded in the context. Output only the number",
       "reasoning": "One sentence reasoning for the score"


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR corrects the `ragas-faithfulness` managed evaluator by rewriting the prompt to properly include `{{context}}` (previously missing, rendering the evaluation semantically meaningless) and updating the `outputDefinition.score` to instruct the LLM to output only a number.

- **P1 – Breaking variable change for existing configs**: `{{question}}` is removed and `{{context}}` is added. Existing `JobConfiguration` records that previously mapped `question` → a trace field will have no mapping for `context`, causing `evalService.ts` to substitute an empty string silently. Evaluations will continue to run but against an empty context, producing incorrect scores.
- **P2 – `version` stays at `1`**: Despite the substantial change in prompt logic, variables, and scoring semantics, `version` is not bumped. Incrementing to `2` would signal the change to users and operators.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without addressing the silent breakage of existing evaluator configs that relied on the old {{question}} variable.

A P1 finding exists: the variable rename from {{question}} to {{context}} will cause all pre-existing JobConfiguration records for the Faithfulness evaluator to silently run with an empty context, producing meaningless scores. This affects existing users' production evaluations without any error surfacing.

worker/src/constants/managed-evaluators.json — the variable mapping change and missing version bump need attention before merge.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/constants/managed-evaluators.json | Faithfulness evaluator prompt corrected to use {{context}} + {{answer}} (replacing {{question}} + {{answer}}); outputDefinition.score improved; updated_at bumped to trigger upsert. Breaking variable change for existing JobConfiguration records and version not bumped are notable concerns. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant JSON as managed-evaluators.json
    participant Script as upsertManagedEvaluators.ts
    participant DB as eval_templates (DB)
    participant JobCfg as JobConfiguration (DB)
    participant EvalSvc as evalService.ts

    Note over JSON,DB: On worker startup / upsert run
    Script->>DB: Check existing updated_at for id=cmal6wart010lynrdtpv6olaf
    DB-->>Script: 2025-05-20 (old) != 2026-04-16 (new)
    Script->>DB: UPSERT prompt, vars=[context,answer], outputDefinition, updatedAt

    Note over JobCfg,EvalSvc: Existing evaluation job execution (post-update)
    EvalSvc->>DB: Fetch EvalTemplate (vars=[context,answer])
    EvalSvc->>JobCfg: Fetch variableMapping
    JobCfg-->>EvalSvc: [{templateVariable:question,...},{templateVariable:answer,...}]
    Note over EvalSvc: mapping for context NOT FOUND
    EvalSvc->>EvalSvc: push({var:context, value:""})
    EvalSvc->>EvalSvc: Render prompt with Context: [EMPTY]
    EvalSvc-->>DB: Score recorded (meaningless — no context grounding)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker/src/constants/managed-evaluators.json
Line: 174

Comment:
**Breaking variable change silently empties `context` for existing configs**

The prompt variables changed from `{{question}}` + `{{answer}}` to `{{context}}` + `{{answer}}`. Any `JobConfiguration` record already mapped against this template will have `question` → some trace field in its `variableMapping`, but no entry for `context`. At eval time, `evalService.ts` resolves unmapped variables to `""` (line 1151: `results.push({ var: variable, value: "" })`), so every existing job will run with `Context:` empty — producing silent, meaningless faithfulness scores.

A migration (or at minimum a note in the PR) to update or invalidate existing `JobConfiguration.variableMapping` entries is needed, or the evaluator ID should be changed so old configs naturally decouple.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: worker/src/constants/managed-evaluators.json
Line: 169

Comment:
**`version` not bumped after significant prompt and variable change**

The `version` field remains `1` despite the prompt logic, input variables (`question` → `context`), and scoring description all changing substantially. The field is stored in the database and exposed as part of the template record; incrementing it to `2` communicates the semantic change to users and operators.

```suggestion
    "version": 2,
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: update managed ragas-faithfulness-e..."](https://github.com/langfuse/langfuse/commit/285d570e83e2d30cebe80d11a57117d8443591e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28749315)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->