### PR TITLE
fix(ci): use exact release tags in action version comments

### DIFF
--- a/.github/workflows/_deploy_ecs_service.yml
+++ b/.github/workflows/_deploy_ecs_service.yml
@@ -46,7 +46,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - name: Login to AWS ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       - name: Build, tag, and push Docker image
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/snyk-web.yml
+++ b/.github/workflows/snyk-web.yml
@@ -47,7 +47,7 @@ jobs:
             echo "No SARIF file found"
           fi
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         if: always()
         with:
           sarif_file: snyk.sarif

--- a/.github/workflows/snyk-worker.yml
+++ b/.github/workflows/snyk-worker.yml
@@ -47,7 +47,7 @@ jobs:
             echo "No SARIF file found"
           fi
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         if: always()
         with:
           sarif_file: snyk.sarif


### PR DESCRIPTION
## Summary
- Fixes zizmor `ref-version-mismatch` code scanning alerts [#491](https://github.com/langfuse/langfuse/security/code-scanning/491), [#492](https://github.com/langfuse/langfuse/security/code-scanning/492), [#493](https://github.com/langfuse/langfuse/security/code-scanning/493)
- Updates version comments on hash-pinned actions from imprecise major tags to exact release tags:
  - `aws-actions/amazon-ecr-login`: `# v2` → `# v2.1.2`
  - `github/codeql-action/upload-sarif` (snyk-worker, snyk-web): `# v4` → `# v4.35.1`

## Test plan
- [ ] No functional change — only version comments updated, action hashes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Updates version comments on three hash-pinned GitHub Actions from imprecise major tags (`# v2`, `# v4`) to exact release tags (`# v2.1.2`, `# v4.35.1`), resolving `zizmor` `ref-version-mismatch` code-scanning alerts. No functional change — action hashes are identical before and after.

<h3>Confidence Score: 5/5</h3>

Safe to merge — comment-only changes with verified correct version tags and unchanged action hashes.

All three changes are purely cosmetic (YAML comment updates). The action hashes are identical pre/post, and both new version labels (v2.1.2 and v4.35.1) are confirmed to match the pinned hashes via the upstream release pages. No functional risk.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/_deploy_ecs_service.yml | Comment-only change: `# v2` → `# v2.1.2` for `aws-actions/amazon-ecr-login`; hash unchanged and verified correct. |
| .github/workflows/snyk-web.yml | Comment-only change: `# v4` → `# v4.35.1` for `github/codeql-action/upload-sarif`; hash unchanged and verified correct. |
| .github/workflows/snyk-worker.yml | Comment-only change: `# v4` → `# v4.35.1` for `github/codeql-action/upload-sarif`; hash unchanged and verified correct. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Hash-pinned GitHub Action] --> B{Version comment accurate?}
    B -- "No: # v2 or # v4\n(major tag only)" --> C[zizmor ref-version-mismatch alert]
    B -- "Yes: # v2.1.2 or # v4.35.1\n(exact release tag)" --> D[Alert resolved ✓]
    C --> E[This PR: update comment to exact tag]
    E --> D
    D --> F[Action hash unchanged\nNo functional impact]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): use exact release tags in actio..."](https://github.com/langfuse/langfuse/commit/7e38cccc7e443cbeedfbd6134f22295c5d7e9670) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28750832)</sub>

<!-- /greptile_comment -->