### PR TITLE
chore(skill): pnpm upgrade skill doesnt change lock file manually

### DIFF
--- a/.agents/skills/pnpm-upgrade-package/SKILL.md
+++ b/.agents/skills/pnpm-upgrade-package/SKILL.md
@@ -28,6 +28,9 @@ Use this skill for interactive dependency bumps in Langfuse.
 - If the current parent range does not cover the requested transitive version,
   upgrade that parent dependency instead of adding the target package directly
   unless the user explicitly wants that.
+- Never manually edit `pnpm-lock.yaml`; regenerate lockfile changes with
+  `pnpm` commands only. If a lockfile-only refresh causes unrelated churn,
+  adjust the pnpm command and rerun instead of patching the lockfile by hand.
 - If a compatible transitive package still stays pinned after the normal
   refresh path, you may suggest `pnpm dedupe` to the user as an optional manual
   follow-up, but do not run it automatically and do not require it.


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a single rule to the `pnpm-upgrade-package` agent skill, explicitly instructing agents never to hand-edit `pnpm-lock.yaml` and to rerun pnpm commands when a lockfile refresh produces unrelated churn rather than patching the lockfile by hand. The addition is well-placed in the instruction sequence and aligns with existing pnpm best practices documented in the skill.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with no code, schema, or runtime impact.

Single documentation addition to an agent skill file; no logic, schema, or runtime changes. The added guidance is accurate, clearly worded, and fits naturally into the existing instruction flow.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .agents/skills/pnpm-upgrade-package/SKILL.md | Adds 3-line rule prohibiting manual edits to pnpm-lock.yaml and directing agents to use pnpm commands for all lockfile changes; no issues found. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Lockfile change needed] --> B{Lockfile-only refresh\ncauses unrelated churn?}
    B -- No --> C[Run pnpm command\nto regenerate lockfile]
    B -- Yes --> D[Adjust pnpm command\nand rerun]
    D --> C
    C --> E[Never hand-edit\npnpm-lock.yaml]
    E --> F[Verify with\npnpm why -r package]
```

<sub>Reviews (1): Last reviewed commit: ["chore(skill): pnpm upgrade skill doesnt ..."](https://github.com/langfuse/langfuse/commit/d2568387066d603d69cd0c1f7dbbbf5e0f8caf92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28760380)</sub>

<!-- /greptile_comment -->