### PR TITLE
fix(prompts): Prevent text overlap when adding prompt reference

### DIFF
--- a/web/src/components/editor/PromptLinkingEditor.tsx
+++ b/web/src/components/editor/PromptLinkingEditor.tsx
@@ -54,7 +54,7 @@ export function PromptLinkingEditor({
   };
 
   return (
-    <div className="relative">
+    <div className="flex flex-col gap-2">
       <CodeMirrorEditor
         value={value}
         onChange={onChange}
@@ -64,15 +64,17 @@ export function PromptLinkingEditor({
         className={className}
         editorRef={editorRef}
       />
-      <Button
-        type="button"
-        variant="outline"
-        className="absolute right-2 bottom-2 flex items-center gap-1 px-2 py-1"
-        onClick={() => setIsDialogOpen(true)}
-      >
-        <Plus className="mr-2 h-4 w-4" />
-        <span className="text-xs">Add prompt reference</span>
-      </Button>
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          variant="outline"
+          className="flex items-center gap-1 px-2 py-1"
+          onClick={() => setIsDialogOpen(true)}
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          <span className="text-xs">Add prompt reference</span>
+        </Button>
+      </div>
 
       {projectId && (
         <PromptSelectionDialog


### PR DESCRIPTION
## What does this PR do?

Moves the "Add prompt reference" button below the text input to avoid it occluding the text.

After:
<img width="1318" height="794" alt="Screenshot 2026-04-17 at 13 56 13" src="https://github.com/user-attachments/assets/448391b1-7c78-4eb3-b4cd-3c262554044d" />

Before:
<img width="1320" height="827" alt="Screenshot 2026-04-17 at 13 55 51" src="https://github.com/user-attachments/assets/7191098e-614a-4d59-90b9-998456528846" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a UI overlap issue in `PromptLinkingEditor` by replacing the absolutely-positioned \"Add prompt reference\" button (which obscured the editor text) with a flex-column layout that places the button below the editor, right-aligned via a `flex justify-end` wrapper.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, focused UI layout fix with no logic changes.

Single-file change that swaps absolute positioning for a flex-column layout. No functional logic, state, or API surface is touched. The fix directly matches the stated bug (button occluding editor text) and the before/after screenshots confirm correct behavior.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/components/editor/PromptLinkingEditor.tsx | Replaces absolute-positioned button overlay with a flex-column layout; no logic changes, clean fix for text occlusion bug |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (relative container)"]
        A1["div.relative"] --> B1["CodeMirrorEditor"]
        A1 --> C1["Button (absolute right-2 bottom-2)\n⚠️ overlaps editor text"]
    end

    subgraph After["After (flex-column container)"]
        A2["div.flex.flex-col.gap-2"] --> B2["CodeMirrorEditor"]
        A2 --> D2["div.flex.justify-end"]
        D2 --> C2["Button (in normal flow)\n✅ below the editor"]
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(prompts): Prevent text overlap when ..."](https://github.com/langfuse/langfuse/commit/dbc39906ffecfa9c2223174a504c2a7438180289) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28761502)</sub>

<!-- /greptile_comment -->