### PR TITLE
fix(web): Stale search highlights

### DIFF
--- a/web/src/components/ChatMessages/messageSearch/context.tsx
+++ b/web/src/components/ChatMessages/messageSearch/context.tsx
@@ -160,9 +160,15 @@ export function useSyncMessageSearchMessages(
     }
 
     actions.registerPageMessages(pageId, messages);
+  }, [actions, messages, pageId]);
+
+  useEffect(() => {
+    if (!actions) {
+      return;
+    }
 
     return () => {
       actions.unregisterPageMessages(pageId);
     };
-  }, [actions, messages, pageId]);
+  }, [actions, pageId]);
 }

--- a/web/src/components/ChatMessages/messageSearch/controller.clienttest.ts
+++ b/web/src/components/ChatMessages/messageSearch/controller.clienttest.ts
@@ -1,6 +1,16 @@
 import { ChatMessageRole, ChatMessageType } from "@langfuse/shared";
+import {
+  applyCodeMirrorSearchQuery,
+  setActiveSearchMarkCodeMirrorRange,
+} from "../../editor";
 
 import { createMessageSearchController } from "./controller";
+
+jest.mock("../../editor", () => ({
+  applyCodeMirrorSearchQuery: jest.fn(),
+  setActiveSearchMarkCodeMirrorRange: jest.fn(),
+  unsetActiveSearchMarkCodeMirrorRange: jest.fn(),
+}));
 
 describe("message search controller", () => {
   beforeEach(() => {
@@ -178,5 +188,52 @@ describe("message search controller", () => {
     expect(controller.getSnapshot().queryInput).toBe("");
     expect(controller.getSnapshot().query).toBe("");
     expect(controller.getSnapshot().matches).toEqual([]);
+  });
+
+  it("reapplies editor search decorations when message content changes during an active search", () => {
+    const controller = createMessageSearchController(["page-1"]);
+    const editorRef = { current: null };
+    const initialMessages = [
+      {
+        id: "message-1",
+        type: ChatMessageType.System,
+        role: ChatMessageRole.System,
+        content: "foo bar",
+      },
+    ] as const;
+
+    controller.registerPageMessages("page-1", [...initialMessages]);
+    controller.registerMessageTarget("page-1", "message-1", {
+      rowRef: { current: null },
+      editorRef,
+    });
+
+    expect(commitQuery(controller, "foo")).toHaveLength(1);
+    const activeMatchBefore = controller.getSnapshot().activeMatch;
+
+    jest.mocked(applyCodeMirrorSearchQuery).mockClear();
+    jest.mocked(setActiveSearchMarkCodeMirrorRange).mockClear();
+
+    controller.registerPageMessages("page-1", [
+      {
+        ...initialMessages[0],
+        content: "foo foo bar",
+      },
+    ]);
+
+    expect(controller.getSnapshot().matches).toHaveLength(2);
+    expect(controller.getSnapshot().activeMatch?.key).toBe(
+      activeMatchBefore?.key,
+    );
+    expect(applyCodeMirrorSearchQuery).toHaveBeenCalledTimes(1);
+    expect(applyCodeMirrorSearchQuery).toHaveBeenCalledWith(editorRef, "foo", [
+      { from: 0, to: 3 },
+      { from: 4, to: 7 },
+    ]);
+    expect(setActiveSearchMarkCodeMirrorRange).toHaveBeenCalledTimes(1);
+    expect(setActiveSearchMarkCodeMirrorRange).toHaveBeenCalledWith(editorRef, {
+      from: 0,
+      to: 3,
+    });
   });
 });

--- a/web/src/components/ChatMessages/messageSearch/controller.clienttest.ts
+++ b/web/src/components/ChatMessages/messageSearch/controller.clienttest.ts
@@ -231,9 +231,96 @@ describe("message search controller", () => {
       { from: 4, to: 7 },
     ]);
     expect(setActiveSearchMarkCodeMirrorRange).toHaveBeenCalledTimes(1);
-    expect(setActiveSearchMarkCodeMirrorRange).toHaveBeenCalledWith(editorRef, {
-      from: 0,
-      to: 3,
+    expect(setActiveSearchMarkCodeMirrorRange).toHaveBeenCalledWith(
+      editorRef,
+      {
+        from: 0,
+        to: 3,
+      },
+      { scrollIntoView: false },
+    );
+  });
+
+  it("does not scroll the active match during streaming updates", () => {
+    const controller = createMessageSearchController(["page-1"]);
+    const editorRef = { current: null };
+    const pageScrollIntoView = jest.fn();
+    const rowScrollIntoView = jest.fn();
+
+    controller.registerPageTarget("page-1", {
+      pageRef: {
+        current: {
+          scrollIntoView: pageScrollIntoView,
+        } as unknown as HTMLDivElement,
+      },
     });
+    controller.registerPageMessages("page-1", [
+      {
+        id: "message-1",
+        type: ChatMessageType.System,
+        role: ChatMessageRole.System,
+        content: "foo",
+      },
+    ]);
+    controller.registerMessageTarget("page-1", "message-1", {
+      rowRef: {
+        current: {
+          scrollIntoView: rowScrollIntoView,
+        } as unknown as HTMLDivElement,
+      },
+      editorRef,
+    });
+
+    commitQuery(controller, "foo");
+
+    expect(pageScrollIntoView).toHaveBeenCalledTimes(1);
+    expect(rowScrollIntoView).toHaveBeenCalledTimes(1);
+    expect(setActiveSearchMarkCodeMirrorRange).toHaveBeenLastCalledWith(
+      editorRef,
+      { from: 0, to: 3 },
+      { scrollIntoView: true },
+    );
+
+    pageScrollIntoView.mockClear();
+    rowScrollIntoView.mockClear();
+    jest.mocked(applyCodeMirrorSearchQuery).mockClear();
+    jest.mocked(setActiveSearchMarkCodeMirrorRange).mockClear();
+
+    controller.registerPageMessages("page-1", [
+      {
+        id: "message-1",
+        type: ChatMessageType.System,
+        role: ChatMessageRole.System,
+        content: "foo bar",
+      },
+    ]);
+    controller.registerPageMessages("page-1", [
+      {
+        id: "message-1",
+        type: ChatMessageType.System,
+        role: ChatMessageRole.System,
+        content: "foo bar baz",
+      },
+    ]);
+
+    expect(controller.getSnapshot().activeMatch?.key).toBe(
+      "page-1:message-1:0:3",
+    );
+    expect(pageScrollIntoView).not.toHaveBeenCalled();
+    expect(rowScrollIntoView).not.toHaveBeenCalled();
+    expect(applyCodeMirrorSearchQuery).toHaveBeenCalledTimes(2);
+    expect(setActiveSearchMarkCodeMirrorRange).toHaveBeenCalledTimes(2);
+    expect(setActiveSearchMarkCodeMirrorRange).toHaveBeenNthCalledWith(
+      1,
+      editorRef,
+      { from: 0, to: 3 },
+      { scrollIntoView: false },
+    );
+    expect(setActiveSearchMarkCodeMirrorRange).toHaveBeenNthCalledWith(
+      2,
+      editorRef,
+      { from: 0, to: 3 },
+      { scrollIntoView: false },
+    );
   });
 });

--- a/web/src/components/ChatMessages/messageSearch/controller.ts
+++ b/web/src/components/ChatMessages/messageSearch/controller.ts
@@ -60,6 +60,11 @@ type MessageSearchMessageTarget = {
   editorRef: RefObject<ReactCodeMirrorRef | null>;
 };
 
+type RefreshSearchOptions = {
+  syncEditors?: boolean;
+  syncActiveMatch?: boolean;
+};
+
 export type MessageSearchController = {
   subscribe: (listener: () => void) => () => void;
   getSnapshot: () => MessageSearchSnapshot;
@@ -339,24 +344,27 @@ export function createMessageSearchController(
     return previousActiveMatchKey !== state.activeMatchKey;
   };
 
-  const refreshSearchResults = (shouldSyncEditors: boolean) => {
+  const refreshSearchResults = ({
+    syncEditors = false,
+    syncActiveMatch = false,
+  }: RefreshSearchOptions) => {
     const activeMatchChanged = recomputeMatches();
 
-    if (shouldSyncEditors || activeMatchChanged) {
+    if (syncEditors || activeMatchChanged) {
       syncEditorsToQuery();
     }
 
-    if (shouldSyncEditors || activeMatchChanged) {
+    if (syncActiveMatch || activeMatchChanged) {
       syncActiveMatchTarget();
     }
   };
 
-  const refreshSearchResultsIfSearching = (shouldSyncEditors: boolean) => {
+  const refreshSearchResultsIfSearching = (options: RefreshSearchOptions) => {
     if (!getCommittedQuery(state)) {
       return;
     }
 
-    refreshSearchResults(shouldSyncEditors);
+    refreshSearchResults(options);
     emit();
   };
 
@@ -366,7 +374,7 @@ export function createMessageSearchController(
     }
 
     state.searchQuery = nextSearchQuery;
-    refreshSearchResults(true);
+    refreshSearchResults({ syncEditors: true, syncActiveMatch: true });
     return true;
   };
 
@@ -520,7 +528,10 @@ export function createMessageSearchController(
       }
 
       state.pageIds = pageIds;
-      refreshSearchResultsIfSearching(false);
+      refreshSearchResultsIfSearching({
+        syncEditors: true,
+        syncActiveMatch: true,
+      });
     },
 
     setPageLabelResolver(getPageLabel) {
@@ -529,12 +540,15 @@ export function createMessageSearchController(
       }
 
       state.getPageLabel = getPageLabel;
-      refreshSearchResultsIfSearching(false);
+      refreshSearchResultsIfSearching({});
     },
 
     registerPageMessages(pageId, messages) {
       state.pageMessagesById[pageId] = messages;
-      refreshSearchResultsIfSearching(false);
+      refreshSearchResultsIfSearching({
+        syncEditors: true,
+        syncActiveMatch: true,
+      });
     },
 
     unregisterPageMessages(pageId) {
@@ -543,7 +557,10 @@ export function createMessageSearchController(
       }
 
       delete state.pageMessagesById[pageId];
-      refreshSearchResultsIfSearching(false);
+      refreshSearchResultsIfSearching({
+        syncEditors: true,
+        syncActiveMatch: true,
+      });
     },
 
     registerPageTarget(pageId, target) {

--- a/web/src/components/ChatMessages/messageSearch/controller.ts
+++ b/web/src/components/ChatMessages/messageSearch/controller.ts
@@ -65,6 +65,11 @@ type RefreshSearchOptions = {
   syncActiveMatch?: boolean;
 };
 
+type SearchMatchRange = {
+  from: number;
+  to: number;
+};
+
 export type MessageSearchController = {
   subscribe: (listener: () => void) => () => void;
   getSnapshot: () => MessageSearchSnapshot;
@@ -262,11 +267,36 @@ export function createMessageSearchController(
     pendingQueryTimeout = null;
   };
 
+  const getMatchRangesForMessageTarget = (pageId: string, messageId: string) =>
+    state.matches
+      .filter(
+        (match) => match.pageId === pageId && match.messageId === messageId,
+      )
+      .map((match) => ({ from: match.from, to: match.to }));
+
   const syncEditorsToQuery = () => {
     const query = getCommittedQuery(state);
+    const matchRangesByTargetKey = new Map<string, SearchMatchRange[]>();
 
-    for (const target of messageTargets.values()) {
-      applyCodeMirrorSearchQuery(target.editorRef, query);
+    for (const match of state.matches) {
+      const targetKey = getMessageTargetKey(match.pageId, match.messageId);
+      const ranges = matchRangesByTargetKey.get(targetKey);
+
+      if (ranges) {
+        ranges.push({ from: match.from, to: match.to });
+      } else {
+        matchRangesByTargetKey.set(targetKey, [
+          { from: match.from, to: match.to },
+        ]);
+      }
+    }
+
+    for (const [targetKey, target] of messageTargets.entries()) {
+      applyCodeMirrorSearchQuery(
+        target.editorRef,
+        query,
+        matchRangesByTargetKey.get(targetKey) ?? [],
+      );
     }
   };
 
@@ -576,9 +606,14 @@ export function createMessageSearchController(
     },
 
     registerMessageTarget(pageId, messageId, target) {
-      messageTargets.set(getMessageTargetKey(pageId, messageId), target);
+      const targetKey = getMessageTargetKey(pageId, messageId);
+      messageTargets.set(targetKey, target);
 
-      applyCodeMirrorSearchQuery(target.editorRef, getCommittedQuery(state));
+      applyCodeMirrorSearchQuery(
+        target.editorRef,
+        getCommittedQuery(state),
+        getMatchRangesForMessageTarget(pageId, messageId),
+      );
 
       const activeMatch = getActiveMatch(state);
       if (

--- a/web/src/components/ChatMessages/messageSearch/controller.ts
+++ b/web/src/components/ChatMessages/messageSearch/controller.ts
@@ -379,12 +379,15 @@ export function createMessageSearchController(
     syncActiveMatch = false,
   }: RefreshSearchOptions) => {
     const activeMatchChanged = recomputeMatches();
+    const shouldSyncEditors = syncEditors || activeMatchChanged;
 
-    if (syncEditors || activeMatchChanged) {
+    if (shouldSyncEditors) {
       syncEditorsToQuery();
     }
 
-    if (syncActiveMatch || activeMatchChanged) {
+    // Redrawing the editor search marks clears the selected active-match mark,
+    // so the active match must always be re-applied after syncing editors.
+    if (shouldSyncEditors || syncActiveMatch) {
       syncActiveMatchTarget();
     }
   };

--- a/web/src/components/ChatMessages/messageSearch/controller.ts
+++ b/web/src/components/ChatMessages/messageSearch/controller.ts
@@ -62,12 +62,16 @@ type MessageSearchMessageTarget = {
 
 type RefreshSearchOptions = {
   syncEditors?: boolean;
-  syncActiveMatch?: boolean;
+  scrollToActiveMatch?: boolean;
 };
 
 type SearchMatchRange = {
   from: number;
   to: number;
+};
+
+type SyncActiveMatchTargetOptions = {
+  scrollIntoView?: boolean;
 };
 
 export type MessageSearchController = {
@@ -300,17 +304,21 @@ export function createMessageSearchController(
     }
   };
 
-  const syncActiveMatchTarget = () => {
+  const syncActiveMatchTarget = ({
+    scrollIntoView = true,
+  }: SyncActiveMatchTargetOptions = {}) => {
     const activeMatch = getActiveMatch(state);
     if (!activeMatch) {
       return;
     }
 
-    pageTargets.get(activeMatch.pageId)?.pageRef.current?.scrollIntoView({
-      behavior: "smooth",
-      block: "nearest",
-      inline: "center",
-    });
+    if (scrollIntoView) {
+      pageTargets.get(activeMatch.pageId)?.pageRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+        inline: "center",
+      });
+    }
 
     let activeMessageTarget: MessageSearchMessageTarget | null = null;
     const inactiveMessageTargets: MessageSearchMessageTarget[] = [];
@@ -332,16 +340,22 @@ export function createMessageSearchController(
       unsetActiveSearchMarkCodeMirrorRange(target?.editorRef);
     }
 
-    activeMessageTarget?.rowRef.current?.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-      inline: "nearest",
-    });
+    if (scrollIntoView) {
+      activeMessageTarget?.rowRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+        inline: "nearest",
+      });
+    }
 
-    setActiveSearchMarkCodeMirrorRange(activeMessageTarget?.editorRef, {
-      from: activeMatch.from,
-      to: activeMatch.to,
-    });
+    setActiveSearchMarkCodeMirrorRange(
+      activeMessageTarget?.editorRef,
+      {
+        from: activeMatch.from,
+        to: activeMatch.to,
+      },
+      { scrollIntoView },
+    );
   };
 
   const recomputeMatches = () => {
@@ -376,10 +390,11 @@ export function createMessageSearchController(
 
   const refreshSearchResults = ({
     syncEditors = false,
-    syncActiveMatch = false,
+    scrollToActiveMatch = false,
   }: RefreshSearchOptions) => {
     const activeMatchChanged = recomputeMatches();
     const shouldSyncEditors = syncEditors || activeMatchChanged;
+    const shouldScrollToActiveMatch = scrollToActiveMatch || activeMatchChanged;
 
     if (shouldSyncEditors) {
       syncEditorsToQuery();
@@ -387,8 +402,8 @@ export function createMessageSearchController(
 
     // Redrawing the editor search marks clears the selected active-match mark,
     // so the active match must always be re-applied after syncing editors.
-    if (shouldSyncEditors || syncActiveMatch) {
-      syncActiveMatchTarget();
+    if (shouldSyncEditors || shouldScrollToActiveMatch) {
+      syncActiveMatchTarget({ scrollIntoView: shouldScrollToActiveMatch });
     }
   };
 
@@ -407,7 +422,7 @@ export function createMessageSearchController(
     }
 
     state.searchQuery = nextSearchQuery;
-    refreshSearchResults({ syncEditors: true, syncActiveMatch: true });
+    refreshSearchResults({ syncEditors: true, scrollToActiveMatch: true });
     return true;
   };
 
@@ -563,7 +578,6 @@ export function createMessageSearchController(
       state.pageIds = pageIds;
       refreshSearchResultsIfSearching({
         syncEditors: true,
-        syncActiveMatch: true,
       });
     },
 
@@ -580,7 +594,6 @@ export function createMessageSearchController(
       state.pageMessagesById[pageId] = messages;
       refreshSearchResultsIfSearching({
         syncEditors: true,
-        syncActiveMatch: true,
       });
     },
 
@@ -592,7 +605,6 @@ export function createMessageSearchController(
       delete state.pageMessagesById[pageId];
       refreshSearchResultsIfSearching({
         syncEditors: true,
-        syncActiveMatch: true,
       });
     },
 

--- a/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.tsx
@@ -309,6 +309,7 @@ const searchHighlightingSupport = StateField.define<DecorationSet>({
 export function applyCodeMirrorSearchQuery(
   editorRef: RefObject<ReactCodeMirrorRef | null> | undefined,
   searchValue: string,
+  matchRanges: { from: number; to: number }[],
 ) {
   const view = editorRef?.current?.view;
   if (!view) {
@@ -324,14 +325,6 @@ export function applyCodeMirrorSearchQuery(
   view.dispatch({
     effects: setSearchQuery.of(searchQuery),
   });
-
-  const cursor = searchQuery.getCursor(view.state);
-  const matchRanges: { from: number; to: number }[] = [];
-  let current = cursor.next();
-  while (!current.done) {
-    matchRanges.push(current.value);
-    current = cursor.next();
-  }
 
   view.dispatch({
     effects: setSearchHighlightMarks.of(matchRanges),

--- a/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.tsx
@@ -334,17 +334,23 @@ export function applyCodeMirrorSearchQuery(
 export function setActiveSearchMarkCodeMirrorRange(
   editorRef: RefObject<ReactCodeMirrorRef | null> | undefined,
   range: { from: number; to: number } | null,
+  { scrollIntoView = true }: { scrollIntoView?: boolean } = {},
 ) {
   const view = editorRef?.current?.view;
   if (!view || !range) {
     return;
   }
 
+  const effects: StateEffect<unknown>[] = [
+    setSelectedSearchHighlightMark.of(range),
+  ];
+
+  if (scrollIntoView) {
+    effects.push(EditorView.scrollIntoView(range.from));
+  }
+
   view.dispatch({
-    effects: [
-      setSelectedSearchHighlightMark.of(range),
-      EditorView.scrollIntoView(range.from),
-    ],
+    effects,
   });
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes stale chat message search highlights when message content changes during an active search.

The search controller now computes and owns the canonical match ranges, and passes those exact ranges into CodeMirror instead of asking the editor to re-scan its current document state. This keeps highlight decorations synchronized when chat messages update, including cases where the editor view remounts or the underlying content changes while search is active.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes stale search highlights in chat messages by moving match-range computation from the CodeMirror editor into the search controller. The controller now passes pre-computed `{ from, to }` ranges to `applyCodeMirrorSearchQuery` instead of having each editor re-scan its own (potentially stale) document state.

- **P1 regression**: `syncEditorsToQuery()` dispatches `setSearchHighlightMarks`, whose StateField filter removes **all** `cm-searchMatch` decorations — including the `selectedSearchMatchMark` used for the active match. Because `syncActiveMatchTarget()` is not called afterward when `activeMatchChanged` is `false` (e.g., message content changes but the active match key is preserved), the active-match \"selected\" styling is silently erased until the user navigates to the next/previous match.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the active-match decoration regression.

The core fix (controller-owned match ranges) is sound and well-tested. However, the change introduces a P1 regression: `syncEditorsToQuery()` removes the `selectedSearchMatchMark` via `setSearchHighlightMarks` but `syncActiveMatchTarget()` is not called to restore it when the active match key is unchanged, causing the active match to lose its 'selected' visual treatment on content changes.

web/src/components/ChatMessages/messageSearch/controller.ts — specifically the `refreshSearchResults` function and the calls to `refreshSearchResultsIfSearching` in `registerPageMessages`, `unregisterPageMessages`, and `setPageIds`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/components/ChatMessages/messageSearch/controller.ts | Central fix: controller now computes match ranges and passes them to editors. `syncEditors` flag added for content/page-ID changes. Regression: `setSearchHighlightMarks` clears the `selectedSearchMatchMark` but `syncActiveMatchTarget` is not re-invoked when `activeMatchChanged` is false, causing the active-match selected decoration to disappear on content updates. |
| web/src/components/editor/CodeMirrorEditor.tsx | Signature of `applyCodeMirrorSearchQuery` extended with an explicit `matchRanges` parameter; internal `getCursor` scan removed. Clean and minimal change. |
| web/src/components/ChatMessages/messageSearch/controller.clienttest.ts | New test verifies highlight ranges are recomputed and dispatched when message content changes during active search. Does not assert that `setActiveSearchMarkCodeMirrorRange` is called, leaving the regression in `controller.ts` uncovered. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant RC as React Component
    participant SC as Search Controller
    participant CM as CodeMirror Editor

    RC->>SC: registerPageMessages(pageId, updatedMessages)
    SC->>SC: recomputeMatches() builds ranges from source-of-truth content
    SC->>SC: syncEditorsToQuery() [syncEditors:true]
    SC->>CM: applyCodeMirrorSearchQuery(editorRef, query, matchRanges)
    CM->>CM: dispatch setSearchQuery
    CM->>CM: dispatch setSearchHighlightMarks(matchRanges) clears selectedSearchMatchMark too
    Note over SC,CM: syncActiveMatchTarget() NOT called when activeMatchChanged=false selected decoration is lost
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/components/ChatMessages/messageSearch/controller.ts
Line: 377-390

Comment:
**Active match selected decoration is erased but not restored**

`syncEditorsToQuery()` dispatches `setSearchHighlightMarks`, which (per the StateField filter on line 216 of `CodeMirrorEditor.tsx`) removes **all** decorations whose class includes `"cm-searchMatch"` — including `selectedSearchMatchMark` (class `"cm-searchMatch cm-searchMatch-selected"`). It then replaces them with plain `searchMatchMark` entries only. So every call to `syncEditorsToQuery()` wipes the active-match's selected styling.

In the old code `registerPageMessages` passed `shouldSyncEditors=false`, so `syncEditorsToQuery()` was never called on content changes (the original bug). The new code correctly calls it, but no longer calls `syncActiveMatchTarget()` afterward when `activeMatchChanged` is false. The net result: after message content updates during an active search (e.g. a streaming LLM response), the active match's highlighted-selected treatment is dropped and only restored when the user navigates to the next/previous match.

The simplest fix is to tie `syncActiveMatchTarget` to `syncEditors` in `refreshSearchResults`, since the two should always travel together:

```ts
const refreshSearchResults = ({
  syncEditors = false,
  syncActiveMatch = false,
}: RefreshSearchOptions) => {
  const activeMatchChanged = recomputeMatches();

  const shouldSyncEditors = syncEditors || activeMatchChanged;
  if (shouldSyncEditors) {
    syncEditorsToQuery();
  }

  // Re-apply the active-match decoration whenever the editors are redrawn,
  // because syncEditorsToQuery clears the selectedSearchMatchMark.
  if (shouldSyncEditors || syncActiveMatch) {
    syncActiveMatchTarget();
  }
};
```

(Note: this will also trigger the scroll-into-view behaviour on content changes, which may be worth separating if that becomes intrusive.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Do not compute search mat..."](https://github.com/langfuse/langfuse/commit/0ea19f1d86ae2acb14d9ecd4c180f42f749f0442) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28764542)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->