### PR TITLE
fix: don't initialize queues from QueueMetricsRunner

### DIFF
--- a/packages/shared/src/server/redis/batchActionQueue.ts
+++ b/packages/shared/src/server/redis/batchActionQueue.ts
@@ -47,4 +47,10 @@ export class BatchActionQueue {
 
     return BatchActionQueue.instance;
   }
+
+  public static getExistingInstance(): Queue<
+    TQueueJobTypes[QueueName.BatchActionQueue]
+  > | null {
+    return BatchActionQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/batchExport.ts
+++ b/packages/shared/src/server/redis/batchExport.ts
@@ -46,4 +46,8 @@ export class BatchExportQueue {
 
     return BatchExportQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return BatchExportQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/blobStorageIntegrationProcessingQueue.ts
+++ b/packages/shared/src/server/redis/blobStorageIntegrationProcessingQueue.ts
@@ -44,4 +44,8 @@ export class BlobStorageIntegrationProcessingQueue {
 
     return BlobStorageIntegrationProcessingQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return BlobStorageIntegrationProcessingQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/blobStorageIntegrationQueue.ts
@@ -57,4 +57,8 @@ export class BlobStorageIntegrationQueue {
 
     return BlobStorageIntegrationQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return BlobStorageIntegrationQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/cloudFreeTierUsageThresholdQueue.ts
+++ b/packages/shared/src/server/redis/cloudFreeTierUsageThresholdQueue.ts
@@ -91,4 +91,8 @@ export class CloudFreeTierUsageThresholdQueue {
 
     return CloudFreeTierUsageThresholdQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return CloudFreeTierUsageThresholdQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/cloudSpendAlertQueue.ts
+++ b/packages/shared/src/server/redis/cloudSpendAlertQueue.ts
@@ -50,4 +50,8 @@ export class CloudSpendAlertQueue {
 
     return CloudSpendAlertQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return CloudSpendAlertQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
+++ b/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
@@ -70,4 +70,8 @@ export class CloudUsageMeteringQueue {
 
     return CloudUsageMeteringQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return CloudUsageMeteringQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
+++ b/packages/shared/src/server/redis/coreDataS3ExportQueue.ts
@@ -62,4 +62,8 @@ export class CoreDataS3ExportQueue {
 
     return CoreDataS3ExportQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return CoreDataS3ExportQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/createEvalQueue.ts
+++ b/packages/shared/src/server/redis/createEvalQueue.ts
@@ -47,4 +47,10 @@ export class CreateEvalQueue {
 
     return CreateEvalQueue.instance;
   }
+
+  public static getExistingInstance(): Queue<
+    TQueueJobTypes[QueueName.CreateEvalQueue]
+  > | null {
+    return CreateEvalQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/dataRetentionProcessingQueue.ts
+++ b/packages/shared/src/server/redis/dataRetentionProcessingQueue.ts
@@ -42,4 +42,8 @@ export class DataRetentionProcessingQueue {
 
     return DataRetentionProcessingQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return DataRetentionProcessingQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/dataRetentionQueue.ts
+++ b/packages/shared/src/server/redis/dataRetentionQueue.ts
@@ -57,4 +57,8 @@ export class DataRetentionQueue {
 
     return DataRetentionQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return DataRetentionQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/datasetDelete.ts
+++ b/packages/shared/src/server/redis/datasetDelete.ts
@@ -47,4 +47,8 @@ export class DatasetDeleteQueue {
 
     return DatasetDeleteQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return DatasetDeleteQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/datasetRunItemUpsert.ts
+++ b/packages/shared/src/server/redis/datasetRunItemUpsert.ts
@@ -49,4 +49,8 @@ export class DatasetRunItemUpsertQueue {
 
     return DatasetRunItemUpsertQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return DatasetRunItemUpsertQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/dlqRetryQueue.ts
+++ b/packages/shared/src/server/redis/dlqRetryQueue.ts
@@ -57,4 +57,8 @@ export class DeadLetterRetryQueue {
 
     return DeadLetterRetryQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return DeadLetterRetryQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/entityChangeQueue.ts
+++ b/packages/shared/src/server/redis/entityChangeQueue.ts
@@ -47,4 +47,10 @@ export class EntityChangeQueue {
 
     return EntityChangeQueue.instance;
   }
+
+  public static getExistingInstance(): Queue<
+    TQueueJobTypes[QueueName.EntityChangeQueue]
+  > | null {
+    return EntityChangeQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/evalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/evalExecutionQueue.ts
@@ -89,6 +89,12 @@ export class EvalExecutionQueue {
 
     return queueInstance;
   }
+
+  public static getExistingInstance(shardName: string): Queue | null {
+    const shardIndex = this.getShardIndexFromShardName(shardName);
+    if (shardIndex === null) return null;
+    return this.instances.get(shardIndex) ?? null;
+  }
 }
 
 export class SecondaryEvalExecutionQueue {
@@ -184,5 +190,11 @@ export class SecondaryEvalExecutionQueue {
     SecondaryEvalExecutionQueue.instances.set(shardIndex, queueInstance);
 
     return queueInstance;
+  }
+
+  public static getExistingInstance(shardName: string): Queue | null {
+    const shardIndex = this.getShardIndexFromShardName(shardName);
+    if (shardIndex === null) return null;
+    return this.instances.get(shardIndex) ?? null;
   }
 }

--- a/packages/shared/src/server/redis/eventPropagationQueue.ts
+++ b/packages/shared/src/server/redis/eventPropagationQueue.ts
@@ -65,4 +65,8 @@ export class EventPropagationQueue {
 
     return EventPropagationQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return EventPropagationQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/experimentCreateQueue.ts
+++ b/packages/shared/src/server/redis/experimentCreateQueue.ts
@@ -47,4 +47,8 @@ export class ExperimentCreateQueue {
 
     return ExperimentCreateQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return ExperimentCreateQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -103,3 +103,82 @@ export function getQueue(
     }
   }
 }
+
+/**
+ * Returns an already-initialized Queue singleton, or null if getInstance()
+ * has not been called yet. Never creates Redis connections or triggers
+ * side effects.
+ */
+export function getExistingQueue(
+  queueName: Exclude<
+    QueueName,
+    | QueueName.IngestionQueue
+    | QueueName.IngestionSecondaryQueue
+    | QueueName.EvaluationExecution
+    | QueueName.EvaluationExecutionSecondaryQueue
+    | QueueName.LLMAsJudgeExecution
+    | QueueName.TraceUpsert
+    | QueueName.OtelIngestionQueue
+  >,
+): Queue | null {
+  switch (queueName) {
+    case QueueName.BatchExport:
+      return BatchExportQueue.getExistingInstance();
+    case QueueName.CloudUsageMeteringQueue:
+      return CloudUsageMeteringQueue.getExistingInstance();
+    case QueueName.CloudSpendAlertQueue:
+      return CloudSpendAlertQueue.getExistingInstance();
+    case QueueName.CloudFreeTierUsageThresholdQueue:
+      return CloudFreeTierUsageThresholdQueue.getExistingInstance();
+    case QueueName.DatasetRunItemUpsert:
+      return DatasetRunItemUpsertQueue.getExistingInstance();
+    case QueueName.DatasetDelete:
+      return DatasetDeleteQueue.getExistingInstance();
+    case QueueName.ExperimentCreate:
+      return ExperimentCreateQueue.getExistingInstance();
+    case QueueName.TraceDelete:
+      return TraceDeleteQueue.getExistingInstance();
+    case QueueName.ProjectDelete:
+      return ProjectDeleteQueue.getExistingInstance();
+    case QueueName.PostHogIntegrationQueue:
+      return PostHogIntegrationQueue.getExistingInstance();
+    case QueueName.PostHogIntegrationProcessingQueue:
+      return PostHogIntegrationProcessingQueue.getExistingInstance();
+    case QueueName.MixpanelIntegrationQueue:
+      return MixpanelIntegrationQueue.getExistingInstance();
+    case QueueName.MixpanelIntegrationProcessingQueue:
+      return MixpanelIntegrationProcessingQueue.getExistingInstance();
+    case QueueName.BlobStorageIntegrationQueue:
+      return BlobStorageIntegrationQueue.getExistingInstance();
+    case QueueName.BlobStorageIntegrationProcessingQueue:
+      return BlobStorageIntegrationProcessingQueue.getExistingInstance();
+    case QueueName.CoreDataS3ExportQueue:
+      return CoreDataS3ExportQueue.getExistingInstance();
+    case QueueName.MeteringDataPostgresExportQueue:
+      return MeteringDataPostgresExportQueue.getExistingInstance();
+    case QueueName.DataRetentionQueue:
+      return DataRetentionQueue.getExistingInstance();
+    case QueueName.DataRetentionProcessingQueue:
+      return DataRetentionProcessingQueue.getExistingInstance();
+    case QueueName.BatchActionQueue:
+      return BatchActionQueue.getExistingInstance();
+    case QueueName.CreateEvalQueue:
+      return CreateEvalQueue.getExistingInstance();
+    case QueueName.ScoreDelete:
+      return ScoreDeleteQueue.getExistingInstance();
+    case QueueName.DeadLetterRetryQueue:
+      return DeadLetterRetryQueue.getExistingInstance();
+    case QueueName.WebhookQueue:
+      return WebhookQueue.getExistingInstance();
+    case QueueName.EntityChangeQueue:
+      return EntityChangeQueue.getExistingInstance();
+    case QueueName.EventPropagationQueue:
+      return EventPropagationQueue.getExistingInstance();
+    case QueueName.NotificationQueue:
+      return NotificationQueue.getExistingInstance();
+    default: {
+      const _exhaustiveCheckDefault: never = queueName;
+      return null;
+    }
+  }
+}

--- a/packages/shared/src/server/redis/ingestionQueue.ts
+++ b/packages/shared/src/server/redis/ingestionQueue.ts
@@ -90,6 +90,12 @@ export class IngestionQueue {
 
     return queueInstance;
   }
+
+  public static getExistingInstance(shardName: string): Queue | null {
+    const shardIndex = this.getShardIndexFromShardName(shardName);
+    if (shardIndex === null) return null;
+    return this.instances.get(shardIndex) ?? null;
+  }
 }
 
 export class SecondaryIngestionQueue {
@@ -176,5 +182,11 @@ export class SecondaryIngestionQueue {
     SecondaryIngestionQueue.instances.set(shardIndex, queueInstance);
 
     return queueInstance;
+  }
+
+  public static getExistingInstance(shardName: string): Queue | null {
+    const shardIndex = this.getShardIndexFromShardName(shardName);
+    if (shardIndex === null) return null;
+    return this.instances.get(shardIndex) ?? null;
   }
 }

--- a/packages/shared/src/server/redis/llmAsJudgeExecutionQueue.ts
+++ b/packages/shared/src/server/redis/llmAsJudgeExecutionQueue.ts
@@ -89,4 +89,10 @@ export class LLMAsJudgeExecutionQueue {
 
     return queueInstance;
   }
+
+  public static getExistingInstance(shardName: string): Queue | null {
+    const shardIndex = this.getShardIndexFromShardName(shardName);
+    if (shardIndex === null) return null;
+    return this.instances.get(shardIndex) ?? null;
+  }
 }

--- a/packages/shared/src/server/redis/meteringDataPostgresExportQueue.ts
+++ b/packages/shared/src/server/redis/meteringDataPostgresExportQueue.ts
@@ -65,4 +65,8 @@ export class MeteringDataPostgresExportQueue {
 
     return MeteringDataPostgresExportQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return MeteringDataPostgresExportQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/mixpanelIntegrationProcessingQueue.ts
+++ b/packages/shared/src/server/redis/mixpanelIntegrationProcessingQueue.ts
@@ -42,4 +42,8 @@ export class MixpanelIntegrationProcessingQueue {
 
     return MixpanelIntegrationProcessingQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return MixpanelIntegrationProcessingQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/mixpanelIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/mixpanelIntegrationQueue.ts
@@ -59,4 +59,8 @@ export class MixpanelIntegrationQueue {
 
     return MixpanelIntegrationQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return MixpanelIntegrationQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/notificationQueue.ts
+++ b/packages/shared/src/server/redis/notificationQueue.ts
@@ -47,4 +47,10 @@ export class NotificationQueue {
 
     return NotificationQueue.instance;
   }
+
+  public static getExistingInstance(): Queue<
+    TQueueJobTypes[QueueName.NotificationQueue]
+  > | null {
+    return NotificationQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/otelIngestionQueue.ts
+++ b/packages/shared/src/server/redis/otelIngestionQueue.ts
@@ -95,4 +95,10 @@ export class OtelIngestionQueue {
 
     return queueInstance;
   }
+
+  public static getExistingInstance(shardName: string): Queue | null {
+    const shardIndex = this.getShardIndexFromShardName(shardName);
+    if (shardIndex === null) return null;
+    return this.instances.get(shardIndex) ?? null;
+  }
 }

--- a/packages/shared/src/server/redis/postHogIntegrationProcessingQueue.ts
+++ b/packages/shared/src/server/redis/postHogIntegrationProcessingQueue.ts
@@ -42,4 +42,8 @@ export class PostHogIntegrationProcessingQueue {
 
     return PostHogIntegrationProcessingQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return PostHogIntegrationProcessingQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/postHogIntegrationQueue.ts
+++ b/packages/shared/src/server/redis/postHogIntegrationQueue.ts
@@ -59,4 +59,8 @@ export class PostHogIntegrationQueue {
 
     return PostHogIntegrationQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return PostHogIntegrationQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/projectDelete.ts
+++ b/packages/shared/src/server/redis/projectDelete.ts
@@ -48,4 +48,8 @@ export class ProjectDeleteQueue {
 
     return ProjectDeleteQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return ProjectDeleteQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/scoreDelete.ts
+++ b/packages/shared/src/server/redis/scoreDelete.ts
@@ -46,4 +46,10 @@ export class ScoreDeleteQueue {
 
     return ScoreDeleteQueue.instance;
   }
+
+  public static getExistingInstance(): Queue<
+    TQueueJobTypes[QueueName.ScoreDelete]
+  > | null {
+    return ScoreDeleteQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/traceDelete.ts
+++ b/packages/shared/src/server/redis/traceDelete.ts
@@ -46,4 +46,8 @@ export class TraceDeleteQueue {
 
     return TraceDeleteQueue.instance;
   }
+
+  public static getExistingInstance(): Queue | null {
+    return TraceDeleteQueue.instance;
+  }
 }

--- a/packages/shared/src/server/redis/traceUpsert.ts
+++ b/packages/shared/src/server/redis/traceUpsert.ts
@@ -94,4 +94,10 @@ export class TraceUpsertQueue {
 
     return queueInstance;
   }
+
+  public static getExistingInstance(shardName: string): Queue | null {
+    const shardIndex = this.getShardIndexFromShardName(shardName);
+    if (shardIndex === null) return null;
+    return this.instances.get(shardIndex) ?? null;
+  }
 }

--- a/packages/shared/src/server/redis/webhookQueue.ts
+++ b/packages/shared/src/server/redis/webhookQueue.ts
@@ -47,4 +47,10 @@ export class WebhookQueue {
 
     return WebhookQueue.instance;
   }
+
+  public static getExistingInstance(): Queue<
+    TQueueJobTypes[QueueName.WebhookQueue]
+  > | null {
+    return WebhookQueue.instance;
+  }
 }

--- a/worker/src/features/queue-metrics-runner/index.ts
+++ b/worker/src/features/queue-metrics-runner/index.ts
@@ -13,7 +13,7 @@ import { WorkerManager } from "../../queues/workerManager";
 import {
   SHARDED_QUEUES,
   SHARDED_QUEUE_BASE_NAMES,
-  resolveQueueInstance,
+  resolveExistingQueueInstance,
 } from "../../queues/shardedQueueRegistry";
 
 type DepthType = "waiting" | "failed" | "active";
@@ -59,10 +59,10 @@ export class QueueMetricsRunner extends PeriodicRunner {
   }
 
   protected async execute(): Promise<void> {
-    // Only poll queues that have registered workers. This avoids calling
-    // getInstance() on queues this worker doesn't consume, which would
-    // create unnecessary Redis connections and can trigger side effects
-    // (e.g. CloudUsageMeteringQueue.getInstance() enqueues cron jobs).
+    // Only poll queues whose instances are already initialized. Uses
+    // getExistingInstance() which never creates Redis connections or
+    // triggers side effects (e.g. CloudUsageMeteringQueue.getInstance()
+    // enqueues cron jobs — getExistingInstance() does not).
     const registeredNames = new Set(WorkerManager.getRegisteredQueueNames());
     const promises: Promise<void>[] = [];
 
@@ -71,7 +71,7 @@ export class QueueMetricsRunner extends PeriodicRunner {
       if (SHARDED_QUEUE_BASE_NAMES.has(queueName)) continue;
       if (!registeredNames.has(queueName)) continue;
 
-      const queue = resolveQueueInstance(queueName);
+      const queue = resolveExistingQueueInstance(queueName);
       if (!queue) continue;
 
       const metricBase = convertQueueNameToMetricName(queueName);
@@ -115,7 +115,7 @@ export class QueueMetricsRunner extends PeriodicRunner {
       const metricBase = convertQueueNameToMetricName(config.baseQueueName);
 
       const shardPromises = shardNames.map((shardName) => {
-        const queue = config.getInstance(shardName);
+        const queue = config.getExistingInstance(shardName);
         if (!queue) return Promise.resolve(null);
 
         return collectDepth(queue)

--- a/worker/src/queues/shardedQueueRegistry.ts
+++ b/worker/src/queues/shardedQueueRegistry.ts
@@ -3,6 +3,7 @@ import { Queue } from "bullmq";
 import {
   QueueName,
   getQueue,
+  getExistingQueue,
   IngestionQueue,
   SecondaryIngestionQueue,
   OtelIngestionQueue,
@@ -16,6 +17,7 @@ export type ShardedQueueDef = {
   baseQueueName: QueueName;
   getShardNames: () => string[];
   getInstance: (shardName: string) => Queue | null;
+  getExistingInstance: (shardName: string) => Queue | null;
 };
 
 export const SHARDED_QUEUES: ShardedQueueDef[] = [
@@ -23,41 +25,53 @@ export const SHARDED_QUEUES: ShardedQueueDef[] = [
     baseQueueName: QueueName.IngestionQueue,
     getShardNames: () => IngestionQueue.getShardNames(),
     getInstance: (shard) => IngestionQueue.getInstance({ shardName: shard }),
+    getExistingInstance: (shard) => IngestionQueue.getExistingInstance(shard),
   },
   {
     baseQueueName: QueueName.IngestionSecondaryQueue,
     getShardNames: () => SecondaryIngestionQueue.getShardNames(),
     getInstance: (shard) =>
       SecondaryIngestionQueue.getInstance({ shardName: shard }),
+    getExistingInstance: (shard) =>
+      SecondaryIngestionQueue.getExistingInstance(shard),
   },
   {
     baseQueueName: QueueName.OtelIngestionQueue,
     getShardNames: () => OtelIngestionQueue.getShardNames(),
     getInstance: (shard) =>
       OtelIngestionQueue.getInstance({ shardName: shard }),
+    getExistingInstance: (shard) =>
+      OtelIngestionQueue.getExistingInstance(shard),
   },
   {
     baseQueueName: QueueName.TraceUpsert,
     getShardNames: () => TraceUpsertQueue.getShardNames(),
     getInstance: (shard) => TraceUpsertQueue.getInstance({ shardName: shard }),
+    getExistingInstance: (shard) => TraceUpsertQueue.getExistingInstance(shard),
   },
   {
     baseQueueName: QueueName.EvaluationExecution,
     getShardNames: () => EvalExecutionQueue.getShardNames(),
     getInstance: (shard) =>
       EvalExecutionQueue.getInstance({ shardName: shard }),
+    getExistingInstance: (shard) =>
+      EvalExecutionQueue.getExistingInstance(shard),
   },
   {
     baseQueueName: QueueName.EvaluationExecutionSecondaryQueue,
     getShardNames: () => SecondaryEvalExecutionQueue.getShardNames(),
     getInstance: (shard) =>
       SecondaryEvalExecutionQueue.getInstance({ shardName: shard }),
+    getExistingInstance: (shard) =>
+      SecondaryEvalExecutionQueue.getExistingInstance(shard),
   },
   {
     baseQueueName: QueueName.LLMAsJudgeExecution,
     getShardNames: () => LLMAsJudgeExecutionQueue.getShardNames(),
     getInstance: (shard) =>
       LLMAsJudgeExecutionQueue.getInstance({ shardName: shard }),
+    getExistingInstance: (shard) =>
+      LLMAsJudgeExecutionQueue.getExistingInstance(shard),
   },
 ];
 
@@ -68,7 +82,7 @@ export const SHARDED_QUEUE_BASE_NAMES = new Set<QueueName>(
 /**
  * Resolve a queue name (possibly a shard name like "ingestion-queue-1") to its
  * BullMQ Queue instance. Checks sharded queues first, then falls back to
- * non-sharded getQueue().
+ * non-sharded getQueue(). Creates the instance if it doesn't exist.
  */
 export function resolveQueueInstance(queueName: string): Queue | null {
   for (const def of SHARDED_QUEUES) {
@@ -78,6 +92,31 @@ export function resolveQueueInstance(queueName: string): Queue | null {
   }
 
   return getQueue(
+    queueName as Exclude<
+      QueueName,
+      | QueueName.IngestionQueue
+      | QueueName.IngestionSecondaryQueue
+      | QueueName.EvaluationExecution
+      | QueueName.EvaluationExecutionSecondaryQueue
+      | QueueName.LLMAsJudgeExecution
+      | QueueName.TraceUpsert
+      | QueueName.OtelIngestionQueue
+    >,
+  );
+}
+
+/**
+ * Like resolveQueueInstance but only returns already-initialized instances.
+ * Never creates Redis connections or triggers side effects.
+ */
+export function resolveExistingQueueInstance(queueName: string): Queue | null {
+  for (const def of SHARDED_QUEUES) {
+    if (queueName.startsWith(def.baseQueueName)) {
+      return def.getExistingInstance(queueName);
+    }
+  }
+
+  return getExistingQueue(
     queueName as Exclude<
       QueueName,
       | QueueName.IngestionQueue


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a bug where `QueueMetricsRunner` was calling `getQueue()`/`getInstance()` on every poll cycle, which unintentionally initialized queues (creating Redis connections and scheduling cron jobs — e.g., `CloudUsageMeteringQueue.getInstance()` enqueues recurring jobs on first call). The fix adds `getExistingInstance()` to all 30+ queue classes, a new `getExistingQueue()` dispatcher in `getQueue.ts`, and `resolveExistingQueueInstance()` in `shardedQueueRegistry.ts`. `QueueMetricsRunner` now only polls queue instances that are already initialized and have a registered worker in the current process.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix correctly prevents queue initialization side effects from the metrics runner, and all 30+ queue classes implement the new getExistingInstance() pattern consistently.

All findings are P2 or lower. The implementation is correct: getExistingInstance() simply returns the static field without creating Redis connections or scheduling cron jobs, and getExistingQueue()'s switch is kept in sync with getQueue(). The logic in QueueMetricsRunner for filtering by registered worker names and using the non-initializing path is sound.

No files require special attention. The minor missing blank line in otelIngestionQueue.ts is cosmetic only.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/features/queue-metrics-runner/index.ts | Core fix: now uses resolveExistingQueueInstance() and filters by registered worker names to avoid initializing queues with side effects |
| worker/src/queues/shardedQueueRegistry.ts | Adds resolveExistingQueueInstance() alongside existing resolveQueueInstance() for safe non-initializing queue lookup |
| packages/shared/src/server/redis/getQueue.ts | Adds getExistingQueue() switch matching all entries in getQueue(); default case correctly returns null rather than throwing |
| packages/shared/src/server/redis/cloudUsageMeteringQueue.ts | Adds getExistingInstance(); the cron-scheduling side effect in getInstance() is now safely skipped by the metrics runner |
| packages/shared/src/server/redis/ingestionQueue.ts | Adds getExistingInstance() for both IngestionQueue and SecondaryIngestionQueue sharded classes; implementation is correct |
| packages/shared/src/server/redis/evalExecutionQueue.ts | Adds getExistingInstance() to EvalExecutionQueue and SecondaryEvalExecutionQueue; consistent with other sharded queue implementations |
| packages/shared/src/server/redis/dlqRetryQueue.ts | Adds getExistingInstance(); getInstance() schedules a cron job so the non-initializing path is important here too |
| packages/shared/src/server/redis/otelIngestionQueue.ts | Adds getExistingInstance(); minor: missing blank line between last import and class declaration (cosmetic, pre-existing or introduced in this PR) |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant QMR as QueueMetricsRunner
    participant WM as WorkerManager
    participant SQR as shardedQueueRegistry
    participant QC as QueueClass

    Note over QMR: execute() on each poll interval

    QMR->>WM: getRegisteredQueueNames()
    WM-->>QMR: registered worker names

    loop For each non-sharded QueueName
        QMR->>QMR: skip if not in registeredNames
        QMR->>SQR: resolveExistingQueueInstance(queueName)
        SQR->>QC: getExistingInstance()
        Note over QC: returns static field only, no Redis init, no cron scheduling
        QC-->>SQR: Queue or null
        SQR-->>QMR: Queue or null
        QMR->>QMR: skip if null, else collectDepth and emitDepth
    end

    loop For each sharded queue config
        QMR->>QMR: filter shardNames by registeredNames
        loop For each matching shard
            QMR->>SQR: config.getExistingInstance(shardName)
            SQR-->>QMR: Queue or null
            QMR->>QMR: collectDepth and emitDepth per shard
        end
        QMR->>QMR: aggregate across shards and emit with shard=all
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t initialize queues from QueueM..."](https://github.com/langfuse/langfuse/commit/57648b989d6a783dc68c08d44e5e3efbc60e23c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28765882)</sub>

<!-- /greptile_comment -->