### PR TITLE
chore: deterministic CloudUsageMeteringQueue init

### DIFF
--- a/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
+++ b/packages/shared/src/server/redis/cloudUsageMeteringQueue.ts
@@ -51,21 +51,40 @@ export class CloudUsageMeteringQueue {
         jobId: "cloud-usage-metering-recurring",
         timestamp: new Date().toISOString(),
       });
-      CloudUsageMeteringQueue.instance.add(
-        QueueJobs.CloudUsageMeteringJob,
-        {},
-        {
-          // Run at minute 5 of every hour (e.g. 1:05, 2:05, 3:05, etc)
-          repeat: { pattern: "5 * * * *" },
-        },
-      );
+      CloudUsageMeteringQueue.instance
+        .add(
+          QueueJobs.CloudUsageMeteringJob,
+          {},
+          {
+            // Run at minute 5 of every hour (e.g. 1:05, 2:05, 3:05, etc)
+            repeat: { pattern: "5 * * * *" },
+          },
+        )
+        .catch((err) => {
+          logger.error(
+            "[CloudUsageMeteringQueue] Failed to schedule recurring job",
+            err,
+          );
+        });
 
       logger.info("[CloudUsageMeteringQueue] Scheduling bootstrap job", {
         jobId: "cloud-usage-metering-bootstrap",
         timestamp: new Date().toISOString(),
       });
-      // Bootstrap job to run immediately on startup
-      CloudUsageMeteringQueue.instance.add(QueueJobs.CloudUsageMeteringJob, {});
+      // Bootstrap job to run immediately on startup. Safe to enqueue from
+      // multiple replicas: the handler (handleCloudUsageMeteringJob) is
+      // idempotent — it acquires a DB lock via optimistic concurrency on the
+      // cronJobs row and exits early ("not due yet") if the metering interval
+      // hasn't elapsed. Duplicate jobs are processed sequentially (concurrency: 1)
+      // and no-op harmlessly.
+      CloudUsageMeteringQueue.instance
+        .add(QueueJobs.CloudUsageMeteringJob, {})
+        .catch((err) => {
+          logger.error(
+            "[CloudUsageMeteringQueue] Failed to schedule bootstrap job",
+            err,
+          );
+        });
     }
 
     return CloudUsageMeteringQueue.instance;

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -37,6 +37,7 @@ import {
   OtelIngestionQueue,
   TraceUpsertQueue,
   CloudFreeTierUsageThresholdQueue,
+  CloudUsageMeteringQueue,
   EventPropagationQueue,
   EvalExecutionQueue,
   SecondaryEvalExecutionQueue,
@@ -357,6 +358,9 @@ if (
   env.QUEUE_CONSUMER_CLOUD_USAGE_METERING_QUEUE_IS_ENABLED === "true" &&
   env.STRIPE_SECRET_KEY
 ) {
+  // Instantiate the queue to trigger scheduled jobs
+  CloudUsageMeteringQueue.getInstance();
+
   WorkerManager.register(
     QueueName.CloudUsageMeteringQueue,
     cloudUsageMeteringQueueProcessor,


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds `CloudUsageMeteringQueue.getInstance()` before registering the queue worker in `app.ts`, matching the pattern already used by other scheduled queues (`CoreDataS3ExportQueue`, `PostHogIntegrationQueue`, `DataRetentionQueue`, etc.). Without this call, the recurring cron job (`"5 * * * *"`) and bootstrap job defined in `CloudUsageMeteringQueue.getInstance()` would never be scheduled on startup, leaving the worker idle on fresh deployments unless jobs were already persisted in Redis from a prior run.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line fix following the established queue initialization pattern.

The change is small, targeted, and strictly additive. It mirrors the pattern used by every other scheduled queue in the file. The only effect is ensuring cron and bootstrap jobs are reliably registered at startup; no existing behavior is removed or altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/app.ts | Adds `CloudUsageMeteringQueue.getInstance()` before `WorkerManager.register()` to ensure the recurring cron job and bootstrap job are scheduled on startup, consistent with how all other scheduled queues are initialized. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as app.ts (startup)
    participant CUMQueue as CloudUsageMeteringQueue
    participant Redis as Redis (BullMQ)
    participant WM as WorkerManager
    participant Proc as cloudUsageMeteringQueueProcessor

    App->>CUMQueue: getInstance()
    CUMQueue->>Redis: new Queue(CloudUsageMeteringQueue)
    CUMQueue->>Redis: add recurring job (cron "5 * * * *")
    CUMQueue->>Redis: add bootstrap job (run immediately)
    App->>WM: register(CloudUsageMeteringQueue, processor)
    WM->>Proc: process CloudUsageMeteringJob (bootstrap)
    loop Every hour at :05
        Redis-->>Proc: process CloudUsageMeteringJob (recurring)
    end
```

<sub>Reviews (1): Last reviewed commit: ["chore: deterministic CloudUsageMeteringQ..."](https://github.com/langfuse/langfuse/commit/dd8cfc2e52468212dec39de28867f147c634c551) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28771556)</sub>

<!-- /greptile_comment -->