### PR TITLE
fix: make new queue depth metrics usable in cloud watch

### DIFF
--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -298,7 +298,19 @@ export const recordGauge = (
     | undefined,
 ) => {
   if (env.ENABLE_AWS_CLOUDWATCH_METRIC_PUBLISHING === "true") {
-    sendCloudWatchMetric(stat, value ?? 0, true);
+    // For .depth metrics, flatten tags into the metric name so CloudWatch
+    // can distinguish e.g. depth.shard_all.type_waiting from depth.type_active.
+    // Other metrics are unaffected.
+    let cwKey = stat;
+    if (stat.endsWith(".depth") && tags) {
+      const suffix = Object.entries(tags)
+        .filter(([k]) => k !== "unit")
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}_${v}`)
+        .join(".");
+      if (suffix) cwKey = `${stat}.${suffix}`;
+    }
+    sendCloudWatchMetric(cwKey, value ?? 0, true);
   }
   dd.dogstatsd.gauge(stat, value, tags);
 };


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes the `recordGauge` function so that queue-depth metrics emitted to CloudWatch include a tag-derived suffix in the metric name, making them distinguishable. Previously, all calls to `recordGauge` with a `.depth` stat would map to the same CloudWatch key regardless of their `type` (waiting/failed/active) or `shard` tag, so only the last-written value survived per flush cycle.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is targeted, correct, and has no P0 or P1 issues.

The tag-flattening logic is correct: tags are sorted for a stable key, the `unit` meta-tag is excluded, and empty suffixes are safely ignored. All actual tag values used by the callers are safe for CloudWatch metric names. No blocking issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/instrumentation/index.ts | Adds tag-flattening into the CloudWatch metric name for `.depth` stats; logic is correct and sorting ensures a stable key regardless of object insertion order. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["recordGauge(stat, value, tags)"] --> B{CloudWatch enabled?}
    B -- No --> E["dd.dogstatsd.gauge only"]
    B -- Yes --> C{stat ends with .depth AND tags present?}
    C -- No --> D["cwKey = stat unchanged"]
    C -- Yes --> F["Filter out unit tag, sort by key, map to key_value pairs, join with dot"]
    F --> G{suffix non-empty?}
    G -- Yes --> H["cwKey = stat + dot + suffix"]
    G -- No --> D
    D --> I["sendCloudWatchMetric(cwKey, value, replace=true)"]
    H --> I
    I --> J[Update metricCache]
    J --> K{30s flush interval?}
    K -- Yes --> L["PutMetricDataCommand, Namespace: Langfuse"]
    K -- No --> M[Wait for next call]
    L --> E
```

<sub>Reviews (1): Last reviewed commit: ["fix: make new queue depth metrics usable..."](https://github.com/langfuse/langfuse/commit/5da59939899d9f4a0bba7b53aaaee41f2ab616de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28779398)</sub>

<!-- /greptile_comment -->