### PR TITLE
chore(scim): add [SCIM] log prefix and operation confirmations

### DIFF
--- a/web/src/pages/api/public/scim/ResourceTypes.ts
+++ b/web/src/pages/api/public/scim/ResourceTypes.ts
@@ -13,7 +13,7 @@ export default async function handler(
 
   if (req.method !== "GET") {
     logger.error(
-      `Method not allowed for ${req.method} on /api/public/scim/ResourceTypes`,
+      `[SCIM] Method not allowed for ${req.method} on /api/public/scim/ResourceTypes`,
     );
     return res.status(405).json({
       schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],

--- a/web/src/pages/api/public/scim/Schemas.ts
+++ b/web/src/pages/api/public/scim/Schemas.ts
@@ -13,7 +13,7 @@ export default async function handler(
 
   if (req.method !== "GET") {
     logger.error(
-      `Method not allowed for ${req.method} on /api/public/scim/Schemas`,
+      `[SCIM] Method not allowed for ${req.method} on /api/public/scim/Schemas`,
     );
     return res.status(405).json({
       schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],

--- a/web/src/pages/api/public/scim/ServiceProviderConfig.ts
+++ b/web/src/pages/api/public/scim/ServiceProviderConfig.ts
@@ -13,7 +13,7 @@ export default async function handler(
 
   if (req.method !== "GET") {
     logger.error(
-      `Method not allowed for ${req.method} on /api/public/scim/ServiceProviderConfig`,
+      `[SCIM] Method not allowed for ${req.method} on /api/public/scim/ServiceProviderConfig`,
     );
     return res.status(405).json({
       schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],

--- a/web/src/pages/api/public/scim/Users/[id].ts
+++ b/web/src/pages/api/public/scim/Users/[id].ts
@@ -13,7 +13,7 @@ export default async function handler(
 
   if (!["GET", "DELETE", "PATCH", "PUT"].includes(req.method || "")) {
     logger.error(
-      `Method not allowed for ${req.method} on /api/public/scim/Users/[id]`,
+      `[SCIM] Method not allowed for ${req.method} on /api/public/scim/Users/[id]`,
     );
     return res.status(405).json({
       schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
@@ -50,7 +50,7 @@ export default async function handler(
   }
 
   logger.info(
-    `Received request for /api/public/scim/Users/[id] with method ${req.method} for orgId ${authCheck.scope.orgId} and userId ${req.query.id}`,
+    `[SCIM] Received request for /api/public/scim/Users/[id] with method ${req.method} for orgId ${authCheck.scope.orgId} and userId ${req.query.id}`,
   );
 
   // First, check if the user exists in the system at all
@@ -89,7 +89,7 @@ export default async function handler(
     }
   } catch (error) {
     logger.error(
-      `Error handling SCIM user ${req.query.id} for ${req.method}`,
+      `[SCIM] Error handling user ${req.query.id} for ${req.method}`,
       error,
     );
     return res.status(500).json({
@@ -162,7 +162,7 @@ async function handlePatch(
     try {
       body = JSON.parse(body);
     } catch (error) {
-      logger.warn("Failed to parse JSON body", error);
+      logger.warn("[SCIM] Failed to parse JSON body", error);
       return res.status(400).json({
         schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
         detail: "Invalid JSON body",
@@ -178,7 +178,7 @@ async function handlePatch(
     !body.schemas.includes("urn:ietf:params:scim:api:messages:2.0:PatchOp")
   ) {
     logger.warn(
-      "Invalid request body. Must include 'schemas' with 'urn:ietf:params:scim:api:messages:2.0:PatchOp'.",
+      "[SCIM] Invalid request body. Must include 'schemas' with 'urn:ietf:params:scim:api:messages:2.0:PatchOp'.",
       body,
     );
     return res.status(400).json({
@@ -192,7 +192,7 @@ async function handlePatch(
   // Check for operations
   if (!body.Operations || !Array.isArray(body.Operations)) {
     logger.warn(
-      "Invalid request body. Must include 'Operations' array with at least one operation.",
+      "[SCIM] Invalid request body. Must include 'Operations' array with at least one operation.",
       body,
     );
     return res.status(400).json({
@@ -226,6 +226,9 @@ async function handlePatch(
           },
           update: {},
         });
+        logger.info(
+          `[SCIM] Provisioned user ${user.id} in org ${orgId} via PATCH`,
+        );
       } else {
         // Deprovision the user by removing them from the organization
         await prisma.organizationMembership.deleteMany({
@@ -234,10 +237,13 @@ async function handlePatch(
             orgId: orgId,
           },
         });
+        logger.info(
+          `[SCIM] Deprovisioned user ${user.id} from org ${orgId} via PATCH`,
+        );
       }
     } else {
       logger.error(
-        "Unsupported operation or invalid value in request body. Only 'replace' with 'active' field is supported.",
+        "[SCIM] Unsupported operation or invalid value in request body. Only 'replace' with 'active' field is supported.",
         op,
       );
       return res.status(400).json({
@@ -266,7 +272,7 @@ async function handlePut(
     try {
       body = JSON.parse(body);
     } catch (error) {
-      logger.warn("Failed to parse JSON body", error);
+      logger.warn("[SCIM] Failed to parse JSON body", error);
       return res.status(400).json({
         schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
         detail: "Invalid JSON body",
@@ -282,7 +288,7 @@ async function handlePut(
     !body.schemas.includes("urn:ietf:params:scim:schemas:core:2.0:User")
   ) {
     logger.warn(
-      "Invalid request body. Must include 'schemas' with 'urn:ietf:params:scim:schemas:core:2.0:User'.",
+      "[SCIM] Invalid request body. Must include 'schemas' with 'urn:ietf:params:scim:schemas:core:2.0:User'.",
       body,
     );
     return res.status(400).json({
@@ -326,6 +332,9 @@ async function handlePut(
           role: role,
         },
       });
+      logger.info(
+        `[SCIM] Provisioned user ${user.id} in org ${orgId} with role ${role} via PUT`,
+      );
     } else {
       // Deprovision the user by removing them from the organization
       await prisma.organizationMembership.deleteMany({
@@ -334,6 +343,9 @@ async function handlePut(
           orgId: orgId,
         },
       });
+      logger.info(
+        `[SCIM] Deprovisioned user ${user.id} from org ${orgId} via PUT`,
+      );
     }
   }
 
@@ -369,6 +381,7 @@ async function handleDelete(
       orgId: orgId,
     },
   });
+  logger.info(`[SCIM] Removed user ${user.id} from org ${orgId} via DELETE`);
 
   // Return empty response with 204 No Content.
   // With NextJS 15, we can't return NextApiResponse objects anymore

--- a/web/src/pages/api/public/scim/Users/index.ts
+++ b/web/src/pages/api/public/scim/Users/index.ts
@@ -16,7 +16,7 @@ export default async function handler(
 
   if (req.method !== "GET" && req.method !== "POST") {
     logger.error(
-      `Method not allowed for ${req.method} on /api/public/scim/Users`,
+      `[SCIM] Method not allowed for ${req.method} on /api/public/scim/Users`,
     );
     return res.status(405).json({
       schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
@@ -53,7 +53,7 @@ export default async function handler(
   }
 
   logger.info(
-    `Received request for /api/public/scim/Users with method ${req.method} for orgId ${authCheck.scope.orgId}`,
+    `[SCIM] Received request for /api/public/scim/Users with method ${req.method} for orgId ${authCheck.scope.orgId}`,
   );
 
   if (req.method === "GET") {
@@ -128,7 +128,7 @@ export default async function handler(
         Resources: scimUsers,
       });
     } catch (error) {
-      logger.error("Error retrieving SCIM users", error);
+      logger.error("[SCIM] Error retrieving users", error);
       return res.status(500).json({
         schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
         detail: "Internal server error",
@@ -144,7 +144,7 @@ export default async function handler(
         try {
           body = JSON.parse(body);
         } catch (error) {
-          logger.error("Failed to parse JSON body", error);
+          logger.error("[SCIM] Failed to parse JSON body", error);
           return res.status(400).json({
             schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
             detail: "Invalid JSON body",
@@ -156,7 +156,7 @@ export default async function handler(
       const { userName, name, password, displayName, roles } = body;
 
       if (!userName) {
-        logger.warn("userName is required for SCIM user creation");
+        logger.warn("[SCIM] userName is required for user creation");
         return res.status(400).json({
           schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
           detail: "userName is required",
@@ -171,7 +171,7 @@ export default async function handler(
         );
         const parsedRoles = roleSchema.safeParse(roles);
         if (!parsedRoles.success) {
-          logger.warn("Invalid roles provided for SCIM user creation");
+          logger.warn("[SCIM] Invalid roles provided for user creation");
           return res.status(400).json({
             schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
             detail: `Invalid roles provided: ${JSON.stringify(roles)}, must be one of OWNER, ADMIN, MEMBER, VIEWER, NONE`,
@@ -194,7 +194,7 @@ export default async function handler(
 
       if (existingUser.length > 0) {
         logger.warn(
-          `User with userName ${userName} already exists in organization ${authCheck.scope.orgId}`,
+          `[SCIM] User ${existingUser[0].userId} already exists in organization ${authCheck.scope.orgId}`,
         );
         return res.status(409).json({
           schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
@@ -222,6 +222,9 @@ export default async function handler(
           role,
         },
       });
+      logger.info(
+        `[SCIM] Assigned user ${user.id} to org ${authCheck.scope.orgId} with role ${role}`,
+      );
 
       // Return SCIM formatted user
       return res.status(201).json({
@@ -245,7 +248,7 @@ export default async function handler(
         },
       });
     } catch (error) {
-      logger.error("Failed to create SCIM user", error);
+      logger.error("[SCIM] Failed to create user", error);
       return res.status(500).json({
         schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
         detail: "Internal server error",


### PR DESCRIPTION
## Summary
- Prefix every log statement in `web/src/pages/api/public/scim/**` with `[SCIM]` so SCIM traffic can be filtered out of aggregate logs.
- Add user-id-based confirmation logs after PUT/PATCH provisioning and deprovisioning and after DELETE, mirroring the existing POST assignment log. Operations can now be traced end-to-end without emitting `userName`/email.
- Drop the email from the 409 already-exists warn in `POST /scim/Users` and log the existing membership `userId` instead.

## Impacted packages
- `web`

## Verification
- `pnpm --filter web run lint` (runs as part of the precommit hook — green).

## Test plan
- [ ] Tail worker logs and hit `GET /api/public/scim/Users`; confirm the request line is prefixed with `[SCIM]`.
- [ ] `POST /api/public/scim/Users` for a new user; confirm the existing `[SCIM] Assigned user ...` log still fires.
- [ ] `POST /api/public/scim/Users` for a userName that already exists in the org; confirm the 409 log prints `userId`, not the email.
- [ ] `PUT /api/public/scim/Users/{id}` with `active: true` and then `active: false`; confirm both `Provisioned ... via PUT` / `Deprovisioned ... via PUT` logs fire with user id + org id.
- [ ] `PATCH /api/public/scim/Users/{id}` toggling `active`; confirm the equivalent PATCH confirmation logs.
- [ ] `DELETE /api/public/scim/Users/{id}`; confirm the `Removed user ... via DELETE` log fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a `[SCIM]` prefix to every log statement under `web/src/pages/api/public/scim/**` and introduces per-operation confirmation logs (Provisioned/Deprovisioned/Removed) after successful PUT, PATCH, and DELETE writes. It also replaces the `userName`/email value in the 409 conflict warning with the opaque `userId`, which is a minor privacy improvement.

The changes are purely additive logging enhancements with no modifications to business logic, database schema, or API contracts.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive logging changes with no business logic or API contract modifications.

All changes are logging-only: adding a consistent [SCIM] prefix and placing confirmation logs immediately after successful DB writes. No database schema, API contracts, or control-flow logic is altered. The 409 log change is a privacy improvement (email → userId). No P0/P1 issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/pages/api/public/scim/Users/[id].ts | Adds [SCIM] prefix throughout and new confirmation logs for PATCH/PUT provision/deprovision and DELETE operations; no logic changes. |
| web/src/pages/api/public/scim/Users/index.ts | Adds [SCIM] prefix, a new confirmation log after POST membership creation, and replaces email with userId in the 409 conflict warn. |
| web/src/pages/api/public/scim/ResourceTypes.ts | Single-line [SCIM] prefix added to the 405 error log; no other changes. |
| web/src/pages/api/public/scim/Schemas.ts | Single-line [SCIM] prefix added to the 405 error log; no other changes. |
| web/src/pages/api/public/scim/ServiceProviderConfig.ts | Single-line [SCIM] prefix added to the 405 error log; no other changes. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as SCIM Client
    participant H as Handler (Next.js)
    participant DB as Prisma / Postgres
    participant L as Logger

    C->>H: POST /scim/Users
    H->>DB: organizationMembership.findMany (check existing)
    alt User already exists in org
        H->>L: warn [SCIM] User {userId} already exists
        H-->>C: 409 Conflict
    else New user
        H->>DB: user.upsert
        H->>DB: organizationMembership.create
        H->>L: info [SCIM] Assigned user {id} to org {orgId} with role {role}
        H-->>C: 201 Created
    end

    C->>H: PUT /scim/Users/{id} (active=true)
    H->>DB: organizationMembership.upsert
    H->>L: info [SCIM] Provisioned user {id} in org {orgId} with role {role} via PUT
    H-->>C: 200 OK

    C->>H: PUT /scim/Users/{id} (active=false)
    H->>DB: organizationMembership.deleteMany
    H->>L: info [SCIM] Deprovisioned user {id} from org {orgId} via PUT
    H-->>C: 200 OK

    C->>H: PATCH /scim/Users/{id} (active=true)
    H->>DB: organizationMembership.upsert
    H->>L: info [SCIM] Provisioned user {id} in org {orgId} via PATCH
    H-->>C: 200 OK

    C->>H: PATCH /scim/Users/{id} (active=false)
    H->>DB: organizationMembership.deleteMany
    H->>L: info [SCIM] Deprovisioned user {id} from org {orgId} via PATCH
    H-->>C: 200 OK

    C->>H: DELETE /scim/Users/{id}
    H->>DB: organizationMembership.deleteMany
    H->>L: info [SCIM] Removed user {id} from org {orgId} via DELETE
    H-->>C: 204 No Content
```

<sub>Reviews (1): Last reviewed commit: ["chore(scim): add \[SCIM\] log prefix and o..."](https://github.com/langfuse/langfuse/commit/80c148d4ee0517d7f8f24b6cecc674e989828c85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28801131)</sub>

<!-- /greptile_comment -->