### PR TITLE
chore: prefix batch export logs

### DIFF
--- a/web/src/features/batch-exports/server/batchExport.ts
+++ b/web/src/features/batch-exports/server/batchExport.ts
@@ -30,7 +30,7 @@ export const batchExportRouter = createTRPCRouter({
         });
 
         const { projectId, query, format, name } = input;
-        logger.info("[TRPC] Creating export job", { job: input });
+        logger.info("[BATCH EXPORT] Creating export job", { job: input });
         const userId = ctx.session.user.id;
 
         // Create export job
@@ -66,7 +66,7 @@ export const batchExportRouter = createTRPCRouter({
           },
         });
       } catch (e) {
-        logger.error(e);
+        logger.error("[BATCH EXPORT] Failed to create export job", e);
         if (e instanceof TRPCError) {
           throw e;
         }

--- a/worker/src/features/batchExport/handleBatchExportJob.ts
+++ b/worker/src/features/batchExport/handleBatchExportJob.ts
@@ -42,7 +42,9 @@ export const handleBatchExportJob = async (
 
   const { projectId, batchExportId } = batchExportJob;
 
-  logger.info(`Starting batch export for ${projectId} and ${batchExportId}`);
+  logger.info(
+    `[BATCH EXPORT] Starting batch export for ${projectId} and ${batchExportId}`,
+  );
 
   const span = getCurrentSpan();
   if (span) {
@@ -70,7 +72,7 @@ export const handleBatchExportJob = async (
   // Check if the batch export has been cancelled
   if (jobDetails.status === BatchExportStatus.CANCELLED) {
     logger.info(
-      `Batch export ${batchExportId} has been cancelled. Skipping processing.`,
+      `[BATCH EXPORT] Batch export ${batchExportId} has been cancelled. Skipping processing.`,
     );
     return; // Exit early without processing
   }
@@ -97,7 +99,7 @@ export const handleBatchExportJob = async (
     });
 
     logger.info(
-      `Batch export ${batchExportId} is older than 30 days. Marked as failed with retry message.`,
+      `[BATCH EXPORT] Batch export ${batchExportId} is older than 30 days. Marked as failed with retry message.`,
     );
 
     return; // Exit early without processing
@@ -105,7 +107,7 @@ export const handleBatchExportJob = async (
 
   if (jobDetails.status !== BatchExportStatus.QUEUED) {
     logger.warn(
-      `Job ${batchExportId} has invalid status: ${jobDetails.status}. Retrying anyway.`,
+      `[BATCH EXPORT] Job ${batchExportId} has invalid status: ${jobDetails.status}. Retrying anyway.`,
     );
   }
 
@@ -150,7 +152,7 @@ export const handleBatchExportJob = async (
     if (hasNoMatches) {
       // No matching items - complete export with empty results
       logger.info(
-        `Batch export ${batchExportId}: comment filter matched no items, completing with empty export`,
+        `[BATCH EXPORT] Batch export ${batchExportId}: comment filter matched no items, completing with empty export`,
       );
 
       // Create an empty stream by using a filter that matches nothing
@@ -208,7 +210,7 @@ export const handleBatchExportJob = async (
       rowCount++;
       if (rowCount % 5000 === 0) {
         logger.info(
-          `Batch export ${batchExportId}: processed ${rowCount} rows`,
+          `[BATCH EXPORT] Batch export ${batchExportId}: processed ${rowCount} rows`,
         );
       }
       callback(null, chunk);
@@ -221,10 +223,13 @@ export const handleBatchExportJob = async (
     streamTransformations[jobDetails.format as BatchExportFileFormat](),
     (err) => {
       if (err) {
-        logger.error("Getting data from DB and transform failed: ", err);
+        logger.error(
+          "[BATCH EXPORT] Getting data from DB and transform failed: ",
+          err,
+        );
       } else {
         logger.info(
-          `Batch export ${batchExportId}: completed processing ${rowCount} total rows`,
+          `[BATCH EXPORT] Batch export ${batchExportId}: completed processing ${rowCount} total rows`,
         );
       }
     },
@@ -270,7 +275,7 @@ export const handleBatchExportJob = async (
     expiresInSeconds,
   );
 
-  logger.info(`Batch export file ${fileName} uploaded`);
+  logger.info(`[BATCH EXPORT] Batch export file ${fileName} uploaded`);
 
   // Update job status
   await prisma.batchExport.update({
@@ -303,7 +308,7 @@ export const handleBatchExportJob = async (
     });
 
     logger.info(
-      `Batch export with id ${batchExportId} for project ${projectId} successful. Email sent to user ${user.id}`,
+      `[BATCH EXPORT] Batch export with id ${batchExportId} for project ${projectId} successful. Email sent to user ${user.id}`,
     );
   }
 };

--- a/worker/src/queues/batchExportQueue.ts
+++ b/worker/src/queues/batchExportQueue.ts
@@ -15,16 +15,16 @@ export const batchExportQueueProcessor = async (
   job: Job<TQueueJobTypes[QueueName.BatchExport]>,
 ) => {
   try {
-    logger.info("Executing Batch Export Job", job.data.payload);
+    logger.info("[BATCH EXPORT] Executing Batch Export Job", job.data.payload);
     await handleBatchExportJob(job.data.payload);
 
-    logger.info("Finished Batch Export Job", job.data.payload);
+    logger.info("[BATCH EXPORT] Finished Batch Export Job", job.data.payload);
 
     return true;
   } catch (e) {
     if (e instanceof LangfuseNotFoundError) {
       logger.warn(
-        `Batch export ${job.data.payload.batchExportId} not found. Job will be skipped.`,
+        `[BATCH EXPORT] Batch export ${job.data.payload.batchExportId} not found. Job will be skipped.`,
       );
       return true;
     }
@@ -44,7 +44,7 @@ export const batchExportQueueProcessor = async (
     });
 
     logger.error(
-      `Failed Batch Export job for id ${job.data.payload.batchExportId} and project id ${job.data.payload.projectId}`,
+      `[BATCH EXPORT] Failed Batch Export job for id ${job.data.payload.batchExportId} and project id ${job.data.payload.projectId}`,
       e,
     );
     traceException(e);


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a `[BATCH EXPORT]` prefix to all log messages across the batch export feature (TRPC router, job handler, and queue processor) to make log filtering and searching easier. In `batchExport.ts`, the error log is also improved by adding a descriptive message alongside the raw error object.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure log message prefix changes with no logic modifications.

All changes are cosmetic additions of a `[BATCH EXPORT]` prefix to existing log statements. One error log is additionally improved with a descriptive message. No business logic, data flow, or error handling is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/batch-exports/server/batchExport.ts | Adds `[BATCH EXPORT]` prefix to two log messages; also improves error logging by adding a descriptive message string alongside the error object. |
| worker/src/features/batchExport/handleBatchExportJob.ts | Adds `[BATCH EXPORT]` prefix to all log messages throughout the batch export handler; no logic changes. |
| worker/src/queues/batchExportQueue.ts | Adds `[BATCH EXPORT]` prefix to all log messages in the queue processor; no logic changes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["TRPC Router\nbatchExport.ts\n[BATCH EXPORT] Creating export job"] --> B["Queue\nbatchExportQueue.ts\n[BATCH EXPORT] Executing Batch Export Job"]
    B --> C["Handler\nhandleBatchExportJob.ts\n[BATCH EXPORT] Starting batch export..."]
    C --> D{Status Check}
    D -- CANCELLED --> E["[BATCH EXPORT] Batch export ... has been cancelled"]
    D -- Too Old --> F["[BATCH EXPORT] Batch export ... is older than 30 days"]
    D -- Not QUEUED --> G["[BATCH EXPORT] Job ... has invalid status"]
    D -- OK --> H[Stream + Transform]
    H --> I["[BATCH EXPORT] processed N rows (every 5000)"]
    I --> J{Stream Done?}
    J -- Error --> K["[BATCH EXPORT] Getting data from DB and transform failed"]
    J -- Success --> L["[BATCH EXPORT] completed processing N total rows"]
    L --> M["[BATCH EXPORT] Batch export file ... uploaded"]
    M --> N["[BATCH EXPORT] ... successful. Email sent to user ..."]
    B -- Error --> O["[BATCH EXPORT] Failed Batch Export job for id ..."]
```

<sub>Reviews (1): Last reviewed commit: ["chore: prefix batch export logs"](https://github.com/langfuse/langfuse/commit/8cb64aeb53a1b7fa8e8d14cbb1bf9bdfdee60308) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28809230)</sub>

<!-- /greptile_comment -->