### PR TITLE
fix: add global concurrency limit to ingest queues

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -112,7 +112,7 @@ const EnvSchema = z.object({
   LANGFUSE_INGESTION_QUEUE_GLOBAL_CONCURRENCY: z.coerce
     .number()
     .nonnegative()
-    .default(50),
+    .default(0),
   LANGFUSE_OTEL_MAX_SPAN_BYTES: z.coerce.number().positive().default(9_500_000), // 9.5MB — just under ClickHouse's 10MB min_chunk_bytes_for_parallel_parsing default
   LANGFUSE_EVAL_EXECUTION_QUEUE_SHARD_COUNT: z.coerce
     .number()

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -109,6 +109,10 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(1),
+  LANGFUSE_INGESTION_QUEUE_GLOBAL_CONCURRENCY: z.coerce
+    .number()
+    .nonnegative()
+    .default(50),
   LANGFUSE_OTEL_MAX_SPAN_BYTES: z.coerce.number().positive().default(9_500_000), // 9.5MB — just under ClickHouse's 10MB min_chunk_bytes_for_parallel_parsing default
   LANGFUSE_EVAL_EXECUTION_QUEUE_SHARD_COUNT: z.coerce
     .number()

--- a/packages/shared/src/server/redis/ingestionQueue.ts
+++ b/packages/shared/src/server/redis/ingestionQueue.ts
@@ -86,6 +86,21 @@ export class IngestionQueue {
       logger.error(`IngestionQueue shard ${shardIndex} error`, err);
     });
 
+    const globalConcurrency = env.LANGFUSE_INGESTION_QUEUE_GLOBAL_CONCURRENCY;
+    if (globalConcurrency > 0) {
+      queueInstance
+        ?.setGlobalConcurrency(globalConcurrency)
+        .catch((err) =>
+          logger.error(`Failed to set global concurrency for ${name}`, err),
+        );
+    } else {
+      queueInstance
+        ?.removeGlobalConcurrency()
+        .catch((err) =>
+          logger.error(`Failed to remove global concurrency for ${name}`, err),
+        );
+    }
+
     IngestionQueue.instances.set(shardIndex, queueInstance);
 
     return queueInstance;


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR introduces a configurable global concurrency limit (`LANGFUSE_INGESTION_QUEUE_GLOBAL_CONCURRENCY`, default 50) for `IngestionQueue` instances, using BullMQ's `setGlobalConcurrency` API and a direct Redis `HDEL` workaround to remove the limit when the value is set to 0. The env var and schema change are clean, but the limit is not applied to `SecondaryIngestionQueue`, which may be an unintentional gap given the PR title refers to "ingest queues" (plural).

<h3>Confidence Score: 4/5</h3>

Safe to merge with low risk; the only notable gap is whether SecondaryIngestionQueue should also be capped.

All findings are P2. The direct Redis HDEL workaround is acknowledged and scoped to the disable path, and the async fire-and-forget pattern is acceptable. Score is 4 rather than 5 because of the potential unintentional omission of the secondary queue, which warrants author confirmation before merging.

packages/shared/src/server/redis/ingestionQueue.ts — verify whether SecondaryIngestionQueue should also receive the global concurrency limit.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/shared/src/env.ts | Adds `LANGFUSE_INGESTION_QUEUE_GLOBAL_CONCURRENCY` env var (coerced number, nonnegative, default 50); schema change is clean and consistent with surrounding env vars. |
| packages/shared/src/server/redis/ingestionQueue.ts | Applies global concurrency limit to `IngestionQueue` only; uses a direct Redis HDEL workaround for the zero/disable case; `SecondaryIngestionQueue` is unchanged and uncapped. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[IngestionQueue.getInstance] --> B{queueInstance created?}
    B -- No --> Z[return null]
    B -- Yes --> C{globalConcurrency > 0?}
    C -- Yes --> D[setGlobalConcurrency\nBullMQ API async]
    C -- No / 0 --> E[client.hdel meta:concurrency\nDirect Redis workaround]
    D --> F[instances.set shardIndex]
    E --> F
    F --> G[return queueInstance]

    style E fill:#ffe0b2,stroke:#e65100
    style D fill:#e8f5e9,stroke:#2e7d32
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/shared/src/server/redis/ingestionQueue.ts`, line 191-198 ([link](https://github.com/langfuse/langfuse/blob/58e797860cd7cc558966aa2d188ddce5683745e1/packages/shared/src/server/redis/ingestionQueue.ts#L191-L198)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`SecondaryIngestionQueue` skips global concurrency**

   The new `LANGFUSE_INGESTION_QUEUE_GLOBAL_CONCURRENCY` limit is applied to `IngestionQueue` but not to `SecondaryIngestionQueue`. If the intent of this fix is to cap concurrency across all ingestion queues (as the PR title implies), the secondary queue will remain uncapped. If the omission is intentional, a clarifying comment explaining why the secondary queue is excluded would help future readers.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/shared/src/server/redis/ingestionQueue.ts
   Line: 191-198

   Comment:
   **`SecondaryIngestionQueue` skips global concurrency**

   The new `LANGFUSE_INGESTION_QUEUE_GLOBAL_CONCURRENCY` limit is applied to `IngestionQueue` but not to `SecondaryIngestionQueue`. If the intent of this fix is to cap concurrency across all ingestion queues (as the PR title implies), the secondary queue will remain uncapped. If the omission is intentional, a clarifying comment explaining why the secondary queue is excluded would help future readers.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/shared/src/server/redis/ingestionQueue.ts
Line: 191-198

Comment:
**`SecondaryIngestionQueue` skips global concurrency**

The new `LANGFUSE_INGESTION_QUEUE_GLOBAL_CONCURRENCY` limit is applied to `IngestionQueue` but not to `SecondaryIngestionQueue`. If the intent of this fix is to cap concurrency across all ingestion queues (as the PR title implies), the secondary queue will remain uncapped. If the omission is intentional, a clarifying comment explaining why the secondary queue is excluded would help future readers.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/shared/src/server/redis/ingestionQueue.ts
Line: 99-105

Comment:
**Direct manipulation of BullMQ internal Redis key**

The HDEL call targets `${queueInstance.qualifiedName}:meta` with field `"concurrency"` — an undocumented internal BullMQ data structure. While the comment correctly explains _why_ this is done (missing `removeGlobalConcurrency()` in BullMQ 5.34), any future BullMQ upgrade that renames or restructures the meta hash will silently fail to remove the cap (the `.catch` only logs), leaving the queue permanently capped at 50 even when the operator sets the env var to 0. Consider adding a `// TODO: replace with removeGlobalConcurrency() once BullMQ supports it` comment and an upgrade note so this workaround isn't forgotten.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add global concurrency limit to ing..."](https://github.com/langfuse/langfuse/commit/58e797860cd7cc558966aa2d188ddce5683745e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28894817)</sub>

<!-- /greptile_comment -->