### PR TITLE
feat: emit .rate and .time metrics with shard tags for DataDog aggregation

### DIFF
--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -288,6 +288,25 @@ const flushMetricsToCloudWatch = () => {
     });
 };
 
+// Metrics ending with these suffixes have their tags flattened into the
+// CloudWatch metric name (excluding "unit"). Other metrics are unaffected.
+const CW_TAG_FLATTENED_SUFFIXES = [".depth", ".rate"];
+
+function buildCloudWatchKey(
+  stat: string,
+  tags?: { [tag: string]: string | number },
+): string {
+  if (!tags || !CW_TAG_FLATTENED_SUFFIXES.some((s) => stat.endsWith(s))) {
+    return stat;
+  }
+  const suffix = Object.entries(tags)
+    .filter(([k]) => k !== "unit")
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}_${v}`)
+    .join(".");
+  return suffix ? `${stat}.${suffix}` : stat;
+}
+
 export const recordGauge = (
   stat: string,
   value?: number | undefined,
@@ -298,19 +317,7 @@ export const recordGauge = (
     | undefined,
 ) => {
   if (env.ENABLE_AWS_CLOUDWATCH_METRIC_PUBLISHING === "true") {
-    // For .depth metrics, flatten tags into the metric name so CloudWatch
-    // can distinguish e.g. depth.shard_all.type_waiting from depth.type_active.
-    // Other metrics are unaffected.
-    let cwKey = stat;
-    if (stat.endsWith(".depth") && tags) {
-      const suffix = Object.entries(tags)
-        .filter(([k]) => k !== "unit")
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([k, v]) => `${k}_${v}`)
-        .join(".");
-      if (suffix) cwKey = `${stat}.${suffix}`;
-    }
-    sendCloudWatchMetric(cwKey, value ?? 0, true);
+    sendCloudWatchMetric(buildCloudWatchKey(stat, tags), value ?? 0, true);
   }
   dd.dogstatsd.gauge(stat, value, tags);
 };
@@ -321,7 +328,7 @@ export const recordIncrement = (
   tags?: { [tag: string]: string | number } | undefined,
 ) => {
   if (env.ENABLE_AWS_CLOUDWATCH_METRIC_PUBLISHING === "true") {
-    sendCloudWatchMetric(stat, value ?? 1, false);
+    sendCloudWatchMetric(buildCloudWatchKey(stat, tags), value ?? 1, false);
   }
   dd.dogstatsd.increment(stat, value, tags);
 };

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -20,76 +20,91 @@ import {
 export class WorkerManager {
   private static workers: { [key: string]: Worker } = {};
 
+  private static resolveMetricInfo(queueName: QueueName): {
+    baseMetric: string;
+    shardTag: { shard: string } | undefined;
+  } {
+    for (const base of SHARDED_QUEUE_BASE_NAMES) {
+      if (queueName.startsWith(base)) {
+        return {
+          baseMetric: convertQueueNameToMetricName(base),
+          shardTag: { shard: queueName },
+        };
+      }
+    }
+    return {
+      baseMetric: convertQueueNameToMetricName(queueName),
+      shardTag: undefined,
+    };
+  }
+
   private static metricWrapper(
     processor: Processor,
     queueName: QueueName,
   ): Processor {
+    const oldMetric = convertQueueNameToMetricName(queueName);
+    const { baseMetric, shardTag } = WorkerManager.resolveMetricInfo(queueName);
+
     return async (job: Job) => {
       const startTime = Date.now();
       const waitTime = Date.now() - job.timestamp;
-      recordIncrement(convertQueueNameToMetricName(queueName) + ".request");
-      recordHistogram(
-        convertQueueNameToMetricName(queueName) + ".wait_time",
-        waitTime,
-        {
-          unit: "milliseconds",
-        },
-      );
+
+      recordIncrement(oldMetric + ".request");
+      recordIncrement(baseMetric + ".rate", 1, {
+        type: "request",
+        ...shardTag,
+      });
+
+      recordHistogram(oldMetric + ".wait_time", waitTime, {
+        unit: "milliseconds",
+      });
+      recordHistogram(baseMetric + ".time", waitTime, {
+        type: "wait",
+        unit: "milliseconds",
+        ...shardTag,
+      });
+
       const result = await processor(job);
+
       const queue = resolveQueueInstance(queueName);
       // Sample queue depth gauges for sharded queues to reduce metric volume.
-      let isShardedQueue = false;
-      for (const base of SHARDED_QUEUE_BASE_NAMES) {
-        if (queueName.startsWith(base)) {
-          isShardedQueue = true;
-          break;
-        }
-      }
-
       const shouldSample =
-        !isShardedQueue ||
-        Math.random() < env.LANGFUSE_QUEUE_METRICS_SAMPLE_RATE;
+        !shardTag || Math.random() < env.LANGFUSE_QUEUE_METRICS_SAMPLE_RATE;
 
       if (shouldSample) {
         Promise.allSettled([
           // Here we only consider waiting jobs instead of the default ("waiting" or "delayed"
           // or "prioritized" or "waiting-children") that count provides
           queue?.getWaitingCount().then((count) => {
-            recordGauge(
-              convertQueueNameToMetricName(queueName) + ".length",
-              count,
-              {
-                unit: "records",
-              },
-            );
+            recordGauge(oldMetric + ".length", count, {
+              unit: "records",
+            });
           }),
           queue?.getFailedCount().then((count) => {
-            recordGauge(
-              convertQueueNameToMetricName(queueName) + ".dlq_length",
-              count,
-              {
-                unit: "records",
-              },
-            );
+            recordGauge(oldMetric + ".dlq_length", count, {
+              unit: "records",
+            });
           }),
           queue?.getActiveCount().then((count) => {
-            recordGauge(
-              convertQueueNameToMetricName(queueName) + ".active",
-              count,
-              {
-                unit: "records",
-              },
-            );
+            recordGauge(oldMetric + ".active", count, {
+              unit: "records",
+            });
           }),
         ]).catch((err) => {
           logger.error("Failed to record queue length", err);
         });
       }
-      recordHistogram(
-        convertQueueNameToMetricName(queueName) + ".processing_time",
-        Date.now() - startTime,
-        { unit: "milliseconds" },
-      );
+
+      const processingTime = Date.now() - startTime;
+      recordHistogram(oldMetric + ".processing_time", processingTime, {
+        unit: "milliseconds",
+      });
+      recordHistogram(baseMetric + ".time", processingTime, {
+        type: "processing",
+        unit: "milliseconds",
+        ...shardTag,
+      });
+
       return result;
     };
   }
@@ -139,6 +154,9 @@ export class WorkerManager {
     WorkerManager.workers[queueName] = worker;
     logger.info(`${queueName} executor started: ${worker.isRunning()}`);
 
+    const oldMetric = convertQueueNameToMetricName(queueName);
+    const { baseMetric, shardTag } = WorkerManager.resolveMetricInfo(queueName);
+
     // Add error handling
     worker.on("failed", (job: Job | undefined, err: Error) => {
       logger.error(
@@ -146,7 +164,11 @@ export class WorkerManager {
         err,
       );
       traceException(err);
-      recordIncrement(convertQueueNameToMetricName(queueName) + ".failed");
+      recordIncrement(oldMetric + ".failed");
+      recordIncrement(baseMetric + ".rate", 1, {
+        type: "failed",
+        ...shardTag,
+      });
     });
     worker.on("error", (failedReason: Error) => {
       logger.error(
@@ -154,7 +176,11 @@ export class WorkerManager {
         failedReason,
       );
       traceException(failedReason);
-      recordIncrement(convertQueueNameToMetricName(queueName) + ".error");
+      recordIncrement(oldMetric + ".error");
+      recordIncrement(baseMetric + ".rate", 1, {
+        type: "error",
+        ...shardTag,
+      });
     });
   }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a `resolveMetricInfo` helper that maps any queue name to a `baseMetric` and an optional `shardTag`, then emits new `baseMetric + \".rate\"` and `baseMetric + \".time\"` metrics (tagged with `type` and `shard`) alongside the existing per-shard metric names. The migration strategy of keeping old metrics while introducing the new tagged ones is intentional and backward-compatible with existing DataDog dashboards.

<h3>Confidence Score: 5/5</h3>

Safe to merge — logic is correct and backward-compatible.

All findings are P2 style suggestions. No data loss, broken behaviour, or correctness issues were found. Spreading `undefined` shardTag is valid TypeScript/JS, `shouldSample` refactoring is semantically identical to the original, and the double-emission of old + new metrics is an intentional migration strategy.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/queues/workerManager.ts | Adds `resolveMetricInfo` helper and emits new `.rate`/`.time` metrics with shard/type tags alongside the existing per-shard metrics; logic is correct, spreading `undefined` shardTag is safe, and the refactored `shouldSample` path is equivalent to the original. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Job enters metricWrapper] --> B[startTime = Date.now
waitTime = now - job.timestamp]
    B --> C[oldMetric.request increment
baseMetric.rate type=request increment]
    C --> D[oldMetric.wait_time histogram
baseMetric.time type=wait histogram]
    D --> E[await processor job]
    E --> F{shardTag?}
    F -->|yes - sharded queue| G[shouldSample = Math.random < SAMPLE_RATE]
    F -->|no - normal queue| H[shouldSample = true]
    G --> I[if shouldSample: fire-and-forget gauge metrics]
    H --> I
    I --> J[processingTime = Date.now - startTime]
    J --> K[oldMetric.processing_time histogram
baseMetric.time type=processing histogram]
    K --> L[return result]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker/src/queues/workerManager.ts
Line: 97-104

Comment:
**`processingTime` includes post-processor overhead**

`processingTime` is captured after `resolveQueueInstance`, the `shouldSample` check, and the `Promise.allSettled` call setup — not immediately after `await processor(job)`. While that overhead is negligible in practice, the new `baseMetric + ".time"` metric with `type: "processing"` inherits this same slight over-count. Moving `Date.now()` immediately after `await processor(job)` would make both old and new metrics more precise.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: emit .rate and .time metrics with ..."](https://github.com/langfuse/langfuse/commit/e1d31aeed8e493436587c0e2d3428a0c5b4cdb8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28895393)</sub>

<!-- /greptile_comment -->