### PR TITLE
fix(web): prevent crash on invalid JSONPath in dataset mapping editor

### DIFF
--- a/packages/shared/src/features/batchAction/applyFieldMapping.ts
+++ b/packages/shared/src/features/batchAction/applyFieldMapping.ts
@@ -31,7 +31,7 @@ export type JsonPathMissInfo = {
 export type JsonPathErrorInfo = JsonPathMissInfo & { message: string };
 
 /**
- * Test if a JSON path is valid against the given data
+ * Test if a JSONPath is valid against the given data
  */
 export function testJsonPath(props: { jsonPath: string; data: unknown }): {
   success: boolean;
@@ -51,7 +51,7 @@ export function testJsonPath(props: { jsonPath: string; data: unknown }): {
 }
 
 /**
- * Evaluate a JSON path against the given data and return the result
+ * Evaluate a JSONPath against the given data and return the result
  */
 export function evaluateJsonPath(data: unknown, jsonPath: string): unknown {
   const parsed = typeof data === "string" ? parseJsonPrioritised(data) : data;
@@ -65,7 +65,7 @@ export function evaluateJsonPath(data: unknown, jsonPath: string): unknown {
 }
 
 /**
- * Check if a value is a JSON path (starts with $)
+ * Check if a value is a JSONPath (starts with $)
  */
 export function isJsonPath(value: string): boolean {
   return value.startsWith("$");
@@ -121,7 +121,7 @@ export function applyFieldMappingConfig(props: {
         sourceField,
         jsonPath,
         mappingKey,
-        message: error instanceof Error ? error.message : "Invalid JSON path",
+        message: error instanceof Error ? error.message : "Invalid JSONPath",
       });
       return { ok: false };
     }
@@ -142,7 +142,7 @@ export function applyFieldMappingConfig(props: {
       }
 
       if (config.custom.type === "root") {
-        // Root mode: extract single value using JSON path
+        // Root mode: extract single value using JSONPath
         const rootConfig = config.custom.rootConfig;
         if (!rootConfig) {
           return observation[defaultSourceField];
@@ -184,7 +184,7 @@ export function applyFieldMappingConfig(props: {
 
           let resolvedValue: unknown;
           if (isJsonPath(entry.value)) {
-            // It's a JSON path - evaluate it
+            // It's a JSONPath - evaluate it
             const evaluated = safeEvaluate(
               entry.sourceField,
               entry.value,
@@ -271,7 +271,7 @@ export function applyFullMapping(props: {
         sourceField: info.sourceField,
         jsonPath: info.jsonPath,
         mappingKey: info.mappingKey,
-        message: `JSON path "${info.jsonPath}" did not match any data in "${info.sourceField}"${info.mappingKey ? ` (key: "${info.mappingKey}")` : ""}`,
+        message: `JSONPath "${info.jsonPath}" did not match any data in "${info.sourceField}"${info.mappingKey ? ` (key: "${info.mappingKey}")` : ""}`,
       });
     };
 
@@ -282,7 +282,7 @@ export function applyFullMapping(props: {
         sourceField: info.sourceField,
         jsonPath: info.jsonPath,
         mappingKey: info.mappingKey,
-        message: `JSON path evaluation error for "${field.key}"${
+        message: `JSONPath evaluation error for "${field.key}"${
           info.mappingKey ? ` (key: "${info.mappingKey}")` : ""
         }: ${info.message}`,
       });
@@ -316,7 +316,7 @@ export function applyFullMapping(props: {
 }
 
 /**
- * Generate autocomplete suggestions for JSON paths based on the data structure
+ * Generate autocomplete suggestions for JSONPaths based on the data structure
  */
 export function generateJsonPathSuggestions(
   data: unknown,

--- a/packages/shared/src/features/batchAction/applyFieldMapping.ts
+++ b/packages/shared/src/features/batchAction/applyFieldMapping.ts
@@ -22,6 +22,14 @@ export type MappingError = {
   message: string;
 };
 
+export type JsonPathMissInfo = {
+  sourceField: SourceField;
+  jsonPath: string;
+  mappingKey: string | null;
+};
+
+export type JsonPathErrorInfo = JsonPathMissInfo & { message: string };
+
 /**
  * Test if a JSON path is valid against the given data
  */
@@ -87,13 +95,37 @@ export function applyFieldMappingConfig(props: {
   observation: ObservationData;
   config: FieldMappingConfig;
   defaultSourceField: SourceField;
-  onJsonPathMiss?: (info: {
-    sourceField: SourceField;
-    jsonPath: string;
-    mappingKey: string | null;
-  }) => void;
+  onJsonPathMiss?: (info: JsonPathMissInfo) => void;
+  onJsonPathError?: (info: JsonPathErrorInfo) => void;
 }): unknown {
-  const { observation, config, defaultSourceField, onJsonPathMiss } = props;
+  const {
+    observation,
+    config,
+    defaultSourceField,
+    onJsonPathMiss,
+    onJsonPathError,
+  } = props;
+
+  const safeEvaluate = (
+    sourceField: SourceField,
+    jsonPath: string,
+    mappingKey: string | null,
+  ): { ok: true; value: unknown } | { ok: false } => {
+    try {
+      return {
+        ok: true,
+        value: evaluateJsonPath(observation[sourceField], jsonPath),
+      };
+    } catch (error) {
+      onJsonPathError?.({
+        sourceField,
+        jsonPath,
+        mappingKey,
+        message: error instanceof Error ? error.message : "Invalid JSON path",
+      });
+      return { ok: false };
+    }
+  };
 
   switch (config.mode) {
     case "full":
@@ -116,8 +148,15 @@ export function applyFieldMappingConfig(props: {
           return observation[defaultSourceField];
         }
 
-        const sourceData = observation[rootConfig.sourceField];
-        const result = evaluateJsonPath(sourceData, rootConfig.jsonPath);
+        const evaluated = safeEvaluate(
+          rootConfig.sourceField,
+          rootConfig.jsonPath,
+          null,
+        );
+        if (!evaluated.ok) {
+          return undefined;
+        }
+        const result = evaluated.value;
         if (result === undefined && onJsonPathMiss) {
           onJsonPathMiss({
             sourceField: rootConfig.sourceField,
@@ -146,14 +185,22 @@ export function applyFieldMappingConfig(props: {
           let resolvedValue: unknown;
           if (isJsonPath(entry.value)) {
             // It's a JSON path - evaluate it
-            const sourceData = observation[entry.sourceField];
-            resolvedValue = evaluateJsonPath(sourceData, entry.value);
-            if (resolvedValue === undefined && onJsonPathMiss) {
-              onJsonPathMiss({
-                sourceField: entry.sourceField,
-                jsonPath: entry.value,
-                mappingKey: entry.key,
-              });
+            const evaluated = safeEvaluate(
+              entry.sourceField,
+              entry.value,
+              entry.key,
+            );
+            if (!evaluated.ok) {
+              resolvedValue = undefined;
+            } else {
+              resolvedValue = evaluated.value;
+              if (resolvedValue === undefined && onJsonPathMiss) {
+                onJsonPathMiss({
+                  sourceField: entry.sourceField,
+                  jsonPath: entry.value,
+                  mappingKey: entry.key,
+                });
+              }
             }
           } else {
             // It's a literal string (including empty string)
@@ -228,32 +275,33 @@ export function applyFullMapping(props: {
       });
     };
 
+    const onJsonPathError = (info: JsonPathErrorInfo) => {
+      errors.push({
+        type: "json_path_error",
+        targetField: field.key,
+        sourceField: info.sourceField,
+        jsonPath: info.jsonPath,
+        mappingKey: info.mappingKey,
+        message: `JSON path evaluation error for "${field.key}"${
+          info.mappingKey ? ` (key: "${info.mappingKey}")` : ""
+        }: ${info.message}`,
+      });
+    };
+
     try {
       results[field.key] = applyFieldMappingConfig({
         observation,
         config: field.config,
         defaultSourceField: field.defaultSourceField,
         onJsonPathMiss,
+        onJsonPathError,
       });
     } catch (error) {
-      // Capture rare JSONPath evaluation errors (e.g. malformed filter expressions)
-      const sourceField =
-        field.config.mode === "custom" && field.config.custom?.type === "root"
-          ? (field.config.custom.rootConfig?.sourceField ??
-            field.defaultSourceField)
-          : field.defaultSourceField;
-      const jsonPath =
-        field.config.mode === "custom" && field.config.custom?.type === "root"
-          ? (field.config.custom.rootConfig?.jsonPath ?? "")
-          : "";
-
-      errors.push({
-        type: "json_path_error",
-        targetField: field.key,
-        sourceField,
-        jsonPath,
+      onJsonPathError({
+        sourceField: field.defaultSourceField,
+        jsonPath: "",
         mappingKey: null,
-        message: `JSON path evaluation error for "${field.key}": ${error instanceof Error ? error.message : "Unknown error"}`,
+        message: error instanceof Error ? error.message : "Unknown error",
       });
       results[field.key] = undefined;
     }

--- a/packages/shared/src/features/batchAction/applyFieldMapping.ts
+++ b/packages/shared/src/features/batchAction/applyFieldMapping.ts
@@ -30,6 +30,12 @@ export type JsonPathMissInfo = {
 
 export type JsonPathErrorInfo = JsonPathMissInfo & { message: string };
 
+export type FieldMappingResult = {
+  value: unknown;
+  misses: JsonPathMissInfo[];
+  errors: JsonPathErrorInfo[];
+};
+
 /**
  * Test if a JSONPath is valid against the given data
  */
@@ -95,107 +101,92 @@ export function applyFieldMappingConfig(props: {
   observation: ObservationData;
   config: FieldMappingConfig;
   defaultSourceField: SourceField;
-  onJsonPathMiss?: (info: JsonPathMissInfo) => void;
-  onJsonPathError?: (info: JsonPathErrorInfo) => void;
-}): unknown {
-  const {
-    observation,
-    config,
-    defaultSourceField,
-    onJsonPathMiss,
-    onJsonPathError,
-  } = props;
+}): FieldMappingResult {
+  const { observation, config, defaultSourceField } = props;
+  const misses: JsonPathMissInfo[] = [];
+  const errors: JsonPathErrorInfo[] = [];
 
   const safeEvaluate = (
     sourceField: SourceField,
     jsonPath: string,
     mappingKey: string | null,
-  ): { ok: true; value: unknown } | { ok: false } => {
+  ): { success: true; value: unknown } | { success: false } => {
     try {
       return {
-        ok: true,
+        success: true,
         value: evaluateJsonPath(observation[sourceField], jsonPath),
       };
     } catch (error) {
-      onJsonPathError?.({
+      errors.push({
         sourceField,
         jsonPath,
         mappingKey,
         message: error instanceof Error ? error.message : "Invalid JSONPath",
       });
-      return { ok: false };
+      return { success: false };
     }
   };
 
+  const withValue = (value: unknown): FieldMappingResult => ({
+    value,
+    misses,
+    errors,
+  });
+
   switch (config.mode) {
     case "full":
-      // Return the full source field
-      return observation[defaultSourceField];
+      return withValue(observation[defaultSourceField]);
 
     case "none":
-      // Return null (will be written as Prisma.DbNull)
-      return null;
+      // null is written as Prisma.DbNull
+      return withValue(null);
 
-    case "custom":
-      if (!config.custom) {
-        return observation[defaultSourceField];
-      }
+    case "custom": {
+      if (!config.custom) return withValue(observation[defaultSourceField]);
 
       if (config.custom.type === "root") {
-        // Root mode: extract single value using JSONPath
         const rootConfig = config.custom.rootConfig;
-        if (!rootConfig) {
-          return observation[defaultSourceField];
-        }
+        if (!rootConfig) return withValue(observation[defaultSourceField]);
 
         const evaluated = safeEvaluate(
           rootConfig.sourceField,
           rootConfig.jsonPath,
           null,
         );
-        if (!evaluated.ok) {
-          return undefined;
-        }
-        const result = evaluated.value;
-        if (result === undefined && onJsonPathMiss) {
-          onJsonPathMiss({
+        if (!evaluated.success) return withValue(undefined);
+        if (evaluated.value === undefined) {
+          misses.push({
             sourceField: rootConfig.sourceField,
             jsonPath: rootConfig.jsonPath,
             mappingKey: null,
           });
         }
-        return result;
+        return withValue(evaluated.value);
       }
 
       if (config.custom.type === "keyValueMap") {
-        // Key-value map mode: build object from entries
-        // Supports dot notation for nested objects (e.g., "context.user_id")
         const keyValueMapConfig = config.custom.keyValueMapConfig;
         if (!keyValueMapConfig || keyValueMapConfig.entries.length === 0) {
-          return observation[defaultSourceField];
+          return withValue(observation[defaultSourceField]);
         }
 
         const result: Record<string, unknown> = {};
         for (const entry of keyValueMapConfig.entries) {
-          // Skip entries with empty values
-          if (!entry.value && entry.value !== "") {
-            continue;
-          }
+          if (!entry.value && entry.value !== "") continue;
 
           let resolvedValue: unknown;
           if (isJsonPath(entry.value)) {
-            // It's a JSONPath - evaluate it
             const evaluated = safeEvaluate(
               entry.sourceField,
               entry.value,
               entry.key,
             );
-            if (!evaluated.ok) {
+            if (!evaluated.success) {
               resolvedValue = undefined;
             } else {
               resolvedValue = evaluated.value;
-              if (resolvedValue === undefined && onJsonPathMiss) {
-                onJsonPathMiss({
+              if (resolvedValue === undefined) {
+                misses.push({
                   sourceField: entry.sourceField,
                   jsonPath: entry.value,
                   mappingKey: entry.key,
@@ -203,24 +194,23 @@ export function applyFieldMappingConfig(props: {
               }
             }
           } else {
-            // It's a literal string (including empty string)
             resolvedValue = entry.value;
           }
 
-          // Use dot notation path setter for nested objects
           if (entry.key.includes(".")) {
             setNestedValue(result, entry.key, resolvedValue);
           } else {
             result[entry.key] = resolvedValue;
           }
         }
-        return result;
+        return withValue(result);
       }
 
-      return observation[defaultSourceField];
+      return withValue(observation[defaultSourceField]);
+    }
 
     default:
-      return observation[defaultSourceField];
+      return withValue(observation[defaultSourceField]);
   }
 }
 
@@ -260,48 +250,45 @@ export function applyFullMapping(props: {
   const results: Record<string, unknown> = {};
 
   for (const field of fields) {
-    const onJsonPathMiss = (info: {
-      sourceField: SourceField;
-      jsonPath: string;
-      mappingKey: string | null;
-    }) => {
-      errors.push({
-        type: "json_path_miss",
-        targetField: field.key,
-        sourceField: info.sourceField,
-        jsonPath: info.jsonPath,
-        mappingKey: info.mappingKey,
-        message: `JSONPath "${info.jsonPath}" did not match any data in "${info.sourceField}"${info.mappingKey ? ` (key: "${info.mappingKey}")` : ""}`,
-      });
-    };
-
-    const onJsonPathError = (info: JsonPathErrorInfo) => {
-      errors.push({
-        type: "json_path_error",
-        targetField: field.key,
-        sourceField: info.sourceField,
-        jsonPath: info.jsonPath,
-        mappingKey: info.mappingKey,
-        message: `JSONPath evaluation error for "${field.key}"${
-          info.mappingKey ? ` (key: "${info.mappingKey}")` : ""
-        }: ${info.message}`,
-      });
-    };
-
     try {
-      results[field.key] = applyFieldMappingConfig({
+      const result = applyFieldMappingConfig({
         observation,
         config: field.config,
         defaultSourceField: field.defaultSourceField,
-        onJsonPathMiss,
-        onJsonPathError,
       });
+      results[field.key] = result.value;
+
+      for (const miss of result.misses) {
+        errors.push({
+          type: "json_path_miss",
+          targetField: field.key,
+          sourceField: miss.sourceField,
+          jsonPath: miss.jsonPath,
+          mappingKey: miss.mappingKey,
+          message: `JSONPath "${miss.jsonPath}" did not match any data in "${miss.sourceField}"${miss.mappingKey ? ` (key: "${miss.mappingKey}")` : ""}`,
+        });
+      }
+
+      for (const err of result.errors) {
+        errors.push({
+          type: "json_path_error",
+          targetField: field.key,
+          sourceField: err.sourceField,
+          jsonPath: err.jsonPath,
+          mappingKey: err.mappingKey,
+          message: `JSONPath evaluation error for "${field.key}"${err.mappingKey ? ` (key: "${err.mappingKey}")` : ""}: ${err.message}`,
+        });
+      }
     } catch (error) {
-      onJsonPathError({
+      // Isolate per-field faults so a throw from one mapping doesn't abort
+      // the remaining fields on the same observation.
+      errors.push({
+        type: "json_path_error",
+        targetField: field.key,
         sourceField: field.defaultSourceField,
         jsonPath: "",
         mappingKey: null,
-        message: error instanceof Error ? error.message : "Unknown error",
+        message: `JSONPath evaluation error for "${field.key}": ${error instanceof Error ? error.message : "Unknown error"}`,
       });
       results[field.key] = undefined;
     }

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
@@ -1,11 +1,20 @@
 import { useMemo } from "react";
 import { Button } from "@/src/components/ui/button";
-import { AlertTriangle, Pencil } from "lucide-react";
+import { AlertCircle, AlertTriangle, Pencil } from "lucide-react";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { cn } from "@/src/utils/tailwind";
 import type { FinalPreviewStepProps, DialogStep } from "./types";
 import { applyFullMapping } from "@langfuse/shared";
 import type { MappingError } from "@langfuse/shared";
+
+const STEP_FOR_FIELD: Record<string, DialogStep> = {
+  input: "input-mapping",
+  expectedOutput: "output-mapping",
+  metadata: "metadata-mapping",
+};
+
+const fieldLabel = (field: string) =>
+  field === "expectedOutput" ? "expected output" : field;
 
 export function FinalPreviewStep({
   dataset,
@@ -14,7 +23,6 @@ export function FinalPreviewStep({
   totalCount,
   onEditStep,
 }: FinalPreviewStepProps) {
-  // Compute the full preview
   const previewResult = useMemo(() => {
     if (!observationData) return null;
 
@@ -28,26 +36,22 @@ export function FinalPreviewStep({
     });
   }, [observationData, mapping]);
 
-  // Group errors by target field
-  const errorsByField = useMemo(() => {
-    const errors = previewResult?.errors ?? [];
-    const grouped: Record<string, MappingError[]> = {};
-    for (const err of errors) {
-      if (!grouped[err.targetField]) {
-        grouped[err.targetField] = [];
+  const { errorsByField, missesByField, errorFields, missFields } =
+    useMemo(() => {
+      const errorsByField: Record<string, MappingError[]> = {};
+      const missesByField: Record<string, MappingError[]> = {};
+      for (const err of previewResult?.errors ?? []) {
+        const bucket =
+          err.type === "json_path_error" ? errorsByField : missesByField;
+        (bucket[err.targetField] ??= []).push(err);
       }
-      grouped[err.targetField].push(err);
-    }
-    return grouped;
-  }, [previewResult?.errors]);
-
-  const hasWarnings = (previewResult?.errors?.length ?? 0) > 0;
-
-  const stepForField: Record<string, DialogStep> = {
-    input: "input-mapping" as DialogStep,
-    expectedOutput: "output-mapping" as DialogStep,
-    metadata: "metadata-mapping" as DialogStep,
-  };
+      return {
+        errorsByField,
+        missesByField,
+        errorFields: Object.keys(errorsByField),
+        missFields: Object.keys(missesByField),
+      };
+    }, [previewResult?.errors]);
 
   return (
     <div className="h-[62vh] space-y-6 p-6">
@@ -60,40 +64,24 @@ export function FinalPreviewStep({
         </p>
       </div>
 
-      {/* Overall warning banner */}
-      {hasWarnings && (
-        <div className="rounded-md border border-amber-500/50 bg-amber-50 p-3 dark:bg-amber-950/30">
-          <div className="flex items-start gap-2">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-500" />
-            <div className="space-y-1">
-              <p className="text-sm font-medium text-amber-600 dark:text-amber-500">
-                Some JSONPaths did not match the preview observation
-              </p>
-              <p className="text-xs text-amber-600/80 dark:text-amber-500/80">
-                Observations with failed mappings will be skipped during
-                processing.
-              </p>
-              <div className="flex flex-wrap gap-2 pt-1">
-                {Object.entries(errorsByField).map(([field]) => (
-                  <Button
-                    key={field}
-                    variant="link"
-                    size="sm"
-                    className="h-auto p-0 text-xs text-amber-600 underline dark:text-amber-500"
-                    onClick={() => {
-                      const step = stepForField[field];
-                      if (step) onEditStep(step);
-                    }}
-                  >
-                    Edit{" "}
-                    {field === "expectedOutput" ? "expected output" : field}{" "}
-                    mapping
-                  </Button>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
+      {errorFields.length > 0 && (
+        <IssueBanner
+          variant="error"
+          title="Some JSONPaths are invalid"
+          description="Items using these mappings will be skipped during processing."
+          fields={errorFields}
+          onEditStep={onEditStep}
+        />
+      )}
+
+      {missFields.length > 0 && (
+        <IssueBanner
+          variant="warning"
+          title="Some JSONPaths did not match the preview observation"
+          description="Observations with failed mappings will be skipped during processing."
+          fields={missFields}
+          onEditStep={onEditStep}
+        />
       )}
 
       <div className="text-muted-foreground text-sm">
@@ -108,31 +96,101 @@ export function FinalPreviewStep({
         </div>
       ) : (
         <div className="space-y-4">
-          {/* Input Preview */}
           <PreviewCard
             label="Input"
             data={previewResult?.input}
-            onEdit={() => onEditStep("input-mapping" as DialogStep)}
-            errors={errorsByField["input"]}
+            onEdit={() => onEditStep("input-mapping")}
+            pathErrors={errorsByField["input"]}
+            pathMisses={missesByField["input"]}
           />
-
-          {/* Expected Output Preview */}
           <PreviewCard
             label="Expected Output"
             data={previewResult?.expectedOutput}
-            onEdit={() => onEditStep("output-mapping" as DialogStep)}
-            errors={errorsByField["expectedOutput"]}
+            onEdit={() => onEditStep("output-mapping")}
+            pathErrors={errorsByField["expectedOutput"]}
+            pathMisses={missesByField["expectedOutput"]}
           />
-
-          {/* Metadata Preview */}
           <PreviewCard
             label="Metadata"
             data={previewResult?.metadata}
-            onEdit={() => onEditStep("metadata-mapping" as DialogStep)}
-            errors={errorsByField["metadata"]}
+            onEdit={() => onEditStep("metadata-mapping")}
+            pathErrors={errorsByField["metadata"]}
+            pathMisses={missesByField["metadata"]}
           />
         </div>
       )}
+    </div>
+  );
+}
+
+type IssueVariant = "error" | "warning";
+
+const bannerStyles: Record<
+  IssueVariant,
+  {
+    borderColor: string;
+    bg: string;
+    text: string;
+    subtext: string;
+    icon: typeof AlertCircle;
+  }
+> = {
+  error: {
+    borderColor: "border-destructive/50",
+    bg: "bg-destructive/10",
+    text: "text-destructive",
+    subtext: "text-destructive/80",
+    icon: AlertCircle,
+  },
+  warning: {
+    borderColor: "border-amber-500/50",
+    bg: "bg-amber-50 dark:bg-amber-950/30",
+    text: "text-amber-600 dark:text-amber-500",
+    subtext: "text-amber-600/80 dark:text-amber-500/80",
+    icon: AlertTriangle,
+  },
+};
+
+function IssueBanner({
+  variant,
+  title,
+  description,
+  fields,
+  onEditStep,
+}: {
+  variant: IssueVariant;
+  title: string;
+  description: string;
+  fields: string[];
+  onEditStep: (step: DialogStep) => void;
+}) {
+  const s = bannerStyles[variant];
+  const Icon = s.icon;
+  return (
+    <div className={cn("rounded-md border p-3", s.borderColor, s.bg)}>
+      <div className="flex items-start gap-2">
+        <Icon className={cn("mt-0.5 h-4 w-4 shrink-0", s.text)} />
+        <div className="space-y-1">
+          <p className={cn("text-sm font-medium", s.text)}>{title}</p>
+          <p className={cn("text-xs", s.subtext)}>{description}</p>
+          <div className="flex flex-wrap gap-2 pt-1">
+            {fields.map((field) => (
+              <Button
+                key={field}
+                variant="link"
+                size="sm"
+                className={cn("h-auto p-0 text-xs underline", s.text)}
+                onClick={() => {
+                  const step = STEP_FOR_FIELD[field];
+                  if (step) onEditStep(step);
+                }}
+              >
+                Edit {fieldLabel(field)} mapping
+              </Button>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -141,21 +199,27 @@ type PreviewCardProps = {
   label: string;
   data: unknown;
   onEdit: () => void;
-  errors?: MappingError[];
+  pathErrors?: MappingError[];
+  pathMisses?: MappingError[];
 };
 
-function PreviewCard({ label, data, onEdit, errors }: PreviewCardProps) {
-  const hasErrors = errors && errors.length > 0;
+function PreviewCard({
+  label,
+  data,
+  onEdit,
+  pathErrors = [],
+  pathMisses = [],
+}: PreviewCardProps) {
+  const variant: IssueVariant | null =
+    pathErrors.length > 0 ? "error" : pathMisses.length > 0 ? "warning" : null;
+  const s = variant ? bannerStyles[variant] : null;
+  const Icon = s?.icon;
 
   return (
-    <div
-      className={cn("rounded-lg border", hasErrors && "border-amber-500/50")}
-    >
+    <div className={cn("rounded-lg border", s?.borderColor)}>
       <div className="bg-muted/30 flex items-center justify-between border-b px-4 py-2">
         <span className="flex items-center gap-1.5 text-sm font-medium">
-          {hasErrors && (
-            <AlertTriangle className="h-3.5 w-3.5 text-amber-600 dark:text-amber-500" />
-          )}
+          {Icon && s && <Icon className={cn("h-3.5 w-3.5", s.text)} />}
           {label}
         </span>
         <Button
@@ -175,12 +239,18 @@ function PreviewCard({ label, data, onEdit, errors }: PreviewCardProps) {
           <JSONView json={data} className="text-xs" />
         )}
       </div>
-      {hasErrors && (
-        <div className="border-t border-amber-500/50 bg-amber-50 px-4 py-2 dark:bg-amber-950/30">
-          <p className="text-xs text-amber-600 dark:text-amber-500">
-            {errors.length} path{errors.length !== 1 ? "s" : ""} did not match
-            in preview observation. These items will be skipped during
-            processing.
+      {variant && s && (
+        <div className={cn("border-t px-4 py-2", s.borderColor, s.bg)}>
+          <p className={cn("text-xs", s.text)}>
+            {[
+              pathErrors.length > 0 &&
+                `${pathErrors.length} path${pathErrors.length !== 1 ? "s" : ""} have invalid syntax`,
+              pathMisses.length > 0 &&
+                `${pathMisses.length} path${pathMisses.length !== 1 ? "s" : ""} did not match in preview observation`,
+            ]
+              .filter(Boolean)
+              .join("; ")}
+            . These items will be skipped during processing.
           </p>
         </div>
       )}

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
@@ -67,7 +67,7 @@ export function FinalPreviewStep({
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-500" />
             <div className="space-y-1">
               <p className="text-sm font-medium text-amber-600 dark:text-amber-500">
-                Some JSON paths did not match the preview observation
+                Some JSONPaths did not match the preview observation
               </p>
               <p className="text-xs text-amber-600/80 dark:text-amber-500/80">
                 Observations with failed mappings will be skipped during

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
@@ -225,7 +225,7 @@ function PreviewCard({
           <p className="text-xs">
             {[
               pathErrors.length > 0 &&
-                `${pathErrors.length} path${pathErrors.length !== 1 ? "s" : ""} have invalid syntax`,
+                `${pathErrors.length} path${pathErrors.length !== 1 ? "s have" : " has"} invalid syntax`,
               pathMisses.length > 0 &&
                 `${pathMisses.length} path${pathMisses.length !== 1 ? "s" : ""} did not match in preview observation`,
             ]

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
@@ -1,11 +1,19 @@
 import { useMemo } from "react";
 import { Button } from "@/src/components/ui/button";
-import { AlertCircle, AlertTriangle, Pencil } from "lucide-react";
+import { Pencil } from "lucide-react";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { cn } from "@/src/utils/tailwind";
 import type { FinalPreviewStepProps, DialogStep } from "./types";
 import { applyFullMapping } from "@langfuse/shared";
 import type { MappingError } from "@langfuse/shared";
+import {
+  IssueBanner,
+  issueCardVariants,
+  issueChromeVariants,
+  issueIcons,
+  issueTextVariants,
+  type IssueVariant,
+} from "@/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/IssueBanner";
 
 const STEP_FOR_FIELD: Record<string, DialogStep> = {
   input: "input-mapping",
@@ -69,9 +77,13 @@ export function FinalPreviewStep({
           variant="error"
           title="Some JSONPaths are invalid"
           description="Items using these mappings will be skipped during processing."
-          fields={errorFields}
-          onEditStep={onEditStep}
-        />
+        >
+          <EditMappingActions
+            variant="error"
+            fields={errorFields}
+            onEditStep={onEditStep}
+          />
+        </IssueBanner>
       )}
 
       {missFields.length > 0 && (
@@ -79,9 +91,13 @@ export function FinalPreviewStep({
           variant="warning"
           title="Some JSONPaths did not match the preview observation"
           description="Observations with failed mappings will be skipped during processing."
-          fields={missFields}
-          onEditStep={onEditStep}
-        />
+        >
+          <EditMappingActions
+            variant="warning"
+            fields={missFields}
+            onEditStep={onEditStep}
+          />
+        </IssueBanner>
       )}
 
       <div className="text-muted-foreground text-sm">
@@ -123,74 +139,34 @@ export function FinalPreviewStep({
   );
 }
 
-type IssueVariant = "error" | "warning";
-
-const bannerStyles: Record<
-  IssueVariant,
-  {
-    borderColor: string;
-    bg: string;
-    text: string;
-    subtext: string;
-    icon: typeof AlertCircle;
-  }
-> = {
-  error: {
-    borderColor: "border-destructive/50",
-    bg: "bg-destructive/10",
-    text: "text-destructive",
-    subtext: "text-destructive/80",
-    icon: AlertCircle,
-  },
-  warning: {
-    borderColor: "border-amber-500/50",
-    bg: "bg-amber-50 dark:bg-amber-950/30",
-    text: "text-amber-600 dark:text-amber-500",
-    subtext: "text-amber-600/80 dark:text-amber-500/80",
-    icon: AlertTriangle,
-  },
-};
-
-function IssueBanner({
+function EditMappingActions({
   variant,
-  title,
-  description,
   fields,
   onEditStep,
 }: {
   variant: IssueVariant;
-  title: string;
-  description: string;
   fields: string[];
   onEditStep: (step: DialogStep) => void;
 }) {
-  const s = bannerStyles[variant];
-  const Icon = s.icon;
   return (
-    <div className={cn("rounded-md border p-3", s.borderColor, s.bg)}>
-      <div className="flex items-start gap-2">
-        <Icon className={cn("mt-0.5 h-4 w-4 shrink-0", s.text)} />
-        <div className="space-y-1">
-          <p className={cn("text-sm font-medium", s.text)}>{title}</p>
-          <p className={cn("text-xs", s.subtext)}>{description}</p>
-          <div className="flex flex-wrap gap-2 pt-1">
-            {fields.map((field) => (
-              <Button
-                key={field}
-                variant="link"
-                size="sm"
-                className={cn("h-auto p-0 text-xs underline", s.text)}
-                onClick={() => {
-                  const step = STEP_FOR_FIELD[field];
-                  if (step) onEditStep(step);
-                }}
-              >
-                Edit {fieldLabel(field)} mapping
-              </Button>
-            ))}
-          </div>
-        </div>
-      </div>
+    <div className="flex flex-wrap gap-2 pt-1">
+      {fields.map((field) => (
+        <Button
+          key={field}
+          variant="link"
+          size="sm"
+          className={cn(
+            "h-auto p-0 text-xs underline",
+            issueTextVariants({ variant }),
+          )}
+          onClick={() => {
+            const step = STEP_FOR_FIELD[field];
+            if (step) onEditStep(step);
+          }}
+        >
+          Edit {fieldLabel(field)} mapping
+        </Button>
+      ))}
     </div>
   );
 }
@@ -212,14 +188,17 @@ function PreviewCard({
 }: PreviewCardProps) {
   const variant: IssueVariant | null =
     pathErrors.length > 0 ? "error" : pathMisses.length > 0 ? "warning" : null;
-  const s = variant ? bannerStyles[variant] : null;
-  const Icon = s?.icon;
+  const Icon = variant ? issueIcons[variant] : null;
 
   return (
-    <div className={cn("rounded-lg border", s?.borderColor)}>
+    <div className={issueCardVariants({ variant: variant ?? "none" })}>
       <div className="bg-muted/30 flex items-center justify-between border-b px-4 py-2">
         <span className="flex items-center gap-1.5 text-sm font-medium">
-          {Icon && s && <Icon className={cn("h-3.5 w-3.5", s.text)} />}
+          {Icon && variant && (
+            <Icon
+              className={cn("h-3.5 w-3.5", issueTextVariants({ variant }))}
+            />
+          )}
           {label}
         </span>
         <Button
@@ -239,9 +218,11 @@ function PreviewCard({
           <JSONView json={data} className="text-xs" />
         )}
       </div>
-      {variant && s && (
-        <div className={cn("border-t px-4 py-2", s.borderColor, s.bg)}>
-          <p className={cn("text-xs", s.text)}>
+      {variant && (
+        <div
+          className={cn("border-t px-4 py-2", issueChromeVariants({ variant }))}
+        >
+          <p className="text-xs">
             {[
               pathErrors.length > 0 &&
                 `${pathErrors.length} path${pathErrors.length !== 1 ? "s" : ""} have invalid syntax`,

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/CustomMappingEditor.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/CustomMappingEditor.tsx
@@ -168,7 +168,7 @@ export function CustomMappingEditor({
             </div>
           </div>
           <div>
-            <Label className="text-sm font-medium">JSON Path</Label>
+            <Label className="text-sm font-medium">JSONPath</Label>
             <div className="mt-1">
               <JsonPathInput
                 value={config.rootConfig?.jsonPath ?? "$."}
@@ -180,7 +180,7 @@ export function CustomMappingEditor({
               />
             </div>
             <p className="text-muted-foreground p-1 text-xs">
-              Start with $. to use a JSON path (e.g., $.field)
+              Start with $. to use a JSONPath (e.g., $.field)
             </p>
           </div>
         </div>
@@ -191,7 +191,7 @@ export function CustomMappingEditor({
           <Label className="text-sm font-medium">Key-value mappings</Label>
           <p className="text-muted-foreground text-xs">
             Build an object with custom keys. Values starting with $ are treated
-            as JSON paths.
+            as JSONPaths.
           </p>
 
           <div className="space-y-3">
@@ -343,7 +343,7 @@ function KeyValueEntryRow({
             )}
 
             <p className="text-muted-foreground pt-1 text-xs">
-              Start with $. to use a JSON path (e.g., $.field)
+              Start with $. to use a JSONPath (e.g., $.field)
             </p>
           </div>
         </div>

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/IssueBanner.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/IssueBanner.tsx
@@ -1,0 +1,106 @@
+import { type ReactNode } from "react";
+import { AlertCircle, AlertTriangle, type LucideIcon } from "lucide-react";
+import { cva } from "class-variance-authority";
+import { cn } from "@/src/utils/tailwind";
+
+export type IssueVariant = "error" | "warning";
+
+/**
+ * Colored chrome — border + bg + text — applied to elements that carry a full
+ * issue notice (banner, list root, card footer strip). Each consumer composes
+ * this with its own layout classes.
+ */
+export const issueChromeVariants = cva("", {
+  variants: {
+    variant: {
+      error: "border-destructive/50 bg-destructive/10 text-destructive",
+      warning:
+        "border-amber-500/50 bg-amber-50 text-amber-600 dark:bg-amber-950/30 dark:text-amber-500",
+    },
+  },
+});
+
+/** Outer card border that picks up a variant accent only when there is an issue. */
+export const issueCardVariants = cva("rounded-lg border", {
+  variants: {
+    variant: {
+      none: "",
+      error: "border-destructive/50",
+      warning: "border-amber-500/50",
+    },
+  },
+  defaultVariants: { variant: "none" },
+});
+
+/**
+ * Text color for inner elements that set their own color and therefore do not
+ * inherit from a variant-styled ancestor (e.g. Button's `variant="link"` that
+ * forces `text-primary`).
+ */
+export const issueTextVariants = cva("", {
+  variants: {
+    variant: {
+      error: "text-destructive",
+      warning: "text-amber-600 dark:text-amber-500",
+    },
+  },
+});
+
+export const issueIcons: Record<IssueVariant, LucideIcon> = {
+  error: AlertCircle,
+  warning: AlertTriangle,
+};
+
+export function IssueBanner({
+  variant,
+  title,
+  description,
+  children,
+}: {
+  variant: IssueVariant;
+  title: string;
+  description?: string;
+  children?: ReactNode;
+}) {
+  const Icon = issueIcons[variant];
+  return (
+    <div
+      className={cn("rounded-md border p-3", issueChromeVariants({ variant }))}
+    >
+      <div className="flex items-start gap-2">
+        <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{title}</p>
+          {description && <p className="text-xs opacity-80">{description}</p>}
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function IssueList({
+  variant,
+  title,
+  children,
+}: {
+  variant: IssueVariant;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "max-h-[5vh] overflow-y-auto rounded-md border p-2",
+        issueChromeVariants({ variant }),
+      )}
+    >
+      <p className="mb-1 text-xs font-medium">{title}</p>
+      <ul className="space-y-0.5">{children}</ul>
+    </div>
+  );
+}
+
+export function IssueItem({ children }: { children: ReactNode }) {
+  return <li className="text-xs">{children}</li>;
+}

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/JsonPathInput.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/JsonPathInput.tsx
@@ -8,7 +8,7 @@ import { darkTheme } from "@/src/components/editor/dark-theme";
 import { cn } from "@/src/utils/tailwind";
 import { evaluateJsonPath } from "@langfuse/shared";
 
-// JSON path language mode for syntax highlighting
+// JSONPath language mode for syntax highlighting
 const jsonPathLanguage = StreamLanguage.define({
   name: "jsonpath",
   startState: () => ({ inBracket: false }),
@@ -101,14 +101,14 @@ export function JsonPathInput({
     (newValue: string) => {
       onChange(newValue);
 
-      // Try to resolve the JSON path
+      // Try to resolve the JSONPath
       if (newValue && newValue.startsWith("$") && parsedSourceData) {
         try {
           const result = evaluateJsonPath(parsedSourceData, newValue);
           setResolveError(null);
           setNoMatchWarning(result === undefined);
         } catch (e) {
-          setResolveError(e instanceof Error ? e.message : "Invalid JSON path");
+          setResolveError(e instanceof Error ? e.message : "Invalid JSONPath");
           setNoMatchWarning(false);
         }
       } else {

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/MappingPreviewPanel.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/MappingPreviewPanel.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useEffect, useRef } from "react";
+import { useMemo, useEffect, useRef, type ReactNode } from "react";
 import {
   ArrowDown,
   AlertCircle,
   AlertTriangle,
   CheckCircle2,
 } from "lucide-react";
+import { cn } from "@/src/utils/tailwind";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import type {
@@ -16,6 +17,8 @@ import type {
 import {
   applyFieldMappingConfig,
   validateFieldAgainstSchema,
+  type JsonPathMissInfo,
+  type JsonPathErrorInfo,
 } from "@langfuse/shared";
 
 type MappingPreviewPanelProps = {
@@ -60,23 +63,17 @@ export function MappingPreviewPanel({
     return observationData[defaultSourceField];
   }, [observationData, config, defaultSourceField]);
 
-  // Compute result data and collect JSON path misses
-  const { resultData, jsonPathMisses } = useMemo(() => {
+  // Compute result data and collect JSON path misses / syntax errors
+  const { resultData, jsonPathMisses, jsonPathErrors } = useMemo(() => {
     if (!observationData)
       return {
         resultData: null,
-        jsonPathMisses: [] as {
-          sourceField: string;
-          jsonPath: string;
-          mappingKey: string | null;
-        }[],
+        jsonPathMisses: [] as JsonPathMissInfo[],
+        jsonPathErrors: [] as JsonPathErrorInfo[],
       };
 
-    const misses: {
-      sourceField: string;
-      jsonPath: string;
-      mappingKey: string | null;
-    }[] = [];
+    const misses: JsonPathMissInfo[] = [];
+    const errors: JsonPathErrorInfo[] = [];
 
     const data = applyFieldMappingConfig({
       observation: {
@@ -89,14 +86,31 @@ export function MappingPreviewPanel({
       onJsonPathMiss: (info) => {
         misses.push(info);
       },
+      onJsonPathError: (info) => {
+        errors.push(info);
+      },
     });
 
-    return { resultData: data, jsonPathMisses: misses };
+    return { resultData: data, jsonPathMisses: misses, jsonPathErrors: errors };
   }, [observationData, config, defaultSourceField]);
 
-  // Validate result against schema
+  // Validate result against schema, and treat JSON path syntax errors as validation failures
   const validationResult = useMemo(() => {
-    // Skip validation if no schema or "none" mode
+    const jsonPathErrorItems: SchemaValidationError[] = jsonPathErrors.map(
+      (err) => ({
+        path: err.mappingKey
+          ? `${err.sourceField} (key: "${err.mappingKey}")`
+          : err.sourceField,
+        message: `Invalid JSON path "${err.jsonPath}": ${err.message}`,
+      }),
+    );
+
+    // Any JSON path syntax error blocks the mapping regardless of schema
+    if (jsonPathErrorItems.length > 0) {
+      return { isValid: false, errors: jsonPathErrorItems };
+    }
+
+    // Skip schema validation if no schema or "none" mode
     if (!hasSchema || config.mode === "none") {
       return { isValid: true, errors: [] as SchemaValidationError[] };
     }
@@ -124,10 +138,10 @@ export function MappingPreviewPanel({
         })),
       };
     } catch {
-      // If validation fails to run, treat as valid (don't block on validation errors)
+      // If schema validation fails to run, treat as valid (don't block on validation errors)
       return { isValid: true, errors: [] as SchemaValidationError[] };
     }
-  }, [hasSchema, config.mode, resultData, schema]);
+  }, [hasSchema, config.mode, resultData, schema, jsonPathErrors]);
 
   // Track previous validation state to avoid redundant callbacks
   const prevValidationRef = useRef<{
@@ -241,7 +255,8 @@ export function MappingPreviewPanel({
           {/* Validation status indicator */}
           {config.mode !== "none" && (
             <div className="flex items-center gap-1">
-              {hasSchema && !validationResult.isValid ? (
+              {jsonPathErrors.length > 0 ||
+              (hasSchema && !validationResult.isValid) ? (
                 <AlertCircle className="text-destructive h-3.5 w-3.5" />
               ) : jsonPathMisses.length > 0 ? (
                 <AlertTriangle className="h-3.5 w-3.5 text-amber-600 dark:text-amber-500" />
@@ -253,7 +268,9 @@ export function MappingPreviewPanel({
         </div>
         <div
           className={`bg-background max-h-[21vh] overflow-auto rounded-md border ${
-            hasSchema && !validationResult.isValid && config.mode !== "none"
+            (jsonPathErrors.length > 0 ||
+              (hasSchema && !validationResult.isValid)) &&
+            config.mode !== "none"
               ? "border-destructive"
               : jsonPathMisses.length > 0 && config.mode !== "none"
                 ? "border-amber-500/50"
@@ -267,46 +284,97 @@ export function MappingPreviewPanel({
           )}
         </div>
 
-        {/* Validation errors */}
+        {/* JSON path syntax errors (always blocking) */}
+        {jsonPathErrors.length > 0 && config.mode !== "none" && (
+          <IssueList variant="error" title="Invalid JSON path:">
+            {jsonPathErrors.map((err, idx) => (
+              <IssueItem key={idx} variant="error">
+                <span className="font-mono">{err.jsonPath}</span>
+                {err.mappingKey ? ` (key: "${err.mappingKey}")` : ""}:{" "}
+                {err.message}
+              </IssueItem>
+            ))}
+          </IssueList>
+        )}
+
+        {/* Schema validation errors (only when no blocking JSON path errors) */}
         {hasSchema &&
-          !validationResult.isValid &&
+          jsonPathErrors.length === 0 &&
           validationResult.errors.length > 0 && (
-            <div className="border-destructive/50 bg-destructive/10 max-h-[5vh] overflow-y-auto rounded-md border p-2">
-              <p className="text-destructive mb-1 text-xs font-medium">
-                Schema validation errors:
-              </p>
-              <ul className="space-y-0.5">
-                {validationResult.errors.map((error, idx) => (
-                  <li key={idx} className="text-destructive text-xs">
-                    <span className="font-mono">{error.path || "root"}</span>:{" "}
-                    {error.message}
-                  </li>
-                ))}
-              </ul>
-            </div>
+            <IssueList variant="error" title="Schema validation errors:">
+              {validationResult.errors.map((error, idx) => (
+                <IssueItem key={idx} variant="error">
+                  <span className="font-mono">{error.path || "root"}</span>:{" "}
+                  {error.message}
+                </IssueItem>
+              ))}
+            </IssueList>
           )}
 
         {/* JSON path warnings */}
         {jsonPathMisses.length > 0 && config.mode !== "none" && (
-          <div className="max-h-[5vh] overflow-y-auto rounded-md border border-amber-500/50 bg-amber-50 p-2 dark:bg-amber-950/30">
-            <p className="mb-1 text-xs font-medium text-amber-600 dark:text-amber-500">
-              JSON path warnings (preview observation):
-            </p>
-            <ul className="space-y-0.5">
-              {jsonPathMisses.map((miss, idx) => (
-                <li
-                  key={idx}
-                  className="text-xs text-amber-600 dark:text-amber-500"
-                >
-                  <span className="font-mono">{miss.jsonPath}</span> did not
-                  match any data in {miss.sourceField}
-                  {miss.mappingKey ? ` (key: "${miss.mappingKey}")` : ""}
-                </li>
-              ))}
-            </ul>
-          </div>
+          <IssueList
+            variant="warning"
+            title="JSON path warnings (preview observation):"
+          >
+            {jsonPathMisses.map((miss, idx) => (
+              <IssueItem key={idx} variant="warning">
+                <span className="font-mono">{miss.jsonPath}</span> did not match
+                any data in {miss.sourceField}
+                {miss.mappingKey ? ` (key: "${miss.mappingKey}")` : ""}
+              </IssueItem>
+            ))}
+          </IssueList>
         )}
       </div>
     </div>
+  );
+}
+
+type IssueVariant = "error" | "warning";
+
+const issueBoxStyles: Record<IssueVariant, string> = {
+  error: "border-destructive/50 bg-destructive/10",
+  warning: "border-amber-500/50 bg-amber-50 dark:bg-amber-950/30",
+};
+
+const issueTextStyles: Record<IssueVariant, string> = {
+  error: "text-destructive",
+  warning: "text-amber-600 dark:text-amber-500",
+};
+
+function IssueList({
+  variant,
+  title,
+  children,
+}: {
+  variant: IssueVariant;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "max-h-[5vh] overflow-y-auto rounded-md border p-2",
+        issueBoxStyles[variant],
+      )}
+    >
+      <p className={cn("mb-1 text-xs font-medium", issueTextStyles[variant])}>
+        {title}
+      </p>
+      <ul className="space-y-0.5">{children}</ul>
+    </div>
+  );
+}
+
+function IssueItem({
+  variant,
+  children,
+}: {
+  variant: IssueVariant;
+  children: ReactNode;
+}) {
+  return (
+    <li className={cn("text-xs", issueTextStyles[variant])}>{children}</li>
   );
 }

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/MappingPreviewPanel.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/MappingPreviewPanel.tsx
@@ -63,7 +63,7 @@ export function MappingPreviewPanel({
     return observationData[defaultSourceField];
   }, [observationData, config, defaultSourceField]);
 
-  // Compute result data and collect JSON path misses / syntax errors
+  // Compute result data and collect JSONPath misses / syntax errors
   const { resultData, jsonPathMisses, jsonPathErrors } = useMemo(() => {
     if (!observationData)
       return {
@@ -94,18 +94,18 @@ export function MappingPreviewPanel({
     return { resultData: data, jsonPathMisses: misses, jsonPathErrors: errors };
   }, [observationData, config, defaultSourceField]);
 
-  // Validate result against schema, and treat JSON path syntax errors as validation failures
+  // Validate result against schema, and treat JSONPath syntax errors as validation failures
   const validationResult = useMemo(() => {
     const jsonPathErrorItems: SchemaValidationError[] = jsonPathErrors.map(
       (err) => ({
         path: err.mappingKey
           ? `${err.sourceField} (key: "${err.mappingKey}")`
           : err.sourceField,
-        message: `Invalid JSON path "${err.jsonPath}": ${err.message}`,
+        message: `Invalid JSONPath "${err.jsonPath}": ${err.message}`,
       }),
     );
 
-    // Any JSON path syntax error blocks the mapping regardless of schema
+    // Any JSONPath syntax error blocks the mapping regardless of schema
     if (jsonPathErrorItems.length > 0) {
       return { isValid: false, errors: jsonPathErrorItems };
     }
@@ -284,9 +284,9 @@ export function MappingPreviewPanel({
           )}
         </div>
 
-        {/* JSON path syntax errors (always blocking) */}
+        {/* JSONPath syntax errors (always blocking) */}
         {jsonPathErrors.length > 0 && config.mode !== "none" && (
-          <IssueList variant="error" title="Invalid JSON path:">
+          <IssueList variant="error" title="Invalid JSONPath:">
             {jsonPathErrors.map((err, idx) => (
               <IssueItem key={idx} variant="error">
                 <span className="font-mono">{err.jsonPath}</span>
@@ -297,7 +297,7 @@ export function MappingPreviewPanel({
           </IssueList>
         )}
 
-        {/* Schema validation errors (only when no blocking JSON path errors) */}
+        {/* Schema validation errors (only when no blocking JSONPath errors) */}
         {hasSchema &&
           jsonPathErrors.length === 0 &&
           validationResult.errors.length > 0 && (
@@ -311,11 +311,11 @@ export function MappingPreviewPanel({
             </IssueList>
           )}
 
-        {/* JSON path warnings */}
+        {/* JSONPath warnings */}
         {jsonPathMisses.length > 0 && config.mode !== "none" && (
           <IssueList
             variant="warning"
-            title="JSON path warnings (preview observation):"
+            title="JSONPath warnings (preview observation):"
           >
             {jsonPathMisses.map((miss, idx) => (
               <IssueItem key={idx} variant="warning">

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/MappingPreviewPanel.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/MappingPreviewPanel.tsx
@@ -72,10 +72,7 @@ export function MappingPreviewPanel({
         jsonPathErrors: [] as JsonPathErrorInfo[],
       };
 
-    const misses: JsonPathMissInfo[] = [];
-    const errors: JsonPathErrorInfo[] = [];
-
-    const data = applyFieldMappingConfig({
+    const result = applyFieldMappingConfig({
       observation: {
         input: observationData.input,
         output: observationData.output,
@@ -83,15 +80,13 @@ export function MappingPreviewPanel({
       },
       config,
       defaultSourceField,
-      onJsonPathMiss: (info) => {
-        misses.push(info);
-      },
-      onJsonPathError: (info) => {
-        errors.push(info);
-      },
     });
 
-    return { resultData: data, jsonPathMisses: misses, jsonPathErrors: errors };
+    return {
+      resultData: result.value,
+      jsonPathMisses: result.misses,
+      jsonPathErrors: result.errors,
+    };
   }, [observationData, config, defaultSourceField]);
 
   // Validate result against schema, and treat JSONPath syntax errors as validation failures

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/MappingPreviewPanel.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/MappingPreviewPanel.tsx
@@ -1,13 +1,16 @@
-import { useMemo, useEffect, useRef, type ReactNode } from "react";
+import { useMemo, useEffect, useRef } from "react";
 import {
   ArrowDown,
   AlertCircle,
   AlertTriangle,
   CheckCircle2,
 } from "lucide-react";
-import { cn } from "@/src/utils/tailwind";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import {
+  IssueList,
+  IssueItem,
+} from "@/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/IssueBanner";
 import type {
   FieldMappingConfig,
   SourceField,
@@ -283,7 +286,7 @@ export function MappingPreviewPanel({
         {jsonPathErrors.length > 0 && config.mode !== "none" && (
           <IssueList variant="error" title="Invalid JSONPath:">
             {jsonPathErrors.map((err, idx) => (
-              <IssueItem key={idx} variant="error">
+              <IssueItem key={idx}>
                 <span className="font-mono">{err.jsonPath}</span>
                 {err.mappingKey ? ` (key: "${err.mappingKey}")` : ""}:{" "}
                 {err.message}
@@ -298,7 +301,7 @@ export function MappingPreviewPanel({
           validationResult.errors.length > 0 && (
             <IssueList variant="error" title="Schema validation errors:">
               {validationResult.errors.map((error, idx) => (
-                <IssueItem key={idx} variant="error">
+                <IssueItem key={idx}>
                   <span className="font-mono">{error.path || "root"}</span>:{" "}
                   {error.message}
                 </IssueItem>
@@ -313,7 +316,7 @@ export function MappingPreviewPanel({
             title="JSONPath warnings (preview observation):"
           >
             {jsonPathMisses.map((miss, idx) => (
-              <IssueItem key={idx} variant="warning">
+              <IssueItem key={idx}>
                 <span className="font-mono">{miss.jsonPath}</span> did not match
                 any data in {miss.sourceField}
                 {miss.mappingKey ? ` (key: "${miss.mappingKey}")` : ""}
@@ -323,53 +326,5 @@ export function MappingPreviewPanel({
         )}
       </div>
     </div>
-  );
-}
-
-type IssueVariant = "error" | "warning";
-
-const issueBoxStyles: Record<IssueVariant, string> = {
-  error: "border-destructive/50 bg-destructive/10",
-  warning: "border-amber-500/50 bg-amber-50 dark:bg-amber-950/30",
-};
-
-const issueTextStyles: Record<IssueVariant, string> = {
-  error: "text-destructive",
-  warning: "text-amber-600 dark:text-amber-500",
-};
-
-function IssueList({
-  variant,
-  title,
-  children,
-}: {
-  variant: IssueVariant;
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <div
-      className={cn(
-        "max-h-[5vh] overflow-y-auto rounded-md border p-2",
-        issueBoxStyles[variant],
-      )}
-    >
-      <p className={cn("mb-1 text-xs font-medium", issueTextStyles[variant])}>
-        {title}
-      </p>
-      <ul className="space-y-0.5">{children}</ul>
-    </div>
-  );
-}
-
-function IssueItem({
-  variant,
-  children,
-}: {
-  variant: IssueVariant;
-  children: ReactNode;
-}) {
-  return (
-    <li className={cn("text-xs", issueTextStyles[variant])}>{children}</li>
   );
 }

--- a/web/src/features/batch-actions/components/RunEvaluationDialog/utils.ts
+++ b/web/src/features/batch-actions/components/RunEvaluationDialog/utils.ts
@@ -47,7 +47,7 @@ export function renderPromptPreviewFromObservation(params: {
       mapping.jsonSelector ?? undefined,
     );
     const rendered = error
-      ? `<invalid JSON path "${mapping.jsonSelector ?? ""}": ${error.message}>`
+      ? `<invalid JSONPath "${mapping.jsonSelector ?? ""}": ${error.message}>`
       : stringifyPreviewValue(value);
     variableValues.set(mapping.templateVariable, rendered);
   }

--- a/web/src/features/batch-actions/components/RunEvaluationDialog/utils.ts
+++ b/web/src/features/batch-actions/components/RunEvaluationDialog/utils.ts
@@ -41,15 +41,12 @@ export function renderPromptPreviewFromObservation(params: {
   const variableValues = new Map<string, string>();
 
   for (const mapping of variableMapping) {
-    const { value, error } = extractValueFromObject(
+    const { value } = extractValueFromObject(
       observation,
       mapping.selectedColumnId,
       mapping.jsonSelector ?? undefined,
     );
-    const rendered = error
-      ? `<invalid JSONPath "${mapping.jsonSelector ?? ""}": ${error.message}>`
-      : stringifyPreviewValue(value);
-    variableValues.set(mapping.templateVariable, rendered);
+    variableValues.set(mapping.templateVariable, stringifyPreviewValue(value));
   }
 
   const renderedPrompt = prompt.replace(/{{([^{}]+)}}/g, (_match, variable) => {

--- a/web/src/features/batch-actions/components/RunEvaluationDialog/utils.ts
+++ b/web/src/features/batch-actions/components/RunEvaluationDialog/utils.ts
@@ -41,12 +41,15 @@ export function renderPromptPreviewFromObservation(params: {
   const variableValues = new Map<string, string>();
 
   for (const mapping of variableMapping) {
-    const { value } = extractValueFromObject(
+    const { value, error } = extractValueFromObject(
       observation,
       mapping.selectedColumnId,
       mapping.jsonSelector ?? undefined,
     );
-    variableValues.set(mapping.templateVariable, stringifyPreviewValue(value));
+    const rendered = error
+      ? `<invalid JSON path "${mapping.jsonSelector ?? ""}": ${error.message}>`
+      : stringifyPreviewValue(value);
+    variableValues.set(mapping.templateVariable, rendered);
   }
 
   const renderedPrompt = prompt.replace(/{{([^{}]+)}}/g, (_match, variable) => {

--- a/web/src/features/evals/hooks/useExtractVariables.ts
+++ b/web/src/features/evals/hooks/useExtractVariables.ts
@@ -159,7 +159,12 @@ export function useExtractVariables({
         mapping.selectedColumnId,
         mapping.jsonSelector ?? undefined,
       );
-      return { variable, value, error };
+      return {
+        variable,
+        value,
+        error,
+        jsonSelector: mapping.jsonSelector ?? null,
+      };
     });
 
     // Resolve all promises and update state
@@ -169,7 +174,11 @@ export function useExtractVariables({
           (result) => result.error instanceof Error,
         );
         if (firstError) {
-          setExtractionError(firstError.error as Error);
+          const baseMessage = (firstError.error as Error).message;
+          const message = firstError.jsonSelector
+            ? `${firstError.jsonSelector}: ${baseMessage}`
+            : baseMessage;
+          setExtractionError(new Error(message));
         }
         setExtractedVariables(results);
         // Update the ref to the current mapping string to track changes

--- a/web/src/features/evals/hooks/useExtractVariables.ts
+++ b/web/src/features/evals/hooks/useExtractVariables.ts
@@ -56,7 +56,7 @@ export function useExtractVariables({
   useEffect(() => {
     if (extractionError) {
       showErrorToast(
-        "Invalid JSON path in variable mapping",
+        "Invalid JSONPath in variable mapping",
         extractionError.message,
         "WARNING",
       );

--- a/web/src/features/evals/hooks/useExtractVariables.ts
+++ b/web/src/features/evals/hooks/useExtractVariables.ts
@@ -56,7 +56,7 @@ export function useExtractVariables({
   useEffect(() => {
     if (extractionError) {
       showErrorToast(
-        "Failed to extract variable",
+        "Invalid JSON path in variable mapping",
         extractionError.message,
         "WARNING",
       );

--- a/web/src/features/evals/hooks/useExtractVariables.ts
+++ b/web/src/features/evals/hooks/useExtractVariables.ts
@@ -1,7 +1,7 @@
 import { type PreviewData } from "@/src/features/evals/hooks/usePreviewData";
 import { type VariableMapping } from "@/src/features/evals/utils/evaluator-form-utils";
 import { api } from "@/src/utils/api";
-import { trpcErrorToast } from "@/src/utils/trpcErrorToast";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { EvalTargetObject, extractValueFromObject } from "@langfuse/shared";
 import { useEffect, useState, useRef } from "react";
 
@@ -55,7 +55,11 @@ export function useExtractVariables({
   // Handle error toasts separately to avoid repeated toasts on re-renders
   useEffect(() => {
     if (extractionError) {
-      trpcErrorToast(extractionError);
+      showErrorToast(
+        "Failed to extract variable",
+        extractionError.message,
+        "WARNING",
+      );
     }
   }, [extractionError]);
 

--- a/web/src/features/evals/hooks/useExtractVariables.ts
+++ b/web/src/features/evals/hooks/useExtractVariables.ts
@@ -23,6 +23,10 @@ type ExtractedVariable = {
   value: unknown;
 };
 
+type ExtractionError =
+  | { kind: "jsonPath"; message: string }
+  | { kind: "unexpected"; message: string };
+
 export function useExtractVariables({
   variables,
   variableMapping,
@@ -39,7 +43,8 @@ export function useExtractVariables({
     ExtractedVariable[]
   >([]);
   const [isExtracting, setIsExtracting] = useState(false);
-  const [extractionError, setExtractionError] = useState<Error | null>(null);
+  const [extractionError, setExtractionError] =
+    useState<ExtractionError | null>(null);
   const previousMappingRef = useRef<string>("");
 
   // Create a stable string representation of the current mapping for comparison
@@ -54,13 +59,12 @@ export function useExtractVariables({
 
   // Handle error toasts separately to avoid repeated toasts on re-renders
   useEffect(() => {
-    if (extractionError) {
-      showErrorToast(
-        "Invalid JSONPath in variable mapping",
-        extractionError.message,
-        "WARNING",
-      );
-    }
+    if (!extractionError) return;
+    const title =
+      extractionError.kind === "jsonPath"
+        ? "Invalid JSONPath in variable mapping"
+        : "Failed to extract variable";
+    showErrorToast(title, extractionError.message, "WARNING");
   }, [extractionError]);
 
   useEffect(() => {
@@ -178,7 +182,7 @@ export function useExtractVariables({
           const message = firstError.jsonSelector
             ? `${firstError.jsonSelector}: ${baseMessage}`
             : baseMessage;
-          setExtractionError(new Error(message));
+          setExtractionError({ kind: "jsonPath", message });
         }
         setExtractedVariables(results);
         // Update the ref to the current mapping string to track changes
@@ -186,7 +190,10 @@ export function useExtractVariables({
       })
       .catch((error) => {
         console.error("Error extracting variables:", error);
-        setExtractionError(error);
+        setExtractionError({
+          kind: "unexpected",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
         setExtractedVariables(
           variables.map((variable) => ({
             variable,

--- a/worker/src/__tests__/applyFieldMapping.test.ts
+++ b/worker/src/__tests__/applyFieldMapping.test.ts
@@ -144,7 +144,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual(sampleObservation.input);
+      expect(result.value).toEqual(sampleObservation.input);
     });
 
     it("should return full output for 'full' mode with output as default", () => {
@@ -154,7 +154,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "output",
       });
 
-      expect(result).toEqual(sampleObservation.output);
+      expect(result.value).toEqual(sampleObservation.output);
     });
 
     it("should return full metadata for 'full' mode with metadata as default", () => {
@@ -164,7 +164,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "metadata",
       });
 
-      expect(result).toEqual(sampleObservation.metadata);
+      expect(result.value).toEqual(sampleObservation.metadata);
     });
   });
 
@@ -176,7 +176,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toBeNull();
+      expect(result.value).toBeNull();
     });
   });
 
@@ -197,7 +197,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toBe("What is 2+2?");
+      expect(result.value).toBe("What is 2+2?");
     });
 
     it("should allow extracting from different source field", () => {
@@ -216,7 +216,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toBe("4");
+      expect(result.value).toBe("4");
     });
 
     it("should return undefined for non-existent path", () => {
@@ -235,7 +235,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toBeUndefined();
+      expect(result.value).toBeUndefined();
     });
 
     it("should fallback to default source field if no custom config", () => {
@@ -250,7 +250,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "metadata",
       });
 
-      expect(result).toEqual(sampleObservation.metadata);
+      expect(result.value).toEqual(sampleObservation.metadata);
     });
   });
 
@@ -283,7 +283,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         prompt: "What is 2+2?",
         response: "4",
       });
@@ -317,7 +317,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         type: "conversation",
         version: "1.0",
       });
@@ -357,7 +357,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         prompt: "What is 2+2?",
         category: "math",
         user: "user-123",
@@ -394,7 +394,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         context: {
           user_id: "user-123",
           session_id: "session-456",
@@ -424,7 +424,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         a: {
           b: {
             c: {
@@ -481,7 +481,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         prompt: "What is 2+2?",
         context: {
           user_id: "user-123",
@@ -528,7 +528,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         prompt: "What is 2+2?",
         context: {
           user: "user-123",
@@ -565,7 +565,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         settings: {
           theme: "dark",
           language: "en",
@@ -601,7 +601,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         prompt: "What is 2+2?",
         empty_string: "",
       });
@@ -637,7 +637,7 @@ describe("applyFieldMapping", () => {
       });
 
       // The nested key should overwrite the flat value
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         context: {
           nested: "nested-value",
         },
@@ -962,7 +962,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toBeNull();
+      expect(result.value).toBeNull();
     });
 
     it("should handle undefined paths gracefully", () => {
@@ -987,7 +987,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         nonexistent: undefined,
       });
     });
@@ -1007,7 +1007,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "input",
       });
 
-      expect(result).toEqual(sampleObservation.input);
+      expect(result.value).toEqual(sampleObservation.input);
     });
 
     it("should handle no custom config by returning default source", () => {
@@ -1019,7 +1019,7 @@ describe("applyFieldMapping", () => {
         defaultSourceField: "metadata",
       });
 
-      expect(result).toEqual(sampleObservation.metadata);
+      expect(result.value).toEqual(sampleObservation.metadata);
     });
   });
 
@@ -1027,13 +1027,6 @@ describe("applyFieldMapping", () => {
     const invalidPath = "$..[?(@.x=)]";
 
     it("should not throw and report error for invalid root path", () => {
-      const errors: {
-        sourceField: string;
-        jsonPath: string;
-        mappingKey: string | null;
-        message: string;
-      }[] = [];
-
       const result = applyFieldMappingConfig({
         observation: sampleObservation,
         config: {
@@ -1047,27 +1040,19 @@ describe("applyFieldMapping", () => {
           },
         },
         defaultSourceField: "input",
-        onJsonPathError: (info) => errors.push(info),
       });
 
-      expect(result).toBeUndefined();
-      expect(errors).toHaveLength(1);
-      expect(errors[0]).toMatchObject({
+      expect(result.value).toBeUndefined();
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
         sourceField: "input",
         jsonPath: invalidPath,
         mappingKey: null,
       });
-      expect(errors[0].message).toBeTruthy();
+      expect(result.errors[0].message).toBeTruthy();
     });
 
     it("should not throw and isolate invalid entries in keyValueMap", () => {
-      const errors: {
-        sourceField: string;
-        jsonPath: string;
-        mappingKey: string | null;
-        message: string;
-      }[] = [];
-
       const result = applyFieldMappingConfig({
         observation: sampleObservation,
         config: {
@@ -1093,12 +1078,11 @@ describe("applyFieldMapping", () => {
           },
         },
         defaultSourceField: "input",
-        onJsonPathError: (info) => errors.push(info),
       });
 
-      expect(result).toEqual({ good: "gpt-4", bad: undefined });
-      expect(errors).toHaveLength(1);
-      expect(errors[0]).toMatchObject({
+      expect(result.value).toEqual({ good: "gpt-4", bad: undefined });
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
         sourceField: "input",
         jsonPath: invalidPath,
         mappingKey: "bad",
@@ -1107,12 +1091,6 @@ describe("applyFieldMapping", () => {
 
     it("should collect multiple errors from multiple invalid keyValueMap entries", () => {
       const secondInvalidPath = "$..[?(@.y<)]";
-      const errors: {
-        sourceField: string;
-        jsonPath: string;
-        mappingKey: string | null;
-        message: string;
-      }[] = [];
 
       const result = applyFieldMappingConfig({
         observation: sampleObservation,
@@ -1145,21 +1123,20 @@ describe("applyFieldMapping", () => {
           },
         },
         defaultSourceField: "input",
-        onJsonPathError: (info) => errors.push(info),
       });
 
-      expect(result).toEqual({
+      expect(result.value).toEqual({
         bad_one: undefined,
         good: "gpt-4",
         bad_two: undefined,
       });
-      expect(errors).toHaveLength(2);
-      expect(errors[0]).toMatchObject({
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors[0]).toMatchObject({
         sourceField: "input",
         jsonPath: invalidPath,
         mappingKey: "bad_one",
       });
-      expect(errors[1]).toMatchObject({
+      expect(result.errors[1]).toMatchObject({
         sourceField: "output",
         jsonPath: secondInvalidPath,
         mappingKey: "bad_two",

--- a/worker/src/__tests__/applyFieldMapping.test.ts
+++ b/worker/src/__tests__/applyFieldMapping.test.ts
@@ -1022,4 +1022,178 @@ describe("applyFieldMapping", () => {
       expect(result).toEqual(sampleObservation.metadata);
     });
   });
+
+  describe("invalid JSON path syntax", () => {
+    const invalidPath = "$..[?(@.x=)]";
+
+    it("should not throw and report error for invalid root path", () => {
+      const errors: {
+        sourceField: string;
+        jsonPath: string;
+        mappingKey: string | null;
+        message: string;
+      }[] = [];
+
+      const result = applyFieldMappingConfig({
+        observation: sampleObservation,
+        config: {
+          mode: "custom",
+          custom: {
+            type: "root",
+            rootConfig: {
+              sourceField: "input",
+              jsonPath: invalidPath,
+            },
+          },
+        },
+        defaultSourceField: "input",
+        onJsonPathError: (info) => errors.push(info),
+      });
+
+      expect(result).toBeUndefined();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        sourceField: "input",
+        jsonPath: invalidPath,
+        mappingKey: null,
+      });
+      expect(errors[0].message).toBeTruthy();
+    });
+
+    it("should not throw and isolate invalid entries in keyValueMap", () => {
+      const errors: {
+        sourceField: string;
+        jsonPath: string;
+        mappingKey: string | null;
+        message: string;
+      }[] = [];
+
+      const result = applyFieldMappingConfig({
+        observation: sampleObservation,
+        config: {
+          mode: "custom",
+          custom: {
+            type: "keyValueMap",
+            keyValueMapConfig: {
+              entries: [
+                {
+                  id: "1",
+                  key: "good",
+                  sourceField: "input",
+                  value: "$.model",
+                },
+                {
+                  id: "2",
+                  key: "bad",
+                  sourceField: "input",
+                  value: invalidPath,
+                },
+              ],
+            },
+          },
+        },
+        defaultSourceField: "input",
+        onJsonPathError: (info) => errors.push(info),
+      });
+
+      expect(result).toEqual({ good: "gpt-4", bad: undefined });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        sourceField: "input",
+        jsonPath: invalidPath,
+        mappingKey: "bad",
+      });
+    });
+
+    it("should collect multiple errors from multiple invalid keyValueMap entries", () => {
+      const secondInvalidPath = "$..[?(@.y<)]";
+      const errors: {
+        sourceField: string;
+        jsonPath: string;
+        mappingKey: string | null;
+        message: string;
+      }[] = [];
+
+      const result = applyFieldMappingConfig({
+        observation: sampleObservation,
+        config: {
+          mode: "custom",
+          custom: {
+            type: "keyValueMap",
+            keyValueMapConfig: {
+              entries: [
+                {
+                  id: "1",
+                  key: "bad_one",
+                  sourceField: "input",
+                  value: invalidPath,
+                },
+                {
+                  id: "2",
+                  key: "good",
+                  sourceField: "input",
+                  value: "$.model",
+                },
+                {
+                  id: "3",
+                  key: "bad_two",
+                  sourceField: "output",
+                  value: secondInvalidPath,
+                },
+              ],
+            },
+          },
+        },
+        defaultSourceField: "input",
+        onJsonPathError: (info) => errors.push(info),
+      });
+
+      expect(result).toEqual({
+        bad_one: undefined,
+        good: "gpt-4",
+        bad_two: undefined,
+      });
+      expect(errors).toHaveLength(2);
+      expect(errors[0]).toMatchObject({
+        sourceField: "input",
+        jsonPath: invalidPath,
+        mappingKey: "bad_one",
+      });
+      expect(errors[1]).toMatchObject({
+        sourceField: "output",
+        jsonPath: secondInvalidPath,
+        mappingKey: "bad_two",
+      });
+    });
+
+    it("applyFullMapping should surface json_path_error for invalid paths", () => {
+      const result = applyFullMapping({
+        observation: sampleObservation,
+        mapping: {
+          input: {
+            mode: "custom",
+            custom: {
+              type: "root",
+              rootConfig: {
+                sourceField: "input",
+                jsonPath: invalidPath,
+              },
+            },
+          },
+          expectedOutput: { mode: "full" },
+          metadata: { mode: "none" },
+        },
+      });
+
+      expect(result.input).toBeUndefined();
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        type: "json_path_error",
+        targetField: "input",
+        sourceField: "input",
+        jsonPath: invalidPath,
+        mappingKey: null,
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes [LFE-9336](https://linear.app/langfuse/issue/LFE-9336/bug-invalid-jsonpath-query-crashes-the-app).

## Summary
- `CustomMappingEditor` (when adding a trace to a dataset) crashed the dialog when a user entered a malformed JSONPath (e.g. `$..[?(@.x=)]`) because `MappingPreviewPanel` invoked `applyFieldMappingConfig` inside a `useMemo` and `jsonpath-plus` threw during render.  ➡️ We now show a validation error

- When mapping input variables of an evaluator with invalid JSONPath we showed an unexpected error toast ➡️ We're now clearly outline the type of error in the toast to make it more actionable for the user

- Added test for JSONPath extractor function

- Loom of the change: https://www.loom.com/share/e7491364cac5439ebfe0fc52c067548f

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a crash in `CustomMappingEditor` caused by `jsonpath-plus` throwing during render when a user typed a malformed JSONPath expression. The fix wraps `evaluateJsonPath` in a `safeEvaluate` helper inside `applyFieldMappingConfig`, funnelling parse errors through a new `onJsonPathError` callback instead of re-throwing, and `MappingPreviewPanel` renders them as inline validation errors. The evaluator variable-mapping toast is also improved with a more specific title. Tests cover root-config, key-value-map isolation, multiple errors, and `applyFullMapping` integration.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the crash is correctly fixed with proper error isolation and good test coverage; remaining findings are P2 copy/UX suggestions.

All remaining comments are P2 (misleading warning copy in FinalPreviewStep and single-error reporting in useExtractVariables). Neither causes incorrect behavior or data loss. The core fix is solid and well-tested.

FinalPreviewStep.tsx — amber warning banner copy is ambiguous for json_path_error entries

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/features/batchAction/applyFieldMapping.ts | Adds JsonPathMissInfo/JsonPathErrorInfo types and safeEvaluate helper to catch jsonpath-plus throws; onJsonPathError callback surfaces errors without re-throwing |
| web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/MappingPreviewPanel.tsx | Collects jsonPathErrors in useMemo instead of letting them crash; renders inline error list and treats errors as blocking validation failures |
| web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx | Now surfaces json_path_error alongside json_path_miss, but the amber warning banner still says 'did not match' for both error types, which is misleading for syntax errors |
| web/src/features/evals/hooks/useExtractVariables.ts | Improves error toast title/message to 'Invalid JSONPath in variable mapping' for clearer actionability; only first error per extraction is shown |
| worker/src/__tests__/applyFieldMapping.test.ts | Good coverage of new onJsonPathError path: root config, keyValueMap isolation, multiple errors, and applyFullMapping integration |
| web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/CustomMappingEditor.tsx | No direct changes; relies on JsonPathInput and MappingPreviewPanel for error display |
| web/src/features/batch-actions/components/AddObservationsToDatasetDialog/components/JsonPathInput.tsx | Already had try/catch around evaluateJsonPath; no behavioral changes |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User types JSONPath] --> B{Starts with $?}
    B -- No --> C[Literal value]
    B -- Yes --> D[safeEvaluate]
    D --> E{evaluateJsonPath throws?}
    E -- Yes --> F[onJsonPathError callback]
    F --> G[MappingPreviewPanel: render error inline]
    F --> H[applyFullMapping: push json_path_error to errors]
    H --> I[FinalPreviewStep: amber warning banner]
    E -- No --> J{result === undefined?}
    J -- Yes --> K[onJsonPathMiss callback]
    K --> L[MappingPreviewPanel: render warning inline]
    J -- No --> M[Return resolved value]
    C --> M
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/features/batch-actions/components/AddObservationsToDatasetDialog/FinalPreviewStep.tsx
Line: 70-73

Comment:
**Misleading warning copy for `json_path_error`**

`previewResult.errors` now contains both `json_path_miss` and the newly added `json_path_error` entries, but the banner always reads "Some JSONPaths did not match the preview observation." For syntax errors the path didn't fail to *match* — it failed to *parse*. A user with `$..[?(@.x=)]` would see a "did not match" amber notice and might spend time hunting for data that would satisfy the path, rather than fixing the syntax.

```suggestion
              <p className="text-sm font-medium text-amber-600 dark:text-amber-500">
                Some JSONPath mappings have issues in the preview observation
              </p>
```

The card footer on line 181 (`"X paths did not match in preview observation"`) has the same ambiguity and may be worth updating as well.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/features/evals/hooks/useExtractVariables.ts
Line: 172-181

Comment:
**Only the first invalid-path error is surfaced**

When multiple variables carry invalid JSONPaths, `results.find(...)` stops at the first one. All subsequent errors are silently swallowed — the user fixes one path, triggers re-extraction, then discovers the next broken path. Consider collecting all error messages and joining them so the toast is actionable in one go:

```ts
const errorMessages = results
  .filter((r) => r.error instanceof Error)
  .map((r) => r.jsonSelector ? `${r.jsonSelector}: ${(r.error as Error).message}` : (r.error as Error).message);
if (errorMessages.length > 0) {
  setExtractionError(new Error(errorMessages.join("; ")));
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;fix(web): surface invalid JSON p..."](https://github.com/langfuse/langfuse/commit/61974e44aff660c687c96dab9e75e1a4f0458ac7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28963054)</sub>

<!-- /greptile_comment -->