### PR TITLE
fix(model-prices): add match on claude-haiku-4-5

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3172,9 +3172,9 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5-20251001|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
-    "updatedAt": "2026-04-13T00:00:00.000Z",
+    "updatedAt": "2026-04-20T00:00:00.000Z",
     "tokenizerId": "claude",
     "pricingTiers": [
       {


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes the `matchPattern` for `claude-haiku-4-5-20251001` so that the model name without the date suffix (`claude-haiku-4-5`) is also matched, enabling correct price lookup when users call the model without the version date. The `updatedAt` timestamp is also bumped to today's date.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core direct-API fix is correct, but Bedrock and Vertex patterns are left inconsistent with analogous models

The primary fix (making the date optional for direct Anthropic API calls) is correct and follows the established convention. One P2 inconsistency remains: Bedrock and Vertex match branches still require the date, unlike the equivalent patterns in claude-sonnet-4-5 and claude-opus-4-5. This could leave Bedrock/Vertex callers unmatched if they omit the date.

worker/src/constants/default-model-prices.json — Bedrock and Vertex regex branches for claude-haiku-4-5

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/constants/default-model-prices.json | Regex updated to make the date suffix optional for direct-API calls to claude-haiku-4-5; Bedrock and Vertex patterns still require the date, unlike analogous sonnet-4-5/opus-4-5 entries |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming model name] --> B{Match against claude-haiku-4-5 pattern}
    B -- "claude-haiku-4-5 (no date)" --> C[✅ Matched after fix]
    B -- "claude-haiku-4-5-20251001 (with date)" --> C
    B -- "anthropic/claude-haiku-4-5-20251001-v1:0 Bedrock" --> C
    B -- "claude-4-5-haiku@20251001 Vertex" --> C
    B -- "anthropic/claude-haiku-4-5 Bedrock no date" --> D[❌ Not matched - still requires date]
    B -- "claude-4-5-haiku Vertex no date" --> D
    C --> E[Apply claude-haiku-4-5 pricing]
    D --> F[No pricing match]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker/src/constants/default-model-prices.json
Line: 3175

Comment:
**Bedrock and Vertex patterns still require the date suffix**

The direct-API branch now correctly makes the date optional (`claude-haiku-4-5(-20251001)?`), but the Bedrock branch (`anthropic\.claude-haiku-4-5-20251001-v1:0`) and the Vertex branch (`claude-4-5-haiku@20251001`) still require the date. Sister models like `claude-sonnet-4-5` and `claude-opus-4-5` have the date made optional in all three branches. If Bedrock/Vertex callers omit the date they will fall through unmatched.

For consistency with the other models, consider:
```suggestion
    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5(-20251001)?-v1(:0)?|claude-4-5-haiku(@20251001)?)$",
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(model-prices): add match on claude-h..."](https://github.com/langfuse/langfuse/commit/af5a806a3036253a71d9107706c6d422ffa1809f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28963424)</sub>

<!-- /greptile_comment -->