### PR TITLE
ci: run zizmor on fork PRs by failing on findings

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,7 +16,6 @@ permissions: {}
 jobs:
   zizmor:
     name: Check GitHub Actions security
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -26,7 +25,16 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run zizmor
+
+      - name: Run zizmor (fork PR - fail on findings)
+        # Fork PRs don't get security-events: write on GITHUB_TOKEN, so SARIF
+        # upload isn't possible. Fail the job on findings instead so contributors
+        # see the error directly in the PR check.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+
+      - name: Run zizmor (trusted - upload SARIF)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
           # Means that the action will only report issues, but not fail the workflow.


### PR DESCRIPTION
## Summary
- Fork PRs were previously skipped entirely by the zizmor job because `GITHUB_TOKEN` can't be granted `security-events: write` on PRs from forks, making the SARIF upload path unavailable. This meant contributor changes to workflow files bypassed zizmor checks.
- Adds a fork-PR step without `advanced-security` that fails the job on findings so contributors see the error directly in the PR check.
- Keeps the existing SARIF-upload step (gated to non-fork events) so the code-scanning ruleset continues to block merges on trusted PRs.

## Test plan
- [ ] Open a draft PR from a fork and confirm the "Check GitHub Actions security" check runs and reports findings inline.
- [ ] Confirm PRs from branches in this repo still upload SARIF to code scanning and respect the existing ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR extends the `zizmor` GitHub Actions security scan to cover fork PRs, which were previously skipped because `GITHUB_TOKEN` cannot be granted `security-events: write` on fork-originated pull requests. It adds a second step that runs zizmor without `advanced-security: true` (causing a direct job failure on findings) while keeping the existing SARIF-upload step gated to trusted (non-fork) contexts.

The two step conditions are logically complementary and exhaustive, so every trigger event is handled exactly once.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the logic is correct, conditions are exhaustive and mutually exclusive, and the change closes a real security-review gap for fork PRs.

No P0 or P1 issues found. The two step conditions (fork PR vs trusted) are logically complementary and every trigger path hits exactly one step. The security-events: write permission declared at the job level is harmless for fork tokens.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/zizmor.yml | Removes the job-level fork-skip guard and replaces it with two mutually-exclusive steps: one for fork PRs (fail on findings) and one for trusted events (SARIF upload). Logic is sound and conditions cover all event types without overlap. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger: push/pull_request/merge_group/workflow_dispatch] --> B{Event type?}
    B -->|pull_request AND fork repo| C[Step: Run zizmor\nfork PR - fail on findings\nno advanced-security]
    B -->|NOT pull_request OR same repo| D[Step: Run zizmor\ntrusted - upload SARIF\nadvanced-security: true]
    C -->|findings found| E[❌ Job fails — contributor sees error in PR check]
    C -->|no findings| F[✅ Job passes]
    D -->|findings found| G[SARIF uploaded to code scanning\nruleset blocks merge]
    D -->|no findings| H[✅ Job passes]
```

<sub>Reviews (1): Last reviewed commit: ["ci: run zizmor on fork PRs by failing on..."](https://github.com/langfuse/langfuse/commit/017299f04b7fdbbe02d2d2794b6c8bad6f557b3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28981556)</sub>

<!-- /greptile_comment -->