### PR TITLE
ci: pin useblacksmith/setup-docker-builder comment to v1.6.0

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -770,7 +770,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@5241b2e9423e8b1fa37ed6050ecb62d0fb9a4e38 # v1
+        uses: useblacksmith/setup-docker-builder@5241b2e9423e8b1fa37ed6050ecb62d0fb9a4e38 # v1.6.0
       - name: Extract metadata (labels) for Docker
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
@@ -864,7 +864,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@5241b2e9423e8b1fa37ed6050ecb62d0fb9a4e38 # v1
+        uses: useblacksmith/setup-docker-builder@5241b2e9423e8b1fa37ed6050ecb62d0fb9a4e38 # v1.6.0
       - name: Download release digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
## Summary
- The SHA `5241b2e9` pinned in `.github/workflows/pipeline.yml` resolves to tag `v1.6.0`, but the inline comment said `# v1` (floating tag).
- Updated both call sites to `# v1.6.0` to match the repo's convention of specific version comments.
- Fixes zizmor `ref-version-mismatch` code-scanning alerts [#500](https://github.com/langfuse/langfuse/security/code-scanning/500) and [#501](https://github.com/langfuse/langfuse/security/code-scanning/501).

## Test plan
- [ ] CI passes (zizmor workflow no longer reports these alerts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR corrects the inline version comments on two uses of `useblacksmith/setup-docker-builder` in `pipeline.yml`, changing `# v1` to `# v1.6.0` to match the already-pinned SHA `5241b2e9423e8b1fa37ed6050ecb62d0fb9a4e38`. The pinned SHA itself is unchanged; only the human-readable comments are updated to satisfy the `zizmor` `ref-version-mismatch` code-scanning alerts.

<h3>Confidence Score: 5/5</h3>

Safe to merge — comment-only fix with no functional impact.

The change is purely cosmetic (comment update), the pinned SHA is untouched, and it resolves legitimate code-scanning alerts. No logic, security, or behavioural changes are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pipeline.yml | Updated two inline version comments from `# v1` to `# v1.6.0` to accurately reflect the pinned SHA `5241b2e9`; no functional change. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pipeline.yml\nuseblacksmith/setup-docker-builder\n@5241b2e9... # v1"] -->|"comment corrected"| B["pipeline.yml\nuseblacksmith/setup-docker-builder\n@5241b2e9... # v1.6.0"]
    B --> C["zizmor ref-version-mismatch\nalerts resolved"]
```

<sub>Reviews (1): Last reviewed commit: ["ci: pin useblacksmith/setup-docker-build..."](https://github.com/langfuse/langfuse/commit/d3b783b1c12d7c3d86d81fd2ed233cca657f2f12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28982470)</sub>

<!-- /greptile_comment -->