### PR TITLE
fix(web): Use overflow-auto instead of overflow-scroll for main content

### DIFF
--- a/web/src/components/layouts/ResizableDesktopLayout.tsx
+++ b/web/src/components/layouts/ResizableDesktopLayout.tsx
@@ -119,7 +119,7 @@ export function ResizableDesktopLayout({
         minSize={`${minMainSize}%`}
       >
         <div
-          className="relative h-full w-full overflow-scroll"
+          className="relative h-full w-full overflow-auto"
           style={{ overscrollBehaviorY: "none" }}
         >
           {mainContent}


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Replaces `overflow-scroll` with `overflow-auto` on the main content `div` in `ResizableDesktopLayout`. `overflow: scroll` forces scrollbars to always render even when content fits the container, while `overflow: auto` only shows them when the content overflows — this is the correct behaviour for most layouts.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, correct CSS fix with no logic changes.

Single Tailwind utility swap; `overflow-auto` is the correct value for on-demand scrollbars. No logic, data, or API changes involved.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/components/layouts/ResizableDesktopLayout.tsx | Single-line Tailwind class change from `overflow-scroll` to `overflow-auto` on the main content wrapper, preventing always-visible scrollbars when content fits within the viewport. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Use overflow-auto instead of o..."](https://github.com/langfuse/langfuse/commit/bc1b8f0050643f272aaa8a6866a35c58bba1fdfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28988803)</sub>

<!-- /greptile_comment -->