### PR TITLE
refactor(traces): Remove unused `updateTags` mutation from router

### DIFF
--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -591,53 +591,6 @@ export const traceRouter = createTRPCRouter({
         });
       }
     }),
-  updateTags: protectedProjectProcedure
-    .input(
-      z.object({
-        projectId: z.string(),
-        traceId: z.string(),
-        tags: z.array(z.string()),
-      }),
-    )
-    .mutation(async ({ input, ctx }) => {
-      throwIfNoProjectAccess({
-        session: ctx.session,
-        projectId: input.projectId,
-        scope: "objects:tag",
-      });
-      try {
-        await auditLog({
-          session: ctx.session,
-          resourceType: "trace",
-          resourceId: input.traceId,
-          action: "updateTags",
-          after: input.tags,
-        });
-
-        const clickhouseTrace = await getTraceById({
-          traceId: input.traceId,
-          projectId: input.projectId,
-          clickhouseFeatureTag: "tracing-trpc",
-        });
-        if (!clickhouseTrace) {
-          logger.error(
-            `Trace not found in Clickhouse: ${input.traceId}. Skipping tag update.`,
-          );
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Trace not found",
-          });
-        }
-        clickhouseTrace.tags = input.tags;
-        await upsertTrace(convertTraceDomainToClickhouse(clickhouseTrace));
-      } catch (error) {
-        logger.error("Failed to call traces.updateTags", error);
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-        });
-      }
-    }),
-
   getAgentGraphData: protectedGetTraceProcedure
     .input(
       z.object({


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR removes the `updateTags` mutation from the traces tRPC router (`web/src/server/api/routers/traces.ts`). A codebase-wide search confirms no callers of `traces.updateTags` exist, so the deletion is safe and leaves no dead references.

<h3>Confidence Score: 5/5</h3>

Safe to merge — dead code removal with no remaining call sites.

The removed mutation is confirmed unused across the entire repo; no functional, security, or correctness concerns were identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/server/api/routers/traces.ts | Removed the unused `updateTags` mutation (~53 lines); no remaining callers found in the codebase. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[traceRouter] --> B[allWithScores]
    A --> C[byId]
    A --> D[deleteMany]
    A --> E[getAgentGraphData]
    A -.->|removed| F["~~updateTags~~"]
    style F stroke-dasharray:5 5,color:#999
```

<sub>Reviews (1): Last reviewed commit: ["refactor(traces): Remove unused \`updateT..."](https://github.com/langfuse/langfuse/commit/3387606e53c98cd4210ad68463e40d3e95941df2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28996817)</sub>

<!-- /greptile_comment -->