### PR TITLE
feat(web): Add region selector to user menu

### DIFF
--- a/web/src/components/EnvLabel.tsx
+++ b/web/src/components/EnvLabel.tsx
@@ -1,3 +1,4 @@
+import { isRegionProduction } from "@/src/features/organizations/cloudRegions";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { cn } from "@/src/utils/tailwind";
 import { useSession } from "next-auth/react";
@@ -8,9 +9,7 @@ export const EnvLabel = ({ className }: { className?: string }) => {
   const session = useSession();
   const { isLangfuseCloud, region } = useLangfuseCloudRegion();
   const label =
-    region && ["EU", "US", "HIPAA", "JP"].includes(region)
-      ? `PROD-${region}`
-      : region;
+    region && isRegionProduction(region) ? `PROD-${region}` : region;
 
   if (!isLangfuseCloud) return null;
   if (!session.data?.user?.email?.endsWith("@langfuse.com")) return null;

--- a/web/src/components/EnvLabel.tsx
+++ b/web/src/components/EnvLabel.tsx
@@ -7,6 +7,11 @@ export const EnvLabel = ({ className }: { className?: string }) => {
   const [isHidden, setIsHidden] = useState(false);
   const session = useSession();
   const { isLangfuseCloud, region } = useLangfuseCloudRegion();
+  const label =
+    region && ["EU", "US", "HIPAA", "JP"].includes(region)
+      ? `PROD-${region}`
+      : region;
+
   if (!isLangfuseCloud) return null;
   if (!session.data?.user?.email?.endsWith("@langfuse.com")) return null;
   if (isHidden) return null;
@@ -23,9 +28,7 @@ export const EnvLabel = ({ className }: { className?: string }) => {
       )}
       onClick={() => setIsHidden(true)}
     >
-      {region && ["EU", "US", "HIPAA", "JP"].includes(region)
-        ? `PROD-${region}`
-        : region}
+      {label}
     </div>
   );
 };

--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -12,7 +12,7 @@ import { Toaster } from "@/src/components/ui/sonner";
 import { TopBannerProvider } from "@/src/features/top-banner";
 import { ResizableContent } from "../components/ResizableContent";
 import { ThemeToggle } from "@/src/features/theming/ThemeToggle";
-import { getUserNavigationCloudRegionOptions } from "@/src/features/organizations/cloudRegions";
+import { getAvailableCloudRegionOptions } from "@/src/features/organizations/cloudRegions";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import type { Session } from "next-auth";
 import type { NavigationItem } from "@/src/components/layouts/utilities/routes";
@@ -108,7 +108,7 @@ export function AuthenticatedLayout({
     return null;
   }
 
-  const regionMenuItems = getUserNavigationCloudRegionOptions().map(
+  const regionMenuItems = getAvailableCloudRegionOptions(currentRegion).map(
     (region) => ({
       name: region.name,
       content: `${region.flag} ${region.name}`,

--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -12,6 +12,8 @@ import { Toaster } from "@/src/components/ui/sonner";
 import { TopBannerProvider } from "@/src/features/top-banner";
 import { ResizableContent } from "../components/ResizableContent";
 import { ThemeToggle } from "@/src/features/theming/ThemeToggle";
+import { getUserNavigationCloudRegionOptions } from "@/src/features/organizations/cloudRegions";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import type { Session } from "next-auth";
 import type { NavigationItem } from "@/src/components/layouts/utilities/routes";
 import type { RouteGroup } from "@/src/components/layouts/routes";
@@ -96,6 +98,8 @@ export function AuthenticatedLayout({
   metadata,
   onSignOut,
 }: AuthenticatedLayoutProps) {
+  const { region: currentRegion } = useLangfuseCloudRegion();
+
   // Safe assertion: AuthenticatedLayout is only rendered after auth checks pass
   // in AppLayout, which guarantees session.user exists at this point
   const user = session.user;
@@ -103,6 +107,17 @@ export function AuthenticatedLayout({
     // This should never happen due to guards in AppLayout, but TypeScript needs this
     return null;
   }
+
+  const regionMenuItems = getUserNavigationCloudRegionOptions().map(
+    (region) => ({
+      name: region.name,
+      content: `${region.flag} ${region.name}`,
+      onClick: () => {
+        if (!region.rootUrl) return;
+        window.open(region.rootUrl, "_blank", "noopener,noreferrer");
+      },
+    }),
+  );
 
   // User navigation items for sidebar dropdown
   const userNavProps = {
@@ -114,6 +129,18 @@ export function AuthenticatedLayout({
     items: [
       { name: "Account Settings", href: "/account/settings" },
       { name: "Theme", onClick: () => {}, content: <ThemeToggle /> },
+      {
+        name: "Regions",
+        subItems: regionMenuItems,
+        content: (
+          <>
+            Regions
+            <div className="ml-2 inline-flex rounded bg-black/5 p-1 text-xs dark:bg-white/10">
+              Current: {currentRegion}
+            </div>
+          </>
+        ),
+      },
       { name: "Sign out", onClick: onSignOut },
     ],
   };

--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -98,7 +98,7 @@ export function AuthenticatedLayout({
   metadata,
   onSignOut,
 }: AuthenticatedLayoutProps) {
-  const { region: currentRegion } = useLangfuseCloudRegion();
+  const { isLangfuseCloud, region: currentRegion } = useLangfuseCloudRegion();
 
   // Safe assertion: AuthenticatedLayout is only rendered after auth checks pass
   // in AppLayout, which guarantees session.user exists at this point
@@ -129,18 +129,22 @@ export function AuthenticatedLayout({
     items: [
       { name: "Account Settings", href: "/account/settings" },
       { name: "Theme", onClick: () => {}, content: <ThemeToggle /> },
-      {
-        name: "Regions",
-        subItems: regionMenuItems,
-        content: (
-          <>
-            Regions
-            <div className="ml-2 inline-flex rounded bg-black/5 p-1 text-xs dark:bg-white/10">
-              Current: {currentRegion}
-            </div>
-          </>
-        ),
-      },
+      ...(isLangfuseCloud
+        ? [
+            {
+              name: "Regions",
+              subItems: regionMenuItems,
+              content: (
+                <>
+                  Regions
+                  <div className="ml-2 inline-flex rounded bg-black/5 p-1 text-xs dark:bg-white/10">
+                    Current: {currentRegion}
+                  </div>
+                </>
+              ),
+            },
+          ]
+        : []),
       { name: "Sign out", onClick: onSignOut },
     ],
   };

--- a/web/src/components/nav/nav-user.tsx
+++ b/web/src/components/nav/nav-user.tsx
@@ -15,6 +15,9 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
 import {
@@ -29,6 +32,7 @@ export type UserNavigationItem = {
   onClick?: () => void;
   content?: React.ReactNode;
   href?: string;
+  subItems?: UserNavigationItem[];
 };
 
 export type UserNavigationProps = {
@@ -49,6 +53,35 @@ export function NavUser({ user, items }: UserNavigationProps) {
     .map((word) => word[0])
     .join("")
     .toUpperCase();
+
+  const renderMenuItem = (item: UserNavigationItem) => {
+    if (item.subItems?.length) {
+      return (
+        <DropdownMenuSub key={item.name}>
+          <DropdownMenuSubTrigger>
+            {item.content ?? item.name}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            {item.subItems.map(renderMenuItem)}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      );
+    }
+
+    if (item.href) {
+      return (
+        <DropdownMenuItem key={item.name} asChild>
+          <Link href={item.href}>{item.content ?? item.name}</Link>
+        </DropdownMenuItem>
+      );
+    }
+
+    return (
+      <DropdownMenuItem key={item.name} onClick={item.onClick}>
+        {item.content ?? item.name}
+      </DropdownMenuItem>
+    );
+  };
 
   return (
     <SidebarMenu>
@@ -97,19 +130,7 @@ export function NavUser({ user, items }: UserNavigationProps) {
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-              {items.map((item) =>
-                item.href ? (
-                  <DropdownMenuItem key={item.name} asChild>
-                    <Link href={item.href}>{item.content ?? item.name}</Link>
-                  </DropdownMenuItem>
-                ) : (
-                  <DropdownMenuItem key={item.name} onClick={item.onClick}>
-                    {item.content ?? item.name}
-                  </DropdownMenuItem>
-                ),
-              )}
-            </DropdownMenuGroup>
+            <DropdownMenuGroup>{items.map(renderMenuItem)}</DropdownMenuGroup>
           </DropdownMenuContent>
         </DropdownMenu>
       </SidebarMenuItem>

--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -17,64 +17,7 @@ import {
   DialogTrigger,
 } from "@/src/components/ui/dialog";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
-
-const regions =
-  env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "STAGING"
-    ? [
-        {
-          name: "STAGING",
-          hostname: "staging.langfuse.com",
-          flag: "🇪🇺",
-        },
-      ]
-    : env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV"
-      ? [
-          {
-            name: "DEV",
-            hostname: null,
-            flag: "🚧",
-          },
-        ]
-      : env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "JP"
-        ? [
-            {
-              name: "JP",
-              hostname: "jp.cloud.langfuse.com",
-              flag: "️🇯🇵",
-            },
-            {
-              name: "US",
-              hostname: "us.cloud.langfuse.com",
-              flag: "🇺🇸",
-            },
-            {
-              name: "EU",
-              hostname: "cloud.langfuse.com",
-              flag: "🇪🇺",
-            },
-            {
-              name: "HIPAA",
-              hostname: "hipaa.cloud.langfuse.com",
-              flag: "⚕️",
-            },
-          ]
-        : [
-            {
-              name: "US",
-              hostname: "us.cloud.langfuse.com",
-              flag: "🇺🇸",
-            },
-            {
-              name: "EU",
-              hostname: "cloud.langfuse.com",
-              flag: "🇪🇺",
-            },
-            {
-              name: "HIPAA",
-              hostname: "hipaa.cloud.langfuse.com",
-              flag: "⚕️",
-            },
-          ];
+import { getAuthCloudRegionOptions } from "@/src/features/organizations/cloudRegions";
 
 export function CloudRegionSwitch({
   isSignUpPage,
@@ -83,6 +26,9 @@ export function CloudRegionSwitch({
 }) {
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud, region: cloudRegion } = useLangfuseCloudRegion();
+  const regions = getAuthCloudRegionOptions(
+    env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ?? cloudRegion,
+  );
 
   if (!isLangfuseCloud) return null;
 

--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -17,7 +17,7 @@ import {
   DialogTrigger,
 } from "@/src/components/ui/dialog";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
-import { getAuthCloudRegionOptions } from "@/src/features/organizations/cloudRegions";
+import { getAvailableCloudRegionOptions } from "@/src/features/organizations/cloudRegions";
 
 export function CloudRegionSwitch({
   isSignUpPage,
@@ -26,7 +26,7 @@ export function CloudRegionSwitch({
 }) {
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud, region: cloudRegion } = useLangfuseCloudRegion();
-  const regions = getAuthCloudRegionOptions(
+  const regions = getAvailableCloudRegionOptions(
     env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION ?? cloudRegion,
   );
 

--- a/web/src/features/organizations/cloudRegions.ts
+++ b/web/src/features/organizations/cloudRegions.ts
@@ -1,0 +1,75 @@
+const cloudRegions = [
+  {
+    name: "DEV",
+    flag: "🚧",
+    hostname: null,
+    rootUrl: null,
+  },
+  {
+    name: "STAGING",
+    flag: "🇪🇺",
+    hostname: "staging.langfuse.com",
+    rootUrl: "https://staging.langfuse.com",
+  },
+  {
+    name: "EU",
+    flag: "🇪🇺",
+    hostname: "cloud.langfuse.com",
+    rootUrl: "https://cloud.langfuse.com",
+  },
+  {
+    name: "US",
+    flag: "🇺🇸",
+    hostname: "us.cloud.langfuse.com",
+    rootUrl: "https://us.cloud.langfuse.com",
+  },
+  {
+    name: "JP",
+    flag: "🇯🇵",
+    hostname: "jp.cloud.langfuse.com",
+    rootUrl: "https://jp.cloud.langfuse.com",
+  },
+  {
+    name: "HIPAA",
+    flag: "⚕️",
+    hostname: "hipaa.cloud.langfuse.com",
+    rootUrl: "https://hipaa.cloud.langfuse.com",
+  },
+] as const;
+
+const authCloudRegionNamesByCurrentRegion = {
+  STAGING: ["STAGING"],
+  DEV: ["DEV"],
+  JP: ["JP", "US", "EU", "HIPAA"],
+  default: ["US", "EU", "HIPAA"],
+} as const;
+
+const userNavigationCloudRegionNames = ["EU", "US", "JP", "HIPAA"] as const;
+
+const getCloudRegion = (name: (typeof cloudRegions)[number]["name"]) => {
+  const region = cloudRegions.find((region) => region.name === name);
+  if (!region) {
+    throw new Error(`Unknown cloud region: ${name}`);
+  }
+
+  return region;
+};
+
+export const getAuthCloudRegionOptions = (currentRegion?: string) => {
+  if (currentRegion === "STAGING") {
+    return authCloudRegionNamesByCurrentRegion.STAGING.map(getCloudRegion);
+  }
+
+  if (currentRegion === "DEV") {
+    return authCloudRegionNamesByCurrentRegion.DEV.map(getCloudRegion);
+  }
+
+  if (currentRegion === "JP") {
+    return authCloudRegionNamesByCurrentRegion.JP.map(getCloudRegion);
+  }
+
+  return authCloudRegionNamesByCurrentRegion.default.map(getCloudRegion);
+};
+
+export const getUserNavigationCloudRegionOptions = () =>
+  userNavigationCloudRegionNames.map(getCloudRegion);

--- a/web/src/features/organizations/cloudRegions.ts
+++ b/web/src/features/organizations/cloudRegions.ts
@@ -43,14 +43,12 @@ const cloudRegions = [
   },
 ] as const;
 
-const authCloudRegionNamesByCurrentRegion = {
+const availableRegionsByCurrentRegion = {
   STAGING: ["STAGING"],
   DEV: ["DEV"],
   JP: ["JP", "US", "EU", "HIPAA"],
   default: ["US", "EU", "HIPAA"],
 } as const;
-
-const userNavigationCloudRegionNames = ["EU", "US", "JP", "HIPAA"] as const;
 
 const getCloudRegion = (name: (typeof cloudRegions)[number]["name"]) => {
   const region = cloudRegions.find((region) => region.name === name);
@@ -61,26 +59,23 @@ const getCloudRegion = (name: (typeof cloudRegions)[number]["name"]) => {
   return region;
 };
 
-export const getAuthCloudRegionOptions = (currentRegion?: string) => {
+export const getAvailableCloudRegionOptions = (currentRegion?: string) => {
   if (currentRegion === "STAGING") {
-    return authCloudRegionNamesByCurrentRegion.STAGING.map(getCloudRegion);
+    return availableRegionsByCurrentRegion.STAGING.map(getCloudRegion);
   }
 
   if (currentRegion === "DEV") {
-    return authCloudRegionNamesByCurrentRegion.DEV.map(getCloudRegion);
+    return availableRegionsByCurrentRegion.DEV.map(getCloudRegion);
   }
 
   if (currentRegion === "JP") {
-    return authCloudRegionNamesByCurrentRegion.JP.map(getCloudRegion);
+    return availableRegionsByCurrentRegion.JP.map(getCloudRegion);
   }
 
-  return authCloudRegionNamesByCurrentRegion.default.map(getCloudRegion);
+  return availableRegionsByCurrentRegion.default.map(getCloudRegion);
 };
 
 export const isRegionProduction = (regionName: string): boolean => {
   const region = cloudRegions.find((r) => r.name === regionName);
   return region ? region.isProduction : false;
 };
-
-export const getUserNavigationCloudRegionOptions = () =>
-  userNavigationCloudRegionNames.map(getCloudRegion);

--- a/web/src/features/organizations/cloudRegions.ts
+++ b/web/src/features/organizations/cloudRegions.ts
@@ -4,36 +4,42 @@ const cloudRegions = [
     flag: "🚧",
     hostname: null,
     rootUrl: null,
+    isProduction: false,
   },
   {
     name: "STAGING",
     flag: "🇪🇺",
     hostname: "staging.langfuse.com",
     rootUrl: "https://staging.langfuse.com",
+    isProduction: false,
   },
   {
     name: "EU",
     flag: "🇪🇺",
     hostname: "cloud.langfuse.com",
     rootUrl: "https://cloud.langfuse.com",
+    isProduction: true,
   },
   {
     name: "US",
     flag: "🇺🇸",
     hostname: "us.cloud.langfuse.com",
     rootUrl: "https://us.cloud.langfuse.com",
+    isProduction: true,
   },
   {
     name: "JP",
     flag: "🇯🇵",
     hostname: "jp.cloud.langfuse.com",
     rootUrl: "https://jp.cloud.langfuse.com",
+    isProduction: true,
   },
   {
     name: "HIPAA",
     flag: "⚕️",
     hostname: "hipaa.cloud.langfuse.com",
     rootUrl: "https://hipaa.cloud.langfuse.com",
+    isProduction: true,
   },
 ] as const;
 
@@ -69,6 +75,11 @@ export const getAuthCloudRegionOptions = (currentRegion?: string) => {
   }
 
   return authCloudRegionNamesByCurrentRegion.default.map(getCloudRegion);
+};
+
+export const isRegionProduction = (regionName: string): boolean => {
+  const region = cloudRegions.find((r) => r.name === regionName);
+  return region ? region.isProduction : false;
 };
 
 export const getUserNavigationCloudRegionOptions = () =>


### PR DESCRIPTION
## What does this PR do?

This PR adds a region submenu to the authenticated user menu in the sidebar. Users can see the current region directly in the menu and open the root domain for other production regions in a new tab.

It also refactors cloud-region configuration so the auth region switch and authenticated user menu share the same source of truth for region names, flags, and hostnames.

<img width="649" height="365" alt="Screenshot 2026-04-20 at 18 00 28" src="https://github.com/user-attachments/assets/a890ae77-aaf0-449c-8188-d5632f67eb4d" />
<img width="769" height="276" alt="Screenshot 2026-04-20 at 18 00 25" src="https://github.com/user-attachments/assets/d92e5948-3dc3-4b36-92bd-335207fcc112" />


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a region selector submenu to the authenticated user menu and refactors cloud-region configuration into a shared `cloudRegions.ts` module, eliminating duplicated inline region data between `AuthCloudRegionSwitch` and the new nav item.

- **P1**: The \"Regions\" submenu is added unconditionally in `AuthenticatedLayout`, missing the `isLangfuseCloud` guard that every other region-aware component uses — self-hosted users will see the submenu with an empty \"Current:\" badge and cloud-only navigation links.

<h3>Confidence Score: 4/5</h3>

One P1 fix needed before merge — the region submenu renders on self-hosted deployments without an isLangfuseCloud guard.

The cloud-region refactor is clean and correct; the only real defect is the missing isLangfuseCloud check in AuthenticatedLayout, which causes visible and potentially confusing UI elements to appear on self-hosted instances.

web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/organizations/cloudRegions.ts | New module centralising cloud region config (name, flag, hostname, rootUrl) with two exported helpers for auth and user-nav use-cases. Logic matches the old inline definitions in AuthCloudRegionSwitch. |
| web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx | Adds region submenu to user nav props, but lacks an isLangfuseCloud guard — the Regions item is rendered for self-hosted deployments with an empty "Current:" badge and cloud-only links. |
| web/src/components/nav/nav-user.tsx | Refactored to support nested subItems via DropdownMenuSub; renderMenuItem helper introduced inside component (minor perf nit). |
| web/src/features/auth/components/AuthCloudRegionSwitch.tsx | Inline regions array replaced by getAuthCloudRegionOptions() call; behavior is equivalent to the original switch/default logic. |
| web/src/components/EnvLabel.tsx | Minor cleanup: inline ternary for region label moved to a named variable. No logic change. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AuthenticatedLayout] -->|calls| B[useLangfuseCloudRegion]
    B --> C{isLangfuseCloud?}
    C -->|true ✅| D[getUserNavigationCloudRegionOptions]
    C -->|false ⚠️ not checked| D
    D --> E[regionMenuItems array]
    E --> F[NavUser items prop]
    F --> G[renderMenuItem]
    G -->|has subItems| H[DropdownMenuSub / SubTrigger / SubContent]
    G -->|has href| I[DropdownMenuItem + Link]
    G -->|onClick only| J[DropdownMenuItem]
    H --> K[Region links open in new tab]

    L[AuthCloudRegionSwitch] -->|calls| M[getAuthCloudRegionOptions]
    M -->|reads env var| N{currentRegion?}
    N -->|STAGING| O[STAGING only]
    N -->|DEV| P[DEV only]
    N -->|JP| Q[JP, US, EU, HIPAA]
    N -->|default| R[US, EU, HIPAA]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
Line: 101-143

Comment:
**Region menu shown on self-hosted instances**

`isLangfuseCloud` is never checked here, so the "Regions" submenu — including an empty "Current: " badge — is rendered for every deployment, not just cloud ones. Every other region-aware component (`EnvLabel`, `CloudRegionSwitch`) guards with `if (!isLangfuseCloud) return null;`. Without the same guard, self-hosted users will see a confusing "Regions" item that opens `langfuse.com` cloud URLs in a new tab.

```tsx
const { region: currentRegion, isLangfuseCloud } = useLangfuseCloudRegion();

// …

const regionMenuItems = isLangfuseCloud
  ? getUserNavigationCloudRegionOptions().map((region) => ({
      name: region.name,
      content: `${region.flag} ${region.name}`,
      onClick: () => {
        if (!region.rootUrl) return;
        window.open(region.rootUrl, "_blank", "noopener,noreferrer");
      },
    }))
  : [];

// …and in items:
...(isLangfuseCloud
  ? [
      {
        name: "Regions",
        subItems: regionMenuItems,
        content: (
          <>
            Regions
            <div className="ml-2 inline-flex rounded bg-black/5 p-1 text-xs dark:bg-white/10">
              Current: {currentRegion}
            </div>
          </>
        ),
      },
    ]
  : []),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/components/nav/nav-user.tsx
Line: 57-84

Comment:
**`renderMenuItem` recreated on every render**

`renderMenuItem` is a function that recurses into itself and is redefined on each render of `NavUser`. Since it doesn't close over any state or props, moving it outside the component or wrapping it in `useCallback` would prevent the unnecessary allocation. Not a correctness issue, but worth cleaning up.

```tsx
// Move outside the component:
const renderMenuItem = (item: UserNavigationItem): React.ReactNode => {
  if (item.subItems?.length) { /* … */ }
  // …
};
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): Add region selector to user m..."](https://github.com/langfuse/langfuse/commit/d79a7488961dc284c71f88347d1edf41a19cf567) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29005683)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->