### PR TITLE
chore(worker): include fileKey in OTEL ingestion failure logs

### DIFF
--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -244,10 +244,16 @@ export const otelIngestionQueueProcessor: Processor = async (
       });
 
       if (!maskingResult.success) {
-        // Fail-closed: drop event
+        // Fail-closed: drop event. Emit the S3 location so operators can
+        // scan logs to identify which raw payloads need to be replayed via
+        // worker/src/scripts/replayIngestionEventsV2 once the upstream
+        // masking callback is healthy again.
         logger.warn(`Dropping OTEL event due to masking failure`, {
           projectId,
+          orgId: job.data.payload.authCheck.scope.orgId,
+          fileKey,
           error: maskingResult.error,
+          propagatedHeaders: job.data.payload.propagatedHeaders,
         });
         return;
       }
@@ -275,7 +281,10 @@ export const otelIngestionQueueProcessor: Processor = async (
         if (!o.success) {
           logger.warn(
             `Failed to parse otel observation for project ${projectId} in ${fileKey}: ${o.error}`,
-            o.error,
+            {
+              error: o.error,
+              fileKey,
+            },
           );
           return [];
         }
@@ -443,7 +452,7 @@ export const otelIngestionQueueProcessor: Processor = async (
           traceException(error);
           logger.error(
             `Failed to create event record for project ${eventInput.projectId} and observation ${eventInput.spanId}`,
-            error,
+            { error, fileKey },
           );
 
           return;
@@ -465,7 +474,7 @@ export const otelIngestionQueueProcessor: Processor = async (
 
             logger.error(
               `Failed to schedule observation evals for project ${eventInput.projectId} and observation ${eventInput.spanId}`,
-              error,
+              { error, fileKey },
             );
           }
         }
@@ -478,22 +487,26 @@ export const otelIngestionQueueProcessor: Processor = async (
             traceException(error);
             logger.error(
               `Failed to write event record for ${eventInput.spanId}`,
-              error,
+              { error, fileKey },
             );
           }
         }
       }),
     );
   } catch (e) {
+    const fileKey = job.data.payload.data.fileKey;
     if (e instanceof ForbiddenError) {
       traceException(e);
-      logger.warn(`Failed to parse otel observation: ${e.message}`, e);
+      logger.warn(`Failed to parse otel observation: ${e.message}`, {
+        error: e,
+        fileKey,
+      });
       return;
     }
 
     logger.error(
       `Failed job otel ingestion processing for ${job.data.payload.authCheck.scope.projectId}`,
-      e,
+      { error: e, fileKey },
     );
     traceException(e);
     throw e;


### PR DESCRIPTION
## Summary
- Emit the S3 `fileKey` on every OTEL ingestion failure path in `worker/src/queues/otelIngestionQueue.ts` so operators can scan their log platform for dropped or errored batches and feed the resulting list into `worker/src/scripts/replayIngestionEventsV2`.
- Covered failure paths: masking fail-closed drops, observation parse failures, per-event record creation / eval scheduling / direct write failures, and the job-level `ForbiddenError` swallow + main catch fallthrough.
- The masking-drop log additionally includes `orgId` and the propagated callback headers to support zero-trust audit trails without requiring a separate `/report-failure` callback.

## Context
Unblocks an Intuit self-hosting requirement: when `LANGFUSE_INGESTION_MASKING_CALLBACK_FAIL_CLOSED=true` causes an event to be dropped, customers need the S3 path in structured logs so an offline Splunk-based backfill job can rebuild the replay-input CSV. Header propagation through to the masking callback is already wired end-to-end (`LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS`) and covered by `worker/src/__tests__/ingestionMasking.test.ts` — no code change needed there.

## Test plan
- [x] `pnpm --filter worker run lint`
- [ ] Manual smoke: with a mock masking endpoint returning HTTP 500, `FAIL_CLOSED=true`, and `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS=x-intuit-tid`, confirm the `Dropping OTEL event due to masking failure` warning contains `projectId`, `orgId`, `fileKey`, `error`, `propagatedHeaders` and the referenced S3 object is intact for replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR enriches structured log payloads across all OTEL ingestion failure paths in `otelIngestionQueue.ts` with the S3 `fileKey` (and `orgId` + `propagatedHeaders` on the masking-drop path), enabling operators to reconstruct replay inputs for dropped batches. The changes are purely additive to log calls — no business logic is altered.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to log-call payloads with no business-logic impact; both findings are defensive P2 suggestions.

All identified issues are P2 (optional chaining in catch block and potential credential exposure via propagatedHeaders depending on operator configuration). No logic, schema, or data-flow changes are introduced.

worker/src/queues/otelIngestionQueue.ts — catch-block fileKey access (line 497) and propagatedHeaders logging (line 256)

<details open><summary><h3>Security Review</h3></summary>

- **Credential exposure via `propagatedHeaders`** (`otelIngestionQueue.ts` line 256): raw propagated request headers are written to structured logs without redaction; if `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS` includes authorization or API-key headers, those values will appear in plaintext in downstream log sinks.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/queues/otelIngestionQueue.ts | Adds `fileKey`, `orgId`, and `propagatedHeaders` to structured log payloads across all OTEL ingestion failure paths; two minor concerns: secondary-throw risk in catch block and potential credential exposure via propagatedHeaders. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Job received] --> B[Extract fileKey, projectId, auth]
    B --> C[Download S3 file]
    C --> D{Masking enabled?}
    D -- Yes --> E[applyIngestionMasking]
    E -- failure --> F["logger.warn: Dropping OTEL event\n{projectId, orgId, fileKey, error, propagatedHeaders}"]
    F --> Z[return]
    E -- success --> G[Parse spans / generate events]
    D -- No --> G
    G --> H{Observation parse}
    H -- fail --> I["logger.warn {error, fileKey}"]
    I --> J[return empty]
    H -- ok --> K[mergeAndWrite + processEventBatch]
    K --> L[createEventRecord per event]
    L -- fail --> M["logger.error {error, fileKey}"]
    L -- ok --> N[scheduleObservationEvals]
    N -- fail --> O["logger.error {error, fileKey}"]
    N -- ok --> P[writeEventRecord]
    P -- fail --> Q["logger.error {error, fileKey}"]
    B -.->|uncaught exception| R{catch block}
    R -- ForbiddenError --> S["logger.warn {error, fileKey}"]
    R -- other --> T["logger.error {error, fileKey}"]
    T --> U[rethrow]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker/src/queues/otelIngestionQueue.ts
Line: 256

Comment:
**`propagatedHeaders` may contain sensitive credentials**

`propagatedHeaders` is logged verbatim to structured logs. If `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS` is configured to forward headers such as `Authorization`, `x-api-key`, or other bearer tokens, those values will appear in plaintext in whatever log aggregation system (e.g. Splunk, CloudWatch, Datadog) is in use. Consider redacting or omitting values before logging, or documenting that sensitive header names must not be added to `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: worker/src/queues/otelIngestionQueue.ts
Line: 497

Comment:
**Secondary throw risk in catch handler**

The same property path `job.data.payload.data.fileKey` is accessed at the very top of the `try` block. If the original exception `e` was caused by `job.data.payload.data` being `undefined` or malformed, this repeated access in the `catch` body will throw a second uncaught exception, suppressing the original error and bypassing the job's retry/dead-letter logic. Using optional chaining (`job.data.payload.data?.fileKey`) avoids the double-fault.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): include fileKey in OTEL i..."](https://github.com/langfuse/langfuse/commit/c49655ad93eff2dca10a148e86eee94bf5dcdca5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29004787)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->