### PR TITLE
fix(dashboards): exclude TEXT and CORRECTION scores from scores-numeric view

### DIFF
--- a/web/src/__tests__/server/queryBuilder.servertest.ts
+++ b/web/src/__tests__/server/queryBuilder.servertest.ts
@@ -313,7 +313,7 @@ describe("queryBuilder", () => {
         observationId?: string;
         value?: number;
         stringValue?: string;
-        dataType: "NUMERIC" | "CATEGORICAL" | "BOOLEAN";
+        dataType: "NUMERIC" | "CATEGORICAL" | "BOOLEAN" | "TEXT" | "CORRECTION";
         source?: string;
         environment?: string;
       }>,
@@ -328,7 +328,9 @@ describe("queryBuilder", () => {
             observation_id: data.observationId,
             name: data.name,
             value: data.dataType === "NUMERIC" ? data.value || 0 : null,
-            string_value: ["CATEGORICAL", "BOOLEAN"].includes(data.dataType)
+            string_value: ["CATEGORICAL", "BOOLEAN", "TEXT"].includes(
+              data.dataType,
+            )
               ? data.stringValue || ""
               : null,
             environment: data.environment || "default",
@@ -1871,6 +1873,25 @@ describe("queryBuilder", () => {
             dataType: "CATEGORICAL" as const,
             source: "human",
           },
+
+          // Adding a TEXT (free-text) score that should also be excluded by the segments filter
+          {
+            name: "feedback",
+            traceId: traces[0].id,
+            observationId: observations[0].id,
+            stringValue: "looks good to me",
+            dataType: "TEXT" as const,
+            source: "human",
+          },
+
+          // Adding a CORRECTION score that should also be excluded by the segments filter
+          {
+            name: "correction",
+            traceId: traces[0].id,
+            observationId: observations[0].id,
+            dataType: "CORRECTION" as const,
+            source: "human",
+          },
         ];
 
         await setupScores(projectId, scores);
@@ -1902,18 +1923,33 @@ describe("queryBuilder", () => {
           projectId,
         );
 
-        // Verify SQL includes segment filter for NUMERIC types
-        // Verify SQL includes segment filter for non-NUMERIC types
-        expect(compiledQuery).toContain("position(scores_numeric.data_type, {");
-        expect(compiledQuery).toContain(": String}) = 0");
-        expect(Object.values(parameters)).toContain("CATEGORICAL");
+        // Verify SQL restricts scores-numeric to the NUMERIC/BOOLEAN allow-list
+        expect(compiledQuery).toContain(
+          "scores_numeric.data_type IN ({stringOptionsFilter",
+        );
+        expect(compiledQuery).toContain(": Array(String)})");
+        expect(Object.values(parameters)).toContainEqual([
+          "NUMERIC",
+          "BOOLEAN",
+        ]);
 
         // Execute query
         const result: { data: Array<any> } = { data: [] };
         result.data = await executeQuery(projectId, query);
 
         // Assert
+        // CATEGORICAL ("evaluation"), TEXT ("feedback"), and CORRECTION ("correction")
+        // scores must be excluded by the segments allow-list
         expect(result.data).toHaveLength(3); // accuracy, relevance, coherence
+        expect(
+          result.data.find((row: any) => row.name === "feedback"),
+        ).toBeUndefined();
+        expect(
+          result.data.find((row: any) => row.name === "evaluation"),
+        ).toBeUndefined();
+        expect(
+          result.data.find((row: any) => row.name === "correction"),
+        ).toBeUndefined();
 
         // Check each score type
         const accuracyRow = result.data.find(

--- a/web/src/features/query/dataModel.ts
+++ b/web/src/features/query/dataModel.ts
@@ -912,10 +912,11 @@ function scoresNumericViewBase(version: "v1" | "v2"): ViewDeclarationType {
     segments: [
       {
         column: "data_type",
-        // We consider NUMERIC and BOOLEAN scores as numeric.
-        operator: "does not contain" as const,
-        value: "CATEGORICAL",
-        type: "string" as const,
+        // Positive allow-list: only NUMERIC and BOOLEAN count as numeric scores.
+        // CATEGORICAL, TEXT, and CORRECTION are excluded.
+        operator: "any of" as const,
+        value: ["NUMERIC", "BOOLEAN"],
+        type: "stringOptions" as const,
       },
     ], // Numeric
     timeDimension: "timestamp",


### PR DESCRIPTION
## Summary

- Fixes [LFE-9399](https://linear.app/langfuse/issue/LFE-9399/fix-to-exclude-free-text-scores-from-filters-and-dashboards): the dashboard / widget-builder `scores-numeric` view was picking up free-text (`TEXT`) scores (and `CORRECTION` scores) alongside the intended `NUMERIC` / `BOOLEAN` ones.
- Root cause: the view's segment filter was expressed as "`data_type` does not contain `CATEGORICAL`", so every other `data_type` value (including `TEXT` and `CORRECTION`) leaked through. Their null numeric values also skewed `avg`/`min`/`max` aggregations.
- Flipped the segment to a positive allow-list (`data_type IN ('NUMERIC', 'BOOLEAN')`) so any future `data_type` enum member is excluded by default — safer failure mode.

## Changes

- `web/src/features/query/dataModel.ts` — replace the two-segment exclusion with a single `stringOptions` / `any of` allow-list segment on `data_type`. Covers both v1 and v2 scores-numeric via the shared factory. `scores-categorical` is unchanged.
- `web/src/__tests__/server/queryBuilder.servertest.ts` — extend `setupScores` to accept `TEXT` / `CORRECTION`; seed both in the existing aggregation test and assert they do not appear in results; update SQL-shape assertion to match the new `IN (...)` compilation.

## Packages impacted

- `web` only.

## Test plan

- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter web run typecheck`
- [x] `pnpm --filter web run test --testPathPatterns="queryBuilder.servertest" -t "scores-numeric view"` — 7 pass
- [x] `pnpm --filter web run test --testPathPatterns="queryBuilder.servertest" -t "should aggregate numeric scores correctly"` — 1 pass (modified test with TEXT + CORRECTION seeded)
- [x] `pnpm --filter web run test --testPathPatterns="queryBuilder.servertest" -t "scores-categorical view"` — 3 pass (sanity check — shared `setupScores` helper was widened)
- [x] `pnpm --filter web run test --testPathPatterns="dashboard-v1-v2-consistency.servertest"` — 35 pass (v1/v2 scores-numeric consistency still holds)

## Notes on behavior change

The `scores-numeric` view is consumed by dashboard widgets (`ChartScores`, `NumericScoreTimeSeriesChart`) and the public `metrics-v2` REST API. Customers with `TEXT`/`CORRECTION` scores will see those rows disappear from scores-numeric query results — this is the intended fix. Existing `scores-categorical` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a data-type leak in the `scores-numeric` view by replacing a negative exclusion (`data_type does not contain 'CATEGORICAL'`) with a positive allow-list (`data_type IN ('NUMERIC', 'BOOLEAN')`), preventing `TEXT` and `CORRECTION` scores from polluting numeric aggregations. The fix is minimal, well-tested, and uses a safer default — future `data_type` enum additions are excluded automatically.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line logic change with comprehensive test coverage and no breaking contract changes.

The only finding is a P2 test-coverage style suggestion. The core fix is correct: the allow-list approach is strictly safer than the previous exclusion. All existing tests pass per the PR description.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/query/dataModel.ts | Replaces negative exclusion (`does not contain CATEGORICAL`) with a positive allow-list (`any of NUMERIC, BOOLEAN`) in `scoresNumericViewBase`; straightforward and safe change. |
| web/src/__tests__/server/queryBuilder.servertest.ts | Widens `setupScores` helper to accept TEXT/CORRECTION types, seeds both in the aggregation test, and asserts they are absent from results; SQL shape assertions updated to match the new `IN (...)` form. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Score row in ClickHouse] --> B{data_type?}
    B -->|NUMERIC| C[scores_numeric view ✅]
    B -->|BOOLEAN| C
    B -->|CATEGORICAL| D[scores_categorical view ✅]
    B -->|TEXT| E[Excluded from both views 🚫]
    B -->|CORRECTION| E

    subgraph Before fix
        F["segment: data_type does not contain CATEGORICAL\n→ TEXT & CORRECTION leaked into scores_numeric"]
    end

    subgraph After fix
        G["segment: data_type IN ('NUMERIC','BOOLEAN')\n→ only intended types pass through"]
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/__tests__/server/queryBuilder.servertest.ts
Line: 1888-1894

Comment:
**CORRECTION score lacks `stringValue`**

The `CORRECTION` data type is excluded from the `string_value` population list in `setupScores`, so the seeded row ends up with both `value = null` and `string_value = null`. This is consistent with how ClickHouse stores correction scores if they have no payload, but if a real `CORRECTION` row in production can carry a string payload, the helper would not exercise that path. This is a minor test-coverage gap rather than a bug, but worth noting in case `CORRECTION` scores do carry a `stringValue` in practice.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboards): exclude TEXT and CORREC..."](https://github.com/langfuse/langfuse/commit/f539f1b600caa7760874b26954786e8e65b00002) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29105123)</sub>

<!-- /greptile_comment -->