### PR TITLE
fix(batch-actions): allow dialog close on status step and fix Go to Dataset 404

### DIFF
--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/StatusStep.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/StatusStep.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from "@/src/components/ui/card";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { Check, AlertCircle, Loader2 } from "lucide-react";
 
 type StatusStepProps = {
@@ -27,6 +28,8 @@ export function StatusStep({
   expectedCount,
   onClose,
 }: StatusStepProps) {
+  const router = useRouter();
+
   // Poll for status updates
   const status = api.batchAction.byId.useQuery(
     {
@@ -192,12 +195,16 @@ export function StatusStep({
               Close
             </Button>
             {isComplete && hasPartialSuccess && (
-              <Link
-                href={`/project/${projectId}/datasets/${dataset.id}/items`}
+              <Button
                 className="flex-1"
+                onClick={() =>
+                  void router.push(
+                    `/project/${projectId}/datasets/${encodeURIComponent(dataset.id)}/items`,
+                  )
+                }
               >
-                <Button className="w-full">Go to Dataset</Button>
-              </Link>
+                Go to Dataset
+              </Button>
             )}
           </div>
         </div>

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/useAddToDatasetWizard.ts
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/useAddToDatasetWizard.ts
@@ -310,7 +310,7 @@ export function useAddToDatasetWizard(props: UseAddToDatasetWizardProps) {
   }, [state.step]);
 
   const showBackButton = state.step !== "choice" && state.step !== "status";
-  const canClose = state.step !== "status";
+  const canClose = !state.submission.isSubmitting;
   const isLoading =
     state.step === "create"
       ? state.createStep.isCreating


### PR DESCRIPTION
## Summary
- Let ESC / outside-click / the Radix ✕ dismiss the add-observations-to-dataset dialog on the status step; the old `canClose = state.step !== "status"` check blocked ambient dismissal there (only the in-step *Close* button worked). New guard is `!state.submission.isSubmitting`, which still prevents accidental close mid-submit but unblocks the "Successfully Added!" screen.
- Fix "Go to Dataset" 404 for datasets whose ids contain slashes (e.g. seed datasets named `folder/simple-dataset`, id `folder/simple-dataset-950dc53a`). Replaced `<Link><Button></Button></Link>` with a `<Button onClick={() => router.push(...)}>` and `encodeURIComponent(dataset.id)` — Next.js `<Link>` silently decoded `%2F` back to `/` on render, breaking the dynamic route.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes two bugs in the "Add Observations to Dataset" dialog: (1) `canClose` is now `!state.submission.isSubmitting` instead of `state.step !== "status"`, which correctly unblocks ESC/overlay-click dismissal on the status step while still preventing close during active submission; (2) "Go to Dataset" replaces `<Link>` with `router.push(encodeURIComponent(dataset.id))` to prevent Next.js from silently decoding `%2F` back to `/` in dataset IDs that contain slashes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both fixes are minimal, well-scoped, and manually verified by the author.

No P0/P1 issues found. Both changes are small and targeted: the `canClose` logic is correct (status step has `isSubmitting=false` after SUBMIT_SUCCESS), and `encodeURIComponent` + `router.push` is the standard Pages Router pattern for path segments containing `/`.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/batch-actions/components/AddObservationsToDatasetDialog/useAddToDatasetWizard.ts | Single-line fix: `canClose` changed from step-based guard to `!isSubmitting`, correctly unblocking the status step while preserving the in-flight protection. |
| web/src/features/batch-actions/components/AddObservationsToDatasetDialog/StatusStep.tsx | Adds `useRouter` and replaces `<Link><Button>` with `<Button onClick={() => router.push(encodeURIComponent(id))}>` to fix URL encoding for slash-containing dataset IDs. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Dialog
    participant Wizard as useAddToDatasetWizard
    participant API

    User->>Dialog: Click "Add to Dataset" (preview step)
    Dialog->>Wizard: handleSubmit()
    Wizard->>Wizard: dispatch(SUBMIT_START) → isSubmitting=true
    Note over Wizard: canClose = false (blocks ESC/overlay)
    Wizard->>API: createBatchAction.mutateAsync()
    API-->>Wizard: success → dispatch(SUBMIT_SUCCESS)
    Wizard->>Wizard: isSubmitting=false, step=status
    Note over Wizard: canClose = true (ESC/overlay now works)
    User->>Dialog: ESC / overlay click
    Dialog->>Wizard: canClose check → true
    Dialog-->>User: Dialog closes ✓

    User->>Dialog: Click "Go to Dataset"
    Dialog->>Dialog: router.push("/datasets/" + encodeURIComponent(id) + "/items")
    Note over Dialog: %2F preserved → correct URL
```

<sub>Reviews (1): Last reviewed commit: ["fix(batch-actions): allow dialog dismiss..."](https://github.com/langfuse/langfuse/commit/3bbf500811eb39281d665d934df1f4d0bdb04b14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29107015)</sub>

<!-- /greptile_comment -->