### PR TITLE
fix(audit-logs): capture after-state and normalise resource ids for member role changes

### DIFF
--- a/web/src/__tests__/server/members-trpc.servertest.ts
+++ b/web/src/__tests__/server/members-trpc.servertest.ts
@@ -261,3 +261,185 @@ describe("membersRouter.create - organization member limit enforcement", () => {
     }, 25_000);
   });
 });
+
+describe("membersRouter.updateOrgMembership - audit log state capture", () => {
+  it("records both before and after when changing an org role", async () => {
+    const { org, caller } = await prepare("cloud:core");
+
+    const targetUser = await createTestUser();
+    const membership = await prisma.organizationMembership.create({
+      data: {
+        userId: targetUser.id,
+        orgId: org.id,
+        role: Role.MEMBER,
+      },
+    });
+
+    await caller.members.updateOrgMembership({
+      orgId: org.id,
+      orgMembershipId: membership.id,
+      role: Role.VIEWER,
+    });
+
+    const logEntry = await prisma.auditLog.findFirst({
+      where: {
+        orgId: org.id,
+        resourceType: "orgMembership",
+        resourceId: membership.id,
+        action: "update",
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    expect(logEntry).not.toBeNull();
+    expect(logEntry?.before).not.toBeNull();
+    expect(logEntry?.after).not.toBeNull();
+
+    const before = JSON.parse(logEntry!.before!);
+    const after = JSON.parse(logEntry!.after!);
+    expect(before.role).toBe(Role.MEMBER);
+    expect(after.role).toBe(Role.VIEWER);
+  });
+});
+
+describe("membersRouter.updateProjectRole - audit log state capture", () => {
+  it("records action=create with after when assigning a new project role", async () => {
+    const { org, project, caller } = await prepare("cloud:core");
+
+    const targetUser = await createTestUser();
+    const orgMembership = await prisma.organizationMembership.create({
+      data: {
+        userId: targetUser.id,
+        orgId: org.id,
+        role: Role.MEMBER,
+      },
+    });
+
+    await caller.members.updateProjectRole({
+      orgId: org.id,
+      orgMembershipId: orgMembership.id,
+      userId: targetUser.id,
+      projectId: project.id,
+      projectRole: Role.ADMIN,
+    });
+
+    const logEntry = await prisma.auditLog.findFirst({
+      where: {
+        orgId: org.id,
+        resourceType: "projectMembership",
+        resourceId: `${project.id}--${targetUser.id}`,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    expect(logEntry).not.toBeNull();
+    expect(logEntry?.action).toBe("create");
+    expect(logEntry?.before).toBeNull();
+    expect(logEntry?.after).not.toBeNull();
+
+    const after = JSON.parse(logEntry!.after!);
+    expect(after.role).toBe(Role.ADMIN);
+    expect(after.projectId).toBe(project.id);
+    expect(after.userId).toBe(targetUser.id);
+  });
+
+  it("records action=update with before and after when changing an existing project role", async () => {
+    const { org, project, caller } = await prepare("cloud:core");
+
+    const targetUser = await createTestUser();
+    const orgMembership = await prisma.organizationMembership.create({
+      data: {
+        userId: targetUser.id,
+        orgId: org.id,
+        role: Role.MEMBER,
+      },
+    });
+    await prisma.projectMembership.create({
+      data: {
+        userId: targetUser.id,
+        projectId: project.id,
+        role: Role.VIEWER,
+        orgMembershipId: orgMembership.id,
+      },
+    });
+
+    await caller.members.updateProjectRole({
+      orgId: org.id,
+      orgMembershipId: orgMembership.id,
+      userId: targetUser.id,
+      projectId: project.id,
+      projectRole: Role.ADMIN,
+    });
+
+    const logEntry = await prisma.auditLog.findFirst({
+      where: {
+        orgId: org.id,
+        resourceType: "projectMembership",
+        resourceId: `${project.id}--${targetUser.id}`,
+        action: "update",
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    expect(logEntry).not.toBeNull();
+    expect(logEntry?.before).not.toBeNull();
+    expect(logEntry?.after).not.toBeNull();
+
+    const before = JSON.parse(logEntry!.before!);
+    const after = JSON.parse(logEntry!.after!);
+    expect(before.role).toBe(Role.VIEWER);
+    expect(after.role).toBe(Role.ADMIN);
+  });
+
+  it("uses consistent resourceId across create, update, and delete", async () => {
+    const { org, project, caller } = await prepare("cloud:core");
+
+    const targetUser = await createTestUser();
+    const orgMembership = await prisma.organizationMembership.create({
+      data: {
+        userId: targetUser.id,
+        orgId: org.id,
+        role: Role.MEMBER,
+      },
+    });
+
+    // create
+    await caller.members.updateProjectRole({
+      orgId: org.id,
+      orgMembershipId: orgMembership.id,
+      userId: targetUser.id,
+      projectId: project.id,
+      projectRole: Role.VIEWER,
+    });
+
+    // update
+    await caller.members.updateProjectRole({
+      orgId: org.id,
+      orgMembershipId: orgMembership.id,
+      userId: targetUser.id,
+      projectId: project.id,
+      projectRole: Role.ADMIN,
+    });
+
+    // delete
+    await caller.members.updateProjectRole({
+      orgId: org.id,
+      orgMembershipId: orgMembership.id,
+      userId: targetUser.id,
+      projectId: project.id,
+      projectRole: null,
+    });
+
+    const expectedResourceId = `${project.id}--${targetUser.id}`;
+    const logs = await prisma.auditLog.findMany({
+      where: {
+        orgId: org.id,
+        resourceType: "projectMembership",
+        resourceId: expectedResourceId,
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    expect(logs.map((l) => l.action)).toEqual(["create", "update", "delete"]);
+  });
+});

--- a/web/src/features/rbac/server/membersRouter.ts
+++ b/web/src/features/rbac/server/membersRouter.ts
@@ -572,15 +572,7 @@ export const membersRouter = createTRPCRouter({
         });
       }
 
-      await auditLog({
-        session: ctx.session,
-        resourceType: "orgMembership",
-        resourceId: membership.id,
-        action: "update",
-        before: membership,
-      });
-
-      return await ctx.prisma.organizationMembership.update({
+      const updatedMembership = await ctx.prisma.organizationMembership.update({
         where: {
           id: membership.id,
           orgId: input.orgId,
@@ -589,6 +581,17 @@ export const membersRouter = createTRPCRouter({
           role: input.role,
         },
       });
+
+      await auditLog({
+        session: ctx.session,
+        resourceType: "orgMembership",
+        resourceId: membership.id,
+        action: "update",
+        before: membership,
+        after: updatedMembership,
+      });
+
+      return updatedMembership;
     }),
   updateProjectRole: protectedOrganizationProcedure
     .input(
@@ -675,7 +678,7 @@ export const membersRouter = createTRPCRouter({
           await auditLog({
             session: ctx.session,
             resourceType: "projectMembership",
-            resourceId: `${input.orgMembershipId}--${input.projectId}`,
+            resourceId: `${input.projectId}--${input.userId}`,
             action: "delete",
             before: projectMembership,
           });
@@ -716,9 +719,10 @@ export const membersRouter = createTRPCRouter({
       await auditLog({
         session: ctx.session,
         resourceType: "projectMembership",
-        resourceId: input.projectId + "--" + input.userId,
-        action: "update",
+        resourceId: `${input.projectId}--${input.userId}`,
+        action: projectMembership ? "update" : "create",
         before: projectMembership,
+        after: updatedProjectMembership,
       });
 
       return updatedProjectMembership;


### PR DESCRIPTION
## Summary
- `updateOrgMembership` now captures the updated record and passes it as `after` to `auditLog()` so org-level role changes log both before and after states.
- `updateProjectRole` passes `updatedProjectMembership` as `after`, uses `action: \"create\"` when the upsert inserts a new row (previously always `\"update\"`), and standardises `resourceId` to `projectId--userId` across create/update/delete so one project membership can be tracked end-to-end.

Fixes [LFE-9056](https://linear.app/langfuse/issue/LFE-9056/bug-audit-logs-on-org-level-not-showing-after-state-and-missing-for) / closes #12880.

## Impacted packages
- `web` only (router + tests). No schema, worker, or shared changes.

## Verification
- [x] `pnpm --filter web run test --testPathPatterns="members-trpc"` — 10/10 passing, including 4 new tests for the audit-log paths. Confirmed new tests fail on `main` before the fix.
- [x] `pnpm --filter web run lint`

## Test plan
- [ ] After deploy, change a user's org role in Organisation Settings → Members and verify the Audit Logs table shows both `Before` and `After` JSON with the old/new role.
- [ ] Assign a user a project role for the first time in Project Settings → Members and verify the entry shows `action: create`, empty `Before`, and populated `After`.
- [ ] Change the same user's project role again and verify `action: update` with both states populated, same `resourceId` as the previous entry.
- [ ] Remove the project role and verify the delete entry shares the same `resourceId` as the create/update entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes two audit-log gaps in the member management TRPC router: `updateOrgMembership` now captures the `after` state by moving `auditLog()` to after the DB write, and `updateProjectRole` normalises the `resourceId` to `${projectId}--${userId}` across create/update/delete paths and correctly distinguishes `action: "create"` vs `"update"` based on pre-upsert existence. Four new integration tests cover all the changed paths and were confirmed to fail on `main`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are narrow, correct, and fully covered by new passing tests.

No P0 or P1 findings. Both changed code paths are logically correct: the DB write happens before the audit log call so the after-state is always available, the resourceId normalisation is consistent, and the create/update discrimination relies on the pre-upsert lookup which is the conventional pattern here. The four new tests exercise every scenario described in the PR.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/rbac/server/membersRouter.ts | Audit-log write moved to after DB update; after-state captured; resourceId and action semantics corrected for project membership upsert/delete. |
| web/src/__tests__/server/members-trpc.servertest.ts | Four new integration tests added covering before/after capture for org membership updates, create vs update action distinction, and consistent resourceId across the full lifecycle of a project membership. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant membersRouter
    participant DB as Prisma / DB
    participant AuditLog

    Note over membersRouter,AuditLog: updateOrgMembership (fixed)
    Client->>membersRouter: updateOrgMembership(orgId, membershipId, role)
    membersRouter->>DB: organizationMembership.update()
    DB-->>membersRouter: updatedMembership (after state)
    membersRouter->>AuditLog: auditLog(before=membership, after=updatedMembership)

    Note over membersRouter,AuditLog: updateProjectRole – create path (fixed)
    Client->>membersRouter: updateProjectRole(projectId, userId, role)
    membersRouter->>DB: projectMembership.findFirst()
    DB-->>membersRouter: null (not found)
    membersRouter->>DB: projectMembership.upsert()
    DB-->>membersRouter: updatedProjectMembership
    membersRouter->>AuditLog: auditLog(action=create, before=null, after=updatedProjectMembership)

    Note over membersRouter,AuditLog: updateProjectRole – update path (fixed)
    Client->>membersRouter: updateProjectRole(projectId, userId, newRole)
    membersRouter->>DB: projectMembership.findFirst()
    DB-->>membersRouter: existingMembership
    membersRouter->>DB: projectMembership.upsert()
    DB-->>membersRouter: updatedProjectMembership
    membersRouter->>AuditLog: auditLog(action=update, before=existingMembership, after=updatedProjectMembership)

    Note over membersRouter,AuditLog: updateProjectRole – delete path (resourceId normalised)
    Client->>membersRouter: updateProjectRole(projectId, userId, null)
    membersRouter->>DB: projectMembership.delete()
    membersRouter->>AuditLog: auditLog(action=delete, before=projectMembership, resourceId=projectId--userId)
```

<sub>Reviews (1): Last reviewed commit: ["fix(audit-logs): capture after-state and..."](https://github.com/langfuse/langfuse/commit/e4bc6b4050fc3a39a658ae942339cae091ea2ad8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29110699)</sub>

<!-- /greptile_comment -->