### PR TITLE
fix(auth): auto-link OAuth accounts for multi-tenant SSO tenants using default credentials (LFE-7725)

### DIFF
--- a/web/src/ee/features/multi-tenant-sso/utils.ts
+++ b/web/src/ee/features/multi-tenant-sso/utils.ts
@@ -10,6 +10,7 @@ import KeycloakProvider from "next-auth/providers/keycloak";
 import Auth0Provider from "next-auth/providers/auth0";
 import AzureADProvider from "next-auth/providers/azure-ad";
 import { multiTenantSsoAvailable } from "@/src/ee/features/multi-tenant-sso/multiTenantSsoAvailable";
+import { env } from "@/src/env.mjs";
 import { type SsoConfig, prisma } from "@langfuse/shared/src/db";
 import { decrypt } from "@langfuse/shared/encryption";
 import { SsoProviderSchema } from "./types";
@@ -187,14 +188,118 @@ const getClientConfig = (authConfig: {
 };
 
 /**
+ * Build a NextAuth provider for an SsoConfig row that has `authConfig = null`
+ * by falling back to the globally configured OAuth credentials (env vars).
+ *
+ * Only supports providers that have global default credentials configured by
+ * for Langfuse Cloud today: google, azure-ad, github. For any other
+ * provider with a null authConfig we return null (no dynamic provider
+ * registered) — those need custom credentials on the sso_configs row.
+ *
+ * The id is domain-scoped (`${domain}.${authProvider}`) so the dynamic
+ * provider is distinct from the static global one and can opt into
+ * `allowDangerousEmailAccountLinking: true` without loosening the static
+ * provider's behavior.
+ */
+const dbToDefaultCredentialsProvider = (
+  provider: SsoProviderSchema,
+): Provider | null => {
+  const id = getAuthProviderIdForSsoConfig(provider);
+
+  if (provider.authProvider === "google") {
+    if (!env.AUTH_GOOGLE_CLIENT_ID || !env.AUTH_GOOGLE_CLIENT_SECRET) {
+      logger.warn(
+        `Multi-tenant SSO: skipping google provider for domain ${provider.domain} — AUTH_GOOGLE_CLIENT_ID/AUTH_GOOGLE_CLIENT_SECRET not set`,
+      );
+      return null;
+    }
+    return GoogleProvider({
+      id,
+      clientId: env.AUTH_GOOGLE_CLIENT_ID,
+      clientSecret: env.AUTH_GOOGLE_CLIENT_SECRET,
+      allowDangerousEmailAccountLinking: true,
+      client: {
+        token_endpoint_auth_method: env.AUTH_GOOGLE_CLIENT_AUTH_METHOD,
+        ...(env.AUTH_GOOGLE_ID_TOKEN_SIGNED_RESPONSE_ALG
+          ? {
+              id_token_signed_response_alg:
+                env.AUTH_GOOGLE_ID_TOKEN_SIGNED_RESPONSE_ALG,
+            }
+          : {}),
+      },
+      ...(env.AUTH_GOOGLE_CHECKS ? { checks: env.AUTH_GOOGLE_CHECKS } : {}),
+    });
+  }
+
+  if (provider.authProvider === "azure-ad") {
+    if (
+      !env.AUTH_AZURE_AD_CLIENT_ID ||
+      !env.AUTH_AZURE_AD_CLIENT_SECRET ||
+      !env.AUTH_AZURE_AD_TENANT_ID
+    ) {
+      logger.warn(
+        `Multi-tenant SSO: skipping azure-ad provider for domain ${provider.domain} — AUTH_AZURE_AD_CLIENT_ID/AUTH_AZURE_AD_CLIENT_SECRET/AUTH_AZURE_AD_TENANT_ID not set`,
+      );
+      return null;
+    }
+    return AzureADProvider({
+      id,
+      clientId: env.AUTH_AZURE_AD_CLIENT_ID,
+      clientSecret: env.AUTH_AZURE_AD_CLIENT_SECRET,
+      tenantId: env.AUTH_AZURE_AD_TENANT_ID,
+      allowDangerousEmailAccountLinking: true,
+      client: {
+        token_endpoint_auth_method: env.AUTH_AZURE_AD_CLIENT_AUTH_METHOD,
+        ...(env.AUTH_AZURE_AD_ID_TOKEN_SIGNED_RESPONSE_ALG
+          ? {
+              id_token_signed_response_alg:
+                env.AUTH_AZURE_AD_ID_TOKEN_SIGNED_RESPONSE_ALG,
+            }
+          : {}),
+      },
+      ...(env.AUTH_AZURE_AD_CHECKS ? { checks: env.AUTH_AZURE_AD_CHECKS } : {}),
+    });
+  }
+
+  if (provider.authProvider === "github") {
+    if (!env.AUTH_GITHUB_CLIENT_ID || !env.AUTH_GITHUB_CLIENT_SECRET) {
+      logger.warn(
+        `Multi-tenant SSO: skipping github provider for domain ${provider.domain} — AUTH_GITHUB_CLIENT_ID/AUTH_GITHUB_CLIENT_SECRET not set`,
+      );
+      return null;
+    }
+    return GitHubProvider({
+      id,
+      clientId: env.AUTH_GITHUB_CLIENT_ID,
+      clientSecret: env.AUTH_GITHUB_CLIENT_SECRET,
+      issuer: "https://github.com/login/oauth",
+      allowDangerousEmailAccountLinking: true,
+      client: {
+        token_endpoint_auth_method: env.AUTH_GITHUB_CLIENT_AUTH_METHOD,
+      },
+      ...(env.AUTH_GITHUB_CHECKS ? { checks: env.AUTH_GITHUB_CHECKS } : {}),
+    });
+  }
+
+  return null;
+};
+
+/**
  * Converts a SsoProviderConfig to a NextAuth Provider instance.
  *
  * @param {SsoProviderSchema} provider - The SSO configuration from the database.
  * @returns {Provider | null} - A NextAuth Provider instance or null if parsing fails or no custom credentials are used for this SSO config.
  */
 const dbToNextAuthProvider = (provider: SsoProviderSchema): Provider | null => {
-  // If the SsoConfig does not use custom credentials, return null as no additional provider needs to be added to NextAuth
-  if (!provider.authConfig) return null;
+  // Null authConfig means: route this domain through SSO using the globally
+  // configured OAuth credentials. For the providers that support this
+  // (google, azure-ad, github) we register a domain-scoped dynamic provider
+  // with `allowDangerousEmailAccountLinking: true` so that an existing
+  // credentials user signing in via SSO gets their OAuth account linked on
+  // first use instead of hitting OAuthAccountNotLinked.
+  if (!provider.authConfig) {
+    return dbToDefaultCredentialsProvider(provider);
+  }
 
   if (provider.authProvider === "google")
     return GoogleProvider({
@@ -315,6 +420,18 @@ const dbToNextAuthProvider = (provider: SsoProviderSchema): Provider | null => {
   }
 };
 
+// Providers that can fall back to globally-configured OAuth credentials when
+// an sso_configs row has `auth_config = NULL`. These get a domain-scoped
+// dynamic provider id (matching the custom-credentials pattern) so that the
+// dynamic provider registered in `dbToDefaultCredentialsProvider` — which
+// opts into `allowDangerousEmailAccountLinking: true` — is the one
+// NextAuth hits on sign-in.
+const DEFAULT_CREDENTIALS_SUPPORTED_PROVIDERS = [
+  "google",
+  "azure-ad",
+  "github",
+] as const;
+
 /**
  * Get the custom SSO providerId for a database SSO configuration. To be used with NextAuth's `signIn(providerId)`.
  *
@@ -324,7 +441,16 @@ const dbToNextAuthProvider = (provider: SsoProviderSchema): Provider | null => {
 const getAuthProviderIdForSsoConfig = (
   dbSsoConfig: SsoProviderSchema,
 ): string => {
-  if (!dbSsoConfig.authConfig) return dbSsoConfig.authProvider;
+  if (!dbSsoConfig.authConfig) {
+    if (
+      (DEFAULT_CREDENTIALS_SUPPORTED_PROVIDERS as readonly string[]).includes(
+        dbSsoConfig.authProvider,
+      )
+    ) {
+      return `${dbSsoConfig.domain}.${dbSsoConfig.authProvider}`;
+    }
+    return dbSsoConfig.authProvider;
+  }
   return `${dbSsoConfig.domain}.${dbSsoConfig.authProvider}`;
 };
 
@@ -344,9 +470,16 @@ export const findMultiTenantSsoConfig = async ({
 > => {
   const allConfigs = await getSsoConfigs();
 
-  const config = allConfigs
-    .filter((config) => Boolean(config.authConfig)) // exclude all that don't use custom credentials (enforcement of social login)
-    .find((c) => getAuthProviderIdForSsoConfig(c) === providerId);
+  // Previously this filtered out rows with `authConfig = null` to avoid
+  // treating static social logins as tenant-scoped SSO. That filter must no
+  // longer apply to providers we now register dynamically against global
+  // credentials (google, azure-ad, github) — otherwise the cross-domain
+  // guard in the signIn callback would never fire for those rows and a
+  // `$domain.google` provider could be used from any email domain. Matching
+  // on the domain-scoped provider id is the correct discriminator.
+  const config = allConfigs.find(
+    (c) => getAuthProviderIdForSsoConfig(c) === providerId,
+  );
 
   if (config) {
     return { isMultiTenantSsoProvider: true, domain: config.domain };


### PR DESCRIPTION
Tracking issue: [LFE-7725](https://linear.app/langfuse/issue/LFE-7725/self-serve-sso-account-linking)

## Summary

- **Bug.** A tenant whose `sso_configs` row has `auth_provider ∈ {google, azure-ad, github}` and `auth_config = NULL` (i.e. "use global env-var OAuth credentials") cannot complete SSO sign-in if the user originally signed up with email + password. NextAuth throws `OAuthAccountNotLinked` because the static provider in `web/src/server/auth.ts` has `allowDangerousEmailAccountLinking` gated on an env flag that is not enabled on Cloud. The frontend surfaces it as "Please sign in with the same provider that you used to create this account…".
- **Fix.** In `web/src/ee/features/multi-tenant-sso/utils.ts`, for null-`authConfig` rows with `authProvider` in `{google, azure-ad, github}`, register a domain-scoped dynamic NextAuth provider (`${domain}.${authProvider}`) that uses the existing global env-var credentials and sets `allowDangerousEmailAccountLinking: true`. Also update `getAuthProviderIdForSsoConfig` so `/api/auth/check-sso` returns the domain-scoped id for those rows, and drop the `authConfig`-required filter in `findMultiTenantSsoConfig` so the existing cross-domain guard in `signIn` still applies to these rows. Static providers in `auth.ts` are untouched.

## Impacted packages

- `web` — `src/ee/features/multi-tenant-sso/utils.ts`

## Required env on Cloud for this to take effect

The env vars are the same ones the static providers already consume — no new ones:
- google: `AUTH_GOOGLE_CLIENT_ID`, `AUTH_GOOGLE_CLIENT_SECRET` (optionally `AUTH_GOOGLE_CLIENT_AUTH_METHOD`, `AUTH_GOOGLE_ID_TOKEN_SIGNED_RESPONSE_ALG`, `AUTH_GOOGLE_CHECKS`)
- azure-ad: `AUTH_AZURE_AD_CLIENT_ID`, `AUTH_AZURE_AD_CLIENT_SECRET`, `AUTH_AZURE_AD_TENANT_ID` (optionally `AUTH_AZURE_AD_CLIENT_AUTH_METHOD`, `AUTH_AZURE_AD_ID_TOKEN_SIGNED_RESPONSE_ALG`, `AUTH_AZURE_AD_CHECKS`)
- github: `AUTH_GITHUB_CLIENT_ID`, `AUTH_GITHUB_CLIENT_SECRET` (optionally `AUTH_GITHUB_CLIENT_AUTH_METHOD`, `AUTH_GITHUB_CHECKS`)

If the required vars are missing for a given provider, the dynamic provider is not registered and a warning is logged with the tenant domain.

## Caveat: existing `accounts` rows are not migrated

A user in an affected tenant with `accounts.provider = "google"` today will get a new `accounts` row with `provider = "${domain}.google"` on their next sign-in. The old row becomes dead weight but is harmless. A back-migration can be done later as a separate PR if desired.

## Test plan

- [ ] Dev DB: create a `users` row with `password` set (credentials signup) and an `sso_configs` row with `domain = <test-domain>`, `auth_provider = "google"`, `auth_config = NULL`.
- [ ] Start `pnpm dev:web` with `AUTH_GOOGLE_CLIENT_ID`/`AUTH_GOOGLE_CLIENT_SECRET` set.
- [ ] On the sign-in page, enter the test user's email → redirect to Google → after Google auth, sign-in completes without the "Please sign in with the same provider" error.
- [ ] Verify `accounts` contains a new row with `provider = "<test-domain>.google"` for the user.
- [ ] Verify a user with a different email domain cannot use the dynamic provider (cross-domain guard in `web/src/server/auth.ts` throws "This domain is not associated with this SSO provider.").
- [ ] Repeat the happy path for `auth_provider = "azure-ad"` with the Azure env vars.
- [ ] Repeat the happy path for `auth_provider = "github"` with the GitHub env vars.

## Verification commands

- `pnpm --filter web run lint` — passes (ran as part of the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes an `OAuthAccountNotLinked` error for multi-tenant SSO tenants whose `sso_configs` row has `authConfig = NULL` and `authProvider ∈ {google, azure-ad, github}`. For those rows, it now registers a domain-scoped dynamic NextAuth provider (e.g., `corp.example.com.google`) that reuses the global env-var OAuth credentials and sets `allowDangerousEmailAccountLinking: true`, allowing existing credentials-signup users to link their OAuth account on first SSO sign-in. The cross-domain guard in `signIn` is preserved via the domain-scoped provider ID — only users whose email matches the configured domain can use the provider.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are minor P2 style and edge-case concerns that do not affect the primary fix or existing users.

The core logic is sound: domain-scoped dynamic providers correctly isolate the allowDangerousEmailAccountLinking behaviour from the static global providers, and the cross-domain guard in signIn remains intact. The two P2 findings (code organisation and an unlikely edge case with unsupported null-authConfig providers) do not affect correctness for the intended use-case.

web/src/ee/features/multi-tenant-sso/utils.ts — specifically the removed authConfig filter in findMultiTenantSsoConfig and the placement of DEFAULT_CREDENTIALS_SUPPORTED_PROVIDERS.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/ee/features/multi-tenant-sso/utils.ts | Core fix for OAuthAccountNotLinked: adds `dbToDefaultCredentialsProvider` to register domain-scoped dynamic providers for null-authConfig rows using global env-var credentials; updates `getAuthProviderIdForSsoConfig` to return domain-scoped IDs for these providers; and removes the `authConfig`-required filter from `findMultiTenantSsoConfig` — with a minor concern about the scope of that filter removal for unsupported null-authConfig providers. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant NA as NextAuth
    participant DP as domain-scoped provider (dynamic)
    participant SP as plain provider (static)
    participant FS as findMultiTenantSsoConfig
    participant SIC as signIn callback

    Note over DP: allowDangerousEmailAccountLinking=true
    Note over DP: registered by dbToDefaultCredentialsProvider
    Note over DP: when sso_configs.authConfig is null

    U->>NA: signIn with domain-scoped provider id
    NA->>DP: OAuth redirect to identity provider
    DP-->>NA: OAuth callback with user profile
    NA->>FS: lookup by domain-scoped provider id
    FS-->>NA: isMultiTenantSsoProvider=true, domain=X
    NA->>SIC: check user email domain vs SSO domain
    SIC-->>NA: domains match, allow
    NA-->>U: account linked and signed in

    Note over SP: static provider unchanged
    U->>NA: signIn with plain static provider id
    NA->>FS: lookup by plain provider id
    FS-->>NA: isMultiTenantSsoProvider=false
    NA-->>U: signed in via original flow
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/ee/features/multi-tenant-sso/utils.ts
Line: 480-482

Comment:
**Cross-domain guard now applies to null-authConfig unsupported providers**

Removing the `Boolean(config.authConfig)` filter means that a `sso_configs` row with `authProvider = "keycloak"` (or any other provider NOT in `DEFAULT_CREDENTIALS_SUPPORTED_PROVIDERS`) and `authConfig = null` now has `getAuthProviderIdForSsoConfig` return the bare provider string (e.g., `"keycloak"`). If a global static Keycloak provider is configured via env vars, its `account.provider` will also be `"keycloak"`, so `findMultiTenantSsoConfig` will now match that row and trigger the cross-domain guard — restricting which users can sign in via the global static provider. The previous behaviour was to silently skip these rows.

This is an unlikely combination (a null-authConfig row for a provider that requires custom credentials), but worth an explicit comment or guard, e.g. only include null-authConfig rows when their computed id is domain-scoped.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/ee/features/multi-tenant-sso/utils.ts
Line: 429-433

Comment:
**`DEFAULT_CREDENTIALS_SUPPORTED_PROVIDERS` declared after its first indirect use**

`dbToDefaultCredentialsProvider` (line 204) calls `getAuthProviderIdForSsoConfig`, which references `DEFAULT_CREDENTIALS_SUPPORTED_PROVIDERS`. Because all three are `const` expressions, there's no runtime TDZ issue — every call happens after the module is fully initialised. But placing the constant 225 lines after its first transitive consumer makes the dependency hard to follow. Moving `DEFAULT_CREDENTIALS_SUPPORTED_PROVIDERS` above `dbToDefaultCredentialsProvider` would make the data flow self-evident.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): auto-link OAuth accounts for ..."](https://github.com/langfuse/langfuse/commit/fbbe7e6f773d12703a2e4c8d20df4dd6be9c5541) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29114471)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->