### PR TITLE
fix(storage): disable default S3 checksums for GCS multipart uploads

### DIFF
--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -509,6 +509,10 @@ class S3StorageService implements StorageService {
       endpoint: params.endpoint,
       region: params.region,
       forcePathStyle: params.forcePathStyle,
+      // Restore pre-v3.729 default so CompleteMultipartUpload doesn't send a
+      // composite CRC32 header, which GCS's S3-compat layer rejects with 412.
+      requestChecksumCalculation: "WHEN_REQUIRED",
+      responseChecksumValidation: "WHEN_REQUIRED",
       requestHandler: {
         httpsAgent: {
           maxSockets: env.LANGFUSE_S3_CONCURRENT_WRITES,
@@ -525,6 +529,8 @@ class S3StorageService implements StorageService {
           endpoint: params.externalEndpoint,
           region: params.region,
           forcePathStyle: params.forcePathStyle,
+          requestChecksumCalculation: "WHEN_REQUIRED",
+          responseChecksumValidation: "WHEN_REQUIRED",
           requestHandler: {
             httpsAgent: {
               maxSockets: env.LANGFUSE_S3_CONCURRENT_WRITES,


### PR DESCRIPTION
## Summary
- AWS SDK v3 >= 3.729 computes a composite CRC32 header on `CompleteMultipartUpload` by default. GCS's S3-compat layer doesn't accept the composite checksum semantics and responds with `412 PreconditionFailed` ("At least one of the pre-conditions you specified did not hold"), breaking buffered multipart uploads to GCS via HMAC keys.
- Set `requestChecksumCalculation` and `responseChecksumValidation` to `WHEN_REQUIRED` on both S3 clients in `S3StorageService`, restoring pre-v3.729 behavior. This fixes the buffered chunked path and the `lib-storage` Upload path in one shot and remains safe for real AWS S3.

## Impacted packages
- `@langfuse/shared` (`packages/shared/src/server/services/StorageService.ts`)

## Test plan
- [ ] `pnpm --filter @langfuse/shared run typecheck`
- [ ] `pnpm --filter @langfuse/shared run lint`
- [ ] Manual: verify buffered multipart export to a GCS bucket (HMAC keys) succeeds with `LANGFUSE_S3_UPLOAD_ENABLE_BUFFERED=true`
- [ ] Manual: regression check — upload/download against AWS S3 still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a GCS compatibility regression introduced by AWS SDK v3 >= 3.729, which began automatically computing composite CRC32 headers on `CompleteMultipartUpload` requests. GCS's S3-compatible layer rejects these with `412 PreconditionFailed`. The fix sets `requestChecksumCalculation` and `responseChecksumValidation` to `"WHEN_REQUIRED"` on both S3 client instances, restoring pre-v3.729 behavior without impacting real AWS S3.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix that restores pre-v3.729 checksum behavior without impacting AWS S3.

The change is two config options set consistently on both S3Client instances. The values are valid, well-documented AWS SDK settings. AWS S3 continues to work correctly with WHEN_REQUIRED; no regressions are expected. No logic, security, or type issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/services/StorageService.ts | Adds `requestChecksumCalculation: "WHEN_REQUIRED"` and `responseChecksumValidation: "WHEN_REQUIRED"` to both S3Client constructors (main client and signed-URL client), fixing GCS multipart upload failures caused by the AWS SDK v3.729+ CRC32 default. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Langfuse App
    participant S3Svc as S3StorageService
    participant SDK as AWS SDK v3 (≥3.729)
    participant GCS as GCS S3-Compat Layer

    Note over SDK: Default: sends composite CRC32 header (WHEN_SUPPORTED)
    App->>S3Svc: uploadFile() / buffered multipart
    S3Svc->>SDK: CompleteMultipartUpload
    SDK-->>GCS: Request + x-amz-checksum-crc32c (composite)
    GCS-->>SDK: 412 PreconditionFailed ❌

    Note over SDK: After fix: requestChecksumCalculation = WHEN_REQUIRED
    App->>S3Svc: uploadFile() / buffered multipart
    S3Svc->>SDK: CompleteMultipartUpload
    SDK-->>GCS: Request (no composite checksum header)
    GCS-->>SDK: 200 OK ✅
    SDK-->>S3Svc: Success
    S3Svc-->>App: Done
```

<sub>Reviews (1): Last reviewed commit: ["fix(storage): disable default S3 checksu..."](https://github.com/langfuse/langfuse/commit/840356e024aaebcbc3aae22e0c4fc3165b4028b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29115051)</sub>

<!-- /greptile_comment -->