### PR TITLE
feat(prompts): Add time window filtering to prompt metrics

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1418,6 +1418,10 @@ export const deleteObservationsOlderThanDays = async (
 export const getObservationsWithPromptName = async (
   projectId: string,
   promptNames: string[],
+  {
+    fromTimestamp,
+    toTimestamp,
+  }: { fromTimestamp?: Date; toTimestamp?: Date } = {},
 ) => {
   const query = `
   SELECT uniq(id) as count, prompt_name
@@ -1425,6 +1429,8 @@ export const getObservationsWithPromptName = async (
   WHERE project_id = {projectId: String}
   AND prompt_name IN ({promptNames: Array(String)})
   AND prompt_name IS NOT NULL
+  ${fromTimestamp ? "AND start_time >= {fromTimestamp: DateTime64(3)}" : ""}
+  ${toTimestamp ? "AND start_time <= {toTimestamp: DateTime64(3)}" : ""}
   GROUP BY prompt_name
 `;
   const rows = await queryClickhouse<{ count: string; prompt_name: string }>({
@@ -1432,6 +1438,12 @@ export const getObservationsWithPromptName = async (
     params: {
       projectId,
       promptNames,
+      fromTimestamp: fromTimestamp
+        ? convertDateToClickhouseDateTime(fromTimestamp)
+        : undefined,
+      toTimestamp: toTimestamp
+        ? convertDateToClickhouseDateTime(toTimestamp)
+        : undefined,
     },
     tags: {
       feature: "tracing",
@@ -1450,6 +1462,10 @@ export const getObservationsWithPromptName = async (
 export const getObservationMetricsForPrompts = async (
   projectId: string,
   promptIds: string[],
+  {
+    fromTimestamp,
+    toTimestamp,
+  }: { fromTimestamp?: Date; toTimestamp?: Date } = {},
 ) => {
   const query = `
       WITH latencies AS
@@ -1468,6 +1484,8 @@ export const getObservationMetricsForPrompts = async (
               AND (prompt_name IS NOT NULL)
               AND project_id={projectId: String}
               AND prompt_id IN ({promptIds: Array(String)})
+              ${fromTimestamp ? "AND start_time >= {fromTimestamp: DateTime64(3)}" : ""}
+              ${toTimestamp ? "AND start_time <= {toTimestamp: DateTime64(3)}" : ""}
           )
       SELECT
           count(*) AS count,
@@ -1500,6 +1518,12 @@ export const getObservationMetricsForPrompts = async (
     params: {
       projectId,
       promptIds,
+      ...(fromTimestamp
+        ? { fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp) }
+        : {}),
+      ...(toTimestamp
+        ? { toTimestamp: convertDateToClickhouseDateTime(toTimestamp) }
+        : {}),
     },
     tags: {
       feature: "tracing",

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1806,6 +1806,10 @@ export const getAggregatedScoresForPrompts = async (
   projectId: string,
   promptIds: string[],
   fetchScoreRelation: "observation" | "trace",
+  {
+    fromTimestamp,
+    toTimestamp,
+  }: { fromTimestamp?: Date; toTimestamp?: Date } = {},
 ) => {
   const query = `
     SELECT
@@ -1827,6 +1831,8 @@ export const getAggregatedScoresForPrompts = async (
     AND s.project_id = {projectId: String}
     AND o.prompt_id IN ({promptIds: Array(String)})
     AND o.type = 'GENERATION'
+    ${fromTimestamp ? "AND o.start_time >= {fromTimestamp: DateTime64(3)}" : ""}
+    ${toTimestamp ? "AND o.start_time <= {toTimestamp: DateTime64(3)}" : ""}
     AND s.name IS NOT NULL
     ${fetchScoreRelation === "trace" ? "AND s.observation_id IS NULL" : ""}
     AND s.data_type IN ({dataTypes: Array(String)})
@@ -1844,6 +1850,12 @@ export const getAggregatedScoresForPrompts = async (
       projectId,
       promptIds,
       dataTypes: LISTABLE_SCORE_TYPES,
+      ...(fromTimestamp
+        ? { fromTimestamp: convertDateToClickhouseDateTime(fromTimestamp) }
+        : {}),
+      ...(toTimestamp
+        ? { toTimestamp: convertDateToClickhouseDateTime(toTimestamp) }
+        : {}),
     },
     tags: {
       feature: "tracing",

--- a/web/src/__tests__/server/api/tables/prompts-ui.servertest.ts
+++ b/web/src/__tests__/server/api/tables/prompts-ui.servertest.ts
@@ -157,6 +157,73 @@ describe("UI Prompts Table", () => {
     );
   });
 
+  it("should filter prompt observation counts by date range", async () => {
+    const projectId = v4();
+    const promptId = v4();
+
+    const olderObservation = createObservation({
+      id: v4(),
+      project_id: projectId,
+      trace_id: v4(),
+      prompt_id: promptId,
+      type: "GENERATION",
+      created_at: Date.parse("2026-01-01T00:00:00.000Z"),
+      updated_at: Date.parse("2026-01-01T00:00:00.000Z"),
+      event_ts: Date.parse("2026-01-01T00:00:00.000Z"),
+      is_deleted: 0,
+      metadata: {},
+      start_time: Date.parse("2026-01-01T00:00:00.000Z"),
+      provided_usage_details: {},
+      provided_cost_details: {},
+      usage_details: { input: 100, output: 200 },
+      cost_details: { input: 100, output: 200 },
+      name: "Old Observation",
+      level: "WARNING",
+      input: "some llm input",
+      output: "some llm output",
+      version: "1.2.0",
+      parent_observation_id: null,
+      status_message: null,
+      provided_model_name: "anthropic",
+      internal_model_id: "some-model-id",
+      model_parameters: null,
+      total_cost: 100,
+      prompt_name: "Test Prompt",
+      prompt_version: 1,
+      end_time: Date.parse("2026-01-01T00:00:01.000Z"),
+      completion_start_time: Date.parse("2026-01-01T00:00:00.500Z"),
+    });
+
+    const newerObservation = createObservation({
+      ...olderObservation,
+      id: v4(),
+      created_at: Date.parse("2026-01-03T00:00:00.000Z"),
+      updated_at: Date.parse("2026-01-03T00:00:00.000Z"),
+      event_ts: Date.parse("2026-01-03T00:00:00.000Z"),
+      start_time: Date.parse("2026-01-03T00:00:00.000Z"),
+      end_time: Date.parse("2026-01-03T00:00:01.000Z"),
+      completion_start_time: Date.parse("2026-01-03T00:00:00.500Z"),
+    });
+
+    await createObservationsCh([olderObservation, newerObservation]);
+
+    const result = await getObservationsWithPromptName(
+      projectId,
+      ["Test Prompt"],
+      {
+        fromTimestamp: new Date("2026-01-02T00:00:00.000Z"),
+        toTimestamp: new Date("2026-01-03T00:00:00.000Z"),
+      },
+    );
+
+    expect(result).toEqual([
+      {
+        promptName: "Test Prompt",
+        count: 1,
+      },
+    ]);
+  });
+
   it("should correctly calculate prompt metrics", async () => {
     const projectId = v4();
     const observation = createObservation({
@@ -246,5 +313,82 @@ describe("UI Prompts Table", () => {
         },
       ]),
     );
+  });
+
+  it("should filter prompt metrics by date range", async () => {
+    const projectId = v4();
+    const promptId = v4();
+
+    const olderObservation = createObservation({
+      id: v4(),
+      project_id: projectId,
+      trace_id: v4(),
+      type: "GENERATION",
+      created_at: Date.parse("2026-01-01T00:00:00.000Z"),
+      updated_at: Date.parse("2026-01-01T00:00:00.000Z"),
+      event_ts: Date.parse("2026-01-01T00:00:00.000Z"),
+      is_deleted: 0,
+      metadata: {},
+      start_time: Date.parse("2026-01-01T00:00:00.000Z"),
+      provided_usage_details: {},
+      provided_cost_details: {},
+      usage_details: { input: 100, output: 200 },
+      cost_details: { total: 1 },
+      name: "Old Observation",
+      level: "WARNING",
+      input: "some llm input",
+      output: "some llm output",
+      version: "1.2.0",
+      parent_observation_id: null,
+      status_message: null,
+      provided_model_name: "anthropic",
+      internal_model_id: "some-model-id",
+      model_parameters: null,
+      total_cost: 1,
+      prompt_name: "Test Prompt",
+      prompt_version: 1,
+      prompt_id: promptId,
+      end_time: Date.parse("2026-01-01T00:00:01.000Z"),
+      completion_start_time: Date.parse("2026-01-01T00:00:00.500Z"),
+    });
+
+    const newerObservation = createObservation({
+      ...olderObservation,
+      id: v4(),
+      created_at: Date.parse("2026-01-03T00:00:00.000Z"),
+      updated_at: Date.parse("2026-01-03T00:00:00.000Z"),
+      event_ts: Date.parse("2026-01-03T00:00:00.000Z"),
+      start_time: Date.parse("2026-01-03T00:00:00.000Z"),
+      end_time: Date.parse("2026-01-03T00:00:01.000Z"),
+      completion_start_time: Date.parse("2026-01-03T00:00:00.500Z"),
+      usage_details: { input: 300, output: 400 },
+      cost_details: { total: 3 },
+      total_cost: 3,
+    });
+
+    await createObservationsCh([olderObservation, newerObservation]);
+
+    const result = await getObservationMetricsForPrompts(
+      projectId,
+      [promptId],
+      {
+        fromTimestamp: new Date("2026-01-02T00:00:00.000Z"),
+        toTimestamp: new Date("2026-01-04T00:00:00.000Z"),
+      },
+    );
+
+    expect(result).toEqual([
+      {
+        count: 1,
+        firstObservation: new Date("2026-01-03T00:00:00.000Z"),
+        lastObservation: new Date("2026-01-03T00:00:00.000Z"),
+        medianInputUsage: 300,
+        medianLatencyMs: 1000,
+        medianOutputUsage: 400,
+        medianTotalCost: 3,
+        promptId,
+        promptVersion: 1,
+      },
+    ]);
   });
 });

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -63,10 +63,19 @@ function createRow(
 export function PromptTable() {
   const projectId = useProjectIdFromURL() ?? "";
   const { setDetailPageList } = useDetailPageLists();
-  const promptMetricsFromTimestamp = useMemo(
-    () => new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
-    [],
-  );
+  const promptMetricsTimeWindow = useMemo(() => {
+    const today = new Date();
+
+    const fromTimestamp = new Date(today);
+    fromTimestamp.setDate(fromTimestamp.getDate() - 7);
+    fromTimestamp.setHours(0, 0, 0, 0);
+
+    const toTimestamp = new Date(today);
+    toTimestamp.setHours(0, 0, 0, 0);
+    toTimestamp.setMilliseconds(toTimestamp.getMilliseconds() - 1);
+
+    return { fromTimestamp, toTimestamp };
+  }, []);
 
   const [filterState] = useQueryFilterState([], "prompts", projectId);
 
@@ -119,7 +128,7 @@ export function PromptTable() {
         prompts.data?.prompts.map((p) =>
           buildFullPath(currentFolderPath, p.name),
         ) ?? [],
-      fromTimestamp: promptMetricsFromTimestamp,
+      ...promptMetricsTimeWindow,
     },
     {
       enabled:

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -20,7 +20,6 @@ import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState
 import { useSidebarFilterState } from "@/src/features/filters/hooks/useSidebarFilterState";
 import { promptFilterConfig } from "@/src/features/filters/config/prompts-config";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
-import { createColumnHelper } from "@tanstack/react-table";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { useDebounce } from "@/src/hooks/useDebounce";
@@ -62,8 +61,12 @@ function createRow(
 }
 
 export function PromptTable() {
-  const projectId = useProjectIdFromURL();
+  const projectId = useProjectIdFromURL() ?? "";
   const { setDetailPageList } = useDetailPageLists();
+  const promptMetricsFromTimestamp = useMemo(
+    () => new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    [],
+  );
 
   const [filterState] = useQueryFilterState([], "prompts", projectId);
 
@@ -93,7 +96,7 @@ export function PromptTable() {
     {
       page: paginationState.pageIndex,
       limit: paginationState.pageSize,
-      projectId: projectId as string, // Typecast as query is enabled only when projectId is present
+      projectId,
       filter: filterState,
       orderBy: orderByState,
       pathPrefix: currentFolderPath,
@@ -111,11 +114,12 @@ export function PromptTable() {
   );
   const promptMetrics = api.prompts.metrics.useQuery(
     {
-      projectId: projectId as string,
+      projectId,
       promptNames:
         prompts.data?.prompts.map((p) =>
           buildFullPath(currentFolderPath, p.name),
         ) ?? [],
+      fromTimestamp: promptMetricsFromTimestamp,
     },
     {
       enabled:
@@ -151,11 +155,16 @@ export function PromptTable() {
     const combinedRows: PromptTableRow[] = [];
 
     for (const prompt of promptsRowData.rows) {
-      const isFolder = (prompt as { row_type?: string }).row_type === "folder";
+      const isFolder = prompt.row_type === "folder";
       const fullPath = prompt.id; // id now contains the full path (used for metrics join)
       // Extract just the name portion (last segment) for display
       const itemName = fullPath.split("/").pop() ?? fullPath;
-      const type = isFolder ? "folder" : (prompt.type as "text" | "chat");
+      const type =
+        isFolder || prompt.type === "folder"
+          ? "folder"
+          : prompt.type === "chat"
+            ? "chat"
+            : "text";
 
       combinedRows.push(
         createRow({
@@ -184,7 +193,7 @@ export function PromptTable() {
 
   const promptFilterOptions = api.prompts.filterOptions.useQuery(
     {
-      projectId: projectId as string,
+      projectId,
     },
     {
       trpc: {
@@ -207,20 +216,22 @@ export function PromptTable() {
       type: ["text", "chat"],
       labels:
         promptFilterOptions.data?.labels?.map((l) => {
-          // API type says { value: string }[], but for some items, there is an optional count
-          const item = l as { value: string; count?: number };
           return {
-            value: item.value,
-            count: item.count !== undefined ? Number(item.count) : undefined,
+            value: l.value,
+            count:
+              "count" in l && l.count !== undefined
+                ? Number(l.count)
+                : undefined,
           };
         }) ?? undefined,
       tags:
         promptFilterOptions.data?.tags?.map((t) => {
-          // API type says { value: string }[], but for some items, there is an optional count
-          const item = t as { value: string; count?: number };
           return {
-            value: item.value,
-            count: item.count !== undefined ? Number(item.count) : undefined,
+            value: t.value,
+            count:
+              "count" in t && t.count !== undefined
+                ? Number(t.count)
+                : undefined,
           };
         }) ?? undefined,
       version: [],
@@ -248,16 +259,16 @@ export function PromptTable() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prompts.isSuccess, prompts.data]);
 
-  const columnHelper = createColumnHelper<PromptTableRow>();
-  const promptColumns = [
-    columnHelper.accessor("name", {
+  const promptColumns: LangfuseColumnDef<PromptTableRow>[] = [
+    {
+      accessorKey: "name",
       header: "Name",
       id: "name",
       enableSorting: true,
       size: 250,
-      cell: (row) => {
-        const name = row.getValue();
-        const rowData = row.row.original;
+      cell: ({ getValue, row }) => {
+        const name = getValue<string>();
+        const rowData = row.original;
 
         if (rowData.type === "folder") {
           return (
@@ -276,45 +287,47 @@ export function PromptTable() {
           />
         ) : undefined;
       },
-    }),
-    columnHelper.accessor("version", {
+    },
+    {
+      accessorKey: "version",
       header: "Versions",
       id: "version",
       enableSorting: true,
       size: 70,
-      cell: (row) => {
-        if (row.row.original.type === "folder") return null;
-        return row.getValue();
+      cell: ({ getValue, row }) => {
+        if (row.original.type === "folder") return null;
+        return getValue<number | undefined>();
       },
-    }),
-    columnHelper.accessor("type", {
+    },
+    {
+      accessorKey: "type",
       header: "Type",
       id: "type",
       enableSorting: true,
       size: 60,
-      cell: (row) => {
-        return row.getValue();
-      },
-    }),
-    columnHelper.accessor("createdAt", {
+    },
+    {
+      accessorKey: "createdAt",
       header: "Latest Version Created At",
       id: "createdAt",
       enableSorting: true,
       size: 200,
-      cell: (row) => {
-        if (row.row.original.type === "folder") return null;
-        const createdAt = row.getValue();
+      cell: ({ getValue, row }) => {
+        if (row.original.type === "folder") return null;
+        const createdAt = getValue<Date | undefined>();
         return createdAt ? <LocalIsoDate date={createdAt} /> : null;
       },
-    }),
-    columnHelper.accessor("numberOfObservations", {
-      header: "Number of Observations",
+    },
+    {
+      accessorKey: "numberOfObservations",
+      header: "Number of Observations (7d)",
+      id: "numberOfObservations",
       size: 170,
-      cell: (row) => {
-        if (row.row.original.type === "folder") return null;
+      cell: ({ getValue, row }) => {
+        if (row.original.type === "folder") return null;
 
-        const numberOfObservations = row.getValue();
-        const promptPath = row.row.original.fullPath;
+        const numberOfObservations = getValue<number | undefined>();
+        const promptPath = row.original.fullPath;
         const filter = encodeURIComponent(
           `promptName;stringOptions;;any of;${promptPath}`,
         );
@@ -328,28 +341,29 @@ export function PromptTable() {
           />
         );
       },
-    }),
-    columnHelper.accessor("tags", {
+    },
+    {
+      accessorKey: "tags",
       header: "Tags",
       id: "tags",
       enableSorting: true,
       size: 120,
-      cell: (row) => {
+      cell: ({ getValue, row }) => {
         // height h-6 to ensure consistent row height for normal & folder rows
-        if (row.row.original.type === "folder") return <div className="h-6" />;
+        if (row.original.type === "folder") return <div className="h-6" />;
 
-        const tags = row.getValue();
-        const promptPath = row.row.original.fullPath;
+        const tags = getValue<string[] | undefined>();
+        const promptPath = row.original.fullPath;
         return (
           <TagPromptPopover
             tags={tags ?? []}
             availableTags={allTags}
-            projectId={projectId as string}
+            projectId={projectId}
             promptName={promptPath}
             promptsFilter={{
               page: 0,
               limit: 50,
-              projectId: projectId as string,
+              projectId,
               filter: filterState,
               orderBy: orderByState,
             }}
@@ -357,13 +371,15 @@ export function PromptTable() {
         );
       },
       enableHiding: true,
-    }),
-    columnHelper.display({
+    },
+    {
+      accessorKey: "id",
       id: "actions",
       header: "Actions",
       size: 70,
-      cell: (row) => {
-        const rowData = row.row.original;
+      enableSorting: false,
+      cell: ({ row }) => {
+        const rowData = row.original;
         if (rowData.type === "folder") {
           return (
             <div className="flex gap-1">
@@ -376,8 +392,8 @@ export function PromptTable() {
         const promptPath = rowData.fullPath;
         return <DeletePrompt promptName={promptPath} />;
       },
-    }),
-  ] as LangfuseColumnDef<PromptTableRow>[];
+    },
+  ];
 
   return (
     <DataTableControlsProvider

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -59,6 +59,19 @@ const PromptFilterOptions = z.object({
   searchType: z.array(TracingSearchType).optional(),
 });
 
+const promptMetricsTimeWindow = {
+  fromTimestamp: z.date().optional(),
+  toTimestamp: z.date().optional(),
+};
+
+const isValidPromptMetricsTimeWindow = ({
+  fromTimestamp,
+  toTimestamp,
+}: {
+  fromTimestamp?: Date;
+  toTimestamp?: Date;
+}) => !fromTimestamp || !toTimestamp || fromTimestamp < toTimestamp;
+
 export const promptRouter = createTRPCRouter({
   hasAny: protectedProjectProcedure
     .input(
@@ -236,16 +249,24 @@ export const promptRouter = createTRPCRouter({
     }),
   metrics: protectedProjectProcedure
     .input(
-      z.object({
-        projectId: z.string(),
-        promptNames: z.array(z.string()),
-      }),
+      z
+        .object({
+          projectId: z.string(),
+          promptNames: z.array(z.string()),
+          ...promptMetricsTimeWindow,
+        })
+        .refine(isValidPromptMetricsTimeWindow, {
+          message: "fromTimestamp must be before toTimestamp",
+        }),
     )
     .query(async ({ input }) => {
-      if (input.promptNames.length === 0) return [];
+      const { projectId, promptNames, ...timeWindow } = input;
+      if (promptNames.length === 0) return [];
+
       const res = await getObservationsWithPromptName(
-        input.projectId,
-        input.promptNames,
+        projectId,
+        promptNames,
+        timeWindow,
       );
       return res.map(({ promptName, count }) => ({
         promptName,
@@ -1213,22 +1234,29 @@ export const promptRouter = createTRPCRouter({
     }),
   versionMetrics: protectedProjectProcedure
     .input(
-      z.object({
-        projectId: z.string(),
-        promptIds: z.array(z.string()),
-      }),
+      z
+        .object({
+          projectId: z.string(),
+          promptIds: z.array(z.string()),
+          ...promptMetricsTimeWindow,
+        })
+        .refine(isValidPromptMetricsTimeWindow, {
+          message: "fromTimestamp must be before toTimestamp",
+        }),
     )
     .query(async ({ input, ctx }) => {
+      const { projectId, promptIds, ...timeWindow } = input;
+
       throwIfNoProjectAccess({
         session: ctx.session,
-        projectId: input.projectId,
+        projectId,
         scope: "prompts:read",
       });
 
       const [observations, observationScores, traceScores] = await Promise.all([
-        getObservationMetricsForPrompts(input.projectId, input.promptIds),
-        getScoresForPromptIds(input.projectId, input.promptIds, "observation"),
-        getScoresForPromptIds(input.projectId, input.promptIds, "trace"),
+        getObservationMetricsForPrompts(projectId, promptIds, timeWindow),
+        getScoresForPromptIds(projectId, promptIds, "observation", timeWindow),
+        getScoresForPromptIds(projectId, promptIds, "trace", timeWindow),
       ]);
 
       return observations.map((r) => {
@@ -1426,11 +1454,16 @@ const getScoresForPromptIds = async (
   projectId: string,
   promptIds: string[],
   fetchScoreRelation: "observation" | "trace",
+  timeWindow: {
+    fromTimestamp?: Date;
+    toTimestamp?: Date;
+  } = {},
 ) => {
   const scores = await getAggregatedScoresForPrompts(
     projectId,
     promptIds,
     fetchScoreRelation,
+    timeWindow,
   );
 
   return promptIds.map((promptId) => {

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -26,6 +26,10 @@ import {
   scoreFilters,
   addPrefixToScoreKeys,
 } from "@/src/features/scores/lib/scoreColumns";
+import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
+import { useTableDateRange } from "@/src/hooks/useTableDateRange";
+import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
+import { useMemo } from "react";
 
 export type PromptVersionTableRow = {
   version: number;
@@ -83,11 +87,12 @@ export default function PromptVersionTable({
   promptName: promptNameProp,
 }: { promptName?: string } = {}) {
   const router = useRouter();
-  const projectId = router.query.projectId as string;
+  const projectId = useProjectIdFromURL() ?? "";
+  const promptNameFromQuery = router.query.promptName;
   const promptName =
     promptNameProp ||
-    (router.query.promptName
-      ? decodeURIComponent(router.query.promptName as string)
+    (typeof promptNameFromQuery === "string"
+      ? decodeURIComponent(promptNameFromQuery)
       : "");
 
   const [paginationState, setPaginationState] = useQueryParams({
@@ -102,10 +107,17 @@ export default function PromptVersionTable({
     "promptVersion",
     "s",
   );
+  const { timeRange, setTimeRange } = useTableDateRange(projectId, {
+    defaultRelativeAggregation: "last30Days",
+  });
+  const dateRange = useMemo(
+    () => ("range" in timeRange ? toAbsoluteTimeRange(timeRange) : timeRange),
+    [timeRange],
+  );
 
   const promptVersions = api.prompts.allVersions.useQuery(
     {
-      projectId: projectId as string, // Typecast as query is enabled only when projectId is present
+      projectId,
       name: promptName,
       page: paginationState.pageIndex,
       limit: paginationState.pageSize,
@@ -119,8 +131,10 @@ export default function PromptVersionTable({
 
   const promptMetrics = api.prompts.versionMetrics.useQuery(
     {
-      projectId: projectId as string, // Typecast as query is enabled only when projectId is present
+      projectId,
       promptIds,
+      fromTimestamp: dateRange?.from,
+      toTimestamp: dateRange?.to,
     },
     {
       enabled: Boolean(projectId) && promptVersions.isSuccess,
@@ -417,6 +431,8 @@ export default function PromptVersionTable({
       <div className="gap-3">
         <DataTableToolbar
           columns={columns}
+          timeRange={timeRange}
+          setTimeRange={setTimeRange}
           rowHeight={rowHeight}
           setRowHeight={setRowHeight}
           columnVisibility={columnVisibility}

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -316,8 +316,7 @@ export default function PromptVersionTable({
       size: 150,
       headerTooltip: {
         description:
-          "The last time this prompt version was used in a generation. See docs for details on how to link generations/traces to prompt versions.",
-        href: "https://langfuse.com/docs/prompt-management/get-started",
+          "This is calculated based on the selected date range, not the full usage history.",
       },
       cell: ({ row }) => {
         const value: number | undefined | null = row.getValue("lastUsed");
@@ -335,8 +334,7 @@ export default function PromptVersionTable({
       enableHiding: true,
       headerTooltip: {
         description:
-          "The first time this prompt version was used in a generation. See docs for details on how to link generations/traces to prompt versions.",
-        href: "https://langfuse.com/docs/prompt-management/get-started",
+          "This is calculated based on the selected date range, not the full usage history.",
       },
       cell: ({ row }) => {
         const value: number | undefined | null = row.getValue("firstUsed");


### PR DESCRIPTION
## What does this PR do?

The prompts overview now labels observation counts as `Number of Observations (7d)` and fetches those counts for the last 7 days. The prompt metrics page now wires the table date-range control into version metrics so latency, usage, cost, and score aggregates match the selected time range.

Overview:
<img width="1513" height="842" alt="Screenshot 2026-04-21 at 14 09 32" src="https://github.com/user-attachments/assets/5567261c-bbc1-43e7-a039-1ccd5a1fa3cc" />

Details:
<img width="1511" height="833" alt="Screenshot 2026-04-21 at 14 10 24" src="https://github.com/user-attachments/assets/209177ba-5de6-4c55-a120-18b4b34b9d7f" />


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds time-window filtering to prompt metrics: the overview table now shows a fixed 7-day observation count, and the prompt metrics detail page wires the existing table date-range control into the version metrics queries (latency, usage, cost, scores) via optional `fromTimestamp`/`toTimestamp` parameters passed through the tRPC router down to ClickHouse.

One minor semantic concern: the `firstUsed` / `lastUsed` columns on the metrics detail page are now computed within the filtered window (`min`/`max` of `start_time` in the same CTE), so they will reflect the first/last observation *in the selected range* rather than the absolute first/last usage — the column headers don't communicate this yet.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 quality/UX suggestions that do not block correctness.

The backend changes are additive and well-guarded (optional params with defaults, validation refinement, early-exit guard). The frontend wiring is straightforward. The only notable concern — firstUsed/lastUsed being scoped to the selected range without header indication — is a UX/labeling issue rather than a data-integrity bug.

web/src/pages/project/[projectId]/prompts/metrics.tsx — "First used" / "Last used" column headers may need a note or tooltip when a date range is active.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/shared/src/server/repositories/observations.ts | Adds optional fromTimestamp/toTimestamp params to getObservationsWithPromptName and getObservationMetricsForPrompts, injected into ClickHouse WHERE clauses via conditional template strings. |
| packages/shared/src/server/repositories/scores.ts | Adds the same optional time-window params to getAggregatedScoresForPrompts, filtering on o.start_time consistently with the observations change. |
| web/src/features/prompts/server/routers/promptRouter.ts | Wires promptMetricsTimeWindow into both the metrics and versionMetrics procedures; adds isValidPromptMetricsTimeWindow refinement and early-exit guard in metrics; passes timeWindow down to repository calls. |
| web/src/features/prompts/components/prompts-table.tsx | Updates column header to "Number of Observations (7d)" and passes a fixed 7-day fromTimestamp to the metrics query, making the overview label accurate. |
| web/src/pages/project/[projectId]/prompts/metrics.tsx | Adds useTableDateRange (default: last 30 days) and pipes fromTimestamp/toTimestamp into versionMetrics; exposes date-range control in the toolbar. First/last used columns are now range-scoped without header indication. |
| web/src/__tests__/server/api/tables/prompts-ui.servertest.ts | Adds a test verifying that getObservationsWithPromptName correctly excludes observations outside the supplied date range. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as metrics.tsx
    participant Router as promptRouter (tRPC)
    participant ObsRepo as observations.ts
    participant ScoreRepo as scores.ts
    participant CH as ClickHouse

    UI->>UI: useTableDateRange() → timeRange
    UI->>UI: toAbsoluteTimeRange() → { from, to }
    UI->>Router: versionMetrics({ projectId, promptIds, fromTimestamp, toTimestamp })
    Router->>Router: isValidPromptMetricsTimeWindow() validate
    par
        Router->>ObsRepo: getObservationMetricsForPrompts(projectId, promptIds, timeWindow)
        ObsRepo->>CH: SELECT … WHERE start_time >= fromTs AND start_time <= toTs
        CH-->>ObsRepo: count, first_observation, last_observation, medians
    and
        Router->>ScoreRepo: getAggregatedScoresForPrompts(…, "observation", timeWindow)
        ScoreRepo->>CH: SELECT … JOIN observations WHERE o.start_time in range
        CH-->>ScoreRepo: score aggregates
    and
        Router->>ScoreRepo: getAggregatedScoresForPrompts(…, "trace", timeWindow)
        ScoreRepo->>CH: SELECT … JOIN observations WHERE o.start_time in range
        CH-->>ScoreRepo: score aggregates
    end
    Router-->>UI: merged metrics rows
    UI->>UI: joinPromptCoreAndMetricData() → table rows
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/src/pages/project/[projectId]/prompts/metrics.tsx`, line 311-348 ([link](https://github.com/langfuse/langfuse/blob/63ecec2c2f60c0d076476697980c047e4c75fa75/web/src/pages/project/[projectId]/prompts/metrics.tsx#L311-L348)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **"First used" / "Last used" scoped to the filtered date range**

   `first_observation` and `last_observation` are computed with `min(start_time)` / `max(start_time)` inside the same CTE that applies the `fromTimestamp`/`toTimestamp` filter, so when a user selects (e.g.) the last 30 days, these columns will silently show the earliest/latest observation *within that window* rather than the absolute first/last use of the prompt version. The column headers don't communicate this, which can mislead users into thinking a version was first used on a more recent date than it actually was.

   Consider either excluding `firstUsed`/`lastUsed` from the time-range filter (query them without the window filter), or updating the column headers to reflect "First used (in range)" / "Last used (in range)", or adding a tooltip note about this behavior.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/pages/project/[projectId]/prompts/metrics.tsx
   Line: 311-348

   Comment:
   **"First used" / "Last used" scoped to the filtered date range**

   `first_observation` and `last_observation` are computed with `min(start_time)` / `max(start_time)` inside the same CTE that applies the `fromTimestamp`/`toTimestamp` filter, so when a user selects (e.g.) the last 30 days, these columns will silently show the earliest/latest observation *within that window* rather than the absolute first/last use of the prompt version. The column headers don't communicate this, which can mislead users into thinking a version was first used on a more recent date than it actually was.

   Consider either excluding `firstUsed`/`lastUsed` from the time-range filter (query them without the window filter), or updating the column headers to reflect "First used (in range)" / "Last used (in range)", or adding a tooltip note about this behavior.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/pages/project/[projectId]/prompts/metrics.tsx
Line: 311-348

Comment:
**"First used" / "Last used" scoped to the filtered date range**

`first_observation` and `last_observation` are computed with `min(start_time)` / `max(start_time)` inside the same CTE that applies the `fromTimestamp`/`toTimestamp` filter, so when a user selects (e.g.) the last 30 days, these columns will silently show the earliest/latest observation *within that window* rather than the absolute first/last use of the prompt version. The column headers don't communicate this, which can mislead users into thinking a version was first used on a more recent date than it actually was.

Consider either excluding `firstUsed`/`lastUsed` from the time-range filter (query them without the window filter), or updating the column headers to reflect "First used (in range)" / "Last used (in range)", or adding a tooltip note about this behavior.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(prompts): Add time window filtering..."](https://github.com/langfuse/langfuse/commit/63ecec2c2f60c0d076476697980c047e4c75fa75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29119452)</sub>

<!-- /greptile_comment -->