### PR TITLE
refactor(web): Always allow toggling V4 in dev mode

### DIFF
--- a/web/src/components/layouts/app-layout/utils/navigationFilters.ts
+++ b/web/src/components/layouts/app-layout/utils/navigationFilters.ts
@@ -79,8 +79,8 @@ export const filters = {
     }
 
     if (route.featureFlag === "v4BetaToggleVisible") {
-      const canToggleV4 = ctx.session?.user?.canToggleV4 === true;
-
+      const isDev = process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV";
+      const canToggleV4 = isDev || ctx.session?.user?.canToggleV4 === true;
       return canToggleV4 && ctx.isLangfuseCloud ? route : null;
     }
 

--- a/web/src/features/events/lib/v4Rollout.ts
+++ b/web/src/features/events/lib/v4Rollout.ts
@@ -38,5 +38,9 @@ export function shouldAutoEnableV4({
 }
 
 export function canToggleV4(context: V4RolloutContext): boolean {
+  if (process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV") {
+    return true;
+  }
+
   return !shouldAutoEnableV4(context);
 }

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -133,7 +133,10 @@ export const userAccountRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const isCloudDeployment = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
-      if (!isCloudDeployment) {
+      if (
+        !isCloudDeployment &&
+        process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION !== "DEV"
+      ) {
         return {
           success: true,
           v4BetaEnabled: false,

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -803,7 +803,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
 
           span.setAttribute("langfuse.user.email", dbUser?.email ?? "");
           span.setAttribute("langfuse.user.id", dbUser?.id ?? "");
-          const isCloudDeployment = Boolean(
+          const isCloudDeploymentOrDev = Boolean(
             env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
           );
 
@@ -828,10 +828,10 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                       : undefined,
                     image: dbUser.image,
                     admin: dbUser.admin,
-                    v4BetaEnabled: isCloudDeployment
+                    v4BetaEnabled: isCloudDeploymentOrDev
                       ? dbUser.v4BetaEnabled
                       : false,
-                    canToggleV4: isCloudDeployment
+                    canToggleV4: isCloudDeploymentOrDev
                       ? canToggleV4({
                           userCreatedAt: dbUser.createdAt,
                           organizations: dbUser.organizationMemberships.map(


### PR DESCRIPTION
It seems locally v4 cannot be toggled by default anymore because `ctx.session?.user?.canToggleV4` does not evaluate to true. This makes working on changes such as https://github.com/langfuse/langfuse/pull/13283 difficult.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR allows the V4 Beta toggle to be visible and usable in the `DEV` cloud region without requiring the `canToggleV4` user permission, by checking `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV"` in both the navigation filter and the `useV4Beta` hook. The change is a developer-convenience refactor and does not affect production environments.

<h3>Confidence Score: 5/5</h3>

Safe to merge — change is purely additive, gated on a compile-time env var, and does not affect production deployments.

Both modifications are identical in intent, tightly scoped to `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === 'DEV'`, and the existing `isLangfuseCloud` guard in the navigation filter ensures nothing leaks to non-cloud environments. No P0/P1 issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/components/layouts/app-layout/utils/navigationFilters.ts | Adds `isDev` short-circuit to `canToggleV4` in the `v4BetaToggleVisible` feature flag branch; the `isLangfuseCloud` guard is preserved, so the route is still hidden in non-cloud contexts. |
| web/src/features/events/hooks/useV4Beta.ts | Mirrors the same `isDev` short-circuit for `canToggleV4`; no `isLangfuseCloud` check in the hook, consistent with prior behaviour where callers rely on navigation filtering to gate visibility. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Route: v4BetaToggleVisible] --> B{isDev?\nNEXT_PUBLIC_LANGFUSE_CLOUD_REGION === 'DEV'}
    B -- Yes --> C[canToggleV4 = true]
    B -- No --> D{session.user.canToggleV4 === true?}
    D -- Yes --> C
    D -- No --> E[canToggleV4 = false]
    C --> F{isLangfuseCloud?}
    E --> F
    F -- Yes --> G[Show toggle route]
    F -- No --> H[Hide toggle route]
```

<sub>Reviews (1): Last reviewed commit: ["ref(web): Always allow toggling V4 in de..."](https://github.com/langfuse/langfuse/commit/f5da0c64db31aedb662806b7d4cd3b5e3e0f61dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29121897)</sub>

<!-- /greptile_comment -->