### PR TITLE
feat: add experiment item metadata support to observation evals and variable-mapping UI

### DIFF
--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -63,6 +63,7 @@ export const observationForEvalSchema = z.object({
   experiment_dataset_id: z.string().nullish(),
   experiment_item_id: z.string().nullish(),
   experiment_item_expected_output: z.string().nullish(),
+  experiment_item_metadata: z.record(z.string(), z.unknown()).nullish(),
   experiment_item_root_span_id: z.string().nullish(),
 
   // Data - accepts any type (string, array, object) from different OTEL SDKs
@@ -80,11 +81,23 @@ export function convertEventRecordToObservationForEval(
     record.metadata_names,
     record.metadata_values,
   );
+  const experimentItemMetadata =
+    record.experiment_item_metadata_names.length > 0
+      ? record.experiment_item_metadata_names.reduce<
+          Record<string, string | null | undefined>
+        >((acc, name, i) => {
+          if (!(name in acc)) {
+            acc[name] = record.experiment_item_metadata_values[i];
+          }
+          return acc;
+        }, {})
+      : undefined;
 
   const toolCallNames = record.tool_call_names ?? [];
   return observationForEvalSchema.parse({
     ...record,
     metadata,
+    experiment_item_metadata: experimentItemMetadata,
     tool_call_count: toolCallNames.length,
   });
 }
@@ -111,7 +124,11 @@ export type ObservationEvalFilterColumnInternal =
 
 export type ObservationEvalMappingColumnInternal = keyof Pick<
   ObservationForEval,
-  "input" | "output" | "metadata" | "experiment_item_expected_output"
+  | "input"
+  | "output"
+  | "metadata"
+  | "experiment_item_expected_output"
+  | "experiment_item_metadata"
 >;
 
 export interface ObservationEvalVariableColumn {
@@ -158,6 +175,13 @@ export const observationEvalVariableColumns: ObservationEvalVariableColumn[] = [
     name: "Expected Output",
     description: "Expected output from experiment item",
     internal: "experiment_item_expected_output",
+  },
+  {
+    id: "experimentItemMetadata",
+    name: "Experiment Item Metadata",
+    description: "Metadata from experiment item",
+    type: "stringObject",
+    internal: "experiment_item_metadata",
   },
 ];
 

--- a/web/src/features/evals/components/variable-mapping-card.tsx
+++ b/web/src/features/evals/components/variable-mapping-card.tsx
@@ -636,9 +636,45 @@ export const VariableMappingCard = ({
                                   ? observationEvalVariableColumns.filter(
                                       (col) =>
                                         col.id !==
-                                        "experimentItemExpectedOutput",
+                                          "experimentItemExpectedOutput" &&
+                                        col.id !== "experimentItemMetadata",
                                     )
                                   : observationEvalVariableColumns;
+                              const displayColumns = availableColumns.map(
+                                (column) => {
+                                  if (
+                                    form.watch("target") ===
+                                      EvalTargetObject.EXPERIMENT &&
+                                    column.id === "input"
+                                  ) {
+                                    return {
+                                      ...column,
+                                      name: "Observation Input",
+                                    };
+                                  }
+                                  if (
+                                    form.watch("target") ===
+                                      EvalTargetObject.EXPERIMENT &&
+                                    column.id === "output"
+                                  ) {
+                                    return {
+                                      ...column,
+                                      name: "Observation Output",
+                                    };
+                                  }
+                                  if (
+                                    form.watch("target") ===
+                                      EvalTargetObject.EXPERIMENT &&
+                                    column.id === "metadata"
+                                  ) {
+                                    return {
+                                      ...column,
+                                      name: "Observation Metadata",
+                                    };
+                                  }
+                                  return column;
+                                },
+                              );
 
                               return (
                                 <div className="flex items-center gap-2">
@@ -662,7 +698,7 @@ export const VariableMappingCard = ({
                                           <SelectValue placeholder="Select field" />
                                         </SelectTrigger>
                                         <SelectContent>
-                                          {availableColumns.map((column) => (
+                                          {displayColumns.map((column) => (
                                             <SelectItem
                                               value={column.id}
                                               key={column.id}
@@ -679,14 +715,9 @@ export const VariableMappingCard = ({
                               );
                             }}
                           />
-                          {(form.watch(`mapping.${index}.selectedColumnId`) ===
-                            "metadata" ||
-                            form.watch(`mapping.${index}.selectedColumnId`) ===
-                              "input" ||
-                            form.watch(`mapping.${index}.selectedColumnId`) ===
-                              "output" ||
-                            form.watch(`mapping.${index}.selectedColumnId`) ===
-                              "experimentItemExpectedOutput") && (
+                          {fieldHasJsonSelectorOption(
+                            form.watch(`mapping.${index}.selectedColumnId`),
+                          ) && (
                             <FormField
                               control={form.control}
                               key={`${mappingField.id}-jsonSelector`}

--- a/web/src/features/evals/utils/evaluator-form-utils.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.ts
@@ -47,8 +47,10 @@ export const fieldHasJsonSelectorOption = (
   selectedColumnId === "metadata" ||
   selectedColumnId === "expected_output" ||
   selectedColumnId === "experiment_item_expected_output" ||
+  selectedColumnId === "experiment_item_metadata" ||
   selectedColumnId === "expectedOutput" ||
-  selectedColumnId === "experimentItemExpectedOutput";
+  selectedColumnId === "experimentItemExpectedOutput" ||
+  selectedColumnId === "experimentItemMetadata";
 
 export const getTargetDisplayName = (target: string): string => {
   switch (target) {

--- a/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
@@ -58,6 +58,7 @@ describe("extractObservationVariables", () => {
     experiment_dataset_id: null,
     experiment_item_id: null,
     experiment_item_expected_output: "expected response",
+    experiment_item_metadata: { cohort: "control", region: "eu" },
 
     // Data fields
     input: JSON.stringify({
@@ -252,6 +253,26 @@ describe("extractObservationVariables", () => {
       expect(result[0].var).toBe("expected");
       expect(result[0].value).toBe("expected response");
     });
+
+    it("should extract experimentItemMetadata variable as JSON string", () => {
+      const variableMapping: ObservationVariableMapping[] = [
+        {
+          templateVariable: "item_metadata",
+          selectedColumnId: "experimentItemMetadata",
+        },
+      ];
+
+      const result = extractObservationVariables({
+        observation: mockObservation,
+        variableMapping,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].var).toBe("item_metadata");
+      expect(result[0].value).toBe(
+        JSON.stringify(mockObservation.experiment_item_metadata),
+      );
+    });
   });
 
   describe("usage extraction", () => {
@@ -334,6 +355,23 @@ describe("extractObservationVariables", () => {
 
       // Single-match results are unwrapped
       expect(result[0].value).toBe("I am fine, thank you!");
+    });
+
+    it("should apply JSON selector to extract nested field from experiment item metadata", () => {
+      const variableMapping: ObservationVariableMapping[] = [
+        {
+          templateVariable: "cohort",
+          selectedColumnId: "experimentItemMetadata",
+          jsonSelector: "$.cohort",
+        },
+      ];
+
+      const result = extractObservationVariables({
+        observation: mockObservation,
+        variableMapping,
+      });
+
+      expect(result[0].value).toBe("control");
     });
 
     // OTel ingestion stringifies metadata.attributes.* values; ingestion stringifies the whole metadata.attributes object


### PR DESCRIPTION
### Motivation
- Support storing and mapping experiment item metadata so experiments can pass structured item-level context into evaluation templates. 
- Ensure the UI and variable extraction logic treat experiment item metadata like other JSON fields (with optional JsonPath selection). 

### Description
- Added `experiment_item_metadata` to the `observationForEvalSchema` and populated it in `convertEventRecordToObservationForEval` from ingestion arrays. 
- Exposed `experiment_item_metadata` as a variable column by updating `observationEvalVariableColumns` and `availableObservationEvalVariableColumns`. 
- Updated form logic in `VariableMappingCard` to filter out experiment-only fields for event targets, rename some columns when target is `experiment`, and render the correct selectable list; and extended `fieldHasJsonSelectorOption` to include `experiment_item_metadata`/`experimentItemMetadata`. 
- Added unit tests to `extractObservationVariables.test.ts` covering extraction and JsonPath selection for `experiment_item_metadata` and updated the mock observation to include `experiment_item_metadata`. 

### Testing
- Ran unit tests for observation evaluation extraction, including `worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts`, and the new tests for `experiment_item_metadata` passed. 
- Existing extraction tests were re-run and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e7a3981ff4832ba5616774f7eb4da1)