### PR TITLE
chore(ci): pin action version comments to immutable patch tags

### DIFF
--- a/.github/workflows/_deploy_ecs_service.yml
+++ b/.github/workflows/_deploy_ecs_service.yml
@@ -88,13 +88,13 @@ jobs:
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
       - name: Render AWS ECS Task Definition
         id: render-task-definition
-        uses: aws-actions/amazon-ecs-render-task-definition@77954e213ba1f9f9cb016b86a1d4f6fcdea0d57e # v1
+        uses: aws-actions/amazon-ecs-render-task-definition@77954e213ba1f9f9cb016b86a1d4f6fcdea0d57e # v1.8.4
         with:
           container-name: ${{ inputs.service }}
           image: ${{ steps.login-ecr.outputs.registry }}/${{ steps.split.outputs._0 }}:${{ github.sha }}
           task-definition-family: ${{ inputs.environment }}-${{ inputs.service }}
       - name: Update AWS ECS Service
-        uses: aws-actions/amazon-ecs-deploy-task-definition@fc8fc60f3a60ffd500fcb13b209c59d221ac8c8c # v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@fc8fc60f3a60ffd500fcb13b209c59d221ac8c8c # v2.6.1
         with:
           task-definition: ${{ steps.render-task-definition.outputs.task-definition }}
           service: ${{ inputs.environment }}-${{ inputs.service }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -790,7 +790,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v3') && !contains(github.ref, '-rc') }}
       - name: Build and push image by digest to GitHub Container Registry (${{ matrix.component }}, ${{ matrix.platform_tag }})
         id: build-ghcr
-        uses: useblacksmith/build-push-action@cbd1f60d194a98cb3be5523b15134501eaf0fbf3 # v2
+        uses: useblacksmith/build-push-action@cbd1f60d194a98cb3be5523b15134501eaf0fbf3 # v2.1.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -801,7 +801,7 @@ jobs:
           sbom: false
       - name: Build and push image by digest to Docker Hub (${{ matrix.component }}, ${{ matrix.platform_tag }})
         id: build-dockerhub
-        uses: useblacksmith/build-push-action@cbd1f60d194a98cb3be5523b15134501eaf0fbf3 # v2
+        uses: useblacksmith/build-push-action@cbd1f60d194a98cb3be5523b15134501eaf0fbf3 # v2.1.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Validate PR title follows conventional commits
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
Tightens the `# v1` / `# v2` / `# v6` floating-major comments on SHA-pinned actions to their exact patch-level tags:
- `aws-actions/amazon-ecs-render-task-definition` → `# v1.8.4` (_deploy_ecs_service.yml)
- `aws-actions/amazon-ecs-deploy-task-definition` → `# v2.6.1` (_deploy_ecs_service.yml)
- `amannn/action-semantic-pull-request` → `# v6.1.1` (validate-pr-title.yml)
- `useblacksmith/build-push-action` → `# v2.1.0` (pipeline.yml ×2)

Same SHAs, zero behavior change. The point is to keep the version comment truthful even if upstream moves the floating major tag to a new SHA — we just ran into exactly that in langfuse-js ([#792](https://github.com/langfuse/langfuse-js/pull/792)), where `actions/setup-node # v6` silently became stale after upstream released `v6.3.0` and broke the zizmor security workflow.

Left alone:
- `winterjung/split` — upstream only publishes a `v2` floating tag; no patch-level tag to tighten to.
- `orange-buffalo/dependabot-auto-rebase` — pins a `v1` *branch* head (not a tag). Switching off a mutable ref is a separate decision.
- `.github/workflows/ci.yml.template` — not an active workflow.

Verified locally with `zizmor --min-severity medium --persona regular` — no findings.

## Test plan
- [ ] zizmor security workflow passes
- [ ] CI still green (no functional change to any action invocation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR tightens floating major-version comments on four SHA-pinned GitHub Actions to their exact patch-level tags. No SHA, logic, or behavior changes — purely a documentation hygiene fix motivated by a prior incident in `langfuse-js` where a stale `# v6` comment caused confusion after upstream moved the floating tag.

<h3>Confidence Score: 5/5</h3>

Safe to merge — comment-only changes with no impact on runtime behavior.

All three files contain purely cosmetic comment updates. SHA pins are identical to the base branch, so no action version actually changes. No logic, security surface, or CI behavior is affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/_deploy_ecs_service.yml | Comment-only update: `# v1` → `# v1.8.4` and `# v2` → `# v2.6.1` for the two AWS ECS actions; SHA pins are unchanged. |
| .github/workflows/pipeline.yml | Comment-only update: `# v2` → `# v2.1.0` on both `useblacksmith/build-push-action` steps; SHA pins are unchanged. |
| .github/workflows/validate-pr-title.yml | Comment-only update: `# v6` → `# v6.1.1` for `amannn/action-semantic-pull-request`; SHA pin is unchanged. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["SHA-pinned action reference\ne.g. aws-actions/…@77954e2…"] --> B{"Version comment"}
    B -- "Before (floating major)" --> C["# v1 / # v2 / # v6"]
    B -- "After (exact patch tag)" --> D["# v1.8.4 / # v2.6.1 / # v6.1.1 / # v2.1.0"]
    C -- "Upstream moves floating tag to new SHA" --> E["❌ Comment becomes stale / misleading"]
    D -- "Upstream moves floating tag to new SHA" --> F["✅ Comment still accurately reflects pinned SHA"]
```

<sub>Reviews (1): Last reviewed commit: ["chore(ci): pin action version comments t..."](https://github.com/langfuse/langfuse/commit/a7a414c4ebf852f0d573dfb38c2562536429af72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29157386)</sub>

<!-- /greptile_comment -->