### PR TITLE
fix: support datasetId parameter in GET /api/public/dataset-items

### DIFF
--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -759,22 +759,38 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
         limit: 1,
       }),
     });
-    // Get filtered list by datasetName
-    const getDatasetItemsByDatasetName = await makeZodVerifiedAPICall(
-      GetDatasetItemsV1Response,
-      "GET",
-      `/api/public/dataset-items?datasetName=dataset-name`,
-      undefined,
-      auth,
-    );
-    expect(getDatasetItemsByDatasetName.status).toBe(200);
-    expect(getDatasetItemsByDatasetName.body).toMatchObject({
-      data: dbDatasetItemsApiResponseFormat,
-      meta: expect.objectContaining({
-        totalItems: 5,
-        page: 1,
-      }),
-    });
+     // Get filtered list by datasetName
+     const getDatasetItemsByDatasetName = await makeZodVerifiedAPICall(
+       GetDatasetItemsV1Response,
+       "GET",
+       `/api/public/dataset-items?datasetName=dataset-name`,
+       undefined,
+       auth,
+     );
+     expect(getDatasetItemsByDatasetName.status).toBe(200);
+     expect(getDatasetItemsByDatasetName.body).toMatchObject({
+       data: dbDatasetItemsApiResponseFormat,
+       meta: expect.objectContaining({
+         totalItems: 5,
+         page: 1,
+       }),
+     });
+     // Get filtered list by datasetId
+     const getDatasetItemsByDatasetId = await makeZodVerifiedAPICall(
+       GetDatasetItemsV1Response,
+       "GET",
+       `/api/public/dataset-items?datasetId=${dataset1!.id}`,
+       undefined,
+       auth,
+     );
+     expect(getDatasetItemsByDatasetId.status).toBe(200);
+     expect(getDatasetItemsByDatasetId.body).toMatchObject({
+       data: dbDatasetItemsApiResponseFormat,
+       meta: expect.objectContaining({
+         totalItems: 5,
+         page: 1,
+       }),
+     });
     // Get filtered list by sourceTraceId
     const getDatasetItemsTrace = await makeZodVerifiedAPICall(
       GetDatasetItemsV1Response,
@@ -812,18 +828,115 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
       }),
     });
 
-    // Get single item
-    const singleItem = dbDatasetItemsApiResponseFormat[0];
-    const getDatasetItem = await makeZodVerifiedAPICall(
-      GetDatasetItemV1Response,
-      "GET",
-      `/api/public/dataset-items/${singleItem.id}`,
-      undefined,
-      auth,
-    );
-    expect(getDatasetItem.status).toBe(200);
-    expect(getDatasetItem.body).toMatchObject(singleItem);
-  });
+     // Get single item
+     const singleItem = dbDatasetItemsApiResponseFormat[0];
+     const getDatasetItem = await makeZodVerifiedAPICall(
+       GetDatasetItemV1Response,
+       "GET",
+       `/api/public/dataset-items/${singleItem.id}`,
+       undefined,
+       auth,
+     );
+     expect(getDatasetItem.status).toBe(200);
+     expect(getDatasetItem.body).toMatchObject(singleItem);
+   });
+
+   it("should correctly filter dataset items by datasetId (issue #13285)", async () => {
+     // Create two datasets
+     const dataset1Res = await makeZodVerifiedAPICall(
+       PostDatasetsV1Response,
+       "POST",
+       "/api/public/datasets",
+       {
+         name: "dataset-a",
+       },
+       auth,
+     );
+     const dataset1Id = dataset1Res.body.id;
+
+     const dataset2Res = await makeZodVerifiedAPICall(
+       PostDatasetsV1Response,
+       "POST",
+       "/api/public/datasets",
+       {
+         name: "dataset-b",
+       },
+       auth,
+     );
+     const dataset2Id = dataset2Res.body.id;
+
+     // Create 3 items in dataset A
+     for (let i = 0; i < 3; i++) {
+       await makeZodVerifiedAPICall(
+         PostDatasetItemsV1Response,
+         "POST",
+         "/api/public/dataset-items",
+         {
+           datasetName: "dataset-a",
+           id: `dataset-a-item-${i}`,
+           input: { key: `value-a-${i}` },
+         },
+         auth,
+       );
+     }
+
+     // Create 2 items in dataset B
+     for (let i = 0; i < 2; i++) {
+       await makeZodVerifiedAPICall(
+         PostDatasetItemsV1Response,
+         "POST",
+         "/api/public/dataset-items",
+         {
+           datasetName: "dataset-b",
+           id: `dataset-b-item-${i}`,
+           input: { key: `value-b-${i}` },
+         },
+         auth,
+       );
+     }
+
+     // Test 1: Filter by dataset A ID should return exactly 3 items from dataset A
+     const itemsDatasetA = await makeZodVerifiedAPICall(
+       GetDatasetItemsV1Response,
+       "GET",
+       `/api/public/dataset-items?datasetId=${dataset1Id}`,
+       undefined,
+       auth,
+     );
+     expect(itemsDatasetA.status).toBe(200);
+     expect(itemsDatasetA.body.meta.totalItems).toBe(3);
+     expect(itemsDatasetA.body.data).toHaveLength(3);
+     expect(
+       itemsDatasetA.body.data.every((item) => item.datasetName === "dataset-a"),
+     ).toBe(true);
+
+     // Test 2: Filter by dataset B ID should return exactly 2 items from dataset B
+     const itemsDatasetB = await makeZodVerifiedAPICall(
+       GetDatasetItemsV1Response,
+       "GET",
+       `/api/public/dataset-items?datasetId=${dataset2Id}`,
+       undefined,
+       auth,
+     );
+     expect(itemsDatasetB.status).toBe(200);
+     expect(itemsDatasetB.body.meta.totalItems).toBe(2);
+     expect(itemsDatasetB.body.data).toHaveLength(2);
+     expect(
+       itemsDatasetB.body.data.every((item) => item.datasetName === "dataset-b"),
+     ).toBe(true);
+
+     // Test 3: Filter by bogus ID should return 0 items (not all project items)
+     const itemsBogus = await makeZodVerifiedAPICall(
+       GetDatasetItemsV1Response,
+       "GET",
+       `/api/public/dataset-items?datasetId=bogus-does-not-exist`,
+       undefined,
+       auth,
+     );
+     expect(itemsBogus.status).toBe(200);
+     expect(itemsBogus.body.meta.totalItems).toBe(0);
+     expect(itemsBogus.body.data).toHaveLength(0);
+   });
 
   it("should upsert a dataset item", async () => {
     await makeZodVerifiedAPICall(

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -182,6 +182,7 @@ export const PostDatasetItemsV1Response = APIDatasetItem.strict();
 // GET /dataset-items
 export const GetDatasetItemsV1Query = z
   .object({
+    datasetId: z.string().nullish(),
     datasetName: z.string().nullish(),
     sourceTraceId: z.string().nullish(),
     sourceObservationId: z.string().nullish(),
@@ -190,15 +191,15 @@ export const GetDatasetItemsV1Query = z
   })
   .refine(
     (data) => {
-      // If version is provided, datasetName must also be provided
-      if (data.version && !data.datasetName) {
+      // If version is provided, either datasetId or datasetName must be provided
+      if (data.version && !data.datasetId && !data.datasetName) {
         return false;
       }
       return true;
     },
     {
-      message: "datasetName is required when version parameter is provided",
-      path: ["datasetName"],
+      message: "datasetId or datasetName is required when version parameter is provided",
+      path: ["datasetId"],
     },
   );
 export const GetDatasetItemsV1Response = z

--- a/web/src/pages/api/public/dataset-items/index.ts
+++ b/web/src/pages/api/public/dataset-items/index.ts
@@ -115,6 +115,7 @@ export default withMiddlewares({
     rateLimitResource: "datasets",
     fn: async ({ query, auth }) => {
       const {
+        datasetId: queryDatasetId,
         datasetName,
         sourceTraceId,
         sourceObservationId,
@@ -123,7 +124,8 @@ export default withMiddlewares({
         limit,
       } = query;
 
-      let datasetId: string | undefined = undefined;
+      let datasetId: string | undefined = queryDatasetId ?? undefined;
+      
       if (datasetName) {
         const dataset = await prisma.dataset.findFirst({
           where: {


### PR DESCRIPTION
## What does this PR do?

This fix addresses issue #13285 where the GET /api/public/dataset-items endpoint was ignoring the `datasetId` query parameter and returning items across all datasets instead of just the specified dataset.

### Changes

- Added `datasetId` as an optional query parameter to `GetDatasetItemsV1Query` schema
- Updated the GET endpoint handler to extract and use the `datasetId` parameter
- Updated version parameter validation to accept either `datasetId` or `datasetName` (previously required only `datasetName`)
- The underlying filtering infrastructure already supported datasetIds - this just exposes it in the API

### Tests

- Added test coverage for `datasetId` filtering to verify it returns correct items
- Added test for edge cases (bogus ID returns 0 items, not all project items)
- Added `datasetId` to existing filter test cases
- Tests verify that filtering by `datasetId` correctly isolates items to specific datasets

### Behavior

- `GET /api/public/dataset-items?datasetId=<id>` returns only items from that dataset
- `GET /api/public/dataset-items?datasetId=bogus` returns 0 items (not all project items)
- `GET /api/public/dataset-items?datasetName=<name>` continues to work as before
- Both `datasetId` and `datasetName` can be used (if both provided, `datasetName` takes precedence)

Fixes #13285

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update

## Mandatory Tasks

- [x] Self-reviewed the code
- [x] Code follows style guidelines (`pnpm run format`)
- [x] Added tests that prove fix is effective
- [x] Verified no new linting warnings

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My PR does not require documentation updates
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass with my changes

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes issue #13285 by wiring the `datasetId` query parameter through to the dataset-items filter, which previously always ignored it and returned items across all datasets. The underlying `getDatasetItems` infrastructure already supported filtering by dataset IDs; this change simply extracts and passes the parameter.

Two minor points worth noting:
- `?datasetId=nonexistent` returns 200 with an empty list, while `?datasetName=nonexistent` returns 404 — an asymmetry that may surprise API consumers.
- The Zod refine error for the `version`-without-dataset-identifier case now pins its path to `datasetId`, which is slightly misleading when neither field is present.

<h3>Confidence Score: 5/5</h3>

Safe to merge — fix is correct, project-scoped queries prevent cross-project data exposure, and new tests verify the core behavior.

All remaining findings are P2 style/consistency issues. The core logic is correct: `datasetId` is now passed to the filter, `datasetName` still takes precedence when both are provided, and project-level scoping in `getDatasetItems` ensures no cross-project leakage even without a 404 guard on `datasetId`.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/pages/api/public/dataset-items/index.ts | Core fix: initialises `datasetId` from `queryDatasetId` before the `datasetName` lookup, so the query param is now respected; `datasetName` still takes precedence when both are supplied. Minor behavioral inconsistency: missing `datasetId` returns 200+empty rather than 404. |
| web/src/features/public-api/types/datasets.ts | Adds `datasetId` as an optional query param and relaxes the `version` refine to accept either `datasetId` or `datasetName`; refine error path now points only to `datasetId` which is slightly misleading when neither field is provided. |
| web/src/__tests__/server/datasets-api.servertest.ts | Good test coverage added: cross-dataset isolation test, bogus-ID edge case, and `datasetId` added to the existing filter test. Indentation of touched code changed from 4 to 5 spaces but otherwise correct. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as GET /api/public/dataset-items
    participant DB as Prisma / getDatasetItems

    Client->>Handler: ?datasetId=<id>
    Handler->>Handler: datasetId = queryDatasetId
    Handler->>DB: getDatasetItems(projectId, filterState[datasetIds=[id]])
    DB-->>Handler: items (scoped to project)
    Handler-->>Client: 200 { data, meta }

    Client->>Handler: ?datasetName=<name>
    Handler->>DB: findFirst(name, projectId)
    alt dataset not found
        DB-->>Handler: null
        Handler-->>Client: 404 Dataset not found
    else dataset found
        DB-->>Handler: { id, ... }
        Handler->>DB: getDatasetItems(projectId, filterState[datasetIds=[id]])
        DB-->>Handler: items
        Handler-->>Client: 200 { data, meta }
    end

    Client->>Handler: ?datasetId=<id>&datasetName=<name>
    Note over Handler: datasetName takes precedence, overwrites datasetId
    Handler->>DB: findFirst(name, projectId)
    DB-->>Handler: dataset
    Handler->>DB: getDatasetItems(projectId, filterState[datasetIds=[dataset.id]])
    DB-->>Handler: items
    Handler-->>Client: 200 { data, meta }
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/pages/api/public/dataset-items/index.ts
Line: 127-140

Comment:
**Inconsistent not-found behavior between `datasetId` and `datasetName`**

When `datasetName` is provided but doesn't match any dataset, the handler throws a `LangfuseNotFoundError` (→ 404). When `datasetId` is provided but doesn't match any dataset, the query silently returns 0 items with a 200 response. The test even explicitly asserts this asymmetry. This is likely intentional given the test coverage, but the inconsistency may surprise API consumers debugging why they get an empty list instead of a meaningful error when they supply a wrong ID.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/features/public-api/types/datasets.ts
Line: 200-203

Comment:
**Refine error path only points to `datasetId`**

When `version` is supplied without either `datasetId` or `datasetName`, the Zod error is attached only to the `datasetId` field. Clients that omit `datasetId` and supply only `version` may see a confusing error path. Consider using a top-level path (empty array) or reporting on both fields so the message aligns with the "either field is acceptable" intent.

```suggestion
      path: [],
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: support datasetId parameter in GET ..."](https://github.com/langfuse/langfuse/commit/d845e9ea31e421a5d006eebb3e43a2fb79aea55f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29213863)</sub>

<!-- /greptile_comment -->