### PR TITLE
fix(otel): preserve int64 as string in OTLP toObject for spec conformance

### DIFF
--- a/web/src/__tests__/server/otel-int64-serialization.servertest.ts
+++ b/web/src/__tests__/server/otel-int64-serialization.servertest.ts
@@ -1,0 +1,46 @@
+import { $root } from "@/src/pages/api/public/otel/otlp-proto/generated/root";
+
+describe("OTel protobuf int64 serialization", () => {
+  it("toObject with longs:String emits OTLP/JSON conformant strings", () => {
+    const Req =
+      $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+
+    const payload = {
+      resourceSpans: [
+        {
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId: Buffer.alloc(16, 1),
+                  spanId: Buffer.alloc(8, 1),
+                  startTimeUnixNano: 1700000000000000000n,
+                  endTimeUnixNano: 1700000001000000000n,
+                  attributes: [
+                    { key: "answer", value: { intValue: 42 } },
+                  ],
+                  status: {},
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const buf = Req.encode(Req.fromObject(payload)).finish();
+    const decoded = Req.decode(buf);
+    const obj = Req.toObject(decoded, { longs: String });
+
+    const span = obj.resourceSpans[0].scopeSpans[0].spans[0];
+    expect(typeof span.startTimeUnixNano).toBe("string");
+    expect(span.startTimeUnixNano).toBe("1700000000000000000");
+    expect(typeof span.attributes[0].value.intValue).toBe("string");
+    expect(span.attributes[0].value.intValue).toBe("42");
+
+    // Negative regression: must not leak protobufjs Long internals
+    const json = JSON.stringify(obj);
+    expect(json).not.toMatch(/"low":/);
+    expect(json).not.toMatch(/"unsigned":/);
+  });
+});

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -95,6 +95,7 @@ export default withMiddlewares({
           resourceSpans =
             $root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest.toObject(
               parsed,
+              { longs: String },
             ).resourceSpans;
         } catch (e) {
           logger.error(`Failed to parse OTel Protobuf`, e);


### PR DESCRIPTION
## What does this PR do?

> fix(otel): preserve int64 as string in OTLP toObject for spec conformance

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #13295 

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

  ## Summary

  After protobufjs 7.4 → 7.5 (#13232), `.toObject()` without an explicit `longs` option emits int64 fields (timestamps, `intValue`) as protobufjs Long internals (`{low, high, unsigned}`) instead of a number. The internal fallback Long
  class created in 7.5 lacks `toJSON`, so `JSON.stringify` leaks raw enumerable properties into the S3-staged OTLP payload and downstream consumers — most notably the **server-side ingestion masking callback**, which receives a shape
  that violates the OTLP/JSON spec and breaks any consumer that strictly type-checks int64 (e.g. pydantic `int`).

  This passes `{ longs: String }` so int64 is encoded as a decimal string per the OTLP/JSON spec, regardless of how `long.js` resolves at install time or which protobufjs minor is in use.

  ## Reproduction

  ```bash
  docker run --rm --entrypoint sh langfuse/langfuse:3.155.1 -c 'cd /app/web && node -e "
  const pb = require(\"protobufjs\");
  const root = pb.Root.fromJSON({ nested: { T: { fields: { v: { type: \"int64\", id: 1 } } } } });
  const T = root.lookupType(\"T\");
  const dec = T.decode(T.encode({ v: 1234567890 }).finish());
  console.log(JSON.stringify(T.toObject(dec)));
  "'
  # → {"v":1234567890}

  docker run --rm --entrypoint sh langfuse/langfuse:3.169.0 -c 'cd /app && node -e "
  const pb = require(\"/app/node_modules/.pnpm/protobufjs@7.5.5/node_modules/protobufjs\");
  const root = pb.Root.fromJSON({ nested: { T: { fields: { v: { type: \"int64\", id: 1 } } } } });
  const T = root.lookupType(\"T\");
  const dec = T.decode(T.encode({ v: 1234567890 }).finish());
  console.log(JSON.stringify(T.toObject(dec)));
  "'
  # → {"v":{"low":1234567890,"high":0,"unsigned":false}}

  Changes

  - web/src/pages/api/public/otel/v1/traces/index.ts: pass { longs: String } to .toObject().
  - web/src/__tests__/server/otel-int64-serialization.servertest.ts: new unit test asserting OTLP/JSON conformance and that protobufjs Long internals never leak into the serialized output.

  Verification

  - pnpm --filter web run lint
  - pnpm --filter web run test --testPathPatterns="otel-int64-serialization"

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a protobufjs 7.5 regression where `.toObject()` without a `longs` option emitted raw `{low, high, unsigned}` Long internals instead of numeric values, corrupting the OTLP payload. Adding `{ longs: String }` correctly encodes all `int64` fields as decimal strings per the OTLP/JSON spec and is already handled by `convertNanoTimestampToISO` for timestamps.

- **P1**: `OtelIngestionProcessor.convertValueToPlainJavascript` has no branch for `typeof intValue === \"string\"`. Because `\"42\".high` is `undefined` and `undefined !== 0` is truthy, the fallback Long-decomposition branch fires and returns `NaN` for every integer span attribute on protobuf-encoded traffic, silently corrupting stored token counts, status codes, and other int metadata.

<h3>Confidence Score: 4/5</h3>

Not safe to merge without also updating `convertValueToPlainJavascript` to handle string `intValue`; integer span attributes will be silently set to `NaN` for all protobuf-encoded traffic.

The serialization fix is correct and the test is solid, but the PR introduces a P1 regression in the downstream processor that corrupts integer attribute values. The `OtelIngestionProcessor` shared package needs a string-`intValue` branch before this lands.

packages/shared/src/server/otel/OtelIngestionProcessor.ts — `convertValueToPlainJavascript` must handle `typeof value.intValue === "string"` before the Long-object guards.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/pages/api/public/otel/v1/traces/index.ts | Adds `{ longs: String }` to `toObject()` — correct for timestamps and OTLP spec conformance, but produces string `intValue` that the downstream `OtelIngestionProcessor.convertValueToPlainJavascript` doesn't handle, resulting in `NaN` for integer span attributes. |
| web/src/__tests__/server/otel-int64-serialization.servertest.ts | New unit test confirming `toObject({ longs: String })` produces OTLP-conformant strings and no Long internals. Does not cover downstream processor attribute conversion. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as traces/index.ts
    participant Queue as OtelIngestionQueue
    participant Worker as OtelIngestionProcessor

    Client->>API: POST /otel/v1/traces (protobuf)
    API->>API: decode(body)
    API->>API: toObject(parsed, { longs: String })
    Note over API: timestamps → "1700000000000000000"<br/>intValue → "42" (string)
    API->>Queue: publishToOtelIngestionQueue(resourceSpans)
    Queue->>Worker: process resourceSpans (JSON)
    Worker->>Worker: convertNanoTimestampToISO("1700000000000000000") ✅
    Worker->>Worker: convertValueToPlainJavascript({ intValue: "42" })
    Note over Worker: ⚠️ No string branch — hits<br/>Long-decomposition guard → NaN
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/pages/api/public/otel/v1/traces/index.ts
Line: 98-99

Comment:
**`intValue` string not handled in downstream processor**

`{ longs: String }` makes every `int64` field — including attribute `intValue` — a decimal string (e.g. `"42"`). `OtelIngestionProcessor.convertValueToPlainJavascript` (packages/shared/src/server/otel/OtelIngestionProcessor.ts ~L1288) has no branch for `typeof intValue === "string"`. Because `"42".high` is `undefined` and `undefined !== 0` is `true`, the fourth guard fires and returns `undefined * 2^32 + undefined = NaN` for every integer attribute on any protobuf-encoded span.

`NaN` will silently propagate into stored attribute values (token counts, status codes, custom int metadata), corrupting span data for all protobuf-encoded traffic.

A minimal fix in `convertValueToPlainJavascript`:
```
if (value.intValue !== undefined && typeof value.intValue === "string") {
  return Number(value.intValue);
}
```
should be inserted before the Long-object checks.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/__tests__/server/otel-int64-serialization.servertest.ts
Line: 1-46

Comment:
**Test doesn't cover downstream processor conversion**

The test verifies that `toObject({ longs: String })` emits strings and doesn't leak Long internals, which is correct. It does not exercise `OtelIngestionProcessor.convertValueToPlainJavascript`, so it would not catch the `NaN` regression described in the trace handler comment. A companion test that round-trips an int attribute through the processor would prevent a silent re-regression.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): preserve int64 as string in O..."](https://github.com/langfuse/langfuse/commit/dc8782095c3b0cfa292a138d958ff5d79f599e6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29218144)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->