### PR TITLE
fix(web): migrate unstable eval unit tests to vitest

### DIFF
--- a/web/src/__tests__/server/unit/evaluator-preflight.servertest.ts
+++ b/web/src/__tests__/server/unit/evaluator-preflight.servertest.ts
@@ -1,18 +1,13 @@
-/** @jest-environment node */
-
-jest.mock("@langfuse/shared/src/server", () => {
-  const actual = jest.requireActual("@langfuse/shared/src/server");
-  return {
-    ...actual,
-    DefaultEvalModelService: {
-      fetchValidModelConfig: jest.fn(),
-    },
-    logger: {
-      debug: jest.fn(),
-    },
-    testModelCall: jest.fn(),
-  };
-});
+vi.mock("@langfuse/shared/src/server", async () => ({
+  ...(await vi.importActual("@langfuse/shared/src/server")),
+  DefaultEvalModelService: {
+    fetchValidModelConfig: vi.fn(),
+  },
+  logger: {
+    debug: vi.fn(),
+  },
+  testModelCall: vi.fn(),
+}));
 
 import {
   createNumericEvalOutputDefinition,
@@ -30,15 +25,15 @@ const numericOutputDefinition = createNumericEvalOutputDefinition({
 });
 
 describe("evaluator preflight", () => {
-  const mockFetchValidModelConfig = jest.mocked(
+  const mockFetchValidModelConfig = vi.mocked(
     DefaultEvalModelService.fetchValidModelConfig,
   );
-  const mockTestModelCall = jest.mocked(testModelCall);
+  const mockTestModelCall = vi.mocked(testModelCall);
   const originalSkipFlag =
     process.env.LANGFUSE_SKIP_EVALUATOR_MODEL_CALL_VALIDATION;
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    vi.resetAllMocks();
     delete process.env.LANGFUSE_SKIP_EVALUATOR_MODEL_CALL_VALIDATION;
     mockFetchValidModelConfig.mockResolvedValue({
       valid: true,

--- a/web/src/__tests__/server/unit/unstable-evals-contract.servertest.ts
+++ b/web/src/__tests__/server/unit/unstable-evals-contract.servertest.ts
@@ -1,5 +1,3 @@
-/** @jest-environment node */
-
 import {
   createNumericEvalOutputDefinition,
   EvalTargetObject,

--- a/web/src/__tests__/server/unit/unstable-evals-queries.servertest.ts
+++ b/web/src/__tests__/server/unit/unstable-evals-queries.servertest.ts
@@ -1,5 +1,3 @@
-/** @jest-environment node */
-
 import type { Mock } from "vitest";
 
 vi.mock("@langfuse/shared/src/db", () => {

--- a/web/src/__tests__/server/unit/unstable-evals-queries.servertest.ts
+++ b/web/src/__tests__/server/unit/unstable-evals-queries.servertest.ts
@@ -1,6 +1,8 @@
 /** @jest-environment node */
 
-jest.mock("@langfuse/shared/src/db", () => {
+import type { Mock } from "vitest";
+
+vi.mock("@langfuse/shared/src/db", () => {
   return {
     Prisma: {
       sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
@@ -9,14 +11,14 @@ jest.mock("@langfuse/shared/src/db", () => {
       }),
     },
     prisma: {
-      $queryRaw: jest.fn(),
+      $queryRaw: vi.fn(),
       evalTemplate: {
-        findMany: jest.fn(),
-        findFirst: jest.fn(),
+        findMany: vi.fn(),
+        findFirst: vi.fn(),
       },
       jobConfiguration: {
-        count: jest.fn(),
-        groupBy: jest.fn(),
+        count: vi.fn(),
+        groupBy: vi.fn(),
       },
     },
   };
@@ -30,16 +32,15 @@ import {
   listPublicEvaluatorTemplates,
 } from "@/src/features/evals/server/unstable-public-api/queries";
 
-const mockQueryRaw = prisma.$queryRaw as jest.Mock;
-const mockEvalTemplateFindMany = prisma.evalTemplate.findMany as jest.Mock;
-const mockEvalTemplateFindFirst = prisma.evalTemplate.findFirst as jest.Mock;
-const mockJobConfigurationCount = prisma.jobConfiguration.count as jest.Mock;
-const mockJobConfigurationGroupBy = prisma.jobConfiguration
-  .groupBy as jest.Mock;
+const mockQueryRaw = prisma.$queryRaw as Mock;
+const mockEvalTemplateFindMany = prisma.evalTemplate.findMany as Mock;
+const mockEvalTemplateFindFirst = prisma.evalTemplate.findFirst as Mock;
+const mockJobConfigurationCount = prisma.jobConfiguration.count as Mock;
+const mockJobConfigurationGroupBy = prisma.jobConfiguration.groupBy as Mock;
 
 describe("unstable public eval queries", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it("paginates latest evaluator versions per family before loading exact templates", async () => {

--- a/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
+++ b/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
@@ -1,5 +1,3 @@
-/** @jest-environment node */
-
 import type { Mock } from "vitest";
 
 const mockEvalTemplateCreate = vi.fn();

--- a/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
+++ b/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
@@ -1,48 +1,50 @@
 /** @jest-environment node */
 
-const mockEvalTemplateCreate = jest.fn();
-const mockEvalTemplateFindMany = jest.fn();
-const mockJobConfigurationFindMany = jest.fn();
-const mockJobConfigurationUpdate = jest.fn();
+import type { Mock } from "vitest";
 
-jest.mock(
+const mockEvalTemplateCreate = vi.fn();
+const mockEvalTemplateFindMany = vi.fn();
+const mockJobConfigurationFindMany = vi.fn();
+const mockJobConfigurationUpdate = vi.fn();
+
+vi.mock(
   "../../../features/evals/server/unstable-public-api/validation",
-  () => {
-    const actual = jest.requireActual(
+  async () => {
+    const actual = await vi.importActual(
       "../../../features/evals/server/unstable-public-api/validation",
     );
 
     return {
       ...actual,
-      assertEvaluatorDefinitionCanRunForPublicApi: jest.fn(),
+      assertEvaluatorDefinitionCanRunForPublicApi: vi.fn(),
     };
   },
 );
 
-jest.mock("../../../features/evals/server/unstable-public-api/queries", () => ({
-  countActiveEvaluationRules: jest.fn(),
-  findPublicEvaluatorTemplateOrThrow: jest.fn(),
-  countEvaluationRulesForEvaluator: jest.fn(),
-  countEvaluationRulesForEvaluatorIds: jest.fn(),
-  listPublicEvaluatorTemplates: jest.fn(),
-  loadEvaluatorForEvaluationRule: jest.fn(),
-  findPublicEvaluationRuleOrThrow: jest.fn(),
+vi.mock("../../../features/evals/server/unstable-public-api/queries", () => ({
+  countActiveEvaluationRules: vi.fn(),
+  findPublicEvaluatorTemplateOrThrow: vi.fn(),
+  countEvaluationRulesForEvaluator: vi.fn(),
+  countEvaluationRulesForEvaluatorIds: vi.fn(),
+  listPublicEvaluatorTemplates: vi.fn(),
+  loadEvaluatorForEvaluationRule: vi.fn(),
+  findPublicEvaluationRuleOrThrow: vi.fn(),
 }));
 
-jest.mock("@langfuse/shared/src/server", () => ({
-  ...jest.requireActual("@langfuse/shared/src/server"),
-  invalidateProjectEvalConfigCaches: jest.fn(),
+vi.mock("@langfuse/shared/src/server", async () => ({
+  ...(await vi.importActual("@langfuse/shared/src/server")),
+  invalidateProjectEvalConfigCaches: vi.fn(),
   ClickHouseClientManager: {
     getInstance: () => ({
-      closeAllConnections: jest.fn().mockResolvedValue(undefined),
+      closeAllConnections: vi.fn().mockResolvedValue(undefined),
     }),
   },
   logger: {
-    debug: jest.fn(),
+    debug: vi.fn(),
   },
 }));
 
-jest.mock("@langfuse/shared/src/db", () => ({
+vi.mock("@langfuse/shared/src/db", () => ({
   Prisma: {
     PrismaClientKnownRequestError: class PrismaClientKnownRequestError extends Error {
       code: string;
@@ -65,14 +67,14 @@ jest.mock("@langfuse/shared/src/db", () => ({
     },
   },
   prisma: {
-    $transaction: jest.fn(),
+    $transaction: vi.fn(),
     dataset: {
-      findMany: jest.fn(),
+      findMany: vi.fn(),
     },
     jobConfiguration: {
-      findFirst: jest.fn(),
-      create: jest.fn(),
-      update: jest.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
     },
   },
 }));
@@ -130,29 +132,29 @@ const managedTemplate = {
 };
 
 const mockedPrisma = prisma as unknown as {
-  $transaction: jest.Mock;
+  $transaction: Mock;
   dataset: {
-    findMany: jest.Mock;
+    findMany: Mock;
   };
   jobConfiguration: {
-    findFirst: jest.Mock;
-    create: jest.Mock;
-    update: jest.Mock;
+    findFirst: Mock;
+    create: Mock;
+    update: Mock;
   };
 };
-const mockAssertEvaluatorDefinitionCanRunForPublicApi = jest.mocked(
+const mockAssertEvaluatorDefinitionCanRunForPublicApi = vi.mocked(
   validationModule.assertEvaluatorDefinitionCanRunForPublicApi,
 );
-const mockLoadEvaluatorForEvaluationRule = jest.mocked(
+const mockLoadEvaluatorForEvaluationRule = vi.mocked(
   queryModule.loadEvaluatorForEvaluationRule,
 );
-const mockCountActiveEvaluationRules = jest.mocked(
+const mockCountActiveEvaluationRules = vi.mocked(
   queryModule.countActiveEvaluationRules,
 );
-const mockFindPublicEvaluationRuleOrThrow = jest.mocked(
+const mockFindPublicEvaluationRuleOrThrow = vi.mocked(
   queryModule.findPublicEvaluationRuleOrThrow,
 );
-const mockCountEvaluationRulesForEvaluator = jest.mocked(
+const mockCountEvaluationRulesForEvaluator = vi.mocked(
   queryModule.countEvaluationRulesForEvaluator,
 );
 
@@ -190,7 +192,7 @@ const createEvaluationRuleRecord = (overrides?: Record<string, unknown>) =>
 
 describe("unstable public eval services", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     mockCountActiveEvaluationRules.mockResolvedValue(0);
     mockCountEvaluationRulesForEvaluator.mockResolvedValue(0);
     mockedPrisma.dataset.findMany.mockResolvedValue([]);

--- a/web/src/__tests__/server/unstable-evals-api.servertest.ts
+++ b/web/src/__tests__/server/unstable-evals-api.servertest.ts
@@ -1,5 +1,3 @@
-/** @jest-environment node */
-
 import {
   makeAPICall,
   makeZodVerifiedAPICall,


### PR DESCRIPTION
## Summary
- migrate the unstable eval query/service unit suites from Jest APIs to Vitest APIs
- replace `jest.mock`, `jest.fn`, `jest.mocked`, and `jest.Mock` with the Vitest equivalents
- keep the unstable eval tests aligned with the test framework now used by `web`

## Verification
- `pnpm --filter web run lint`

## Local blockers
- `vitest run` is blocked on this machine by the signed native Rollup binary failing to load (`@rollup/rollup-darwin-arm64`)
- `pnpm --filter web run typecheck` currently fails on an unrelated `next-auth` adapter type mismatch in `web/src/server/auth.ts`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR completes the migration of the unstable eval unit test suites from Jest to Vitest, replacing all `jest.mock`, `jest.fn`, `jest.mocked`, and `jest.Mock` references with their `vi.*` equivalents. The migration is mechanically correct. The only leftover artefact is the `/** @jest-environment node */` JSDoc comment on line 1 of both files — it is a Jest-only directive that Vitest silently ignores, and should be replaced with `// @vitest-environment node` or removed.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are cosmetic cleanup from the Jest→Vitest migration.

All Jest APIs have been correctly replaced with Vitest equivalents; mock hoisting, `vi.importActual` usage, and type imports are all idiomatic. The only open items are two P2 stale JSDoc comments that have no runtime impact.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/__tests__/server/unit/unstable-evals-queries.servertest.ts | Jest APIs fully replaced with Vitest equivalents (`vi.mock`, `vi.fn`, `Mock` type); one stale `/** @jest-environment node */` docblock remains. |
| web/src/__tests__/server/unit/unstable-evals-service.servertest.ts | Jest APIs fully replaced with Vitest equivalents including `vi.mocked`, `vi.importActual`, and `vi.fn`; one stale `/** @jest-environment node */` docblock remains. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Test file loads] --> B{vi.mock hoisting}
    B --> C[Mock: @langfuse/shared/src/db\nprisma, Prisma]
    B --> D[Mock: queries module\ncountActive, findTemplate, etc.]
    B --> E[Mock: @langfuse/shared/src/server\ninvalidateCache, logger, CH]
    B --> F[Mock: validation module\nassertEvaluatorDefinitionCanRun]
    C & D & E & F --> G[Imports resolved\nwith mock substitutions]
    G --> H[beforeEach: vi.clearAllMocks\n+ default mock return values]
    H --> I[Individual test cases\nset per-test mock returns]
    I --> J[Call SUT: queries or services]
    J --> K[Assert mock interactions\n+ return values]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/__tests__/server/unit/unstable-evals-queries.servertest.ts
Line: 1

Comment:
**Stale Jest docblock after migration**

`/** @jest-environment node */` is a Jest-specific test-environment directive; Vitest does not recognise it and silently ignores it. If an explicit node environment is needed, Vitest expects `// @vitest-environment node` at the top of the file. Otherwise this comment is dead noise left from the pre-migration state.

```suggestion
// @vitest-environment node
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
Line: 1

Comment:
**Stale Jest docblock after migration**

Same issue as the queries file: `/** @jest-environment node */` is a Jest-only directive that Vitest ignores. Replace it with the Vitest equivalent or remove it if the default Vitest environment is already `node`.

```suggestion
// @vitest-environment node
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): migrate unstable eval unit tes..."](https://github.com/langfuse/langfuse/commit/9c8f5be125696cdd0abe061a52cc966ca969c60d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29248956)</sub>

<!-- /greptile_comment -->