### PR TITLE
fix(widgets): handle pivot table legacy sorting

### DIFF
--- a/web/src/features/widgets/components/DashboardWidget.tsx
+++ b/web/src/features/widgets/components/DashboardWidget.tsx
@@ -23,6 +23,7 @@ import { DownloadButton } from "@/src/features/widgets/chart-library/DownloadBut
 import {
   formatMetricName,
   shouldUseWidgetSSE,
+  sanitizePivotTableDefaultSort,
 } from "@/src/features/widgets/utils";
 import { ChartLoadingState } from "@/src/features/widgets/chart-library/ChartLoadingState";
 import {
@@ -101,7 +102,10 @@ export function DashboardWidget({
   // Initialize sort state for pivot tables
   const defaultSort =
     widget.data?.chartConfig.type === "PIVOT_TABLE"
-      ? widget.data?.chartConfig.defaultSort
+      ? sanitizePivotTableDefaultSort(widget.data.chartConfig.defaultSort, {
+          dimensions: widget.data.dimensions,
+          metrics: widget.data.metrics,
+        })
       : undefined;
 
   const [sortState, setSortState] = useState<OrderByState | null>(() => {
@@ -437,6 +441,7 @@ export function DashboardWidget({
                   metrics: widget.data.metrics.map(
                     (metric) => `${metric.agg}_${metric.measure}`,
                   ),
+                  defaultSort,
                 }),
               }}
               sortState={

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -71,6 +71,7 @@ import {
   buildWidgetName,
   buildWidgetDescription,
   formatMetricName,
+  sanitizePivotTableDefaultSort,
 } from "@/src/features/widgets/utils";
 import {
   MAX_PIVOT_TABLE_DIMENSIONS,
@@ -364,6 +365,22 @@ export function WidgetForm({
   const [selectedChartType, setSelectedChartType] = useState<string>(
     initialValues.chartType,
   );
+  const initialDefaultSort =
+    initialValues.chartType === "PIVOT_TABLE"
+      ? sanitizePivotTableDefaultSort(initialValues.chartConfig?.defaultSort, {
+          dimensions: initialValues.dimensions ?? [],
+          metrics:
+            initialValues.metrics ??
+            (initialValues.measure && initialValues.aggregation
+              ? [
+                  {
+                    measure: initialValues.measure,
+                    agg: initialValues.aggregation,
+                  },
+                ]
+              : []),
+        })
+      : undefined;
   const [rowLimit, setRowLimit] = useState<number>(
     initialValues.chartConfig?.row_limit ?? 100,
   );
@@ -373,10 +390,10 @@ export function WidgetForm({
 
   // Default sort configuration for pivot tables
   const [defaultSortColumn, setDefaultSortColumn] = useState<string>(
-    initialValues.chartConfig?.defaultSort?.column ?? "none",
+    initialDefaultSort?.column ?? "none",
   );
   const [defaultSortOrder, setDefaultSortOrder] = useState<"ASC" | "DESC">(
-    initialValues.chartConfig?.defaultSort?.order ?? "DESC",
+    initialDefaultSort?.order ?? "DESC",
   );
 
   // Filter state
@@ -473,6 +490,43 @@ export function WidgetForm({
         : null,
     [selectedChartType, defaultSortColumn, defaultSortOrder],
   );
+
+  useEffect(() => {
+    if (selectedChartType !== "PIVOT_TABLE") return;
+
+    // Old widgets can carry persisted default sort keys for metrics or
+    // dimensions that are no longer part of the pivot query. Clear those stale
+    // sort columns so preview/save do not send invalid orderBy fields.
+    const sanitizedDefaultSort = sanitizePivotTableDefaultSort(
+      defaultSortColumn !== "none"
+        ? { column: defaultSortColumn, order: defaultSortOrder }
+        : undefined,
+      {
+        dimensions: pivotDimensions
+          .filter((field) => field && field !== "none")
+          .map((field) => ({ field })),
+        metrics: selectedMetrics
+          .filter((metric) => metric.measure && metric.measure !== "")
+          .map((metric) => ({
+            measure: metric.measure,
+            agg: metric.aggregation,
+          })),
+      },
+    );
+
+    if (defaultSortColumn !== "none" && !sanitizedDefaultSort) {
+      setDefaultSortColumn("none");
+      setDefaultSortOrder("DESC");
+    }
+  }, [
+    defaultSortColumn,
+    defaultSortOrder,
+    pivotDimensions,
+    selectedMetrics,
+    selectedChartType,
+    setDefaultSortColumn,
+    setDefaultSortOrder,
+  ]);
 
   // Helper function to update pivot table dimensions
   const updatePivotDimension = (index: number, value: string) => {

--- a/web/src/features/widgets/utils.ts
+++ b/web/src/features/widgets/utils.ts
@@ -13,6 +13,43 @@ export type WidgetChartConfig = {
   };
 };
 
+type PivotSortMetric = {
+  measure: string;
+  agg: string;
+};
+
+type PivotSortDimension = {
+  field: string;
+};
+
+type PivotDefaultSort = NonNullable<WidgetChartConfig["defaultSort"]>;
+
+/**
+ * Old widgets can retain stale pivot defaultSort fields after metrics or
+ * dimensions change. Ignore those persisted sort keys instead of letting them
+ * reach QueryBuilder as invalid orderBy columns.
+ */
+export function sanitizePivotTableDefaultSort(
+  defaultSort: WidgetChartConfig["defaultSort"] | undefined,
+  params: {
+    dimensions: PivotSortDimension[];
+    metrics: PivotSortMetric[];
+  },
+): PivotDefaultSort | undefined {
+  if (!defaultSort) {
+    return undefined;
+  }
+
+  const validDimensionSort = params.dimensions.some(
+    (dimension) => dimension.field === defaultSort.column,
+  );
+  const validMetricSort = params.metrics.some(
+    (metric) => `${metric.agg}_${metric.measure}` === defaultSort.column,
+  );
+
+  return validDimensionSort || validMetricSort ? defaultSort : undefined;
+}
+
 /**
  * Formats a metric name for display, handling special cases like count_count -> Count
  */


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a legacy-compatibility bug where saved pivot-table widgets could have a `defaultSort.column` referencing a dimension or metric that no longer exists in the query, causing an invalid `orderBy` to reach the QueryBuilder. The fix introduces `sanitizePivotTableDefaultSort` in `utils.ts` and applies it in both `DashboardWidget` (at render) and `WidgetForm` (at form init and via a `useEffect` that reacts to dimension/metric changes).

<h3>Confidence Score: 5/5</h3>

Safe to merge; the fix correctly nullifies stale pivot sort columns without introducing loops or regressions.

All findings are P2 style suggestions (unnecessary stable setter refs in useEffect deps). The core sanitization logic is sound, no infinite-loop risk exists in either component, and TypeScript types align across call sites.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/widgets/utils.ts | Adds sanitizePivotTableDefaultSort utility — validates sort column against current dimensions (by field) and metrics (by agg_measure key); returns undefined for stale columns. Logic is correct and well-typed. |
| web/src/features/widgets/components/DashboardWidget.tsx | Applies sanitizePivotTableDefaultSort to defaultSort at render time and passes the sanitized value into the chart's chartConfig spread, replacing the raw persisted value. No loop risk; existing useEffect guards against repeated setSortState calls. |
| web/src/features/widgets/components/WidgetForm.tsx | Sanitizes legacy defaultSort on form init (initialDefaultSort) and adds a useEffect to clear a stale sort column whenever dimensions/metrics change; no infinite-loop risk. Minor: stable state-setter refs in dep array are unnecessary. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Widget Loads / Form Opens] --> B{Chart type == PIVOT_TABLE?}
    B -- No --> C[defaultSort = undefined]
    B -- Yes --> D[sanitizePivotTableDefaultSort\ndefaultSort, dimensions, metrics]
    D --> E{column matches a current\ndimension or metric?}
    E -- Yes --> F[Return defaultSort unchanged]
    E -- No --> G[Return undefined\nstale sort cleared]
    F --> H[Pass sanitized defaultSort\nto chartConfig + sortState]
    G --> H
    H --> I[PivotTable renders with\nvalid or no sort]

    J[WidgetForm: user changes\ndimensions / metrics] --> K[useEffect fires]
    K --> L[sanitizePivotTableDefaultSort\nwith new dimensions/metrics]
    L --> M{current column still valid?}
    M -- Yes --> N[No state change]
    M -- No --> O[Reset defaultSortColumn to 'none'\ndefaultSortOrder to 'DESC']
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/features/widgets/components/WidgetForm.tsx
Line: 521-528

Comment:
**Unnecessary stable setter refs in dep array**

`setDefaultSortColumn` and `setDefaultSortOrder` are React state-setter functions whose references are guaranteed to be stable across renders; they never actually change and do not need to be listed as `useEffect` dependencies. Keeping them adds noise and can mislead readers into thinking these setters could change.

```suggestion
  }, [
    defaultSortColumn,
    defaultSortOrder,
    pivotDimensions,
    selectedMetrics,
    selectedChartType,
  ]);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(widgets): handle pivot table legacy ..."](https://github.com/langfuse/langfuse/commit/e43a5d329ccdb96b15fb563a4523082a73dfb1a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29270145)</sub>

<!-- /greptile_comment -->