### PR TITLE
chore: add ingestion_size_stats table and MVs to dev-tables

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -457,6 +457,52 @@ SELECT
     is_deleted
 FROM events_full;
 
+-- Diagnostic table to track event size distributions across projects.
+-- Every insert (including updates) produces a row — no deduplication.
+-- See LFE-9402 for context.
+CREATE TABLE IF NOT EXISTS ingestion_size_stats (
+    project_id String,
+    trace_id String,
+    span_id String,
+    created_at DateTime64(3),
+    input_size UInt64,
+    output_size UInt64,
+    metadata_size UInt64,
+    total_size UInt64
+) ENGINE = MergeTree
+PRIMARY KEY (toStartOfHour(created_at), project_id)
+ORDER BY (toStartOfHour(created_at), project_id, trace_id, span_id, created_at);
+
+-- MV: observations -> ingestion_size_stats
+CREATE MATERIALIZED VIEW IF NOT EXISTS ingestion_size_stats_observations_mv
+TO ingestion_size_stats AS
+SELECT
+    project_id,
+    trace_id,
+    id AS span_id,
+    created_at,
+    length(coalesce(input, '')) AS input_size,
+    length(coalesce(output, '')) AS output_size,
+    arraySum(arrayMap(k -> length(k), mapKeys(metadata)))
+      + arraySum(arrayMap(v -> length(v), mapValues(metadata))) AS metadata_size,
+    byteSize(*) AS total_size
+FROM observations;
+
+-- MV: traces -> ingestion_size_stats
+CREATE MATERIALIZED VIEW IF NOT EXISTS ingestion_size_stats_traces_mv
+TO ingestion_size_stats AS
+SELECT
+    project_id,
+    id AS trace_id,
+    concat('t-', id) AS span_id,
+    created_at,
+    length(coalesce(input, '')) AS input_size,
+    length(coalesce(output, '')) AS output_size,
+    arraySum(arrayMap(k -> length(k), mapKeys(metadata)))
+      + arraySum(arrayMap(v -> length(v), mapValues(metadata))) AS metadata_size,
+    byteSize(*) AS total_size
+FROM traces;
+
 CREATE VIEW analytics_events_core AS
 SELECT
   project_id,


### PR DESCRIPTION
Track event size distributions across projects via a MergeTree table fed by two materialized views (one from traces, one from observations). Every insert including updates gets its own row for full ingestion visibility.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Adds an `ingestion_size_stats` MergeTree table and two materialized views (from `observations` and `traces`) to the dev-tables script, recording per-insert size metrics (input, output, metadata, and full row) for ingestion diagnostics without deduplication. The schema and sort key are sensible; both P2 findings (misleading `total_size` semantics and missing TTL on an append-only table) are worth addressing before promoting this to production.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/quality suggestions with no blocking correctness issues.

Both comments are non-blocking: the `total_size` naming is a potential source of confusion but doesn't break functionality, and the missing TTL is acceptable for a dev-only diagnostic table. No logic errors, schema incompatibilities, or security concerns found.

No files require special attention for merge.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/clickhouse/scripts/dev-tables.sh | Adds `ingestion_size_stats` MergeTree table and two MVs (one for `observations`, one for `traces`). Two P2 concerns: `total_size` computed via `byteSize(*)` includes all source columns rather than just the three tracked size fields (misleading naming), and the append-only table has no TTL. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    OBS[observations table] -->|INSERT / UPDATE| MV1[ingestion_size_stats_observations_mv]
    TRC[traces table] -->|INSERT / UPDATE| MV2[ingestion_size_stats_traces_mv]
    MV1 --> ISS[ingestion_size_stats MergeTree]
    MV2 --> ISS
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/shared/clickhouse/scripts/dev-tables.sh
Line: 488-489

Comment:
**`total_size` semantics differ from other `*_size` columns**

`byteSize(*)` expands to all columns of the `observations` source table (model parameters, usage details, tool definitions, etc.), so `total_size` will be significantly larger than `input_size + output_size + metadata_size`. A reader querying the table would reasonably expect `total_size` to represent the sum of those three breakdowns. Consider either renaming it (e.g., `row_size` or `full_row_size`) to signal it's the entire ingested row, or computing it explicitly as the sum of the three size fields.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/shared/clickhouse/scripts/dev-tables.sh
Line: 463-474

Comment:
**No TTL on an append-only diagnostic table**

The comment explicitly states "every insert including updates produces a row — no deduplication." Without a TTL, the table will grow unboundedly. For a dev/diagnostic table tracking high-frequency ingestion events, even a generous TTL (e.g., 30 or 90 days) would prevent unbounded storage growth:

```sql
TTL toDateTime(created_at) + INTERVAL 90 DAY
SETTINGS ttl_only_drop_parts = 1;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add ingestion\_size\_stats table an..."](https://github.com/langfuse/langfuse/commit/34e88a68e19c1bb0b54c0e8cd580993ec1a2b81c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29271504)</sub>

<!-- /greptile_comment -->