### PR TITLE
fix(observations): resolve `t-<traceId>` ids on the classic read path

### DIFF
--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -1,6 +1,17 @@
 import z from "zod";
 import { DEFAULT_TRACE_ENVIRONMENT } from "../ingestion/types";
 
+/**
+ * Prefix the ingestion pipeline adds to a trace id when representing the trace
+ * as a synthetic SPAN observation in the events pipeline (see
+ * `convertTraceToStagingObservation`). Read-side lookups of `t-<traceId>` must
+ * resolve against the events table, not the classic observations table.
+ */
+export const TRACE_OBSERVATION_ID_PREFIX = "t-" as const;
+
+export const isTraceObservationId = (id: string): boolean =>
+  id.startsWith(TRACE_OBSERVATION_ID_PREFIX);
+
 export const clickhouseStringDateSchema = z
   .string()
   // clickhouse stores UTC like '2024-05-23 18:33:41.602000'
@@ -385,7 +396,7 @@ export const convertTraceToStagingObservation = (
 ): ObservationBatchStagingRecordInsertType => {
   return {
     // Identity - trace acts as its own span. Modify traceId to avoid cases where users set spanId = traceId.
-    id: `t-${traceRecord.id}`,
+    id: `${TRACE_OBSERVATION_ID_PREFIX}${traceRecord.id}`,
     trace_id: traceRecord.id,
     project_id: traceRecord.project_id,
 

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -668,7 +668,7 @@ export const getTraceIdsForObservationIdsFromEventsTable = async ({
       SELECT
         span_id as id,
         trace_id
-      FROM events_full
+      FROM events_core
       WHERE project_id = {projectId: String}
         AND span_id IN ({observationIds: Array(String)})
       ORDER BY event_ts DESC
@@ -702,7 +702,7 @@ export const checkObservationExistsInEventsTable = async ({
   const rows = await queryClickhouse<{ id: string }>({
     query: `
       SELECT span_id as id
-      FROM events_full
+      FROM events_core
       WHERE project_id = {projectId: String}
         AND span_id = {observationId: String}
         ${startTime ? `AND start_time >= {startTime: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -75,6 +75,7 @@ import { UiColumnMappings } from "../../tableDefinitions";
 import { eventsTableCols } from "../../eventsTable";
 import { tracesTableCols } from "../../tableDefinitions/tracesTable";
 import { parseMetadataCHRecordToDomain } from "../utils/metadata_conversion";
+import { OBSERVATIONS_TO_TRACE_INTERVAL } from "./constants";
 
 type ObservationsTableQueryResultWitouhtTraceFields = Omit<
   ObservationsTableQueryResult,
@@ -649,6 +650,82 @@ export const getObservationByIdFromEventsTable = async ({
     );
   }
   return mapped.shift();
+};
+
+export const getTraceIdsForObservationIdsFromEventsTable = async ({
+  projectId,
+  observationIds,
+}: {
+  projectId: string;
+  observationIds: string[];
+}): Promise<Array<{ id: string; traceId: string }>> => {
+  if (observationIds.length === 0) {
+    return [];
+  }
+
+  const rows = await queryClickhouse<{ id: string; trace_id: string }>({
+    query: `
+      SELECT
+        span_id as id,
+        trace_id
+      FROM events_full
+      WHERE project_id = {projectId: String}
+        AND span_id IN ({observationIds: Array(String)})
+      ORDER BY event_ts DESC
+      LIMIT 1 BY id
+    `,
+    params: {
+      projectId,
+      observationIds,
+    },
+    tags: {
+      feature: "tracing",
+      type: "events",
+      kind: "list",
+      projectId,
+    },
+    preferredClickhouseService: "EventsReadOnly",
+  });
+
+  return rows.map((row) => ({ id: row.id, traceId: row.trace_id }));
+};
+
+export const checkObservationExistsInEventsTable = async ({
+  projectId,
+  observationId,
+  startTime,
+}: {
+  projectId: string;
+  observationId: string;
+  startTime?: Date;
+}): Promise<boolean> => {
+  const rows = await queryClickhouse<{ id: string }>({
+    query: `
+      SELECT span_id as id
+      FROM events_full
+      WHERE project_id = {projectId: String}
+        AND span_id = {observationId: String}
+        ${startTime ? `AND start_time >= {startTime: DateTime64(3)} - ${OBSERVATIONS_TO_TRACE_INTERVAL}` : ""}
+      ORDER BY event_ts DESC
+      LIMIT 1 BY id
+    `,
+    params: {
+      projectId,
+      observationId,
+      ...(startTime
+        ? { startTime: convertDateToClickhouseDateTime(startTime) }
+        : {}),
+    },
+    tags: {
+      feature: "tracing",
+      type: "events",
+      kind: "exists",
+      projectId,
+    },
+    preferredClickhouseService: "EventsReadOnly",
+  });
+
+  return rows.length > 0;
 };
 
 async function getObservationByIdFromEventsTableInternal({

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -8,7 +8,12 @@ import {
 import { logger } from "../logger";
 import { InternalServerError, LangfuseNotFoundError } from "../../errors";
 import { prisma } from "../../db";
-import { ObservationRecordReadType } from "./definitions";
+import { isTraceObservationId, ObservationRecordReadType } from "./definitions";
+import {
+  checkObservationExistsInEventsTable,
+  getObservationByIdFromEventsTable,
+  getTraceIdsForObservationIdsFromEventsTable,
+} from "./events";
 import { FilterState } from "../../types";
 import {
   DateTimeFilter,
@@ -92,7 +97,14 @@ export const checkObservationExists = async (
     },
   });
 
-  return rows.length > 0;
+  if (rows.length > 0) return true;
+  return isTraceObservationId(id)
+    ? checkObservationExistsInEventsTable({
+        projectId,
+        observationId: id,
+        startTime,
+      })
+    : false;
 };
 
 /**
@@ -370,6 +382,17 @@ export const getObservationById = async ({
     );
   });
   if (mapped.length === 0) {
+    if (isTraceObservationId(id)) {
+      return getObservationByIdFromEventsTable({
+        id,
+        projectId,
+        fetchWithInputOutput,
+        startTime,
+        type,
+        traceId,
+        renderingProps,
+      });
+    }
     throw new LangfuseNotFoundError(`Observation with id ${id} not found`);
   }
 
@@ -382,58 +405,6 @@ export const getObservationById = async ({
     );
   }
   return mapped.shift();
-};
-
-export const getObservationsById = async (
-  ids: string[],
-  projectId: string,
-  fetchWithInputOutput: boolean = false,
-) => {
-  const query = `
-  SELECT
-    id,
-    trace_id,
-    project_id,
-    type,
-    parent_observation_id,
-    start_time,
-    end_time,
-    name,
-    metadata,
-    level,
-    status_message,
-    version,
-    ${fetchWithInputOutput ? "input, output," : ""}
-    provided_model_name,
-    internal_model_id,
-    model_parameters,
-    provided_usage_details,
-    usage_details,
-    provided_cost_details,
-    cost_details,
-    total_cost,
-    usage_pricing_tier_id,
-    usage_pricing_tier_name,
-    completion_start_time,
-    prompt_id,
-    prompt_name,
-    prompt_version,
-    tool_definitions,
-    tool_calls,
-    tool_call_names,
-    created_at,
-    updated_at,
-    event_ts
-  FROM observations
-  WHERE id IN ({ids: Array(String)})
-  AND project_id = {projectId: String}
-  ORDER BY event_ts desc
-  LIMIT 1 by id, project_id`;
-  const records = await queryClickhouse<ObservationRecordReadType>({
-    query,
-    params: { ids, projectId },
-  });
-  return records.map((record) => convertObservation(record));
 };
 
 const getObservationByIdInternal = async ({
@@ -1522,49 +1493,6 @@ export const getObservationMetricsForPrompts = async (
   }));
 };
 
-export const getLatencyAndTotalCostForObservations = async (
-  projectId: string,
-  observationIds: string[],
-  timestamp?: Date,
-) => {
-  const query = `
-    SELECT
-        id,
-        cost_details['total'] AS total_cost,
-        dateDiff('millisecond', start_time, end_time) AS latency_ms
-    FROM observations FINAL
-    WHERE project_id = {projectId: String}
-    AND id IN ({observationIds: Array(String)})
-    ${timestamp ? `AND start_time >= {timestamp: DateTime64(3)}` : ""}
-`;
-  const rows = await queryClickhouse<{
-    id: string;
-    total_cost: string;
-    latency_ms: string;
-  }>({
-    query: query,
-    params: {
-      projectId,
-      observationIds,
-      ...(timestamp
-        ? { timestamp: convertDateToClickhouseDateTime(timestamp) }
-        : {}),
-    },
-    tags: {
-      feature: "tracing",
-      type: "observation",
-      kind: "analytic",
-      projectId,
-    },
-  });
-
-  return rows.map((r) => ({
-    id: r.id,
-    totalCost: Number(r.total_cost),
-    latency: Number(r.latency_ms) / 1000,
-  }));
-};
-
 export const getLatencyAndTotalCostForObservationsByTraces = async (
   projectId: string,
   traceIds: string[],
@@ -1773,10 +1701,20 @@ export const getTraceIdsForObservations = async (
     },
   });
 
-  return rows.map((row) => ({
-    id: row.id,
-    traceId: row.trace_id,
-  }));
+  const found = new Set(rows.map((r) => r.id));
+  const missingSyntheticIds = observationIds.filter(
+    (id) => !found.has(id) && isTraceObservationId(id),
+  );
+
+  const syntheticFallbacks = await getTraceIdsForObservationIdsFromEventsTable({
+    projectId,
+    observationIds: missingSyntheticIds,
+  });
+
+  return [
+    ...rows.map((row) => ({ id: row.id, traceId: row.trace_id })),
+    ...syntheticFallbacks,
+  ];
 };
 
 export const getObservationsForBlobStorageExport = function (

--- a/web/src/__tests__/server/observation-api.servertest.ts
+++ b/web/src/__tests__/server/observation-api.servertest.ts
@@ -475,4 +475,119 @@ describe("/api/public/observations API Endpoint", () => {
     runTestSuite(true); // with events table
   }
   runTestSuite(false); // with observations table
+
+  describe("trace-observation id (`t-<traceId>`)", () => {
+    it("resolves a t-prefixed id via the events reader even when the classic path is selected", async () => {
+      const traceId = uuidv4();
+      const syntheticId = `t-${traceId}`;
+
+      const trace = createTrace({
+        id: traceId,
+        project_id: projectId,
+        name: "lfe-9379-trace",
+      });
+      const syntheticSpan = createEvent({
+        id: syntheticId,
+        span_id: syntheticId,
+        project_id: projectId,
+        trace_id: traceId,
+        type: "SPAN",
+        name: "lfe-9379-trace",
+        parent_span_id: null,
+        input: "trace-input",
+        output: "trace-output",
+        provided_model_name: null,
+        model_id: null,
+      });
+
+      await createTracesCh([trace]);
+      await createEventsCh([syntheticSpan]);
+
+      // useEventsTable=false: classic path must delegate and return the synthetic span.
+      const classicRes = await makeZodVerifiedAPICall(
+        GetObservationV1Response,
+        "GET",
+        `/api/public/observations/${syntheticId}?useEventsTable=false`,
+      );
+      expect(classicRes.status).toBe(200);
+      expect(classicRes.body).toMatchObject({
+        id: syntheticId,
+        traceId,
+        type: "SPAN",
+      });
+
+      // useEventsTable=true: explicit events-table routing continues to work.
+      const eventsRes = await makeZodVerifiedAPICall(
+        GetObservationV1Response,
+        "GET",
+        `/api/public/observations/${syntheticId}?useEventsTable=true`,
+      );
+      expect(eventsRes.status).toBe(200);
+      expect(eventsRes.body).toMatchObject({
+        id: syntheticId,
+        traceId,
+        type: "SPAN",
+      });
+
+      // No query param: default (env flag) must still succeed because the
+      // delegation lives below the endpoint-level routing.
+      const defaultRes = await makeZodVerifiedAPICall(
+        GetObservationV1Response,
+        "GET",
+        `/api/public/observations/${syntheticId}`,
+      );
+      expect(defaultRes.status).toBe(200);
+      expect(defaultRes.body).toMatchObject({
+        id: syntheticId,
+        traceId,
+        type: "SPAN",
+      });
+    });
+
+    it("returns 404 when the synthetic span does not exist", async () => {
+      const missingId = `t-${uuidv4()}`;
+      await expect(
+        makeZodVerifiedAPICall(
+          GetObservationV1Response,
+          "GET",
+          `/api/public/observations/${missingId}?useEventsTable=false`,
+        ),
+      ).rejects.toThrow();
+    });
+
+    it("prefers the real observation when a user-ingested span id starts with `t-`", async () => {
+      // Users can ingest real spans whose id happens to start with `t-` (see
+      // `idSchema` in `packages/shared/src/server/ingestion/types.ts`). The
+      // classic-path reader must return that real row, not silently route to
+      // the synthetic trace-as-span fallback.
+      const traceId = uuidv4();
+      const realObservationId = `t-custom-${uuidv4()}`;
+
+      const realObservation = createObservation({
+        id: realObservationId,
+        project_id: projectId,
+        trace_id: traceId,
+        type: "SPAN",
+        name: "user-span-with-t-prefix",
+        input: "real-input",
+        output: "real-output",
+      });
+      await createObservationsCh([realObservation]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetObservationV1Response,
+        "GET",
+        `/api/public/observations/${realObservationId}?useEventsTable=false`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        id: realObservationId,
+        traceId,
+        type: "SPAN",
+        name: "user-span-with-t-prefix",
+        input: "real-input",
+        output: "real-output",
+      });
+    });
+  });
 });

--- a/web/src/__tests__/server/observation-api.servertest.ts
+++ b/web/src/__tests__/server/observation-api.servertest.ts
@@ -16,6 +16,10 @@ import snakeCase from "lodash/snakeCase";
 import { env } from "@/src/env.mjs";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+const describeIfEventsTableEnabled =
+  env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
+    ? describe
+    : describe.skip;
 
 // Helper type for observation data
 type ObservationData = {
@@ -476,7 +480,7 @@ describe("/api/public/observations API Endpoint", () => {
   }
   runTestSuite(false); // with observations table
 
-  describe("trace-observation id (`t-<traceId>`)", () => {
+  describeIfEventsTableEnabled("trace-observation id (`t-<traceId>`)", () => {
     it("resolves a t-prefixed id via the events reader even when the classic path is selected", async () => {
       const traceId = uuidv4();
       const syntheticId = `t-${traceId}`;

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -3,7 +3,9 @@ import {
   createEventsCh,
   getObservationsWithModelDataFromEventsTable,
   getObservationsCountFromEventsTable,
+  checkObservationExistsInEventsTable,
   getObservationByIdFromEventsTable,
+  getTraceIdsForObservationIdsFromEventsTable,
   getObservationsFromEventsTableForPublicApi,
   getObservationsCountFromEventsTableForPublicApi,
   updateEvents,
@@ -1508,6 +1510,70 @@ describe("Clickhouse Events Repository Test", () => {
           startTime: wrongDate,
         }),
       ).rejects.toThrow();
+    });
+  });
+
+  maybe("getTraceIdsForObservationIdsFromEventsTable", () => {
+    it("should resolve trace ids for matching span ids", async () => {
+      const traceId = randomUUID();
+      const syntheticId = `t-${traceId}`;
+
+      await createEventsCh([
+        createEvent({
+          id: syntheticId,
+          span_id: syntheticId,
+          project_id: projectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "synthetic-root-span",
+        }),
+      ]);
+
+      const result = await getTraceIdsForObservationIdsFromEventsTable({
+        projectId,
+        observationIds: [syntheticId],
+      });
+
+      expect(result).toEqual([{ id: syntheticId, traceId }]);
+    });
+
+    it("should return an empty array for missing span ids", async () => {
+      const result = await getTraceIdsForObservationIdsFromEventsTable({
+        projectId,
+        observationIds: [`t-${randomUUID()}`],
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  maybe("checkObservationExistsInEventsTable", () => {
+    it("should respect the observations-to-trace lookback window across midnight", async () => {
+      const traceId = randomUUID();
+      const syntheticId = `t-${traceId}`;
+      const eventStartTime = new Date("2024-01-15T23:55:00.000Z");
+      const lookupTime = new Date("2024-01-16T00:05:00.000Z");
+
+      await createEventsCh([
+        createEvent({
+          id: syntheticId,
+          span_id: syntheticId,
+          project_id: projectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "synthetic-root-span",
+          start_time: eventStartTime.getTime() * 1000,
+          event_ts: eventStartTime.getTime() * 1000,
+        }),
+      ]);
+
+      const exists = await checkObservationExistsInEventsTable({
+        projectId,
+        observationId: syntheticId,
+        startTime: lookupTime,
+      });
+
+      expect(exists).toBe(true);
     });
   });
 

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -1514,7 +1514,7 @@ describe("Clickhouse Events Repository Test", () => {
   });
 
   maybe("getTraceIdsForObservationIdsFromEventsTable", () => {
-    it("should resolve trace ids for matching span ids", async () => {
+    it("should resolve trace ids for matching span ids from the lightweight events table", async () => {
       const traceId = randomUUID();
       const syntheticId = `t-${traceId}`;
 
@@ -1548,7 +1548,7 @@ describe("Clickhouse Events Repository Test", () => {
   });
 
   maybe("checkObservationExistsInEventsTable", () => {
-    it("should respect the observations-to-trace lookback window across midnight", async () => {
+    it("should respect the observations-to-trace lookback window across midnight from the lightweight events table", async () => {
       const traceId = randomUUID();
       const syntheticId = `t-${traceId}`;
       const eventStartTime = new Date("2024-01-15T23:55:00.000Z");

--- a/web/src/__tests__/server/repositories/observation-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/observation-repository.servertest.ts
@@ -1,10 +1,14 @@
 import {
+  createEvent,
+  createEventsCh,
   createObservation,
   createObservationsCh,
 } from "@langfuse/shared/src/server";
 import {
+  checkObservationExists,
   getObservationById,
   getObservationsForTrace,
+  getTraceIdsForObservations,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
 
@@ -148,6 +152,65 @@ describe("Clickhouse Observations Repository Test", () => {
     expect(result.projectId).toEqual(observation.project_id);
     expect(result.type).toEqual(observation.type);
   });
+
+  it("should resolve synthetic trace observation ids via the events table", async () => {
+    const traceId = v4();
+    const syntheticId = `t-${traceId}`;
+
+    const syntheticSpan = createEvent({
+      id: syntheticId,
+      span_id: syntheticId,
+      project_id: projectId,
+      trace_id: traceId,
+      type: "SPAN",
+      name: "synthetic-root-span",
+      parent_span_id: null,
+    });
+
+    await createEventsCh([syntheticSpan]);
+
+    const result = await getTraceIdsForObservations(projectId, [syntheticId]);
+
+    expect(result).toEqual([{ id: syntheticId, traceId }]);
+  });
+
+  it("should not invent a trace id for missing t-prefixed observations", async () => {
+    const missingId = `t-${v4()}`;
+
+    const result = await getTraceIdsForObservations(projectId, [missingId]);
+
+    expect(result).toEqual([]);
+  });
+
+  it("should find synthetic trace observations across midnight in existence checks", async () => {
+    const traceId = v4();
+    const syntheticId = `t-${traceId}`;
+    const eventStartTime = new Date("2024-01-15T23:55:00.000Z");
+    const lookupTime = new Date("2024-01-16T00:05:00.000Z");
+
+    const syntheticSpan = createEvent({
+      id: syntheticId,
+      span_id: syntheticId,
+      project_id: projectId,
+      trace_id: traceId,
+      type: "SPAN",
+      name: "synthetic-root-span",
+      parent_span_id: null,
+      start_time: eventStartTime.getTime() * 1000,
+      event_ts: eventStartTime.getTime() * 1000,
+    });
+
+    await createEventsCh([syntheticSpan]);
+
+    const exists = await checkObservationExists(
+      projectId,
+      syntheticId,
+      lookupTime,
+    );
+
+    expect(exists).toBe(true);
+  });
+
   it("should return an observation view", async () => {
     const observationId = v4();
     const traceId = v4();

--- a/web/src/__tests__/server/repositories/observation-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/observation-repository.servertest.ts
@@ -10,9 +10,14 @@ import {
   getObservationsForTrace,
   getTraceIdsForObservations,
 } from "@langfuse/shared/src/server";
+import { env } from "@/src/env.mjs";
 import { v4 } from "uuid";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+const describeIfEventsTableEnabled =
+  env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
+    ? describe
+    : describe.skip;
 
 describe("Clickhouse Observations Repository Test", () => {
   it("should throw if no observations are found", async () => {
@@ -153,62 +158,64 @@ describe("Clickhouse Observations Repository Test", () => {
     expect(result.type).toEqual(observation.type);
   });
 
-  it("should resolve synthetic trace observation ids via the events table", async () => {
-    const traceId = v4();
-    const syntheticId = `t-${traceId}`;
+  describeIfEventsTableEnabled("trace-observation id (`t-<traceId>`)", () => {
+    it("should resolve synthetic trace observation ids via the events table", async () => {
+      const traceId = v4();
+      const syntheticId = `t-${traceId}`;
 
-    const syntheticSpan = createEvent({
-      id: syntheticId,
-      span_id: syntheticId,
-      project_id: projectId,
-      trace_id: traceId,
-      type: "SPAN",
-      name: "synthetic-root-span",
-      parent_span_id: null,
+      const syntheticSpan = createEvent({
+        id: syntheticId,
+        span_id: syntheticId,
+        project_id: projectId,
+        trace_id: traceId,
+        type: "SPAN",
+        name: "synthetic-root-span",
+        parent_span_id: null,
+      });
+
+      await createEventsCh([syntheticSpan]);
+
+      const result = await getTraceIdsForObservations(projectId, [syntheticId]);
+
+      expect(result).toEqual([{ id: syntheticId, traceId }]);
     });
 
-    await createEventsCh([syntheticSpan]);
+    it("should not invent a trace id for missing t-prefixed observations", async () => {
+      const missingId = `t-${v4()}`;
 
-    const result = await getTraceIdsForObservations(projectId, [syntheticId]);
+      const result = await getTraceIdsForObservations(projectId, [missingId]);
 
-    expect(result).toEqual([{ id: syntheticId, traceId }]);
-  });
-
-  it("should not invent a trace id for missing t-prefixed observations", async () => {
-    const missingId = `t-${v4()}`;
-
-    const result = await getTraceIdsForObservations(projectId, [missingId]);
-
-    expect(result).toEqual([]);
-  });
-
-  it("should find synthetic trace observations across midnight in existence checks", async () => {
-    const traceId = v4();
-    const syntheticId = `t-${traceId}`;
-    const eventStartTime = new Date("2024-01-15T23:55:00.000Z");
-    const lookupTime = new Date("2024-01-16T00:05:00.000Z");
-
-    const syntheticSpan = createEvent({
-      id: syntheticId,
-      span_id: syntheticId,
-      project_id: projectId,
-      trace_id: traceId,
-      type: "SPAN",
-      name: "synthetic-root-span",
-      parent_span_id: null,
-      start_time: eventStartTime.getTime() * 1000,
-      event_ts: eventStartTime.getTime() * 1000,
+      expect(result).toEqual([]);
     });
 
-    await createEventsCh([syntheticSpan]);
+    it("should find synthetic trace observations across midnight in existence checks", async () => {
+      const traceId = v4();
+      const syntheticId = `t-${traceId}`;
+      const eventStartTime = new Date("2024-01-15T23:55:00.000Z");
+      const lookupTime = new Date("2024-01-16T00:05:00.000Z");
 
-    const exists = await checkObservationExists(
-      projectId,
-      syntheticId,
-      lookupTime,
-    );
+      const syntheticSpan = createEvent({
+        id: syntheticId,
+        span_id: syntheticId,
+        project_id: projectId,
+        trace_id: traceId,
+        type: "SPAN",
+        name: "synthetic-root-span",
+        parent_span_id: null,
+        start_time: eventStartTime.getTime() * 1000,
+        event_ts: eventStartTime.getTime() * 1000,
+      });
 
-    expect(exists).toBe(true);
+      await createEventsCh([syntheticSpan]);
+
+      const exists = await checkObservationExists(
+        projectId,
+        syntheticId,
+        lookupTime,
+      );
+
+      expect(exists).toBe(true);
+    });
   });
 
   it("should return an observation view", async () => {

--- a/worker/src/backgroundMigrations/backfillExperimentsHistoric.ts
+++ b/worker/src/backgroundMigrations/backfillExperimentsHistoric.ts
@@ -4,6 +4,7 @@ import {
   convertDateToClickhouseDateTime,
   logger,
   queryClickhouse,
+  TRACE_OBSERVATION_ID_PREFIX,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
@@ -480,7 +481,8 @@ export default class BackfillExperimentsHistoric implements IBackgroundMigration
       let skippedCount = 0;
 
       for (const dri of dris) {
-        const rootSpanId = dri.observation_id || `t-${dri.trace_id}`;
+        const rootSpanId =
+          dri.observation_id || `${TRACE_OBSERVATION_ID_PREFIX}${dri.trace_id}`;
         const rootSpan = spanMap.get(rootSpanId);
 
         if (!rootSpan) {

--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -5,6 +5,7 @@ import {
   convertDateToClickhouseDateTime,
   flattenJsonToPathArrays,
   recordGauge,
+  TRACE_OBSERVATION_ID_PREFIX,
   type EventRecordInsertType,
 } from "@langfuse/shared/src/server";
 import { env } from "../../env";
@@ -898,7 +899,8 @@ async function processExperimentBackfill(
 
     for (const dri of driChunk) {
       // Find the root span (either observation or trace)
-      const rootSpanId = dri.observation_id || `t-${dri.trace_id}`;
+      const rootSpanId =
+        dri.observation_id || `${TRACE_OBSERVATION_ID_PREFIX}${dri.trace_id}`;
       const rootSpan = spanMap.get(rootSpanId);
 
       if (!rootSpan) {


### PR DESCRIPTION
## Summary

Fixes [LFE-9379](https://linear.app/langfuse/issue/LFE-9379/ui-bug-incorrect-source-observation-id-when-adding-trace-to-dataset).

## Failure path

1. User traces with v3 SDK → we insert a `t-` observation in the events table as the replacement for the v3 root trace.
2. User uses v4 in the UI and adds the item to the dataset (which stamps the `t-` id into `sourceObservationId`).
3. User then uses the v3 SDK to retrieve the dataset and access the `sourceObservationId` (`t-…`) → since it's the old SDK, it uses the old tables (`useEventsTable: false`) that of course don't have it → 404.

## Fix

Teach the classic read helpers (`getObservationById`, `checkObservationExists`, `getTraceIdsForObservations`) to fall back to the events reader when the classic lookup misses **and** the id is `t-`-prefixed. Classic-first preserves user-ingested real spans whose id happens to start with `t-`; the events fallback only fires on a genuine miss.

- `TRACE_OBSERVATION_ID_PREFIX` + `isTraceObservationId` introduced in `definitions.ts`, adopted in `convertTraceToStagingObservation` and the two worker backfill sites that previously used the literal.
- New `getTraceIdsForObservationIdsFromEventsTable` helper for the plural-lookup fallback.
- Dead code removed: `getObservationsById`, `getLatencyAndTotalCostForObservations` (singular) — zero callers repo-wide.

## Why we didn't touch the write path

We considered preventing the UI from stamping `t-<traceId>` into `source_observation_id` in the first place (and backfilling existing rows to `NULL`). We deliberately kept the write path as-is for two reasons:

- **Avoids a data migration.** No backfill needed for existing `dataset_item` rows with `source_observation_id LIKE 't-%'`; they resolve correctly through the fixed read path.
- **More robust across surfaces.** Other features also let users interact with the synthetic trace-as-span node (e.g. scoring on it produces a score with `observation_id = t-<traceId>`). Fixing the read path uniformly means those cross-cutting cases keep their linkage instead of being quietly stripped.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a 404 regression where v3 SDK clients calling `GET /api/public/observations/t-<traceId>` on the classic read path got a not-found error because the synthetic `t-` observation only lives in the events table. The fix teaches `getObservationById`, `checkObservationExists`, and `getTraceIdsForObservations` to fall back to the events table when the classic lookup misses and the ID is `t-`-prefixed, preserving classic-first priority so user-ingested spans that happen to start with `t-` are returned without fallback. Dead code (`getObservationsById`, `getLatencyAndTotalCostForObservations`) is also cleaned up.

<h3>Confidence Score: 5/5</h3>

Safe to merge — fix is narrowly scoped, classic-first ordering is preserved, and all three read helpers have new test coverage.

No P0/P1 findings. The fallback only fires on a genuine miss for `t-`-prefixed IDs, so no regression risk for existing observation lookups. Dead code removal has zero callers. Tests cover the resolution path, the 404 path, and the classic-priority edge case.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/repositories/definitions.ts | Introduces `TRACE_OBSERVATION_ID_PREFIX` constant and `isTraceObservationId` helper; replaces the hardcoded `t-` literal in `convertTraceToStagingObservation`. |
| packages/shared/src/server/repositories/events.ts | Adds `getTraceIdsForObservationIdsFromEventsTable` and `checkObservationExistsInEventsTable`; `OBSERVATIONS_TO_TRACE_INTERVAL` import correctly moved to top of file. |
| packages/shared/src/server/repositories/observations.ts | Classic-first fallback added to `checkObservationExists`, `getObservationById`, and `getTraceIdsForObservations`; dead code (`getObservationsById`, `getLatencyAndTotalCostForObservations`) removed. |
| web/src/__tests__/server/observation-api.servertest.ts | Adds three new server tests covering: synthetic `t-<traceId>` resolution, 404 on missing synthetic id, and classic-first priority for user-ingested `t-`-prefixed spans. |
| web/src/__tests__/server/repositories/event-repository.servertest.ts | New tests for `getTraceIdsForObservationIdsFromEventsTable` and `checkObservationExistsInEventsTable`, including the cross-midnight lookback window case. |
| web/src/__tests__/server/repositories/observation-repository.servertest.ts | Adds repository-level tests for synthetic ID resolution, missing-ID no-data-invention, and cross-midnight existence checks. |
| worker/src/backgroundMigrations/backfillExperimentsHistoric.ts | Replaces hardcoded `t-${dri.trace_id}` with `${TRACE_OBSERVATION_ID_PREFIX}${dri.trace_id}` to use the shared constant. |
| worker/src/features/eventPropagation/handleExperimentBackfill.ts | Same constant adoption as `backfillExperimentsHistoric.ts`; no functional change. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as v3 SDK Client
    participant API as GET /observations/:id
    participant Classic as observations table (classic)
    participant Events as events_full table

    Client->>API: GET /observations/t-<traceId>?useEventsTable=false
    API->>Classic: getObservationByIdInternal(id)
    Classic-->>API: [] (not found — t- id lives in events)
    API->>API: mapped.length === 0 && isTraceObservationId(id)?
    Note over API: YES → fall back
    API->>Events: getObservationByIdFromEventsTable(id)
    Events-->>API: observation record
    API-->>Client: 200 OK

    Note over Client,Events: Classic-first: if a real span with t- prefix exists it is returned before fallback fires
```

<sub>Reviews (1): Last reviewed commit: ["fix(observations): resolve \`t-&lt;traceId&gt;\`..."](https://github.com/langfuse/langfuse/commit/6a96bc9285c29381a894625e140bfa1ea513a669) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29285519)</sub>

<!-- /greptile_comment -->