### PR TITLE
fix(ui-eval): add onError handler to DeactivateEvalConfig mutation

### DIFF
--- a/web/src/features/evals/components/deactivate-config.tsx
+++ b/web/src/features/evals/components/deactivate-config.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/src/components/ui/popover";
 import { Button } from "@/src/components/ui/button";
 import { Switch } from "@/src/components/ui/switch";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 
 export function DeactivateEvalConfig({
   projectId,
@@ -28,6 +29,9 @@ export function DeactivateEvalConfig({
     onSuccess: () => {
       void utils.evals.invalidate();
     },
+    onError: (error) => {
+      showErrorToast("Evaluator update failed", error.message);
+    },
   });
 
   const onClick = () => {
@@ -38,7 +42,7 @@ export function DeactivateEvalConfig({
 
     const prevStatus = evalConfig?.status;
 
-    mutEvaluator.mutateAsync({
+    mutEvaluator.mutate({
       projectId,
       evalConfigId: evalConfig?.id ?? "",
       config: {


### PR DESCRIPTION
## Summary

Fix #13315 — when a server-side guard rejects an evaluator deactivation (e.g. when timeScope includes EXISTING), the error was silently swallowed with no user feedback.

## Root Cause

 calls  without an  callback. Other components using the same mutation (e.g. ) do handle errors properly.

## Fix

Added  callback with  to surface the server error to the user:

```typescript
const mutEvaluator = api.evals.updateEvalJob.useMutation({
  onSuccess: () => { void utils.evals.invalidate(); },
  onError: (error) => {
    showErrorToast("Evaluator update failed", error.message);
  },
});
```

## Verification

- [x] Lint: `pnpm --filter web run lint`
- [ ] Full test suite (CI)
- [ ] Browser test of the eval config deactivation flow

Fixes #13315

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a silent failure in `DeactivateEvalConfig` by adding an `onError` callback that calls `showErrorToast` when the `updateEvalJob` mutation is rejected (e.g., when `timeScope` includes `EXISTING`). The change is minimal, consistent with how other components handle the same mutation, and the new import is correctly placed at the top of the module.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line logic addition with no risk of regressions.

The only finding is a pre-existing P2 style issue (using `mutateAsync` without `await`); the core fix is correct, minimal, and consistent with the rest of the codebase.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/evals/components/deactivate-config.tsx | Adds `onError` callback to `updateEvalJob` mutation to surface server-side rejection errors via `showErrorToast`; import placed correctly at the top of the module. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DeactivateEvalConfig
    participant tRPC as tRPC (updateEvalJob)
    participant Toast as showErrorToast

    User->>DeactivateEvalConfig: Click Deactivate/Activate
    DeactivateEvalConfig->>tRPC: mutate({ status: INACTIVE/ACTIVE })
    alt Success
        tRPC-->>DeactivateEvalConfig: onSuccess
        DeactivateEvalConfig->>DeactivateEvalConfig: utils.evals.invalidate()
    else Error (e.g. timeScope includes EXISTING)
        tRPC-->>DeactivateEvalConfig: onError(error)
        DeactivateEvalConfig->>Toast: showErrorToast("Evaluator update failed", error.message)
        Toast-->>User: Display error toast
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/features/evals/components/deactivate-config.tsx
Line: 45-51

Comment:
**`mutateAsync` used without `await` — prefer `mutate`**

`mutateAsync` returns a Promise that rejects on failure. Calling it without `await` or `.catch()` will produce an unhandled-promise-rejection warning in the browser console even though `onError` fires correctly (React Query swallows the throw internally for `onError`, but the raw promise still rejects). Switching to `mutate` is the idiomatic fix — it never throws and relies entirely on the `onError` callback.

```suggestion
    mutEvaluator.mutate({
      projectId,
      evalConfigId: evalConfig?.id ?? "",
      config: {
        status: isActive ? EvaluatorStatus.INACTIVE : EvaluatorStatus.ACTIVE,
      },
    });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui-eval): add onError handler to Dea..."](https://github.com/langfuse/langfuse/commit/824abf7bbee5687205c621cf5fb6b34a9d0b061a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29377289)</sub>

<!-- /greptile_comment -->