### PR TITLE
fix(clickhouse): URL-encode credentials in migration scripts to handle special characters

### DIFF
--- a/packages/shared/clickhouse/scripts/down.sh
+++ b/packages/shared/clickhouse/scripts/down.sh
@@ -28,12 +28,16 @@ if [ -z "${CLICKHOUSE_CLUSTER_NAME}" ]; then
     export CLICKHOUSE_CLUSTER_NAME="default"
 fi
 
+# URL-encode credentials to handle special characters safely
+ENCODED_CLICKHOUSE_USER=$(node -e "console.log(encodeURIComponent(process.env.CLICKHOUSE_USER))")
+ENCODED_CLICKHOUSE_PASSWORD=$(node -e "console.log(encodeURIComponent(process.env.CLICKHOUSE_PASSWORD))")
+
 # Construct the database URL
 if [ "$CLICKHOUSE_CLUSTER_ENABLED" == "false" ] ; then
   if [ "$CLICKHOUSE_MIGRATION_SSL" = true ] ; then
-      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&secure=true&skip_verify=true&x-migrations-table-engine=MergeTree"
+      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${ENCODED_CLICKHOUSE_USER}&password=${ENCODED_CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&secure=true&skip_verify=true&x-migrations-table-engine=MergeTree"
   else
-      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&x-migrations-table-engine=MergeTree"
+      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${ENCODED_CLICKHOUSE_USER}&password=${ENCODED_CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&x-migrations-table-engine=MergeTree"
   fi
 
   # If SKIP_CONFIRM is set, automatically answer the confirmation prompt. Otherwise run interactively.
@@ -44,9 +48,9 @@ if [ "$CLICKHOUSE_CLUSTER_ENABLED" == "false" ] ; then
   fi
 else
   if [ "$CLICKHOUSE_MIGRATION_SSL" = true ] ; then
-      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&secure=true&skip_verify=true&x-cluster-name=${CLICKHOUSE_CLUSTER_NAME}&x-migrations-table-engine=ReplicatedMergeTree"
+      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${ENCODED_CLICKHOUSE_USER}&password=${ENCODED_CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&secure=true&skip_verify=true&x-cluster-name=${CLICKHOUSE_CLUSTER_NAME}&x-migrations-table-engine=ReplicatedMergeTree"
   else
-      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&x-cluster-name=${CLICKHOUSE_CLUSTER_NAME}&x-migrations-table-engine=ReplicatedMergeTree"
+      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${ENCODED_CLICKHOUSE_USER}&password=${ENCODED_CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&x-cluster-name=${CLICKHOUSE_CLUSTER_NAME}&x-migrations-table-engine=ReplicatedMergeTree"
   fi
 
   # If SKIP_CONFIRM is set, automatically answer the confirmation prompt. Otherwise run interactively.

--- a/packages/shared/clickhouse/scripts/down.sh
+++ b/packages/shared/clickhouse/scripts/down.sh
@@ -28,6 +28,22 @@ if [ -z "${CLICKHOUSE_CLUSTER_NAME}" ]; then
     export CLICKHOUSE_CLUSTER_NAME="default"
 fi
 
+# Check if CLICKHOUSE_USER is set (required before URL-encoding to avoid the
+# literal string "undefined" being injected into the connection URL).
+if [ -z "${CLICKHOUSE_USER}" ]; then
+  echo "Error: CLICKHOUSE_USER is not set."
+  echo "Please set CLICKHOUSE_USER in your environment variables."
+  exit 1
+fi
+
+# Check if CLICKHOUSE_PASSWORD is set (required before URL-encoding to avoid
+# the literal string "undefined" being injected into the connection URL).
+if [ -z "${CLICKHOUSE_PASSWORD}" ]; then
+  echo "Error: CLICKHOUSE_PASSWORD is not set."
+  echo "Please set CLICKHOUSE_PASSWORD in your environment variables."
+  exit 1
+fi
+
 # URL-encode credentials to handle special characters safely
 ENCODED_CLICKHOUSE_USER=$(node -e "console.log(encodeURIComponent(process.env.CLICKHOUSE_USER))")
 ENCODED_CLICKHOUSE_PASSWORD=$(node -e "console.log(encodeURIComponent(process.env.CLICKHOUSE_PASSWORD))")

--- a/packages/shared/clickhouse/scripts/drop.sh
+++ b/packages/shared/clickhouse/scripts/drop.sh
@@ -17,11 +17,15 @@ if [ -z "${CLICKHOUSE_DB}" ]; then
     export CLICKHOUSE_DB="default"
 fi
 
+# URL-encode credentials to handle special characters safely
+ENCODED_CLICKHOUSE_USER=$(node -e "console.log(encodeURIComponent(process.env.CLICKHOUSE_USER))")
+ENCODED_CLICKHOUSE_PASSWORD=$(node -e "console.log(encodeURIComponent(process.env.CLICKHOUSE_PASSWORD))")
+
 # Construct the database URL
 if [ "$CLICKHOUSE_MIGRATION_SSL" = true ] ; then
-    DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&secure=true&skip_verify=true&x-migrations-table-engine=MergeTree"
+    DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${ENCODED_CLICKHOUSE_USER}&password=${ENCODED_CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&secure=true&skip_verify=true&x-migrations-table-engine=MergeTree"
 else
-    DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&x-migrations-table-engine=MergeTree"
+    DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${ENCODED_CLICKHOUSE_USER}&password=${ENCODED_CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&x-migrations-table-engine=MergeTree"
 fi
 # Execute the drop command
 migrate -source file://clickhouse/migrations -database "$DATABASE_URL" drop

--- a/packages/shared/clickhouse/scripts/drop.sh
+++ b/packages/shared/clickhouse/scripts/drop.sh
@@ -17,6 +17,22 @@ if [ -z "${CLICKHOUSE_DB}" ]; then
     export CLICKHOUSE_DB="default"
 fi
 
+# Check if CLICKHOUSE_USER is set (required before URL-encoding to avoid the
+# literal string "undefined" being injected into the connection URL).
+if [ -z "${CLICKHOUSE_USER}" ]; then
+  echo "Error: CLICKHOUSE_USER is not set."
+  echo "Please set CLICKHOUSE_USER in your environment variables."
+  exit 1
+fi
+
+# Check if CLICKHOUSE_PASSWORD is set (required before URL-encoding to avoid
+# the literal string "undefined" being injected into the connection URL).
+if [ -z "${CLICKHOUSE_PASSWORD}" ]; then
+  echo "Error: CLICKHOUSE_PASSWORD is not set."
+  echo "Please set CLICKHOUSE_PASSWORD in your environment variables."
+  exit 1
+fi
+
 # URL-encode credentials to handle special characters safely
 ENCODED_CLICKHOUSE_USER=$(node -e "console.log(encodeURIComponent(process.env.CLICKHOUSE_USER))")
 ENCODED_CLICKHOUSE_PASSWORD=$(node -e "console.log(encodeURIComponent(process.env.CLICKHOUSE_PASSWORD))")

--- a/packages/shared/clickhouse/scripts/up.sh
+++ b/packages/shared/clickhouse/scripts/up.sh
@@ -50,21 +50,25 @@ if [ -z "${CLICKHOUSE_CLUSTER_NAME}" ]; then
     export CLICKHOUSE_CLUSTER_NAME="default"
 fi
 
+# URL-encode credentials to handle special characters safely
+ENCODED_CLICKHOUSE_USER=$(node -e "console.log(encodeURIComponent(process.env.CLICKHOUSE_USER))")
+ENCODED_CLICKHOUSE_PASSWORD=$(node -e "console.log(encodeURIComponent(process.env.CLICKHOUSE_PASSWORD))")
+
 # Construct the database URL
 if [ "$CLICKHOUSE_CLUSTER_ENABLED" == "false" ] ; then
   if [ "$CLICKHOUSE_MIGRATION_SSL" = true ] ; then
-      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&secure=true&skip_verify=true&x-migrations-table-engine=MergeTree"
+      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${ENCODED_CLICKHOUSE_USER}&password=${ENCODED_CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&secure=true&skip_verify=true&x-migrations-table-engine=MergeTree"
   else
-      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&x-migrations-table-engine=MergeTree"
+      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${ENCODED_CLICKHOUSE_USER}&password=${ENCODED_CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&x-migrations-table-engine=MergeTree"
   fi
 
   # Execute the up command
   migrate -source file://clickhouse/migrations/unclustered -database "$DATABASE_URL" up
 else
 if [ "$CLICKHOUSE_MIGRATION_SSL" = true ] ; then
-      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&secure=true&skip_verify=true&x-cluster-name=${CLICKHOUSE_CLUSTER_NAME}&x-migrations-table-engine=ReplicatedMergeTree"
+      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${ENCODED_CLICKHOUSE_USER}&password=${ENCODED_CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&secure=true&skip_verify=true&x-cluster-name=${CLICKHOUSE_CLUSTER_NAME}&x-migrations-table-engine=ReplicatedMergeTree"
   else
-      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&x-cluster-name=${CLICKHOUSE_CLUSTER_NAME}&x-migrations-table-engine=ReplicatedMergeTree"
+      DATABASE_URL="${CLICKHOUSE_MIGRATION_URL}?username=${ENCODED_CLICKHOUSE_USER}&password=${ENCODED_CLICKHOUSE_PASSWORD}&database=${CLICKHOUSE_DB}&x-multi-statement=true&x-cluster-name=${CLICKHOUSE_CLUSTER_NAME}&x-migrations-table-engine=ReplicatedMergeTree"
   fi
 
   # Execute the up command


### PR DESCRIPTION
Fixes #13314

## Problem

The ClickHouse migration scripts (`up.sh`, `down.sh`, `drop.sh`) interpolated `CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD` directly into the `DATABASE_URL` query string without URL-encoding. Passwords or usernames containing URL-unsafe characters (e.g. `&`, `@`, `?`, `+`) caused the URL to be parsed incorrectly, resulting in golang-migrate failing with:

```
error: failed to open database: driver: bad connection
```

## Solution

URL-encode both credentials using `node encodeURIComponent` before interpolating them into `DATABASE_URL`. Node.js is always available in the deployment environment since Langfuse is a Next.js application.

The change is applied consistently across all three migration scripts:
- `packages/shared/clickhouse/scripts/up.sh`
- `packages/shared/clickhouse/scripts/down.sh`
- `packages/shared/clickhouse/scripts/drop.sh`

## Testing

Verified locally that `encodeURIComponent` correctly encodes special characters:
- `p@ss&word?` → `p%40ss%26word%3F`
- Standard alphanumeric passwords are unchanged

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

URL-encodes ClickHouse credentials via `node encodeURIComponent` in all three migration shell scripts (`up.sh`, `down.sh`, `drop.sh`) so that special characters in usernames or passwords no longer break the `DATABASE_URL` query string parsed by golang-migrate.

The fix is correct for the primary case. One minor consistency gap: `up.sh` already validates that credentials are set before reaching the encoding step, but `down.sh` and `drop.sh` do not. If either credential variable is unset in those two scripts, `encodeURIComponent` will encode the JS `undefined` value and produce the literal string `\"undefined\"` in the URL rather than an empty value — a subtly different (and harder to diagnose) failure mode.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the encoding fix is correct for all configured environments; the undefined-string edge case only affects already-broken misconfigured deployments.

All findings are P2. The core fix is sound: encodeURIComponent is the right function for URL query parameters, Node is confirmed available in the Docker runtime images, and the change is applied consistently across all three scripts.

No files require special attention for merge.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/clickhouse/scripts/up.sh | Adds URL-encoding of credentials via node encodeURIComponent before constructing DATABASE_URL; pre-flight checks for missing creds already exist in this script, so behavior is consistent. |
| packages/shared/clickhouse/scripts/down.sh | URL-encoding applied correctly, but unlike up.sh this script has no guard for unset credentials; missing vars now produce the literal string "undefined" in the URL instead of empty string. |
| packages/shared/clickhouse/scripts/drop.sh | Same fix as down.sh; same missing-credential guard caveat — encodeURIComponent on undefined produces the string "undefined" in the URL. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Shell script starts] --> B{Credentials env vars set?}
    B -- "up.sh: No" --> C[Exit 1 with error message]
    B -- "down.sh / drop.sh: No" --> D["node encodeURIComponent(undefined)\n→ literal string 'undefined'"]
    B -- Yes --> E["node encodeURIComponent(VALUE)\n→ percent-encoded string"]
    E --> F[Construct DATABASE_URL with encoded params]
    D --> F
    F --> G[golang-migrate runs with DATABASE_URL]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/shared/clickhouse/scripts/down.sh
Line: 32-33

Comment:
**Unset variable produces literal `"undefined"` in URL**

`down.sh` and `drop.sh` have no pre-flight check for missing connection credentials (unlike `up.sh` which exits early at lines 20–32). In shell, an unset variable expands to an empty string, so the old code produced `username=`. With the new code, Node reads the variable as `undefined` and `encodeURIComponent(undefined)` returns the four-letter string `"undefined"`, resulting in `username=undefined` — a harder-to-diagnose error.

Adding the same existence guard already present in `up.sh` would keep the behavior consistent.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/shared/clickhouse/scripts/drop.sh
Line: 21-22

Comment:
**Same `"undefined"` encoding risk as `down.sh`**

`drop.sh` also has no guard for missing connection credentials before the `encodeURIComponent` call. An unset variable yields the literal string `"undefined"` in the URL instead of an empty query-param value, as described in the `down.sh` comment.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(clickhouse): URL-encode credentials ..."](https://github.com/langfuse/langfuse/commit/ac03b133ed4114884fd8b966937995a63d1e4a1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29382404)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->