### PR TITLE
fix(pricing): remove Large Context tier from claude-sonnet-4-6 and claude-sonnet-4-5

### DIFF
--- a/worker/src/__tests__/pricing-tier-matcher.test.ts
+++ b/worker/src/__tests__/pricing-tier-matcher.test.ts
@@ -217,7 +217,7 @@ describe("default-model-prices.json", () => {
     );
     expect(claudeModel).toBeDefined();
     expect(claudeModel!.modelName).toBe("claude-sonnet-4-5-20250929");
-    expect(claudeModel!.pricingTiers.length).toBe(2);
+    expect(claudeModel!.pricingTiers.length).toBe(1);
 
     // Convert to PricingTierWithPrices format
     const tiers: PricingTierWithPrices[] = claudeModel!.pricingTiers.map(
@@ -234,7 +234,7 @@ describe("default-model-prices.json", () => {
       }),
     );
 
-    // Test standard pricing (input <= 200K)
+    // Test standard pricing
     const standardResult = matchPricingTier(tiers, {
       input: 150000,
       output: 5000,
@@ -243,14 +243,14 @@ describe("default-model-prices.json", () => {
     expect(standardResult?.pricingTierName).toBe("Standard");
     expect(standardResult?.prices.input.toNumber()).toBe(0.000003);
 
-    // Test large context pricing (input > 200K)
-    const largeContextResult = matchPricingTier(tiers, {
+    // Large Context tier was removed — input > 200K should still match Standard
+    // (no tier condition matches, falls back to default)
+    const largeInputResult = matchPricingTier(tiers, {
       input: 250000,
       output: 5000,
     });
-    expect(largeContextResult).not.toBeNull();
-    expect(largeContextResult?.pricingTierName).toBe("Large Context");
-    expect(largeContextResult?.prices.input.toNumber()).toBe(0.000006);
+    expect(largeInputResult).not.toBeNull();
+    expect(largeInputResult?.pricingTierName).toBe("Standard");
   });
 });
 

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2597,33 +2597,6 @@
           "input_cached_tokens": 3e-7,
           "input_cache_read": 3e-7
         }
-      },
-      {
-        "id": "00b65240-047b-4722-9590-808edbc2067f",
-        "name": "Large Context",
-        "isDefault": false,
-        "priority": 1,
-        "conditions": [
-          {
-            "usageDetailPattern": "input",
-            "operator": "gt",
-            "value": 200000,
-            "caseSensitive": false
-          }
-        ],
-        "prices": {
-          "input": 0.000006,
-          "input_tokens": 0.000006,
-          "output": 0.0000225,
-          "output_tokens": 0.0000225,
-          "cache_creation_input_tokens": 0.0000075,
-          "input_cache_creation": 0.0000075,
-          "input_cache_creation_5m": 0.0000075,
-          "input_cache_creation_1h": 0.000012,
-          "cache_read_input_tokens": 6e-7,
-          "input_cached_tokens": 6e-7,
-          "input_cache_read": 6e-7
-        }
       }
     ]
   },
@@ -3317,33 +3290,6 @@
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
           "input_cache_read": 3e-7
-        }
-      },
-      {
-        "id": "7830bfc2-c464-4ffe-b9a2-6e741f6c5486",
-        "name": "Large Context",
-        "isDefault": false,
-        "priority": 1,
-        "conditions": [
-          {
-            "usageDetailPattern": "input",
-            "operator": "gt",
-            "value": 200000,
-            "caseSensitive": false
-          }
-        ],
-        "prices": {
-          "input": 6e-6,
-          "input_tokens": 6e-6,
-          "output": 22.5e-6,
-          "output_tokens": 22.5e-6,
-          "cache_creation_input_tokens": 7.5e-6,
-          "input_cache_creation": 7.5e-6,
-          "input_cache_creation_5m": 7.5e-6,
-          "input_cache_creation_1h": 12e-6,
-          "cache_read_input_tokens": 6e-7,
-          "input_cached_tokens": 6e-7,
-          "input_cache_read": 6e-7
         }
       }
     ]


### PR DESCRIPTION
## Summary

Fix #12996 — remove the obsolete "Large Context" pricing tier from `claude-sonnet-4-6` and `claude-sonnet-4-5-20250929` model definitions.

**Root Cause:** Anthropic removed the long-context premium for sonnet-4-6 and sonnet-4-5 models, but the pricing tiers were never updated. The Large Context condition (`input > 200K`) also incorrectly matched `cache_read_input_tokens` due to a regex pattern of just `input`, causing ~2x cost inflation whenever cache reads were large.

**Models fixed:**
- `claude-sonnet-4-6` — removed Large Context tier
- `claude-sonnet-4-5-20250929` — removed Large Context tier

**Models NOT affected:**
- `claude-opus-4-6` — never had a Large Context tier
- `claude-opus-4-7`, `claude-haiku-4-5`, `claude-opus-4-5` — already Standard only

**Files changed:**
- `worker/src/constants/default-model-prices.json` — removed Large Context tier from the two affected models
- `worker/src/__tests__/pricing-tier-matcher.test.ts` — updated test to reflect new tier count and behavior

Fixes #12996

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR removes the obsolete \"Large Context\" pricing tier from `claude-sonnet-4-5-20250929` and `claude-sonnet-4-6` in `default-model-prices.json`, reflecting Anthropic's removal of the long-context premium for these models. The regex pattern `input` used in the tier condition would also have incorrectly matched fields like `cache_read_input_tokens`, potentially causing ~2x cost inflation on cached reads — so the removal is doubly justified.

<h3>Confidence Score: 5/5</h3>

Safe to merge — straightforward removal of obsolete pricing tiers with corresponding test updates.

Both affected models are correctly left with only a Standard tier, the JSON structure is valid, and the test is updated to match. The only remaining finding is a P2 suggestion to add a test for the second model. No P0/P1 issues were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/constants/default-model-prices.json | Removed Large Context tiers (IDs `00b65240` and `7830bfc2`) from `claude-sonnet-4-5-20250929` and `claude-sonnet-4-6`; both models now have only a Standard tier. Remaining Large Context tiers (Gemini models) are untouched. |
| worker/src/__tests__/pricing-tier-matcher.test.ts | Updated `claude-sonnet-4-5` tier count assertion from 2→1 and replaced the Large Context match expectation with a Standard fallback check for inputs >200K. No test added for `claude-sonnet-4-6`. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming usage details\ne.g. input, output, cache_read_input_tokens] --> B{Match pricing tier\nfor model}

    B --> C[claude-sonnet-4-5-20250929\nclaude-sonnet-4-6]
    B --> D[Other models with\nLarge Context tier\ne.g. Gemini 2.5 Pro]

    C --> E[Standard tier\nonly — always matches]
    E --> F[input: $0.000003/tok\noutput: $0.0000150/tok]

    D --> G{input > 200K?}
    G -- yes --> H[Large Context tier\nhigher prices]
    G -- no --> I[Standard tier\nnormal prices]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker/src/__tests__/pricing-tier-matcher.test.ts
Line: 214-254

Comment:
**Missing test coverage for `claude-sonnet-4-6`**

The test suite covers the Large Context removal for `claude-sonnet-4-5-20250929` but has no corresponding test for `claude-sonnet-4-6`, even though both models had the same tier removed. A parallel test block (looking up by `claude-sonnet-4-6`'s model ID) would provide symmetrical confidence that the JSON edit for the second model is correct and won't regress.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing): remove Large Context tier ..."](https://github.com/langfuse/langfuse/commit/211c1beb4f0c354ab2b1d0335259569a738181ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29383966)</sub>

<!-- /greptile_comment -->