### PR TITLE
chore(worker): harden cloud free tier usage threshold job

### DIFF
--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -2019,6 +2019,7 @@ export const getObservationCountsByProjectAndDay = async ({
       startDate: convertDateToClickhouseDateTime(startDate),
       endDate: convertDateToClickhouseDateTime(endDate),
     },
+    clickhouseConfigs: { request_timeout: 120_000 },
     tags: {
       feature: "tracing",
       type: "observation",

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2281,6 +2281,7 @@ export const getScoreCountsByProjectAndDay = async ({
       endDate: convertDateToClickhouseDateTime(endDate),
       dataTypes: LISTABLE_SCORE_TYPES,
     },
+    clickhouseConfigs: { request_timeout: 120_000 },
     tags: {
       feature: "tracing",
       type: "score",

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1641,6 +1641,7 @@ export const getTraceCountsByProjectAndDay = async ({
       startDate: convertDateToClickhouseDateTime(startDate),
       endDate: convertDateToClickhouseDateTime(endDate),
     },
+    clickhouseConfigs: { request_timeout: 120_000 },
     tags: {
       feature: "tracing",
       type: "trace",

--- a/worker/src/ee/usageThresholds/usageAggregation.ts
+++ b/worker/src/ee/usageThresholds/usageAggregation.ts
@@ -8,10 +8,12 @@ import {
   endOfDayUTC,
   getDaysToLookBack,
   recordIncrement,
+  instrumentAsync,
 } from "@langfuse/shared/src/server";
 
 import { parseDbOrg, type ParsedOrganization } from "@langfuse/shared";
 import { logger } from "@langfuse/shared/src/server";
+import { backOff } from "exponential-backoff";
 
 import {
   processThresholds,
@@ -19,6 +21,23 @@ import {
   type OrgUpdateData,
 } from "./thresholdProcessing";
 import { bulkUpdateOrganizationsRawSQL } from "./bulkUpdates";
+
+const DAILY_QUERY_MAX_ATTEMPTS = 3;
+
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  return backOff(fn, {
+    numOfAttempts: DAILY_QUERY_MAX_ATTEMPTS,
+    startingDelay: 500,
+    timeMultiple: 2,
+    retry: (error: Error, attemptNumber: number) => {
+      logger.warn(
+        `[FREE TIER USAGE THRESHOLDS] ${label} failed (attempt ${attemptNumber}/${DAILY_QUERY_MAX_ATTEMPTS}): ${error.message}`,
+        { error: error.message, attemptNumber },
+      );
+      return attemptNumber < DAILY_QUERY_MAX_ATTEMPTS;
+    },
+  });
+}
 
 /**
  * Map of projectId to orgId
@@ -230,102 +249,135 @@ export async function processUsageAggregationForAllOrgs(
     const dayEnd =
       daysAgo === 0 ? normalizedReferenceDate : endOfDayUTC(dayDate);
 
-    // Fetch counts from Clickhouse (3 queries for ALL projects)
-    const [traceCounts, obsCounts, scoreCounts] = await Promise.all([
-      getTraceCountsByProjectAndDay({ startDate: dayStart, endDate: dayEnd }),
-      getObservationCountsByProjectAndDay({
-        startDate: dayStart,
-        endDate: dayEnd,
-      }),
-      getScoreCountsByProjectAndDay({ startDate: dayStart, endDate: dayEnd }),
-    ]);
-
-    // Aggregate to org level
-    const orgDailyCounts = aggregateByOrg(
-      traceCounts,
-      obsCounts,
-      scoreCounts,
-      projectToOrgMap,
-    );
-
-    // Accumulate for all orgs and previous days
-    for (const [orgId, counts] of Object.entries(orgDailyCounts)) {
-      const state = usageByOrgMap[orgId];
-      if (state) {
-        state.traces += counts.traces;
-        state.observations += counts.observations;
-        state.scores += counts.scores;
-        state.total += counts.total;
-      }
-    }
-
-    // Process orgs with billing cycle starting THIS day
     const dayDateString = dayStart.toISOString().split("T")[0];
-    const orgsToProcess = orgsByBillingStartMap.get(dayDateString) || [];
 
-    // Collect updates instead of executing immediately
-    const updatesToProcess: OrgUpdateData[] = [];
+    await instrumentAsync(
+      { name: "cloud-free-tier-usage-threshold-day" },
+      async (span) => {
+        span.setAttribute(
+          "langfuse.free_tier.dayStart",
+          dayStart.toISOString(),
+        );
+        span.setAttribute("langfuse.free_tier.dayEnd", dayEnd.toISOString());
+        span.setAttribute("langfuse.free_tier.dayDate", dayDateString);
+        span.setAttribute("langfuse.free_tier.daysAgo", daysAgo);
 
-    for (const org of orgsToProcess) {
-      const state = usageByOrgMap[org.id];
-      if (state) {
-        const result: ThresholdProcessingResult = await processThresholds(
-          org,
-          state.total,
+        // Fetch counts from Clickhouse (3 queries for ALL projects).
+        // Each query gets an extended timeout and automatic retries — a single
+        // re-run is cheap compared to failing the whole job.
+        const [traceCounts, obsCounts, scoreCounts] = await Promise.all([
+          withRetry("getTraceCountsByProjectAndDay", () =>
+            getTraceCountsByProjectAndDay({
+              startDate: dayStart,
+              endDate: dayEnd,
+            }),
+          ),
+          withRetry("getObservationCountsByProjectAndDay", () =>
+            getObservationCountsByProjectAndDay({
+              startDate: dayStart,
+              endDate: dayEnd,
+            }),
+          ),
+          withRetry("getScoreCountsByProjectAndDay", () =>
+            getScoreCountsByProjectAndDay({
+              startDate: dayStart,
+              endDate: dayEnd,
+            }),
+          ),
+        ]);
+
+        // Aggregate to org level
+        const orgDailyCounts = aggregateByOrg(
+          traceCounts,
+          obsCounts,
+          scoreCounts,
+          projectToOrgMap,
         );
 
-        // Collect the update data for bulk processing
-        updatesToProcess.push(result.updateData);
-
-        // Track statistics with increments
-        recordIncrement("langfuse.queue.usage_threshold_queue.total_orgs", 1, {
-          unit: "organizations",
-        });
-
-        if (result.actionTaken === "PAID_PLAN") {
-          recordIncrement(
-            "langfuse.queue.usage_threshold_queue.paid_plan_orgs",
-            1,
-            {
-              unit: "organizations",
-            },
-          );
-        } else {
-          // Count as free tier if not paid plan
-          recordIncrement(
-            "langfuse.queue.usage_threshold_queue.free_tier_orgs",
-            1,
-            {
-              unit: "organizations",
-            },
-          );
+        // Accumulate for all orgs and previous days
+        for (const [orgId, counts] of Object.entries(orgDailyCounts)) {
+          const state = usageByOrgMap[orgId];
+          if (state) {
+            state.traces += counts.traces;
+            state.observations += counts.observations;
+            state.scores += counts.scores;
+            state.total += counts.total;
+          }
         }
-      }
-    }
 
-    // Execute bulk update after processing all orgs for this day
-    if (updatesToProcess.length > 0) {
-      const bulkResult = await bulkUpdateOrganizationsRawSQL(updatesToProcess);
+        // Process orgs with billing cycle starting THIS day
+        const orgsToProcess = orgsByBillingStartMap.get(dayDateString) || [];
 
-      logger.info(
-        `[FREE TIER USAGE THRESHOLDS] Day ${dayDateString}: Bulk updated ${bulkResult.successCount} orgs, ${bulkResult.failedCount} failed`,
-      );
+        // Collect updates instead of executing immediately
+        const updatesToProcess: OrgUpdateData[] = [];
 
-      // Track bulk update statistics
-      stats.totalOrgsProcessed += updatesToProcess.length;
-      stats.totalOrgsUpdatedSuccessfully += bulkResult.successCount;
-      stats.totalOrgsFailed += bulkResult.failedCount;
-      stats.failedOrgIds.push(...bulkResult.failedOrgIds);
+        for (const org of orgsToProcess) {
+          const state = usageByOrgMap[org.id];
+          if (state) {
+            const result: ThresholdProcessingResult = await processThresholds(
+              org,
+              state.total,
+            );
 
-      // Track bulk update failures metric
-      if (bulkResult.failedCount > 0) {
-        recordIncrement(
-          "langfuse.queue.usage_threshold_queue.bulk_update_failures",
-          bulkResult.failedCount,
-          { unit: "organizations" },
-        );
-      }
-    }
+            // Collect the update data for bulk processing
+            updatesToProcess.push(result.updateData);
+
+            // Track statistics with increments
+            recordIncrement(
+              "langfuse.queue.usage_threshold_queue.total_orgs",
+              1,
+              {
+                unit: "organizations",
+              },
+            );
+
+            if (result.actionTaken === "PAID_PLAN") {
+              recordIncrement(
+                "langfuse.queue.usage_threshold_queue.paid_plan_orgs",
+                1,
+                {
+                  unit: "organizations",
+                },
+              );
+            } else {
+              // Count as free tier if not paid plan
+              recordIncrement(
+                "langfuse.queue.usage_threshold_queue.free_tier_orgs",
+                1,
+                {
+                  unit: "organizations",
+                },
+              );
+            }
+          }
+        }
+
+        // Execute bulk update after processing all orgs for this day
+        if (updatesToProcess.length > 0) {
+          const bulkResult =
+            await bulkUpdateOrganizationsRawSQL(updatesToProcess);
+
+          logger.info(
+            `[FREE TIER USAGE THRESHOLDS] Day ${dayDateString}: Bulk updated ${bulkResult.successCount} orgs, ${bulkResult.failedCount} failed`,
+          );
+
+          // Track bulk update statistics
+          stats.totalOrgsProcessed += updatesToProcess.length;
+          stats.totalOrgsUpdatedSuccessfully += bulkResult.successCount;
+          stats.totalOrgsFailed += bulkResult.failedCount;
+          stats.failedOrgIds.push(...bulkResult.failedOrgIds);
+
+          // Track bulk update failures metric
+          if (bulkResult.failedCount > 0) {
+            recordIncrement(
+              "langfuse.queue.usage_threshold_queue.bulk_update_failures",
+              bulkResult.failedCount,
+              { unit: "organizations" },
+            );
+          }
+        }
+      },
+    );
 
     // Update progress
     if (onProgress) {

--- a/worker/src/queues/cloudFreeTierUsageThresholdQueue.ts
+++ b/worker/src/queues/cloudFreeTierUsageThresholdQueue.ts
@@ -1,36 +1,50 @@
 import { Processor } from "bullmq";
-import { logger, QueueJobs } from "@langfuse/shared/src/server";
+import {
+  instrumentAsync,
+  logger,
+  QueueJobs,
+} from "@langfuse/shared/src/server";
 import { handleCloudFreeTierUsageThresholdJob } from "../ee/usageThresholds/handleCloudFreeTierUsageThresholdJob";
+import { SpanKind } from "@opentelemetry/api";
 
 export const cloudFreeTierUsageThresholdQueueProcessor: Processor = async (
   job,
 ) => {
   if (job.name === QueueJobs.CloudFreeTierUsageThresholdJob) {
-    logger.info(
-      "[CloudFreeTierUsageThresholdJob] Executing Free Tier Usage Threshold Job",
+    return await instrumentAsync(
       {
-        jobId: job.id,
-        jobName: job.name,
-        jobData: job.data,
-        timestamp: new Date().toISOString(),
-        opts: {
-          repeat: job.opts.repeat,
-          jobId: job.opts.jobId,
-        },
+        name: "process cloud-free-tier-usage-threshold",
+        startNewTrace: true,
+        spanKind: SpanKind.CONSUMER,
+      },
+      async () => {
+        logger.info(
+          "[CloudFreeTierUsageThresholdJob] Executing Free Tier Usage Threshold Job",
+          {
+            jobId: job.id,
+            jobName: job.name,
+            jobData: job.data,
+            timestamp: new Date().toISOString(),
+            opts: {
+              repeat: job.opts.repeat,
+              jobId: job.opts.jobId,
+            },
+          },
+        );
+        try {
+          return await handleCloudFreeTierUsageThresholdJob(job);
+        } catch (error) {
+          logger.error(
+            "[CloudFreeTierUsageThresholdJob] Error executing Free Tier Usage Threshold Job",
+            {
+              jobId: job.id,
+              error: error,
+              timestamp: new Date().toISOString(),
+            },
+          );
+          throw error;
+        }
       },
     );
-    try {
-      return await handleCloudFreeTierUsageThresholdJob(job);
-    } catch (error) {
-      logger.error(
-        "[CloudFreeTierUsageThresholdJob] Error executing Free Tier Usage Threshold Job",
-        {
-          jobId: job.id,
-          error: error,
-          timestamp: new Date().toISOString(),
-        },
-      );
-      throw error;
-    }
   }
 };


### PR DESCRIPTION
## Summary

- Wrap each day of the usage aggregation loop in its own span (`cloud-free-tier-usage-threshold-day`) with `langfuse.free_tier.dayStart`, `dayEnd`, `dayDate`, and `daysAgo` attributes, so per-day work is individually visible in traces instead of appearing as one long list of spans under the job.
- Extend the ClickHouse `request_timeout` to 120s on `getTraceCountsByProjectAndDay`, `getObservationCountsByProjectAndDay`, and `getScoreCountsByProjectAndDay`. The default ~30s timeout was frequently tripping `getTraceCountsByProjectAndDay` in cloud.
- Retry each of the three daily count queries up to 2 additional times on error (`exponential-backoff`, 500ms starting delay, 2× multiplier). A single re-run is cheap compared to a full job failure/retry.

## Test plan

- [x] `pnpm --filter @langfuse/shared run build`
- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter worker run lint`
- [x] `pnpm --filter worker run typecheck`
- [x] `pnpm --filter worker exec vitest run src/__tests__/usageAggregation.test.ts`
- [ ] Verify in Datadog after deploy that each daily iteration appears as its own span with the `langfuse.free_tier.dayStart`/`dayEnd` attributes, and that retry warnings (if any) surface in logs rather than failing the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR hardens the cloud free-tier usage threshold job with three targeted improvements: per-day OTel spans for observability, extended ClickHouse `request_timeout` (30s → 120s) on the three count queries, and exponential-backoff retries (up to 3 total attempts) to absorb transient CH failures without failing the entire job.

<h3>Confidence Score: 5/5</h3>

Safe to merge — focused reliability hardening with no logic changes to billing calculations.

All three changes (tracing, timeout extension, retries) are purely additive. The retry logic is correct: numOfAttempts=3 caps at 3 total tries, and the retry callback is consistent with that cap while ensuring the last failure is logged before propagating. Stats accumulation and usageByOrgMap mutations inside instrumentAsync are safe because the loop awaits each day sequentially. No P0/P1 issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/ee/usageThresholds/usageAggregation.ts | Main change: wraps each day's iteration in an instrumentAsync span with attributes, and adds exponential-backoff retries for the three ClickHouse count queries. Logic is correct; stats/usageByOrgMap mutations are safely sequential. |
| worker/src/queues/cloudFreeTierUsageThresholdQueue.ts | Wraps the job processor in instrumentAsync with startNewTrace + SpanKind.CONSUMER for top-level tracing. Clean, no logic changes. |
| packages/shared/src/server/repositories/traces.ts | Adds request_timeout: 120_000 to getTraceCountsByProjectAndDay to address frequent CH timeouts. |
| packages/shared/src/server/repositories/observations.ts | Adds request_timeout: 120_000 to getObservationCountsByProjectAndDay for consistency with traces. |
| packages/shared/src/server/repositories/scores.ts | Adds request_timeout: 120_000 to getScoreCountsByProjectAndDay for consistency with traces. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Q as BullMQ Queue
    participant P as QueueProcessor
    participant J as handleCloudFreeTierUsageThresholdJob
    participant A as processUsageAggregationForAllOrgs
    participant CH as ClickHouse
    participant DB as PostgreSQL

    Q->>P: CloudFreeTierUsageThresholdJob
    P->>P: instrumentAsync(startNewTrace, CONSUMER)
    P->>J: handleCloudFreeTierUsageThresholdJob(job)
    J->>A: processUsageAggregationForAllOrgs()
    A->>DB: buildProjectToOrgMap()
    A->>DB: fetchAllOrgsWithBillingInfo()

    loop For each day (0..daysToLookBack)
        A->>A: instrumentAsync(cloud-free-tier-usage-threshold-day)
        Note over A: sets dayStart/dayEnd/dayDate/daysAgo attributes
        par withRetry (up to 3 attempts, 500ms/1s backoff)
            A->>CH: getTraceCountsByProjectAndDay (timeout=120s)
        and withRetry
            A->>CH: getObservationCountsByProjectAndDay (timeout=120s)
        and withRetry
            A->>CH: getScoreCountsByProjectAndDay (timeout=120s)
        end
        A->>A: aggregateByOrg()
        A->>A: accumulate into usageByOrgMap
        A->>A: processThresholds() for orgs whose billing cycle starts today
        A->>DB: bulkUpdateOrganizationsRawSQL()
    end

    A-->>J: UsageAggregationStats
    J-->>P: result
    P-->>Q: done
```

<sub>Reviews (1): Last reviewed commit: ["chore(worker): harden cloud free tier us..."](https://github.com/langfuse/langfuse/commit/cf0900b17ee04d9f133b0d530517d60e88abda28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29456421)</sub>

<!-- /greptile_comment -->