### PR TITLE
feat: Support placeholder messages in MCP

### DIFF
--- a/web/src/__tests__/server/mcp-tools-write.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-write.servertest.ts
@@ -509,6 +509,121 @@ describe("MCP Write Tools", () => {
 
       expect(result.createdBy).toBe("API");
     });
+
+    it("should create chat prompt with placeholder messages", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      const messages = [
+        { role: "system", content: "You are a helpful assistant." },
+        { type: "placeholder" as const, name: "history" },
+        { role: "user", content: "Answer {{question}}" },
+      ];
+
+      const result = (await handleCreateChatPrompt(
+        {
+          name: promptName,
+          prompt: messages,
+        },
+        context,
+      )) as { id: string; type: string };
+
+      expect(result.type).toBe("chat");
+
+      const prompt = await prisma.prompt.findUnique({
+        where: { id: result.id },
+      });
+      expect(prompt?.prompt).toEqual(messages);
+    });
+
+    it("should reject placeholder message with invalid name", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      await expect(
+        handleCreateChatPrompt(
+          {
+            name: promptName,
+            prompt: [
+              { role: "system", content: "Intro" },
+              { type: "placeholder", name: "1bad" },
+            ],
+          },
+          context,
+        ),
+      ).rejects.toMatchObject({
+        code: -32602,
+      });
+    });
+
+    it("should reject placeholder message that also has role/content", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      await expect(
+        handleCreateChatPrompt(
+          {
+            name: promptName,
+            prompt: [
+              {
+                type: "placeholder",
+                name: "history",
+                role: "user",
+                content: "stray content",
+              },
+            ],
+          },
+          context,
+        ),
+      ).rejects.toMatchObject({
+        code: -32602,
+        message: expect.stringContaining(
+          "Placeholder messages must not include role or content",
+        ),
+      });
+    });
+
+    it("should reject content message missing role or content", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      await expect(
+        handleCreateChatPrompt(
+          {
+            name: promptName,
+            prompt: [{ content: "Missing role" }],
+          },
+          context,
+        ),
+      ).rejects.toMatchObject({
+        code: -32602,
+        message: expect.stringContaining(
+          "Content messages require a non-empty 'role' field",
+        ),
+      });
+    });
+
+    it("should reject when a variable name collides with a placeholder name", async () => {
+      const { context } = await createMcpTestSetup();
+      const promptName = `chat-prompt-${nanoid()}`;
+
+      await expect(
+        handleCreateChatPrompt(
+          {
+            name: promptName,
+            prompt: [
+              { role: "user", content: "Tell me about {{history}}" },
+              { type: "placeholder", name: "history" },
+            ],
+          },
+          context,
+        ),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining(
+          "variables and placeholders must be unique",
+        ),
+      });
+    });
   });
 
   describe("updatePromptLabels tool", () => {

--- a/web/src/features/mcp/README.md
+++ b/web/src/features/mcp/README.md
@@ -50,7 +50,7 @@ The MCP server provides 6 tools for prompt management:
 - **`getPromptUnresolved`** - Fetch a specific prompt WITHOUT resolving dependencies (useful for prompt composition analysis)
 - **`listPrompts`** - List all prompts in the project with filtering (name/label/tag/updatedAt range) and pagination
 - **`createTextPrompt`** - Create a new text prompt version
-- **`createChatPrompt`** - Create a new chat prompt version (OpenAI-style messages)
+- **`createChatPrompt`** - Create a new chat prompt version. Messages are either `{role, content}` or `{type: "placeholder", name}` entries (placeholders are filled in at compile time with `compileChatMessages`).
 - **`updatePromptLabels`** - Add/move labels across prompt versions
 
 **Implementation:** See [`/web/src/features/mcp/features/prompts/tools/`](/web/src/features/mcp/features/prompts/tools/) for detailed schemas, parameters, and examples for each tool.

--- a/web/src/features/mcp/features/prompts/tools/createChatPrompt.ts
+++ b/web/src/features/mcp/features/prompts/tools/createChatPrompt.ts
@@ -13,6 +13,8 @@ import {
   PromptNameSchema,
   COMMIT_MESSAGE_MAX_LENGTH,
   PROMPT_NAME_MAX_LENGTH,
+  PlaceholderMessageSchema,
+  PromptChatMessageSchema,
 } from "@langfuse/shared";
 import { createPrompt as createPromptAction } from "@/src/features/prompts/server/actions/createPrompt";
 import { prisma } from "@langfuse/shared/src/db";
@@ -21,13 +23,89 @@ import { instrumentAsync } from "@langfuse/shared/src/server";
 import { SpanKind } from "@opentelemetry/api";
 
 /**
- * Schema for a single chat message (role + content)
- * Note: Using simple object schema instead of union to comply with MCP spec
+ * Schema for a single chat message advertised to MCP clients.
+ *
+ * Intentionally a flat object with all optional fields (no union) so that the
+ * generated JSON Schema for `prompt.items` stays a single object shape. Some
+ * MCP clients ignore or mis-render nested `oneOf`/`anyOf` inside array items,
+ * so we keep the advertised schema simple and enforce the either/or shape
+ * (role+content vs. type='placeholder'+name) at runtime in the input schema.
  */
-const ChatMessageSchema = z.object({
-  role: z.string().describe("The role (e.g., 'system', 'user', 'assistant')"),
-  content: z.string().describe("The message content"),
-});
+const ChatMessageBaseSchema = z
+  .object({
+    role: z
+      .string()
+      .optional()
+      .describe(
+        "The role (e.g., 'system', 'user', 'assistant'). Required for content messages; omit for placeholders.",
+      ),
+    content: z
+      .string()
+      .optional()
+      .describe(
+        "The message content. Required for content messages; omit for placeholders.",
+      ),
+    type: z
+      .literal("placeholder")
+      .optional()
+      .describe(
+        "Set to 'placeholder' to mark this entry as a message placeholder.",
+      ),
+    name: z
+      .string()
+      .optional()
+      .describe("Placeholder name; required when type='placeholder'."),
+  })
+  .describe(
+    "A chat message. Either provide role+content OR type='placeholder' with name.",
+  );
+
+/**
+ * Validates a single chat message entry against the either/or contract.
+ * Pushes validation issues onto the provided zod context with the correct path.
+ */
+const validateChatMessage = (
+  msg: z.infer<typeof ChatMessageBaseSchema>,
+  ctx: z.RefinementCtx,
+  index: number,
+): void => {
+  if (msg.type === "placeholder") {
+    if (msg.role !== undefined || msg.content !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Placeholder messages must not include role or content fields",
+        path: [index],
+      });
+    }
+    const parsed = PlaceholderMessageSchema.safeParse({
+      type: "placeholder",
+      name: msg.name,
+    });
+    if (!parsed.success) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          parsed.error.issues[0]?.message ?? "Invalid placeholder message",
+        path: [index],
+      });
+    }
+  } else {
+    if (typeof msg.role !== "string" || msg.role.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Content messages require a non-empty 'role' field",
+        path: [index, "role"],
+      });
+    }
+    if (typeof msg.content !== "string") {
+      ctx.addIssue({
+        code: "custom",
+        message: "Content messages require a 'content' field",
+        path: [index, "content"],
+      });
+    }
+  }
+};
 
 /**
  * Base schema for JSON Schema generation (MCP client display)
@@ -40,9 +118,11 @@ const CreateChatPromptBaseSchema = z.object({
     .max(PROMPT_NAME_MAX_LENGTH)
     .describe("The name of the prompt"),
   prompt: z
-    .array(ChatMessageSchema)
+    .array(ChatMessageBaseSchema)
     .min(1)
-    .describe("Array of chat messages with role and content"),
+    .describe(
+      "Array of chat messages. Each entry is either {role, content} or {type: 'placeholder', name}.",
+    ),
   labels: z
     .array(z.string())
     .optional()
@@ -65,13 +145,17 @@ const CreateChatPromptBaseSchema = z.object({
 
 /**
  * Input schema for runtime validation
- * Uses full validation schemas from shared package
+ * Uses full validation schemas from shared package and enforces the
+ * either/or shape per message via a superRefine on the prompt array.
  */
 const CreateChatPromptInputSchema = z.object({
   name: PromptNameSchema,
   prompt: z
-    .array(ChatMessageSchema)
-    .min(1, "Chat prompts must have at least one message"),
+    .array(ChatMessageBaseSchema)
+    .min(1, "Chat prompts must have at least one message")
+    .superRefine((messages, ctx) => {
+      messages.forEach((msg, i) => validateChatMessage(msg, ctx, i));
+    }),
   labels: z.array(PromptLabelSchema).optional(),
   config: z.record(z.string(), z.any()).optional(),
   tags: z.array(z.string()).optional(),
@@ -84,7 +168,7 @@ const CreateChatPromptInputSchema = z.object({
 export const [createChatPromptTool, handleCreateChatPrompt] = defineTool({
   name: "createChatPrompt",
   description: [
-    "Create a new chat prompt version in Langfuse. Chat prompts are arrays of messages with roles and content.",
+    "Create a new chat prompt version in Langfuse. Chat prompts are arrays of messages.",
     "",
     "Important:",
     "- Prompts are immutable - cannot modify existing versions",
@@ -92,8 +176,11 @@ export const [createChatPromptTool, handleCreateChatPrompt] = defineTool({
     "- To promote to production, use updatePromptLabels",
     "- Labels are unique across versions",
     "",
-    "Message roles: system (instructions), user (input, can contain {{variables}}), assistant (examples)",
-    "Accepts: name, prompt (array of {role, content}), optional labels, config, tags, commitMessage",
+    "Each message in the prompt array is one of two shapes:",
+    "- Content message: {role, content}. Roles: system (instructions), user (input, can contain {{variables}}), assistant (examples).",
+    "- Placeholder message: {type: 'placeholder', name}. Marks a position filled in at compile time with runtime-provided messages. Name must match /^[a-zA-Z][a-zA-Z0-9_]*$/ and must not collide with any {{variable}} name used in the prompt.",
+    "",
+    "Accepts: name, prompt (array of content and/or placeholder messages), optional labels, config, tags, commitMessage",
   ].join("\n"),
   baseSchema: CreateChatPromptBaseSchema,
   inputSchema: CreateChatPromptInputSchema,
@@ -110,11 +197,21 @@ export const [createChatPromptTool, handleCreateChatPrompt] = defineTool({
           "mcp.prompt_type": "chat",
         });
 
+        // Narrow the loosely-typed input messages to the strict shape expected
+        // by the createPrompt action by re-parsing with the canonical shared
+        // schema. The superRefine above has already guaranteed the either/or
+        // shape, so this parse is effectively just a type narrow: Zod strips
+        // the undefined fields left over from the flat advertised schema and
+        // returns a proper {role, content} | {type: 'placeholder', name}.
+        const narrowedPrompt = input.prompt.map((msg) =>
+          PromptChatMessageSchema.parse(msg),
+        );
+
         const createdPrompt = await createPromptAction({
           projectId: context.projectId,
           name: input.name,
           type: PromptType.Chat,
-          prompt: input.prompt,
+          prompt: narrowedPrompt,
           labels: input.labels ?? [],
           config: input.config ?? {},
           tags: input.tags,


### PR DESCRIPTION
## What does this PR do?

Adds placeholder-message support to the Langfuse MCP `createChatPrompt` tool so MCP clients (Claude Code, Cursor, etc.) can create new chat prompt versions that contain `{type: "placeholder", name}` entries — matching what the public REST API, tRPC, and the UI already support.

Before this change, the MCP tool schema only accepted `{role, content}` messages:

```ts
const ChatMessageSchema = z.object({
  role: z.string().describe("The role (e.g., 'system', 'user', 'assistant')"),
  content: z.string().describe("The message content"),
});
```

The shared `PromptChatMessageSchema` (used by REST/tRPC) already supports both shapes; only the MCP tool's input schema needed to catch up.

### Key design choice

The advertised JSON Schema stays a single flat object (no nested `oneOf`/`anyOf` inside `prompt.items`). The prior comment `Using simple object schema instead of union to comply with MCP spec` was load-bearing — some MCP clients render array items as forms and mishandle nested unions. So:

- **Advertised (`baseSchema`)**: one flat object with `role`, `content`, `type`, `name` all optional.
- **Runtime (`inputSchema`)**: a `.superRefine` on the `prompt` array enforces the either/or contract and reuses `PlaceholderMessageSchema` from `@langfuse/shared` for the placeholder name regex.
- **Handler**: narrows the loosely-typed input to the strict `{role, content} | {type: ChatMessageType.Placeholder, name}` shape before calling `createPrompt`, so stored JSON stays clean.

No changes are needed to the backend: `createPrompt` already accepts placeholder-shaped messages and enforces the existing variable-vs-placeholder name-collision rule.

### Files changed

- `web/src/features/mcp/features/prompts/tools/createChatPrompt.ts` — new base/input schemas, refined validation, updated tool description documenting both message shapes and the placeholder name regex.
- `web/src/__tests__/server/mcp-tools-write.servertest.ts` — five new test cases:
  - mixed content + placeholder messages (happy path, round-trips through Prisma)
  - rejects invalid placeholder name (e.g. `"1bad"`)
  - rejects placeholder that also sets `role`/`content`
  - rejects content message missing `role`
  - rejects variable name colliding with a placeholder name (exercises existing backend rule)
- `web/src/features/mcp/README.md` — `createChatPrompt` bullet updated.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR extends the MCP `createChatPrompt` tool to accept placeholder messages (`{type: "placeholder", name}`) alongside regular content messages (`{role, content}`), bringing the MCP tool's input schema in line with what the REST API, tRPC, and UI already support. The implementation uses a deliberate two-schema approach: a flat base schema for MCP client display (avoiding `anyOf`/`oneOf` compatibility issues) and a runtime `superRefine` that enforces the either/or shape before narrowing to the strict `PromptChatMessageSchema` required by `createPromptAction`. The changes are minimal, well-tested, and require no backend changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 findings; all remaining observations are minor P2 quality notes.

The implementation is correct, the two-schema design is well-motivated, all five new test cases cover both happy paths and error cases, and the narrowing + non-null assertions are provably safe due to the preceding superRefine validation.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/mcp/features/prompts/tools/createChatPrompt.ts | Adds placeholder-message support via a flat base schema (MCP-client friendly) + runtime superRefine validation. Handler narrows loosely-typed input to strict PromptChatMessageSchema before persisting. Logic is sound and well-documented. |
| web/src/__tests__/server/mcp-tools-write.servertest.ts | Five new integration tests cover the happy path (round-trip through Prisma), invalid placeholder name, role/content on a placeholder, missing role, and variable-placeholder name collision. |
| web/src/features/mcp/README.md | Single-line doc update correctly describes both message shapes for createChatPrompt. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Client sends createChatPrompt] --> B[baseSchema\nflat object - MCP display]
    A --> C[inputSchema\nChatMessageBaseSchema array + superRefine]
    C --> D{For each message}
    D -->|type === 'placeholder'| E{role or content present?}
    E -->|yes| F[addIssue: must not include role/content]
    E -->|no| G[PlaceholderMessageSchema.safeParse\nvalidates name regex]
    G -->|fail| H[addIssue: invalid placeholder]
    G -->|pass| I[✓ Valid placeholder]
    D -->|no type| J{role non-empty string?}
    J -->|no| K[addIssue: requires role]
    J -->|yes| L{content is string?}
    L -->|no| M[addIssue: requires content]
    L -->|yes| N[✓ Valid content message]
    I --> O[Narrow: type=ChatMessageType.Placeholder + name]
    N --> P[Narrow: role + content only]
    O --> Q[createPromptAction\nPromptChatMessageSchema array]
    P --> Q
    Q --> R[Persisted to DB]
```

<sub>Reviews (1): Last reviewed commit: ["feat(web): Support placeholder messages ..."](https://github.com/langfuse/langfuse/commit/b6dc1ab458a8b301f6919a8bd22e5041beb82376) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29456523)</sub>

<!-- /greptile_comment -->