### PR TITLE
fix(worker): cap PostHog export window at next UTC day boundary (LFE-9475)

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2977,7 +2977,7 @@ export const getEventsForAnalyticsIntegrations = async function* (
       "mapFromArrays(arrayReverse(e.metadata_names), arrayReverse(e.metadata_values))['$mixpanel_session_id'] as mixpanel_session_id",
     )
     .whereRaw(
-      "e.start_time >= {minTimestamp: DateTime64(3)} AND e.start_time <= {maxTimestamp: DateTime64(3)}",
+      "e.start_time >= {minTimestamp: DateTime64(3)} AND e.start_time < {maxTimestamp: DateTime64(3)}",
       {
         minTimestamp: convertDateToClickhouseDateTime(minTimestamp),
         maxTimestamp: convertDateToClickhouseDateTime(maxTimestamp),

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1907,7 +1907,7 @@ export const getGenerationsForAnalyticsIntegrations = async function* (
     WHERE o.project_id = {projectId: String}
     AND t.project_id = {projectId: String}
     AND o.start_time >= {minTimestamp: DateTime64(3)}
-    AND o.start_time <= {maxTimestamp: DateTime64(3)}
+    AND o.start_time < {maxTimestamp: DateTime64(3)}
     AND t.timestamp >= {minTimestamp: DateTime64(3)} - INTERVAL 7 DAY
     AND t.timestamp <= {maxTimestamp: DateTime64(3)}
     AND o.type = 'GENERATION'

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2083,7 +2083,7 @@ export const getScoresForAnalyticsIntegrations = async function* (
     LEFT JOIN ${traceTable} t FINAL ON s.trace_id = t.id AND s.project_id = t.project_id
     WHERE s.project_id = {projectId: String}
     AND s.timestamp >= {minTimestamp: DateTime64(3)}
-    AND s.timestamp <= {maxTimestamp: DateTime64(3)}
+    AND s.timestamp < {maxTimestamp: DateTime64(3)}
     AND s.data_type IN ({dataTypes: Array(String)})
     AND (
       s.trace_id IS NOT NULL

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1449,7 +1449,7 @@ export const getTracesForAnalyticsIntegrations = async function* (
     LEFT JOIN observations_agg o ON t.id = o.trace_id AND t.project_id = o.project_id
     WHERE t.project_id = {projectId: String}
     AND t.timestamp >= {minTimestamp: DateTime64(3)}
-    AND t.timestamp <= {maxTimestamp: DateTime64(3)}
+    AND t.timestamp < {maxTimestamp: DateTime64(3)}
   `;
 
   const records = queryClickhouseStream<Record<string, unknown>>({

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -275,8 +275,7 @@ export const handlePostHogIntegrationProjectJob = async (
   }
 
   // Resume from lastSyncAt. On first run, fall back to the project's
-  // createdAt since no trace data can precede it — a tight, meaningful lower
-  // bound that lets the day-cap below also bound initial backfills.
+  // createdAt since no trace data can precede it.
   const minTimestamp =
     postHogIntegration.lastSyncAt || postHogIntegration.project.createdAt;
   const uncappedMaxTimestamp = new Date(Date.now() - 30 * 60 * 1000); // 30 minutes ago

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -243,7 +243,7 @@ export const handlePostHogIntegrationProjectJob = async (
     },
     include: {
       project: {
-        select: { name: true },
+        select: { name: true, createdAt: true },
       },
     },
   });
@@ -274,30 +274,29 @@ export const handlePostHogIntegrationProjectJob = async (
     );
   }
 
-  // Start from 2000-01-01 if no lastSyncAt. Workaround because 1970-01-01 leads to subtle bugs in ClickHouse
-  const minTimestamp = postHogIntegration.lastSyncAt || new Date("2000-01-01");
+  // Resume from lastSyncAt. On first run, fall back to the project's
+  // createdAt since no trace data can precede it — a tight, meaningful lower
+  // bound that lets the day-cap below also bound initial backfills.
+  const minTimestamp =
+    postHogIntegration.lastSyncAt || postHogIntegration.project.createdAt;
   const uncappedMaxTimestamp = new Date(Date.now() - 30 * 60 * 1000); // 30 minutes ago
 
-  // When resuming from a prior sync, cap maxTimestamp at the next UTC day
-  // boundary. Bounds per-run work if an integration has been stuck (otherwise
-  // retries re-scan an ever-growing window) and aligns with the toDate(...)
-  // ClickHouse partition/ordering keys for better pruning. Healthy
-  // integrations are unaffected because uncappedMaxTimestamp wins when the
-  // sync is within one day. Initial backfills (no lastSyncAt) skip the cap
-  // because stepping day-by-day from 2000-01-01 would be pathological.
-  let maxTimestamp = uncappedMaxTimestamp;
-  if (postHogIntegration.lastSyncAt) {
-    const nextDayBoundary = new Date(
-      Date.UTC(
-        minTimestamp.getUTCFullYear(),
-        minTimestamp.getUTCMonth(),
-        minTimestamp.getUTCDate() + 1,
-      ),
-    );
-    maxTimestamp = new Date(
-      Math.min(nextDayBoundary.getTime(), uncappedMaxTimestamp.getTime()),
-    );
-  }
+  // Cap maxTimestamp at the next UTC day boundary after minTimestamp. Bounds
+  // per-run work so a stuck integration (or a backfill on an older project)
+  // does not re-scan an ever-growing window on each hourly retry, and aligns
+  // with the toDate(...) ClickHouse partition/ordering keys for better
+  // pruning. Healthy integrations are unaffected because uncappedMaxTimestamp
+  // wins whenever the sync is within one day of present.
+  const nextDayBoundary = new Date(
+    Date.UTC(
+      minTimestamp.getUTCFullYear(),
+      minTimestamp.getUTCMonth(),
+      minTimestamp.getUTCDate() + 1,
+    ),
+  );
+  const maxTimestamp = new Date(
+    Math.min(nextDayBoundary.getTime(), uncappedMaxTimestamp.getTime()),
+  );
 
   if (maxTimestamp <= minTimestamp) {
     logger.info(

--- a/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
+++ b/worker/src/features/posthog/handlePostHogIntegrationProjectJob.ts
@@ -274,13 +274,48 @@ export const handlePostHogIntegrationProjectJob = async (
     );
   }
 
+  // Start from 2000-01-01 if no lastSyncAt. Workaround because 1970-01-01 leads to subtle bugs in ClickHouse
+  const minTimestamp = postHogIntegration.lastSyncAt || new Date("2000-01-01");
+  const uncappedMaxTimestamp = new Date(Date.now() - 30 * 60 * 1000); // 30 minutes ago
+
+  // When resuming from a prior sync, cap maxTimestamp at the next UTC day
+  // boundary. Bounds per-run work if an integration has been stuck (otherwise
+  // retries re-scan an ever-growing window) and aligns with the toDate(...)
+  // ClickHouse partition/ordering keys for better pruning. Healthy
+  // integrations are unaffected because uncappedMaxTimestamp wins when the
+  // sync is within one day. Initial backfills (no lastSyncAt) skip the cap
+  // because stepping day-by-day from 2000-01-01 would be pathological.
+  let maxTimestamp = uncappedMaxTimestamp;
+  if (postHogIntegration.lastSyncAt) {
+    const nextDayBoundary = new Date(
+      Date.UTC(
+        minTimestamp.getUTCFullYear(),
+        minTimestamp.getUTCMonth(),
+        minTimestamp.getUTCDate() + 1,
+      ),
+    );
+    maxTimestamp = new Date(
+      Math.min(nextDayBoundary.getTime(), uncappedMaxTimestamp.getTime()),
+    );
+  }
+
+  if (maxTimestamp <= minTimestamp) {
+    logger.info(
+      `[POSTHOG] Skipping PostHog integration for project ${projectId}: empty sync window (min: ${minTimestamp.toISOString()}, max: ${maxTimestamp.toISOString()})`,
+    );
+    return;
+  }
+
+  logger.info(
+    `[POSTHOG] Syncing project ${projectId} from ${minTimestamp.toISOString()} to ${maxTimestamp.toISOString()}`,
+  );
+
   // Fetch relevant data and send it to PostHog
   const executionConfig: PostHogExecutionConfig = {
     projectId,
     projectName: postHogIntegration.project.name,
-    // Start from 2000-01-01 if no lastSyncAt. Workaround because 1970-01-01 leads to subtle bugs in ClickHouse
-    minTimestamp: postHogIntegration.lastSyncAt || new Date("2000-01-01"),
-    maxTimestamp: new Date(new Date().getTime() - 30 * 60 * 1000), // 30 minutes ago
+    minTimestamp,
+    maxTimestamp,
     decryptedPostHogApiKey: decrypt(postHogIntegration.encryptedPosthogApiKey),
     postHogHost: postHogIntegration.posthogHostName,
   };


### PR DESCRIPTION
## Summary

- When a PostHog integration failed repeatedly, `lastSyncAt` never advanced and each hourly retry re-scanned an ever-growing window against ClickHouse (the LFE-9475 regression).
- Cap `maxTimestamp` at the next UTC day boundary after `minTimestamp` so per-run work is bounded and aligned with the `toDate(...)` partition/ordering keys for cleaner pruning.
- On first run, seed `minTimestamp` from the project's `createdAt` instead of `2000-01-01`. No trace data can precede it, and it makes the day cap meaningful for initial backfills too (older projects catch up one day per hourly run instead of scanning decades of empty range or blowing up in a single shot).
- Switch the primary event-timestamp filter in the four `getXForAnalyticsIntegrations` queries (traces, generations, scores, events) from `<=` to `<`. Since the PostHog and Mixpanel schedulers advance `lastSyncAt` to the previous run's `maxTimestamp`, a row exactly on a window boundary was previously emitted on both sides; half-open semantics make each row emit exactly once across consecutive runs. Secondary trace-join bounds (7-day lookback) keep `<=` because they are metadata-range optimizations, not emission bounds, and flipping them could drop a legitimate join at the boundary.
- Healthy integrations are unaffected: `now - 30min` wins whenever `lastSyncAt` is within a day of present.
- Added a skip guard for empty windows and a per-run log line showing the actual `[min, max]` window for observability.

## Backlog catch-up

With the hourly cron (`POSTHOG_SYNC_CRON_PATTERN = "30 * * * *"`) and day-sized chunks, a backlog catches up at 1 day per hour. For realistic outage windows (hours to a couple weeks) that's acceptable. A brand-new integration on a multi-year-old project will take a few weeks of wall clock to backfill; if that becomes a concern we can mirror blob storage's pattern of immediately re-enqueuing the next chunk after a successful partial run (no schema change needed — dedupe key already uses `lastSyncAt`).

## Scope note

The half-open-bound change also benefits Mixpanel (same caller pattern). Blob storage's equivalent query in `getEventsForBlobStorageExport` is intentionally out of scope for this PR: its file naming depends on `maxTimestamp`, so changing semantics there deserves its own review.

## Impacted packages
- `worker` (logic)
- `@langfuse/shared` (ClickHouse filters)

## Verification
- `pnpm --filter worker run lint`
- `pnpm --filter worker run typecheck`
- `pnpm --filter @langfuse/shared run lint`
- `pnpm --filter web run typecheck`

## Test plan
- [ ] Trigger a manual worker run against a project with `lastSyncAt` more than a day in the past — confirm the export window ends at the next UTC midnight after `lastSyncAt` (visible in the `[POSTHOG] Syncing project …` log line) and `lastSyncAt` advances to that boundary.
- [ ] Trigger a manual worker run against a project with `lastSyncAt` within the last day — confirm the export window ends at `now - 30min` (cap does not kick in) and behavior is unchanged.
- [ ] Trigger a manual worker run against a project with no `lastSyncAt` — confirm the initial backfill uses `project.createdAt` as the floor and the first window ends at the next UTC midnight after the project was created.
- [ ] Simulate a backlog of several days by manually setting `lastSyncAt` to `T - 5d`; confirm successive hourly runs advance one UTC day at a time until caught up.
- [ ] Write a trace/observation/score/event with a `start_time` exactly equal to a prospective boundary value, run the sync twice across the boundary, and confirm PostHog receives exactly one event per record (no duplicates, no drops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)