### PR TITLE
feat(api): migrate scores public API and traces/[traceId] to events tables

### DIFF
--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -79,10 +79,16 @@ async function main() {
     },
   });
 
+  // createdAt is set to a fixed date before V4_DEFAULT_ENABLED_FROM_AT so the
+  // seeded project uses the legacy (non-events) read path by default.
+  // Tests that need the events path should create a fresh org with a post-cutoff date.
+  const seedOrgCreatedAt = new Date("2024-01-01T00:00:00.000Z");
+
   await prisma.organization.upsert({
     where: { id: seedOrgId },
     update: {
       name: "Seed Org",
+      createdAt: seedOrgCreatedAt,
       cloudConfig: {
         plan: "Team",
       },
@@ -90,6 +96,7 @@ async function main() {
     create: {
       id: seedOrgId,
       name: "Seed Org",
+      createdAt: seedOrgCreatedAt,
       cloudConfig: {
         plan: "Team",
       },

--- a/packages/shared/src/features/scores/interfaces/api/shared.ts
+++ b/packages/shared/src/features/scores/interfaces/api/shared.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { publicApiPaginationZod } from "../../../../utils/zod";
+import {
+  publicApiPaginationZod,
+  useEventsTableSchema,
+} from "../../../../utils/zod";
 import { stringDateTime } from "../../../../utils/typeChecks";
 import { applyScoreValidation } from "../../../../utils/scores";
 import { PostScoreBodyFoundationSchema } from "../shared";
@@ -62,6 +65,7 @@ export const GetScoresQuery = z.object({
         .filter((f) => SCORE_FIELD_GROUPS.includes(f as ScoreFieldGroup));
     })
     .pipe(z.array(z.enum(SCORE_FIELD_GROUPS)).nullable()),
+  useEventsTable: useEventsTableSchema,
   filter: z
     .string()
     .optional()

--- a/packages/shared/src/server/auth/types.ts
+++ b/packages/shared/src/server/auth/types.ts
@@ -14,6 +14,7 @@ const ApiKeyBaseSchema = z.object({
   fastHashedSecretKey: z.string(),
   hashedSecretKey: z.string(),
   orgId: z.string(),
+  orgCreatedAt: z.string().datetime().nullable(),
   plan: z.enum(plans as unknown as [string, ...string[]]),
   rateLimitOverrides: CloudConfigRateLimit.nullish(),
   isIngestionSuspended: z.boolean().nullish(),
@@ -63,6 +64,7 @@ type BaseApiAccessScope = {
 
 type ApiAccessScopeMetadata = {
   orgId: string;
+  orgCreatedAt: string | null;
   plan: Plan;
   rateLimitOverrides: z.infer<typeof CloudConfigRateLimit>;
   apiKeyId: string;

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -310,8 +310,9 @@ export const getObservationsForTraceFromEventsTable = async (params: {
   projectId: string;
   traceId: string;
   timestamp?: Date;
+  selectIOAndMetadata?: boolean;
 }): Promise<{ observations: FullEventsObservations; totalCount: number }> => {
-  const { projectId, traceId, timestamp } = params;
+  const { projectId, traceId, timestamp, selectIOAndMetadata } = params;
 
   const filter: FilterState = [
     {
@@ -337,6 +338,7 @@ export const getObservationsForTraceFromEventsTable = async (params: {
       {
         projectId,
         filter,
+        selectIOAndMetadata,
         orderBy: { column: "startTime", order: "ASC" },
         limit: MAX_OBSERVATIONS_PER_TRACE + 1,
         offset: 0,

--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -185,3 +185,15 @@ export function sanitizeEmailSubject(input: string): string {
  * versionZod.parse(undefined) // Returns undefined
  */
 export const versionZod = z.coerce.date().optional();
+
+/**
+ * Zod schema for the `useEventsTable` query parameter on public API endpoints.
+ * Accepts "true"/"false" strings or booleans, preserves undefined when omitted
+ * so callers can distinguish "not set" from "explicitly false".
+ */
+export const useEventsTableSchema = z
+  .union([z.literal("true"), z.literal("false"), z.boolean()])
+  .optional()
+  .transform((val) =>
+    val === undefined ? undefined : val === "true" || val === true,
+  );

--- a/web/src/__tests__/server/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v1.servertest.ts
@@ -5,13 +5,16 @@ import {
   createSessionScore,
   getScoresByIds,
   getScoreById,
+  createEvent,
 } from "@langfuse/shared/src/server";
 import {
   createObservationsCh,
   createScoresCh,
   createTracesCh,
+  createEventsCh,
   createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
 import {
   makeAPICall,
   makeZodVerifiedAPICall,
@@ -21,10 +24,11 @@ import {
   GetScoreResponseV1,
   GetScoresResponseV1,
 } from "@langfuse/shared";
-import { prisma } from "@langfuse/shared/src/db";
 import { v4 } from "uuid";
 import { z } from "zod";
 import waitForExpect from "wait-for-expect";
+import { env } from "@/src/env.mjs";
+import { V4_DEFAULT_ENABLED_FROM_AT } from "@/src/features/events/lib/v4Rollout";
 
 describe("/api/public/scores API Endpoint", () => {
   describe("GET /api/public/scores/:scoreId", () => {
@@ -1575,5 +1579,329 @@ describe("/api/public/scores API Endpoint", () => {
         500,
       );
     }, 15000);
+  });
+
+  // Dual-path tests: events table vs physical traces table.
+  // Legacy suite: seeded project, no query param override.
+  // Events suite: seeded project + useEventsTable=true query param override.
+  (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
+    ? describe
+    : describe.skip)(
+    "GET /api/public/scores - Events Table Migration Tests",
+    () => {
+      const seedProjectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+      const runTestSuite = (useEventsTable: boolean) => {
+        const suiteName = useEventsTable
+          ? "with events table"
+          : "with traces table";
+        const eventsParam = useEventsTable ? "&useEventsTable=true" : "";
+
+        describe(`${suiteName}`, () => {
+          it("should return scores with trace metadata", async () => {
+            const traceId = v4();
+            const userId = "test-user-events";
+            const traceTags = ["events-tag1", "events-tag2"];
+
+            const trace = createTrace({
+              id: traceId,
+              project_id: seedProjectId,
+              user_id: userId,
+              tags: traceTags,
+              environment: "production",
+            });
+            await createTracesCh([trace]);
+
+            if (useEventsTable) {
+              const eventId = v4();
+              const rootEvent = createEvent({
+                id: eventId,
+                span_id: eventId,
+                parent_span_id: null,
+                trace_id: traceId,
+                project_id: seedProjectId,
+                name: "trace",
+                trace_name: "trace",
+                type: "GENERATION",
+                start_time: Date.now() * 1000,
+                environment: "production",
+                user_id: userId,
+                tags: traceTags,
+              });
+              await createEventsCh([rootEvent] as any);
+            }
+
+            const scoreName = `events-test-score-${v4()}`;
+            const scoreId = v4();
+            const score = createTraceScore({
+              id: scoreId,
+              project_id: seedProjectId,
+              trace_id: traceId,
+              name: scoreName,
+              value: 42,
+              data_type: "NUMERIC",
+              source: "API",
+            });
+            await createScoresCh([score]);
+
+            const response = await makeZodVerifiedAPICall(
+              GetScoresResponseV1,
+              "GET",
+              `/api/public/scores?name=${scoreName}${eventsParam}`,
+              undefined,
+              undefined,
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.body.data).toHaveLength(1);
+            expect(response.body.data[0]).toMatchObject({
+              id: scoreId,
+              name: scoreName,
+              value: 42,
+              traceId,
+            });
+            expect(response.body.data[0].trace).toMatchObject({
+              userId,
+              tags: expect.arrayContaining(traceTags),
+            });
+            expect(response.body.meta.totalItems).toBe(1);
+          });
+
+          it("should filter by userId through trace metadata", async () => {
+            const traceId1 = v4();
+            const traceId2 = v4();
+            const targetUser = `target-user-${v4()}`;
+
+            const trace1 = createTrace({
+              id: traceId1,
+              project_id: seedProjectId,
+              user_id: targetUser,
+            });
+            const trace2 = createTrace({
+              id: traceId2,
+              project_id: seedProjectId,
+              user_id: "other-user",
+            });
+            await createTracesCh([trace1, trace2]);
+
+            if (useEventsTable) {
+              const eid1 = v4();
+              const eid2 = v4();
+              await createEventsCh([
+                createEvent({
+                  id: eid1,
+                  span_id: eid1,
+                  parent_span_id: null,
+                  trace_id: traceId1,
+                  project_id: seedProjectId,
+                  name: "trace",
+                  trace_name: "trace",
+                  type: "GENERATION",
+                  start_time: Date.now() * 1000,
+                  user_id: targetUser,
+                }),
+                createEvent({
+                  id: eid2,
+                  span_id: eid2,
+                  parent_span_id: null,
+                  trace_id: traceId2,
+                  project_id: seedProjectId,
+                  name: "trace",
+                  trace_name: "trace",
+                  type: "GENERATION",
+                  start_time: Date.now() * 1000,
+                  user_id: "other-user",
+                }),
+              ] as any);
+            }
+
+            const scoreName = `filter-test-${v4()}`;
+            const score1 = createTraceScore({
+              id: v4(),
+              project_id: seedProjectId,
+              trace_id: traceId1,
+              name: scoreName,
+              value: 1,
+              source: "API",
+            });
+            const score2 = createTraceScore({
+              id: v4(),
+              project_id: seedProjectId,
+              trace_id: traceId2,
+              name: scoreName,
+              value: 2,
+              source: "API",
+            });
+            await createScoresCh([score1, score2]);
+
+            const response = await makeZodVerifiedAPICall(
+              GetScoresResponseV1,
+              "GET",
+              `/api/public/scores?userId=${targetUser}&name=${scoreName}${eventsParam}`,
+              undefined,
+              undefined,
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.body.data).toHaveLength(1);
+            expect(response.body.data[0].traceId).toBe(traceId1);
+            expect(response.body.data[0].value).toBe(1);
+            expect(response.body.meta.totalItems).toBe(1);
+          });
+
+          it("should return correct pagination metadata", async () => {
+            const traceId = v4();
+            const trace = createTrace({
+              id: traceId,
+              project_id: seedProjectId,
+            });
+            await createTracesCh([trace]);
+
+            if (useEventsTable) {
+              const eid = v4();
+              await createEventsCh([
+                createEvent({
+                  id: eid,
+                  span_id: eid,
+                  parent_span_id: null,
+                  trace_id: traceId,
+                  project_id: seedProjectId,
+                  name: "trace",
+                  trace_name: "trace",
+                  type: "GENERATION",
+                  start_time: Date.now() * 1000,
+                }),
+              ] as any);
+            }
+
+            const scoreName = `pagination-test-${v4()}`;
+            const scores = Array.from({ length: 3 }, () =>
+              createTraceScore({
+                id: v4(),
+                project_id: seedProjectId,
+                trace_id: traceId,
+                name: scoreName,
+                value: Math.random() * 100,
+                source: "API",
+              }),
+            );
+            await createScoresCh(scores);
+
+            const response = await makeZodVerifiedAPICall(
+              GetScoresResponseV1,
+              "GET",
+              `/api/public/scores?name=${scoreName}&limit=2&page=1${eventsParam}`,
+              undefined,
+              undefined,
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.body.data).toHaveLength(2);
+            expect(response.body.meta.totalItems).toBe(3);
+            expect(response.body.meta.totalPages).toBe(2);
+          });
+        });
+      };
+
+      runTestSuite(false); // seeded project, no override → legacy traces table
+      runTestSuite(true); // seeded project + useEventsTable=true → events CTE
+    },
+  );
+
+  // Verify org createdAt date-based routing works without useEventsTable query param.
+  // Post-cutoff org → events path; pre-cutoff org → legacy path.
+  // Each test populates ONLY the table its expected path reads from,
+  // so using the wrong path causes a missing-data failure.
+  (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
+    ? describe
+    : describe.skip)("scores org createdAt routing", () => {
+    const setupOrgWithDate = async (createdAt: Date) => {
+      const result = await createOrgProjectAndApiKey();
+      await prisma.organization.update({
+        where: { id: result.orgId },
+        data: { createdAt },
+      });
+      return result;
+    };
+
+    it("post-cutoff org routes to events path", async () => {
+      const { projectId: pid, auth } = await setupOrgWithDate(
+        new Date(V4_DEFAULT_ENABLED_FROM_AT.getTime() + 1000),
+      );
+      const traceId = v4();
+      const scoreName = `ev-${v4()}`;
+
+      await createTracesCh([
+        createTrace({ id: traceId, project_id: pid, user_id: "u1" }),
+      ]);
+      const eid = v4();
+      await createEventsCh([
+        createEvent({
+          id: eid,
+          span_id: eid,
+          parent_span_id: null,
+          trace_id: traceId,
+          project_id: pid,
+          name: "t",
+          trace_name: "t",
+          type: "GENERATION",
+          start_time: Date.now() * 1000,
+          user_id: "u1",
+        }),
+      ] as any);
+      await createScoresCh([
+        createTraceScore({
+          id: v4(),
+          project_id: pid,
+          trace_id: traceId,
+          name: scoreName,
+          value: 1,
+          source: "API",
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV1,
+        "GET",
+        `/api/public/scores?name=${scoreName}`,
+        undefined,
+        auth,
+      );
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].trace).toMatchObject({ userId: "u1" });
+    });
+
+    it("pre-cutoff org routes to legacy path", async () => {
+      const { projectId: pid, auth } = await setupOrgWithDate(
+        new Date("2020-01-01"),
+      );
+      const traceId = v4();
+      const scoreName = `leg-${v4()}`;
+
+      await createTracesCh([
+        createTrace({ id: traceId, project_id: pid, user_id: "u2" }),
+      ]);
+      // No events data — legacy path reads traces table directly
+      await createScoresCh([
+        createTraceScore({
+          id: v4(),
+          project_id: pid,
+          trace_id: traceId,
+          name: scoreName,
+          value: 1,
+          source: "API",
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV1,
+        "GET",
+        `/api/public/scores?name=${scoreName}`,
+        undefined,
+        auth,
+      );
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0].trace).toMatchObject({ userId: "u2" });
+    });
   });
 });

--- a/web/src/__tests__/server/traces-api.servertest.ts
+++ b/web/src/__tests__/server/traces-api.servertest.ts
@@ -12,7 +12,9 @@ import {
   createObservationsCh,
   createTracesCh,
   createEventsCh,
+  createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
 import {
   makeZodVerifiedAPICall,
   makeZodVerifiedAPICallSilent,
@@ -26,6 +28,7 @@ import {
 import { randomUUID } from "crypto";
 import snakeCase from "lodash/snakeCase";
 import { env } from "@/src/env.mjs";
+import { V4_DEFAULT_ENABLED_FROM_AT } from "@/src/features/events/lib/v4Rollout";
 import waitForExpect from "wait-for-expect";
 
 const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
@@ -2496,5 +2499,198 @@ describe("/api/public/traces API Endpoint", () => {
     if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
       runFilterTests(true);
     }
+  });
+
+  // Dual-path tests for GET /api/public/traces/{traceId}.
+  // Legacy suite: seeded project, no query param override.
+  // Events suite: seeded project + useEventsTable=true query param override.
+  (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
+    ? describe
+    : describe.skip)(
+    "GET /api/public/traces/{traceId} - Events Table Migration Tests",
+    () => {
+      const runTestSuite = (useEventsTable: boolean) => {
+        const suiteName = useEventsTable
+          ? "with events table"
+          : "with traces table";
+        const eventsParam = useEventsTable ? "&useEventsTable=true" : "";
+
+        describe(`${suiteName}`, () => {
+          it("should return trace with observations, scores, and metrics", async () => {
+            const timestamp = new Date();
+            const traceId = randomUUID();
+
+            const createdTrace = createTrace({
+              id: traceId,
+              name: "single-trace-test",
+              user_id: "single-trace-user",
+              session_id: "single-trace-session",
+              timestamp: timestamp.getTime(),
+              project_id: projectId,
+              metadata: { key: "value" },
+              environment: "production",
+            });
+
+            await createTraceWithObservations(useEventsTable, createdTrace, [
+              {
+                trace_id: traceId,
+                project_id: projectId,
+                name: "gen-1",
+                type: "GENERATION",
+                start_time: timestamp.getTime(),
+                end_time: timestamp.getTime() + 1000,
+                cost_details: { total: 0.05 },
+                total_cost: 0.05,
+              },
+            ]);
+
+            const scoreId = randomUUID();
+            const score = createTraceScore({
+              id: scoreId,
+              project_id: projectId,
+              trace_id: traceId,
+              name: "test-score",
+              value: 0.9,
+              data_type: "NUMERIC",
+              source: "API",
+              timestamp: timestamp.getTime(),
+            });
+            await createScoresCh([score]);
+
+            const response = await makeZodVerifiedAPICall(
+              GetTraceV1Response,
+              "GET",
+              `/api/public/traces/${traceId}?_=1${eventsParam}`,
+              undefined,
+              undefined,
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.body.id).toBe(traceId);
+            expect(response.body.name).toBe("single-trace-test");
+            // Events path includes root trace event as an observation
+            expect(response.body.observations.length).toBeGreaterThanOrEqual(1);
+            expect(
+              response.body.observations.find((o) => o.name === "gen-1"),
+            ).toBeDefined();
+            expect(response.body.scores).toHaveLength(1);
+            expect(response.body.scores[0].name).toBe("test-score");
+            expect(response.body.scores[0].value).toBe(0.9);
+            expect(response.body.latency).toBeGreaterThanOrEqual(0);
+            expect(response.body.totalCost).toBeGreaterThanOrEqual(0);
+          });
+
+          it("should respect field groups - scores only", async () => {
+            const traceId = randomUUID();
+
+            const createdTrace = createTrace({
+              id: traceId,
+              name: "fields-test",
+              project_id: projectId,
+              timestamp: Date.now(),
+            });
+
+            await createTraceWithObservations(useEventsTable, createdTrace, [
+              {
+                trace_id: traceId,
+                project_id: projectId,
+                name: "obs-1",
+                type: "SPAN",
+                start_time: Date.now(),
+              },
+            ]);
+
+            const response = await makeZodVerifiedAPICall(
+              GetTraceV1Response,
+              "GET",
+              `/api/public/traces/${traceId}?fields=scores${eventsParam}`,
+              undefined,
+              undefined,
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.body.id).toBe(traceId);
+            expect(response.body.observations).toEqual([]);
+            expect(response.body.latency).toBe(-1);
+            expect(response.body.totalCost).toBe(-1);
+          });
+        });
+      };
+
+      runTestSuite(false); // seeded project, no override → legacy traces table
+      runTestSuite(true); // seeded project + useEventsTable=true → events CTE
+    },
+  );
+
+  // Verify org createdAt date-based routing works without useEventsTable query param.
+  (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
+    ? describe
+    : describe.skip)("traces/[traceId] org createdAt routing", () => {
+    const setupOrgWithDate = async (createdAt: Date) => {
+      const result = await createOrgProjectAndApiKey();
+      await prisma.organization.update({
+        where: { id: result.orgId },
+        data: { createdAt },
+      });
+      return result;
+    };
+
+    it("post-cutoff org routes to events path", async () => {
+      const { projectId: pid, auth } = await setupOrgWithDate(
+        new Date(V4_DEFAULT_ENABLED_FROM_AT.getTime() + 1000),
+      );
+      const traceId = randomUUID();
+
+      await createTraceWithObservations(
+        true,
+        createTrace({
+          id: traceId,
+          project_id: pid,
+          name: "ev-trace",
+          user_id: "u1",
+          timestamp: Date.now(),
+        }),
+        [],
+      );
+
+      const res = await makeZodVerifiedAPICall(
+        GetTraceV1Response,
+        "GET",
+        `/api/public/traces/${traceId}`,
+        undefined,
+        auth,
+      );
+      expect(res.body.id).toBe(traceId);
+      expect(res.body.name).toBe("ev-trace");
+    });
+
+    it("pre-cutoff org routes to legacy path", async () => {
+      const { projectId: pid, auth } = await setupOrgWithDate(
+        new Date("2020-01-01"),
+      );
+      const traceId = randomUUID();
+
+      await createTraceWithObservations(
+        false,
+        createTrace({
+          id: traceId,
+          project_id: pid,
+          name: "leg-trace",
+          user_id: "u2",
+          timestamp: Date.now(),
+        }),
+        [],
+      );
+
+      const res = await makeZodVerifiedAPICall(
+        GetTraceV1Response,
+        "GET",
+        `/api/public/traces/${traceId}`,
+        undefined,
+        auth,
+      );
+      expect(res.body.id).toBe(traceId);
+      expect(res.body.name).toBe("leg-trace");
+    });
   });
 });

--- a/web/src/features/public-api/server/apiAuth.ts
+++ b/web/src/features/public-api/server/apiAuth.ts
@@ -187,6 +187,7 @@ export class ApiAuthService {
                 projectId: finalApiKey.projectId,
                 accessLevel,
                 orgId: finalApiKey.orgId,
+                orgCreatedAt: finalApiKey.orgCreatedAt,
                 plan: plan,
                 rateLimitOverrides: finalApiKey.rateLimitOverrides ?? [],
                 apiKeyId: finalApiKey.id,
@@ -211,6 +212,11 @@ export class ApiAuthService {
             const { orgId, cloudConfig, cloudFreeTierUsageThresholdState } =
               this.extractOrgIdAndCloudConfig(dbKey);
 
+            const bearerOrgCreatedAt =
+              dbKey.project?.organization.createdAt ??
+              dbKey.organization?.createdAt ??
+              null;
+
             addUserToSpan({
               projectId: dbKey.projectId ?? undefined,
               orgId,
@@ -223,6 +229,7 @@ export class ApiAuthService {
                 projectId: dbKey.projectId,
                 accessLevel: "scores",
                 orgId,
+                orgCreatedAt: bearerOrgCreatedAt?.toISOString() ?? null,
                 plan: getOrganizationPlanServerSide(cloudConfig),
                 rateLimitOverrides: cloudConfig?.rateLimitOverrides ?? [],
                 apiKeyId: dbKey.id,
@@ -472,10 +479,16 @@ export class ApiAuthService {
     const { orgId, cloudConfig, cloudFreeTierUsageThresholdState } =
       this.extractOrgIdAndCloudConfig(apiKeyAndOrganisation);
 
+    const orgCreatedAt =
+      apiKeyAndOrganisation.project?.organization.createdAt ??
+      apiKeyAndOrganisation.organization?.createdAt ??
+      null;
+
     const newApiKey = OrgEnrichedApiKey.parse({
       ...apiKeyAndOrganisation,
       createdAt: apiKeyAndOrganisation.createdAt?.toISOString(),
       orgId,
+      orgCreatedAt: orgCreatedAt?.toISOString() ?? null,
       plan: getOrganizationPlanServerSide(cloudConfig),
       rateLimitOverrides: cloudConfig?.rateLimitOverrides,
       isIngestionSuspended: cloudFreeTierUsageThresholdState === "BLOCKED",

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -218,6 +218,7 @@ async function verifyAdminApiKeyAuth(req: NextApiRequest): Promise<
       projectId: project.id,
       accessLevel: "project" as const,
       orgId: project.orgId,
+      orgCreatedAt: null,
       plan: "oss",
       rateLimitOverrides: [],
       apiKeyId: "ADMIN_API_KEY", // Special identifier for audit logging

--- a/web/src/features/public-api/server/scores-api-service.ts
+++ b/web/src/features/public-api/server/scores-api-service.ts
@@ -46,12 +46,16 @@ export class ScoresApiService {
    * v1: Returns listable scores (NUMERIC, BOOLEAN, CATEGORICAL, TEXT) - excludes CORRECTION
    * v2: Returns all score types including CORRECTION and TEXT
    */
-  async generateScoresForPublicApi(props: ScoreQueryType) {
+  async generateScoresForPublicApi(
+    props: ScoreQueryType,
+    useEventsTable = false,
+  ) {
     return _handleGenerateScoresForPublicApi({
       props,
       scoreScope: this.apiVersion === "v1" ? "traces_only" : "all",
       scoreDataTypes:
         this.apiVersion === "v1" ? LISTABLE_SCORE_TYPES : undefined,
+      useEventsTable,
     });
   }
 
@@ -60,12 +64,16 @@ export class ScoresApiService {
    * v1: Only counts listable scores (NUMERIC, BOOLEAN, CATEGORICAL, TEXT) - excludes CORRECTION
    * v2: Counts all score types including CORRECTION and TEXT
    */
-  async getScoresCountForPublicApi(props: ScoreQueryType) {
+  async getScoresCountForPublicApi(
+    props: ScoreQueryType,
+    useEventsTable = false,
+  ) {
     return _handleGetScoresCountForPublicApi({
       props,
       scoreScope: this.apiVersion === "v1" ? "traces_only" : "all",
       scoreDataTypes:
         this.apiVersion === "v1" ? LISTABLE_SCORE_TYPES : undefined,
+      useEventsTable,
     });
   }
 }

--- a/web/src/features/public-api/server/scores.ts
+++ b/web/src/features/public-api/server/scores.ts
@@ -8,6 +8,7 @@ import {
   queryClickhouse,
   measureAndReturn,
   scoresTableUiColumnDefinitions,
+  eventsTraceMetadata,
 } from "@langfuse/shared/src/server";
 import {
   removeObjectKeys,
@@ -88,10 +89,12 @@ export const _handleGenerateScoresForPublicApi = async ({
   props,
   scoreScope,
   scoreDataTypes,
+  useEventsTable = false,
 }: {
   props: ScoreQueryType;
   scoreScope: "traces_only" | "all";
   scoreDataTypes?: readonly ScoreDataTypeType[];
+  useEventsTable?: boolean;
 }) => {
   const { scoresFilter, tracesFilter } = generateScoreFilter(
     props,
@@ -106,7 +109,12 @@ export const _handleGenerateScoresForPublicApi = async ({
     tracesFilter.length(),
   );
 
+  const { tracesCTEClause, tracesCTEParams } = useEventsTable
+    ? buildEventsTracesCTE(props.projectId, needsTraceJoin)
+    : { tracesCTEClause: "", tracesCTEParams: {} };
+
   const query = `
+      ${tracesCTEClause}
       SELECT
           ${needsTraceJoin ? "t.user_id as user_id, t.tags as tags, t.environment as trace_environment, t.session_id as trace_session_id," : ""}
           s.id as id,
@@ -163,13 +171,18 @@ export const _handleGenerateScoresForPublicApi = async ({
       ${props.limit !== undefined && props.page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
       `;
 
+  const operationName = useEventsTable
+    ? "_handleGenerateScoresForPublicApiFromEvents"
+    : "_handleGenerateScoresForPublicApi";
+
   return measureAndReturn({
-    operationName: "_handleGenerateScoresForPublicApi",
+    operationName,
     projectId: props.projectId,
     input: {
       params: {
         ...appliedScoresFilter.params,
         ...appliedTracesFilter.params,
+        ...tracesCTEParams,
         projectId: props.projectId,
         ...(props.limit !== undefined ? { limit: props.limit } : {}),
         ...(props.page !== undefined
@@ -181,7 +194,7 @@ export const _handleGenerateScoresForPublicApi = async ({
         type: "score",
         projectId: props.projectId,
         scoreScope,
-        operation_name: "_handleGenerateScoresForPublicApi",
+        operation_name: operationName,
         includeTrace: includeTrace.toString(),
       },
     },
@@ -229,10 +242,12 @@ export const _handleGetScoresCountForPublicApi = async ({
   props,
   scoreScope,
   scoreDataTypes,
+  useEventsTable = false,
 }: {
   props: ScoreQueryType;
   scoreScope: "traces_only" | "all";
   scoreDataTypes?: readonly ScoreDataTypeType[];
+  useEventsTable?: boolean;
 }) => {
   const { scoresFilter, tracesFilter } = generateScoreFilter(
     props,
@@ -247,7 +262,12 @@ export const _handleGetScoresCountForPublicApi = async ({
     tracesFilter.length(),
   );
 
+  const { tracesCTEClause, tracesCTEParams } = useEventsTable
+    ? buildEventsTracesCTE(props.projectId, needsTraceJoin)
+    : { tracesCTEClause: "", tracesCTEParams: {} };
+
   const query = `
+      ${tracesCTEClause}
       SELECT
         count() as count
       FROM
@@ -276,13 +296,18 @@ export const _handleGetScoresCountForPublicApi = async ({
       ${tracesFilter.length() > 0 ? `AND ${appliedTracesFilter.query}` : ""}
       `;
 
+  const operationName = useEventsTable
+    ? "_handleGetScoresCountForPublicApiFromEvents"
+    : "_handleGetScoresCountForPublicApi";
+
   return measureAndReturn({
-    operationName: "_handleGetScoresCountForPublicApi",
+    operationName,
     projectId: props.projectId,
     input: {
       params: {
         ...appliedScoresFilter.params,
         ...appliedTracesFilter.params,
+        ...tracesCTEParams,
         projectId: props.projectId,
       },
       tags: {
@@ -290,7 +315,7 @@ export const _handleGetScoresCountForPublicApi = async ({
         type: "score",
         projectId: props.projectId,
         scoreScope,
-        operation_name: "_handleGetScoresCountForPublicApi",
+        operation_name: operationName,
         includeTrace: includeTrace.toString(),
       },
     },
@@ -500,4 +525,31 @@ const generateScoreFilter = (
   }
 
   return { scoresFilter, tracesFilter };
+};
+
+/**
+ * Build a traces CTE from the events table for use in scores queries.
+ * Extends the shared eventsTraceMetadata builder with additional columns
+ * needed by the public API response (project_id, environment, session_id).
+ */
+const buildEventsTracesCTE = (
+  projectId: string,
+  needsTraceJoin: boolean,
+): { tracesCTEClause: string; tracesCTEParams: Record<string, unknown> } => {
+  if (!needsTraceJoin) {
+    return { tracesCTEClause: "", tracesCTEParams: {} };
+  }
+
+  const builder = eventsTraceMetadata(projectId).selectRaw(
+    "e.project_id AS project_id",
+    "e.environment AS environment",
+    "e.session_id AS session_id",
+  );
+
+  const { query: cteQuery, params: cteParams } = builder.buildWithParams();
+
+  return {
+    tracesCTEClause: `WITH traces AS (${cteQuery})`,
+    tracesCTEParams: cteParams,
+  };
 };

--- a/web/src/features/public-api/server/useEventsTable.ts
+++ b/web/src/features/public-api/server/useEventsTable.ts
@@ -1,0 +1,20 @@
+import { env } from "@/src/env.mjs";
+import { V4_DEFAULT_ENABLED_FROM_AT } from "@/src/features/events/lib/v4Rollout";
+
+export function shouldUseEventsTable(params: {
+  queryParam?: boolean;
+  orgCreatedAt?: string | null;
+}): boolean {
+  // Explicit query param takes precedence
+  if (params.queryParam !== undefined && params.queryParam !== null) {
+    return params.queryParam === true;
+  }
+  // When the env-var gate is enabled, use events for orgs created after the v4 cutoff
+  if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+    return (
+      !!params.orgCreatedAt &&
+      new Date(params.orgCreatedAt) >= V4_DEFAULT_ENABLED_FROM_AT
+    );
+  }
+  return false;
+}

--- a/web/src/features/public-api/types/traces.ts
+++ b/web/src/features/public-api/types/traces.ts
@@ -138,6 +138,7 @@ export const GetTraceV1Query = z.object({
       return parsed.length > 0 ? parsed : null;
     })
     .pipe(z.array(z.enum(TRACE_FIELD_GROUPS)).nullable()),
+  useEventsTable: useEventsTableSchema,
 });
 export const GetTraceV1Response = APIExtendedTrace.extend({
   scores: z.array(APIScoreSchemaV1),

--- a/web/src/features/query/types.ts
+++ b/web/src/features/query/types.ts
@@ -192,7 +192,4 @@ export const query = z
       new Date(query.fromTimestamp) < new Date(query.toTimestamp),
   );
 
-export const useEventsTableSchema = z
-  .union([z.literal("true"), z.literal("false"), z.boolean()])
-  .optional()
-  .transform((val) => val === "true" || val === true);
+export { useEventsTableSchema } from "@langfuse/shared";

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -12,7 +12,7 @@ import {
   getObservationById,
   getObservationByIdFromEventsTable,
 } from "@langfuse/shared/src/server";
-import { env } from "@/src/env.mjs";
+import { shouldUseEventsTable } from "@/src/features/public-api/server/useEventsTable";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -20,11 +20,10 @@ export default withMiddlewares({
     querySchema: GetObservationV1Query,
     responseSchema: GetObservationV1Response,
     fn: async ({ query, auth }) => {
-      // Use events table if query parameter is explicitly set, otherwise use environment variable
-      const useEventsTable =
-        query.useEventsTable !== undefined && query.useEventsTable !== null
-          ? query.useEventsTable === true
-          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
+      const useEventsTable = shouldUseEventsTable({
+        queryParam: query.useEventsTable,
+        orgCreatedAt: auth.scope.orgCreatedAt,
+      });
 
       const clickhouseObservation = useEventsTable
         ? await getObservationByIdFromEventsTable({

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -3,8 +3,7 @@ import {
   getObservationsFromEventsTableForPublicApi,
   getObservationsCountFromEventsTableForPublicApi,
 } from "@langfuse/shared/src/server";
-import { env } from "@/src/env.mjs";
-
+import { shouldUseEventsTable } from "@/src/features/public-api/server/useEventsTable";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 
@@ -41,11 +40,10 @@ export default withMiddlewares({
         advancedFilters: query.filter,
       };
 
-      // Use events table if query parameter is explicitly set, otherwise use environment variable
-      const useEventsTable =
-        query.useEventsTable !== undefined && query.useEventsTable !== null
-          ? query.useEventsTable === true
-          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
+      const useEventsTable = shouldUseEventsTable({
+        queryParam: query.useEventsTable,
+        orgCreatedAt: auth.scope.orgCreatedAt,
+      });
 
       if (useEventsTable) {
         const [items, count] = await Promise.all([

--- a/web/src/pages/api/public/scores/index.ts
+++ b/web/src/pages/api/public/scores/index.ts
@@ -16,6 +16,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { ForbiddenError } from "@langfuse/shared";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
+import { shouldUseEventsTable } from "@/src/features/public-api/server/useEventsTable";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
@@ -61,6 +62,11 @@ export default withMiddlewares({
     fn: async ({ query, auth }) => {
       const scoresApiService = new ScoresApiService("v1");
 
+      const useEventsTable = shouldUseEventsTable({
+        queryParam: query.useEventsTable,
+        orgCreatedAt: auth.scope.orgCreatedAt,
+      });
+
       const scoreParams = {
         projectId: auth.scope.projectId,
         page: query.page ?? undefined,
@@ -81,8 +87,14 @@ export default withMiddlewares({
         advancedFilters: query.filter,
       };
       const [items, count] = await Promise.all([
-        scoresApiService.generateScoresForPublicApi(scoreParams),
-        scoresApiService.getScoresCountForPublicApi(scoreParams),
+        scoresApiService.generateScoresForPublicApi(
+          scoreParams,
+          useEventsTable,
+        ),
+        scoresApiService.getScoresCountForPublicApi(
+          scoreParams,
+          useEventsTable,
+        ),
       ]);
 
       const finalCount = count ? count : 0;

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -19,11 +19,16 @@ import {
   getObservationsForTrace,
   getScoresForTraces,
   getTraceById,
+  getTraceByIdFromEventsTable,
+  getObservationsForTraceFromEventsTable,
   traceException,
   traceDeletionProcessor,
+  type ObservationPriceFields,
 } from "@langfuse/shared/src/server";
+import type { Observation, EventsObservation } from "@langfuse/shared";
 import Decimal from "decimal.js";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { shouldUseEventsTable } from "@/src/features/public-api/server/useEventsTable";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -32,6 +37,11 @@ export default withMiddlewares({
     responseSchema: GetTraceV1Response,
     fn: async ({ query, auth }) => {
       const { traceId } = query;
+
+      const useEventsTable = shouldUseEventsTable({
+        queryParam: query.useEventsTable,
+        orgCreatedAt: auth.scope.orgCreatedAt,
+      });
 
       let effectiveFields: readonly TraceFieldGroup[] =
         query.fields ?? TRACE_FIELD_GROUPS;
@@ -51,14 +61,25 @@ export default withMiddlewares({
       const includeScores = requestedFields.includes("scores");
       const includeMetrics = requestedFields.includes("metrics");
 
-      const trace = await getTraceById({
-        traceId,
-        projectId: auth.scope.projectId,
-        clickhouseFeatureTag: "tracing-public-api",
-        preferredClickhouseService: "ReadOnly",
-        excludeInputOutput: !includeIO,
-        excludeMetadata: !includeIO,
-      });
+      const trace = useEventsTable
+        ? await getTraceByIdFromEventsTable({
+            traceId,
+            projectId: auth.scope.projectId,
+            clickhouseFeatureTag: "tracing-public-api",
+            preferredClickhouseService: "ReadOnly",
+            renderingProps: {
+              truncated: !includeIO,
+              shouldJsonParse: true,
+            },
+          })
+        : await getTraceById({
+            traceId,
+            projectId: auth.scope.projectId,
+            clickhouseFeatureTag: "tracing-public-api",
+            preferredClickhouseService: "ReadOnly",
+            excludeInputOutput: !includeIO,
+            excludeMetadata: !includeIO,
+          });
 
       if (!trace) {
         throw new LangfuseNotFoundError(
@@ -66,16 +87,82 @@ export default withMiddlewares({
         );
       }
 
-      const [observations, scores] = await Promise.all([
-        includeObservations || includeMetrics
-          ? getObservationsForTrace({
+      // Fetch observations and scores in parallel.
+      // Events path: already enriched with model data, strip events-only fields.
+      // Legacy path: manual Prisma model lookup for pricing after fetch.
+      type ApiObservation = (Observation | EventsObservation) &
+        ObservationPriceFields;
+
+      const fetchObservations = async (): Promise<ApiObservation[]> => {
+        if (!(includeObservations || includeMetrics)) return [];
+
+        if (useEventsTable) {
+          const { observations: eventsObs } =
+            await getObservationsForTraceFromEventsTable({
               traceId,
               projectId: auth.scope.projectId,
               timestamp: trace?.timestamp,
-              includeIO: includeObservations,
-              preferredClickhouseService: "ReadOnly",
-            })
-          : Promise.resolve([]),
+              selectIOAndMetadata: includeObservations,
+            });
+          return eventsObs.map(
+            ({
+              traceTimestamp: _tt,
+              toolDefinitionsCount: _tdc,
+              toolCallsCount: _tcc,
+              ...obs
+            }) => obs,
+          );
+        }
+
+        const legacyObs = await getObservationsForTrace({
+          traceId,
+          projectId: auth.scope.projectId,
+          timestamp: trace?.timestamp,
+          includeIO: includeObservations,
+          preferredClickhouseService: "ReadOnly",
+        });
+
+        const uniqueModels = Array.from(
+          new Set(
+            legacyObs
+              .map((r) => r.internalModelId)
+              .filter((id): id is string => !!id),
+          ),
+        );
+
+        const models =
+          uniqueModels.length > 0
+            ? await prisma.model.findMany({
+                where: {
+                  id: { in: uniqueModels },
+                  OR: [
+                    { projectId: auth.scope.projectId },
+                    { projectId: null },
+                  ],
+                },
+                include: { Price: true },
+              })
+            : [];
+
+        return legacyObs.map((o) => {
+          const model = models.find((m) => m.id === o.internalModelId);
+          return {
+            ...o,
+            inputPrice:
+              model?.Price.find((p) => p.usageType === "input")?.price ??
+              new Decimal(0),
+            outputPrice:
+              model?.Price.find((p) => p.usageType === "output")?.price ??
+              new Decimal(0),
+            totalPrice:
+              model?.Price.find((p) => p.usageType === "total")?.price ??
+              new Decimal(0),
+          };
+        });
+      };
+
+      const [observationsView, scores] = await Promise.all([
+        fetchObservations(),
         includeScores
           ? getScoresForTraces({
               projectId: auth.scope.projectId,
@@ -86,63 +173,19 @@ export default withMiddlewares({
           : Promise.resolve([]),
       ]);
 
-      const uniqueModels: string[] = Array.from(
-        new Set(
-          observations
-            .map((r) => r.internalModelId)
-            .filter((r): r is string => Boolean(r)),
-        ),
-      );
-
-      const models =
-        uniqueModels.length > 0
-          ? await prisma.model.findMany({
-              where: {
-                id: {
-                  in: uniqueModels,
-                },
-                OR: [{ projectId: auth.scope.projectId }, { projectId: null }],
-              },
-              include: {
-                Price: true,
-              },
-            })
-          : [];
-
-      const observationsView = observations.map((o) => {
-        const model = models.find((m) => m.id === o.internalModelId);
-        const inputPrice =
-          model?.Price.find((p) => p.usageType === "input")?.price ??
-          new Decimal(0);
-        const outputPrice =
-          model?.Price.find((p) => p.usageType === "output")?.price ??
-          new Decimal(0);
-        const totalPrice =
-          model?.Price.find((p) => p.usageType === "total")?.price ??
-          new Decimal(0);
-        return {
-          ...o,
-          inputPrice,
-          outputPrice,
-          totalPrice,
-        };
-      });
-
       const outObservations = observationsView.map(transformDbToApiObservation);
-      // As these are traces scores, we expect all scores to have a traceId set
-      // For type consistency, we validate the scores against the v1 schema which requires a traceId
       const validatedScores = filterAndValidateDbTraceScoreList({
         scores,
         onParseError: traceException,
       });
 
-      const obsStartTimes = observations
+      const obsStartTimes = observationsView
         .map((o) => o.startTime)
         .sort((a, b) => a.getTime() - b.getTime());
-      const obsEndTimes = observations
+      const obsEndTimes = observationsView
         .map((o) => o.endTime)
-        .filter((t) => t)
-        .sort((a, b) => (a as Date).getTime() - (b as Date).getTime());
+        .filter((t): t is Date => !!t)
+        .sort((a, b) => a.getTime() - b.getTime());
 
       const latencyMs =
         obsStartTimes.length > 0

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -27,6 +27,7 @@ import {
   getTracesCountForPublicApi,
 } from "@/src/features/public-api/server/traces";
 import { env } from "@/src/env.mjs";
+import { shouldUseEventsTable } from "@/src/features/public-api/server/useEventsTable";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
@@ -119,11 +120,10 @@ export default withMiddlewares({
         toTimestamp: query.toTimestamp ?? undefined,
       };
 
-      // Use events table if query parameter is explicitly set, otherwise use environment variable
-      const useEventsTable =
-        query.useEventsTable !== undefined && query.useEventsTable !== null
-          ? query.useEventsTable === true
-          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+      const useEventsTable = shouldUseEventsTable({
+        queryParam: query.useEventsTable,
+        orgCreatedAt: auth.scope.orgCreatedAt,
+      });
 
       if (useEventsTable) {
         const [items, count] = await Promise.all([

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -7,6 +7,7 @@ import {
   InvalidRequestError,
 } from "@langfuse/shared";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
+import { shouldUseEventsTable } from "@/src/features/public-api/server/useEventsTable";
 import { logger } from "@langfuse/shared/src/server";
 
 export default withMiddlewares({
@@ -60,9 +61,21 @@ export default withMiddlewares({
         advancedFilters: query.filter,
       };
       const scoresApiService = new ScoresApiService("v2");
+
+      const useEventsTable = shouldUseEventsTable({
+        queryParam: query.useEventsTable,
+        orgCreatedAt: auth.scope.orgCreatedAt,
+      });
+
       const [items, count] = await Promise.all([
-        scoresApiService.generateScoresForPublicApi(scoreParams),
-        scoresApiService.getScoresCountForPublicApi(scoreParams),
+        scoresApiService.generateScoresForPublicApi(
+          scoreParams,
+          useEventsTable,
+        ),
+        scoresApiService.getScoresCountForPublicApi(
+          scoreParams,
+          useEventsTable,
+        ),
       ]);
 
       const finalCount = count ? count : 0;


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR migrates the scores public API (v1 and v2) and the `GET /traces/{traceId}` endpoint to support reading from the events table, using a per-org `createdAt` cutoff date to route automatically and an explicit `useEventsTable` query parameter as an override. The `useEventsTableSchema` is moved to `@langfuse/shared` and updated to preserve `undefined` (unset) vs `false` (explicit), fixing previously dead env-var fallback logic in the observations endpoints as a side effect.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only P2 findings remain — the Redis cache concern is a graceful degradation, not a correctness issue.

All remaining findings are P2: a temporary Redis parse-error burst on first deploy (safe fallback to DB) and a dead null guard. Core routing logic, CTE construction, parameter merging, and auth-scope propagation are all correct. Tests cover both legacy and events paths plus org-date-based routing.

packages/shared/src/server/auth/types.ts — orgCreatedAt should be .optional() or .nullish() to survive existing Redis cache entries cleanly.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/shared/src/server/auth/types.ts | Adds `orgCreatedAt` to auth scope; non-optional field will cause Redis cache parse failures until TTL expires |
| web/src/features/public-api/server/useEventsTable.ts | New routing helper; logic is correct, minor dead null check on queryParam |
| web/src/features/public-api/server/scores.ts | Adds CTE-based events-table path for scores queries; __TRACE_TABLE__ substitution and param merging look correct |
| web/src/pages/api/public/traces/[traceId].ts | Dual-path observation fetch refactored cleanly; events-specific fields stripped before shared transform, pricing logic preserved for legacy path |
| web/src/features/public-api/server/apiAuth.ts | orgCreatedAt correctly extracted from project.organization or direct organization and forwarded to auth scope |
| packages/shared/src/utils/zod.ts | Schema correctly preserves undefined (unset) vs false (explicit), enabling downstream routing logic |
| web/src/__tests__/server/scores-api-v1.servertest.ts | Comprehensive dual-path and org-date routing tests added |
| web/src/__tests__/server/traces-api.servertest.ts | Dual-path and routing tests for single trace endpoint look thorough |
| packages/shared/scripts/seeder/seed-postgres.ts | Seeds org with pre-cutoff createdAt to keep seeded project on legacy path by default |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Public API Request] --> C{useEventsTable\nquery param}

    C -->|explicit true| E[Events Table Path]
    C -->|explicit false| F[Legacy Traces Table Path]
    C -->|undefined / omitted| D{LANGFUSE_ENABLE_EVENTS\n_TABLE_OBSERVATIONS env var}

    D -->|false / unset| F
    D -->|true| G{org.createdAt\n>= V4_DEFAULT_ENABLED_FROM_AT?}

    G -->|yes| E
    G -->|no or null| F

    E --> H[CTE: WITH traces AS eventsTraceMetadata]
    F --> I[Physical traces table]

    H --> J[scores LEFT JOIN CTE traces]
    I --> K[scores LEFT JOIN traces]

    J --> L[API Response]
    K --> L
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/shared/src/server/auth/types.ts`, line 60 ([link](https://github.com/langfuse/langfuse/blob/76978a9681f2703daed5959badb52aeee3803416/packages/shared/src/server/auth/types.ts#L60)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`orgCreatedAt` not marked optional — stale Redis entries will error-log on parse**

   `orgCreatedAt: z.string().datetime().nullable()` is non-optional, so any key that was cached in Redis before this deploy will fail `CachedApiKey.safeParse`. Each failure triggers a logged error, a Redis key deletion, and a DB fallback. During the cache TTL window after rollout this could produce a large burst of spurious error logs and extra DB load.

   Marking the field `.optional()` (or using `.nullish()`) would allow existing cached entries to parse cleanly, defaulting to `null` and routing to the legacy path — exactly the safe behavior desired for pre-existing keys.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/shared/src/server/auth/types.ts
   Line: 60

   Comment:
   **`orgCreatedAt` not marked optional — stale Redis entries will error-log on parse**

   `orgCreatedAt: z.string().datetime().nullable()` is non-optional, so any key that was cached in Redis before this deploy will fail `CachedApiKey.safeParse`. Each failure triggers a logged error, a Redis key deletion, and a DB fallback. During the cache TTL window after rollout this could produce a large burst of spurious error logs and extra DB load.

   Marking the field `.optional()` (or using `.nullish()`) would allow existing cached entries to parse cleanly, defaulting to `null` and routing to the legacy path — exactly the safe behavior desired for pre-existing keys.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/shared/src/server/auth/types.ts
Line: 60

Comment:
**`orgCreatedAt` not marked optional — stale Redis entries will error-log on parse**

`orgCreatedAt: z.string().datetime().nullable()` is non-optional, so any key that was cached in Redis before this deploy will fail `CachedApiKey.safeParse`. Each failure triggers a logged error, a Redis key deletion, and a DB fallback. During the cache TTL window after rollout this could produce a large burst of spurious error logs and extra DB load.

Marking the field `.optional()` (or using `.nullish()`) would allow existing cached entries to parse cleanly, defaulting to `null` and routing to the legacy path — exactly the safe behavior desired for pre-existing keys.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/features/public-api/server/useEventsTable.ts
Line: 9

Comment:
**Dead `!== null` guard — `queryParam` is typed `boolean | undefined`**

`queryParam` is typed as `boolean | undefined` (produced by the `useEventsTableSchema` transform which never yields `null`), so the `!== null` branch can never be true. The check is harmless but misleading about the contract.

```suggestion
  if (params.queryParam !== undefined) {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api): migrate scores public API and..."](https://github.com/langfuse/langfuse/commit/76978a9681f2703daed5959badb52aeee3803416) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29481506)</sub>

<!-- /greptile_comment -->