### PR TITLE
fix(shared): cap analytics observations CTE upper bound (LFE-9475)

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -1427,6 +1427,7 @@ export const getTracesForAnalyticsIntegrations = async function* (
       FROM observations o FINAL
       WHERE o.project_id = {projectId: String}
       AND o.start_time >= {minTimestamp: DateTime64(3)} - ${TRACE_TO_OBSERVATIONS_INTERVAL}
+      AND o.start_time < {maxTimestamp: DateTime64(3)} + ${OBSERVATIONS_TO_TRACE_INTERVAL}
       GROUP BY o.project_id, o.trace_id
     )
 


### PR DESCRIPTION
## Summary
- Adds an upper bound to the `observations_agg` CTE in `getTracesForAnalyticsIntegrations` so the observations scan is no longer unbounded.
- Caps at `maxTimestamp + OBSERVATIONS_TO_TRACE_INTERVAL` (2 days), consistent with the observation-to-trace convention used elsewhere in `traces.ts`.
- Follow-up to #13326 (LFE-9475): that PR bounded the outer window; this PR bounds the CTE that feeds it.

## Why this is safe
- Traces outside `[minTimestamp, maxTimestamp)` are already filtered in the outer `SELECT`, so any observation starting more than 2 days after `maxTimestamp` belongs to a trace we aren't emitting this run.
- For the traces we do emit, healthy schedulers run with the 30-min `now` buffer, so a trace's observations have settled well before the window boundary advances.
- The 2-day cap matches how we already bound observation-to-trace lookups elsewhere (`traces.ts:122`, `traces.ts:1261`).

## Test plan
- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter @langfuse/shared run typecheck`
- [ ] Manual verification: run PostHog analytics export on a project with long-running traces and confirm observation counts/costs remain correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a single upper-bound predicate to the `observations_agg` CTE inside `getTracesForAnalyticsIntegrations`, capping the ClickHouse observations scan at `maxTimestamp + OBSERVATIONS_TO_TRACE_INTERVAL` (2 days) to eliminate the previously unbounded right-side scan. The outer `SELECT` already constrains emitted traces to `[minTimestamp, maxTimestamp)`, so correctness is preserved — the CTE widening only affects query scan cost, not result accuracy.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a conservative scan bound that cannot drop valid observations from results.

The only finding is a P2 style note about using the 2-day constant rather than the tighter 1-hour constant for the upper bound. The choice is conservative (wider, not narrower) so no data is lost, and the outer WHERE clause guarantees only in-window traces are emitted regardless of CTE width.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/repositories/traces.ts | Adds a single upper-bound condition to the `observations_agg` CTE, capping the scan at `maxTimestamp + OBSERVATIONS_TO_TRACE_INTERVAL` (2 days) to prevent unbounded ClickHouse scans; outer SELECT already filters to `[minTimestamp, maxTimestamp)` so correctness is unaffected. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getTracesForAnalyticsIntegrations\n(projectId, minTimestamp, maxTimestamp)"] --> B

    subgraph CTE["observations_agg CTE"]
        B["Scan observations\nWHERE project_id = projectId"]
        B --> C["lower: start_time >= minTimestamp - 1h\n(TRACE_TO_OBSERVATIONS_INTERVAL)"]
        C --> D["upper (NEW): start_time < maxTimestamp + 2d\n(OBSERVATIONS_TO_TRACE_INTERVAL)"]
        D --> E["GROUP BY project_id, trace_id\n→ total_cost, observation_count, latency"]
    end

    subgraph OUTER["Outer SELECT"]
        F["Join traces t FINAL\nWHERE t.timestamp ∈ [minTimestamp, maxTimestamp)"]
        F --> G["LEFT JOIN observations_agg\nON t.id = o.trace_id"]
        G --> H["Yield enriched trace records\n(cost, latency, observation_count)"]
    end

    E --> F
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/shared/src/server/repositories/traces.ts
Line: 1429-1430

Comment:
**Asymmetric interval constants for lower vs upper bound**

The existing lower bound uses `TRACE_TO_OBSERVATIONS_INTERVAL` (1 hour), while the new upper bound uses `OBSERVATIONS_TO_TRACE_INTERVAL` (2 days). Per `constants.ts`, these constants represent different semantic directions of the trace-observation relationship, and neither is explicitly designed as an upper bound. Using 2 days is conservative (won't miss any observations), but it is wider than the tightest safe choice and creates asymmetry with the lower bound. If performance matters on large datasets, `TRACE_TO_OBSERVATIONS_INTERVAL` (1 hour) would give a tighter upper bound that still safely covers all observations for traces within the window.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): cap analytics observations ..."](https://github.com/langfuse/langfuse/commit/63fd850de17937e6e5d4c1be15cfdb0f71d996f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29482533)</sub>

<!-- /greptile_comment -->