### PR TITLE
fixbug: Applying clickhouse migrations failed #13321

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-}
 
   clickhouse:
-    image: docker.io/clickhouse/clickhouse-server
+    image: docker.io/clickhouse/clickhouse-server:24.3
     restart: always
     user: "101:101"
     environment:


### PR DESCRIPTION
https://github.com/langfuse/langfuse/issues/13321

## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes ClickHouse migration failures (issue #13321) by pinning the ClickHouse Docker image from the floating `latest` tag to `24.3`, preventing unexpected breakage when a new upstream ClickHouse release ships incompatible DDL changes. The fix is correct in principle; the only open question is whether `24.3` aligns with the version targeted by the rest of Langfuse's infrastructure (Helm/K8s/CI) and whether a fully-qualified patch tag would be preferable for full reproducibility.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line config change that correctly pins an unversioned Docker image; only remaining feedback is a style-level suggestion about full semver pinning.

The change is a one-line image tag pin in docker-compose.yml. It addresses the root cause of the reported migration failure (floating `latest` tag picking up a breaking ClickHouse release). All remaining review findings are P2 style suggestions that do not block correctness or safety.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docker-compose.yml | Pins ClickHouse image from untagged (latest) to version 24.3 to fix migration failures; version may already be outdated (24.3 is LTS but newer stable releases exist). |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Docker as Docker Compose
    participant CH as ClickHouse (24.3)
    participant LF as Langfuse Server

    Docker->>CH: Pull docker.io/clickhouse/clickhouse-server:24.3
    CH-->>Docker: Image ready
    Docker->>LF: Start langfuse-server
    LF->>CH: Apply migrations
    CH-->>LF: Migrations succeed (pinned version is compatible)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docker-compose.yml
Line: 90

Comment:
**Consider pinning to the same version used in CI/production**

Pinning to `24.3` fixes the unpredictable-latest problem, but `24.3` is the minor-tag only — Docker will still pull the newest `24.3.x` patch, and the tag does not lock down the patch level. More importantly, if Langfuse's other infrastructure configs (Helm chart, Kubernetes manifests, or CI pipelines) target a different ClickHouse version, this compose file will diverge and reproduce the migration-compatibility problem for new contributors.

Check which ClickHouse version is declared in those configs and use the same full semver tag (e.g. `24.3.6.48`) here to guarantee bit-for-bit reproducibility.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fixbug: Applying clickhouse migrations f..."](https://github.com/langfuse/langfuse/commit/e673fb761a0d77c704c098825cb95aee6461b6cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29547698)</sub>

<!-- /greptile_comment -->