### PR TITLE
perf(clickhouse): scores query in events.all scans all partitions

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -621,6 +621,12 @@ export type GetScoresForObservationsProps<
 > = {
   projectId: string;
   observationIds: string[];
+  /**
+   * When provided, adds `AND s.timestamp >= minTimestamp - SCORE_TO_TRACE_OBSERVATIONS_INTERVAL`
+   * to the query so ClickHouse can prune monthly partitions and avoid full-table scans.
+   * Pass the minimum startTime of the observations whose scores you are fetching.
+   */
+  minTimestamp?: Date;
   limit?: number;
   offset?: number;
   clickhouseConfigs?: ClickHouseClientConfigOptions;
@@ -638,6 +644,7 @@ export const getScoresForObservations = async <
   const {
     projectId,
     observationIds,
+    minTimestamp,
     limit,
     offset,
     clickhouseConfigs,
@@ -661,6 +668,7 @@ export const getScoresForObservations = async <
       WHERE s.project_id = {projectId: String}
       AND s.observation_id IN ({observationIds: Array(String)})
       AND s.data_type IN ({dataTypes: Array(String)})
+      ${minTimestamp ? `AND s.timestamp >= {minTimestamp: DateTime64(3)} - ${SCORE_TO_TRACE_OBSERVATIONS_INTERVAL}` : ""}
       ORDER BY s.event_ts DESC
       LIMIT 1 BY s.id, s.project_id
       ${limit !== undefined && offset !== undefined ? `limit {limit: Int32} offset {offset: Int32}` : ""}
@@ -682,6 +690,9 @@ export const getScoresForObservations = async <
       dataTypes: LISTABLE_SCORE_TYPES,
       limit: limit,
       offset: offset,
+      ...(minTimestamp
+        ? { minTimestamp: convertDateToClickhouseDateTime(minTimestamp) }
+        : {}),
     },
     tags: {
       feature: "tracing",

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -109,10 +109,30 @@ export async function getEventList(params: GetObservationsListParams) {
     ),
   );
 
+  // Earliest observation startTime on this page — used as a partition-pruning
+  // lower bound for observation-level scores.  Safe because
+  // score.timestamp >= observation.start_time - 1 hour
+  // (SCORE_TO_TRACE_OBSERVATIONS_INTERVAL).
+  const minStartTime = observations.reduce(
+    (min, obs) => (obs.startTime < min ? obs.startTime : min),
+    observations[0].startTime,
+  );
+
+  // For trace-level scores the bound must account for the fact that
+  // trace.timestamp can be up to 2 days before observation.start_time
+  // (OBSERVATIONS_TO_TRACE_INTERVAL).  The events table does not carry
+  // trace timestamps, so we derive a safe lower bound:
+  //   minStartTime - 2 days  (earliest possible trace.timestamp)
+  // getScoresForTraces then applies its own 1-hour buffer, giving:
+  //   s.timestamp >= (minStartTime - 2 days) - 1 hour
+  const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000;
+  const minTraceTimestamp = new Date(minStartTime.getTime() - TWO_DAYS_MS);
+
   const [scores, traceScores] = await Promise.all([
     getScoresForObservations({
       projectId: params.projectId,
       observationIds: observations.map((observation) => observation.id),
+      minTimestamp: minStartTime,
       excludeMetadata: true,
       includeHasMetadata: true,
     }),
@@ -120,6 +140,7 @@ export async function getEventList(params: GetObservationsListParams) {
       ? getScoresForTraces({
           projectId: params.projectId,
           traceIds,
+          timestamp: minTraceTimestamp,
           excludeMetadata: true,
           includeHasMetadata: true,
         })


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a ClickHouse full-table scan on the `scores` table in the events list query by computing `minStartTime` (the earliest observation `startTime` on the current page) and passing it as a lower-bound hint to both `getScoresForObservations` and `getScoresForTraces`. The added `AND s.timestamp >= minTimestamp - INTERVAL 1 HOUR` predicate allows ClickHouse to prune monthly partitions and mirrors the existing pattern already used in dashboard queries.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the performance fix is correct for the common case, with a minor edge case risk on long-running or backfilled traces.

Only P2 findings present. The observation `minStartTime` used as the trace timestamp lower-bound for `getScoresForTraces` is semantically off and could theoretically miss scores when a trace's creation time significantly predates its first observation, but this is unlikely to affect typical tracing workflows. The `scores.ts` change is clean and consistent with the existing pattern.

web/src/features/events/server/eventsService.ts — the `timestamp: minStartTime` argument to `getScoresForTraces` warrants attention for long-running/backfilled trace scenarios.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/repositories/scores.ts | Adds optional `minTimestamp` to `GetScoresForObservationsProps`; injects it into the ClickHouse WHERE clause as a lower-bound on `s.timestamp` to enable monthly partition pruning — mirrors the existing `timestamp` pattern in `getScoresForTracesInternal`. |
| web/src/features/events/server/eventsService.ts | Computes `minStartTime` from the page of observations and passes it to both `getScoresForObservations` and `getScoresForTraces`; observation startTime is semantically close but not identical to trace timestamp used by `getScoresForTraces`, which could miss scores on long-running/backfilled traces. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant eventsService
    participant getScoresForObservations
    participant getScoresForTraces
    participant ClickHouse

    Client->>eventsService: getEventList(params)
    eventsService->>ClickHouse: getObservationsWithModelDataFromEventsTable
    ClickHouse-->>eventsService: observations[]
    eventsService->>eventsService: minStartTime = min(obs.startTime)
    par Parallel score fetches
        eventsService->>getScoresForObservations: { observationIds, minTimestamp: minStartTime }
        getScoresForObservations->>ClickHouse: WHERE s.timestamp >= minStartTime - 1h
        ClickHouse-->>getScoresForObservations: scores[]
    and
        eventsService->>getScoresForTraces: { traceIds, timestamp: minStartTime }
        getScoresForTraces->>ClickHouse: WHERE s.timestamp >= minStartTime - 1h
        ClickHouse-->>getScoresForTraces: traceScores[]
    end
    eventsService-->>Client: observations with scores attached
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/features/events/server/eventsService.ts
Line: 136

Comment:
**Semantic mismatch: observation minStartTime passed as trace timestamp**

`getScoresForTraces` uses `timestamp` to build the filter `s.timestamp >= {traceTimestamp} - INTERVAL 1 HOUR`. The intent is that `timestamp` is the minimum *trace* start time, not the minimum *observation* start time. Parent traces are typically created before their first observation, so the true minimum trace timestamp may be earlier. If scores for those traces have `s.timestamp` close to the trace creation time and the trace predates the oldest observation by more than an hour, those scores will be excluded from the result. The risk is low for typical synchronous tracing, but long-running or backfilled traces could cross the 1-hour boundary.

Consider using the minimum trace timestamp or adding an additional safety margin rather than `minStartTime`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(clickhouse): scores query in events..."](https://github.com/langfuse/langfuse/commit/31eabf35a61d280499bff89c65f8f68fb8b8c918) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29571992)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->