### PR TITLE
fix(dev): fix seed command

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -69,11 +69,11 @@
     "ch:drop": "bash clickhouse/scripts/drop.sh",
     "ch:dev-tables": "bash clickhouse/scripts/dev-tables.sh",
     "ch:reset": "pnpm run ch:down && pnpm run ch:up && pnpm run ch:seed && pnpm run ch:dev-tables",
-    "ch:seed": "dotenv -e ../../.env -- ts-node -r tsconfig-paths/register -r dotenv/config --compiler-options '{\"module\":\"CommonJS\"}' scripts/seeder/seed-clickhouse.ts",
+    "ch:seed": "dotenv -e ../../.env -- ts-node -r dotenv/config --compiler-options '{\"module\":\"CommonJS\"}' scripts/seeder/seed-clickhouse.ts",
     "load:setup": "dotenv -e ../../.env -- tsx scripts/seeder/load-seed-clickhouse.ts"
   },
   "prisma": {
-    "seed": "ts-node -r tsconfig-paths/register -r dotenv/config --compiler-options {\"module\":\"CommonJS\"} scripts/seeder/seed-postgres.ts"
+    "seed": "ts-node -r dotenv/config --compiler-options {\"module\":\"CommonJS\"} scripts/seeder/seed-postgres.ts"
   },
   "dependencies": {
     "@anthropic-ai/tokenizer": "^0.0.4",


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Removes the `-r tsconfig-paths/register` flag from the `ch:seed` and `prisma.seed` ts-node commands in `packages/shared/package.json`. Both seed scripts (`seed-clickhouse.ts` and `seed-postgres.ts`) rely only on relative imports and do not use TypeScript path aliases, so the flag was unnecessary and is safe to drop.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, targeted fix with no functional risk.

The only change is removing an unused ts-node flag. Both affected seed scripts use only relative imports, confirming tsconfig-paths was never needed. No logic, schema, or API changes are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/package.json | Removes `-r tsconfig-paths/register` from `ch:seed` and `prisma.seed` ts-node commands; safe since the seed scripts use only relative imports with no TypeScript path aliases. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm run ch:seed / prisma db seed] --> B[ts-node]
    B --> C[-r dotenv/config]
    C --> D[seed-clickhouse.ts / seed-postgres.ts]
    D --> E[Relative imports only\n../../src/...]
    E --> F[No path aliases used\ntsconfig-paths not needed]
```

<sub>Reviews (1): Last reviewed commit: ["fix(dev): fix seed command"](https://github.com/langfuse/langfuse/commit/4808180daf388617bd6f208581215812bca13c3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29572842)</sub>

<!-- /greptile_comment -->