### PR TITLE
chore: hide eval preview if user has not ingested with otel in the past 7 days

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3284,7 +3284,11 @@ export async function getLatestSdkVersionInfoFromEvents(params: {
   ]);
 
   const builder = new EventsQueryBuilder({ projectId })
-    .selectRaw("e.scope_name", "e.scope_version", "e.telemetry_sdk_language")
+    .selectRaw(
+      "e.scope_name AS scope_name",
+      "e.scope_version AS scope_version",
+      "e.telemetry_sdk_language AS telemetry_sdk_language",
+    )
     .selectMetadataExpanded([]) // Full metadata values from events_full
     .applyFilters(filter)
     // OR condition: v4 has scope_name column, v3 has scope in metadata

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -205,10 +205,12 @@ const ObservationsPreview = memo(
     projectId,
     filterState,
     isNewCompatible,
+    compatibilityCheckWasPerformed,
   }: {
     projectId: string;
     filterState: z.infer<typeof singleFilter>[];
     isNewCompatible: boolean;
+    compatibilityCheckWasPerformed: boolean;
   }) => {
     const { isBetaEnabled } = useV4Beta();
 
@@ -221,8 +223,9 @@ const ObservationsPreview = memo(
       } as TableDateRange;
     }, []);
 
-    // When v4 is enabled but user is not on OTEL SDK, show upgrade message
-    const showSdkUpgradeMessage = isBetaEnabled && !isNewCompatible;
+    // Show upgrade message only when SDK check was performed and user is not on OTEL SDK
+    const showSdkUpgradeMessage =
+      compatibilityCheckWasPerformed && !isNewCompatible;
 
     return (
       <>
@@ -1102,6 +1105,9 @@ export const InnerEvaluatorForm = (props: {
                         projectId={props.projectId}
                         filterState={form.watch("filter") ?? []}
                         isNewCompatible={props.evalCapabilities.isNewCompatible}
+                        compatibilityCheckWasPerformed={
+                          props.evalCapabilities.compatibilityCheckWasPerformed
+                        }
                       />
                     )}
                   </>
@@ -1172,6 +1178,9 @@ export const InnerEvaluatorForm = (props: {
         hideAdvancedSettings={props.hideAdvancedSettings}
         oldConfigId={props.oldConfigId}
         isNewCompatible={props.evalCapabilities.isNewCompatible}
+        compatibilityCheckWasPerformed={
+          props.evalCapabilities.compatibilityCheckWasPerformed
+        }
       />
     </div>
   );

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -204,9 +204,11 @@ const ObservationsPreview = memo(
   ({
     projectId,
     filterState,
+    isNewCompatible,
   }: {
     projectId: string;
     filterState: z.infer<typeof singleFilter>[];
+    isNewCompatible: boolean;
   }) => {
     const { isBetaEnabled } = useV4Beta();
 
@@ -219,6 +221,9 @@ const ObservationsPreview = memo(
       } as TableDateRange;
     }, []);
 
+    // When v4 is enabled but user is not on OTEL SDK, show upgrade message
+    const showSdkUpgradeMessage = isBetaEnabled && !isNewCompatible;
+
     return (
       <>
         <div className="flex flex-col items-start gap-1">
@@ -228,7 +233,32 @@ const ObservationsPreview = memo(
         </div>
         <div className="mb-4 flex max-h-[30dvh] w-full flex-col overflow-hidden border-r border-b border-l">
           <Suspense fallback={<Skeleton className="h-[30dvh] w-full" />}>
-            {isBetaEnabled ? (
+            {showSdkUpgradeMessage ? (
+              <div className="flex h-[30dvh] flex-col items-center justify-center gap-2 border-t p-4 text-center">
+                <AlertTriangle className="text-dark-yellow h-8 w-8" />
+                <div className="flex flex-col gap-1">
+                  <span className="text-foreground font-medium">
+                    Please verify your SDK version
+                  </span>
+                  <span className="text-muted-foreground max-w-md text-sm">
+                    We did not find any data ingested with langfuse
+                    OTEL-compatible SDKs in the last 7 days. Observation-level
+                    evaluators require JS SDK v4+ or Python SDK v3+. You can
+                    still configure this evaluator now—it will start running
+                    once you upgrade.{" "}
+                    <a
+                      href="https://langfuse.com/docs/observability/sdk/upgrade-path"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-dark-blue font-medium hover:opacity-80"
+                    >
+                      Learn more
+                    </a>
+                    .
+                  </span>
+                </div>
+              </div>
+            ) : isBetaEnabled ? (
               <EventsTable
                 projectId={projectId}
                 hideControls
@@ -1071,6 +1101,7 @@ export const InnerEvaluatorForm = (props: {
                       <ObservationsPreview
                         projectId={props.projectId}
                         filterState={form.watch("filter") ?? []}
+                        isNewCompatible={props.evalCapabilities.isNewCompatible}
                       />
                     )}
                   </>
@@ -1140,6 +1171,7 @@ export const InnerEvaluatorForm = (props: {
         shouldWrapVariables={props.shouldWrapVariables}
         hideAdvancedSettings={props.hideAdvancedSettings}
         oldConfigId={props.oldConfigId}
+        isNewCompatible={props.evalCapabilities.isNewCompatible}
       />
     </div>
   );

--- a/web/src/features/evals/components/variable-mapping-card.tsx
+++ b/web/src/features/evals/components/variable-mapping-card.tsx
@@ -62,6 +62,7 @@ export const VariableMappingCard = ({
   disabled = false,
   shouldWrapVariables = false,
   hideAdvancedSettings = false,
+  isNewCompatible = true,
 }: {
   projectId: string;
   availableVariables:
@@ -73,6 +74,7 @@ export const VariableMappingCard = ({
   disabled?: boolean;
   shouldWrapVariables?: boolean;
   hideAdvancedSettings?: boolean;
+  isNewCompatible?: boolean;
 }) => {
   const [showPreview, setShowPreview] = useState(false);
   const [selectedPreviewIds, setSelectedPreviewIds] = useState<{
@@ -102,10 +104,14 @@ export const VariableMappingCard = ({
   );
 
   useEffect(() => {
-    if (isTraceOrEventTarget(form.getValues("target")) && !disabled) {
+    const target = form.getValues("target");
+    // Disable preview for event targets when user is not on OTEL SDK
+    const shouldDisableForNonOtel = isEventTarget(target) && !isNewCompatible;
+
+    if (isTraceOrEventTarget(target) && !disabled && !shouldDisableForNonOtel) {
       setShowPreview(true);
     } else {
-      // For dataset and experiment targets, disable preview
+      // For dataset and experiment targets, or event targets without OTEL SDK
       setShowPreview(false);
     }
 
@@ -113,7 +119,7 @@ export const VariableMappingCard = ({
       setSelectedPreviewIds(undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.watch("target"), disabled, isPeekView]);
+  }, [form.watch("target"), disabled, isPeekView, isNewCompatible]);
 
   useEffect(() => {
     if (isPeekView) {
@@ -121,9 +127,15 @@ export const VariableMappingCard = ({
     }
   }, [isPeekView, peekId]);
 
+  // Hide preview controls for event targets when user is not on OTEL SDK
+  const shouldShowPreviewControls =
+    isTraceOrEventTarget(form.watch("target")) &&
+    !disabled &&
+    !(isEventTarget(form.watch("target")) && !isNewCompatible);
+
   const mappingControlButtons = (
     <div className="flex items-center gap-2">
-      {isTraceOrEventTarget(form.watch("target")) && !disabled && (
+      {shouldShowPreviewControls && (
         <>
           <span className="text-muted-foreground text-xs">Preview</span>
           <Switch

--- a/web/src/features/evals/components/variable-mapping-card.tsx
+++ b/web/src/features/evals/components/variable-mapping-card.tsx
@@ -63,6 +63,7 @@ export const VariableMappingCard = ({
   shouldWrapVariables = false,
   hideAdvancedSettings = false,
   isNewCompatible = true,
+  compatibilityCheckWasPerformed = false,
 }: {
   projectId: string;
   availableVariables:
@@ -75,6 +76,7 @@ export const VariableMappingCard = ({
   shouldWrapVariables?: boolean;
   hideAdvancedSettings?: boolean;
   isNewCompatible?: boolean;
+  compatibilityCheckWasPerformed?: boolean;
 }) => {
   const [showPreview, setShowPreview] = useState(false);
   const [selectedPreviewIds, setSelectedPreviewIds] = useState<{
@@ -103,10 +105,12 @@ export const VariableMappingCard = ({
     isPeekView ? (selectedPreviewIds ?? {}) : undefined,
   );
 
+  const nonOtelCompatible = compatibilityCheckWasPerformed && !isNewCompatible;
+
   useEffect(() => {
     const target = form.getValues("target");
-    // Disable preview for event targets when user is not on OTEL SDK
-    const shouldDisableForNonOtel = isEventTarget(target) && !isNewCompatible;
+    // Disable preview for event targets only when SDK check was performed and user is not on OTEL SDK
+    const shouldDisableForNonOtel = isEventTarget(target) && nonOtelCompatible;
 
     if (isTraceOrEventTarget(target) && !disabled && !shouldDisableForNonOtel) {
       setShowPreview(true);
@@ -119,7 +123,7 @@ export const VariableMappingCard = ({
       setSelectedPreviewIds(undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.watch("target"), disabled, isPeekView, isNewCompatible]);
+  }, [form.watch("target"), disabled, isPeekView, nonOtelCompatible]);
 
   useEffect(() => {
     if (isPeekView) {
@@ -127,11 +131,11 @@ export const VariableMappingCard = ({
     }
   }, [isPeekView, peekId]);
 
-  // Hide preview controls for event targets when user is not on OTEL SDK
+  // Hide preview controls for event targets only when SDK check was performed and user is not on OTEL SDK
   const shouldShowPreviewControls =
     isTraceOrEventTarget(form.watch("target")) &&
     !disabled &&
-    !(isEventTarget(form.watch("target")) && !isNewCompatible);
+    !(isEventTarget(form.watch("target")) && nonOtelCompatible);
 
   const mappingControlButtons = (
     <div className="flex items-center gap-2">

--- a/web/src/features/evals/hooks/useEvalCapabilities.ts
+++ b/web/src/features/evals/hooks/useEvalCapabilities.ts
@@ -1,6 +1,8 @@
 import { useSession } from "next-auth/react";
 import { api } from "@/src/utils/api";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
+
 export interface EvalCapabilities {
   isNewCompatible: boolean;
   allowLegacy: boolean;
@@ -8,11 +10,6 @@ export interface EvalCapabilities {
   isLoading: boolean;
   hasLegacyEvals: boolean;
 }
-
-const mockOtelStatus = {
-  isOtel: false,
-  isPropagating: false,
-};
 
 /**
  * Hook to determine which eval configuration features are available
@@ -22,9 +19,18 @@ const mockOtelStatus = {
 export function useEvalCapabilities(projectId: string): EvalCapabilities {
   const { data: session, status: sessionStatus } = useSession();
   const isSessionLoading = sessionStatus === "loading";
+  const { isBetaEnabled } = useV4Beta();
 
-  // Query OTEL SDK status
-  const { isOtel, isPropagating } = mockOtelStatus;
+  // Query SDK version info from events table (only when v4 beta is enabled)
+  const sdkVersionInfo = api.events.getSdkVersionInfo.useQuery(
+    { projectId },
+    { enabled: isBetaEnabled },
+  );
+
+  // Determine OTEL status from SDK version info
+  const isOtel = sdkVersionInfo.data?.isOtel ?? false;
+  // TODO: Implement propagation check
+  const isPropagating = false;
 
   // Get eval counts including legacy eval count
   const evalCounts = api.evals.counts.useQuery({ projectId });
@@ -43,7 +49,8 @@ export function useEvalCapabilities(projectId: string): EvalCapabilities {
     allowLegacy: !isLangfuseCloud || hasLegacyEvals || canToggleV4,
     // Allow propagation filters only when using OTEL and spans are propagating
     allowPropagationFilters: isOtel && isPropagating,
-    isLoading: evalCounts.isLoading || isSessionLoading,
+    isLoading:
+      evalCounts.isLoading || isSessionLoading || sdkVersionInfo.isLoading,
     hasLegacyEvals,
   };
 }

--- a/web/src/features/evals/hooks/useEvalCapabilities.ts
+++ b/web/src/features/evals/hooks/useEvalCapabilities.ts
@@ -5,6 +5,7 @@ import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
 export interface EvalCapabilities {
   isNewCompatible: boolean;
+  compatibilityCheckWasPerformed: boolean;
   allowLegacy: boolean;
   allowPropagationFilters: boolean;
   isLoading: boolean;
@@ -45,6 +46,8 @@ export function useEvalCapabilities(projectId: string): EvalCapabilities {
 
   return {
     isNewCompatible: isOtel,
+    // True when v4 beta is enabled (SDK check query was run)
+    compatibilityCheckWasPerformed: isBetaEnabled,
     // Allow legacy if: not cloud OR user has legacy evals OR user can toggle v4 (existing user)
     allowLegacy: !isLangfuseCloud || hasLegacyEvals || canToggleV4,
     // Allow propagation filters only when using OTEL and spans are propagating


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR replaces a mock OTEL status with a real `getSdkVersionInfo` query and uses the result to hide the eval observation preview (and show an upgrade message) when no OTEL-compatible SDK data has been ingested in the last 7 days.

- **`isNewCompatible` is semantically wrong when beta is disabled**: the SDK version query is only enabled when `isBetaEnabled` is true, so `isOtel` — and therefore `isNewCompatible` — is always `false` for non-beta projects. `variable-mapping-card.tsx` then suppresses the event-target preview whenever `isNewCompatible` is false, without checking `isBetaEnabled`, meaning a beta flag rollback would silently hide previews for all event-target evals.
- `inner-evaluator-form.tsx` correctly guards the upgrade message with `isBetaEnabled && !isNewCompatible`; the same guard should be applied in `variable-mapping-card.tsx`.

<h3>Confidence Score: 3/5</h3>

Mergeable with caution — a logic inconsistency in variable-mapping-card.tsx can silently suppress the observation preview for event-target evals when the beta flag is off.

One P1 finding: shouldDisableForNonOtel in variable-mapping-card.tsx does not mirror the isBetaEnabled guard used in ObservationsPreview, making preview suppression leak into non-beta contexts. A related P2 in useEvalCapabilities reinforces that isNewCompatible semantics are unclear when beta is disabled.

web/src/features/evals/components/variable-mapping-card.tsx and web/src/features/evals/hooks/useEvalCapabilities.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/repositories/events.ts | Adds explicit AS column aliases to the ClickHouse SELECT — ensures column names in the result set are stable regardless of query builder internals. |
| web/src/features/evals/hooks/useEvalCapabilities.ts | Replaces mock OTEL status with a real getSdkVersionInfo tRPC query gated on isBetaEnabled; isNewCompatible is always false when beta is off, which can mislead consumers that don't also check isBetaEnabled. |
| web/src/features/evals/components/inner-evaluator-form.tsx | Adds isNewCompatible prop to ObservationsPreview and renders an SDK upgrade message when beta is enabled but OTEL data is absent; correctly guards with isBetaEnabled && !isNewCompatible. |
| web/src/features/evals/components/variable-mapping-card.tsx | Hides preview controls for event targets when !isNewCompatible, but omits the isBetaEnabled check present in the sibling component, causing suppression whenever beta is disabled. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useEvalCapabilities] --> B{isBetaEnabled?}
    B -- Yes --> C[getSdkVersionInfo query]
    B -- No --> D[query disabled\nisOtel = false\nisNewCompatible = false]
    C --> E{sdkVersionInfo.data.isOtel?}
    E -- Yes --> F[isNewCompatible = true]
    E -- No --> G[isNewCompatible = false]
    F & G --> H[InnerEvaluatorForm]
    D --> H
    H --> I[ObservationsPreview]
    H --> J[VariableMappingCard]
    I --> K{isBetaEnabled AND not isNewCompatible?}
    K -- Yes --> L[Show SDK Upgrade Message]
    K -- No --> M{isBetaEnabled?}
    M -- Yes --> N[Show EventsTable]
    M -- No --> O[Show ObservationsTable]
    J --> P{isEventTarget AND not isNewCompatible?}
    P -- Yes --> Q[Hide preview controls ⚠️ also fires when beta=false]
    P -- No --> R[Show preview controls]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/features/evals/components/variable-mapping-card.tsx
Line: 109-115

Comment:
**Preview suppressed for event targets when beta is disabled**

`isNewCompatible` defaults to `false` in `useEvalCapabilities` whenever `isBetaEnabled` is `false`, because the SDK version query is conditionally disabled (`enabled: isBetaEnabled`). As a result, any call site that passes `evalCapabilities.isNewCompatible` will suppress the preview for event targets even when the beta flag is off — not just when OTEL ingestion is absent.

The `ObservationsPreview` in `inner-evaluator-form.tsx` correctly guards with `isBetaEnabled && !isNewCompatible`, but the analogous guard here does not include that check. Without this guard, if `isBetaEnabled` flips off, existing evaluators with event targets would lose their preview silently.

```suggestion
    const shouldDisableForNonOtel =
      isEventTarget(target) && isBetaEnabled && !isNewCompatible;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/features/evals/hooks/useEvalCapabilities.ts
Line: 31-33

Comment:
**`isNewCompatible` is always `false` when beta is disabled**

When `isBetaEnabled` is `false`, the SDK version query is skipped (`enabled: isBetaEnabled`), so `sdkVersionInfo.data` remains `undefined` and `isOtel` defaults to `false`. This means `isNewCompatible` is always `false` for non-beta projects, not just ones that lack OTEL ingestion. Consider returning `true` when the query is not applicable so consumers get correct semantics without needing to also check `isBetaEnabled`.

```suggestion
  const isOtel = isBetaEnabled ? (sdkVersionInfo.data?.isOtel ?? false) : true;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/features/evals/components/variable-mapping-card.tsx
Line: 131-134

Comment:
**Redundant double `form.watch("target")` call**

`form.watch("target")` is called twice in `shouldShowPreviewControls`, creating two separate subscriptions for the same value. Cache it in a variable to avoid potential duplicate re-renders.

```suggestion
  const currentTarget = form.watch("target");
  const shouldShowPreviewControls =
    isTraceOrEventTarget(currentTarget) &&
    !disabled &&
    !(isEventTarget(currentTarget) && !isNewCompatible);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: hide eval preview if user has not..."](https://github.com/langfuse/langfuse/commit/28868bd371f24bde5321ef00492963dcbba3520b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29592579)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->