### PR TITLE
fix: add breadcrumb to dataset items page

### DIFF
--- a/web/src/features/datasets/utils/getDatasetBreadcrumb.ts
+++ b/web/src/features/datasets/utils/getDatasetBreadcrumb.ts
@@ -1,0 +1,20 @@
+import { createBreadcrumbItems } from "@/src/features/folders/utils";
+
+export const getDatasetBreadcrumb = (
+  projectId: string,
+  datasetName?: string,
+) => {
+  const segments = (datasetName ?? "")
+    .split("/")
+    .filter((segment) => segment.trim());
+  const folderPath = segments.length > 1 ? segments.slice(0, -1).join("/") : "";
+  const breadcrumbItems = folderPath ? createBreadcrumbItems(folderPath) : [];
+
+  return [
+    { name: "Datasets", href: `/project/${projectId}/datasets` },
+    ...breadcrumbItems.map((item) => ({
+      name: item.name,
+      href: `/project/${projectId}/datasets?folder=${encodeURIComponent(item.folderPath)}`,
+    })),
+  ];
+};

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -40,7 +40,7 @@ import { useExperimentAccess } from "@/src/features/experiments/hooks/useExperim
 import { ExperimentsBetaSwitch } from "@/src/features/experiments/components/ExperimentsBetaSwitch";
 import { EvaluatorForm } from "@/src/features/evals/components/evaluator-form";
 import useLocalStorage from "@/src/components/useLocalStorage";
-import { createBreadcrumbItems } from "@/src/features/folders/utils";
+import { getDatasetBreadcrumb } from "@/src/features/datasets/utils/getDatasetBreadcrumb";
 import { ExperimentsTable } from "@/src/features/experiments/components/table";
 
 export default function Dataset() {
@@ -156,10 +156,7 @@ export default function Dataset() {
   // For experiment evaluators, we only run on new data (not historic)
   const preprocessFormValues = useCallback((values: any) => values, []);
 
-  const datasetName = dataset.data?.name ?? "";
-  const segments = datasetName.split("/").filter((s) => s.trim());
-  const folderPath = segments.length > 1 ? segments.slice(0, -1).join("/") : "";
-  const breadcrumbItems = folderPath ? createBreadcrumbItems(folderPath) : [];
+  const breadcrumb = getDatasetBreadcrumb(projectId, dataset.data?.name);
   const betaSwitch = canUseExperimentsBetaToggle ? (
     <ExperimentsBetaSwitch
       enabled={isExperimentsBetaEnabled}
@@ -173,13 +170,7 @@ export default function Dataset() {
         headerProps={{
           title: dataset.data?.name ?? "",
           itemType: "DATASET",
-          breadcrumb: [
-            { name: "Datasets", href: `/project/${projectId}/datasets` },
-            ...breadcrumbItems.map((item) => ({
-              name: item.name,
-              href: `/project/${projectId}/datasets?folder=${encodeURIComponent(item.folderPath)}`,
-            })),
-          ],
+          breadcrumb,
           tabsProps: {
             tabs: getDatasetTabs(projectId, datasetId),
             activeTab: DATASET_TABS.RUNS,
@@ -254,13 +245,7 @@ export default function Dataset() {
       headerProps={{
         title: dataset.data?.name ?? "",
         itemType: "DATASET",
-        breadcrumb: [
-          { name: "Datasets", href: `/project/${projectId}/datasets` },
-          ...breadcrumbItems.map((item) => ({
-            name: item.name,
-            href: `/project/${projectId}/datasets?folder=${encodeURIComponent(item.folderPath)}`,
-          })),
-        ],
+        breadcrumb,
         help: dataset.data?.description
           ? {
               description: dataset.data.description,

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx
@@ -28,6 +28,7 @@ import { useState } from "react";
 import { useDatasetVersion } from "@/src/features/datasets/hooks/useDatasetVersion";
 import { useExperimentAccess } from "@/src/features/experiments/hooks/useExperimentAccess";
 import { ExperimentsBetaSwitch } from "@/src/features/experiments/components/ExperimentsBetaSwitch";
+import { getDatasetBreadcrumb } from "@/src/features/datasets/utils/getDatasetBreadcrumb";
 
 function DatasetItemsView() {
   const router = useRouter();
@@ -74,6 +75,8 @@ function DatasetItemsView() {
     setIsVersionPanelOpen(open);
   };
 
+  const breadcrumb = getDatasetBreadcrumb(projectId, dataset.data?.name);
+
   const betaSwitch = canUseExperimentsBetaToggle ? (
     <ExperimentsBetaSwitch
       enabled={isExperimentsBetaEnabled}
@@ -86,9 +89,7 @@ function DatasetItemsView() {
       headerProps={{
         title: dataset.data?.name ?? "",
         itemType: "DATASET",
-        breadcrumb: [
-          { name: "Datasets", href: `/project/${projectId}/datasets` },
-        ],
+        breadcrumb,
         tabsProps: {
           tabs: getDatasetTabs(projectId, datasetId),
           activeTab: DATASET_TABS.ITEMS,


### PR DESCRIPTION
### Motivation
- Centralize breadcrumb generation for dataset pages to remove duplicated logic and ensure consistent folder handling.

### Description
- Add `web/src/features/datasets/utils/getDatasetBreadcrumb.ts` which implements `getDatasetBreadcrumb(projectId, datasetName?)` and builds breadcrumb items using `createBreadcrumbItems` with URL-encoded folder links.
- Replace inline breadcrumb construction in `web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx` with a call to `getDatasetBreadcrumb` and remove the direct `createBreadcrumbItems` import from that file.
- Replace inline breadcrumb construction in `web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx` with a call to `getDatasetBreadcrumb`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb2bbe61f8832bb9200d52c66615b8)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR centralizes dataset breadcrumb generation into a new `getDatasetBreadcrumb` utility and replaces the duplicated inline logic in two dataset pages. The refactoring is functionally equivalent for `index.tsx`, and `items.tsx` gains a behavior improvement — it now correctly includes folder-level breadcrumb items that were previously omitted.

<h3>Confidence Score: 5/5</h3>

Safe to merge — clean refactor with no logic regressions and a minor behavior improvement in items.tsx.

The utility faithfully mirrors the original inline logic in index.tsx and adds missing folder breadcrumbs to items.tsx. No new edge cases introduced; empty/undefined dataset names are handled via the ?? "" fallback.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/datasets/utils/getDatasetBreadcrumb.ts | New utility that extracts and centralizes dataset breadcrumb logic; correctly handles folder paths, filters empty segments, and URL-encodes folder paths. |
| web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx | Replaces duplicated inline breadcrumb construction (used twice) with a single `getDatasetBreadcrumb` call; behavior is identical to the removed code. |
| web/src/pages/project/[projectId]/datasets/[datasetId]/items.tsx | Switches from a static single-item breadcrumb to `getDatasetBreadcrumb`, adding folder-aware breadcrumbs that were previously missing on the items tab. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["dataset.data?.name"] --> B["getDatasetBreadcrumb(projectId, datasetName?)"]
    B --> C["split('/') + filter empty segments"]
    C --> D{segments.length > 1?}
    D -- Yes --> E["folderPath = segments minus last"]
    D -- No --> F["folderPath = ''"]
    E --> G["createBreadcrumbItems(folderPath)"]
    F --> H["breadcrumbItems = []"]
    G --> I["breadcrumbItems = [{name, folderPath}]"]
    H --> J["Return: [Datasets root, ...folder items]"]
    I --> J
    J --> K["index.tsx breadcrumb prop"]
    J --> L["items.tsx breadcrumb prop"]
```

<sub>Reviews (1): Last reviewed commit: ["chore(web): remove dataset breadcrumb ut..."](https://github.com/langfuse/langfuse/commit/006efe312f0d7e32cfa743fee016a5670a856df3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29597691)</sub>

<!-- /greptile_comment -->