### PR TITLE
feat(api): add events-based dataset run items endpoints for public GET API

### DIFF
--- a/fern/apis/server/definition/datasets.yml
+++ b/fern/apis/server/definition/datasets.yml
@@ -35,12 +35,21 @@ service:
       response: commons.Dataset
     getRun:
       method: GET
-      docs: Get a dataset run and its items
+      docs: Get a dataset run and its items. Returns paginated results with a default limit of 50 items per page.
       path: /datasets/{datasetName}/runs/{runName}
       path-parameters:
         datasetName: string
         runName: string
-      response: commons.DatasetRunWithItems
+      request:
+        name: GetDatasetRunRequest
+        query-parameters:
+          page:
+            type: optional<integer>
+            docs: Page number, starts at 1. Defaults to 1.
+          limit:
+            type: optional<integer>
+            docs: Limit of items per page. Defaults to 50.
+      response: PaginatedDatasetRunWithItems
     deleteRun:
       method: DELETE
       docs: Delete a dataset run and all its run items. This action is irreversible.
@@ -70,6 +79,11 @@ types:
   PaginatedDatasets:
     properties:
       data: list<commons.Dataset>
+      meta: pagination.MetaResponse
+  PaginatedDatasetRunWithItems:
+    extends: commons.DatasetRun
+    properties:
+      datasetRunItems: list<commons.DatasetRunItem>
       meta: pagination.MetaResponse
   CreateDatasetRequest:
     properties:

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -1017,8 +1017,9 @@ export const getDatasetRunItemsFromEventsForPublicApi = async (
       "e.trace_id as trace_id",
       "e.start_time as start_time",
     )
+    // Return latest row per item (until repetitions are modeled, see LFE-8965)
     .orderByColumns([{ column: "e.start_time", direction: "DESC" }])
-    .limitBy("e.experiment_item_id")
+    .limitBy("e.experiment_item_id, e.experiment_id")
     .limit(limit, offset);
 
   const { query, params } = queryBuilder.buildWithParams();

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -968,3 +968,99 @@ export const getExperimentNamesFromEvents = async (props: {
 
   return res;
 };
+
+// ============================================================================
+// Dataset Run Items for Public API (Events-based)
+// ============================================================================
+
+/**
+ * Return type for dataset run items from events table.
+ * Used by GET /api/public/dataset-run-items with useEventsTable=true.
+ */
+export type DatasetRunItemFromEventsRecord = {
+  span_id: string;
+  experiment_id: string; // dataset_run_id
+  experiment_name: string; // dataset_run_name
+  item_id: string; // experiment_item_id = dataset_item_id
+  trace_id: string;
+  start_time: string;
+};
+
+type DatasetRunItemsFromEventsQuery = {
+  projectId: string;
+  experimentId: string; // dataset_run_id
+  limit: number;
+  offset: number;
+};
+
+/**
+ * Get dataset run items from events table for public API.
+ * Returns items for a single experiment (dataset run).
+ *
+ * Note: The `id` field is the span_id (observation ID), representing
+ * the root observation linked to this dataset item in this run.
+ */
+export const getDatasetRunItemsFromEventsForPublicApi = async (
+  props: DatasetRunItemsFromEventsQuery,
+): Promise<DatasetRunItemFromEventsRecord[]> => {
+  const { projectId, experimentId, limit, offset } = props;
+
+  const queryBuilder = eventsExperimentsRootSpans({
+    projectId,
+    experimentIds: [experimentId],
+  })
+    .selectRaw(
+      "e.span_id as span_id",
+      "e.experiment_id as experiment_id",
+      "e.experiment_name as experiment_name",
+      "e.experiment_item_id as item_id",
+      "e.trace_id as trace_id",
+      "e.start_time as start_time",
+    )
+    .orderByColumns([{ column: "e.start_time", direction: "DESC" }])
+    .limitBy("e.experiment_item_id")
+    .limit(limit, offset);
+
+  const { query, params } = queryBuilder.buildWithParams();
+
+  return queryClickhouse<DatasetRunItemFromEventsRecord>({
+    query,
+    params,
+    tags: {
+      feature: "datasets",
+      type: "experiment-items-public-api",
+      kind: "list",
+      projectId,
+    },
+  });
+};
+
+/**
+ * Get count of dataset run items from events table for public API.
+ */
+export const getDatasetRunItemsCountFromEventsForPublicApi = async (props: {
+  projectId: string;
+  experimentId: string;
+}): Promise<number> => {
+  const { projectId, experimentId } = props;
+
+  const queryBuilder = eventsExperimentsRootSpans({
+    projectId,
+    experimentIds: [experimentId],
+  }).selectRaw("count(DISTINCT e.experiment_item_id) as count");
+
+  const { query, params } = queryBuilder.buildWithParams();
+
+  const result = await queryClickhouse<{ count: string }>({
+    query,
+    params,
+    tags: {
+      feature: "datasets",
+      type: "experiment-items-public-api",
+      kind: "count",
+      projectId,
+    },
+  });
+
+  return result.length > 0 ? Number(result[0].count) : 0;
+};

--- a/packages/shared/src/server/test-utils/tracing-factory.ts
+++ b/packages/shared/src/server/test-utils/tracing-factory.ts
@@ -305,3 +305,35 @@ export const createEvent = (
     ...eventOverrides,
   };
 };
+
+/**
+ * Helper to create an experiment event with experiment-specific fields populated.
+ * Wraps createEvent with experiment defaults for testing dataset/experiment flows.
+ */
+export const createExperimentEvent = (
+  params: Partial<EventRecordInsertType> & {
+    experimentId: string;
+    experimentName: string;
+    datasetId?: string;
+    itemId: string;
+    experimentItemRootSpanId: string;
+  },
+): EventRecordInsertType => {
+  const {
+    experimentId,
+    experimentName,
+    datasetId,
+    itemId,
+    experimentItemRootSpanId,
+    ...rest
+  } = params;
+
+  return createEvent({
+    experiment_id: experimentId,
+    experiment_name: experimentName,
+    experiment_dataset_id: datasetId,
+    experiment_item_id: itemId,
+    experiment_item_root_span_id: experimentItemRootSpanId,
+    ...rest,
+  });
+};

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -1413,7 +1413,9 @@ paths:
         - BasicAuth: []
   /api/public/datasets/{datasetName}/runs/{runName}:
     get:
-      description: Get a dataset run and its items
+      description: >-
+        Get a dataset run and its items. Returns paginated results with a
+        default limit of 50 items per page.
       operationId: datasets_getRun
       tags:
         - Datasets
@@ -1428,13 +1430,27 @@ paths:
           required: true
           schema:
             type: string
+        - name: page
+          in: query
+          description: Page number, starts at 1. Defaults to 1.
+          required: false
+          schema:
+            type: integer
+            nullable: true
+        - name: limit
+          in: query
+          description: Limit of items per page. Defaults to 50.
+          required: false
+          schema:
+            type: integer
+            nullable: true
       responses:
         '200':
           description: ''
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DatasetRunWithItems'
+                $ref: '#/components/schemas/PaginatedDatasetRunWithItems'
         '400':
           description: ''
           content:
@@ -7243,6 +7259,7 @@ components:
       title: BlobStorageExportFrequency
       type: string
       enum:
+        - every_20_minutes
         - hourly
         - daily
         - weekly
@@ -7431,9 +7448,9 @@ components:
         Compare `lastSyncAt` against your
 
         ETL bookmark to determine if new data is available. Note that exports
-        run with a 30-minute lag buffer,
+        run with a 20-minute lag buffer,
 
-        so `lastSyncAt` will always be at least 30 minutes behind real-time.
+        so `lastSyncAt` will always be at least 20 minutes behind real-time.
     BlobStorageIntegrationStatusResponse:
       title: BlobStorageIntegrationStatusResponse
       type: object
@@ -9373,6 +9390,21 @@ components:
       required:
         - data
         - meta
+    PaginatedDatasetRunWithItems:
+      title: PaginatedDatasetRunWithItems
+      type: object
+      properties:
+        datasetRunItems:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatasetRunItem'
+        meta:
+          $ref: '#/components/schemas/utilsMetaResponse'
+      required:
+        - datasetRunItems
+        - meta
+      allOf:
+        - $ref: '#/components/schemas/DatasetRun'
     CreateDatasetRequest:
       title: CreateDatasetRequest
       type: object

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -2339,3 +2339,113 @@ describe("GET /api/public/dataset-run-items with useEventsTable", () => {
   }
   runTestSuite(false); // with legacy table
 });
+
+describe("GET /api/public/datasets/{name}/runs/{runName} with useEventsTable", () => {
+  const runTestSuite = (useEventsTable: boolean) => {
+    const suiteName = useEventsTable
+      ? "with events table"
+      : "with legacy table";
+    const queryParam = useEventsTable ? "?useEventsTable=true" : "";
+
+    describe(suiteName, () => {
+      it("should fetch dataset run with items using correct data structure", async () => {
+        const { auth, projectId } = await createOrgProjectAndApiKey();
+
+        // Create dataset and run in Postgres
+        const datasetId = v4();
+        const datasetName = `test-dataset-${v4()}`;
+        await prisma.dataset.create({
+          data: { id: datasetId, name: datasetName, projectId },
+        });
+
+        const runId = v4();
+        const runName = `test-run-${v4()}`;
+        await prisma.datasetRuns.create({
+          data: {
+            id: runId,
+            name: runName,
+            datasetId,
+            projectId,
+            metadata: {},
+          },
+        });
+
+        // Create dataset item in Postgres
+        const itemId = v4();
+        await createDatasetItem({
+          id: itemId,
+          projectId,
+          datasetId,
+          input: { test: "input" },
+        });
+
+        const traceId = v4();
+        const spanId = v4();
+        const now = Date.now() * 1000; // microseconds for events
+
+        if (useEventsTable) {
+          // Create event with experiment fields
+          const event = createExperimentEvent({
+            project_id: projectId,
+            trace_id: traceId,
+            span_id: spanId,
+            experimentId: runId,
+            experimentName: runName,
+            datasetId: datasetId,
+            itemId: itemId,
+            experimentItemRootSpanId: spanId,
+            start_time: now,
+          });
+          await createEventsCh([event]);
+        } else {
+          // Create in legacy dataset_run_items table
+          await createDatasetRunItemsCh([
+            createDatasetRunItem({
+              dataset_item_id: itemId,
+              trace_id: traceId,
+              observation_id: spanId,
+              dataset_run_id: runId,
+              dataset_run_name: runName,
+              dataset_id: datasetId,
+              project_id: projectId,
+            }),
+          ]);
+        }
+
+        await waitForExpect(async () => {
+          const response = await makeZodVerifiedAPICall(
+            GetDatasetRunV1Response,
+            "GET",
+            `/api/public/datasets/${encodeURIComponent(datasetName)}/runs/${encodeURIComponent(runName)}${queryParam}`,
+            undefined,
+            auth,
+          );
+
+          expect(response.status).toBe(200);
+
+          // Verify run metadata
+          expect(response.body.id).toBe(runId);
+          expect(response.body.name).toBe(runName);
+          expect(response.body.datasetName).toBe(datasetName);
+          expect(response.body.datasetId).toBe(datasetId);
+
+          // Verify run items
+          expect(response.body.datasetRunItems).toHaveLength(1);
+          const item = response.body.datasetRunItems[0];
+          expect(item.datasetRunId).toBe(runId);
+          expect(item.datasetRunName).toBe(runName);
+          expect(item.datasetItemId).toBe(itemId);
+          expect(item.traceId).toBe(traceId);
+          expect(item.createdAt).toBeDefined();
+          expect(item.updatedAt).toBeDefined();
+        }, 30000);
+      }, 60000);
+    });
+  };
+
+  // Run tests with both implementations
+  if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+    runTestSuite(true); // with events table
+  }
+  runTestSuite(false); // with legacy table
+});

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -40,8 +40,11 @@ import {
   createDatasetItemFilterState,
   createDatasetItem,
   getDatasetItems,
+  createExperimentEvent,
+  createEventsCh,
 } from "@langfuse/shared/src/server";
 import waitForExpect from "wait-for-expect";
+import { env } from "@/src/env.mjs";
 
 describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () => {
   const traceId = v4();
@@ -2124,4 +2127,215 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
     expect(runAfterSecond?.createdAt).toEqual(customCreatedAt); // Still original timestamp
   });
+});
+
+describe("GET /api/public/dataset-run-items with useEventsTable", () => {
+  const runTestSuite = (useEventsTable: boolean) => {
+    const suiteName = useEventsTable
+      ? "with events table"
+      : "with legacy table";
+    const queryParam = useEventsTable ? "&useEventsTable=true" : "";
+
+    describe(suiteName, () => {
+      it("should fetch dataset run items with correct data structure", async () => {
+        const { auth, projectId } = await createOrgProjectAndApiKey();
+
+        // Create dataset and run in Postgres
+        const datasetId = v4();
+        const datasetName = `test-dataset-${v4()}`;
+        await prisma.dataset.create({
+          data: { id: datasetId, name: datasetName, projectId },
+        });
+
+        const runId = v4();
+        const runName = `test-run-${v4()}`;
+        await prisma.datasetRuns.create({
+          data: {
+            id: runId,
+            name: runName,
+            datasetId,
+            projectId,
+            metadata: {},
+          },
+        });
+
+        // Create dataset item in Postgres
+        const itemId = v4();
+        await createDatasetItem({
+          id: itemId,
+          projectId,
+          datasetId,
+          input: { test: "input" },
+        });
+
+        const traceId = v4();
+        const spanId = v4();
+        const now = Date.now() * 1000; // microseconds for events
+
+        if (useEventsTable) {
+          // Create event with experiment fields
+          const event = createExperimentEvent({
+            project_id: projectId,
+            trace_id: traceId,
+            span_id: spanId,
+            experimentId: runId,
+            experimentName: runName,
+            datasetId: datasetId,
+            itemId: itemId,
+            experimentItemRootSpanId: spanId,
+            start_time: now,
+          });
+          await createEventsCh([event]);
+        } else {
+          // Create in legacy dataset_run_items table
+          await createDatasetRunItemsCh([
+            createDatasetRunItem({
+              dataset_item_id: itemId,
+              trace_id: traceId,
+              observation_id: spanId,
+              dataset_run_id: runId,
+              dataset_run_name: runName,
+              dataset_id: datasetId,
+              project_id: projectId,
+            }),
+          ]);
+        }
+
+        await waitForExpect(async () => {
+          const response = await makeZodVerifiedAPICall(
+            GetDatasetRunItemsV1Response,
+            "GET",
+            `/api/public/dataset-run-items?datasetId=${datasetId}&runName=${encodeURIComponent(runName)}${queryParam}`,
+            undefined,
+            auth,
+          );
+
+          expect(response.status).toBe(200);
+          expect(response.body.data).toHaveLength(1);
+
+          const item = response.body.data[0];
+          expect(item.datasetRunId).toBe(runId);
+          expect(item.datasetRunName).toBe(runName);
+          expect(item.datasetItemId).toBe(itemId);
+          expect(item.traceId).toBe(traceId);
+          expect(item.createdAt).toBeDefined();
+          expect(item.updatedAt).toBeDefined();
+
+          // Verify pagination meta
+          expect(response.body.meta.totalItems).toBe(1);
+          expect(response.body.meta.page).toBe(1);
+        }, 30000);
+      }, 60000);
+
+      it("should paginate results correctly", async () => {
+        const { auth, projectId } = await createOrgProjectAndApiKey();
+
+        // Create dataset and run
+        const datasetId = v4();
+        const datasetName = `pagination-test-${v4()}`;
+        await prisma.dataset.create({
+          data: { id: datasetId, name: datasetName, projectId },
+        });
+
+        const runId = v4();
+        const runName = `pagination-run-${v4()}`;
+        await prisma.datasetRuns.create({
+          data: {
+            id: runId,
+            name: runName,
+            datasetId,
+            projectId,
+            metadata: {},
+          },
+        });
+
+        // Create 5 items and corresponding run items
+        const now = Date.now() * 1000;
+        const itemIds: string[] = [];
+
+        for (let i = 0; i < 5; i++) {
+          const itemId = v4();
+          itemIds.push(itemId);
+
+          await createDatasetItem({
+            id: itemId,
+            projectId,
+            datasetId,
+            input: { index: i },
+          });
+
+          const traceId = v4();
+          const spanId = v4();
+
+          if (useEventsTable) {
+            const event = createExperimentEvent({
+              project_id: projectId,
+              trace_id: traceId,
+              span_id: spanId,
+              experimentId: runId,
+              experimentName: runName,
+              datasetId: datasetId,
+              itemId: itemId,
+              experimentItemRootSpanId: spanId,
+              start_time: now + i * 1000000,
+            });
+            await createEventsCh([event]);
+          } else {
+            await createDatasetRunItemsCh([
+              createDatasetRunItem({
+                dataset_item_id: itemId,
+                trace_id: traceId,
+                observation_id: spanId,
+                dataset_run_id: runId,
+                dataset_run_name: runName,
+                dataset_id: datasetId,
+                project_id: projectId,
+              }),
+            ]);
+          }
+        }
+
+        await waitForExpect(async () => {
+          // Fetch page 1 with limit 2
+          const page1 = await makeZodVerifiedAPICall(
+            GetDatasetRunItemsV1Response,
+            "GET",
+            `/api/public/dataset-run-items?datasetId=${datasetId}&runName=${encodeURIComponent(runName)}&limit=2&page=1${queryParam}`,
+            undefined,
+            auth,
+          );
+
+          expect(page1.status).toBe(200);
+          expect(page1.body.data).toHaveLength(2);
+          expect(page1.body.meta.totalItems).toBe(5);
+          expect(page1.body.meta.totalPages).toBe(3);
+
+          // Fetch page 2
+          const page2 = await makeZodVerifiedAPICall(
+            GetDatasetRunItemsV1Response,
+            "GET",
+            `/api/public/dataset-run-items?datasetId=${datasetId}&runName=${encodeURIComponent(runName)}&limit=2&page=2${queryParam}`,
+            undefined,
+            auth,
+          );
+
+          expect(page2.status).toBe(200);
+          expect(page2.body.data).toHaveLength(2);
+
+          // Verify no overlap between pages
+          const page1Ids = page1.body.data.map((d) => d.datasetItemId);
+          const page2Ids = page2.body.data.map((d) => d.datasetItemId);
+          page2Ids.forEach((id) => {
+            expect(page1Ids).not.toContain(id);
+          });
+        }, 30000);
+      }, 90000);
+    });
+  };
+
+  // Run tests with both implementations
+  if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+    runTestSuite(true); // with events table
+  }
+  runTestSuite(false); // with legacy table
 });

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -2161,11 +2161,13 @@ describe("GET /api/public/dataset-run-items with useEventsTable", () => {
 
         // Create dataset item in Postgres
         const itemId = v4();
-        await createDatasetItem({
-          id: itemId,
-          projectId,
-          datasetId,
-          input: { test: "input" },
+        await prisma.datasetItem.create({
+          data: {
+            id: itemId,
+            projectId,
+            datasetId,
+            input: { test: "input" },
+          },
         });
 
         const traceId = v4();
@@ -2257,11 +2259,13 @@ describe("GET /api/public/dataset-run-items with useEventsTable", () => {
           const itemId = v4();
           itemIds.push(itemId);
 
-          await createDatasetItem({
-            id: itemId,
-            projectId,
-            datasetId,
-            input: { index: i },
+          await prisma.datasetItem.create({
+            data: {
+              id: itemId,
+              projectId,
+              datasetId,
+              input: { index: i },
+            },
           });
 
           const traceId = v4();
@@ -2372,11 +2376,13 @@ describe("GET /api/public/datasets/{name}/runs/{runName} with useEventsTable", (
 
         // Create dataset item in Postgres
         const itemId = v4();
-        await createDatasetItem({
-          id: itemId,
-          projectId,
-          datasetId,
-          input: { test: "input" },
+        await prisma.datasetItem.create({
+          data: {
+            id: itemId,
+            projectId,
+            datasetId,
+            input: { test: "input" },
+          },
         });
 
         const traceId = v4();
@@ -2438,8 +2444,122 @@ describe("GET /api/public/datasets/{name}/runs/{runName} with useEventsTable", (
           expect(item.traceId).toBe(traceId);
           expect(item.createdAt).toBeDefined();
           expect(item.updatedAt).toBeDefined();
+
+          // Verify pagination meta is present
+          expect(response.body.meta).toBeDefined();
+          expect(response.body.meta.page).toBe(1);
+          expect(response.body.meta.limit).toBe(50);
+          expect(response.body.meta.totalItems).toBe(1);
+          expect(response.body.meta.totalPages).toBe(1);
         }, 30000);
       }, 60000);
+
+      it("should paginate dataset run items correctly", async () => {
+        const { auth, projectId } = await createOrgProjectAndApiKey();
+
+        // Create dataset and run
+        const datasetId = v4();
+        const datasetName = `pagination-dataset-${v4()}`;
+        await prisma.dataset.create({
+          data: { id: datasetId, name: datasetName, projectId },
+        });
+
+        const runId = v4();
+        const runName = `pagination-run-${v4()}`;
+        await prisma.datasetRuns.create({
+          data: {
+            id: runId,
+            name: runName,
+            datasetId,
+            projectId,
+            metadata: {},
+          },
+        });
+
+        // Create 5 items and run items
+        const now = Date.now() * 1000;
+        for (let i = 0; i < 5; i++) {
+          const itemId = v4();
+          await prisma.datasetItem.create({
+            data: {
+              id: itemId,
+              projectId,
+              datasetId,
+              input: { test: "input" },
+            },
+          });
+
+          const traceId = v4();
+          const spanId = v4();
+
+          if (useEventsTable) {
+            const event = createExperimentEvent({
+              project_id: projectId,
+              trace_id: traceId,
+              span_id: spanId,
+              experimentId: runId,
+              experimentName: runName,
+              datasetId: datasetId,
+              itemId: itemId,
+              experimentItemRootSpanId: spanId,
+              start_time: now + i * 1000000,
+            });
+            await createEventsCh([event]);
+          } else {
+            await createDatasetRunItemsCh([
+              createDatasetRunItem({
+                dataset_item_id: itemId,
+                trace_id: traceId,
+                observation_id: spanId,
+                dataset_run_id: runId,
+                dataset_run_name: runName,
+                dataset_id: datasetId,
+                project_id: projectId,
+              }),
+            ]);
+          }
+        }
+
+        const separator = useEventsTable ? "&" : "?";
+
+        await waitForExpect(async () => {
+          // Test page 1 with limit 2
+          const page1 = await makeZodVerifiedAPICall(
+            GetDatasetRunV1Response,
+            "GET",
+            `/api/public/datasets/${encodeURIComponent(datasetName)}/runs/${encodeURIComponent(runName)}${queryParam}${separator}limit=2&page=1`,
+            undefined,
+            auth,
+          );
+
+          expect(page1.status).toBe(200);
+          expect(page1.body.datasetRunItems).toHaveLength(2);
+          expect(page1.body.meta.totalItems).toBe(5);
+          expect(page1.body.meta.totalPages).toBe(3);
+          expect(page1.body.meta.page).toBe(1);
+          expect(page1.body.meta.limit).toBe(2);
+
+          // Test page 2
+          const page2 = await makeZodVerifiedAPICall(
+            GetDatasetRunV1Response,
+            "GET",
+            `/api/public/datasets/${encodeURIComponent(datasetName)}/runs/${encodeURIComponent(runName)}${queryParam}${separator}limit=2&page=2`,
+            undefined,
+            auth,
+          );
+
+          expect(page2.status).toBe(200);
+          expect(page2.body.datasetRunItems).toHaveLength(2);
+          expect(page2.body.meta.page).toBe(2);
+
+          // Verify no overlap between pages
+          const page1Ids = page1.body.datasetRunItems.map((i) => i.id);
+          const page2Ids = page2.body.datasetRunItems.map((i) => i.id);
+          page2Ids.forEach((id) => {
+            expect(page1Ids).not.toContain(id);
+          });
+        }, 30000);
+      }, 90000);
     });
   };
 

--- a/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/experiment-items-repository.servertest.ts
@@ -6,43 +6,11 @@ import {
   getExperimentItemsCountFromEvents,
   getExperimentItemsBatchIO,
   createTraceScore,
-  type EventRecordInsertType,
+  createExperimentEvent,
 } from "@langfuse/shared/src/server";
 import { randomUUID } from "crypto";
 import { env } from "@/src/env.mjs";
 import { type FilterCondition } from "@langfuse/shared";
-
-/**
- * Helper to create an experiment event with experiment-specific fields populated.
- * Wraps createEvent with experiment defaults.
- */
-function createExperimentEvent(
-  params: Partial<EventRecordInsertType> & {
-    experimentId: string;
-    experimentName: string;
-    datasetId?: string;
-    itemId: string;
-    experimentItemRootSpanId: string;
-  },
-): EventRecordInsertType {
-  const {
-    experimentId,
-    experimentName,
-    datasetId,
-    itemId,
-    experimentItemRootSpanId,
-    ...rest
-  } = params;
-
-  return createEvent({
-    experiment_id: experimentId,
-    experiment_name: experimentName,
-    experiment_dataset_id: datasetId,
-    experiment_item_id: itemId,
-    experiment_item_root_span_id: experimentItemRootSpanId,
-    ...rest,
-  });
-}
 
 /**
  * Helper to create a root observation score.

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -119,6 +119,13 @@ export const transformDbDatasetRunItemToAPIDatasetRunItemCh = (
  * Note: The `id` field is the span_id (observation ID) in the events-based path,
  * representing the root observation linked to this dataset item in this run.
  * This differs from the legacy path which uses the dataset_run_item table's UUID.
+ *
+ * `observationId` is set unconditionally to `span_id` because in the events model,
+ * traces are stored as synthetic observations with `span_id = 't-<traceId>'`
+ * (see `convertTraceToStagingObservation`). This differs from the legacy path where
+ * `observationId` is `null` for trace-only items. Users must use `useEventsTable`
+ * consistently: fetch with `GET /observations/{observationId}?useEventsTable=true`
+ * to resolve both real observation IDs and synthetic trace span IDs.
  */
 export const transformEventsDatasetRunItemToAPI = (item: {
   span_id: string;

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -201,6 +201,7 @@ export const GetDatasetRunsV1Response = z
 export const GetDatasetRunV1Query = z.object({
   name: queryStringZod, // dataset name from URL, name as it is v1
   runName: queryStringZod,
+  useEventsTable: useEventsTableSchema,
 });
 export const GetDatasetRunV1Response = APIDatasetRun.extend({
   datasetRunItems: z.array(APIDatasetRunItem),

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -3,6 +3,7 @@ import {
   publicApiPaginationZod,
   paginationZod,
   paginationMetaResponseZod,
+  optionalPaginationZod,
   queryStringZod,
   versionZod,
   type DatasetRuns as DbDatasetRuns,
@@ -202,9 +203,11 @@ export const GetDatasetRunV1Query = z.object({
   name: queryStringZod, // dataset name from URL, name as it is v1
   runName: queryStringZod,
   useEventsTable: useEventsTableSchema,
+  ...optionalPaginationZod,
 });
 export const GetDatasetRunV1Response = APIDatasetRun.extend({
   datasetRunItems: z.array(APIDatasetRunItem),
+  meta: paginationMetaResponseZod,
 }).strict();
 
 // POST /dataset-items

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -12,7 +12,11 @@ import {
   type DatasetItemDomain,
   stringDateTime,
 } from "@langfuse/shared";
-import { DatasetJSONSchema } from "@langfuse/shared/src/server";
+import { useEventsTableSchema } from "@/src/features/query/types";
+import {
+  DatasetJSONSchema,
+  parseClickhouseUTCDateTimeFormat,
+} from "@langfuse/shared/src/server";
 import { z } from "zod";
 
 /**
@@ -108,6 +112,31 @@ export const transformDbDatasetRunItemToAPIDatasetRunItemCh = (
     "datasetId",
     "error",
   ]);
+
+/**
+ * Transform events-based dataset run item to API format.
+ *
+ * Note: The `id` field is the span_id (observation ID) in the events-based path,
+ * representing the root observation linked to this dataset item in this run.
+ * This differs from the legacy path which uses the dataset_run_item table's UUID.
+ */
+export const transformEventsDatasetRunItemToAPI = (item: {
+  span_id: string;
+  experiment_id: string;
+  experiment_name: string;
+  item_id: string;
+  trace_id: string;
+  start_time: string;
+}): z.infer<typeof APIDatasetRunItem> => ({
+  id: item.span_id,
+  datasetRunId: item.experiment_id,
+  datasetRunName: item.experiment_name,
+  datasetItemId: item.item_id,
+  traceId: item.trace_id,
+  observationId: item.span_id,
+  createdAt: parseClickhouseUTCDateTimeFormat(item.start_time),
+  updatedAt: parseClickhouseUTCDateTimeFormat(item.start_time),
+});
 
 export const transformDbDatasetToAPIDataset = (
   dataset: DbDataset,
@@ -251,6 +280,7 @@ export const PostDatasetRunItemsV1Response = APIDatasetRunItem.strict();
 export const GetDatasetRunItemsV1Query = z.object({
   datasetId: z.string(),
   runName: z.string(),
+  useEventsTable: useEventsTableSchema,
   ...publicApiPaginationZod,
 });
 export const GetDatasetRunItemsV1Response = z

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -3,7 +3,6 @@ import {
   publicApiPaginationZod,
   paginationZod,
   paginationMetaResponseZod,
-  optionalPaginationZod,
   queryStringZod,
   versionZod,
   type DatasetRuns as DbDatasetRuns,
@@ -203,7 +202,7 @@ export const GetDatasetRunV1Query = z.object({
   name: queryStringZod, // dataset name from URL, name as it is v1
   runName: queryStringZod,
   useEventsTable: useEventsTableSchema,
-  ...optionalPaginationZod,
+  ...publicApiPaginationZod,
 });
 export const GetDatasetRunV1Response = APIDatasetRun.extend({
   datasetRunItems: z.array(APIDatasetRunItem),

--- a/web/src/pages/api/public/dataset-run-items.ts
+++ b/web/src/pages/api/public/dataset-run-items.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@langfuse/shared/src/db";
+import { env } from "@/src/env.mjs";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import {
@@ -7,6 +8,7 @@ import {
   GetDatasetRunItemsV1Response,
   PostDatasetRunItemsV1Body,
   PostDatasetRunItemsV1Response,
+  transformEventsDatasetRunItemToAPI,
 } from "@/src/features/public-api/types/datasets";
 import { type JSONValue, LangfuseNotFoundError } from "@langfuse/shared";
 import { addDatasetRunItemsToEvalQueue } from "@/src/features/evals/server/addDatasetRunItemsToEvalQueue";
@@ -16,6 +18,8 @@ import {
   processEventBatch,
   getObservationById,
   getDatasetItemById,
+  getDatasetRunItemsFromEventsForPublicApi,
+  getDatasetRunItemsCountFromEventsForPublicApi,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
 import { createOrFetchDatasetRun } from "@/src/features/public-api/server/dataset-runs";
@@ -197,10 +201,43 @@ export default withMiddlewares({
       }
 
       const { datasetId, limit, page } = query;
+
+      // Use events table if query parameter is explicitly set, otherwise use environment variable
+      const useEventsTable =
+        query.useEventsTable !== undefined && query.useEventsTable !== null
+          ? query.useEventsTable === true
+          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+
       /**************
        * RESPONSE *
        **************/
 
+      if (useEventsTable) {
+        const [items, count] = await Promise.all([
+          getDatasetRunItemsFromEventsForPublicApi({
+            projectId: auth.scope.projectId,
+            experimentId: datasetRun.id,
+            limit,
+            offset: (page - 1) * limit,
+          }),
+          getDatasetRunItemsCountFromEventsForPublicApi({
+            projectId: auth.scope.projectId,
+            experimentId: datasetRun.id,
+          }),
+        ]);
+
+        return {
+          data: items.map(transformEventsDatasetRunItemToAPI),
+          meta: {
+            page,
+            limit,
+            totalItems: count,
+            totalPages: Math.ceil(count / limit),
+          },
+        };
+      }
+
+      // Legacy code path
       const [items, count] = await Promise.all([
         generateDatasetRunItemsForPublicApi({
           props: {

--- a/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
+++ b/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
@@ -60,9 +60,8 @@ export default withMiddlewares({
           ? query.useEventsTable === true
           : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
 
-      // Apply pagination with defaults
-      const page = query.page ?? 1;
-      const limit = query.limit ?? 50;
+      // Apply pagination (defaults provided by publicApiPaginationZod: page=1, limit=50)
+      const { page, limit } = query;
       const offset = (page - 1) * limit;
 
       const [datasetRunItems, totalItems] = useEventsTable

--- a/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
+++ b/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
@@ -15,8 +15,12 @@ import { auditLog } from "@/src/features/audit-logs/auditLog";
 import {
   addToDeleteDatasetQueue,
   getDatasetRunItemsFromEventsForPublicApi,
+  getDatasetRunItemsCountFromEventsForPublicApi,
 } from "@langfuse/shared/src/server";
-import { generateDatasetRunItemsForPublicApi } from "@/src/features/public-api/server/dataset-run-items";
+import {
+  generateDatasetRunItemsForPublicApi,
+  getDatasetRunItemsCountForPublicApi,
+} from "@/src/features/public-api/server/dataset-run-items";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({
@@ -56,22 +60,42 @@ export default withMiddlewares({
           ? query.useEventsTable === true
           : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
 
-      const datasetRunItems = useEventsTable
-        ? (
-            await getDatasetRunItemsFromEventsForPublicApi({
+      // Apply pagination with defaults
+      const page = query.page ?? 1;
+      const limit = query.limit ?? 50;
+      const offset = (page - 1) * limit;
+
+      const [datasetRunItems, totalItems] = useEventsTable
+        ? await Promise.all([
+            getDatasetRunItemsFromEventsForPublicApi({
               projectId: auth.scope.projectId,
               experimentId: run.id,
-              limit: 10000, // No pagination on this endpoint, fetch all items
-              offset: 0,
-            })
-          ).map(transformEventsDatasetRunItemToAPI)
-        : await generateDatasetRunItemsForPublicApi({
-            props: {
-              datasetId: run.datasetId,
-              runId: run.id,
+              limit,
+              offset,
+            }).then((items) => items.map(transformEventsDatasetRunItemToAPI)),
+            getDatasetRunItemsCountFromEventsForPublicApi({
               projectId: auth.scope.projectId,
-            },
-          });
+              experimentId: run.id,
+            }),
+          ])
+        : await Promise.all([
+            generateDatasetRunItemsForPublicApi({
+              props: {
+                datasetId: run.datasetId,
+                runId: run.id,
+                projectId: auth.scope.projectId,
+                page,
+                limit,
+              },
+            }),
+            getDatasetRunItemsCountForPublicApi({
+              props: {
+                datasetId: run.datasetId,
+                runId: run.id,
+                projectId: auth.scope.projectId,
+              },
+            }),
+          ]);
 
       return {
         ...transformDbDatasetRunToAPIDatasetRun({
@@ -79,6 +103,12 @@ export default withMiddlewares({
           datasetName: dataset.name,
         }),
         datasetRunItems,
+        meta: {
+          page,
+          limit,
+          totalItems,
+          totalPages: Math.ceil(totalItems / limit),
+        },
       };
     },
   }),

--- a/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
+++ b/web/src/pages/api/public/datasets/[name]/runs/[runName].ts
@@ -1,16 +1,21 @@
 import { prisma } from "@langfuse/shared/src/db";
+import { env } from "@/src/env.mjs";
 import {
   GetDatasetRunV1Query,
   GetDatasetRunV1Response,
   DeleteDatasetRunV1Query,
   DeleteDatasetRunV1Response,
   transformDbDatasetRunToAPIDatasetRun,
+  transformEventsDatasetRunItemToAPI,
 } from "@/src/features/public-api/types/datasets";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { ApiError, LangfuseNotFoundError } from "@langfuse/shared";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { addToDeleteDatasetQueue } from "@langfuse/shared/src/server";
+import {
+  addToDeleteDatasetQueue,
+  getDatasetRunItemsFromEventsForPublicApi,
+} from "@langfuse/shared/src/server";
 import { generateDatasetRunItemsForPublicApi } from "@/src/features/public-api/server/dataset-run-items";
 
 export default withMiddlewares({
@@ -45,13 +50,28 @@ export default withMiddlewares({
 
       const { dataset, ...run } = datasetRuns[0];
 
-      const datasetRunItems = await generateDatasetRunItemsForPublicApi({
-        props: {
-          datasetId: run.datasetId,
-          runId: run.id,
-          projectId: auth.scope.projectId,
-        },
-      });
+      // Use events table if query parameter is explicitly set, otherwise use environment variable
+      const useEventsTable =
+        query.useEventsTable !== undefined && query.useEventsTable !== null
+          ? query.useEventsTable === true
+          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+
+      const datasetRunItems = useEventsTable
+        ? (
+            await getDatasetRunItemsFromEventsForPublicApi({
+              projectId: auth.scope.projectId,
+              experimentId: run.id,
+              limit: 10000, // No pagination on this endpoint, fetch all items
+              offset: 0,
+            })
+          ).map(transformEventsDatasetRunItemToAPI)
+        : await generateDatasetRunItemsForPublicApi({
+            props: {
+              datasetId: run.datasetId,
+              runId: run.id,
+              projectId: auth.scope.projectId,
+            },
+          });
 
       return {
         ...transformDbDatasetRunToAPIDatasetRun({


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds an events-table-based code path to `GET /api/public/dataset-run-items`, mirroring the pattern already used by the traces and observations endpoints. New ClickHouse query helpers are added in `experiments.ts` and a new transformer maps the events-table row shape to the existing `APIDatasetRunItem` response type.

- **P1 — Env var fallback is dead code**: `useEventsTableSchema` transforms `undefined` → `false` via its Zod `.transform()`, so `query.useEventsTable` is always a `boolean` after parsing. The `!== undefined && !== null` guard is always truthy and `env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS` is never evaluated. Operators who rely on the env var feature flag to enable this path without passing the query param will get the legacy path instead.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the environment variable feature flag is silently ignored, meaning the events-table path is only reachable via explicit query param, contrary to the stated intent.

One P1 finding (dead env var fallback) that makes the feature toggle non-functional for operators who set LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS=true but don't pass useEventsTable=true in every API call. The same bug exists in peer endpoints but is explicitly propagated here.

web/src/pages/api/public/dataset-run-items.ts — the useEventsTable fallback logic; also consider auditing web/src/pages/api/public/traces/index.ts and observations endpoints for the same issue.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/pages/api/public/dataset-run-items.ts | Adds events-table code path for GET /dataset-run-items; the env var fallback for LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS is unreachable due to Zod transform behavior (P1). |
| web/src/features/public-api/types/datasets.ts | Adds useEventsTable to GetDatasetRunItemsV1Query and a new transformEventsDatasetRunItemToAPI transformer; both createdAt and updatedAt are mapped to observation start_time which differs from legacy path semantics. |
| packages/shared/src/server/repositories/experiments.ts | Adds getDatasetRunItemsFromEventsForPublicApi and getDatasetRunItemsCountFromEventsForPublicApi; ClickHouse query construction looks correct with LIMIT 1 BY for deduplication and DISTINCT count. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as GET /dataset-run-items
    participant Prisma
    participant CH as ClickHouse (Events)
    participant Legacy as Legacy (Prisma/CH)

    Client->>API: GET ?datasetId=X&runName=Y[&useEventsTable=true]
    API->>Prisma: findUnique(datasetRuns) → datasetRun.id
    Prisma-->>API: { id, name }
    API->>API: resolve useEventsTable flag
    alt useEventsTable = true
        API->>CH: getDatasetRunItemsFromEventsForPublicApi(experimentId, limit, offset)
        API->>CH: getDatasetRunItemsCountFromEventsForPublicApi(experimentId)
        CH-->>API: items (span_id, experiment_id, …)
        API->>API: transformEventsDatasetRunItemToAPI(items)
    else useEventsTable = false (legacy)
        API->>Legacy: generateDatasetRunItemsForPublicApi(runId, …)
        API->>Legacy: getDatasetRunItemsCountForPublicApi(runId, …)
        Legacy-->>API: items
    end
    API-->>Client: { data, meta }

    Note over API: env var fallback is unreachable due to Zod transform
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/pages/api/public/dataset-run-items.ts
Line: 206-209

Comment:
**Env var fallback is dead code**

The `useEventsTableSchema` Zod transform always converts `undefined` to `false` — `(val) => val === "true" || val === true` returns `false` when `val` is `undefined`. So after schema parsing, `query.useEventsTable` is always a `boolean`, never `undefined` or `null`. The ternary condition is therefore always truthy, and the right-hand branch (`env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"`) can never be reached.

As a result, setting `LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS=true` in the environment will have no effect on this endpoint unless the caller also passes `useEventsTable=true` explicitly. The same pre-existing issue exists in the traces and observations endpoints; this PR copies the pattern and propagates it.

To respect the env var as a default, the transform in `useEventsTableSchema` should preserve `undefined` for the unset case, or the check here should be done on the raw query string before parsing.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/features/public-api/types/datasets.ts
Line: 137-138

Comment:
**`createdAt`/`updatedAt` both mapped to `start_time`**

Both `createdAt` and `updatedAt` are set to `parseClickhouseUTCDateTimeFormat(item.start_time)`, which is the observation's start time. The legacy path uses the actual `createdAt`/`updatedAt` timestamps from the `dataset_run_items` table record. While the events table may not have a true "item creation" timestamp, returning the observation's start time for both fields introduces a subtle semantic difference from the legacy path — callers that rely on `updatedAt` reflecting the last modification of a run item will observe stale or incorrect values if the observation was amended after linking.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api): add events-based dataset run ..."](https://github.com/langfuse/langfuse/commit/0e1160bf56af738261c2501e51ecaa7844bbd269) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29615064)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->