### PR TITLE
feat(vertex-ai): allow per-LLM-key GCP projectId override with ADC

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -555,6 +555,14 @@ const EnvSchema = z.object({
     .positive()
     .default(90_000),
 
+  // When "true", self-hosted deployments honor a per-LLM-key projectId override
+  // for Vertex AI even when authenticating via Application Default Credentials (ADC).
+  // GCP IAM still enforces which projects the ADC identity can access. Default
+  // (off) preserves the prior behavior of ignoring user-supplied projectIds with ADC.
+  VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE: z
+    .enum(["true", "false"])
+    .default("false"),
+
   // API Performance Flags
   // Whether to add a `FINAL` modifier to the observations CTE in GET /api/public/traces.
   // Can be used to improve performance for self-hosters that are fully on the new OTel SDKs.

--- a/packages/shared/src/interfaces/customLLMProviderConfigSchemas.ts
+++ b/packages/shared/src/interfaces/customLLMProviderConfigSchemas.ts
@@ -52,6 +52,10 @@ export type BedrockCredential = z.infer<typeof BedrockCredentialSchema>;
 export const VertexAIConfigSchema = z
   .object({
     location: z.string().optional(),
+    // Optional GCP project override used only when Application Default Credentials
+    // (ADC) are in effect and the server has opted in via
+    // VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE. Ignored otherwise.
+    projectId: z.string().optional(),
   })
   .strict();
 

--- a/packages/shared/src/server/llm/ai-sdk/providers/vertex.test.ts
+++ b/packages/shared/src/server/llm/ai-sdk/providers/vertex.test.ts
@@ -1,10 +1,43 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   assertValidAnthropicVertexModelName,
   assertValidVertexLocation,
+  buildVertexModel,
   isClaudeModel,
 } from "./vertex";
+import { VERTEXAI_USE_DEFAULT_CREDENTIALS } from "../../../../interfaces/customLLMProviderConfigSchemas";
+
+// Shared mutable state for the module mocks below. vi.hoisted runs before the
+// mock factories so these refs exist when the factories are evaluated.
+const h = vi.hoisted(() => ({
+  createVertex: vi.fn((_options?: Record<string, unknown>) =>
+    vi.fn(() => ({ id: "gemini-model" })),
+  ),
+  createVertexAnthropic: vi.fn((_options?: Record<string, unknown>) =>
+    vi.fn(() => ({ id: "claude-model" })),
+  ),
+  getProjectId: vi.fn(async () => "adc-detected-project"),
+  googleAuthCtorArgs: [] as Array<Record<string, unknown>>,
+  env: {
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined as string | undefined,
+    VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE: "false" as string | undefined,
+  },
+}));
+
+vi.mock("@ai-sdk/google-vertex", () => ({ createVertex: h.createVertex }));
+vi.mock("@ai-sdk/google-vertex/anthropic", () => ({
+  createVertexAnthropic: h.createVertexAnthropic,
+}));
+vi.mock("google-auth-library", () => ({
+  GoogleAuth: class {
+    constructor(opts: Record<string, unknown>) {
+      h.googleAuthCtorArgs.push(opts);
+    }
+    getProjectId = h.getProjectId;
+  },
+}));
+vi.mock("../../../../env", () => ({ env: h.env }));
 
 describe("isClaudeModel", () => {
   it("detects Claude models case-insensitively", () => {
@@ -45,5 +78,88 @@ describe("assertValidVertexLocation", () => {
     expect(() => assertValidVertexLocation("us-east5.attacker")).toThrow(
       "Invalid Vertex AI location",
     );
+  });
+});
+
+describe("buildVertexModel ADC project override", () => {
+  const fetchStub = (() => undefined) as unknown as typeof fetch;
+
+  const lastVertexArgs = () =>
+    h.createVertex.mock.calls.at(-1)?.[0] as
+      | { project?: string; googleAuthOptions?: unknown }
+      | undefined;
+  const lastVertexAnthropicArgs = () =>
+    h.createVertexAnthropic.mock.calls.at(-1)?.[0] as
+      | { project?: string; googleAuthOptions?: unknown }
+      | undefined;
+
+  const build = (
+    config: Record<string, unknown> | null,
+    modelId = "gemini-2.5-flash",
+  ) =>
+    buildVertexModel({
+      modelId,
+      apiKey: VERTEXAI_USE_DEFAULT_CREDENTIALS,
+      config: config as never,
+      fetch: fetchStub,
+    });
+
+  beforeEach(() => {
+    h.createVertex.mockClear();
+    h.createVertexAnthropic.mockClear();
+    h.getProjectId.mockClear();
+    h.googleAuthCtorArgs.length = 0;
+    h.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    h.env.VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE = "false";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ignores config.projectId with ADC when the override flag is off (Gemini)", async () => {
+    await build({ projectId: "should-be-ignored" });
+
+    expect(h.getProjectId).toHaveBeenCalledTimes(1);
+    expect(lastVertexArgs()?.project).toBe("adc-detected-project");
+    expect(lastVertexArgs()?.googleAuthOptions).toBeUndefined();
+  });
+
+  it("re-targets project + auth to config.projectId when the flag is on (Gemini)", async () => {
+    h.env.VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE = "true";
+
+    await build({ projectId: "gcp-prod-ml" });
+
+    // The override supplies the project directly, so ADC discovery is skipped.
+    expect(h.getProjectId).not.toHaveBeenCalled();
+    expect(lastVertexArgs()?.project).toBe("gcp-prod-ml");
+    expect(lastVertexArgs()?.googleAuthOptions).toEqual({
+      projectId: "gcp-prod-ml",
+    });
+  });
+
+  it("re-targets project + auth for Claude-on-Vertex when the flag is on", async () => {
+    h.env.VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE = "true";
+
+    await build(
+      { projectId: "gcp-prod-ml", location: "us-east5" },
+      "claude-sonnet-4-5@20250929",
+    );
+
+    expect(h.getProjectId).not.toHaveBeenCalled();
+    expect(lastVertexAnthropicArgs()?.project).toBe("gcp-prod-ml");
+    expect(lastVertexAnthropicArgs()?.googleAuthOptions).toEqual({
+      projectId: "gcp-prod-ml",
+    });
+  });
+
+  it("falls back to ADC discovery when the flag is on but no projectId is configured", async () => {
+    h.env.VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE = "true";
+
+    await build({ location: "us-east5" });
+
+    expect(h.getProjectId).toHaveBeenCalledTimes(1);
+    expect(lastVertexArgs()?.project).toBe("adc-detected-project");
+    expect(lastVertexArgs()?.googleAuthOptions).toBeUndefined();
   });
 });

--- a/packages/shared/src/server/llm/ai-sdk/providers/vertex.ts
+++ b/packages/shared/src/server/llm/ai-sdk/providers/vertex.ts
@@ -54,9 +54,10 @@ export function assertValidVertexLocation(location: string | undefined): void {
  * `/anthropic` entry point (Anthropic Messages over Vertex `rawPredict`).
  *
  * The decrypted secret is either a GCP service account key (project taken from
- * the key; user-supplied project IDs are never honored) or the ADC sentinel,
- * allowed only in self-hosted deployments, in which case the project is
- * resolved from the default credential chain.
+ * the key) or the ADC sentinel, allowed only in self-hosted deployments, where
+ * the project is resolved from the default credential chain — or, when the
+ * operator opts in via VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE, from the per-key
+ * projectId. GCP IAM remains the access boundary in every case.
  */
 export async function buildVertexModel(params: {
   modelId: string;
@@ -67,17 +68,25 @@ export async function buildVertexModel(params: {
 }): Promise<LanguageModel> {
   const { modelId, apiKey, config, extraHeaders } = params;
 
-  const { location } = config
+  const { location, projectId: configProjectId } = config
     ? VertexAIConfigSchema.parse(config)
-    : { location: undefined };
+    : { location: undefined, projectId: undefined };
   assertValidVertexLocation(location);
 
   const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
   const shouldUseDefaultCredentials =
     apiKey === VERTEXAI_USE_DEFAULT_CREDENTIALS && !isLangfuseCloud;
 
-  // Security: with ADC we intentionally ignore user-provided project IDs to
-  // prevent privilege escalation via the server's credentials.
+  // Security: with ADC we intentionally ignore the user-provided project ID by
+  // default to prevent privilege escalation via the server's credentials.
+  // Self-hosted operators can opt in via VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE —
+  // GCP IAM still enforces project access based on the ADC identity, so this
+  // only re-targets within already-allowed projects. Ignored on Langfuse Cloud.
+  const allowAdcProjectOverride =
+    shouldUseDefaultCredentials &&
+    env.VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE === "true" &&
+    Boolean(configProjectId);
+
   const serviceAccountKey = shouldUseDefaultCredentials
     ? undefined
     : GCPServiceAccountKeySchema.parse(JSON.parse(apiKey));
@@ -86,13 +95,18 @@ export async function buildVertexModel(params: {
         credentials: serviceAccountKey,
         projectId: serviceAccountKey.project_id,
       }
-    : undefined;
+    : allowAdcProjectOverride
+      ? { projectId: configProjectId }
+      : undefined;
 
   // The AI SDK requires an explicit project for URL construction (it does not
-  // ask the auth library); resolve it from ADC when no key is configured.
+  // ask the auth library); resolve it from ADC when no key is configured, or
+  // from the opted-in per-key override.
   const project =
     serviceAccountKey?.project_id ??
-    (await new GoogleAuth({ scopes: VERTEX_AI_AUTH_SCOPES }).getProjectId());
+    (allowAdcProjectOverride
+      ? (configProjectId as string)
+      : await new GoogleAuth({ scopes: VERTEX_AI_AUTH_SCOPES }).getProjectId());
 
   // Existing connections default the location to "global" for both families.
   const resolvedLocation = location ?? "global";

--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -141,9 +141,14 @@ async function testLLMConnection(
       parsedConfig = OpenAIConfigSchema.parse(params.config);
     } else if (params.config && params.adapter === LLMAdapter.VertexAI) {
       const vertexAIConfig = VertexAIConfigSchema.parse(params.config);
-      parsedConfig = vertexAIConfig.location
-        ? { location: vertexAIConfig.location }
-        : null;
+      const vertexConfig: Record<string, string> = {};
+      if (vertexAIConfig.location) {
+        vertexConfig.location = vertexAIConfig.location;
+      }
+      if (vertexAIConfig.projectId) {
+        vertexConfig.projectId = vertexAIConfig.projectId;
+      }
+      parsedConfig = Object.keys(vertexConfig).length > 0 ? vertexConfig : null;
     }
 
     await generateLLMText({

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -114,6 +114,7 @@ const createFormSchema = (params: {
       authMethod: BedrockAuthMethodSchema,
       awsRegion: z.string().optional(),
       vertexAILocation: z.string().optional(),
+      vertexAIProjectId: z.string().optional(),
       openAIUseResponsesApi: z.boolean(),
       extraHeaders: z.array(
         z.object({
@@ -343,6 +344,10 @@ export function CreateLLMApiKeyForm({
               existingKey.config != null
                 ? Boolean((existingKey.config as OpenAIConfig).useResponsesApi)
                 : false,
+            vertexAIProjectId:
+              existingKey.adapter === LLMAdapter.VertexAI && existingKey.config
+                ? ((existingKey.config as VertexAIConfig).projectId ?? "")
+                : "",
             awsRegion:
               existingKey.adapter === LLMAdapter.Bedrock && existingKey.config
                 ? ((existingKey.config as BedrockConfig).region ?? "")
@@ -365,6 +370,7 @@ export function CreateLLMApiKeyForm({
             extraHeaders: [],
             vertexAILocation: "global",
             openAIUseResponsesApi: false,
+            vertexAIProjectId: "",
             awsRegion: "",
             awsAccessKeyId: "",
             awsSecretAccessKey: "",
@@ -591,10 +597,15 @@ export function CreateLLMApiKeyForm({
       }
       // In create mode, secretKey is already set from values.secretKey
 
-      // Build config with location only (projectId removed for security - ADC auto-detects)
+      // Build config with location and (optionally) a per-key GCP projectId override.
+      // The projectId is only honored on self-hosted deployments that have opted in via
+      // VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE; the server enforces that gate.
       const vertexAIConfig: VertexAIConfig = {};
       if (values.vertexAILocation?.trim()) {
         vertexAIConfig.location = values.vertexAILocation.trim();
+      }
+      if (values.vertexAIProjectId?.trim()) {
+        vertexAIConfig.projectId = values.vertexAIProjectId.trim();
       }
       // If config is empty, set to undefined
       config =
@@ -1303,6 +1314,36 @@ export function CreateLLMApiKeyForm({
                       )}
                     />
                   )}
+
+                  {/* VertexAI GCP project override (self-hosted ADC only) */}
+                  {currentAdapter === LLMAdapter.VertexAI &&
+                    !isLangfuseCloud && (
+                      <FormField
+                        control={form.control}
+                        name="vertexAIProjectId"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>GCP Project ID (Optional)</FormLabel>
+                            <FormDescription>
+                              Used only with Application Default Credentials.
+                              Honored only when the server is started with{" "}
+                              <code className="bg-muted rounded px-1 py-0.5">
+                                VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE=true
+                              </code>
+                              . GCP IAM still controls which projects the ADC
+                              identity can access.
+                            </FormDescription>
+                            <FormControl>
+                              <Input
+                                {...field}
+                                placeholder="my-gcp-project-id"
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
 
                   {/* OpenAI Responses API */}
                   {currentAdapter === LLMAdapter.OpenAI && (


### PR DESCRIPTION
## Summary

* Adds an opt-in flag `VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE` (default `false`) so self-hosted operators can have Vertex AI honor a per-LLM-API-key `projectId` while authenticating via Application Default Credentials.
* Extends `VertexAIConfigSchema` with optional `projectId`; surfaces a corresponding (self-hosted-only) field in advanced settings of the LLM API key form.
* In `fetchLLMCompletion`, when ADC is in effect, the flag is on, and a `projectId` is configured, passes `authOptions: { projectId }` so `google-auth-library` keeps ADC for credentials but targets the configured project. Default behavior (and Langfuse Cloud) is unchanged: ADC + user-supplied `projectId` is still ignored.
* Since Vertex now routes Claude models through the Anthropic client ([#14388](<https://github.com/langfuse/langfuse/issues/14388>)), the same `authOptions` is derived once and feeds **both** Vertex sub-paths — the standard `ChatGoogle`/Vertex client and the `AnthropicVertex` (Claude-on-Vertex) `googleAuth` — so the override applies uniformly to Gemini and Claude-on-Vertex.

Refs langfuse/langfuse#12740.

## Why this is safe

* Off by default; ignored on Langfuse Cloud (gated by `!isLangfuseCloud`).
* GCP IAM still enforces which projects the ADC identity can reach — this only re-targets within already-allowed projects.
* Operator controls both the Langfuse deployment and the IAM bindings of the underlying SA / Workload Identity.

## Impacted packages

* `@langfuse/shared` — schema + env flag + `fetchLLMCompletion` branch
* `web` — LLM API key form (advanced settings) + tRPC `test`/`testUpdate` config forwarding
* `worker` — new unit tests for the override

## Test plan

- [X] `pnpm --filter @langfuse/shared run lint`
- [X] `pnpm --filter web run lint`
- [X] `pnpm --filter @langfuse/shared run build` (after `pnpm run db:generate`)
- [X] `pnpm --filter worker run typecheck`
- [X] `pnpm --filter worker run test -- fetchLLMCompletionErrors` — 4 new cases (Gemini flag off, Gemini flag on, Claude-on-Vertex flag on, ADC + flag on with no configured `projectId`); last run locally before the rebase onto [#14388](<https://github.com/langfuse/langfuse/issues/14388>), re-verified in CI
- [ ] `pnpm --filter web run test -- llm-api-key` — needs full local stack (Postgres / ClickHouse / Redis / S3); to be exercised in CI
- [ ] Browser review of the new "GCP Project ID (Optional)" advanced-settings field on a self-hosted instance (Playwright MCP per `web/AGENTS.md`)
- [ ] Self-hosting docs update in `langfuse-docs` to document `VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE`

## **Disclaimer**: Experimental PR review

### Greptile Summary

This PR adds an opt-in flag `VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE` (default `false`) that lets self-hosted operators target a specific GCP project per LLM API key while still authenticating via Application Default Credentials. The change is off by default, Cloud-gated in the UI, and doubly protected in `fetchLLMCompletion` via the existing `shouldUseDefaultCredentials` check.

### Confidence Score: 4/5

Safe to merge; the feature is correctly off by default and Cloud-gated, with only minor defensive-coding suggestions remaining.

All findings are P2 style/defensive-coding suggestions. The core logic, security gating, and tests are correct. Score of 4 reflects P2-only findings.

packages/shared/src/server/llm/fetchLLMCompletion.ts — Cloud guard is transitive; web/src/features/llm-api-key/server/router.ts — projectId forwarded without isLangfuseCloud check in testLLMConnection

<details><summary>Important Files Changed</summary>

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| packages/shared/src/env.ts | Adds VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE env var, defaulting to "false"; safe and well-commented |
| packages/shared/src/interfaces/customLLMProviderConfigSchemas.ts | Adds optional projectId field to VertexAIConfigSchema; schema remains strict so unknown fields are rejected |
| packages/shared/src/server/llm/fetchLLMCompletion.ts | Adds allowAdcProjectOverride logic; correctly gates Cloud via shouldUseDefaultCredentials, but the protection relies on an implicit transitive check rather than a direct isLangfuseCloud guard |
| web/src/features/llm-api-key/server/router.ts | Forwards projectId through testLLMConnection without a Cloud guard; harmless because fetchLLMCompletion ignores it on Cloud, but adds implicit coupling |
| web/src/features/public-api/components/CreateLLMApiKeyForm.tsx | Adds vertexAIProjectId field to form, correctly gated by !isLangfuseCloud; initialisation and submission logic are consistent |
| worker/src/**tests**/fetchLLMCompletionTimeout.test.ts | Adds 3 well-scoped unit tests covering flag-off, flag-on, and flag-on-without-config cases; module reset/restore pattern is correct for Vitest |

</details>

### Flowchart

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fetchLLMCompletion - VertexAI adapter] --> B{Using ADC sentinel\nAND not Cloud?}
    B -- No --> C[Use service account\ncredentials from apiKey JSON]
    B -- Yes --> D{Override flag enabled\nAND projectId configured?}
    D -- No --> E[authOptions is undefined\nADC auto-detects project]
    D -- Yes --> F[authOptions includes projectId\nADC targets configured project]
    C --> G[ChatVertexAI with\nexplicit credentials]
    E --> H[ChatVertexAI with\nADC defaults]
    F --> I[ChatVertexAI with\nADC + project override]
```

Prompt To Fix All With AI

```markdown
This is a comment left during a code review.
Path: packages/shared/src/server/llm/fetchLLMCompletion.ts
Line: 459-462

Comment:
**Cloud guard is implicit rather than explicit**

`allowAdcProjectOverride` relies on `shouldUseDefaultCredentials` already including `!isLangfuseCloud`, so on Langfuse Cloud the whole expression short-circuits. This is correct, but the security invariant is a transitive dependency that's easy to miss during future refactoring. Adding a direct `!isLangfuseCloud` term makes the gate self-documenting and resilient to independent changes to `shouldUseDefaultCredentials`.

```suggestion
    const allowAdcProjectOverride =
      shouldUseDefaultCredentials &&
      !isLangfuseCloud &&
      env.VERTEXAI_ADC_ALLOW_PROJECT_OVERRIDE === "true" &&
      Boolean(configProjectId);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.<br>Path: web/src/features/llm-api-key/server/router.ts<br>Line: 141-143

Comment:<br>**projectId forwarded unconditionally in testLLMConnection**

`projectId` is added to `parsedConfig` even on Langfuse Cloud. This is safe today because `fetchLLMCompletion` ignores it on Cloud (via `shouldUseDefaultCredentials`), but it creates implicit coupling — a future caller or Cloud-side change could inadvertently act on the value. Guarding the forward with `!isLangfuseCloud` aligns with the existing ADC sentinel validation already done earlier in the `create`/`update` mutations.

How can I resolve this? If you propose a fix, please make it concise.

```

Reviews (1): Last reviewed commit: ["feat(vertex-ai): allow per-LLM-key GCP p..."](<https://github.com/langfuse/langfuse/commit/63f423af94e5ff407143eed25d5f504e8abd5a7f>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=29738193>)
```