### PR TITLE
fix(web): support image preview when CDN returns application/octet-stream

### DIFF
--- a/web/src/__tests__/server/unit/utilities.servertest.ts
+++ b/web/src/__tests__/server/unit/utilities.servertest.ts
@@ -1,0 +1,135 @@
+import {
+  hasImageExtension,
+  isOctetStream,
+  isValidImageUrl,
+} from "@/src/server/api/routers/utilities";
+
+describe("utilities image url validation", () => {
+  describe("hasImageExtension", () => {
+    it("returns true for known image extension", () => {
+      expect(hasImageExtension("https://cdn.example.com/img/photo.webp")).toBe(
+        true,
+      );
+    });
+
+    it("returns false for non-image extension", () => {
+      expect(hasImageExtension("https://cdn.example.com/file.zip")).toBe(false);
+    });
+
+    it("returns false when no extension is present", () => {
+      expect(hasImageExtension("https://cdn.example.com/data")).toBe(false);
+    });
+
+    it("returns true when query string is present", () => {
+      expect(
+        hasImageExtension("https://cdn.example.com/photo.jpg?token=abc"),
+      ).toBe(true);
+    });
+
+    it("returns false for double-extension that ends with non-image", () => {
+      expect(hasImageExtension("https://cdn.example.com/file.png.exe")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("isOctetStream", () => {
+    const responseWith = (contentType: string | null) =>
+      new Response(null, {
+        headers: contentType ? { "content-type": contentType } : {},
+      });
+
+    it("returns true for application/octet-stream", () => {
+      expect(isOctetStream(responseWith("application/octet-stream"))).toBe(
+        true,
+      );
+    });
+
+    it("returns true for octet-stream with charset suffix", () => {
+      expect(
+        isOctetStream(responseWith("application/octet-stream; charset=utf-8")),
+      ).toBe(true);
+    });
+
+    it("returns false for image content-type", () => {
+      expect(isOctetStream(responseWith("image/png"))).toBe(false);
+    });
+
+    it("returns false for text/html content-type", () => {
+      expect(isOctetStream(responseWith("text/html"))).toBe(false);
+    });
+
+    it("returns false when content-type header is missing", () => {
+      expect(isOctetStream(responseWith(null))).toBe(false);
+    });
+  });
+
+  describe("isValidImageUrl (non-S3 CDN)", () => {
+    const cloudfrontUrl = (path: string) =>
+      `https://d1234.cloudfront.net${path}`;
+
+    const mockHeadResponse = (init: ResponseInit) =>
+      vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(new Response(null, init));
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("returns true for octet-stream + image extension (core bug scenario)", async () => {
+      mockHeadResponse({
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      });
+
+      await expect(
+        isValidImageUrl(cloudfrontUrl("/img/photo.webp")),
+      ).resolves.toBe(true);
+    });
+
+    it("returns false for octet-stream without extension", async () => {
+      mockHeadResponse({
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      });
+
+      await expect(isValidImageUrl(cloudfrontUrl("/data"))).resolves.toBe(
+        false,
+      );
+    });
+
+    it("returns false for octet-stream + non-image extension", async () => {
+      mockHeadResponse({
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      });
+
+      await expect(isValidImageUrl(cloudfrontUrl("/file.zip"))).resolves.toBe(
+        false,
+      );
+    });
+
+    it("returns true for image/* content-type (existing behavior preserved)", async () => {
+      mockHeadResponse({
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+
+      await expect(isValidImageUrl(cloudfrontUrl("/photo.png"))).resolves.toBe(
+        true,
+      );
+    });
+
+    it("returns false for text/html even with image extension (octet-stream is the only fallback)", async () => {
+      mockHeadResponse({
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
+
+      await expect(isValidImageUrl(cloudfrontUrl("/photo.jpg"))).resolves.toBe(
+        false,
+      );
+    });
+  });
+});

--- a/web/src/server/api/routers/utilities.ts
+++ b/web/src/server/api/routers/utilities.ts
@@ -111,6 +111,25 @@ const s3UrlSchema = z.object({
   }),
 });
 
+const IMAGE_EXTENSIONS = /\.(jpe?g|png|gif|webp|svg|bmp|ico|avif|tiff?|heic)$/i;
+
+export const hasImageExtension = (url: string): boolean => {
+  try {
+    const pathname = new URL(url).pathname;
+    return IMAGE_EXTENSIONS.test(pathname);
+  } catch {
+    return false;
+  }
+};
+
+export const isOctetStream = (response: Response): boolean => {
+  const contentType = response.headers.get("content-type");
+  return (
+    contentType?.trim().toLowerCase().startsWith("application/octet-stream") ??
+    false
+  );
+};
+
 const isImageContent = (response: Response): boolean => {
   const contentType = response.headers.get("content-type");
   return !!contentType && contentType.startsWith("image/");
@@ -144,7 +163,11 @@ const isValidPresignedS3Url = async (url: string): Promise<boolean> => {
     });
 
     // Status 200 indicates the URL is valid
-    if (response.ok && isImageContent(response)) {
+    if (
+      response.ok &&
+      (isImageContent(response) ||
+        (isOctetStream(response) && hasImageExtension(url)))
+    ) {
       return true;
     }
 
@@ -160,7 +183,11 @@ const isValidPresignedS3Url = async (url: string): Promise<boolean> => {
         headers: { Range: "bytes=0-1" }, // Fetch only the first byte, expected server response for valid pre-signed URLs is 206 Partial Content
       });
 
-      return getResponse.ok && isImageContent(getResponse); // 200 or 206 Partial Content indicates success
+      return (
+        getResponse.ok &&
+        (isImageContent(getResponse) ||
+          (isOctetStream(getResponse) && hasImageExtension(url)))
+      ); // 200 or 206 Partial Content indicates success
     }
 
     return false;
@@ -176,7 +203,7 @@ const isValidPresignedS3Url = async (url: string): Promise<boolean> => {
   }
 };
 
-const isValidImageUrl = async (url: string): Promise<boolean> => {
+export const isValidImageUrl = async (url: string): Promise<boolean> => {
   try {
     // Pre-signed URLs (AWS S3) often have restricted access methods. Some only allow GET requests, others only HEAD. We need to try both.
     if (await isValidPresignedS3Url(url)) {
@@ -192,7 +219,10 @@ const isValidImageUrl = async (url: string): Promise<boolean> => {
       return false;
     }
 
-    return isImageContent(response);
+    return (
+      isImageContent(response) ||
+      (isOctetStream(response) && hasImageExtension(url))
+    );
   } catch (error) {
     logger.info("Invalid image error:", error);
     return false;


### PR DESCRIPTION
## What does this PR do?

Some CDNs (e.g. CloudFront) serve image files with `Content-Type: application/octet-stream`. The current `validateImgUrl` flow rejects these because `isImageContent` only accepts content types that start with `image/`, so the image preview fails to render in the trace UI.

This PR adds a narrow fallback: when the response content type is `application/octet-stream` **and** the URL pathname ends with a known image extension, treat it as a valid image. Other non-image content types (`text/html`, `application/json`, etc.) are still rejected, so the SSRF-style protections in the surrounding code remain intact.

The fallback is applied at three call sites:
1. `isValidPresignedS3Url` HEAD response check
2. `isValidPresignedS3Url` GET (Range) response check
3. `isValidImageUrl` non-S3 (CDN) HEAD response check — the actual bug location

Two small helpers (`hasImageExtension`, `isOctetStream`) are introduced and exported for unit-testability. `isValidImageUrl` is also exported so the CDN scenario can be exercised with a `fetch` mock. The file is server-only (`web/src/server/...`), so no client bundle leakage.

Fixes #13183

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed

## Verification

- `pnpm run format` — no diff
- `pnpm --filter web run lint` — clean
- `pnpm --filter web run typecheck` — clean
- `pnpm exec dotenv -e ../.env.test -e ../.env -- vitest run --project server src/__tests__/server/unit/utilities.servertest.ts` — 15/15 passed

## Changes

- `web/src/server/api/routers/utilities.ts`
  - Add `IMAGE_EXTENSIONS` regex + exported `hasImageExtension(url)` helper
  - Add exported `isOctetStream(response)` helper
  - Export `isValidImageUrl` (test mock target)
  - Apply `octet-stream + image-extension` fallback at the three call sites listed above
  - `isImageContent` is intentionally left untouched (kept as MIME-only single-responsibility)
- `web/src/__tests__/server/unit/utilities.servertest.ts` (new)
  - 5 cases for `hasImageExtension`
  - 5 cases for `isOctetStream`
  - 5 integration cases for `isValidImageUrl` over a CloudFront URL with `fetch` mocked, including the core bug scenario (octet-stream + `.webp` → true), the `text/html + .jpg` rejection, and the no-extension rejection

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a narrow `application/octet-stream` fallback to the image URL validation logic so that CDN-served images (e.g. CloudFront) with a known image file extension are accepted even when the server doesn't set a proper `image/*` content type. The fix is applied at all three response-check call sites in `isValidPresignedS3Url` and `isValidImageUrl`, and is backed by unit tests covering the new helpers and the core CDN scenario.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, well-tested, and does not weaken existing SSRF protections.

No logic or security issues found. The octet-stream fallback is gated on both a known image extension AND an `application/octet-stream` content type, leaving all other non-image types rejected. The surrounding `isValidAndSecureUrl` guard is untouched. All three call sites are handled consistently and the new helpers are unit-tested.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/server/api/routers/utilities.ts | Adds `hasImageExtension` and `isOctetStream` helpers plus octet-stream fallback at three validation call sites; logic is correct and SSRF protections are preserved. |
| web/src/__tests__/server/unit/utilities.servertest.ts | New test file covering `hasImageExtension`, `isOctetStream`, and the full CDN integration scenario via `fetch` mock; coverage is thorough for the introduced code paths. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validateImgUrl] --> B[isValidAndSecureUrl]
    B -- invalid --> Z[return false]
    B -- valid --> C[isValidPresignedS3Url]
    C -- S3 schema invalid --> D[isValidImageUrl HEAD]
    C -- HEAD ok --> E{isImageContent OR\noctet-stream + image ext?}
    E -- yes --> T[return true]
    E -- no, 403 --> F[GET Range request]
    F --> G{isImageContent OR\noctet-stream + image ext?}
    G -- yes --> T
    G -- no --> Z
    D --> H{response.ok?}
    H -- no --> Z
    H -- yes --> I{isImageContent OR\noctet-stream + image ext?}
    I -- yes --> T
    I -- no --> Z
```

<sub>Reviews (1): Last reviewed commit: ["fix(web): support image preview when CDN..."](https://github.com/langfuse/langfuse/commit/1e394dfe051d9fd1eba60afa8e5306e15180c630) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29765234)</sub>

<!-- /greptile_comment -->