### PR TITLE
chore: add langfuse JP to region picker

### DIFF
--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -119,10 +119,11 @@ const DataRegionInfo = () => (
       </DialogHeader>
       <DialogBody>
         <DialogDescription className="flex flex-col gap-2">
-          <p>Langfuse Cloud is available in three data regions:</p>
+          <p>Langfuse Cloud is available in four data regions:</p>
           <ul className="list-disc pl-5">
             <li>US: Oregon (AWS us-west-2)</li>
             <li>EU: Ireland (AWS eu-west-1)</li>
+            <li>JP: Tokyo (AWS ap-northeast-1)</li>
             <li>
               HIPAA: Oregon (AWS us-west-2) - HIPAA-compliant region (available
               with Pro and Teams plans)

--- a/web/src/features/organizations/cloudRegions.ts
+++ b/web/src/features/organizations/cloudRegions.ts
@@ -46,8 +46,7 @@ const cloudRegions = [
 const availableRegionsByCurrentRegion = {
   STAGING: ["STAGING"],
   DEV: ["DEV"],
-  JP: ["JP", "US", "EU", "HIPAA"],
-  default: ["US", "EU", "HIPAA"],
+  default: ["US", "EU", "JP", "HIPAA"],
 } as const;
 
 const getCloudRegion = (name: (typeof cloudRegions)[number]["name"]) => {
@@ -66,10 +65,6 @@ export const getAvailableCloudRegionOptions = (currentRegion?: string) => {
 
   if (currentRegion === "DEV") {
     return availableRegionsByCurrentRegion.DEV.map(getCloudRegion);
-  }
-
-  if (currentRegion === "JP") {
-    return availableRegionsByCurrentRegion.JP.map(getCloudRegion);
   }
 
   return availableRegionsByCurrentRegion.default.map(getCloudRegion);


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds the Japan (`JP`) region to the default cloud region picker so all users can select it, and removes the previously special-cased handling that only offered JP as an option when the current region was already JP. The `cloudRegions` definition already included the JP entry; this change simply makes it universally selectable.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-scoped change with no logic errors or security implications.

The change removes a special-case branch for JP and adds JP to the universal default list. The JP region entry already existed in cloudRegions, so no new data is introduced. The logic simplification is correct and there are no edge cases, security concerns, or breaking changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/organizations/cloudRegions.ts | Adds JP to the default region picker list for all users and removes the special JP-only branch, simplifying the region selection logic. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getAvailableCloudRegionOptions] --> B{currentRegion?}
    B -->|STAGING| C[Return: STAGING]
    B -->|DEV| D[Return: DEV]
    B -->|anything else / undefined| E[Return: US, EU, JP, HIPAA]

    style E fill:#d4edda,stroke:#28a745
```

<sub>Reviews (1): Last reviewed commit: ["chore: add langfuse JP to region picker"](https://github.com/langfuse/langfuse/commit/446049dd6eb11d5044cd09f07757173db50e2fae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29786172)</sub>

<!-- /greptile_comment -->