### PR TITLE
fix(web): add Japan to the sign-in region selector

### DIFF
--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -119,10 +119,11 @@ const DataRegionInfo = () => (
       </DialogHeader>
       <DialogBody>
         <DialogDescription className="flex flex-col gap-2">
-          <p>Langfuse Cloud is available in three data regions:</p>
+          <p>Langfuse Cloud is available in four data regions:</p>
           <ul className="list-disc pl-5">
             <li>US: Oregon (AWS us-west-2)</li>
             <li>EU: Ireland (AWS eu-west-1)</li>
+            <li>JP: Tokyo (AWS ap-northeast-1)</li>
             <li>
               HIPAA: Oregon (AWS us-west-2) - HIPAA-compliant region (available
               with Pro and Teams plans)

--- a/web/src/features/organizations/cloudRegions.clienttest.ts
+++ b/web/src/features/organizations/cloudRegions.clienttest.ts
@@ -1,0 +1,9 @@
+import { getAvailableCloudRegionOptions } from "@/src/features/organizations/cloudRegions";
+
+describe("getAvailableCloudRegionOptions", () => {
+  it("includes the Japan region in the default cloud selector options", () => {
+    expect(
+      getAvailableCloudRegionOptions("EU").map((region) => region.name),
+    ).toEqual(["US", "EU", "JP", "HIPAA"]);
+  });
+});

--- a/web/src/features/organizations/cloudRegions.ts
+++ b/web/src/features/organizations/cloudRegions.ts
@@ -47,7 +47,7 @@ const availableRegionsByCurrentRegion = {
   STAGING: ["STAGING"],
   DEV: ["DEV"],
   JP: ["JP", "US", "EU", "HIPAA"],
-  default: ["US", "EU", "HIPAA"],
+  default: ["US", "EU", "JP", "HIPAA"],
 } as const;
 
 const getCloudRegion = (name: (typeof cloudRegions)[number]["name"]) => {


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds Japan (JP) to the default cloud region selector so that all users — not just those already on the JP region — can sign up or switch to `jp.cloud.langfuse.com`. The JP region entry already existed in `cloudRegions.ts`; the fix simply adds it to the `default` list, updates the info-dialog copy from "three" to "four" regions, and adds a client test to verify the new ordering.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-scoped change with no breaking impact.

All three changed files are correct: the region was already defined with a valid hostname, the default list is updated consistently, the UI copy matches, and a test covers the new behavior. No logic errors or regressions identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/organizations/cloudRegions.ts | Adds JP to the default available regions list; the JP region was already defined in cloudRegions but was absent from the default selector. |
| web/src/features/auth/components/AuthCloudRegionSwitch.tsx | Updates the info dialog copy from three to four regions and adds the JP (Tokyo, AWS ap-northeast-1) entry to the list. |
| web/src/features/organizations/cloudRegions.clienttest.ts | Adds a new client test asserting that the default region selector (called with EU) includes the JP region in the correct order. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getAvailableCloudRegionOptions"] --> B{currentRegion}
    B -->|STAGING| C["STAGING only"]
    B -->|DEV| D["DEV only"]
    B -->|JP| E["JP, US, EU, HIPAA"]
    B -->|default| F["US, EU, JP, HIPAA — JP added here"]
    F --> G["CloudRegionSwitch selector"]
    E --> G
```

<sub>Reviews (1): Last reviewed commit: ["fix(web): add Japan to the sign-in regio..."](https://github.com/langfuse/langfuse/commit/aeb5f28815e700edc2e49d5cc2fa1e659116f328) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29786193)</sub>

<!-- /greptile_comment -->