### PR TITLE
fix(model-prices): remove long-context pricing for claude-sonnet-4-6 due to Anthropic 1M update

### DIFF
--- a/worker/src/__tests__/pricing-tier-matcher.test.ts
+++ b/worker/src/__tests__/pricing-tier-matcher.test.ts
@@ -252,6 +252,42 @@ describe("default-model-prices.json", () => {
     expect(largeContextResult?.pricingTierName).toBe("Large Context");
     expect(largeContextResult?.prices.input.toNumber()).toBe(0.000006);
   });
+
+  it("should keep claude-sonnet-4-6 on standard pricing even with large cache reads", () => {
+    const claudeModel = defaultModelPrices.find(
+      (m) => m.modelName === "claude-sonnet-4-6",
+    );
+    expect(claudeModel).toBeDefined();
+    expect(claudeModel!.pricingTiers.length).toBe(1);
+
+    const tiers: PricingTierWithPrices[] = claudeModel!.pricingTiers.map(
+      (tier) => ({
+        id: tier.id,
+        name: tier.name,
+        isDefault: tier.isDefault,
+        priority: tier.priority,
+        conditions: tier.conditions,
+        prices: Object.entries(tier.prices).map(([usageType, price]) => ({
+          usageType,
+          price: new Decimal(price),
+        })),
+      }),
+    );
+
+    const pricingResult = matchPricingTier(tiers, {
+      input: 16,
+      cache_read_input_tokens: 226784,
+      cache_creation_input_tokens: 48454,
+      output: 2621,
+    });
+
+    expect(pricingResult).not.toBeNull();
+    expect(pricingResult?.pricingTierName).toBe("Standard");
+    expect(pricingResult?.prices.input.toNumber()).toBe(0.000003);
+    expect(pricingResult?.prices.cache_read_input_tokens.toNumber()).toBe(
+      0.0000003,
+    );
+  });
 });
 
 describe("validateRegexPattern", () => {

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3295,7 +3295,7 @@
     "modelName": "claude-sonnet-4-6",
     "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-6(-v1(:0)?)?|claude-sonnet-4-6)$",
     "createdAt": "2026-02-18T00:00:00.000Z",
-    "updatedAt": "2026-04-13T00:00:00.000Z",
+    "updatedAt": "2026-04-26T00:00:00.000Z",
     "tokenizerConfig": null,
     "tokenizerId": "claude",
     "pricingTiers": [
@@ -3317,33 +3317,6 @@
           "cache_read_input_tokens": 3e-7,
           "input_cached_tokens": 3e-7,
           "input_cache_read": 3e-7
-        }
-      },
-      {
-        "id": "7830bfc2-c464-4ffe-b9a2-6e741f6c5486",
-        "name": "Large Context",
-        "isDefault": false,
-        "priority": 1,
-        "conditions": [
-          {
-            "usageDetailPattern": "input",
-            "operator": "gt",
-            "value": 200000,
-            "caseSensitive": false
-          }
-        ],
-        "prices": {
-          "input": 6e-6,
-          "input_tokens": 6e-6,
-          "output": 22.5e-6,
-          "output_tokens": 22.5e-6,
-          "cache_creation_input_tokens": 7.5e-6,
-          "input_cache_creation": 7.5e-6,
-          "input_cache_creation_5m": 7.5e-6,
-          "input_cache_creation_1h": 12e-6,
-          "cache_read_input_tokens": 6e-7,
-          "input_cached_tokens": 6e-7,
-          "input_cache_read": 6e-7
         }
       }
     ]


### PR DESCRIPTION
## What does this PR do?

Fixes #12996 

## Summary

Update the default pricing definition for `claude-sonnet-4-6` to match Anthropic's March 13, 2026 pricing update.

Anthropic now states that Claude Sonnet 4.6 includes the full 1M token context window at standard pricing, with prompt caching discounts also applying at standard rates across the full context window. This removes the previously configured large-context premium tier for `claude-sonnet-4-6` and adds a regression test covering a cache-heavy request that should remain on standard pricing.

References:
- [Anthropic 1M context GA announcement](https://claude.com/blog/1m-context-ga)
- [Anthropic pricing docs: long context pricing](https://platform.claude.com/docs/en/about-claude/pricing#long-context-pricing)

## Impacted packages

- `worker`

## Verification

- `pnpm --filter worker run test src/__tests__/pricing-tier-matcher.test.ts`

## Caveat

This change is intended to make pricing accurate for future ingests after deployment.

Since calculated observation costs are stored at ingestion time, this PR should not retroactively rewrite historical costs already stored in observations. It also does not introduce effective-date versioning for default model pricing. If maintainers want historical repricing/backfill behavior to distinguish pre-and post-March 13, 2026 Sonnet 4.6 pricing, that should be handled separately with date-versioned model definitions.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR removes the Large Context pricing tier for `claude-sonnet-4-6` in `default-model-prices.json`, aligning the configuration with Anthropic's March 13, 2026 announcement that the full 1M token context window is now included at standard pricing. A regression test is also added to verify that cache-heavy requests continue to use Standard pricing. The change is purely forward-looking (no historical backfill) and is clearly scoped.

<h3>Confidence Score: 5/5</h3>

Safe to merge — narrowly scoped config change with a dedicated regression test and no other logic touched.

The only changes are deleting a now-invalid pricing tier from a JSON config file and adding a test that mirrors the existing proven pattern. No P0 or P1 issues were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/constants/default-model-prices.json | Removes the `Large Context` pricing tier (id: `7830bfc2-c464-4ffe-b9a2-6e741f6c5486`) from `claude-sonnet-4-6` and bumps `updatedAt` to `2026-04-26T00:00:00.000Z`; Standard tier and its prices are unchanged. |
| worker/src/__tests__/pricing-tier-matcher.test.ts | Adds a regression test confirming `claude-sonnet-4-6` stays on Standard pricing even with 226K cache-read tokens; follows the same construction pattern as the existing `claude-sonnet-4-5` tier test. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Ingestion request\nfor claude-sonnet-4-6] --> B{matchPricingTier}
    B --> C[Standard Tier\n$3/MTok input\n$15/MTok output\ncache read $0.30/MTok]
    
    subgraph Before PR
        D[matchPricingTier] --> E{input > 200K?}
        E -- Yes --> F[Large Context Tier\n$6/MTok input\n$22.5/MTok output]
        E -- No --> G[Standard Tier]
    end
    
    subgraph After PR
        B
        C
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(model-prices): remove long-context p..."](https://github.com/langfuse/langfuse/commit/4ae862678e876d454dc1c0745c2c10319d972ebd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29800525)</sub>

<!-- /greptile_comment -->