### PR TITLE
fix(server): ingest flattened experiment metadata

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2036,16 +2036,20 @@ export class OtelIngestionProcessor {
     const topLevelMetadata = this.parseMetadataAttribute(
       attributes[metadataKeyPrefix] || attributes["langfuse.metadata"],
     );
-    const langfuseMetadata = this.extractPrefixedMetadataAttributes(
+    const langfuseMetadata = this.extractPrefixedMetadataAttributes({
       attributes,
-      [metadataKeyPrefix, "langfuse.metadata", "ai.telemetry.metadata"],
-      new Set([
+      prefixes: [
+        metadataKeyPrefix,
+        "langfuse.metadata",
+        "ai.telemetry.metadata",
+      ],
+      excludedKeys: new Set([
         "ai.telemetry.metadata.userId",
         "ai.telemetry.metadata.sessionId",
         "ai.telemetry.metadata.tags",
         "ai.telemetry.metadata.langfusePrompt",
       ]),
-    );
+    });
 
     // Vercel AI SDK
     const tools =
@@ -2690,11 +2694,12 @@ export class OtelIngestionProcessor {
     return {};
   }
 
-  private extractPrefixedMetadataAttributes(
-    attributes: Record<string, unknown>,
-    prefixes: string[],
-    excludedKeys = new Set<string>(),
-  ): Record<string, unknown> {
+  private extractPrefixedMetadataAttributes(params: {
+    attributes: Record<string, unknown>;
+    prefixes: string[];
+    excludedKeys?: Set<string>;
+  }): Record<string, unknown> {
+    const { attributes, prefixes, excludedKeys = new Set<string>() } = params;
     const metadata: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(attributes)) {
       for (const prefix of prefixes) {
@@ -2714,13 +2719,17 @@ export class OtelIngestionProcessor {
     return metadata;
   }
 
-  private extractMetadataFromPrefix(
-    attributes: Record<string, unknown>,
-    prefix: string,
-  ): Record<string, unknown> {
+  private extractMetadataFromPrefix(params: {
+    attributes: Record<string, unknown>;
+    prefix: string;
+  }): Record<string, unknown> {
+    const { attributes, prefix } = params;
     return {
       ...this.parseMetadataAttribute(attributes[prefix]),
-      ...this.extractPrefixedMetadataAttributes(attributes, [prefix]),
+      ...this.extractPrefixedMetadataAttributes({
+        attributes,
+        prefixes: [prefix],
+      }),
     };
   }
 
@@ -2762,18 +2771,18 @@ export class OtelIngestionProcessor {
 
     // Extract experiment metadata
     const experimentMetadataFlattened = flattenJsonToPathArrays(
-      this.extractMetadataFromPrefix(
+      this.extractMetadataFromPrefix({
         attributes,
-        LangfuseOtelSpanAttributes.EXPERIMENT_METADATA,
-      ),
+        prefix: LangfuseOtelSpanAttributes.EXPERIMENT_METADATA,
+      }),
     );
 
     // Extract experiment item metadata
     const experimentItemMetadataFlattened = flattenJsonToPathArrays(
-      this.extractMetadataFromPrefix(
+      this.extractMetadataFromPrefix({
         attributes,
-        LangfuseOtelSpanAttributes.EXPERIMENT_ITEM_METADATA,
-      ),
+        prefix: LangfuseOtelSpanAttributes.EXPERIMENT_ITEM_METADATA,
+      }),
     );
 
     return {

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2028,54 +2028,24 @@ export class OtelIngestionProcessor {
     attributes: Record<string, unknown>,
     domain: "trace" | "observation",
   ): Record<string, unknown> {
-    let topLevelMetadata: Record<string, unknown> = {};
-
     const metadataKeyPrefix =
       domain === "observation"
         ? LangfuseOtelSpanAttributes.OBSERVATION_METADATA
         : LangfuseOtelSpanAttributes.TRACE_METADATA;
 
-    const langfuseMetadataAttribute =
-      attributes[metadataKeyPrefix] || attributes["langfuse.metadata"];
-
-    if (langfuseMetadataAttribute) {
-      try {
-        if (typeof langfuseMetadataAttribute === "string") {
-          topLevelMetadata = JSON.parse(langfuseMetadataAttribute as string);
-        } else if (typeof langfuseMetadataAttribute === "object") {
-          topLevelMetadata = langfuseMetadataAttribute as Record<
-            string,
-            unknown
-          >;
-        }
-      } catch {
-        // Continue with nested metadata extraction
-      }
-    }
-
-    const langfuseMetadata: Record<string, unknown> = {};
-
-    for (const [key, value] of Object.entries(attributes)) {
-      for (const prefix of [
-        metadataKeyPrefix,
-        "langfuse.metadata",
-        "ai.telemetry.metadata",
-      ]) {
-        if (
-          key.startsWith(`${prefix}.`) &&
-          // Filter out the Vercel AI SDK trace attribute keys
-          ![
-            "ai.telemetry.metadata.userId",
-            "ai.telemetry.metadata.sessionId",
-            "ai.telemetry.metadata.tags",
-            "ai.telemetry.metadata.langfusePrompt",
-          ].includes(key)
-        ) {
-          const newKey = key.replace(`${prefix}.`, "");
-          langfuseMetadata[newKey] = value;
-        }
-      }
-    }
+    const topLevelMetadata = this.parseMetadataAttribute(
+      attributes[metadataKeyPrefix] || attributes["langfuse.metadata"],
+    );
+    const langfuseMetadata = this.extractPrefixedMetadataAttributes(
+      attributes,
+      [metadataKeyPrefix, "langfuse.metadata", "ai.telemetry.metadata"],
+      new Set([
+        "ai.telemetry.metadata.userId",
+        "ai.telemetry.metadata.sessionId",
+        "ai.telemetry.metadata.tags",
+        "ai.telemetry.metadata.langfusePrompt",
+      ]),
+    );
 
     // Vercel AI SDK
     const tools =
@@ -2697,6 +2667,63 @@ export class OtelIngestionProcessor {
     return [];
   }
 
+  private parseMetadataAttribute(value: unknown): Record<string, unknown> {
+    if (!value) {
+      return {};
+    }
+
+    if (typeof value === "string") {
+      try {
+        const parsed = JSON.parse(value);
+        return parsed && typeof parsed === "object"
+          ? (parsed as Record<string, unknown>)
+          : {};
+      } catch {
+        return {};
+      }
+    }
+
+    if (typeof value === "object") {
+      return value as Record<string, unknown>;
+    }
+
+    return {};
+  }
+
+  private extractPrefixedMetadataAttributes(
+    attributes: Record<string, unknown>,
+    prefixes: string[],
+    excludedKeys = new Set<string>(),
+  ): Record<string, unknown> {
+    const metadata: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(attributes)) {
+      for (const prefix of prefixes) {
+        if (!key.startsWith(`${prefix}.`) || excludedKeys.has(key)) {
+          continue;
+        }
+
+        const metadataKey = key.slice(prefix.length + 1);
+        if (!metadataKey) {
+          continue;
+        }
+
+        metadata[metadataKey] = value;
+      }
+    }
+
+    return metadata;
+  }
+
+  private extractMetadataFromPrefix(
+    attributes: Record<string, unknown>,
+    prefix: string,
+  ): Record<string, unknown> {
+    return {
+      ...this.parseMetadataAttribute(attributes[prefix]),
+      ...this.extractPrefixedMetadataAttributes(attributes, [prefix]),
+    };
+  }
+
   /**
    * Extracts experiment-related fields from span attributes.
    * Returns undefined for fields that are not present.
@@ -2734,35 +2761,19 @@ export class OtelIngestionProcessor {
       attributes[LangfuseOtelSpanAttributes.EXPERIMENT_ITEM_VERSION];
 
     // Extract experiment metadata
-    const experimentMetadataStr =
-      attributes[LangfuseOtelSpanAttributes.EXPERIMENT_METADATA];
-    let experimentMetadata: Record<string, unknown> = {};
-    if (experimentMetadataStr && typeof experimentMetadataStr === "string") {
-      try {
-        experimentMetadata = JSON.parse(experimentMetadataStr);
-      } catch {
-        // If parsing fails, treat as empty
-      }
-    }
-    const experimentMetadataFlattened =
-      flattenJsonToPathArrays(experimentMetadata);
+    const experimentMetadataFlattened = flattenJsonToPathArrays(
+      this.extractMetadataFromPrefix(
+        attributes,
+        LangfuseOtelSpanAttributes.EXPERIMENT_METADATA,
+      ),
+    );
 
     // Extract experiment item metadata
-    const experimentItemMetadataStr =
-      attributes[LangfuseOtelSpanAttributes.EXPERIMENT_ITEM_METADATA];
-    let experimentItemMetadata: Record<string, unknown> = {};
-    if (
-      experimentItemMetadataStr &&
-      typeof experimentItemMetadataStr === "string"
-    ) {
-      try {
-        experimentItemMetadata = JSON.parse(experimentItemMetadataStr);
-      } catch {
-        // If parsing fails, treat as empty
-      }
-    }
     const experimentItemMetadataFlattened = flattenJsonToPathArrays(
-      experimentItemMetadata,
+      this.extractMetadataFromPrefix(
+        attributes,
+        LangfuseOtelSpanAttributes.EXPERIMENT_ITEM_METADATA,
+      ),
     );
 
     return {

--- a/worker/src/queues/__tests__/otelMetadataProcessing.test.ts
+++ b/worker/src/queues/__tests__/otelMetadataProcessing.test.ts
@@ -138,6 +138,19 @@ async function processAndCreateEvent(
   return { eventRecord, nameToValue };
 }
 
+function arraysToRecord(
+  names: string[],
+  values: Array<string | null | undefined>,
+) {
+  return names.reduce<Record<string, string | null | undefined>>(
+    (acc, name, index) => {
+      acc[name] = values[index];
+      return acc;
+    },
+    {},
+  );
+}
+
 describe("OTel metadata processing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -182,6 +195,139 @@ describe("OTel metadata processing", () => {
       expect(nameToValue["topic"]).toBe("test");
       expect(nameToValue["resourceAttributes"]).toBeUndefined();
       expect(nameToValue["scope.attributes"]).toBeUndefined();
+    });
+  });
+
+  describe("experiment metadata", () => {
+    it("extracts serialized and flattened experiment metadata attributes", async () => {
+      const otelSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "telemetry.sdk.language",
+              value: { stringValue: "python" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "langfuse-sdk",
+              version: "4.5.0",
+              attributes: [
+                { key: "public_key", value: { stringValue: "pk-test" } },
+              ],
+            },
+            spans: [
+              {
+                traceId: createBufferId("bb9cee80f1800c7d51ef67439c379032"),
+                spanId: createBufferId("c874c627f90e96a6"),
+                name: "experiment-child-span",
+                kind: 1,
+                startTimeUnixNano: createNanoTimestamp(
+                  BigInt(1777044156622912000),
+                ),
+                endTimeUnixNano: createNanoTimestamp(
+                  BigInt(1777044156622993000),
+                ),
+                attributes: [
+                  {
+                    key: "langfuse.observation.type",
+                    value: { stringValue: "generation" },
+                  },
+                  {
+                    key: "langfuse.experiment.id",
+                    value: { stringValue: "972b5387f1607558" },
+                  },
+                  {
+                    key: "langfuse.experiment.name",
+                    value: {
+                      stringValue: "myexp - 2026-04-24T15:22:36.622383Z",
+                    },
+                  },
+                  {
+                    key: "langfuse.experiment.metadata",
+                    value: {
+                      stringValue: JSON.stringify({
+                        source: "serialized",
+                        override: "serialized-value",
+                        nested: { key: "nested-value" },
+                      }),
+                    },
+                  },
+                  {
+                    key: "langfuse.experiment.metadata.override",
+                    value: { stringValue: "flattened-value" },
+                  },
+                  {
+                    key: "langfuse.experiment.metadata.region",
+                    value: { stringValue: "emea" },
+                  },
+                  {
+                    key: "langfuse.experiment.item.id",
+                    value: { stringValue: "80db4ccdca106d37" },
+                  },
+                  {
+                    key: "langfuse.experiment.item.root_observation_id",
+                    value: { stringValue: "842d3593cd7c818e" },
+                  },
+                  {
+                    key: "langfuse.experiment.item.metadata",
+                    value: {
+                      stringValue: JSON.stringify({
+                        legacy: true,
+                        continent: "serialized-continent",
+                      }),
+                    },
+                  },
+                  {
+                    key: "langfuse.experiment.item.metadata.continent",
+                    value: { stringValue: "Europe" },
+                  },
+                  {
+                    key: "langfuse.experiment.item.metadata.position",
+                    value: { intValue: 3 },
+                  },
+                  {
+                    key: "langfuse.observation.metadata.continent",
+                    value: { stringValue: "observation-continent" },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const { eventRecord, nameToValue } =
+        await processAndCreateEvent(otelSpan);
+
+      expect(eventRecord.experiment_id).toBe("972b5387f1607558");
+      expect(eventRecord.experiment_item_id).toBe("80db4ccdca106d37");
+      expect(nameToValue["continent"]).toBe("observation-continent");
+
+      expect(
+        arraysToRecord(
+          eventRecord.experiment_metadata_names,
+          eventRecord.experiment_metadata_values,
+        ),
+      ).toEqual({
+        source: "serialized",
+        override: "flattened-value",
+        "nested.key": "nested-value",
+        region: "emea",
+      });
+      expect(
+        arraysToRecord(
+          eventRecord.experiment_item_metadata_names,
+          eventRecord.experiment_item_metadata_values,
+        ),
+      ).toEqual({
+        legacy: "true",
+        continent: "Europe",
+        position: "3",
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes LFE-9506 by teaching OTel ingestion to parse flattened SDK v4 experiment metadata attributes:

- `langfuse.experiment.metadata.*`
- `langfuse.experiment.item.metadata.*`

The implementation reuses the same metadata parsing shape used for regular trace/observation metadata: parse the exact JSON/object metadata attribute, extract dotted metadata keys, then flatten into the existing ClickHouse event arrays. Experiment-level metadata remains separate from experiment-item metadata, and both remain separate from normal observation metadata.

## Root cause

`extractExperimentFields()` only parsed the legacy serialized attributes `langfuse.experiment.metadata` and `langfuse.experiment.item.metadata`. Flattened per-key attributes emitted by SDK v4 were present on incoming OTel spans but dropped before `createEventRecord()` wrote `experiment_metadata_names/values` and `experiment_item_metadata_names/values`.

## Impacted packages

- `packages/shared`
- `worker`

## Verification

- `pnpm --dir .. exec prettier --check packages/shared/src/server/otel/OtelIngestionProcessor.ts worker/src/queues/__tests__/otelMetadataProcessing.test.ts`
- `pnpm --dir .. --filter @langfuse/shared exec eslint src/server/otel/OtelIngestionProcessor.ts --max-warnings 0`
- `pnpm exec vitest run src/queues/__tests__/otelMetadataProcessing.test.ts`
- pre-commit hook: `pnpm run format:check` and `pnpm run lint`

Note: `pnpm --dir .. --filter @langfuse/shared run build` still fails on unrelated existing `fetchLLMCompletion.ts` `undici` dispatcher type errors.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes dropped SDK v4 experiment metadata by teaching `extractExperimentFields` to parse both the legacy serialized attribute (`langfuse.experiment.metadata`) and flattened per-key attributes (`langfuse.experiment.metadata.*`) via three new private helpers: `parseMetadataAttribute`, `extractPrefixedMetadataAttributes`, and `extractMetadataFromPrefix`. The same helpers are reused to refactor the existing observation/trace metadata path, and the spread order (serialized first, flattened second) ensures that flattened keys win on conflict. Attribute-domain isolation (experiment vs. experiment-item vs. observation) is preserved correctly because none of the three prefixes is a prefix of another.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted fix with correct attribute isolation and good test coverage.

No logic errors, security concerns, or regressions found. The refactoring faithfully preserves existing behavior while adding flattened-key support. Tests cover the key override semantics, domain isolation, and integer-value coercion. The three attribute prefixes are mutually non-prefixing, so there is no cross-contamination risk.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/otel/OtelIngestionProcessor.ts | Refactors metadata parsing into reusable private helpers and extends extractExperimentFields to pick up SDK v4 flattened dot-suffix attributes; logic is correct and attribute-domain separation is preserved. |
| worker/src/queues/__tests__/otelMetadataProcessing.test.ts | Adds a new describe block verifying serialized + flattened experiment/item metadata extraction, flattened-key-wins override semantics, and correct isolation between observation and experiment metadata domains. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OTel Span Attributes] --> B[extractExperimentFields]
    B --> G[extractMetadataFromPrefix prefix: langfuse.experiment.metadata]
    B --> H[extractMetadataFromPrefix prefix: langfuse.experiment.item.metadata]
    G --> G1[parseMetadataAttribute exact key JSON]
    G --> G2[extractPrefixedMetadataAttributes dot-suffix keys]
    G1 & G2 --> I[flattenJsonToPathArrays]
    I --> K[experiment_metadata_names/values]
    H --> H1[parseMetadataAttribute exact key JSON]
    H --> H2[extractPrefixedMetadataAttributes dot-suffix keys]
    H1 & H2 --> J[flattenJsonToPathArrays]
    J --> L[experiment_item_metadata_names/values]
```

<sub>Reviews (1): Last reviewed commit: ["refactor: use params object for otel met..."](https://github.com/langfuse/langfuse/commit/2635038fefc707cff837b0750876a3283a9bdda2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29801869)</sub>

<!-- /greptile_comment -->