### PR TITLE
perf(clickhouse): emit has(metadata_names) conjunct for events filters

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -373,7 +373,8 @@ CREATE TABLE IF NOT EXISTS events_core
     INDEX idx_created_at created_at TYPE minmax GRANULARITY 1,
     INDEX idx_updated_at updated_at TYPE minmax GRANULARITY 1,
     INDEX idx_provided_model_name provided_model_name TYPE bloom_filter(0.01) GRANULARITY 2,
-    INDEX idx_experiment_id experiment_id TYPE bloom_filter(0.01) GRANULARITY 1
+    INDEX idx_experiment_id experiment_id TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_metadata_names metadata_names TYPE bloom_filter(0.01) GRANULARITY 1
 )
 ENGINE = ReplacingMergeTree(event_ts, is_deleted)
 PARTITION BY toYYYYMM(start_time)

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -310,26 +310,33 @@ export class StringObjectFilter implements Filter {
 
     let query: string;
     if (isEventsTable) {
-      // For events tables, use array access: {field}_values[indexOf({field}_names, key)]
+      // ClickHouse's index analyzer cannot extract `has(names, k)` from
+      // `values[indexOf(names, k)] OP v` (cross-array arrayElement form), so a
+      // bloom_filter skipping index on `names` would never prune granules.
+      // Emitting an explicit `has(names, k) AND (...)` prefix conjunct makes
+      // the index actionable and corrects the absent-key matching semantic
+      // (Otherwise `arr[0] = ''` causes some predicates to match rows that never
+      // had the key — including `does not contain`).
       const namesColumn = `${prefix}${this.field}_names`;
       const valuesColumn = `${prefix}${this.field}_values`;
       const valueAccessor = `${valuesColumn}[indexOf(${namesColumn}, {${varKeyName}: String})]`;
+      const hasKey = `has(${namesColumn}, {${varKeyName}: String})`;
 
       switch (this.operator) {
         case "=":
-          query = `${valueAccessor} = {${varValueName}: String}`;
+          query = `${hasKey} AND (${valueAccessor} = {${varValueName}: String})`;
           break;
         case "contains":
-          query = `position(${valueAccessor}, {${varValueName}: String}) > 0`;
+          query = `${hasKey} AND (position(${valueAccessor}, {${varValueName}: String}) > 0)`;
           break;
         case "does not contain":
-          query = `position(${valueAccessor}, {${varValueName}: String}) = 0`;
+          query = `${hasKey} AND (position(${valueAccessor}, {${varValueName}: String}) = 0)`;
           break;
         case "starts with":
-          query = `startsWith(${valueAccessor}, {${varValueName}: String})`;
+          query = `${hasKey} AND (startsWith(${valueAccessor}, {${varValueName}: String}))`;
           break;
         case "ends with":
-          query = `endsWith(${valueAccessor}, {${varValueName}: String})`;
+          query = `${hasKey} AND (endsWith(${valueAccessor}, {${varValueName}: String}))`;
           break;
         default:
           throw new Error(`Unsupported operator: ${this.operator}`);

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -1244,6 +1244,113 @@ describe("Clickhouse Events Repository Test", () => {
 
         expect(resultBaz.length).toBe(0);
       });
+
+      it("equality on absent key with empty value does NOT match", async () => {
+        // Today arr[indexOf(names, missing)] resolves to '' (Array(String)
+        // default), so `metadata.foo = ''` would match rows that never had
+        // the key. The has(metadata_names, ?) conjunct fixes this.
+        const traceId = randomUUID();
+        const observationId = randomUUID();
+        const now = Date.now();
+        const filterTime = new Date(now - 5000);
+
+        await createEventsCh([
+          createEvent({
+            id: observationId,
+            span_id: observationId,
+            project_id: projectId,
+            trace_id: traceId,
+            type: "SPAN",
+            name: "no-foo-key-eq-empty",
+            metadata_names: ["bar"],
+            metadata_values: ["baz"],
+            start_time: now * 1000,
+          }),
+        ]);
+
+        const result = await getObservationsWithModelDataFromEventsTable({
+          projectId,
+          filter: [
+            {
+              type: "stringObject",
+              column: "metadata",
+              operator: "=",
+              key: "foo",
+              value: "",
+            },
+            {
+              type: "datetime",
+              column: "startTime",
+              operator: ">=",
+              value: filterTime,
+            },
+            {
+              type: "string",
+              column: "traceId",
+              operator: "=",
+              value: traceId,
+            },
+          ],
+          limit: 1000,
+          offset: 0,
+        });
+
+        expect(result.length).toBe(0);
+      });
+
+      it("'does not contain' on absent key with non-empty needle does NOT match", async () => {
+        // Headline correctness fix: previously rows with the key absent
+        // matched `does not contain V` (because position('', V) = 0 is true
+        // for non-empty V). The has(metadata_names, ?) conjunct restricts
+        // the result to rows where the key actually exists.
+        const traceId = randomUUID();
+        const observationId = randomUUID();
+        const now = Date.now();
+        const filterTime = new Date(now - 5000);
+
+        await createEventsCh([
+          createEvent({
+            id: observationId,
+            span_id: observationId,
+            project_id: projectId,
+            trace_id: traceId,
+            type: "SPAN",
+            name: "no-foo-key-dnc",
+            metadata_names: ["bar"],
+            metadata_values: ["baz"],
+            start_time: now * 1000,
+          }),
+        ]);
+
+        const result = await getObservationsWithModelDataFromEventsTable({
+          projectId,
+          filter: [
+            {
+              type: "stringObject",
+              column: "metadata",
+              operator: "does not contain",
+              key: "foo",
+              value: "anything",
+            },
+            {
+              type: "datetime",
+              column: "startTime",
+              operator: ">=",
+              value: filterTime,
+            },
+            {
+              type: "string",
+              column: "traceId",
+              operator: "=",
+              value: traceId,
+            },
+          ],
+          limit: 1000,
+          offset: 0,
+        });
+
+        expect(result.length).toBe(0);
+      });
     });
   });
 


### PR DESCRIPTION
The ClickHouse index analyzer cannot extract has(names, k) semantics
from `values[indexOf(names, k)] OP v (cross-array arrayElement form)`, so a
`bloom_filter` skipping index on `metadata_names` cannot prune granules for
this shape. Wrap every operator branch in `StringObjectFilter.apply()` for
`events_core` / `events_full` with an explicit `has(names, k) AND (...)` conjunct.

Also corrects a latent semantic bug: today `arr[indexOf(names, missing)]`
resolves to the empty string `(Array(String) default)`, making
"does not contain V" match rows where the key was never written, and
"OP empty-value" match similarly. The `has(...)` conjunct fixes this for
all five operators uniformly.

Add `bloom_filter` on `events_core.metadata_names`. `events_core` is the
table that takes filters in the V2 split-query pattern; `events_full`
reads by ID after the base CTE narrows things down, so the symmetric
index is intentionally omitted for now.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a semantic bug in `StringObjectFilter` for events tables (`events_core`, `events_full`, `events_proto`) by prepending an explicit `has(metadata_names, key)` conjunct to all five operator branches. Previously, `arr[indexOf(names, missing_key)]` resolved to `''`, causing predicates like "does not contain" to falsely match rows where the key was never stored; the fix eliminates these false positives and also makes the `bloom_filter` skipping index on `metadata_names` actionable by the ClickHouse index analyzer.

- **P1**: The new `idx_metadata_names` bloom_filter index is added only to `dev-tables.sh`; no production migration file exists (compare `0025_add_observations_metadata_indexes.up.sql`), so the performance benefit will not materialize on any existing deployment without a corresponding `ALTER TABLE events_core ADD INDEX … MATERIALIZE INDEX` migration.
- **P2**: The observations/traces `else` branch uses ClickHouse Map access (`metadata[key]`), which has the same absent-key-returns-`''` semantic; it is not fixed here, leaving a behavioral inconsistency between the two code paths for the same filter type.

<h3>Confidence Score: 3/5</h3>

Safe to merge the query-logic fix, but the performance goal will not be realized on production without a migration for the new bloom_filter index.

The filter logic change is correct and well-tested. However, the bloom_filter index added to dev-tables.sh lacks a corresponding production migration, meaning the index won't exist on any live deployment — defeating the main performance objective of the PR. This is a P1 gap that lowers confidence below the clean-PR ceiling.

packages/shared/clickhouse/scripts/dev-tables.sh — needs a companion migration file for the new idx_metadata_names index.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts | Adds has(names, k) AND (...) conjunct to all 5 operators in the events-table branch of StringObjectFilter.apply(), enabling bloom_filter index usage and fixing absent-key false-positive matches; the non-events Map path retains the same latent semantic bug. |
| packages/shared/clickhouse/scripts/dev-tables.sh | Adds bloom_filter(0.01) skipping index on events_core.metadata_names, but no corresponding production migration file is included. |
| web/src/__tests__/server/repositories/event-repository.servertest.ts | Adds two regression tests verifying the absent-key fix: equality with empty value and 'does not contain' with a non-empty needle no longer match rows missing the key. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[StringObjectFilter.apply] --> B{isEventsTable?}
    B -- Yes --> C[Build namesColumn / valuesColumn / valueAccessor]
    C --> D[hasKey: has metadata_names key]
    D --> E{operator switch}
    E -- equality --> F[hasKey AND valueAccessor equals value]
    E -- contains --> G[hasKey AND position check greater than 0]
    E -- does not contain --> H[hasKey AND position check equals 0]
    E -- starts with --> I[hasKey AND startsWith check]
    E -- ends with --> J[hasKey AND endsWith check]
    F & G & H & I & J --> K[bloom_filter on metadata_names can prune granules]
    B -- No --> L[Map access metadata-key OP value - absent-key bug still present]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts`, line 344-366 ([link](https://github.com/langfuse/langfuse/blob/90614dc47b2a18bf869412c99ae6d20810435d6e/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts#L344-L366)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Same absent-key semantic bug in the Map column path**

   The observations/traces branch (`else` block) uses `metadata[{key}]` Map access, which also returns `''` for a missing key in ClickHouse — the same semantic bug the PR fixes for the array path. Operators like `"does not contain"` and `"="` on absent keys in the Map path will still silently match rows that never stored the key. This is not introduced by this PR, but since the fix is applied only to the events path, there is now a behavioral inconsistency between the two code paths for the same filter type.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
   Line: 344-366

   Comment:
   **Same absent-key semantic bug in the Map column path**

   The observations/traces branch (`else` block) uses `metadata[{key}]` Map access, which also returns `''` for a missing key in ClickHouse — the same semantic bug the PR fixes for the array path. Operators like `"does not contain"` and `"="` on absent keys in the Map path will still silently match rows that never stored the key. This is not introduced by this PR, but since the fix is applied only to the events path, there is now a behavioral inconsistency between the two code paths for the same filter type.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/shared/clickhouse/scripts/dev-tables.sh
Line: 376

Comment:
**Missing production migration for new index**

The `idx_metadata_names` bloom_filter index is added to `dev-tables.sh`, but there is no corresponding migration file (e.g. `0035_add_events_core_metadata_names_index.up.sql`) under `packages/shared/clickhouse/migrations/clustered|unclustered/`. The existing precedent for adding indexes — such as `0025_add_observations_metadata_indexes.up.sql` — uses `ALTER TABLE ... ADD INDEX IF NOT EXISTS ... MATERIALIZE INDEX` migrations that run against production. Without this, the performance goal of enabling the bloom_filter to prune granules won't be realized on any existing deployment.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
Line: 344-366

Comment:
**Same absent-key semantic bug in the Map column path**

The observations/traces branch (`else` block) uses `metadata[{key}]` Map access, which also returns `''` for a missing key in ClickHouse — the same semantic bug the PR fixes for the array path. Operators like `"does not contain"` and `"="` on absent keys in the Map path will still silently match rows that never stored the key. This is not introduced by this PR, but since the fix is applied only to the events path, there is now a behavioral inconsistency between the two code paths for the same filter type.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(clickhouse): emit has(metadata\_name..."](https://github.com/langfuse/langfuse/commit/90614dc47b2a18bf869412c99ae6d20810435d6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29802186)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->