### PR TITLE
fix(internal-tracing): remove output parser spans

### DIFF
--- a/packages/shared/src/server/llm/getInternalTracingHandler.ts
+++ b/packages/shared/src/server/llm/getInternalTracingHandler.ts
@@ -17,12 +17,7 @@ export function prepareInternalTraceEvents(params: {
   const { events, environment, prompt } = params;
 
   const blockedSpanIds = new Set();
-  const blockedSpanNames = [
-    "RunnableLambda",
-    "StructuredOutputParser",
-    "StrOutputParser",
-    "JsonOutputParser",
-  ];
+  const blockedSpanNameSubstrings = ["RunnableLambda", "OutputParser"];
 
   for (const event of events) {
     const eventName = "name" in event.body ? event.body.name : "";
@@ -31,7 +26,12 @@ export function prepareInternalTraceEvents(params: {
       continue;
     }
 
-    if (blockedSpanNames.includes(eventName as string) && "id" in event.body) {
+    if (
+      blockedSpanNameSubstrings.some((blockedSubstring) =>
+        eventName.includes(blockedSubstring),
+      ) &&
+      "id" in event.body
+    ) {
       blockedSpanIds.add(event.body.id);
     }
   }

--- a/packages/shared/src/server/llm/getInternalTracingHandler.ts
+++ b/packages/shared/src/server/llm/getInternalTracingHandler.ts
@@ -30,7 +30,8 @@ export function prepareInternalTraceEvents(params: {
       blockedSpanNameSubstrings.some((blockedSubstring) =>
         eventName.includes(blockedSubstring),
       ) &&
-      "id" in event.body
+      "id" in event.body &&
+      event.type !== "trace-create"
     ) {
       blockedSpanIds.add(event.body.id);
     }


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR refactors the output-parser span blocking logic in `prepareInternalTraceEvents` to use substring matching instead of an exact-name allowlist, consolidating `StructuredOutputParser`, `StrOutputParser`, and `JsonOutputParser` into a single `"OutputParser"` substring. This simplifies maintenance and ensures any future output-parser variant is automatically suppressed from internal traces.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted simplification of an internal span-filtering heuristic with no externally visible side effects.

Single-file change that replaces an exact-name list with substring matching, reducing future maintenance. No new control-flow paths, no schema changes, no security surface. All custom import rules are satisfied.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/llm/getInternalTracingHandler.ts | Replaces exact-name blocklist with substring matching for output-parser spans; logic is correct and all imports remain at the module top level. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[events array] --> B{for each event}
    B --> C{eventName is string\nand non-empty?}
    C -- No --> B
    C -- Yes --> D{eventName contains\n'RunnableLambda' or\n'OutputParser'?}
    D -- Yes --> E[add event.body.id\nto blockedSpanIds]
    D -- No --> B
    E --> B
    B --> F[filter events:\nremove if id in blockedSpanIds]
    F --> G[inject environment\ninto each event]
    G --> H{event is generation-create\nand prompt provided?}
    H -- Yes --> I[add promptName & promptVersion]
    H -- No --> J[pass through]
    I --> K[ProcessedTraceEvent array]
    J --> K
```

<sub>Reviews (1): Last reviewed commit: ["fix(internal-tracing): remove output par..."](https://github.com/langfuse/langfuse/commit/1680e8980c614abfc4ab2a48fc50886ed9ab1f39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29807835)</sub>

<!-- /greptile_comment -->