### PR TITLE
fix(web): Improve toast title for `ClickHouseResourceError` errors

### DIFF
--- a/web/src/__tests__/server/trpc-error-formatting.servertest.ts
+++ b/web/src/__tests__/server/trpc-error-formatting.servertest.ts
@@ -1,0 +1,110 @@
+import type { Session } from "next-auth";
+import { TRPCError } from "@trpc/server";
+import * as z from "zod";
+import { ClickHouseResourceError } from "@langfuse/shared/src/server";
+import {
+  createInnerTRPCContext,
+  createTRPCRouter,
+  protectedProcedureWithoutTracing,
+} from "@/src/server/api/trpc";
+
+describe("tRPC error formatting", () => {
+  it("ClickHouseResourceError", async () => {
+    const session = {
+      user: {
+        id: "user-1",
+      },
+    } as Session;
+
+    const formatterTestRouter = createTRPCRouter({
+      clickhouse: protectedProcedureWithoutTracing
+        .input(z.object({}))
+        .query(() => {
+          throw new ClickHouseResourceError(
+            "MEMORY_LIMIT",
+            new Error("Memory limit exceeded"),
+          );
+        }),
+    });
+
+    const formatter = (formatterTestRouter as any)._def._config
+      .errorFormatter as (args: any) => {
+      data: Record<string, unknown>;
+    };
+
+    const context = createInnerTRPCContext({
+      session,
+      headers: {},
+    });
+    const caller = formatterTestRouter.createCaller(context);
+
+    let error: TRPCError | undefined;
+    try {
+      await caller.clickhouse({});
+    } catch (caught) {
+      error = caught as TRPCError;
+    }
+
+    expect(error).toBeInstanceOf(TRPCError);
+
+    const formatted = formatter({
+      shape: {
+        code: -32603,
+        message: error!.message,
+        data: {
+          code: error!.code,
+          httpStatus: 422,
+        },
+      },
+      error: error!,
+    });
+
+    expect(formatted.data["errorName"]).toBe("ClickHouseResourceError");
+    expect(formatted.data["stack"]).toBeNull();
+    expect(formatted.data["zodError"]).toBeNull();
+  });
+
+  it("preserves the default stack behavior for non-ClickHouse errors", () => {
+    const formatterTestRouter = createTRPCRouter({});
+
+    const formatter = (formatterTestRouter as any)._def._config
+      .errorFormatter as (args: any) => {
+      data: Record<string, unknown>;
+    };
+
+    const error = new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Internal error",
+    });
+
+    const formattedWithNoStack = formatter({
+      shape: {
+        code: -32603,
+        message: error.message,
+        data: {
+          code: error.code,
+          httpStatus: 500,
+          stack: undefined,
+        },
+      },
+      error,
+    });
+
+    expect(formattedWithNoStack.data["stack"]).toBeUndefined();
+
+    const formattedWithStack = formatter({
+      shape: {
+        code: -32603,
+        message: error.message,
+        data: {
+          code: error.code,
+          httpStatus: 500,
+          stack: "dev stack",
+        },
+      },
+      error,
+    });
+
+    expect(formattedWithStack.data["stack"]).toBe("dev stack");
+  });
+});

--- a/web/src/__tests__/server/withMiddlewares.servertest.ts
+++ b/web/src/__tests__/server/withMiddlewares.servertest.ts
@@ -209,7 +209,7 @@ describe("withMiddlewares error handling", () => {
       expect(jsonData["message"]).toContain(
         ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
       );
-      expect(jsonData["error"]).toBe("Unprocessable Content");
+      expect(jsonData["error"]).toBe("Request timed out");
     });
   });
 

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -133,7 +133,7 @@ export function withMiddlewares(
 
           return res.status(422).json({
             message: CH_ERROR_ADVICE_FULL,
-            error: "Unprocessable Content",
+            error: "Request timed out",
           });
         }
 

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -108,6 +108,15 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
         ...shape.data,
         zodError:
           error.cause instanceof ZodError ? z.flattenError(error.cause) : null,
+        errorName:
+          error.cause instanceof ClickHouseResourceError
+            ? "ClickHouseResourceError"
+            : null,
+        // do not expose stack traces for CH errors as they may contain sensitive info
+        stack:
+          error.cause instanceof ClickHouseResourceError
+            ? null
+            : shape.data.stack,
       },
     };
   },
@@ -165,6 +174,8 @@ const withErrorHandling = t.middleware(async ({ ctx, next }) => {
       res.error = new TRPCError({
         code: "UNPROCESSABLE_CONTENT",
         message: ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
+        // Keep the original error, it will be removed by `errorFormatter`
+        cause: res.error.cause,
       });
     } else {
       // Throw a new TRPC error with:

--- a/web/src/utils/trpcErrorToast.tsx
+++ b/web/src/utils/trpcErrorToast.tsx
@@ -38,6 +38,17 @@ const getErrorTitleAndHttpCode = (error: TRPCClientError<any>) => {
   const httpStatus: number =
     typeof error.data?.httpStatus === "number" ? error.data.httpStatus : 500;
 
+  if (
+    httpStatus === 422 &&
+    error.data?.errorName === "ClickHouseResourceError"
+  ) {
+    // Handle ClickHouse resource limit errors with specific messaging
+    return {
+      errorTitle: "Request Timed Out",
+      httpStatus,
+    };
+  }
+
   if (httpStatus in httpStatusOverride) {
     return {
       errorTitle: errorTitleMap[httpStatusOverride[httpStatus]],


### PR DESCRIPTION
<img width="416" height="179" alt="Screenshot 2026-04-27 at 16 30 18" src="https://github.com/user-attachments/assets/f34cab49-e889-4b28-96fb-d5efb5b9070c" />

instead of 
<img width="402" height="156" alt="image" src="https://github.com/user-attachments/assets/8af166aa-cda8-4b38-a173-48082436d1bb" />

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR improves the client-side toast title for `ClickHouseResourceError` responses from the generic "Unprocessable Content" to "Request Timed Out" by propagating an `errorName` field through the tRPC `errorFormatter` and adding a matching check in `trpcErrorToast`. It also suppresses stack traces for these errors to avoid leaking sensitive information.

- **P1**: The test in `withMiddlewares.servertest.ts` was updated to assert `"Request timed out"`, but `withMiddlewares.ts` (the REST API handler) still returns `"Unprocessable Content"` — the test will fail as-is.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — one test will fail due to a missing implementation change in withMiddlewares.ts.

There is a clear P1 defect: the test assertion in withMiddlewares.servertest.ts was changed to match behavior that was never implemented (withMiddlewares.ts was not updated). This will cause CI to fail. The rest of the tRPC-side changes are sound.

web/src/__tests__/server/withMiddlewares.servertest.ts and web/src/features/public-api/server/withMiddlewares.ts (unchanged but must be reviewed together).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/__tests__/server/withMiddlewares.servertest.ts | Test expectation changed to "Request timed out" but corresponding implementation in withMiddlewares.ts was not updated — test will fail. |
| web/src/server/api/trpc.ts | Adds errorName and stack suppression fields to errorFormatter for ClickHouseResourceError, and preserves the original cause in withErrorHandling so the formatter can detect it. |
| web/src/utils/trpcErrorToast.tsx | Adds special-case toast title "Request Timed Out" for HTTP 422 + errorName=ClickHouseResourceError; title is inaccurate for MEMORY_LIMIT/OVERCOMMIT error types. |
| web/src/__tests__/server/trpc-error-formatting.servertest.ts | New test verifying that the errorFormatter correctly sets errorName and nullifies stack for ClickHouseResourceError. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ClickHouseResourceError thrown] --> B{tRPC or REST?}
    B -- tRPC --> C[withErrorHandling middleware\nre-wraps as TRPCError UNPROCESSABLE_CONTENT\npreserves cause: ClickHouseResourceError]
    C --> D[errorFormatter\nsets errorName=ClickHouseResourceError\nstack=null]
    D --> E[Client receives\nhttpStatus=422\nerrorName=ClickHouseResourceError]
    E --> F[trpcErrorToast\nshows 'Request Timed Out']
    B -- REST --> G[withMiddlewares\nreturns 422\nerror: 'Unprocessable Content'\n⚠️ test now expects 'Request timed out']
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/__tests__/server/withMiddlewares.servertest.ts
Line: 212

Comment:
**Test expects value the implementation does not produce**

The test was changed to expect `"Request timed out"`, but `withMiddlewares.ts` (line 136) still returns `error: "Unprocessable Content"` for `ClickHouseResourceError`. This test will fail as-is because the implementation was not updated in this PR.

Either revert this assertion back to `"Unprocessable Content"`, or also update `withMiddlewares.ts` to return `"Request timed out"` in the `ClickHouseResourceError` handler.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: web/src/utils/trpcErrorToast.tsx
Line: 41-50

Comment:
**Misleading toast title for non-timeout ClickHouse errors**

The title `"Request Timed Out"` is shown for every `ClickHouseResourceError` regardless of the underlying `errorType`. The `ClickHouseResourceError` class covers three distinct conditions — `MEMORY_LIMIT`, `OVERCOMMIT`, and `TIMEOUT` — so a memory-limit error would be labelled as a timeout, which could mislead users trying to diagnose the problem. Consider a more neutral title like `"Query Resource Limit Exceeded"` to cover all cases accurately.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Improve toast title for \`Click..."](https://github.com/langfuse/langfuse/commit/eb84c60c24f8de35523202acf5bd35d890998f94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29811379)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->