### PR TITLE
feat(api-keys): add read-only access permission for project API keys

### DIFF
--- a/packages/shared/prisma/migrations/20260426144520_add_api_key_access_permission/migration.sql
+++ b/packages/shared/prisma/migrations/20260426144520_add_api_key_access_permission/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ApiKeyAccessPermission" AS ENUM ('READ_ONLY', 'READ_AND_WRITE');
+
+-- AlterTable
+ALTER TABLE "api_keys" ADD COLUMN     "access_permission" "ApiKeyAccessPermission" NOT NULL DEFAULT 'READ_AND_WRITE';

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -176,21 +176,27 @@ enum ApiKeyScope {
   PROJECT
 }
 
+enum ApiKeyAccessPermission {
+  READ_ONLY
+  READ_AND_WRITE
+}
+
 model ApiKey {
-  id                  String        @id @unique @default(cuid())
-  createdAt           DateTime      @default(now()) @map("created_at")
+  id                  String                 @id @unique @default(cuid())
+  createdAt           DateTime               @default(now()) @map("created_at")
   note                String?
-  publicKey           String        @unique @map("public_key")
-  hashedSecretKey     String        @unique @map("hashed_secret_key")
-  fastHashedSecretKey String?       @unique @map("fast_hashed_secret_key")
-  displaySecretKey    String        @map("display_secret_key")
-  lastUsedAt          DateTime?     @map("last_used_at")
-  expiresAt           DateTime?     @map("expires_at")
-  projectId           String?       @map("project_id")
-  project             Project?      @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  orgId               String?       @map("organization_id")
-  organization        Organization? @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  scope               ApiKeyScope   @default(PROJECT) @map("scope")
+  publicKey           String                 @unique @map("public_key")
+  hashedSecretKey     String                 @unique @map("hashed_secret_key")
+  fastHashedSecretKey String?                @unique @map("fast_hashed_secret_key")
+  displaySecretKey    String                 @map("display_secret_key")
+  lastUsedAt          DateTime?              @map("last_used_at")
+  expiresAt           DateTime?              @map("expires_at")
+  projectId           String?                @map("project_id")
+  project             Project?               @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  orgId               String?                @map("organization_id")
+  organization        Organization?          @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  scope               ApiKeyScope            @default(PROJECT) @map("scope")
+  accessPermission    ApiKeyAccessPermission @default(READ_AND_WRITE) @map("access_permission")
 
   @@index(orgId)
   @@index(projectId)

--- a/packages/shared/src/server/auth/apiKeys.ts
+++ b/packages/shared/src/server/auth/apiKeys.ts
@@ -1,4 +1,5 @@
 import { PrismaClient, ApiKeyScope } from "@prisma/client";
+import type { ApiKeyAccessPermission } from "@prisma/client";
 import { compare, hash } from "bcryptjs";
 import { randomUUID } from "crypto";
 import * as crypto from "crypto";
@@ -41,6 +42,7 @@ export async function createAndAddApiKeysToDb(p: {
   entityId: string;
   scope: ApiKeyScope;
   note?: string;
+  accessPermission?: ApiKeyAccessPermission;
   predefinedKeys?: {
     secretKey: string;
     publicKey: string;
@@ -72,6 +74,7 @@ export async function createAndAddApiKeysToDb(p: {
       fastHashedSecretKey: hashFromProvidedKey,
       note: p.note,
       scope: p.scope,
+      accessPermission: p.accessPermission ?? "READ_AND_WRITE",
     },
   });
 

--- a/packages/shared/src/server/auth/types.ts
+++ b/packages/shared/src/server/auth/types.ts
@@ -1,7 +1,7 @@
 import z from "zod";
 import { Plan, plans } from "../../features/entitlements/plans";
 import { CloudConfigRateLimit } from "../../interfaces/rate-limits";
-import { ApiKeyScope, MakeOptional } from "../../";
+import { ApiKeyScope, ApiKeyAccessPermission, MakeOptional } from "../../";
 
 const ApiKeyBaseSchema = z.object({
   id: z.string(),
@@ -17,6 +17,7 @@ const ApiKeyBaseSchema = z.object({
   plan: z.enum(plans as unknown as [string, ...string[]]),
   rateLimitOverrides: CloudConfigRateLimit.nullish(),
   isIngestionSuspended: z.boolean().nullish(),
+  accessPermission: z.nativeEnum(ApiKeyAccessPermission),
 });
 
 export const OrgEnrichedApiKey = z.discriminatedUnion("scope", [
@@ -59,6 +60,7 @@ export type ApiAccessLevel = "organization" | "project" | "scores";
 type BaseApiAccessScope = {
   projectId: string | null;
   accessLevel: ApiAccessLevel;
+  accessPermission: ApiKeyAccessPermission;
 };
 
 type ApiAccessScopeMetadata = {

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 
 import {
+  ApiKeyAccessPermission,
   ForbiddenError,
   ObservationLevel,
   ObservationTypeDomain,
@@ -37,6 +38,7 @@ interface TraceState {
 
 export interface OtelIngestionProcessorConfig {
   projectId: string;
+  accessPermission: ApiKeyAccessPermission;
   publicKey?: string;
   orgId?: string;
   propagatedHeaders?: Record<string, string>;
@@ -151,6 +153,7 @@ export class OtelIngestionProcessor {
     traceUpdated: 0,
   };
   private readonly projectId: string;
+  private readonly accessPermission: ApiKeyAccessPermission;
   private readonly publicKey?: string;
   private readonly orgId?: string;
   private readonly propagatedHeaders?: Record<string, string>;
@@ -160,6 +163,7 @@ export class OtelIngestionProcessor {
 
   constructor(config: OtelIngestionProcessorConfig) {
     this.projectId = config.projectId;
+    this.accessPermission = config.accessPermission;
     this.publicKey = config.publicKey;
     this.orgId = config.orgId;
     this.propagatedHeaders = config.propagatedHeaders;
@@ -207,6 +211,7 @@ export class OtelIngestionProcessor {
               scope: {
                 projectId: this.projectId,
                 accessLevel: "project" as const,
+                accessPermission: this.accessPermission,
                 orgId: this.orgId,
               },
             },

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ApiKeyAccessPermission } from "@prisma/client";
 import { eventTypes } from "./ingestion/types";
 import {
   ActionId,
@@ -37,6 +38,7 @@ export const OtelIngestionEvent = z.object({
     scope: z.object({
       projectId: z.string(),
       accessLevel: z.literal("project"),
+      accessPermission: z.nativeEnum(ApiKeyAccessPermission),
       orgId: z.string().optional(),
     }),
   }),

--- a/packages/shared/src/server/test-utils/org-factory.ts
+++ b/packages/shared/src/server/test-utils/org-factory.ts
@@ -16,6 +16,7 @@ export function createBasicAuthHeader(
 export type CreateOrgProjectAndApiKeyOptions = {
   projectId?: string;
   plan?: "Team" | "Hobby" | "Core" | "Pro" | "Enterprise";
+  accessPermission?: "READ_ONLY" | "READ_AND_WRITE";
 };
 export const createOrgProjectAndApiKey = async (
   props?: CreateOrgProjectAndApiKeyOptions,
@@ -49,6 +50,7 @@ export const createOrgProjectAndApiKey = async (
       hashedSecretKey: await hashSecretKey(secretKey),
       displaySecretKey: getDisplaySecretKey(secretKey),
       scope: "PROJECT",
+      accessPermission: props?.accessPermission ?? "READ_AND_WRITE",
     },
   });
 

--- a/web/src/__tests__/server/api-key-access-permission.servertest.ts
+++ b/web/src/__tests__/server/api-key-access-permission.servertest.ts
@@ -1,0 +1,172 @@
+import { makeAPICall } from "@/src/__tests__/test-utils";
+import {
+  createOrgProjectAndApiKey,
+  hashSecretKey,
+  getDisplaySecretKey,
+  createBasicAuthHeader,
+} from "@langfuse/shared/src/server";
+import { prisma } from "@langfuse/shared/src/db";
+import { v4 as uuidv4 } from "uuid";
+
+describe("API Key Access Permission", () => {
+  describe("READ_ONLY key behavior", () => {
+    let readOnlyAuth: string;
+
+    beforeEach(async () => {
+      const setup = await createOrgProjectAndApiKey({
+        accessPermission: "READ_ONLY",
+      });
+      readOnlyAuth = setup.auth;
+    });
+
+    it("should allow GET requests (200)", async () => {
+      const result = await makeAPICall(
+        "GET",
+        "/api/public/traces",
+        undefined,
+        readOnlyAuth,
+      );
+      expect(result.status).toBe(200);
+    });
+
+    it("should block non-GET requests with 403 and read-only message", async () => {
+      const result = await makeAPICall(
+        "POST",
+        "/api/public/traces",
+        {
+          id: uuidv4(),
+          name: "test-trace",
+        },
+        readOnlyAuth,
+      );
+      expect(result.status).toBe(403);
+      expect((result.body as any).message).toBe(
+        "This API key has read-only access",
+      );
+    });
+
+    it("should block legacy prompt POST with 403", async () => {
+      const result = await makeAPICall(
+        "POST",
+        "/api/public/prompts",
+        {
+          name: "test-prompt",
+          prompt: "hello world",
+          isActive: true,
+        },
+        readOnlyAuth,
+      );
+      expect(result.status).toBe(403);
+      expect((result.body as any).message).toBe(
+        "This API key has read-only access",
+      );
+    });
+
+    it("should block ingestion POST with 403", async () => {
+      const result = await makeAPICall(
+        "POST",
+        "/api/public/ingestion",
+        {
+          batch: [
+            {
+              id: uuidv4(),
+              type: "trace-create",
+              timestamp: new Date().toISOString(),
+              body: {
+                id: uuidv4(),
+                name: "test-trace",
+              },
+            },
+          ],
+        },
+        readOnlyAuth,
+      );
+      expect(result.status).toBe(403);
+      expect((result.body as any).message).toBe(
+        "This API key has read-only access",
+      );
+    });
+  });
+
+  describe("READ_AND_WRITE key behavior", () => {
+    let readWriteAuth: string;
+
+    beforeEach(async () => {
+      const setup = await createOrgProjectAndApiKey({
+        accessPermission: "READ_AND_WRITE",
+      });
+      readWriteAuth = setup.auth;
+    });
+
+    it("should allow POST requests (not 403)", async () => {
+      const result = await makeAPICall(
+        "POST",
+        "/api/public/traces",
+        {
+          id: uuidv4(),
+          name: "test-trace",
+        },
+        readWriteAuth,
+      );
+      // Should not be 403 (could be 200, 201, etc.)
+      expect(result.status).not.toBe(403);
+    });
+  });
+
+  describe("Cross-key interactions in the same project", () => {
+    let readOnlyAuth: string;
+    let readWriteAuth: string;
+    let sharedProjectId: string;
+
+    beforeEach(async () => {
+      // Create the first key (read-write) and capture the projectId
+      const rwSetup = await createOrgProjectAndApiKey({
+        accessPermission: "READ_AND_WRITE",
+      });
+      readWriteAuth = rwSetup.auth;
+      sharedProjectId = rwSetup.projectId;
+
+      // Create a read-only key directly in the same project (no new org/project needed)
+      const roPublicKey = uuidv4();
+      const roSecretKey = uuidv4();
+      await prisma.apiKey.create({
+        data: {
+          id: uuidv4(),
+          projectId: sharedProjectId,
+          publicKey: roPublicKey,
+          hashedSecretKey: await hashSecretKey(roSecretKey),
+          displaySecretKey: getDisplaySecretKey(roSecretKey),
+          scope: "PROJECT",
+          accessPermission: "READ_ONLY",
+        },
+      });
+      readOnlyAuth = createBasicAuthHeader(roPublicKey, roSecretKey);
+    });
+
+    it("should allow read-only key to GET legacy prompts created by a read-write key", async () => {
+      const promptName = `test-prompt-${uuidv4()}`;
+
+      // Create a prompt using the read-write key
+      const createResult = await makeAPICall(
+        "POST",
+        "/api/public/prompts",
+        {
+          name: promptName,
+          prompt: "hello world",
+          isActive: true,
+        },
+        readWriteAuth,
+      );
+      expect(createResult.status).toBe(201);
+
+      // Read the prompt using the read-only key
+      const getResult = await makeAPICall(
+        "GET",
+        `/api/public/prompts?name=${encodeURIComponent(promptName)}`,
+        undefined,
+        readOnlyAuth,
+      );
+      expect(getResult.status).toBe(200);
+    });
+  });
+});

--- a/web/src/ee/features/admin-api/server/projects/projectById/apiKeys/index.ts
+++ b/web/src/ee/features/admin-api/server/projects/projectById/apiKeys/index.ts
@@ -34,6 +34,7 @@ export async function handleGetApiKeys(
       note: true,
       publicKey: true,
       displaySecretKey: true,
+      accessPermission: true,
     },
     orderBy: {
       createdAt: "asc",
@@ -54,6 +55,10 @@ export async function handleCreateApiKey(
     note: z.string().optional(),
     publicKey: z.string().optional(),
     secretKey: z.string().optional(),
+    accessPermission: z
+      .enum(["READ_ONLY", "READ_AND_WRITE"])
+      .optional()
+      .default("READ_AND_WRITE"),
   });
 
   const validationResult = createApiKeySchema.safeParse(req.body);
@@ -98,6 +103,7 @@ export async function handleCreateApiKey(
       entityId: projectId,
       note,
       scope: "PROJECT",
+      accessPermission: validationResult.data.accessPermission,
       predefinedKeys:
         publicKey && secretKey ? { publicKey, secretKey } : undefined,
     });

--- a/web/src/features/public-api/components/ApiKeyList.tsx
+++ b/web/src/features/public-api/components/ApiKeyList.tsx
@@ -111,6 +111,7 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
               <TableHead className="text-primary">Note</TableHead>
               <TableHead className="text-primary">Public Key</TableHead>
               <TableHead className="text-primary">Secret Key</TableHead>
+              <TableHead className="text-primary">Permission</TableHead>
               {/* <TableHead className="text-primary">Last used</TableHead> */}
               <TableHead />
             </TableRow>
@@ -120,7 +121,7 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
               <TableRow>
                 <TableCell
                   density="comfortable"
-                  colSpan={5}
+                  colSpan={6}
                   className="text-center"
                 >
                   None
@@ -152,6 +153,13 @@ export function ApiKeyList(props: { entityId: string; scope: ApiKeyScope }) {
                   />
                   <TableCell density="comfortable" className="font-mono">
                     {apiKey.displaySecretKey}
+                  </TableCell>
+                  <TableCell density="comfortable">
+                    {"accessPermission" in apiKey
+                      ? apiKey.accessPermission === "READ_ONLY"
+                        ? "Read Only"
+                        : "Read and Write"
+                      : "Read and Write"}
                   </TableCell>
                   {/* <TableCell>
                   {apiKey.lastUsedAt?.toLocaleDateString() ?? "Never"}

--- a/web/src/features/public-api/components/CreateApiKeyButton.tsx
+++ b/web/src/features/public-api/components/CreateApiKeyButton.tsx
@@ -20,6 +20,13 @@ import { useLangfuseEnvCode } from "@/src/features/public-api/hooks/useLangfuseE
 import { Label } from "@/src/components/ui/label";
 import { cn } from "@/src/utils/tailwind";
 import { SubHeader } from "@/src/components/layouts/header";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/src/components/ui/select";
 
 type ApiKeyScope = "project" | "organization";
 
@@ -51,6 +58,9 @@ export function CreateApiKeyButton(props: {
 
   const [open, setOpen] = useState(false);
   const [note, setNote] = useState("");
+  const [accessPermission, setAccessPermission] = useState<
+    "READ_ONLY" | "READ_AND_WRITE"
+  >("READ_AND_WRITE");
   const [generatedKeys, setGeneratedKeys] = useState<{
     secretKey: string;
     publicKey: string;
@@ -62,6 +72,7 @@ export function CreateApiKeyButton(props: {
       // Reset state when closing
       setGeneratedKeys(null);
       setNote("");
+      setAccessPermission("READ_AND_WRITE");
     }
   };
 
@@ -71,6 +82,7 @@ export function CreateApiKeyButton(props: {
         .mutateAsync({
           projectId: props.entityId,
           note: note || undefined,
+          accessPermission,
         })
         .then(({ secretKey, publicKey }) => {
           setGeneratedKeys({
@@ -137,6 +149,27 @@ export function CreateApiKeyButton(props: {
                   className="mt-1.5"
                 />
               </div>
+              {props.scope === "project" && (
+                <div>
+                  <Label htmlFor="accessPermission">Access Permission</Label>
+                  <Select
+                    value={accessPermission}
+                    onValueChange={(value: "READ_ONLY" | "READ_AND_WRITE") =>
+                      setAccessPermission(value)
+                    }
+                  >
+                    <SelectTrigger className="mt-1.5">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="READ_AND_WRITE">
+                        Read and Write
+                      </SelectItem>
+                      <SelectItem value="READ_ONLY">Read Only</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
             </div>
           )}
         </DialogBody>

--- a/web/src/features/public-api/server/apiAuth.ts
+++ b/web/src/features/public-api/server/apiAuth.ts
@@ -193,6 +193,7 @@ export class ApiAuthService {
                 scope: finalApiKey.scope,
                 publicKey,
                 isIngestionSuspended: finalApiKey.isIngestionSuspended,
+                accessPermission: finalApiKey.accessPermission,
               },
             };
           }
@@ -230,6 +231,7 @@ export class ApiAuthService {
                 publicKey,
                 isIngestionSuspended:
                   cloudFreeTierUsageThresholdState === "BLOCKED",
+                accessPermission: dbKey.accessPermission,
               },
             };
           }

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -223,6 +223,7 @@ async function verifyAdminApiKeyAuth(req: NextApiRequest): Promise<
       apiKeyId: "ADMIN_API_KEY", // Special identifier for audit logging
       publicKey: "ADMIN_API_KEY",
       isIngestionSuspended: false,
+      accessPermission: "READ_AND_WRITE" as const,
     },
   };
 }
@@ -299,6 +300,14 @@ export const createAuthedProjectAPIRoute = <
 
       res.status(statusCode).json({ message });
 
+      return;
+    }
+
+    // Enforce read-only API key permissions
+    if (auth.scope.accessPermission === "READ_ONLY" && req.method !== "GET") {
+      res.status(403).json({
+        message: "This API key has read-only access",
+      });
       return;
     }
 

--- a/web/src/features/public-api/server/projectApiKeyRouter.ts
+++ b/web/src/features/public-api/server/projectApiKeyRouter.ts
@@ -37,6 +37,7 @@ export const projectApiKeysRouter = createTRPCRouter({
           note: true,
           publicKey: true,
           displaySecretKey: true,
+          accessPermission: true,
         },
         orderBy: {
           createdAt: "asc",
@@ -48,6 +49,10 @@ export const projectApiKeysRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         note: StringNoHTML.optional(),
+        accessPermission: z
+          .enum(["READ_ONLY", "READ_AND_WRITE"])
+          .optional()
+          .default("READ_AND_WRITE"),
       }),
     )
     .mutation(async ({ input, ctx }) => {
@@ -62,6 +67,7 @@ export const projectApiKeysRouter = createTRPCRouter({
         entityId: input.projectId,
         note: input.note,
         scope: "PROJECT",
+        accessPermission: input.accessPermission,
       });
 
       await auditLog({

--- a/web/src/pages/api/admin/ingestion-replay.ts
+++ b/web/src/pages/api/admin/ingestion-replay.ts
@@ -1,6 +1,7 @@
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { z } from "zod";
 import { randomUUID } from "crypto";
+import { ApiKeyAccessPermission } from "@langfuse/shared";
 import {
   eventTypes,
   logger,
@@ -153,7 +154,11 @@ export default async function handler(
             data: { fileKey: key },
             authCheck: {
               validKey: true,
-              scope: { projectId: projectId!, accessLevel: "project" },
+              scope: {
+                projectId: projectId!,
+                accessLevel: "project",
+                accessPermission: ApiKeyAccessPermission.READ_AND_WRITE,
+              },
             },
           },
           name: QueueJobs.OtelIngestionJob,

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -93,6 +93,10 @@ export default async function handler(
       );
     }
 
+    if (authCheck.scope.accessPermission === "READ_ONLY") {
+      throw new ForbiddenError("This API key has read-only access");
+    }
+
     const ctx = contextWithLangfuseProps({
       headers: req.headers,
       projectId: authCheck.scope.projectId,

--- a/web/src/pages/api/public/mcp/index.ts
+++ b/web/src/pages/api/public/mcp/index.ts
@@ -103,6 +103,13 @@ export default async function handler(
       );
     }
 
+    if (
+      authCheck.scope.accessPermission === "READ_ONLY" &&
+      req.method !== "GET"
+    ) {
+      throw new ForbiddenError("This API key has read-only access");
+    }
+
     // Rate limit MCP requests
     const rateLimitCheck =
       await RateLimitService.getInstance().rateLimitRequest(

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -171,6 +171,7 @@ export default withMiddlewares({
 
       const processor = new OtelIngestionProcessor({
         projectId: auth.scope.projectId,
+        accessPermission: auth.scope.accessPermission,
         publicKey: auth.scope.publicKey,
         orgId: auth.scope.orgId,
         propagatedHeaders:

--- a/web/src/pages/api/public/prompts.ts
+++ b/web/src/pages/api/public/prompts.ts
@@ -43,6 +43,13 @@ export default async function handler(
       );
     }
 
+    if (
+      authCheck.scope.accessPermission === "READ_ONLY" &&
+      req.method !== "GET"
+    ) {
+      throw new ForbiddenError("This API key has read-only access");
+    }
+
     await telemetry();
 
     // Handle GET requests

--- a/worker/src/features/experiments/experimentServiceClickhouse.ts
+++ b/worker/src/features/experiments/experimentServiceClickhouse.ts
@@ -1,4 +1,5 @@
 import {
+  ApiKeyAccessPermission,
   asRecord,
   convertEventRecordToObservationForEval,
   DatasetItemDomain,
@@ -104,6 +105,7 @@ async function processItem(
       scope: {
         projectId: config.projectId,
         accessLevel: "project" as const,
+        accessPermission: ApiKeyAccessPermission.READ_AND_WRITE,
       },
     },
     {
@@ -471,6 +473,7 @@ async function createAllDatasetRunItemsWithConfigError(
         scope: {
           projectId,
           accessLevel: "project" as const,
+          accessPermission: ApiKeyAccessPermission.READ_AND_WRITE,
         },
       },
       { isLangfuseInternal: true },

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -263,6 +263,7 @@ export const otelIngestionQueueProcessor: Processor = async (
     // Generate events via OtelIngestionProcessor
     const processor = new OtelIngestionProcessor({
       projectId,
+      accessPermission: auth.scope.accessPermission,
       publicKey,
     });
     const events: IngestionEventType[] =

--- a/worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts
+++ b/worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts
@@ -64,6 +64,7 @@ interface OTelJsonOutputItem {
     scope: {
       projectId: string;
       accessLevel: "project";
+      accessPermission: "READ_AND_WRITE";
     };
   };
   data: {
@@ -352,6 +353,7 @@ async function convertCsvToJsonl(
             scope: {
               projectId,
               accessLevel: "project",
+              accessPermission: "READ_AND_WRITE",
             },
           },
           data: {


### PR DESCRIPTION
Allow project API keys to be scoped as READ_ONLY or READ_AND_WRITE so teams can issue keys that can only fetch data, not ingest or mutate it. A new Prisma enum and column default to READ_AND_WRITE for backwards compatibility while every write-path endpoint (ingestion, prompts, MCP, OTEL, createAuthedProjectAPIRoute) now checks the permission and returns 403 for read-only keys.

Related to #7104


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds a `READ_ONLY` / `READ_AND_WRITE` access permission to project API keys, enforced at the API layer via `createAuthedProjectAPIRoute`, and also independently checked in the `ingestion`, `prompts`, and `mcp` handlers. The DB migration is backwards-compatible (`NOT NULL DEFAULT 'READ_AND_WRITE'`), and the UI exposes a permission selector when creating project-scoped keys.

- **P1 – unupdated replay script**: `worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts` (not in this PR's changeset) builds `OTelJsonOutputItem` scopes without `accessPermission`. After this PR lands, the `OtelIngestionEvent` Zod schema requires the field, so jobs emitted by this script will fail queue validation and silently drop replayed OTEL events.

<h3>Confidence Score: 3/5</h3>

Safe for the live API path, but the unupdated replay script will silently drop OTEL replay events after deployment

A single P1 finding (broken replay script) exists on an operator-facing path rather than the hot API path. Core ingestion and read-only enforcement logic is correctly implemented and well-tested.

worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts — must add `accessPermission: "READ_AND_WRITE"` to both the interface definition and the object literal to fix queue schema validation

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts | NOT changed in this PR but now broken — `OTelJsonOutputItem.scope` is missing the required `accessPermission` field added to the queue schema, causing Zod validation failures for replayed events |
| packages/shared/src/server/queues.ts | Adds required `accessPermission` to `OtelIngestionEvent` scope schema using a hardcoded string enum instead of `z.nativeEnum` |
| web/src/features/public-api/server/createAuthedProjectAPIRoute.ts | Centralized READ_ONLY enforcement added — blocks non-GET requests before rate limiting for all routes using this wrapper |
| web/src/pages/api/public/ingestion.ts | Correctly blocks READ_ONLY keys before any ingestion processing; this route has its own auth path separate from `createAuthedProjectAPIRoute` |
| web/src/features/public-api/server/apiAuth.ts | Correctly propagates `accessPermission` from DB to scope for both Basic and Bearer auth paths; old Redis-cached entries without the field will fail parse and be evicted (handled gracefully) |
| web/src/__tests__/server/api-key-access-permission.servertest.ts | Good integration tests covering READ_ONLY blocking for ingestion/prompts and cross-key read access; OTEL/MCP endpoints not directly tested |
| packages/shared/prisma/migrations/20260426144520_add_api_key_access_permission/migration.sql | Adds `ApiKeyAccessPermission` enum and `access_permission` column with `NOT NULL DEFAULT 'READ_AND_WRITE'` — backwards-compatible and correct |
| web/src/pages/api/admin/ingestion-replay.ts | Admin replay path correctly hardcodes `READ_AND_WRITE` for the synthetic auth scope |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API Request] --> B[ApiAuthService\nverifyAuthHeaderAndReturnScope]
    B --> C{Auth valid?}
    C -- No --> D[401 Unauthorized]
    C -- Yes --> E{Route uses\ncreateAuthedProjectAPIRoute?}
    E -- Yes --> F{accessPermission\n== READ_ONLY &&\nmethod != GET?}
    E -- No\ningestion/prompts/mcp --> G{accessPermission\n== READ_ONLY?}
    F -- Yes --> H[403 Forbidden\nread-only access]
    F -- No --> I[Rate limit → handler fn]
    G -- Yes --> H
    G -- No --> J[Process request]
    I -- OTEL traces POST --> K[OtelIngestionProcessor\n.publishToOtelIngestionQueue]
    K --> L[S3 + OtelIngestionQueue\njob with accessPermission in scope]
    L --> M[Worker: otelIngestionQueue\nprocessor.processToIngestionEvents]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts`, line 61-72 ([link](https://github.com/langfuse/langfuse/blob/06c7db57e9610d8bc9bf5e8c556f7318f5a388f0/worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts#L61-L72)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing required `accessPermission` breaks queue schema validation**

   `OTelJsonOutputItem` defines the scope as `{ projectId: string; accessLevel: "project" }`, omitting the new required `accessPermission` field added to `OtelIngestionEvent` in `queues.ts`. Any jobs produced by this script after deployment will be rejected by Zod schema validation in the worker (`otelIngestionQueue.ts`), causing silently-dropped replay events.

   The interface and the object literal at line ~350 both need `accessPermission: "READ_AND_WRITE"` added to the scope.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts
   Line: 61-72

   Comment:
   **Missing required `accessPermission` breaks queue schema validation**

   `OTelJsonOutputItem` defines the scope as `{ projectId: string; accessLevel: "project" }`, omitting the new required `accessPermission` field added to `OtelIngestionEvent` in `queues.ts`. Any jobs produced by this script after deployment will be rejected by Zod schema validation in the worker (`otelIngestionQueue.ts`), causing silently-dropped replay events.

   The interface and the object literal at line ~350 both need `accessPermission: "READ_AND_WRITE"` added to the scope.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts
Line: 61-72

Comment:
**Missing required `accessPermission` breaks queue schema validation**

`OTelJsonOutputItem` defines the scope as `{ projectId: string; accessLevel: "project" }`, omitting the new required `accessPermission` field added to `OtelIngestionEvent` in `queues.ts`. Any jobs produced by this script after deployment will be rejected by Zod schema validation in the worker (`otelIngestionQueue.ts`), causing silently-dropped replay events.

The interface and the object literal at line ~350 both need `accessPermission: "READ_AND_WRITE"` added to the scope.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/shared/src/server/queues.ts
Line: 40

Comment:
**Inline string enum instead of `z.nativeEnum(ApiKeyAccessPermission)`**

The `accessPermission` field is validated with a hardcoded `z.enum(["READ_ONLY", "READ_AND_WRITE"])`, while every other location in this PR (e.g. `types.ts`) uses `z.nativeEnum(ApiKeyAccessPermission)`. If the Prisma enum gains a new value later, this Zod validator will silently reject valid jobs.

```suggestion
      accessPermission: z.nativeEnum(ApiKeyAccessPermission),
```

You'll need to add `import { ApiKeyAccessPermission } from "@prisma/client";` (or re-export it through the shared barrel).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api-keys): add read-only access per..."](https://github.com/langfuse/langfuse/commit/06c7db57e9610d8bc9bf5e8c556f7318f5a388f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29871895)</sub>

<!-- /greptile_comment -->