### PR TITLE
chore(web): Track error notification clicks

### DIFF
--- a/web/src/features/notifications/ErrorNotification.tsx
+++ b/web/src/features/notifications/ErrorNotification.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/src/components/ui/button";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 import { AlertTriangle, X } from "lucide-react";
 
@@ -20,6 +21,7 @@ export const ErrorNotification: React.FC<ErrorNotificationProps> = ({
   path,
 }) => {
   const { setOpen } = useSupportDrawer();
+  const capture = usePostHogClientCapture();
   const isError = type === "ERROR";
   const textColor = isError
     ? "text-destructive-foreground"
@@ -61,6 +63,10 @@ export const ErrorNotification: React.FC<ErrorNotificationProps> = ({
             variant="errorNotification"
             size={"sm"}
             onClick={() => {
+              capture("toast:report_issue", {
+                toast_type: type,
+                path,
+              });
               setOpen(true);
             }}
           >
@@ -70,7 +76,13 @@ export const ErrorNotification: React.FC<ErrorNotificationProps> = ({
       </div>
       <button
         className={`flex h-6 w-6 cursor-pointer items-start justify-end border-none bg-transparent p-0 ${textColor} transition-colors duration-200`}
-        onClick={() => dismissToast(toast)}
+        onClick={() => {
+          capture("toast:dismiss", {
+            toast_type: type,
+            path,
+          });
+          dismissToast(toast);
+        }}
         onPointerDown={(e) => {
           e.stopPropagation();
           e.preventDefault();

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -166,6 +166,7 @@ export const events = {
     "compare_run_removed",
   ],
   notification: ["click_link", "dismiss_notification"],
+  toast: ["report_issue", "dismiss"],
   tag: [
     "add_existing_tag",
     "remove_tag",


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds PostHog analytics tracking to the "Report issue to Langfuse team" button in `ErrorNotification.tsx`, capturing the `toast_type` and `path` properties, and registers the corresponding `toast:report_issue` event in the allowlist. The change is minimal, follows established patterns, and imports are correctly placed at the module top.

<h3>Confidence Score: 5/5</h3>

Safe to merge — small, well-scoped analytics addition with no logic or security concerns.

Only a P2 style observation (redundant toast_type property); no logic errors, no security issues, and the change follows existing codebase conventions exactly.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/notifications/ErrorNotification.tsx | Adds PostHog capture call on "Report issue" button click, sending toast_type and path; toast_type is always "ERROR" since the button only renders for errors |
| web/src/features/posthog-analytics/usePostHogClientCapture.ts | Registers new toast:report_issue event in the allowlist, following established naming conventions |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ErrorNotification
    participant PostHog
    participant SupportDrawer

    User->>ErrorNotification: Clicks "Report issue" button
    ErrorNotification->>PostHog: capture("toast:report_issue", { toast_type, path })
    ErrorNotification->>SupportDrawer: setOpen(true)
    SupportDrawer-->>User: Support drawer opens
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: web/src/features/notifications/ErrorNotification.tsx
Line: 66-69

Comment:
**`toast_type` is always `"ERROR"`**

The "Report issue" button is only rendered inside `{isError && (...)}` (line 61), so `toast_type` will always be `"ERROR"` in the captured event. The property adds no discriminating signal and may mislead future readers of the analytics. Consider either removing it or keeping it for forward-compatibility with a comment noting the invariant.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(web): Track error notification cli..."](https://github.com/langfuse/langfuse/commit/4d9d4f426619c275353dae3049f9f46003a704f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29963158)</sub>

<!-- /greptile_comment -->