### PR TITLE
chore(skills): suggest to run pnpm dedupe

### DIFF
--- a/.agents/skills/pnpm-upgrade-package/AGENTS.md
+++ b/.agents/skills/pnpm-upgrade-package/AGENTS.md
@@ -31,9 +31,6 @@ pnpm workspace.
      lock refresh / reinstall path before changing `package.json`.
    - If the current parent range does not cover the requested version, upgrade
      the direct parent dependency that pulls the package in.
-   - If a compatible transitive package still stays pinned after the normal
-     refresh path, you may suggest `pnpm dedupe` to the user as an optional
-     manual follow-up, but do not run it automatically and do not require it.
    - Do not add the transitive package directly unless the user explicitly asks.
 
 4. Ask before changing `minimumReleaseAgeExclude`.
@@ -53,6 +50,9 @@ pnpm workspace.
    - Use the nearest package `AGENTS.md` plus the root verification matrix.
    - Finish with `pnpm why -r <package>`.
    - If companions moved too, run `pnpm why -r <companion-package>` for them as well.
+   - After fixing or upgrading a package, strongly suggest that the user run
+     `pnpm dedupe` as an optional cleanup step, but do not run it automatically
+     and do not require it.
 
 ## Quick Commands
 
@@ -64,6 +64,8 @@ pnpm workspace.
   `npm view <parent>@<installedVersion> dependencies peerDependencies optionalDependencies --json`
 - Final graph verification:
   `pnpm why -r <package>`
+- Optional lockfile cleanup for the user to run after the fix:
+  `pnpm dedupe`
 - Bump in the root workspace:
   `pnpm -w up <package>@<version>`
 - Bump in one workspace:

--- a/.agents/skills/pnpm-upgrade-package/SKILL.md
+++ b/.agents/skills/pnpm-upgrade-package/SKILL.md
@@ -31,9 +31,9 @@ Use this skill for interactive dependency bumps in Langfuse.
 - Never manually edit `pnpm-lock.yaml`; regenerate lockfile changes with
   `pnpm` commands only. If a lockfile-only refresh causes unrelated churn,
   adjust the pnpm command and rerun instead of patching the lockfile by hand.
-- If a compatible transitive package still stays pinned after the normal
-  refresh path, you may suggest `pnpm dedupe` to the user as an optional manual
-  follow-up, but do not run it automatically and do not require it.
+- After fixing or upgrading a package, strongly suggest that the user run
+  `pnpm dedupe` as an optional cleanup step, but do not run it automatically
+  and do not require it.
 - Resolve the registry latest version, but do not silently upgrade to latest
   unless the user asked for latest.
 - Compare the target version with the latest version installable under the


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR widens the scope of the `pnpm dedupe` suggestion in the `pnpm-upgrade-package` skill: instead of recommending it only when a transitive package stays pinned after the normal refresh, the skill now strongly suggests running it as a general cleanup step after any package fix or upgrade. Both `AGENTS.md` and `SKILL.md` are updated consistently, and a Quick Commands entry is added for convenience.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code impact — safe to merge.

Both files contain only Markdown skill/agent instructions. The change is internally consistent, no logic or code is affected, and the intent is clearly expressed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .agents/skills/pnpm-upgrade-package/AGENTS.md | Moves the `pnpm dedupe` suggestion from a conditional (transitive-pinned) context to a general post-upgrade recommendation, and adds it to the Quick Commands reference section. |
| .agents/skills/pnpm-upgrade-package/SKILL.md | Mirrors the AGENTS.md change: replaces the conditional `pnpm dedupe` hint (only when a transitive package stays pinned) with a broader "strongly suggest after any fix/upgrade" instruction. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start: fix or upgrade a package] --> B[Run pnpm install / pnpm up]
    B --> C[Verify with pnpm why -r package]
    C --> D{Companions moved?}
    D -- Yes --> E[Run pnpm why -r companion]
    D -- No --> F[Suggest: pnpm dedupe as optional cleanup]
    E --> F
```

<sub>Reviews (1): Last reviewed commit: ["chore(skills): suggest to run pnpm dedup..."](https://github.com/langfuse/langfuse/commit/7d7bcf5437960e3e0760c240106247687fb2fd04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30120897)</sub>

<!-- /greptile_comment -->