### PR TITLE
chore(web): Remove unused `graphql` dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,9 +584,6 @@ importers:
       fastest-levenshtein:
         specifier: ^1.0.16
         version: 1.0.16
-      graphql:
-        specifier: ^16.13.2
-        version: 16.13.2
       https-proxy-agent:
         specifier: ^7.0.6
         version: 7.0.6

--- a/web/package.json
+++ b/web/package.json
@@ -113,7 +113,6 @@
     "diff": "^8.0.4",
     "dompurify": "^3.4.0",
     "fastest-levenshtein": "^1.0.16",
-    "graphql": "^16.13.2",
     "https-proxy-agent": "^7.0.6",
     "ioredis": "^5.10.1",
     "ip-address": "^9.0.5",


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR removes the unused `graphql` dependency (`^16.13.2`) from `web/package.json` and the corresponding resolved entry from `pnpm-lock.yaml`. No files in the `web` package import from `graphql`, confirming the dependency is genuinely unused and safe to drop.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it removes a confirmed-unused dependency with no functional impact.

The change is purely additive housekeeping: the `graphql` package is not imported anywhere in the `web` package, so removing it carries zero functional risk. Both changed files (`web/package.json` and `pnpm-lock.yaml`) are consistent with each other.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/package.json | Removes the unused `graphql` dependency; no remaining imports of `graphql` found in the `web` package. |
| pnpm-lock.yaml | Removes the resolved `graphql@16.13.2` lockfile entry corresponding to the deleted `web/package.json` dependency. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[web/package.json] -->|removed dependency| B["graphql ^16.13.2"]
    A --> C[pnpm-lock.yaml]
    C -->|removed resolved entry| D["graphql@16.13.2"]
    E[No imports found in web/] -->|confirms| F[Safe to remove]
```

<sub>Reviews (1): Last reviewed commit: ["chore(web): Remove unused \`graphql\` depe..."](https://github.com/langfuse/langfuse/commit/0d0d20df5df6b50d4a289b4962b8e8b2bfd40f8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30268574)</sub>

<!-- /greptile_comment -->