### PR TITLE
chore(shared): fix typo in clickhouse upsert ts-ignore comment

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -138,7 +138,7 @@ export async function upsertClickhouse<
           // Only applicable to scores and traces.
           let eventType = `${opts.table.slice(0, -1)}-create`;
           if (opts.table === "observations") {
-            // @ts-ignore - If it's an observation we now that `type` is a string
+            // @ts-ignore - If it's an observation we know that `type` is a string
             eventType = `${record["type"].toLowerCase()}-create`;
           }
 


### PR DESCRIPTION
## Summary

Tiny single-character typo fix in a `@ts-ignore` comment in
`packages/shared/src/server/repositories/clickhouse.ts`:

```diff
-            // @ts-ignore - If it's an observation we now that `type` is a string
+            // @ts-ignore - If it's an observation we know that `type` is a string
```

No behavior change - this is purely a comment fix in `upsertClickhouse`.

## How to test

- `pnpm --filter=shared run typecheck` should still pass (the ts-ignore directive itself is unchanged).
- No runtime change, so no test or lint impact.

## Why

Found while reading the upsert path; `we now that` should be `we know that`.
Tiny correctness-of-prose cleanup that doesn't touch any logic.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a single-word typo in a `@ts-ignore` comment in `packages/shared/src/server/repositories/clickhouse.ts`, changing "we now that" to "we know that". There is no functional, behavioral, or type-checking impact.

<h3>Confidence Score: 5/5</h3>

Safe to merge — comment-only typo fix with zero runtime impact.

The change is purely cosmetic (one word in a comment) and does not affect any logic, types, or behavior.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/repositories/clickhouse.ts | Single-character typo fix in a `@ts-ignore` comment: "now" → "know". No logic or behavior change. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[upsertClickhouse called] --> B{opts.table === 'observations'?}
    B -- Yes --> C["// @ts-ignore - If it's an observation we know that `type` is a string\n(typo fixed: 'now' → 'know')"]
    C --> D["eventType = record['type'].toLowerCase() + '-create'"]
    B -- No --> E["eventType = table.slice(0,-1) + '-create'"]
    D --> F[Continue upsert]
    E --> F
```

<sub>Reviews (1): Last reviewed commit: ["chore(shared): fix typo in clickhouse up..."](https://github.com/langfuse/langfuse/commit/4b4b54306311d2c10bd8cc6708cb3debc53e5997) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30270393)</sub>

<!-- /greptile_comment -->