### PR TITLE
test: deflake DNS-dependent CI tests

### DIFF
--- a/web/src/__tests__/server/llm-connections-api.servertest.ts
+++ b/web/src/__tests__/server/llm-connections-api.servertest.ts
@@ -16,6 +16,14 @@ import { encrypt } from "@langfuse/shared/encryption";
 const generateUniqueProvider = (baseName: string) =>
   `${baseName}-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
+// Use public IP literals for happy-path baseURL tests so these API tests do
+// not depend on external DNS. DNS/SSRF behavior is covered by focused
+// baseUrlValidation tests.
+const TEST_PUBLIC_LLM_BASE_URL = "https://1.1.1.1/v1";
+const TEST_UPDATED_PUBLIC_LLM_BASE_URL = "https://1.1.1.1/v2";
+const TEST_CUSTOM_PUBLIC_LLM_BASE_URL = "https://1.1.1.1/custom/v1";
+const TEST_SCHEMA_PUBLIC_LLM_BASE_URL = "https://1.1.1.1/schema/v1";
+
 const BEDROCK_AWS_CREDENTIALS = {
   accessKeyId: "AKIAIOSFODNN7EXAMPLE",
   secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -79,7 +87,7 @@ describe("/api/public/llm-connections API Endpoints", () => {
           adapter: LLMAdapter.OpenAI,
           secretKey: encrypt("sk-test1"),
           displaySecretKey: "...est1",
-          baseURL: "https://api.openai.com/v1",
+          baseURL: TEST_PUBLIC_LLM_BASE_URL,
           customModels: ["gpt-4", "gpt-3.5-turbo"],
           withDefaultModels: true,
           extraHeaders: encrypt(JSON.stringify({ "X-Custom": "header1" })),
@@ -136,7 +144,7 @@ describe("/api/public/llm-connections API Endpoints", () => {
       expect(secondConnection.provider).toBe(provider1);
       expect(secondConnection.adapter).toBe(LLMAdapter.OpenAI);
       expect(secondConnection.displaySecretKey).toBe("...est1");
-      expect(secondConnection.baseURL).toBe("https://api.openai.com/v1");
+      expect(secondConnection.baseURL).toBe(TEST_PUBLIC_LLM_BASE_URL);
       expect(secondConnection.customModels).toEqual(["gpt-4", "gpt-3.5-turbo"]);
       expect(secondConnection.withDefaultModels).toBe(true);
       expect(secondConnection.extraHeaderKeys).toEqual(["X-Custom"]);
@@ -302,7 +310,7 @@ describe("/api/public/llm-connections API Endpoints", () => {
         provider: generateUniqueProvider("openai"),
         adapter: LLMAdapter.OpenAI,
         secretKey: "sk-test123",
-        baseURL: "https://api.openai.com/v1",
+        baseURL: TEST_PUBLIC_LLM_BASE_URL,
         customModels: ["gpt-4", "gpt-3.5-turbo"],
         withDefaultModels: true,
         extraHeaders: {
@@ -323,7 +331,7 @@ describe("/api/public/llm-connections API Endpoints", () => {
       expect(response.body.provider).toBe(createData.provider);
       expect(response.body.adapter).toBe(LLMAdapter.OpenAI);
       expect(response.body.displaySecretKey).toBe("...t123");
-      expect(response.body.baseURL).toBe("https://api.openai.com/v1");
+      expect(response.body.baseURL).toBe(TEST_PUBLIC_LLM_BASE_URL);
       expect(response.body.customModels).toEqual(["gpt-4", "gpt-3.5-turbo"]);
       expect(response.body.withDefaultModels).toBe(true);
       expect(response.body.extraHeaderKeys).toEqual(["X-Custom"]);
@@ -403,7 +411,7 @@ describe("/api/public/llm-connections API Endpoints", () => {
           adapter: LLMAdapter.OpenAI,
           secretKey: encrypt("sk-original"),
           displaySecretKey: "...nal",
-          baseURL: "https://original.com",
+          baseURL: TEST_PUBLIC_LLM_BASE_URL,
           customModels: ["gpt-3.5"],
           withDefaultModels: true,
         },
@@ -414,7 +422,7 @@ describe("/api/public/llm-connections API Endpoints", () => {
         provider: existingProvider,
         adapter: LLMAdapter.Anthropic, // Changed adapter
         secretKey: "sk-updated",
-        baseURL: "https://updated.com",
+        baseURL: TEST_UPDATED_PUBLIC_LLM_BASE_URL,
         customModels: ["claude-3"],
         withDefaultModels: false,
       };
@@ -433,7 +441,7 @@ describe("/api/public/llm-connections API Endpoints", () => {
       expect(response.body.provider).toBe(existingProvider);
       expect(response.body.adapter).toBe(LLMAdapter.Anthropic); // Updated
       expect(response.body.displaySecretKey).toBe("...ated"); // Updated
-      expect(response.body.baseURL).toBe("https://updated.com"); // Updated
+      expect(response.body.baseURL).toBe(TEST_UPDATED_PUBLIC_LLM_BASE_URL); // Updated
       expect(response.body.customModels).toEqual(["claude-3"]); // Updated
       expect(response.body.withDefaultModels).toBe(false); // Updated
     });
@@ -634,7 +642,7 @@ describe("/api/public/llm-connections API Endpoints", () => {
           provider: generateUniqueProvider("full-test"),
           adapter: LLMAdapter.OpenAI,
           secretKey: "sk-full-test",
-          baseURL: "https://custom.api.com/v1",
+          baseURL: TEST_CUSTOM_PUBLIC_LLM_BASE_URL,
           customModels: ["custom-model-1", "custom-model-2"],
           withDefaultModels: false,
           extraHeaders: {
@@ -647,7 +655,9 @@ describe("/api/public/llm-connections API Endpoints", () => {
       );
 
       expect(fullDataResponse.status).toBe(201);
-      expect(fullDataResponse.body.baseURL).toBe("https://custom.api.com/v1");
+      expect(fullDataResponse.body.baseURL).toBe(
+        TEST_CUSTOM_PUBLIC_LLM_BASE_URL,
+      );
       expect(fullDataResponse.body.customModels).toEqual([
         "custom-model-1",
         "custom-model-2",
@@ -1539,7 +1549,7 @@ describe("/api/public/llm-connections API Endpoints", () => {
           provider: generateUniqueProvider("schema-test"),
           adapter: LLMAdapter.OpenAI,
           secretKey: "sk-schema-test",
-          baseURL: "https://api.example.com/v1",
+          baseURL: TEST_SCHEMA_PUBLIC_LLM_BASE_URL,
           customModels: ["model-1", "model-2"],
           withDefaultModels: true,
           extraHeaders: { "X-Test": "value" },

--- a/worker/src/__tests__/webhook-validation.test.ts
+++ b/worker/src/__tests__/webhook-validation.test.ts
@@ -1,5 +1,38 @@
-import { describe, it, expect } from "vitest";
-import { validateWebhookURL } from "@langfuse/shared/src/server";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+const { resolve4Mock, resolve6Mock } = vi.hoisted(() => ({
+  resolve4Mock: vi.fn<(hostname: string) => Promise<string[]>>(),
+  resolve6Mock: vi.fn<(hostname: string) => Promise<string[]>>(),
+}));
+
+vi.mock("node:dns/promises", () => ({
+  default: {
+    resolve4: resolve4Mock,
+    resolve6: resolve6Mock,
+  },
+  resolve4: resolve4Mock,
+  resolve6: resolve6Mock,
+}));
+
+import { validateWebhookURL } from "../../../packages/shared/src/server/webhooks/validation";
+
+const nonexistentDomain = "this-domain-definitely-does-not-exist-12345.com";
+
+const dnsError = (code: string, hostname: string) =>
+  Object.assign(new Error(`queryA ${code} ${hostname}`), { code });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  resolve4Mock.mockImplementation(async (hostname: string) => {
+    if (hostname === nonexistentDomain) {
+      throw dnsError("ENOTFOUND", hostname);
+    }
+
+    return ["93.184.216.34"];
+  });
+  resolve6Mock.mockRejectedValue(dnsError("ENODATA", "mocked-hostname"));
+});
 
 describe("Webhook URL Validation", () => {
   describe("validateWebhookURL", () => {
@@ -109,10 +142,10 @@ describe("Webhook URL Validation", () => {
 
     it("should handle DNS resolution failures gracefully", async () => {
       await expect(
-        validateWebhookURL(
-          "https://this-domain-definitely-does-not-exist-12345.com/hook",
-        ),
+        validateWebhookURL(`https://${nonexistentDomain}/hook`),
       ).rejects.toThrow("DNS lookup failed");
+      expect(resolve4Mock).toHaveBeenCalledWith(nonexistentDomain);
+      expect(resolve6Mock).toHaveBeenCalledWith(nonexistentDomain);
     });
 
     it("should reject URL-encoded localhost bypass attempts", async () => {


### PR DESCRIPTION
## What
- Mock DNS resolution in webhook URL validation tests instead of relying on real NXDOMAIN resolution.
- Use public IP literal base URLs in LLM connection API happy-path tests to avoid external DNS latency.

## Why
These address CI runs that failed on DNS-dependent tests and succeeded on retry:
- https://github.com/langfuse/langfuse/actions/runs/24776421737
- https://github.com/langfuse/langfuse/actions/runs/24771625527
- https://github.com/langfuse/langfuse/actions/runs/24571451102

## Verification
- pnpm --filter worker exec vitest run src/__tests__/webhook-validation.test.ts
- cd web && pnpm exec dotenv -e ../.env.test -e ../.env -- vitest run --project server llm-connections-api.servertest.ts --maxWorkers 1
- pnpm --filter worker run lint
- pnpm --filter web run lint
- git diff --check origin/main..HEAD

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Deflakes two categories of DNS-dependent CI tests: webhook URL validation tests now use `vi.hoisted` + `vi.mock` to intercept `node:dns/promises` entirely, and LLM connection API tests replace domain-based `baseURL` strings with public IP literal constants (`1.1.1.1`). The mocking strategy is sound — `vi.hoisted` ensures mocks are available before module imports, and `Promise.allSettled` in `resolveHost` means the interception of both `resolve4` and `resolve6` is correctly exercised.

<h3>Confidence Score: 4/5</h3>

Safe to merge — test-only changes with a correct mocking strategy and no production code affected.

Only P2 findings: a static hostname string in the IPv6 rejection mock (minor debuggability concern) and a cross-workspace relative import path (fragility). No P0/P1 issues.

worker/src/__tests__/webhook-validation.test.ts — cross-workspace relative import and static rejection hostname worth reconsidering.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/__tests__/webhook-validation.test.ts | Replaces live DNS resolution with vi.hoisted mocks; mock setup is correct but uses a cross-workspace relative import and a static hostname string in the IPv6 rejection. |
| web/src/__tests__/server/llm-connections-api.servertest.ts | Substitutes domain-based baseURL strings with public IP literal constants (1.1.1.1) to remove external DNS dependence; changes are straightforward and correct. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Test: webhook-validation] -->|vi.hoisted mocks| B[node:dns/promises mock]
    B --> C{hostname == nonexistentDomain?}
    C -- yes --> D[resolve4Mock throws ENOTFOUND]
    C -- no --> E[resolve4Mock returns 93.184.216.34]
    B --> F[resolve6Mock always throws ENODATA]
    D & F --> G[resolveHost: both settled as rejected - ips empty]
    G --> H[throws DNS lookup failed]
    E & F --> I[resolveHost: v4 fulfilled - ips = 93.184.216.34]
    I --> J[isIPBlocked check false - valid URL]
    K[Test: llm-connections-api] -->|replace domain URLs| L[1.1.1.1 IP literal constants]
    L --> M[No DNS lookup at URL storage time]
    M --> N[SSRF check on literal IP passes]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/__tests__/webhook-validation.test.ts:34
**Hardcoded hostname in resolve6 rejection obscures debugging**

`resolve6Mock.mockRejectedValue(dnsError("ENODATA", "mocked-hostname"))` uses a static sentinel string rather than the actual hostname passed to the mock. If a test unexpectedly fails because of an IPv6 path, the rejection error says `"mocked-hostname"` rather than the hostname under test, making the failure harder to diagnose. Using `mockImplementation` here (as done for `resolve4Mock`) would preserve the real hostname in the error.

```suggestion
  resolve6Mock.mockImplementation(async (hostname: string) => {
    throw dnsError("ENODATA", hostname);
  });
```

### Issue 2 of 2
worker/src/__tests__/webhook-validation.test.ts:17
**Cross-workspace relative import bypasses the package public API**

The import was changed from `@langfuse/shared/src/server` to `"../../../packages/shared/src/server/webhooks/validation"`. This relative path crosses the workspace boundary and imports directly from an internal file. If `validation.ts` is ever moved or the shared-package file structure changes, this test silently breaks without any type-system or tooling warning. The original package-alias import is more robust.

If the motivation was to ensure `vi.mock("node:dns/promises")` intercepts the `dns` import (a known Vitest ESM quirk), it's worth adding a comment explaining that.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: deflake DNS-dependent CI tests"](https://github.com/langfuse/langfuse/commit/4254b2566703735c7a0f540e51fb4e68b38eba06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30284057)</sub>

<!-- /greptile_comment -->