### PR TITLE
chore: Increase admin access webhook dedupe window to 24 hours

### DIFF
--- a/web/src/__tests__/server/async/admin-access-webhook.servertest.ts
+++ b/web/src/__tests__/server/async/admin-access-webhook.servertest.ts
@@ -81,7 +81,7 @@ describe("sendAdminAccessWebhook", () => {
     });
   });
 
-  it("should dedupe repeated sends within 5 minutes for same email/project/org", async () => {
+  it("should dedupe repeated sends within 24 hours for same email/project/org", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-19T19:39:37.000Z"));
     (env as any).LANGFUSE_ADMIN_ACCESS_WEBHOOK = "https://example.com/hook";
@@ -119,7 +119,7 @@ describe("sendAdminAccessWebhook", () => {
       orgId: "org-1",
     });
 
-    vi.setSystemTime(new Date("2026-02-19T19:44:38.000Z"));
+    vi.setSystemTime(new Date("2026-02-20T19:39:38.000Z"));
 
     await sendAdminAccessWebhook({
       email: "admin@langfuse.com",

--- a/web/src/server/adminAccessWebhook.ts
+++ b/web/src/server/adminAccessWebhook.ts
@@ -9,7 +9,7 @@ type AdminAccessWebhookPayload = {
   region: string;
 };
 
-const DEDUPE_WINDOW_MS = 5 * 60_000;
+const DEDUPE_WINDOW_MS = 24 * 60 * 60_000;
 const lastWebhookByKey = new Map<string, number>();
 
 export const resetAdminAccessWebhookCacheForTests = () => {


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR increases the admin access webhook deduplication window from 5 minutes to 24 hours, preventing repeated webhook notifications when the same admin accesses the same project/org multiple times throughout a day. The test is updated to match the new window by advancing the simulated clock by 24 hours + 1 second instead of ~5 minutes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-tested constant change with no logic impact

The only change is a single numeric constant and its corresponding test. The boundary test correctly advances the clock by 24 h + 1 s to confirm the second send fires after the window expires. No logic, API contracts, or security surface is affected.

No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/server/adminAccessWebhook.ts | Single constant changed from 5 min to 24 h; logic and structure unchanged |
| web/src/__tests__/server/async/admin-access-webhook.servertest.ts | Test description and simulated clock advancement updated to match the new 24-hour dedupe window |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant sendAdminAccessWebhook
    participant DedupeMap as lastWebhookByKey (in-memory)
    participant Webhook as External Webhook URL

    Caller->>sendAdminAccessWebhook: call(email, projectId, orgId)
    sendAdminAccessWebhook->>DedupeMap: get(email:project:org)
    alt key not found OR last sent > 24 h ago
        DedupeMap-->>sendAdminAccessWebhook: proceed
        sendAdminAccessWebhook->>DedupeMap: set(key, now)
        sendAdminAccessWebhook->>Webhook: POST payload
        Webhook-->>sendAdminAccessWebhook: 200 OK
    else sent within last 24 h
        DedupeMap-->>sendAdminAccessWebhook: skip
        sendAdminAccessWebhook-->>Caller: return (no-op)
    end
```

<sub>Reviews (1): Last reviewed commit: ["Increase admin access webhook dedupe win..."](https://github.com/langfuse/langfuse/commit/67b75570edf0044e688891d05dc835be98f9ccb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30289701)</sub>

<!-- /greptile_comment -->