### PR TITLE
fix(web): include today in Prompts table observation count window

### DIFF
--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -70,9 +70,7 @@ export function PromptTable() {
     fromTimestamp.setDate(fromTimestamp.getDate() - 7);
     fromTimestamp.setHours(0, 0, 0, 0);
 
-    const toTimestamp = new Date(today);
-    toTimestamp.setHours(0, 0, 0, 0);
-    toTimestamp.setMilliseconds(toTimestamp.getMilliseconds() - 1);
+    const toTimestamp = today;
 
     return { fromTimestamp, toTimestamp };
   }, []);


### PR DESCRIPTION
Context: https://app.usepylon.com/support/issues/views/fb96aea1-cd38-4445-a9e7-14ae83e48d67?issueNumber=1152&view=fs

## Summary

The "Number of Observations (7d)" column on the Prompts table was passing `toTimestamp` set to **end of yesterday** (`new Date(today); setHours(0,0,0,0); -1ms`). The metrics query (`getObservationsWithPromptName`) filters by `start_time <= toTimestamp`, so every observation produced today was excluded from the count.

Symptoms (reported in [Pylon #1152](https://app.usepylon.com/issues?issueNumber=1152)):
- Recent prompt calls don't increment the counter even after 10–30 min
- Prompts only used today show 0
- Counts on the table match older trace data exactly, but never the current day

Fix: use the current timestamp as `toTimestamp`. `fromTimestamp` continues to snap to midnight 7 days ago.

## Test plan

- [ ] Verify Prompts table "Number of Observations (7d)" reflects today's calls within ingestion latency
- [ ] Spot-check unchanged historical counts (older days unaffected)
- [ ] `pnpm --filter web run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a one-day gap in the Prompts table's "Number of Observations (7d)" metric. The old code computed `toTimestamp` as midnight today minus 1 ms (i.e., end of yesterday), which caused the `start_time ≤ toTimestamp` filter in `getObservationsWithPromptName` to exclude all observations from the current day. The fix replaces that calculation with `today` — the `Date` object already captured at the top of the memo — so `toTimestamp` now reflects the actual current moment at component mount time.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, clearly correct one-line fix to a well-understood off-by-one-day bug.

The diff removes the explicit midnight-minus-1ms calculation and reuses the `today` reference that already exists in scope. No logic is added, no new state is introduced, and the fix directly matches the described root cause. The only theoretical concern (stale `toTimestamp` if the tab stays open across midnight) is a pre-existing consequence of the empty-dependency `useMemo` and is out of scope for this PR.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/prompts/components/prompts-table.tsx | Fixes off-by-one-day bug in `toTimestamp` calculation; changes 3 lines to use the current moment instead of midnight-minus-1ms as the upper bound of the 7-day observation window. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as PromptTable (UI)
    participant API as prompts.metrics API
    participant DB as ClickHouse

    UI->>UI: useMemo — compute time window<br/>fromTimestamp = midnight 7 days ago<br/>toTimestamp = now ✅ (was: midnight today − 1ms ❌)
    UI->>API: query(fromTimestamp, toTimestamp)
    API->>DB: WHERE start_time >= fromTimestamp AND start_time <= toTimestamp
    DB-->>API: observation counts (now includes today)
    API-->>UI: metrics rows
    UI->>UI: render "Number of Observations (7d)"
```

<sub>Reviews (1): Last reviewed commit: ["fix(web): include today in Prompts table..."](https://github.com/langfuse/langfuse/commit/87a8dc1edcf6aed57e50248eed074fe9fe267401) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30291602)</sub>

<!-- /greptile_comment -->