### PR TITLE
fix(worker): make Bedrock version suffix optional in 14 Claude model match patterns

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1287,7 +1287,7 @@
   {
     "id": "cltgy0iuw000008le3vod1hhy",
     "modelName": "claude-3-opus-20240229",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-opus-20240229|anthropic\\.claude-3-opus-20240229-v1:0|claude-3-opus@20240229)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-opus-20240229|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-opus-20240229(-v1(:0)?)?|claude-3-opus@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1308,7 +1308,7 @@
   {
     "id": "cltgy0pp6000108le56se7bl3",
     "modelName": "claude-3-sonnet-20240229",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-sonnet-20240229|anthropic\\.claude-3-sonnet-20240229-v1:0|claude-3-sonnet@20240229)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-sonnet-20240229|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-sonnet-20240229(-v1(:0)?)?|claude-3-sonnet@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1338,7 +1338,7 @@
   {
     "id": "cltr0w45b000008k1407o9qv1",
     "modelName": "claude-3-haiku-20240307",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-haiku-20240307|anthropic\\.claude-3-haiku-20240307-v1:0|claude-3-haiku@20240307)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-haiku-20240307|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-haiku-20240307(-v1(:0)?)?|claude-3-haiku@20240307)$",
     "createdAt": "2024-03-14T09:41:18.736Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1537,7 +1537,7 @@
   {
     "id": "clxt0n0m60000pumz1j5b7zsf",
     "modelName": "claude-3-5-sonnet-20240620",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-5-sonnet-20240620(-v1(:0)?)?|claude-3-5-sonnet@20240620)$",
     "createdAt": "2024-06-25T11:47:24.475Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1807,7 +1807,7 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "modelName": "claude-3-5-haiku-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-5-haiku-20241022(-v1(:0)?)?|claude-3-5-haiku-V1@20241022)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2157,7 +2157,7 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "modelName": "claude-3.7-sonnet-20250219",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3.7-sonnet-20250219(-v1(:0)?)?|claude-3-7-sonnet-V1@20250219)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2573,7 +2573,7 @@
   {
     "id": "c5qmrqolku82tra3vgdixmys",
     "modelName": "claude-sonnet-4-5-20250929",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?(-v1(:0)?)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
     "createdAt": "2025-09-29T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2630,7 +2630,7 @@
   {
     "id": "cmazmkzlm00000djp1e1qe4k4",
     "modelName": "claude-sonnet-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?(-v1(:0)?)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2690,7 +2690,7 @@
   {
     "id": "cmazmlm2p00020djpa9s64jw5",
     "modelName": "claude-opus-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4(-20250514)?(-v1(:0)?)?|claude-opus-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2876,7 +2876,7 @@
   {
     "id": "cmdysde5w0000rkmzbc1g5au3",
     "modelName": "claude-opus-4-1-20250805",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-1(-20250805)?(-v1(:0)?)?|claude-opus-4-1(@20250805)?)$",
     "createdAt": "2025-08-05T15:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3172,7 +3172,7 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001(-v1(:0)?)?|claude-4-5-haiku@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
     "updatedAt": "2026-04-20T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3262,7 +3262,7 @@
   {
     "id": "cmieupdva000004l541kwae70",
     "modelName": "claude-opus-4-5-20251101",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-5(-20251101)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-5(-20251101)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-20251101)?(-v1(:0)?)?|claude-opus-4-5(@20251101)?)$",
     "createdAt": "2025-11-24T20:53:27.571Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3351,7 +3351,7 @@
   {
     "id": "13458bc0-1c20-44c2-8753-172f54b67647",
     "modelName": "claude-opus-4-6",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6(-v1(:0)?)?|claude-opus-4-6)$",
     "createdAt": "2026-02-09T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3382,7 +3382,7 @@
   {
     "id": "d506b291-cc9c-4833-9014-0f387a8e1cc8",
     "modelName": "claude-opus-4-7",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7-v1(:0)?|claude-opus-4-7)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7(-v1(:0)?)?|claude-opus-4-7)$",
     "createdAt": "2026-04-16T00:00:00.000Z",
     "updatedAt": "2026-04-16T00:00:00.000Z",
     "tokenizerConfig": null,


### PR DESCRIPTION
# PR: fix(worker): make Bedrock version suffix optional in 14 Claude model match patterns

## What does this PR do?

Fixes broken `matchPattern` regexes for **14 Claude models** in `default-model-prices.json`.
The Bedrock version suffix `-v1(:0)?` is currently **required** instead of optional for these
models, causing Bedrock-prefixed model names (e.g. `us.anthropic.claude-opus-4-6`) to fail
matching. Affected models get `internal_model_id = NULL` and `total_cost = NULL` for every
Bedrock-originated observation.

Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## The Problem

When using Claude via **AWS Bedrock**, the SDK sends model names in the format
`{region}.anthropic.{model}` (e.g. `us.anthropic.claude-opus-4-6`), typically **without**
a `-v1` suffix. The broken patterns require `-v1(:0)?` at the end of the Bedrock alternative,
so these names fail to match.

```
# Broken — claude-opus-4-6
(?i)^(anthropic/)?(claude-opus-4-6|(eu\.|us\.|apac\.|global\.)?anthropic\.claude-opus-4-6-v1(:0)?|...)$
#                                                                                              ^^^^^^^^^
#                                                                                              required, not optional

# Correct reference — claude-sonnet-4-6 (already fixed in a prior PR)
(?i)^(anthropic/)?(claude-sonnet-4-6|(eu\.|us\.|apac\.|global\.)?anthropic\.claude-sonnet-4-6(-v1(:0)?)?|...)$
#                                                                                              ^^^^^^^^^^^^^
#                                                                                              outer optional group
```

## The Fix

Wrap `-v1(:0)?` in an outer optional group `(-v1(:0)?)?` for all 14 affected models.
Three of the Claude 3 models (`claude-3-5-sonnet-20240620`, `claude-3-5-haiku-20241022`,
`claude-3.7-sonnet-20250219`) and two Claude 4 models (`claude-opus-4-20250514`,
`claude-opus-4-1-20250805`) are also missing `global\.` in their region prefix group —
those are corrected in the same change.

### Affected models

**Claude 3 family:**

| Model | Broken segment | Fix |
| ---- | ---- | ---- |
| `claude-3-opus-20240229` | `anthropic\.claude-3-opus-20240229-v1:0` | `(-v1(:0)?)?` |
| `claude-3-sonnet-20240229` | `anthropic\.claude-3-sonnet-20240229-v1:0` | `(-v1(:0)?)?` |
| `claude-3-haiku-20240307` | `anthropic\.claude-3-haiku-20240307-v1:0` | `(-v1(:0)?)?` |
| `claude-3-5-sonnet-20240620` | `(eu\.\|us\.\|apac\.)?...–v1:0` | `(-v1(:0)?)?` + add `global\.` |
| `claude-3-5-haiku-20241022` | `(eu\.\|us\.\|apac\.)?...–v1:0` | `(-v1(:0)?)?` + add `global\.` |
| `claude-3.7-sonnet-20250219` | `(eu\.\|us\.\|apac\.)?...–v1:0` | `(-v1(:0)?)?` + add `global\.` |

**Claude 4 family:**

| Model | Broken segment | Fix |
| ---- | ---- | ---- |
| `claude-opus-4-20250514` | `(eu\.\|us\.\|apac\.)?...-v1(:0)?` | `(-v1(:0)?)?` + add `global\.` |
| `claude-opus-4-1-20250805` | `(eu\.\|us\.\|apac\.)?...-v1(:0)?` | `(-v1(:0)?)?` + add `global\.` |
| `claude-opus-4-5-20251101` | `...-v1(:0)?` | `(-v1(:0)?)?` |
| `claude-opus-4-6` | `...-v1(:0)?` | `(-v1(:0)?)?` |
| `claude-opus-4-7` | `...-v1(:0)?` | `(-v1(:0)?)?` |
| `claude-sonnet-4-20250514` | `...-v1(:0)?` | `(-v1(:0)?)?` |
| `claude-sonnet-4-5-20250929` | `...-v1(:0)?` | `(-v1(:0)?)?` |
| `claude-haiku-4-5-20251001` | `...-v1:0` (exact) | `(-v1(:0)?)?` |

Full before/after patterns for all 14 models are in `affected-patterns.md` in this folder.

## Evidence

Confirmed on self-hosted v3.167.0 against production ClickHouse. The same model sent as the
Anthropic short name (`claude-opus-4-6`) matches correctly; sent as the Bedrock name
(`us.anthropic.claude-opus-4-6`) it does not:

| `provided_model_name` | `internal_model_id` | `total_cost` | Count |
| --- | --- | --- | --- |
| `us.anthropic.claude-opus-4-6` | NULL | NULL | 197,135 |
| `claude-opus-4-6` | 13458bc0-… | $350.79 | 26,621 |

After deploying the fix, Bedrock-prefixed names resolved correctly and cost attribution
resumed within seconds of worker pod restart.

## Root cause

The pattern is inconsistently applied when new models are added. `claude-sonnet-4-6` (added
earlier) correctly uses `(-v1(:0)?)?`, but subsequent additions omit the outer optional group.
A consistent template for Bedrock alternatives would prevent recurrence:

```
(region-prefix)?anthropic\.{model-id}(-v1(:0)?)?
```

## Checklist

- [x] Self-reviewed
- [x] Change is limited to `default-model-prices.json` (data only, no logic change)
- [x] Verified against real production data

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR makes the Bedrock version suffix `-v1(:0)?` optional (via an outer `(-v1(:0)?)?` group) in 14 Claude model `matchPattern` regexes, fixing cost attribution failures for Bedrock-prefixed model names sent without a version suffix. Five models also receive a missing `global\.` region alternative. The 11 newer Claude 3.5/3.7/4 models are correctly fixed across both dimensions; the three oldest Claude 3 entries (`claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307`) receive only the version fix and continue to lack the `(eu.|us.|apac.|global.)?` region prefix, so cross-region Bedrock inference profile names (e.g. `us.anthropic.claude-3-opus-20240229`) remain unmatched for those three models.

<h3>Confidence Score: 4/5</h3>

Safe to merge — fixes a real cost-attribution regression; the only gap is a pre-existing missing region prefix on three older models that is not made worse by this PR.

All 14 intended version-suffix fixes are correct and the five `global\.` additions are accurate. The sole finding is a pre-existing incompleteness (missing region prefix) for three Claude 3 originals that falls outside the stated scope of this PR; no new regressions are introduced.

worker/src/constants/default-model-prices.json — three Claude 3 original entries (`claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307`) still lack the region-prefix alternative for cross-region Bedrock inference profiles.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/constants/default-model-prices.json | Makes `-v1(:0)?` optional for 14 Claude model patterns and adds `global\.` to 5 region prefix groups; the version-suffix fix is correct across all 14 models, but 3 older Claude 3 entries remain without the `(eu.|us.|apac.|global.)?` region prefix, leaving cross-region Bedrock inference profile names still unmatched for those models. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Bedrock model name received\ne.g. us.anthropic.claude-opus-4-6"] --> B{"matchPattern regex"}
    B -->|"Anthropic short name\ne.g. claude-opus-4-6"| C["✅ Matches first alternative"]
    B -->|"Bedrock cross-region\ne.g. us.anthropic.claude-opus-4-6"| D{"Has region prefix\nin pattern?"}
    B -->|"Bedrock versioned\ne.g. anthropic.claude-opus-4-6-v1:0"| E["✅ Matches (version required OR optional)"]
    D -->|"Yes — Claude 3.5 / 3.7 / 4 models\n(eu|us|apac|global)?"| F{"Version suffix present?"}
    D -->|"No — Claude 3 originals\nopus/sonnet/haiku 2024"| G["❌ Still fails — pre-existing gap\nnot addressed by this PR"]
    F -->|"With -v1:0\nBEFORE: required → AFTER: optional"| H["✅ Matches (fixed by this PR)"]
    F -->|"Without -v1:0\nBEFORE: no match → AFTER: matches"| I["✅ Matches (fixed by this PR)"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/constants/default-model-prices.json:1290-1342
**Incomplete fix: region prefix still absent for three Claude 3 originals**

`claude-3-opus-20240229`, `claude-3-sonnet-20240229`, and `claude-3-haiku-20240307` have their version suffix correctly made optional, but their Bedrock alternatives still lack the `(eu\.|us\.|apac\.|global\.)?` region prefix present on every other model in this file. A cross-region inference profile name like `us.anthropic.claude-3-opus-20240229` will still fail to match even after this fix — the `us.` prefix has nowhere to go in the pattern. The fix here only helps callers sending `anthropic.claude-3-*` (without a region prefix), which is less common when cross-region inference is enabled.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): make Bedrock version suffix..."](https://github.com/langfuse/langfuse/commit/8645bc191cbe97247a8e31b2e82da050ca13a84d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30371952)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->