### PR TITLE
fix(traces): refresh scores in trace detail

### DIFF
--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -212,6 +212,17 @@ export default function ScoresTable({
       void utils.scores.all.invalidate();
       void utils.scores.allFromEvents.invalidate();
       void utils.scores.countAllFromEvents.invalidate();
+
+      if (traceId) {
+        void utils.traces.byIdWithObservationsAndScores.invalidate({
+          projectId,
+          traceId,
+        });
+        void utils.events.scoresForTrace.invalidate({
+          projectId,
+          traceId,
+        });
+      }
     },
   });
 

--- a/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
+++ b/web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx
@@ -81,6 +81,7 @@ export function ObservationDetailView({
     selectedTab: globalSelectedTab,
     setSelectedTab: setGlobalSelectedTab,
   } = useSelection();
+  const utils = api.useUtils();
 
   // V4 beta mode and observations for log tab
   const { isBetaEnabled: isV4Enabled } = useV4Beta();
@@ -120,7 +121,21 @@ export function ObservationDetailView({
     return "preview" as const;
   }, [globalSelectedTab, showLogViewTab]);
 
+  const refreshTraceScores = useCallback(() => {
+    void utils.traces.byIdWithObservationsAndScores.invalidate({
+      projectId,
+      traceId,
+    });
+    void utils.events.scoresForTrace.invalidate({
+      projectId,
+      traceId,
+    });
+  }, [projectId, traceId, utils]);
+
   const setSelectedTab = (tab: "preview" | "log" | "scores") => {
+    if (tab === "scores") {
+      refreshTraceScores();
+    }
     setGlobalSelectedTab(tab);
   };
 

--- a/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
+++ b/web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx
@@ -70,6 +70,7 @@ export function TraceDetailView({
 }: TraceDetailViewProps) {
   // Tab and view state from URL (via SelectionContext)
   const { selectedTab, setSelectedTab } = useSelection();
+  const utils = api.useUtils();
   const [isPrettyViewAvailable, setIsPrettyViewAvailable] = useState(true);
   const [isJSONBetaVirtualized, setIsJSONBetaVirtualized] = useState(false);
 
@@ -182,8 +183,22 @@ export function TraceDetailView({
     useIsAuthenticatedAndProjectMember(projectId);
   const showScoresTab = isAuthenticatedAndProjectMember;
 
+  const refreshTraceScores = useCallback(() => {
+    void utils.traces.byIdWithObservationsAndScores.invalidate({
+      projectId,
+      traceId: trace.id,
+    });
+    void utils.events.scoresForTrace.invalidate({
+      projectId,
+      traceId: trace.id,
+    });
+  }, [projectId, trace.id, utils]);
+
   // Handle tab change
   const handleTabChange = (value: string) => {
+    if (value === "scores") {
+      refreshTraceScores();
+    }
     setSelectedTab(value as "preview" | "log" | "scores");
   };
 


### PR DESCRIPTION
## What
- Refresh trace-detail score data when opening the Scores tab so asynchronously created evaluator/API scores are reflected in the detail/sidebar state.
- Refresh trace-detail score data after deleting scores from a trace-scoped Scores table.

## Issue
- Linear: https://linear.app/langfuse/issue/LFE-9569/boolean-scores-are-not-shown-in-trace-detail-not-filterable-in-trace

## Verification
- pnpm --filter web exec eslint src/components/table/use-cases/scores.tsx src/components/trace2/components/TraceDetailView/TraceDetailView.tsx src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx --max-warnings 0
- pnpm --filter web run typecheck
- pre-commit: pnpm run format:check
- pre-commit: pnpm run lint

## Impacted packages
- web

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes stale score data in the trace detail panel by invalidating the relevant tRPC query cache when: (1) the user opens the Scores tab (in both `TraceDetailView` and `ObservationDetailView`), and (2) scores are deleted from a trace-scoped Scores table. The approach is straightforward and consistent with existing cache-invalidation patterns in the codebase; the only minor concern is that the `invalidate()` calls lack input filters, causing all cached queries for those endpoints (across all trace IDs) to be refetched instead of just the current trace.

<h3>Confidence Score: 4/5</h3>

Safe to merge — fixes a real stale-data bug with no correctness regressions; only P2 style findings remain.

All findings are P2 (broad cache invalidation, missing useCallback). No logic errors, security concerns, or breaking changes are present.

TraceDetailView.tsx and ObservationDetailView.tsx — consider narrowing the invalidate() calls to the specific traceId.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx | Adds `api.useUtils()` and a `refreshTraceScores` callback that invalidates score-related queries when the Scores tab is opened. Broad (unfiltered) invalidation and a missing `useCallback` on `handleTabChange` are minor style concerns. |
| web/src/components/trace2/components/ObservationDetailView/ObservationDetailView.tsx | Mirrors TraceDetailView change — adds `refreshTraceScores` callback and triggers it on Scores tab selection. Same broad-invalidation concern applies. |
| web/src/components/table/use-cases/scores.tsx | Extends the `onSettled` handler of `scoreDeleteMutation` to also invalidate `byIdWithObservationsAndScores` and `scoresForTrace` when a `traceId` is present, keeping the trace detail panel in sync after deletion. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TabsBar
    participant TraceDetailView/ObservationDetailView
    participant tRPC Cache

    User->>TabsBar: Click "Scores" tab
    TabsBar->>TraceDetailView/ObservationDetailView: handleTabChange("scores")
    TraceDetailView/ObservationDetailView->>tRPC Cache: invalidate traces.byIdWithObservationsAndScores
    TraceDetailView/ObservationDetailView->>tRPC Cache: invalidate events.scoresForTrace
    tRPC Cache-->>TraceDetailView/ObservationDetailView: re-fetch (all trace IDs)
    TraceDetailView/ObservationDetailView-->>User: Scores tab rendered with fresh data

    User->>ScoresTable: Delete selected scores
    ScoresTable->>tRPC Cache: invalidate scores.all / allFromEvents / countAllFromEvents
    ScoresTable->>tRPC Cache: invalidate traces.byIdWithObservationsAndScores (if traceId present)
    ScoresTable->>tRPC Cache: invalidate events.scoresForTrace (if traceId present)
    tRPC Cache-->>ScoresTable: re-fetch updated score lists
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx:186-189
**Broad cache invalidation on every tab switch**

`utils.traces.byIdWithObservationsAndScores.invalidate()` and `utils.events.scoresForTrace.invalidate()` are called without input filters, so every cached query across all trace IDs is invalidated and re-fetched each time the user clicks the Scores tab. Narrowing to the current trace would limit the network impact:

```
void utils.traces.byIdWithObservationsAndScores.invalidate({ traceId: trace.id, projectId });
void utils.events.scoresForTrace.invalidate({ traceId: trace.id, projectId });
```

(Same pattern applies in `ObservationDetailView.tsx`.)

### Issue 2 of 2
web/src/components/trace2/components/TraceDetailView/TraceDetailView.tsx:192-197
**`handleTabChange` not memoized**

`handleTabChange` closes over `refreshTraceScores` and `setSelectedTab` but is not wrapped in `useCallback`. It is passed directly to `onValueChange` on `TabsBar`, which may cause unnecessary re-renders if `TabsBar` is memoized. Consider wrapping it:

```suggestion
  const handleTabChange = useCallback((value: string) => {
    if (value === "scores") {
      refreshTraceScores();
    }
    setSelectedTab(value as "preview" | "log" | "scores");
  }, [refreshTraceScores, setSelectedTab]);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traces): refresh scores in trace det..."](https://github.com/langfuse/langfuse/commit/3ac9dd116600ec7a402aae8746d242ea88036f7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30436518)</sub>

<!-- /greptile_comment -->