### PR TITLE
fix(evals): do not drop langfuseObject on config on template upgrades

### DIFF
--- a/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
+++ b/web/src/__tests__/server/unit/unstable-evals-service.servertest.ts
@@ -305,6 +305,7 @@ describe("unstable public eval services", () => {
       {
         id: "ceval_123",
         scoreName: "answer_quality",
+        targetObject: EvalTargetObject.EVENT,
         variableMapping: [
           {
             templateVariable: "input",
@@ -346,6 +347,7 @@ describe("unstable public eval services", () => {
       select: {
         id: true,
         scoreName: true,
+        targetObject: true,
         variableMapping: true,
       },
     });
@@ -373,6 +375,64 @@ describe("unstable public eval services", () => {
     });
   });
 
+  it("preserves legacy trace mapping fields when auto-upgrading linked evaluators", async () => {
+    mockEvalTemplateFindMany.mockResolvedValueOnce([
+      {
+        id: "tmpl_project_v2",
+        version: 2,
+      },
+    ]);
+    mockJobConfigurationFindMany.mockResolvedValueOnce([
+      {
+        id: "ceval_legacy_trace",
+        scoreName: "answer_quality",
+        targetObject: EvalTargetObject.TRACE,
+        variableMapping: [
+          {
+            templateVariable: "input",
+            langfuseObject: "trace",
+            objectName: null,
+            selectedColumnId: "input",
+            jsonSelector: null,
+          },
+        ],
+      },
+    ]);
+    mockEvalTemplateCreate.mockResolvedValueOnce({
+      ...projectTemplate,
+      id: "tmpl_project_v3",
+      version: 3,
+    });
+
+    await createPublicEvaluator({
+      projectId: "project_123",
+      input: {
+        name: "Answer correctness",
+        prompt: "Judge {{input}}",
+        outputDefinition: numericOutputDefinition,
+      },
+    });
+
+    expect(mockJobConfigurationUpdate).toHaveBeenCalledWith({
+      where: {
+        id: "ceval_legacy_trace",
+        projectId: "project_123",
+      },
+      data: {
+        evalTemplateId: "tmpl_project_v3",
+        variableMapping: [
+          {
+            templateVariable: "input",
+            langfuseObject: "trace",
+            objectName: null,
+            selectedColumnId: "input",
+            jsonSelector: null,
+          },
+        ],
+      },
+    });
+  });
+
   it("drops obsolete variable mappings when auto-upgrading linked evaluation rules", async () => {
     mockEvalTemplateFindMany.mockResolvedValueOnce([
       {
@@ -384,6 +444,7 @@ describe("unstable public eval services", () => {
       {
         id: "ceval_123",
         scoreName: "answer_quality",
+        targetObject: EvalTargetObject.EVENT,
         variableMapping: [
           {
             templateVariable: "input",
@@ -444,6 +505,7 @@ describe("unstable public eval services", () => {
       {
         id: "ceval_123",
         scoreName: "answer_quality",
+        targetObject: EvalTargetObject.EVENT,
         variableMapping: [
           {
             templateVariable: "input",

--- a/web/src/features/evals/server/unstable-public-api/evaluator-service.ts
+++ b/web/src/features/evals/server/unstable-public-api/evaluator-service.ts
@@ -1,4 +1,5 @@
 import {
+  EvalTargetObject,
   extractVariables,
   InternalServerError,
   observationVariableMappingList,
@@ -6,7 +7,6 @@ import {
 } from "@langfuse/shared";
 import { invalidateProjectEvalConfigCaches } from "@langfuse/shared/src/server";
 import { Prisma, prisma } from "@langfuse/shared/src/db";
-import { z } from "zod";
 import type { PostUnstableEvaluatorBodyType } from "@/src/features/public-api/types/unstable-evaluators";
 import {
   toApiEvaluator,
@@ -25,12 +25,16 @@ import type { StoredPublicEvaluatorTemplate } from "./types";
 
 function prepareVariableMappingForEvaluatorUpgrade(params: {
   scoreName: string;
+  targetObject: string;
   variableMapping: unknown;
   nextVariables: string[];
 }) {
-  const mappingParseResult = z
-    .union([observationVariableMappingList, variableMappingList])
-    .safeParse(params.variableMapping);
+  const mappingSchema =
+    params.targetObject === EvalTargetObject.EVENT ||
+    params.targetObject === EvalTargetObject.EXPERIMENT
+      ? observationVariableMappingList
+      : variableMappingList;
+  const mappingParseResult = mappingSchema.safeParse(params.variableMapping);
 
   if (!mappingParseResult.success) {
     throw new InternalServerError("Evaluation rule mapping is corrupted");
@@ -158,6 +162,7 @@ export async function createPublicEvaluator(params: {
                 select: {
                   id: true,
                   scoreName: true,
+                  targetObject: true,
                   variableMapping: true,
                 },
               })
@@ -166,6 +171,7 @@ export async function createPublicEvaluator(params: {
           id: config.id,
           variableMapping: prepareVariableMappingForEvaluatorUpgrade({
             scoreName: config.scoreName,
+            targetObject: config.targetObject,
             variableMapping: config.variableMapping,
             nextVariables,
           }),


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a bug where `langfuseObject` (and `objectName`) were silently dropped from TRACE-target evaluation rule variable mappings during template auto-upgrades. The root cause was `z.union([observationVariableMappingList, variableMappingList])` picking the first schema (`observationVariableMappingList`), which strips unknown fields including `langfuseObject`. The fix replaces the union with an explicit schema dispatch based on `targetObject`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — targeted fix with appropriate test coverage and no risk to other paths.

Only P2 style findings; the logic change is correct and well-tested.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/evals/server/unstable-public-api/evaluator-service.ts | Fixes schema selection in prepareVariableMappingForEvaluatorUpgrade: chooses observationVariableMappingList for EVENT/EXPERIMENT and variableMappingList (which preserves langfuseObject) for TRACE/DATASET; removes now-unused z import. |
| web/src/__tests__/server/unit/unstable-evals-service.servertest.ts | Adds targetObject to existing mock fixtures and a new test verifying TRACE-target configs preserve their langfuseObject field during template upgrades. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[prepareVariableMappingForEvaluatorUpgrade] --> B{targetObject?}
    B -- EVENT or EXPERIMENT --> C[observationVariableMappingList\nno langfuseObject field]
    B -- TRACE or DATASET\nor unknown --> D[variableMappingList\npreserves langfuseObject]
    C --> E[safeParse variableMapping]
    D --> E
    E -- failure --> F[throw InternalServerError\nMapping is corrupted]
    E -- success --> G[filter to nextVariables]
    G --> H{missing variables?}
    H -- yes --> I[throw 409 conflict]
    H -- no --> J[return migratedVariableMapping]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/evals/server/unstable-public-api/evaluator-service.ts:28
**`targetObject` typed as `string` instead of `EvalTargetObject`**

The parameter is typed as `string`, but all callers pass a `config.targetObject` that comes from Prisma and should conform to the `EvalTargetObject` union. Narrowing this to `EvalTargetObject` would surface any future unrecognised values at compile time rather than silently falling through to the `variableMappingList` branch.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix-eval-upgrad..."](https://github.com/langfuse/langfuse/commit/2b9dd220ab17a2a014daacd685593f48208eca83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30474982)</sub>

<!-- /greptile_comment -->