### PR TITLE
fix(evals): validate evaluator mapping target server-side

### DIFF
--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -401,6 +401,54 @@ describe("evals trpc", () => {
     });
   });
 
+  describe("evals.createJob", () => {
+    it("rejects observation-only variable mappings for trace evaluators", async () => {
+      const { project, caller } = await prepare();
+
+      const evalTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: "trace-template",
+          version: 1,
+          prompt: "Score this response",
+          outputDefinition: createNumericEvalOutputDefinition({
+            reasoningDescription: "Why",
+            scoreDescription: "How good",
+          }),
+        },
+      });
+
+      await expect(
+        caller.evals.createJob({
+          projectId: project.id,
+          evalTemplateId: evalTemplate.id,
+          scoreName: "bad-trace-score",
+          target: EvalTargetObject.TRACE,
+          filter: [],
+          mapping: [
+            {
+              templateVariable: "input",
+              selectedColumnId: "input",
+              jsonSelector: null,
+            },
+          ],
+          sampling: 1,
+          delay: 0,
+          timeScope: ["NEW"],
+        }),
+      ).rejects.toThrow("Variable mapping does not match evaluator target.");
+
+      await expect(
+        prisma.jobConfiguration.findFirst({
+          where: {
+            projectId: project.id,
+            scoreName: "bad-trace-score",
+          },
+        }),
+      ).resolves.toBeNull();
+    });
+  });
+
   describe("evals.updateConfig", () => {
     it("should update an evaluator configuration", async () => {
       const { project, caller } = await prepare();
@@ -442,6 +490,59 @@ describe("evals trpc", () => {
       expect(updatedJob?.id).toEqual(evalJobConfig.id);
       expect(updatedJob?.status).toEqual("INACTIVE");
       expect(updatedJob?.timeScope).toEqual(["NEW"]);
+    });
+
+    it("rejects observation-only variable mapping updates for trace evaluators", async () => {
+      const { project, caller } = await prepare();
+
+      const traceVariableMapping = [
+        {
+          templateVariable: "input",
+          objectName: null,
+          langfuseObject: "trace",
+          selectedColumnId: "input",
+          jsonSelector: null,
+        },
+      ];
+
+      const evalJobConfig = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          scoreName: "test-score",
+          filter: [],
+          targetObject: EvalTargetObject.TRACE,
+          variableMapping: traceVariableMapping,
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+          timeScope: ["NEW"],
+        },
+      });
+
+      await expect(
+        caller.evals.updateEvalJob({
+          projectId: project.id,
+          evalConfigId: evalJobConfig.id,
+          config: {
+            variableMapping: [
+              {
+                templateVariable: "input",
+                selectedColumnId: "input",
+                jsonSelector: null,
+              },
+            ],
+          },
+        }),
+      ).rejects.toThrow("Variable mapping does not match evaluator target.");
+
+      const unchangedJob = await prisma.jobConfiguration.findUnique({
+        where: {
+          id: evalJobConfig.id,
+        },
+      });
+
+      expect(unchangedJob?.variableMapping).toEqual(traceVariableMapping);
     });
 
     it("when the evaluator ran on existing traces, time scope cannot be changed to NEW only", async () => {

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -52,7 +52,7 @@ import {
 } from "@/src/features/evals/utils/evaluator-form-utils";
 import { validateAndTransformVariableMapping } from "@/src/features/evals/utils/variable-mapping-validation";
 import { useVariableMappingSync } from "@/src/features/evals/hooks/useVariableMappingSync";
-import { EvalTargetObject } from "@langfuse/shared";
+import { EvalTargetObject, EvalTargetObjectSchema } from "@langfuse/shared";
 import { ExecutionCountTooltip } from "@/src/features/evals/components/execution-count-tooltip";
 import { Suspense, lazy } from "react";
 import {
@@ -335,6 +335,14 @@ export const InnerEvaluatorForm = (props: {
   } = useEvalConfigFilterOptions({ projectId: props.projectId });
 
   const targetState = useEvaluatorTargetState();
+  const defaultTargetResult = EvalTargetObjectSchema.safeParse(
+    props.existingEvaluator?.targetObject ??
+      props.defaultTarget ??
+      EvalTargetObject.EVENT,
+  );
+  const defaultTarget = defaultTargetResult.success
+    ? defaultTargetResult.data
+    : EvalTargetObject.EVENT;
 
   const form = useForm({
     resolver: zodResolver(evalConfigFormSchema),
@@ -342,20 +350,13 @@ export const InnerEvaluatorForm = (props: {
     defaultValues: {
       scoreName:
         props.existingEvaluator?.scoreName ?? `${props.evalTemplate.name}`,
-      target:
-        props.existingEvaluator?.targetObject ??
-        props.defaultTarget ??
-        EvalTargetObject.EVENT,
+      target: defaultTarget,
       filter: props.existingEvaluator?.filter
         ? z.array(singleFilter).parse(props.existingEvaluator.filter)
-        : (props.existingEvaluator?.targetObject ??
-              props.defaultTarget ??
-              EvalTargetObject.EVENT) === EvalTargetObject.TRACE
+        : defaultTarget === EvalTargetObject.TRACE
           ? // For new trace evaluators, exclude internal environments by default
             DEFAULT_TRACE_FILTER
-          : (props.existingEvaluator?.targetObject ??
-                props.defaultTarget ??
-                EvalTargetObject.EVENT) === EvalTargetObject.EVENT
+          : defaultTarget === EvalTargetObject.EVENT
             ? // For new observation evaluators, default to GENERATION type
               DEFAULT_OBSERVATION_FILTER
             : [],

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -26,6 +26,7 @@ import {
   orderBy,
   jsonSchema,
   EvalTargetObject,
+  EvalTargetObjectSchema,
 } from "@langfuse/shared";
 import {
   getQueue,
@@ -77,7 +78,7 @@ const ConfigWithTemplateSchema = z.object({
   projectId: z.string(),
   evalTemplateId: z.string(),
   scoreName: z.string(),
-  targetObject: z.string(),
+  targetObject: EvalTargetObjectSchema,
   filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   // Accept either full variableMapping (trace/dataset) or simplified observationVariableMapping (event/experiment)
   variableMapping: z.union([
@@ -156,7 +157,7 @@ const CreateEvalJobSchema = z.object({
   projectId: z.string(),
   evalTemplateId: z.string(),
   scoreName: z.string().min(1),
-  target: z.string(), // should be z.enum(["trace", "dataset-run-item"])
+  target: EvalTargetObjectSchema,
   filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   // Accept either full variableMapping (trace/dataset) or simplified observationVariableMapping (event/experiment)
   mapping: z.union([
@@ -181,6 +182,32 @@ const UpdateEvalJobSchema = z.object({
   status: z.enum(EvaluatorStatus).optional(),
   timeScope: z.array(JobTimeScopeZod).optional(),
 });
+
+const validateVariableMappingForTarget = ({
+  targetObject,
+  mapping,
+}: {
+  targetObject: string;
+  mapping: unknown;
+}) => {
+  const result =
+    targetObject === EvalTargetObject.EVENT ||
+    targetObject === EvalTargetObject.EXPERIMENT
+      ? z.array(observationVariableMapping).safeParse(mapping)
+      : targetObject === EvalTargetObject.TRACE ||
+          targetObject === EvalTargetObject.DATASET
+        ? z.array(variableMapping).safeParse(mapping)
+        : null;
+
+  if (!result?.success) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Variable mapping does not match evaluator target.",
+    });
+  }
+
+  return result.data;
+};
 
 const validateEvalTemplateCanRun = async ({
   prisma,
@@ -735,6 +762,11 @@ export const evalRouter = createTRPCRouter({
         throw new Error("Template not found");
       }
 
+      const variableMappingForTarget = validateVariableMappingForTarget({
+        targetObject: input.target,
+        mapping: input.mapping,
+      });
+
       const jobId = uuidv4();
       await auditLog({
         session: ctx.session,
@@ -752,7 +784,7 @@ export const evalRouter = createTRPCRouter({
           scoreName: input.scoreName,
           targetObject: input.target,
           filter: input.filter ?? [],
-          variableMapping: input.mapping,
+          variableMapping: variableMappingForTarget,
           sampling: input.sampling,
           delay: input.delay,
           status: input.status,
@@ -1142,6 +1174,18 @@ export const evalRouter = createTRPCRouter({
         });
       }
 
+      const validatedConfig = {
+        ...config,
+        ...(config.variableMapping !== undefined
+          ? {
+              variableMapping: validateVariableMappingForTarget({
+                targetObject: existingJob.targetObject,
+                mapping: config.variableMapping,
+              }),
+            }
+          : {}),
+      };
+
       await auditLog({
         session: ctx.session,
         resourceType: JOB_CONFIGURATION_AUDIT_LOG_RESOURCE_TYPE,
@@ -1171,8 +1215,10 @@ export const evalRouter = createTRPCRouter({
       }
 
       const updatedConfig = {
-        ...config,
-        ...(config.status !== undefined ? resetEvalConfigBlockFields : {}),
+        ...validatedConfig,
+        ...(validatedConfig.status !== undefined
+          ? resetEvalConfigBlockFields
+          : {}),
       };
 
       const updatedJob = await ctx.prisma.jobConfiguration.update({

--- a/web/src/features/evals/utils/evaluator-form-utils.ts
+++ b/web/src/features/evals/utils/evaluator-form-utils.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  EvalTargetObjectSchema,
   singleFilter,
   type langfuseObjects,
   TimeScopeSchema,
@@ -14,7 +15,7 @@ export const isLegacyEvalTarget = (target: string): boolean =>
 
 export const evalConfigFormSchema = z.object({
   scoreName: z.string(),
-  target: z.string(),
+  target: EvalTargetObjectSchema,
   filter: z.array(singleFilter).nullable(), // reusing the filter type from the tables
   mapping: z.array(wipVariableMapping),
   sampling: z.coerce.number().gt(0).lte(1),


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds server-side validation that the variable mapping type matches the evaluator target: observation-style mappings (no `langfuseObject`/`objectName`) are now rejected for TRACE/DATASET targets, and vice versa. It also tightens related Zod schemas from `z.string()` to `EvalTargetObjectSchema` across the router and form utilities, and refactors a repeated triple-fallback expression in the form component into a single validated `defaultTarget` variable.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the validation logic is correct, tests cover the key paths, and only P2 style concerns remain.

All findings are P2. The only noteworthy concern is that `existingJob.targetObject` from the DB is passed as a raw string to `validateVariableMappingForTarget`, so an unknown/legacy DB value would permanently break `updateEvalJob` for that config's variableMapping updates — but this is a theoretical edge case and the function correctly throws BAD_REQUEST rather than silently corrupting data.

No files require special attention; `router.ts` contains the new validation helper and is the most logic-heavy file.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/evals/server/router.ts | Adds `validateVariableMappingForTarget` helper and applies it in `createJob` and `updateEvalJob`; also tightens `targetObject` schema from `z.string()` to `EvalTargetObjectSchema` in `ConfigWithTemplateSchema` and `CreateEvalJobSchema`. |
| web/src/features/evals/utils/evaluator-form-utils.ts | Tightens `target` field in `evalConfigFormSchema` from `z.string()` to `EvalTargetObjectSchema`, aligning the client-side schema with the server. |
| web/src/features/evals/components/inner-evaluator-form.tsx | Refactors triple-repeated target fallback expression into a single `defaultTarget` variable with `safeParse` defensive validation; no functional changes to form behavior. |
| web/src/__tests__/server/evals-trpc.servertest.ts | Adds two server-side tests for the new validation: one for `createJob` rejecting observation-style mapping for a trace target, and one for `updateEvalJob` doing the same. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createJob / updateEvalJob request] --> B{input.target or existingJob.targetObject}
    B -->|EVENT or EXPERIMENT| C[z.array observationVariableMapping .safeParse mapping]
    B -->|TRACE or DATASET| D[z.array variableMapping .safeParse mapping]
    B -->|unknown string| E[result = null]
    C --> F{result.success?}
    D --> F
    E --> G[throw BAD_REQUEST: Variable mapping does not match evaluator target]
    F -->|false| G
    F -->|true| H[proceed with validated mapping]
    H --> I[auditLog + DB write]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/evals/server/router.ts:186-210
**`result` can be `null` but is never excluded from the `!result?.success` check**

When `targetObject` is an unknown string (e.g., a legacy value stored directly in the DB), `result` is `null`. `!null?.success` evaluates to `!undefined` → `true`, which correctly throws. However, the function parameter type is `string` rather than `EvalTargetObject`, so a caller could theoretically pass an unrecognized value. Because `targetObject` is now validated to be `EvalTargetObjectSchema` on the way in (for `createJob`), the `null` branch is unreachable there, but for `updateEvalJob` the value comes from the DB (`existingJob.targetObject`) without re-validation. This is fine for correctness (it will throw BAD_REQUEST), but it means a DB row with a stale/unknown target string permanently breaks `updateEvalJob` for that config — even updates that don't touch `variableMapping` at all (those skip this function). A narrow concern, but worth noting in a comment or narrowing the parameter type to `EvalTargetObject`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): validate evaluator mapping t..."](https://github.com/langfuse/langfuse/commit/17e7987d686f940a940b74cfb18a92ef5aec5274) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30487973)</sub>

<!-- /greptile_comment -->