### PR TITLE
refactor(prompts): minor code quality improvements.

### DIFF
--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -372,7 +372,7 @@ export class PromptService {
         resolvedPrompt,
       };
     } catch (err) {
-      console.error(err);
+      this.logError("Error building and resolving prompt graph", err);
 
       throw err;
     }

--- a/web/src/features/prompts/server/actions/createPrompt.ts
+++ b/web/src/features/prompts/server/actions/createPrompt.ts
@@ -107,7 +107,7 @@ export const createPrompt = async ({
     }
   }
 
-  const finalLabels = [...labels, LATEST_PROMPT_LABEL]; // Newly created prompts are always labeled as 'latest'
+  const finalLabels = [...new Set([...labels, LATEST_PROMPT_LABEL])]; // Newly created prompts are always labeled as 'latest'
 
   // If tags are undefined, use the tags from the latest prompt version
   const finalTags = [...new Set(tags ?? latestPrompt?.tags ?? [])];

--- a/web/src/features/prompts/server/actions/deletePrompt.ts
+++ b/web/src/features/prompts/server/actions/deletePrompt.ts
@@ -1,4 +1,8 @@
-import { InvalidRequestError, LangfuseNotFoundError } from "@langfuse/shared";
+import {
+  InvalidRequestError,
+  LangfuseNotFoundError,
+  LATEST_PROMPT_LABEL,
+} from "@langfuse/shared";
 import { prisma, type Prompt } from "@langfuse/shared/src/db";
 import { PromptService, redis } from "@langfuse/shared/src/server";
 
@@ -94,10 +98,10 @@ export const deletePrompt = async (params: DeletePromptParams) => {
   const promptService = new PromptService(prisma, redis);
 
   const deletingLatest = promptVersions.some((p) =>
-    p.labels.includes("latest"),
+    p.labels.includes(LATEST_PROMPT_LABEL),
   );
   const latestRemainsAfterDeletion = remainingVersions.some((v) =>
-    v.labels.includes("latest"),
+    v.labels.includes(LATEST_PROMPT_LABEL),
   );
 
   // reattach "latest" to highest remaining version
@@ -113,7 +117,9 @@ export const deletePrompt = async (params: DeletePromptParams) => {
     await prisma.prompt.update({
       where: { id: highestRemainingVersion.id },
       data: {
-        labels: [...new Set([...highestRemainingVersion.labels, "latest"])],
+        labels: [
+          ...new Set([...highestRemainingVersion.labels, LATEST_PROMPT_LABEL]),
+        ],
       },
     });
   }

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -1220,8 +1220,9 @@ export const promptRouter = createTRPCRouter({
         },
       });
 
+      const userMap = new Map(users.map((u) => [u.id, u]));
       const joinedPromptAndUsers = prompts.map((p) => {
-        const user = users.find((u) => u.id === p.createdBy);
+        const user = userMap.get(p.createdBy);
         if (!user && p.createdBy === "API") {
           return { ...p, creator: "API" };
         }


### PR DESCRIPTION
## Summary

This PR makes four small, non-breaking code quality improvements to the prompt
management feature.

### 1. Use structured logger in `PromptService.buildAndResolvePromptGraph`

`packages/shared/src/server/services/PromptService/index.ts`

The catch block in `buildAndResolvePromptGraph` used a bare `console.error(err)`
while the class already defines a `private logError()` method (used consistently
everywhere else) that prefixes messages with `[PromptService]` and routes through
the structured `logger` instance. This was an oversight that bypassed observability
tooling. Replaced with `this.logError("Error building and resolving prompt graph", err)`.

### 2. Replace `Array.find` with `Map` lookup in `allVersions` tRPC procedure

`web/src/features/prompts/server/routers/promptRouter.ts`

After fetching users in bulk, the join back to prompts used `users.find(u => u.id === p.createdBy)`
inside a `prompts.map(...)` — an O(n·m) scan. Replaced with a `Map` built once
from the users array, making each lookup O(1).

### 3. Replace `"latest"` string literals with `LATEST_PROMPT_LABEL` constant

`web/src/features/prompts/server/actions/deletePrompt.ts`

Three occurrences of the hardcoded string `"latest"` were used in `deletePrompt`
instead of the `LATEST_PROMPT_LABEL` constant already defined in `@langfuse/shared`
and used consistently across the rest of the codebase (including `createPrompt.ts`,
the router, etc.). Added the import and replaced all three occurrences, so a
future rename of the label value would be caught by a single change.

### 4. Deduplicate `finalLabels` using `Set` in `createPrompt`

`web/src/features/prompts/server/actions/createPrompt.ts`

`finalLabels` was built as `[...labels, LATEST_PROMPT_LABEL]`. If a caller already
included `"latest"` in their `labels` array, this produced a duplicate entry.
The line immediately below (`finalTags`) already used `new Set` for exactly this
reason. Made `finalLabels` consistent: `[...new Set([...labels, LATEST_PROMPT_LABEL])]`.

## Packages affected

- `packages/shared`
- `web`

## Verification

```bash
pnpm --filter web run lint
pnpm --filter @langfuse/shared run lint
pnpm run typecheck
pnpm --filter web exec dotenv -e ../.env.test -e ../.env -- \
  vitest run --project server \
  "src/__tests__/server/prompts-trpc.servertest.ts" \
  "src/__tests__/server/prompts.v1.servertest.ts" \
  "src/__tests__/server/prompts.v2.servertest.ts" \
  "src/__tests__/server/promptCache.servertest.ts"

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Four targeted code-quality improvements to prompt management: structured logging in `PromptService`, `Set`-based deduplication for `finalLabels` in `createPrompt`, `LATEST_PROMPT_LABEL` constant replacing hardcoded `"latest"` strings in `deletePrompt`, and an O(1) `Map` lookup replacing an O(n·m) `Array.find` in the `allVersions` tRPC procedure. All changes are non-breaking and functionally equivalent to the code they replace.

<h3>Confidence Score: 5/5</h3>

All four changes are safe, non-breaking refactors with no logic regressions introduced.

Every change is a well-scoped improvement: one is a pure logging fix, one eliminates a possible duplicate label, one substitutes a constant for a repeated string literal, and one is a performance-neutral algorithmic cleanup. No new code paths, no schema or API changes, and no security surface introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/services/PromptService/index.ts | Replaced bare `console.error(err)` with `this.logError(...)` to route through the structured logger consistently. |
| web/src/features/prompts/server/actions/createPrompt.ts | Wraps `finalLabels` construction in `new Set(...)` to deduplicate when the caller already includes `LATEST_PROMPT_LABEL` in `labels`, matching the existing `finalTags` pattern. |
| web/src/features/prompts/server/actions/deletePrompt.ts | Replaced three hardcoded `"latest"` string literals with `LATEST_PROMPT_LABEL` constant and added the import at the top of the module. |
| web/src/features/prompts/server/routers/promptRouter.ts | Replaced O(n·m) `Array.find` inside `prompts.map` with a pre-built `Map` for O(1) user lookups; logic is functionally equivalent. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(prompts): minor code quality im..."](https://github.com/langfuse/langfuse/commit/d3975d3f3d40609a13db45ec24313d95b14de8c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30491147)</sub>

<!-- /greptile_comment -->