### PR TITLE
fix: encode dataset name in navigation URLs to handle slashes

### DIFF
--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/StatusStep.tsx
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/StatusStep.tsx
@@ -13,6 +13,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { Check, AlertCircle } from "lucide-react";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 type StatusStepProps = {
   projectId: string;
@@ -200,7 +201,7 @@ export function StatusStep({
                 className="flex-1"
                 onClick={() =>
                   router.push(
-                    `/project/${projectId}/datasets/${encodeURIComponent(dataset.id)}/items`,
+                    `/project/${projectId}/datasets/${encodeDatasetPathSegment(dataset.id)}/items`,
                   )
                 }
               >

--- a/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetCompareRunsTable.tsx
@@ -29,6 +29,7 @@ import { type Prisma } from "@langfuse/shared";
 import { type EnrichedDatasetRunItem } from "@langfuse/shared/src/server";
 import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
 import { TablePeekViewTraceDetail } from "@/src/components/table/peek/peek-trace-detail";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 export type DatasetCompareRunRowData = {
   id: string;
@@ -142,7 +143,7 @@ function DatasetCompareRunsTableInternal(props: {
         const id: string = row.getValue("id");
         return (
           <TableLink
-            path={`/project/${props.projectId}/datasets/${props.datasetId}/items/${id}`}
+            path={`/project/${props.projectId}/datasets/${encodeDatasetPathSegment(props.datasetId)}/items/${id}`}
             value={id}
           />
         );

--- a/web/src/features/datasets/components/DatasetForm.tsx
+++ b/web/src/features/datasets/components/DatasetForm.tsx
@@ -34,6 +34,7 @@ import { useUniqueNameValidation } from "@/src/hooks/useUniqueNameValidation";
 import { DialogBody, DialogFooter } from "@/src/components/ui/dialog";
 import { DatasetSchemaInput } from "./DatasetSchemaInput";
 import { DatasetSchemaValidationError } from "./DatasetSchemaValidationError";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 type ServerSideSchemaValidationErrors = {
   datasetItemId: string;
@@ -289,7 +290,7 @@ export const DatasetForm = forwardRef<DatasetFormRef, DatasetFormProps>(
               form.reset();
               if (props.redirectOnSuccess !== false) {
                 router.push(
-                  `/project/${props.projectId}/datasets/${result.dataset.id}/items`,
+                  `/project/${props.projectId}/datasets/${encodeDatasetPathSegment(result.dataset.id)}/items`,
                 );
               }
             } else {

--- a/web/src/features/datasets/components/DatasetItemDetailPage.tsx
+++ b/web/src/features/datasets/components/DatasetItemDetailPage.tsx
@@ -30,6 +30,7 @@ import { useDatasetVersion } from "@/src/features/datasets/hooks/useDatasetVersi
 import { toDatasetSchema } from "@/src/features/datasets/utils/datasetItemUtils";
 import { useExperimentAccess } from "@/src/features/experiments/hooks/useExperimentAccess";
 import { ExperimentsBetaSwitch } from "@/src/features/experiments/components/ExperimentsBetaSwitch";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 export const DatasetItemDetailPage = ({
   activeTab,
@@ -81,7 +82,9 @@ export const DatasetItemDetailPage = ({
 
   const mutDelete = api.datasets.deleteDatasetItem.useMutation({
     onSuccess: () => {
-      router.push(`/project/${projectId}/datasets/${datasetId}/items`);
+      router.push(
+        `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/items`,
+      );
     },
   });
 
@@ -131,11 +134,11 @@ export const DatasetItemDetailPage = ({
           { name: "Datasets", href: `/project/${projectId}/datasets` },
           {
             name: dataset.data?.name ?? datasetId,
-            href: `/project/${projectId}/datasets/${datasetId}`,
+            href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`,
           },
           {
             name: "Items",
-            href: `/project/${projectId}/datasets/${datasetId}/items`,
+            href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/items`,
           },
         ],
         tabsProps: {
@@ -211,7 +214,7 @@ export const DatasetItemDetailPage = ({
             <DetailPageNav
               currentId={itemId}
               path={(entry) =>
-                `/project/${projectId}/datasets/${datasetId}/items/${entry.id}`
+                `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/items/${entry.id}`
               }
               listKey="datasetItems"
             />

--- a/web/src/features/datasets/components/DatasetItemsTable.tsx
+++ b/web/src/features/datasets/components/DatasetItemsTable.tsx
@@ -37,6 +37,7 @@ import { useDebounce } from "@/src/hooks/useDebounce";
 import { useFullTextSearch } from "@/src/components/table/use-cases/useFullTextSearch";
 import { useDatasetVersion } from "../hooks/useDatasetVersion";
 import { EditDatasetItemDialog } from "./EditDatasetItemDialog";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 type RowData = {
   id: string;
@@ -155,7 +156,7 @@ export function DatasetItemsTable({
           : "";
         return (
           <TableLink
-            path={`/project/${projectId}/datasets/${datasetId}/items/${id}${versionParam}`}
+            path={`/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/items/${id}${versionParam}`}
             value={id}
           />
         );

--- a/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunItemsByRunTable.tsx
@@ -24,6 +24,7 @@ import { type DatasetRunItemByRunRowData } from "@/src/features/datasets/lib/typ
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import { useQueryFilterState } from "@/src/features/filters/hooks/useFilterState";
 import { useDebounce } from "@/src/hooks/useDebounce";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 export function DatasetRunItemsByRunTable(props: {
   projectId: string;
@@ -108,7 +109,7 @@ export function DatasetRunItemsByRunTable(props: {
           : "";
         return (
           <TableLink
-            path={`/project/${props.projectId}/datasets/${props.datasetId}/items/${datasetItemId}${versionParam}`}
+            path={`/project/${props.projectId}/datasets/${encodeDatasetPathSegment(props.datasetId)}/items/${datasetItemId}${versionParam}`}
             value={datasetItemId}
           />
         );

--- a/web/src/features/datasets/components/DatasetRunsTable.tsx
+++ b/web/src/features/datasets/components/DatasetRunsTable.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/src/features/scores/lib/scoreColumns";
 import { getScoreLabelFromKey } from "@/src/features/scores/lib/aggregateScores";
 import { NoDataOrLoading } from "@/src/components/NoDataOrLoading";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 export type DatasetRunRowData = {
   id: string;
@@ -119,7 +120,7 @@ const DatasetRunTableMultiSelectAction = ({
           <Link
             key="compare"
             href={{
-              pathname: `/project/${projectId}/datasets/${datasetId}/compare`,
+              pathname: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/compare`,
               query: { runs: selectedRunIds },
             }}
           >
@@ -392,7 +393,7 @@ export function DatasetRunsTable(props: {
         const id: DatasetRunRowData["id"] = row.getValue("id");
         return (
           <TableLink
-            path={`/project/${props.projectId}/datasets/${props.datasetId}/runs/${id}`}
+            path={`/project/${props.projectId}/datasets/${encodeDatasetPathSegment(props.datasetId)}/runs/${id}`}
             value={name}
           />
         );
@@ -409,7 +410,7 @@ export function DatasetRunsTable(props: {
         const id: DatasetRunRowData["id"] = row.getValue("id");
         return (
           <TableLink
-            path={`/project/${props.projectId}/datasets/${props.datasetId}/runs/${id}`}
+            path={`/project/${props.projectId}/datasets/${encodeDatasetPathSegment(props.datasetId)}/runs/${id}`}
             value={id}
           />
         );

--- a/web/src/features/datasets/components/DatasetSchemaValidationError.tsx
+++ b/web/src/features/datasets/components/DatasetSchemaValidationError.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { Button } from "@/src/components/ui/button";
 import Link from "next/link";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 type ValidationError = {
   datasetItemId: string;
@@ -68,7 +69,7 @@ export const DatasetSchemaValidationError: React.FC<
                       #{idx + 1}
                     </span>
                     <Link
-                      href={`/project/${projectId}/datasets/${datasetId}/items/${error.datasetItemId}`}
+                      href={`/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/items/${error.datasetItemId}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="flex items-center gap-1 text-sm font-medium hover:underline"

--- a/web/src/features/datasets/components/DatasetsTable.tsx
+++ b/web/src/features/datasets/components/DatasetsTable.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/src/components/ui/dropdown-menu";
 import { DatasetActionButton } from "@/src/features/datasets/components/DatasetActionButton";
 import { DatasetSchemaHoverCard } from "@/src/features/datasets/components/DatasetSchemaHoverCard";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { api } from "@/src/utils/api";
 import { withDefault, useQueryParam, StringParam } from "use-query-params";
@@ -144,7 +145,7 @@ export function DatasetsTable(props: { projectId: string }) {
 
         return (
           <TableLink
-            path={`/project/${props.projectId}/datasets/${encodeURIComponent(key.id)}`}
+            path={`/project/${props.projectId}/datasets/${encodeDatasetPathSegment(key.id)}`}
             value={key.name}
           />
         );

--- a/web/src/features/datasets/components/DuplicateDatasetButton.tsx
+++ b/web/src/features/datasets/components/DuplicateDatasetButton.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/src/components/ui/button";
 import { api } from "@/src/utils/api";
 import { Copy } from "lucide-react";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 export const DuplicateDatasetButton: React.FC<{
   projectId: string;
@@ -15,7 +16,7 @@ export const DuplicateDatasetButton: React.FC<{
   });
   const duplicateDataset = api.datasets.duplicateDataset.useMutation({
     onSuccess: ({ id }) => {
-      router.push(`/project/${projectId}/datasets/${id}`);
+      router.push(`/project/${projectId}/datasets/${encodeDatasetPathSegment(id)}`);
     },
   });
 

--- a/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
@@ -25,6 +25,7 @@ import { parseJsonPrioritised } from "@langfuse/shared";
 import { ActionButton } from "@/src/components/ActionButton";
 import { type MetadataDomainClient } from "@/src/utils/clientSideDomainTypes";
 import { type Prisma } from "@langfuse/shared";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 /**
  * Component for creating a new dataset item from an existing object.
@@ -126,7 +127,7 @@ export const NewDatasetItemFromExistingObject = (props: {
                     asChild
                   >
                     <Link
-                      href={`/project/${props.projectId}/datasets/${datasetId}/items/${datasetItemId}`}
+                      href={`/project/${props.projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/items/${datasetItemId}`}
                     >
                       {datasetName}
                     </Link>

--- a/web/src/features/datasets/utils/encodeDatasetPathSegment.ts
+++ b/web/src/features/datasets/utils/encodeDatasetPathSegment.ts
@@ -1,0 +1,7 @@
+/**
+ * Encode a dataset identifier for use as a single URL path segment.
+ * Dataset names may contain `/` (folders UI); encoding avoids incorrect routing.
+ */
+export function encodeDatasetPathSegment(datasetId: string): string {
+  return encodeURIComponent(datasetId);
+}

--- a/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
+++ b/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
@@ -9,6 +9,7 @@ import {
   ExperimentOverviewField,
   ExperimentOverviewSectionHeading,
 } from "./ExperimentOverviewField";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 const isSafeHttpUrl = (value: string | undefined) => {
   if (!value) return false;
@@ -149,7 +150,7 @@ export function ExperimentOverviewPanel({
 
               <ExperimentOverviewField label="Dataset">
                 <Link
-                  href={`/project/${projectId}/datasets/${encodeURIComponent(experiment.datasetId)}`}
+                  href={`/project/${projectId}/datasets/${encodeDatasetPathSegment(experiment.datasetId)}`}
                   className="text-primary hover:underline"
                 >
                   {experiment.datasetName || experiment.datasetId}

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -31,6 +31,7 @@ import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrde
 import { GitCompareArrows, LightbulbIcon } from "lucide-react";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
 import Link from "next/link";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 import { TableActionMenu } from "@/src/features/table/components/TableActionMenu";
 import { type TableAction } from "@/src/features/table/types";
 import { Badge } from "@/src/components/ui/badge";
@@ -336,7 +337,7 @@ export default function ExperimentsTable({
 
         return (
           <Link
-            href={`/project/${projectId}/datasets/${encodeURIComponent(datasetId)}`}
+            href={`/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/web/src/features/navigation/utils/dataset-item-tabs.ts
+++ b/web/src/features/navigation/utils/dataset-item-tabs.ts
@@ -1,3 +1,5 @@
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
+
 export const DATASET_ITEM_TABS = {
   ITEM: "item",
   RUNS: "runs",
@@ -18,11 +20,11 @@ export const getDatasetItemTabs = ({
   {
     value: DATASET_ITEM_TABS.ITEM,
     label: "Item",
-    href: `/project/${projectId}/datasets/${datasetId}/items/${itemId}`,
+    href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/items/${itemId}`,
   },
   {
     value: DATASET_ITEM_TABS.RUNS,
     label: "Experiments",
-    href: `/project/${projectId}/datasets/${datasetId}/items/${itemId}/runs`,
+    href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/items/${itemId}/runs`,
   },
 ];

--- a/web/src/features/navigation/utils/dataset-run-compare-tabs.ts
+++ b/web/src/features/navigation/utils/dataset-run-compare-tabs.ts
@@ -1,4 +1,5 @@
 import { type ParsedUrlQuery } from "querystring";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 export const DATASET_RUN_COMPARE_TABS = {
   COMPARE: "compare",
@@ -15,13 +16,13 @@ export const getDatasetRunCompareTabs = (
   {
     value: DATASET_RUN_COMPARE_TABS.COMPARE,
     label: "Outputs",
-    href: `/project/${projectId}/datasets/${datasetId}/compare`,
+    href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/compare`,
     querySelector: (query: ParsedUrlQuery) => ({ runs: query.runs }),
   },
   {
     value: DATASET_RUN_COMPARE_TABS.CHARTS,
     label: "Charts",
-    href: `/project/${projectId}/datasets/${datasetId}/compare/charts`,
+    href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/compare/charts`,
     querySelector: (query: ParsedUrlQuery) => ({ runs: query.runs }),
   },
 ];

--- a/web/src/features/navigation/utils/dataset-tabs.ts
+++ b/web/src/features/navigation/utils/dataset-tabs.ts
@@ -1,3 +1,5 @@
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
+
 export const DATASET_TABS = {
   RUNS: "runs",
   ITEMS: "items",
@@ -10,12 +12,12 @@ export const getDatasetTabs = (projectId: string, datasetId: string) => {
     {
       value: DATASET_TABS.RUNS,
       label: "Experiments",
-      href: `/project/${projectId}/datasets/${datasetId}`,
+      href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`,
     },
     {
       value: DATASET_TABS.ITEMS,
       label: "Items",
-      href: `/project/${projectId}/datasets/${datasetId}/items`,
+      href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/items`,
     },
   ];
 };

--- a/web/src/features/prompts/components/prompt-detail.tsx
+++ b/web/src/features/prompts/components/prompt-detail.tsx
@@ -46,6 +46,7 @@ import {
 import { CreateExperimentsForm } from "@/src/features/experiments/components/CreateExperimentsForm";
 import { useMemo, useState } from "react";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 import { DuplicatePromptButton } from "@/src/features/prompts/components/duplicate-prompt";
 import Page from "@/src/components/layouts/page";
 import {
@@ -213,7 +214,7 @@ export const PromptDetail = ({
       description: "Waiting for experiment to complete...",
       link: {
         text: "View experiment",
-        href: `/project/${projectId}/datasets/${data.datasetId}/compare?runs=${data.runId}`,
+        href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(data.datasetId)}/compare?runs=${data.runId}`,
       },
     });
   };

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare/charts.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare/charts.tsx
@@ -45,6 +45,7 @@ import { useExperimentAccess } from "@/src/features/experiments/hooks/useExperim
 import { ExperimentsBetaSwitch } from "@/src/features/experiments/components/ExperimentsBetaSwitch";
 import { toExperimentsResultsUrl } from "@/src/features/experiments/utils/experimentUrlTranslation";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 export default function DatasetCompare() {
   const router = useRouter();
@@ -131,7 +132,7 @@ export default function DatasetCompare() {
             },
             {
               name: dataset.data?.name ?? datasetId,
-              href: `/project/${projectId}/datasets/${datasetId}`,
+              href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`,
             },
           ],
           actionButtonsLeft: betaSwitch,
@@ -159,7 +160,7 @@ export default function DatasetCompare() {
           },
           {
             name: dataset.data?.name ?? datasetId,
-            href: `/project/${projectId}/datasets/${datasetId}`,
+            href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`,
           },
         ],
         help: {

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/compare/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/compare/index.tsx
@@ -28,6 +28,7 @@ import { toExperimentsResultsUrl } from "@/src/features/experiments/utils/experi
 import { useExperimentAccess } from "@/src/features/experiments/hooks/useExperimentAccess";
 import { ExperimentsBetaSwitch } from "@/src/features/experiments/components/ExperimentsBetaSwitch";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 function DatasetCompareInternal() {
   const router = useRouter();
@@ -132,7 +133,7 @@ function DatasetCompareInternal() {
             },
             {
               name: dataset.data?.name ?? datasetId,
-              href: `/project/${projectId}/datasets/${datasetId}`,
+              href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`,
             },
           ],
           tabsProps: {
@@ -160,7 +161,7 @@ function DatasetCompareInternal() {
           },
           {
             name: dataset.data?.name ?? datasetId,
-            href: `/project/${projectId}/datasets/${datasetId}`,
+            href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`,
           },
         ],
         help: {

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/index.tsx
@@ -42,6 +42,7 @@ import { EvaluatorForm } from "@/src/features/evals/components/evaluator-form";
 import useLocalStorage from "@/src/components/useLocalStorage";
 import { getDatasetBreadcrumb } from "@/src/features/datasets/utils/getDatasetBreadcrumb";
 import { ExperimentsTable } from "@/src/features/experiments/components/table";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 export default function Dataset() {
   const router = useRouter();
@@ -106,7 +107,7 @@ export default function Dataset() {
       description: "Waiting for experiment to complete...",
       link: {
         text: "View experiment",
-        href: `/project/${projectId}/datasets/${data.datasetId}/compare?runs=${data.runId}`,
+        href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(data.datasetId)}/compare?runs=${data.runId}`,
       },
     });
   };
@@ -310,7 +311,9 @@ export default function Dataset() {
 
             <DetailPageNav
               currentId={datasetId}
-              path={(entry) => `/project/${projectId}/datasets/${entry.id}`}
+              path={(entry) =>
+                `/project/${projectId}/datasets/${encodeDatasetPathSegment(entry.id)}`
+              }
               listKey="datasets"
             />
             <DropdownMenu>

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/items/index.tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/items/index.tsx
@@ -29,6 +29,7 @@ import { useDatasetVersion } from "@/src/features/datasets/hooks/useDatasetVersi
 import { useExperimentAccess } from "@/src/features/experiments/hooks/useExperimentAccess";
 import { ExperimentsBetaSwitch } from "@/src/features/experiments/components/ExperimentsBetaSwitch";
 import { getDatasetBreadcrumb } from "@/src/features/datasets/utils/getDatasetBreadcrumb";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 function DatasetItemsView() {
   const router = useRouter();
@@ -112,7 +113,7 @@ function DatasetItemsView() {
             <DetailPageNav
               currentId={datasetId}
               path={(entry) =>
-                `/project/${projectId}/datasets/${entry.id}/items/`
+                `/project/${projectId}/datasets/${encodeDatasetPathSegment(entry.id)}/items/`
               }
               listKey="datasets"
             />

--- a/web/src/pages/project/[projectId]/datasets/[datasetId]/runs/[runId].tsx
+++ b/web/src/pages/project/[projectId]/datasets/[datasetId]/runs/[runId].tsx
@@ -27,6 +27,7 @@ import { useExperimentAccess } from "@/src/features/experiments/hooks/useExperim
 import { ExperimentsBetaSwitch } from "@/src/features/experiments/components/ExperimentsBetaSwitch";
 import { singleRunToExperimentsUrl } from "@/src/features/experiments/utils/experimentUrlTranslation";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { encodeDatasetPathSegment } from "@/src/features/datasets/utils/encodeDatasetPathSegment";
 
 export default function Dataset() {
   const router = useRouter();
@@ -82,11 +83,11 @@ export default function Dataset() {
             { name: "Datasets", href: `/project/${projectId}/datasets` },
             {
               name: dataset.data?.name ?? datasetId,
-              href: `/project/${projectId}/datasets/${datasetId}`,
+              href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`,
             },
             {
               name: "Experiments",
-              href: `/project/${projectId}/datasets/${datasetId}`,
+              href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`,
             },
           ],
           actionButtonsLeft: betaSwitch,
@@ -108,11 +109,11 @@ export default function Dataset() {
           { name: "Datasets", href: `/project/${projectId}/datasets` },
           {
             name: dataset.data?.name ?? datasetId,
-            href: `/project/${projectId}/datasets/${datasetId}`,
+            href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`,
           },
           {
             name: "Experiments",
-            href: `/project/${projectId}/datasets/${datasetId}`,
+            href: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`,
           },
         ],
         actionButtonsLeft: betaSwitch,
@@ -120,7 +121,7 @@ export default function Dataset() {
           <>
             <Link
               href={{
-                pathname: `/project/${projectId}/datasets/${datasetId}/compare`,
+                pathname: `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/compare`,
                 query: { runs: [runId] },
               }}
             >
@@ -132,7 +133,7 @@ export default function Dataset() {
             <DetailPageNav
               currentId={runId}
               path={(entry) =>
-                `/project/${projectId}/datasets/${datasetId}/runs/${entry.id}`
+                `/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/runs/${entry.id}`
               }
               listKey="datasetRuns"
             />
@@ -148,7 +149,7 @@ export default function Dataset() {
                     projectId={projectId}
                     datasetRunId={runId}
                     datasetId={datasetId}
-                    redirectUrl={`/project/${projectId}/datasets/${datasetId}`}
+                    redirectUrl={`/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}`}
                   />
                 </DropdownMenuItem>
               </DropdownMenuContent>
@@ -182,7 +183,7 @@ export default function Dataset() {
                   <div className="flex flex-col gap-2 p-1">
                     <span className="text-sm font-medium">Dataset Version</span>
                     <Link
-                      href={`/project/${projectId}/datasets/${datasetId}/items?version=${run.data.datasetVersion.toISOString()}`}
+                      href={`/project/${projectId}/datasets/${encodeDatasetPathSegment(datasetId)}/items?version=${run.data.datasetVersion.toISOString()}`}
                       className="text-accent-dark-blue hover:text-primary-accent/60 text-sm"
                     >
                       <LocalIsoDate date={run.data.datasetVersion} />


### PR DESCRIPTION
## Summary

Fixes #13039

Dataset names containing forward slashes (from the folders feature) cause 404 errors when navigating to dataset items, because the unencoded slash splits the URL path into additional route segments.

## Root Cause

URLs like `/datasets/myDataset/golden/items/123` are ambiguous — the router interprets `golden` as a sub-path. The dataset name needs to be encoded as `myDataset%2Fgolden` to be treated as a single path segment.

## Fix

Applied `encodeURIComponent()` to dataset names when constructing navigation URLs, ensuring slashes and other special characters are properly encoded.

## Testing

- Dataset names with slashes now navigate correctly
- Dataset names without special characters continue to work unchanged

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes navigation 404s for dataset names containing forward slashes (the "folders" feature) by wrapping `encodeURIComponent` in a new `encodeDatasetPathSegment` utility and applying it consistently across all 23 files that construct dataset navigation URLs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is mechanically consistent, covers all dataset navigation paths, and correctly uses encodeURIComponent which Next.js's pages router will decode back to the original dataset ID.

All 23 changed files apply the same straightforward encoding via a thin, centralized utility. No unencoded dataset URL paths were found elsewhere in the codebase. The encoding/decoding roundtrip through Next.js's router is correct. No logic regressions or security concerns were identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/datasets/utils/encodeDatasetPathSegment.ts | New utility that wraps encodeURIComponent for dataset path segments — clean, minimal, and centralizes the encoding logic. |
| web/src/features/navigation/utils/dataset-tabs.ts | Tab href helpers updated to encode datasetId; encoding applied to both RUNS and ITEMS tab paths. |
| web/src/features/navigation/utils/dataset-item-tabs.ts | Item tab paths (ITEM and RUNS) now use encodeDatasetPathSegment for the datasetId segment. |
| web/src/features/navigation/utils/dataset-run-compare-tabs.ts | Compare and Charts tab paths now encode the datasetId segment correctly. |
| web/src/pages/project/[projectId]/datasets/[datasetId]/runs/[runId].tsx | All dataset navigation URLs in the run detail page now encode the datasetId segment. |
| web/src/features/datasets/components/DatasetRunsTable.tsx | Encoding applied to runs table links and compare multi-select action; two TableLink paths updated. |
| web/src/features/datasets/components/DatasetItemDetailPage.tsx | All four navigation URLs (delete redirect, breadcrumbs, DetailPageNav path) updated with encodeDatasetPathSegment. |
| web/src/features/batch-actions/components/AddObservationsToDatasetDialog/StatusStep.tsx | Replaces encodeURIComponent with the new utility; functionally identical but consistent with the rest of the codebase. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Dataset name: 'myDataset/golden'"] --> B["encodeDatasetPathSegment(datasetId)"]
    B --> C["encodeURIComponent → 'myDataset%2Fgolden'"]
    C --> D["URL: /project/pid/datasets/myDataset%2Fgolden/items"]
    D --> E["Next.js router matches [datasetId]"]
    E --> F["router.query.datasetId = 'myDataset/golden' (decoded)"]
    F --> G["API call: datasets.byId({ datasetId: 'myDataset/golden' })"]
```

<sub>Reviews (1): Last reviewed commit: ["fix: encode dataset name in navigation U..."](https://github.com/langfuse/langfuse/commit/eb799d506489476596b14c43cf707522b0298f90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30495148)</sub>

<!-- /greptile_comment -->