### PR TITLE
fix(batch-actions): compute count subject to searchQuery and searchType

### DIFF
--- a/web/src/features/batch-actions/server/addToDatasetRouter.ts
+++ b/web/src/features/batch-actions/server/addToDatasetRouter.ts
@@ -46,6 +46,8 @@ export const addToDatasetRouter = createTRPCRouter({
         const queryOpts = {
           projectId,
           filter: query.filter ?? [],
+          searchQuery: query.searchQuery,
+          searchType: query.searchType,
           limit: 1,
           offset: 0,
         };


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes the observation count check in `addToDatasetRouter.ts` to include `searchQuery` and `searchType` when computing how many items match a batch action, bringing it into parity with `runEvaluationRouter.ts` which already passes those fields. Before the fix, a user who filtered by a search query could be incorrectly rejected—the count would include all filter-matching observations, not just those narrowed by the search, potentially exceeding `MAX_BATCH_ADD_TO_DATASET_ITEMS` even when the actual scoped result set was well within the limit.

<h3>Confidence Score: 5/5</h3>

Safe to merge — isolated, correct fix with no new logic or side effects.

The change is minimal (two lines added to an existing object literal), the `ObservationTableQuery` type already accepts `searchQuery` and `searchType`, and the identical pattern already exists in `runEvaluationRouter.ts`. No issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/batch-actions/server/addToDatasetRouter.ts | Adds `searchQuery` and `searchType` to `queryOpts` so the pre-flight observation count correctly accounts for search filters; no issues found. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant addToDatasetRouter
    participant CountFn as getObservationsCount*
    participant ClickHouse

    Client->>addToDatasetRouter: create({ projectId, query: { filter, searchQuery, searchType }, config })
    addToDatasetRouter->>CountFn: queryOpts = { projectId, filter, searchQuery, searchType, limit:1, offset:0 }
    Note over addToDatasetRouter,CountFn: Previously missing searchQuery/searchType (bug)
    CountFn->>ClickHouse: SELECT count() WHERE filter AND searchQuery
    ClickHouse-->>CountFn: count
    CountFn-->>addToDatasetRouter: observationCount
    alt observationCount > MAX (1000)
        addToDatasetRouter-->>Client: TRPCError BAD_REQUEST
    else within limit
        addToDatasetRouter->>addToDatasetRouter: create batchAction record
        addToDatasetRouter->>addToDatasetRouter: enqueue BatchActionProcessingJob
        addToDatasetRouter-->>Client: { id: batchAction.id }
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(batch-actions): compute count subjec..."](https://github.com/langfuse/langfuse/commit/3a9bb337ec8c82f107a74ab86742b955d888afa7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30654775)</sub>

<!-- /greptile_comment -->