### PR TITLE
chore: upgrade bullmq to 5.76.3

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -100,7 +100,7 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "bcryptjs": "^2.4.3",
-    "bullmq": "^5.73.5",
+    "bullmq": "^5.76.3",
     "date-fns": "^3.6.0",
     "dd-trace": "5.97.0",
     "decimal.js": "^10.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
         version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -206,8 +206,8 @@ importers:
         specifier: ^2.4.3
         version: 2.4.3
       bullmq:
-        specifier: ^5.73.5
-        version: 5.73.5
+        specifier: ^5.76.3
+        version: 5.76.3
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
@@ -246,7 +246,7 @@ importers:
         version: 11.2.7
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nodemailer:
         specifier: ^7.0.11
         version: 7.0.11
@@ -325,7 +325,7 @@ importers:
         version: 0.0.4
       '@appsignal/opentelemetry-instrumentation-bullmq':
         specifier: ^0.8.0
-        version: 0.8.0(bullmq@5.73.5)
+        version: 0.8.0(bullmq@5.76.3)
       '@baselime/trpc-opentelemetry-middleware':
         specifier: ^0.1.2
         version: 0.1.2(@opentelemetry/api@1.9.0)(@trpc/server@11.13.4(typescript@5.9.2))
@@ -543,8 +543,8 @@ importers:
         specifier: ^2.4.3
         version: 2.4.3
       bullmq:
-        specifier: ^5.73.5
-        version: 5.73.5
+        specifier: ^5.76.3
+        version: 5.76.3
       chroma-js:
         specifier: ^3.1.2
         version: 3.1.2
@@ -622,7 +622,7 @@ importers:
         version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-query-params:
         specifier: ^5.1.0
         version: 5.1.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(use-query-params@2.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -839,7 +839,7 @@ importers:
         version: 0.0.4
       '@appsignal/opentelemetry-instrumentation-bullmq':
         specifier: ^0.8.0
-        version: 0.8.0(bullmq@5.73.5)
+        version: 0.8.0(bullmq@5.76.3)
       '@aws-sdk/client-s3':
         specifier: ^3.1013.0
         version: 3.1024.0
@@ -889,8 +889,8 @@ importers:
         specifier: ^2.5.0
         version: 2.5.0
       bullmq:
-        specifier: ^5.73.5
-        version: 5.73.5
+        specifier: ^5.76.3
+        version: 5.76.3
       cors:
         specifier: ^2.8.5
         version: 2.8.6
@@ -5804,8 +5804,9 @@ packages:
   buffer@5.6.0:
     resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
-  bullmq@5.73.5:
-    resolution: {integrity: sha512-bZu3t1c/1smbA8Jk46OrLA4JRHPTv4uLbqUP0uaviV7S4c/rSl/qKmg3twgKKz+3aB4E0NL0jcjQW5eHwGyQOw==}
+  bullmq@5.76.3:
+    resolution: {integrity: sha512-UBICMeWLYa+Dz7IGBNebXApQ1OIxNd4t6nX+AFPQ5gFA3sosW34PENe8Q1cvbjcbMTaU3xrKPorb6tM1czRSsw==}
+    engines: {node: '>=12.22.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -10625,14 +10626,14 @@ snapshots:
       '@types/node': 18.19.123
       tiktoken: 1.0.20
 
-  '@appsignal/opentelemetry-instrumentation-bullmq@0.8.0(bullmq@5.73.5)':
+  '@appsignal/opentelemetry-instrumentation-bullmq@0.8.0(bullmq@5.76.3)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
       flat: 5.0.2
     optionalDependencies:
-      bullmq: 5.73.5
+      bullmq: 5.76.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12846,7 +12847,7 @@ snapshots:
   '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@prisma/client': 6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2)
-      next-auth: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-auth: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   '@next/env@16.2.4': {}
 
@@ -16362,7 +16363,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bullmq@5.73.5:
+  bullmq@5.76.3:
     dependencies:
       cron-parser: 4.9.0
       ioredis: 5.10.1
@@ -16370,7 +16371,6 @@ snapshots:
       node-abort-controller: 3.1.1
       semver: 7.7.4
       tslib: 2.8.1
-      uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17232,7 +17232,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -19728,7 +19728,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.4(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@babel/runtime': 7.29.2
       '@panva/hkdf': 1.2.1

--- a/web/package.json
+++ b/web/package.json
@@ -99,7 +99,7 @@
     "@uiw/codemirror-themes": "^4.23.7",
     "@uiw/react-codemirror": "^4.25.8",
     "bcryptjs": "^2.4.3",
-    "bullmq": "^5.73.5",
+    "bullmq": "^5.76.3",
     "chroma-js": "^3.1.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/worker/package.json
+++ b/worker/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/sdk-node": "^0.213.0",
     "@prisma/instrumentation": "^6.19.3",
     "backoff": "^2.5.0",
-    "bullmq": "^5.73.5",
+    "bullmq": "^5.76.3",
     "cors": "^2.8.5",
     "csv-parse": "^5.6.0",
     "dd-trace": "5.97.0",


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR upgrades `bullmq` from `^5.73.5` to `^5.76.3` consistently across `packages/shared`, `web`, and `worker`. The version range between 5.73.5 and 5.76.3 contains no breaking changes (the 5.76.0 release notes explicitly state "nothing changed" for Node.js — it was triggered by a Python version release), and the `uuid` package dependency was dropped internally in favour of `crypto.randomUUID()`, which is transparent to consumers. The only minor concern is some incidental peer-dependency resolution-string changes in `pnpm-lock.yaml` for `next-auth` and `eslint-plugin-import` that appear to be pnpm re-resolution side-effects unrelated to the stated change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minor patch-level bump with no breaking changes for Node.js consumers.

The bullmq upgrade is a well-scoped, non-breaking patch/minor bump with consistent version ranges across all three consuming packages. The only finding is a P2 style observation about incidental lockfile changes, which does not block merging.

pnpm-lock.yaml — verify the incidental next-auth and eslint-plugin-import peer-dep resolution changes are benign.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/package.json | Bumps bullmq from ^5.73.5 to ^5.76.3 — straightforward version range update. |
| web/package.json | Bumps bullmq from ^5.73.5 to ^5.76.3 — consistent with the other package.json changes. |
| worker/package.json | Bumps bullmq from ^5.73.5 to ^5.76.3 — consistent with the other package.json changes. |
| pnpm-lock.yaml | Lockfile reflects the bullmq bump (5.73.5→5.76.3, uuid dep removed) plus incidental peer-dep resolution changes in next-auth and eslint-plugin-import that are unrelated to the stated intent of the PR. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm install / pnpm update bullmq] --> B[bullmq 5.73.5 → 5.76.3]
    B --> C[packages/shared/package.json]
    B --> D[web/package.json]
    B --> E[worker/package.json]
    B --> F[pnpm-lock.yaml]
    F --> G[uuid dep dropped from bullmq snapshot
 uses crypto.randomUUID internally]
    F --> H[appsignal bullmq instrumentation
peer dep updated to 5.76.3]
    F --> I[Incidental lockfile changes
next-auth + eslint-plugin-import
peer dep resolution strings updated]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
pnpm-lock.yaml:63-67
**Unintended lockfile peer-dep resolution changes**

The lockfile contains resolution-string changes for `next-auth` and `eslint-plugin-import` that are unrelated to the bullmq bump. Specifically, `@babel/core@7.29.0` and `babel-plugin-macros@3.1.0` were dropped from `next`'s peer-dep resolution key in the `next-auth` snapshot, and `@typescript-eslint/parser@8.58.0` was dropped from `eslint-plugin-import`'s key. These look like incidental pnpm re-resolution side-effects; it's worth confirming they are intentional and that no Babel-dependent Next.js features are affected in CI.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/upgrade-b..."](https://github.com/langfuse/langfuse/commit/77981e4879577d6f9f793cb0bed0667c69b5418b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30656952)</sub>

<!-- /greptile_comment -->