### PR TITLE
chore(deps): upgrade uuid v9 → v14 

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -119,7 +119,7 @@
     "oci-objectstorage": "^2.125.0",
     "safe-regex2": "^5.0.0",
     "undici": "^7.24.6",
-    "uuid": "^9.0.1",
+    "uuid": "^14.0.0",
     "winston": "^3.15.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,8 +266,8 @@ importers:
         specifier: ^7.24.6
         version: 7.25.0
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^14.0.0
+        version: 14.0.0
       winston:
         specifier: ^3.15.0
         version: 3.15.0
@@ -726,14 +726,14 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^14.0.0
+        version: 14.0.0
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       vis-network:
         specifier: ^9.1.13
-        version: 9.1.13(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@9.0.1)(vis-data@7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+        version: 9.1.13(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@14.0.0)(vis-data@7.1.9(uuid@14.0.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -940,8 +940,8 @@ importers:
         specifier: ^1.0.20
         version: 1.0.20
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^14.0.0
+        version: 14.0.0
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -10229,6 +10229,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -10239,17 +10240,23 @@ packages:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
   uuid@3.3.3:
     resolution: {integrity: sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -21744,6 +21751,8 @@ snapshots:
 
   uuid@13.0.0: {}
 
+  uuid@14.0.0: {}
+
   uuid@3.3.3: {}
 
   uuid@8.3.2: {}
@@ -21803,18 +21812,18 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vis-data@7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
+  vis-data@7.1.9(uuid@14.0.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
     dependencies:
-      uuid: 9.0.1
+      uuid: 14.0.0
       vis-util: 5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)
 
-  vis-network@9.1.13(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@9.0.1)(vis-data@7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
+  vis-network@9.1.13(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@14.0.0)(vis-data@7.1.9(uuid@14.0.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       component-emitter: 1.3.1
       keycharm: 0.4.0
-      uuid: 9.0.1
-      vis-data: 7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+      uuid: 14.0.0
+      vis-data: 7.1.9(uuid@14.0.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
       vis-util: 5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)
 
   vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1):

--- a/web/package.json
+++ b/web/package.json
@@ -160,7 +160,7 @@
     "tailwindcss-animate": "^1.0.7",
     "unified": "^11.0.5",
     "use-query-params": "^2.2.2",
-    "uuid": "^9.0.1",
+    "uuid": "^14.0.0",
     "vaul": "^1.1.2",
     "vis-network": "^9.1.13",
     "zod": "^4.3.6"

--- a/worker/package.json
+++ b/worker/package.json
@@ -64,7 +64,7 @@
     "posthog-node": "^5.8.4",
     "stripe": "^17.4.0",
     "tiktoken": "^1.0.20",
-    "uuid": "^9.0.1",
+    "uuid": "^14.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

## uuid v14 compatibility

- Import API unchanged: `import { v4 } from "uuid"` still works
- Requires Node 20+ — we run Node 24 in both dev and Docker
- ESM-only since v12 — compatible with our build setup

## Verification

- `pnpm install` — clean
- `pnpm run typecheck` — 7/7 tasks successful
- `pnpm run lint` — 4/4 tasks successful

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR upgrades `uuid` from `^9.0.1` to `^14.0.0` across `web`, `worker`, and `packages/shared` to address a Snyk security alert, and dismisses 13 non-exploitable Snyk findings. All call sites use ESM `import` syntax, so the ESM-only restriction in uuid@12+ is satisfied; on the worker the Node 24 CJS-ESM interop handles any compiled-CJS `require()` calls transparently.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only finding is a P2 peer-dependency range violation in vis-data that is masked by Next.js bundling in practice.

No P0 or P1 issues found. The single P2 note (vis-data@7.1.9 peer range excludes uuid@10+) does not cause a runtime failure given Next.js webpack bundling and Node 24 CJS-ESM interop. All uuid usages are ESM imports, typecheck and lint passed.

pnpm-lock.yaml — vis-data/vis-network peer dependency resolution with uuid@14 outside declared range

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/package.json | uuid bumped from ^9.0.1 to ^14.0.0; straightforward dependency version change |
| web/package.json | uuid bumped from ^9.0.1 to ^14.0.0; vis-network also depends on uuid@14 via peer dep resolution, which technically violates vis-data@7.1.9's peer range |
| worker/package.json | uuid bumped to ^14.0.0; worker has no "type": "module" but uses Node 24 CJS-ESM interop, so require() of ESM uuid@14 should work at runtime |
| pnpm-lock.yaml | Lockfile correctly updated to uuid@14.0.0; vis-data@7.1.9 and vis-network@9.1.13 now peer-resolved to uuid@14.0.0, which is outside vis-data's declared peer range (^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0) |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[uuid v9 to v14 upgrade] --> B{Consumer}
    B -->|web| C[Next.js webpack bundles uuid]
    B -->|worker| D[tsc NodeNext compiles to CJS]
    C --> E[vis-data peer dep mismatch
uuid v14 outside declared range]
    E --> F[Webpack bundling masks mismatch
in browser - works OK]
    D --> G[Node 24 CJS-ESM interop
allows require of sync ESM]
    G --> H[Worker starts successfully]
    F --> I[Browser renders correctly]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
pnpm-lock.yaml:21815-21821
**vis-data peer dependency range violated by uuid@14**

`vis-data@7.1.9` declares its peer dependency as `uuid@"^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"` — uuid@14 falls outside this range ([open issue](https://github.com/visjs/vis-data/issues/1154)). pnpm silently resolves it anyway. In the browser context Next.js bundles everything so webpack's ESM/CJS interop saves you, but if vis-data internally calls `require('uuid')` in any SSR or server-component path the Node.js runtime would still need CJS-ESM interop (available on Node 24, but worth being aware of). Consider pinning `vis-network` to a newer release that widens its uuid peer range, or adding a `pnpm.peerDependencyRules.ignoreMissing` entry to make the intentional override explicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into claude/clever-w..."](https://github.com/langfuse/langfuse/commit/2206e9c71c559f70266b2db92a61a8992de47a06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30659607)</sub>

<!-- /greptile_comment -->