### PR TITLE
fix(organizations): add margin to separator when no project is selected

### DIFF
--- a/web/src/features/organizations/components/ProjectOverview.tsx
+++ b/web/src/features/organizations/components/ProjectOverview.tsx
@@ -322,7 +322,7 @@ export const OrganizationProjectOverview = () => {
         .map((org) => (
           <Fragment key={org.id}>
             {!queryOrgId && org.id === env.NEXT_PUBLIC_DEMO_ORG_ID && (
-              <Separator />
+              <Separator className="my-4" />
             )}
             <SingleOrganizationProjectOverviewTile
               orgId={org.id}


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Adds `className="my-4"` to the `Separator` component rendered between regular organizations and the demo organization on the project overview page, fixing missing vertical margin when no project is selected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — trivial one-line UI styling fix with no logic changes.

The change is a single className addition to a visual separator, with no effect on logic, state, or data flow.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/organizations/components/ProjectOverview.tsx | Single-line Tailwind margin fix — adds `my-4` to the `Separator` shown before the demo org when no org is selected. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OrganizationProjectOverview renders] --> B{queryOrgId set?}
    B -- No --> C{org.id === DEMO_ORG_ID?}
    C -- Yes --> D["<Separator className='my-4' />"]
    D --> E[SingleOrganizationProjectOverviewTile]
    C -- No --> E
    B -- Yes --> E
```

<sub>Reviews (1): Last reviewed commit: ["fix(organizations): add margin to separa..."](https://github.com/langfuse/langfuse/commit/eabce3e3aeb0b24600c20dc28eeea6c629b79a17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30662258)</sub>

<!-- /greptile_comment -->