### PR TITLE
chore(deps): remove redundant @types/uuid devDependency

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -119,7 +119,7 @@
     "oci-objectstorage": "^2.125.0",
     "safe-regex2": "^5.0.0",
     "undici": "^7.24.6",
-    "uuid": "^9.0.1",
+    "uuid": "^14.0.0",
     "winston": "^3.15.0",
     "zod": "^4.3.6"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -131,7 +131,6 @@
     "@types/nodemailer": "^7.0.11",
     "@types/pg": "^8.11.10",
     "@types/react": "19.2.14",
-    "@types/uuid": "^9.0.8",
     "eslint": "^9.39.2",
     "prettier": "^3.8.3",
     "prisma": "^6.19.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,9 +296,6 @@ importers:
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
-      '@types/uuid':
-        specifier: ^9.0.8
-        version: 9.0.8
       eslint:
         specifier: ^9.39.2
         version: 9.39.4(jiti@2.6.1)
@@ -789,9 +786,6 @@ importers:
       '@types/react-grid-layout':
         specifier: ^1.3.6
         version: 1.3.6
-      '@types/uuid':
-        specifier: ^9.0.8
-        version: 9.0.8
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260122.3
         version: 7.0.0-dev.20260122.3
@@ -970,9 +964,6 @@ importers:
       '@types/pg':
         specifier: ^8.11.10
         version: 8.15.6
-      '@types/uuid':
-        specifier: ^9.0.8
-        version: 9.0.8
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260122.3
         version: 7.0.0-dev.20260122.3
@@ -5143,9 +5134,6 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -15613,8 +15601,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@types/yargs-parser@21.0.3':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,8 +266,8 @@ importers:
         specifier: ^7.24.6
         version: 7.25.0
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^14.0.0
+        version: 14.0.0
       winston:
         specifier: ^3.15.0
         version: 3.15.0
@@ -726,14 +726,14 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^14.0.0
+        version: 14.0.0
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       vis-network:
         specifier: ^9.1.13
-        version: 9.1.13(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@9.0.1)(vis-data@7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+        version: 9.1.13(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@14.0.0)(vis-data@7.1.9(uuid@14.0.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -940,8 +940,8 @@ importers:
         specifier: ^1.0.20
         version: 1.0.20
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^14.0.0
+        version: 14.0.0
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -10229,6 +10229,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -10239,17 +10240,23 @@ packages:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
   uuid@3.3.3:
     resolution: {integrity: sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -21744,6 +21751,8 @@ snapshots:
 
   uuid@13.0.0: {}
 
+  uuid@14.0.0: {}
+
   uuid@3.3.3: {}
 
   uuid@8.3.2: {}
@@ -21803,18 +21812,18 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vis-data@7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
+  vis-data@7.1.9(uuid@14.0.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
     dependencies:
-      uuid: 9.0.1
+      uuid: 14.0.0
       vis-util: 5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)
 
-  vis-network@9.1.13(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@9.0.1)(vis-data@7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
+  vis-network@9.1.13(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@14.0.0)(vis-data@7.1.9(uuid@14.0.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       component-emitter: 1.3.1
       keycharm: 0.4.0
-      uuid: 9.0.1
-      vis-data: 7.1.9(uuid@9.0.1)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+      uuid: 14.0.0
+      vis-data: 7.1.9(uuid@14.0.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
       vis-util: 5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)
 
   vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1):

--- a/web/package.json
+++ b/web/package.json
@@ -160,7 +160,7 @@
     "tailwindcss-animate": "^1.0.7",
     "unified": "^11.0.5",
     "use-query-params": "^2.2.2",
-    "uuid": "^9.0.1",
+    "uuid": "^14.0.0",
     "vaul": "^1.1.2",
     "vis-network": "^9.1.13",
     "zod": "^4.3.6"

--- a/web/package.json
+++ b/web/package.json
@@ -183,7 +183,6 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/react-grid-layout": "^1.3.6",
-    "@types/uuid": "^9.0.8",
     "@typescript/native-preview": "7.0.0-dev.20260122.3",
     "@vitejs/plugin-react": "^4.7.0",
     "dotenv-cli": "^7.4.2",

--- a/worker/package.json
+++ b/worker/package.json
@@ -64,7 +64,7 @@
     "posthog-node": "^5.8.4",
     "stripe": "^17.4.0",
     "tiktoken": "^1.0.20",
-    "uuid": "^9.0.1",
+    "uuid": "^14.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -76,7 +76,6 @@
     "@types/lodash": "^4.17.24",
     "@types/node": "^24.3.0",
     "@types/pg": "^8.11.10",
-    "@types/uuid": "^9.0.8",
     "@typescript/native-preview": "7.0.0-dev.20260122.3",
     "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^9.39.2",


### PR DESCRIPTION
## Summary

Removes `@types/uuid` from `devDependencies` in `web`, `worker`, and `packages/shared`.

uuid v7+ ships bundled TypeScript declarations (`"types": "./dist/index.d.ts"`), so the DefinitelyTyped `@types/uuid` package is redundant after the uuid v9 → v14 upgrade in [#13443](https://github.com/langfuse/langfuse/pull/13443). Keeping it around risks the stale v9-era types shadowing the bundled ones.

## Packages changed

- `web/package.json`
- `worker/package.json`
- `packages/shared/package.json`
- `pnpm-lock.yaml`

## Verification

- `pnpm install` — clean
- `pnpm run typecheck` — 7/7 tasks successful
- `pnpm run lint` — 4/4 tasks successful

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

Removes the now-redundant `@types/uuid` devDependency from `web`, `worker`, and `packages/shared`, and upgrades the `uuid` runtime dependency from `^9.0.1` to `^14.0.0` across all three packages. This is a straightforward follow-up cleanup: uuid@7+ ships bundled TypeScript declarations, so the DefinitelyTyped package is unnecessary and risks stale v9-era types shadowing the bundled ones.

<h3>Confidence Score: 4/5</h3>

Safe to merge with low risk; only a P2 style concern about CJS/ESM interop mitigated by Node.js 24's native ESM require support.

All changes are dependency metadata cleanup with no logic modifications. The one concern (uuid@14 being ESM-only while the worker targets CJS output) is practically mitigated by Node.js 24's stable synchronous ESM require feature, and all uuid API usage (v4, v5) is stable across versions. Typecheck and lint passed.

worker/package.json — CJS build target with ESM-only uuid@14

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/package.json | Removes @types/uuid devDep and upgrades uuid to ^14.0.0; Next.js/webpack bundles ESM correctly. |
| worker/package.json | Removes @types/uuid and upgrades uuid to ^14.0.0; worker compiles to CJS via tsc/NodeNext but Node.js 24's native ESM require mitigates the ESM-only concern. |
| packages/shared/package.json | Removes @types/uuid devDep and upgrades uuid to ^14.0.0; shared library cleanly removes redundant types. |
| pnpm-lock.yaml | Lock file correctly reflects uuid@14.0.0 resolution, removal of @types/uuid@9.0.8 snapshot, and updated vis-data/vis-network peer dep resolutions. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["uuid@14.0.0 ESM-only"] --> B["packages/shared"]
    A --> C["web - Next.js"]
    A --> D["worker - tsc/NodeNext"]
    B --> B1["Bundled - ESM safe"]
    C --> C1["webpack bundles - ESM safe"]
    D --> D1["CJS require via Node.js 24 native ESM require"]
    E["@types/uuid@9.0.8 - REMOVED"] -. was shadowing .-> F["uuid bundled types dist/index.d.ts"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/package.json:64
**ESM-only uuid in CJS worker**

The worker builds with `tsc` (`"module": "NodeNext"`, no `"type": "module"` in `package.json`), so TSC emits CJS `require()` calls. Starting with uuid@12, the package dropped CommonJS support entirely — the uuid maintainers explicitly recommend uuid@11 for CJS codebases. In practice this is mitigated because Node.js 24 (the required engine) supports synchronous `require()` of ESM modules without a flag, and uuid@14 has no top-level await. However, the official uuid guidance and the deprecation notice in the lockfile (`"For CommonJS codebases, use uuid@11"`) make this worth acknowledging before merging.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): remove redundant @types/uui..."](https://github.com/langfuse/langfuse/commit/644a259a145f1a407d55562093a4e8235d8d30ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30685059)</sub>

<!-- /greptile_comment -->