### PR TITLE
fix(traces): Remove numerical score filter from sidebar

### DIFF
--- a/packages/shared/src/observationsTable.ts
+++ b/packages/shared/src/observationsTable.ts
@@ -279,7 +279,7 @@ export type ObservationOptions = {
   name: Array<SingleValueOption>;
   traceName: Array<SingleValueOption>;
   environment: Array<SingleValueOption>;
-  scores_avg: Array<string>;
+  scores_avg?: Array<string>;
   score_categories: Array<MultiValueOption>;
   promptName: Array<SingleValueOption>;
   tags: Array<SingleValueOption>;

--- a/web/src/__tests__/server/traces-trpc.servertest.ts
+++ b/web/src/__tests__/server/traces-trpc.servertest.ts
@@ -455,7 +455,7 @@ describe("traces trpc", () => {
       expect(sentimentScore?.values).toHaveLength(4);
     });
 
-    it("should include observation-only score names for trace-scoped aggregates", async () => {
+    it("should omit numeric score filter options from the traces filter options contract", async () => {
       const trace = createTrace({
         project_id: projectId,
       });
@@ -490,10 +490,7 @@ describe("traces trpc", () => {
         projectId,
       });
 
-      expect(filterOptions.scores_avg).toEqual(
-        expect.arrayContaining(["observation_only_quality"]),
-      );
-      expect(filterOptions.scores_avg).not.toContain("session_only_quality");
+      expect(filterOptions).not.toHaveProperty("scores_avg");
     });
   });
 

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -713,13 +713,6 @@ export const SessionEventsPage: React.FC<{
         ) {
           return { ...column, options: scoreCategoryOptions };
         }
-
-        if (column.type === "numberObject" && column.id === "scores_avg") {
-          return filterOptions.scores_avg
-            ? { ...column, keyOptions: filterOptions.scores_avg }
-            : column;
-        }
-
         return column;
       });
   }, [filterOptions, sessionEventsFilterConfig.columnDefinitions]);

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -382,8 +382,6 @@ export default function ObservationsTable({
         {} as Record<string, string[]>,
       ) ?? undefined;
 
-    const scoresNumeric = filterOptions.data?.scores_avg ?? undefined;
-
     return {
       environment:
         environmentFilterOptions.data?.map((value) => value.environment) ??
@@ -444,7 +442,6 @@ export default function ObservationsTable({
       outputCost: [],
       totalCost: [],
       score_categories: scoreCategories,
-      scores_avg: scoresNumeric,
     };
   }, [environmentFilterOptions.data, filterOptions.data]);
 

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -302,9 +302,6 @@ export default function TracesTable({
         {} as Record<string, string[]>,
       ) ?? undefined;
 
-    const scoresNumeric =
-      traceFilterOptionsResponse.data?.scores_avg ?? undefined;
-
     return {
       traceName:
         traceFilterOptionsResponse.data?.name?.map((n) => ({
@@ -337,7 +334,6 @@ export default function TracesTable({
       outputCost: [],
       totalCost: [],
       score_categories: scoreCategories,
-      scores_avg: scoresNumeric,
     };
   }, [environmentFilterOptions.data, traceFilterOptionsResponse.data]);
 

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -15,7 +15,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Tabs, TabsList, TabsTrigger } from "@/src/components/ui/tabs";
 import { Badge } from "@/src/components/ui/badge";
 import {
-  tracesTableColsWithOptions,
   singleFilter,
   availableTraceEvalVariables,
   datasetFormFilterColsWithOptions,
@@ -24,6 +23,7 @@ import {
   type ColumnDefinition,
   type availableDatasetEvalVariables,
   JobConfigState,
+  tracesTableColsWithOptions,
 } from "@langfuse/shared";
 import { z } from "zod";
 import { useEffect, useMemo, useState, memo } from "react";
@@ -103,6 +103,7 @@ import {
 import { useEvalConfigFilterOptions } from "@/src/features/evals/hooks/useEvalConfigFilterOptions";
 import { VariableMappingCard } from "@/src/features/evals/components/variable-mapping-card";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
+import { validateFilters } from "@/src/components/table/table-view-presets/validation";
 
 /**
  * Adds propagation warnings to columns that require OTEL SDK with span propagation
@@ -142,6 +143,18 @@ const addPropagationWarnings = (
     return col;
   });
 };
+
+const isLegacyTraceScoreFilter = (
+  filter: z.infer<typeof singleFilter>,
+  columns: ColumnDefinition[],
+) =>
+  columns.some(
+    (definition) =>
+      definition.id === "scores_avg" &&
+      (definition.id === filter.column ||
+        definition.name === filter.column ||
+        definition.aliases?.includes(filter.column)),
+  );
 
 // Lazy load tables
 const TracesTable = lazy(
@@ -343,6 +356,37 @@ export const InnerEvaluatorForm = (props: {
   const defaultTarget = defaultTargetResult.success
     ? defaultTargetResult.data
     : EvalTargetObject.EVENT;
+  const existingFilter = props.existingEvaluator?.filter
+    ? z.array(singleFilter).parse(props.existingEvaluator.filter)
+    : undefined;
+  const allTraceFilterColumns = useMemo(
+    () => tracesTableColsWithOptions(traceFilterOptions),
+    [traceFilterOptions],
+  );
+  const editableTraceFilterColumns = useMemo(
+    () => allTraceFilterColumns.filter((column) => column.id !== "scores_avg"),
+    [allTraceFilterColumns],
+  );
+  const preservedLegacyTraceScoreFilters = useMemo(
+    () =>
+      defaultTarget === EvalTargetObject.TRACE
+        ? (existingFilter ?? []).filter((filter) =>
+            isLegacyTraceScoreFilter(filter, allTraceFilterColumns),
+          )
+        : [],
+    [allTraceFilterColumns, defaultTarget, existingFilter],
+  );
+  const initialFilter = existingFilter
+    ? defaultTarget === EvalTargetObject.TRACE && !props.disabled
+      ? validateFilters(existingFilter, editableTraceFilterColumns)
+      : existingFilter
+    : defaultTarget === EvalTargetObject.TRACE
+      ? // For new trace evaluators, exclude internal environments by default
+        DEFAULT_TRACE_FILTER
+      : defaultTarget === EvalTargetObject.EVENT
+        ? // For new observation evaluators, default to GENERATION type
+          DEFAULT_OBSERVATION_FILTER
+        : [];
 
   const form = useForm({
     resolver: zodResolver(evalConfigFormSchema),
@@ -351,15 +395,7 @@ export const InnerEvaluatorForm = (props: {
       scoreName:
         props.existingEvaluator?.scoreName ?? `${props.evalTemplate.name}`,
       target: defaultTarget,
-      filter: props.existingEvaluator?.filter
-        ? z.array(singleFilter).parse(props.existingEvaluator.filter)
-        : defaultTarget === EvalTargetObject.TRACE
-          ? // For new trace evaluators, exclude internal environments by default
-            DEFAULT_TRACE_FILTER
-          : defaultTarget === EvalTargetObject.EVENT
-            ? // For new observation evaluators, default to GENERATION type
-              DEFAULT_OBSERVATION_FILTER
-            : [],
+      filter: initialFilter,
       mapping: props.existingEvaluator?.variableMapping
         ? isEventTarget(props.existingEvaluator.targetObject) ||
           isExperimentTarget(props.existingEvaluator.targetObject)
@@ -557,7 +593,12 @@ export const InnerEvaluatorForm = (props: {
     const delay = values.delay * 1000; // convert to ms
     const sampling = values.sampling;
     const mapping = validatedVarMapping.data;
-    const filter = validatedFilter.data;
+    const filter =
+      props.mode === "edit" && isTraceTarget(values.target)
+        ? preservedLegacyTraceScoreFilters.concat(
+            validateFilters(validatedFilter.data, editableTraceFilterColumns),
+          )
+        : validatedFilter.data;
     const scoreName = values.scoreName;
 
     // For modern targets, derive status from runOnLive
@@ -996,6 +1037,20 @@ export const InnerEvaluatorForm = (props: {
                   name="filter"
                   render={({ field }) => {
                     const target = form.watch("target");
+                    const visibleFilters = field.value ?? [];
+                    const effectiveTraceFilters =
+                      props.mode === "edit" && isTraceTarget(target)
+                        ? preservedLegacyTraceScoreFilters.concat(
+                            validateFilters(
+                              visibleFilters,
+                              editableTraceFilterColumns,
+                            ),
+                          )
+                        : visibleFilters;
+                    const hasHiddenLegacyTraceFilters =
+                      !props.disabled &&
+                      isTraceTarget(target) &&
+                      preservedLegacyTraceScoreFilters.length > 0;
 
                     // Get appropriate columns based on target type
                     const getFilterColumns = () => {
@@ -1010,7 +1065,12 @@ export const InnerEvaluatorForm = (props: {
                           allowPropagationFilters,
                         );
                       } else if (isTraceTarget(target)) {
-                        return tracesTableColsWithOptions(traceFilterOptions);
+                        if (props.disabled) {
+                          // Keep "scores_avg" column to preserve visibility of existing filters when disabled
+                          return tracesTableColsWithOptions(traceFilterOptions);
+                        }
+
+                        return editableTraceFilterColumns;
                       } else if (isExperimentTarget(target)) {
                         // Experiment evaluators - only dataset filter
                         return experimentEvalFilterColsWithOptions(
@@ -1024,7 +1084,10 @@ export const InnerEvaluatorForm = (props: {
                       }
                     };
 
-                    const hasFilters = field.value && field.value.length > 0;
+                    const hasFilters =
+                      isTraceTarget(target) && props.mode === "edit"
+                        ? effectiveTraceFilters.length > 0
+                        : visibleFilters.length > 0;
 
                     return (
                       <FormItem>
@@ -1046,7 +1109,7 @@ export const InnerEvaluatorForm = (props: {
                                     : "id"
                                 }
                                 columns={getFilterColumns()}
-                                filterState={field.value ?? []}
+                                filterState={visibleFilters}
                                 onChange={(
                                   value: z.infer<typeof singleFilter>[],
                                 ) => {
@@ -1076,6 +1139,16 @@ export const InnerEvaluatorForm = (props: {
                             )}
                           </div>
                         </FormControl>
+                        {hasHiddenLegacyTraceFilters && (
+                          <div className="align-center flex max-w-[500px] gap-1">
+                            <AlertTriangle className="text-dark-yellow h-4 w-4" />
+                            <AlertDescription className="text-dark-yellow">
+                              This evaluator still includes hidden legacy trace
+                              score filters. They are preserved on save but
+                              cannot be edited here.
+                            </AlertDescription>
+                          </div>
+                        )}
                         {!props.disabled && !hasFilters && (
                           <div className="align-center flex max-w-[500px] gap-1">
                             <AlertTriangle className="text-dark-yellow h-4 w-4" />
@@ -1097,7 +1170,16 @@ export const InnerEvaluatorForm = (props: {
                     {isTraceTarget(form.watch("target")) && (
                       <TracesPreview
                         projectId={props.projectId}
-                        filterState={form.watch("filter") ?? []}
+                        filterState={
+                          props.mode === "edit"
+                            ? preservedLegacyTraceScoreFilters.concat(
+                                validateFilters(
+                                  form.watch("filter") ?? [],
+                                  editableTraceFilterColumns,
+                                ),
+                              )
+                            : (form.watch("filter") ?? [])
+                        }
                       />
                     )}
 

--- a/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
+++ b/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
@@ -49,7 +49,6 @@ export function useEvalConfigFilterOptions({
             value: n.value,
             count: Number(n.count),
           })),
-          scores_avg: traceFilterOptionsResponse.data.scores_avg,
           score_categories: traceFilterOptionsResponse.data.score_categories,
           traceTags: traceFilterOptionsResponse.data.tags?.map((t) => ({
             value: t.value,

--- a/web/src/features/events/config/filter-config.ts
+++ b/web/src/features/events/config/filter-config.ts
@@ -28,7 +28,9 @@ export type ObservationEventsOmittableFilterColumn = "sessionId" | "userId";
 export const observationEventsFilterConfig: FilterConfig = {
   tableName: "observations-events",
 
-  columnDefinitions: eventsTableCols,
+  columnDefinitions: eventsTableCols.filter((column) => {
+    return column.id !== "scores_avg" && column.id !== "trace_scores_avg";
+  }),
 
   defaultExpanded: ["environment", "name", "hasParentObservation", "type"],
 
@@ -223,19 +225,9 @@ export const observationEventsFilterConfig: FilterConfig = {
       label: "Categorical Scores",
     },
     {
-      type: "numericKeyValue" as const,
-      column: "scores_avg",
-      label: "Numeric Scores",
-    },
-    {
       type: "keyValue" as const,
       column: "trace_score_categories",
       label: "Trace Categorical Scores",
-    },
-    {
-      type: "numericKeyValue" as const,
-      column: "trace_scores_avg",
-      label: "Trace Numeric Scores",
     },
     {
       type: "numeric" as const,

--- a/web/src/features/events/hooks/useEventsFilterOptions.ts
+++ b/web/src/features/events/hooks/useEventsFilterOptions.ts
@@ -56,8 +56,6 @@ export function useEventsFilterOptions({
         },
         {} as Record<string, string[]>,
       ) ?? undefined;
-
-    const scoresNumeric = filterOptions.data?.scores_avg ?? undefined;
     const traceScoreCategories =
       filterOptions.data?.trace_score_categories?.reduce(
         (acc, score) => {
@@ -66,8 +64,6 @@ export function useEventsFilterOptions({
         },
         {} as Record<string, string[]>,
       ) ?? undefined;
-    const traceScoresNumeric =
-      filterOptions.data?.trace_scores_avg ?? undefined;
 
     return {
       environment: filterOptions.data?.environment ?? undefined,
@@ -101,9 +97,7 @@ export function useEventsFilterOptions({
       outputCost: [],
       totalCost: [],
       score_categories: scoreCategories,
-      scores_avg: scoresNumeric,
       trace_score_categories: traceScoreCategories,
-      trace_scores_avg: traceScoresNumeric,
     };
   }, [filterOptions.data]);
 

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -26,7 +26,6 @@ import {
   getEventsGroupedByHasParentObservation,
   getEventsGroupedByToolName,
   getEventsGroupedByCalledToolName,
-  getNumericScoresGroupedByName,
   getScoresGroupedByNameSourceType,
   getObservationsBatchIOFromEventsTable,
   getScoresForObservations,
@@ -263,7 +262,6 @@ export async function getEventFilterOptions(
       : [];
 
   const [
-    numericScoreNames,
     categoricalScoreNames,
     traceScoreColumns,
     providedModelName,
@@ -285,7 +283,6 @@ export async function getEventFilterOptions(
     toolNames,
     calledToolNames,
   ] = await Promise.all([
-    getNumericScoresGroupedByName(projectId, traceTimestampFilters),
     getCategoricalScoresGroupedByName(projectId, traceTimestampFilters),
     getScoresGroupedByNameSourceType({
       projectId,
@@ -310,16 +307,6 @@ export async function getEventFilterOptions(
     getEventsGroupedByToolName(projectId, eventsFilter),
     getEventsGroupedByCalledToolName(projectId, eventsFilter),
   ]);
-  const traceNumericScoreNames = Array.from(
-    new Set(
-      traceScoreColumns
-        .filter(
-          (score) =>
-            score.dataType === "NUMERIC" || score.dataType === "BOOLEAN",
-        )
-        .map((score) => score.name),
-    ),
-  );
   const traceCategoricalScoreNames = new Set(
     traceScoreColumns
       .filter((score) => score.dataType === "CATEGORICAL")
@@ -339,9 +326,7 @@ export async function getEventFilterOptions(
     name: name
       .filter((i) => i.name !== null)
       .map((i) => ({ value: i.name as string, count: i.count })),
-    scores_avg: numericScoreNames.map((score) => score.name),
     score_categories: categoricalScoreNames,
-    trace_scores_avg: traceNumericScoreNames,
     trace_score_categories: categoricalScoreNames.filter((score) =>
       traceCategoricalScoreNames.has(score.label),
     ),

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -720,7 +720,7 @@ function FilterBuilderForm({
                         filter.type === "stringObject") &&
                       (column?.type === "numberObject" ||
                         column?.type === "stringObject") ? (
-                        column.keyOptions ? (
+                        column.keyOptions && column.keyOptions.length > 0 ? (
                           // Case 1: object with keyOptions - selector of the key of the object
                           <Select
                             disabled={!filter.column}

--- a/web/src/features/filters/config/observations-config.ts
+++ b/web/src/features/filters/config/observations-config.ts
@@ -19,7 +19,9 @@ export const OBSERVATION_COLUMN_TO_BACKEND_KEY: ColumnToBackendKeyMap = {
 export const observationFilterConfig: FilterConfig = {
   tableName: "observations",
 
-  columnDefinitions: observationsTableCols,
+  columnDefinitions: observationsTableCols.filter(
+    (column) => column.id !== "scores_avg",
+  ),
 
   defaultExpanded: ["environment", "name"],
 
@@ -169,11 +171,6 @@ export const observationFilterConfig: FilterConfig = {
       type: "keyValue" as const,
       column: "score_categories",
       label: "Categorical Scores",
-    },
-    {
-      type: "numericKeyValue" as const,
-      column: "scores_avg",
-      label: "Numeric Scores",
     },
     {
       type: "numeric" as const,

--- a/web/src/features/filters/config/traces-config.ts
+++ b/web/src/features/filters/config/traces-config.ts
@@ -9,7 +9,9 @@ export type TraceOmittableFilterColumn = "userId" | "sessionId";
 export const traceFilterConfig: FilterConfig = {
   tableName: "traces",
 
-  columnDefinitions: tracesTableCols,
+  columnDefinitions: tracesTableCols.filter(
+    (column) => column.id !== "scores_avg",
+  ),
 
   defaultExpanded: ["environment", "traceName"],
 
@@ -140,11 +142,6 @@ export const traceFilterConfig: FilterConfig = {
       type: "keyValue" as const,
       column: "score_categories",
       label: "Categorical Scores",
-    },
-    {
-      type: "numericKeyValue" as const,
-      column: "scores_avg",
-      label: "Numeric Scores",
     },
   ],
 };

--- a/web/src/features/filters/filter-config.clienttest.ts
+++ b/web/src/features/filters/filter-config.clienttest.ts
@@ -7,7 +7,28 @@ describe("omitFilterFacets", () => {
   it("removes omitted facets and default-expanded entries", () => {
     const config: FilterConfig = {
       tableName: "test",
-      columnDefinitions: [],
+      columnDefinitions: [
+        {
+          name: "User ID",
+          id: "userId",
+          type: "stringOptions",
+          options: [],
+          internal: "user_id",
+        },
+        {
+          name: "Name",
+          id: "name",
+          type: "stringOptions",
+          options: [],
+          internal: "name",
+        },
+        {
+          name: "Timestamp",
+          id: "timestamp",
+          type: "datetime",
+          internal: "timestamp",
+        },
+      ],
       defaultExpanded: ["userId", "name"],
       facets: [
         { type: "categorical", column: "userId", label: "User ID" },
@@ -18,6 +39,10 @@ describe("omitFilterFacets", () => {
     const result = omitFilterFacets(config, ["userId"]);
 
     expect(result.facets.map((facet) => facet.column)).toEqual(["name"]);
+    expect(result.columnDefinitions.map((column) => column.id)).toEqual([
+      "name",
+      "timestamp",
+    ]);
     expect(result.defaultExpanded).toEqual(["name"]);
   });
 });

--- a/web/src/features/filters/filter-integration.clienttest.ts
+++ b/web/src/features/filters/filter-integration.clienttest.ts
@@ -16,7 +16,10 @@ import {
   computeSelectedValues,
 } from "./lib/filter-query-encoding";
 import { validateFilters } from "@/src/components/table/table-view-presets/validation";
-import { traceFilterConfig } from "./config/traces-config";
+import {
+  traceFilterConfig,
+  getTraceFilterConfig,
+} from "./config/traces-config";
 import { observationFilterConfig } from "./config/observations-config";
 import { transformFiltersForBackend } from "./lib/filter-transform";
 import { sessionFilterConfig } from "./config/sessions-config";
@@ -642,9 +645,89 @@ describe("Filter Flow: URL → Decode → Normalize → Transform", () => {
 
     expect(normalized).toEqual([]);
   });
+
+  it("should preserve startTime URL filters on the session detail events view", () => {
+    const sessionEventColumns: ColumnDefinition[] = [
+      ...observationEventsFilterConfig.columnDefinitions,
+      {
+        name: "Position in Trace",
+        id: "positionInTrace",
+        type: "positionInTrace",
+        internal: "positionInTrace",
+      },
+    ];
+    const urlFilter = encodeFiltersGeneric([
+      {
+        column: "startTime",
+        type: "datetime",
+        operator: ">=",
+        value: new Date("2024-01-01T00:00:00.000Z"),
+      },
+      {
+        column: "positionInTrace",
+        type: "positionInTrace",
+        operator: "=",
+        key: "last",
+      },
+    ]);
+
+    const normalized = decodeAndNormalizeFilters(
+      urlFilter,
+      sessionEventColumns,
+    );
+
+    expect(normalized).toEqual([
+      {
+        column: "startTime",
+        type: "datetime",
+        operator: ">=",
+        value: new Date("2024-01-01T00:00:00.000Z"),
+      },
+      {
+        column: "positionInTrace",
+        type: "positionInTrace",
+        operator: "=",
+        key: "last",
+      },
+    ]);
+  });
 });
 
 describe("Saved view validation", () => {
+  it("should discard stale numeric score filters when the facet is removed", () => {
+    const config = getTraceFilterConfig();
+    const filters: FilterState = [
+      {
+        column: "scores_avg",
+        type: "numberObject",
+        operator: ">=",
+        key: "accuracy",
+        value: 0.8,
+      },
+      {
+        column: "traceName",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["checkout"],
+      },
+      {
+        column: "legacyUnknownColumn",
+        type: "string",
+        operator: "contains",
+        value: "deprecated",
+      },
+    ];
+
+    expect(validateFilters(filters, config.columnDefinitions)).toEqual([
+      {
+        column: "traceName",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["checkout"],
+      },
+    ]);
+  });
+
   it("should discard stale positionInTrace filters on the general events table", () => {
     const filters: FilterState = [
       {

--- a/web/src/features/filters/lib/filter-config.ts
+++ b/web/src/features/filters/lib/filter-config.ts
@@ -78,6 +78,9 @@ export function omitFilterFacets(
 
   return {
     ...config,
+    columnDefinitions: config.columnDefinitions.filter(
+      (column) => !omittedColumnSet.has(column.id),
+    ),
     defaultExpanded: config.defaultExpanded?.filter(
       (column) => !omittedColumnSet.has(column),
     ),

--- a/web/src/server/api/routers/generations/filterOptionsQuery.ts
+++ b/web/src/server/api/routers/generations/filterOptionsQuery.ts
@@ -14,7 +14,6 @@ import {
   getObservationsGroupedByPromptName,
   getObservationsGroupedByToolName,
   getObservationsGroupedByCalledToolName,
-  getNumericScoresGroupedByName,
   getTracesGroupedByName,
   getTracesGroupedByTags,
   tracesTableUiColumnDefinitions,
@@ -66,7 +65,6 @@ export const filterOptionsQuery = protectedProjectProcedure
     };
 
     const [
-      numericScoreNames,
       categoricalScoreNames,
       model,
       name,
@@ -77,8 +75,6 @@ export const filterOptionsQuery = protectedProjectProcedure
       toolNames,
       calledToolNames,
     ] = await Promise.all([
-      // numeric scores
-      getNumericScoresGroupedByName(input.projectId, traceTimestampFilters),
       // categorical scores
       getCategoricalScoresGroupedByName(input.projectId, traceTimestampFilters),
       //model
@@ -127,7 +123,6 @@ export const filterOptionsQuery = protectedProjectProcedure
         .map((i) => ({
           value: i.traceName as string,
         })),
-      scores_avg: numericScoreNames.map((score) => score.name),
       score_categories: categoricalScoreNames,
       promptName: promptNames
         .filter((i) => i.promptName !== null)

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -31,7 +31,6 @@ import {
   getTracesTable,
   getTracesTableCount,
   getScoresForTraces,
-  getNumericScoresGroupedByName,
   getTracesGroupedByName,
   getTracesGroupedByTags,
   getObservationsForTrace,
@@ -276,47 +275,39 @@ export const traceRouter = createTRPCRouter({
         ...scoreFilters.forTraceScopedAggregates(),
       ];
 
-      const [
-        numericScoreNames,
-        categoricalScoreNames,
-        traceNames,
-        tags,
-        userIds,
-        sessionIds,
-      ] = await Promise.all([
-        getNumericScoresGroupedByName(input.projectId, traceScopedScoreFilters),
-        getCategoricalScoresGroupedByName(
-          input.projectId,
-          traceScopedScoreFilters,
-        ),
-        getTracesGroupedByName(
-          input.projectId,
-          tracesTableUiColumnDefinitions,
-          timestampFilter ?? [],
-        ),
-        getTracesGroupedByTags({
-          projectId: input.projectId,
-          filter: timestampFilter ?? [],
-        }),
-        getTracesGroupedByUsers(
-          input.projectId,
-          timestampFilter ?? [],
-          undefined,
-          100,
-          0,
-        ),
-        getTracesGroupedBySessionId(
-          input.projectId,
-          timestampFilter ?? [],
-          undefined,
-          100,
-          0,
-        ),
-      ]);
+      const [categoricalScoreNames, traceNames, tags, userIds, sessionIds] =
+        await Promise.all([
+          getCategoricalScoresGroupedByName(
+            input.projectId,
+            traceScopedScoreFilters,
+          ),
+          getTracesGroupedByName(
+            input.projectId,
+            tracesTableUiColumnDefinitions,
+            timestampFilter ?? [],
+          ),
+          getTracesGroupedByTags({
+            projectId: input.projectId,
+            filter: timestampFilter ?? [],
+          }),
+          getTracesGroupedByUsers(
+            input.projectId,
+            timestampFilter ?? [],
+            undefined,
+            100,
+            0,
+          ),
+          getTracesGroupedBySessionId(
+            input.projectId,
+            timestampFilter ?? [],
+            undefined,
+            100,
+            0,
+          ),
+        ]);
 
       return {
         name: traceNames.map((n) => ({ value: n.name, count: n.count })),
-        scores_avg: numericScoreNames.map((s) => s.name),
         score_categories: categoricalScoreNames,
         tags: tags,
         users: userIds.map((u) => ({


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR removes the numerical score (`scores_avg`) filter from the filter sidebar across traces, observations, and events tables, as well as from the trace evaluator filter form. The change eliminates the associated DB queries for numeric scores, sanitizes legacy saved evaluator configs that may contain stale `scores_avg` filters, and fixes `omitFilterFacets` to also strip column definitions (not just facets) for omitted columns.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the removal is consistent across all layers (DB query, API response, filter config, and UI), and legacy saved filters are sanitized on load.

All changes are consistent and well-tested. The only finding is a minor duplicate import statement in a test file. Score kept at 4 due to the P2 finding.

web/src/features/filters/filter-integration.clienttest.ts — minor duplicate import

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/evals/lib/traceEvalFilterColumns.ts | New file: exposes getTraceEvalFilterColumns (strips scores_avg) and sanitizeTraceEvalFilters for migrating legacy saved evaluator filters |
| web/src/features/filters/lib/filter-config.ts | omitFilterFacets now also removes matching columnDefinitions, fixing a gap where the column definition stayed even when its facet was omitted |
| web/src/server/api/routers/traces.ts | Removes getNumericScoresGroupedByName query from filterOptions endpoint and drops scores_avg from returned payload |
| web/src/features/events/server/eventsService.ts | Removes numeric score DB queries and removes scores_avg / trace_scores_avg from events filter options response |
| web/src/features/filters/config/traces-config.ts | Filters out scores_avg from column definitions and removes the numericKeyValue scores facet from the trace filter sidebar |
| web/src/features/evals/components/inner-evaluator-form.tsx | Extracts initialFilter computation and calls sanitizeTraceEvalFilters to drop stale scores_avg filters from persisted trace evaluator configs |
| packages/shared/src/observationsTable.ts | Marks scores_avg as optional in ObservationOptions to reflect that it is no longer returned by the API |
| web/src/features/filters/filter-integration.clienttest.ts | Adds tests verifying stale scores_avg filters are discarded and session-detail startTime filters are preserved; has a duplicate import from the same module |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/filters/filter-integration.clienttest.ts:19-20
**Duplicate import from the same module**

`traceFilterConfig` and `getTraceFilterConfig` are imported from `"./config/traces-config"` in two separate `import` statements. These should be merged into one.

```suggestion
import { traceFilterConfig, getTraceFilterConfig } from "./config/traces-config";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traces): Remove numerical score filt..."](https://github.com/langfuse/langfuse/commit/bd81f62aad36a7d0eb236538f8ac58259ab93036) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30687002)</sub>

<!-- /greptile_comment -->