### PR TITLE
feat(web): In-app agent scaffolding

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
       "glob": "^10.5.0",
       "qs": "6.14.1",
       "path-to-regexp@0.1.12": "0.1.13",
-      "ip-address@10.1.0": "10.2.0"
+      "ip-address@10.1.0": "10.2.0",
+      "@anthropic-ai/claude-agent-sdk>@anthropic-ai/sdk": "0.95.1"
     },
     "patchedDependencies": {
       "next-auth@4.24.13": "patches/next-auth@4.24.13.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   qs: 6.14.1
   path-to-regexp@0.1.12: 0.1.13
   ip-address@10.1.0: 10.2.0
+  '@anthropic-ai/claude-agent-sdk>@anthropic-ai/sdk': 0.95.1
 
 patchedDependencies:
   next-auth@4.24.13:
@@ -346,6 +347,18 @@ importers:
 
   web:
     dependencies:
+      '@ag-ui/claude-agent-sdk':
+        specifier: 0.0.2
+        version: 0.0.2(@ag-ui/client@0.0.52)(@ag-ui/core@0.0.52)(@anthropic-ai/claude-agent-sdk@0.2.133(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@anthropic-ai/sdk@0.95.1(zod@4.3.6))(zod@4.3.6)
+      '@ag-ui/client':
+        specifier: ^0.0.52
+        version: 0.0.52
+      '@ag-ui/core':
+        specifier: ^0.0.52
+        version: 0.0.52
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.2.133
+        version: 0.2.133(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@anthropic-ai/tokenizer':
         specifier: ^0.0.4
         version: 0.0.4
@@ -718,6 +731,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      streamdown:
+        specifier: ^2.5.0
+        version: 2.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       stripe:
         specifier: ^18.5.0
         version: 18.5.0(@types/node@24.3.0)
@@ -1036,12 +1052,95 @@ packages:
   '@adobe/css-tools@4.4.0':
     resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
 
+  '@ag-ui/claude-agent-sdk@0.0.2':
+    resolution: {integrity: sha512-QgsT1afuO+s/wMVfTSx9EA4Kx+efttm3BGfgths+x+fA9e0u1gFIXj1z8l9oW74WC74N3Lu4KYmshQ9q7G96xQ==}
+    peerDependencies:
+      '@ag-ui/client': '>=0.0.42'
+      '@ag-ui/core': '>=0.0.42'
+      '@anthropic-ai/claude-agent-sdk': ^0.2.58
+      '@anthropic-ai/sdk': '>=0.50.0'
+      zod: 4.3.6
+
+  '@ag-ui/client@0.0.52':
+    resolution: {integrity: sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==}
+
+  '@ag-ui/core@0.0.52':
+    resolution: {integrity: sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==}
+
+  '@ag-ui/encoder@0.0.52':
+    resolution: {integrity: sha512-6GVDTb1dv2rjap7VVnmXYypDutZi6nrsTcdfxoP6ryDG5ynlXtmmS+FSDAt62JbIMD5CtEE963xNCb6d1iXw9g==}
+
+  '@ag-ui/proto@0.0.52':
+    resolution: {integrity: sha512-+iCGzNUNL50YIoThVmsolWPjG4MJidl+R9k8QAGVwErEfHRtQ64KFyrdpeOXNVuWtM3SViJqPSgFyv7eGVS63A==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.133':
+    resolution: {integrity: sha512-J79AWcnoPaVU55fLAcdUdgYuj4PjXx1qkZGHtoKAMQ7XMktH21nW/VTFkIo/aKcGDsbSYNxMtw+zp/gduCmYww==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.133':
+    resolution: {integrity: sha512-juKz5zhWMYPClHWzraJ+CY/DoRfYfgaKsIQC0Tvln+scVJecEYt7tmvw+mmy2yQtPI66BqtoH12Aqnwyq5+RVw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.133':
+    resolution: {integrity: sha512-lvB9C7mnGO1zZp6W90H7zcj11Qaw2Thcwcoov5cFRuC31NDuIZTdMHYMwXBqACep61aBX1fgawoY/+pq0Hptpw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.133':
+    resolution: {integrity: sha512-80agdXdE1/wCofiyiSGw1EINXv+xcjXaXkmAQgtAwhE22rtzjPh6D+Zm6sHRhyEdogj8PAVw6iAVRVV1xLYq6w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.133':
+    resolution: {integrity: sha512-IShZIbuXLxHzjVcccKFZUYXtN6FwrHVlh3y5YDuQORLYSGSHtcUAfGAT1csGz7fTQ3ZvBfY8ApoWXMR8I65l8g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.133':
+    resolution: {integrity: sha512-nl9Law15GS90GEhddMaMuuSJXpRCHLOFm39Aqy5KxSqA6sdLXvi1kLEs2IIJ6XrUDTq0LnwDYACSTR21ybq3cg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.133':
+    resolution: {integrity: sha512-yiQqa9t5OLXsM2a49FS7evQyalEWPtAd5sv4LbymSlq/QrBqDymvgrxSwxHwaZan5JlNYoQKRlUW27lc2vTLQA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.133':
+    resolution: {integrity: sha512-tH6tviy+vYPoL6M7qGCg4gKLt3w5AxhmUN7yi8Rs/2AjMbYjPuM6F/G7T+4/CTg246k9gZxxA86Dxs95gQMv8A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.2.133':
+    resolution: {integrity: sha512-teqnsqYB7LeZ7BYRQx66BSB+ykiswiVJyeEQ3chdQrTsVhz7lK47uWqZ70zD6vJIh4a5PgljFcZabTNFHjJcJA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: 4.3.6
+
   '@anthropic-ai/sdk@0.74.0':
     resolution: {integrity: sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==}
+    hasBin: true
+    peerDependencies:
+      zod: 4.3.6
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@anthropic-ai/sdk@0.95.1':
+    resolution: {integrity: sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg==}
     hasBin: true
     peerDependencies:
       zod: 4.3.6
@@ -1416,6 +1515,12 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@bufbuild/protobuf@2.12.0':
+    resolution: {integrity: sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==}
+
   '@bundled-es-modules/cookie@2.0.1':
     resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
 
@@ -1427,6 +1532,9 @@ packages:
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@clickhouse/client-common@1.13.0':
     resolution: {integrity: sha512-QlGUMd3EaKkIRLCv0WW8Rw9cOlqhwQPT+ucNWY8eC4UALsMhJLpa0H7Cd7MYc9CEtTv/xlr3IcYw5Tdho4Hr2g==}
@@ -1875,6 +1983,12 @@ packages:
   '@iarna/toml@3.0.0':
     resolution: {integrity: sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==}
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -2317,6 +2431,9 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -3157,6 +3274,10 @@ packages:
     resolution: {integrity: sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==}
     peerDependencies:
       '@opentelemetry/api': ^1.8
+
+  '@protobuf-ts/protoc@2.11.1':
+    resolution: {integrity: sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==}
+    hasBin: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -4475,6 +4596,9 @@ packages:
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -4878,11 +5002,50 @@ packages:
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
 
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
@@ -4890,17 +5053,44 @@ packages:
   '@types/d3-path@3.1.1':
     resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
 
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
   '@types/d3-scale@4.0.9':
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
 
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
   '@types/d3-shape@3.1.8':
     resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
 
   '@types/d3-time@3.0.4':
     resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -4931,6 +5121,9 @@ packages:
 
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hammerjs@2.0.46':
     resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
@@ -5060,6 +5253,9 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@typescript-eslint/eslint-plugin@8.58.0':
     resolution: {integrity: sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==}
@@ -5347,6 +5543,9 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -5937,8 +6136,19 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
@@ -5990,6 +6200,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -6027,33 +6243,128 @@ packages:
   csv-parse@5.6.0:
     resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.3:
+    resolution: {integrity: sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
     engines: {node: '>=12'}
 
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
     engines: {node: '>=12'}
 
   d3-format@3.1.2:
     resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
     engines: {node: '>=12'}
 
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
 
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
     engines: {node: '>=12'}
 
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
   d3-scale@4.0.2:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
 
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
@@ -6070,6 +6381,23 @@ packages:
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -6110,6 +6438,9 @@ packages:
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   dc-polyfill@0.1.10:
     resolution: {integrity: sha512-9iSbB8XZ7aIrhUtWI5ulEOJ+IyUN+axquodHK+bZO4r7HfY/xwmo6I4fYYf+aiDom+WMcN/wnzCz+pKvHDDCug==}
@@ -6190,6 +6521,9 @@ packages:
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -6699,11 +7033,17 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-json-patch@3.1.1:
+    resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
@@ -6992,6 +7332,9 @@ packages:
     resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
     engines: {node: '>=18'}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -7019,11 +7362,29 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
@@ -7058,6 +7419,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
@@ -7142,6 +7506,9 @@ packages:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
     engines: {node: '>=18'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -7172,6 +7539,9 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
@@ -7544,11 +7914,18 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
+    hasBin: true
+
   keycharm@0.4.0:
     resolution: {integrity: sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
@@ -7603,6 +7980,12 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
@@ -7823,6 +8206,16 @@ packages:
   markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
 
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@17.0.6:
+    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   marked@7.0.4:
     resolution: {integrity: sha512-t8eP0dXRJMtMvBojtkcsA7n48BkauktUKzfkPSCq85ZMTJ0v76Rke4DYz01omYpPTUh4p/f7HePgRo3ebG8+QQ==}
     engines: {node: '>= 16'}
@@ -7906,6 +8299,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -8430,6 +8826,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -8459,6 +8858,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -8569,6 +8971,12 @@ packages:
     resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -8988,6 +9396,15 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  rehype-harden@1.1.8:
+    resolution: {integrity: sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
   release-it@19.2.4:
     resolution: {integrity: sha512-BwaJwQYUIIAKuDYvpqQTSoy0U7zIy6cHyEjih/aNaFICphGahia4cjDANuFXb7gVZ51hIK9W0io6fjNQWXqICg==}
     engines: {node: ^20.12.0 || >=22.0.0}
@@ -9004,6 +9421,9 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remend@1.3.0:
+    resolution: {integrity: sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -9067,10 +9487,16 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -9089,6 +9515,12 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -9288,6 +9720,9 @@ packages:
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -9326,6 +9761,12 @@ packages:
 
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
+  streamdown@2.5.0:
+    resolution: {integrity: sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -9443,6 +9884,9 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
   superjson@2.2.2:
     resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
@@ -9771,6 +10215,9 @@ packages:
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
+  untruncate-json@0.0.1:
+    resolution: {integrity: sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -9876,6 +10323,9 @@ packages:
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -10023,6 +10473,9 @@ packages:
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -10223,11 +10676,102 @@ snapshots:
 
   '@adobe/css-tools@4.4.0': {}
 
+  '@ag-ui/claude-agent-sdk@0.0.2(@ag-ui/client@0.0.52)(@ag-ui/core@0.0.52)(@anthropic-ai/claude-agent-sdk@0.2.133(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@anthropic-ai/sdk@0.95.1(zod@4.3.6))(zod@4.3.6)':
+    dependencies:
+      '@ag-ui/client': 0.0.52
+      '@ag-ui/core': 0.0.52
+      '@anthropic-ai/claude-agent-sdk': 0.2.133(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.95.1(zod@4.3.6)
+      rxjs: 7.8.1
+      zod: 4.3.6
+
+  '@ag-ui/client@0.0.52':
+    dependencies:
+      '@ag-ui/core': 0.0.52
+      '@ag-ui/encoder': 0.0.52
+      '@ag-ui/proto': 0.0.52
+      '@types/uuid': 10.0.0
+      compare-versions: 6.1.1
+      fast-json-patch: 3.1.1
+      rxjs: 7.8.1
+      untruncate-json: 0.0.1
+      uuid: 11.1.0
+      zod: 4.3.6
+
+  '@ag-ui/core@0.0.52':
+    dependencies:
+      zod: 4.3.6
+
+  '@ag-ui/encoder@0.0.52':
+    dependencies:
+      '@ag-ui/core': 0.0.52
+      '@ag-ui/proto': 0.0.52
+
+  '@ag-ui/proto@0.0.52':
+    dependencies:
+      '@ag-ui/core': 0.0.52
+      '@bufbuild/protobuf': 2.12.0
+      '@protobuf-ts/protoc': 2.11.1
+
   '@alloc/quick-lru@5.2.0': {}
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.2
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.133':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.2.133(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.95.1(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      zod: 4.3.6
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.133
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.133
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
 
   '@anthropic-ai/sdk@0.74.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@anthropic-ai/sdk@0.95.1(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.3.6
 
@@ -11179,6 +11723,10 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@bufbuild/protobuf@2.12.0': {}
+
   '@bundled-es-modules/cookie@2.0.1':
     dependencies:
       cookie: 0.7.2
@@ -11193,6 +11741,8 @@ snapshots:
       tough-cookie: 4.1.4
 
   '@cfworker/json-schema@4.1.1': {}
+
+  '@chevrotain/types@11.1.2': {}
 
   '@clickhouse/client-common@1.13.0': {}
 
@@ -11636,6 +12186,14 @@ snapshots:
 
   '@iarna/toml@3.0.0': {}
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -12068,6 +12626,10 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
       react: 19.2.4
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
@@ -12990,6 +13552,8 @@ snapshots:
       '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@protobuf-ts/protoc@2.11.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -14446,6 +15010,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -14843,9 +15409,48 @@ snapshots:
 
   '@types/d3-array@3.2.2': {}
 
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
   '@types/d3-color@3.1.3': {}
 
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
   '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
 
   '@types/d3-interpolate@3.0.4':
     dependencies:
@@ -14853,17 +15458,71 @@ snapshots:
 
   '@types/d3-path@3.1.1': {}
 
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
   '@types/d3-scale@4.0.9':
     dependencies:
       '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
 
   '@types/d3-shape@3.1.8':
     dependencies:
       '@types/d3-path': 3.1.1
 
+  '@types/d3-time-format@4.0.3': {}
+
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
 
   '@types/debug@4.1.12':
     dependencies:
@@ -14903,6 +15562,8 @@ snapshots:
       '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 5.1.1
       '@types/serve-static': 2.2.0
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hammerjs@2.0.46': {}
 
@@ -15038,6 +15699,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/uuid@10.0.0': {}
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.2))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.2)':
     dependencies:
@@ -15339,6 +16002,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-react@4.7.0(vite@7.0.5(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.20.5)(yaml@2.8.4))':
     dependencies:
@@ -16039,7 +16707,13 @@ snapshots:
 
   commander@2.20.3: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   commondir@1.0.1: {}
+
+  compare-versions@6.1.1: {}
 
   component-emitter@1.3.1: {}
 
@@ -16075,6 +16749,14 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   create-require@1.1.1: {}
 
@@ -16114,21 +16796,106 @@ snapshots:
 
   csv-parse@5.6.0: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.3):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.3
+
+  cytoscape-fcose@2.2.0(cytoscape@3.33.3):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.3
+
+  cytoscape@3.33.3: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
   d3-array@3.2.4:
     dependencies:
       internmap: 2.0.3
 
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
   d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
 
   d3-ease@3.0.1: {}
 
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
   d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
 
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
 
+  d3-path@1.0.9: {}
+
   d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
 
   d3-scale@4.0.2:
     dependencies:
@@ -16137,6 +16904,12 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-time: 3.1.0
       d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
 
   d3-shape@3.2.0:
     dependencies:
@@ -16151,6 +16924,61 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
 
   damerau-levenshtein@1.0.8: {}
 
@@ -16191,6 +17019,8 @@ snapshots:
   date-fns@3.6.0: {}
 
   date-fns@4.1.0: {}
+
+  dayjs@1.11.20: {}
 
   dc-polyfill@0.1.10: {}
 
@@ -16268,6 +17098,10 @@ snapshots:
       ast-types: 0.13.4
       escodegen: 2.1.0
       esprima: 4.0.1
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -16990,9 +17824,13 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-patch@3.1.1: {}
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.2: {}
 
@@ -17317,6 +18155,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hachure-fill@0.5.2: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -17339,6 +18179,43 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.1
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.1
+      unist-util-position: 5.0.0
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -17359,9 +18236,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   headers-polyfill@4.0.3: {}
 
@@ -17393,6 +18288,8 @@ snapshots:
       selderee: 0.11.0
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   htmlparser2@10.1.0:
     dependencies:
@@ -17496,6 +18393,8 @@ snapshots:
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -17523,6 +18422,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  internmap@1.0.1: {}
 
   internmap@2.0.3: {}
 
@@ -17905,11 +18806,17 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  katex@0.16.45:
+    dependencies:
+      commander: 8.3.0
+
   keycharm@0.4.0: {}
 
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
 
   kuler@2.0.0: {}
 
@@ -17966,6 +18873,10 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   leac@0.6.0: {}
 
@@ -18132,6 +19043,10 @@ snapshots:
   map-stream@0.1.0: {}
 
   markdown-table@3.0.3: {}
+
+  marked@16.4.2: {}
+
+  marked@17.0.6: {}
 
   marked@7.0.4: {}
 
@@ -18310,6 +19225,30 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.33.3
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.3)
+      cytoscape-fcose: 2.2.0(cytoscape@3.33.3)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.4.0
+      es-toolkit: 1.45.1
+      katex: 0.16.45
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 14.0.0
 
   methods@1.1.2: {}
 
@@ -19003,6 +19942,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@1.6.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -19045,6 +19986,8 @@ snapshots:
       peberminta: 0.9.0
 
   parseurl@1.3.3: {}
+
+  path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
 
@@ -19135,6 +20078,13 @@ snapshots:
       playwright-core: 1.57.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -19550,6 +20500,21 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  rehype-harden@1.1.8:
+    dependencies:
+      unist-util-visit: 5.0.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
+
   release-it@19.2.4(@types/node@25.6.0)(magicast@0.5.2):
     dependencies:
       '@nodeutils/defaults-deep': 1.1.0
@@ -19614,6 +20579,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  remend@1.3.0: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -19675,6 +20642,8 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.60.2:
     dependencies:
       '@types/estree': 1.0.8
@@ -19706,6 +20675,13 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -19726,6 +20702,12 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
+
+  rxjs@7.8.1:
+    dependencies:
+      tslib: 2.8.1
 
   rxjs@7.8.2:
     dependencies:
@@ -19988,6 +20970,11 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@4.0.0: {}
@@ -20037,6 +21024,29 @@ snapshots:
       stubs: 3.0.0
 
   stream-shift@1.0.3: {}
+
+  streamdown@2.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      clsx: 2.1.1
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      marked: 17.0.6
+      mermaid: 11.15.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      rehype-harden: 1.1.8
+      rehype-raw: 7.0.0
+      rehype-sanitize: 6.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remend: 1.3.0
+      tailwind-merge: 3.5.0
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      unist-util-visit-parents: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   strict-event-emitter@0.5.1: {}
 
@@ -20169,6 +21179,8 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.29.0
+
+  stylis@4.4.0: {}
 
   superjson@2.2.2:
     dependencies:
@@ -20528,6 +21540,8 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  untruncate-json@0.0.1: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -20604,6 +21618,11 @@ snapshots:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
 
   vfile-message@4.0.3:
     dependencies:
@@ -20747,6 +21766,8 @@ snapshots:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+
+  web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -276,7 +276,7 @@ importers:
         version: 11.2.7
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nodemailer:
         specifier: ^7.0.11
         version: 7.0.11
@@ -658,7 +658,7 @@ importers:
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-query-params:
         specifier: ^5.1.0
         version: 5.1.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(use-query-params@2.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -789,6 +789,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.2.2)
       '@testing-library/jest-dom':
         specifier: ^6.4.6
         version: 6.9.1
@@ -4814,6 +4817,11 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tanstack/query-core@5.85.1':
     resolution: {integrity: sha512-TkPBjaILO6p02JNvRjwBbBJb4ZkI2vCGuV2B29od2j7UxFqYZ6sKwNVQ2CJ+qGDcJ9+qr4L1JGedVTms3V7bSQ==}
 
@@ -6232,6 +6240,11 @@ packages:
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
@@ -8981,6 +8994,10 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -12699,7 +12716,7 @@ snapshots:
   '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@prisma/client': 6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2)
-      next-auth: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-auth: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   '@next/env@16.0.0': {}
 
@@ -15228,6 +15245,11 @@ snapshots:
       postcss: 8.5.13
       tailwindcss: 4.2.2
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.2.2)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.2.2
+
   '@tanstack/query-core@5.85.1': {}
 
   '@tanstack/react-query@5.85.1(react@19.2.4)':
@@ -16786,6 +16808,8 @@ snapshots:
 
   css.escape@1.5.1: {}
 
+  cssesc@3.0.0: {}
+
   cssstyle@4.6.0:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
@@ -17469,7 +17493,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -19557,7 +19581,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@babel/runtime': 7.29.2
       '@panva/hkdf': 1.2.1
@@ -20087,6 +20111,11 @@ snapshots:
       points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss@8.4.31:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,8 @@ minimumReleaseAgeExclude:
   - "@opentelemetry/otlp-transformer@0.218.0"
   - "@opentelemetry/sdk-logs@0.218.0"
   - "@opentelemetry/sdk-node@0.218.0"
+  - "mermaid@11.15.0"
+  - "@mermaid-js/parser@1.1.1"
 allowBuilds:
   "@prisma/client": true
   "@prisma/engines": true

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,10 @@
     "build-storybook": "dotenv -e ../.env -- storybook build"
   },
   "dependencies": {
+    "@ag-ui/claude-agent-sdk": "0.0.2",
+    "@ag-ui/client": "^0.0.52",
+    "@ag-ui/core": "^0.0.52",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.133",
     "@anthropic-ai/tokenizer": "^0.0.4",
     "@appsignal/opentelemetry-instrumentation-bullmq": "^0.8.0",
     "@baselime/trpc-opentelemetry-middleware": "^0.1.2",
@@ -152,6 +156,7 @@
     "recharts": "^3.8.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
+    "streamdown": "^2.5.0",
     "stripe": "^18.5.0",
     "superjson": "2.2.2",
     "tailwind-merge": "^3.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -177,6 +177,7 @@
     "@storybook/nextjs-vite": "^10.3.6",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/postcss": "^4.2.2",
+    "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^15.0.7",
     "@types/bcryptjs": "^2.4.6",

--- a/web/src/__tests__/server/in-app-agent-session-token.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-session-token.servertest.ts
@@ -1,0 +1,69 @@
+import {
+  InvalidInAppAgentSessionTokenError,
+  signInAppAgentSessionToken,
+  verifyInAppAgentSessionToken,
+} from "@/src/features/in-app-agent/server/auth";
+
+const tokenParams = {
+  userId: "user-1",
+  projectId: "project-1",
+  threadId: "thread-1",
+  claudeSessionId: "session-1",
+};
+
+describe("in-app agent session tokens", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("signs and verifies a Claude session token", () => {
+    const token = signInAppAgentSessionToken(tokenParams);
+
+    expect(
+      verifyInAppAgentSessionToken(token, {
+        userId: tokenParams.userId,
+        threadId: tokenParams.threadId,
+      }),
+    ).toEqual({
+      projectId: tokenParams.projectId,
+      claudeSessionId: tokenParams.claudeSessionId,
+    });
+  });
+
+  it("rejects tokens for a different user or thread", () => {
+    const token = signInAppAgentSessionToken(tokenParams);
+
+    expect(() =>
+      verifyInAppAgentSessionToken(token, {
+        userId: "other-user",
+        threadId: tokenParams.threadId,
+      }),
+    ).toThrow(InvalidInAppAgentSessionTokenError);
+  });
+
+  it("rejects tampered tokens", () => {
+    const token = signInAppAgentSessionToken(tokenParams);
+
+    expect(() =>
+      verifyInAppAgentSessionToken(`${token}tampered`, {
+        userId: tokenParams.userId,
+        threadId: tokenParams.threadId,
+      }),
+    ).toThrow(InvalidInAppAgentSessionTokenError);
+  });
+
+  it("rejects expired tokens", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-13T00:00:00.000Z"));
+    const token = signInAppAgentSessionToken(tokenParams);
+
+    vi.setSystemTime(new Date("2026-05-21T00:00:00.000Z"));
+
+    expect(() =>
+      verifyInAppAgentSessionToken(token, {
+        userId: tokenParams.userId,
+        threadId: tokenParams.threadId,
+      }),
+    ).toThrow(InvalidInAppAgentSessionTokenError);
+  });
+});

--- a/web/src/app/api/in-app-agent/route.ts
+++ b/web/src/app/api/in-app-agent/route.ts
@@ -1,0 +1,7 @@
+import inAppAgentHandler from "@/src/features/in-app-agent/server/handler";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+export const POST = inAppAgentHandler;

--- a/web/src/components/layouts/MobileDrawer.tsx
+++ b/web/src/components/layouts/MobileDrawer.tsx
@@ -46,7 +46,7 @@ export function MobileDrawer({
             </div>
             {/* sr-only for screen readers and accessibility */}
             <DrawerTitle className="sr-only">
-              {showAiAgent ? "AI-Agent" : "Support"}
+              {showAiAgent ? "AI Assistant" : "Support"}
             </DrawerTitle>
             <DrawerDescription className="sr-only">
               {showAiAgent

--- a/web/src/components/layouts/MobileDrawer.tsx
+++ b/web/src/components/layouts/MobileDrawer.tsx
@@ -8,9 +8,16 @@ import {
 } from "@/src/components/ui/drawer";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 import { SupportDrawer } from "@/src/features/support-chat/SupportDrawer";
+import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
+import { ControlledInAppAgentDrawer } from "@/src/features/in-app-agent/components";
 
-export function MobileDrawer({ children }: PropsWithChildren) {
-  const { open, setOpen } = useSupportDrawer();
+export function MobileDrawer({
+  aiAgentEnabled,
+  children,
+}: PropsWithChildren<{ aiAgentEnabled?: boolean }>) {
+  const { open: supportOpen, setOpen: setSupportOpen } = useSupportDrawer();
+  const { open: aiAgentOpen, setOpen: setAiAgentOpen } = useInAppAiAgent();
+  const showAiAgent = Boolean(aiAgentEnabled && aiAgentOpen);
 
   return (
     <>
@@ -18,7 +25,16 @@ export function MobileDrawer({ children }: PropsWithChildren) {
         {children}
       </main>
 
-      <Drawer open={open} onOpenChange={setOpen} forceDirection="bottom">
+      <Drawer
+        open={showAiAgent || supportOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setAiAgentOpen(false);
+            setSupportOpen(false);
+          }
+        }}
+        forceDirection="bottom"
+      >
         <DrawerContent
           id="support-drawer"
           className="min-h-screen-with-banner inset-x-0 top-[calc(var(--banner-offset)+10px)] bottom-0"
@@ -29,13 +45,21 @@ export function MobileDrawer({ children }: PropsWithChildren) {
               <div className="bg-muted h-2 w-20 rounded-full" />
             </div>
             {/* sr-only for screen readers and accessibility */}
-            <DrawerTitle className="sr-only">Support</DrawerTitle>
+            <DrawerTitle className="sr-only">
+              {showAiAgent ? "AI-Agent" : "Support"}
+            </DrawerTitle>
             <DrawerDescription className="sr-only">
-              A list of resources and options to help you with your questions.
+              {showAiAgent
+                ? "An AI assistant to help you with your questions."
+                : "A list of resources and options to help you with your questions."}
             </DrawerDescription>
           </DrawerHeader>
           <div className="mt-4 max-h-full">
-            <SupportDrawer showCloseButton={false} className="h-full pb-20" />
+            {showAiAgent ? (
+              <ControlledInAppAgentDrawer showCloseButton={false} />
+            ) : (
+              <SupportDrawer showCloseButton={false} className="h-full pb-20" />
+            )}
           </div>
         </DrawerContent>
       </Drawer>

--- a/web/src/components/layouts/app-layout/components/ResizableContent.tsx
+++ b/web/src/components/layouts/app-layout/components/ResizableContent.tsx
@@ -10,6 +10,7 @@ import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvi
 import { type PropsWithChildren } from "react";
 import { useMediaQuery } from "react-responsive";
 import dynamic from "next/dynamic";
+import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 
 const MobileLayout = dynamic(
   () =>
@@ -38,6 +39,15 @@ const SupportDrawer = dynamic(
     ssr: false,
   },
 );
+const ControlledInAppAgentDrawer = dynamic(
+  () =>
+    import("@/src/features/in-app-agent/components").then((mod) => ({
+      default: mod.ControlledInAppAgentDrawer,
+    })),
+  {
+    ssr: false,
+  },
+);
 
 /**
  * Resizable content for support drawer on the right side of the screen (desktop).
@@ -46,24 +56,38 @@ const SupportDrawer = dynamic(
  * Key optimization: Always renders ResizablePanelGroup on desktop to prevent
  * remounting children when drawer opens/closes. Uses refs for programmatic control.
  */
-export function ResizableContent({ children }: PropsWithChildren) {
+export function ResizableContent({
+  aiAgentEnabled,
+  children,
+}: PropsWithChildren<{ aiAgentEnabled?: boolean }>) {
   const isDesktop = useMediaQuery({ query: "(min-width: 768px)" });
-  const { open } = useSupportDrawer();
+  const { open: supportOpen } = useSupportDrawer();
+  const { open: aiAgentOpen, setOpen: setAiAgentOpen } = useInAppAiAgent();
+  const showAiAgent = Boolean(aiAgentEnabled && aiAgentOpen);
 
   if (!isDesktop) {
-    return <MobileLayout>{children}</MobileLayout>;
+    return (
+      <MobileLayout aiAgentEnabled={aiAgentEnabled}>{children}</MobileLayout>
+    );
   }
 
   return (
     <DesktopLayout
       mainContent={children}
-      sidebarContent={<SupportDrawer />}
-      open={open}
-      showHandle={false}
-      defaultMainSize={70}
-      defaultSidebarSize={30}
+      sidebarContent={
+        showAiAgent ? (
+          <ControlledInAppAgentDrawer onClose={() => setAiAgentOpen(false)} />
+        ) : (
+          <SupportDrawer />
+        )
+      }
+      open={showAiAgent || supportOpen}
+      showHandle={showAiAgent}
+      defaultMainSize={showAiAgent ? 72 : 70}
+      defaultSidebarSize={showAiAgent ? 28 : 30}
       minMainSize={30}
       maxSidebarSize={60}
+      persistId={showAiAgent ? "assistant-sidebar" : undefined}
     />
   );
 }

--- a/web/src/components/layouts/app-layout/index.tsx
+++ b/web/src/components/layouts/app-layout/index.tsx
@@ -142,6 +142,7 @@ export function AppLayout(props: PropsWithChildren) {
       session={session.data}
       navigation={navigation}
       metadata={metadata}
+      aiFeaturesEnabled={organization?.aiFeaturesEnabled ?? false}
       onSignOut={handleSignOut}
     >
       {props.children}

--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -11,6 +11,7 @@ import { AppSidebar } from "@/src/components/nav/app-sidebar";
 import { Toaster } from "@/src/components/ui/sonner";
 import { TopBannerProvider } from "@/src/features/top-banner";
 import { ResizableContent } from "../components/ResizableContent";
+import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
 import { ThemeToggle } from "@/src/features/theming/ThemeToggle";
 import {
   getAvailableCloudRegionOptions,
@@ -82,6 +83,7 @@ type AuthenticatedLayoutProps = PropsWithChildren<{
     favicon256Path: string;
     appleTouchIconPath: string;
   };
+  aiFeaturesEnabled: boolean;
   onSignOut: () => void;
 }>;
 
@@ -99,9 +101,12 @@ export function AuthenticatedLayout({
   session,
   navigation,
   metadata,
+  aiFeaturesEnabled,
   onSignOut,
 }: AuthenticatedLayoutProps) {
   const { isLangfuseCloud, region: currentRegion } = useLangfuseCloudRegion();
+  const assistantEnabled =
+    useIsFeatureEnabled("inAppAgent") && aiFeaturesEnabled;
 
   // Safe assertion: AuthenticatedLayout is only rendered after auth checks pass
   // in AppLayout, which guarantees session.user exists at this point
@@ -183,7 +188,9 @@ export function AuthenticatedLayout({
                 userNavProps={userNavProps}
               />
               <SidebarInset className="h-screen-with-banner max-w-full md:peer-data-[state=collapsed]:w-[calc(100vw-var(--sidebar-width-icon))] md:peer-data-[state=expanded]:w-[calc(100vw-var(--sidebar-width))]">
-                <ResizableContent>{children}</ResizableContent>
+                <ResizableContent aiAgentEnabled={assistantEnabled}>
+                  {children}
+                </ResizableContent>
                 <Toaster visibleToasts={1} />
                 <CommandMenu mainNavigation={navigation.navigation} />
               </SidebarInset>

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -25,6 +25,7 @@ import { type Entitlement } from "@/src/features/entitlements/constants/entitlem
 import { type User } from "next-auth";
 import { type OrganizationScope } from "@/src/features/rbac/constants/organizationAccessRights";
 import { SupportButton } from "@/src/components/nav/support-button";
+import { InAppAiAgentButton } from "@/src/components/nav/in-app-ai-agent-button";
 import { BookACallButton } from "@/src/components/nav/book-a-call-button";
 import { V4SidebarToggle } from "@/src/features/events/components/V4SidebarToggle";
 import { SidebarMenuButton } from "@/src/components/ui/sidebar";
@@ -228,6 +229,14 @@ export const ROUTES: Route[] = [
     section: RouteSection.Secondary,
     pathname: "",
     menuNode: <BookACallButton />,
+  },
+  {
+    title: "AI-Agent",
+    section: RouteSection.Secondary,
+    pathname: "/project/[projectId]",
+    featureFlag: "inAppAgent",
+    show: ({ organization }) => organization?.aiFeaturesEnabled === true,
+    menuNode: <InAppAiAgentButton />,
   },
   {
     title: "Support",

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -233,7 +233,7 @@ export const ROUTES: Route[] = [
   {
     title: "AI Assistant",
     section: RouteSection.Secondary,
-    pathname: "/project/[projectId]",
+    pathname: "",
     featureFlag: "inAppAgent",
     show: ({ organization }) => organization?.aiFeaturesEnabled === true,
     menuNode: <InAppAiAgentButton />,

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -231,7 +231,7 @@ export const ROUTES: Route[] = [
     menuNode: <BookACallButton />,
   },
   {
-    title: "AI-Agent",
+    title: "AI Assistant",
     section: RouteSection.Secondary,
     pathname: "/project/[projectId]",
     featureFlag: "inAppAgent",

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -31,7 +31,7 @@ export const InAppAiAgentButton = () => {
       }}
     >
       <Bot className="h-4 w-4" />
-      AI-Assistant
+      AI Assistant
     </SidebarMenuButton>
   );
 };

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -1,0 +1,37 @@
+import { Bot } from "lucide-react";
+
+import { SidebarMenuButton, useSidebar } from "@/src/components/ui/sidebar";
+import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
+import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
+
+export const InAppAiAgentButton = () => {
+  const { setOpen } = useInAppAiAgent();
+  const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
+  const { isMobile, setOpenMobile: setOpenMobileSidebar } = useSidebar();
+
+  const toggleInAppAiAgent = () => {
+    setSupportDrawerOpen(false);
+    setOpen((currentOpen) => !currentOpen);
+  };
+
+  return (
+    <SidebarMenuButton
+      isActive={false}
+      onClick={() => {
+        if (isMobile) {
+          setOpenMobileSidebar(false);
+          setTimeout(() => {
+            // push to next tick to avoid flickering when hiding sidebar on mobile
+            toggleInAppAiAgent();
+          }, 1);
+          return;
+        }
+
+        toggleInAppAiAgent();
+      }}
+    >
+      <Bot className="h-4 w-4" />
+      AI-Agent
+    </SidebarMenuButton>
+  );
+};

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -5,9 +5,13 @@ import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiA
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 
 export const InAppAiAgentButton = () => {
-  const { setOpen } = useInAppAiAgent();
+  const { isAvailable, setOpen } = useInAppAiAgent();
   const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
   const { isMobile, setOpenMobile: setOpenMobileSidebar } = useSidebar();
+
+  if (!isAvailable) {
+    return null;
+  }
 
   const toggleInAppAiAgent = () => {
     setSupportDrawerOpen(false);

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -31,7 +31,7 @@ export const InAppAiAgentButton = () => {
       }}
     >
       <Bot className="h-4 w-4" />
-      AI-Agent
+      AI-Assistant
     </SidebarMenuButton>
   );
 };

--- a/web/src/components/nav/support-button.tsx
+++ b/web/src/components/nav/support-button.tsx
@@ -1,9 +1,11 @@
 import { LifeBuoy } from "lucide-react";
 import { SidebarMenuButton, useSidebar } from "@/src/components/ui/sidebar";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
+import { useInAppAiAgent } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 
 export const SupportButton = () => {
   const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
+  const { setOpen: setAiAgentOpen } = useInAppAiAgent();
   const { isMobile, setOpenMobile: setOpenMobileSidebar } = useSidebar();
 
   return (
@@ -14,6 +16,7 @@ export const SupportButton = () => {
         }
         setTimeout(() => {
           // push to next tick to avoid flickering when hiding sidebar on mobile
+          setAiAgentOpen(false);
           setSupportDrawerOpen(true);
         }, 1);
       }}

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -466,6 +466,9 @@ export const env = createEnv({
         }
         return map;
       }),
+    AWS_ACCESS_KEY_ID: z.string().optional(),
+    AWS_SECRET_ACCESS_KEY: z.string().optional(),
+    LANGFUSE_AWS_BEDROCK_REGION: z.string().optional(),
   },
 
   /**
@@ -519,6 +522,9 @@ export const env = createEnv({
     NEXT_PUBLIC_SIGN_UP_DISABLED: process.env.NEXT_PUBLIC_SIGN_UP_DISABLED,
     LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES:
       process.env.LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES,
+    AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+    LANGFUSE_AWS_BEDROCK_REGION: process.env.LANGFUSE_AWS_BEDROCK_REGION,
     LANGFUSE_TEAM_SLACK_WEBHOOK: process.env.LANGFUSE_TEAM_SLACK_WEBHOOK,
     LANGFUSE_NEW_USER_SIGNUP_WEBHOOK:
       process.env.LANGFUSE_NEW_USER_SIGNUP_WEBHOOK,

--- a/web/src/features/feature-flags/available-flags.ts
+++ b/web/src/features/feature-flags/available-flags.ts
@@ -1,4 +1,5 @@
 export const availableFlags = [
+  "inAppAgent",
   "templateFlag",
   "excludeClickhouseRead",
   "v4BetaToggleVisible",

--- a/web/src/features/in-app-agent/components/ControlledInAppAgentDrawer.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentDrawer.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useMemo } from "react";
+import { z } from "zod";
+import {
+  InAppAgentDrawer,
+  type InAppAgentDrawerMessage,
+} from "./InAppAgentDrawer";
+import { useInAppAiAgent } from "./InAppAiAgentProvider";
+import { AgUiMessageSchema } from "@/src/features/in-app-agent/schema";
+
+type ControlledInAppAgentDrawerProps =
+  | {
+      showCloseButton: false;
+      onClose?: () => void;
+    }
+  | {
+      showCloseButton?: true;
+      onClose: () => void;
+    };
+
+export function ControlledInAppAgentDrawer(
+  props: ControlledInAppAgentDrawerProps,
+) {
+  const { error, isRunning, messages, submit } = useInAppAiAgent();
+  const drawerMessages = useMemo(() => {
+    const parsedMessages = z.array(AgUiMessageSchema).parse(messages);
+
+    const mappedMessages = parsedMessages.flatMap(
+      (message, index): InAppAgentDrawerMessage[] => {
+        if (message.role === "system" || message.role === "activity") {
+          return [];
+        }
+
+        const role = message.role === "user" ? "user" : "assistant";
+        const isLoading = message.role === "reasoning";
+
+        if (isLoading) {
+          const hasLaterAssistantMessage = parsedMessages.some(
+            (message, messageIndex) =>
+              messageIndex > index && message.role === "assistant",
+          );
+
+          if (!isRunning || hasLaterAssistantMessage) {
+            return [];
+          }
+
+          return [
+            {
+              id: message.id,
+              role,
+              content: [{ type: "loading" }],
+            },
+          ];
+        }
+
+        const text =
+          typeof message.content === "string"
+            ? message.content
+            : Array.isArray(message.content)
+              ? message.content
+                  .flatMap((part) => (part.type === "text" ? [part.text] : []))
+                  .join("")
+              : "";
+
+        if (role === "assistant" && !text.trim()) {
+          return [];
+        }
+
+        return [
+          {
+            id: message.id,
+            role,
+            content: [
+              {
+                type: "text",
+                text,
+              },
+            ],
+          },
+        ];
+      },
+    );
+
+    const lastMessage = mappedMessages.at(-1);
+    const hasAssistantAnswer = mappedMessages.some(
+      (message) =>
+        message.role === "assistant" &&
+        message.content.some((content) => content.type === "text"),
+    );
+
+    // Insert an optimistic loading message
+    if (isRunning && !error && lastMessage?.role === "user") {
+      return [
+        ...mappedMessages,
+        {
+          id: hasAssistantAnswer ? "loading" : "connecting",
+          role: "assistant",
+          content: [
+            hasAssistantAnswer
+              ? { type: "loading" }
+              : { type: "loading", label: "Connecting..." },
+          ],
+        } satisfies InAppAgentDrawerMessage,
+      ];
+    }
+
+    return mappedMessages;
+  }, [error, isRunning, messages]);
+
+  const closeButtonProps =
+    props.showCloseButton === false
+      ? ({ showCloseButton: false } as const)
+      : ({ showCloseButton: true, onClose: props.onClose } as const);
+
+  return (
+    <InAppAgentDrawer
+      error={error}
+      isRunning={isRunning}
+      messages={drawerMessages}
+      onSubmit={submit}
+      {...closeButtonProps}
+    />
+  );
+}

--- a/web/src/features/in-app-agent/components/InAppAgentDrawer.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentDrawer.stories.tsx
@@ -1,0 +1,149 @@
+import preview from "../../../../.storybook/preview";
+import { fn } from "storybook/test";
+import { InAppAgentDrawer } from "./InAppAgentDrawer";
+
+const meta = preview.meta({
+  component: InAppAgentDrawer,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-screen w-full">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    error: null,
+    isRunning: false,
+    onClose: fn(),
+    onSubmit: fn(),
+    showCloseButton: true,
+  },
+});
+
+export const Empty = meta.story({
+  args: {
+    messages: [],
+  },
+});
+
+export const Conversation = meta.story({
+  args: {
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Which traces had the highest latency today?",
+          },
+        ],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Start by filtering traces by timestamp, then sort by latency. Open the slowest traces to inspect long-running observations.",
+          },
+        ],
+      },
+      {
+        id: "user-2",
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Can I compare that with scores?",
+          },
+        ],
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Yes. Add score filters or group the traces by score name to see whether latency correlates with lower quality.",
+          },
+        ],
+      },
+    ],
+  },
+});
+
+export const LoadingResponse = meta.story({
+  args: {
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Summarize recent ingestion errors.",
+          },
+        ],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: [
+          {
+            type: "loading",
+          },
+        ],
+      },
+    ],
+  },
+});
+
+export const Connecting = meta.story({
+  args: {
+    isRunning: true,
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Summarize recent ingestion errors.",
+          },
+        ],
+      },
+      {
+        id: "connecting",
+        role: "assistant",
+        content: [
+          {
+            type: "loading",
+            label: "Connecting...",
+          },
+        ],
+      },
+    ],
+  },
+});
+
+export const Error = meta.story({
+  args: {
+    error: "Assistant is not enabled for this user",
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Help me inspect this trace.",
+          },
+        ],
+      },
+    ],
+  },
+});

--- a/web/src/features/in-app-agent/components/InAppAgentDrawer.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentDrawer.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { Bot, PanelRightClose, SendHorizontal } from "lucide-react";
+import { Button } from "@/src/components/ui/button";
+import { cn } from "@/src/utils/tailwind";
+import {
+  InAppAgentMessage,
+  type InAppAgentMessageContent,
+  type InAppAgentMessageRole,
+} from "./InAppAgentMessage";
+
+const AUTO_SCROLL_THRESHOLD_PX = 200;
+
+export type InAppAgentDrawerMessage = {
+  id: string;
+  role: InAppAgentMessageRole;
+  content: InAppAgentMessageContent[];
+};
+
+type InAppAgentDrawerCloseButtonProps =
+  | {
+      showCloseButton: false;
+      onClose?: () => void;
+    }
+  | {
+      showCloseButton?: true;
+      onClose: () => void;
+    };
+
+export type InAppAgentDrawerProps = {
+  error: string | null;
+  isRunning: boolean;
+  messages: InAppAgentDrawerMessage[];
+  onSubmit: (input: string) => void;
+} & InAppAgentDrawerCloseButtonProps;
+
+export function InAppAgentDrawer(props: InAppAgentDrawerProps) {
+  const { error, isRunning, messages, onSubmit } = props;
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const scrollPositionRef = useRef<{
+    scrollHeight: number;
+    scrollTop: number;
+    clientHeight: number;
+  } | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const [input, setInput] = useState("");
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+
+    if (!viewport) {
+      return;
+    }
+
+    const scrollPosition = scrollPositionRef.current;
+    const isNearBottom =
+      !scrollPosition ||
+      scrollPosition.scrollHeight -
+        scrollPosition.scrollTop -
+        scrollPosition.clientHeight <=
+        AUTO_SCROLL_THRESHOLD_PX;
+
+    if (!isNearBottom) {
+      return;
+    }
+
+    viewport.scrollTo({
+      top: viewport.scrollHeight,
+      behavior: "smooth",
+    });
+  }, [messages]);
+
+  useEffect(() => {
+    const input = inputRef.current;
+
+    if (!input) {
+      return;
+    }
+
+    input.style.height = "auto";
+    input.style.height = `${Math.min(input.scrollHeight, 160)}px`;
+  }, [input]);
+
+  return (
+    <section className="bg-background flex h-full min-w-0 flex-col">
+      <header className="bg-background flex h-11.25 shrink-0 items-center justify-between border-b px-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <div className="bg-muted text-foreground flex h-6 w-6 items-center justify-center rounded-xl">
+            <Bot className="h-3 w-3" />
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold">AI-Agent</p>
+          </div>
+        </div>
+        {props.showCloseButton !== false && (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={props.onClose}
+            aria-label="Close AI agent drawer"
+          >
+            <PanelRightClose className="h-4 w-4" />
+          </Button>
+        )}
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div
+          ref={viewportRef}
+          className="min-h-0 flex-1 overflow-y-auto"
+          onScroll={(event) => {
+            const viewport = event.currentTarget;
+            scrollPositionRef.current = {
+              scrollHeight: viewport.scrollHeight,
+              scrollTop: viewport.scrollTop,
+              clientHeight: viewport.clientHeight,
+            };
+          }}
+        >
+          <div className="flex w-full flex-col gap-4 px-4 py-4">
+            {messages.length === 0 ? (
+              <div className="border-border rounded-2xl border border-dashed px-4 py-5">
+                <p className="text-muted-foreground text-sm">
+                  Ask about Langfuse
+                </p>
+              </div>
+            ) : null}
+
+            <ol className="flex w-full flex-col gap-4">
+              {messages.map((message) => (
+                <li
+                  key={message.id}
+                  className={cn(
+                    "w-fit max-w-[92%]",
+                    message.role === "user" && "ml-auto",
+                  )}
+                >
+                  <div className="flex w-full">
+                    {message.content.map((content, index) => (
+                      <InAppAgentMessage
+                        key={`${message.id}-${index}`}
+                        role={message.role}
+                        content={content}
+                      />
+                    ))}
+                  </div>
+                </li>
+              ))}
+            </ol>
+
+            {error ? (
+              <div
+                role="alert"
+                className="border-destructive/40 bg-destructive/10 text-destructive rounded-lg border px-3 py-2 text-sm"
+              >
+                {error}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div className="bg-background border-t p-3">
+          <form
+            className="flex w-full items-end gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+
+              const content = input.trim();
+
+              if (!content || isRunning) {
+                return;
+              }
+
+              onSubmit(content);
+              setInput("");
+            }}
+          >
+            <textarea
+              ref={inputRef}
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
+                if (
+                  event.key === "Enter" &&
+                  !event.shiftKey &&
+                  !event.nativeEvent.isComposing
+                ) {
+                  event.preventDefault();
+                  event.currentTarget.form?.requestSubmit();
+                }
+              }}
+              disabled={isRunning}
+              aria-label="Ask about Langfuse"
+              placeholder="Ask about Langfuse..."
+              rows={1}
+              className="bg-background max-h-40 min-h-10 flex-1 resize-none overflow-y-auto rounded-xl px-3 py-2 text-sm leading-5 disabled:cursor-not-allowed disabled:opacity-60"
+            />
+            <Button
+              type="submit"
+              size="icon"
+              className="h-10 w-10 rounded-xl"
+              aria-label="Send message"
+              disabled={isRunning || !input.trim()}
+            >
+              <SendHorizontal className="h-4 w-4" />
+            </Button>
+          </form>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/features/in-app-agent/components/InAppAgentDrawer.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
-import { Bot, PanelRightClose, SendHorizontal } from "lucide-react";
+import { PanelRightClose, SendHorizontal } from "lucide-react";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 import {
@@ -84,13 +84,10 @@ export function InAppAgentDrawer(props: InAppAgentDrawerProps) {
 
   return (
     <section className="bg-background flex h-full min-w-0 flex-col">
-      <header className="bg-background flex h-11.25 shrink-0 items-center justify-between border-b px-4">
+      <header className="bg-background flex h-11.25 shrink-0 items-center justify-between border-b px-3">
         <div className="flex min-w-0 items-center gap-2">
-          <div className="bg-muted text-foreground flex h-6 w-6 items-center justify-center rounded-xl">
-            <Bot className="h-3 w-3" />
-          </div>
           <div className="min-w-0">
-            <p className="truncate text-sm font-semibold">AI-Agent</p>
+            <p className="truncate text-sm font-semibold">AI Assistant</p>
           </div>
         </div>
         {props.showCloseButton !== false && (
@@ -117,9 +114,9 @@ export function InAppAgentDrawer(props: InAppAgentDrawerProps) {
             };
           }}
         >
-          <div className="flex w-full flex-col gap-4 px-4 py-4">
+          <div className="flex w-full flex-col gap-4 px-3 py-4">
             {messages.length === 0 ? (
-              <div className="border-border rounded-2xl border border-dashed px-4 py-5">
+              <div className="border-border rounded-2xl border border-dashed px-4 py-3">
                 <p className="text-muted-foreground text-sm">
                   Ask about Langfuse
                 </p>
@@ -192,12 +189,12 @@ export function InAppAgentDrawer(props: InAppAgentDrawerProps) {
               aria-label="Ask about Langfuse"
               placeholder="Ask about Langfuse..."
               rows={1}
-              className="bg-background max-h-40 min-h-10 flex-1 resize-none overflow-y-auto rounded-xl px-3 py-2 text-sm leading-5 disabled:cursor-not-allowed disabled:opacity-60"
+              className="bg-background text-muted-foreground border-input max-h-40 min-h-10 flex-1 resize-none overflow-y-auto rounded-md px-3 py-2 text-sm leading-5 disabled:cursor-not-allowed disabled:opacity-60"
             />
             <Button
               type="submit"
               size="icon"
-              className="h-10 w-10 rounded-xl"
+              className="h-10 w-10 rounded-md"
               aria-label="Send message"
               disabled={isRunning || !input.trim()}
             >

--- a/web/src/features/in-app-agent/components/InAppAgentDrawer.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentDrawer.tsx
@@ -189,7 +189,7 @@ export function InAppAgentDrawer(props: InAppAgentDrawerProps) {
               aria-label="Ask about Langfuse"
               placeholder="Ask about Langfuse..."
               rows={1}
-              className="bg-background text-muted-foreground border-input max-h-40 min-h-10 flex-1 resize-none overflow-y-auto rounded-md px-3 py-2 text-sm leading-5 disabled:cursor-not-allowed disabled:opacity-60"
+              className="bg-background placeholder:text-muted-foreground border-input max-h-40 min-h-10 flex-1 resize-none overflow-y-auto rounded-md px-3 py-2 text-sm leading-5 disabled:cursor-not-allowed disabled:opacity-60"
             />
             <Button
               type="submit"

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.stories.tsx
@@ -1,0 +1,93 @@
+import preview from "../../../../.storybook/preview";
+import { InAppAgentMessage } from "./InAppAgentMessage";
+
+const meta = preview.meta({
+  component: InAppAgentMessage,
+});
+
+export const AssistantText = meta.story({
+  args: {
+    role: "assistant",
+    content: {
+      type: "text",
+      text: "Langfuse tracks traces, observations, scores, and metadata so teams can debug LLM applications.",
+    },
+  },
+});
+
+export const AssistantMarkdown = meta.story({
+  args: {
+    role: "assistant",
+    content: {
+      type: "text",
+      text: [
+        "## Debugging checklist",
+        "",
+        "You can use **Langfuse** to inspect _production traces_ and compare `input`, `output`, and metadata across releases.",
+        "",
+        "- Inspect traces with nested observations",
+        "- Evaluate outputs with scores",
+        "- Monitor production quality over time",
+        "",
+        "1. Filter for `level = ERROR`.",
+        "2. Open the slowest trace.",
+        "3. Compare model settings and prompt versions.",
+        "",
+        "> Tip: add scores and metadata early so regressions are easier to segment later.",
+        "",
+        "| Signal | Where to look |",
+        "| --- | --- |",
+        "| Latency | Observation timings |",
+        "| Cost | Usage and model pricing |",
+        "| Quality | Scores and comments |",
+        "",
+        "```ts",
+        "const trace = {",
+        '  name: "checkout-agent",',
+        '  environment: "production",',
+        '  metadata: { region: "eu" },',
+        "};",
+        "```",
+        "",
+        "Streaming partial markdown:",
+        "",
+        "- The assistant can render a list item while it is still streaming",
+        "- It can also keep an unfinished **bold phrase",
+        "",
+        "```json",
+        "{",
+        '  "status": "streaming",',
+        '  "next": "content still arriving"',
+      ].join("\n"),
+    },
+  },
+});
+
+export const UserText = meta.story({
+  args: {
+    role: "user",
+    content: {
+      type: "text",
+      text: "How do I find failed traces from the last 24 hours?",
+    },
+  },
+});
+
+export const Loading = meta.story({
+  args: {
+    role: "assistant",
+    content: {
+      type: "loading",
+    },
+  },
+});
+
+export const Connecting = meta.story({
+  args: {
+    role: "assistant",
+    content: {
+      type: "loading",
+      label: "Connecting...",
+    },
+  },
+});

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -21,7 +21,7 @@ export function InAppAgentMessage({ role, content }: InAppAgentMessageProps) {
   return (
     <div
       className={cn(
-        "rounded-2xl px-4 py-3 text-sm shadow-xs",
+        "rounded-2xl px-3.5 py-2.5 text-sm shadow-xs",
         isUser
           ? "bg-primary text-primary-foreground"
           : "bg-card text-card-foreground border-border border",
@@ -44,12 +44,39 @@ function MessageText({
   text: string;
 }) {
   if (role === "user") {
-    return <p className="leading-6 whitespace-pre-wrap">{text}</p>;
+    return <p className="leading-5.5 whitespace-pre-wrap">{text}</p>;
   }
 
   return (
-    <div className="assistant-streamdown text-sm leading-6">
-      <Streamdown>{text}</Streamdown>
+    <div className="prose prose-sm text-foreground prose-headings:my-2.5 prose-p:my-1.5 prose-ul:my-1.5 prose-li:my-1 prose-ol:my-1.5 prose-strong:text-inherit prose-blockquote:my-2.5 prose-pre:my-2.5 prose-pre:bg-muted prose-pre:text-foreground prose-code:text-foreground prose-table:my-2.5 max-w-none leading-5.5">
+      <Streamdown
+        // Remove all default classNames so that tailwind's prose styling can be applied without conflicts
+        components={{
+          h1: ({ children }) => <h1>{children}</h1>,
+          h2: ({ children }) => <h2>{children}</h2>,
+          h3: ({ children }) => <h3>{children}</h3>,
+          h4: ({ children }) => <h4>{children}</h4>,
+          h5: ({ children }) => <h5>{children}</h5>,
+          h6: ({ children }) => <h6>{children}</h6>,
+          p: ({ children }) => <p>{children}</p>,
+          a: ({ children, href }) => (
+            <a href={href} target="_blank" rel="noopener noreferrer">
+              {children}
+            </a>
+          ),
+          ul: ({ children }) => <ul>{children}</ul>,
+          ol: ({ children }) => <ol>{children}</ol>,
+          li: ({ children }) => <li>{children}</li>,
+          b: ({ children }) => <b>{children}</b>,
+          strong: ({ children }) => <strong>{children}</strong>,
+          i: ({ children }) => <i>{children}</i>,
+          em: ({ children }) => <em>{children}</em>,
+          code: ({ children }) => <code>{children}</code>,
+          pre: ({ children }) => <pre>{children}</pre>,
+        }}
+      >
+        {text}
+      </Streamdown>
     </div>
   );
 }

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { Streamdown } from "streamdown";
+import { cn } from "@/src/utils/tailwind";
+
+export type InAppAgentMessageRole = "assistant" | "user";
+
+export type InAppAgentMessageContent =
+  | { type: "loading"; label?: string }
+  | { type: "text"; text: string };
+
+export type InAppAgentMessageProps = {
+  role: InAppAgentMessageRole;
+  content: InAppAgentMessageContent;
+};
+
+export function InAppAgentMessage({ role, content }: InAppAgentMessageProps) {
+  const isUser = role === "user";
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl px-4 py-3 text-sm shadow-xs",
+        isUser
+          ? "bg-primary text-primary-foreground"
+          : "bg-card text-card-foreground border-border border",
+      )}
+    >
+      {content.type === "loading" ? (
+        <ThinkingIndicator label={content.label} />
+      ) : (
+        <MessageText role={role} text={content.text} />
+      )}
+    </div>
+  );
+}
+
+function MessageText({
+  role,
+  text,
+}: {
+  role: InAppAgentMessageRole;
+  text: string;
+}) {
+  if (role === "user") {
+    return <p className="leading-6 whitespace-pre-wrap">{text}</p>;
+  }
+
+  return (
+    <div className="assistant-streamdown text-sm leading-6">
+      <Streamdown>{text}</Streamdown>
+    </div>
+  );
+}
+
+function ThinkingIndicator({
+  className,
+  label = "Thinking...",
+}: {
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <div className={cn("flex items-center gap-2 text-sm", className)}>
+      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -39,6 +39,7 @@ const getEmptySession = (projectId: string): PersistentInAppAiAgentSession => ({
 });
 
 const NOOP_CONTEXT: InAppAiAgentContextType = {
+  isAvailable: false,
   open: false,
   setOpen: () => undefined,
   isRunning: false,
@@ -50,6 +51,7 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
 type InAppAiAgentMessage = Extract<AgUiMessage, { role: "user" | "assistant" }>;
 
 type InAppAiAgentContextType = {
+  isAvailable: boolean;
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
   isRunning: boolean;
@@ -318,6 +320,7 @@ function InAppAiAgentProviderInner({
 
   const value = useMemo<InAppAiAgentContextType>(
     () => ({
+      isAvailable: true,
       open,
       setOpen,
       isRunning,

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -1,0 +1,391 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PropsWithChildren,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { HttpAgent } from "@ag-ui/client";
+import { useRouter } from "next/router";
+import { z } from "zod";
+import { env } from "@/src/env.mjs";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import {
+  AgUiMessageSchema,
+  InAppAgentRuntimeStateSchema,
+  PersistentInAppAiAgentSessionSchema,
+  type InAppAgentRuntimeState,
+  type PersistentInAppAiAgentSession,
+  type AgUiMessage,
+} from "@/src/features/in-app-agent/schema";
+import useSessionStorage from "@/src/components/useSessionStorage";
+
+const SESSION_STORAGE_KEY_PREFIX = "langfuse:in-app-ai-agent-session";
+const OPEN_STORAGE_KEY = "langfuse:in-app-ai-agent-open";
+
+const getInitialAgentState = (projectId: string): InAppAgentRuntimeState => ({
+  type: "newSession",
+  projectId,
+});
+
+const getEmptySession = (projectId: string): PersistentInAppAiAgentSession => ({
+  state: getInitialAgentState(projectId),
+  messages: [],
+});
+
+const NOOP_CONTEXT: InAppAiAgentContextType = {
+  open: false,
+  setOpen: () => undefined,
+  isRunning: false,
+  error: null,
+  messages: [],
+  submit: () => undefined,
+};
+
+type InAppAiAgentMessage = Extract<AgUiMessage, { role: "user" | "assistant" }>;
+
+type InAppAiAgentContextType = {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  isRunning: boolean;
+  error: string | null;
+  messages: InAppAiAgentMessage[];
+  submit: (content: string) => void;
+};
+
+const InAppAiAgentContext = createContext<InAppAiAgentContextType | null>(null);
+
+export interface InAppAiAgentProviderProps extends PropsWithChildren {
+  defaultOpen?: boolean;
+}
+
+export function InAppAiAgentProvider({
+  children,
+  defaultOpen = false,
+}: InAppAiAgentProviderProps) {
+  const router = useRouter();
+  const routerProjectId = router.query.projectId;
+  const projectId =
+    typeof routerProjectId === "string" ? routerProjectId : undefined;
+
+  if (!projectId) {
+    return <>{children}</>;
+  }
+
+  return (
+    <InAppAiAgentProjectProvider
+      projectId={projectId}
+      defaultOpen={defaultOpen}
+    >
+      {children}
+    </InAppAiAgentProjectProvider>
+  );
+}
+
+function InAppAiAgentProjectProvider({
+  children,
+  projectId,
+  defaultOpen,
+}: InAppAiAgentProviderProps & { projectId: string }) {
+  const [open, setOpen] = useSessionStorage<boolean>(
+    OPEN_STORAGE_KEY,
+    defaultOpen ?? false,
+  );
+
+  return (
+    <InAppAiAgentProviderInner
+      key={projectId}
+      projectId={projectId}
+      sessionStorageKey={`${SESSION_STORAGE_KEY_PREFIX}:${projectId}`}
+      open={open}
+      setOpen={setOpen}
+    >
+      {children}
+    </InAppAiAgentProviderInner>
+  );
+}
+
+type InAppAiAgentProviderInnerProps = PropsWithChildren<{
+  projectId: string;
+  sessionStorageKey: string;
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+}>;
+
+function InAppAiAgentProviderInner({
+  children,
+  projectId,
+  sessionStorageKey,
+  open,
+  setOpen,
+}: InAppAiAgentProviderInnerProps) {
+  const [storedSession, setStoredSession] =
+    useSessionStorage<PersistentInAppAiAgentSession>(
+      sessionStorageKey,
+      getEmptySession(projectId),
+    );
+
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const agentRef = useRef<HttpAgent | null>(null);
+  const subscriptionRef = useRef<ReturnType<HttpAgent["subscribe"]> | null>(
+    null,
+  );
+
+  const restoredSession = useMemo(() => {
+    const result = PersistentInAppAiAgentSessionSchema.safeParse(storedSession);
+
+    return result.success ? result.data : getEmptySession(projectId);
+  }, [projectId, storedSession]);
+
+  const restoredMessages = useMemo(
+    () => restoredSession.messages.filter(isAgentConversationMessage),
+    [restoredSession.messages],
+  );
+
+  const persistSession = useCallback(
+    (params: {
+      agent: { threadId: string };
+      messages: readonly unknown[];
+      state: unknown;
+    }) => {
+      const state = InAppAgentRuntimeStateSchema.safeParse(params.state);
+
+      setStoredSession((previousStoredSession) => {
+        const previousSession = PersistentInAppAiAgentSessionSchema.safeParse(
+          previousStoredSession,
+        );
+        const previousMessages = previousSession.success
+          ? previousSession.data.messages.filter(isAgentConversationMessage)
+          : [];
+        const incomingMessages = z
+          .array(AgUiMessageSchema)
+          .safeParse(params.messages);
+
+        const incomingMessageIds = new Set(
+          incomingMessages.success
+            ? incomingMessages.data.map((message) => message.id)
+            : [],
+        );
+        const result = PersistentInAppAiAgentSessionSchema.safeParse({
+          threadId: params.agent.threadId,
+          state: state.success ? state.data : getInitialAgentState(projectId),
+          messages: incomingMessages.success
+            ? [
+                ...previousMessages.filter(
+                  (message) => !incomingMessageIds.has(message.id),
+                ),
+                ...incomingMessages.data.filter(isAgentConversationMessage),
+              ]
+            : previousMessages,
+        });
+
+        return result.success ? result.data : getEmptySession(projectId);
+      });
+    },
+    [projectId, setStoredSession],
+  );
+
+  const ensureSubscription = useCallback(
+    (agent: HttpAgent) => {
+      if (subscriptionRef.current) {
+        return;
+      }
+
+      subscriptionRef.current = agent.subscribe({
+        onMessagesChanged: ({ messages, state, agent }) => {
+          persistSession({
+            agent,
+            messages,
+            state,
+          });
+        },
+        onStateChanged: ({ messages, state, agent }) => {
+          persistSession({
+            agent,
+            messages,
+            state,
+          });
+        },
+      });
+    },
+    [persistSession],
+  );
+
+  const runAgent = useCallback(
+    (agent: HttpAgent, retryOnInvalidSession = true) => {
+      persistSession({
+        agent,
+        messages: agent.messages,
+        state: agent.state,
+      });
+      setIsRunning(true);
+      let retriedWithFreshSession = false;
+
+      void agent
+        .runAgent()
+        .catch((error) => {
+          if (retryOnInvalidSession && isInvalidSessionTokenError(error)) {
+            retriedWithFreshSession = true;
+            subscriptionRef.current?.unsubscribe();
+            subscriptionRef.current = null;
+            agent.abortRun();
+
+            const freshAgent = new HttpAgent({
+              url: `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/in-app-agent`,
+              initialMessages: agent.messages.filter(
+                isAgentConversationMessage,
+              ),
+              initialState: getInitialAgentState(projectId),
+            });
+
+            agentRef.current = freshAgent;
+            ensureSubscription(freshAgent);
+            runAgent(freshAgent, false);
+            return;
+          }
+
+          const errorMessage = getAgentErrorMessage(error);
+          setError(errorMessage);
+          showErrorToast("Assistant failed", errorMessage);
+          console.error("In-app agent drawer error", error);
+        })
+        .finally(() => {
+          if (retriedWithFreshSession) {
+            return;
+          }
+
+          setIsRunning(false);
+          persistSession({
+            agent,
+            messages: agent.messages,
+            state: agent.state,
+          });
+        });
+    },
+    [ensureSubscription, persistSession, projectId],
+  );
+
+  useEffect(() => {
+    return () => {
+      subscriptionRef.current?.unsubscribe();
+      agentRef.current?.abortRun();
+    };
+  }, []);
+
+  const submit = useCallback(
+    (content: string) => {
+      if (!content) {
+        return;
+      }
+
+      setError(null);
+
+      // Create the agent if none exists
+      if (!agentRef.current) {
+        agentRef.current = new HttpAgent({
+          url: `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/in-app-agent`,
+          threadId: restoredSession.threadId,
+          initialMessages: restoredMessages,
+          initialState: restoredSession.state,
+        });
+      }
+
+      const agent = agentRef.current;
+
+      if (agent.isRunning) {
+        return;
+      }
+
+      ensureSubscription(agent);
+
+      const userMessage = {
+        id: crypto.randomUUID(),
+        role: "user",
+        content,
+      } satisfies AgUiMessage;
+
+      agent.addMessage(userMessage);
+      runAgent(agent);
+    },
+    [ensureSubscription, restoredMessages, restoredSession, runAgent],
+  );
+
+  const value = useMemo<InAppAiAgentContextType>(
+    () => ({
+      open,
+      setOpen,
+      isRunning,
+      error,
+      messages: restoredMessages,
+      submit,
+    }),
+    [error, isRunning, open, restoredMessages, setOpen, submit],
+  );
+
+  return (
+    <InAppAiAgentContext.Provider value={value}>
+      {children}
+    </InAppAiAgentContext.Provider>
+  );
+}
+
+function isInvalidSessionTokenError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const payload = "payload" in error ? error.payload : undefined;
+
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "code" in payload &&
+    payload.code === "invalid_session_token"
+  );
+}
+
+function isAgentConversationMessage(
+  message: unknown,
+): message is InAppAiAgentMessage {
+  const result = AgUiMessageSchema.safeParse(message);
+
+  return (
+    result.success &&
+    (result.data.role === "user" || result.data.role === "assistant")
+  );
+}
+
+function getAgentErrorMessage(error: unknown): string {
+  if (error && typeof error === "object") {
+    const payload = "payload" in error ? error.payload : undefined;
+
+    if (
+      payload &&
+      typeof payload === "object" &&
+      "error" in payload &&
+      typeof payload.error === "string"
+    ) {
+      return payload.error;
+    }
+
+    if ("message" in error && typeof error.message === "string") {
+      return error.message;
+    }
+  }
+
+  return "Assistant request failed. Please try again.";
+}
+
+export function useInAppAiAgent() {
+  const ctx = useContext(InAppAiAgentContext);
+  if (!ctx) {
+    return NOOP_CONTEXT;
+  }
+  return ctx;
+}

--- a/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -240,6 +240,7 @@ function InAppAiAgentProviderInner({
 
             const freshAgent = new HttpAgent({
               url: `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/in-app-agent`,
+              threadId: agent.threadId,
               initialMessages: agent.messages.filter(
                 isAgentConversationMessage,
               ),

--- a/web/src/features/in-app-agent/components/index.ts
+++ b/web/src/features/in-app-agent/components/index.ts
@@ -1,0 +1,2 @@
+export { ControlledInAppAgentDrawer } from "./ControlledInAppAgentDrawer";
+export { InAppAiAgentProvider, useInAppAiAgent } from "./InAppAiAgentProvider";

--- a/web/src/features/in-app-agent/schema.ts
+++ b/web/src/features/in-app-agent/schema.ts
@@ -1,0 +1,177 @@
+import type { EventType } from "@ag-ui/core";
+import { z } from "zod";
+
+// @ag-ui/core@0.0.52 publishes Zod v3-shaped declarations, but this package
+// uses Zod v4, causing its exported z.infer-based types to resolve as unknown.
+// Duplicate the relevant schemas locally until
+// https://github.com/ag-ui-protocol/ag-ui/pull/1637 is merged, then remove
+// these definitions and use @ag-ui/core directly again.
+
+const AgUiBaseMessageSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  encryptedValue: z.string().optional(),
+});
+
+const AgUiToolCallSchema = z.object({
+  id: z.string(),
+  type: z.literal("function"),
+  function: z.object({
+    name: z.string(),
+    arguments: z.string(),
+  }),
+  encryptedValue: z.string().optional(),
+});
+
+const AgUiInputContentSourceSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("data"),
+    value: z.string(),
+    mimeType: z.string(),
+  }),
+  z.object({
+    type: z.literal("url"),
+    value: z.string(),
+    mimeType: z.string().optional(),
+  }),
+]);
+
+const AgUiInputContentSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("text"),
+    text: z.string(),
+  }),
+  z.object({
+    type: z.literal("image"),
+    source: AgUiInputContentSourceSchema,
+    metadata: z.unknown().optional(),
+  }),
+  z.object({
+    type: z.literal("audio"),
+    source: AgUiInputContentSourceSchema,
+    metadata: z.unknown().optional(),
+  }),
+  z.object({
+    type: z.literal("video"),
+    source: AgUiInputContentSourceSchema,
+    metadata: z.unknown().optional(),
+  }),
+  z.object({
+    type: z.literal("document"),
+    source: AgUiInputContentSourceSchema,
+    metadata: z.unknown().optional(),
+  }),
+  z.object({
+    type: z.literal("binary"),
+    mimeType: z.string(),
+    id: z.string().optional(),
+    url: z.string().optional(),
+    data: z.string().optional(),
+    filename: z.string().optional(),
+  }),
+]);
+
+export const AgUiMessageSchema = z.discriminatedUnion("role", [
+  AgUiBaseMessageSchema.extend({
+    role: z.literal("developer"),
+    content: z.string(),
+  }),
+  AgUiBaseMessageSchema.extend({
+    role: z.literal("system"),
+    content: z.string(),
+  }),
+  AgUiBaseMessageSchema.extend({
+    role: z.literal("assistant"),
+    content: z.string().optional(),
+    toolCalls: z.array(AgUiToolCallSchema).optional(),
+  }),
+  AgUiBaseMessageSchema.extend({
+    role: z.literal("user"),
+    content: z.union([z.string(), z.array(AgUiInputContentSchema)]),
+  }),
+  z.object({
+    id: z.string(),
+    content: z.string(),
+    role: z.literal("tool"),
+    toolCallId: z.string(),
+    error: z.string().optional(),
+    encryptedValue: z.string().optional(),
+  }),
+  z.object({
+    id: z.string(),
+    role: z.literal("activity"),
+    activityType: z.string(),
+    content: z.record(z.string(), z.any()),
+  }),
+  z.object({
+    id: z.string(),
+    role: z.literal("reasoning"),
+    content: z.string(),
+    encryptedValue: z.string().optional(),
+  }),
+]);
+
+export type AgUiMessage = z.infer<typeof AgUiMessageSchema>;
+
+const AgUiToolSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  parameters: z.any().optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
+});
+
+const AgUiContextSchema = z.object({
+  description: z.string(),
+  value: z.string(),
+});
+
+export const AgUiRunAgentInputSchema = z.object({
+  threadId: z.string(),
+  runId: z.string(),
+  parentRunId: z.string().optional(),
+  state: z.any().optional(),
+  messages: z.array(AgUiMessageSchema),
+  tools: z.array(AgUiToolSchema),
+  context: z.array(AgUiContextSchema),
+  forwardedProps: z.any().optional(),
+});
+
+export type AgUiRunAgentInput = z.infer<typeof AgUiRunAgentInputSchema>;
+
+export type AgUiEvent = {
+  type: EventType;
+  timestamp?: number;
+  rawEvent?: unknown;
+  [key: string]: unknown;
+};
+
+export type AgUiCustomEvent = AgUiEvent & {
+  type: EventType.CUSTOM;
+  name: string;
+  value: unknown;
+};
+
+export const InAppAgentRuntimeStateSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("newSession"),
+    projectId: z.string(),
+  }),
+  z.object({
+    type: z.literal("existingSession"),
+    claudeSessionToken: z.string(),
+  }),
+]);
+
+export type InAppAgentRuntimeState = z.infer<
+  typeof InAppAgentRuntimeStateSchema
+>;
+
+export const PersistentInAppAiAgentSessionSchema = z.object({
+  threadId: z.string().optional(),
+  state: InAppAgentRuntimeStateSchema,
+  messages: z.array(AgUiMessageSchema).default([]),
+});
+
+export type PersistentInAppAiAgentSession = z.infer<
+  typeof PersistentInAppAiAgentSessionSchema
+>;

--- a/web/src/features/in-app-agent/server/agent.ts
+++ b/web/src/features/in-app-agent/server/agent.ts
@@ -15,6 +15,7 @@ const ASSISTANT_SYSTEM_PROMPT = [
   "If you are not confident in the answer, say that directly instead of guessing.",
   "Use markdown when it improves clarity.",
 ].join(" ");
+const MAX_AGENT_BUDGET_USD = 5;
 
 type CreateAgUiStreamOptions = {
   resumeSessionId?: string;
@@ -40,6 +41,7 @@ export function createAgUiStream(params: {
     allowedTools: [],
     settingSources: [],
     additionalDirectories: [],
+    maxBudgetUsd: MAX_AGENT_BUDGET_USD,
     env: {
       CLAUDE_CODE_USE_BEDROCK: "1",
       CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1",
@@ -98,6 +100,11 @@ export function createAgUiStream(params: {
           }
         },
         error(error) {
+          if (closed || params.signal.aborted) {
+            closeController();
+            return;
+          }
+
           console.error("Error in agent execution:", error);
 
           const message =

--- a/web/src/features/in-app-agent/server/agent.ts
+++ b/web/src/features/in-app-agent/server/agent.ts
@@ -83,7 +83,21 @@ export function createAgUiStream(params: {
         closeController();
       };
 
-      const subscription = adapter.run(adapterInput).subscribe({
+      let subscription: { unsubscribe: () => void } | undefined;
+
+      const handleAbort = () => {
+        subscription?.unsubscribe();
+        abort();
+      };
+
+      if (params.signal.aborted) {
+        abort();
+        return;
+      }
+
+      params.signal.addEventListener("abort", handleAbort, { once: true });
+
+      subscription = adapter.run(adapterInput).subscribe({
         next(event) {
           if (closed || params.signal.aborted) {
             abort();
@@ -124,15 +138,6 @@ export function createAgUiStream(params: {
           closeController();
         },
       });
-
-      params.signal.addEventListener(
-        "abort",
-        () => {
-          subscription.unsubscribe();
-          abort();
-        },
-        { once: true },
-      );
     },
   });
 }

--- a/web/src/features/in-app-agent/server/agent.ts
+++ b/web/src/features/in-app-agent/server/agent.ts
@@ -1,0 +1,175 @@
+import { EventType } from "@ag-ui/core";
+import { ClaudeAgentAdapter } from "@ag-ui/claude-agent-sdk";
+import { z } from "zod";
+
+import type {
+  AgUiCustomEvent,
+  AgUiEvent,
+  AgUiRunAgentInput,
+} from "@/src/features/in-app-agent/schema";
+
+const ASSISTANT_TITLE = "Langfuse Assistant";
+const ASSISTANT_SYSTEM_PROMPT = [
+  "You are the persistent in-app assistant for Langfuse.",
+  "Be concise, factual, and useful.",
+  "If you are not confident in the answer, say that directly instead of guessing.",
+  "Use markdown when it improves clarity.",
+].join(" ");
+
+type CreateAgUiStreamOptions = {
+  resumeSessionId?: string;
+  createResumeStateForSessionId: (sessionId: string) => unknown;
+  awsCredentials: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    region: string;
+  };
+};
+
+export function createAgUiStream(params: {
+  input: AgUiRunAgentInput;
+  signal: AbortSignal;
+  options: CreateAgUiStreamOptions;
+}) {
+  const encoder = new TextEncoder();
+
+  const adapter = new ClaudeAgentAdapter({
+    permissionMode: "dontAsk",
+    title: ASSISTANT_TITLE,
+    systemPrompt: ASSISTANT_SYSTEM_PROMPT,
+    allowedTools: [],
+    settingSources: [],
+    additionalDirectories: [],
+    env: {
+      CLAUDE_CODE_USE_BEDROCK: "1",
+      CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1",
+      AWS_DEFAULT_REGION: params.options.awsCredentials.region,
+      AWS_REGION: params.options.awsCredentials.region,
+      AWS_ACCESS_KEY_ID: params.options.awsCredentials.accessKeyId,
+      AWS_SECRET_ACCESS_KEY: params.options.awsCredentials.secretAccessKey,
+    },
+    includePartialMessages: true,
+    model: "haiku",
+  });
+
+  const adapterInput = params.options.resumeSessionId
+    ? {
+        ...params.input,
+        forwardedProps: {
+          ...(z
+            .record(z.string(), z.unknown())
+            .safeParse(params.input.forwardedProps).data ?? {}),
+          resume: params.options.resumeSessionId,
+        },
+      }
+    : params.input;
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false;
+      const closeController = () => {
+        if (closed) {
+          return;
+        }
+
+        closed = true;
+        controller.close();
+      };
+
+      const abort = () => {
+        void adapter.interrupt().catch(() => undefined);
+        closeController();
+      };
+
+      const subscription = adapter.run(adapterInput).subscribe({
+        next(event) {
+          if (closed || params.signal.aborted) {
+            abort();
+            return;
+          }
+
+          for (const agUiEvent of normalizeAdapterEvent(
+            event,
+            params.options.createResumeStateForSessionId,
+          )) {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(agUiEvent)}\n\n`),
+            );
+          }
+        },
+        error(error) {
+          console.error("Error in agent execution:", error);
+
+          const message =
+            error instanceof Error ? error.message : "Unknown assistant error";
+
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({
+                type: EventType.RUN_ERROR,
+                message,
+              } satisfies AgUiEvent)}\n\n`,
+            ),
+          );
+          closeController();
+        },
+        complete() {
+          closeController();
+        },
+      });
+
+      params.signal.addEventListener(
+        "abort",
+        () => {
+          subscription.unsubscribe();
+          abort();
+        },
+        { once: true },
+      );
+    },
+  });
+}
+
+function normalizeAdapterEvent(
+  event: AgUiEvent,
+  createResumeStateForSessionId: (sessionId: string) => unknown,
+): AgUiEvent[] {
+  if (isSystemInitEvent(event)) {
+    let sessionId: string | undefined;
+
+    if (event.value && typeof event.value === "object") {
+      if (
+        "session_id" in event.value &&
+        typeof event.value.session_id === "string"
+      ) {
+        sessionId = event.value.session_id;
+      } else if (
+        "sessionId" in event.value &&
+        typeof event.value.sessionId === "string"
+      ) {
+        sessionId = event.value.sessionId;
+      }
+    }
+
+    return sessionId
+      ? [
+          {
+            type: EventType.STATE_DELTA,
+            delta: [
+              {
+                op: "replace",
+                path: "",
+                value: createResumeStateForSessionId(sessionId),
+              },
+            ],
+          },
+        ]
+      : [];
+  }
+
+  return [event];
+}
+
+function isSystemInitEvent(event: AgUiEvent): event is AgUiCustomEvent {
+  return event.type === EventType.CUSTOM && event.name === "system:init";
+}

--- a/web/src/features/in-app-agent/server/auth.ts
+++ b/web/src/features/in-app-agent/server/auth.ts
@@ -1,0 +1,144 @@
+import crypto from "crypto";
+import { z } from "zod";
+
+import { env } from "@/src/env.mjs";
+
+const IN_APP_AGENT_SESSION_TOKEN_PREFIX = "lfcas_";
+const IN_APP_AGENT_SESSION_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+export class InvalidInAppAgentSessionTokenError extends Error {
+  constructor() {
+    super("Invalid in-app agent session token");
+    this.name = "InvalidInAppAgentSessionTokenError";
+  }
+}
+
+const InAppAgentSessionTokenPayloadSchema = z.object({
+  v: z.literal(1),
+  userId: z.string(),
+  projectId: z.string(),
+  threadId: z.string(),
+  claudeSessionId: z.string(),
+  exp: z.number().int(),
+});
+
+const EncodedInAppAgentSessionTokenPayloadSchema = z
+  .string()
+  .transform((payload, ctx) => {
+    try {
+      return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    } catch {
+      ctx.addIssue({
+        code: "custom",
+        message: "Invalid token payload",
+      });
+      return z.NEVER;
+    }
+  })
+  .pipe(InAppAgentSessionTokenPayloadSchema);
+
+const InAppAgentSessionTokenSchema = z
+  .string()
+  .startsWith(IN_APP_AGENT_SESSION_TOKEN_PREFIX)
+  .transform((token, ctx) => {
+    const [encodedPayload, signature, ...extraParts] = token
+      .slice(IN_APP_AGENT_SESSION_TOKEN_PREFIX.length)
+      .split(".");
+
+    if (!encodedPayload || !signature || extraParts.length > 0) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Invalid token format",
+      });
+      return z.NEVER;
+    }
+
+    const payload =
+      EncodedInAppAgentSessionTokenPayloadSchema.safeParse(encodedPayload);
+
+    if (!payload.success) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Invalid token payload",
+      });
+      return z.NEVER;
+    }
+
+    return {
+      encodedPayload,
+      payload: payload.data,
+      signature,
+    };
+  });
+
+export function signInAppAgentSessionToken(params: {
+  userId: string;
+  projectId: string;
+  threadId: string;
+  claudeSessionId: string;
+}): string {
+  const payload = Buffer.from(
+    JSON.stringify({
+      v: 1,
+      ...params,
+      exp:
+        Math.floor(Date.now() / 1000) + IN_APP_AGENT_SESSION_TOKEN_TTL_SECONDS,
+    }),
+    "utf8",
+  ).toString("base64url");
+
+  return `${IN_APP_AGENT_SESSION_TOKEN_PREFIX}${payload}.${sign(payload)}`;
+}
+
+export function verifyInAppAgentSessionToken(
+  token: string,
+  params: {
+    userId: string;
+    threadId: string;
+  },
+): {
+  projectId: string;
+  claudeSessionId: string;
+} {
+  const parsedToken = InAppAgentSessionTokenSchema.safeParse(token);
+
+  if (!parsedToken.success) {
+    throw new InvalidInAppAgentSessionTokenError();
+  }
+
+  const { encodedPayload, payload, signature } = parsedToken.data;
+
+  if (!safeEqual(signature, sign(encodedPayload))) {
+    throw new InvalidInAppAgentSessionTokenError();
+  }
+
+  if (
+    payload.userId !== params.userId ||
+    payload.threadId !== params.threadId ||
+    payload.exp < Math.floor(Date.now() / 1000)
+  ) {
+    throw new InvalidInAppAgentSessionTokenError();
+  }
+
+  return {
+    projectId: payload.projectId,
+    claudeSessionId: payload.claudeSessionId,
+  };
+}
+
+function sign(payload: string): string {
+  return crypto
+    .createHmac("sha256", env.NEXTAUTH_SECRET ?? env.SALT)
+    .update(payload, "utf8")
+    .digest("base64url");
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  return (
+    leftBuffer.length === rightBuffer.length &&
+    crypto.timingSafeEqual(leftBuffer, rightBuffer)
+  );
+}

--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -1,0 +1,211 @@
+import { getServerSession } from "next-auth";
+
+import { env } from "@/src/env.mjs";
+import {
+  AgUiRunAgentInputSchema,
+  type AgUiRunAgentInput,
+  InAppAgentRuntimeStateSchema,
+  type AgUiMessage,
+} from "@/src/features/in-app-agent/schema";
+import { createAgUiStream } from "@/src/features/in-app-agent/server/agent";
+import {
+  InvalidInAppAgentSessionTokenError,
+  signInAppAgentSessionToken,
+  verifyInAppAgentSessionToken,
+} from "@/src/features/in-app-agent/server/auth";
+import { getAuthOptions } from "@/src/server/auth";
+import { isProjectMemberOrAdmin } from "@/src/server/utils/checkProjectMembershipOrAdmin";
+import {
+  BaseError,
+  ForbiddenError,
+  InvalidRequestError,
+  UnauthorizedError,
+} from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+
+export default async function handler(request: Request) {
+  try {
+    const authOptions = await getAuthOptions();
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user) {
+      throw new UnauthorizedError("Unauthenticated");
+    }
+
+    if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+      throw new BaseError(
+        "PreconditionFailedError",
+        412,
+        "Assistant is not available in self-hosted deployments.",
+        true,
+      );
+    }
+
+    if (
+      !env.LANGFUSE_AWS_BEDROCK_REGION ||
+      !env.AWS_ACCESS_KEY_ID ||
+      !env.AWS_SECRET_ACCESS_KEY
+    ) {
+      throw new BaseError(
+        "PreconditionFailedError",
+        412,
+        "Assistant is not configured",
+        true,
+      );
+    }
+
+    const body = await request.json().catch(() => null);
+    const parsedInput = AgUiRunAgentInputSchema.safeParse(body);
+
+    if (!parsedInput.success) {
+      throw new InvalidRequestError("Invalid input");
+    }
+
+    const input = parsedInput.data;
+    const parsedState = InAppAgentRuntimeStateSchema.safeParse(input.state);
+
+    if (!parsedState.success) {
+      throw new InvalidRequestError("Invalid agent state");
+    }
+
+    const auth = { userId: session.user.id, user: session.user };
+
+    const { projectId, claudeSessionId } = (() => {
+      if (parsedState.data.type === "newSession") {
+        return {
+          projectId: parsedState.data.projectId,
+          claudeSessionId: undefined,
+        };
+      }
+
+      return verifyInAppAgentSessionToken(parsedState.data.claudeSessionToken, {
+        userId: auth.userId,
+        threadId: input.threadId,
+      });
+    })();
+
+    if (!isProjectMemberOrAdmin(auth.user, projectId)) {
+      throw new ForbiddenError("User is not a member of this project");
+    }
+
+    // This condition should match `useIsFeatureEnabled("inAppAgent")` in the frontend
+    const isInAppAgentEnabled =
+      auth.user.featureFlags.inAppAgent === true ||
+      auth.user.admin === true ||
+      session.environment.enableExperimentalFeatures === true;
+
+    if (!isInAppAgentEnabled) {
+      throw new ForbiddenError("Assistant is not enabled for this user");
+    }
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: {
+        organization: {
+          select: {
+            aiFeaturesEnabled: true,
+          },
+        },
+      },
+    });
+
+    if (!project?.organization.aiFeaturesEnabled) {
+      throw new ForbiddenError(
+        "Assistant is not enabled for this organization",
+      );
+    }
+
+    const sanitizedInput = sanitizeAgentInput(input);
+
+    const stream = createAgUiStream({
+      input: sanitizedInput,
+      signal: request.signal,
+      options: {
+        resumeSessionId: claudeSessionId,
+        createResumeStateForSessionId: (claudeSessionId) => ({
+          type: "existingSession",
+          claudeSessionToken: signInAppAgentSessionToken({
+            userId: auth.userId,
+            projectId,
+            threadId: sanitizedInput.threadId,
+            claudeSessionId,
+          }),
+        }),
+        awsCredentials: {
+          region: env.LANGFUSE_AWS_BEDROCK_REGION,
+          accessKeyId: env.AWS_ACCESS_KEY_ID,
+          secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+        },
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream; charset=utf-8",
+        "Content-Encoding": "none",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no",
+      },
+    });
+  } catch (err) {
+    if (err instanceof BaseError) {
+      return Response.json({ error: err.message }, { status: err.httpCode });
+    }
+
+    if (err instanceof InvalidInAppAgentSessionTokenError) {
+      return Response.json(
+        { error: err.message, code: "invalid_session_token" },
+        { status: 400 },
+      );
+    }
+
+    throw err;
+  }
+}
+
+function sanitizeAgentInput(input: AgUiRunAgentInput): AgUiRunAgentInput {
+  const lastUserMessage = getLastUserMessage(input.messages);
+
+  if (!lastUserMessage) {
+    throw new InvalidRequestError("Input payload must include a user message");
+  }
+
+  return {
+    threadId: input.threadId,
+    runId: input.runId,
+    ...(input.parentRunId ? { parentRunId: input.parentRunId } : {}),
+    state: null,
+    messages: [lastUserMessage],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+  };
+}
+
+function getLastUserMessage(
+  messages: AgUiMessage[],
+): Extract<AgUiMessage, { role: "user" }> | undefined {
+  const lastMessage = messages.at(-1);
+
+  if (lastMessage?.role !== "user") {
+    return undefined;
+  }
+
+  const text =
+    typeof lastMessage.content === "string"
+      ? lastMessage.content
+      : lastMessage.content
+          .flatMap((part) => (part.type === "text" ? [part.text] : []))
+          .join("");
+
+  if (!text.trim()) {
+    return undefined;
+  }
+
+  return {
+    id: lastMessage.id,
+    role: "user",
+    content: text,
+  };
+}

--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -22,6 +22,9 @@ import {
   UnauthorizedError,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
+import { assertUnreachable } from "@/src/utils/types";
+
+const MAX_IN_APP_AGENT_INPUT_BYTES = 1024 * 1024;
 
 export default async function handler(request: Request) {
   try {
@@ -54,8 +57,29 @@ export default async function handler(request: Request) {
       );
     }
 
-    const body = await request.json().catch(() => null);
-    const parsedInput = AgUiRunAgentInputSchema.safeParse(body);
+    const bodyResult = await readBoundedJsonBody(
+      request,
+      MAX_IN_APP_AGENT_INPUT_BYTES,
+    );
+
+    if (!bodyResult.success) {
+      if (bodyResult.error === "invalid_body") {
+        throw new InvalidRequestError("Invalid input");
+      }
+
+      if (bodyResult.error === "payload_too_large") {
+        throw new BaseError(
+          "PayloadTooLargeError",
+          413,
+          "Input payload is too large",
+          true,
+        );
+      }
+
+      assertUnreachable(bodyResult.error);
+    }
+
+    const parsedInput = AgUiRunAgentInputSchema.safeParse(bodyResult.data);
 
     if (!parsedInput.success) {
       throw new InvalidRequestError("Invalid input");
@@ -208,4 +232,52 @@ function getLastUserMessage(
     role: "user",
     content: text,
   };
+}
+
+type BoundedJsonBodyResult =
+  | { success: true; data: unknown }
+  | { success: false; error: "invalid_body" | "payload_too_large" };
+
+async function readBoundedJsonBody(
+  request: Request,
+  maxSizeBytes: number,
+): Promise<BoundedJsonBodyResult> {
+  const contentLength = Number(request.headers.get("content-length"));
+
+  if (Number.isFinite(contentLength) && contentLength > maxSizeBytes) {
+    return { success: false, error: "payload_too_large" };
+  }
+
+  const reader = request.body?.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+
+  if (!reader) {
+    return { success: false, error: "invalid_body" };
+  }
+
+  while (true) {
+    const { done, value } = await reader.read();
+
+    if (done) {
+      break;
+    }
+
+    receivedBytes += value.byteLength;
+
+    if (receivedBytes > maxSizeBytes) {
+      await reader.cancel().catch(() => undefined);
+      return { success: false, error: "payload_too_large" };
+    }
+
+    chunks.push(value);
+  }
+
+  const bodyText = new TextDecoder().decode(Buffer.concat(chunks));
+
+  try {
+    return { success: true, data: bodyText ? JSON.parse(bodyText) : null };
+  } catch {
+    return { success: false, error: "invalid_body" };
+  }
 }

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -28,6 +28,7 @@ import "core-js/features/array/to-spliced";
 import "core-js/features/array/to-sorted";
 
 import "react18-json-view/src/style.css";
+import "streamdown/styles.css";
 
 // Polyfill to prevent React crashes when Google Translate modifies the DOM.
 // Google Translate wraps text nodes in <font> elements, which breaks React's
@@ -74,6 +75,7 @@ import { env } from "@/src/env.mjs";
 import { ThemeProvider } from "@/src/features/theming/ThemeProvider";
 import { MarkdownContextProvider } from "@/src/features/theming/useMarkdownContext";
 import { SupportDrawerProvider } from "@/src/features/support-chat/SupportDrawerProvider";
+import { InAppAiAgentProvider } from "@/src/features/in-app-agent/components/InAppAiAgentProvider";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { ScoreCacheProvider } from "@/src/features/scores/contexts/ScoreCacheContext";
 import { CorrectionCacheProvider } from "@/src/features/corrections/contexts/CorrectionCacheContext";
@@ -150,10 +152,12 @@ const MyApp: AppType<{ session: Session | null }> = ({
                     <ScoreCacheProvider>
                       <CorrectionCacheProvider>
                         <SupportDrawerProvider defaultOpen={false}>
-                          <AppLayout>
-                            <Component {...pageProps} />
-                            <UserTracking />
-                          </AppLayout>
+                          <InAppAiAgentProvider defaultOpen={false}>
+                            <AppLayout>
+                              <Component {...pageProps} />
+                              <UserTracking />
+                            </AppLayout>
+                          </InAppAiAgentProvider>
                         </SupportDrawerProvider>
                       </CorrectionCacheProvider>
                     </ScoreCacheProvider>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss" source("..");
+@plugin "@tailwindcss/typography";
 
 @source "../../node_modules/@ferrucc-io/emoji-picker/dist";
 @source "../../node_modules/streamdown/dist/*.js";

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss" source("..");
 
 @source "../../node_modules/@ferrucc-io/emoji-picker/dist";
+@source "../../node_modules/streamdown/dist/*.js";
 
 @plugin "@tailwindcss/forms";
 @plugin "tailwindcss-animate";

--- a/web/src/utils/types.ts
+++ b/web/src/utils/types.ts
@@ -3,6 +3,12 @@ import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
 import { type AppRouter } from "@/src/server/api/root";
 import { type ObservationReturnType } from "@/src/server/api/routers/traces";
 
+// unreachable code check
+
+export function assertUnreachable(_x: never): never {
+  throw new Error("Didn't expect to get here");
+}
+
 // primitive type checks
 
 export function isString(value: unknown): value is string {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces an in-app AI agent drawer backed by AWS Bedrock via the AG-UI / Claude Agent SDK. A custom signed HMAC session token ties each Claude Code session to a specific user and thread, enabling stateless continuation across turns without server-side session storage.

- **Auth and feature-gating**: The handler now calls `getServerSession`, verifies project membership, checks the org-level `aiFeaturesEnabled` flag, and applies a feature-gate condition that matches the client-side `useIsFeatureEnabled` check (admin || experimentalFeatures || per-user flag).
- **Input sanitization**: `sanitizeAgentInput` strips all messages except the final user message and clears `tools`, `context`, and `forwardedProps`, preventing history and tool injection from the client. AWS credentials never leave the server.
- **Session resumption**: The server embeds a short-lived signed token in a `STATE_DELTA` event; on each subsequent turn the client presents this token, and the server extracts and verifies the Claude session ID before passing it as `forwardedProps.resume` to the adapter.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The core auth, session-token, and sanitization paths are well-structured and the previously flagged gaps have been addressed; the remaining findings are non-blocking quality suggestions.

Authentication, feature gating, project membership, and org-level checks are all present and consistent between client and server. The session token is cryptographically bound to userId and threadId and expires in 7 days. Input sanitization strips all client-supplied data except the final user message. Error states now surface to the user via toast and inline display. No new correctness issues were found beyond two non-blocking quality suggestions.

No files require special attention for merge safety, though the activity/reasoning message accumulation in session storage in `InAppAiAgentProvider.tsx` is worth addressing before heavy usage.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User Browser
    participant P as InAppAiAgentProvider
    participant SS as SessionStorage
    participant API as /api/in-app-agent
    participant H as Handler
    participant CA as ClaudeAgentAdapter (Bedrock)

    U->>P: submit(content)
    P->>P: Create HttpAgent (initialMessages, state from SS)
    P->>P: agent.addMessage(userMessage)
    P->>API: "POST /api/in-app-agent (SSE, state=newSession|existingSession)"
    API->>H: handler(request)
    H->>H: getServerSession() — authenticate
    H->>H: "Check feature flags (inAppAgent || admin || experimentalFeatures)"
    H->>H: verifyInAppAgentSessionToken
    H->>H: isProjectMemberOrAdmin check
    H->>H: aiFeaturesEnabled org check
    H->>H: sanitizeAgentInput — keep only last user message
    H->>CA: createAgUiStream(input, resumeSessionId)
    CA-->>API: system:init event (claude sessionId)
    H->>H: normalizeAdapterEvent → STATE_DELTA with signed claudeSessionToken
    API-->>P: STATE_DELTA (signed claudeSessionToken for resume)
    API-->>P: MESSAGE_DELTA / MESSAGE_SNAPSHOT events
    P->>SS: persistSession(messages, state)
    API-->>P: RUN_FINISHED
    P->>P: setIsRunning(false)

    alt Invalid session token
        P->>P: Detect invalid_session_token
        P->>P: Create freshAgent with old messages
        P->>API: "POST /api/in-app-agent (state=newSession)"
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/in-app-agent/components/ControlledInAppAgentDrawer.tsx:27
Using `.parse()` inside `useMemo` will throw an unhandled exception if any message stored in session storage doesn't match the current schema — for example, after a schema change in a future deploy. Because the component has no error boundary, that throw would crash the drawer silently. `.safeParse()` with a fallback to an empty array is safer.

```suggestion
    const parsedMessages =
      z.array(AgUiMessageSchema).safeParse(messages).data ?? [];
```

### Issue 2 of 2
web/src/features/in-app-agent/components/InAppAiAgentProvider.tsx:353-357
`isAgentConversationMessage` only excludes `tool` and `developer` messages, so `system`, `activity`, and `reasoning` messages pass through, are persisted to session storage, and are handed to every new `HttpAgent` as `initialMessages`. `activity` messages carry `content: Record<string, any>` payloads that can be large; over many interactions they accumulate and can silently push the session entry toward browser storage limits (~5 MB). Filtering these non-conversational roles keeps the persisted footprint proportional to the visible conversation.

```suggestion
function isAgentConversationMessage(
  message: AgUiMessage,
): message is InAppAiAgentMessage {
  return (
    message.role !== "tool" &&
    message.role !== "developer" &&
    message.role !== "system" &&
    message.role !== "activity" &&
    message.role !== "reasoning"
  );
}
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["feat(web): In-app agent scaffolding"](https://github.com/langfuse/langfuse/commit/6538b124e9e2766e861f416340022197e89bb133) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31935776)</sub>

<!-- /greptile_comment -->