### PR TITLE
fix(web): Saved views UX improvements

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -781,12 +781,17 @@ export const SessionEventsPage: React.FC<{
       setColumnOrder,
       setColumnVisibility,
       setFilters: setFiltersWrapper,
+      setExpandedFilters: queryFilter.onExpandedChange,
     },
     validationContext: {
       columns: [],
       filterColumnDefinition: sessionEventsFilterConfig.columnDefinitions,
+      expandableFilterColumns: sessionEventsFilterConfig.facets.map(
+        (facet) => facet.column,
+      ),
     },
-    currentFilterState: queryFilter.filterState,
+    currentFilterState: queryFilter.explicitFilterState,
+    currentExpandedFilters: queryFilter.expanded,
   });
 
   const applySystemPreset = useCallback(

--- a/web/src/components/table/data-table-controls.clienttest.tsx
+++ b/web/src/components/table/data-table-controls.clienttest.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { Accordion } from "@/src/components/ui/accordion";
+import { CategoricalFacet } from "./data-table-controls";
+
+describe("CategoricalFacet", () => {
+  it("shows selected values even when the backend returns no options", () => {
+    render(
+      <Accordion type="multiple" value={["type"]}>
+        <CategoricalFacet
+          label="Type"
+          filterKey="type"
+          expanded
+          loading={false}
+          options={[]}
+          counts={new Map()}
+          value={["AGENT"]}
+          onChange={() => {}}
+          isActive
+          isDisabled={false}
+          onReset={() => {}}
+        />
+      </Accordion>,
+    );
+
+    expect(screen.getByText("AGENT")).toBeInTheDocument();
+    expect(screen.queryByText("No options found")).not.toBeInTheDocument();
+  });
+
+  it("shows Clear for active selected values even when the backend returns no options", () => {
+    render(
+      <Accordion type="multiple" value={["type"]}>
+        <CategoricalFacet
+          label="Type"
+          filterKey="type"
+          expanded
+          loading={false}
+          options={[]}
+          counts={new Map()}
+          value={["AGENT"]}
+          onChange={() => {}}
+          isActive
+          isDisabled={false}
+          onReset={() => {}}
+        />
+      </Accordion>,
+    );
+
+    expect(screen.getByLabelText("Clear Type filter")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/table/data-table-controls.tsx
+++ b/web/src/components/table/data-table-controls.tsx
@@ -597,11 +597,14 @@ export function CategoricalFacet({
   );
 
   const MAX_VISIBLE_OPTIONS = 12;
-  const hasMoreOptions = options.length > MAX_VISIBLE_OPTIONS;
+  const visibleOptionValues = Array.from(
+    new Set([...options, ...value.filter((option) => option.length > 0)]),
+  );
+  const hasMoreOptions = visibleOptionValues.length > MAX_VISIBLE_OPTIONS;
 
   // Filter options by search query (check both raw value and display label)
   const filteredOptions = searchQuery
-    ? options.filter((option) => {
+    ? visibleOptionValues.filter((option) => {
         const search = searchQuery.toLowerCase();
         const displayLabel = displayByValue?.get(option) ?? option;
         return (
@@ -609,7 +612,7 @@ export function CategoricalFacet({
           displayLabel.toLowerCase().includes(search)
         );
       })
-    : options;
+    : visibleOptionValues;
 
   const hasMoreFilteredOptions = filteredOptions.length > MAX_VISIBLE_OPTIONS;
   const visibleOptions = showAll
@@ -715,7 +718,7 @@ export function CategoricalFacet({
                   </div>
                 ))}
               </>
-            ) : options.length === 0 ? (
+            ) : visibleOptionValues.length === 0 ? (
               <div className="text-muted-foreground py-1 text-xs">
                 {filterKey === "sessionId" ? (
                   <span>
@@ -816,8 +819,8 @@ export function CategoricalFacet({
                   </>
                 )}
                 {filterKey === "environment" &&
-                options.length === 1 &&
-                options[0]?.toLowerCase() === "default" ? (
+                visibleOptionValues.length === 1 &&
+                visibleOptionValues[0]?.toLowerCase() === "default" ? (
                   <div className="text-muted-foreground mt-2 px-2 text-xs">
                     <a
                       href="https://langfuse.com/docs/observability/features/environments"

--- a/web/src/components/table/key-value-filter-builder.clienttest.tsx
+++ b/web/src/components/table/key-value-filter-builder.clienttest.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { KeyValueFilterBuilder } from "./key-value-filter-builder";
+
+const noop = () => {};
+
+describe("KeyValueFilterBuilder", () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("shows selected keys in the combobox even when keyOptions omit them", () => {
+    render(
+      <KeyValueFilterBuilder
+        mode="numeric"
+        keyOptions={["known-key"]}
+        activeFilters={[{ key: "missing-key", operator: "=", value: 1 }]}
+        onChange={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("combobox")[0]);
+
+    expect(screen.getAllByText("missing-key")).not.toHaveLength(0);
+  });
+
+  it("preserves incomplete local filters across equivalent parent rerenders", () => {
+    const { rerender } = render(
+      <KeyValueFilterBuilder
+        mode="string"
+        activeFilters={[]}
+        onChange={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Add filter"));
+    fireEvent.change(screen.getByPlaceholderText("Key"), {
+      target: { value: "draft-key" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Value"), {
+      target: { value: "draft-value" },
+    });
+
+    rerender(
+      <KeyValueFilterBuilder
+        mode="string"
+        activeFilters={[]}
+        onChange={noop}
+      />,
+    );
+
+    expect(screen.getByDisplayValue("draft-value")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/table/key-value-filter-builder.tsx
+++ b/web/src/components/table/key-value-filter-builder.tsx
@@ -186,6 +186,15 @@ export function KeyValueFilterBuilder(props: KeyValueFilterBuilderProps) {
         const availableValuesForKey = filter.key
           ? (availableValues[filter.key] ?? [])
           : [];
+        const hasKeyOptions = (keyOptions?.length ?? 0) > 0;
+        const mergedKeyOptions = Array.from(
+          new Set(
+            [
+              ...(keyOptions ?? []),
+              ...localFilters.map((item) => item.key),
+            ].filter((value) => value.length > 0),
+          ),
+        );
 
         return (
           <div
@@ -194,7 +203,7 @@ export function KeyValueFilterBuilder(props: KeyValueFilterBuilderProps) {
           >
             {/* Key input and delete button row */}
             <div className="flex items-center gap-2">
-              {keyOptions ? (
+              {hasKeyOptions ? (
                 // Combobox for known keys
                 <Popover
                   open={openPopoverIndex === index}
@@ -225,7 +234,7 @@ export function KeyValueFilterBuilder(props: KeyValueFilterBuilderProps) {
                       <InputCommandList>
                         <InputCommandEmpty>No keys found.</InputCommandEmpty>
                         <InputCommandGroup>
-                          {keyOptions.map((option) => (
+                          {mergedKeyOptions.map((option) => (
                             <InputCommandItem
                               key={option}
                               value={option}

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -25,6 +25,7 @@ interface TableStateUpdaters {
   setOrderBy?: (orderBy: OrderByState) => void;
   setFilters?: (filters: FilterState) => void;
   setSearchQuery?: (searchQuery: string) => void;
+  setExpandedFilters?: (expandedFilters: string[]) => void;
 }
 
 interface UseTableStateProps {
@@ -34,8 +35,10 @@ interface UseTableStateProps {
   validationContext?: {
     columns?: LangfuseColumnDef<any, any>[];
     filterColumnDefinition?: ColumnDefinition[];
+    expandableFilterColumns?: string[];
   };
   currentFilterState?: FilterState;
+  currentExpandedFilters?: string[];
   disabled?: boolean;
 }
 
@@ -56,6 +59,7 @@ export function useTableViewManager({
   stateUpdaters,
   validationContext = {},
   currentFilterState,
+  currentExpandedFilters,
   disabled = false,
 }: UseTableStateProps) {
   const router = useRouter();
@@ -114,6 +118,7 @@ export function useTableViewManager({
     setColumnOrder,
     setColumnVisibility,
     setSearchQuery,
+    setExpandedFilters,
   } = stateUpdaters;
 
   // Use refs to always get latest function references to avoid stale closures in applyViewState
@@ -121,11 +126,13 @@ export function useTableViewManager({
   const setFiltersRef = useRef(setFilters);
   const setOrderByRef = useRef(setOrderBy);
   const setSearchQueryRef = useRef(setSearchQuery);
+  const setExpandedFiltersRef = useRef(setExpandedFilters);
 
   // Update refs immediately on every render
   setFiltersRef.current = setFilters;
   setOrderByRef.current = setOrderBy;
   setSearchQueryRef.current = setSearchQuery;
+  setExpandedFiltersRef.current = setExpandedFilters;
 
   // Extract primitive for effect dep (rerender-dependencies: avoid object deps)
   const defaultViewId = resolvedDefault?.viewId;
@@ -227,6 +234,24 @@ export function useTableViewManager({
 
       const filtersAlreadyApplied = isEqual(currentFilterState, validFilters);
 
+      if (
+        setExpandedFiltersRef.current &&
+        validationContext.expandableFilterColumns?.length
+      ) {
+        const nextExpandedFilters = Array.from(
+          new Set([
+            ...(currentExpandedFilters ?? []),
+            ...validFilters
+              .map((filter) => filter.column)
+              .filter((column) =>
+                validationContext.expandableFilterColumns?.includes(column),
+              ),
+          ]),
+        );
+
+        setExpandedFiltersRef.current(nextExpandedFilters);
+      }
+
       if (setFiltersRef.current) {
         setFiltersRef.current(validFilters);
         // Track expected filters to observe when state actually updates (for useEffect below)
@@ -263,6 +288,7 @@ export function useTableViewManager({
       setColumnVisibility,
       validationContext,
       currentFilterState,
+      currentExpandedFilters,
     ],
   );
 

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1286,6 +1286,7 @@ export default function ObservationsTable({
     stateUpdaters: {
       setOrderBy: setOrderByState,
       setFilters: setFiltersWrapper,
+      setExpandedFilters: queryFilter.onExpandedChange,
       setColumnOrder: setColumnOrder,
       setColumnVisibility: setColumnVisibilityState,
       setSearchQuery: setSearchQuery,
@@ -1293,8 +1294,12 @@ export default function ObservationsTable({
     validationContext: {
       columns,
       filterColumnDefinition: observationsFilterConfig.columnDefinitions,
+      expandableFilterColumns: observationsFilterConfig.facets.map(
+        (facet) => facet.column,
+      ),
     },
     currentFilterState: queryFilter.explicitFilterState,
+    currentExpandedFilters: queryFilter.expanded,
     disabled: hideControls,
   });
 

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -1456,7 +1456,13 @@ export default function ObservationsTable({
 
         {/* Content area with sidebar and table */}
         <ResizableFilterLayout>
-          {!hideControls && <DataTableControls queryFilter={queryFilter} />}
+          {!hideControls && (
+            <DataTableControls
+              // Remount the sidebar when the saved view changes so the new view's filters replace any stale draft UI state.
+              key={viewControllers.selectedViewId ?? "no-view"}
+              queryFilter={queryFilter}
+            />
+          )}
 
           <div className="flex flex-1 flex-col overflow-hidden">
             <DataTable

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -971,7 +971,11 @@ export default function ScoresTable({
 
         {/* Content area with sidebar and table */}
         <ResizableFilterLayout>
-          <DataTableControls queryFilter={queryFilter} />
+          <DataTableControls
+            // Remount the sidebar when the saved view changes so the new view's filters replace any stale draft UI state.
+            key={viewControllers.selectedViewId ?? "no-view"}
+            queryFilter={queryFilter}
+          />
 
           <div className="flex flex-1 flex-col overflow-hidden">
             <DataTable

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -889,14 +889,19 @@ export default function ScoresTable({
     stateUpdaters: {
       setOrderBy: setOrderByState,
       setFilters: setFiltersWrapper,
+      setExpandedFilters: queryFilter.onExpandedChange,
       setColumnOrder: setColumnOrder,
       setColumnVisibility: setColumnVisibility,
     },
     validationContext: {
       columns,
       filterColumnDefinition: scoresFilterConfig.columnDefinitions,
+      expandableFilterColumns: scoresFilterConfig.facets.map(
+        (facet) => facet.column,
+      ),
     },
     currentFilterState: queryFilter.explicitFilterState,
+    currentExpandedFilters: queryFilter.expanded,
   });
 
   const visibleSelectedScoreIds = useMemo(

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -869,7 +869,11 @@ export default function SessionsTable({
 
         {/* Content area with sidebar and table */}
         <ResizableFilterLayout>
-          <DataTableControls queryFilter={queryFilter} />
+          <DataTableControls
+            // Remount the sidebar when the saved view changes so the new view's filters replace any stale draft UI state.
+            key={viewControllers.selectedViewId ?? "no-view"}
+            queryFilter={queryFilter}
+          />
 
           <div className="flex flex-1 flex-col overflow-hidden">
             <DataTable

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -797,14 +797,19 @@ export default function SessionsTable({
     stateUpdaters: {
       setOrderBy: setOrderByState,
       setFilters: setFiltersWrapper,
+      setExpandedFilters: queryFilter.onExpandedChange,
       setColumnOrder: setColumnOrder,
       setColumnVisibility: setColumnVisibility,
     },
     validationContext: {
       columns,
       filterColumnDefinition: sessionsFilterConfig.columnDefinitions,
+      expandableFilterColumns: sessionsFilterConfig.facets.map(
+        (facet) => facet.column,
+      ),
     },
     currentFilterState: queryFilter.explicitFilterState,
+    currentExpandedFilters: queryFilter.expanded,
   });
 
   return (

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1317,6 +1317,7 @@ export default function TracesTable({
     stateUpdaters: {
       setOrderBy: setOrderByState,
       setFilters: setFiltersWrapper,
+      setExpandedFilters: queryFilter.onExpandedChange,
       setColumnOrder: setColumnOrder,
       setColumnVisibility: setColumnVisibility,
       setSearchQuery: setSearchQuery,
@@ -1324,8 +1325,12 @@ export default function TracesTable({
     validationContext: {
       columns,
       filterColumnDefinition: tracesFilterConfig.columnDefinitions,
+      expandableFilterColumns: tracesFilterConfig.facets.map(
+        (facet) => facet.column,
+      ),
     },
     currentFilterState: queryFilter.explicitFilterState,
+    currentExpandedFilters: queryFilter.expanded,
     disabled: hideControls,
   });
 

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -1471,7 +1471,12 @@ export default function TracesTable({
         {/* Content area with sidebar and table */}
         <ResizableFilterLayout>
           {!hideControls && (
-            <DataTableControls queryFilter={queryFilter} filterWithAI />
+            <DataTableControls
+              // Remount the sidebar when the saved view changes so the new view's filters replace any stale draft UI state.
+              key={viewControllers.selectedViewId ?? "no-view"}
+              queryFilter={queryFilter}
+              filterWithAI
+            />
           )}
 
           <div className="flex flex-1 flex-col overflow-hidden">

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1437,7 +1437,12 @@ export default function ObservationsEventsTable({
         {/* Content area with sidebar and table */}
         <ResizableFilterLayout>
           {!hideControls && (
-            <DataTableControls queryFilter={queryFilter} filterWithAI />
+            <DataTableControls
+              // Remount the sidebar when the saved view changes so the new view's filters replace any stale draft UI state.
+              key={viewControllers.selectedViewId ?? "no-view"}
+              queryFilter={queryFilter}
+              filterWithAI
+            />
           )}
 
           <div className="flex flex-1 flex-col overflow-hidden">

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -1218,6 +1218,7 @@ export default function ObservationsEventsTable({
     stateUpdaters: {
       setOrderBy: setOrderByState,
       setFilters: setFiltersWrapper,
+      setExpandedFilters: queryFilter.onExpandedChange,
       setColumnOrder: setColumnOrder,
       setColumnVisibility: setColumnVisibilityState,
       setSearchQuery: setSearchQuery,
@@ -1225,8 +1226,12 @@ export default function ObservationsEventsTable({
     validationContext: {
       columns,
       filterColumnDefinition: eventsFilterConfig.columnDefinitions,
+      expandableFilterColumns: eventsFilterConfig.facets.map(
+        (facet) => facet.column,
+      ),
     },
     currentFilterState: queryFilter.explicitFilterState,
+    currentExpandedFilters: queryFilter.expanded,
     disabled: hideControls,
   });
 

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -1088,7 +1088,13 @@ export default function ExperimentItemsTable({
 
         {/* Content area with sidebar and table */}
         <ResizableFilterLayout>
-          {!hideControls && <DataTableControls queryFilter={queryFilter} />}
+          {!hideControls && (
+            <DataTableControls
+              // Remount the sidebar when the saved view changes so the new view's filters replace any stale draft UI state.
+              key={viewControllers.selectedViewId ?? "no-view"}
+              queryFilter={queryFilter}
+            />
+          )}
 
           <div className="flex flex-1 flex-col overflow-hidden">
             {layout === "grid" ? (

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -888,14 +888,19 @@ export default function ExperimentItemsTable({
     stateUpdaters: {
       setOrderBy: setOrderByState,
       setFilters: setFiltersWrapper,
+      setExpandedFilters: queryFilter.onExpandedChange,
       setColumnOrder: setColumnOrder,
       setColumnVisibility: setColumnVisibilityState,
     },
     validationContext: {
       columns,
       filterColumnDefinition: experimentItemsFilterConfig.columnDefinitions,
+      expandableFilterColumns: experimentItemsFilterConfig.facets.map(
+        (facet) => facet.column,
+      ),
     },
-    currentFilterState: queryFilter.filterState,
+    currentFilterState: queryFilter.explicitFilterState,
+    currentExpandedFilters: queryFilter.expanded,
   });
 
   const peekConfig: DataTablePeekViewProps | undefined = useMemo(() => {

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -647,7 +647,11 @@ export default function ExperimentsTable({
 
           {/* Content area with sidebar and table */}
           <ResizableFilterLayout>
-            <DataTableControls queryFilter={queryFilter} />
+            <DataTableControls
+              // Remount the sidebar when the saved view changes so the new view's filters replace any stale draft UI state.
+              key={viewControllers.selectedViewId ?? "no-view"}
+              queryFilter={queryFilter}
+            />
 
             <div className="flex flex-1 flex-col overflow-hidden">
               <DataTable

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -482,14 +482,17 @@ export default function ExperimentsTable({
     stateUpdaters: {
       setOrderBy: setOrderByState,
       setFilters: setFiltersWrapper,
+      setExpandedFilters: queryFilter.onExpandedChange,
       setColumnOrder: setColumnOrder,
       setColumnVisibility: setColumnVisibilityState,
     },
     validationContext: {
       columns,
       filterColumnDefinition: filterConfig.columnDefinitions,
+      expandableFilterColumns: filterConfig.facets.map((facet) => facet.column),
     },
-    currentFilterState: queryFilter.filterState,
+    currentFilterState: queryFilter.explicitFilterState,
+    currentExpandedFilters: queryFilter.expanded,
   });
 
   const rows: ExperimentsTableRow[] = useMemo(() => {

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -249,6 +249,51 @@ export type UIFilter =
 
 const EMPTY_MAP: Map<string, number> = new Map();
 
+const mergeUniqueStrings = (...lists: (string[] | undefined)[]): string[] =>
+  Array.from(
+    new Set(
+      lists.flatMap((list) => (list ?? []).filter((value) => value.length > 0)),
+    ),
+  );
+
+const resolveKnownKeyOptions = (
+  facetKeyOptions: string[] | undefined,
+  availableKeys:
+    | (string | SingleValueOption)[]
+    | Record<string, string[]>
+    | undefined,
+  activeKeys: string[],
+): string[] | undefined => {
+  if (facetKeyOptions !== undefined) {
+    return mergeUniqueStrings(facetKeyOptions, activeKeys);
+  }
+
+  if (!Array.isArray(availableKeys)) {
+    return undefined;
+  }
+
+  return mergeUniqueStrings(
+    availableKeys.map((option) =>
+      typeof option === "string" ? option : option.value,
+    ),
+    activeKeys,
+  );
+};
+
+const mergeAvailableValuesWithActiveFilters = (
+  availableValues: Record<string, string[]>,
+  activeFilters: KeyValueFilterEntry[],
+): Record<string, string[]> => {
+  const merged: Record<string, string[]> = { ...availableValues };
+
+  for (const filter of activeFilters) {
+    if (!filter.key) continue;
+    merged[filter.key] = mergeUniqueStrings(merged[filter.key], filter.value);
+  }
+
+  return merged;
+};
+
 // extract values and counts from options array
 // for both string[] and SingleValueOption[]
 function processOptions(options: (string | SingleValueOption)[]): {
@@ -1146,14 +1191,22 @@ export function useSidebarFilterState(
 
           // Get available values from options
           const availableValues = options[facet.column] ?? {};
+          const mergedAvailableValues =
+            typeof availableValues === "object" &&
+            !Array.isArray(availableValues)
+              ? mergeAvailableValuesWithActiveFilters(
+                  availableValues as Record<string, string[]>,
+                  activeFilters,
+                )
+              : ({} as Record<string, string[]>);
 
           // Extract key options from availableValues if not defined in facet
           const keyOptions =
             facet.keyOptions ??
-            (typeof availableValues === "object" &&
-            !Array.isArray(availableValues)
-              ? Object.keys(availableValues as Record<string, string[]>)
-              : undefined);
+            mergeUniqueStrings(
+              Object.keys(mergedAvailableValues),
+              activeFilters.map((filter) => filter.key),
+            );
 
           return {
             type: "keyValue",
@@ -1163,11 +1216,7 @@ export function useSidebarFilterState(
 
             value: activeFilters,
             keyOptions,
-            availableValues:
-              typeof availableValues === "object" &&
-              !Array.isArray(availableValues)
-                ? (availableValues as Record<string, string[]>)
-                : ({} as Record<string, string[]>),
+            availableValues: mergedAvailableValues,
             loading: shouldShowLoading(facet.column),
             expanded: expandedSet.has(facet.column),
             isActive,
@@ -1236,13 +1285,11 @@ export function useSidebarFilterState(
 
           // Get available keys from options (should be array of score names)
           const availableKeys = options[facet.column];
-          const keyOptions =
-            facet.keyOptions ??
-            (Array.isArray(availableKeys)
-              ? availableKeys.map((opt) =>
-                  typeof opt === "string" ? opt : opt.value,
-                )
-              : undefined);
+          const keyOptions = resolveKnownKeyOptions(
+            facet.keyOptions,
+            availableKeys,
+            activeFilters.map((filter) => filter.key),
+          );
 
           return {
             type: "numericKeyValue",
@@ -1320,13 +1367,11 @@ export function useSidebarFilterState(
 
           // Get available keys from options
           const availableKeys = options[facet.column];
-          const keyOptions =
-            facet.keyOptions ??
-            (Array.isArray(availableKeys)
-              ? availableKeys.map((opt) =>
-                  typeof opt === "string" ? opt : opt.value,
-                )
-              : undefined);
+          const keyOptions = resolveKnownKeyOptions(
+            facet.keyOptions,
+            availableKeys,
+            activeFilters.map((filter) => filter.key),
+          );
 
           return {
             type: "stringKeyValue",
@@ -1536,6 +1581,14 @@ export function useSidebarFilterState(
           }));
 
         const hasTextFilters = textFilters.length > 0;
+        const hasExplicitCheckboxFilter =
+          !!checkboxFilter &&
+          Array.isArray(checkboxFilter.value) &&
+          checkboxFilter.value.length > 0;
+        const hasExplicitCheckboxFilterWhileLoading =
+          hasExplicitCheckboxFilter &&
+          selectedValues.length === 0 &&
+          availableValues.length === 0;
         const hasCheckboxSelections =
           selectedValues.length > 0 &&
           selectedValues.length !== availableValues.length;
@@ -1564,9 +1617,12 @@ export function useSidebarFilterState(
           (isManagedEnvironmentFacet
             ? hasManagedEnvironmentSelectionOverride
             : (currentOperator === "all of" &&
-                selectedValues.length === availableValues.length) ||
-              (currentOperator === "none of" && selectedValues.length > 0) ||
-              hasCheckboxSelections);
+                (selectedValues.length === availableValues.length ||
+                  hasExplicitCheckboxFilterWhileLoading)) ||
+              (currentOperator === "none of" &&
+                hasExplicitCheckboxFilterWhileLoading) ||
+              hasCheckboxSelections ||
+              hasExplicitCheckboxFilterWhileLoading);
         const disableState = getFacetDisabledState(facet);
 
         return {


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR improves the UX of saved views by ensuring that filter facets remain visible and marked as active even before the backend has returned the matching option values — covering categorical facets, key-value facets, and the auto-expansion of relevant filter accordions on view load.

- **`CategoricalFacet`** now merges currently-selected `value` items into `visibleOptionValues` so that a selection from a saved view is always rendered in the checkbox list, not silently hidden when the backend returns an empty options list.
- **`KeyValueFilterBuilder`** gains a `lodash/isEqual`-gated `useEffect` to sync `localFilters` when `activeFilters` changes externally, and merges selected keys from local state into the combobox options so previously-chosen keys remain visible.
- **`useTableViewManager`** auto-expands filter accordion items that correspond to columns in an applied view's filters, and all table use-cases are updated to pass `setExpandedFilters` / `expandableFilterColumns` / `currentExpandedFilters` as well as to use `explicitFilterState` over the broader `filterState`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are well-scoped UX improvements backed by new tests, with one minor isActive edge case worth discussing

The core logic — surfacing selected values during loading and auto-expanding filter facets from saved views — is sound and covered by new client tests. The only concern is in useSidebarFilterState: the terminal standalone hasExplicitCheckboxFilter condition lacks an operator guard, so a facet where the user has selected every available option under 'any of' now shows as active (with a Clear button) whereas it previously did not. It won't corrupt data or break navigation, but may confuse users who see a Clear badge on a facet that effectively filters nothing.

web/src/features/filters/hooks/useSidebarFilterState.tsx — specifically the new isActive expression around line 1600

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| web/src/features/filters/hooks/useSidebarFilterState.tsx | Adds helpers to merge active filter values into available options for key-value facets and fixes isActive for loading states; the standalone hasExplicitCheckboxFilter condition slightly over-broadens the active check for "any of" + all-values-selected case |
| web/src/components/table/data-table-controls.tsx | CategoricalFacet now includes currently-selected values in the visible options list even when the backend returns none, correctly fixing the empty-options UX issue |
| web/src/components/table/key-value-filter-builder.tsx | Adds a deep-equality-gated useEffect to sync localFilters with external activeFilters changes; merges selected keys from local state into the combobox options |
| web/src/components/table/table-view-presets/hooks/useTableViewManager.ts | Adds setExpandedFilters + currentExpandedFilters wiring; when a saved view is applied, filter facets matching expandableFilterColumns are auto-expanded |
| web/src/components/table/data-table-controls.clienttest.tsx | New client tests validating that CategoricalFacet renders selected values and the Clear button when the backend returns no options |
| web/src/components/table/key-value-filter-builder.clienttest.tsx | New client tests covering external activeFilters sync, missing key display in combobox, and draft preservation across equivalent rerenders |
| web/src/components/table/use-cases/traces.tsx | Wires setExpandedFilters, expandableFilterColumns, and currentExpandedFilters into useTableViewManager for the traces table |
| web/src/components/table/use-cases/observations.tsx | Same expanded-filter wiring as traces for the observations table; switches from filterState to explicitFilterState |
| web/src/components/table/use-cases/sessions.tsx | Adds expanded-filter wiring and switches to explicitFilterState for the sessions table |
| web/src/components/table/use-cases/scores.tsx | Adds expanded-filter wiring and switches to explicitFilterState for the scores table |
| web/src/features/events/components/EventsTable.tsx | Adds expanded-filter wiring and switches to explicitFilterState for the events table |
| web/src/features/experiments/components/table/ExperimentsTable.tsx | Switches from filterState to explicitFilterState and adds expanded-filter wiring consistent with the other table use-cases |
| web/src/features/experiments/components/table/ExperimentItemsTable.tsx | Same explicitFilterState switch and expanded-filter wiring for experiment items table |
| web/src/components/session/index.tsx | Wires setExpandedFilters and expandableFilterColumns into useTableViewManager for the session events page; switches to explicitFilterState |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User applies Saved View] --> B[useTableViewManager.applyViewState]
    B --> C[Validate filters]
    C --> D{expandableFilterColumns configured?}
    D -- Yes --> E[Compute nextExpandedFilters from validFilters columns]
    E --> F[setExpandedFilters]
    F --> G[useSidebarFilterState expandedSet updated]
    D -- No --> H[setFilters]
    G --> H
    H --> I[useSidebarFilterState recomputes UIFilters]
    I --> J{Backend options loaded?}
    J -- Yes --> K[selectedValues from options and filter.value]
    J -- No --> L[CategoricalFacet shows value from visibleOptionValues]
    J -- No --> M[hasExplicitCheckboxFilter marks facet isActive]
    K --> N[Normal render with counts]
    L --> N
    M --> O[Clear badge shown even during loading]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/src/features/filters/hooks/useSidebarFilterState.tsx`, line 1600-1609 ([link](https://github.com/langfuse/langfuse/blob/3ec8f2c84a130086bf3edb29a7018c62d2ff8a48/web/src/features/filters/hooks/useSidebarFilterState.tsx#L1600-L1609)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Standalone `hasExplicitCheckboxFilter` makes all-selected "any of" facets appear active**

   The terminal `hasExplicitCheckboxFilter` guard has no operator constraint, so it fires when `checkboxFilter` exists with values regardless of operator. This changes a pre-existing intentional behaviour: when a user selects **all** available options under the `"any of"` operator, the old code set `isActive = false` (semantically equivalent to no filter, so no Clear badge). Now `hasExplicitCheckboxFilter` is `true` in that case, so the facet shows as active and renders a Clear button that does nothing semantically useful. The "none of" loading-state fix should be scoped to the actual problem by only applying `hasExplicitCheckboxFilter` when `selectedValues` is empty (i.e., during loading before the backend has returned any options).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/features/filters/hooks/useSidebarFilterState.tsx
   Line: 1600-1609

   Comment:
   **Standalone `hasExplicitCheckboxFilter` makes all-selected "any of" facets appear active**

   The terminal `hasExplicitCheckboxFilter` guard has no operator constraint, so it fires when `checkboxFilter` exists with values regardless of operator. This changes a pre-existing intentional behaviour: when a user selects **all** available options under the `"any of"` operator, the old code set `isActive = false` (semantically equivalent to no filter, so no Clear badge). Now `hasExplicitCheckboxFilter` is `true` in that case, so the facet shows as active and renders a Clear button that does nothing semantically useful. The "none of" loading-state fix should be scoped to the actual problem by only applying `hasExplicitCheckboxFilter` when `selectedValues` is empty (i.e., during loading before the backend has returned any options).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/filters/hooks/useSidebarFilterState.tsx:1600-1609
**Standalone `hasExplicitCheckboxFilter` makes all-selected "any of" facets appear active**

The terminal `hasExplicitCheckboxFilter` guard has no operator constraint, so it fires when `checkboxFilter` exists with values regardless of operator. This changes a pre-existing intentional behaviour: when a user selects **all** available options under the `"any of"` operator, the old code set `isActive = false` (semantically equivalent to no filter, so no Clear badge). Now `hasExplicitCheckboxFilter` is `true` in that case, so the facet shows as active and renders a Clear button that does nothing semantically useful. The "none of" loading-state fix should be scoped to the actual problem by only applying `hasExplicitCheckboxFilter` when `selectedValues` is empty (i.e., during loading before the backend has returned any options).


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Always consider saved view fil..."](https://github.com/langfuse/langfuse/commit/3ec8f2c84a130086bf3edb29a7018c62d2ff8a48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30801586)</sub>

<!-- /greptile_comment -->