### PR TITLE
feat(experiments): show metadata in overview

### DIFF
--- a/web/src/features/experiments/components/ExperimentMetadataSection.tsx
+++ b/web/src/features/experiments/components/ExperimentMetadataSection.tsx
@@ -6,7 +6,6 @@ import {
 } from "@/src/components/ui/collapsible";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
-import { ExperimentOverviewSectionHeading } from "./ExperimentOverviewField";
 
 export const ExperimentMetadataSection = ({
   metadata,
@@ -20,15 +19,18 @@ export const ExperimentMetadataSection = ({
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
       <div className="border-t pt-4">
-        <CollapsibleTrigger className="flex w-full items-center justify-between text-left">
-          <ExperimentOverviewSectionHeading>
-            Metadata
-          </ExperimentOverviewSectionHeading>
-          {isOpen ? (
-            <ChevronDown className="text-muted-foreground h-4 w-4" />
-          ) : (
-            <ChevronRight className="text-muted-foreground h-4 w-4" />
-          )}
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center justify-between text-left"
+          >
+            <span className="text-sm font-medium">Metadata</span>
+            {isOpen ? (
+              <ChevronDown className="text-muted-foreground h-4 w-4" />
+            ) : (
+              <ChevronRight className="text-muted-foreground h-4 w-4" />
+            )}
+          </button>
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-2">
           <PrettyJsonView

--- a/web/src/features/experiments/components/ExperimentMetadataSection.tsx
+++ b/web/src/features/experiments/components/ExperimentMetadataSection.tsx
@@ -20,7 +20,7 @@ export const ExperimentMetadataSection = ({
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
       <div className="border-t pt-4">
         <CollapsibleTrigger className="flex w-full items-center justify-between text-left">
-          <h4 className="text-sm font-medium">Metadata</h4>
+          <h4 className="mb-2 text-sm font-medium">Metadata</h4>
           {isOpen ? (
             <ChevronDown className="text-muted-foreground h-4 w-4" />
           ) : (
@@ -32,7 +32,6 @@ export const ExperimentMetadataSection = ({
             json={metadata}
             currentView="pretty"
             className="w-full"
-            codeClassName="max-h-96 overflow-y-auto"
           />
         </CollapsibleContent>
       </div>

--- a/web/src/features/experiments/components/ExperimentMetadataSection.tsx
+++ b/web/src/features/experiments/components/ExperimentMetadataSection.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/src/components/ui/collapsible";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
+import { ExperimentOverviewSectionHeading } from "./ExperimentOverviewField";
 
 export const ExperimentMetadataSection = ({
   metadata,
@@ -20,7 +21,9 @@ export const ExperimentMetadataSection = ({
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
       <div className="border-t pt-4">
         <CollapsibleTrigger className="flex w-full items-center justify-between text-left">
-          <h4 className="mb-2 text-sm font-medium">Metadata</h4>
+          <ExperimentOverviewSectionHeading>
+            Metadata
+          </ExperimentOverviewSectionHeading>
           {isOpen ? (
             <ChevronDown className="text-muted-foreground h-4 w-4" />
           ) : (

--- a/web/src/features/experiments/components/ExperimentMetadataSection.tsx
+++ b/web/src/features/experiments/components/ExperimentMetadataSection.tsx
@@ -1,0 +1,41 @@
+import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/src/components/ui/collapsible";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+export const ExperimentMetadataSection = ({
+  metadata,
+}: {
+  metadata: Record<string, unknown> | undefined;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (Object.keys(metadata ?? {}).length === 0) return null;
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <div className="border-t pt-4">
+        <CollapsibleTrigger className="flex w-full items-center justify-between text-left">
+          <h4 className="text-sm font-medium">Metadata</h4>
+          {isOpen ? (
+            <ChevronDown className="text-muted-foreground h-4 w-4" />
+          ) : (
+            <ChevronRight className="text-muted-foreground h-4 w-4" />
+          )}
+        </CollapsibleTrigger>
+        <CollapsibleContent className="mt-2">
+          <PrettyJsonView
+            json={metadata}
+            currentView="pretty"
+            className="w-full"
+            codeClassName="max-h-96 overflow-y-auto"
+          />
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+};

--- a/web/src/features/experiments/components/ExperimentOverviewField.tsx
+++ b/web/src/features/experiments/components/ExperimentOverviewField.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+export const ExperimentOverviewSectionHeading = ({
+  children,
+}: {
+  children: ReactNode;
+}) => <h4 className="mb-2 text-sm font-medium">{children}</h4>;
+
+export const ExperimentOverviewField = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) => (
+  <div>
+    <div className="text-muted-foreground text-xs">{label}</div>
+    {children}
+  </div>
+);

--- a/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
+++ b/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
@@ -49,19 +49,19 @@ export function ExperimentOverviewPanel({
 }: ExperimentOverviewPanelProps) {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
 
-  const { provider, model, ...metadataWithoutModelConfig } =
-    experiment?.metadata ?? {};
-  const pullRequestUrl = metadataWithoutModelConfig["langfuse.pr_url"];
-  const githubJobUrl = metadataWithoutModelConfig["langfuse.github_job_url"];
+  const {
+    provider,
+    model,
+    "langfuse.pr_url": pullRequestUrl,
+    "langfuse.github_job_url": githubJobUrl,
+    ...additionalMetadata
+  } = experiment?.metadata ?? {};
   const safePullRequestUrl = isSafeHttpUrl(pullRequestUrl)
     ? pullRequestUrl
     : undefined;
   const safeGithubJobUrl = isSafeHttpUrl(githubJobUrl)
     ? githubJobUrl
     : undefined;
-  const additionalMetadata = { ...metadataWithoutModelConfig };
-  if (safePullRequestUrl) delete additionalMetadata["langfuse.pr_url"];
-  if (safeGithubJobUrl) delete additionalMetadata["langfuse.github_job_url"];
 
   // Get the first prompt name and version from the prompts array
   const [promptName, promptVersion] =
@@ -79,7 +79,9 @@ export function ExperimentOverviewPanel({
 
   return (
     <div className="space-y-4">
-      <div className="bg-background sticky top-0 z-10 space-y-4 border-b pb-4">
+      <div className="bg-background sticky -top-4 z-30 -mx-4 -mt-4 space-y-4 px-4 pt-2 pb-2">
+        <h3 className="text-lg font-semibold">Experiment Details</h3>
+
         <div>
           <h4 className="mb-2 text-sm font-medium">Baseline</h4>
           <ExperimentBaselineControls
@@ -105,110 +107,114 @@ export function ExperimentOverviewPanel({
 
       {hasBaseline && experiment ? (
         <>
-          <h3 className="text-lg font-semibold">Overview</h3>
-
-          <div className="space-y-3 text-sm">
-            {/* Name */}
-            <div>
-              <div className="text-muted-foreground text-xs">Name</div>
-              <div className="font-medium">{experiment.name}</div>
-            </div>
-
-            {/* Description */}
-            {experiment.description && (
+          <div className="border-t pt-4">
+            <h4 className="mb-2 text-sm font-medium">Overview</h4>
+            <div className="space-y-3 text-sm">
+              {/* Name */}
               <div>
-                <div className="text-muted-foreground text-xs">Description</div>
-                <div className="break-words">{displayDescription}</div>
-                {isLongDescription && (
-                  <Button
-                    variant="link"
-                    size="sm"
-                    className="h-auto p-0 text-xs"
-                    onClick={() =>
-                      setIsDescriptionExpanded(!isDescriptionExpanded)
-                    }
-                  >
-                    {isDescriptionExpanded ? "Show less" : "Show more"}
-                  </Button>
-                )}
+                <div className="text-muted-foreground text-xs">Name</div>
+                <div className="font-medium">{experiment.name}</div>
               </div>
-            )}
 
-            {/* Dataset */}
-            <div>
-              <div className="text-muted-foreground text-xs">Dataset</div>
-              <Link
-                href={`/project/${projectId}/datasets/${encodeURIComponent(experiment.datasetId)}`}
-                className="text-primary hover:underline"
-              >
-                {experiment.datasetName || experiment.datasetId}
-              </Link>
-            </div>
-
-            {/* Prompt */}
-            {promptName && (
-              <div>
-                <div className="text-muted-foreground text-xs">Prompt</div>
-                <Link
-                  href={`/project/${projectId}/prompts/${encodeURIComponent(promptName)}${promptVersion !== null ? `?version=${promptVersion}` : ""}`}
-                  className="text-primary hover:underline"
-                >
-                  {promptName}
-                  {promptVersion !== null && (
-                    <span className="text-muted-foreground ml-1">
-                      (v{promptVersion})
-                    </span>
-                  )}
-                </Link>
-              </div>
-            )}
-
-            {/* Model Configuration */}
-            {(provider || model) && (
-              <div>
-                <div className="text-muted-foreground text-xs">Model</div>
+              {/* Description */}
+              {experiment.description && (
                 <div>
-                  {provider && model
-                    ? `${provider}/${model}`
-                    : provider || model}
+                  <div className="text-muted-foreground text-xs">
+                    Description
+                  </div>
+                  <div className="break-words">{displayDescription}</div>
+                  {isLongDescription && (
+                    <Button
+                      variant="link"
+                      size="sm"
+                      className="h-auto p-0 text-xs"
+                      onClick={() =>
+                        setIsDescriptionExpanded(!isDescriptionExpanded)
+                      }
+                    >
+                      {isDescriptionExpanded ? "Show less" : "Show more"}
+                    </Button>
+                  )}
                 </div>
-              </div>
-            )}
+              )}
 
-            {safePullRequestUrl && (
+              {/* Dataset */}
               <div>
-                <div className="text-muted-foreground text-xs">
-                  Pull Request
-                </div>
+                <div className="text-muted-foreground text-xs">Dataset</div>
                 <Link
-                  href={safePullRequestUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  href={`/project/${projectId}/datasets/${encodeURIComponent(experiment.datasetId)}`}
                   className="text-primary hover:underline"
                 >
-                  {safePullRequestUrl}
+                  {experiment.datasetName || experiment.datasetId}
                 </Link>
               </div>
-            )}
 
-            {safeGithubJobUrl && (
+              {/* Prompt */}
+              {promptName && (
+                <div>
+                  <div className="text-muted-foreground text-xs">Prompt</div>
+                  <Link
+                    href={`/project/${projectId}/prompts/${encodeURIComponent(promptName)}${promptVersion !== null ? `?version=${promptVersion}` : ""}`}
+                    className="text-primary hover:underline"
+                  >
+                    {promptName}
+                    {promptVersion !== null && (
+                      <span className="text-muted-foreground ml-1">
+                        (v{promptVersion})
+                      </span>
+                    )}
+                  </Link>
+                </div>
+              )}
+
+              {/* Model Configuration */}
+              {(provider || model) && (
+                <div>
+                  <div className="text-muted-foreground text-xs">Model</div>
+                  <div>
+                    {provider && model
+                      ? `${provider}/${model}`
+                      : provider || model}
+                  </div>
+                </div>
+              )}
+
+              {/* Start Time */}
               <div>
-                <div className="text-muted-foreground text-xs">GitHub Job</div>
-                <Link
-                  href={safeGithubJobUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline"
-                >
-                  {safeGithubJobUrl}
-                </Link>
+                <div className="text-muted-foreground text-xs">Start Time</div>
+                <LocalIsoDate date={experiment.startTime} />
               </div>
-            )}
+              {safePullRequestUrl && (
+                <div>
+                  <div className="text-muted-foreground text-xs">
+                    Pull Request URL
+                  </div>
+                  <a
+                    href={safePullRequestUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:underline"
+                  >
+                    {safePullRequestUrl}
+                  </a>
+                </div>
+              )}
 
-            {/* Start Time */}
-            <div>
-              <div className="text-muted-foreground text-xs">Start Time</div>
-              <LocalIsoDate date={experiment.startTime} />
+              {safeGithubJobUrl && (
+                <div>
+                  <div className="text-muted-foreground text-xs">
+                    GitHub Job URL
+                  </div>
+                  <a
+                    href={safeGithubJobUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:underline"
+                  >
+                    {safeGithubJobUrl}
+                  </a>
+                </div>
+              )}
             </div>
           </div>
 

--- a/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
+++ b/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
@@ -193,7 +193,7 @@ export function ExperimentOverviewPanel({
                     href={safePullRequestUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-primary hover:underline"
+                    className="text-primary break-all hover:underline"
                   >
                     {safePullRequestUrl}
                   </a>
@@ -209,7 +209,7 @@ export function ExperimentOverviewPanel({
                     href={safeGithubJobUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-primary hover:underline"
+                    className="text-primary break-all hover:underline"
                   >
                     {safeGithubJobUrl}
                   </a>

--- a/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
+++ b/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
@@ -65,8 +65,10 @@ export function ExperimentOverviewPanel({
     ? githubJobUrl
     : undefined;
   const additionalMetadata = { ...metadata };
-  if (provider) delete additionalMetadata.provider;
-  if (model) delete additionalMetadata.model;
+  if (provider || model) {
+    delete additionalMetadata.provider;
+    delete additionalMetadata.model;
+  }
   if (safePullRequestUrl) delete additionalMetadata["langfuse.pr_url"];
   if (safeGithubJobUrl) delete additionalMetadata["langfuse.github_job_url"];
 

--- a/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
+++ b/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
@@ -1,9 +1,21 @@
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
-import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { ExperimentComparisonSelector } from "./ExperimentComparisonSelector";
 import { ExperimentBaselineControls } from "./ExperimentBaselineControls";
+import Link from "next/link";
+import { ExperimentMetadataSection } from "./ExperimentMetadataSection";
+
+const isSafeHttpUrl = (value: string | undefined) => {
+  if (!value) return false;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
 
 type ExperimentOverviewPanelProps = {
   projectId: string;
@@ -37,8 +49,19 @@ export function ExperimentOverviewPanel({
 }: ExperimentOverviewPanelProps) {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
 
-  const provider = experiment?.metadata?.provider;
-  const model = experiment?.metadata?.model;
+  const { provider, model, ...metadataWithoutModelConfig } =
+    experiment?.metadata ?? {};
+  const pullRequestUrl = metadataWithoutModelConfig["langfuse.pr_url"];
+  const githubJobUrl = metadataWithoutModelConfig["langfuse.github_job_url"];
+  const safePullRequestUrl = isSafeHttpUrl(pullRequestUrl)
+    ? pullRequestUrl
+    : undefined;
+  const safeGithubJobUrl = isSafeHttpUrl(githubJobUrl)
+    ? githubJobUrl
+    : undefined;
+  const additionalMetadata = { ...metadataWithoutModelConfig };
+  if (safePullRequestUrl) delete additionalMetadata["langfuse.pr_url"];
+  if (safeGithubJobUrl) delete additionalMetadata["langfuse.github_job_url"];
 
   // Get the first prompt name and version from the prompts array
   const [promptName, promptVersion] =
@@ -56,9 +79,33 @@ export function ExperimentOverviewPanel({
 
   return (
     <div className="space-y-4">
+      <div className="bg-background sticky top-0 z-10 space-y-4 border-b pb-4">
+        <div>
+          <h4 className="mb-2 text-sm font-medium">Baseline</h4>
+          <ExperimentBaselineControls
+            projectId={projectId}
+            baselineId={experiment?.id}
+            baselineName={experiment?.name}
+            onBaselineChange={onBaselineChange}
+            onBaselineClear={onBaselineClear}
+            canClearBaseline={comparisonIds.length > 0}
+          />
+        </div>
+
+        <div className="border-t pt-4">
+          <h4 className="mb-2 text-sm font-medium">Compare with</h4>
+          <ExperimentComparisonSelector
+            projectId={projectId}
+            baselineExperimentId={experiment?.id}
+            selectedIds={comparisonIds}
+            onSelectedIdsChange={onComparisonIdsChange}
+          />
+        </div>
+      </div>
+
       {hasBaseline && experiment ? (
         <>
-          <h3 className="text-lg font-semibold">Experiment Details</h3>
+          <h3 className="text-lg font-semibold">Overview</h3>
 
           <div className="space-y-3 text-sm">
             {/* Name */}
@@ -128,38 +175,46 @@ export function ExperimentOverviewPanel({
               </div>
             )}
 
+            {safePullRequestUrl && (
+              <div>
+                <div className="text-muted-foreground text-xs">
+                  Pull Request
+                </div>
+                <Link
+                  href={safePullRequestUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  {safePullRequestUrl}
+                </Link>
+              </div>
+            )}
+
+            {safeGithubJobUrl && (
+              <div>
+                <div className="text-muted-foreground text-xs">GitHub Job</div>
+                <Link
+                  href={safeGithubJobUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  {safeGithubJobUrl}
+                </Link>
+              </div>
+            )}
+
             {/* Start Time */}
             <div>
               <div className="text-muted-foreground text-xs">Start Time</div>
               <LocalIsoDate date={experiment.startTime} />
             </div>
           </div>
+
+          <ExperimentMetadataSection metadata={additionalMetadata} />
         </>
       ) : null}
-
-      {/* Baseline Controls */}
-      <div className={hasBaseline ? "border-t pt-4" : undefined}>
-        <h4 className="mb-2 text-sm font-medium">Baseline</h4>
-        <ExperimentBaselineControls
-          projectId={projectId}
-          baselineId={experiment?.id}
-          baselineName={experiment?.name}
-          onBaselineChange={onBaselineChange}
-          onBaselineClear={onBaselineClear}
-          canClearBaseline={comparisonIds.length > 0}
-        />
-      </div>
-
-      {/* Comparison Selector */}
-      <div className="border-t pt-4">
-        <h4 className="mb-2 text-sm font-medium">Compare with</h4>
-        <ExperimentComparisonSelector
-          projectId={projectId}
-          baselineExperimentId={experiment?.id}
-          selectedIds={comparisonIds}
-          onSelectedIdsChange={onComparisonIdsChange}
-        />
-      </div>
     </div>
   );
 }

--- a/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
+++ b/web/src/features/experiments/components/ExperimentOverviewPanel.tsx
@@ -5,6 +5,10 @@ import { ExperimentComparisonSelector } from "./ExperimentComparisonSelector";
 import { ExperimentBaselineControls } from "./ExperimentBaselineControls";
 import Link from "next/link";
 import { ExperimentMetadataSection } from "./ExperimentMetadataSection";
+import {
+  ExperimentOverviewField,
+  ExperimentOverviewSectionHeading,
+} from "./ExperimentOverviewField";
 
 const isSafeHttpUrl = (value: string | undefined) => {
   if (!value) return false;
@@ -49,19 +53,22 @@ export function ExperimentOverviewPanel({
 }: ExperimentOverviewPanelProps) {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
 
-  const {
-    provider,
-    model,
-    "langfuse.pr_url": pullRequestUrl,
-    "langfuse.github_job_url": githubJobUrl,
-    ...additionalMetadata
-  } = experiment?.metadata ?? {};
+  const metadata = experiment?.metadata ?? {};
+  const provider = metadata.provider;
+  const model = metadata.model;
+  const pullRequestUrl = metadata["langfuse.pr_url"];
+  const githubJobUrl = metadata["langfuse.github_job_url"];
   const safePullRequestUrl = isSafeHttpUrl(pullRequestUrl)
     ? pullRequestUrl
     : undefined;
   const safeGithubJobUrl = isSafeHttpUrl(githubJobUrl)
     ? githubJobUrl
     : undefined;
+  const additionalMetadata = { ...metadata };
+  if (provider) delete additionalMetadata.provider;
+  if (model) delete additionalMetadata.model;
+  if (safePullRequestUrl) delete additionalMetadata["langfuse.pr_url"];
+  if (safeGithubJobUrl) delete additionalMetadata["langfuse.github_job_url"];
 
   // Get the first prompt name and version from the prompts array
   const [promptName, promptVersion] =
@@ -79,11 +86,13 @@ export function ExperimentOverviewPanel({
 
   return (
     <div className="space-y-4">
-      <div className="bg-background sticky -top-4 z-30 -mx-4 -mt-4 space-y-4 px-4 pt-2 pb-2">
+      <div className="bg-background sticky -top-4 z-30 -mx-4 -mt-4 space-y-4 px-4 pt-4 pb-4">
         <h3 className="text-lg font-semibold">Experiment Details</h3>
 
         <div>
-          <h4 className="mb-2 text-sm font-medium">Baseline</h4>
+          <ExperimentOverviewSectionHeading>
+            Baseline
+          </ExperimentOverviewSectionHeading>
           <ExperimentBaselineControls
             projectId={projectId}
             baselineId={experiment?.id}
@@ -95,7 +104,9 @@ export function ExperimentOverviewPanel({
         </div>
 
         <div className="border-t pt-4">
-          <h4 className="mb-2 text-sm font-medium">Compare with</h4>
+          <ExperimentOverviewSectionHeading>
+            Compare with
+          </ExperimentOverviewSectionHeading>
           <ExperimentComparisonSelector
             projectId={projectId}
             baselineExperimentId={experiment?.id}
@@ -108,20 +119,16 @@ export function ExperimentOverviewPanel({
       {hasBaseline && experiment ? (
         <>
           <div className="border-t pt-4">
-            <h4 className="mb-2 text-sm font-medium">Overview</h4>
+            <ExperimentOverviewSectionHeading>
+              Overview
+            </ExperimentOverviewSectionHeading>
             <div className="space-y-3 text-sm">
-              {/* Name */}
-              <div>
-                <div className="text-muted-foreground text-xs">Name</div>
+              <ExperimentOverviewField label="Name">
                 <div className="font-medium">{experiment.name}</div>
-              </div>
+              </ExperimentOverviewField>
 
-              {/* Description */}
               {experiment.description && (
-                <div>
-                  <div className="text-muted-foreground text-xs">
-                    Description
-                  </div>
+                <ExperimentOverviewField label="Description">
                   <div className="break-words">{displayDescription}</div>
                   {isLongDescription && (
                     <Button
@@ -135,24 +142,20 @@ export function ExperimentOverviewPanel({
                       {isDescriptionExpanded ? "Show less" : "Show more"}
                     </Button>
                   )}
-                </div>
+                </ExperimentOverviewField>
               )}
 
-              {/* Dataset */}
-              <div>
-                <div className="text-muted-foreground text-xs">Dataset</div>
+              <ExperimentOverviewField label="Dataset">
                 <Link
                   href={`/project/${projectId}/datasets/${encodeURIComponent(experiment.datasetId)}`}
                   className="text-primary hover:underline"
                 >
                   {experiment.datasetName || experiment.datasetId}
                 </Link>
-              </div>
+              </ExperimentOverviewField>
 
-              {/* Prompt */}
               {promptName && (
-                <div>
-                  <div className="text-muted-foreground text-xs">Prompt</div>
+                <ExperimentOverviewField label="Prompt">
                   <Link
                     href={`/project/${projectId}/prompts/${encodeURIComponent(promptName)}${promptVersion !== null ? `?version=${promptVersion}` : ""}`}
                     className="text-primary hover:underline"
@@ -164,31 +167,25 @@ export function ExperimentOverviewPanel({
                       </span>
                     )}
                   </Link>
-                </div>
+                </ExperimentOverviewField>
               )}
 
-              {/* Model Configuration */}
               {(provider || model) && (
-                <div>
-                  <div className="text-muted-foreground text-xs">Model</div>
+                <ExperimentOverviewField label="Model">
                   <div>
                     {provider && model
                       ? `${provider}/${model}`
                       : provider || model}
                   </div>
-                </div>
+                </ExperimentOverviewField>
               )}
 
-              {/* Start Time */}
-              <div>
-                <div className="text-muted-foreground text-xs">Start Time</div>
+              <ExperimentOverviewField label="Start Time">
                 <LocalIsoDate date={experiment.startTime} />
-              </div>
+              </ExperimentOverviewField>
+
               {safePullRequestUrl && (
-                <div>
-                  <div className="text-muted-foreground text-xs">
-                    Pull Request URL
-                  </div>
+                <ExperimentOverviewField label="Pull Request URL">
                   <a
                     href={safePullRequestUrl}
                     target="_blank"
@@ -197,14 +194,11 @@ export function ExperimentOverviewPanel({
                   >
                     {safePullRequestUrl}
                   </a>
-                </div>
+                </ExperimentOverviewField>
               )}
 
               {safeGithubJobUrl && (
-                <div>
-                  <div className="text-muted-foreground text-xs">
-                    GitHub Job URL
-                  </div>
+                <ExperimentOverviewField label="GitHub Job URL">
                   <a
                     href={safeGithubJobUrl}
                     target="_blank"
@@ -213,7 +207,7 @@ export function ExperimentOverviewPanel({
                   >
                     {safeGithubJobUrl}
                   </a>
-                </div>
+                </ExperimentOverviewField>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Shows experiment metadata in the experiment overview sidebar for LFE-9600.
- Pulls out `provider` / `model`, `langfuse.pr_url`, and `langfuse.github_job_url` as first-class overview fields while keeping remaining metadata available below.
- Renders remaining metadata in a collapsed-by-default Pretty JSON view to keep arbitrary metadata inspectable without overwhelming the sidebar.
- Moves Baseline / Compare with controls to a sticky top section so selection controls stay accessible while reviewing overview details.

## Linear

- https://linear.app/langfuse/issue/LFE-9600/show-metadata-in-ui

## Major Decisions

- Metadata is rendered only in the overview sidebar, not in the experiments table, because table cells are not well-suited for interacting with individual metadata values.
- Filtering of promoted metadata keys happens at the overview panel callsite so the metadata view displays only additional metadata.
- Reused the existing Pretty JSON view for arbitrary metadata to reduce bespoke UI logic and align with existing metadata displays.

## Review Focus

- UI layout of the overview sidebar, especially the sticky Baseline / Compare with controls and the collapsed metadata section.
- Whether the promoted PR / GitHub job links and remaining metadata placement feel right in the sidebar priority order.