### PR TITLE
test(ingestion-masking): cover propagated-header pipeline

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -176,6 +176,32 @@ export class OtelIngestionProcessor {
     return `${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, "0")}/${String(now.getDate()).padStart(2, "0")}/${String(now.getHours()).padStart(2, "0")}/${String(now.getMinutes()).padStart(2, "0")}`;
   }
 
+  buildOtelIngestionJob(fileKey: string) {
+    return {
+      id: randomUUID(),
+      timestamp: new Date(),
+      name: QueueJobs.OtelIngestionJob as const,
+      payload: {
+        data: {
+          fileKey,
+          publicKey: this.publicKey,
+        },
+        authCheck: {
+          validKey: true as const,
+          scope: {
+            projectId: this.projectId,
+            accessLevel: "project" as const,
+            orgId: this.orgId,
+          },
+        },
+        propagatedHeaders: this.propagatedHeaders,
+        sdkName: this.sdkName,
+        sdkVersion: this.sdkVersion,
+        ingestionVersion: this.ingestionVersion,
+      },
+    };
+  }
+
   /**
    * Uploads a batch of resourceSpans to blob storage and adds a job to process them
    * into the otel-ingestion-queue.
@@ -193,29 +219,10 @@ export class OtelIngestionProcessor {
       shardingKey: `${this.projectId}-${fileKey}`,
     });
     return queue
-      ? queue.add(QueueJobs.OtelIngestionJob, {
-          id: randomUUID(),
-          timestamp: new Date(),
-          name: QueueJobs.OtelIngestionJob as const,
-          payload: {
-            data: {
-              fileKey,
-              publicKey: this.publicKey,
-            },
-            authCheck: {
-              validKey: true,
-              scope: {
-                projectId: this.projectId,
-                accessLevel: "project" as const,
-                orgId: this.orgId,
-              },
-            },
-            propagatedHeaders: this.propagatedHeaders,
-            sdkName: this.sdkName,
-            sdkVersion: this.sdkVersion,
-            ingestionVersion: this.ingestionVersion,
-          },
-        })
+      ? queue.add(
+          QueueJobs.OtelIngestionJob,
+          this.buildOtelIngestionJob(fileKey),
+        )
       : Promise.reject("Failed to instantiate otel ingestion queue");
   }
 

--- a/web/src/__tests__/server/unit/extractPropagatedHeaders.servertest.ts
+++ b/web/src/__tests__/server/unit/extractPropagatedHeaders.servertest.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { extractPropagatedHeaders } from "@/src/features/public-api/server/extractPropagatedHeaders";
+
+describe("extractPropagatedHeaders", () => {
+  it("captures a header that is listed in the allow-list", () => {
+    const result = extractPropagatedHeaders(
+      { intuit_tid: "abc-123", "user-agent": "test" },
+      ["intuit_tid"],
+    );
+
+    expect(result).toEqual({ intuit_tid: "abc-123" });
+  });
+
+  it("captures multiple allow-listed headers and ignores the rest", () => {
+    const result = extractPropagatedHeaders(
+      {
+        intuit_tid: "abc-123",
+        "x-trace-id": "trace-9",
+        "user-agent": "test",
+        authorization: "Bearer secret",
+      },
+      ["intuit_tid", "x-trace-id"],
+    );
+
+    expect(result).toEqual({
+      intuit_tid: "abc-123",
+      "x-trace-id": "trace-9",
+    });
+  });
+
+  it("omits headers that are listed but missing from the request", () => {
+    const result = extractPropagatedHeaders({ "x-trace-id": "trace-9" }, [
+      "intuit_tid",
+      "x-trace-id",
+    ]);
+
+    expect(result).toEqual({ "x-trace-id": "trace-9" });
+    expect(result).not.toHaveProperty("intuit_tid");
+  });
+
+  it("returns an empty object when the allow-list is empty", () => {
+    const result = extractPropagatedHeaders({ intuit_tid: "abc-123" }, []);
+
+    expect(result).toEqual({});
+  });
+
+  it("matches headers case-insensitively because Node lowercases req.headers keys", () => {
+    // Node's http module lowercases incoming header keys before exposing them
+    // on req.headers. The env parser also lowercases the allow-list. So an
+    // upstream header sent as `INTUIT_TID` is observed by Node as `intuit_tid`
+    // and matched against the lowercased allow-list entry.
+    const result = extractPropagatedHeaders({ intuit_tid: "abc-123" }, [
+      "intuit_tid",
+    ]);
+
+    expect(result).toEqual({ intuit_tid: "abc-123" });
+  });
+
+  it("skips array-valued headers (duplicated header on the request)", () => {
+    const result = extractPropagatedHeaders(
+      { "set-cookie": ["a=1", "b=2"], intuit_tid: "abc-123" },
+      ["set-cookie", "intuit_tid"],
+    );
+
+    expect(result).toEqual({ intuit_tid: "abc-123" });
+    expect(result).not.toHaveProperty("set-cookie");
+  });
+
+  it("skips undefined header values", () => {
+    const result = extractPropagatedHeaders(
+      { intuit_tid: undefined, "x-trace-id": "trace-9" },
+      ["intuit_tid", "x-trace-id"],
+    );
+
+    expect(result).toEqual({ "x-trace-id": "trace-9" });
+  });
+});

--- a/web/src/features/public-api/server/extractPropagatedHeaders.ts
+++ b/web/src/features/public-api/server/extractPropagatedHeaders.ts
@@ -1,0 +1,24 @@
+/**
+ * Filter incoming HTTP headers down to the allow-list configured via
+ * `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS`. Names in the allow-list
+ * are already lowercased (see env parsing in `packages/shared/src/env.ts`),
+ * and Node lowercases `req.headers` keys, so the comparison is case-insensitive
+ * by construction.
+ *
+ * Returns only string-valued headers; array-valued headers (set when a header
+ * appears multiple times on the request) are skipped to keep the downstream
+ * `Record<string, string>` contract honest.
+ */
+export function extractPropagatedHeaders(
+  reqHeaders: Record<string, string | string[] | undefined>,
+  propagatedHeaderNames: readonly string[],
+): Record<string, string> {
+  const propagatedHeaders: Record<string, string> = {};
+  for (const headerName of propagatedHeaderNames) {
+    const value = reqHeaders[headerName];
+    if (typeof value === "string") {
+      propagatedHeaders[headerName] = value;
+    }
+  }
+  return propagatedHeaders;
+}

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -1,5 +1,6 @@
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+import { extractPropagatedHeaders } from "@/src/features/public-api/server/extractPropagatedHeaders";
 import {
   logger,
   OtelIngestionProcessor,
@@ -158,16 +159,10 @@ export default withMiddlewares({
         };
       }
 
-      // Extract headers to propagate for ingestion masking
-      const propagatedHeaderNames =
-        env.LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS;
-      const propagatedHeaders: Record<string, string> = {};
-      for (const headerName of propagatedHeaderNames) {
-        const value = req.headers[headerName];
-        if (typeof value === "string") {
-          propagatedHeaders[headerName] = value;
-        }
-      }
+      const propagatedHeaders = extractPropagatedHeaders(
+        req.headers,
+        env.LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS,
+      );
 
       const processor = new OtelIngestionProcessor({
         projectId: auth.scope.projectId,

--- a/worker/src/__tests__/otelIngestionProcessor.propagatedHeaders.test.ts
+++ b/worker/src/__tests__/otelIngestionProcessor.propagatedHeaders.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { OtelIngestionProcessor } from "@langfuse/shared/src/server";
+
+describe("OtelIngestionProcessor.buildOtelIngestionJob propagated headers", () => {
+  it("includes propagatedHeaders on the queue payload when configured", () => {
+    const processor = new OtelIngestionProcessor({
+      projectId: "test-project",
+      orgId: "test-org",
+      publicKey: "pk-lf-test",
+      propagatedHeaders: {
+        intuit_tid: "abc-123",
+        "x-langfuse-test": "ok",
+      },
+    });
+
+    const job = processor.buildOtelIngestionJob("test-file-key.json");
+
+    expect(job.payload.propagatedHeaders).toEqual({
+      intuit_tid: "abc-123",
+      "x-langfuse-test": "ok",
+    });
+  });
+
+  it("passes propagatedHeaders as undefined when none are configured", () => {
+    const processor = new OtelIngestionProcessor({
+      projectId: "test-project",
+      orgId: "test-org",
+      publicKey: "pk-lf-test",
+    });
+
+    const job = processor.buildOtelIngestionJob("test-file-key.json");
+
+    expect(job.payload.propagatedHeaders).toBeUndefined();
+  });
+
+  it("preserves arbitrary header values on the queue payload (no normalization)", () => {
+    const processor = new OtelIngestionProcessor({
+      projectId: "test-project",
+      orgId: "test-org",
+      publicKey: "pk-lf-test",
+      propagatedHeaders: {
+        // Underscored header — relevant to the Intuit case where intuit_tid
+        // must survive untouched all the way to the masking callback. The
+        // processor stores whatever it was handed; any drop must therefore
+        // happen earlier (e.g. an upstream proxy that strips underscored
+        // headers before Node sees them) rather than inside this code path.
+        intuit_tid: "trace-id-with-underscore",
+      },
+    });
+
+    const job = processor.buildOtelIngestionJob("test-file-key.json");
+
+    expect(job.payload.propagatedHeaders).toEqual({
+      intuit_tid: "trace-id-with-underscore",
+    });
+  });
+
+  it("populates the rest of the queue payload with project context", () => {
+    const processor = new OtelIngestionProcessor({
+      projectId: "test-project",
+      orgId: "test-org",
+      publicKey: "pk-lf-test",
+      sdkName: "langfuse-python",
+      sdkVersion: "2.60.3",
+      ingestionVersion: "4",
+    });
+
+    const job = processor.buildOtelIngestionJob("test-file-key.json");
+
+    expect(job.payload.data).toEqual({
+      fileKey: "test-file-key.json",
+      publicKey: "pk-lf-test",
+    });
+    expect(job.payload.authCheck).toEqual({
+      validKey: true,
+      scope: {
+        projectId: "test-project",
+        accessLevel: "project",
+        orgId: "test-org",
+      },
+    });
+    expect(job.payload.sdkName).toBe("langfuse-python");
+    expect(job.payload.sdkVersion).toBe("2.60.3");
+    expect(job.payload.ingestionVersion).toBe("4");
+  });
+});


### PR DESCRIPTION
## Summary

- Anchor the `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS` flow with tests so any future regression in the request → queue → masking-callback path is caught.
- Extract two small helpers along the way: `extractPropagatedHeaders` in web (filters `req.headers` against the env allow-list) and `OtelIngestionProcessor.buildOtelIngestionJob` in shared (constructs the queue-job body). Both are exercised directly by the new tests so we don't need to mock S3 or BullMQ.
- No runtime behaviour change. Existing `worker/src/__tests__/ingestionMasking.test.ts` already covers the masking-callback HTTP hop and continues to pass.

Motivation: a recent customer thread asked whether `intuit_tid` is propagated end-to-end — the existing test only proved the last hop, leaving the web capture and queue payload unverified.

## Impacted packages

- `@langfuse/shared` — adds `OtelIngestionProcessor.buildOtelIngestionJob`; `publishToOtelIngestionQueue` now delegates payload construction to it.
- `web` — extracts inline header-filter loop in `pages/api/public/otel/v1/traces/index.ts` into `features/public-api/server/extractPropagatedHeaders.ts`.
- `worker` — adds `__tests__/otelIngestionProcessor.propagatedHeaders.test.ts` (4 cases).
- `web` — adds `__tests__/server/unit/extractPropagatedHeaders.servertest.ts` (7 cases).

## Verification

- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter worker run lint`
- [x] `pnpm --filter @langfuse/shared run build`
- [x] `pnpm --filter worker exec vitest run src/__tests__/otelIngestionProcessor.propagatedHeaders.test.ts src/__tests__/ingestionMasking.test.ts` (4 + 15 passing)
- [x] `pnpm --filter web exec vitest run --project server src/__tests__/server/unit/extractPropagatedHeaders.servertest.ts` (7 passing)

## Test plan

- [ ] CI lint + tests pass on all touched packages.
- [ ] Reviewer confirms `buildOtelIngestionJob` is a faithful extraction of the original inline payload (no semantic drift).
- [ ] Reviewer confirms `extractPropagatedHeaders` matches the prior inline behaviour (string-only values, allow-list filter, lowercased keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR refactors the `LANGFUSE_INGESTION_MASKING_PROPAGATED_HEADERS` pipeline to improve testability by extracting two small helpers — `extractPropagatedHeaders` (web) and `OtelIngestionProcessor.buildOtelIngestionJob` (shared) — and adds 11 unit tests covering the full request → queue payload path without requiring S3 or BullMQ mocks. No runtime behaviour changes; all extractions are faithful to the original inline code.

<h3>Confidence Score: 4/5</h3>

Safe to merge — pure refactor with faithful extractions and no runtime changes.

All findings are P2 style suggestions (a misleading test title and an implicit-public method). No logic errors, no semantic drift in the extractions, and existing tests continue to pass.

No files require special attention; the minor test-title issue in `extractPropagatedHeaders.servertest.ts` and the implicit-public `buildOtelIngestionJob` are cosmetic.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/otel/OtelIngestionProcessor.ts | Faithful extraction of inline queue-payload construction into `buildOtelIngestionJob`; `publishToOtelIngestionQueue` delegates to it. Only type-narrowing additions (`as const`) with no runtime change. |
| web/src/features/public-api/server/extractPropagatedHeaders.ts | New helper that faithfully extracts the inline header-filter loop; skips array-valued and undefined headers, returns `Record<string, string>`. |
| web/src/pages/api/public/otel/v1/traces/index.ts | Inline header-filter loop replaced with `extractPropagatedHeaders` call; behaviour identical to before. |
| worker/src/__tests__/otelIngestionProcessor.propagatedHeaders.test.ts | 4 unit tests for `buildOtelIngestionJob` covering propagated headers present, absent, value preservation, and full payload structure. |
| web/src/__tests__/server/unit/extractPropagatedHeaders.servertest.ts | 7 unit tests; logic and filtering correct, but the case-insensitivity test title overstates what is actually exercised. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant WebAPI as web/otel/v1/traces
    participant Helper as extractPropagatedHeaders
    participant Processor as OtelIngestionProcessor
    participant Builder as buildOtelIngestionJob
    participant S3
    participant Queue as OtelIngestionQueue

    Client->>WebAPI: POST /api/public/otel/v1/traces (+ propagated headers)
    WebAPI->>Helper: extractPropagatedHeaders(req.headers, allowList)
    Helper-->>WebAPI: Record<string, string>
    WebAPI->>Processor: new OtelIngestionProcessor({ propagatedHeaders, ... })
    WebAPI->>Processor: publishToOtelIngestionQueue(resourceSpans)
    Processor->>S3: uploadJson(fileKey, resourceSpans)
    Processor->>Builder: buildOtelIngestionJob(fileKey)
    Builder-->>Processor: { id, name, payload: { data, authCheck, propagatedHeaders, ... } }
    Processor->>Queue: queue.add(OtelIngestionJob, job)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/__tests__/server/unit/extractPropagatedHeaders.servertest.ts:53-62
**Misleading test title — case-insensitivity isn't actually exercised**

The test is titled `"matches headers case-insensitively because Node lowercases req.headers keys"`, but both the input map (`{ intuit_tid: "abc-123" }`) and the allow-list (`["intuit_tid"]`) are already lowercase, so the test only verifies that a fully-lowercased key matches a fully-lowercased allow-list entry. It doesn't cover the actual case-folding assumption. To make the intent clear, rename it to something like `"handles already-lowercased keys from Node (case normalization is a Node/env concern)"`, or add a complementary test that feeds a mixed-case allow-list entry and confirms the behavior.

### Issue 2 of 2
packages/shared/src/server/otel/OtelIngestionProcessor.ts:179-203
**`buildOtelIngestionJob` is now an unguarded public API**

The method was extracted to enable unit testing without mocking S3/BullMQ, which is valid. However, leaving it as an implicit `public` member makes it part of `OtelIngestionProcessor`'s external contract — any caller can build and discard a job object without ever enqueuing it. Consider marking it `/** @internal */` or documenting that it is intentionally public for testability.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ingestion-masking): cover propagate..."](https://github.com/langfuse/langfuse/commit/b569ae155aade91cbd6b61108ac2bee39ee83842) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30721655)</sub>

<!-- /greptile_comment -->