### PR TITLE
fix(api): support decoded slash prompt names

### DIFF
--- a/web/src/__tests__/server/prompts.v2.servertest.ts
+++ b/web/src/__tests__/server/prompts.v2.servertest.ts
@@ -181,6 +181,39 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       testPromptEquality(createPromptParams, fetchedPrompt.body);
     });
 
+    it("should fetch a prompt when a proxy decodes slashes in the prompt name", async () => {
+      const { projectId, auth } = await createOrgProjectAndApiKey();
+      const promptName = `folder/${nanoid()}/prompt`;
+
+      const createPromptParams: CreatePromptInDBParams = {
+        name: promptName,
+        prompt: "prompt",
+        labels: ["production"],
+        version: 1,
+        config: {
+          temperature: 0.1,
+        },
+        projectId,
+        createdBy: "user-1",
+      };
+
+      await createPromptInDB(createPromptParams);
+
+      const fetchedPrompt = await makeAPICall<Prompt>(
+        "GET",
+        `${baseURI}/${promptName}`,
+        undefined,
+        auth,
+      );
+      expect(fetchedPrompt.status).toBe(200);
+
+      if (!isPrompt(fetchedPrompt.body)) {
+        throw new Error("Expected body to be a prompt");
+      }
+
+      testPromptEquality(createPromptParams, fetchedPrompt.body);
+    });
+
     it("should fetch a prompt with special characters", async () => {
       const { projectId, auth } = await createOrgProjectAndApiKey();
       const promptName = "promptName?!+ =@#;" + nanoid();
@@ -1895,6 +1928,42 @@ describe("/api/public/v2/prompts API Endpoint", () => {
 describe("PATCH api/public/v2/prompts/[promptName]/versions/[version]", () => {
   let triggerId: string;
   let actionId: string;
+
+  it("should update labels when a proxy decodes slashes in the prompt name", async () => {
+    const { projectId: newProjectId, auth: newAuth } =
+      await createOrgProjectAndApiKey();
+
+    const promptName = `folder/${nanoid()}/prompt`;
+    const originalPrompt = await prisma.prompt.create({
+      data: {
+        name: promptName,
+        projectId: newProjectId,
+        version: 1,
+        labels: ["production"],
+        createdBy: "user-test",
+        prompt: "prompt-1",
+      },
+    });
+
+    const response = await makeAPICall(
+      "PATCH",
+      `${baseURI}/${promptName}/versions/1`,
+      {
+        newLabels: ["new-label"],
+      },
+      newAuth,
+    );
+
+    expect(response.status).toBe(200);
+
+    const updatedPrompt = await prisma.prompt.findUnique({
+      where: {
+        id: originalPrompt.id,
+      },
+    });
+    expect(updatedPrompt?.labels).toContain("production");
+    expect(updatedPrompt?.labels).toContain("new-label");
+  });
 
   it("should update the labels of a prompt", async () => {
     const { projectId: newProjectId, auth: newAuth } =

--- a/web/src/__tests__/server/prompts.v2.servertest.ts
+++ b/web/src/__tests__/server/prompts.v2.servertest.ts
@@ -214,6 +214,39 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       testPromptEquality(createPromptParams, fetchedPrompt.body);
     });
 
+    it("should fetch a prompt when the decoded name contains a versions segment", async () => {
+      const { projectId, auth } = await createOrgProjectAndApiKey();
+      const promptName = `folder/versions/${nanoid()}`;
+
+      const createPromptParams: CreatePromptInDBParams = {
+        name: promptName,
+        prompt: "prompt",
+        labels: ["production"],
+        version: 1,
+        config: {
+          temperature: 0.1,
+        },
+        projectId,
+        createdBy: "user-1",
+      };
+
+      await createPromptInDB(createPromptParams);
+
+      const fetchedPrompt = await makeAPICall<Prompt>(
+        "GET",
+        `${baseURI}/${promptName}`,
+        undefined,
+        auth,
+      );
+      expect(fetchedPrompt.status).toBe(200);
+
+      if (!isPrompt(fetchedPrompt.body)) {
+        throw new Error("Expected body to be a prompt");
+      }
+
+      testPromptEquality(createPromptParams, fetchedPrompt.body);
+    });
+
     it("should fetch a prompt with special characters", async () => {
       const { projectId, auth } = await createOrgProjectAndApiKey();
       const promptName = "promptName?!+ =@#;" + nanoid();
@@ -1963,6 +1996,51 @@ describe("PATCH api/public/v2/prompts/[promptName]/versions/[version]", () => {
     });
     expect(updatedPrompt?.labels).toContain("production");
     expect(updatedPrompt?.labels).toContain("new-label");
+  });
+
+  it("should not treat an existing prompt name ending in versions/{number} as a version route", async () => {
+    const { projectId: newProjectId, auth: newAuth } =
+      await createOrgProjectAndApiKey();
+
+    const ambiguousPrompt = await prisma.prompt.create({
+      data: {
+        name: "api/versions/2",
+        projectId: newProjectId,
+        version: 1,
+        labels: ["production"],
+        createdBy: "user-test",
+        prompt: "ambiguous-prompt",
+      },
+    });
+
+    const apiPromptVersionTwo = await prisma.prompt.create({
+      data: {
+        name: "api",
+        projectId: newProjectId,
+        version: 2,
+        labels: ["production"],
+        createdBy: "user-test",
+        prompt: "api-prompt",
+      },
+    });
+
+    const response = await makeAPICall(
+      "PATCH",
+      `${baseURI}/${ambiguousPrompt.name}`,
+      {
+        newLabels: ["new-label"],
+      },
+      newAuth,
+    );
+
+    expect(response.status).toBe(405);
+
+    const unchangedApiPrompt = await prisma.prompt.findUnique({
+      where: {
+        id: apiPromptVersionTwo.id,
+      },
+    });
+    expect(unchangedApiPrompt?.labels).toEqual(["production"]);
   });
 
   it("should update the labels of a prompt", async () => {

--- a/web/src/__tests__/server/prompts.v2.servertest.ts
+++ b/web/src/__tests__/server/prompts.v2.servertest.ts
@@ -247,6 +247,61 @@ describe("/api/public/v2/prompts API Endpoint", () => {
       testPromptEquality(createPromptParams, fetchedPrompt.body);
     });
 
+    it("should fetch an existing prompt whose decoded name ends in versions/{number}", async () => {
+      const { projectId, auth } = await createOrgProjectAndApiKey();
+      const promptName = `folder/versions/2`;
+
+      const createPromptParams: CreatePromptInDBParams = {
+        name: promptName,
+        prompt: "prompt",
+        labels: ["production"],
+        version: 1,
+        config: {
+          temperature: 0.1,
+        },
+        projectId,
+        createdBy: "user-1",
+      };
+
+      await createPromptInDB(createPromptParams);
+
+      const fetchedPrompt = await makeAPICall<Prompt>(
+        "GET",
+        `${baseURI}/${promptName}`,
+        undefined,
+        auth,
+      );
+      expect(fetchedPrompt.status).toBe(200);
+
+      if (!isPrompt(fetchedPrompt.body)) {
+        throw new Error("Expected body to be a prompt");
+      }
+
+      testPromptEquality(createPromptParams, fetchedPrompt.body);
+    });
+
+    it("should return method not allowed for non-PATCH version paths", async () => {
+      const { projectId, auth } = await createOrgProjectAndApiKey();
+
+      await createPromptInDB({
+        name: "versioned-prompt",
+        prompt: "prompt",
+        labels: ["production"],
+        version: 1,
+        projectId,
+        createdBy: "user-1",
+      });
+
+      const response = await makeAPICall(
+        "GET",
+        `${baseURI}/versioned-prompt/versions/1`,
+        undefined,
+        auth,
+      );
+
+      expect(response.status).toBe(405);
+    });
+
     it("should fetch a prompt with special characters", async () => {
       const { projectId, auth } = await createOrgProjectAndApiKey();
       const promptName = "promptName?!+ =@#;" + nanoid();

--- a/web/src/features/prompts/server/handlers/promptNameHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptNameHandler.ts
@@ -13,6 +13,22 @@ import { RateLimitService } from "@/src/features/public-api/server/RateLimitServ
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { prisma } from "@langfuse/shared/src/db";
 
+const normalizePromptName = (
+  promptName: string | string[] | undefined,
+): string | undefined => {
+  if (Array.isArray(promptName)) {
+    return promptName.join("/");
+  }
+
+  return promptName;
+};
+
+const parsePromptRequest = (req: NextApiRequest) =>
+  GetPromptByNameSchema.parse({
+    ...req.query,
+    promptName: normalizePromptName(req.query.promptName),
+  });
+
 const getPromptNameHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
@@ -28,9 +44,7 @@ const getPromptNameHandler = async (
     return rateLimitCheck.sendRestResponseIfLimited(res);
   }
 
-  const { promptName, version, label, resolve } = GetPromptByNameSchema.parse(
-    req.query,
-  );
+  const { promptName, version, label, resolve } = parsePromptRequest(req);
 
   const prompt = await getPromptByName({
     promptName: promptName,
@@ -73,7 +87,7 @@ const deletePromptNameHandler = async (
     return rateLimitCheck.sendRestResponseIfLimited(res);
   }
 
-  const { promptName, version, label } = GetPromptByNameSchema.parse(req.query);
+  const { promptName, version, label } = parsePromptRequest(req);
 
   // Fetch prompts for audit logging
   const where = {

--- a/web/src/features/prompts/server/handlers/promptVersionHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptVersionHandler.ts
@@ -15,19 +15,27 @@ const UpdatePromptBodySchema = z.object({
     }),
 });
 
+const PromptVersionQuerySchema = z.object({
+  promptName: z
+    .union([z.string(), z.array(z.string())])
+    .transform((value) => (Array.isArray(value) ? value.join("/") : value)),
+  promptVersion: z.coerce.number().int(),
+});
+
 export const promptVersionHandler = withMiddlewares({
   PATCH: createAuthedProjectAPIRoute({
     name: "Update Prompt",
+    querySchema: PromptVersionQuerySchema,
     bodySchema: UpdatePromptBodySchema,
     responseSchema: z.any(),
-    fn: async ({ body, req, auth }) => {
+    fn: async ({ body, query, auth }) => {
       const { newLabels } = UpdatePromptBodySchema.parse(body);
-      const { promptName, promptVersion } = req.query;
+      const { promptName, promptVersion } = query;
 
       const prompt = await updatePrompt({
-        promptName: promptName as string,
+        promptName,
         projectId: auth.scope.projectId,
-        promptVersion: Number(promptVersion),
+        promptVersion,
         newLabels,
       });
 

--- a/web/src/pages/api/public/v2/prompts/[...promptName].ts
+++ b/web/src/pages/api/public/v2/prompts/[...promptName].ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { promptNameHandler } from "@/src/features/prompts/server/handlers/promptNameHandler";
+import { promptVersionHandler } from "@/src/features/prompts/server/handlers/promptVersionHandler";
+
+const VERSION_SEGMENT = "versions";
+
+const setPromptRouteQuery = (req: NextApiRequest) => {
+  const promptPath = req.query.promptName;
+  const segments = Array.isArray(promptPath) ? promptPath : [promptPath];
+  const versionSegmentIndex = segments.lastIndexOf(VERSION_SEGMENT);
+
+  if (
+    versionSegmentIndex > 0 &&
+    versionSegmentIndex === segments.length - 2 &&
+    req.method === "PATCH"
+  ) {
+    req.query.promptName = segments.slice(0, versionSegmentIndex);
+    req.query.promptVersion = segments[versionSegmentIndex + 1];
+    return promptVersionHandler;
+  }
+
+  req.query.promptName = segments;
+  return promptNameHandler;
+};
+
+export default function promptRouteHandler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  return setPromptRouteQuery(req)(req, res);
+}

--- a/web/src/pages/api/public/v2/prompts/[...promptName].ts
+++ b/web/src/pages/api/public/v2/prompts/[...promptName].ts
@@ -2,21 +2,38 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { promptNameHandler } from "@/src/features/prompts/server/handlers/promptNameHandler";
 import { promptVersionHandler } from "@/src/features/prompts/server/handlers/promptVersionHandler";
+import { prisma } from "@langfuse/shared/src/db";
 
 const VERSION_SEGMENT = "versions";
 
-const setPromptRouteQuery = (req: NextApiRequest) => {
-  const promptPath = req.query.promptName;
-  const segments = Array.isArray(promptPath) ? promptPath : [promptPath];
+const isVersionRoute = (segments: string[]) => {
   const versionSegmentIndex = segments.lastIndexOf(VERSION_SEGMENT);
 
-  if (
+  return (
     versionSegmentIndex > 0 &&
     versionSegmentIndex === segments.length - 2 &&
-    req.method === "PATCH"
-  ) {
-    req.query.promptName = segments.slice(0, versionSegmentIndex);
-    req.query.promptVersion = segments[versionSegmentIndex + 1];
+    /^\d+$/.test(segments[versionSegmentIndex + 1] ?? "")
+  );
+};
+
+const promptExists = async (promptName: string) =>
+  Boolean(
+    await prisma.prompt.findFirst({
+      where: { name: promptName },
+      select: { id: true },
+    }),
+  );
+
+const setPromptRouteQuery = async (req: NextApiRequest) => {
+  const promptPath = req.query.promptName;
+  const segments = (Array.isArray(promptPath) ? promptPath : [promptPath]).filter(
+    (segment): segment is string => typeof segment === "string",
+  );
+  const promptName = segments.join("/");
+
+  if (isVersionRoute(segments) && !(await promptExists(promptName))) {
+    req.query.promptName = segments.slice(0, -2);
+    req.query.promptVersion = segments[segments.length - 1];
     return promptVersionHandler;
   }
 
@@ -24,9 +41,9 @@ const setPromptRouteQuery = (req: NextApiRequest) => {
   return promptNameHandler;
 };
 
-export default function promptRouteHandler(
+export default async function promptRouteHandler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  return setPromptRouteQuery(req)(req, res);
+  return (await setPromptRouteQuery(req))(req, res);
 }

--- a/web/src/pages/api/public/v2/prompts/[...promptName].ts
+++ b/web/src/pages/api/public/v2/prompts/[...promptName].ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { promptNameHandler } from "@/src/features/prompts/server/handlers/promptNameHandler";
 import { promptVersionHandler } from "@/src/features/prompts/server/handlers/promptVersionHandler";
+import { authorizePromptRequestOrThrow } from "@/src/features/prompts/server/utils/authorizePromptRequest";
+import { ForbiddenError, UnauthorizedError } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 
 const VERSION_SEGMENT = "versions";
@@ -16,22 +18,39 @@ const isVersionRoute = (segments: string[]) => {
   );
 };
 
-const promptExists = async (promptName: string) =>
-  Boolean(
-    await prisma.prompt.findFirst({
-      where: { name: promptName },
-      select: { id: true },
-    }),
-  );
+const promptExistsForRequestProject = async (
+  req: NextApiRequest,
+  promptName: string,
+) => {
+  try {
+    const authCheck = await authorizePromptRequestOrThrow(req);
+
+    return Boolean(
+      await prisma.prompt.findFirst({
+        where: { name: promptName, projectId: authCheck.scope.projectId },
+        select: { id: true },
+      }),
+    );
+  } catch (error) {
+    if (error instanceof ForbiddenError || error instanceof UnauthorizedError) {
+      return false;
+    }
+
+    throw error;
+  }
+};
 
 const setPromptRouteQuery = async (req: NextApiRequest) => {
   const promptPath = req.query.promptName;
-  const segments = (Array.isArray(promptPath) ? promptPath : [promptPath]).filter(
-    (segment): segment is string => typeof segment === "string",
-  );
+  const segments = (
+    Array.isArray(promptPath) ? promptPath : [promptPath]
+  ).filter((segment): segment is string => typeof segment === "string");
   const promptName = segments.join("/");
 
-  if (isVersionRoute(segments) && !(await promptExists(promptName))) {
+  if (
+    isVersionRoute(segments) &&
+    !(await promptExistsForRequestProject(req, promptName))
+  ) {
     req.query.promptName = segments.slice(0, -2);
     req.query.promptVersion = segments[segments.length - 1];
     return promptVersionHandler;

--- a/web/src/pages/api/public/v2/prompts/[promptName]/index.ts
+++ b/web/src/pages/api/public/v2/prompts/[promptName]/index.ts
@@ -1,1 +1,0 @@
-export { promptNameHandler as default } from "@/src/features/prompts/server/handlers/promptNameHandler";

--- a/web/src/pages/api/public/v2/prompts/[promptName]/versions/[promptVersion].ts
+++ b/web/src/pages/api/public/v2/prompts/[promptName]/versions/[promptVersion].ts
@@ -1,1 +1,0 @@
-export { promptVersionHandler as default } from "@/src/features/prompts/server/handlers/promptVersionHandler";


### PR DESCRIPTION
## Summary
- Replace the single prompt-name API segment with a catch-all prompt route
- Normalize prompt name arrays back into folder-style names for get/delete/update handlers
- Preserve prompt-version updates by routing `/versions/:version` suffixes explicitly
- Add regression coverage for proxy-decoded folder prompt names

Fixes #12720

## Testing
- `git diff --cached --check`
- Attempted `corepack pnpm --filter web test src/__tests__/server/prompts.v2.servertest.ts` but local validation is blocked because dependencies are not installed (`dotenv: not found`) and this machine has Node 22 while the repo wants Node 24.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR replaces the Next.js dynamic `[promptName]/index.ts` and `[promptName]/versions/[promptVersion].ts` routes with a single catch-all `[...promptName].ts` route, enabling proxy-decoded slash-based prompt names (e.g., `folder/prompt`) to be resolved correctly by joining the path array segments back into a single string.

- **P1**: The dispatch logic in the catch-all uses `lastIndexOf("versions")` to decide whether a request is a PATCH-version update. Any prompt whose folder path contains the literal segment `versions` (e.g., `api/versions/doc`) is silently misrouted — PATCH either fails validation or mutates the wrong prompt record.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the "versions" reserved-segment ambiguity can cause silent data mutation for a valid class of prompt names.

A single P1 is present: PATCH requests to prompts whose slash-based name contains the literal segment "versions" are silently misrouted, potentially updating the wrong prompt or failing with an opaque validation error. The core happy-path fix is correct, but the dispatch heuristic needs a safer design to avoid false positives.

web/src/pages/api/public/v2/prompts/[...promptName].ts — the setPromptRouteQuery dispatch function

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/pages/api/public/v2/prompts/[...promptName].ts | New catch-all route that dispatches to promptNameHandler or promptVersionHandler; contains a P1 routing ambiguity when prompt names contain the literal "versions" path segment. |
| web/src/features/prompts/server/handlers/promptNameHandler.ts | Adds normalizePromptName helper to join array segments with "/" for GET and DELETE handlers; logic is correct for intended cases. |
| web/src/features/prompts/server/handlers/promptVersionHandler.ts | Adds PromptVersionQuerySchema with array-to-string transform for promptName; replaces manual cast with typed schema parsing — a clean improvement. |
| web/src/__tests__/server/prompts.v2.servertest.ts | Adds two new integration tests for decoded slash prompt names (GET and PATCH); missing coverage for prompts whose names contain the reserved "versions" segment. |
| web/src/pages/api/public/v2/prompts/[promptName]/index.ts | Deleted; replaced by the new catch-all route — no concerns. |
| web/src/pages/api/public/v2/prompts/[promptName]/versions/[promptVersion].ts | Deleted; replaced by the new catch-all route — no concerns. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Request: /api/public/v2/prompts/[...segments]"] --> B["setPromptRouteQuery(req)"]
    B --> C{"lastIndexOf('versions')\nversionSegmentIndex"}
    C --> D{"versionSegmentIndex > 0\nAND == segments.length-2\nAND method == PATCH?"}
    D -->|Yes| E["req.query.promptName = segments before 'versions'\nreq.query.promptVersion = segments[vIdx+1]"]
    E --> F["promptVersionHandler (PATCH only)"]
    F --> G["PromptVersionQuerySchema\narray join + coerce version number"]
    G --> H["updatePrompt()"]
    D -->|No| I["req.query.promptName = all segments (array)"]
    I --> J["promptNameHandler (GET / DELETE)"]
    J --> K["normalizePromptName: array.join('/')"]
    K --> L["getPromptByName / deletePrompt"]
    style D fill:#f9c,stroke:#c00
    style E fill:#f9c,stroke:#c00
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/pages/api/public/v2/prompts/[...promptName].ts:13-21
**Ambiguous routing for prompts with "versions" in their name**

The dispatch logic uses `lastIndexOf("versions")` to detect version routes, but this creates a collision for any prompt whose folder path contains the literal segment `versions`. For example, a prompt named `api/versions/final` — a perfectly valid slash-based name — would be treated as a PATCH to version `final` of prompt `api`, failing schema validation (`z.coerce.number().int()` rejects non-numeric strings). A prompt named `api/versions/2` is worse: the PATCH silently operates on prompt `api` at version `2` instead of on the prompt named `api/versions/2`, mutating the wrong record without any error.

### Issue 2 of 3
web/src/pages/api/public/v2/prompts/[...promptName].ts:13-24
**Non-PATCH methods on version paths now return 404 instead of 405**

With the old `[promptName]/versions/[promptVersion].ts` route, any non-PATCH request (e.g., `GET /v2/prompts/name/versions/1`) would hit `promptVersionHandler` → `withMiddlewares({ PATCH: … })` and receive a proper 405 Method Not Allowed. Now those requests fall through to `promptNameHandler`, which treats the full path (e.g., `name/versions/1`) as a prompt name and returns 404 Not Found. Callers that relied on the 405 to detect a mis-typed method will now receive a misleading error.

### Issue 3 of 3
web/src/__tests__/server/prompts.v2.servertest.ts:1960-1961
**Test does not cover prompts whose name contains the literal segment "versions"**

The new regression test exercises the happy path (`folder/{id}/prompt/versions/1`) but never asserts that a prompt whose name actually includes the segment `versions` (e.g., `folder/versions/1`) can still be retrieved or updated correctly — which is the class of inputs the new dispatch logic mishandles. Adding a test for this case would catch the routing ambiguity described in the catch-all route comment.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): support decoded slash prompt n..."](https://github.com/langfuse/langfuse/commit/2f54e9ccc3bf12ab6a292f10278911b3a1b69675) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30737312)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->