### PR TITLE
fix(webhooks): shrink GitHub dispatch prompt payloads

### DIFF
--- a/packages/shared/src/domain/webhooks.ts
+++ b/packages/shared/src/domain/webhooks.ts
@@ -43,11 +43,39 @@ export const PromptWebhookOutboundSchema = z
 
 export type PromptWebhookOutput = z.infer<typeof PromptWebhookOutboundSchema>;
 
-export const GitHubDispatchWebhookOutboundSchema = z.object({
-  event_type: z.string(),
-  client_payload: PromptWebhookOutboundSchema,
+export const GitHubDispatchPromptMetadataSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  version: z.number(),
+  projectId: z.string(),
+  labels: z.array(z.string()),
+  tags: z.array(z.string()),
+  type: z.string(),
+  createdBy: z.string(),
+  commitMessage: z.string().nullable(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
 });
 
+export const GitHubDispatchClientPayloadSchema =
+  WebhookOutboundBaseSchema.extend({
+    prompt: GitHubDispatchPromptMetadataSchema,
+    user: z
+      .object({
+        name: z.string().nullable(),
+        email: z.string().nullable(),
+      })
+      .optional(),
+  });
+
+export const GitHubDispatchWebhookOutboundSchema = z.object({
+  event_type: z.string(),
+  client_payload: GitHubDispatchClientPayloadSchema,
+});
+
+export type GitHubDispatchClientPayload = z.infer<
+  typeof GitHubDispatchClientPayloadSchema
+>;
 export type GitHubDispatchWebhookOutput = z.infer<
   typeof GitHubDispatchWebhookOutboundSchema
 >;

--- a/packages/shared/src/domain/webhooks.ts
+++ b/packages/shared/src/domain/webhooks.ts
@@ -59,13 +59,13 @@ export const GitHubDispatchPromptMetadataSchema = z.object({
 
 export const GitHubDispatchClientPayloadSchema =
   WebhookOutboundBaseSchema.extend({
-    prompt: GitHubDispatchPromptMetadataSchema,
     user: z
       .object({
         name: z.string().nullable(),
         email: z.string().nullable(),
       })
       .optional(),
+    prompt: GitHubDispatchPromptMetadataSchema,
   });
 
 export const GitHubDispatchWebhookOutboundSchema = z.object({

--- a/worker/src/__tests__/webhooks.test.ts
+++ b/worker/src/__tests__/webhooks.test.ts
@@ -1466,6 +1466,19 @@ describe("Webhook Integration Tests", () => {
         email: testUser.email,
       });
       expect(payload.client_payload.user.id).toBeUndefined();
+      expect(payload.client_payload.prompt).toMatchObject({
+        id: promptId,
+        name: "test-prompt",
+        version: 1,
+        projectId,
+        labels: [],
+        tags: [],
+        type: "text",
+        createdBy: "test-user",
+        commitMessage: null,
+      });
+      expect(payload.client_payload.prompt.prompt).toBeUndefined();
+      expect(payload.client_payload.prompt.config).toBeUndefined();
       // Verify prompt is still the last field in client_payload
       const clientPayloadKeys = Object.keys(payload.client_payload);
       expect(clientPayloadKeys[clientPayloadKeys.length - 1]).toBe("prompt");

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -1,6 +1,7 @@
 import {
   InternalServerError,
   PromptWebhookOutboundSchema,
+  GitHubDispatchWebhookOutboundSchema,
   WebhookDefaultHeaders,
   ActionExecutionStatus,
   LangfuseNotFoundError,
@@ -10,6 +11,7 @@ import {
   isGitHubDispatchAction,
   type AutomationDomain,
   type ActionDomainWithSecrets,
+  type PromptDomain,
 } from "@langfuse/shared";
 import { decrypt, createSignatureHeader } from "@langfuse/shared/encryption";
 import { prisma } from "@langfuse/shared/src/db";
@@ -425,6 +427,22 @@ async function executeWebhookAction({
 /**
  * Execute GitHub Dispatch action with repository dispatch API
  */
+function toGitHubDispatchPromptMetadata(prompt: PromptDomain) {
+  return {
+    id: prompt.id,
+    name: prompt.name,
+    version: prompt.version,
+    projectId: prompt.projectId,
+    labels: prompt.labels,
+    tags: prompt.tags,
+    type: prompt.type,
+    createdBy: prompt.createdBy,
+    commitMessage: prompt.commitMessage,
+    createdAt: prompt.createdAt,
+    updatedAt: prompt.updatedAt,
+  };
+}
+
 async function executeGitHubDispatchAction({
   input,
   automation,
@@ -462,36 +480,28 @@ async function executeGitHubDispatchAction({
       }
     : undefined;
 
-  // Validate and prepare Langfuse payload
-  const validatedPayload = PromptWebhookOutboundSchema.safeParse({
+  const clientPayload = {
     id: input.executionId,
     timestamp: new Date(),
     type: input.payload.type,
-    apiVersion: "v1",
+    apiVersion: "v1" as const,
     action: input.payload.action,
-    prompt: input.payload.prompt,
-    user: webhookUser,
+    ...(webhookUser ? { user: webhookUser } : {}),
+    prompt: toGitHubDispatchPromptMetadata(input.payload.prompt),
+  };
+
+  const validatedPayload = GitHubDispatchWebhookOutboundSchema.safeParse({
+    event_type: githubConfig.eventType,
+    client_payload,
   });
 
   if (!validatedPayload.success) {
     throw new InternalServerError(
-      `Invalid webhook payload: ${validatedPayload.error.message}`,
+      `Invalid GitHub dispatch payload: ${validatedPayload.error.message}`,
     );
   }
 
-  // Use configured event_type (required field)
-  const eventType = githubConfig.eventType;
-
-  // Transform to GitHub dispatch format
-  const { prompt, user, ...otherFields } = validatedPayload.data;
-  const githubPayload = JSON.stringify({
-    event_type: eventType,
-    client_payload: {
-      ...otherFields,
-      ...(user ? { user } : {}),
-      prompt,
-    },
-  });
+  const githubPayload = JSON.stringify(validatedPayload.data);
 
   // Prepare headers with GitHub token
   const requestHeaders: Record<string, string> = {};

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -501,7 +501,15 @@ async function executeGitHubDispatchAction({
     );
   }
 
-  const githubPayload = JSON.stringify(validatedPayload.data);
+  const { prompt, ...clientPayloadWithoutPrompt } =
+    validatedPayload.data.client_payload;
+  const githubPayload = JSON.stringify({
+    ...validatedPayload.data,
+    client_payload: {
+      ...clientPayloadWithoutPrompt,
+      prompt,
+    },
+  });
 
   // Prepare headers with GitHub token
   const requestHeaders: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- Add a dedicated GitHub dispatch client payload schema that carries prompt metadata only
- Strip large prompt content/config fields from repository dispatch payloads while keeping normal webhooks unchanged
- Keep user metadata support and add regression assertions that GitHub dispatch no longer serializes prompt text/config

Fixes #12588

## Duplicate check
- Checked related PRs/issues for `#12588`, `client_payload`, `repository dispatch`, and `GitHub dispatch`. Existing PR #9998 covers the older missing `event_type/client_payload` wrapping issue, not the current oversized prompt-content payload bug.

## Testing
- `git diff --check`
- Attempted `corepack pnpm --filter worker test webhooks.test.ts`, but local validation is blocked because dependencies are not installed (`vitest: not found`) and this machine has Node 22 while the repo wants Node 24.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes oversized GitHub dispatch payloads by introducing a dedicated `GitHubDispatchClientPayloadSchema` that strips the large `prompt` content and `config` fields, leaving only prompt metadata. Normal webhook payloads remain unchanged.

- **P1**: `GitHubDispatchClientPayloadSchema` defines `prompt` before `user`, so Zod's `safeParse` output reorders keys to `[…action, prompt, user]`. When a user is present the last key becomes `user`, not `prompt` — breaking the pre-existing assertion `expect(clientPayloadKeys[clientPayloadKeys.length - 1]).toBe(\"prompt\")`. The old code manually spread fields to ensure `prompt` was last; the new Zod-validated path loses that guarantee. Fix by declaring `user` before `prompt` in the schema (suggestion left inline).

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the test suite will fail and there is a behavioral regression in JSON key ordering.

A single P1 defect: Zod reorders output keys so `prompt` is no longer last in `client_payload` when a user is present, which breaks the existing test assertion and is a behavioral change from the old manual spread. The PR author explicitly could not run tests locally and the bug would surface immediately in CI.

packages/shared/src/domain/webhooks.ts — swap `user`/`prompt` field declaration order in `GitHubDispatchClientPayloadSchema`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/domain/webhooks.ts | Adds GitHubDispatchPromptMetadataSchema (strips prompt content and config) and GitHubDispatchClientPayloadSchema; note that schema defines `prompt` before `user`, which affects serialized key order after Zod validation. |
| worker/src/queues/webhooks.ts | Refactors executeGitHubDispatchAction to use the new trimmed schema; introduces toGitHubDispatchPromptMetadata helper correctly, but Zod validation silently reorders keys, breaking the prompt-last guarantee. |
| worker/src/__tests__/webhooks.test.ts | Adds good regression assertions that prompt.prompt and prompt.config are absent; the pre-existing key-order assertion will fail with the new Zod-validated output when user is present. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Worker as Worker (webhooks.ts)
    participant Schema as GitHubDispatchWebhookOutboundSchema
    participant GH as GitHub API

    Worker->>Worker: toGitHubDispatchPromptMetadata(prompt)<br/>(strips .prompt content and .config)
    Worker->>Worker: Build clientPayload<br/>{id, timestamp, type, apiVersion, action, [user], prompt}
    Worker->>Schema: safeParse({event_type, client_payload})
    Schema-->>Worker: validatedPayload (keys reordered by schema definition)
    Note over Worker,Schema: Zod reorders to: id, timestamp, type,<br/>apiVersion, action, prompt, user<br/>(prompt no longer last when user present)
    Worker->>Worker: JSON.stringify(validatedPayload.data)
    Worker->>GH: POST repository_dispatch<br/>{event_type, client_payload: {prompt: metadata only}}
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/queues/webhooks.ts:493-504
**Zod validation reorders `client_payload` keys, breaking the "prompt is last" guarantee**

When `GitHubDispatchWebhookOutboundSchema.safeParse` runs, Zod reconstructs the output object in **schema definition order** — not input order. `GitHubDispatchClientPayloadSchema` extends `WebhookOutboundBaseSchema` with `prompt` declared before `user`, so the serialized output will have keys ordered as `[id, timestamp, type, apiVersion, action, prompt, user]`. When a user is present (as in the test at line 1391), `user` becomes the last key, not `prompt`. The pre-existing test assertion `expect(clientPayloadKeys[clientPayloadKeys.length - 1]).toBe("prompt")` will therefore fail. The old code explicitly placed `prompt` last via object spread, but this guarantee is lost after Zod validation. Either reorder the schema to put `user` before `prompt`, or rebuild the JSON directly from `validatedPayload.data` fields in the desired order.

### Issue 2 of 2
packages/shared/src/domain/webhooks.ts:60-69
Swapping `user` before `prompt` in the schema so Zod's output order matches the intended "prompt is last" invariant that the existing test asserts.

```suggestion
export const GitHubDispatchClientPayloadSchema =
  WebhookOutboundBaseSchema.extend({
    user: z
      .object({
        name: z.string().nullable(),
        email: z.string().nullable(),
      })
      .optional(),
    prompt: GitHubDispatchPromptMetadataSchema,
  });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(webhooks): shrink GitHub dispatch pr..."](https://github.com/langfuse/langfuse/commit/49a9ddcf49ac8df9695ea8e2f1def44f3fd292cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30738356)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->