### PR TITLE
fix(worker): keep spend alert billing skips healthy

### DIFF
--- a/worker/src/ee/cloudSpendAlerts/__tests__/handleCloudSpendAlertJob.test.ts
+++ b/worker/src/ee/cloudSpendAlerts/__tests__/handleCloudSpendAlertJob.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Job } from "bullmq";
+
+const {
+  mockOrganizationFindFirst,
+  mockLoggerInfo,
+  mockLoggerWarn,
+  mockLoggerError,
+  mockLoggerDebug,
+  mockRecordIncrement,
+  mockTraceException,
+  mockSendCloudSpendAlertEmail,
+} = vi.hoisted(() => ({
+  mockOrganizationFindFirst: vi.fn(),
+  mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockLoggerDebug: vi.fn(),
+  mockRecordIncrement: vi.fn(),
+  mockTraceException: vi.fn(),
+  mockSendCloudSpendAlertEmail: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared", () => ({
+  parseDbOrg: (org: unknown) => org,
+  Role: {
+    ADMIN: "ADMIN",
+    OWNER: "OWNER",
+  },
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    organization: {
+      findFirst: mockOrganizationFindFirst,
+    },
+    organizationMembership: {
+      findMany: vi.fn(),
+    },
+    cloudSpendAlert: {
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: {
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+    error: mockLoggerError,
+    debug: mockLoggerDebug,
+  },
+  recordIncrement: mockRecordIncrement,
+  traceException: mockTraceException,
+  sendCloudSpendAlertEmail: mockSendCloudSpendAlertEmail,
+}));
+
+vi.mock("../../../env", () => ({
+  env: {
+    STRIPE_SECRET_KEY: "sk_test",
+  },
+}));
+
+import { handleCloudSpendAlertJob } from "../handleCloudSpendAlertJob";
+
+const createJob = (orgId = "org-1") =>
+  ({
+    data: { orgId },
+  }) as Job<{ orgId: string }>;
+
+const createOrg = (cloudConfig: Record<string, unknown>) => ({
+  id: "org-1",
+  name: "Test Org",
+  cloudConfig,
+  cloudSpendAlerts: [
+    {
+      id: "alert-1",
+      title: "Default Spend alert ($200)",
+      threshold: { toString: () => "200" },
+      triggeredAt: null,
+    },
+  ],
+});
+
+describe("handleCloudSpendAlertJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips with a healthy span when the Stripe customer id is missing", async () => {
+    mockOrganizationFindFirst.mockResolvedValue(
+      createOrg({
+        plan: "cloud:core",
+        stripe: {},
+      }),
+    );
+
+    await expect(
+      handleCloudSpendAlertJob(createJob()),
+    ).resolves.toBeUndefined();
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "[CLOUD SPEND ALERTS] Stripe customer id not found for org org-1",
+    );
+    expect(mockTraceException).not.toHaveBeenCalled();
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(mockRecordIncrement).toHaveBeenCalledWith(
+      "langfuse.queue.cloud_spend_alert_queue.skipped_orgs_missing_billing_config",
+      1,
+      {
+        unit: "organizations",
+        reason: "missing_stripe_customer_id",
+      },
+    );
+  });
+
+  it("skips with a healthy span when the Stripe subscription id is missing", async () => {
+    mockOrganizationFindFirst.mockResolvedValue(
+      createOrg({
+        plan: "cloud:core",
+        stripe: {
+          customerId: "cus_test",
+        },
+      }),
+    );
+
+    await expect(
+      handleCloudSpendAlertJob(createJob()),
+    ).resolves.toBeUndefined();
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      "[CLOUD SPEND ALERTS] Stripe subscription id not found for org org-1",
+    );
+    expect(mockTraceException).not.toHaveBeenCalled();
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(mockRecordIncrement).toHaveBeenCalledWith(
+      "langfuse.queue.cloud_spend_alert_queue.skipped_orgs_missing_billing_config",
+      1,
+      {
+        unit: "organizations",
+        reason: "missing_stripe_subscription_id",
+      },
+    );
+  });
+});

--- a/worker/src/ee/cloudSpendAlerts/handleCloudSpendAlertJob.ts
+++ b/worker/src/ee/cloudSpendAlerts/handleCloudSpendAlertJob.ts
@@ -8,6 +8,19 @@ import { Job } from "bullmq";
 import { backOff } from "exponential-backoff";
 import { sendCloudSpendAlertEmail } from "@langfuse/shared/src/server";
 
+const recordMissingBillingConfigSkip = (
+  reason: "missing_stripe_customer_id" | "missing_stripe_subscription_id",
+) => {
+  recordIncrement(
+    "langfuse.queue.cloud_spend_alert_queue.skipped_orgs_missing_billing_config",
+    1,
+    {
+      unit: "organizations",
+      reason,
+    },
+  );
+};
+
 export const handleCloudSpendAlertJob = async (job: Job<{ orgId: string }>) => {
   const { orgId } = job.data;
 
@@ -55,23 +68,19 @@ export const handleCloudSpendAlertJob = async (job: Job<{ orgId: string }>) => {
   // Get Stripe customer ID
   const stripeCustomerId = org.cloudConfig?.stripe?.customerId;
   if (!stripeCustomerId) {
-    logger.error(
+    logger.warn(
       `[CLOUD SPEND ALERTS] Stripe customer id not found for org ${orgId}`,
     );
-    traceException(
-      `[CLOUD SPEND ALERTS] Stripe customer id not found for org ${orgId}`,
-    );
+    recordMissingBillingConfigSkip("missing_stripe_customer_id");
     return;
   }
   // Get Stripe subscription ID
   const stripeSubscriptionId = org.cloudConfig?.stripe?.activeSubscriptionId;
   if (!stripeSubscriptionId) {
-    logger.error(
+    logger.warn(
       `[CLOUD SPEND ALERTS] Stripe subscription id not found for org ${orgId}`,
     );
-    traceException(
-      `[CLOUD SPEND ALERTS] Stripe subscription id not found for org ${orgId}`,
-    );
+    recordMissingBillingConfigSkip("missing_stripe_subscription_id");
     return;
   }
 


### PR DESCRIPTION
## Summary

- Treat missing Stripe customer/subscription metadata in cloud spend alert jobs as expected skip paths instead of Datadog span errors.
- Replace `traceException`/error logging with warning logs plus a dedicated skip metric tagged by missing billing config reason.
- Add worker unit coverage that verifies both missing billing metadata paths do not call `traceException`.

## Root Cause

`handleCloudSpendAlertJob` returned when Stripe billing metadata was missing, but it also called `traceException(...)`. `traceException` sets the active OpenTelemetry span status to `ERROR`, so Datadog showed these skipped jobs as failed worker spans.

## Impacted Packages

- `worker`

## Verification

- `pnpm run db:generate`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter worker run test src/ee/cloudSpendAlerts/__tests__/handleCloudSpendAlertJob.test.ts`
- `pnpm --filter worker run lint`
- pre-commit hook: `pnpm run format:check` and `pnpm run lint`

Refs LFE-9608

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a Datadog false-alarm problem where missing Stripe billing metadata on cloud spend alert jobs was marking the worker span as `ERROR` via `traceException`. The fix replaces `logger.error` + `traceException` with `logger.warn` + a dedicated skip metric tagged by reason.

- In `handleCloudSpendAlertJob.ts`, the two early-return paths for missing Stripe customer ID and subscription ID now emit a warning log plus a `recordIncrement` metric instead of calling `traceException`; a small helper `recordMissingBillingConfigSkip` encapsulates the metric call.
- New unit tests in `handleCloudSpendAlertJob.test.ts` verify that both skip paths resolve without calling `traceException` or logging an error, and that the correct metric tag is emitted.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is surgical, the catch block still calls traceException for genuine errors, and the new tests verify the exact behavior.

Both changed code paths are simple early-returns; the only material change is swapping logger.error+traceException for logger.warn+recordIncrement. The catch block at the bottom is untouched, so real errors continue to surface. The new unit tests directly assert the absence of traceException and the presence of the new metric, covering exactly what the PR claims to fix.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/src/ee/cloudSpendAlerts/handleCloudSpendAlertJob.ts | Replaces traceException + logger.error with logger.warn + recordIncrement for missing-Stripe-billing-metadata skip paths; adds a module-level helper; genuine error paths in the catch block are unchanged. |
| worker/src/ee/cloudSpendAlerts/__tests__/handleCloudSpendAlertJob.test.ts | New test file; two cases cover the missing-customer-id and missing-subscription-id skip paths, asserting warn log, metric tag, and absence of traceException / logger.error calls. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleCloudSpendAlertJob] --> B{STRIPE_SECRET_KEY?}
    B -- No --> C[throw Error]
    B -- Yes --> D[prisma.organization.findFirst]
    D --> E{org found?}
    E -- No --> F[logger.error + return]
    E -- Yes --> G{spendAlerts.length > 0?}
    G -- No --> H[logger.info + return]
    G -- Yes --> I{plan === Hobby?}
    I -- Yes --> J[logger.info + return]
    I -- No --> K{stripeCustomerId?}
    K -- No --> L["logger.warn + recordIncrement(missing_stripe_customer_id) + return"]
    K -- Yes --> M{stripeSubscriptionId?}
    M -- No --> N["logger.warn + recordIncrement(missing_stripe_subscription_id) + return"]
    M -- Yes --> O[new Stripe + retrieve subscription]
    O --> P{canCreateInvoicePreview?}
    P -- No --> Q[logger.warn + return]
    P -- Yes --> R[createPreview invoice]
    R --> S[Check alerts & send emails]
    S --> T[recordIncrement processed_orgs]
    O -- throws --> U[logger.error + traceException + recordIncrement + rethrow]
```

<sub>Reviews (1): Last reviewed commit: ["fix(worker): keep spend alert billing sk..."](https://github.com/langfuse/langfuse/commit/07f0d65dd945d6c1c61c758e6dfdc5bba02a2bb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30821713)</sub>

<!-- /greptile_comment -->