### PR TITLE
fix(experiments): prioritize prompt config over UI model selection

### DIFF
--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -232,11 +232,23 @@ export const experimentsRouter = createTRPCRouter({
         throw new UnauthorizedError("Experiment creation failed");
       }
 
+      const prompt = await ctx.prisma.prompt.findFirst({
+        where: {
+          id: input.promptId,
+          projectId: input.projectId,
+        },
+      });
+
+      const promptConfig = (prompt?.config as Record<string, any>) || {};
+
       const metadata: ExperimentMetadata = {
         prompt_id: input.promptId,
-        provider: input.modelConfig.provider,
-        model: input.modelConfig.model,
-        model_params: input.modelConfig.modelParams,
+        provider: promptConfig.provider || input.modelConfig.provider,
+        model: promptConfig.model || input.modelConfig.model,
+        model_params: {
+          ...input.modelConfig.modelParams,
+          ...promptConfig,
+        },
         ...(input.structuredOutputSchema && {
           structured_output_schema: input.structuredOutputSchema,
         }),

--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -45,6 +45,7 @@ import {
   timeFilter,
   AGGREGATABLE_SCORE_TYPES,
   filterAndValidateDbScoreList,
+  LangfuseNotFoundError,
 } from "@langfuse/shared";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
@@ -239,7 +240,13 @@ export const experimentsRouter = createTRPCRouter({
         },
       });
 
+      if (!prompt) {
+        throw new LangfuseNotFoundError("Prompt not found");
+      }
+
       const promptConfig = (prompt?.config as Record<string, any>) || {};
+      const { provider: _provider, model: _model, ...promptModelParams } =
+        promptConfig;
 
       const metadata: ExperimentMetadata = {
         prompt_id: input.promptId,
@@ -247,7 +254,7 @@ export const experimentsRouter = createTRPCRouter({
         model: promptConfig.model || input.modelConfig.model,
         model_params: {
           ...input.modelConfig.modelParams,
-          ...promptConfig,
+          ...promptModelParams,
         },
         ...(input.structuredOutputSchema && {
           structured_output_schema: input.structuredOutputSchema,


### PR DESCRIPTION
## What does this PR do?

When running Prompt Experiments, the UI restricts model selection to a static, predefined list. This prevents users from executing experiments with arbitrary, newly released, or custom models (e.g., `gemini-3.1-flash-lite-preview`) that are correctly defined within their Prompt configurations. 

This PR introduces a server-side override during experiment creation. The `createExperiment` TRPC mutation now fetches the selected `Prompt` from the database. If the prompt contains a valid model configuration in its `config` JSON, those parameters will take precedence over the UI's selected values. This ensures the experiment engine correctly respects the exact model and provider intended by the prompt author, seamlessly bypassing UI constraints without requiring heavy modifications to the frontend UI state.

Fixes #13350

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`npm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes a UI constraint that limited model selection to a static list when creating prompt experiments. It adds a server-side DB lookup of the selected prompt's `config` JSON during `createExperiment`, using any `provider` and `model` fields found there to override the UI-supplied values.

- The `model_params` object is built by spreading the entire `promptConfig` (including `provider` and `model` keys) on top of `input.modelConfig.modelParams`, which leaks non-parameter fields into `model_params` and may break the downstream experiment worker.
- If the prompt is not found in the DB (e.g., deleted after validation), the mutation silently falls back to UI values and enqueues a job referencing a non-existent `prompt_id`, deferring the failure to the worker.

<h3>Confidence Score: 3/5</h3>

The change introduces two defects in the createExperiment mutation affecting all experiments where the prompt config contains provider/model keys.

Spreading the full promptConfig into model_params injects provider and model fields where the worker expects only LLM tuning parameters, which could silently corrupt every experiment run relying on prompt config overrides. A missing prompt also goes undetected, queuing jobs that will fail at execution time with no user-facing error.

web/src/features/experiments/server/router.ts — specifically the model_params construction and the missing null-check on the prompt lookup result.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/experiments/server/router.ts | Adds prompt config DB lookup in `createExperiment` to override UI-selected provider/model, but spreads the full `promptConfig` (including `provider` and `model` keys) into `model_params`, and silently continues when the prompt is missing. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Frontend UI
    participant TRPC as createExperiment TRPC
    participant DB as PostgreSQL (Prisma)
    participant Queue as ExperimentCreateQueue

    UI->>TRPC: createExperiment(promptId, modelConfig, ...)
    TRPC->>DB: prompt.findFirst({ id, projectId })
    DB-->>TRPC: prompt (or null)
    Note over TRPC: promptConfig = prompt?.config || {}
    Note over TRPC: provider = promptConfig.provider || modelConfig.provider
    Note over TRPC: model = promptConfig.model || modelConfig.model
    Note over TRPC: model_params spreads full promptConfig including provider and model
    TRPC->>DB: datasetRuns.create({ metadata })
    DB-->>TRPC: datasetRun
    TRPC->>Queue: ExperimentCreateJob(projectId, datasetId, runId)
    Queue-->>TRPC: queued
    TRPC-->>UI: { success, runId }
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/experiments/server/router.ts:248-251
The entire `promptConfig` object (including `provider` and `model` keys) is spread into `model_params`. This means downstream consumers will see `model_params` containing `{ provider: "...", model: "...", ...actualParams }`. The `provider` and `model` fields belong at the top-level of `ExperimentMetadata`, not inside `model_params`, and passing them there may cause the experiment worker to misinterpret the LLM call configuration.

```suggestion
        model_params: {
          ...input.modelConfig.modelParams,
          ...(({ provider: _p, model: _m, ...rest }) => rest)(promptConfig),
        },
```

### Issue 2 of 2
web/src/features/experiments/server/router.ts:235-242
**Silent fallback when prompt is not found**

If the prompt lookup returns `null` (e.g., the prompt was deleted between form validation and submission), `promptConfig` becomes `{}` and the code silently proceeds with the UI-supplied provider and model instead of failing early. The experiment will then be enqueued with a `prompt_id` referencing a non-existent prompt, and the worker will fail later with no clear user-facing error.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(experiments): support custom model ..."](https://github.com/langfuse/langfuse/commit/d46a01ec1e3ca9c40eadf06f21e011a4cf50a2e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30819120)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->