### PR TITLE
fix(docker): remove corepack cache from runtime-base stage

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -16,7 +16,8 @@ RUN corepack prepare pnpm@10.33.0 --activate
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS runtime-base
 # Remove build-only package managers. npm stays here because the runner stage
 # uses it to install prisma and optional dd-trace before removing it.
-RUN rm -rf /usr/local/lib/node_modules/corepack && \
+RUN rm -rf /usr/local/lib/node_modules/corepack \
+            /root/.cache/node/corepack && \
     rm -f /usr/local/bin/corepack /usr/local/bin/yarn /usr/local/bin/yarnpkg
 
 FROM --platform=${BUILDPLATFORM} golang:1.24 AS migrate-builder

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -15,7 +15,8 @@ RUN corepack prepare pnpm@10.33.0 --activate
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS runtime-base
 # package managers and build-only CLIs only increase exposure to CVEs -> remove them
-RUN rm -rf /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/npm && \
+RUN rm -rf /usr/local/lib/node_modules/corepack /usr/local/lib/node_modules/npm \
+            /root/.cache/node/corepack && \
     rm -f /usr/local/bin/corepack /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/yarn /usr/local/bin/yarnpkg
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} build-base AS pruner


### PR DESCRIPTION
## Summary

- The `node:24-alpine` base image pre-populates `/root/.cache/node/corepack/` when `corepack enable` + `corepack prepare` run in the `build-base` stage
- Both Dockerfiles already removed `/usr/local/lib/node_modules/corepack`, but the cache directory survived into the `runtime-base` (and therefore final `runner`) image
- Snyk Container scans the final image layers and flags packages found in this cache directory
- This PR adds `/root/.cache/node/corepack` to the `rm -rf` in the `runtime-base` stage of both `web/Dockerfile` and `worker/Dockerfile`

## Impacted packages

- `web/Dockerfile`
- `worker/Dockerfile`

## Verification

- Pre-commit lint passed (`turbo run lint`, `prettier --check`)
- No logic changes — pure filesystem cleanup in the Docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR removes the corepack cache directory (`/root/.cache/node/corepack`) from the `runtime-base` stage in both `web/Dockerfile` and `worker/Dockerfile`, preventing it from appearing in the final image layers where Snyk Container scans were flagging packages bundled in that cache.

- Both Dockerfiles already stripped `/usr/local/lib/node_modules/corepack` and its symlinks; this adds the corresponding user-level cache path to the same `rm -rf` command.
- The change is purely additive to existing cleanup logic — `rm -rf` is a no-op when the path is absent, so there is no risk of breakage on images where the directory was not created.

<h3>Confidence Score: 5/5</h3>

Safe to merge — filesystem-only cleanup with no runtime or build-logic impact.

The change appends a single path to an already-present `rm -rf` in two Dockerfiles. The `runtime-base` stage inherits from `alpine` (not `build-base`), so it cannot inadvertently remove anything the build artifacts depend on. `rm -rf` on a non-existent path exits cleanly, so images where the cache was never created are unaffected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/Dockerfile | Adds `/root/.cache/node/corepack` to the `rm -rf` in `runtime-base` to strip the corepack cache directory from the final image layers; no logic changes |
| worker/Dockerfile | Same corepack cache cleanup as web/Dockerfile; adds `/root/.cache/node/corepack` to the `runtime-base` rm command alongside the existing npm/corepack module removals |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["node:24-alpine\n(base image)\n/root/.cache/node/corepack pre-populated"] --> B["alpine\n(apk upgrade)"]
    B --> C["build-base\ncorepack enable\ncorepack prepare pnpm\nPNPM_HOME=/pnpm"]
    B --> D["runtime-base\n✅ rm -rf /usr/local/lib/node_modules/corepack\n✅ rm -rf /root/.cache/node/corepack  ← NEW\n✅ rm -f corepack/yarn/yarnpkg bins"]
    C --> E["pruner / builder\n(build artifacts)"]
    D --> F["runner\n(final image)\nNo corepack modules or cache"]
    E --> F
```

<sub>Reviews (1): Last reviewed commit: ["fix(docker): remove corepack cache from ..."](https://github.com/langfuse/langfuse/commit/25244acb15f111a218b26e22aff10307cb6ab09f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30820632)</sub>

<!-- /greptile_comment -->