### PR TITLE
refactor(comments): Make comment TRPC routes read from events table

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-fragments.ts
@@ -31,6 +31,7 @@ interface EventsTracesAggregationParams {
   projectId: string;
   traceIds?: string[];
   startTimeFrom?: string | null;
+  orderByTimestamp?: boolean;
   /**
    * Whether to use truncated I/O (events_core) or full I/O (events_full).
    * Default is false (full) for better compatibility.
@@ -59,7 +60,9 @@ export const eventsTracesAggregation = (
     .withStartTimeFrom(params.startTimeFrom)
     .withTruncated(params.truncated ?? false);
 
-  builder.orderByColumns([{ column: "timestamp", direction: "DESC" }]);
+  if (params.orderByTimestamp ?? true) {
+    builder.orderByColumns([{ column: "timestamp", direction: "DESC" }]);
+  }
 
   return builder;
 };

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -24,6 +24,7 @@ import {
   deriveFilters,
   type ApiColumnMapping,
   ObservationPriceFields,
+  StringFilter,
 } from "../queries";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import type { FilterState } from "../../types";
@@ -3345,3 +3346,92 @@ export async function getLatestSdkVersionInfoFromEvents(params: {
     ...sdkInfo,
   };
 }
+
+export const getTracesIdentifierForSessionFromEvents = async (
+  projectId: string,
+  sessionId: string,
+) => {
+  // Build traces CTE using eventsTracesAggregation
+  const tracesBuilder = eventsTracesAggregation({
+    projectId,
+    truncated: true,
+  });
+
+  tracesBuilder.whereRaw(
+    `e.trace_id IN (
+      SELECT DISTINCT trace_id
+      FROM events_core
+      WHERE project_id = {projectId: String}
+        AND session_id = {sessionId: String}
+    )`,
+    {
+      projectId: projectId,
+      sessionId: sessionId,
+    },
+  );
+
+  // Build the final query
+  const queryBuilder = new CTEQueryBuilder()
+    .withCTEFromBuilder("traces", tracesBuilder)
+    .from("traces", "t")
+    .selectColumns(
+      "t.id",
+      "t.user_id",
+      "t.name",
+      "t.timestamp",
+      "t.project_id",
+      "t.environment",
+    )
+    .applyFilters(
+      new FilterList([
+        new StringFilter({
+          clickhouseTable: "traces",
+          field: "session_id",
+          operator: "=",
+          value: sessionId,
+          tablePrefix: "t",
+        }),
+      ]),
+    )
+    .orderBy("ORDER BY t.timestamp ASC")
+    .limitBy("t.id", "t.project_id");
+
+  const { query, params } = queryBuilder.buildWithParams();
+
+  const rows = await measureAndReturn({
+    operationName: "getTracesIdentifierForSessionFromEvents",
+    projectId,
+    input: {
+      params,
+      tags: {
+        feature: "tracing",
+        type: "trace",
+        kind: "list",
+        projectId,
+        operation_name: "getTracesIdentifierForSessionFromEvents",
+      },
+    },
+    fn: async (input) => {
+      return await queryClickhouse<{
+        id: string;
+        user_id: string;
+        name: string;
+        timestamp: string;
+        environment: string;
+      }>({
+        query,
+        params: input.params,
+        tags: input.tags,
+        preferredClickhouseService: "EventsReadOnly",
+      });
+    },
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    userId: row.user_id,
+    name: row.name,
+    timestamp: parseClickhouseUTCDateTimeFormat(row.timestamp),
+    environment: row.environment,
+  }));
+};

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -24,7 +24,6 @@ import {
   deriveFilters,
   type ApiColumnMapping,
   ObservationPriceFields,
-  StringFilter,
 } from "../queries";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import type { FilterState } from "../../types";
@@ -3355,6 +3354,7 @@ export const getTracesIdentifierForSessionFromEvents = async (
   const tracesBuilder = eventsTracesAggregation({
     projectId,
     truncated: true,
+    orderByTimestamp: false,
   });
 
   tracesBuilder.whereRaw(
@@ -3370,6 +3370,10 @@ export const getTracesIdentifierForSessionFromEvents = async (
     },
   );
 
+  tracesBuilder.havingRaw("session_id = {sessionId: String}", {
+    sessionId: sessionId,
+  });
+
   // Build the final query
   const queryBuilder = new CTEQueryBuilder()
     .withCTEFromBuilder("traces", tracesBuilder)
@@ -3381,17 +3385,6 @@ export const getTracesIdentifierForSessionFromEvents = async (
       "t.timestamp",
       "t.project_id",
       "t.environment",
-    )
-    .applyFilters(
-      new FilterList([
-        new StringFilter({
-          clickhouseTable: "traces",
-          field: "session_id",
-          operator: "=",
-          value: sessionId,
-          tablePrefix: "t",
-        }),
-      ]),
     )
     .orderBy("ORDER BY t.timestamp ASC")
     .limitBy("t.id", "t.project_id");

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -10,6 +10,7 @@ import {
   getTraceByIdFromEventsTable,
   getObservationsBatchIOFromEventsTable,
   getLatestSdkVersionInfoFromEvents,
+  getTracesIdentifierForSessionFromEvents,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "crypto";
@@ -2012,6 +2013,144 @@ describe("Clickhouse Events Repository Test", () => {
 
       // Cleanup
       await prisma.model.delete({ where: { id: modelId } });
+    });
+  });
+
+  maybe("getTracesIdentifierForSessionFromEvents", () => {
+    it("should return distinct traces for a session ordered by earliest trace timestamp", async () => {
+      const uniqueProjectId = randomUUID();
+      const sessionId = randomUUID();
+      const otherSessionId = randomUUID();
+      const traceId1 = randomUUID();
+      const traceId2 = randomUUID();
+      const traceId3 = randomUUID();
+      const nowMicro = Date.now() * 1000;
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId1,
+          trace_name: "trace-one-initial",
+          session_id: sessionId,
+          user_id: "user-1-old",
+          environment: "staging",
+          start_time: nowMicro,
+          event_ts: nowMicro,
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId1,
+          trace_name: "trace-one-latest",
+          session_id: sessionId,
+          user_id: "user-1-new",
+          environment: "production",
+          start_time: nowMicro + 1_000,
+          event_ts: nowMicro + 1_000,
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId2,
+          trace_name: "trace-two",
+          session_id: sessionId,
+          user_id: "user-2",
+          environment: "default",
+          start_time: nowMicro + 5_000,
+          event_ts: nowMicro + 5_000,
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId3,
+          trace_name: "trace-three-other-session",
+          session_id: otherSessionId,
+          user_id: "user-3",
+          start_time: nowMicro + 10_000,
+          event_ts: nowMicro + 10_000,
+        }),
+      ]);
+
+      await waitForExpect(async () => {
+        const traces = await getTracesIdentifierForSessionFromEvents(
+          uniqueProjectId,
+          sessionId,
+        );
+
+        expect(traces).toHaveLength(2);
+        expect(traces.map((trace) => trace.id)).toEqual([traceId1, traceId2]);
+        expect(traces[0]).toMatchObject({
+          id: traceId1,
+          name: "trace-one-latest",
+          userId: "user-1-new",
+          environment: "production",
+        });
+        expect(traces[0]?.timestamp.getTime()).toBe(nowMicro / 1000);
+        expect(traces[1]).toMatchObject({
+          id: traceId2,
+          name: "trace-two",
+          userId: "user-2",
+          environment: "default",
+        });
+        expect(traces[1]?.timestamp.getTime()).toBe((nowMicro + 5_000) / 1000);
+      });
+    });
+
+    it("should resolve session membership from the latest non-empty session_id in the trace aggregation", async () => {
+      const uniqueProjectId = randomUUID();
+      const originalSessionId = randomUUID();
+      const latestSessionId = randomUUID();
+      const traceId = randomUUID();
+      const nowMicro = Date.now() * 1000;
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          trace_name: "trace-before-session-change",
+          session_id: originalSessionId,
+          start_time: nowMicro,
+          event_ts: nowMicro,
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          trace_name: "trace-after-session-change",
+          session_id: latestSessionId,
+          start_time: nowMicro + 2_000,
+          event_ts: nowMicro + 2_000,
+        }),
+      ]);
+
+      await waitForExpect(async () => {
+        await expect(
+          getTracesIdentifierForSessionFromEvents(
+            uniqueProjectId,
+            originalSessionId,
+          ),
+        ).resolves.toEqual([]);
+
+        await expect(
+          getTracesIdentifierForSessionFromEvents(
+            uniqueProjectId,
+            latestSessionId,
+          ),
+        ).resolves.toEqual([
+          expect.objectContaining({
+            id: traceId,
+            name: "trace-after-session-change",
+          }),
+        ]);
+      });
     });
   });
 

--- a/web/src/server/api/routers/comments.ts
+++ b/web/src/server/api/routers/comments.ts
@@ -12,6 +12,7 @@ import { TRPCError } from "@trpc/server";
 import { validateCommentReferenceObject } from "@/src/features/comments/validateCommentReferenceObject";
 import {
   getTracesIdentifierForSession,
+  getTracesIdentifierForSessionFromEvents,
   logger,
   NotificationQueue,
   QueueJobs,
@@ -358,10 +359,12 @@ export const commentsRouter = createTRPCRouter({
         scope: "comments:read",
       });
 
-      const clickhouseTraces = await getTracesIdentifierForSession(
-        input.projectId,
-        input.sessionId,
-      );
+      const clickhouseTraces = ctx.session.user?.v4BetaEnabled
+        ? await getTracesIdentifierForSessionFromEvents(
+            input.projectId,
+            input.sessionId,
+          )
+        : await getTracesIdentifierForSession(input.projectId, input.sessionId);
 
       const allTraceCommentCounts = await ctx.prisma.$queryRaw<
         Array<{ objectId: string; count: bigint }>
@@ -394,10 +397,12 @@ export const commentsRouter = createTRPCRouter({
         scope: "comments:read",
       });
 
-      const clickhouseTraces = await getTracesIdentifierForSession(
-        input.projectId,
-        input.sessionId,
-      );
+      const clickhouseTraces = ctx.session.user?.v4BetaEnabled
+        ? await getTracesIdentifierForSessionFromEvents(
+            input.projectId,
+            input.sessionId,
+          )
+        : await getTracesIdentifierForSession(input.projectId, input.sessionId);
 
       const traceIds = clickhouseTraces.map((t) => t.id);
 


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR refactors two `comments` TRPC routes (`getTraceCommentCountsBySessionId` and `getTraceCommentsBySessionId`) to read trace identifiers from the `events_core` table instead of the `traces` materialized view, continuing an ongoing migration away from pre-aggregated tables.

- A new `getTracesIdentifierForSessionFromEvents` function is added to `events.ts` that builds a CTE via `eventsTracesAggregation` and filters on `session_id`, using `preferredClickhouseService: "EventsReadOnly"`. Session membership is now resolved via `argMaxIf(session_id, event_ts, session_id <> '')`, picking the most-recent non-empty session assignment — semantically equivalent to the materialized view.
- Two call sites in `comments.ts` are updated to use the new function; no other logic changes.
- Server tests cover distinct-trace ordering and session-reassignment semantics.

<h3>Confidence Score: 4/5</h3>

Safe to merge — swaps one ClickHouse read path for another with equivalent semantics and well-targeted tests.

The new function is functionally equivalent to the one it replaces. Session membership is resolved identically via argMaxIf on the events table, the two server tests confirm both ordering and session-reassignment behavior, and the two call sites in comments.ts are straightforward drop-in replacements. Two minor cleanup items (an unused project_id column and a redundant LIMIT 1 BY) are the only open points.

packages/shared/src/server/repositories/events.ts — the new function has a small unused column and a redundant deduplication clause worth tidying up.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/repositories/events.ts | Adds getTracesIdentifierForSessionFromEvents using eventsTracesAggregation CTE; project_id is selected but not present in the queryClickhouse generic type, and the outer LIMIT 1 BY is redundant since the CTE already groups by (trace_id, project_id). |
| web/src/__tests__/server/repositories/event-repository.servertest.ts | Adds two integration tests covering trace ordering and session-reassignment semantics for the new function; coverage is thorough. |
| web/src/server/api/routers/comments.ts | Straightforward swap of getTracesIdentifierForSession for getTracesIdentifierForSessionFromEvents in two route handlers; no other logic changes. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant CommentsRouter
    participant getTracesIdentifierForSessionFromEvents
    participant ClickHouse as ClickHouse (EventsReadOnly)
    participant Prisma as Postgres (comments)

    Client->>CommentsRouter: getTraceCommentsBySessionId / getTraceCommentCountsBySessionId
    CommentsRouter->>getTracesIdentifierForSessionFromEvents: (projectId, sessionId)
    getTracesIdentifierForSessionFromEvents->>ClickHouse: WITH traces AS (SELECT from events_core GROUP BY trace_id, project_id) SELECT id, user_id, name, timestamp, environment WHERE t.session_id = sessionId ORDER BY t.timestamp ASC
    ClickHouse-->>getTracesIdentifierForSessionFromEvents: rows
    getTracesIdentifierForSessionFromEvents-->>CommentsRouter: [{id, userId, name, timestamp, environment}]
    CommentsRouter->>Prisma: SELECT comments WHERE project_id AND object_type = TRACE
    Prisma-->>CommentsRouter: comment rows
    CommentsRouter-->>Client: filtered comment data
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/repositories/events.ts:3363-3370
`t.project_id` is included in `selectColumns` but is absent from the `queryClickhouse<{…}>` generic type and is never used in the `rows.map` transformation. Selecting it silently inflates every response row over the wire. It can be dropped from the column list.

```suggestion
    .selectColumns(
      "t.id",
      "t.user_id",
      "t.name",
      "t.timestamp",
      "t.environment",
    )
```

### Issue 2 of 2
packages/shared/src/server/repositories/events.ts:3382-3383
The `.limitBy("t.id", "t.project_id")` call is redundant. The `eventsTracesAggregation` CTE already uses `GROUP BY trace_id, project_id`, so it returns at most one row per `(trace_id, project_id)` pair — there is nothing for this deduplication to collapse. The clause is harmless but adds noise. Consider removing it.

```suggestion
    .orderBy("ORDER BY t.timestamp ASC");
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(comments): Make comment TRPC ro..."](https://github.com/langfuse/langfuse/commit/e9561c4d7138e1361cdb8da8d4388e191dafa031) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30966782)</sub>

<!-- /greptile_comment -->