### PR TITLE
fix(evals): add evaluator filter validation and handling

### DIFF
--- a/packages/shared/src/features/evals/validateEvaluatorFilters.ts
+++ b/packages/shared/src/features/evals/validateEvaluatorFilters.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+import { singleFilter } from "../../interfaces/filters";
+import type { ColumnDefinition } from "../../tableDefinitions";
+import {
+  evalDatasetFormFilterCols,
+  evalTraceTableCols,
+} from "../../tableDefinitions/tracesTable";
+import type { FilterCondition, FilterState } from "../../types";
+import {
+  experimentEvalFilterColumns,
+  observationEvalFilterColumns,
+} from "./observationForEval";
+import { COMPATIBLE_FILTER_TYPES } from "../../server/queries/clickhouse-sql/filterTypeCompatibility";
+import {
+  EvalTargetObject,
+  type EvalTargetObject as EvalTargetObjectType,
+} from "./types";
+
+export type EvaluatorFilterValidationIssueCode =
+  | "invalid_filter_shape"
+  | "unsupported_column"
+  | "incompatible_filter_type";
+
+export type EvaluatorFilterValidationIssue = {
+  code: EvaluatorFilterValidationIssueCode;
+  message: string;
+  index: number | null;
+  column: string | null;
+  normalizedColumn: string | null;
+  filterType: FilterCondition["type"] | null;
+  expectedColumnType?: ColumnDefinition["type"];
+};
+
+export type EvaluatorFilterValidationResult = {
+  isValid: boolean;
+  normalizedFilter: FilterState;
+  issues: EvaluatorFilterValidationIssue[];
+};
+
+const parsedFilterSchema = z.array(singleFilter).nullable();
+
+const getSupportedColumnsForTarget = (
+  targetObject: EvalTargetObjectType,
+): ColumnDefinition[] => {
+  switch (targetObject) {
+    case EvalTargetObject.TRACE:
+      return evalTraceTableCols;
+    case EvalTargetObject.DATASET:
+      return evalDatasetFormFilterCols;
+    case EvalTargetObject.EVENT:
+      return observationEvalFilterColumns;
+    case EvalTargetObject.EXPERIMENT:
+      return experimentEvalFilterColumns;
+  }
+};
+
+const findMatchingColumnDefinition = (
+  filterColumn: string,
+  columns: ColumnDefinition[],
+): ColumnDefinition | undefined =>
+  columns.find(
+    (column) =>
+      column.id === filterColumn ||
+      column.name === filterColumn ||
+      column.aliases?.includes(filterColumn),
+  );
+
+export function validateEvaluatorFiltersForTarget(params: {
+  targetObject: EvalTargetObjectType;
+  filter: unknown;
+}): EvaluatorFilterValidationResult {
+  const columns = getSupportedColumnsForTarget(params.targetObject);
+  const parsedFilter = parsedFilterSchema.safeParse(params.filter);
+
+  if (!parsedFilter.success) {
+    return {
+      isValid: false,
+      normalizedFilter: [],
+      issues: [
+        {
+          code: "invalid_filter_shape",
+          message:
+            "Evaluator filters are invalid. Remove unsupported or incomplete filters and try again.",
+          index: null,
+          column: null,
+          normalizedColumn: null,
+          filterType: null,
+        },
+      ],
+    };
+  }
+
+  const filters = parsedFilter.data ?? [];
+
+  const issues: EvaluatorFilterValidationIssue[] = filters.flatMap(
+    (filter, index): EvaluatorFilterValidationIssue[] => {
+      const column = findMatchingColumnDefinition(filter.column, columns);
+
+      if (!column) {
+        return [
+          {
+            code: "unsupported_column" as const,
+            message: `Filter column "${filter.column}" is not supported for target "${params.targetObject}".`,
+            index,
+            column: filter.column,
+            normalizedColumn: null,
+            filterType: filter.type,
+          },
+        ];
+      }
+
+      if (filter.type === "null") {
+        return [];
+      }
+
+      const compatibleFilterTypes = COMPATIBLE_FILTER_TYPES[column.type];
+
+      if (
+        compatibleFilterTypes &&
+        compatibleFilterTypes.includes(filter.type)
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          code: "incompatible_filter_type" as const,
+          message: `Filter type "${filter.type}" is not supported for column "${column.name}".`,
+          index,
+          column: filter.column,
+          normalizedColumn: column.id,
+          filterType: filter.type,
+          expectedColumnType: column.type,
+        },
+      ];
+    },
+  );
+
+  return {
+    isValid: issues.length === 0,
+    normalizedFilter: filters,
+    issues,
+  };
+}

--- a/packages/shared/src/features/evals/validateEvaluatorFilters.ts
+++ b/packages/shared/src/features/evals/validateEvaluatorFilters.ts
@@ -26,14 +26,13 @@ export type EvaluatorFilterValidationIssue = {
   message: string;
   index: number | null;
   column: string | null;
-  normalizedColumn: string | null;
   filterType: FilterCondition["type"] | null;
   expectedColumnType?: ColumnDefinition["type"];
 };
 
 export type EvaluatorFilterValidationResult = {
   isValid: boolean;
-  normalizedFilter: FilterState;
+  validatedFilters: FilterState;
   issues: EvaluatorFilterValidationIssue[];
 };
 
@@ -75,7 +74,7 @@ export function validateEvaluatorFiltersForTarget(params: {
   if (!parsedFilter.success) {
     return {
       isValid: false,
-      normalizedFilter: [],
+      validatedFilters: [],
       issues: [
         {
           code: "invalid_filter_shape",
@@ -83,7 +82,6 @@ export function validateEvaluatorFiltersForTarget(params: {
             "Evaluator filters are invalid. Remove unsupported or incomplete filters and try again.",
           index: null,
           column: null,
-          normalizedColumn: null,
           filterType: null,
         },
       ],
@@ -103,7 +101,6 @@ export function validateEvaluatorFiltersForTarget(params: {
             message: `Filter column "${filter.column}" is not supported for target "${params.targetObject}".`,
             index,
             column: filter.column,
-            normalizedColumn: null,
             filterType: filter.type,
           },
         ];
@@ -128,7 +125,6 @@ export function validateEvaluatorFiltersForTarget(params: {
           message: `Filter type "${filter.type}" is not supported for column "${column.name}".`,
           index,
           column: filter.column,
-          normalizedColumn: column.id,
           filterType: filter.type,
           expectedColumnType: column.type,
         },
@@ -138,7 +134,7 @@ export function validateEvaluatorFiltersForTarget(params: {
 
   return {
     isValid: issues.length === 0,
-    normalizedFilter: filters,
+    validatedFilters: filters,
     issues,
   };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,6 +36,7 @@ export * from "./features/evals/outputDefinition";
 export * from "./features/evals/utilities";
 export * from "./features/evals/observationForEval";
 export * from "./features/evals/evalConfigBlocking";
+export * from "./features/evals/validateEvaluatorFilters";
 // table actions
 export * from "./features/batchExport/types";
 export * from "./features/batchAction/types";

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -9,6 +9,7 @@ import {
   type ColumnDefinition,
   type UiColumnMappings,
 } from "../../../tableDefinitions";
+import { COMPATIBLE_FILTER_TYPES } from "./filterTypeCompatibility";
 import {
   StringFilter,
   DateTimeFilter,
@@ -29,21 +30,6 @@ export class QueryBuilderError extends Error {
     this.name = "QueryBuilderError";
   }
 }
-
-// Maps each ColumnDefinition.type to the filter types that are structurally compatible
-// at the ClickHouse level. string/stringOptions both operate on String columns,
-// and stringOptions "any of" works on Array columns too.
-const COMPATIBLE_FILTER_TYPES: Record<string, string[]> = {
-  string: ["string", "stringOptions"],
-  stringOptions: ["string", "stringOptions"],
-  arrayOptions: ["arrayOptions", "stringOptions"],
-  datetime: ["datetime"],
-  number: ["number"],
-  boolean: ["boolean"],
-  stringObject: ["stringObject"],
-  numberObject: ["numberObject"],
-  categoryOptions: ["categoryOptions", "stringOptions"],
-};
 
 // This function ensures that the user only selects valid columns from the clickhouse schema.
 // The filter property in this column needs to be zod verified.

--- a/packages/shared/src/server/queries/clickhouse-sql/filterTypeCompatibility.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/filterTypeCompatibility.ts
@@ -1,0 +1,16 @@
+import type { ColumnDefinition } from "../../../tableDefinitions";
+import type { FilterCondition } from "../../../types";
+
+export const COMPATIBLE_FILTER_TYPES: Partial<
+  Record<ColumnDefinition["type"], FilterCondition["type"][]>
+> = {
+  string: ["string", "stringOptions"],
+  stringOptions: ["string", "stringOptions"],
+  arrayOptions: ["arrayOptions", "stringOptions"],
+  datetime: ["datetime"],
+  number: ["number"],
+  boolean: ["boolean"],
+  stringObject: ["stringObject"],
+  numberObject: ["numberObject"],
+  categoryOptions: ["categoryOptions", "stringOptions"],
+};

--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -447,6 +447,47 @@ describe("evals trpc", () => {
         }),
       ).resolves.toBeNull();
     });
+
+    it("rejects unsupported trace filters", async () => {
+      const { project, caller } = await prepare();
+
+      const evalTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: "trace-template",
+          version: 1,
+          prompt: "Score this response",
+          outputDefinition: createNumericEvalOutputDefinition({
+            reasoningDescription: "Why",
+            scoreDescription: "How good",
+          }),
+        },
+      });
+
+      await expect(
+        caller.evals.createJob({
+          projectId: project.id,
+          evalTemplateId: evalTemplate.id,
+          scoreName: "bad-trace-filter",
+          target: EvalTargetObject.TRACE,
+          filter: [
+            {
+              type: "numberObject",
+              column: "Scores (numeric)",
+              key: "accuracy",
+              operator: ">",
+              value: 0.8,
+            },
+          ],
+          mapping: [],
+          sampling: 1,
+          delay: 0,
+          timeScope: ["NEW"],
+        }),
+      ).rejects.toThrow(
+        'Filter column "Scores (numeric)" is not supported for target "trace".',
+      );
+    });
   });
 
   describe("evals.updateConfig", () => {
@@ -543,6 +584,84 @@ describe("evals trpc", () => {
       });
 
       expect(unchangedJob?.variableMapping).toEqual(traceVariableMapping);
+    });
+
+    it("rejects updates when an evaluator still has unsupported filters", async () => {
+      const { project, caller } = await prepare();
+
+      const evalJobConfig = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          scoreName: "test-score",
+          filter: [
+            {
+              type: "numberObject",
+              column: "Scores (numeric)",
+              key: "accuracy",
+              operator: ">",
+              value: 0.8,
+            },
+          ],
+          targetObject: EvalTargetObject.TRACE,
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+          timeScope: ["NEW"],
+        },
+      });
+
+      await expect(
+        caller.evals.updateEvalJob({
+          projectId: project.id,
+          evalConfigId: evalJobConfig.id,
+          config: {
+            status: "INACTIVE",
+          },
+        }),
+      ).rejects.toThrow(
+        'Filter column "Scores (numeric)" is not supported for target "trace".',
+      );
+    });
+
+    it("allows updates once unsupported filters are removed", async () => {
+      const { project, caller } = await prepare();
+
+      const evalJobConfig = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          scoreName: "test-score",
+          filter: [
+            {
+              type: "numberObject",
+              column: "Scores (numeric)",
+              key: "accuracy",
+              operator: ">",
+              value: 0.8,
+            },
+          ],
+          targetObject: EvalTargetObject.TRACE,
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+          timeScope: ["NEW"],
+        },
+      });
+
+      const response = await caller.evals.updateEvalJob({
+        projectId: project.id,
+        evalConfigId: evalJobConfig.id,
+        config: {
+          filter: [],
+          status: "INACTIVE",
+        },
+      });
+
+      expect(response.status).toBe("INACTIVE");
+      expect(response.filter).toEqual([]);
     });
 
     it("when the evaluator ran on existing traces, time scope cannot be changed to NEW only", async () => {

--- a/web/src/__tests__/server/unit/evaluator-filter-validation.servertest.ts
+++ b/web/src/__tests__/server/unit/evaluator-filter-validation.servertest.ts
@@ -1,0 +1,112 @@
+import {
+  EvalTargetObject,
+  validateEvaluatorFiltersForTarget,
+  type FilterState,
+} from "@langfuse/shared";
+
+describe("validateEvaluatorFiltersForTarget", () => {
+  it.each([
+    {
+      targetObject: EvalTargetObject.TRACE,
+      filter: [
+        {
+          type: "string",
+          column: "name",
+          operator: "=",
+          value: "checkout-trace",
+        },
+      ] satisfies FilterState,
+      expectedColumn: "traceName",
+    },
+    {
+      targetObject: EvalTargetObject.DATASET,
+      filter: [
+        {
+          type: "stringOptions",
+          column: "Dataset",
+          operator: "any of",
+          value: ["dataset-1"],
+        },
+      ] satisfies FilterState,
+      expectedColumn: "datasetId",
+    },
+    {
+      targetObject: EvalTargetObject.EVENT,
+      filter: [
+        {
+          type: "stringOptions",
+          column: "Trace Name",
+          operator: "any of",
+          value: ["checkout"],
+        },
+      ] satisfies FilterState,
+      expectedColumn: "traceName",
+    },
+    {
+      targetObject: EvalTargetObject.EXPERIMENT,
+      filter: [
+        {
+          type: "stringOptions",
+          column: "Dataset",
+          operator: "any of",
+          value: ["dataset-1"],
+        },
+      ] satisfies FilterState,
+      expectedColumn: "experimentDatasetId",
+    },
+  ])(
+    "accepts supported filters for $targetObject and normalizes columns",
+    ({ targetObject, filter, expectedColumn }) => {
+      const result = validateEvaluatorFiltersForTarget({
+        targetObject,
+        filter,
+      });
+
+      expect(result.isValid).toBe(true);
+      expect(result.issues).toEqual([]);
+      expect(result.normalizedFilter[0]?.column).toBe(expectedColumn);
+    },
+  );
+
+  it("rejects unsupported trace-level score filters", () => {
+    const result = validateEvaluatorFiltersForTarget({
+      targetObject: EvalTargetObject.TRACE,
+      filter: [
+        {
+          type: "numberObject",
+          column: "Scores (numeric)",
+          key: "accuracy",
+          operator: ">",
+          value: 0.8,
+        },
+      ] satisfies FilterState,
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.issues[0]).toMatchObject({
+      code: "unsupported_column",
+      column: "Scores (numeric)",
+    });
+  });
+
+  it("rejects incompatible filter types", () => {
+    const result = validateEvaluatorFiltersForTarget({
+      targetObject: EvalTargetObject.EVENT,
+      filter: [
+        {
+          type: "number",
+          column: "Environment",
+          operator: ">",
+          value: 1,
+        },
+      ] satisfies FilterState,
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.issues[0]).toMatchObject({
+      code: "incompatible_filter_type",
+      normalizedColumn: "environment",
+      expectedColumnType: "stringOptions",
+    });
+  });
+});

--- a/web/src/__tests__/server/unit/evaluator-filter-validation.servertest.ts
+++ b/web/src/__tests__/server/unit/evaluator-filter-validation.servertest.ts
@@ -16,7 +16,6 @@ describe("validateEvaluatorFiltersForTarget", () => {
           value: "checkout-trace",
         },
       ] satisfies FilterState,
-      expectedColumn: "traceName",
     },
     {
       targetObject: EvalTargetObject.DATASET,
@@ -28,7 +27,6 @@ describe("validateEvaluatorFiltersForTarget", () => {
           value: ["dataset-1"],
         },
       ] satisfies FilterState,
-      expectedColumn: "datasetId",
     },
     {
       targetObject: EvalTargetObject.EVENT,
@@ -40,7 +38,6 @@ describe("validateEvaluatorFiltersForTarget", () => {
           value: ["checkout"],
         },
       ] satisfies FilterState,
-      expectedColumn: "traceName",
     },
     {
       targetObject: EvalTargetObject.EXPERIMENT,
@@ -52,11 +49,10 @@ describe("validateEvaluatorFiltersForTarget", () => {
           value: ["dataset-1"],
         },
       ] satisfies FilterState,
-      expectedColumn: "experimentDatasetId",
     },
   ])(
-    "accepts supported filters for $targetObject and normalizes columns",
-    ({ targetObject, filter, expectedColumn }) => {
+    "accepts supported filters for $targetObject",
+    ({ targetObject, filter }) => {
       const result = validateEvaluatorFiltersForTarget({
         targetObject,
         filter,
@@ -64,7 +60,8 @@ describe("validateEvaluatorFiltersForTarget", () => {
 
       expect(result.isValid).toBe(true);
       expect(result.issues).toEqual([]);
-      expect(result.normalizedFilter[0]?.column).toBe(expectedColumn);
+      // Filter columns are passed through as-is (no normalization)
+      expect(result.validatedFilters).toEqual(filter);
     },
   );
 
@@ -105,7 +102,7 @@ describe("validateEvaluatorFiltersForTarget", () => {
     expect(result.isValid).toBe(false);
     expect(result.issues[0]).toMatchObject({
       code: "incompatible_filter_type",
-      normalizedColumn: "environment",
+      column: "environment",
       expectedColumnType: "stringOptions",
     });
   });

--- a/web/src/__tests__/server/unit/evaluator-filter-validation.servertest.ts
+++ b/web/src/__tests__/server/unit/evaluator-filter-validation.servertest.ts
@@ -92,7 +92,7 @@ describe("validateEvaluatorFiltersForTarget", () => {
       filter: [
         {
           type: "number",
-          column: "Environment",
+          column: "environment",
           operator: ">",
           value: 1,
         },

--- a/web/src/features/evals/components/evaluator-detail.tsx
+++ b/web/src/features/evals/components/evaluator-detail.tsx
@@ -8,8 +8,14 @@ import Page from "@/src/components/layouts/page";
 import { LevelCountsDisplay } from "@/src/components/level-counts-display";
 import { generateJobExecutionCounts } from "@/src/features/evals/utils/job-execution-utils";
 import { EvaluatorPausedCallout } from "@/src/features/evals/components/evaluator-paused-callout";
-import { type EvaluatorExecutionStatusCount } from "@langfuse/shared";
+import {
+  type EvalTargetObject,
+  type EvaluatorExecutionStatusCount,
+  validateEvaluatorFiltersForTarget,
+} from "@langfuse/shared";
 import { useLazyEvaluatorExecutionCounts } from "@/src/features/evals/hooks/useLazyEvaluatorExecutionCounts";
+import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
+import { AlertTriangle } from "lucide-react";
 
 const JobExecutionCounts = ({
   isLoading,
@@ -42,6 +48,16 @@ export const EvaluatorDetail = () => {
     evaluatorId,
     evaluator: evaluator.data,
   });
+  const filterValidation = React.useMemo(() => {
+    if (!evaluator.data) {
+      return null;
+    }
+
+    return validateEvaluatorFiltersForTarget({
+      targetObject: evaluator.data.targetObject as EvalTargetObject,
+      filter: evaluator.data.filter,
+    });
+  }, [evaluator.data]);
 
   // get all templates for the current template name
   const allTemplates = api.evals.allTemplatesForName.useQuery(
@@ -126,6 +142,19 @@ export const EvaluatorDetail = () => {
     >
       {existingEvaluator && (
         <div className="flex h-full flex-col overflow-hidden">
+          {filterValidation && !filterValidation.isValid && (
+            <div className="mx-3 mt-3">
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Unsupported filters</AlertTitle>
+                <AlertDescription>
+                  This evaluator contains deprecated or unsupported filters. The
+                  filters must be removed. Until the filters are removed, the
+                  evaluator is paused and will not be run.{" "}
+                </AlertDescription>
+              </Alert>
+            </div>
+          )}
           {existingEvaluator.blockedAt && (
             <div className="mx-3 mt-3">
               <EvaluatorPausedCallout

--- a/web/src/features/evals/components/inner-evaluator-form.tsx
+++ b/web/src/features/evals/components/inner-evaluator-form.tsx
@@ -1,5 +1,5 @@
 import { type UseFormReturn, useForm } from "react-hook-form";
-import { AlertDescription } from "@/src/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { Input } from "@/src/components/ui/input";
 import { Button } from "@/src/components/ui/button";
 import {
@@ -24,6 +24,8 @@ import {
   type ColumnDefinition,
   type availableDatasetEvalVariables,
   JobConfigState,
+  validateEvaluatorFiltersForTarget,
+  evalTraceTableCols,
 } from "@langfuse/shared";
 import { z } from "zod";
 import { useEffect, useMemo, useState, memo } from "react";
@@ -38,6 +40,7 @@ import {
   observationVariableMapping,
 } from "@langfuse/shared";
 import { useRouter } from "next/router";
+import { toast } from "sonner";
 import { Slider } from "@/src/components/ui/slider";
 import { Card } from "@/src/components/ui/card";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
@@ -335,6 +338,22 @@ export const InnerEvaluatorForm = (props: {
   } = useEvalConfigFilterOptions({ projectId: props.projectId });
 
   const targetState = useEvaluatorTargetState();
+
+  // Check if existing trace evaluator has invalid filters (e.g., score filters added by bug ff4b03c0b)
+  const hasInvalidTraceFilters = useMemo(() => {
+    if (
+      !props.existingEvaluator?.filter ||
+      props.existingEvaluator.targetObject !== EvalTargetObject.TRACE
+    ) {
+      return false;
+    }
+    const validation = validateEvaluatorFiltersForTarget({
+      targetObject: EvalTargetObject.TRACE,
+      filter: props.existingEvaluator.filter,
+    });
+    return !validation.isValid;
+  }, [props.existingEvaluator?.filter, props.existingEvaluator?.targetObject]);
+
   const defaultTargetResult = EvalTargetObjectSchema.safeParse(
     props.existingEvaluator?.targetObject ??
       props.defaultTarget ??
@@ -457,11 +476,17 @@ export const InnerEvaluatorForm = (props: {
   const utils = api.useUtils();
   const createJobMutation = api.evals.createJob.useMutation({
     onSuccess: () => utils.models.invalidate(),
-    onError: (error) => setFormError(error.message),
+    onError: (error) => {
+      setFormError(error.message);
+      toast.error(error.message);
+    },
   });
   const updateJobMutation = api.evals.updateEvalJob.useMutation({
     onSuccess: () => utils.evals.invalidate(),
-    onError: (error) => setFormError(error.message),
+    onError: (error) => {
+      setFormError(error.message);
+      toast.error(error.message);
+    },
   });
   const [availableVariables, setAvailableVariables] = useState<
     typeof availableTraceEvalVariables | typeof availableDatasetEvalVariables
@@ -691,6 +716,17 @@ export const InnerEvaluatorForm = (props: {
       />
       {!props.hideTargetSection && (
         <Card className="flex max-w-full flex-col gap-2 overflow-y-auto p-4">
+          {hasInvalidTraceFilters && (
+            <Alert variant="destructive">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Unsupported filter detected</AlertTitle>
+              <AlertDescription>
+                This evaluator has a filter that is not supported for
+                trace-level evaluators. It is effectively paused. Please remove
+                all filters and re-add them from scratch to resume execution.
+              </AlertDescription>
+            </Alert>
+          )}
           <div className="flex flex-col gap-4">
             {!props.hideTargetSelection && (
               <FormField
@@ -1010,7 +1046,10 @@ export const InnerEvaluatorForm = (props: {
                           allowPropagationFilters,
                         );
                       } else if (isTraceTarget(target)) {
-                        return tracesTableColsWithOptions(traceFilterOptions);
+                        return tracesTableColsWithOptions(
+                          traceFilterOptions,
+                          evalTraceTableCols,
+                        );
                       } else if (isExperimentTarget(target)) {
                         // Experiment evaluators - only dataset filter
                         return experimentEvalFilterColsWithOptions(

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -27,6 +27,8 @@ import {
   jsonSchema,
   EvalTargetObject,
   EvalTargetObjectSchema,
+  validateEvaluatorFiltersForTarget,
+  InvalidRequestError,
 } from "@langfuse/shared";
 import {
   getQueue,
@@ -766,6 +768,17 @@ export const evalRouter = createTRPCRouter({
         targetObject: input.target,
         mapping: input.mapping,
       });
+      const filterValidation = validateEvaluatorFiltersForTarget({
+        targetObject: input.target,
+        filter: input.filter ?? [],
+      });
+      if (!filterValidation.isValid) {
+        throw new InvalidRequestError(
+          filterValidation.issues[0]?.message ??
+            "Evaluator filters are invalid. Remove unsupported or incomplete filters and try again.",
+        );
+      }
+      const validatedFilter = filterValidation.normalizedFilter;
 
       const jobId = uuidv4();
       await auditLog({
@@ -783,7 +796,7 @@ export const evalRouter = createTRPCRouter({
           evalTemplateId: input.evalTemplateId,
           scoreName: input.scoreName,
           targetObject: input.target,
-          filter: input.filter ?? [],
+          filter: validatedFilter,
           variableMapping: variableMappingForTarget,
           sampling: input.sampling,
           delay: input.delay,
@@ -825,7 +838,7 @@ export const evalRouter = createTRPCRouter({
               cutoffCreatedAt: new Date(),
               targetObject: input.target,
               query: {
-                filter: input.filter ?? [],
+                filter: validatedFilter,
                 orderBy: {
                   column: "timestamp",
                   order: "DESC",
@@ -1185,6 +1198,17 @@ export const evalRouter = createTRPCRouter({
             }
           : {}),
       };
+      const filterValidation = validateEvaluatorFiltersForTarget({
+        targetObject: existingJob.targetObject as EvalTargetObject,
+        filter: config.filter ?? existingJob.filter ?? [],
+      });
+      if (!filterValidation.isValid) {
+        throw new InvalidRequestError(
+          filterValidation.issues[0]?.message ??
+            "Evaluator filters are invalid. Remove unsupported or incomplete filters and try again.",
+        );
+      }
+      const validatedFilter = filterValidation.normalizedFilter;
 
       await auditLog({
         session: ctx.session,
@@ -1216,6 +1240,11 @@ export const evalRouter = createTRPCRouter({
 
       const updatedConfig = {
         ...validatedConfig,
+        ...(config.filter !== undefined
+          ? {
+              filter: validatedFilter,
+            }
+          : {}),
         ...(validatedConfig.status !== undefined
           ? resetEvalConfigBlockFields
           : {}),

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -778,7 +778,7 @@ export const evalRouter = createTRPCRouter({
             "Evaluator filters are invalid. Remove unsupported or incomplete filters and try again.",
         );
       }
-      const validatedFilter = filterValidation.normalizedFilter;
+      const validatedFilter = filterValidation.validatedFilters;
 
       const jobId = uuidv4();
       await auditLog({
@@ -796,7 +796,7 @@ export const evalRouter = createTRPCRouter({
           evalTemplateId: input.evalTemplateId,
           scoreName: input.scoreName,
           targetObject: input.target,
-          filter: validatedFilter,
+          filter: validatedFilter ?? [],
           variableMapping: variableMappingForTarget,
           sampling: input.sampling,
           delay: input.delay,
@@ -1208,7 +1208,7 @@ export const evalRouter = createTRPCRouter({
             "Evaluator filters are invalid. Remove unsupported or incomplete filters and try again.",
         );
       }
-      const validatedFilter = filterValidation.normalizedFilter;
+      const validatedFilter = filterValidation.validatedFilters;
 
       await auditLog({
         session: ctx.session,
@@ -1242,7 +1242,7 @@ export const evalRouter = createTRPCRouter({
         ...validatedConfig,
         ...(config.filter !== undefined
           ? {
-              filter: validatedFilter,
+              filter: validatedFilter ?? [],
             }
           : {}),
         ...(validatedConfig.status !== undefined

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -60,7 +60,9 @@ import {
   ScoreDataTypeEnum,
   validateEvalOutputResult,
   extractValueFromObject,
+  validateEvaluatorFiltersForTarget,
 } from "@langfuse/shared";
+import { env } from "../../env";
 import { prisma } from "@langfuse/shared/src/db";
 import { createW3CTraceId } from "../utils";
 import { UnrecoverableError } from "../../errors/UnrecoverableError";
@@ -369,6 +371,25 @@ export const createEvalJobs = async ({
     if (config.status === JobConfigState.INACTIVE) {
       logger.debug(`Skipping inactive config ${config.id}`);
       continue;
+    }
+
+    // Self-hosted only: Skip trace-level evaluators with invalid filters.
+    // A bug (ff4b03c0b, Feb 2026) allowed score filters on trace evaluators, which the worker doesn't support.
+    // Cloud deployments are fixed; self-hosters need this runtime check.
+    if (
+      !env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION &&
+      config.targetObject === EvalTargetObject.TRACE
+    ) {
+      const filterValidation = validateEvaluatorFiltersForTarget({
+        targetObject: EvalTargetObject.TRACE,
+        filter: config.filter,
+      });
+      if (!filterValidation.isValid) {
+        logger.debug(
+          `Skipping trace evaluator ${config.id} with invalid filters: ${filterValidation.issues[0]?.message}`,
+        );
+        continue;
+      }
     }
 
     logger.debug("Creating eval job for config", config.id);


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds validation for evaluator filters across all target types (TRACE, DATASET, EVENT, EXPERIMENT) to address a bug (`ff4b03c0b`) that allowed score filters to be attached to trace-level evaluators. It introduces `validateEvaluatorFiltersForTarget`, threads it through the tRPC router (blocking create/update when filters are invalid), adds UI warning banners, restricts the trace evaluator filter picker to non-score columns, and adds a self-hosted runtime skip in the worker.

- `validateEvaluatorFiltersForTarget` correctly detects unsupported columns and incompatible filter types, but the `normalizedFilter` return value doesn't rewrite `filter.column` from display names/aliases to canonical IDs — all four parameterized unit-test assertions that check this normalization will fail.
- The destructive warning banner in `inner-evaluator-form.tsx` is scoped to `TRACE` targets only, while the backend rejects invalid filters for every target type; non-TRACE evaluators with bad filters will hit a silent backend error with no in-form explanation.

<h3>Confidence Score: 3/5</h3>

The core filter-gating logic is structurally sound, but the new unit tests assert column normalization that the implementation does not perform, meaning the tests will fail in CI as written.

The `normalizedFilter` field is returned as the raw parsed filters without rewriting matched column names/aliases to canonical IDs. Every one of the four parameterized test cases in the new unit test file asserts this normalization (e.g. `"name"` → `"traceName"`), so they will all fail. Additionally the UI warning in `inner-evaluator-form.tsx` is wired only for TRACE targets while the backend blocks all target types, leaving non-TRACE users with no in-form explanation when their update is rejected.

packages/shared/src/features/evals/validateEvaluatorFilters.ts (missing column normalization) and web/src/__tests__/server/unit/evaluator-filter-validation.servertest.ts (assertions will fail)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/features/evals/validateEvaluatorFilters.ts | New validation helper — correctly detects unsupported/incompatible filters but the `normalizedFilter` return value doesn't rewrite `filter.column` to `column.id`, causing all normalization-asserting unit tests to fail. |
| web/src/__tests__/server/unit/evaluator-filter-validation.servertest.ts | New unit tests assert column normalization (e.g., `"name"` → `"traceName"`) that the implementation doesn't perform — all four parameterized column assertions will fail. |
| web/src/features/evals/components/inner-evaluator-form.tsx | Passes evalTraceTableCols as a column-allow-list to tracesTableColsWithOptions (restricting the filter picker to non-score columns) and adds a warning banner, but the warning is TRACE-only while the backend validates all target types. |
| web/src/features/evals/server/router.ts | Filter validation added to createJob and updateEvalJob; the update path uses `config.filter ?? existingJob.filter` meaning any update (even status-only) is blocked when persisted filters are invalid — intentional per the tests but worth confirming UX intent. |
| worker/src/features/evaluation/evalService.ts | Adds a self-hosted-only runtime skip for trace evaluators with invalid filters, gated on the absence of NEXT_PUBLIC_LANGFUSE_CLOUD_REGION; logic is sound. |
| web/src/features/evals/components/evaluator-detail.tsx | Adds a destructive Alert banner when the evaluator's filters fail validation; correctly gated on `filterValidation.isValid`. |
| packages/shared/src/server/queries/clickhouse-sql/filterTypeCompatibility.ts | Straightforward extraction of the COMPATIBLE_FILTER_TYPES constant into its own module with proper typed keys; logic is identical to the original in factory.ts. |
| packages/shared/src/index.ts | Trivial barrel re-export of the new validateEvaluatorFilters module. |
| web/src/__tests__/server/evals-trpc.servertest.ts | Integration tests cover creation rejection and update-gating for invalid filters, plus an allow-path once filters are cleared; coverage looks thorough for the server-side behavior. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Evaluator Form / Detail
    participant Router as tRPC Router
    participant Validator as validateEvaluatorFiltersForTarget
    participant DB as Prisma / DB
    participant Worker as evalService

    UI->>Router: createJob(filter, target, ...)
    Router->>Validator: validate(filter, target)
    alt filters invalid
        Validator-->>Router: isValid=false
        Router-->>UI: InvalidRequestError
    else filters valid
        Validator-->>Router: isValid=true, normalizedFilter
        Router->>DB: store filter=normalizedFilter
        Router-->>UI: success
    end

    UI->>Router: updateEvalJob(config.filter?, ...)
    Router->>DB: fetch existingJob.filter
    Router->>Validator: validate(config.filter ?? existingJob.filter, target)
    alt still invalid
        Validator-->>Router: isValid=false
        Router-->>UI: InvalidRequestError (blocks ALL updates)
    else valid
        Router->>DB: update with validatedFilter
        Router-->>UI: updated job
    end

    Worker->>Worker: createEvalJobs loop
    alt self-hosted AND TRACE target
        Worker->>Validator: validate(config.filter, TRACE)
        alt invalid
            Worker->>Worker: skip (continue)
        else valid
            Worker->>Worker: proceed with eval job
        end
    else cloud OR non-TRACE target
        Worker->>Worker: proceed normally
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/features/evals/validateEvaluatorFilters.ts:139-143
**`normalizedFilter` doesn't normalize column names to canonical IDs**

The new unit tests in `evaluator-filter-validation.servertest.ts` assert that `normalizedFilter[0]?.column` equals the column's canonical `id` (e.g. input `"name"` → expected `"traceName"`, input `"Dataset"` → expected `"datasetId"`). However, `normalizedFilter` is returned as the raw `filters` array without rewriting each `filter.column` from a display name or alias to `column.id`. All four parameterized test cases will therefore fail on the column assertion. If downstream query building (`factory.ts`) resolves filters by `column.id` rather than aliases, evaluators using alias-matched column names will also silently produce wrong queries.

### Issue 2 of 2
web/src/features/evals/components/inner-evaluator-form.tsx:342-355
**Warning only surfaces for TRACE evaluators, not all target types**

`hasInvalidTraceFilters` short-circuits to `false` when `props.existingEvaluator.targetObject !== EvalTargetObject.TRACE`, but the router's `validateEvaluatorFiltersForTarget` (called in `updateEvalJob`) runs against all target types. An evaluator with an incompatible filter on a non-TRACE target (DATASET, EVENT, EXPERIMENT) would have no UI warning yet still receive a blocking error from the backend when the user tries to save any update.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): add evaluator filter validat..."](https://github.com/langfuse/langfuse/commit/c6829442da37a5987944fd0b629e3c4832f545a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30837751)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->