### PR TITLE
chore: add migration hints for legacy public ClickHouse APIs

### DIFF
--- a/web/src/__tests__/server/withMiddlewares.servertest.ts
+++ b/web/src/__tests__/server/withMiddlewares.servertest.ts
@@ -215,7 +215,7 @@ describe("withMiddlewares error handling", () => {
       expect(jsonData["error"]).toBe("Request timed out");
     });
 
-    it("should handle ClickHouseResourceError with method-specific advice", async () => {
+    it("should handle ClickHouseResourceError with custom advice", async () => {
       const originalError = new Error("Timeout exceeded");
       const resourceError = new ClickHouseResourceError(
         "TIMEOUT",
@@ -228,11 +228,7 @@ describe("withMiddlewares error handling", () => {
             throw resourceError;
           },
         },
-        {
-          clickHouseResourceErrorMessage: {
-            GET: LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
-          },
-        },
+        LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
       );
 
       const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
@@ -250,48 +246,6 @@ describe("withMiddlewares error handling", () => {
         LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
       );
       expect(jsonData["message"]).toContain(
-        "https://langfuse.com/docs/metrics/features/metrics-api",
-      );
-    });
-
-    it("should keep default advice for methods without a custom message", async () => {
-      const originalError = new Error("Timeout exceeded");
-      const resourceError = new ClickHouseResourceError(
-        "TIMEOUT",
-        originalError,
-      );
-
-      const handler = withMiddlewares(
-        {
-          POST: async () => {
-            throw resourceError;
-          },
-        },
-        {
-          clickHouseResourceErrorMessage: {
-            GET: LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
-          },
-        },
-      );
-
-      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
-        method: "POST",
-        headers: {
-          "x-langfuse-public-key": "test-key",
-        },
-      });
-
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(422);
-      const jsonData = JSON.parse(res._getData());
-      expect(jsonData["message"]).toContain(
-        ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
-      );
-      expect(jsonData["message"]).toContain(
-        "https://langfuse.com/docs/api-and-data-platform/features/public-api",
-      );
-      expect(jsonData["message"]).not.toContain(
         "https://langfuse.com/docs/metrics/features/metrics-api",
       );
     });

--- a/web/src/__tests__/server/withMiddlewares.servertest.ts
+++ b/web/src/__tests__/server/withMiddlewares.servertest.ts
@@ -228,7 +228,10 @@ describe("withMiddlewares error handling", () => {
             throw resourceError;
           },
         },
-        LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+        {
+          clickHouseResourceErrorMessage:
+            LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+        },
       );
 
       const { req, res } = createMocks<NextApiRequest, NextApiResponse>({

--- a/web/src/__tests__/server/withMiddlewares.servertest.ts
+++ b/web/src/__tests__/server/withMiddlewares.servertest.ts
@@ -1,5 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import {
+  LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  withMiddlewares,
+} from "@/src/features/public-api/server/withMiddlewares";
 import {
   BaseError,
   LangfuseNotFoundError,
@@ -210,6 +213,87 @@ describe("withMiddlewares error handling", () => {
         ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
       );
       expect(jsonData["error"]).toBe("Request timed out");
+    });
+
+    it("should handle ClickHouseResourceError with method-specific advice", async () => {
+      const originalError = new Error("Timeout exceeded");
+      const resourceError = new ClickHouseResourceError(
+        "TIMEOUT",
+        originalError,
+      );
+
+      const handler = withMiddlewares(
+        {
+          GET: async () => {
+            throw resourceError;
+          },
+        },
+        {
+          clickHouseResourceErrorMessage: {
+            GET: LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+          },
+        },
+      );
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        headers: {
+          "x-langfuse-public-key": "test-key",
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(422);
+      const jsonData = JSON.parse(res._getData());
+      expect(jsonData["message"]).toBe(
+        LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+      );
+      expect(jsonData["message"]).toContain(
+        "https://langfuse.com/docs/metrics/features/metrics-api",
+      );
+    });
+
+    it("should keep default advice for methods without a custom message", async () => {
+      const originalError = new Error("Timeout exceeded");
+      const resourceError = new ClickHouseResourceError(
+        "TIMEOUT",
+        originalError,
+      );
+
+      const handler = withMiddlewares(
+        {
+          POST: async () => {
+            throw resourceError;
+          },
+        },
+        {
+          clickHouseResourceErrorMessage: {
+            GET: LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+          },
+        },
+      );
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "POST",
+        headers: {
+          "x-langfuse-public-key": "test-key",
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(422);
+      const jsonData = JSON.parse(res._getData());
+      expect(jsonData["message"]).toContain(
+        ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
+      );
+      expect(jsonData["message"]).toContain(
+        "https://langfuse.com/docs/api-and-data-platform/features/public-api",
+      );
+      expect(jsonData["message"]).not.toContain(
+        "https://langfuse.com/docs/metrics/features/metrics-api",
+      );
     });
   });
 

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -55,35 +55,24 @@ export const LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE = [
   "Docs: https://langfuse.com/docs/metrics/features/metrics-api",
 ].join("\n");
 
-type ClickHouseResourceErrorMessage =
-  | string
-  | Partial<Record<HttpMethod, string>>;
-
 type MiddlewareOptions = {
   errorContract?: PublicApiErrorContract;
-  clickHouseResourceErrorMessage?: ClickHouseResourceErrorMessage;
-};
-
-const getClickHouseResourceErrorMessage = (
-  message: ClickHouseResourceErrorMessage | undefined,
-  method: string | undefined,
-) => {
-  if (typeof message === "string") return message;
-
-  if (method && httpMethods.includes(method as HttpMethod)) {
-    return (
-      message?.[method as HttpMethod] ??
-      DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE
-    );
-  }
-
-  return DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE;
 };
 
 export function withMiddlewares(
   handlers: Handlers,
-  options?: MiddlewareOptions,
+  optionsOrClickHouseResourceErrorMessage?: MiddlewareOptions | string,
+  clickHouseResourceErrorMessage?: string,
 ) {
+  const options =
+    typeof optionsOrClickHouseResourceErrorMessage === "string"
+      ? undefined
+      : optionsOrClickHouseResourceErrorMessage;
+  const clickHouseResourceErrorMessageOverride =
+    typeof optionsOrClickHouseResourceErrorMessage === "string"
+      ? optionsOrClickHouseResourceErrorMessage
+      : clickHouseResourceErrorMessage;
+
   return async (req: NextApiRequest, res: NextApiResponse) => {
     const ctx = contextWithLangfuseProps({
       headers: req.headers,
@@ -158,10 +147,9 @@ export function withMiddlewares(
         // Handle ClickHouse resource errors
         if (error instanceof ClickHouseResourceError) {
           const resourceError = error as ClickHouseResourceError;
-          const errorMessage = getClickHouseResourceErrorMessage(
-            options?.clickHouseResourceErrorMessage,
-            req.method,
-          );
+          const errorMessage =
+            clickHouseResourceErrorMessageOverride ??
+            DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE;
 
           logger.warn("ClickHouse resource limit exceeded", {
             errorType: resourceError.errorType,

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -37,13 +37,47 @@ const defaultHandler = () => {
   throw new MethodNotAllowedError();
 };
 
-const CH_ERROR_ADVICE_FULL = [
+const DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE = [
   ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
   "See https://langfuse.com/docs/api-and-data-platform/features/public-api for more details.",
 ].join("\n");
 
+export const LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE =
+  [
+    ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
+    "This legacy endpoint can be slow for large exports. Please migrate to the high-performance Observations API v2 at /api/public/v2/observations.",
+    "Docs: https://langfuse.com/docs/api-and-data-platform/features/observations-api",
+  ].join("\n");
+
+export const LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE = [
+  ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
+  "This legacy endpoint can be slow for large exports. Please migrate to the high-performance Metrics API v2 at /api/public/v2/metrics.",
+  "Docs: https://langfuse.com/docs/metrics/features/metrics-api",
+].join("\n");
+
+type ClickHouseResourceErrorMessage =
+  | string
+  | Partial<Record<HttpMethod, string>>;
+
 type MiddlewareOptions = {
   errorContract?: PublicApiErrorContract;
+  clickHouseResourceErrorMessage?: ClickHouseResourceErrorMessage;
+};
+
+const getClickHouseResourceErrorMessage = (
+  message: ClickHouseResourceErrorMessage | undefined,
+  method: string | undefined,
+) => {
+  if (typeof message === "string") return message;
+
+  if (method && httpMethods.includes(method as HttpMethod)) {
+    return (
+      message?.[method as HttpMethod] ??
+      DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE
+    );
+  }
+
+  return DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE;
 };
 
 export function withMiddlewares(
@@ -124,15 +158,19 @@ export function withMiddlewares(
         // Handle ClickHouse resource errors
         if (error instanceof ClickHouseResourceError) {
           const resourceError = error as ClickHouseResourceError;
+          const errorMessage = getClickHouseResourceErrorMessage(
+            options?.clickHouseResourceErrorMessage,
+            req.method,
+          );
 
           logger.warn("ClickHouse resource limit exceeded", {
             errorType: resourceError.errorType,
             message: resourceError.message,
-            suggestion: CH_ERROR_ADVICE_FULL,
+            suggestion: errorMessage,
           });
 
           return res.status(422).json({
-            message: CH_ERROR_ADVICE_FULL,
+            message: errorMessage,
             error: "Request timed out",
           });
         }

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -57,22 +57,13 @@ export const LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE = [
 
 type MiddlewareOptions = {
   errorContract?: PublicApiErrorContract;
+  clickHouseResourceErrorMessage?: string;
 };
 
 export function withMiddlewares(
   handlers: Handlers,
-  optionsOrClickHouseResourceErrorMessage?: MiddlewareOptions | string,
-  clickHouseResourceErrorMessage?: string,
+  options?: MiddlewareOptions,
 ) {
-  const options =
-    typeof optionsOrClickHouseResourceErrorMessage === "string"
-      ? undefined
-      : optionsOrClickHouseResourceErrorMessage;
-  const clickHouseResourceErrorMessageOverride =
-    typeof optionsOrClickHouseResourceErrorMessage === "string"
-      ? optionsOrClickHouseResourceErrorMessage
-      : clickHouseResourceErrorMessage;
-
   return async (req: NextApiRequest, res: NextApiResponse) => {
     const ctx = contextWithLangfuseProps({
       headers: req.headers,
@@ -148,7 +139,7 @@ export function withMiddlewares(
         if (error instanceof ClickHouseResourceError) {
           const resourceError = error as ClickHouseResourceError;
           const errorMessage =
-            clickHouseResourceErrorMessageOverride ??
+            options?.clickHouseResourceErrorMessage ??
             DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE;
 
           logger.warn("ClickHouse resource limit exceeded", {

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -46,12 +46,14 @@ export const LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE =
   [
     ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
     "This legacy endpoint can be slow. Please migrate to the high-performance Observations API v2 at /api/public/v2/observations.",
+    "This applies to Langfuse Cloud only until v4 is released in OSS.",
     "Docs: https://langfuse.com/docs/api-and-data-platform/features/observations-api",
   ].join("\n");
 
 export const LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE = [
   ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
   "This legacy endpoint can be slow. Please migrate to the high-performance Metrics API v2 at /api/public/v2/metrics.",
+  "This applies to Langfuse Cloud only until v4 is released in OSS.",
   "Docs: https://langfuse.com/docs/metrics/features/metrics-api",
 ].join("\n");
 

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -45,13 +45,13 @@ const DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE = [
 export const LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE =
   [
     ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
-    "This legacy endpoint can be slow for large exports. Please migrate to the high-performance Observations API v2 at /api/public/v2/observations.",
+    "This legacy endpoint can be slow. Please migrate to the high-performance Observations API v2 at /api/public/v2/observations.",
     "Docs: https://langfuse.com/docs/api-and-data-platform/features/observations-api",
   ].join("\n");
 
 export const LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE = [
   ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
-  "This legacy endpoint can be slow for large exports. Please migrate to the high-performance Metrics API v2 at /api/public/v2/metrics.",
+  "This legacy endpoint can be slow. Please migrate to the high-performance Metrics API v2 at /api/public/v2/metrics.",
   "Docs: https://langfuse.com/docs/metrics/features/metrics-api",
 ].join("\n");
 

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -10,47 +10,40 @@ import {
 } from "@/src/features/public-api/types/metrics";
 import { executeQuery } from "@/src/features/query/server/queryExecutor";
 
-export default withMiddlewares(
-  {
-    GET: createAuthedProjectAPIRoute({
-      name: "Get Metrics",
-      rateLimitResource: "public-api-metrics",
-      querySchema: GetMetricsV1Query,
-      responseSchema: GetMetricsV1Response,
-      fn: async ({ query, auth }) => {
-        try {
-          // Extract the parsed query object
-          const queryParams = query.query;
+export default withMiddlewares({
+  GET: createAuthedProjectAPIRoute({
+    name: "Get Metrics",
+    rateLimitResource: "public-api-metrics",
+    querySchema: GetMetricsV1Query,
+    responseSchema: GetMetricsV1Response,
+    fn: async ({ query, auth }) => {
+      try {
+        // Extract the parsed query object
+        const queryParams = query.query;
 
-          // Log the received query for debugging
-          logger.debug("Received metrics query", {
-            query: queryParams,
-            projectId: auth.scope.projectId,
-          });
+        // Log the received query for debugging
+        logger.debug("Received metrics query", {
+          query: queryParams,
+          projectId: auth.scope.projectId,
+        });
 
-          // Execute the query using QueryBuilder
-          const result = await executeQuery(auth.scope.projectId, queryParams);
+        // Execute the query using QueryBuilder
+        const result = await executeQuery(auth.scope.projectId, queryParams);
 
-          // Format and return the result
-          return {
-            data: result,
-            // meta: {
-            //   page: queryParams.page,
-            //   limit: queryParams.limit,
-            //   totalItems: result.length,
-            //   totalPages: Math.ceil(result.length / queryParams.limit),
-            // },
-          };
-        } catch (error) {
-          logger.error("Error in metrics API", { error, query });
-          throw error;
-        }
-      },
-    }),
-  },
-  {
-    clickHouseResourceErrorMessage: {
-      GET: LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+        // Format and return the result
+        return {
+          data: result,
+          // meta: {
+          //   page: queryParams.page,
+          //   limit: queryParams.limit,
+          //   totalItems: result.length,
+          //   totalPages: Math.ceil(result.length / queryParams.limit),
+          // },
+        };
+      } catch (error) {
+        logger.error("Error in metrics API", { error, query });
+        throw error;
+      }
     },
-  },
-);
+  }),
+}, LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE);

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -46,4 +46,7 @@ export default withMiddlewares({
       }
     },
   }),
-}, LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE);
+}, {
+  clickHouseResourceErrorMessage:
+    LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+});

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -10,43 +10,46 @@ import {
 } from "@/src/features/public-api/types/metrics";
 import { executeQuery } from "@/src/features/query/server/queryExecutor";
 
-export default withMiddlewares({
-  GET: createAuthedProjectAPIRoute({
-    name: "Get Metrics",
-    rateLimitResource: "public-api-metrics",
-    querySchema: GetMetricsV1Query,
-    responseSchema: GetMetricsV1Response,
-    fn: async ({ query, auth }) => {
-      try {
-        // Extract the parsed query object
-        const queryParams = query.query;
+export default withMiddlewares(
+  {
+    GET: createAuthedProjectAPIRoute({
+      name: "Get Metrics",
+      rateLimitResource: "public-api-metrics",
+      querySchema: GetMetricsV1Query,
+      responseSchema: GetMetricsV1Response,
+      fn: async ({ query, auth }) => {
+        try {
+          // Extract the parsed query object
+          const queryParams = query.query;
 
-        // Log the received query for debugging
-        logger.debug("Received metrics query", {
-          query: queryParams,
-          projectId: auth.scope.projectId,
-        });
+          // Log the received query for debugging
+          logger.debug("Received metrics query", {
+            query: queryParams,
+            projectId: auth.scope.projectId,
+          });
 
-        // Execute the query using QueryBuilder
-        const result = await executeQuery(auth.scope.projectId, queryParams);
+          // Execute the query using QueryBuilder
+          const result = await executeQuery(auth.scope.projectId, queryParams);
 
-        // Format and return the result
-        return {
-          data: result,
-          // meta: {
-          //   page: queryParams.page,
-          //   limit: queryParams.limit,
-          //   totalItems: result.length,
-          //   totalPages: Math.ceil(result.length / queryParams.limit),
-          // },
-        };
-      } catch (error) {
-        logger.error("Error in metrics API", { error, query });
-        throw error;
-      }
-    },
-  }),
-}, {
-  clickHouseResourceErrorMessage:
-    LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
-});
+          // Format and return the result
+          return {
+            data: result,
+            // meta: {
+            //   page: queryParams.page,
+            //   limit: queryParams.limit,
+            //   totalItems: result.length,
+            //   totalPages: Math.ceil(result.length / queryParams.limit),
+            // },
+          };
+        } catch (error) {
+          logger.error("Error in metrics API", { error, query });
+          throw error;
+        }
+      },
+    }),
+  },
+  {
+    clickHouseResourceErrorMessage:
+      LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  },
+);

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -1,4 +1,7 @@
-import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import {
+  LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  withMiddlewares,
+} from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { logger } from "@langfuse/shared/src/server";
 import {
@@ -7,40 +10,47 @@ import {
 } from "@/src/features/public-api/types/metrics";
 import { executeQuery } from "@/src/features/query/server/queryExecutor";
 
-export default withMiddlewares({
-  GET: createAuthedProjectAPIRoute({
-    name: "Get Metrics",
-    rateLimitResource: "public-api-metrics",
-    querySchema: GetMetricsV1Query,
-    responseSchema: GetMetricsV1Response,
-    fn: async ({ query, auth }) => {
-      try {
-        // Extract the parsed query object
-        const queryParams = query.query;
+export default withMiddlewares(
+  {
+    GET: createAuthedProjectAPIRoute({
+      name: "Get Metrics",
+      rateLimitResource: "public-api-metrics",
+      querySchema: GetMetricsV1Query,
+      responseSchema: GetMetricsV1Response,
+      fn: async ({ query, auth }) => {
+        try {
+          // Extract the parsed query object
+          const queryParams = query.query;
 
-        // Log the received query for debugging
-        logger.debug("Received metrics query", {
-          query: queryParams,
-          projectId: auth.scope.projectId,
-        });
+          // Log the received query for debugging
+          logger.debug("Received metrics query", {
+            query: queryParams,
+            projectId: auth.scope.projectId,
+          });
 
-        // Execute the query using QueryBuilder
-        const result = await executeQuery(auth.scope.projectId, queryParams);
+          // Execute the query using QueryBuilder
+          const result = await executeQuery(auth.scope.projectId, queryParams);
 
-        // Format and return the result
-        return {
-          data: result,
-          // meta: {
-          //   page: queryParams.page,
-          //   limit: queryParams.limit,
-          //   totalItems: result.length,
-          //   totalPages: Math.ceil(result.length / queryParams.limit),
-          // },
-        };
-      } catch (error) {
-        logger.error("Error in metrics API", { error, query });
-        throw error;
-      }
+          // Format and return the result
+          return {
+            data: result,
+            // meta: {
+            //   page: queryParams.page,
+            //   limit: queryParams.limit,
+            //   totalItems: result.length,
+            //   totalPages: Math.ceil(result.length / queryParams.limit),
+            // },
+          };
+        } catch (error) {
+          logger.error("Error in metrics API", { error, query });
+          throw error;
+        }
+      },
+    }),
+  },
+  {
+    clickHouseResourceErrorMessage: {
+      GET: LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
     },
-  }),
-});
+  },
+);

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -92,4 +92,7 @@ export default withMiddlewares({
       return transformDbToApiObservation(observation);
     },
   }),
-}, LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE);
+}, {
+  clickHouseResourceErrorMessage:
+    LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+});

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -4,7 +4,10 @@ import {
   GetObservationV1Response,
   transformDbToApiObservation,
 } from "@/src/features/public-api/types/observations";
-import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import {
+  LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  withMiddlewares,
+} from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { LangfuseNotFoundError } from "@langfuse/shared";
 import {
@@ -14,79 +17,86 @@ import {
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
 
-export default withMiddlewares({
-  GET: createAuthedProjectAPIRoute({
-    name: "Get Observation",
-    querySchema: GetObservationV1Query,
-    responseSchema: GetObservationV1Response,
-    fn: async ({ query, auth }) => {
-      // Use events table if query parameter is explicitly set, otherwise use environment variable
-      const useEventsTable =
-        query.useEventsTable !== undefined && query.useEventsTable !== null
-          ? query.useEventsTable === true
-          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
+export default withMiddlewares(
+  {
+    GET: createAuthedProjectAPIRoute({
+      name: "Get Observation",
+      querySchema: GetObservationV1Query,
+      responseSchema: GetObservationV1Response,
+      fn: async ({ query, auth }) => {
+        // Use events table if query parameter is explicitly set, otherwise use environment variable
+        const useEventsTable =
+          query.useEventsTable !== undefined && query.useEventsTable !== null
+            ? query.useEventsTable === true
+            : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
 
-      const clickhouseObservation = useEventsTable
-        ? await getObservationByIdFromEventsTable({
-            id: query.observationId,
-            projectId: auth.scope.projectId,
-            fetchWithInputOutput: true,
-          })
-        : await getObservationById({
-            id: query.observationId,
-            projectId: auth.scope.projectId,
-            fetchWithInputOutput: true,
-            preferredClickhouseService: "ReadOnly",
-          });
+        const clickhouseObservation = useEventsTable
+          ? await getObservationByIdFromEventsTable({
+              id: query.observationId,
+              projectId: auth.scope.projectId,
+              fetchWithInputOutput: true,
+            })
+          : await getObservationById({
+              id: query.observationId,
+              projectId: auth.scope.projectId,
+              fetchWithInputOutput: true,
+              preferredClickhouseService: "ReadOnly",
+            });
 
-      if (!clickhouseObservation) {
-        throw new LangfuseNotFoundError(
-          "Observation not found within authorized project",
-        );
-      }
+        if (!clickhouseObservation) {
+          throw new LangfuseNotFoundError(
+            "Observation not found within authorized project",
+          );
+        }
 
-      const model = clickhouseObservation.internalModelId
-        ? await prisma.model.findFirst({
-            where: {
-              AND: [
-                {
-                  id: clickhouseObservation.internalModelId,
-                },
-                {
-                  OR: [
-                    {
-                      projectId: auth.scope.projectId,
-                    },
-                    {
-                      projectId: null,
-                    },
-                  ],
-                },
-              ],
-            },
-            include: {
-              Price: true,
-            },
-            orderBy: {
-              projectId: {
-                sort: "desc",
-                nulls: "last",
+        const model = clickhouseObservation.internalModelId
+          ? await prisma.model.findFirst({
+              where: {
+                AND: [
+                  {
+                    id: clickhouseObservation.internalModelId,
+                  },
+                  {
+                    OR: [
+                      {
+                        projectId: auth.scope.projectId,
+                      },
+                      {
+                        projectId: null,
+                      },
+                    ],
+                  },
+                ],
               },
-            },
-          })
-        : undefined;
+              include: {
+                Price: true,
+              },
+              orderBy: {
+                projectId: {
+                  sort: "desc",
+                  nulls: "last",
+                },
+              },
+            })
+          : undefined;
 
-      const observation = {
-        ...clickhouseObservation,
-        ...enrichObservationWithModelData(model),
-      };
+        const observation = {
+          ...clickhouseObservation,
+          ...enrichObservationWithModelData(model),
+        };
 
-      if (!observation) {
-        throw new LangfuseNotFoundError(
-          "Observation not found within authorized project",
-        );
-      }
-      return transformDbToApiObservation(observation);
+        if (!observation) {
+          throw new LangfuseNotFoundError(
+            "Observation not found within authorized project",
+          );
+        }
+        return transformDbToApiObservation(observation);
+      },
+    }),
+  },
+  {
+    clickHouseResourceErrorMessage: {
+      GET: LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
     },
-  }),
-});
+  },
+);

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -17,82 +17,85 @@ import {
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
 
-export default withMiddlewares({
-  GET: createAuthedProjectAPIRoute({
-    name: "Get Observation",
-    querySchema: GetObservationV1Query,
-    responseSchema: GetObservationV1Response,
-    fn: async ({ query, auth }) => {
-      // Use events table if query parameter is explicitly set, otherwise use environment variable
-      const useEventsTable =
-        query.useEventsTable !== undefined && query.useEventsTable !== null
-          ? query.useEventsTable === true
-          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
+export default withMiddlewares(
+  {
+    GET: createAuthedProjectAPIRoute({
+      name: "Get Observation",
+      querySchema: GetObservationV1Query,
+      responseSchema: GetObservationV1Response,
+      fn: async ({ query, auth }) => {
+        // Use events table if query parameter is explicitly set, otherwise use environment variable
+        const useEventsTable =
+          query.useEventsTable !== undefined && query.useEventsTable !== null
+            ? query.useEventsTable === true
+            : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
 
-      const clickhouseObservation = useEventsTable
-        ? await getObservationByIdFromEventsTable({
-            id: query.observationId,
-            projectId: auth.scope.projectId,
-            fetchWithInputOutput: true,
-          })
-        : await getObservationById({
-            id: query.observationId,
-            projectId: auth.scope.projectId,
-            fetchWithInputOutput: true,
-            preferredClickhouseService: "ReadOnly",
-          });
+        const clickhouseObservation = useEventsTable
+          ? await getObservationByIdFromEventsTable({
+              id: query.observationId,
+              projectId: auth.scope.projectId,
+              fetchWithInputOutput: true,
+            })
+          : await getObservationById({
+              id: query.observationId,
+              projectId: auth.scope.projectId,
+              fetchWithInputOutput: true,
+              preferredClickhouseService: "ReadOnly",
+            });
 
-      if (!clickhouseObservation) {
-        throw new LangfuseNotFoundError(
-          "Observation not found within authorized project",
-        );
-      }
+        if (!clickhouseObservation) {
+          throw new LangfuseNotFoundError(
+            "Observation not found within authorized project",
+          );
+        }
 
-      const model = clickhouseObservation.internalModelId
-        ? await prisma.model.findFirst({
-            where: {
-              AND: [
-                {
-                  id: clickhouseObservation.internalModelId,
-                },
-                {
-                  OR: [
-                    {
-                      projectId: auth.scope.projectId,
-                    },
-                    {
-                      projectId: null,
-                    },
-                  ],
-                },
-              ],
-            },
-            include: {
-              Price: true,
-            },
-            orderBy: {
-              projectId: {
-                sort: "desc",
-                nulls: "last",
+        const model = clickhouseObservation.internalModelId
+          ? await prisma.model.findFirst({
+              where: {
+                AND: [
+                  {
+                    id: clickhouseObservation.internalModelId,
+                  },
+                  {
+                    OR: [
+                      {
+                        projectId: auth.scope.projectId,
+                      },
+                      {
+                        projectId: null,
+                      },
+                    ],
+                  },
+                ],
               },
-            },
-          })
-        : undefined;
+              include: {
+                Price: true,
+              },
+              orderBy: {
+                projectId: {
+                  sort: "desc",
+                  nulls: "last",
+                },
+              },
+            })
+          : undefined;
 
-      const observation = {
-        ...clickhouseObservation,
-        ...enrichObservationWithModelData(model),
-      };
+        const observation = {
+          ...clickhouseObservation,
+          ...enrichObservationWithModelData(model),
+        };
 
-      if (!observation) {
-        throw new LangfuseNotFoundError(
-          "Observation not found within authorized project",
-        );
-      }
-      return transformDbToApiObservation(observation);
-    },
-  }),
-}, {
-  clickHouseResourceErrorMessage:
-    LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
-});
+        if (!observation) {
+          throw new LangfuseNotFoundError(
+            "Observation not found within authorized project",
+          );
+        }
+        return transformDbToApiObservation(observation);
+      },
+    }),
+  },
+  {
+    clickHouseResourceErrorMessage:
+      LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  },
+);

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -17,86 +17,79 @@ import {
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
 
-export default withMiddlewares(
-  {
-    GET: createAuthedProjectAPIRoute({
-      name: "Get Observation",
-      querySchema: GetObservationV1Query,
-      responseSchema: GetObservationV1Response,
-      fn: async ({ query, auth }) => {
-        // Use events table if query parameter is explicitly set, otherwise use environment variable
-        const useEventsTable =
-          query.useEventsTable !== undefined && query.useEventsTable !== null
-            ? query.useEventsTable === true
-            : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
+export default withMiddlewares({
+  GET: createAuthedProjectAPIRoute({
+    name: "Get Observation",
+    querySchema: GetObservationV1Query,
+    responseSchema: GetObservationV1Response,
+    fn: async ({ query, auth }) => {
+      // Use events table if query parameter is explicitly set, otherwise use environment variable
+      const useEventsTable =
+        query.useEventsTable !== undefined && query.useEventsTable !== null
+          ? query.useEventsTable === true
+          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
 
-        const clickhouseObservation = useEventsTable
-          ? await getObservationByIdFromEventsTable({
-              id: query.observationId,
-              projectId: auth.scope.projectId,
-              fetchWithInputOutput: true,
-            })
-          : await getObservationById({
-              id: query.observationId,
-              projectId: auth.scope.projectId,
-              fetchWithInputOutput: true,
-              preferredClickhouseService: "ReadOnly",
-            });
+      const clickhouseObservation = useEventsTable
+        ? await getObservationByIdFromEventsTable({
+            id: query.observationId,
+            projectId: auth.scope.projectId,
+            fetchWithInputOutput: true,
+          })
+        : await getObservationById({
+            id: query.observationId,
+            projectId: auth.scope.projectId,
+            fetchWithInputOutput: true,
+            preferredClickhouseService: "ReadOnly",
+          });
 
-        if (!clickhouseObservation) {
-          throw new LangfuseNotFoundError(
-            "Observation not found within authorized project",
-          );
-        }
+      if (!clickhouseObservation) {
+        throw new LangfuseNotFoundError(
+          "Observation not found within authorized project",
+        );
+      }
 
-        const model = clickhouseObservation.internalModelId
-          ? await prisma.model.findFirst({
-              where: {
-                AND: [
-                  {
-                    id: clickhouseObservation.internalModelId,
-                  },
-                  {
-                    OR: [
-                      {
-                        projectId: auth.scope.projectId,
-                      },
-                      {
-                        projectId: null,
-                      },
-                    ],
-                  },
-                ],
-              },
-              include: {
-                Price: true,
-              },
-              orderBy: {
-                projectId: {
-                  sort: "desc",
-                  nulls: "last",
+      const model = clickhouseObservation.internalModelId
+        ? await prisma.model.findFirst({
+            where: {
+              AND: [
+                {
+                  id: clickhouseObservation.internalModelId,
                 },
+                {
+                  OR: [
+                    {
+                      projectId: auth.scope.projectId,
+                    },
+                    {
+                      projectId: null,
+                    },
+                  ],
+                },
+              ],
+            },
+            include: {
+              Price: true,
+            },
+            orderBy: {
+              projectId: {
+                sort: "desc",
+                nulls: "last",
               },
-            })
-          : undefined;
+            },
+          })
+        : undefined;
 
-        const observation = {
-          ...clickhouseObservation,
-          ...enrichObservationWithModelData(model),
-        };
+      const observation = {
+        ...clickhouseObservation,
+        ...enrichObservationWithModelData(model),
+      };
 
-        if (!observation) {
-          throw new LangfuseNotFoundError(
-            "Observation not found within authorized project",
-          );
-        }
-        return transformDbToApiObservation(observation);
-      },
-    }),
-  },
-  {
-    clickHouseResourceErrorMessage: {
-      GET: LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+      if (!observation) {
+        throw new LangfuseNotFoundError(
+          "Observation not found within authorized project",
+        );
+      }
+      return transformDbToApiObservation(observation);
     },
-  },
-);
+  }),
+}, LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE);

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -21,110 +21,116 @@ import {
   getObservationsCountForPublicApi,
 } from "@/src/features/public-api/server/observations";
 
-export default withMiddlewares({
-  GET: createAuthedProjectAPIRoute({
-    name: "Get Observations",
-    querySchema: GetObservationsV1Query,
-    responseSchema: GetObservationsV1Response,
-    fn: async ({ query, auth }) => {
-      const filterProps = {
-        projectId: auth.scope.projectId,
-        page: query.page,
-        limit: query.limit,
-        traceId: query.traceId ?? undefined,
-        userId: query.userId ?? undefined,
-        level: query.level ?? undefined,
-        name: query.name ?? undefined,
-        type: query.type ?? undefined,
-        environment: query.environment ?? undefined,
-        parentObservationId: query.parentObservationId ?? undefined,
-        fromStartTime: query.fromStartTime ?? undefined,
-        toStartTime: query.toStartTime ?? undefined,
-        version: query.version ?? undefined,
-        advancedFilters: query.filter,
-      };
+export default withMiddlewares(
+  {
+    GET: createAuthedProjectAPIRoute({
+      name: "Get Observations",
+      querySchema: GetObservationsV1Query,
+      responseSchema: GetObservationsV1Response,
+      fn: async ({ query, auth }) => {
+        const filterProps = {
+          projectId: auth.scope.projectId,
+          page: query.page,
+          limit: query.limit,
+          traceId: query.traceId ?? undefined,
+          userId: query.userId ?? undefined,
+          level: query.level ?? undefined,
+          name: query.name ?? undefined,
+          type: query.type ?? undefined,
+          environment: query.environment ?? undefined,
+          parentObservationId: query.parentObservationId ?? undefined,
+          fromStartTime: query.fromStartTime ?? undefined,
+          toStartTime: query.toStartTime ?? undefined,
+          version: query.version ?? undefined,
+          advancedFilters: query.filter,
+        };
 
-      // Use events table if query parameter is explicitly set, otherwise use environment variable
-      const useEventsTable =
-        query.useEventsTable !== undefined && query.useEventsTable !== null
-          ? query.useEventsTable === true
-          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
+        // Use events table if query parameter is explicitly set, otherwise use environment variable
+        const useEventsTable =
+          query.useEventsTable !== undefined && query.useEventsTable !== null
+            ? query.useEventsTable === true
+            : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
 
-      if (useEventsTable) {
+        if (useEventsTable) {
+          const [items, count] = await Promise.all([
+            getObservationsFromEventsTableForPublicApi(filterProps),
+            getObservationsCountFromEventsTableForPublicApi(filterProps),
+          ]);
+
+          return {
+            data: items.map(transformDbToApiObservation),
+            meta: {
+              page: query.page,
+              limit: query.limit,
+              totalItems: count,
+              totalPages: Math.ceil(count / query.limit),
+            },
+          };
+        }
+
+        // Legacy code path using observations table
         const [items, count] = await Promise.all([
-          getObservationsFromEventsTableForPublicApi(filterProps),
-          getObservationsCountFromEventsTableForPublicApi(filterProps),
+          generateObservationsForPublicApi(filterProps),
+          getObservationsCountForPublicApi(filterProps),
         ]);
+        const uniqueModels: string[] = Array.from(
+          new Set(
+            items
+              .map((r) => r.internalModelId)
+              .filter((r): r is string => Boolean(r)),
+          ),
+        );
+
+        const models =
+          uniqueModels.length > 0
+            ? await prisma.model.findMany({
+                where: {
+                  id: {
+                    in: uniqueModels,
+                  },
+                  OR: [
+                    { projectId: auth.scope.projectId },
+                    { projectId: null },
+                  ],
+                },
+                include: {
+                  Price: true,
+                },
+              })
+            : [];
+        const finalCount = count ? count : 0;
 
         return {
-          data: items.map(transformDbToApiObservation),
+          data: items
+            .map((i) => {
+              const model = models.find((m) => m.id === i.internalModelId);
+              return {
+                ...i,
+                modelId: model?.id ?? null,
+                inputPrice:
+                  model?.Price?.find((m) => m.usageType === "input")?.price ??
+                  null,
+                outputPrice:
+                  model?.Price?.find((m) => m.usageType === "output")?.price ??
+                  null,
+                totalPrice:
+                  model?.Price?.find((m) => m.usageType === "total")?.price ??
+                  null,
+              };
+            })
+            .map(transformDbToApiObservation),
           meta: {
             page: query.page,
             limit: query.limit,
-            totalItems: count,
-            totalPages: Math.ceil(count / query.limit),
+            totalItems: finalCount,
+            totalPages: Math.ceil(finalCount / query.limit),
           },
         };
-      }
-
-      // Legacy code path using observations table
-      const [items, count] = await Promise.all([
-        generateObservationsForPublicApi(filterProps),
-        getObservationsCountForPublicApi(filterProps),
-      ]);
-      const uniqueModels: string[] = Array.from(
-        new Set(
-          items
-            .map((r) => r.internalModelId)
-            .filter((r): r is string => Boolean(r)),
-        ),
-      );
-
-      const models =
-        uniqueModels.length > 0
-          ? await prisma.model.findMany({
-              where: {
-                id: {
-                  in: uniqueModels,
-                },
-                OR: [{ projectId: auth.scope.projectId }, { projectId: null }],
-              },
-              include: {
-                Price: true,
-              },
-            })
-          : [];
-      const finalCount = count ? count : 0;
-
-      return {
-        data: items
-          .map((i) => {
-            const model = models.find((m) => m.id === i.internalModelId);
-            return {
-              ...i,
-              modelId: model?.id ?? null,
-              inputPrice:
-                model?.Price?.find((m) => m.usageType === "input")?.price ??
-                null,
-              outputPrice:
-                model?.Price?.find((m) => m.usageType === "output")?.price ??
-                null,
-              totalPrice:
-                model?.Price?.find((m) => m.usageType === "total")?.price ??
-                null,
-            };
-          })
-          .map(transformDbToApiObservation),
-        meta: {
-          page: query.page,
-          limit: query.limit,
-          totalItems: finalCount,
-          totalPages: Math.ceil(finalCount / query.limit),
-        },
-      };
-    },
-  }),
-}, {
-  clickHouseResourceErrorMessage:
-    LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
-});
+      },
+    }),
+  },
+  {
+    clickHouseResourceErrorMessage:
+      LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  },
+);

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -21,117 +21,107 @@ import {
   getObservationsCountForPublicApi,
 } from "@/src/features/public-api/server/observations";
 
-export default withMiddlewares(
-  {
-    GET: createAuthedProjectAPIRoute({
-      name: "Get Observations",
-      querySchema: GetObservationsV1Query,
-      responseSchema: GetObservationsV1Response,
-      fn: async ({ query, auth }) => {
-        const filterProps = {
-          projectId: auth.scope.projectId,
-          page: query.page,
-          limit: query.limit,
-          traceId: query.traceId ?? undefined,
-          userId: query.userId ?? undefined,
-          level: query.level ?? undefined,
-          name: query.name ?? undefined,
-          type: query.type ?? undefined,
-          environment: query.environment ?? undefined,
-          parentObservationId: query.parentObservationId ?? undefined,
-          fromStartTime: query.fromStartTime ?? undefined,
-          toStartTime: query.toStartTime ?? undefined,
-          version: query.version ?? undefined,
-          advancedFilters: query.filter,
-        };
+export default withMiddlewares({
+  GET: createAuthedProjectAPIRoute({
+    name: "Get Observations",
+    querySchema: GetObservationsV1Query,
+    responseSchema: GetObservationsV1Response,
+    fn: async ({ query, auth }) => {
+      const filterProps = {
+        projectId: auth.scope.projectId,
+        page: query.page,
+        limit: query.limit,
+        traceId: query.traceId ?? undefined,
+        userId: query.userId ?? undefined,
+        level: query.level ?? undefined,
+        name: query.name ?? undefined,
+        type: query.type ?? undefined,
+        environment: query.environment ?? undefined,
+        parentObservationId: query.parentObservationId ?? undefined,
+        fromStartTime: query.fromStartTime ?? undefined,
+        toStartTime: query.toStartTime ?? undefined,
+        version: query.version ?? undefined,
+        advancedFilters: query.filter,
+      };
 
-        // Use events table if query parameter is explicitly set, otherwise use environment variable
-        const useEventsTable =
-          query.useEventsTable !== undefined && query.useEventsTable !== null
-            ? query.useEventsTable === true
-            : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
+      // Use events table if query parameter is explicitly set, otherwise use environment variable
+      const useEventsTable =
+        query.useEventsTable !== undefined && query.useEventsTable !== null
+          ? query.useEventsTable === true
+          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
 
-        if (useEventsTable) {
-          const [items, count] = await Promise.all([
-            getObservationsFromEventsTableForPublicApi(filterProps),
-            getObservationsCountFromEventsTableForPublicApi(filterProps),
-          ]);
-
-          return {
-            data: items.map(transformDbToApiObservation),
-            meta: {
-              page: query.page,
-              limit: query.limit,
-              totalItems: count,
-              totalPages: Math.ceil(count / query.limit),
-            },
-          };
-        }
-
-        // Legacy code path using observations table
+      if (useEventsTable) {
         const [items, count] = await Promise.all([
-          generateObservationsForPublicApi(filterProps),
-          getObservationsCountForPublicApi(filterProps),
+          getObservationsFromEventsTableForPublicApi(filterProps),
+          getObservationsCountFromEventsTableForPublicApi(filterProps),
         ]);
-        const uniqueModels: string[] = Array.from(
-          new Set(
-            items
-              .map((r) => r.internalModelId)
-              .filter((r): r is string => Boolean(r)),
-          ),
-        );
-
-        const models =
-          uniqueModels.length > 0
-            ? await prisma.model.findMany({
-                where: {
-                  id: {
-                    in: uniqueModels,
-                  },
-                  OR: [
-                    { projectId: auth.scope.projectId },
-                    { projectId: null },
-                  ],
-                },
-                include: {
-                  Price: true,
-                },
-              })
-            : [];
-        const finalCount = count ? count : 0;
 
         return {
-          data: items
-            .map((i) => {
-              const model = models.find((m) => m.id === i.internalModelId);
-              return {
-                ...i,
-                modelId: model?.id ?? null,
-                inputPrice:
-                  model?.Price?.find((m) => m.usageType === "input")?.price ??
-                  null,
-                outputPrice:
-                  model?.Price?.find((m) => m.usageType === "output")?.price ??
-                  null,
-                totalPrice:
-                  model?.Price?.find((m) => m.usageType === "total")?.price ??
-                  null,
-              };
-            })
-            .map(transformDbToApiObservation),
+          data: items.map(transformDbToApiObservation),
           meta: {
             page: query.page,
             limit: query.limit,
-            totalItems: finalCount,
-            totalPages: Math.ceil(finalCount / query.limit),
+            totalItems: count,
+            totalPages: Math.ceil(count / query.limit),
           },
         };
-      },
-    }),
-  },
-  {
-    clickHouseResourceErrorMessage: {
-      GET: LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+      }
+
+      // Legacy code path using observations table
+      const [items, count] = await Promise.all([
+        generateObservationsForPublicApi(filterProps),
+        getObservationsCountForPublicApi(filterProps),
+      ]);
+      const uniqueModels: string[] = Array.from(
+        new Set(
+          items
+            .map((r) => r.internalModelId)
+            .filter((r): r is string => Boolean(r)),
+        ),
+      );
+
+      const models =
+        uniqueModels.length > 0
+          ? await prisma.model.findMany({
+              where: {
+                id: {
+                  in: uniqueModels,
+                },
+                OR: [{ projectId: auth.scope.projectId }, { projectId: null }],
+              },
+              include: {
+                Price: true,
+              },
+            })
+          : [];
+      const finalCount = count ? count : 0;
+
+      return {
+        data: items
+          .map((i) => {
+            const model = models.find((m) => m.id === i.internalModelId);
+            return {
+              ...i,
+              modelId: model?.id ?? null,
+              inputPrice:
+                model?.Price?.find((m) => m.usageType === "input")?.price ??
+                null,
+              outputPrice:
+                model?.Price?.find((m) => m.usageType === "output")?.price ??
+                null,
+              totalPrice:
+                model?.Price?.find((m) => m.usageType === "total")?.price ??
+                null,
+            };
+          })
+          .map(transformDbToApiObservation),
+        meta: {
+          page: query.page,
+          limit: query.limit,
+          totalItems: finalCount,
+          totalPages: Math.ceil(finalCount / query.limit),
+        },
+      };
     },
-  },
-);
+  }),
+}, LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE);

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -124,4 +124,7 @@ export default withMiddlewares({
       };
     },
   }),
-}, LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE);
+}, {
+  clickHouseResourceErrorMessage:
+    LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+});

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -5,7 +5,10 @@ import {
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
 
-import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import {
+  LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  withMiddlewares,
+} from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 
 import {
@@ -18,107 +21,117 @@ import {
   getObservationsCountForPublicApi,
 } from "@/src/features/public-api/server/observations";
 
-export default withMiddlewares({
-  GET: createAuthedProjectAPIRoute({
-    name: "Get Observations",
-    querySchema: GetObservationsV1Query,
-    responseSchema: GetObservationsV1Response,
-    fn: async ({ query, auth }) => {
-      const filterProps = {
-        projectId: auth.scope.projectId,
-        page: query.page,
-        limit: query.limit,
-        traceId: query.traceId ?? undefined,
-        userId: query.userId ?? undefined,
-        level: query.level ?? undefined,
-        name: query.name ?? undefined,
-        type: query.type ?? undefined,
-        environment: query.environment ?? undefined,
-        parentObservationId: query.parentObservationId ?? undefined,
-        fromStartTime: query.fromStartTime ?? undefined,
-        toStartTime: query.toStartTime ?? undefined,
-        version: query.version ?? undefined,
-        advancedFilters: query.filter,
-      };
+export default withMiddlewares(
+  {
+    GET: createAuthedProjectAPIRoute({
+      name: "Get Observations",
+      querySchema: GetObservationsV1Query,
+      responseSchema: GetObservationsV1Response,
+      fn: async ({ query, auth }) => {
+        const filterProps = {
+          projectId: auth.scope.projectId,
+          page: query.page,
+          limit: query.limit,
+          traceId: query.traceId ?? undefined,
+          userId: query.userId ?? undefined,
+          level: query.level ?? undefined,
+          name: query.name ?? undefined,
+          type: query.type ?? undefined,
+          environment: query.environment ?? undefined,
+          parentObservationId: query.parentObservationId ?? undefined,
+          fromStartTime: query.fromStartTime ?? undefined,
+          toStartTime: query.toStartTime ?? undefined,
+          version: query.version ?? undefined,
+          advancedFilters: query.filter,
+        };
 
-      // Use events table if query parameter is explicitly set, otherwise use environment variable
-      const useEventsTable =
-        query.useEventsTable !== undefined && query.useEventsTable !== null
-          ? query.useEventsTable === true
-          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
+        // Use events table if query parameter is explicitly set, otherwise use environment variable
+        const useEventsTable =
+          query.useEventsTable !== undefined && query.useEventsTable !== null
+            ? query.useEventsTable === true
+            : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
 
-      if (useEventsTable) {
+        if (useEventsTable) {
+          const [items, count] = await Promise.all([
+            getObservationsFromEventsTableForPublicApi(filterProps),
+            getObservationsCountFromEventsTableForPublicApi(filterProps),
+          ]);
+
+          return {
+            data: items.map(transformDbToApiObservation),
+            meta: {
+              page: query.page,
+              limit: query.limit,
+              totalItems: count,
+              totalPages: Math.ceil(count / query.limit),
+            },
+          };
+        }
+
+        // Legacy code path using observations table
         const [items, count] = await Promise.all([
-          getObservationsFromEventsTableForPublicApi(filterProps),
-          getObservationsCountFromEventsTableForPublicApi(filterProps),
+          generateObservationsForPublicApi(filterProps),
+          getObservationsCountForPublicApi(filterProps),
         ]);
+        const uniqueModels: string[] = Array.from(
+          new Set(
+            items
+              .map((r) => r.internalModelId)
+              .filter((r): r is string => Boolean(r)),
+          ),
+        );
+
+        const models =
+          uniqueModels.length > 0
+            ? await prisma.model.findMany({
+                where: {
+                  id: {
+                    in: uniqueModels,
+                  },
+                  OR: [
+                    { projectId: auth.scope.projectId },
+                    { projectId: null },
+                  ],
+                },
+                include: {
+                  Price: true,
+                },
+              })
+            : [];
+        const finalCount = count ? count : 0;
 
         return {
-          data: items.map(transformDbToApiObservation),
+          data: items
+            .map((i) => {
+              const model = models.find((m) => m.id === i.internalModelId);
+              return {
+                ...i,
+                modelId: model?.id ?? null,
+                inputPrice:
+                  model?.Price?.find((m) => m.usageType === "input")?.price ??
+                  null,
+                outputPrice:
+                  model?.Price?.find((m) => m.usageType === "output")?.price ??
+                  null,
+                totalPrice:
+                  model?.Price?.find((m) => m.usageType === "total")?.price ??
+                  null,
+              };
+            })
+            .map(transformDbToApiObservation),
           meta: {
             page: query.page,
             limit: query.limit,
-            totalItems: count,
-            totalPages: Math.ceil(count / query.limit),
+            totalItems: finalCount,
+            totalPages: Math.ceil(finalCount / query.limit),
           },
         };
-      }
-
-      // Legacy code path using observations table
-      const [items, count] = await Promise.all([
-        generateObservationsForPublicApi(filterProps),
-        getObservationsCountForPublicApi(filterProps),
-      ]);
-      const uniqueModels: string[] = Array.from(
-        new Set(
-          items
-            .map((r) => r.internalModelId)
-            .filter((r): r is string => Boolean(r)),
-        ),
-      );
-
-      const models =
-        uniqueModels.length > 0
-          ? await prisma.model.findMany({
-              where: {
-                id: {
-                  in: uniqueModels,
-                },
-                OR: [{ projectId: auth.scope.projectId }, { projectId: null }],
-              },
-              include: {
-                Price: true,
-              },
-            })
-          : [];
-      const finalCount = count ? count : 0;
-
-      return {
-        data: items
-          .map((i) => {
-            const model = models.find((m) => m.id === i.internalModelId);
-            return {
-              ...i,
-              modelId: model?.id ?? null,
-              inputPrice:
-                model?.Price?.find((m) => m.usageType === "input")?.price ??
-                null,
-              outputPrice:
-                model?.Price?.find((m) => m.usageType === "output")?.price ??
-                null,
-              totalPrice:
-                model?.Price?.find((m) => m.usageType === "total")?.price ??
-                null,
-            };
-          })
-          .map(transformDbToApiObservation),
-        meta: {
-          page: query.page,
-          limit: query.limit,
-          totalItems: finalCount,
-          totalPages: Math.ceil(finalCount / query.limit),
-        },
-      };
+      },
+    }),
+  },
+  {
+    clickHouseResourceErrorMessage: {
+      GET: LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
     },
-  }),
-});
+  },
+);

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -28,183 +28,191 @@ import {
 import Decimal from "decimal.js";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 
-export default withMiddlewares({
-  GET: createAuthedProjectAPIRoute({
-    name: "Get Single Trace",
-    querySchema: GetTraceV1Query,
-    responseSchema: GetTraceV1Response,
-    fn: async ({ query, auth }) => {
-      const { traceId } = query;
+export default withMiddlewares(
+  {
+    GET: createAuthedProjectAPIRoute({
+      name: "Get Single Trace",
+      querySchema: GetTraceV1Query,
+      responseSchema: GetTraceV1Response,
+      fn: async ({ query, auth }) => {
+        const { traceId } = query;
 
-      let effectiveFields: readonly TraceFieldGroup[] =
-        query.fields ?? TRACE_FIELD_GROUPS;
-      if (!query.fields && env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS) {
-        const parsed = env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS.split(",")
-          .map((f) => f.trim())
-          .filter((f): f is TraceFieldGroup =>
-            TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
-          );
-        if (parsed.length > 0) {
-          effectiveFields = parsed;
+        let effectiveFields: readonly TraceFieldGroup[] =
+          query.fields ?? TRACE_FIELD_GROUPS;
+        if (!query.fields && env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS) {
+          const parsed = env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS.split(",")
+            .map((f) => f.trim())
+            .filter((f): f is TraceFieldGroup =>
+              TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
+            );
+          if (parsed.length > 0) {
+            effectiveFields = parsed;
+          }
         }
-      }
-      const requestedFields = effectiveFields;
-      const includeIO = requestedFields.includes("io");
-      const includeObservations = requestedFields.includes("observations");
-      const includeScores = requestedFields.includes("scores");
-      const includeMetrics = requestedFields.includes("metrics");
+        const requestedFields = effectiveFields;
+        const includeIO = requestedFields.includes("io");
+        const includeObservations = requestedFields.includes("observations");
+        const includeScores = requestedFields.includes("scores");
+        const includeMetrics = requestedFields.includes("metrics");
 
-      const trace = await getTraceById({
-        traceId,
-        projectId: auth.scope.projectId,
-        clickhouseFeatureTag: "tracing-public-api",
-        preferredClickhouseService: "ReadOnly",
-        excludeInputOutput: !includeIO,
-        excludeMetadata: !includeIO,
-      });
+        const trace = await getTraceById({
+          traceId,
+          projectId: auth.scope.projectId,
+          clickhouseFeatureTag: "tracing-public-api",
+          preferredClickhouseService: "ReadOnly",
+          excludeInputOutput: !includeIO,
+          excludeMetadata: !includeIO,
+        });
 
-      if (!trace) {
-        throw new LangfuseNotFoundError(
-          `Trace ${traceId} not found within authorized project`,
+        if (!trace) {
+          throw new LangfuseNotFoundError(
+            `Trace ${traceId} not found within authorized project`,
+          );
+        }
+
+        const [observations, scores] = await Promise.all([
+          includeObservations || includeMetrics
+            ? getObservationsForTrace({
+                traceId,
+                projectId: auth.scope.projectId,
+                timestamp: trace?.timestamp,
+                includeIO: includeObservations,
+                preferredClickhouseService: "ReadOnly",
+              })
+            : Promise.resolve([]),
+          includeScores
+            ? getScoresForTraces({
+                projectId: auth.scope.projectId,
+                traceIds: [traceId],
+                timestamp: trace?.timestamp,
+                preferredClickhouseService: "ReadOnly",
+              })
+            : Promise.resolve([]),
+        ]);
+
+        const uniqueModels: string[] = Array.from(
+          new Set(
+            observations
+              .map((r) => r.internalModelId)
+              .filter((r): r is string => Boolean(r)),
+          ),
         );
-      }
 
-      const [observations, scores] = await Promise.all([
-        includeObservations || includeMetrics
-          ? getObservationsForTrace({
-              traceId,
-              projectId: auth.scope.projectId,
-              timestamp: trace?.timestamp,
-              includeIO: includeObservations,
-              preferredClickhouseService: "ReadOnly",
-            })
-          : Promise.resolve([]),
-        includeScores
-          ? getScoresForTraces({
-              projectId: auth.scope.projectId,
-              traceIds: [traceId],
-              timestamp: trace?.timestamp,
-              preferredClickhouseService: "ReadOnly",
-            })
-          : Promise.resolve([]),
-      ]);
-
-      const uniqueModels: string[] = Array.from(
-        new Set(
-          observations
-            .map((r) => r.internalModelId)
-            .filter((r): r is string => Boolean(r)),
-        ),
-      );
-
-      const models =
-        uniqueModels.length > 0
-          ? await prisma.model.findMany({
-              where: {
-                id: {
-                  in: uniqueModels,
+        const models =
+          uniqueModels.length > 0
+            ? await prisma.model.findMany({
+                where: {
+                  id: {
+                    in: uniqueModels,
+                  },
+                  OR: [
+                    { projectId: auth.scope.projectId },
+                    { projectId: null },
+                  ],
                 },
-                OR: [{ projectId: auth.scope.projectId }, { projectId: null }],
-              },
-              include: {
-                Price: true,
-              },
-            })
-          : [];
+                include: {
+                  Price: true,
+                },
+              })
+            : [];
 
-      const observationsView = observations.map((o) => {
-        const model = models.find((m) => m.id === o.internalModelId);
-        const inputPrice =
-          model?.Price.find((p) => p.usageType === "input")?.price ??
-          new Decimal(0);
-        const outputPrice =
-          model?.Price.find((p) => p.usageType === "output")?.price ??
-          new Decimal(0);
-        const totalPrice =
-          model?.Price.find((p) => p.usageType === "total")?.price ??
-          new Decimal(0);
-        return {
-          ...o,
-          inputPrice,
-          outputPrice,
-          totalPrice,
-        };
-      });
+        const observationsView = observations.map((o) => {
+          const model = models.find((m) => m.id === o.internalModelId);
+          const inputPrice =
+            model?.Price.find((p) => p.usageType === "input")?.price ??
+            new Decimal(0);
+          const outputPrice =
+            model?.Price.find((p) => p.usageType === "output")?.price ??
+            new Decimal(0);
+          const totalPrice =
+            model?.Price.find((p) => p.usageType === "total")?.price ??
+            new Decimal(0);
+          return {
+            ...o,
+            inputPrice,
+            outputPrice,
+            totalPrice,
+          };
+        });
 
-      const outObservations = observationsView.map(transformDbToApiObservation);
-      // As these are traces scores, we expect all scores to have a traceId set
-      // For type consistency, we validate the scores against the v1 schema which requires a traceId
-      const validatedScores = filterAndValidateDbLegacyTraceScoreList({
-        scores,
-        onParseError: traceException,
-      });
+        const outObservations = observationsView.map(
+          transformDbToApiObservation,
+        );
+        // As these are traces scores, we expect all scores to have a traceId set
+        // For type consistency, we validate the scores against the v1 schema which requires a traceId
+        const validatedScores = filterAndValidateDbLegacyTraceScoreList({
+          scores,
+          onParseError: traceException,
+        });
 
-      const obsStartTimes = observations
-        .map((o) => o.startTime)
-        .sort((a, b) => a.getTime() - b.getTime());
-      const obsEndTimes = observations
-        .map((o) => o.endTime)
-        .filter((t) => t)
-        .sort((a, b) => (a as Date).getTime() - (b as Date).getTime());
+        const obsStartTimes = observations
+          .map((o) => o.startTime)
+          .sort((a, b) => a.getTime() - b.getTime());
+        const obsEndTimes = observations
+          .map((o) => o.endTime)
+          .filter((t) => t)
+          .sort((a, b) => (a as Date).getTime() - (b as Date).getTime());
 
-      const latencyMs =
-        obsStartTimes.length > 0
-          ? obsEndTimes.length > 0
-            ? (obsEndTimes[obsEndTimes.length - 1] as Date).getTime() -
-              obsStartTimes[0]!.getTime()
-            : obsStartTimes.length > 1
-              ? obsStartTimes[obsStartTimes.length - 1]!.getTime() -
+        const latencyMs =
+          obsStartTimes.length > 0
+            ? obsEndTimes.length > 0
+              ? (obsEndTimes[obsEndTimes.length - 1] as Date).getTime() -
                 obsStartTimes[0]!.getTime()
-              : undefined
-          : undefined;
-      return {
-        ...trace,
-        externalId: null,
-        metadata: includeIO ? trace.metadata : {},
-        scores: includeScores ? validatedScores : [],
-        latency: includeMetrics
-          ? latencyMs !== undefined
-            ? latencyMs / 1000
-            : 0
-          : -1,
-        observations: includeObservations ? outObservations : [],
-        htmlPath: `/project/${auth.scope.projectId}/traces/${traceId}`,
-        totalCost: includeMetrics
-          ? outObservations
-              .reduce(
-                (acc, obs) =>
-                  acc.add(obs.calculatedTotalCost ?? new Decimal(0)),
-                new Decimal(0),
-              )
-              .toNumber()
-          : -1,
-      };
-    },
-  }),
+              : obsStartTimes.length > 1
+                ? obsStartTimes[obsStartTimes.length - 1]!.getTime() -
+                  obsStartTimes[0]!.getTime()
+                : undefined
+            : undefined;
+        return {
+          ...trace,
+          externalId: null,
+          metadata: includeIO ? trace.metadata : {},
+          scores: includeScores ? validatedScores : [],
+          latency: includeMetrics
+            ? latencyMs !== undefined
+              ? latencyMs / 1000
+              : 0
+            : -1,
+          observations: includeObservations ? outObservations : [],
+          htmlPath: `/project/${auth.scope.projectId}/traces/${traceId}`,
+          totalCost: includeMetrics
+            ? outObservations
+                .reduce(
+                  (acc, obs) =>
+                    acc.add(obs.calculatedTotalCost ?? new Decimal(0)),
+                  new Decimal(0),
+                )
+                .toNumber()
+            : -1,
+        };
+      },
+    }),
 
-  DELETE: createAuthedProjectAPIRoute({
-    name: "Delete Single Trace",
-    querySchema: DeleteTraceV1Query,
-    responseSchema: DeleteTraceV1Response,
-    rateLimitResource: "trace-delete",
-    fn: async ({ query, auth }) => {
-      const { traceId } = query;
+    DELETE: createAuthedProjectAPIRoute({
+      name: "Delete Single Trace",
+      querySchema: DeleteTraceV1Query,
+      responseSchema: DeleteTraceV1Response,
+      rateLimitResource: "trace-delete",
+      fn: async ({ query, auth }) => {
+        const { traceId } = query;
 
-      await auditLog({
-        resourceType: "trace",
-        resourceId: traceId,
-        action: "delete",
-        projectId: auth.scope.projectId,
-        apiKeyId: auth.scope.apiKeyId,
-        orgId: auth.scope.orgId,
-      });
+        await auditLog({
+          resourceType: "trace",
+          resourceId: traceId,
+          action: "delete",
+          projectId: auth.scope.projectId,
+          apiKeyId: auth.scope.apiKeyId,
+          orgId: auth.scope.orgId,
+        });
 
-      await traceDeletionProcessor(auth.scope.projectId, [traceId]);
+        await traceDeletionProcessor(auth.scope.projectId, [traceId]);
 
-      return { message: "Trace deleted successfully" };
-    },
-  }),
-}, {
-  clickHouseResourceErrorMessage:
-    LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
-});
+        return { message: "Trace deleted successfully" };
+      },
+    }),
+  },
+  {
+    clickHouseResourceErrorMessage:
+      LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  },
+);

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -204,4 +204,7 @@ export default withMiddlewares({
       return { message: "Trace deleted successfully" };
     },
   }),
-}, LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE);
+}, {
+  clickHouseResourceErrorMessage:
+    LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+});

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -1,5 +1,8 @@
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
-import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import {
+  LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  withMiddlewares,
+} from "@/src/features/public-api/server/withMiddlewares";
 import { transformDbToApiObservation } from "@/src/features/public-api/types/observations";
 import {
   GetTraceV1Query,
@@ -25,180 +28,192 @@ import {
 import Decimal from "decimal.js";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 
-export default withMiddlewares({
-  GET: createAuthedProjectAPIRoute({
-    name: "Get Single Trace",
-    querySchema: GetTraceV1Query,
-    responseSchema: GetTraceV1Response,
-    fn: async ({ query, auth }) => {
-      const { traceId } = query;
+export default withMiddlewares(
+  {
+    GET: createAuthedProjectAPIRoute({
+      name: "Get Single Trace",
+      querySchema: GetTraceV1Query,
+      responseSchema: GetTraceV1Response,
+      fn: async ({ query, auth }) => {
+        const { traceId } = query;
 
-      let effectiveFields: readonly TraceFieldGroup[] =
-        query.fields ?? TRACE_FIELD_GROUPS;
-      if (!query.fields && env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS) {
-        const parsed = env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS.split(",")
-          .map((f) => f.trim())
-          .filter((f): f is TraceFieldGroup =>
-            TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
-          );
-        if (parsed.length > 0) {
-          effectiveFields = parsed;
+        let effectiveFields: readonly TraceFieldGroup[] =
+          query.fields ?? TRACE_FIELD_GROUPS;
+        if (!query.fields && env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS) {
+          const parsed = env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS.split(",")
+            .map((f) => f.trim())
+            .filter((f): f is TraceFieldGroup =>
+              TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
+            );
+          if (parsed.length > 0) {
+            effectiveFields = parsed;
+          }
         }
-      }
-      const requestedFields = effectiveFields;
-      const includeIO = requestedFields.includes("io");
-      const includeObservations = requestedFields.includes("observations");
-      const includeScores = requestedFields.includes("scores");
-      const includeMetrics = requestedFields.includes("metrics");
+        const requestedFields = effectiveFields;
+        const includeIO = requestedFields.includes("io");
+        const includeObservations = requestedFields.includes("observations");
+        const includeScores = requestedFields.includes("scores");
+        const includeMetrics = requestedFields.includes("metrics");
 
-      const trace = await getTraceById({
-        traceId,
-        projectId: auth.scope.projectId,
-        clickhouseFeatureTag: "tracing-public-api",
-        preferredClickhouseService: "ReadOnly",
-        excludeInputOutput: !includeIO,
-        excludeMetadata: !includeIO,
-      });
+        const trace = await getTraceById({
+          traceId,
+          projectId: auth.scope.projectId,
+          clickhouseFeatureTag: "tracing-public-api",
+          preferredClickhouseService: "ReadOnly",
+          excludeInputOutput: !includeIO,
+          excludeMetadata: !includeIO,
+        });
 
-      if (!trace) {
-        throw new LangfuseNotFoundError(
-          `Trace ${traceId} not found within authorized project`,
+        if (!trace) {
+          throw new LangfuseNotFoundError(
+            `Trace ${traceId} not found within authorized project`,
+          );
+        }
+
+        const [observations, scores] = await Promise.all([
+          includeObservations || includeMetrics
+            ? getObservationsForTrace({
+                traceId,
+                projectId: auth.scope.projectId,
+                timestamp: trace?.timestamp,
+                includeIO: includeObservations,
+                preferredClickhouseService: "ReadOnly",
+              })
+            : Promise.resolve([]),
+          includeScores
+            ? getScoresForTraces({
+                projectId: auth.scope.projectId,
+                traceIds: [traceId],
+                timestamp: trace?.timestamp,
+                preferredClickhouseService: "ReadOnly",
+              })
+            : Promise.resolve([]),
+        ]);
+
+        const uniqueModels: string[] = Array.from(
+          new Set(
+            observations
+              .map((r) => r.internalModelId)
+              .filter((r): r is string => Boolean(r)),
+          ),
         );
-      }
 
-      const [observations, scores] = await Promise.all([
-        includeObservations || includeMetrics
-          ? getObservationsForTrace({
-              traceId,
-              projectId: auth.scope.projectId,
-              timestamp: trace?.timestamp,
-              includeIO: includeObservations,
-              preferredClickhouseService: "ReadOnly",
-            })
-          : Promise.resolve([]),
-        includeScores
-          ? getScoresForTraces({
-              projectId: auth.scope.projectId,
-              traceIds: [traceId],
-              timestamp: trace?.timestamp,
-              preferredClickhouseService: "ReadOnly",
-            })
-          : Promise.resolve([]),
-      ]);
-
-      const uniqueModels: string[] = Array.from(
-        new Set(
-          observations
-            .map((r) => r.internalModelId)
-            .filter((r): r is string => Boolean(r)),
-        ),
-      );
-
-      const models =
-        uniqueModels.length > 0
-          ? await prisma.model.findMany({
-              where: {
-                id: {
-                  in: uniqueModels,
+        const models =
+          uniqueModels.length > 0
+            ? await prisma.model.findMany({
+                where: {
+                  id: {
+                    in: uniqueModels,
+                  },
+                  OR: [
+                    { projectId: auth.scope.projectId },
+                    { projectId: null },
+                  ],
                 },
-                OR: [{ projectId: auth.scope.projectId }, { projectId: null }],
-              },
-              include: {
-                Price: true,
-              },
-            })
-          : [];
+                include: {
+                  Price: true,
+                },
+              })
+            : [];
 
-      const observationsView = observations.map((o) => {
-        const model = models.find((m) => m.id === o.internalModelId);
-        const inputPrice =
-          model?.Price.find((p) => p.usageType === "input")?.price ??
-          new Decimal(0);
-        const outputPrice =
-          model?.Price.find((p) => p.usageType === "output")?.price ??
-          new Decimal(0);
-        const totalPrice =
-          model?.Price.find((p) => p.usageType === "total")?.price ??
-          new Decimal(0);
-        return {
-          ...o,
-          inputPrice,
-          outputPrice,
-          totalPrice,
-        };
-      });
+        const observationsView = observations.map((o) => {
+          const model = models.find((m) => m.id === o.internalModelId);
+          const inputPrice =
+            model?.Price.find((p) => p.usageType === "input")?.price ??
+            new Decimal(0);
+          const outputPrice =
+            model?.Price.find((p) => p.usageType === "output")?.price ??
+            new Decimal(0);
+          const totalPrice =
+            model?.Price.find((p) => p.usageType === "total")?.price ??
+            new Decimal(0);
+          return {
+            ...o,
+            inputPrice,
+            outputPrice,
+            totalPrice,
+          };
+        });
 
-      const outObservations = observationsView.map(transformDbToApiObservation);
-      // As these are traces scores, we expect all scores to have a traceId set
-      // For type consistency, we validate the scores against the v1 schema which requires a traceId
-      const validatedScores = filterAndValidateDbLegacyTraceScoreList({
-        scores,
-        onParseError: traceException,
-      });
+        const outObservations = observationsView.map(
+          transformDbToApiObservation,
+        );
+        // As these are traces scores, we expect all scores to have a traceId set
+        // For type consistency, we validate the scores against the v1 schema which requires a traceId
+        const validatedScores = filterAndValidateDbLegacyTraceScoreList({
+          scores,
+          onParseError: traceException,
+        });
 
-      const obsStartTimes = observations
-        .map((o) => o.startTime)
-        .sort((a, b) => a.getTime() - b.getTime());
-      const obsEndTimes = observations
-        .map((o) => o.endTime)
-        .filter((t) => t)
-        .sort((a, b) => (a as Date).getTime() - (b as Date).getTime());
+        const obsStartTimes = observations
+          .map((o) => o.startTime)
+          .sort((a, b) => a.getTime() - b.getTime());
+        const obsEndTimes = observations
+          .map((o) => o.endTime)
+          .filter((t) => t)
+          .sort((a, b) => (a as Date).getTime() - (b as Date).getTime());
 
-      const latencyMs =
-        obsStartTimes.length > 0
-          ? obsEndTimes.length > 0
-            ? (obsEndTimes[obsEndTimes.length - 1] as Date).getTime() -
-              obsStartTimes[0]!.getTime()
-            : obsStartTimes.length > 1
-              ? obsStartTimes[obsStartTimes.length - 1]!.getTime() -
+        const latencyMs =
+          obsStartTimes.length > 0
+            ? obsEndTimes.length > 0
+              ? (obsEndTimes[obsEndTimes.length - 1] as Date).getTime() -
                 obsStartTimes[0]!.getTime()
-              : undefined
-          : undefined;
-      return {
-        ...trace,
-        externalId: null,
-        metadata: includeIO ? trace.metadata : {},
-        scores: includeScores ? validatedScores : [],
-        latency: includeMetrics
-          ? latencyMs !== undefined
-            ? latencyMs / 1000
-            : 0
-          : -1,
-        observations: includeObservations ? outObservations : [],
-        htmlPath: `/project/${auth.scope.projectId}/traces/${traceId}`,
-        totalCost: includeMetrics
-          ? outObservations
-              .reduce(
-                (acc, obs) =>
-                  acc.add(obs.calculatedTotalCost ?? new Decimal(0)),
-                new Decimal(0),
-              )
-              .toNumber()
-          : -1,
-      };
+              : obsStartTimes.length > 1
+                ? obsStartTimes[obsStartTimes.length - 1]!.getTime() -
+                  obsStartTimes[0]!.getTime()
+                : undefined
+            : undefined;
+        return {
+          ...trace,
+          externalId: null,
+          metadata: includeIO ? trace.metadata : {},
+          scores: includeScores ? validatedScores : [],
+          latency: includeMetrics
+            ? latencyMs !== undefined
+              ? latencyMs / 1000
+              : 0
+            : -1,
+          observations: includeObservations ? outObservations : [],
+          htmlPath: `/project/${auth.scope.projectId}/traces/${traceId}`,
+          totalCost: includeMetrics
+            ? outObservations
+                .reduce(
+                  (acc, obs) =>
+                    acc.add(obs.calculatedTotalCost ?? new Decimal(0)),
+                  new Decimal(0),
+                )
+                .toNumber()
+            : -1,
+        };
+      },
+    }),
+
+    DELETE: createAuthedProjectAPIRoute({
+      name: "Delete Single Trace",
+      querySchema: DeleteTraceV1Query,
+      responseSchema: DeleteTraceV1Response,
+      rateLimitResource: "trace-delete",
+      fn: async ({ query, auth }) => {
+        const { traceId } = query;
+
+        await auditLog({
+          resourceType: "trace",
+          resourceId: traceId,
+          action: "delete",
+          projectId: auth.scope.projectId,
+          apiKeyId: auth.scope.apiKeyId,
+          orgId: auth.scope.orgId,
+        });
+
+        await traceDeletionProcessor(auth.scope.projectId, [traceId]);
+
+        return { message: "Trace deleted successfully" };
+      },
+    }),
+  },
+  {
+    clickHouseResourceErrorMessage: {
+      GET: LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
     },
-  }),
-
-  DELETE: createAuthedProjectAPIRoute({
-    name: "Delete Single Trace",
-    querySchema: DeleteTraceV1Query,
-    responseSchema: DeleteTraceV1Response,
-    rateLimitResource: "trace-delete",
-    fn: async ({ query, auth }) => {
-      const { traceId } = query;
-
-      await auditLog({
-        resourceType: "trace",
-        resourceId: traceId,
-        action: "delete",
-        projectId: auth.scope.projectId,
-        apiKeyId: auth.scope.apiKeyId,
-        orgId: auth.scope.orgId,
-      });
-
-      await traceDeletionProcessor(auth.scope.projectId, [traceId]);
-
-      return { message: "Trace deleted successfully" };
-    },
-  }),
-});
+  },
+);

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -28,192 +28,180 @@ import {
 import Decimal from "decimal.js";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 
-export default withMiddlewares(
-  {
-    GET: createAuthedProjectAPIRoute({
-      name: "Get Single Trace",
-      querySchema: GetTraceV1Query,
-      responseSchema: GetTraceV1Response,
-      fn: async ({ query, auth }) => {
-        const { traceId } = query;
+export default withMiddlewares({
+  GET: createAuthedProjectAPIRoute({
+    name: "Get Single Trace",
+    querySchema: GetTraceV1Query,
+    responseSchema: GetTraceV1Response,
+    fn: async ({ query, auth }) => {
+      const { traceId } = query;
 
-        let effectiveFields: readonly TraceFieldGroup[] =
-          query.fields ?? TRACE_FIELD_GROUPS;
-        if (!query.fields && env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS) {
-          const parsed = env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS.split(",")
-            .map((f) => f.trim())
-            .filter((f): f is TraceFieldGroup =>
-              TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
-            );
-          if (parsed.length > 0) {
-            effectiveFields = parsed;
-          }
-        }
-        const requestedFields = effectiveFields;
-        const includeIO = requestedFields.includes("io");
-        const includeObservations = requestedFields.includes("observations");
-        const includeScores = requestedFields.includes("scores");
-        const includeMetrics = requestedFields.includes("metrics");
-
-        const trace = await getTraceById({
-          traceId,
-          projectId: auth.scope.projectId,
-          clickhouseFeatureTag: "tracing-public-api",
-          preferredClickhouseService: "ReadOnly",
-          excludeInputOutput: !includeIO,
-          excludeMetadata: !includeIO,
-        });
-
-        if (!trace) {
-          throw new LangfuseNotFoundError(
-            `Trace ${traceId} not found within authorized project`,
+      let effectiveFields: readonly TraceFieldGroup[] =
+        query.fields ?? TRACE_FIELD_GROUPS;
+      if (!query.fields && env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS) {
+        const parsed = env.LANGFUSE_API_TRACEBYID_DEFAULT_FIELDS.split(",")
+          .map((f) => f.trim())
+          .filter((f): f is TraceFieldGroup =>
+            TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
           );
+        if (parsed.length > 0) {
+          effectiveFields = parsed;
         }
+      }
+      const requestedFields = effectiveFields;
+      const includeIO = requestedFields.includes("io");
+      const includeObservations = requestedFields.includes("observations");
+      const includeScores = requestedFields.includes("scores");
+      const includeMetrics = requestedFields.includes("metrics");
 
-        const [observations, scores] = await Promise.all([
-          includeObservations || includeMetrics
-            ? getObservationsForTrace({
-                traceId,
-                projectId: auth.scope.projectId,
-                timestamp: trace?.timestamp,
-                includeIO: includeObservations,
-                preferredClickhouseService: "ReadOnly",
-              })
-            : Promise.resolve([]),
-          includeScores
-            ? getScoresForTraces({
-                projectId: auth.scope.projectId,
-                traceIds: [traceId],
-                timestamp: trace?.timestamp,
-                preferredClickhouseService: "ReadOnly",
-              })
-            : Promise.resolve([]),
-        ]);
+      const trace = await getTraceById({
+        traceId,
+        projectId: auth.scope.projectId,
+        clickhouseFeatureTag: "tracing-public-api",
+        preferredClickhouseService: "ReadOnly",
+        excludeInputOutput: !includeIO,
+        excludeMetadata: !includeIO,
+      });
 
-        const uniqueModels: string[] = Array.from(
-          new Set(
-            observations
-              .map((r) => r.internalModelId)
-              .filter((r): r is string => Boolean(r)),
-          ),
+      if (!trace) {
+        throw new LangfuseNotFoundError(
+          `Trace ${traceId} not found within authorized project`,
         );
+      }
 
-        const models =
-          uniqueModels.length > 0
-            ? await prisma.model.findMany({
-                where: {
-                  id: {
-                    in: uniqueModels,
-                  },
-                  OR: [
-                    { projectId: auth.scope.projectId },
-                    { projectId: null },
-                  ],
+      const [observations, scores] = await Promise.all([
+        includeObservations || includeMetrics
+          ? getObservationsForTrace({
+              traceId,
+              projectId: auth.scope.projectId,
+              timestamp: trace?.timestamp,
+              includeIO: includeObservations,
+              preferredClickhouseService: "ReadOnly",
+            })
+          : Promise.resolve([]),
+        includeScores
+          ? getScoresForTraces({
+              projectId: auth.scope.projectId,
+              traceIds: [traceId],
+              timestamp: trace?.timestamp,
+              preferredClickhouseService: "ReadOnly",
+            })
+          : Promise.resolve([]),
+      ]);
+
+      const uniqueModels: string[] = Array.from(
+        new Set(
+          observations
+            .map((r) => r.internalModelId)
+            .filter((r): r is string => Boolean(r)),
+        ),
+      );
+
+      const models =
+        uniqueModels.length > 0
+          ? await prisma.model.findMany({
+              where: {
+                id: {
+                  in: uniqueModels,
                 },
-                include: {
-                  Price: true,
-                },
-              })
-            : [];
+                OR: [{ projectId: auth.scope.projectId }, { projectId: null }],
+              },
+              include: {
+                Price: true,
+              },
+            })
+          : [];
 
-        const observationsView = observations.map((o) => {
-          const model = models.find((m) => m.id === o.internalModelId);
-          const inputPrice =
-            model?.Price.find((p) => p.usageType === "input")?.price ??
-            new Decimal(0);
-          const outputPrice =
-            model?.Price.find((p) => p.usageType === "output")?.price ??
-            new Decimal(0);
-          const totalPrice =
-            model?.Price.find((p) => p.usageType === "total")?.price ??
-            new Decimal(0);
-          return {
-            ...o,
-            inputPrice,
-            outputPrice,
-            totalPrice,
-          };
-        });
-
-        const outObservations = observationsView.map(
-          transformDbToApiObservation,
-        );
-        // As these are traces scores, we expect all scores to have a traceId set
-        // For type consistency, we validate the scores against the v1 schema which requires a traceId
-        const validatedScores = filterAndValidateDbLegacyTraceScoreList({
-          scores,
-          onParseError: traceException,
-        });
-
-        const obsStartTimes = observations
-          .map((o) => o.startTime)
-          .sort((a, b) => a.getTime() - b.getTime());
-        const obsEndTimes = observations
-          .map((o) => o.endTime)
-          .filter((t) => t)
-          .sort((a, b) => (a as Date).getTime() - (b as Date).getTime());
-
-        const latencyMs =
-          obsStartTimes.length > 0
-            ? obsEndTimes.length > 0
-              ? (obsEndTimes[obsEndTimes.length - 1] as Date).getTime() -
-                obsStartTimes[0]!.getTime()
-              : obsStartTimes.length > 1
-                ? obsStartTimes[obsStartTimes.length - 1]!.getTime() -
-                  obsStartTimes[0]!.getTime()
-                : undefined
-            : undefined;
+      const observationsView = observations.map((o) => {
+        const model = models.find((m) => m.id === o.internalModelId);
+        const inputPrice =
+          model?.Price.find((p) => p.usageType === "input")?.price ??
+          new Decimal(0);
+        const outputPrice =
+          model?.Price.find((p) => p.usageType === "output")?.price ??
+          new Decimal(0);
+        const totalPrice =
+          model?.Price.find((p) => p.usageType === "total")?.price ??
+          new Decimal(0);
         return {
-          ...trace,
-          externalId: null,
-          metadata: includeIO ? trace.metadata : {},
-          scores: includeScores ? validatedScores : [],
-          latency: includeMetrics
-            ? latencyMs !== undefined
-              ? latencyMs / 1000
-              : 0
-            : -1,
-          observations: includeObservations ? outObservations : [],
-          htmlPath: `/project/${auth.scope.projectId}/traces/${traceId}`,
-          totalCost: includeMetrics
-            ? outObservations
-                .reduce(
-                  (acc, obs) =>
-                    acc.add(obs.calculatedTotalCost ?? new Decimal(0)),
-                  new Decimal(0),
-                )
-                .toNumber()
-            : -1,
+          ...o,
+          inputPrice,
+          outputPrice,
+          totalPrice,
         };
-      },
-    }),
+      });
 
-    DELETE: createAuthedProjectAPIRoute({
-      name: "Delete Single Trace",
-      querySchema: DeleteTraceV1Query,
-      responseSchema: DeleteTraceV1Response,
-      rateLimitResource: "trace-delete",
-      fn: async ({ query, auth }) => {
-        const { traceId } = query;
+      const outObservations = observationsView.map(transformDbToApiObservation);
+      // As these are traces scores, we expect all scores to have a traceId set
+      // For type consistency, we validate the scores against the v1 schema which requires a traceId
+      const validatedScores = filterAndValidateDbLegacyTraceScoreList({
+        scores,
+        onParseError: traceException,
+      });
 
-        await auditLog({
-          resourceType: "trace",
-          resourceId: traceId,
-          action: "delete",
-          projectId: auth.scope.projectId,
-          apiKeyId: auth.scope.apiKeyId,
-          orgId: auth.scope.orgId,
-        });
+      const obsStartTimes = observations
+        .map((o) => o.startTime)
+        .sort((a, b) => a.getTime() - b.getTime());
+      const obsEndTimes = observations
+        .map((o) => o.endTime)
+        .filter((t) => t)
+        .sort((a, b) => (a as Date).getTime() - (b as Date).getTime());
 
-        await traceDeletionProcessor(auth.scope.projectId, [traceId]);
-
-        return { message: "Trace deleted successfully" };
-      },
-    }),
-  },
-  {
-    clickHouseResourceErrorMessage: {
-      GET: LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+      const latencyMs =
+        obsStartTimes.length > 0
+          ? obsEndTimes.length > 0
+            ? (obsEndTimes[obsEndTimes.length - 1] as Date).getTime() -
+              obsStartTimes[0]!.getTime()
+            : obsStartTimes.length > 1
+              ? obsStartTimes[obsStartTimes.length - 1]!.getTime() -
+                obsStartTimes[0]!.getTime()
+              : undefined
+          : undefined;
+      return {
+        ...trace,
+        externalId: null,
+        metadata: includeIO ? trace.metadata : {},
+        scores: includeScores ? validatedScores : [],
+        latency: includeMetrics
+          ? latencyMs !== undefined
+            ? latencyMs / 1000
+            : 0
+          : -1,
+        observations: includeObservations ? outObservations : [],
+        htmlPath: `/project/${auth.scope.projectId}/traces/${traceId}`,
+        totalCost: includeMetrics
+          ? outObservations
+              .reduce(
+                (acc, obs) =>
+                  acc.add(obs.calculatedTotalCost ?? new Decimal(0)),
+                new Decimal(0),
+              )
+              .toNumber()
+          : -1,
+      };
     },
-  },
-);
+  }),
+
+  DELETE: createAuthedProjectAPIRoute({
+    name: "Delete Single Trace",
+    querySchema: DeleteTraceV1Query,
+    responseSchema: DeleteTraceV1Response,
+    rateLimitResource: "trace-delete",
+    fn: async ({ query, auth }) => {
+      const { traceId } = query;
+
+      await auditLog({
+        resourceType: "trace",
+        resourceId: traceId,
+        action: "delete",
+        projectId: auth.scope.projectId,
+        apiKeyId: auth.scope.apiKeyId,
+        orgId: auth.scope.orgId,
+      });
+
+      await traceDeletionProcessor(auth.scope.projectId, [traceId]);
+
+      return { message: "Trace deleted successfully" };
+    },
+  }),
+}, LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE);

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -9,7 +9,10 @@ import {
   type TraceFieldGroup,
 } from "@/src/features/public-api/types/traces";
 import { InvalidRequestError } from "@langfuse/shared";
-import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
+import {
+  LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  withMiddlewares,
+} from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import { processEventBatch } from "@langfuse/shared/src/server";
 import {
@@ -28,116 +31,145 @@ import {
 } from "@/src/features/public-api/server/traces";
 import { env } from "@/src/env.mjs";
 
-export default withMiddlewares({
-  POST: createAuthedProjectAPIRoute({
-    name: "Create Trace (Legacy)",
-    bodySchema: PostTracesV1Body,
-    responseSchema: PostTracesV1Response, // Adjust this if you have a specific response schema
-    rateLimitResource: "legacy-ingestion",
-    fn: async ({ body, auth, res }) => {
-      await telemetry();
-      const event = {
-        id: v4(),
-        type: eventTypes.TRACE_CREATE,
-        timestamp: new Date().toISOString(),
-        body: body,
-      };
-      if (!event.body.id) {
-        event.body.id = v4();
-      }
-      const result = await processEventBatch([event], auth);
-      if (result.errors.length > 0) {
-        const error = result.errors[0];
-        res
-          .status(error.status)
-          .json({ message: error.error ?? error.message });
-        return { id: "" }; // dummy return
-      }
-      if (result.successes.length !== 1) {
-        logger.error("Failed to create trace", { result });
-        throw new Error("Failed to create trace");
-      }
-      return { id: event.body.id };
-    },
-  }),
-
-  GET: createAuthedProjectAPIRoute({
-    name: "Get Traces",
-    querySchema: GetTracesV1Query,
-    responseSchema: GetTracesV1Response,
-    fn: async ({ query, auth }) => {
-      // Api-performance controls.
-      // 1. Reject if no date range and rejection is enabled
-      if (
-        env.LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE === "true" &&
-        !query.fromTimestamp
-      ) {
-        throw new InvalidRequestError(
-          "fromTimestamp is required. Set the fromTimestamp query parameter to filter traces by date.",
-        );
-      }
-
-      // 2. Apply default date range if configured and no fromTimestamp provided
-      const defaultDateRangeDays =
-        env.LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS;
-      let effectiveFromTimestamp = query.fromTimestamp ?? undefined;
-      if (!query.fromTimestamp && defaultDateRangeDays) {
-        const referenceDateMs = query.toTimestamp
-          ? new Date(query.toTimestamp).getTime()
-          : Date.now();
-        effectiveFromTimestamp = new Date(
-          referenceDateMs - defaultDateRangeDays * 24 * 60 * 60 * 1000,
-        ).toISOString();
-      }
-
-      // 3. Apply default fields if configured and no fields query param provided
-      let effectiveFields = query.fields ?? undefined;
-      if (!query.fields && env.LANGFUSE_API_TRACES_DEFAULT_FIELDS) {
-        const parsed = env.LANGFUSE_API_TRACES_DEFAULT_FIELDS.split(",")
-          .map((f) => f.trim())
-          .filter((f): f is TraceFieldGroup =>
-            TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
-          );
-        if (parsed.length > 0) {
-          effectiveFields = parsed;
+export default withMiddlewares(
+  {
+    POST: createAuthedProjectAPIRoute({
+      name: "Create Trace (Legacy)",
+      bodySchema: PostTracesV1Body,
+      responseSchema: PostTracesV1Response, // Adjust this if you have a specific response schema
+      rateLimitResource: "legacy-ingestion",
+      fn: async ({ body, auth, res }) => {
+        await telemetry();
+        const event = {
+          id: v4(),
+          type: eventTypes.TRACE_CREATE,
+          timestamp: new Date().toISOString(),
+          body: body,
+        };
+        if (!event.body.id) {
+          event.body.id = v4();
         }
-      }
+        const result = await processEventBatch([event], auth);
+        if (result.errors.length > 0) {
+          const error = result.errors[0];
+          res
+            .status(error.status)
+            .json({ message: error.error ?? error.message });
+          return { id: "" }; // dummy return
+        }
+        if (result.successes.length !== 1) {
+          logger.error("Failed to create trace", { result });
+          throw new Error("Failed to create trace");
+        }
+        return { id: event.body.id };
+      },
+    }),
 
-      const filterProps = {
-        projectId: auth.scope.projectId,
-        page: query.page ?? undefined,
-        limit: query.limit ?? undefined,
-        fields: effectiveFields,
-        userId: query.userId ?? undefined,
-        name: query.name ?? undefined,
-        tags: query.tags ?? undefined,
-        environment: query.environment ?? undefined,
-        sessionId: query.sessionId ?? undefined,
-        version: query.version ?? undefined,
-        release: query.release ?? undefined,
-        fromTimestamp: effectiveFromTimestamp,
-        toTimestamp: query.toTimestamp ?? undefined,
-      };
+    GET: createAuthedProjectAPIRoute({
+      name: "Get Traces",
+      querySchema: GetTracesV1Query,
+      responseSchema: GetTracesV1Response,
+      fn: async ({ query, auth }) => {
+        // Api-performance controls.
+        // 1. Reject if no date range and rejection is enabled
+        if (
+          env.LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE === "true" &&
+          !query.fromTimestamp
+        ) {
+          throw new InvalidRequestError(
+            "fromTimestamp is required. Set the fromTimestamp query parameter to filter traces by date.",
+          );
+        }
 
-      // Use events table if query parameter is explicitly set, otherwise use environment variable
-      const useEventsTable =
-        query.useEventsTable !== undefined && query.useEventsTable !== null
-          ? query.useEventsTable === true
-          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+        // 2. Apply default date range if configured and no fromTimestamp provided
+        const defaultDateRangeDays =
+          env.LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS;
+        let effectiveFromTimestamp = query.fromTimestamp ?? undefined;
+        if (!query.fromTimestamp && defaultDateRangeDays) {
+          const referenceDateMs = query.toTimestamp
+            ? new Date(query.toTimestamp).getTime()
+            : Date.now();
+          effectiveFromTimestamp = new Date(
+            referenceDateMs - defaultDateRangeDays * 24 * 60 * 60 * 1000,
+          ).toISOString();
+        }
 
-      if (useEventsTable) {
+        // 3. Apply default fields if configured and no fields query param provided
+        let effectiveFields = query.fields ?? undefined;
+        if (!query.fields && env.LANGFUSE_API_TRACES_DEFAULT_FIELDS) {
+          const parsed = env.LANGFUSE_API_TRACES_DEFAULT_FIELDS.split(",")
+            .map((f) => f.trim())
+            .filter((f): f is TraceFieldGroup =>
+              TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
+            );
+          if (parsed.length > 0) {
+            effectiveFields = parsed;
+          }
+        }
+
+        const filterProps = {
+          projectId: auth.scope.projectId,
+          page: query.page ?? undefined,
+          limit: query.limit ?? undefined,
+          fields: effectiveFields,
+          userId: query.userId ?? undefined,
+          name: query.name ?? undefined,
+          tags: query.tags ?? undefined,
+          environment: query.environment ?? undefined,
+          sessionId: query.sessionId ?? undefined,
+          version: query.version ?? undefined,
+          release: query.release ?? undefined,
+          fromTimestamp: effectiveFromTimestamp,
+          toTimestamp: query.toTimestamp ?? undefined,
+        };
+
+        // Use events table if query parameter is explicitly set, otherwise use environment variable
+        const useEventsTable =
+          query.useEventsTable !== undefined && query.useEventsTable !== null
+            ? query.useEventsTable === true
+            : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+
+        if (useEventsTable) {
+          const [items, count] = await Promise.all([
+            getTracesFromEventsTableForPublicApi({
+              ...filterProps,
+              advancedFilters: query.filter,
+              orderBy: query.orderBy ?? null,
+            }),
+            getTracesCountFromEventsTableForPublicApi({
+              ...filterProps,
+              advancedFilters: query.filter,
+            }),
+          ]);
+
+          return {
+            data: items.map((item) => ({
+              ...item,
+              externalId: null,
+            })),
+            meta: {
+              page: query.page,
+              limit: query.limit,
+              totalItems: count,
+              totalPages: Math.ceil(count / query.limit),
+            },
+          };
+        }
+
+        // Legacy code path using traces table
         const [items, count] = await Promise.all([
-          getTracesFromEventsTableForPublicApi({
-            ...filterProps,
+          generateTracesForPublicApi({
+            props: filterProps,
             advancedFilters: query.filter,
             orderBy: query.orderBy ?? null,
           }),
-          getTracesCountFromEventsTableForPublicApi({
-            ...filterProps,
+          getTracesCountForPublicApi({
+            props: filterProps,
             advancedFilters: query.filter,
           }),
         ]);
 
+        const finalCount = count || 0;
         return {
           data: items.map((item) => ({
             ...item,
@@ -146,65 +178,43 @@ export default withMiddlewares({
           meta: {
             page: query.page,
             limit: query.limit,
-            totalItems: count,
-            totalPages: Math.ceil(count / query.limit),
+            totalItems: finalCount,
+            totalPages: Math.ceil(finalCount / query.limit),
           },
         };
-      }
+      },
+    }),
 
-      // Legacy code path using traces table
-      const [items, count] = await Promise.all([
-        generateTracesForPublicApi({
-          props: filterProps,
-          advancedFilters: query.filter,
-          orderBy: query.orderBy ?? null,
-        }),
-        getTracesCountForPublicApi({
-          props: filterProps,
-          advancedFilters: query.filter,
-        }),
-      ]);
+    DELETE: createAuthedProjectAPIRoute({
+      name: "Delete Multiple Traces",
+      bodySchema: DeleteTracesV1Body,
+      responseSchema: DeleteTracesV1Response,
+      rateLimitResource: "trace-delete",
+      fn: async ({ body, auth }) => {
+        const { traceIds } = body;
 
-      const finalCount = count || 0;
-      return {
-        data: items.map((item) => ({
-          ...item,
-          externalId: null,
-        })),
-        meta: {
-          page: query.page,
-          limit: query.limit,
-          totalItems: finalCount,
-          totalPages: Math.ceil(finalCount / query.limit),
-        },
-      };
+        await Promise.all(
+          traceIds.map((traceId) =>
+            auditLog({
+              resourceType: "trace",
+              resourceId: traceId,
+              action: "delete",
+              projectId: auth.scope.projectId,
+              apiKeyId: auth.scope.apiKeyId,
+              orgId: auth.scope.orgId,
+            }),
+          ),
+        );
+
+        await traceDeletionProcessor(auth.scope.projectId, traceIds);
+
+        return { message: "Traces deleted successfully" };
+      },
+    }),
+  },
+  {
+    clickHouseResourceErrorMessage: {
+      GET: LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
     },
-  }),
-
-  DELETE: createAuthedProjectAPIRoute({
-    name: "Delete Multiple Traces",
-    bodySchema: DeleteTracesV1Body,
-    responseSchema: DeleteTracesV1Response,
-    rateLimitResource: "trace-delete",
-    fn: async ({ body, auth }) => {
-      const { traceIds } = body;
-
-      await Promise.all(
-        traceIds.map((traceId) =>
-          auditLog({
-            resourceType: "trace",
-            resourceId: traceId,
-            action: "delete",
-            projectId: auth.scope.projectId,
-            apiKeyId: auth.scope.apiKeyId,
-            orgId: auth.scope.orgId,
-          }),
-        ),
-      );
-
-      await traceDeletionProcessor(auth.scope.projectId, traceIds);
-
-      return { message: "Traces deleted successfully" };
-    },
-  }),
-});
+  },
+);

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -31,145 +31,116 @@ import {
 } from "@/src/features/public-api/server/traces";
 import { env } from "@/src/env.mjs";
 
-export default withMiddlewares(
-  {
-    POST: createAuthedProjectAPIRoute({
-      name: "Create Trace (Legacy)",
-      bodySchema: PostTracesV1Body,
-      responseSchema: PostTracesV1Response, // Adjust this if you have a specific response schema
-      rateLimitResource: "legacy-ingestion",
-      fn: async ({ body, auth, res }) => {
-        await telemetry();
-        const event = {
-          id: v4(),
-          type: eventTypes.TRACE_CREATE,
-          timestamp: new Date().toISOString(),
-          body: body,
-        };
-        if (!event.body.id) {
-          event.body.id = v4();
-        }
-        const result = await processEventBatch([event], auth);
-        if (result.errors.length > 0) {
-          const error = result.errors[0];
-          res
-            .status(error.status)
-            .json({ message: error.error ?? error.message });
-          return { id: "" }; // dummy return
-        }
-        if (result.successes.length !== 1) {
-          logger.error("Failed to create trace", { result });
-          throw new Error("Failed to create trace");
-        }
-        return { id: event.body.id };
-      },
-    }),
+export default withMiddlewares({
+  POST: createAuthedProjectAPIRoute({
+    name: "Create Trace (Legacy)",
+    bodySchema: PostTracesV1Body,
+    responseSchema: PostTracesV1Response, // Adjust this if you have a specific response schema
+    rateLimitResource: "legacy-ingestion",
+    fn: async ({ body, auth, res }) => {
+      await telemetry();
+      const event = {
+        id: v4(),
+        type: eventTypes.TRACE_CREATE,
+        timestamp: new Date().toISOString(),
+        body: body,
+      };
+      if (!event.body.id) {
+        event.body.id = v4();
+      }
+      const result = await processEventBatch([event], auth);
+      if (result.errors.length > 0) {
+        const error = result.errors[0];
+        res
+          .status(error.status)
+          .json({ message: error.error ?? error.message });
+        return { id: "" }; // dummy return
+      }
+      if (result.successes.length !== 1) {
+        logger.error("Failed to create trace", { result });
+        throw new Error("Failed to create trace");
+      }
+      return { id: event.body.id };
+    },
+  }),
 
-    GET: createAuthedProjectAPIRoute({
-      name: "Get Traces",
-      querySchema: GetTracesV1Query,
-      responseSchema: GetTracesV1Response,
-      fn: async ({ query, auth }) => {
-        // Api-performance controls.
-        // 1. Reject if no date range and rejection is enabled
-        if (
-          env.LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE === "true" &&
-          !query.fromTimestamp
-        ) {
-          throw new InvalidRequestError(
-            "fromTimestamp is required. Set the fromTimestamp query parameter to filter traces by date.",
+  GET: createAuthedProjectAPIRoute({
+    name: "Get Traces",
+    querySchema: GetTracesV1Query,
+    responseSchema: GetTracesV1Response,
+    fn: async ({ query, auth }) => {
+      // Api-performance controls.
+      // 1. Reject if no date range and rejection is enabled
+      if (
+        env.LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE === "true" &&
+        !query.fromTimestamp
+      ) {
+        throw new InvalidRequestError(
+          "fromTimestamp is required. Set the fromTimestamp query parameter to filter traces by date.",
+        );
+      }
+
+      // 2. Apply default date range if configured and no fromTimestamp provided
+      const defaultDateRangeDays =
+        env.LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS;
+      let effectiveFromTimestamp = query.fromTimestamp ?? undefined;
+      if (!query.fromTimestamp && defaultDateRangeDays) {
+        const referenceDateMs = query.toTimestamp
+          ? new Date(query.toTimestamp).getTime()
+          : Date.now();
+        effectiveFromTimestamp = new Date(
+          referenceDateMs - defaultDateRangeDays * 24 * 60 * 60 * 1000,
+        ).toISOString();
+      }
+
+      // 3. Apply default fields if configured and no fields query param provided
+      let effectiveFields = query.fields ?? undefined;
+      if (!query.fields && env.LANGFUSE_API_TRACES_DEFAULT_FIELDS) {
+        const parsed = env.LANGFUSE_API_TRACES_DEFAULT_FIELDS.split(",")
+          .map((f) => f.trim())
+          .filter((f): f is TraceFieldGroup =>
+            TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
           );
+        if (parsed.length > 0) {
+          effectiveFields = parsed;
         }
+      }
 
-        // 2. Apply default date range if configured and no fromTimestamp provided
-        const defaultDateRangeDays =
-          env.LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS;
-        let effectiveFromTimestamp = query.fromTimestamp ?? undefined;
-        if (!query.fromTimestamp && defaultDateRangeDays) {
-          const referenceDateMs = query.toTimestamp
-            ? new Date(query.toTimestamp).getTime()
-            : Date.now();
-          effectiveFromTimestamp = new Date(
-            referenceDateMs - defaultDateRangeDays * 24 * 60 * 60 * 1000,
-          ).toISOString();
-        }
+      const filterProps = {
+        projectId: auth.scope.projectId,
+        page: query.page ?? undefined,
+        limit: query.limit ?? undefined,
+        fields: effectiveFields,
+        userId: query.userId ?? undefined,
+        name: query.name ?? undefined,
+        tags: query.tags ?? undefined,
+        environment: query.environment ?? undefined,
+        sessionId: query.sessionId ?? undefined,
+        version: query.version ?? undefined,
+        release: query.release ?? undefined,
+        fromTimestamp: effectiveFromTimestamp,
+        toTimestamp: query.toTimestamp ?? undefined,
+      };
 
-        // 3. Apply default fields if configured and no fields query param provided
-        let effectiveFields = query.fields ?? undefined;
-        if (!query.fields && env.LANGFUSE_API_TRACES_DEFAULT_FIELDS) {
-          const parsed = env.LANGFUSE_API_TRACES_DEFAULT_FIELDS.split(",")
-            .map((f) => f.trim())
-            .filter((f): f is TraceFieldGroup =>
-              TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
-            );
-          if (parsed.length > 0) {
-            effectiveFields = parsed;
-          }
-        }
+      // Use events table if query parameter is explicitly set, otherwise use environment variable
+      const useEventsTable =
+        query.useEventsTable !== undefined && query.useEventsTable !== null
+          ? query.useEventsTable === true
+          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
 
-        const filterProps = {
-          projectId: auth.scope.projectId,
-          page: query.page ?? undefined,
-          limit: query.limit ?? undefined,
-          fields: effectiveFields,
-          userId: query.userId ?? undefined,
-          name: query.name ?? undefined,
-          tags: query.tags ?? undefined,
-          environment: query.environment ?? undefined,
-          sessionId: query.sessionId ?? undefined,
-          version: query.version ?? undefined,
-          release: query.release ?? undefined,
-          fromTimestamp: effectiveFromTimestamp,
-          toTimestamp: query.toTimestamp ?? undefined,
-        };
-
-        // Use events table if query parameter is explicitly set, otherwise use environment variable
-        const useEventsTable =
-          query.useEventsTable !== undefined && query.useEventsTable !== null
-            ? query.useEventsTable === true
-            : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
-
-        if (useEventsTable) {
-          const [items, count] = await Promise.all([
-            getTracesFromEventsTableForPublicApi({
-              ...filterProps,
-              advancedFilters: query.filter,
-              orderBy: query.orderBy ?? null,
-            }),
-            getTracesCountFromEventsTableForPublicApi({
-              ...filterProps,
-              advancedFilters: query.filter,
-            }),
-          ]);
-
-          return {
-            data: items.map((item) => ({
-              ...item,
-              externalId: null,
-            })),
-            meta: {
-              page: query.page,
-              limit: query.limit,
-              totalItems: count,
-              totalPages: Math.ceil(count / query.limit),
-            },
-          };
-        }
-
-        // Legacy code path using traces table
+      if (useEventsTable) {
         const [items, count] = await Promise.all([
-          generateTracesForPublicApi({
-            props: filterProps,
+          getTracesFromEventsTableForPublicApi({
+            ...filterProps,
             advancedFilters: query.filter,
             orderBy: query.orderBy ?? null,
           }),
-          getTracesCountForPublicApi({
-            props: filterProps,
+          getTracesCountFromEventsTableForPublicApi({
+            ...filterProps,
             advancedFilters: query.filter,
           }),
         ]);
 
-        const finalCount = count || 0;
         return {
           data: items.map((item) => ({
             ...item,
@@ -178,43 +149,65 @@ export default withMiddlewares(
           meta: {
             page: query.page,
             limit: query.limit,
-            totalItems: finalCount,
-            totalPages: Math.ceil(finalCount / query.limit),
+            totalItems: count,
+            totalPages: Math.ceil(count / query.limit),
           },
         };
-      },
-    }),
+      }
 
-    DELETE: createAuthedProjectAPIRoute({
-      name: "Delete Multiple Traces",
-      bodySchema: DeleteTracesV1Body,
-      responseSchema: DeleteTracesV1Response,
-      rateLimitResource: "trace-delete",
-      fn: async ({ body, auth }) => {
-        const { traceIds } = body;
+      // Legacy code path using traces table
+      const [items, count] = await Promise.all([
+        generateTracesForPublicApi({
+          props: filterProps,
+          advancedFilters: query.filter,
+          orderBy: query.orderBy ?? null,
+        }),
+        getTracesCountForPublicApi({
+          props: filterProps,
+          advancedFilters: query.filter,
+        }),
+      ]);
 
-        await Promise.all(
-          traceIds.map((traceId) =>
-            auditLog({
-              resourceType: "trace",
-              resourceId: traceId,
-              action: "delete",
-              projectId: auth.scope.projectId,
-              apiKeyId: auth.scope.apiKeyId,
-              orgId: auth.scope.orgId,
-            }),
-          ),
-        );
-
-        await traceDeletionProcessor(auth.scope.projectId, traceIds);
-
-        return { message: "Traces deleted successfully" };
-      },
-    }),
-  },
-  {
-    clickHouseResourceErrorMessage: {
-      GET: LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+      const finalCount = count || 0;
+      return {
+        data: items.map((item) => ({
+          ...item,
+          externalId: null,
+        })),
+        meta: {
+          page: query.page,
+          limit: query.limit,
+          totalItems: finalCount,
+          totalPages: Math.ceil(finalCount / query.limit),
+        },
+      };
     },
-  },
-);
+  }),
+
+  DELETE: createAuthedProjectAPIRoute({
+    name: "Delete Multiple Traces",
+    bodySchema: DeleteTracesV1Body,
+    responseSchema: DeleteTracesV1Response,
+    rateLimitResource: "trace-delete",
+    fn: async ({ body, auth }) => {
+      const { traceIds } = body;
+
+      await Promise.all(
+        traceIds.map((traceId) =>
+          auditLog({
+            resourceType: "trace",
+            resourceId: traceId,
+            action: "delete",
+            projectId: auth.scope.projectId,
+            apiKeyId: auth.scope.apiKeyId,
+            orgId: auth.scope.orgId,
+          }),
+        ),
+      );
+
+      await traceDeletionProcessor(auth.scope.projectId, traceIds);
+
+      return { message: "Traces deleted successfully" };
+    },
+  }),
+}, LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE);

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -210,4 +210,7 @@ export default withMiddlewares({
       return { message: "Traces deleted successfully" };
     },
   }),
-}, LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE);
+}, {
+  clickHouseResourceErrorMessage:
+    LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+});

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -31,116 +31,145 @@ import {
 } from "@/src/features/public-api/server/traces";
 import { env } from "@/src/env.mjs";
 
-export default withMiddlewares({
-  POST: createAuthedProjectAPIRoute({
-    name: "Create Trace (Legacy)",
-    bodySchema: PostTracesV1Body,
-    responseSchema: PostTracesV1Response, // Adjust this if you have a specific response schema
-    rateLimitResource: "legacy-ingestion",
-    fn: async ({ body, auth, res }) => {
-      await telemetry();
-      const event = {
-        id: v4(),
-        type: eventTypes.TRACE_CREATE,
-        timestamp: new Date().toISOString(),
-        body: body,
-      };
-      if (!event.body.id) {
-        event.body.id = v4();
-      }
-      const result = await processEventBatch([event], auth);
-      if (result.errors.length > 0) {
-        const error = result.errors[0];
-        res
-          .status(error.status)
-          .json({ message: error.error ?? error.message });
-        return { id: "" }; // dummy return
-      }
-      if (result.successes.length !== 1) {
-        logger.error("Failed to create trace", { result });
-        throw new Error("Failed to create trace");
-      }
-      return { id: event.body.id };
-    },
-  }),
-
-  GET: createAuthedProjectAPIRoute({
-    name: "Get Traces",
-    querySchema: GetTracesV1Query,
-    responseSchema: GetTracesV1Response,
-    fn: async ({ query, auth }) => {
-      // Api-performance controls.
-      // 1. Reject if no date range and rejection is enabled
-      if (
-        env.LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE === "true" &&
-        !query.fromTimestamp
-      ) {
-        throw new InvalidRequestError(
-          "fromTimestamp is required. Set the fromTimestamp query parameter to filter traces by date.",
-        );
-      }
-
-      // 2. Apply default date range if configured and no fromTimestamp provided
-      const defaultDateRangeDays =
-        env.LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS;
-      let effectiveFromTimestamp = query.fromTimestamp ?? undefined;
-      if (!query.fromTimestamp && defaultDateRangeDays) {
-        const referenceDateMs = query.toTimestamp
-          ? new Date(query.toTimestamp).getTime()
-          : Date.now();
-        effectiveFromTimestamp = new Date(
-          referenceDateMs - defaultDateRangeDays * 24 * 60 * 60 * 1000,
-        ).toISOString();
-      }
-
-      // 3. Apply default fields if configured and no fields query param provided
-      let effectiveFields = query.fields ?? undefined;
-      if (!query.fields && env.LANGFUSE_API_TRACES_DEFAULT_FIELDS) {
-        const parsed = env.LANGFUSE_API_TRACES_DEFAULT_FIELDS.split(",")
-          .map((f) => f.trim())
-          .filter((f): f is TraceFieldGroup =>
-            TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
-          );
-        if (parsed.length > 0) {
-          effectiveFields = parsed;
+export default withMiddlewares(
+  {
+    POST: createAuthedProjectAPIRoute({
+      name: "Create Trace (Legacy)",
+      bodySchema: PostTracesV1Body,
+      responseSchema: PostTracesV1Response, // Adjust this if you have a specific response schema
+      rateLimitResource: "legacy-ingestion",
+      fn: async ({ body, auth, res }) => {
+        await telemetry();
+        const event = {
+          id: v4(),
+          type: eventTypes.TRACE_CREATE,
+          timestamp: new Date().toISOString(),
+          body: body,
+        };
+        if (!event.body.id) {
+          event.body.id = v4();
         }
-      }
+        const result = await processEventBatch([event], auth);
+        if (result.errors.length > 0) {
+          const error = result.errors[0];
+          res
+            .status(error.status)
+            .json({ message: error.error ?? error.message });
+          return { id: "" }; // dummy return
+        }
+        if (result.successes.length !== 1) {
+          logger.error("Failed to create trace", { result });
+          throw new Error("Failed to create trace");
+        }
+        return { id: event.body.id };
+      },
+    }),
 
-      const filterProps = {
-        projectId: auth.scope.projectId,
-        page: query.page ?? undefined,
-        limit: query.limit ?? undefined,
-        fields: effectiveFields,
-        userId: query.userId ?? undefined,
-        name: query.name ?? undefined,
-        tags: query.tags ?? undefined,
-        environment: query.environment ?? undefined,
-        sessionId: query.sessionId ?? undefined,
-        version: query.version ?? undefined,
-        release: query.release ?? undefined,
-        fromTimestamp: effectiveFromTimestamp,
-        toTimestamp: query.toTimestamp ?? undefined,
-      };
+    GET: createAuthedProjectAPIRoute({
+      name: "Get Traces",
+      querySchema: GetTracesV1Query,
+      responseSchema: GetTracesV1Response,
+      fn: async ({ query, auth }) => {
+        // Api-performance controls.
+        // 1. Reject if no date range and rejection is enabled
+        if (
+          env.LANGFUSE_API_TRACES_REJECT_NO_DATE_RANGE === "true" &&
+          !query.fromTimestamp
+        ) {
+          throw new InvalidRequestError(
+            "fromTimestamp is required. Set the fromTimestamp query parameter to filter traces by date.",
+          );
+        }
 
-      // Use events table if query parameter is explicitly set, otherwise use environment variable
-      const useEventsTable =
-        query.useEventsTable !== undefined && query.useEventsTable !== null
-          ? query.useEventsTable === true
-          : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+        // 2. Apply default date range if configured and no fromTimestamp provided
+        const defaultDateRangeDays =
+          env.LANGFUSE_API_TRACES_DEFAULT_DATE_RANGE_DAYS;
+        let effectiveFromTimestamp = query.fromTimestamp ?? undefined;
+        if (!query.fromTimestamp && defaultDateRangeDays) {
+          const referenceDateMs = query.toTimestamp
+            ? new Date(query.toTimestamp).getTime()
+            : Date.now();
+          effectiveFromTimestamp = new Date(
+            referenceDateMs - defaultDateRangeDays * 24 * 60 * 60 * 1000,
+          ).toISOString();
+        }
 
-      if (useEventsTable) {
+        // 3. Apply default fields if configured and no fields query param provided
+        let effectiveFields = query.fields ?? undefined;
+        if (!query.fields && env.LANGFUSE_API_TRACES_DEFAULT_FIELDS) {
+          const parsed = env.LANGFUSE_API_TRACES_DEFAULT_FIELDS.split(",")
+            .map((f) => f.trim())
+            .filter((f): f is TraceFieldGroup =>
+              TRACE_FIELD_GROUPS.includes(f as TraceFieldGroup),
+            );
+          if (parsed.length > 0) {
+            effectiveFields = parsed;
+          }
+        }
+
+        const filterProps = {
+          projectId: auth.scope.projectId,
+          page: query.page ?? undefined,
+          limit: query.limit ?? undefined,
+          fields: effectiveFields,
+          userId: query.userId ?? undefined,
+          name: query.name ?? undefined,
+          tags: query.tags ?? undefined,
+          environment: query.environment ?? undefined,
+          sessionId: query.sessionId ?? undefined,
+          version: query.version ?? undefined,
+          release: query.release ?? undefined,
+          fromTimestamp: effectiveFromTimestamp,
+          toTimestamp: query.toTimestamp ?? undefined,
+        };
+
+        // Use events table if query parameter is explicitly set, otherwise use environment variable
+        const useEventsTable =
+          query.useEventsTable !== undefined && query.useEventsTable !== null
+            ? query.useEventsTable === true
+            : env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+
+        if (useEventsTable) {
+          const [items, count] = await Promise.all([
+            getTracesFromEventsTableForPublicApi({
+              ...filterProps,
+              advancedFilters: query.filter,
+              orderBy: query.orderBy ?? null,
+            }),
+            getTracesCountFromEventsTableForPublicApi({
+              ...filterProps,
+              advancedFilters: query.filter,
+            }),
+          ]);
+
+          return {
+            data: items.map((item) => ({
+              ...item,
+              externalId: null,
+            })),
+            meta: {
+              page: query.page,
+              limit: query.limit,
+              totalItems: count,
+              totalPages: Math.ceil(count / query.limit),
+            },
+          };
+        }
+
+        // Legacy code path using traces table
         const [items, count] = await Promise.all([
-          getTracesFromEventsTableForPublicApi({
-            ...filterProps,
+          generateTracesForPublicApi({
+            props: filterProps,
             advancedFilters: query.filter,
             orderBy: query.orderBy ?? null,
           }),
-          getTracesCountFromEventsTableForPublicApi({
-            ...filterProps,
+          getTracesCountForPublicApi({
+            props: filterProps,
             advancedFilters: query.filter,
           }),
         ]);
 
+        const finalCount = count || 0;
         return {
           data: items.map((item) => ({
             ...item,
@@ -149,68 +178,42 @@ export default withMiddlewares({
           meta: {
             page: query.page,
             limit: query.limit,
-            totalItems: count,
-            totalPages: Math.ceil(count / query.limit),
+            totalItems: finalCount,
+            totalPages: Math.ceil(finalCount / query.limit),
           },
         };
-      }
+      },
+    }),
 
-      // Legacy code path using traces table
-      const [items, count] = await Promise.all([
-        generateTracesForPublicApi({
-          props: filterProps,
-          advancedFilters: query.filter,
-          orderBy: query.orderBy ?? null,
-        }),
-        getTracesCountForPublicApi({
-          props: filterProps,
-          advancedFilters: query.filter,
-        }),
-      ]);
+    DELETE: createAuthedProjectAPIRoute({
+      name: "Delete Multiple Traces",
+      bodySchema: DeleteTracesV1Body,
+      responseSchema: DeleteTracesV1Response,
+      rateLimitResource: "trace-delete",
+      fn: async ({ body, auth }) => {
+        const { traceIds } = body;
 
-      const finalCount = count || 0;
-      return {
-        data: items.map((item) => ({
-          ...item,
-          externalId: null,
-        })),
-        meta: {
-          page: query.page,
-          limit: query.limit,
-          totalItems: finalCount,
-          totalPages: Math.ceil(finalCount / query.limit),
-        },
-      };
-    },
-  }),
+        await Promise.all(
+          traceIds.map((traceId) =>
+            auditLog({
+              resourceType: "trace",
+              resourceId: traceId,
+              action: "delete",
+              projectId: auth.scope.projectId,
+              apiKeyId: auth.scope.apiKeyId,
+              orgId: auth.scope.orgId,
+            }),
+          ),
+        );
 
-  DELETE: createAuthedProjectAPIRoute({
-    name: "Delete Multiple Traces",
-    bodySchema: DeleteTracesV1Body,
-    responseSchema: DeleteTracesV1Response,
-    rateLimitResource: "trace-delete",
-    fn: async ({ body, auth }) => {
-      const { traceIds } = body;
+        await traceDeletionProcessor(auth.scope.projectId, traceIds);
 
-      await Promise.all(
-        traceIds.map((traceId) =>
-          auditLog({
-            resourceType: "trace",
-            resourceId: traceId,
-            action: "delete",
-            projectId: auth.scope.projectId,
-            apiKeyId: auth.scope.apiKeyId,
-            orgId: auth.scope.orgId,
-          }),
-        ),
-      );
-
-      await traceDeletionProcessor(auth.scope.projectId, traceIds);
-
-      return { message: "Traces deleted successfully" };
-    },
-  }),
-}, {
-  clickHouseResourceErrorMessage:
-    LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
-});
+        return { message: "Traces deleted successfully" };
+      },
+    }),
+  },
+  {
+    clickHouseResourceErrorMessage:
+      LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
+  },
+);


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds per-method migration hints to legacy ClickHouse public API endpoints so that when a `ClickHouseResourceError` is returned (HTTP 422), users receive endpoint-specific guidance pointing them toward the v2 APIs. The `withMiddlewares` helper is extended to accept an optional `clickHouseResourceErrorMessage` (string or per-`HttpMethod` map), and two new exported constants provide the observations and metrics migration text.

- New `getClickHouseResourceErrorMessage` helper resolves the correct hint based on the HTTP method, falling back to the default advice if no method-specific message is configured.
- Observations and Metrics endpoints are correctly wired to their respective constants.
- Both traces endpoints incorrectly use `LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE`, meaning a traces timeout will advise users to migrate to the Observations v2 API rather than the Traces v2 API.

<h3>Confidence Score: 3/5</h3>

The change is safe to merge functionally but two traces endpoints will actively mislead users by pointing them to the Observations v2 API when a traces endpoint times out.

The core middleware extension in withMiddlewares.ts is correct and well-tested. The observations and metrics endpoints are wired correctly. However, both traces/index.ts and traces/[traceId].ts import and apply LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE, whose body explicitly says 'Please migrate to the high-performance Observations API v2' — wrong advice for a traces caller.

web/src/pages/api/public/traces/index.ts and web/src/pages/api/public/traces/[traceId].ts both need a dedicated traces migration constant instead of the observations one.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/public-api/server/withMiddlewares.ts | Adds per-method ClickHouse error message support via a new `ClickHouseResourceErrorMessage` type and `getClickHouseResourceErrorMessage` helper; exports two new legacy-endpoint constants for observations and metrics. |
| web/src/__tests__/server/withMiddlewares.servertest.ts | Adds two new test cases covering method-specific and default ClickHouse resource error message routing; coverage looks correct for the `withMiddlewares` logic being changed. |
| web/src/pages/api/public/traces/index.ts | Wires up a per-method ClickHouse error message, but incorrectly uses LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE for a traces endpoint. |
| web/src/pages/api/public/traces/[traceId].ts | Same wrong constant issue as traces/index.ts — the observations migration hint is applied to the single-trace endpoint. |
| web/src/pages/api/public/observations/index.ts | Correctly uses LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE for the observations list endpoint. |
| web/src/pages/api/public/observations/[observationId].ts | Correctly applies the observations ClickHouse error message constant to the single-observation endpoint. |
| web/src/pages/api/public/metrics/index.ts | Correctly wires up LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE for the metrics endpoint. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ClickHouseResourceError thrown] --> B[withMiddlewares catch block]
    B --> C{options.clickHouseResourceErrorMessage?}
    C -- undefined --> D[DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE]
    C -- string --> E[Use that string directly]
    C -- Partial Record HttpMethod string --> F{req.method in httpMethods?}
    F -- No --> D
    F -- Yes --> G{message method key exists?}
    G -- No --> D
    G -- Yes --> H[Use method-specific message]
    D & E & H --> I[res.status 422 .json message errorMessage]

    subgraph Endpoints
        J["/api/public/observations"] --> |OBSERVATIONS constant| C
        K["/api/public/observations/id"] --> |OBSERVATIONS constant| C
        L["/api/public/metrics"] --> |METRICS constant| C
        M["/api/public/traces"] --> |OBSERVATIONS constant X| C
        N["/api/public/traces/id"] --> |OBSERVATIONS constant X| C
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/api/public/traces/index.ts:13-15
**Wrong error-message constant for traces endpoint**

`LEGACY_PUBLIC_API_OBSERVATIONS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE` tells callers to "migrate to the high-performance Observations API v2 at /api/public/v2/observations" — but this is the *traces* endpoint. A user experiencing a ClickHouse timeout on `GET /api/public/traces` will receive migration advice pointing at the Observations API, which is actively misleading. A dedicated `LEGACY_PUBLIC_API_TRACES_CLICKHOUSE_RESOURCE_ERROR_MESSAGE` constant (analogous to the metrics one) referencing the correct v2 traces path should be created and used here (and in `traces/[traceId].ts`).

### Issue 2 of 2
web/src/pages/api/public/traces/[traceId].ts:3-5
**Wrong error-message constant for single-trace endpoint**

Same issue as in `traces/index.ts`: the observations constant is imported and applied to a traces route. When `GET /api/public/traces/{traceId}` triggers a `ClickHouseResourceError`, the 422 response body will instruct the caller to switch to the Observations v2 API, which is unrelated to the actual resource being fetched. A traces-specific constant should be used here as well.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add migration hints for legacy public Cl..."](https://github.com/langfuse/langfuse/commit/75875c301a97534623cb0e684fe5c8918387950c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30843558)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->