### PR TITLE
fix(web): Prisma also returns "Unique constraint failed", so check lowercase string

### DIFF
--- a/web/src/features/public-api/server/dataset-runs.ts
+++ b/web/src/features/public-api/server/dataset-runs.ts
@@ -9,7 +9,7 @@ const isUniqueConstraintError = (error: any): boolean => {
   return (
     error.code === "P2002" || // Prisma unique constraint
     error.message?.includes("duplicate key") ||
-    error.message?.includes("UNIQUE constraint") ||
+    error.message?.toLowerCase().includes("unique constraint") ||
     error.message?.includes("violates unique constraint")
   );
 };


### PR DESCRIPTION
## What does this PR do?

Fixes uniqueness checking by accepting also lowercase errors.
As prisma may return

```
prisma:error 
Invalid `prisma.datasetRuns.create()` invocation:


Unique constraint failed on the fields: (`dataset_id`,`project_id`,`name`)
```

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR attempts to make the unique-constraint error detection in `createOrFetchDatasetRun` case-insensitive, covering Prisma's "Unique constraint failed" message in addition to the SQLite-style "UNIQUE constraint" string. However, the implementation has an error in the changed line.

- `toLowerCase()` is applied to the message, but the search substring is left as `"UNIQUE constraint"` (mixed case) — a fully lowercased string will never contain that substring, so this branch now always returns `false` instead of matching the intended Prisma error message.

<h3>Confidence Score: 3/5</h3>

The fix introduces a case-insensitive check that will never trigger, leaving the Prisma unique-constraint message undetected and causing concurrent duplicate-creation to throw instead of returning the existing run.

The one changed line calls toLowerCase() on the message but still searches for the mixed-case string 'UNIQUE constraint', which can never appear in a fully lowercased string. The branch meant to handle Prisma's 'Unique constraint failed' wording is permanently dead, so the race-condition guard will not behave as intended.

web/src/features/public-api/server/dataset-runs.ts — specifically the isUniqueConstraintError helper and its search string

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/public-api/server/dataset-runs.ts | isUniqueConstraintError: toLowerCase() is applied to the message but the search term remains uppercase, so the "UNIQUE constraint" branch can never match after the fix. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/public-api/server/dataset-runs.ts:12
The search string still contains uppercase `UNIQUE` after calling `toLowerCase()` on the message. Since `toLowerCase()` converts the entire message to lowercase, the subsequent `includes("UNIQUE constraint")` will never match — a lowercased string cannot contain the uppercase substring `"UNIQUE constraint"`. This inverts the intent of the fix and silently breaks the "Unique constraint failed" detection path.

```suggestion
    error.message?.toLowerCase().includes("unique constraint") ||
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Prisma also returns &quot;Unique constraint f..."](https://github.com/langfuse/langfuse/commit/fe99a0edc32762419f88fc463cd4ffd656e38287) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30880972)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->