### PR TITLE
feat(blob-export): add exportFieldGroups DB column and tRPC passthrough

### DIFF
--- a/packages/shared/prisma/migrations/20260506000000_add_blob_storage_export_field_groups/migration.sql
+++ b/packages/shared/prisma/migrations/20260506000000_add_blob_storage_export_field_groups/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "blob_storage_integrations"
+  ADD COLUMN "export_field_groups" TEXT[]
+  NOT NULL DEFAULT ARRAY['core','basic','time','io','metadata','model','usage','prompt','metrics','tools','trace_context'];

--- a/packages/shared/prisma/migrations/20260506000000_add_blob_storage_export_field_groups/migration.sql
+++ b/packages/shared/prisma/migrations/20260506000000_add_blob_storage_export_field_groups/migration.sql
@@ -1,4 +1,4 @@
 -- AlterTable
-ALTER TABLE "blob_storage_integrations"
-  ADD COLUMN "export_field_groups" TEXT[]
+ALTER TABLE IF EXISTS "blob_storage_integrations"
+  ADD COLUMN IF NOT EXISTS "export_field_groups" TEXT[]
   NOT NULL DEFAULT ARRAY['core','basic','time','io','metadata','model','usage','prompt','metrics','tools','trace_context'];

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -917,9 +917,9 @@ model EvalTemplate {
   projectId String?  @map("project_id")
   project   Project? @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
-  name        String
-  version     Int
-  prompt      String
+  name    String
+  version Int
+  prompt  String
 
   partner String? // e.g. "ragas", describes the partner that created the template
 
@@ -1130,16 +1130,16 @@ model BlobStorageIntegration {
   forcePathStyle  Boolean                    @map("force_path_style")
 
   // Integration Config
-  nextSyncAt      DateTime?                        @map("next_sync_at")
-  lastSyncAt      DateTime?                        @map("last_sync_at")
-  enabled         Boolean
-  exportFrequency String                           @map("export_frequency")
-  fileType        BlobStorageIntegrationFileType   @default(CSV) @map("file_type")
-  exportMode      BlobStorageExportMode            @default(FULL_HISTORY) @map("export_mode")
-  exportStartDate DateTime?                        @map("export_start_date")
-  exportSource    AnalyticsIntegrationExportSource @default(TRACES_OBSERVATIONS) @map("export_source")
-  exportFieldGroups String[]                       @default(["core", "basic", "time", "io", "metadata", "model", "usage", "prompt", "metrics", "tools", "trace_context"]) @map("export_field_groups")
-  compressed      Boolean                          @default(true) @map("compressed")
+  nextSyncAt        DateTime?                        @map("next_sync_at")
+  lastSyncAt        DateTime?                        @map("last_sync_at")
+  enabled           Boolean
+  exportFrequency   String                           @map("export_frequency")
+  fileType          BlobStorageIntegrationFileType   @default(CSV) @map("file_type")
+  exportMode        BlobStorageExportMode            @default(FULL_HISTORY) @map("export_mode")
+  exportStartDate   DateTime?                        @map("export_start_date")
+  exportSource      AnalyticsIntegrationExportSource @default(TRACES_OBSERVATIONS) @map("export_source")
+  exportFieldGroups String[]                         @default(["core", "basic", "time", "io", "metadata", "model", "usage", "prompt", "metrics", "tools", "trace_context"]) @map("export_field_groups")
+  compressed        Boolean                          @default(true) @map("compressed")
 
   // Error tracking
   lastError   String?   @map("last_error")

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1137,9 +1137,9 @@ model BlobStorageIntegration {
   fileType        BlobStorageIntegrationFileType   @default(CSV) @map("file_type")
   exportMode      BlobStorageExportMode            @default(FULL_HISTORY) @map("export_mode")
   exportStartDate DateTime?                        @map("export_start_date")
-  exportSource      AnalyticsIntegrationExportSource @default(TRACES_OBSERVATIONS) @map("export_source")
-  exportFieldGroups String[]                         @default(["core", "basic", "time", "io", "metadata", "model", "usage", "prompt", "metrics", "tools", "trace_context"]) @map("export_field_groups")
-  compressed        Boolean                          @default(true) @map("compressed")
+  exportSource    AnalyticsIntegrationExportSource @default(TRACES_OBSERVATIONS) @map("export_source")
+  exportFieldGroups String[]                       @default(["core", "basic", "time", "io", "metadata", "model", "usage", "prompt", "metrics", "tools", "trace_context"]) @map("export_field_groups")
+  compressed      Boolean                          @default(true) @map("compressed")
 
   // Error tracking
   lastError   String?   @map("last_error")

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -1137,8 +1137,9 @@ model BlobStorageIntegration {
   fileType        BlobStorageIntegrationFileType   @default(CSV) @map("file_type")
   exportMode      BlobStorageExportMode            @default(FULL_HISTORY) @map("export_mode")
   exportStartDate DateTime?                        @map("export_start_date")
-  exportSource    AnalyticsIntegrationExportSource @default(TRACES_OBSERVATIONS) @map("export_source")
-  compressed      Boolean                          @default(true) @map("compressed")
+  exportSource      AnalyticsIntegrationExportSource @default(TRACES_OBSERVATIONS) @map("export_source")
+  exportFieldGroups String[]                         @default(["core", "basic", "time", "io", "metadata", "model", "usage", "prompt", "metrics", "tools", "trace_context"]) @map("export_field_groups")
+  compressed        Boolean                          @default(true) @map("compressed")
 
   // Error tracking
   lastError   String?   @map("last_error")

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -30,3 +30,19 @@ export const EXPORT_SOURCE_OPTIONS: Array<{
 
 export type ExportSourceOption = (typeof EXPORT_SOURCE_OPTIONS)[number];
 export type ExportSourceValue = ExportSourceOption["value"];
+
+export const BLOB_EXPORT_FIELD_GROUPS = [
+  "core",
+  "basic",
+  "time",
+  "io",
+  "metadata",
+  "model",
+  "usage",
+  "prompt",
+  "metrics",
+  "tools",
+  "trace_context",
+] as const;
+
+export type BlobExportFieldGroup = (typeof BLOB_EXPORT_FIELD_GROUPS)[number];

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -559,6 +559,65 @@ describe("Blob Storage Integrations API", () => {
       });
       expect(savedIntegration?.compressed).toBe(false);
     });
+
+    it("should store all exportFieldGroups by default when creating via REST", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+      };
+
+      await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+
+      const saved = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      });
+      expect(saved?.exportFieldGroups).toHaveLength(11);
+    });
+
+    it("should preserve exportFieldGroups in DB when updating via REST", async () => {
+      // Seed a row with a custom subset
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject1Id,
+          type: "S3",
+          bucketName: "initial-bucket",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportFieldGroups: ["core", "io"],
+        },
+      });
+
+      // Update via REST — exportFieldGroups is not part of the REST API schema
+      await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        {
+          ...validBlobStorageConfig,
+          projectId: testProject1Id,
+          bucketName: "updated-bucket",
+        },
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+
+      const saved = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      });
+      expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
+    });
   });
 
   describe("DELETE /api/public/integrations/blob-storage/{id}", () => {

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -11,6 +11,7 @@ import {
   QueueJobs,
   StorageServiceFactory,
 } from "@langfuse/shared/src/server";
+import { BLOB_EXPORT_FIELD_GROUPS } from "@langfuse/shared";
 
 vi.mock("@langfuse/shared/src/server", async () => {
   const actual = await vi.importActual("@langfuse/shared/src/server");
@@ -121,6 +122,26 @@ const findAuditLog = async ({
 
 const parseAuditLogAfter = (after: string | null) =>
   after ? (JSON.parse(after) as Record<string, unknown>) : null;
+
+// Base config for tRPC update calls (exportFieldGroups tests).
+// exportSource EVENTS triggers field-group validation.
+const baseConfig = {
+  type: "S3" as const,
+  bucketName: "test-bucket",
+  endpoint: null,
+  region: "us-east-1",
+  accessKeyId: "AKIA123456789",
+  secretAccessKey: "secret123456789",
+  prefix: "exports/",
+  exportFrequency: "daily" as const,
+  enabled: true,
+  forcePathStyle: false,
+  fileType: "JSONL" as const,
+  exportMode: "FULL_HISTORY" as const,
+  exportStartDate: null,
+  compressed: true,
+  exportSource: "EVENTS" as const,
+};
 
 describe("Blob Storage Integration tRPC Router", () => {
   afterAll(async () => {
@@ -311,6 +332,64 @@ describe("Blob Storage Integration tRPC Router", () => {
       expect(result.success).toBe(true);
       expect(uploadWithSignedUrl).toHaveBeenCalledTimes(1);
       expect(auditLogCreateSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("exportFieldGroups", () => {
+    it("stores a custom subset and round-trips via get", async () => {
+      const { caller, project } = await prepare();
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportFieldGroups: ["core", "io"],
+      });
+
+      const result = await caller.blobStorageIntegration.get({
+        projectId: project.id,
+      });
+      expect(result?.exportFieldGroups).toStrictEqual(["core", "io"]);
+    });
+
+    it("defaults to all groups when exportFieldGroups is omitted", async () => {
+      const { caller, project } = await prepare();
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+      });
+
+      const stored = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: project.id },
+      });
+      expect(stored?.exportFieldGroups).toStrictEqual([
+        ...BLOB_EXPORT_FIELD_GROUPS,
+      ]);
+    });
+
+    it("overwrites stored subset when a new subset is submitted", async () => {
+      const { caller, project } = await prepare();
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportFieldGroups: ["core", "basic"],
+      });
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportFieldGroups: ["core", "io", "metrics"],
+      });
+
+      const result = await caller.blobStorageIntegration.get({
+        projectId: project.id,
+      });
+      expect(result?.exportFieldGroups).toStrictEqual([
+        "core",
+        "io",
+        "metrics",
+      ]);
     });
   });
 });

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -106,6 +106,7 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
             exportMode: rest.exportMode,
             exportStartDate: rest.exportStartDate ?? null,
             exportSource: rest.exportSource,
+            exportFieldGroups: rest.exportFieldGroups,
             compressed: rest.compressed,
           },
         });

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -24,6 +24,7 @@ type UpsertBlobStorageIntegrationInput = {
   exportMode: BlobStorageExportMode;
   exportStartDate: Date | null;
   exportSource?: AnalyticsIntegrationExportSource;
+  exportFieldGroups?: string[];
   compressed?: boolean;
 };
 
@@ -82,6 +83,7 @@ export async function upsertBlobStorageIntegration(params: {
     exportMode: data.exportMode,
     exportStartDate: resolvedExportStartDate,
     exportSource: data.exportSource,
+    exportFieldGroups: data.exportFieldGroups,
     compressed: data.compressed ?? true,
   };
 

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -5,6 +5,7 @@ import {
   InvalidRequestError,
   type BlobStorageIntegrationFileType,
   type AnalyticsIntegrationExportSource,
+  type BlobExportFieldGroup,
 } from "@langfuse/shared";
 import { encrypt } from "@langfuse/shared/encryption";
 import { env } from "@/src/env.mjs";
@@ -24,7 +25,7 @@ type UpsertBlobStorageIntegrationInput = {
   exportMode: BlobStorageExportMode;
   exportStartDate: Date | null;
   exportSource?: AnalyticsIntegrationExportSource;
-  exportFieldGroups?: string[];
+  exportFieldGroups?: BlobExportFieldGroup[];
   compressed?: boolean;
 };
 

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -36,7 +36,7 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
     .enum(AnalyticsIntegrationExportSource)
     .default(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
   exportFieldGroups: z
-    .array(z.enum([...BLOB_EXPORT_FIELD_GROUPS] as [string, ...string[]]))
+    .array(z.enum(BLOB_EXPORT_FIELD_GROUPS))
     .min(1, { message: "At least one field group must be selected" })
     .default([...BLOB_EXPORT_FIELD_GROUPS]),
   compressed: z.boolean().default(true),

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -4,6 +4,7 @@ import {
   BlobStorageIntegrationFileType,
   BlobStorageExportMode,
   AnalyticsIntegrationExportSource,
+  BLOB_EXPORT_FIELD_GROUPS,
 } from "@langfuse/shared";
 import { validateAzureContainerName } from "@/src/features/blobstorage-integration/validation";
 
@@ -34,6 +35,10 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
   exportSource: z
     .enum(AnalyticsIntegrationExportSource)
     .default(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+  exportFieldGroups: z
+    .array(z.enum([...BLOB_EXPORT_FIELD_GROUPS] as [string, ...string[]]))
+    .min(1, { message: "At least one field group must be selected" })
+    .default([...BLOB_EXPORT_FIELD_GROUPS]),
   compressed: z.boolean().default(true),
 });
 

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -51,6 +51,8 @@ import {
   AnalyticsIntegrationExportSource,
   type BlobStorageIntegration,
   EXPORT_SOURCE_OPTIONS,
+  BLOB_EXPORT_FIELD_GROUPS,
+  type BlobExportFieldGroup,
 } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
@@ -260,6 +262,10 @@ const BlobStorageIntegrationSettingsForm = ({
         (isBetaEnabled
           ? AnalyticsIntegrationExportSource.EVENTS
           : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      exportFieldGroups:
+        (state?.exportFieldGroups as BlobExportFieldGroup[]) ?? [
+          ...BLOB_EXPORT_FIELD_GROUPS,
+        ],
       compressed: state?.compressed ?? true,
     },
     disabled: isLoading,
@@ -290,6 +296,10 @@ const BlobStorageIntegrationSettingsForm = ({
         (isBetaEnabled
           ? AnalyticsIntegrationExportSource.EVENTS
           : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      exportFieldGroups:
+        (state?.exportFieldGroups as BlobExportFieldGroup[]) ?? [
+          ...BLOB_EXPORT_FIELD_GROUPS,
+        ],
       compressed: state?.compressed ?? true,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

Part 2 of [LFE-9456](https://linear.app/langfuse/issue/LFE-9456) — stacked on top of the test-coverage PR.

- Adds `export_field_groups TEXT[] NOT NULL DEFAULT ARRAY[...]` column to `blob_storage_integrations`
- Adds `BLOB_EXPORT_FIELD_GROUPS` client-safe constant to `@langfuse/shared` (analytics-integrations module)
- Adds `exportFieldGroups` to the Zod form schema (`types.ts`) with `min(1)` validation and all-groups default
- Wires `exportFieldGroups` through `upsertBlobStorageIntegration` service and tRPC `update` mutation
- No behaviour change: default = all 11 groups = today's output

The 11-group default includes `tools` and `trace_context` which the query builder doesn't handle yet (PR 3). These values are stored but ignored by the worker until PR 3 is merged.

### Impacted packages

- `packages/shared` — prisma schema, migration, new shared constant
- `web` — Zod schema, service type, tRPC router

## Test plan

- [x] `pnpm run db:generate`
- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter @langfuse/shared run typecheck`
- [x] `pnpm --filter web run typecheck`
- [x] `dotenv -e .env -- pnpm --filter web exec vitest run blobstorage` — 24/24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)