### PR TITLE
chore(web): Setup in-source testing with Vitest

### DIFF
--- a/packages/config-eslint/base.js
+++ b/packages/config-eslint/base.js
@@ -3,6 +3,7 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import turboConfig from "eslint-config-turbo/flat";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import langfusePlugin from "@repo/eslint-plugin";
 import "eslint-plugin-only-warn";
 
 export default tseslint.config(
@@ -86,6 +87,17 @@ export default tseslint.config(
         },
       ],
       "@typescript-eslint/no-deprecated": "warn",
+    },
+  },
+
+  // Vitest in-source testing should only be used while developing, not in committed code.
+  {
+    name: "langfuse/no-in-source-vitest",
+    plugins: {
+      "@repo": langfusePlugin,
+    },
+    rules: {
+      "@repo/no-in-source-vitest": "warn",
     },
   },
 );

--- a/packages/config-eslint/next.js
+++ b/packages/config-eslint/next.js
@@ -107,4 +107,15 @@ export default [
       "react/no-unused-prop-types": "warn",
     },
   },
+
+  // Vitest in-source testing should only be used while developing, not in committed code.
+  {
+    name: "langfuse/no-in-source-vitest",
+    plugins: {
+      "@repo": langfusePlugin,
+    },
+    rules: {
+      "@repo/no-in-source-vitest": "warn",
+    },
+  },
 ];

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,7 +1,9 @@
 import { default as noTailwindOverflowScroll } from "./rules/no-tailwind-overflow-scroll.js";
+import { default as noInSourceVitest } from "./rules/no-in-source-vitest.js";
 
 export const plugin = {
   rules: {
+    "no-in-source-vitest": noInSourceVitest,
     "no-tailwind-overflow-scroll": noTailwindOverflowScroll,
   },
 };

--- a/packages/eslint-plugin/src/rules/no-in-source-vitest.test.ts
+++ b/packages/eslint-plugin/src/rules/no-in-source-vitest.test.ts
@@ -1,0 +1,36 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as typescriptEslintParser from "@typescript-eslint/parser";
+import rule from "./no-in-source-vitest.js";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: typescriptEslintParser,
+    parserOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run("no-in-source-vitest", rule, {
+  valid: [
+    {
+      code: `export const value = 42;`,
+      filename: "/repo/web/src/features/example/value.ts",
+    },
+    {
+      code: `if (import.meta.env.DEV) console.log("dev");`,
+      filename: "/repo/web/src/features/example/value.ts",
+    },
+  ],
+  invalid: [
+    {
+      code: `if (import.meta.vitest) {}`,
+      filename: "/repo/web/src/features/example/value.ts",
+      errors: [{ messageId: "unexpected" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-in-source-vitest.ts
+++ b/packages/eslint-plugin/src/rules/no-in-source-vitest.ts
@@ -1,0 +1,29 @@
+import { createRule } from "../util.js";
+
+const rule = createRule({
+  name: "no-in-source-vitest",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Vitest in-source testing should only be used while developing, not in committed code.",
+    },
+    messages: {
+      unexpected:
+        "Vitest in-source testing should only be used while developing, not in committed code.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      'MemberExpression[computed=false][property.name="vitest"][object.type="MetaProperty"][object.meta.name="import"][object.property.name="meta"]'(
+        node,
+      ) {
+        context.report({ node, messageId: "unexpected" });
+      },
+    };
+  },
+});
+
+export default rule;

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -92,7 +92,9 @@ signoff of user-visible changes.
 
   ```tsx
   const cardVariants = cva("rounded-md border", {
-    variants: { intent: { default: "bg-background", error: "border-destructive" } },
+    variants: {
+      intent: { default: "bg-background", error: "border-destructive" },
+    },
     defaultVariants: { intent: "default" },
   });
 
@@ -117,6 +119,12 @@ signoff of user-visible changes.
   unique test data over global reset helpers.
 - Put pure server unit tests that do not need Postgres bootstrap under
   `src/__tests__/server/unit/**` so they skip the shared DB setup hook.
+- For small utility functions, prefer Vitest in-source tests when colocated
+  coverage is the simplest option, especially when the test needs access to
+  private implementation details without widening the module API.
+- Do not extract private utility functions into separate files only to make
+  them testable. Keep them local unless the user explicitly asks for extraction
+  or the utility is meaningfully reused.
 
 ## Quick Commands
 
@@ -124,8 +132,9 @@ signoff of user-visible changes.
 - Lint: `pnpm --filter web run lint`
 - Lint fix: `pnpm --filter web run lint:fix`
 - Typecheck: `pnpm --filter web run typecheck`
-- Server tests: `pnpm --filter web run test -- <pattern>`
-- Client tests: `pnpm --filter web run test-client -- <pattern>`
+- Server tests: `pnpm --filter web run test -- <args>`
+- In-source tests: `pnpm --filter web run test:in-source -- <args>`
+- Client tests: `pnpm --filter web run test-client -- <args>`
 - E2E tests: `pnpm --filter web run test:e2e`
 - Agent browser install to the default user-level Playwright cache: `pnpm run playwright:install`
 - Build: `pnpm --filter web run build`
@@ -170,4 +179,13 @@ signoff of user-visible changes.
 - Router style is Pages Router-centric; follow existing routing patterns.
 - Keep tests independent; no reliance on test execution order.
 - Confirm the target `*.clienttest.*` or `*.servertest.*` file exists before passing a pattern to `vitest run`; source files do not always have a matching colocated test file.
+- When passing a Vitest file or pattern through `pnpm --filter web ...`, make it
+  relative to `web/` because the script runs with `web` as the working
+  directory. Example: use `src/features/widgets/chart-library/BigNumber.tsx`,
+  not `web/src/features/widgets/chart-library/BigNumber.tsx`.
+- Prefer separate test files for components, integration coverage, and broader
+  behaviors; use Vitest in-source tests mainly for small-scoped utilities.
+- Run Vitest in-source utility coverage with `pnpm --filter web run test:in-source`;
+  do not try to target these through `test-client` or by assuming a separate
+  `*.clienttest.*`/`*.servertest.*` file exists.
 - Do not hand-edit build artifacts: `.next/*`, `.next-check/*`, `dist/*`.

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -70,6 +70,11 @@ const nextConfig = {
   ],
   poweredByHeader: false,
   basePath: env.NEXT_PUBLIC_BASE_PATH,
+  compiler: {
+    define: {
+      "import.meta.vitest": "undefined",
+    },
+  },
   turbopack: {
     resolveAlias: {
       "@langfuse/shared": "./packages/shared/src",
@@ -194,10 +199,18 @@ const nextConfig = {
     ];
   },
 
-  webpack(config, { isServer }) {
+  webpack(config, { isServer, webpack }) {
     // Exclude Datadog packages from webpack bundling to avoid issues
     // see: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/#bundling-with-nextjs
     config.externals.push("@datadog/pprof", "dd-trace");
+
+    // Setup in-source testing: https://vitest.dev/guide/in-source.html#other-bundlers
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        "import.meta.vitest": "undefined",
+      }),
+    );
+
     return config;
   },
 };

--- a/web/package.json
+++ b/web/package.json
@@ -17,9 +17,10 @@
     "analyze": "dotenv -e ../.env -- next experimental-analyze",
     "clean": "rm -rf node_modules",
     "start": "dotenv -e ../.env -- sh -c 'NEXT_MANUAL_SIG_HANDLE=true next start'",
-    "test": "dotenv -e ../.env.test -e ../.env -- vitest run --project server",
+    "test": "dotenv -e ../.env.test -e ../.env -- vitest run --project server --project in-source",
+    "test:in-source": "dotenv -e ../.env.test -e ../.env -- vitest run --project in-source",
     "test-client": "dotenv -e ../.env.test -e ../.env -- vitest run --project client",
-    "test:watch": "dotenv -e ../.env.test -e ../.env -- vitest --project client --project server",
+    "test:watch": "dotenv -e ../.env.test -e ../.env -- vitest --project client --project server --project in-source",
     "test:e2e": "dotenv -e ../.env.test -e ../.env -- playwright test --reporter=line",
     "test:e2e:server": "dotenv -e ../.env.test -e ../.env -- vitest run --project e2e-server",
     "build-trace": "dotenv -e ../.env -- next internal trace .next/trace-turbopack"

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -15,7 +15,7 @@
       ]
     },
     "strictNullChecks": true,
-    "types": ["node", "vitest/globals", "@testing-library/jest-dom"]
+    "types": ["node", "vitest/globals", "vitest/importMeta", "@testing-library/jest-dom"]
   },
   "exclude": [
     "node_modules",

--- a/web/vitest.config.mts
+++ b/web/vitest.config.mts
@@ -3,6 +3,13 @@ import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { VitestCiReporter } from "../scripts/vitest/ci-reporter";
 
+const sharedExclude = [
+  "**/node_modules/**",
+  "**/.next/**",
+  "**/.next-check/**",
+  "**/dist/**",
+];
+
 export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
@@ -21,8 +28,24 @@ export default defineConfig({
       {
         extends: true,
         test: {
+          name: "in-source",
+          includeSource: ["./src/**/*.{ts,tsx}"],
+          exclude: [
+            ...sharedExclude,
+            "src/**/*.clienttest.{ts,tsx}",
+            "src/**/*.servertest.{ts,tsx}",
+            "src/**/__tests__/**",
+            "src/**/__e2e__/**",
+          ],
+          environment: "node",
+        },
+      },
+      {
+        extends: true,
+        test: {
           name: "client",
           include: ["src/**/*.clienttest.{ts,tsx}"],
+          exclude: sharedExclude,
           environment: "jsdom",
           setupFiles: ["@testing-library/jest-dom/vitest"],
         },
@@ -32,7 +55,7 @@ export default defineConfig({
         test: {
           name: "server",
           include: ["src/**/server/**/*.servertest.{ts,tsx}"],
-          exclude: ["src/__e2e__/**"],
+          exclude: [...sharedExclude, "src/__e2e__/**"],
           environment: "node",
           setupFiles: ["./src/__tests__/after-teardown.ts"],
           globalSetup: ["./src/__tests__/vitest-global-teardown.ts"],
@@ -43,7 +66,7 @@ export default defineConfig({
         test: {
           name: "e2e-server",
           include: ["src/**/*.servertest.{ts,tsx}"],
-          exclude: ["src/__tests__/**"],
+          exclude: [...sharedExclude, "src/__tests__/**"],
           environment: "node",
           setupFiles: ["./src/__tests__/after-teardown.ts"],
           globalSetup: ["./src/__tests__/vitest-global-teardown.ts"],


### PR DESCRIPTION
AI coding tools love writing tests. A common pattern is extracting tiny helper functions into `utils` files just so they can be unit tested.

Most of these tests are only useful while the model is working. Keeping them long term slows down development and CI, so we usually remove them before merging.

The problem is that the extracted functions often stay behind. Now we either accept worse code structure or spend time inlining them back into their original context.

This PR enables Vitest in-source testing. Functions can now be tested where they are defined, without exporting them or moving them into separate files.

That lets AI coding tools validate behavior in-place while keeping the final code cleaner. Less churn, less cleanup, better generated code.

The two in-source tests here are only meant for demonstration purposes, they should normally not be committed.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR enables Vitest in-source testing for the `web` package, allowing test blocks to live alongside the functions they test inside `if (import.meta.vitest)` guards. A `DefinePlugin` entry replaces `import.meta.vitest` with `undefined` in webpack builds so test code is tree-shaken from production bundles.

- A new `"in-source"` Vitest project is added in `vitest.config.mts` that scans all `src/**/*.{ts,tsx}` files with `includeSource`; it inherits the root config via `extends: true` and runs with a `node` environment.
- `vitest/importMeta` is added to `tsconfig.json` types, and a dedicated `test:in-source` npm script plus a separate CI pipeline step are wired up.
- Two example in-source test blocks are added: one for `getFileExtensionFromContentType` and one for the private `stripTrailingDecimalZeros` helper in `BigNumber.tsx`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — production bundles are protected by the DefinePlugin replacement and no runtime behavior is affected.

The infrastructure changes are correct and follow the Vitest in-source testing guide. Both example test blocks destructure `it` and `expect` from `import.meta.vitest` but leave `describe` as an implicit global, creating an inconsistency that relies on `globals: true` remaining in the root config.

Both in-source test files (`getFileExtensionFromContentType.ts` and `BigNumber.tsx`) have the same `describe` inconsistency worth fixing before this pattern spreads.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/vitest.config.mts | Adds a new "in-source" Vitest project that scans all src .ts/.tsx files for test blocks, inheriting the root config (globals, reporters, retry, timeout) |
| web/next.config.mjs | Adds a DefinePlugin entry to replace `import.meta.vitest` with `undefined` in webpack builds, ensuring test blocks are tree-shaken from production bundles |
| web/src/features/media/server/getFileExtensionFromContentType.ts | Adds an in-source test block; `describe` is used from the global scope rather than being destructured from `import.meta.vitest` like `it` and `expect` are |
| web/src/features/widgets/chart-library/BigNumber.tsx | Adds an in-source test block for the private `stripTrailingDecimalZeros` helper; same `describe` global-scope inconsistency as the other test file |
| .github/workflows/pipeline.yml | Splits the existing test step into separate "run server tests" and "run in-source tests" steps; in-source step runs in the same job context with DB available |
| web/package.json | Adds `test:in-source` script and includes the in-source project in the default `test` and `test:watch` scripts |
| web/tsconfig.json | Adds `vitest/importMeta` to the types array so TypeScript recognises `import.meta.vitest` without errors |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    SRC["Source file (.ts / .tsx)"]
    GUARD{"if (import.meta.vitest)"}
    TEST["In-source test block\n(describe / it / expect)"]
    VITEST["Vitest 'in-source' project\n(includeSource scan)"]
    WEBPACK["webpack build\n(DefinePlugin: import.meta.vitest -> undefined)"]
    TREESHAKE["Test block tree-shaken\n(dead-code elimination)"]
    CI_STEP["CI: 'run in-source tests' step"]

    SRC --> GUARD
    GUARD -- "vitest run" --> TEST
    TEST --> VITEST
    VITEST --> CI_STEP
    GUARD -- "next build" --> WEBPACK
    WEBPACK --> TREESHAKE
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/media/server/getFileExtensionFromContentType.ts:70-71
`describe` not destructured from `import.meta.vitest`

`it` and `expect` are pulled from `import.meta.vitest`, but `describe` is taken from the global scope instead. While this works today because `globals: true` is set in the root vitest config, the Vitest in-source testing docs recommend destructuring all required symbols from `import.meta.vitest` to keep the block self-contained and avoid a silent dependency on the global scope. The same pattern appears in `BigNumber.tsx`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(web): Setup in-source testing with..."](https://github.com/langfuse/langfuse/commit/a3b22abf30a5a3bb92abcd6f9fcc53136889bb5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30976645)</sub>

<!-- /greptile_comment -->