### PR TITLE
fix(shared): harden outbound URL validation against SSRF bypasses

### DIFF
--- a/packages/shared/src/server/llm/baseUrlValidation.ts
+++ b/packages/shared/src/server/llm/baseUrlValidation.ts
@@ -1,18 +1,11 @@
-import { URL } from "node:url";
 import { env } from "../../env";
-import { logger } from "../logger";
 import {
-  isHostnameBlocked,
-  isIPBlocked,
-  isIPAddress,
-} from "../webhooks/ipBlocking";
-import { resolveHost } from "../webhooks/validation";
+  type OutboundUrlValidationWhitelist,
+  parseOutboundUrl,
+  validateOutboundUrlHost,
+} from "../outboundUrlValidation";
 
-export interface LlmBaseUrlValidationWhitelist {
-  hosts: string[];
-  ips: string[];
-  ip_ranges: string[];
-}
+export type LlmBaseUrlValidationWhitelist = OutboundUrlValidationWhitelist;
 
 export function llmBaseUrlWhitelistFromEnv(): LlmBaseUrlValidationWhitelist {
   if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
@@ -42,92 +35,23 @@ export async function validateLlmConnectionBaseURL(
       }
     : whitelist;
 
-  let url: URL;
-  try {
-    url = new URL(normalizeURL(urlString));
-  } catch {
-    throw new Error("Invalid URL syntax");
-  }
+  const url = parseOutboundUrl(urlString);
 
   if (!["https:", "http:"].includes(url.protocol)) {
     throw new Error("Only HTTP and HTTPS protocols are allowed");
   }
 
-  const hostname = normalizeHostname(url.hostname);
-
-  if (effectiveWhitelist.hosts.includes(hostname)) {
-    return;
-  }
-
-  if (isHostnameBlocked(hostname)) {
-    throw new Error("Blocked hostname detected");
-  }
+  await validateOutboundUrlHost({
+    url,
+    whitelist: effectiveWhitelist,
+    shouldThrowIfDnsResolutionFails: false,
+    logContext: "LLM base URL",
+    // Existing LLM validation accepts public IP literals after CIDR checks so
+    // custom gateways are not forced through DNS at write time.
+    shouldSkipDnsCheckForLiteralIps: true,
+  });
 
   if (env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION && url.protocol !== "https:") {
     throw new Error("Only HTTPS base URLs are allowed on Langfuse Cloud");
   }
-
-  if (isIPAddress(hostname)) {
-    if (
-      isIPBlocked(
-        hostname,
-        effectiveWhitelist.ips,
-        effectiveWhitelist.ip_ranges,
-      )
-    ) {
-      logger.warn(
-        `LLM base URL validation blocked IP address in hostname: ${hostname}`,
-      );
-      throw new Error("Blocked IP address detected");
-    }
-
-    return;
-  }
-
-  let ips: string[];
-  try {
-    ips = await resolveHost(hostname);
-  } catch {
-    // DNS resolution is best-effort here so valid custom gateways do not fail at write time.
-    return;
-  }
-
-  for (const ip of ips) {
-    if (isIPBlocked(ip, effectiveWhitelist.ips, effectiveWhitelist.ip_ranges)) {
-      logger.warn(
-        `LLM base URL validation blocked resolved IP address: ${ip} for hostname: ${hostname}`,
-      );
-      throw new Error("Blocked IP address detected");
-    }
-  }
-}
-
-function normalizeURL(urlString: string): string {
-  let normalized = urlString.trim();
-
-  try {
-    normalized = decodeURIComponent(normalized);
-  } catch {
-    throw new Error("Invalid URL encoding");
-  }
-
-  try {
-    normalized = normalized.normalize("NFC");
-  } catch {
-    throw new Error("Invalid unicode in URL");
-  }
-
-  return normalized;
-}
-
-function normalizeHostname(hostname: string): string {
-  let normalized = hostname.toLowerCase();
-
-  try {
-    normalized = new URL(`http://${normalized}`).hostname;
-  } catch {
-    // Keep the original hostname so URL parsing can fail consistently elsewhere.
-  }
-
-  return normalized;
 }

--- a/packages/shared/src/server/outboundUrlValidation.ts
+++ b/packages/shared/src/server/outboundUrlValidation.ts
@@ -15,22 +15,33 @@ export interface OutboundUrlValidationWhitelist {
 
 export async function resolveHost(hostname: string): Promise<string[]> {
   // Returns every A + AAAA address.
-  const [v4, v6] = await Promise.allSettled([
+  const [v4, v6, lookup] = await Promise.allSettled([
     dns.resolve4(hostname),
     dns.resolve6(hostname),
+    // fetch resolves through getaddrinfo, which can include hosts file/NSS
+    // entries that resolve4/resolve6 do not see. Include them so validation
+    // checks the same local resolution sources that runtime requests can use.
+    dns.lookup(hostname, { all: true }),
   ]);
 
-  const ips: string[] = [];
+  const ips = new Set<string>();
   if (v4.status === "fulfilled") {
     const validV4Ips = v4.value.filter((ip) => ip && typeof ip === "string");
-    ips.push(...validV4Ips);
+    validV4Ips.forEach((ip) => ips.add(ip));
   }
   if (v6.status === "fulfilled") {
     const validV6Ips = v6.value.filter((ip) => ip && typeof ip === "string");
-    ips.push(...validV6Ips);
+    validV6Ips.forEach((ip) => ips.add(ip));
   }
-  if (!ips.length) throw new Error(`DNS lookup failed for ${hostname}`);
-  return ips;
+  if (lookup.status === "fulfilled") {
+    lookup.value
+      .map(({ address }) => address)
+      .filter((ip) => ip && typeof ip === "string")
+      .forEach((ip) => ips.add(ip));
+  }
+
+  if (!ips.size) throw new Error(`DNS lookup failed for ${hostname}`);
+  return [...ips];
 }
 
 export function parseOutboundUrl(urlString: string): URL {

--- a/packages/shared/src/server/outboundUrlValidation.ts
+++ b/packages/shared/src/server/outboundUrlValidation.ts
@@ -1,0 +1,122 @@
+import dns from "node:dns/promises";
+import { URL } from "node:url";
+import { logger } from "./logger";
+import {
+  isHostnameBlocked,
+  isIPBlocked,
+  isIPAddress,
+} from "./webhooks/ipBlocking";
+
+export interface OutboundUrlValidationWhitelist {
+  hosts: string[];
+  ips: string[];
+  ip_ranges: string[];
+}
+
+export async function resolveHost(hostname: string): Promise<string[]> {
+  // Returns every A + AAAA address.
+  const [v4, v6] = await Promise.allSettled([
+    dns.resolve4(hostname),
+    dns.resolve6(hostname),
+  ]);
+
+  const ips: string[] = [];
+  if (v4.status === "fulfilled") {
+    const validV4Ips = v4.value.filter((ip) => ip && typeof ip === "string");
+    ips.push(...validV4Ips);
+  }
+  if (v6.status === "fulfilled") {
+    const validV6Ips = v6.value.filter((ip) => ip && typeof ip === "string");
+    ips.push(...validV6Ips);
+  }
+  if (!ips.length) throw new Error(`DNS lookup failed for ${hostname}`);
+  return ips;
+}
+
+export function parseOutboundUrl(urlString: string): URL {
+  const trimmedUrl = urlString.trim();
+  assertValidUrlEncoding(trimmedUrl);
+
+  let url: URL;
+  try {
+    // Parse the original URL string so validation uses the same WHATWG URL
+    // semantics as fetch. Decoding the whole URL first can turn encoded data
+    // into delimiters and make validation inspect a different hostname.
+    url = new URL(trimmedUrl);
+  } catch {
+    throw new Error("Invalid URL syntax");
+  }
+
+  if (url.username !== "" || url.password !== "") {
+    throw new Error(
+      "URL credentials are not allowed. Use authentication headers instead.",
+    );
+  }
+
+  return url;
+}
+
+export async function validateOutboundUrlHost({
+  url,
+  whitelist,
+  shouldThrowIfDnsResolutionFails,
+  logContext,
+  shouldSkipDnsCheckForLiteralIps,
+}: {
+  url: URL;
+  whitelist: OutboundUrlValidationWhitelist;
+  shouldThrowIfDnsResolutionFails: boolean;
+  logContext: string;
+  shouldSkipDnsCheckForLiteralIps: boolean;
+}): Promise<void> {
+  // WHATWG URL parsing already lowercases and punycodes HTTP(S) hostnames, so
+  // host safety checks stay tied to the parsed URL component.
+  const hostname = url.hostname;
+
+  if (whitelist.hosts.includes(hostname)) {
+    return;
+  }
+
+  if (isHostnameBlocked(hostname)) {
+    throw new Error("Blocked hostname detected");
+  }
+
+  if (isIPAddress(hostname)) {
+    if (isIPBlocked(hostname, whitelist.ips, whitelist.ip_ranges)) {
+      logger.warn(
+        `${logContext} validation blocked IP address in hostname: ${hostname}`,
+      );
+      throw new Error("Blocked IP address detected");
+    }
+
+    if (shouldSkipDnsCheckForLiteralIps) return;
+  }
+
+  let ips: string[];
+  try {
+    ips = await resolveHost(hostname);
+  } catch (error) {
+    if (!shouldThrowIfDnsResolutionFails) return;
+    throw error;
+  }
+
+  for (const ip of ips) {
+    if (isIPBlocked(ip, whitelist.ips, whitelist.ip_ranges)) {
+      logger.warn(
+        `${logContext} validation blocked resolved IP address: ${ip} for hostname: ${hostname}`,
+      );
+      throw new Error("Blocked IP address detected");
+    }
+  }
+}
+
+function assertValidUrlEncoding(urlString: string): void {
+  // This intentionally checks encoding validity only. Do not parse or validate
+  // the decoded result: decoding the whole URL can turn encoded data into URL
+  // delimiters and make validation inspect a different hostname than fetch.
+  try {
+    decodeURIComponent(urlString);
+  } catch {
+    throw new Error("Invalid URL encoding");
+  }
+}

--- a/packages/shared/src/server/webhooks/ipBlocking.ts
+++ b/packages/shared/src/server/webhooks/ipBlocking.ts
@@ -26,8 +26,10 @@ const BLOCKED_CIDRS = [
   "fe80::/10", // link-local
   "ff00::/8", // multicast
   "100::/64", // discard-only
+  "64:ff9b::/96", // NAT64 IPv4 embedded in IPv6
   "2001::/32", // Teredo tunneling
   "2001:db8::/32", // doc
+  "2002::/16", // IPv6 prefix for transmitting IPv6 to IPv4 via 6to4 tunneling
 ];
 
 // Pre-parse blocked networks once for performance

--- a/packages/shared/src/server/webhooks/ipBlocking.ts
+++ b/packages/shared/src/server/webhooks/ipBlocking.ts
@@ -27,6 +27,8 @@ const BLOCKED_CIDRS = [
   "ff00::/8", // multicast
   "100::/64", // discard-only
   "64:ff9b::/96", // NAT64 IPv4 embedded in IPv6
+  "64:ff9b:1::/48", // NAT64 IPv4 embedded in IPv6 (local-use)
+  "::/96", // IPv4-compatible IPv6
   "2001::/32", // Teredo tunneling
   "2001:db8::/32", // doc
   "2002::/16", // IPv6 prefix for transmitting IPv6 to IPv4 via 6to4 tunneling

--- a/packages/shared/src/server/webhooks/redirectHandler.ts
+++ b/packages/shared/src/server/webhooks/redirectHandler.ts
@@ -2,6 +2,13 @@ import { validateWebhookURL } from "./validation";
 import type { WebhookValidationWhitelist } from "./validation";
 import { logger } from "../logger";
 
+const SENSITIVE_REDIRECT_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "x-langfuse-signature",
+]);
+
 /**
  * Custom error for redirect validation failures
  */
@@ -99,8 +106,8 @@ export async function fetchWithSecureRedirects(
   let currentUrl = url;
   let redirectDepth = 0;
 
-  // Force manual redirect handling to prevent automatic following
-  const fetchOptions: RequestInit = {
+  // Force manual redirect handling to prevent automatic following.
+  let fetchOptions: RequestInit = {
     ...options,
     redirect: "manual",
   };
@@ -199,6 +206,30 @@ export async function fetchWithSecureRedirects(
       }
     }
 
+    const currentOrigin = new URL(currentUrl).origin;
+    const redirectOrigin = new URL(redirectUrl).origin;
+    if (currentOrigin !== redirectOrigin) {
+      const { headers, strippedHeaderNames } = stripSensitiveRedirectHeaders(
+        fetchOptions.headers,
+      );
+
+      if (strippedHeaderNames.length > 0) {
+        logger.warn("Stripping sensitive headers for cross-origin redirect", {
+          from: currentOrigin,
+          to: redirectOrigin,
+          redirectDepth,
+          strippedHeaderNames,
+        });
+
+        fetchOptions = {
+          ...fetchOptions,
+          // Sensitive credentials are origin-scoped. Keep them on same-origin
+          // redirects, but strip them before a cross-origin follow-up request.
+          headers,
+        };
+      }
+    }
+
     // Follow the redirect
     currentUrl = redirectUrl;
     redirectDepth++;
@@ -210,4 +241,27 @@ export async function fetchWithSecureRedirects(
     ...redirectChain,
     currentUrl,
   ]);
+}
+
+function stripSensitiveRedirectHeaders(headers: RequestInit["headers"]): {
+  headers: RequestInit["headers"];
+  strippedHeaderNames: string[];
+} {
+  const strippedHeaderNames: string[] = [];
+
+  const headerEntries = Array.from(new Headers(headers).entries()).filter(
+    ([headerName]) => {
+      if (SENSITIVE_REDIRECT_HEADERS.has(headerName)) {
+        strippedHeaderNames.push(headerName);
+        return false;
+      }
+
+      return true;
+    },
+  );
+
+  return {
+    headers: new Headers(headerEntries),
+    strippedHeaderNames,
+  };
 }

--- a/packages/shared/src/server/webhooks/redirectHandler.ts
+++ b/packages/shared/src/server/webhooks/redirectHandler.ts
@@ -66,6 +66,7 @@ export interface RedirectOptions {
   maxRedirects: number;
   skipValidation?: boolean;
   whitelist?: WebhookValidationWhitelist;
+  additionalSensitiveHeaders?: string[];
 }
 
 /**
@@ -99,7 +100,16 @@ export async function fetchWithSecureRedirects(
   options: RequestInit,
   redirectOptions: RedirectOptions,
 ): Promise<RedirectResult> {
-  const { maxRedirects, skipValidation = false, whitelist } = redirectOptions;
+  const {
+    maxRedirects,
+    skipValidation = false,
+    whitelist,
+    additionalSensitiveHeaders = [],
+  } = redirectOptions;
+  const sensitiveRedirectHeaders = new Set([
+    ...SENSITIVE_REDIRECT_HEADERS,
+    ...additionalSensitiveHeaders.map((headerName) => headerName.toLowerCase()),
+  ]);
 
   // Track redirect chain for loop detection and logging
   const redirectChain: string[] = [];
@@ -211,6 +221,7 @@ export async function fetchWithSecureRedirects(
     if (currentOrigin !== redirectOrigin) {
       const { headers, strippedHeaderNames } = stripSensitiveRedirectHeaders(
         fetchOptions.headers,
+        sensitiveRedirectHeaders,
       );
 
       if (strippedHeaderNames.length > 0) {
@@ -243,7 +254,10 @@ export async function fetchWithSecureRedirects(
   ]);
 }
 
-function stripSensitiveRedirectHeaders(headers: RequestInit["headers"]): {
+function stripSensitiveRedirectHeaders(
+  headers: RequestInit["headers"],
+  sensitiveHeaderNames: Set<string>,
+): {
   headers: RequestInit["headers"];
   strippedHeaderNames: string[];
 } {
@@ -251,7 +265,7 @@ function stripSensitiveRedirectHeaders(headers: RequestInit["headers"]): {
 
   const headerEntries = Array.from(new Headers(headers).entries()).filter(
     ([headerName]) => {
-      if (SENSITIVE_REDIRECT_HEADERS.has(headerName)) {
+      if (sensitiveHeaderNames.has(headerName)) {
         strippedHeaderNames.push(headerName);
         return false;
       }

--- a/packages/shared/src/server/webhooks/validation.ts
+++ b/packages/shared/src/server/webhooks/validation.ts
@@ -1,38 +1,13 @@
-import dns from "node:dns/promises";
-import { URL } from "node:url";
-import { isIPBlocked, isIPAddress, isHostnameBlocked } from "./ipBlocking";
 import { env } from "../../env";
-import { logger } from "../logger";
+import {
+  type OutboundUrlValidationWhitelist,
+  parseOutboundUrl,
+  resolveHost,
+  validateOutboundUrlHost,
+} from "../outboundUrlValidation";
 
-export async function resolveHost(hostname: string): Promise<string[]> {
-  // Returns every A + AAAA address
-  const [v4, v6] = await Promise.allSettled([
-    dns.resolve4(hostname),
-    dns.resolve6(hostname),
-  ]);
-
-  const ips: string[] = [];
-  if (v4.status === "fulfilled") {
-    // Filter out any undefined/null values
-    const validV4Ips = v4.value.filter((ip) => ip && typeof ip === "string");
-
-    ips.push(...validV4Ips);
-  }
-  if (v6.status === "fulfilled") {
-    // Filter out any undefined/null values
-    const validV6Ips = v6.value.filter((ip) => ip && typeof ip === "string");
-
-    ips.push(...validV6Ips);
-  }
-  if (!ips.length) throw new Error(`DNS lookup failed for ${hostname}`);
-  return ips;
-}
-
-export interface WebhookValidationWhitelist {
-  hosts: string[];
-  ips: string[];
-  ip_ranges: string[];
-}
+export type WebhookValidationWhitelist = OutboundUrlValidationWhitelist;
+export { resolveHost };
 
 export function whitelistFromEnv(): WebhookValidationWhitelist {
   return {
@@ -54,82 +29,23 @@ export async function validateWebhookURL(
   urlString: string,
   whitelist: WebhookValidationWhitelist = whitelistFromEnv(),
 ): Promise<void> {
-  // Step 1: Basic URL parsing and normalization
-  const trimmedUrl = urlString.trim();
-  assertValidUrlEncoding(trimmedUrl);
-
-  let url: URL;
-  try {
-    // Parse the original URL string so validation uses the same WHATWG URL
-    // semantics as fetch. Decoding the whole URL first can turn encoded data
-    // into delimiters and make validation inspect a different hostname.
-    url = new URL(trimmedUrl);
-  } catch {
-    throw new Error("Invalid URL syntax");
-  }
+  const url = parseOutboundUrl(urlString);
 
   if (!["https:", "http:"].includes(url.protocol)) {
     throw new Error("Only HTTP and HTTPS protocols are allowed");
   }
 
-  if (url.username !== "" || url.password !== "") {
-    throw new Error(
-      "URL credentials are not allowed. Use webhook headers for authentication instead.",
-    );
-  }
-
-  // Step 2: Port validation
   if (url.port && !["443", "80"].includes(url.port)) {
     throw new Error("Only ports 80 and 443 are allowed");
   }
 
-  // Step 3: Hostname validation. WHATWG URL parsing already lowercases and
-  // punycodes HTTP(S) hostnames, so keep this tied to the parsed URL component.
-  const hostname = url.hostname;
-
-  if (whitelist.hosts.includes(hostname)) {
-    // skip further checks if hostname is whitelisted
-    return;
-  }
-
-  // Block obviously dangerous hostnames
-  if (isHostnameBlocked(hostname)) {
-    throw new Error("Blocked hostname detected");
-  }
-
-  // Step 4: Check for IP address literals in hostname
-  if (isIPAddress(hostname)) {
-    if (isIPBlocked(hostname, whitelist.ips, whitelist.ip_ranges)) {
-      // Log detailed error internally for debugging
-      logger.warn(
-        `Webhook validation blocked IP address in hostname: ${hostname}`,
-      );
-      // Throw generic error to user to prevent IP leakage
-      throw new Error("Blocked IP address detected");
-    }
-  }
-
-  // Step 5: DNS resolution and validation
-  const ips = await resolveHost(hostname);
-  for (const ip of ips) {
-    if (isIPBlocked(ip, whitelist.ips, whitelist.ip_ranges)) {
-      // Log detailed error internally for debugging
-      logger.warn(
-        `Webhook validation blocked resolved IP address: ${ip} for hostname: ${hostname}`,
-      );
-      // Throw generic error to user to prevent IP leakage
-      throw new Error("Blocked IP address detected");
-    }
-  }
-}
-
-function assertValidUrlEncoding(urlString: string): void {
-  // This intentionally checks encoding validity only. Do not parse or validate
-  // the decoded result: decoding the whole URL can turn encoded data into URL
-  // delimiters and make validation inspect a different hostname than fetch.
-  try {
-    decodeURIComponent(urlString);
-  } catch {
-    throw new Error("Invalid URL encoding");
-  }
+  await validateOutboundUrlHost({
+    url,
+    whitelist,
+    shouldThrowIfDnsResolutionFails: true,
+    logContext: "Webhook",
+    // Preserve the existing webhook behavior: public IP literals must still
+    // pass the same DNS-resolution path as hostname destinations.
+    shouldSkipDnsCheckForLiteralIps: false,
+  });
 }

--- a/packages/shared/src/server/webhooks/validation.ts
+++ b/packages/shared/src/server/webhooks/validation.ts
@@ -55,11 +55,15 @@ export async function validateWebhookURL(
   whitelist: WebhookValidationWhitelist = whitelistFromEnv(),
 ): Promise<void> {
   // Step 1: Basic URL parsing and normalization
+  const trimmedUrl = urlString.trim();
+  assertValidUrlEncoding(trimmedUrl);
+
   let url: URL;
   try {
-    // Normalize the URL string first to handle encoding issues
-    const normalizedUrl = normalizeURL(urlString);
-    url = new URL(normalizedUrl);
+    // Parse the original URL string so validation uses the same WHATWG URL
+    // semantics as fetch. Decoding the whole URL first can turn encoded data
+    // into delimiters and make validation inspect a different hostname.
+    url = new URL(trimmedUrl);
   } catch {
     throw new Error("Invalid URL syntax");
   }
@@ -68,13 +72,20 @@ export async function validateWebhookURL(
     throw new Error("Only HTTP and HTTPS protocols are allowed");
   }
 
+  if (url.username !== "" || url.password !== "") {
+    throw new Error(
+      "URL credentials are not allowed. Use webhook headers for authentication instead.",
+    );
+  }
+
   // Step 2: Port validation
   if (url.port && !["443", "80"].includes(url.port)) {
     throw new Error("Only ports 80 and 443 are allowed");
   }
 
-  // Step 3: Hostname normalization and validation
-  const hostname = normalizeHostname(url.hostname);
+  // Step 3: Hostname validation. WHATWG URL parsing already lowercases and
+  // punycodes HTTP(S) hostnames, so keep this tied to the parsed URL component.
+  const hostname = url.hostname;
 
   if (whitelist.hosts.includes(hostname)) {
     // skip further checks if hostname is whitelisted
@@ -112,44 +123,13 @@ export async function validateWebhookURL(
   }
 }
 
-/**
- * Normalize URL to prevent encoding/unicode bypass attempts
- */
-function normalizeURL(urlString: string): string {
-  // Remove leading/trailing whitespace
-  let normalized = urlString.trim();
-
-  // Decode URL encoding to prevent bypass attempts like %6C%6F%63%61%6C%68%6F%73%74 (localhost)
+function assertValidUrlEncoding(urlString: string): void {
+  // This intentionally checks encoding validity only. Do not parse or validate
+  // the decoded result: decoding the whole URL can turn encoded data into URL
+  // delimiters and make validation inspect a different hostname than fetch.
   try {
-    normalized = decodeURIComponent(normalized);
+    decodeURIComponent(urlString);
   } catch {
     throw new Error("Invalid URL encoding");
   }
-
-  // Normalize unicode to prevent IDN bypass attempts
-  try {
-    normalized = normalized.normalize("NFC");
-  } catch {
-    throw new Error("Invalid unicode in URL");
-  }
-
-  return normalized;
-}
-
-/**
- * Normalize hostname to handle IDN and case sensitivity
- */
-function normalizeHostname(hostname: string): string {
-  let normalized = hostname.toLowerCase();
-
-  // Convert internationalized domain names to ASCII (Punycode)
-  try {
-    // This will convert unicode domain names to their ASCII representation
-    const url = new URL(`http://${normalized}`);
-    normalized = url.hostname;
-  } catch {
-    // If hostname is invalid, keep the original for later validation failure
-  }
-
-  return normalized;
 }

--- a/worker/src/__tests__/ip-blocking.test.ts
+++ b/worker/src/__tests__/ip-blocking.test.ts
@@ -84,6 +84,8 @@ describe("IP Blocking Module", () => {
 
       it("should block NAT64 and 6to4 transition addresses", () => {
         expect(isIPBlocked("64:ff9b::7f00:1", [], [])).toBe(true); // NAT64 for 127.0.0.1
+        expect(isIPBlocked("64:ff9b:1::7f00:1", [], [])).toBe(true); // NAT64 local-use for 127.0.0.1
+        expect(isIPBlocked("::7f00:1", [], [])).toBe(true); // IPv4-compatible IPv6 for 127.0.0.1
         expect(isIPBlocked("2002:7f00:1::", [], [])).toBe(true); // 6to4 for 127.0.0.1
       });
     });

--- a/worker/src/__tests__/ip-blocking.test.ts
+++ b/worker/src/__tests__/ip-blocking.test.ts
@@ -81,6 +81,11 @@ describe("IP Blocking Module", () => {
           isIPBlocked("2001:0000:4136:e378:8000:63bf:3fff:fdd2", [], []),
         ).toBe(true);
       });
+
+      it("should block NAT64 and 6to4 transition addresses", () => {
+        expect(isIPBlocked("64:ff9b::7f00:1", [], [])).toBe(true); // NAT64 for 127.0.0.1
+        expect(isIPBlocked("2002:7f00:1::", [], [])).toBe(true); // 6to4 for 127.0.0.1
+      });
     });
 
     describe("allowed public addresses", () => {

--- a/worker/src/__tests__/llm-base-url-validation.test.ts
+++ b/worker/src/__tests__/llm-base-url-validation.test.ts
@@ -1,4 +1,28 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { resolve4Mock, resolve6Mock, lookupMock } = vi.hoisted(() => ({
+  resolve4Mock: vi.fn<(hostname: string) => Promise<string[]>>(),
+  resolve6Mock: vi.fn<(hostname: string) => Promise<string[]>>(),
+  lookupMock:
+    vi.fn<
+      (
+        hostname: string,
+        options: { all: true },
+      ) => Promise<Array<{ address: string; family: 4 | 6 }>>
+    >(),
+}));
+
+vi.mock("node:dns/promises", () => ({
+  default: {
+    resolve4: resolve4Mock,
+    resolve6: resolve6Mock,
+    lookup: lookupMock,
+  },
+  resolve4: resolve4Mock,
+  resolve6: resolve6Mock,
+  lookup: lookupMock,
+}));
+
 import {
   validateLlmConnectionBaseURL,
   type LlmBaseUrlValidationWhitelist,
@@ -12,6 +36,14 @@ const originalAllowedIpSegments =
   env.LANGFUSE_LLM_CONNECTION_WHITELISTED_IP_SEGMENTS;
 
 describe("LLM base URL validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    resolve4Mock.mockRejectedValue(new Error("ENOTFOUND"));
+    resolve6Mock.mockRejectedValue(new Error("ENODATA"));
+    lookupMock.mockRejectedValue(new Error("ENOTFOUND"));
+  });
+
   afterEach(() => {
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
     (env as any).LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST =
@@ -47,6 +79,19 @@ describe("LLM base URL validation", () => {
     ).rejects.toThrow(
       "URL credentials are not allowed. Use authentication headers instead.",
     );
+  });
+
+  it("should reject hostnames that resolve to blocked IPs through local lookup", async () => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+    lookupMock.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+
+    await expect(validateLlmConnectionBaseURL("http://vm/v1")).rejects.toThrow(
+      "Blocked IP address detected",
+    );
+
+    expect(resolve4Mock).toHaveBeenCalledWith("vm");
+    expect(resolve6Mock).toHaveBeenCalledWith("vm");
+    expect(lookupMock).toHaveBeenCalledWith("vm", { all: true });
   });
 
   it("should allow explicitly allowlisted localhost hosts for self-hosted instances", async () => {

--- a/worker/src/__tests__/llm-base-url-validation.test.ts
+++ b/worker/src/__tests__/llm-base-url-validation.test.ts
@@ -29,6 +29,26 @@ describe("LLM base URL validation", () => {
     ).rejects.toThrow("Blocked hostname detected");
   });
 
+  it("should reject encoded delimiter userinfo SSRF bypass attempts", async () => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+
+    await expect(
+      validateLlmConnectionBaseURL("https://example.com%2F@127.0.0.1/v1"),
+    ).rejects.toThrow(
+      "URL credentials are not allowed. Use authentication headers instead.",
+    );
+  });
+
+  it("should reject URLs with embedded credentials", async () => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+
+    await expect(
+      validateLlmConnectionBaseURL("https://user:pass@example.com/v1"),
+    ).rejects.toThrow(
+      "URL credentials are not allowed. Use authentication headers instead.",
+    );
+  });
+
   it("should allow explicitly allowlisted localhost hosts for self-hosted instances", async () => {
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
 

--- a/worker/src/__tests__/webhook-redirect-headers.test.ts
+++ b/worker/src/__tests__/webhook-redirect-headers.test.ts
@@ -30,10 +30,15 @@ describe("fetchWithSecureRedirects header handling", () => {
           Cookie: "session=secret",
           "Proxy-Authorization": "Basic proxy-secret",
           "x-langfuse-signature": "t=1,v1=secret",
+          "X-API-Key": "custom-secret",
           "x-custom-header": "keep-me",
         },
       },
-      { maxRedirects: 1, skipValidation: true },
+      {
+        maxRedirects: 1,
+        skipValidation: true,
+        additionalSensitiveHeaders: ["X-API-Key"],
+      },
     );
 
     const finalRequest = fetchMock.mock.calls[1];
@@ -43,6 +48,7 @@ describe("fetchWithSecureRedirects header handling", () => {
     expect(finalHeaders.get("cookie")).toBe("session=secret");
     expect(finalHeaders.get("proxy-authorization")).toBe("Basic proxy-secret");
     expect(finalHeaders.get("x-langfuse-signature")).toBe("t=1,v1=secret");
+    expect(finalHeaders.get("x-api-key")).toBe("custom-secret");
     expect(finalHeaders.get("x-custom-header")).toBe("keep-me");
   });
 
@@ -69,10 +75,15 @@ describe("fetchWithSecureRedirects header handling", () => {
           Cookie: "session=secret",
           "Proxy-Authorization": "Basic proxy-secret",
           "x-langfuse-signature": "t=1,v1=secret",
+          "X-API-Key": "custom-secret",
           "x-custom-header": "keep-me",
         },
       },
-      { maxRedirects: 1, skipValidation: true },
+      {
+        maxRedirects: 1,
+        skipValidation: true,
+        additionalSensitiveHeaders: ["X-API-Key"],
+      },
     );
 
     const finalRequest = fetchMock.mock.calls[1];
@@ -82,6 +93,7 @@ describe("fetchWithSecureRedirects header handling", () => {
     expect(finalHeaders.get("cookie")).toBeNull();
     expect(finalHeaders.get("proxy-authorization")).toBeNull();
     expect(finalHeaders.get("x-langfuse-signature")).toBeNull();
+    expect(finalHeaders.get("x-api-key")).toBeNull();
     expect(finalHeaders.get("x-custom-header")).toBe("keep-me");
     expect(warnSpy).toHaveBeenCalledWith(
       "Stripping sensitive headers for cross-origin redirect",
@@ -93,6 +105,7 @@ describe("fetchWithSecureRedirects header handling", () => {
           "authorization",
           "cookie",
           "proxy-authorization",
+          "x-api-key",
           "x-langfuse-signature",
         ],
       },

--- a/worker/src/__tests__/webhook-redirect-headers.test.ts
+++ b/worker/src/__tests__/webhook-redirect-headers.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../../../packages/shared/src/server/logger";
+import { fetchWithSecureRedirects } from "../../../packages/shared/src/server/webhooks/redirectHandler";
+
+const fetchMock = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", fetchMock);
+
+afterEach(() => {
+  fetchMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("fetchWithSecureRedirects header handling", () => {
+  it("should keep sensitive headers on same-origin redirects", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://example.com/final" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    await fetchWithSecureRedirects(
+      "https://example.com/start",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer token",
+          Cookie: "session=secret",
+          "Proxy-Authorization": "Basic proxy-secret",
+          "x-langfuse-signature": "t=1,v1=secret",
+          "x-custom-header": "keep-me",
+        },
+      },
+      { maxRedirects: 1, skipValidation: true },
+    );
+
+    const finalRequest = fetchMock.mock.calls[1];
+    const finalHeaders = new Headers(finalRequest?.[1]?.headers);
+
+    expect(finalHeaders.get("authorization")).toBe("Bearer token");
+    expect(finalHeaders.get("cookie")).toBe("session=secret");
+    expect(finalHeaders.get("proxy-authorization")).toBe("Basic proxy-secret");
+    expect(finalHeaders.get("x-langfuse-signature")).toBe("t=1,v1=secret");
+    expect(finalHeaders.get("x-custom-header")).toBe("keep-me");
+  });
+
+  it("should strip sensitive headers on cross-origin redirects", async () => {
+    const warnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://other.example.com/final" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    await fetchWithSecureRedirects(
+      "https://example.com/start",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer token",
+          Cookie: "session=secret",
+          "Proxy-Authorization": "Basic proxy-secret",
+          "x-langfuse-signature": "t=1,v1=secret",
+          "x-custom-header": "keep-me",
+        },
+      },
+      { maxRedirects: 1, skipValidation: true },
+    );
+
+    const finalRequest = fetchMock.mock.calls[1];
+    const finalHeaders = new Headers(finalRequest?.[1]?.headers);
+
+    expect(finalHeaders.get("authorization")).toBeNull();
+    expect(finalHeaders.get("cookie")).toBeNull();
+    expect(finalHeaders.get("proxy-authorization")).toBeNull();
+    expect(finalHeaders.get("x-langfuse-signature")).toBeNull();
+    expect(finalHeaders.get("x-custom-header")).toBe("keep-me");
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Stripping sensitive headers for cross-origin redirect",
+      {
+        from: "https://example.com",
+        to: "https://other.example.com",
+        redirectDepth: 0,
+        strippedHeaderNames: [
+          "authorization",
+          "cookie",
+          "proxy-authorization",
+          "x-langfuse-signature",
+        ],
+      },
+    );
+  });
+
+  it("should not warn on cross-origin redirects without sensitive headers", async () => {
+    const warnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://other.example.com/final" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    await fetchWithSecureRedirects(
+      "https://example.com/start",
+      {
+        method: "POST",
+        headers: {
+          "x-custom-header": "keep-me",
+        },
+      },
+      { maxRedirects: 1, skipValidation: true },
+    );
+
+    const finalRequest = fetchMock.mock.calls[1];
+    const finalHeaders = new Headers(finalRequest?.[1]?.headers);
+
+    expect(finalHeaders.get("x-custom-header")).toBe("keep-me");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/worker/src/__tests__/webhook-validation.test.ts
+++ b/worker/src/__tests__/webhook-validation.test.ts
@@ -155,6 +155,38 @@ describe("Webhook URL Validation", () => {
       ).rejects.toThrow("Blocked hostname detected");
     });
 
+    it("should reject encoded delimiter userinfo SSRF bypass attempts", async () => {
+      // Percent-encoded delimiters are data to the WHATWG URL parser before
+      // parsing, but become syntax if the whole URL is decoded first.
+      // Validation must parse the same URL string that fetch will execute.
+      const encodedDelimiters = ["%2F", "%23", "%3F", "%5C"];
+
+      for (const delimiter of encodedDelimiters) {
+        await expect(
+          validateWebhookURL(`http://example.com${delimiter}@127.0.0.1/hook`),
+        ).rejects.toThrow(
+          "URL credentials are not allowed. Use webhook headers for authentication instead.",
+        );
+      }
+    });
+
+    it("should reject URLs with embedded credentials", async () => {
+      await expect(
+        validateWebhookURL("https://user:pass@example.com/hook"),
+      ).rejects.toThrow(
+        "URL credentials are not allowed. Use webhook headers for authentication instead.",
+      );
+    });
+
+    it("should validate IDN hostnames using their punycoded hostname", async () => {
+      await expect(
+        validateWebhookURL("http://тест.example.com/hook"),
+      ).resolves.not.toThrow();
+
+      expect(resolve4Mock).toHaveBeenCalledWith("xn--e1aybc.example.com");
+      expect(resolve6Mock).toHaveBeenCalledWith("xn--e1aybc.example.com");
+    });
+
     it("should reject internal/intranet hostnames", async () => {
       // Note: "internal.company.com" would require DNS resolution which can timeout
       // Using domains that match blocked patterns directly for faster tests

--- a/worker/src/__tests__/webhook-validation.test.ts
+++ b/worker/src/__tests__/webhook-validation.test.ts
@@ -165,7 +165,7 @@ describe("Webhook URL Validation", () => {
         await expect(
           validateWebhookURL(`http://example.com${delimiter}@127.0.0.1/hook`),
         ).rejects.toThrow(
-          "URL credentials are not allowed. Use webhook headers for authentication instead.",
+          "URL credentials are not allowed. Use authentication headers instead.",
         );
       }
     });
@@ -174,7 +174,7 @@ describe("Webhook URL Validation", () => {
       await expect(
         validateWebhookURL("https://user:pass@example.com/hook"),
       ).rejects.toThrow(
-        "URL credentials are not allowed. Use webhook headers for authentication instead.",
+        "URL credentials are not allowed. Use authentication headers instead.",
       );
     });
 

--- a/worker/src/__tests__/webhook-validation.test.ts
+++ b/worker/src/__tests__/webhook-validation.test.ts
@@ -1,17 +1,26 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 
-const { resolve4Mock, resolve6Mock } = vi.hoisted(() => ({
+const { resolve4Mock, resolve6Mock, lookupMock } = vi.hoisted(() => ({
   resolve4Mock: vi.fn<(hostname: string) => Promise<string[]>>(),
   resolve6Mock: vi.fn<(hostname: string) => Promise<string[]>>(),
+  lookupMock:
+    vi.fn<
+      (
+        hostname: string,
+        options: { all: true },
+      ) => Promise<Array<{ address: string; family: 4 | 6 }>>
+    >(),
 }));
 
 vi.mock("node:dns/promises", () => ({
   default: {
     resolve4: resolve4Mock,
     resolve6: resolve6Mock,
+    lookup: lookupMock,
   },
   resolve4: resolve4Mock,
   resolve6: resolve6Mock,
+  lookup: lookupMock,
 }));
 
 import { validateWebhookURL } from "../../../packages/shared/src/server/webhooks/validation";
@@ -32,6 +41,13 @@ beforeEach(() => {
     return ["93.184.216.34"];
   });
   resolve6Mock.mockRejectedValue(dnsError("ENODATA", "mocked-hostname"));
+  lookupMock.mockImplementation(async (hostname: string) => {
+    if (hostname === nonexistentDomain) {
+      throw dnsError("ENOTFOUND", hostname);
+    }
+
+    return [{ address: "93.184.216.34", family: 4 }];
+  });
 });
 
 describe("Webhook URL Validation", () => {
@@ -146,6 +162,9 @@ describe("Webhook URL Validation", () => {
       ).rejects.toThrow("DNS lookup failed");
       expect(resolve4Mock).toHaveBeenCalledWith(nonexistentDomain);
       expect(resolve6Mock).toHaveBeenCalledWith(nonexistentDomain);
+      expect(lookupMock).toHaveBeenCalledWith(nonexistentDomain, {
+        all: true,
+      });
     });
 
     it("should reject URL-encoded localhost bypass attempts", async () => {
@@ -185,6 +204,9 @@ describe("Webhook URL Validation", () => {
 
       expect(resolve4Mock).toHaveBeenCalledWith("xn--e1aybc.example.com");
       expect(resolve6Mock).toHaveBeenCalledWith("xn--e1aybc.example.com");
+      expect(lookupMock).toHaveBeenCalledWith("xn--e1aybc.example.com", {
+        all: true,
+      });
     });
 
     it("should reject internal/intranet hostnames", async () => {

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -115,6 +115,7 @@ async function executeHttpAction({
   executionId,
   executionStart,
   actionConfig,
+  additionalSensitiveHeaders,
 }: {
   url: string;
   payload: string;
@@ -125,6 +126,7 @@ async function executeHttpAction({
   executionId: string;
   executionStart: Date;
   actionConfig: ActionDomainWithSecrets;
+  additionalSensitiveHeaders?: string[];
 }): Promise<{ httpStatus: number; responseBody: string }> {
   let httpStatus: number | undefined;
   let responseBody: string | undefined;
@@ -161,6 +163,7 @@ async function executeHttpAction({
               maxRedirects: env.LANGFUSE_WEBHOOK_MAX_REDIRECTS,
               skipValidation,
               whitelist: whitelistFromEnv(),
+              additionalSensitiveHeaders,
             },
           );
 
@@ -383,11 +386,15 @@ async function executeWebhookAction({
 
   // Prepare headers with signature if secret exists
   const requestHeaders: Record<string, string> = {};
+  const additionalSensitiveHeaders: string[] = [];
 
   // Add webhook config headers first
   if (webhookConfig.requestHeaders) {
     for (const [key, value] of Object.entries(webhookConfig.requestHeaders)) {
       requestHeaders[key] = value.value;
+      if (value.secret) {
+        additionalSensitiveHeaders.push(key);
+      }
     }
   }
 
@@ -419,6 +426,7 @@ async function executeWebhookAction({
     executionId,
     executionStart,
     actionConfig,
+    additionalSensitiveHeaders,
   });
 }
 


### PR DESCRIPTION
Linear: [LF-2112](https://linear.app/langfuse/issue/LF-2112/securitycritical-ssrf-bypass-via-decodeuricomponent-normalization), [LF-2113](https://linear.app/langfuse/issue/LF-2113/critical-ssrf-bypass-via-decodeuricomponent-normalization-mismatch), [INT-1228](https://linear.app/langfuse/issue/INT-1228)

## Changes

- Parse webhook URLs before validation without whole-URL `decodeURIComponent` normalization, because decoding the full URL can make validation inspect a different host than the WHATWG/fetch parser ultimately requests.

- Reject URLs with embedded username/password credentials and guide users to use authentication headers instead, because userinfo syntax can obscure the effective host and is not needed for supported webhook authentication flows.

- Deduplicate common outbound URL host validation between webhook and LLM base URL validation, because both validators had the same risky parse/decode/host-check shape and should share the same safer primitive.

- Add blocked IPv6 transition ranges for NAT64 and 6to4 embedded IP paths, because those prefixes can encode IPv4 destinations inside IPv6 addresses and bypass private/link-local IPv4 checks if left uncovered.

- Strip sensitive headers on cross-origin webhook redirects while preserving them on same-origin redirects, because credentials such as `Authorization`, `Cookie`, `Proxy-Authorization`, and `x-langfuse-signature` are origin-scoped and should not be forwarded to a redirected third-party host.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR hardens outbound URL validation against several classes of SSRF bypass: it removes the whole-URL `decodeURIComponent` normalization that could make validation inspect a different host than `fetch` ultimately requests, rejects userinfo credentials in URLs, strips sensitive headers on cross-origin redirects, and extends the IPv6 blocked-CIDR list with NAT64 and 6to4 transition ranges.

- **Shared `outboundUrlValidation` module** (`parseOutboundUrl` + `validateOutboundUrlHost`) deduplicates the previously parallel parse/decode/check logic in both the webhook and LLM base URL validators, with configurable DNS-failure policy and IP-literal handling per caller.
- **Cross-origin redirect header stripping** in `fetchWithSecureRedirects` removes `Authorization`, `Cookie`, `Proxy-Authorization`, and `x-langfuse-signature` before following any redirect that changes origin, while preserving them on same-origin hops.
- **IPv6 CIDR additions** — `64:ff9b::/96` (NAT64 Well-Known Prefix) and `2002::/16` (6to4) — close IPv4-embedding bypass paths; the RFC 8215 Local NAT64 Prefix `64:ff9b:1::/48` is not yet included.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core SSRF fixes are correct and well-tested with one minor gap in IPv6 CIDR coverage.

The credential-rejection, encoding-bypass fix, header-stripping, and 6to4 blocks all look correct and are well-tested. The one concrete gap is the RFC 8215 NAT64 local-use prefix — an operator using that prefix could still route a private IPv4 address through an IPv6 literal without being caught.

packages/shared/src/server/webhooks/ipBlocking.ts — the RFC 8215 64:ff9b:1::/48 NAT64 local-use prefix is the only entry missing from the new CIDR block list.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/server/outboundUrlValidation.ts | New shared module: parses URLs without full-URL decodeURIComponent to prevent SSRF bypass via encoded delimiters, rejects userinfo credentials, and deduplicates DNS-based host validation with configurable DNS-failure policy. |
| packages/shared/src/server/webhooks/redirectHandler.ts | Adds cross-origin redirect detection that strips Authorization, Cookie, Proxy-Authorization, and x-langfuse-signature before following cross-origin redirects while preserving them on same-origin hops; fetchOptions correctly promoted to let. |
| packages/shared/src/server/webhooks/ipBlocking.ts | Adds 64:ff9b::/96 (NAT64 Well-Known) and 2002::/16 (6to4) CIDRs; the RFC 8215 Local NAT64 Prefix 64:ff9b:1::/48 is not covered and could encode private IPv4 targets. |
| packages/shared/src/server/webhooks/validation.ts | Refactored to delegate to shared parseOutboundUrl and validateOutboundUrlHost; preserves strict webhook behavior (shouldThrowIfDnsResolutionFails: true, shouldSkipDnsCheckForLiteralIps: false). |
| packages/shared/src/server/llm/baseUrlValidation.ts | Delegates to shared primitives; intentionally uses shouldSkipDnsCheckForLiteralIps: true so public IP literals are allowed for custom LLM gateways without forcing DNS at write time. |
| worker/src/__tests__/webhook-redirect-headers.test.ts | New test file covering same-origin header preservation, cross-origin stripping of all four sensitive headers, and no-warn path when no sensitive headers are present. |
| worker/src/__tests__/webhook-validation.test.ts | Adds tests for encoded-delimiter userinfo bypass, plain credential rejection, and IDN punycode validation path; all test cases are clear and targeted. |
| worker/src/__tests__/ip-blocking.test.ts | Adds unit tests for NAT64 (64:ff9b::7f00:1) and 6to4 (2002:7f00:1::) blocking; correctly exercises the two new CIDR entries. |
| worker/src/__tests__/llm-base-url-validation.test.ts | Adds tests for encoded-delimiter SSRF bypass and plain credentials rejection in LLM base URL validation, mirroring the webhook test cases. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Incoming URL string"] --> B["assertValidUrlEncoding\n(decodeURIComponent validity check only)"]
    B -->|invalid %xx| ERR1["Invalid URL encoding"]
    B --> C["new URL(trimmedUrl)\n(WHATWG parse same as fetch)"]
    C -->|parse error| ERR2["Invalid URL syntax"]
    C --> D{"username or password set?"}
    D -->|yes| ERR3["Credentials not allowed"]
    D -->|no| E["validateOutboundUrlHost"]
    E --> F{"hostname in whitelist?"}
    F -->|yes| OK1["Allowed"]
    F -->|no| G{"isHostnameBlocked?"}
    G -->|yes| ERR4["Blocked hostname"]
    G -->|no| H{"isIPAddress?"}
    H -->|yes + blocked CIDR| ERR5["Blocked IP"]
    H -->|yes + not blocked + skipDnsCheck=true| OK2["Allowed (LLM)"]
    H -->|yes + not blocked + skipDnsCheck=false| I["DNS resolve4 + resolve6"]
    H -->|no hostname| I
    I -->|fails + throwOnFail=true| ERR6["DNS lookup failed"]
    I -->|fails + throwOnFail=false| OK3["Allowed (LLM)"]
    I -->|resolved IPs| J{"any IP in blocked CIDR?"}
    J -->|yes| ERR7["Blocked IP"]
    J -->|no| OK4["Allowed"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/webhooks/ipBlocking.ts:29
**Missing RFC 8215 NAT64 local-use prefix**

The PR adds `64:ff9b::/96` (Well-Known NAT64 Prefix, RFC 6052) and `2002::/16` (6to4), but omits `64:ff9b:1::/48` — the Local NAT64 Prefix defined in RFC 8215. An operator-deployed NAT64 gateway using this prefix could translate a private IPv4 address (e.g., `64:ff9b:1::7f00:1` → 127.0.0.1) without being caught by the current block list, since that address falls entirely outside `64:ff9b::/96`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): strip credentials on cross-..."](https://github.com/langfuse/langfuse/commit/1fea2029300c2e159a08e8dc0fc509e42eb7f423) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30978800)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->