### PR TITLE
chore(deps): web - build migrate binary with Go 1.26

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -20,7 +20,7 @@ RUN rm -rf /usr/local/lib/node_modules/corepack \
             /root/.cache/node/corepack && \
     rm -f /usr/local/bin/corepack /usr/local/bin/yarn /usr/local/bin/yarnpkg
 
-FROM --platform=${BUILDPLATFORM} golang:1.24 AS migrate-builder
+FROM --platform=${BUILDPLATFORM} golang:1.26 AS migrate-builder
 ARG TARGETOS
 ARG TARGETARCH
 ENV CGO_ENABLED=0 \


### PR DESCRIPTION
## What does this PR do?

Fixes CVEs : 
- CVE-2026-32280
- CVE-2026-32281
- CVE-2026-32283

Fixes # (issue)

N/A

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

N/A

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR upgrades the Go toolchain used in the `migrate-builder` Docker stage from `golang:1.24` to `golang:1.26` to address three CVEs (`CVE-2026-32280`, `CVE-2026-32281`, `CVE-2026-32283`) in Go's `crypto/x509` and `crypto/tls` standard library packages.

- The three CVEs (DoS via certificate chain building, quadratic policy-mapping validation, and TLS key-update deadlock) were fixed in Go **1.26.2** and Go 1.25.9 — not in the base 1.26.0 release. The `golang:1.26` floating tag resolves to 1.26.2 today, so builds currently pick up the fixes.
- Only the `migrate-builder` stage is affected; the compiled binary is statically linked (`CGO_ENABLED=0`) and copied into the final Alpine-based runner image, so no other layers change.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only concern is that the floating `golang:1.26` tag understates which patch actually carries the security fixes, though it resolves correctly today.

The change is a single-line version bump in one build stage. The CVEs it targets are genuinely fixed in the resolved image (`golang:1.26` → 1.26.2 today), and the binary produced is statically compiled with no CGO, limiting the attack surface. The suggestion to pin to `golang:1.26.2` is advisory — it would make the security intent more precise but does not block the fix from working today.

No files require special attention beyond the optional version-pin suggestion in `web/Dockerfile`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/Dockerfile | Bumps the migrate-builder stage from golang:1.24 to golang:1.26 (floating minor tag) to pick up CVE-2026-32280, CVE-2026-32281, and CVE-2026-32283 fixes; those CVEs land in Go 1.26.2, so the floating tag is safe now but the version could be pinned more precisely. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["golang:1.26 (migrate-builder)"] -->|"go install golang-migrate (clickhouse tag)"| B["Static migrate binary\n/out/migrate"]
    C["node:24-alpine (alpine)"] --> D["build-base / runtime-base"]
    D --> E["pruner → builder\n(Next.js build)"]
    E --> F["runner (final image)"]
    B -->|"COPY /out/migrate /usr/bin/migrate"| F
    E -->|"COPY next.js output"| F
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/Dockerfile:23
The three CVEs listed in the PR description (CVE-2026-32280, CVE-2026-32281, CVE-2026-32283) were fixed specifically in Go 1.26.2 — they are **not** fully addressed by Go 1.26.0 or 1.26.1. The `golang:1.26` floating tag currently resolves to 1.26.2 on Docker Hub, so builds today pick up the fixes, but a future rebuild after Go 1.26.3 is tagged would silently drift again. Pinning to `golang:1.26.2` makes the security fix explicit and reproducible.

```suggestion
FROM --platform=${BUILDPLATFORM} golang:1.26.2 AS migrate-builder
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): web - build migrate binary ..."](https://github.com/langfuse/langfuse/commit/c3e94402ebd6457552c9fec07650de43cd878520) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30981184)</sub>

<!-- /greptile_comment -->