### PR TITLE
Improve OTEL JSON trace parse diagnostics

### DIFF
--- a/web/src/__tests__/server/api/otel/parseOtelJsonTrace.servertest.ts
+++ b/web/src/__tests__/server/api/otel/parseOtelJsonTrace.servertest.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { parseOtelJsonTrace } from "@/src/features/otel/parseOtelJsonTrace";
+
+describe("parseOtelJsonTrace", () => {
+  it("returns actionable guidance for malformed JSON", () => {
+    const result = parseOtelJsonTrace(Buffer.from('{"resourceSpans": ['));
+
+    expect(result.success).toBe(false);
+    expect(result).toMatchObject({
+      error: expect.stringContaining("Failed to parse OTel JSON Trace"),
+    });
+    expect(result).toMatchObject({
+      error: expect.stringContaining("resourceSpans"),
+    });
+    expect(result).toMatchObject({
+      error: expect.stringContaining("Content-Type: application/json"),
+    });
+  });
+
+  it("requires a top-level resourceSpans array", () => {
+    const result = parseOtelJsonTrace(Buffer.from('{"scopeSpans": []}'));
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "Failed to parse OTel JSON Trace: expected a top-level resourceSpans array in the OTLP JSON payload.",
+    });
+  });
+
+  it("accepts a valid OTLP JSON trace payload", () => {
+    const result = parseOtelJsonTrace(
+      Buffer.from(
+        JSON.stringify({
+          resourceSpans: [
+            {
+              scopeSpans: [],
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(result).toEqual({
+      success: true,
+      resourceSpans: [{ scopeSpans: [] }],
+    });
+  });
+});

--- a/web/src/features/otel/parseOtelJsonTrace.ts
+++ b/web/src/features/otel/parseOtelJsonTrace.ts
@@ -1,0 +1,34 @@
+export type OtelJsonTraceParseResult =
+  | { success: true; resourceSpans: unknown[] }
+  | { success: false; error: string };
+
+function formatOtelJsonSyntaxError(error: unknown): string {
+  const details = error instanceof Error ? `: ${error.message}` : "";
+
+  return `Failed to parse OTel JSON Trace${details}. Ensure the request body is valid OTLP JSON with a top-level resourceSpans array and Content-Type: application/json.`;
+}
+
+export function parseOtelJsonTrace(body: Buffer): OtelJsonTraceParseResult {
+  let parsedBody: unknown;
+
+  try {
+    parsedBody = JSON.parse(body.toString());
+  } catch (error) {
+    return { success: false, error: formatOtelJsonSyntaxError(error) };
+  }
+
+  const resourceSpans =
+    typeof parsedBody === "object" && parsedBody !== null
+      ? (parsedBody as { resourceSpans?: unknown }).resourceSpans
+      : undefined;
+
+  if (!Array.isArray(resourceSpans)) {
+    return {
+      success: false,
+      error:
+        "Failed to parse OTel JSON Trace: expected a top-level resourceSpans array in the OTLP JSON payload.",
+    };
+  }
+
+  return { success: true, resourceSpans };
+}

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -10,6 +10,7 @@ import { $root } from "@/src/pages/api/public/otel/otlp-proto/generated/root";
 import { gunzip } from "node:zlib";
 import { ForbiddenError } from "@langfuse/shared";
 import { env } from "@/src/env.mjs";
+import { parseOtelJsonTrace } from "@/src/features/otel/parseOtelJsonTrace";
 
 /** Read a Langfuse header that may arrive with hyphens or underscores. */
 function getLangfuseHeader(
@@ -103,13 +104,15 @@ export default withMiddlewares({
         }
       }
       if (contentType.includes("application/json")) {
-        try {
-          resourceSpans = JSON.parse(body.toString()).resourceSpans;
-        } catch (e) {
-          logger.error(`Failed to parse OTel JSON`, e);
+        const parsed = parseOtelJsonTrace(body);
+
+        if (!parsed.success) {
+          logger.error(parsed.error);
           res.status(400);
-          return { error: "Failed to parse OTel JSON Trace" };
+          return { error: parsed.error };
         }
+
+        resourceSpans = parsed.resourceSpans;
       }
 
       if (!resourceSpans || resourceSpans.length === 0) {


### PR DESCRIPTION
## Summary
- add a small OTLP JSON parser helper that validates the top-level `resourceSpans` array before ingestion
- return actionable 400 errors for malformed OTLP JSON and invalid JSON payload shape
- add focused server tests for malformed JSON, missing `resourceSpans`, and valid OTLP JSON shape

## Validation
- `corepack pnpm exec prettier --check web/src/features/otel/parseOtelJsonTrace.ts web/src/pages/api/public/otel/v1/traces/index.ts web/src/__tests__/server/api/otel/parseOtelJsonTrace.servertest.ts`
- `git diff --check`
- `corepack pnpm --filter @langfuse/shared db:generate`
- `corepack pnpm --filter @langfuse/shared build`
- `corepack pnpm --filter web exec vitest run --project server src/__tests__/server/api/otel/parseOtelJsonTrace.servertest.ts`

Notes on local validation: this Windows shell is running Node 20 while the repo declares Node 24, so pnpm emitted engine warnings. The focused Vitest run passed all 3 tests; the test harness also logged expected local setup noise because no Postgres server is running at `localhost:5432`.

Part of #9701.

I found and scoped this through an AANA-gated community issue workflow. AANA was used here as a verifier/checklist gate for evidence, diff scope, test evidence, and unsupported-claim control; it does not certify correctness, compliance, or production readiness.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR extracts OTLP JSON body validation into a dedicated `parseOtelJsonTrace` utility and wires it into the OTel traces route handler, replacing a bare `JSON.parse` call with structured error returns and matching 3-test coverage.

- **New parser** (`parseOtelJsonTrace.ts`): validates that the body is well-formed JSON containing a top-level `resourceSpans` array; returns a discriminated union so callers can't accidentally ignore failures.
- **Route handler update** (`index.ts`): swaps the inline try/catch for the new helper, returning the helper's actionable message directly as the 400 response body — clients now receive context-rich errors instead of the generic `"Failed to parse OTel JSON Trace"` string.
- **Tests** (`parseOtelJsonTrace.servertest.ts`): covers malformed JSON, missing `resourceSpans`, and a valid payload against the utility in isolation.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new parser is a straightforward extraction with correct logic and the route handler behaviour is preserved.

The change is narrow and well-tested. The one thing worth a second look is that the original SyntaxError object no longer reaches logger.error — only the pre-formatted string does — which quietly reduces log fidelity for JSON parse failures compared to the previous call site.

web/src/pages/api/public/otel/v1/traces/index.ts — specifically the logger.error call at line 110 where the raw exception is no longer forwarded.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/features/otel/parseOtelJsonTrace.ts | New utility that validates OTLP JSON bodies; logic is correct. The original error object is captured inside the function but not surfaced to callers, losing stack-trace richness in log output. |
| web/src/pages/api/public/otel/v1/traces/index.ts | JSON parsing now delegates to parseOtelJsonTrace; happy-path and error-path handling are correct. The logger.error call no longer receives the raw Error object — only a pre-formatted string — which reduces log fidelity for JSON parse failures. |
| web/src/__tests__/server/api/otel/parseOtelJsonTrace.servertest.ts | Three focused unit tests covering malformed JSON, missing resourceSpans, and valid payload; assertions are appropriate. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /otel/v1/traces] --> B{content-type?}
    B -->|application/x-protobuf| C[Protobuf decode]
    B -->|application/json| D[parseOtelJsonTrace\nnew utility]
    D --> E{valid JSON?}
    E -->|No| F[return 400\nformatOtelJsonSyntaxError message]
    E -->|Yes| G{resourceSpans\nis array?}
    G -->|No| H[return 400\nmissing resourceSpans message]
    G -->|Yes| I[resourceSpans = parsed.resourceSpans]
    C --> J{resourceSpans\nempty?}
    I --> J
    J -->|Yes| K[return 200 empty]
    J -->|No| L[publishToOtelIngestionQueue]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/api/public/otel/v1/traces/index.ts:110
**Original error object dropped from log**

`logger.error` now receives only the formatted string, not the underlying `SyntaxError` instance. Most structured logging libraries (Pino, Winston) enrich log records with `err.stack` when an `Error` object is supplied as the second argument — that context is now silently discarded. The PR's `OtelJsonTraceParseResult` type doesn't surface the original error, so it can't be passed through at the call site. Consider adding an optional `cause?: unknown` field to the failure shape, or restructuring so the catch block in `index.ts` can still forward the raw exception to the logger alongside the user-facing message.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: improve OTEL JSON trace parse diagn..."](https://github.com/langfuse/langfuse/commit/7a9b113626da6464ac6477947d2bb309c3a3640b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31108175)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->