### PR TITLE
fix(scim): write audit log on user creation via SCIM POST

### DIFF
--- a/web/src/__tests__/server/scim-api.servertest.ts
+++ b/web/src/__tests__/server/scim-api.servertest.ts
@@ -574,6 +574,43 @@ describe("SCIM API", () => {
         expect(orgMemberships[0].role).toBe("ADMIN");
       });
 
+      it("should write an audit log entry when creating a user", async () => {
+        const uniqueEmail = `test.user.${randomUUID().substring(0, 8)}@example.com`;
+        const response = await makeAPICall(
+          "POST",
+          "/api/public/scim/Users",
+          {
+            userName: uniqueEmail,
+            name: {
+              formatted: "Audited User",
+            },
+            roles: ["MEMBER"],
+          },
+          createBasicAuthHeader(orgApiKey, orgSecretKey),
+        );
+
+        expect(response.status).toBe(201);
+        testUserId = response.body.id;
+
+        const orgMembership = await prisma.organizationMembership.findFirst({
+          where: { userId: testUserId, orgId: orgId },
+        });
+        expect(orgMembership).not.toBeNull();
+
+        const auditLogs = await prisma.auditLog.findMany({
+          where: {
+            resourceType: "orgMembership",
+            resourceId: orgMembership!.id,
+            action: "create",
+            orgId: orgId,
+          },
+        });
+        expect(auditLogs.length).toBe(1);
+        expect(auditLogs[0].apiKeyId).not.toBeNull();
+        expect(auditLogs[0].userId).toBeNull();
+        expect(auditLogs[0].after).toContain(orgMembership!.id);
+      });
+
       it("should return 409 when user with the same userName already exists", async () => {
         const uniqueEmail = `test.user.${randomUUID().substring(0, 8)}@example.com`;
 

--- a/web/src/pages/api/public/scim/Users/index.ts
+++ b/web/src/pages/api/public/scim/Users/index.ts
@@ -7,6 +7,7 @@ import { type NextApiRequest, type NextApiResponse } from "next";
 import { hashPassword } from "@/src/features/auth-credentials/lib/credentialsServerUtils";
 import { z } from "zod";
 import { type Role } from "@langfuse/shared";
+import { auditLog } from "@/src/features/audit-logs/auditLog";
 
 export default async function handler(
   req: NextApiRequest,
@@ -215,12 +216,20 @@ export default async function handler(
         },
         update: {},
       });
-      await prisma.organizationMembership.create({
+      const orgMembership = await prisma.organizationMembership.create({
         data: {
           userId: user.id,
           orgId: authCheck.scope.orgId,
           role,
         },
+      });
+      await auditLog({
+        resourceType: "orgMembership",
+        resourceId: orgMembership.id,
+        action: "create",
+        after: orgMembership,
+        apiKeyId: authCheck.scope.apiKeyId,
+        orgId: authCheck.scope.orgId,
       });
       logger.info(
         `[SCIM] Assigned user ${user.id} to org ${authCheck.scope.orgId} with role ${role}`,


### PR DESCRIPTION
## Summary

- POST `/api/public/scim/Users` now emits an `auditLog` entry when an `organizationMembership` is created, matching the tRPC `members.create` behavior. Without this, an org-scoped API key could create users with arbitrary roles via SCIM and leave no audit trail.
- Closes [INT-1250](https://linear.app/langfuse/issue/INT-1250).

The audit row uses the API-key meta variant (`AuditLogRecordType.API_KEY`), so an org owner can later trace which org-scoped SCIM key created the membership.

## Impacted packages

- `web` only — `web/src/pages/api/public/scim/Users/index.ts` and `web/src/__tests__/server/scim-api.servertest.ts`.

## Out of scope

- The SCIM `[id].ts` PUT (deactivate/reactivate via membership delete/create) and DELETE handlers also mutate `organizationMembership` rows without `auditLog` calls. INT-1250 only flags POST, but the same gap exists there and warrants a follow-up.

## Test plan

- [x] `pnpm --filter web run lint`
- [ ] `pnpm --filter web run test -- scim-api` — runs the new "should write an audit log entry when creating a user" case (requires local Postgres/Redis/ClickHouse)
- [ ] Manual: POST to `/api/public/scim/Users` with an org-scoped API key, verify a row appears in `audit_logs` with `resource_type = 'orgMembership'`, `action = 'create'`, `api_key_id` populated, `user_id` null

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds an `auditLog` call to the SCIM `POST /api/public/scim/Users` handler so that every org membership created via a SCIM provisioner is traceable to the org-scoped API key that issued the request, closing the gap noted in INT-1250.

- **`web/src/pages/api/public/scim/Users/index.ts`**: Captures the return value of `organizationMembership.create` and immediately follows it with `auditLog({ resourceType: \"orgMembership\", action: \"create\", apiKeyId, orgId, ... })`, matching the shape used in the tRPC `members.create` router.
- **`web/src/__tests__/server/scim-api.servertest.ts`**: Adds an integration test asserting that exactly one `auditLog` row is written with `apiKeyId` populated and `userId` null after a successful SCIM POST.

<h3>Confidence Score: 3/5</h3>

The membership creation and audit-log write are sequential but not atomic; an audit-log failure leaves the membership row orphaned and causes the SCIM client to get a 500 followed by a stuck 409 on retry.

The core audit-log logic is correct (right resource type, action, and caller identity variant), but the two database writes happen outside a transaction. In the failure path the membership is persisted while the handler returns 500 to the SCIM provisioner, making the provisioned user invisible to the provisioner and unretryable via SCIM without manual cleanup.

web/src/pages/api/public/scim/Users/index.ts — the membership create and auditLog.create calls should be wrapped in a single Prisma transaction.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/pages/api/public/scim/Users/index.ts | Adds auditLog call after organizationMembership.create; the two writes are not wrapped in a transaction, creating a stuck-state risk for SCIM clients on audit-log failure. |
| web/src/__tests__/server/scim-api.servertest.ts | New test verifies that a POST to /api/public/scim/Users creates exactly one audit log row with apiKeyId set and userId null; assertions are correct given the String? schema type for the after column. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/api/public/scim/Users/index.ts:219-233
**Non-atomic membership + audit-log creation leaves stuck SCIM state**

`organizationMembership.create` and the `auditLog` call are not wrapped in a transaction. If `auditLog` throws (e.g., a transient DB error), the membership row already exists but the handler falls through to the `catch` block and returns `500`. A SCIM provisioner that follows RFC 7644 will retry on `5xx`, but the retry then hits the `existingUser` guard and gets `409 Conflict` — the provisioner is permanently stuck and the membership has no audit trail. The `auditLog` helper already accepts an optional `prisma` argument to support transactions, so both writes can be made atomic with `prisma.$transaction`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scim): write audit log on user creat..."](https://github.com/langfuse/langfuse/commit/2889a3ad172270cb8373567c5b8ccc124657ebc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31126235)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->