### PR TITLE
fix(public-api): rate-limit project apiKeys admin and prompt POST

### DIFF
--- a/web/src/pages/api/public/projects/[projectId]/apiKeys/[apiKeyId].ts
+++ b/web/src/pages/api/public/projects/[projectId]/apiKeys/[apiKeyId].ts
@@ -3,6 +3,7 @@ import { prisma } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 import {
   validateQueryParams,
   handleDeleteApiKey,
@@ -53,6 +54,15 @@ export default async function handler(
       return res.status(403).json({
         error: "This feature is not available on your current plan.",
       });
+    }
+
+    const rateLimitCheck =
+      await RateLimitService.getInstance().rateLimitRequest(
+        authCheck.scope,
+        "public-api",
+      );
+    if (rateLimitCheck?.isRateLimited()) {
+      return rateLimitCheck.sendRestResponseIfLimited(res);
     }
 
     const params = validateQueryParams(req.query);

--- a/web/src/pages/api/public/projects/[projectId]/apiKeys/index.ts
+++ b/web/src/pages/api/public/projects/[projectId]/apiKeys/index.ts
@@ -3,6 +3,7 @@ import { prisma } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 import {
   validateQueryAndExtractId,
   handleGetApiKeys,
@@ -54,6 +55,15 @@ export default async function handler(
       return res.status(403).json({
         error: "This feature is not available on your current plan.",
       });
+    }
+
+    const rateLimitCheck =
+      await RateLimitService.getInstance().rateLimitRequest(
+        authCheck.scope,
+        "public-api",
+      );
+    if (rateLimitCheck?.isRateLimited()) {
+      return rateLimitCheck.sendRestResponseIfLimited(res);
     }
 
     const projectId = validateQueryAndExtractId(req.query);

--- a/web/src/pages/api/public/prompts.ts
+++ b/web/src/pages/api/public/prompts.ts
@@ -78,6 +78,16 @@ export default async function handler(
 
     // Handle POST requests
     if (req.method === "POST") {
+      const rateLimitCheck =
+        await RateLimitService.getInstance().rateLimitRequest(
+          authCheck.scope,
+          "prompts",
+        );
+
+      if (rateLimitCheck?.isRateLimited()) {
+        return rateLimitCheck.sendRestResponseIfLimited(res);
+      }
+
       const input = LegacyCreatePromptSchema.parse(req.body);
       const prompt = await createPrompt({
         ...input,


### PR DESCRIPTION
## Summary

Three legacy Next.js handlers authenticate directly via `ApiAuthService` without using `createAuthedProjectAPIRoute` and never invoke `RateLimitService`. This PR adds the standard `RateLimitService.rateLimitRequest` + `sendRestResponseIfLimited` short-circuit to all three after auth/entitlement checks:

- `web/src/pages/api/public/projects/[projectId]/apiKeys/index.ts` (GET/POST) — backdoor-credential minting via caller-chosen `publicKey`/`secretKey` was unbounded with a leaked org-scoped key. Closes [INT-1271](https://linear.app/langfuse/issue/INT-1271).
- `web/src/pages/api/public/projects/[projectId]/apiKeys/[apiKeyId].ts` (DELETE) — unbounded enumeration / churn of project API keys. Closes [INT-1265](https://linear.app/langfuse/issue/INT-1265).
- `web/src/pages/api/public/prompts.ts` POST — unlimited prompt-version writes; the GET branch already consumed the `prompts` bucket but POST silently bypassed it. Closes [INT-1260](https://linear.app/langfuse/issue/INT-1260).

The apiKeys admin endpoints use the `public-api` resource. The prompts POST uses the `prompts` resource, matching the GET branch on the same handler.

## Impacted packages

- `web` only — three route files under `web/src/pages/api/public/**`.

## Notes

- Rate limiting only takes effect on Cloud (`NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` set) and when `LANGFUSE_RATE_LIMITS_ENABLED !== "false"`. Self-hosted users are unaffected.
- The pattern intentionally mirrors the existing GET branch in `prompts.ts` and the `createAuthedProjectAPIRoute` pipeline — no abstraction introduced. A follow-up to migrate these admin endpoints to a shared org-scope route helper would be the cleaner long-term fix.

## Test plan

- [x] `pnpm --filter web run lint`
- [ ] Manual on Cloud staging: hammer one of the three endpoints with a valid org-scoped key past the configured limit and confirm 429 with rate-limit headers
- [ ] Manual on self-hosted: confirm requests still pass through without throttling (`LANGFUSE_RATE_LIMITS_ENABLED` unset / Redis off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR closes three legacy Next.js API routes that bypassed `RateLimitService` entirely, adding the standard `rateLimitRequest` + `sendRestResponseIfLimited` short-circuit to the apiKeys admin endpoints (GET, POST, DELETE) and the prompts POST endpoint.

- **`apiKeys/index.ts` and `apiKeys/[apiKeyId].ts`**: rate limiting now applies after auth and entitlement checks using the `public-api` bucket, which has concrete per-plan limits on Cloud (e.g. 30 req/min on hobby, 1000 req/min on pro).
- **`prompts.ts` POST branch**: mirrors the existing GET branch by consuming from the `prompts` bucket; however, the `prompts` resource currently has `null` points/duration for all built-in plans, so actual throttling only occurs for orgs with a custom `rateLimitOverrides` entry for `\"prompts\"`.
- All three changes follow the established pattern and are no-ops for self-hosted deployments.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes add rate limiting guards that fail open when Redis is unavailable or on self-hosted, and the new code paths follow the exact same pattern already in use elsewhere in the handler.

The apiKeys endpoints are well-protected — `public-api` has non-null per-plan limits on Cloud. The prompts POST addition is consistent with the GET branch but the `prompts` resource defaults to `null` for all plans, meaning the new guard only bites for orgs with a custom override. This is worth a follow-up to confirm whether default prompts limits should also be introduced to fully close the described issue.

web/src/pages/api/public/prompts.ts — confirm whether the `prompts` rate-limit resource should carry default per-plan limits rather than relying solely on custom org overrides.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/pages/api/public/projects/[projectId]/apiKeys/[apiKeyId].ts | Adds `public-api` rate limit check after auth and entitlement guards for the DELETE endpoint; placement and pattern are consistent with the existing route pipeline. |
| web/src/pages/api/public/projects/[projectId]/apiKeys/index.ts | Adds `public-api` rate limit check (before method dispatch) after auth and entitlement guards, covering both the GET list and POST create paths. |
| web/src/pages/api/public/prompts.ts | Adds `prompts` rate limit check to the POST branch, mirroring the existing GET branch; however, the `prompts` resource has `null` points/duration for all built-in plans, so the check is only effective for orgs with custom `rateLimitOverrides`. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP Request] --> B[ApiAuthService.verifyAuthHeaderAndReturnScope]
    B --> C{Valid key and org-scope?}
    C -- No --> D[Return 401/403]
    C -- Yes --> E{hasEntitlementBasedOnPlan admin-api?}
    E -- No --> F[Return 403]
    E -- Yes --> G[RateLimitService.rateLimitRequest]
    G --> H{isRateLimited?}
    H -- Yes --> I[Return 429 with Retry-After header]
    H -- No --> J[Dispatch to method handler]
    J --> K[Database operation]
    K --> L[Return 200/201/204]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/api/public/prompts.ts:81-89
**`prompts` rate-limit bucket has null points for all built-in plans**

`RateLimitService.getPlanBasedRateLimitConfig` returns `{ points: null, durationInSec: null }` for the `"prompts"` resource on every plan (`cloud:hobby`, `cloud:core`, `cloud:pro/team/enterprise`, and all self-hosted plans). `checkRateLimit` exits early when `effectiveConfig.points` is falsy, so neither this new POST check nor the pre-existing GET check will reject any request unless the org has a custom `rateLimitOverrides` entry for `"prompts"`. The fix makes POST consistent with GET (good), but the stated goal of bounding "unlimited prompt-version writes" only takes effect for orgs where such a custom override is explicitly set. Worth confirming this is the intended scope of the fix or whether default per-plan limits for `"prompts"` should also be introduced.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(public-api): rate-limit project apiK..."](https://github.com/langfuse/langfuse/commit/9247de4cec002a778d48d5c702a962298aa6e0ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31127482)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->