### PR TITLE
feat(blob-export): add exportFieldGroups multi-checkbox to blobstorage settings UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ web/test-results/*
 # Refactoring planning files (local only)
 **/.refactor/
 **/.pi-lens/
+
+# Serena MCP server config (local only)
+.serena/

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -46,3 +46,67 @@ export const BLOB_EXPORT_FIELD_GROUPS = [
 ] as const;
 
 export type BlobExportFieldGroup = (typeof BLOB_EXPORT_FIELD_GROUPS)[number];
+
+export const EXPORT_FIELD_GROUP_OPTIONS: Array<{
+  value: BlobExportFieldGroup;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "core",
+    label: "Core",
+    description:
+      "id, traceId, startTime, endTime, projectId, parentObservationId, type",
+  },
+  {
+    value: "basic",
+    label: "Basic",
+    description:
+      "name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId",
+  },
+  {
+    value: "time",
+    label: "Time",
+    description: "completionStartTime, createdAt, updatedAt",
+  },
+  {
+    value: "io",
+    label: "Input / Output",
+    description: "input, output",
+  },
+  {
+    value: "metadata",
+    label: "Metadata",
+    description: "metadata",
+  },
+  {
+    value: "model",
+    label: "Model",
+    description: "providedModelName, modelId, modelParameters",
+  },
+  {
+    value: "usage",
+    label: "Usage",
+    description: "usageDetails, costDetails, totalCost",
+  },
+  {
+    value: "prompt",
+    label: "Prompt",
+    description: "promptId, promptName, promptVersion",
+  },
+  {
+    value: "metrics",
+    label: "Metrics",
+    description: "latency, timeToFirstToken",
+  },
+  {
+    value: "tools",
+    label: "Tools",
+    description: "toolDefinitions, toolCalls, toolCallNames",
+  },
+  {
+    value: "trace_context",
+    label: "Trace Context",
+    description: "tags, release, traceName, usagePricingTierName",
+  },
+];

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -47,66 +47,60 @@ export const BLOB_EXPORT_FIELD_GROUPS = [
 
 export type BlobExportFieldGroup = (typeof BLOB_EXPORT_FIELD_GROUPS)[number];
 
-export const EXPORT_FIELD_GROUP_OPTIONS: Array<{
-  value: BlobExportFieldGroup;
-  label: string;
-  description: string;
-}> = [
-  {
-    value: "core",
+// Keyed by BlobExportFieldGroup so TypeScript errors if a group is added to
+// BLOB_EXPORT_FIELD_GROUPS without a corresponding label/description here.
+const EXPORT_FIELD_GROUP_LABELS = {
+  core: {
     label: "Core",
     description:
       "id, trace_id, start_time, end_time, project_id, parent_observation_id, type",
   },
-  {
-    value: "basic",
+  basic: {
     label: "Basic",
     description:
       "name, level, status_message, version, environment, bookmarked, public, user_id, session_id",
   },
-  {
-    value: "time",
+  time: {
     label: "Time",
     description: "completion_start_time, created_at, updated_at",
   },
-  {
-    value: "io",
+  io: {
     label: "Input / Output",
     description: "input, output",
   },
-  {
-    value: "metadata",
+  metadata: {
     label: "Metadata",
     description: "metadata",
   },
-  {
-    value: "model",
+  model: {
     label: "Model",
     description: "provided_model_name, model_id, model_parameters",
   },
-  {
-    value: "usage",
+  usage: {
     label: "Usage",
     description: "usage_details, cost_details, total_cost",
   },
-  {
-    value: "prompt",
+  prompt: {
     label: "Prompt",
     description: "prompt_id, prompt_name, prompt_version",
   },
-  {
-    value: "metrics",
+  metrics: {
     label: "Metrics",
     description: "latency, time_to_first_token",
   },
-  {
-    value: "tools",
+  tools: {
     label: "Tools",
     description: "tool_definitions, tool_calls, tool_call_names",
   },
-  {
-    value: "trace_context",
+  trace_context: {
     label: "Trace Context",
     description: "tags, release, trace_name, usage_pricing_tier_name",
   },
-];
+} satisfies Record<
+  BlobExportFieldGroup,
+  { label: string; description: string }
+>;
+
+export const EXPORT_FIELD_GROUP_OPTIONS = BLOB_EXPORT_FIELD_GROUPS.map(
+  (value) => ({ value, ...EXPORT_FIELD_GROUP_LABELS[value] }),
+);

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -56,18 +56,18 @@ export const EXPORT_FIELD_GROUP_OPTIONS: Array<{
     value: "core",
     label: "Core",
     description:
-      "id, traceId, startTime, endTime, projectId, parentObservationId, type",
+      "id, trace_id, start_time, end_time, project_id, parent_observation_id, type",
   },
   {
     value: "basic",
     label: "Basic",
     description:
-      "name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId",
+      "name, level, status_message, version, environment, bookmarked, public, user_id, session_id",
   },
   {
     value: "time",
     label: "Time",
-    description: "completionStartTime, createdAt, updatedAt",
+    description: "completion_start_time, created_at, updated_at",
   },
   {
     value: "io",
@@ -82,31 +82,31 @@ export const EXPORT_FIELD_GROUP_OPTIONS: Array<{
   {
     value: "model",
     label: "Model",
-    description: "providedModelName, modelId, modelParameters",
+    description: "provided_model_name, model_id, model_parameters",
   },
   {
     value: "usage",
     label: "Usage",
-    description: "usageDetails, costDetails, totalCost",
+    description: "usage_details, cost_details, total_cost",
   },
   {
     value: "prompt",
     label: "Prompt",
-    description: "promptId, promptName, promptVersion",
+    description: "prompt_id, prompt_name, prompt_version",
   },
   {
     value: "metrics",
     label: "Metrics",
-    description: "latency, timeToFirstToken",
+    description: "latency, time_to_first_token",
   },
   {
     value: "tools",
     label: "Tools",
-    description: "toolDefinitions, toolCalls, toolCallNames",
+    description: "tool_definitions, tool_calls, tool_call_names",
   },
   {
     value: "trace_context",
     label: "Trace Context",
-    description: "tags, release, traceName, usagePricingTierName",
+    description: "tags, release, trace_name, usage_pricing_tier_name",
   },
 ];

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -1,5 +1,4 @@
 import { renderHook, act } from "@testing-library/react";
-import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -33,57 +32,38 @@ const VALID_BASE: BlobStorageIntegrationFormSchema = {
   exportStartDate: null,
 };
 
-function useBlobStorageForm(defaults: BlobStorageIntegrationFormSchema) {
-  const form = useForm<BlobStorageIntegrationFormSchema>({
-    resolver: zodResolver(blobStorageIntegrationFormSchema),
-    defaultValues: defaults,
-    mode: "onChange",
+describe("blob storage form — exportFieldGroups validation", () => {
+  it("blocks submission when exportSource is EVENTS and all groups are deselected", async () => {
+    const { result } = renderHook(() =>
+      useForm<BlobStorageIntegrationFormSchema>({
+        resolver: zodResolver(blobStorageIntegrationFormSchema),
+        defaultValues: {
+          ...VALID_BASE,
+          exportSource: AnalyticsIntegrationExportSource.EVENTS,
+          exportFieldGroups: [],
+        },
+      }),
+    );
+
+    const onSubmit = vi.fn();
+    await act(async () => {
+      await result.current.handleSubmit(onSubmit)();
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  const exportSource = form.watch("exportSource");
-
-  useEffect(() => {
-    if (exportSource !== AnalyticsIntegrationExportSource.EVENTS) {
-      form.setValue("exportFieldGroups", [...BLOB_EXPORT_FIELD_GROUPS]);
-    }
-  }, [exportSource]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  return form;
-}
-
-describe("blob storage form — exportFieldGroups reset on source switch", () => {
-  it("resets exportFieldGroups to the full default when switching away from EVENTS", async () => {
-    const { result } = renderHook(() => useBlobStorageForm(VALID_BASE));
-
-    // Simulate user unchecking all field groups while on EVENTS
-    await act(async () => {
-      result.current.setValue("exportFieldGroups", []);
-    });
-    expect(result.current.getValues("exportFieldGroups")).toStrictEqual([]);
-
-    // Switch away from EVENTS — useEffect should reset exportFieldGroups
-    await act(async () => {
-      result.current.setValue(
-        "exportSource",
-        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-      );
-    });
-
-    expect(result.current.getValues("exportFieldGroups")).toStrictEqual([
-      ...BLOB_EXPORT_FIELD_GROUPS,
-    ]);
-  });
-
-  it("allows submission after switching from EVENTS with empty groups to TRACES_OBSERVATIONS", async () => {
-    const { result } = renderHook(() => useBlobStorageForm(VALID_BASE));
-
-    await act(async () => {
-      result.current.setValue("exportFieldGroups", []);
-      result.current.setValue(
-        "exportSource",
-        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-      );
-    });
+  it("allows submission when exportSource is TRACES_OBSERVATIONS regardless of exportFieldGroups", async () => {
+    const { result } = renderHook(() =>
+      useForm<BlobStorageIntegrationFormSchema>({
+        resolver: zodResolver(blobStorageIntegrationFormSchema),
+        defaultValues: {
+          ...VALID_BASE,
+          exportSource: AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+          exportFieldGroups: [],
+        },
+      }),
+    );
 
     const onSubmit = vi.fn();
     await act(async () => {
@@ -91,5 +71,31 @@ describe("blob storage form — exportFieldGroups reset on source switch", () =>
     });
 
     expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("preserves a saved subset when switching exportSource away from EVENTS", async () => {
+    const { result } = renderHook(() =>
+      useForm<BlobStorageIntegrationFormSchema>({
+        resolver: zodResolver(blobStorageIntegrationFormSchema),
+        defaultValues: {
+          ...VALID_BASE,
+          exportSource: AnalyticsIntegrationExportSource.EVENTS,
+          exportFieldGroups: ["core", "basic"],
+        },
+      }),
+    );
+
+    await act(async () => {
+      result.current.setValue(
+        "exportSource",
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      );
+    });
+
+    // Subset must be preserved — no automatic reset
+    expect(result.current.getValues("exportFieldGroups")).toStrictEqual([
+      "core",
+      "basic",
+    ]);
   });
 });

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -2,8 +2,8 @@ import { renderHook, act } from "@testing-library/react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
-  blobStorageIntegrationFormSchema,
   type BlobStorageIntegrationFormSchema,
+  blobStorageIntegrationFormSchema,
 } from "@/src/features/blobstorage-integration/types";
 import {
   AnalyticsIntegrationExportSource,
@@ -33,29 +33,35 @@ const VALID_BASE: BlobStorageIntegrationFormSchema = {
 };
 
 describe("blob storage form — exportFieldGroups validation", () => {
-  it("blocks submission when exportSource is EVENTS and all groups are deselected", async () => {
-    const { result } = renderHook(() =>
-      useForm<BlobStorageIntegrationFormSchema>({
-        resolver: zodResolver(blobStorageIntegrationFormSchema),
-        defaultValues: {
-          ...VALID_BASE,
-          exportSource: AnalyticsIntegrationExportSource.EVENTS,
-          exportFieldGroups: [],
-        },
-      }),
-    );
+  it.each([
+    AnalyticsIntegrationExportSource.EVENTS,
+    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+  ])(
+    "blocks submission when exportSource is %s and all groups are deselected",
+    async (source) => {
+      const { result } = renderHook(() =>
+        useForm({
+          resolver: zodResolver(blobStorageIntegrationFormSchema),
+          defaultValues: {
+            ...VALID_BASE,
+            exportSource: source,
+            exportFieldGroups: [],
+          },
+        }),
+      );
 
-    const onSubmit = vi.fn();
-    await act(async () => {
-      await result.current.handleSubmit(onSubmit)();
-    });
+      const onSubmit = vi.fn();
+      await act(async () => {
+        await result.current.handleSubmit(onSubmit)();
+      });
 
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
+      expect(onSubmit).not.toHaveBeenCalled();
+    },
+  );
 
   it("allows submission when exportSource is TRACES_OBSERVATIONS regardless of exportFieldGroups", async () => {
     const { result } = renderHook(() =>
-      useForm<BlobStorageIntegrationFormSchema>({
+      useForm({
         resolver: zodResolver(blobStorageIntegrationFormSchema),
         defaultValues: {
           ...VALID_BASE,
@@ -75,7 +81,7 @@ describe("blob storage form — exportFieldGroups validation", () => {
 
   it("preserves a saved subset when switching exportSource away from EVENTS", async () => {
     const { result } = renderHook(() =>
-      useForm<BlobStorageIntegrationFormSchema>({
+      useForm({
         resolver: zodResolver(blobStorageIntegrationFormSchema),
         defaultValues: {
           ...VALID_BASE,

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -1,0 +1,95 @@
+import { renderHook, act } from "@testing-library/react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  blobStorageIntegrationFormSchema,
+  type BlobStorageIntegrationFormSchema,
+} from "@/src/features/blobstorage-integration/types";
+import {
+  AnalyticsIntegrationExportSource,
+  BLOB_EXPORT_FIELD_GROUPS,
+  BlobStorageExportMode,
+  BlobStorageIntegrationFileType,
+  BlobStorageIntegrationType,
+} from "@langfuse/shared";
+
+const VALID_BASE: BlobStorageIntegrationFormSchema = {
+  type: BlobStorageIntegrationType.S3,
+  bucketName: "my-bucket",
+  region: "us-east-1",
+  exportFrequency: "daily",
+  enabled: true,
+  forcePathStyle: false,
+  fileType: BlobStorageIntegrationFileType.JSONL,
+  exportMode: BlobStorageExportMode.FULL_HISTORY,
+  exportSource: AnalyticsIntegrationExportSource.EVENTS,
+  exportFieldGroups: [...BLOB_EXPORT_FIELD_GROUPS],
+  compressed: true,
+  endpoint: null,
+  accessKeyId: "",
+  secretAccessKey: null,
+  prefix: "",
+  exportStartDate: null,
+};
+
+function useBlobStorageForm(defaults: BlobStorageIntegrationFormSchema) {
+  const form = useForm<BlobStorageIntegrationFormSchema>({
+    resolver: zodResolver(blobStorageIntegrationFormSchema),
+    defaultValues: defaults,
+    mode: "onChange",
+  });
+
+  const exportSource = form.watch("exportSource");
+
+  useEffect(() => {
+    if (exportSource !== AnalyticsIntegrationExportSource.EVENTS) {
+      form.setValue("exportFieldGroups", [...BLOB_EXPORT_FIELD_GROUPS]);
+    }
+  }, [exportSource]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return form;
+}
+
+describe("blob storage form — exportFieldGroups reset on source switch", () => {
+  it("resets exportFieldGroups to the full default when switching away from EVENTS", async () => {
+    const { result } = renderHook(() => useBlobStorageForm(VALID_BASE));
+
+    // Simulate user unchecking all field groups while on EVENTS
+    await act(async () => {
+      result.current.setValue("exportFieldGroups", []);
+    });
+    expect(result.current.getValues("exportFieldGroups")).toStrictEqual([]);
+
+    // Switch away from EVENTS — useEffect should reset exportFieldGroups
+    await act(async () => {
+      result.current.setValue(
+        "exportSource",
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      );
+    });
+
+    expect(result.current.getValues("exportFieldGroups")).toStrictEqual([
+      ...BLOB_EXPORT_FIELD_GROUPS,
+    ]);
+  });
+
+  it("allows submission after switching from EVENTS with empty groups to TRACES_OBSERVATIONS", async () => {
+    const { result } = renderHook(() => useBlobStorageForm(VALID_BASE));
+
+    await act(async () => {
+      result.current.setValue("exportFieldGroups", []);
+      result.current.setValue(
+        "exportSource",
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      );
+    });
+
+    const onSubmit = vi.fn();
+    await act(async () => {
+      await result.current.handleSubmit(onSubmit)();
+    });
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -59,6 +59,32 @@ describe("blob storage form — exportFieldGroups validation", () => {
     },
   );
 
+  it.each([
+    AnalyticsIntegrationExportSource.EVENTS,
+    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+  ])(
+    "blocks submission when exportSource is %s and core is missing from groups",
+    async (source) => {
+      const { result } = renderHook(() =>
+        useForm({
+          resolver: zodResolver(blobStorageIntegrationFormSchema),
+          defaultValues: {
+            ...VALID_BASE,
+            exportSource: source,
+            exportFieldGroups: ["basic", "io"],
+          },
+        }),
+      );
+
+      const onSubmit = vi.fn();
+      await act(async () => {
+        await result.current.handleSubmit(onSubmit)();
+      });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    },
+  );
+
   it("allows submission when exportSource is TRACES_OBSERVATIONS regardless of exportFieldGroups", async () => {
     const { result } = renderHook(() =>
       useForm({

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -78,30 +78,4 @@ describe("blob storage form — exportFieldGroups validation", () => {
 
     expect(onSubmit).toHaveBeenCalledOnce();
   });
-
-  it("preserves a saved subset when switching exportSource away from EVENTS", async () => {
-    const { result } = renderHook(() =>
-      useForm({
-        resolver: zodResolver(blobStorageIntegrationFormSchema),
-        defaultValues: {
-          ...VALID_BASE,
-          exportSource: AnalyticsIntegrationExportSource.EVENTS,
-          exportFieldGroups: ["core", "basic"],
-        },
-      }),
-    );
-
-    await act(async () => {
-      result.current.setValue(
-        "exportSource",
-        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-      );
-    });
-
-    // Subset must be preserved — no automatic reset
-    expect(result.current.getValues("exportFieldGroups")).toStrictEqual([
-      "core",
-      "basic",
-    ]);
-  });
 });

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -34,44 +34,23 @@ const VALID_BASE: BlobStorageIntegrationFormSchema = {
 
 describe("blob storage form — exportFieldGroups validation", () => {
   it.each([
-    AnalyticsIntegrationExportSource.EVENTS,
-    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
-  ])(
-    "blocks submission when exportSource is %s and all groups are deselected",
-    async (source) => {
+    [AnalyticsIntegrationExportSource.EVENTS, []],
+    [AnalyticsIntegrationExportSource.EVENTS, ["basic", "io"]],
+    [AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS, []],
+    [
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+      ["basic", "io"],
+    ],
+  ] as const)(
+    "blocks submission when exportSource is %s and core is absent (groups: %s)",
+    async (source, exportFieldGroups) => {
       const { result } = renderHook(() =>
         useForm({
           resolver: zodResolver(blobStorageIntegrationFormSchema),
           defaultValues: {
             ...VALID_BASE,
             exportSource: source,
-            exportFieldGroups: [],
-          },
-        }),
-      );
-
-      const onSubmit = vi.fn();
-      await act(async () => {
-        await result.current.handleSubmit(onSubmit)();
-      });
-
-      expect(onSubmit).not.toHaveBeenCalled();
-    },
-  );
-
-  it.each([
-    AnalyticsIntegrationExportSource.EVENTS,
-    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
-  ])(
-    "blocks submission when exportSource is %s and core is missing from groups",
-    async (source) => {
-      const { result } = renderHook(() =>
-        useForm({
-          resolver: zodResolver(blobStorageIntegrationFormSchema),
-          defaultValues: {
-            ...VALID_BASE,
-            exportSource: source,
-            exportFieldGroups: ["basic", "io"],
+            exportFieldGroups: [...exportFieldGroups],
           },
         }),
       );

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -379,6 +379,19 @@ describe("Blob Storage Integration tRPC Router", () => {
       ).rejects.toThrow();
     });
 
+    it("rejects empty exportFieldGroups when exportSource is TRACES_OBSERVATIONS_EVENTS", async () => {
+      const { caller, project } = await prepare();
+
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS_EVENTS" as const,
+          exportFieldGroups: [],
+        }),
+      ).rejects.toThrow();
+    });
+
     it("accepts empty exportFieldGroups when exportSource is TRACES_OBSERVATIONS", async () => {
       const { caller, project } = await prepare();
 

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -367,6 +367,31 @@ describe("Blob Storage Integration tRPC Router", () => {
       ]);
     });
 
+    it("rejects submission when core group is absent (exportSource EVENTS)", async () => {
+      const { caller, project } = await prepare();
+
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportFieldGroups: ["basic", "io"],
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("accepts empty exportFieldGroups when exportSource is TRACES_OBSERVATIONS", async () => {
+      const { caller, project } = await prepare();
+
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+          exportFieldGroups: [],
+        }),
+      ).resolves.not.toThrow();
+    });
+
     it("overwrites stored subset when a new subset is submitted", async () => {
       const { caller, project } = await prepare();
 

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -74,7 +74,9 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         .superRefine(validateAzureContainerName)
         .superRefine((data, ctx) => {
           if (
-            data.exportSource === AnalyticsIntegrationExportSource.EVENTS &&
+            (data.exportSource === AnalyticsIntegrationExportSource.EVENTS ||
+              data.exportSource ===
+                AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS) &&
             data.exportFieldGroups.length === 0
           ) {
             ctx.addIssue({

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -8,6 +8,7 @@ import {
 } from "@/src/server/api/trpc";
 import { blobStorageIntegrationFormSchemaBase } from "@/src/features/blobstorage-integration/types";
 import { validateAzureContainerName } from "@/src/features/blobstorage-integration/validation";
+import { AnalyticsIntegrationExportSource } from "@langfuse/shared";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { TRPCError } from "@trpc/server";
 import {
@@ -70,7 +71,19 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
     .input(
       blobStorageIntegrationFormSchemaBase
         .extend({ projectId: z.string() })
-        .superRefine(validateAzureContainerName),
+        .superRefine(validateAzureContainerName)
+        .superRefine((data, ctx) => {
+          if (
+            data.exportSource === AnalyticsIntegrationExportSource.EVENTS &&
+            data.exportFieldGroups.length === 0
+          ) {
+            ctx.addIssue({
+              code: "custom",
+              message: "At least one field group must be selected",
+              path: ["exportFieldGroups"],
+            });
+          }
+        }),
     )
     .mutation(async ({ input, ctx }) => {
       try {

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -7,8 +7,10 @@ import {
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
 import { blobStorageIntegrationFormSchemaBase } from "@/src/features/blobstorage-integration/types";
-import { validateAzureContainerName } from "@/src/features/blobstorage-integration/validation";
-import { AnalyticsIntegrationExportSource } from "@langfuse/shared";
+import {
+  validateAzureContainerName,
+  validateExportFieldGroups,
+} from "@/src/features/blobstorage-integration/validation";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { TRPCError } from "@trpc/server";
 import {
@@ -72,20 +74,7 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
       blobStorageIntegrationFormSchemaBase
         .extend({ projectId: z.string() })
         .superRefine(validateAzureContainerName)
-        .superRefine((data, ctx) => {
-          if (
-            (data.exportSource === AnalyticsIntegrationExportSource.EVENTS ||
-              data.exportSource ===
-                AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS) &&
-            data.exportFieldGroups.length === 0
-          ) {
-            ctx.addIssue({
-              code: "custom",
-              message: "At least one field group must be selected",
-              path: ["exportFieldGroups"],
-            });
-          }
-        }),
+        .superRefine(validateExportFieldGroups),
     )
     .mutation(async ({ input, ctx }) => {
       try {

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -46,7 +46,9 @@ export const blobStorageIntegrationFormSchema =
     .superRefine(validateAzureContainerName)
     .superRefine((data, ctx) => {
       if (
-        data.exportSource === AnalyticsIntegrationExportSource.EVENTS &&
+        (data.exportSource === AnalyticsIntegrationExportSource.EVENTS ||
+          data.exportSource ===
+            AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS) &&
         data.exportFieldGroups.length === 0
       ) {
         ctx.addIssue({

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -6,7 +6,10 @@ import {
   AnalyticsIntegrationExportSource,
   BLOB_EXPORT_FIELD_GROUPS,
 } from "@langfuse/shared";
-import { validateAzureContainerName } from "@/src/features/blobstorage-integration/validation";
+import {
+  validateAzureContainerName,
+  validateExportFieldGroups,
+} from "@/src/features/blobstorage-integration/validation";
 
 export const blobStorageIntegrationFormSchemaBase = z.object({
   type: z.enum(BlobStorageIntegrationType),
@@ -44,20 +47,7 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
 export const blobStorageIntegrationFormSchema =
   blobStorageIntegrationFormSchemaBase
     .superRefine(validateAzureContainerName)
-    .superRefine((data, ctx) => {
-      if (
-        (data.exportSource === AnalyticsIntegrationExportSource.EVENTS ||
-          data.exportSource ===
-            AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS) &&
-        data.exportFieldGroups.length === 0
-      ) {
-        ctx.addIssue({
-          code: "custom",
-          message: "At least one field group must be selected",
-          path: ["exportFieldGroups"],
-        });
-      }
-    });
+    .superRefine(validateExportFieldGroups);
 
 export type BlobStorageIntegrationFormSchema = z.infer<
   typeof blobStorageIntegrationFormSchema

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -37,13 +37,25 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
     .default(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
   exportFieldGroups: z
     .array(z.enum(BLOB_EXPORT_FIELD_GROUPS))
-    .min(1, { message: "At least one field group must be selected" })
     .default([...BLOB_EXPORT_FIELD_GROUPS]),
   compressed: z.boolean().default(true),
 });
 
 export const blobStorageIntegrationFormSchema =
-  blobStorageIntegrationFormSchemaBase.superRefine(validateAzureContainerName);
+  blobStorageIntegrationFormSchemaBase
+    .superRefine(validateAzureContainerName)
+    .superRefine((data, ctx) => {
+      if (
+        data.exportSource === AnalyticsIntegrationExportSource.EVENTS &&
+        data.exportFieldGroups.length === 0
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          message: "At least one field group must be selected",
+          path: ["exportFieldGroups"],
+        });
+      }
+    });
 
 export type BlobStorageIntegrationFormSchema = z.infer<
   typeof blobStorageIntegrationFormSchema

--- a/web/src/features/blobstorage-integration/validation.ts
+++ b/web/src/features/blobstorage-integration/validation.ts
@@ -5,15 +5,26 @@ export function validateExportFieldGroups(
   data: { exportSource: string; exportFieldGroups: unknown[] },
   ctx: z.RefinementCtx,
 ) {
-  if (
-    (data.exportSource === AnalyticsIntegrationExportSource.EVENTS ||
-      data.exportSource ===
-        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS) &&
-    data.exportFieldGroups.length === 0
-  ) {
+  const requiresFieldGroups =
+    data.exportSource === AnalyticsIntegrationExportSource.EVENTS ||
+    data.exportSource ===
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS;
+
+  if (!requiresFieldGroups) return;
+
+  if (data.exportFieldGroups.length === 0) {
     ctx.addIssue({
       code: "custom",
       message: "At least one field group must be selected",
+      path: ["exportFieldGroups"],
+    });
+    return;
+  }
+
+  if (!data.exportFieldGroups.includes("core")) {
+    ctx.addIssue({
+      code: "custom",
+      message: "The Core field group is required",
       path: ["exportFieldGroups"],
     });
   }

--- a/web/src/features/blobstorage-integration/validation.ts
+++ b/web/src/features/blobstorage-integration/validation.ts
@@ -12,15 +12,6 @@ export function validateExportFieldGroups(
 
   if (!requiresFieldGroups) return;
 
-  if (data.exportFieldGroups.length === 0) {
-    ctx.addIssue({
-      code: "custom",
-      message: "At least one field group must be selected",
-      path: ["exportFieldGroups"],
-    });
-    return;
-  }
-
   if (!data.exportFieldGroups.includes("core")) {
     ctx.addIssue({
       code: "custom",

--- a/web/src/features/blobstorage-integration/validation.ts
+++ b/web/src/features/blobstorage-integration/validation.ts
@@ -1,4 +1,23 @@
 import type { z } from "zod";
+import { AnalyticsIntegrationExportSource } from "@langfuse/shared";
+
+export function validateExportFieldGroups(
+  data: { exportSource: string; exportFieldGroups: unknown[] },
+  ctx: z.RefinementCtx,
+) {
+  if (
+    (data.exportSource === AnalyticsIntegrationExportSource.EVENTS ||
+      data.exportSource ===
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS) &&
+    data.exportFieldGroups.length === 0
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      message: "At least one field group must be selected",
+      path: ["exportFieldGroups"],
+    });
+  }
+}
 
 /**
  * Azure container names must be 3-63 characters, lowercase letters, numbers,

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from "@/src/components/ui/input";
 import { PasswordInput } from "@/src/components/ui/password-input";
 import { Switch } from "@/src/components/ui/switch";
+import { Checkbox } from "@/src/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -51,6 +52,7 @@ import {
   AnalyticsIntegrationExportSource,
   type BlobStorageIntegration,
   EXPORT_SOURCE_OPTIONS,
+  EXPORT_FIELD_GROUP_OPTIONS,
   BLOB_EXPORT_FIELD_GROUPS,
   type BlobExportFieldGroup,
 } from "@langfuse/shared";
@@ -304,6 +306,8 @@ const BlobStorageIntegrationSettingsForm = ({
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
+
+  const watchedExportSource = blobStorageForm.watch("exportSource");
 
   const utils = api.useUtils();
   const mut = api.blobStorageIntegration.update.useMutation({
@@ -722,6 +726,56 @@ const BlobStorageIntegrationSettingsForm = ({
             )}
           />
         )}
+
+        {isBetaEnabled &&
+          watchedExportSource === AnalyticsIntegrationExportSource.EVENTS && (
+            <FormField
+              control={blobStorageForm.control}
+              name="exportFieldGroups"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Export Field Groups</FormLabel>
+                  <FormDescription>
+                    Choose which field groups to include in enriched observation
+                    exports. Deselect sensitive groups (e.g. Input / Output,
+                    Metadata) to reduce export size.
+                  </FormDescription>
+                  <div className="mt-2 space-y-2">
+                    {EXPORT_FIELD_GROUP_OPTIONS.map((option) => (
+                      <div
+                        key={option.value}
+                        className="flex items-start gap-2"
+                      >
+                        <Checkbox
+                          id={`field-group-${option.value}`}
+                          checked={(field.value ?? []).includes(option.value)}
+                          onCheckedChange={(checked) => {
+                            const current = field.value ?? [];
+                            const next = checked
+                              ? [...current, option.value]
+                              : current.filter((v) => v !== option.value);
+                            field.onChange(next);
+                          }}
+                        />
+                        <label
+                          htmlFor={`field-group-${option.value}`}
+                          className="cursor-pointer space-y-0.5"
+                        >
+                          <div className="text-sm leading-none font-medium">
+                            {option.label}
+                          </div>
+                          <div className="text-muted-foreground text-xs">
+                            {option.description}
+                          </div>
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
 
         {blobStorageForm.watch("exportMode") ===
           BlobStorageExportMode.FROM_CUSTOM_DATE && (

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -731,7 +731,9 @@ const BlobStorageIntegrationSettingsForm = ({
         )}
 
         {isBetaEnabled &&
-          watchedExportSource === AnalyticsIntegrationExportSource.EVENTS && (
+          (watchedExportSource === AnalyticsIntegrationExportSource.EVENTS ||
+            watchedExportSource ===
+              AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS) && (
             <FormField
               control={blobStorageForm.control}
               name="exportFieldGroups"
@@ -739,10 +741,11 @@ const BlobStorageIntegrationSettingsForm = ({
                 <FormItem>
                   <FormLabel>Export Field Groups</FormLabel>
                   <FormDescription>
-                    Choose which field groups to include in enriched observation
-                    exports. Deselect large groups (e.g. Input / Output) to
-                    reduce export size, or privacy-sensitive groups (e.g.
-                    Metadata) to avoid storing user data.
+                    Choose which field groups to include in the enriched
+                    observations export. Deselect large groups (e.g. Input /
+                    Output) to reduce export size, or privacy-sensitive groups
+                    (e.g. Metadata) to avoid storing user data. Traces, scores,
+                    and legacy observations are always exported in full.
                   </FormDescription>
                   <div className="mt-2 space-y-2">
                     {EXPORT_FIELD_GROUP_OPTIONS.map((option) => (

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -762,12 +762,15 @@ const BlobStorageIntegrationSettingsForm = ({
                           checked={(field.value ?? []).includes(option.value)}
                           onCheckedChange={(checked) => {
                             const current = field.value ?? [];
-                            const next = checked
-                              ? [...current, option.value]
-                              : current.filter(
-                                  (v: BlobExportFieldGroup) =>
-                                    v !== option.value,
-                                );
+                            const next =
+                              checked === true
+                                ? current.includes(option.value)
+                                  ? current
+                                  : [...current, option.value]
+                                : current.filter(
+                                    (v: BlobExportFieldGroup) =>
+                                      v !== option.value,
+                                  );
                             field.onChange(next);
                           }}
                         />

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -745,8 +745,11 @@ const BlobStorageIntegrationSettingsForm = ({
                     Choose which field groups to include in the enriched
                     observations export. Deselect large groups (e.g. Input /
                     Output) to reduce export size, or privacy-sensitive groups
-                    (e.g. Metadata) to avoid storing user data. Traces, scores,
-                    and legacy observations are always exported in full.
+                    (e.g. Metadata) to avoid storing user data. Scores are
+                    always exported.
+                    {watchedExportSource ===
+                      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS &&
+                      " Traces and legacy observations are also exported in full."}
                   </FormDescription>
                   <div className="mt-2 space-y-2">
                     {EXPORT_FIELD_GROUP_OPTIONS.map((option) => (

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -309,6 +309,16 @@ const BlobStorageIntegrationSettingsForm = ({
 
   const watchedExportSource = blobStorageForm.watch("exportSource");
 
+  // When the user switches away from EVENTS, reset exportFieldGroups to the
+  // full default so the hidden .min(1) constraint never blocks submission.
+  useEffect(() => {
+    if (watchedExportSource !== AnalyticsIntegrationExportSource.EVENTS) {
+      blobStorageForm.setValue("exportFieldGroups", [
+        ...BLOB_EXPORT_FIELD_GROUPS,
+      ]);
+    }
+  }, [watchedExportSource]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const utils = api.useUtils();
   const mut = api.blobStorageIntegration.update.useMutation({
     onSuccess: () => {
@@ -754,7 +764,10 @@ const BlobStorageIntegrationSettingsForm = ({
                             const current = field.value ?? [];
                             const next = checked
                               ? [...current, option.value]
-                              : current.filter((v) => v !== option.value);
+                              : current.filter(
+                                  (v: BlobExportFieldGroup) =>
+                                    v !== option.value,
+                                );
                             field.onChange(next);
                           }}
                         />

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -314,6 +314,9 @@ const BlobStorageIntegrationSettingsForm = ({
     onSuccess: () => {
       utils.blobStorageIntegration.invalidate();
     },
+    onError: (error) => {
+      showErrorToast("Failed to save integration", error.message);
+    },
   });
   const mutDelete = api.blobStorageIntegration.delete.useMutation({
     onSuccess: () => {

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -309,16 +309,6 @@ const BlobStorageIntegrationSettingsForm = ({
 
   const watchedExportSource = blobStorageForm.watch("exportSource");
 
-  // When the user switches away from EVENTS, reset exportFieldGroups to the
-  // full default so the hidden .min(1) constraint never blocks submission.
-  useEffect(() => {
-    if (watchedExportSource !== AnalyticsIntegrationExportSource.EVENTS) {
-      blobStorageForm.setValue("exportFieldGroups", [
-        ...BLOB_EXPORT_FIELD_GROUPS,
-      ]);
-    }
-  }, [watchedExportSource]); // eslint-disable-line react-hooks/exhaustive-deps
-
   const utils = api.useUtils();
   const mut = api.blobStorageIntegration.update.useMutation({
     onSuccess: () => {

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -752,41 +752,62 @@ const BlobStorageIntegrationSettingsForm = ({
                       " Traces and legacy observations are also exported in full."}
                   </FormDescription>
                   <div className="mt-2 space-y-2">
-                    {EXPORT_FIELD_GROUP_OPTIONS.map((option) => (
-                      <div
-                        key={option.value}
-                        className="flex items-start gap-2"
-                      >
-                        <Checkbox
-                          id={`field-group-${option.value}`}
-                          checked={(field.value ?? []).includes(option.value)}
-                          onCheckedChange={(checked) => {
-                            const current = field.value ?? [];
-                            const next =
-                              checked === true
-                                ? current.includes(option.value)
-                                  ? current
-                                  : [...current, option.value]
-                                : current.filter(
-                                    (v: BlobExportFieldGroup) =>
-                                      v !== option.value,
-                                  );
-                            field.onChange(next);
-                          }}
-                        />
-                        <label
-                          htmlFor={`field-group-${option.value}`}
-                          className="cursor-pointer space-y-0.5"
+                    {EXPORT_FIELD_GROUP_OPTIONS.map((option) => {
+                      const isCore = option.value === "core";
+                      return (
+                        <div
+                          key={option.value}
+                          className="flex items-start gap-2"
                         >
-                          <div className="text-sm leading-none font-medium">
-                            {option.label}
-                          </div>
-                          <div className="text-muted-foreground text-xs">
-                            {option.description}
-                          </div>
-                        </label>
-                      </div>
-                    ))}
+                          <Checkbox
+                            id={`field-group-${option.value}`}
+                            checked={
+                              isCore
+                                ? true
+                                : (field.value ?? []).includes(option.value)
+                            }
+                            disabled={isCore}
+                            onCheckedChange={
+                              isCore
+                                ? undefined
+                                : (checked) => {
+                                    const current = field.value ?? [];
+                                    const next =
+                                      checked === true
+                                        ? current.includes(option.value)
+                                          ? current
+                                          : [...current, option.value]
+                                        : current.filter(
+                                            (v: BlobExportFieldGroup) =>
+                                              v !== option.value,
+                                          );
+                                    field.onChange(next);
+                                  }
+                            }
+                          />
+                          <label
+                            htmlFor={`field-group-${option.value}`}
+                            className={
+                              isCore
+                                ? "space-y-0.5"
+                                : "cursor-pointer space-y-0.5"
+                            }
+                          >
+                            <div className="text-sm leading-none font-medium">
+                              {option.label}
+                              {isCore && (
+                                <span className="text-muted-foreground ml-1 font-normal">
+                                  (required)
+                                </span>
+                              )}
+                            </div>
+                            <div className="text-muted-foreground text-xs">
+                              {option.description}
+                            </div>
+                          </label>
+                        </div>
+                      );
+                    })}
                   </div>
                   <FormMessage>
                     {

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -308,6 +308,7 @@ const BlobStorageIntegrationSettingsForm = ({
   }, [state]);
 
   const watchedExportSource = blobStorageForm.watch("exportSource");
+  const watchedExportMode = blobStorageForm.watch("exportMode");
 
   const utils = api.useUtils();
   const mut = api.blobStorageIntegration.update.useMutation({
@@ -784,14 +785,18 @@ const BlobStorageIntegrationSettingsForm = ({
                       </div>
                     ))}
                   </div>
-                  <FormMessage />
+                  <FormMessage>
+                    {
+                      blobStorageForm.formState.errors.exportFieldGroups
+                        ?.message
+                    }
+                  </FormMessage>
                 </FormItem>
               )}
             />
           )}
 
-        {blobStorageForm.watch("exportMode") ===
-          BlobStorageExportMode.FROM_CUSTOM_DATE && (
+        {watchedExportMode === BlobStorageExportMode.FROM_CUSTOM_DATE && (
           <FormField
             control={blobStorageForm.control}
             name="exportStartDate"

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -737,8 +737,9 @@ const BlobStorageIntegrationSettingsForm = ({
                   <FormLabel>Export Field Groups</FormLabel>
                   <FormDescription>
                     Choose which field groups to include in enriched observation
-                    exports. Deselect sensitive groups (e.g. Input / Output,
-                    Metadata) to reduce export size.
+                    exports. Deselect large groups (e.g. Input / Output) to
+                    reduce export size, or privacy-sensitive groups (e.g.
+                    Metadata) to avoid storing user data.
                   </FormDescription>
                   <div className="mt-2 space-y-2">
                     {EXPORT_FIELD_GROUP_OPTIONS.map((option) => (


### PR DESCRIPTION
## Summary

Part 4 of [LFE-9456](https://linear.app/langfuse/issue/LFE-9456) — stacked on top of the worker wiring PR.

- Adds `EXPORT_FIELD_GROUP_OPTIONS` constant to `@langfuse/shared` (analytics-integrations module) — one entry per group with `value`, `label`, and `description` (column list)
- Adds `exportFieldGroups` multi-checkbox `FormField` to the blob storage settings form, rendered only when `isBetaEnabled && exportSource === EVENTS`
- Default: all 11 groups checked, preserving today's behaviour on first load
- Clarifies the field group description copy: large groups (e.g. Input / Output) reduce export size; privacy-sensitive groups (e.g. Metadata) avoid storing user data
- Also adds `.serena/` to the root `.gitignore`

### Impacted packages

- `packages/shared` — new `EXPORT_FIELD_GROUP_OPTIONS` export
- `web` — form field in blobstorage settings page

## Test plan

- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter @langfuse/shared run typecheck`
- [x] `pnpm --filter web run typecheck`
- [x] `dotenv -e .env -- pnpm --filter web exec vitest run blob-storage-integration-trpc` — 4/4 passed
- [ ] Manual browser review: open blob storage settings, switch export source to EVENTS, confirm checkboxes appear with correct labels and descriptions; deselect all and confirm form rejects submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR adds an `exportFieldGroups` multi-checkbox UI to the blob storage settings form, allowing users to select which field groups are included in enriched observation exports. It also introduces `EXPORT_FIELD_GROUP_OPTIONS` to `@langfuse/shared` and removes the now-complete planning document.

- **`packages/shared`**: New `EXPORT_FIELD_GROUP_OPTIONS` constant with `value`, `label`, and `description` for all 11 field groups, typed against `BlobExportFieldGroup`.
- **`web` blobstorage settings**: Conditional `exportFieldGroups` `FormField` rendered when `isBetaEnabled && exportSource === EVENTS`; defaults to all groups on first load, with `.min(1)` Zod validation preventing empty selection.
- **Cleanup**: Planning document deleted; `.serena/` added to `.gitignore`.

<h3>Confidence Score: 3/5</h3>

Requires a fix for the hidden validation dead-lock before merging; the checkbox type and `as const` issues are minor follow-ups.

After unchecking all groups on the EVENTS source and switching away, the form permanently blocks submission with a validation error that never surfaces to the user — the `<FormMessage />` is inside the same conditional block that hides the field. This is a real, reproducible UX breakage on the changed path that can leave the settings page in an unrecoverable state without a page reload.

`web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx` needs the export-source-switch / validation interaction addressed.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx | Adds `exportFieldGroups` multi-checkbox field gated by `isBetaEnabled && EVENTS` source; has a silent validation failure edge case when switching export sources after unchecking all groups, and a minor `onCheckedChange` type handling issue. |
| packages/shared/src/features/analytics-integrations/index.ts | Adds `EXPORT_FIELD_GROUP_OPTIONS` constant with all 11 field groups and their display metadata; values match `BLOB_EXPORT_FIELD_GROUPS` exactly; missing `as const` unlike the sibling `EXPORT_SOURCE_OPTIONS`. |
| .gitignore | Adds `.serena/` to gitignore for the Serena MCP server local config directory. |
| plans/export-field-selection.md | Planning document deleted now that the 4-PR feature is complete. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Blob Storage Settings] --> B{isBetaEnabled?}
    B -- No --> C[Standard form, no field group selector]
    B -- Yes --> D{watchedExportSource}
    D -- TRACES_OBSERVATIONS / TRACES_OBSERVATIONS_EVENTS --> E[Hide exportFieldGroups field\nBut Zod min-1 still active]
    D -- EVENTS --> F[Show exportFieldGroups checkboxes\ndefault: all 11 groups checked]
    F --> G[User toggles checkboxes]
    G --> H{Any group still checked?}
    H -- Yes --> I[field.onChange updates form state]
    H -- No --> J[Array becomes empty\nZod min-1 blocks submit]
    J --> K{exportSource still EVENTS?}
    K -- Yes --> L[FormMessage visible: error shown]
    K -- No --> M[FormMessage hidden: silent block]
    I --> N[Submit to mut.mutate with exportFieldGroups]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx:730-778
**Silent validation failure when switching export source**

The `exportFieldGroups` field has a `.min(1)` Zod constraint that runs regardless of whether the field is visible. A user can uncheck all 11 groups while `EVENTS` is selected, then switch to `TRACES_OBSERVATIONS` — the form will reject submission due to the hidden validation error, but the `<FormMessage />` is inside the conditional block and never shown, leaving the user with no indication of what went wrong. Consider resetting `exportFieldGroups` back to the full default when the user switches away from `EVENTS`, or applying `.superRefine` to skip the `min(1)` check when `exportSource !== EVENTS`.

### Issue 2 of 3
web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx:753-757
The `onCheckedChange` callback receives `CheckedState` (`boolean | "indeterminate"`), not just `boolean`. When `checked === "indeterminate"` (truthy), the current code adds the value unconditionally, potentially creating duplicate entries if the item is already present. Narrowing to `checked === true` avoids the ambiguity.

```suggestion
                          onCheckedChange={(checked) => {
                            const current = field.value ?? [];
                            const next =
                              checked === true
                                ? current.includes(option.value)
                                  ? current
                                  : [...current, option.value]
                                : current.filter((v) => v !== option.value);
```

### Issue 3 of 3
packages/shared/src/features/analytics-integrations/index.ts:107-112
`EXPORT_SOURCE_OPTIONS` is declared with `as const` (line 29), but `EXPORT_FIELD_GROUP_OPTIONS` is not. Applying `as const` keeps the array type narrowed and consistent with the existing pattern in this file.

```suggestion
  {
    value: "trace_context",
    label: "Trace Context",
    description: "tags, release, traceName, usagePricingTierName",
  },
] as const;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove completed export-field-sel..."](https://github.com/langfuse/langfuse/commit/c62646bb323ac05d770c6a3631beebdc6315076f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31181259)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->