### PR TITLE
fix(formatted-trace): restore inline media rendering

### DIFF
--- a/web/src/components/trace/components/IOPreview/components/ChatMessageList.clienttest.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ChatMessageList.clienttest.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { ChatMessageList } from "./ChatMessageList";
+
+const sectionMediaSpy = vi.fn(() => <div data-testid="section-media" />);
+
+vi.mock("./ChatMessage", () => ({
+  ChatMessage: () => <div data-testid="chat-message" />,
+}));
+
+vi.mock("./SectionMedia", () => ({
+  SectionMedia: (props: unknown) => sectionMediaSpy(props),
+}));
+
+afterEach(() => {
+  cleanup();
+  sectionMediaSpy.mockClear();
+});
+
+describe("ChatMessageList", () => {
+  it("dedupes media already rendered inline from multimodal content", () => {
+    const mediaReference =
+      "@@@langfuseMedia:type=image/png|id=media-1|source=base64_data_uri@@@";
+
+    render(
+      <ChatMessageList
+        messages={
+          [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: "before" },
+                { type: "image_url", image_url: { url: mediaReference } },
+              ],
+            },
+          ] as any
+        }
+        shouldRenderMarkdown={true}
+        media={
+          [
+            {
+              mediaId: "media-1",
+              contentType: "image/png",
+              contentLength: 1,
+              url: "https://example.com/media-1.png",
+              urlExpiry: "2099-01-01T00:00:00.000Z",
+              field: "input",
+            },
+          ] as any
+        }
+        currentView="pretty"
+        messageToToolCallNumbers={new Map()}
+      />,
+    );
+
+    expect(screen.queryByTestId("section-media")).not.toBeInTheDocument();
+    expect(sectionMediaSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/trace/components/IOPreview/components/ChatMessageList.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ChatMessageList.tsx
@@ -79,10 +79,7 @@ export function ChatMessageList({
     visibleMessages.forEach(({ message }) => {
       const content = message.content;
 
-      // Queue previews reliably render standalone media tags in strings and
-      // output audio inline, but OpenAI content-part images still fall back to
-      // the shared media strip on this surface.
-      if (typeof content === "string") {
+      if (typeof content === "string" || Array.isArray(content)) {
         getRenderedInlineMediaIds({
           markdown: content,
           audio: message.audio,

--- a/web/src/components/ui/MarkdownJsonView.clienttest.tsx
+++ b/web/src/components/ui/MarkdownJsonView.clienttest.tsx
@@ -1,0 +1,38 @@
+import { render, cleanup } from "@testing-library/react";
+import { MarkdownJsonView } from "@/src/components/ui/MarkdownJsonView";
+
+const markdownViewSpy = vi.fn(() => <div data-testid="markdown-view" />);
+
+vi.mock("@/src/components/ui/MarkdownViewer", () => ({
+  MarkdownView: (props: unknown) => markdownViewSpy(props),
+}));
+
+afterEach(() => {
+  cleanup();
+  markdownViewSpy.mockClear();
+});
+
+describe("MarkdownJsonView", () => {
+  it("passes raw multimodal content to MarkdownView so media references stay renderable", () => {
+    const content = [
+      { type: "text", text: "before" },
+      {
+        type: "image_url",
+        image_url: {
+          url: "@@@langfuseMedia:type=image/png|id=media-1|source=base64_data_uri@@@",
+        },
+      },
+    ] as const;
+
+    render(<MarkdownJsonView content={content} title="Input" />);
+
+    expect(markdownViewSpy).toHaveBeenCalledTimes(1);
+    expect(markdownViewSpy.mock.calls[0]?.[0]).toMatchObject({
+      markdown: content,
+    });
+    expect(
+      (markdownViewSpy.mock.calls[0]?.[0] as { markdown: typeof content })
+        .markdown[1],
+    ).toEqual(content[1]);
+  });
+});

--- a/web/src/components/ui/MarkdownJsonView.tsx
+++ b/web/src/components/ui/MarkdownJsonView.tsx
@@ -114,9 +114,7 @@ export function MarkdownJsonView({
     <>
       {canEnableMarkdown ? (
         <MarkdownView
-          markdown={
-            validatedOpenAIContent.success ? validatedOpenAIContent.data : null
-          }
+          markdown={content}
           title={title}
           titleIcon={titleIcon}
           customCodeHeaderClassName={customCodeHeaderClassName}


### PR DESCRIPTION
## Summary
- pass the raw validated multimodal content into `MarkdownView` so Langfuse media reference strings remain renderable inline
- treat OpenAI content arrays as inline-rendered media when deduping the shared Media strip
- add regression tests for both code paths

## Testing
- `pnpm exec vitest run --config vitest.config.mts --project client src/components/ui/MarkdownJsonView.clienttest.tsx src/components/trace2/components/IOPreview/components/ChatMessageList.clienttest.tsx`

Fixes langfuse/langfuse#13330

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<h3>Greptile Summary</h3>

This PR fixes inline media rendering in the formatted chat view by passing raw (pre-Zod-transform) multimodal content to `MarkdownView` and by extending media deduplication to cover OpenAI array-format messages.

- **`MarkdownJsonView.tsx`**: The previous code passed `validatedOpenAIContent.data` to `MarkdownView`. Because `MediaReferenceStringSchema` uses a `.transform()` that converts the `@@@langfuseMedia:...@@@` string into a `ParsedMediaReferenceType` object, the validated data caused `parseOpenAIContentParts` to interpolate `[object Object]` into the markdown image/audio syntax instead of the original reference string. The fix passes the raw `content` directly so the string is preserved.
- **`ChatMessageList.tsx`**: Media deduplication previously only ran for string content (`typeof content === \"string\"`). Array-format (multimodal) messages were skipped, so their images always appeared in the shared media strip even when already rendered inline. Adding `|| Array.isArray(content)` corrects this.
- Regression tests cover both paths: `MarkdownJsonView.clienttest.tsx` asserts the raw array is forwarded unchanged to `MarkdownView`, and `ChatMessageList.clienttest.tsx` asserts `SectionMedia` is not rendered when media is already inline.

<h3>Confidence Score: 4/5</h3>

Safe to merge — both changes are minimal, target a clear root cause, and are covered by new regression tests.

The `MarkdownJsonView` fix relies on a `isSupportedMarkdownFormat` type-predicate guard so raw content is only forwarded when Zod validation already succeeded. `parseOpenAIContentParts` is typed for post-transform output but now receives pre-transform raw strings; this works correctly since string is a valid subtype, with no observable effect today.

web/src/components/ui/MarkdownJsonView.tsx — the `parseOpenAIContentParts` helper in MarkdownViewer.tsx is typed for post-transform Zod output but now receives pre-transform data; future changes to that helper should account for this.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/components/ui/MarkdownJsonView.tsx | Passes raw `content` instead of Zod-validated/transformed data to MarkdownView, restoring media reference string fidelity. Relies on the `isSupportedMarkdownFormat` type predicate to guard the branch. |
| web/src/components/trace2/components/IOPreview/components/ChatMessageList.tsx | Extends media deduplication to array-format (multimodal) messages so images already rendered inline are no longer duplicated in the shared SectionMedia strip. |
| web/src/components/ui/MarkdownJsonView.clienttest.tsx | New regression test verifying that the raw content array (including media reference objects) is forwarded unchanged to MarkdownView. |
| web/src/components/trace2/components/IOPreview/components/ChatMessageList.clienttest.tsx | New regression test confirming SectionMedia is suppressed when media is already rendered inline via an image_url content part. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant MarkdownJsonView
    participant MarkdownView
    participant parseOpenAIContentParts

    Caller->>MarkdownJsonView: content (raw unknown)
    MarkdownJsonView->>MarkdownJsonView: OpenAIContentSchema.safeParse(content)
    Note over MarkdownJsonView: isSupportedMarkdownFormat guard
    alt canEnableMarkdown (valid schema)
        MarkdownJsonView->>MarkdownView: "markdown = content (raw, media refs preserved)"
        MarkdownView->>parseOpenAIContentParts: raw content array
        parseOpenAIContentParts-->>MarkdownView: "![image](@@@langfuseMedia:...@@@)"
        Note over MarkdownView: Media reference string intact
    else invalid / too large
        MarkdownJsonView-->>Caller: PrettyJsonView fallback
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix: restore inline media rendering in f..."](https://github.com/langfuse/langfuse/commit/fd183aabc23bd738440b9cb0bdc050461b2bdb11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31168542)</sub>

<!-- /greptile_comment -->