### PR TITLE
fix(annotation-queues): fetch parent trace id from events table on cloud

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2696,6 +2696,16 @@ export const getObservationsBatchIOFromEventsTable = async (opts: {
   }));
 };
 
+/**
+ * Discouraged: Avoid using this function for new code.
+ *
+ * This function exists solely to support the annotation queue items lookup,
+ * which needs to resolve parent trace IDs for observation-type queue items.
+ * It is problematic for performance as it lacks time filtering, requiring
+ * ClickHouse to scan a broad range of data.
+ * We aim to refactor the annotation queue data model to eliminate this
+ * dependency in a future iteration.
+ */
 export const getObservationsTraceIdsFromEventsTable = async (opts: {
   projectId: string;
   observationIds: string[];

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -2696,6 +2696,41 @@ export const getObservationsBatchIOFromEventsTable = async (opts: {
   }));
 };
 
+export const getObservationsTraceIdsFromEventsTable = async (opts: {
+  projectId: string;
+  observationIds: string[];
+}) => {
+  const { projectId, observationIds } = opts;
+
+  const queryBuilder = new EventsQueryBuilder({ projectId })
+    .selectRaw("e.trace_id AS trace_id", "e.span_id AS span_id")
+    .whereRaw("e.span_id IN {observationIds: Array(String)}", {
+      observationIds,
+    });
+
+  const { query, params: queryParams } = queryBuilder.buildWithParams();
+
+  const result = await queryClickhouse<{
+    trace_id: string;
+    span_id: string;
+  }>({
+    query,
+    params: queryParams,
+    tags: {
+      feature: "tracing",
+      type: "events",
+      kind: "getObservationsTraceIdsFromEventsTable",
+      projectId,
+    },
+    preferredClickhouseService: "EventsReadOnly",
+  });
+
+  return result.map((row) => ({
+    id: row.span_id,
+    traceId: row.trace_id,
+  }));
+};
+
 /**
  * Column mappings for user queries from events table.
  * Includes a "Timestamp" mapping that points to start_time for compatibility

--- a/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
+++ b/web/src/features/annotation-queues/components/AnnotationQueueItemPage.tsx
@@ -16,7 +16,6 @@ import { useAnnotationObjectData } from "./shared/hooks/useAnnotationObjectData"
 import { TraceAnnotationProcessor } from "./processors/TraceAnnotationProcessor";
 import { SessionAnnotationProcessor } from "./processors/SessionAnnotationProcessor";
 import { ObjectNotFoundCard } from "@/src/components/ui/object-not-found-card";
-import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { useSession } from "next-auth/react";
 
 export const AnnotationQueueItemPage: React.FC<{
@@ -28,7 +27,6 @@ export const AnnotationQueueItemPage: React.FC<{
   const router = useRouter();
   const { status: sessionStatus } = useSession();
   const sessionLoaded = sessionStatus !== "loading";
-  const { isBetaEnabled } = useV4Beta();
   const isSingleItem = router.query.singleItem === "true";
   const [nextItemData, setNextItemData] = useState<
     RouterOutput["annotationQueues"]["fetchAndLockNext"] | null
@@ -44,7 +42,7 @@ export const AnnotationQueueItemPage: React.FC<{
   const itemId = isSingleItem ? queryItemId : seenItemIds[progressIndex];
 
   const seenItemData = api.annotationQueueItems.byId.useQuery(
-    { projectId, itemId: itemId as string, isBetaEnabled },
+    { projectId, itemId: itemId as string },
     { enabled: !!itemId && sessionLoaded, refetchOnMount: false },
   );
 
@@ -59,7 +57,6 @@ export const AnnotationQueueItemPage: React.FC<{
           queueId: annotationQueueId,
           projectId,
           seenItemIds,
-          isBetaEnabled,
         });
         setNextItemData(nextItem);
       }
@@ -92,7 +89,6 @@ export const AnnotationQueueItemPage: React.FC<{
           queueId: annotationQueueId,
           projectId,
           seenItemIds,
-          isBetaEnabled,
         });
         setNextItemData(nextItem);
       }
@@ -171,7 +167,6 @@ export const AnnotationQueueItemPage: React.FC<{
         queueId: annotationQueueId,
         projectId,
         seenItemIds,
-        isBetaEnabled,
       });
       setNextItemData(nextItem);
     }

--- a/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
@@ -220,12 +220,13 @@ export const queueItemRouter = createTRPCRouter({
       let traceIds: { id: string; traceId: string }[];
 
       if (hasQueueItemsReferencingObservations) {
-        env.LANGFUSE_ENABLE_EVENTS_TABLE_UI === "true"
-          ? await getObservationsTraceIdsFromEventsTable({
-              projectId: input.projectId,
-              observationIds,
-            })
-          : await getTraceIdsForObservations(input.projectId, observationIds);
+        traceIds =
+          env.LANGFUSE_ENABLE_EVENTS_TABLE_UI === "true"
+            ? await getObservationsTraceIdsFromEventsTable({
+                projectId: input.projectId,
+                observationIds,
+              })
+            : await getTraceIdsForObservations(input.projectId, observationIds);
       } else {
         traceIds = [];
       }

--- a/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
@@ -21,11 +21,13 @@ import {
 import {
   getObservationById,
   getObservationByIdFromEventsTable,
+  getObservationsTraceIdsFromEventsTable,
   getTraceIdsForObservations,
   logger,
 } from "@langfuse/shared/src/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { env } from "@/src/env.mjs";
 
 const isItemLocked = (item: AnnotationQueueItem) => {
   return (
@@ -126,15 +128,16 @@ export const queueItemRouter = createTRPCRouter({
       };
 
       if (item.objectType === AnnotationQueueObjectType.OBSERVATION) {
-        const clickhouseObservation = input.isBetaEnabled
-          ? await getObservationByIdFromEventsTable({
-              id: item.objectId,
-              projectId: input.projectId,
-            })
-          : await getObservationById({
-              id: item.objectId,
-              projectId: input.projectId,
-            });
+        const clickhouseObservation =
+          env.LANGFUSE_ENABLE_EVENTS_TABLE_UI === "true"
+            ? await getObservationByIdFromEventsTable({
+                id: item.objectId,
+                projectId: input.projectId,
+              })
+            : await getObservationById({
+                id: item.objectId,
+                projectId: input.projectId,
+              });
 
         if (!clickhouseObservation) {
           throw new LangfuseNotFoundError("Observation not found");
@@ -212,10 +215,20 @@ export const queueItemRouter = createTRPCRouter({
         )
         .map((item) => item.objectId);
 
-      const traceIds =
-        observationIds.length > 0
-          ? await getTraceIdsForObservations(input.projectId, observationIds)
-          : [];
+      const hasQueueItemsReferencingObservations = observationIds.length > 0;
+
+      let traceIds: { id: string; traceId: string }[];
+
+      if (hasQueueItemsReferencingObservations) {
+        env.LANGFUSE_ENABLE_EVENTS_TABLE_UI === "true"
+          ? await getObservationsTraceIdsFromEventsTable({
+              projectId: input.projectId,
+              observationIds,
+            })
+          : await getTraceIdsForObservations(input.projectId, observationIds);
+      } else {
+        traceIds = [];
+      }
 
       return {
         queueItems: queueItems.map((item) => ({

--- a/web/src/features/annotation-queues/server/annotationQueuesRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueuesRouter.ts
@@ -1,3 +1,4 @@
+import { env } from "@/src/env.mjs";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
@@ -520,15 +521,16 @@ export const queueRouter = createTRPCRouter({
       };
 
       if (item.objectType === AnnotationQueueObjectType.OBSERVATION) {
-        const clickhouseObservation = input.isBetaEnabled
-          ? await getObservationByIdFromEventsTable({
-              id: item.objectId,
-              projectId: input.projectId,
-            })
-          : await getObservationById({
-              id: item.objectId,
-              projectId: input.projectId,
-            });
+        const clickhouseObservation =
+          env.LANGFUSE_ENABLE_EVENTS_TABLE_UI === "true"
+            ? await getObservationByIdFromEventsTable({
+                id: item.objectId,
+                projectId: input.projectId,
+              })
+            : await getObservationById({
+                id: item.objectId,
+                projectId: input.projectId,
+              });
         return {
           ...inflatedUpdatedItem,
           parentTraceId: clickhouseObservation?.traceId,


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the per-user `isBetaEnabled` beta flag (derived from `useV4Beta`) with a server-side environment variable (`LANGFUSE_ENABLE_EVENTS_TABLE_UI`) for deciding whether to fetch observation data from the new events table or the classic observations table in annotation queue workflows. It also adds a new ClickHouse repository function (`getObservationsTraceIdsFromEventsTable`) to resolve parent trace IDs for batch observation queue items when the events table is active.

- **Flag migration**: All three tRPC endpoints (`byId`, `itemsByQueueId`, `fetchAndLockNext`) and the React component are updated to drop the client-passed `isBetaEnabled` field in favour of the server-side env var, so cloud deployments consistently use the events table without requiring per-session opt-in.
- **New repository function**: `getObservationsTraceIdsFromEventsTable` is introduced in `events.ts` to batch-look up trace IDs from the events table for a list of observation IDs, mirroring `getTraceIdsForObservations` from the observations table.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core logic is sound and the flag migration is consistent across all three tRPC endpoints. The main concerns are cosmetic: two leftover isBetaEnabled fields in the input schemas that are no longer read, and the new events-table query returning multiple rows per observation due to the append-only nature of the table.

The flag switch from client-side to server-side is straightforward and applied consistently. The new getObservationsTraceIdsFromEventsTable function is functionally correct because find() picks the first match and a trace_id does not change for a given span_id. However, the query lacks deduplication, so observations with many update events will cause oversized result sets. The unused isBetaEnabled schema fields are harmless but add noise.

Pay closest attention to packages/shared/src/server/repositories/events.ts where the new getObservationsTraceIdsFromEventsTable query may return multiple rows per observation. The two router files (annotationQueueItemsRouter.ts and annotationQueuesRouter.ts) have leftover isBetaEnabled schema fields worth cleaning up.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as AnnotationQueueItemPage
    participant ItemsRouter as queueItemRouter (byId / itemsByQueueId)
    participant QueueRouter as queueRouter (fetchAndLockNext)
    participant Env as env.LANGFUSE_ENABLE_EVENTS_TABLE_UI
    participant EventsCH as ClickHouse (events table)
    participant ObsCH as ClickHouse (observations table)

    UI->>ItemsRouter: "byId({ projectId, itemId })"
    ItemsRouter->>Env: check flag
    alt "flag === true (cloud)"
        ItemsRouter->>EventsCH: getObservationByIdFromEventsTable(id, projectId)
        EventsCH-->>ItemsRouter: observation with traceId
    else "flag !== true (self-hosted)"
        ItemsRouter->>ObsCH: getObservationById(id, projectId)
        ObsCH-->>ItemsRouter: observation with traceId
    end
    ItemsRouter-->>UI: "{ ...item, parentTraceId }"

    UI->>ItemsRouter: "itemsByQueueId({ queueId, projectId })"
    ItemsRouter->>Env: check flag
    alt "flag === true"
        ItemsRouter->>EventsCH: getObservationsTraceIdsFromEventsTable(projectId, observationIds)
        EventsCH-->>ItemsRouter: "[{ id, traceId }]"
    else
        ItemsRouter->>ObsCH: getTraceIdsForObservations(projectId, observationIds)
        ObsCH-->>ItemsRouter: "[{ id, traceId }]"
    end
    ItemsRouter-->>UI: "{ queueItems with parentTraceId, totalItems }"

    UI->>QueueRouter: "fetchAndLockNext({ queueId, projectId, seenItemIds })"
    QueueRouter->>Env: check flag
    alt "flag === true"
        QueueRouter->>EventsCH: getObservationByIdFromEventsTable(id, projectId)
        EventsCH-->>QueueRouter: observation with traceId
    else
        QueueRouter->>ObsCH: getObservationById(id, projectId)
        ObsCH-->>QueueRouter: observation with traceId
    end
    QueueRouter-->>UI: "{ ...item, parentTraceId }"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/src/server/repositories/events.ts:2705-2709
The events table is an append-only log — every create/update to an observation lands as a separate row with the same `span_id`. Without a `DISTINCT` or `GROUP BY e.span_id`, this query can return multiple rows per observation ID. While the consuming `find()` call works correctly (it just takes the first match, and `trace_id` is stable for a given `span_id`), the result set may be far larger than the number of unique observations when observations have been updated multiple times, wasting network and memory bandwidth.

```suggestion
  const queryBuilder = new EventsQueryBuilder({ projectId })
    .selectRaw(
      "argMax(e.trace_id, e.event_ts) AS trace_id",
      "e.span_id AS span_id",
    )
    .whereRaw("e.span_id IN {observationIds: Array(String)}", {
      observationIds,
    })
    .groupBy("e.span_id");
```

### Issue 2 of 3
web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts:88-95
The `isBetaEnabled` field in this input schema is now dead code. The handler no longer reads `input.isBetaEnabled`; instead it reads `env.LANGFUSE_ENABLE_EVENTS_TABLE_UI` directly. The field can be safely removed to avoid misleading callers into thinking the flag still influences behavior.

```suggestion
  byId: protectedProjectProcedure
    .input(
      z.object({
        projectId: z.string(),
        itemId: z.string(),
      }),
    )
```

### Issue 3 of 3
web/src/features/annotation-queues/server/annotationQueuesRouter.ts:466-474
Same dead-code situation as `annotationQueueItemsRouter.ts`: `isBetaEnabled` is accepted in the `fetchAndLockNext` input schema but is never read in the handler — the env var drives the branch instead. Removing it keeps the schema in sync with how the mutation actually behaves.

```suggestion
  fetchAndLockNext: protectedProjectProcedure
    .input(
      z.object({
        queueId: z.string(),
        projectId: z.string(),
        seenItemIds: z.array(z.string()),
      }),
    )
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: assignment"](https://github.com/langfuse/langfuse/commit/6469177e82e6cad2fa72c40703b5e554b616fbc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31188342)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->