### PR TITLE
fix(shared): reject DNS-failing hostnames in outbound URL validation

### DIFF
--- a/packages/shared/src/server/llm/baseUrlValidation.ts
+++ b/packages/shared/src/server/llm/baseUrlValidation.ts
@@ -44,7 +44,6 @@ export async function validateLlmConnectionBaseURL(
   await validateOutboundUrlHost({
     url,
     whitelist: effectiveWhitelist,
-    shouldThrowIfDnsResolutionFails: false,
     logContext: "LLM base URL",
     // Existing LLM validation accepts public IP literals after CIDR checks so
     // custom gateways are not forced through DNS at write time.

--- a/packages/shared/src/server/outbound-url/validation.ts
+++ b/packages/shared/src/server/outbound-url/validation.ts
@@ -16,7 +16,6 @@ export interface OutboundUrlValidationWhitelist {
 export interface ValidateOutboundUrlHostOptions {
   url: URL;
   whitelist: OutboundUrlValidationWhitelist;
-  shouldThrowIfDnsResolutionFails: boolean;
   logContext: string;
   shouldSkipDnsCheckForLiteralIps: boolean;
 }
@@ -78,7 +77,6 @@ export function parseOutboundUrl(urlString: string): URL {
 export async function validateOutboundUrlHost({
   url,
   whitelist,
-  shouldThrowIfDnsResolutionFails,
   logContext,
   shouldSkipDnsCheckForLiteralIps,
 }: ValidateOutboundUrlHostOptions): Promise<void> {
@@ -105,13 +103,11 @@ export async function validateOutboundUrlHost({
     if (shouldSkipDnsCheckForLiteralIps) return;
   }
 
-  let ips: string[];
-  try {
-    ips = await resolveHost(hostname);
-  } catch (error) {
-    if (!shouldThrowIfDnsResolutionFails) return;
-    throw error;
-  }
+  // DNS-resolution failure is treated as a hard validation error: silently
+  // returning here would let attacker-controlled or split-horizon DNS bypass
+  // the IP blocklist (DNS-rebinding SSRF). Self-hosted gateways that the
+  // validator cannot resolve must be added to the host whitelist above.
+  const ips = await resolveHost(hostname);
 
   for (const ip of ips) {
     if (isIPBlocked(ip, whitelist.ips, whitelist.ip_ranges)) {

--- a/packages/shared/src/server/webhooks/validation.ts
+++ b/packages/shared/src/server/webhooks/validation.ts
@@ -42,7 +42,6 @@ export async function validateWebhookURL(
   await validateOutboundUrlHost({
     url,
     whitelist,
-    shouldThrowIfDnsResolutionFails: true,
     logContext: "Webhook",
     // Preserve the existing webhook behavior: public IP literals must still
     // pass the same DNS-resolution path as hostname destinations.

--- a/web/src/__tests__/server/llm-api-key.servertest.ts
+++ b/web/src/__tests__/server/llm-api-key.servertest.ts
@@ -108,7 +108,7 @@ describe("llmApiKey.all RPC", () => {
     const provider = "openai";
     const adapter = LLMAdapter.OpenAI;
     const customModels = ["fancy-gpt-3.5-turbo"];
-    const baseURL = "https://custom.openai.com/v1";
+    const baseURL = "https://example.com/v1";
     const withDefaultModels = false;
 
     await caller.llmApiKey.create({
@@ -200,7 +200,7 @@ describe("llmApiKey.all RPC", () => {
     const provider = "openai";
     const adapter = LLMAdapter.OpenAI;
     const customModels = ["fancy-gpt-3.5-turbo"];
-    const baseURL = "https://custom.openai.com/v1";
+    const baseURL = "https://example.com/v1";
     const withDefaultModels = false;
 
     await caller.llmApiKey.create({
@@ -490,13 +490,13 @@ describe("llmApiKey.all RPC", () => {
       provider: "openai",
       adapter: LLMAdapter.OpenAI,
       secretKey: "sk-rotated",
-      baseURL: "https://new-endpoint.example.com/v1",
+      baseURL: "https://example.net/v1",
     });
 
     expect(result).toEqual({ success: true });
     expect(mockFetchLLMCompletion).toHaveBeenCalledTimes(1);
     const llmConnection = mockFetchLLMCompletion.mock.calls[0][0].llmConnection;
-    expect(llmConnection.baseURL).toBe("https://new-endpoint.example.com/v1");
+    expect(llmConnection.baseURL).toBe("https://example.net/v1");
     expect(decrypt(llmConnection.secretKey)).toBe("sk-rotated");
     expect(llmConnection.extraHeaders).toBeUndefined();
   });
@@ -506,7 +506,7 @@ describe("llmApiKey.all RPC", () => {
     const provider = "openai";
     const adapter = LLMAdapter.OpenAI;
     const customModels = ["fancy-gpt-3.5-turbo"];
-    const baseURL = "https://custom.openai.com/v1";
+    const baseURL = "https://example.com/v1";
     const withDefaultModels = false;
 
     // Create initial key
@@ -539,7 +539,7 @@ describe("llmApiKey.all RPC", () => {
 
     // Update the key
     const newSecret = "new-test-secret";
-    const newBaseURL = "https://new-custom.openai.com/v1";
+    const newBaseURL = "https://example.org/v1";
     const newCustomModels = ["new-fancy-gpt-3.5-turbo"];
     const newWithDefaultModels = true;
 
@@ -858,7 +858,7 @@ describe("llmApiKey.all RPC", () => {
     const provider = "openai";
     const adapter = LLMAdapter.OpenAI;
     const customModels = ["fancy-gpt-3.5-turbo"];
-    const baseURL = "https://custom.openai.com/v1";
+    const baseURL = "https://example.com/v1";
     const withDefaultModels = false;
 
     // Create initial key
@@ -921,7 +921,7 @@ describe("llmApiKey.all RPC", () => {
     const provider = "openai";
     const adapter = LLMAdapter.OpenAI;
     const customModels = ["fancy-gpt-3.5-turbo"];
-    const baseURL = "https://custom.openai.com/v1";
+    const baseURL = "https://example.com/v1";
     const withDefaultModels = false;
     const extraHeaders = {
       "X-Custom-Header": "custom-value",

--- a/web/src/server/api/routers/utilities.ts
+++ b/web/src/server/api/routers/utilities.ts
@@ -14,7 +14,6 @@ import {
 const MAX_IMAGE_URL_REDIRECTS = 5;
 const IMAGE_URL_VALIDATION_OPTIONS = {
   whitelist: { hosts: [], ips: [], ip_ranges: [] },
-  shouldThrowIfDnsResolutionFails: true,
   logContext: "Image URL",
   shouldSkipDnsCheckForLiteralIps: true,
 } satisfies Omit<ValidateOutboundUrlHostOptions, "url">;

--- a/worker/src/__tests__/llm-base-url-validation.test.ts
+++ b/worker/src/__tests__/llm-base-url-validation.test.ts
@@ -158,12 +158,40 @@ describe("LLM base URL validation", () => {
     ).resolves.not.toThrow();
   });
 
-  it("should allow unresolved public hostnames by default", async () => {
+  it("should reject hostnames that fail DNS resolution to close the SSRF rebinding gap", async () => {
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
 
     await expect(
       validateLlmConnectionBaseURL("https://gateway.invalid/v1"),
+    ).rejects.toThrow(/DNS lookup failed/);
+  });
+
+  it("should allow unresolved hostnames when explicitly allowlisted", async () => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+
+    const whitelist: LlmBaseUrlValidationWhitelist = {
+      hosts: ["gateway.invalid"],
+      ips: [],
+      ip_ranges: [],
+    };
+
+    await expect(
+      validateLlmConnectionBaseURL("https://gateway.invalid/v1", whitelist),
     ).resolves.not.toThrow();
+  });
+
+  it("should reject unresolved hostnames on Langfuse Cloud regardless of whitelist", async () => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "US";
+
+    const whitelist: LlmBaseUrlValidationWhitelist = {
+      hosts: ["gateway.invalid"],
+      ips: [],
+      ip_ranges: [],
+    };
+
+    await expect(
+      validateLlmConnectionBaseURL("https://gateway.invalid/v1", whitelist),
+    ).rejects.toThrow(/DNS lookup failed/);
   });
 
   it("should reject non-HTTPS URLs on Langfuse Cloud", async () => {


### PR DESCRIPTION
## Summary

- Treat DNS-resolution failure as a hard validation error in `validateOutboundUrlHost`. Previously the LLM base URL path passed `shouldThrowIfDnsResolutionFails: false`, so any hostname the validator couldn't resolve (NXDOMAIN, SERVFAIL, attacker-timed DNS, split-horizon DNS) silently skipped the IP blocklist. Combined with the encrypted `LlmApiKey` row being persisted and a separate runtime DNS lookup at request time, this enabled DNS-rebinding SSRF — including reach to cloud metadata services (IMDS / GCP metadata) and arbitrary internal HTTP endpoints, with response bodies surfaced to the caller via the LLM error path.
- Drop the `shouldThrowIfDnsResolutionFails` flag entirely. After flipping the LLM caller, all three call sites (LLM base URL, webhook URL, image URL) want strict behavior; a unified contract is simpler and removes the dangerous opt-out.
- Self-hosters whose validator network cannot resolve internal gateways still have an explicit escape hatch via `LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST`, which short-circuits before DNS in `validateOutboundUrlHost`. On Langfuse Cloud the whitelist is force-emptied as before, so DNS-failing hostnames are rejected unconditionally.
- Replace the test that asserted the buggy "allow unresolved public hostnames" behavior with three regression tests covering: DNS-failure rejects by default; whitelist still bypasses the DNS path for self-hosters; Cloud rejects DNS-failing hostnames regardless of whitelist.

## Linear

- INT-1226 — https://linear.app/langfuse/issue/INT-1226

## Major Decisions

- **Remove the `shouldThrowIfDnsResolutionFails` flag rather than just flipping the LLM caller.** Keeping it as a per-caller knob preserves the footgun: a future caller could accidentally re-introduce the bypass. With no remaining `false` consumer, the flag is dead weight.
- **Rely on `LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST` as the sole escape hatch for unresolvable self-hosted gateways.** The original "best-effort DNS" justification was already largely redundant — the env-var allowlist short-circuits before DNS resolution and is the only mechanism that works on Cloud anyway. Operators with internal-only DNS now get a single documented path instead of a silent fallthrough.

## Review Focus

- Self-hosted upgrade impact: existing self-hosters who configured a custom LLM gateway whose hostname does *not* resolve from their Langfuse pod and who never set `LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST` will see write-time validation fail after this change. This is the intended trade-off — please flag for release notes.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a DNS-rebinding SSRF vulnerability in outbound URL validation by removing the `shouldThrowIfDnsResolutionFails` flag and making DNS resolution failures a hard error across all call sites. Self-hosted operators whose validator network cannot reach a custom LLM gateway now have one explicit escape hatch (`LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST`) rather than a silent bypass.

- **SSRF fix**: `validateOutboundUrlHost` no longer swallows `resolveHost` failures — a hostname that cannot be resolved at write-time is rejected, preventing an attacker from exploiting split-horizon / rebinding DNS to bypass the IP blocklist at request time.
- **API simplification**: The `shouldThrowIfDnsResolutionFails` option is removed entirely from `ValidateOutboundUrlHostOptions`, so all three call sites (LLM base URL, webhook, image URL) share one strict contract and no future caller can accidentally re-introduce the bypass.
- **Self-hosted breaking change**: Existing self-hosters with an LLM gateway hostname that is unresolvable from the Langfuse pod will see write-time validation failures after this change; they must add the hostname to `LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST`. This should be highlighted in release notes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change correctly hardens all three outbound-URL call sites and removes a documented SSRF bypass. Self-hosters with unresolvable LLM gateway hostnames need a whitelisting entry before upgrading, so a release note is required.

The removed `shouldThrowIfDnsResolutionFails` flag was the only mechanism that let a DNS-failing LLM base URL skip the IP blocklist at write time. Dropping it and propagating the `resolveHost` error unconditionally is the right fix. The three new regression tests cover the key scenarios (self-hosted fail, self-hosted whitelist bypass, Cloud unconditional reject). The intentional breaking change — unresolvable hostnames now fail at write time instead of silently passing — is clearly documented and mitigated by the pre-existing whitelist env var, but it will affect anyone who never set that env var and relied on the old silent-pass behavior.

No files require special attention beyond the release-note obligation for self-hosted deployments using unresolvable custom LLM gateway hostnames.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Admin / Caller
    participant Val as validateOutboundUrlHost
    participant WL as Whitelist check
    participant DNS as resolveHost (dns.resolve4/6 + lookup)
    participant Block as isIPBlocked

    Caller->>Val: url, whitelist, logContext, shouldSkipDnsCheckForLiteralIps

    Val->>WL: whitelist.hosts.includes(hostname)?
    alt host in whitelist
        WL-->>Val: return (skip DNS)
        Val-->>Caller: resolved (no DNS needed)
    else not in whitelist
        Val->>Val: isHostnameBlocked(hostname)?
        alt blocked hostname
            Val-->>Caller: throw Blocked hostname detected
        else
            Val->>Val: isIPAddress(hostname)?
            alt literal IP + shouldSkipDnsCheckForLiteralIps
                Val-->>Caller: return (no DNS)
            else
                Val->>DNS: resolve4 + resolve6 + lookup (allSettled)
                alt ALL three methods fail
                    DNS-->>Val: throw DNS lookup failed for hostname
                    Val-->>Caller: propagate error (SSRF gap closed)
                else at least one resolves
                    DNS-->>Val: ips[]
                    Val->>Block: isIPBlocked for each ip
                    alt blocked IP
                        Block-->>Val: throw Blocked IP address detected
                        Val-->>Caller: propagate error
                    else all IPs clean
                        Val-->>Caller: return
                    end
                end
            end
        end
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): reject DNS-failing hostname..."](https://github.com/langfuse/langfuse/commit/45a56ab7534402d9d1626d0e71c03178ed9ff7f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31194083)</sub>

<!-- /greptile_comment -->