### PR TITLE
ci: harden prettier check file arguments

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -145,10 +145,10 @@ jobs:
 
           echo "Checking files changed from $BASE_SHA to HEAD"
 
-          if git diff --quiet --exit-code "$BASE_SHA" HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' '*.css'; then
+          if git diff --quiet --exit-code --diff-filter=d "$BASE_SHA" HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' '*.css'; then
             echo "No JS/TS/CSS files changed - skipping prettier check"
           else
-            git diff --name-only -z "$BASE_SHA" HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' '*.css' \
+            git diff --name-only -z --diff-filter=d "$BASE_SHA" HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' '*.css' \
               | xargs -0 --no-run-if-empty pnpm prettier --check --experimental-cli --
           fi
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,17 +34,22 @@ jobs:
       # was already tested in a prior successful run of this workflow.
       - id: skip_check
         env:
+          EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "should_skip=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          CURRENT_TREE=$(gh api "repos/${{ github.repository }}/git/commits/${{ github.sha }}" --jq '.tree.sha')
+          CURRENT_TREE=$(gh api "repos/$REPOSITORY/git/commits/$COMMIT_SHA" --jq '.tree.sha')
 
-          MATCH=$(gh api "repos/${{ github.repository }}/actions/workflows/pipeline.yml/runs?status=success&per_page=20" \
-            --jq "[.workflow_runs[] | select(.id != ${{ github.run_id }} and .head_commit.tree_id == \"$CURRENT_TREE\")] | first | .head_sha // empty")
+          MATCH=$(gh api "repos/$REPOSITORY/actions/workflows/pipeline.yml/runs?status=success&per_page=20" \
+            | jq -r --argjson run_id "$RUN_ID" --arg current_tree "$CURRENT_TREE" \
+              '[.workflow_runs[] | select(.id != $run_id and .head_commit.tree_id == $current_tree)] | first | .head_sha // empty')
 
           if [[ -n "$MATCH" ]]; then
             echo "::notice::Tree $CURRENT_TREE already tested in a prior successful run (commit $MATCH) — skipping"
@@ -128,23 +133,23 @@ jobs:
         run: |
           cp .env.dev.example .env
       - name: Check formatting on changed files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA=${{ github.event.pull_request.base.sha }}
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA="$PR_BASE_SHA"
           else
             BASE_SHA=$(git merge-base origin/main HEAD)
           fi
 
           echo "Checking files changed from $BASE_SHA to HEAD"
 
-          # Get changed files
-          CHANGED_FILES=$(git diff --name-only $BASE_SHA HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' '*.css' | tr '\n' ' ')
-
-          if [ -n "$CHANGED_FILES" ] && [ "$CHANGED_FILES" != " " ]; then
-            echo "Files to check: $CHANGED_FILES"
-            pnpm prettier --check --experimental-cli $CHANGED_FILES
-          else
+          if git diff --quiet --exit-code "$BASE_SHA" HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' '*.css'; then
             echo "No JS/TS/CSS files changed - skipping prettier check"
+          else
+            git diff --name-only -z "$BASE_SHA" HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' '*.css' \
+              | xargs -0 --no-run-if-empty pnpm prettier --check --experimental-cli --
           fi
 
   tests-eslint-plugin:


### PR DESCRIPTION
## Summary

- Hardened the CI `prettier-check` job against argument injection from crafted PR filenames.
- Replaced space-joined changed-file handling with `git diff --name-only -z | xargs -0` so filenames are passed as discrete arguments.
- Added Prettier’s `--` end-of-options delimiter so filenames like `--config-path=...` or `--plugin=...` are treated as paths, not CLI flags.
- Moved GitHub context values used in shell scripts into `env:` variables and replaced dynamic `gh --jq` interpolation with explicit `jq --arg` usage to reduce related injection footguns.

## Linear

- [INT-1241](https://linear.app/langfuse/issue/INT-1241)

## Major Decisions

- Used null-delimited file passing plus Prettier’s `--` delimiter instead of filename validation. This preserves support for valid unusual filenames while preventing shell word-splitting and option parsing attacks.

## Review Focus

- Confirm the `prettier-check` pipeline behavior still skips clean diffs and runs only on changed JS/TS/CSS files.
- Review the `gh api | jq` change in `pre-job` to ensure the duplicate-run skip logic remains equivalent while avoiding direct context interpolation.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the CI pipeline against argument injection attacks by replacing shell word-splitting and direct context interpolation with safer alternatives. No functional behavior changes are intended.

- **prettier-check**: Switches from space-joined filenames to null-delimited `git diff -z | xargs -0` piping plus a `--` end-of-options delimiter, preventing crafted filenames from being interpreted as Prettier CLI flags. The \"no files changed\" check is replaced with `git diff --quiet --exit-code`, which is more robust than the previous empty-string test.
- **pre-job/skip_check**: GitHub context values (`github.event_name`, `github.repository`, `github.sha`, `github.run_id`) are moved from inline `${{ }}` interpolation into `env:` variables, and the `MATCH` jq filter is rewritten to use `--argjson`/`--arg` parameter binding instead of interpolated string fragments in the `--jq` argument.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — no behavioral regressions found and the security hardening is correctly implemented throughout both changed steps.

The null-delimited piping, -- delimiter, and env-var promotion are all correctly applied. The only minor observation is that --no-run-if-empty in the prettier step is redundant (the surrounding git diff --quiet guard ensures xargs always receives input in that branch), but it is harmless on the Ubuntu 24.04 GNU xargs runner and adds defensive clarity.

.github/workflows/pipeline.yml is the only changed file; no areas require special attention beyond confirming runner environment assumptions.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([prettier-check triggered]) --> B{EVENT_NAME == 'pull_request'?}
    B -- yes --> C[BASE_SHA = PR_BASE_SHA env var]
    B -- no --> D["BASE_SHA = git merge-base origin/main HEAD"]
    C --> E
    D --> E["git diff --quiet --exit-code BASE_SHA HEAD\n-- *.js *.jsx *.ts *.tsx *.css"]
    E -- exit 0: no changes --> F[/"Echo: No JS/TS/CSS files changed - skipping"/]
    E -- exit 1: changes exist --> G["git diff --name-only -z BASE_SHA HEAD\n-- *.js *.jsx *.ts *.tsx *.css"]
    G --> H["xargs -0 --no-run-if-empty\npnpm prettier --check --experimental-cli --"]
    H -- pass --> I([Step succeeds])
    H -- fail --> J([Step fails: formatting issues found])
    F --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: harden prettier check file arguments"](https://github.com/langfuse/langfuse/commit/17c0e8499ba637a530be6c33f92095cf4877901f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31195840)</sub>

<!-- /greptile_comment -->