### PR TITLE
fix(web): emit audit log for public blob storage deletion

### DIFF
--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -67,6 +67,7 @@ describe("Blob Storage Integrations API", () => {
   let testProject2Id: string;
   let testApiKey: string;
   let testApiSecretKey: string;
+  let testApiKeyId: string;
   let otherOrgId: string;
   let otherProjectId: string;
 
@@ -110,6 +111,7 @@ describe("Blob Storage Integrations API", () => {
     });
     testApiKey = orgApiKey.publicKey;
     testApiSecretKey = orgApiKey.secretKey;
+    testApiKeyId = orgApiKey.id;
 
     // Create another organization for cross-org tests
     const otherOrg = await prisma.organization.create({
@@ -610,6 +612,34 @@ describe("Blob Storage Integrations API", () => {
         },
       );
       expect(deletedIntegration).toBeNull();
+    });
+
+    it("should create an audit log entry for delete", async () => {
+      const auditLogWhere = {
+        resourceType: "blobStorageIntegration",
+        resourceId: testIntegrationId,
+        action: "delete",
+        orgId: testOrgId,
+        projectId: testIntegrationId,
+        apiKeyId: testApiKeyId,
+      };
+      const auditLogCountBefore = await prisma.auditLog.count({
+        where: auditLogWhere,
+      });
+
+      await makeZodVerifiedAPICall(
+        BlobStorageIntegrationDeletionResponseSchema,
+        "DELETE",
+        `/api/public/integrations/blob-storage/${testIntegrationId}`,
+        undefined,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+
+      const auditLogCountAfter = await prisma.auditLog.count({
+        where: auditLogWhere,
+      });
+      expect(auditLogCountAfter).toBe(auditLogCountBefore + 1);
     });
 
     it("should return 404 for non-existent integration", async () => {

--- a/web/src/pages/api/public/integrations/blob-storage/[id].ts
+++ b/web/src/pages/api/public/integrations/blob-storage/[id].ts
@@ -4,6 +4,7 @@ import { prisma } from "@langfuse/shared/src/db";
 import { redis } from "@langfuse/shared/src/server";
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { hasEntitlementBasedOnPlan } from "@/src/features/entitlements/server/hasEntitlement";
+import { auditLog } from "@/src/features/audit-logs/auditLog";
 import {
   InvalidRequestError,
   LangfuseNotFoundError,
@@ -75,6 +76,15 @@ async function handleDeleteBlobStorageIntegration(
   // Delete the integration
   await prisma.blobStorageIntegration.delete({
     where: { projectId: id },
+  });
+
+  await auditLog({
+    action: "delete",
+    resourceType: "blobStorageIntegration",
+    resourceId: integration.projectId,
+    projectId: integration.projectId,
+    orgId: authCheck.scope.orgId,
+    apiKeyId: authCheck.scope.apiKeyId,
   });
 
   return res.status(200).json({


### PR DESCRIPTION
## Summary
- Add an audit log entry to the public `DELETE /api/public/integrations/blob-storage/[id]` handler after successful deletion.
- Extend the blob-storage public API server test to verify the delete request increments the expected audit log count for the organization API key.

## Testing
- `pnpm --filter web exec dotenv -e ../.env.test -e ../.env -- vitest run --project server src/__tests__/server/blob-storage-integration-api.servertest.ts`
- `pnpm --filter web run lint`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an audit log entry to the public `DELETE /api/public/integrations/blob-storage/[id]` handler and extends the server test suite to verify the entry is written.

- The `auditLog()` call is placed **after** `prisma.delete`, which is inconsistent with the internal TRPC router (`blobstorage-integration-router.ts`) that records the audit log before deletion; if the log write fails the caller receives a 500 despite the resource already being gone.
- The new test correctly captures `testApiKeyId` in `beforeAll` and uses `beforeEach`/`afterEach` to give each case a fresh integration, matching what the handler writes to the `auditLog` table.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The delete succeeds, but if the subsequent audit log write fails the caller gets a 500 even though the resource is already gone — a confusing error surface for a retrying client.

The audit log is recorded after the destructive Prisma delete, reversing the ordering used everywhere else in the codebase. A write failure in auditLog() returns 500 to the caller after the integration is already deleted, with no audit record written.

web/src/pages/api/public/integrations/blob-storage/[id].ts — the ordering of the audit log call relative to the deletion should be reviewed.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as DELETE /api/public/integrations/blob-storage/[id]
    participant DB as Prisma / Postgres

    Client->>Handler: DELETE request (org API key)
    Handler->>DB: verifyAuthHeaderAndReturnScope
    DB-->>Handler: authCheck (orgId, apiKeyId)
    Handler->>DB: findUnique blobStorageIntegration
    DB-->>Handler: integration (or null → 404)
    Handler->>DB: delete blobStorageIntegration
    DB-->>Handler: deleted
    Handler->>DB: "auditLog.create (action=delete, after deletion)"
    DB-->>Handler: audit log created
    Handler-->>Client: "200 { message }"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/api/public/integrations/blob-storage/[id].ts:81-88
**Audit log fires after deletion, creating an inconsistent error surface**

The `prisma.delete` call completes on line 77 before `auditLog()` is awaited. `auditLog()` does a direct Prisma insert with no internal error handling — if that write fails (e.g., transient DB error), the handler propagates a 500 to the caller even though the integration is already gone. The client has no clean way to distinguish "delete succeeded, audit log failed" from a real failure, and a retry would produce a 404.

The internal TRPC router (`blobstorage-integration-router.ts`, lines 128–135) records the audit log *before* `prisma.delete`, which is the established pattern in this codebase. Reversing the order here moves the error-prone step to the end, after the irreversible side effect.

### Issue 2 of 2
web/src/pages/api/public/integrations/blob-storage/[id].ts:81-88
The `before` field is not populated with the deleted integration's state. Audit logs for deletions are most useful when they record what was removed — `integration` is already fetched above and available here at no extra cost.

```suggestion
  await auditLog({
    action: "delete",
    resourceType: "blobStorageIntegration",
    resourceId: integration.projectId,
    projectId: integration.projectId,
    orgId: authCheck.scope.orgId,
    apiKeyId: authCheck.scope.apiKeyId,
    before: integration,
  });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add audit log for blob storage deletion"](https://github.com/langfuse/langfuse/commit/3cb080dab87bb97f82ad6dc39619a42ddd7df77a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31299317)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->