### PR TITLE
fix(rbac): keep invite totalCount aligned with project filters

### DIFF
--- a/web/src/__tests__/server/members-trpc.servertest.ts
+++ b/web/src/__tests__/server/members-trpc.servertest.ts
@@ -50,7 +50,11 @@ function createSession(
   org: { id: string; name: string },
   project: { id: string; name: string },
   plan: Plan,
+  roles: { orgRole?: Role; projectRole?: Role } = {},
 ): Session {
+  const orgRole = roles.orgRole ?? Role.OWNER;
+  const projectRole = roles.projectRole ?? Role.OWNER;
+
   return {
     expires: "1",
     user: {
@@ -62,7 +66,7 @@ function createSession(
         {
           id: org.id,
           name: org.name,
-          role: "OWNER",
+          role: orgRole,
           plan: plan,
           cloudConfig: undefined,
           metadata: {},
@@ -70,7 +74,7 @@ function createSession(
           projects: [
             {
               id: project.id,
-              role: "OWNER",
+              role: projectRole,
               retentionDays: 30,
               deletedAt: null,
               name: project.name,
@@ -257,6 +261,90 @@ describe("membersRouter.create - organization member limit enforcement", () => {
       });
       expect(inviteCount).toBe(4);
     }, 25_000);
+  });
+});
+
+describe("membersRouter.allInvitesFromProject", () => {
+  it("returns a totalCount that matches project-scoped invitation filtering", async () => {
+    const { org, project, ownerUser } = await prepare("cloud:core");
+    const otherProject = await prisma.project.create({
+      data: {
+        id: uuidv4(),
+        name: `Other Project ${uuidv4().substring(0, 8)}`,
+        orgId: org.id,
+      },
+    });
+    const projectOnlyUser = await createTestUser();
+    const orgMembership = await prisma.organizationMembership.create({
+      data: {
+        userId: projectOnlyUser.id,
+        orgId: org.id,
+        role: Role.NONE,
+      },
+    });
+    await prisma.projectMembership.create({
+      data: {
+        userId: projectOnlyUser.id,
+        projectId: project.id,
+        role: Role.MEMBER,
+        orgMembershipId: orgMembership.id,
+      },
+    });
+
+    const orgInviteEmail = `org-invite-${uuidv4().substring(0, 8)}@test.com`;
+    const projectInviteEmail = `project-invite-${uuidv4().substring(0, 8)}@test.com`;
+    const otherProjectInviteEmail = `other-project-invite-${uuidv4().substring(0, 8)}@test.com`;
+
+    await prisma.membershipInvitation.createMany({
+      data: [
+        {
+          orgId: org.id,
+          email: orgInviteEmail,
+          orgRole: Role.MEMBER,
+          invitedByUserId: ownerUser.id,
+        },
+        {
+          orgId: org.id,
+          projectId: project.id,
+          email: projectInviteEmail,
+          orgRole: Role.NONE,
+          projectRole: Role.MEMBER,
+          invitedByUserId: ownerUser.id,
+        },
+        {
+          orgId: org.id,
+          projectId: otherProject.id,
+          email: otherProjectInviteEmail,
+          orgRole: Role.NONE,
+          projectRole: Role.MEMBER,
+          invitedByUserId: ownerUser.id,
+        },
+      ],
+    });
+
+    const projectOnlySession = createSession(
+      projectOnlyUser,
+      org,
+      project,
+      "cloud:core",
+      { orgRole: Role.NONE, projectRole: Role.MEMBER },
+    );
+    const ctx = createInnerTRPCContext({
+      session: projectOnlySession,
+      headers: {},
+    });
+    const caller = appRouter.createCaller({ ...ctx, prisma });
+
+    const result = await caller.members.allInvitesFromProject({
+      projectId: project.id,
+      page: 0,
+      limit: 10,
+    });
+
+    expect(result.totalCount).toBe(2);
+    expect(result.invitations.map((invite) => invite.email).sort()).toEqual(
+      [orgInviteEmail, projectInviteEmail].sort(),
+    );
   });
 });
 

--- a/web/src/features/rbac/server/allInvitesRoutes.ts
+++ b/web/src/features/rbac/server/allInvitesRoutes.ts
@@ -7,7 +7,12 @@ import {
   protectedOrganizationProcedure,
   protectedProjectProcedure,
 } from "@/src/server/api/trpc";
-import { paginationZod, type PrismaClient, Role } from "@langfuse/shared";
+import {
+  paginationZod,
+  type Prisma,
+  type PrismaClient,
+  Role,
+} from "@langfuse/shared";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
@@ -26,28 +31,30 @@ async function getInvites(
     | (z.infer<typeof projectLevelInviteQuery> & { orgId: string }),
   showAllOrgMembers: boolean = true,
 ) {
+  const where: Prisma.MembershipInvitationWhereInput = {
+    orgId: query.orgId,
+    // restrict to only invites with role in a project if projectId is set
+    ...("projectId" in query && !showAllOrgMembers
+      ? {
+          OR: [
+            {
+              orgRole: {
+                not: Role.NONE,
+              },
+            },
+            {
+              projectId: query.projectId,
+              projectRole: {
+                not: Role.NONE,
+              },
+            },
+          ],
+        }
+      : {}),
+  };
+
   const invitations = await prisma.membershipInvitation.findMany({
-    where: {
-      orgId: query.orgId,
-      // restrict to only invites with role in a project if projectId is set
-      ...("projectId" in query && !showAllOrgMembers
-        ? {
-            OR: [
-              {
-                orgRole: {
-                  not: Role.NONE,
-                },
-              },
-              {
-                projectId: query.projectId,
-                projectRole: {
-                  not: Role.NONE,
-                },
-              },
-            ],
-          }
-        : {}),
-    },
+    where,
     include: {
       invitedByUser: {
         select: {
@@ -64,9 +71,7 @@ async function getInvites(
   });
 
   const totalCount = await prisma.membershipInvitation.count({
-    where: {
-      orgId: query.orgId,
-    },
+    where,
   });
 
   return {


### PR DESCRIPTION
## Summary
- Reuse a single Prisma `where` clause for invite list and count queries in `allInvitesRoutes`.
- Add a regression test that covers project-scoped invites and verifies `totalCount` matches the filtered rows.

## Testing
- `pnpm --filter web run lint`
- `pnpm --dir web exec dotenv -e ../.env.test -e ../.env -- vitest run --project server src/__tests__/server/members-trpc.servertest.ts`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `totalCount` in `allInvitesFromProject` was computed over all org invites rather than the project-filtered subset, causing pagination metadata to be inflated for project-scoped users. The fix extracts the shared `where` clause into a variable and reuses it in both the `findMany` and `count` queries.

- **`allInvitesRoutes.ts`**: Lifts the `Prisma.MembershipInvitationWhereInput` filter into a `const where` block and passes it to both `findMany` and `count`, eliminating the stale unfiltered count.
- **`members-trpc.servertest.ts`**: Adds a regression test verifying that a user with org `NONE`/project `MEMBER` roles sees exactly the 2 matching invitations (org-wide + project-specific) and that `totalCount` equals `2` rather than the full org count of `3`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted fix that aligns the count query with the already-correct list query.

Both the findMany and count paths now share the same where clause with no logic changes to the filter itself. The regression test directly exercises the previously broken path (project-scoped user, mixed invite types) and asserts both the returned rows and totalCount. Org-level callers are unaffected because showAllOrgMembers defaults to true, leaving the where clause as a plain orgId filter identical to the old behavior.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix invite pagination totalCount mismatc..."](https://github.com/langfuse/langfuse/commit/bbf48d0b195e791af87e37de5529844acb022af6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31299330)</sub>

<!-- /greptile_comment -->