### PR TITLE
fix(annotation-queues): enforce read scope in typeById

### DIFF
--- a/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
+++ b/web/src/__tests__/server/annotation-queue-items-trpc.servertest.ts
@@ -1,0 +1,118 @@
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { AnnotationQueueObjectType } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import type { Session } from "next-auth";
+import { v4 as uuidv4 } from "uuid";
+
+describe("annotationQueueItems trpc", () => {
+  const orgIds: string[] = [];
+
+  type TestSetup = Awaited<ReturnType<typeof createOrgProjectAndApiKey>>;
+
+  const createCallerForProjectRole = (
+    setup: TestSetup,
+    projectRole: "ADMIN" | "NONE" = "ADMIN",
+  ) => {
+    const session: Session = {
+      expires: "1",
+      user: {
+        id: "user-1",
+        name: "Demo User",
+        canCreateOrganizations: true,
+        admin: false,
+        organizations: [
+          {
+            id: setup.org.id,
+            name: setup.org.name,
+            role: "MEMBER",
+            plan: "cloud:hobby",
+            cloudConfig: undefined,
+            metadata: {},
+            projects: [
+              {
+                id: setup.project.id,
+                role: projectRole,
+                name: setup.project.name,
+                deletedAt: null,
+                retentionDays: null,
+                metadata: {},
+              },
+            ],
+          },
+        ],
+        featureFlags: {
+          templateFlag: true,
+          excludeClickhouseRead: false,
+        },
+      },
+      environment: {} as Session["environment"],
+    };
+
+    const ctx = createInnerTRPCContext({ session, headers: {} });
+
+    return {
+      caller: appRouter.createCaller({ ...ctx, prisma }),
+    };
+  };
+
+  afterAll(async () => {
+    await prisma.organization.deleteMany({
+      where: {
+        id: {
+          in: orgIds,
+        },
+      },
+    });
+  });
+
+  describe("typeById", () => {
+    it("requires annotationQueues:read access", async () => {
+      const setup = await createOrgProjectAndApiKey();
+      orgIds.push(setup.org.id);
+
+      const { caller: adminCaller } = createCallerForProjectRole(
+        setup,
+        "ADMIN",
+      );
+      const queue = await prisma.annotationQueue.create({
+        data: {
+          name: "Test Queue",
+          description: "Test Queue Description",
+          scoreConfigIds: [],
+          projectId: setup.project.id,
+        },
+      });
+      const item = await prisma.annotationQueueItem.create({
+        data: {
+          queueId: queue.id,
+          objectId: uuidv4(),
+          objectType: AnnotationQueueObjectType.TRACE,
+          projectId: setup.project.id,
+        },
+      });
+
+      await expect(
+        adminCaller.annotationQueueItems.typeById({
+          projectId: setup.project.id,
+          queueId: queue.id,
+          itemId: item.id,
+        }),
+      ).resolves.toBe(AnnotationQueueObjectType.TRACE);
+
+      const { caller: limitedCaller } = createCallerForProjectRole(
+        setup,
+        "NONE",
+      );
+
+      await expect(
+        limitedCaller.annotationQueueItems.typeById({
+          projectId: setup.project.id,
+          queueId: queue.id,
+          itemId: item.id,
+        }),
+      ).rejects.toThrow("User does not have access to this resource or action");
+    });
+  });
+});

--- a/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
@@ -71,6 +71,12 @@ export const queueItemRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "annotationQueues:read",
+      });
+
       const item = await ctx.prisma.annotationQueueItem.findUnique({
         where: {
           id: input.itemId,


### PR DESCRIPTION
## Summary
- Add the missing `annotationQueues:read` project-scope check to `annotationQueueItems.typeById`
- Add a regression test covering an allowed project member and a user without the scope

## Testing
- `pnpm --dir web exec dotenv -e ../.env.test -e ../.env -- vitest run --project server src/__tests__/server/annotation-queue-items-trpc.servertest.ts --maxWorkers=1`
- `pnpm --filter web run lint`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the missing `annotationQueues:read` scope check to the `typeById` tRPC procedure in `annotationQueueItemsRouter.ts`, closing an authorization gap that left one endpoint unprotected while all sibling procedures were already guarded. A regression test is included that seeds a real queue item, verifies an ADMIN can read the type, and confirms a `NONE`-role user is rejected.

- **`annotationQueueItemsRouter.ts`**: Inserts a `throwIfNoProjectAccess` call at the top of the `typeById` query handler, consistent with the pattern used in `byId`, `itemsByQueueId`, and `unseenPendingItemCountByQueueId`.
- **`annotation-queue-items-trpc.servertest.ts`**: New server-integration test that exercises the fixed authorization boundary using two callers with different project roles against a live database.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted authorization fix that follows the existing pattern already used in every other endpoint in the router.

The diff is a one-procedure guard addition and a corresponding integration test. The fix aligns typeById with all sibling procedures, the test exercises both the passing and failing authorization paths against a real database, and cleanup is handled correctly in afterAll.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant typeById as annotationQueueItems.typeById
    participant RBAC as throwIfNoProjectAccess
    participant DB as Prisma (annotationQueueItem)

    Client->>typeById: "{ projectId, queueId, itemId }"
    typeById->>RBAC: "session, projectId, scope="annotationQueues:read""
    alt has scope
        RBAC-->>typeById: OK
        typeById->>DB: findUnique(itemId, projectId, queueId)
        DB-->>typeById: "{ objectType }"
        typeById-->>Client: objectType
    else "missing scope (e.g. role=NONE)"
        RBAC-->>typeById: throw TRPCError UNAUTHORIZED
        typeById-->>Client: "User does not have access to this resource or action"
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix annotation queue item access check"](https://github.com/langfuse/langfuse/commit/4ba4fd105f79dd74480b508b324969c8d217bf45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31299413)</sub>

<!-- /greptile_comment -->