### PR TITLE
fix(datasets): validate remote experiment URLs before saving

### DIFF
--- a/web/src/__tests__/server/datasets-remote-experiment.servertest.ts
+++ b/web/src/__tests__/server/datasets-remote-experiment.servertest.ts
@@ -63,8 +63,12 @@ describe("datasets.upsertRemoteExperiment", () => {
 
   it.each([
     {
-      url: "http://example.com/hook",
-      message: "Only HTTPS URLs are allowed",
+      url: "not-a-url",
+      message: "Invalid URL syntax",
+    },
+    {
+      url: "ftp://example.com/hook",
+      message: "Only HTTP and HTTPS protocols are allowed",
     },
     {
       url: "https://127.0.0.1/hook",

--- a/web/src/__tests__/server/datasets-remote-experiment.servertest.ts
+++ b/web/src/__tests__/server/datasets-remote-experiment.servertest.ts
@@ -85,6 +85,7 @@ describe("datasets.upsertRemoteExperiment", () => {
           id: datasetId,
           projectId,
           name: `remote-experiment-${datasetId}`,
+          remoteExperimentEnabled: false,
         },
       });
 
@@ -117,7 +118,7 @@ describe("datasets.upsertRemoteExperiment", () => {
 
       expect(dataset.remoteExperimentUrl).toBeNull();
       expect(dataset.remoteExperimentPayload).toBeNull();
-      expect(dataset.remoteExperimentEnabled).toBe(true);
+      expect(dataset.remoteExperimentEnabled).toBe(false);
     },
   );
 });

--- a/web/src/__tests__/server/datasets-remote-experiment.servertest.ts
+++ b/web/src/__tests__/server/datasets-remote-experiment.servertest.ts
@@ -1,0 +1,119 @@
+import type { Session } from "next-auth";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { prisma } from "@langfuse/shared/src/db";
+import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+
+const orgIds: string[] = [];
+
+const prepare = async () => {
+  const setup = await createOrgProjectAndApiKey();
+  orgIds.push(setup.orgId);
+
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: "user-1",
+      name: "Demo User",
+      canCreateOrganizations: true,
+      organizations: [
+        {
+          id: setup.orgId,
+          name: "Test Organization",
+          role: "OWNER",
+          plan: "cloud:hobby",
+          cloudConfig: undefined,
+          metadata: {},
+          projects: [
+            {
+              id: setup.projectId,
+              role: "ADMIN",
+              name: "Test Project",
+              deletedAt: null,
+              retentionDays: null,
+              metadata: {},
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        templateFlag: true,
+        excludeClickhouseRead: false,
+      },
+      admin: true,
+    },
+    environment: {} as any,
+  };
+
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+  const caller = appRouter.createCaller({ ...ctx, prisma });
+
+  return { caller, projectId: setup.projectId };
+};
+
+describe("datasets.upsertRemoteExperiment", () => {
+  afterAll(async () => {
+    await prisma.organization.deleteMany({
+      where: {
+        id: { in: orgIds },
+      },
+    });
+  });
+
+  it.each([
+    {
+      url: "http://example.com/hook",
+      message: "Only HTTPS URLs are allowed",
+    },
+    {
+      url: "https://127.0.0.1/hook",
+      message: "Blocked IP address detected",
+    },
+  ])(
+    "rejects invalid remote experiment URL $url before saving it",
+    async ({ url, message }) => {
+      const { caller, projectId } = await prepare();
+      const datasetId = randomUUID();
+
+      await prisma.dataset.create({
+        data: {
+          id: datasetId,
+          projectId,
+          name: `remote-experiment-${datasetId}`,
+        },
+      });
+
+      await expect(
+        caller.datasets.upsertRemoteExperiment({
+          projectId,
+          datasetId,
+          url,
+          defaultPayload: "{}",
+          enabled: true,
+        }),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+        message: expect.stringContaining(message),
+      });
+
+      const dataset = await prisma.dataset.findUniqueOrThrow({
+        where: {
+          id_projectId: {
+            id: datasetId,
+            projectId,
+          },
+        },
+        select: {
+          remoteExperimentUrl: true,
+          remoteExperimentPayload: true,
+          remoteExperimentEnabled: true,
+        },
+      });
+
+      expect(dataset.remoteExperimentUrl).toBeNull();
+      expect(dataset.remoteExperimentPayload).toBeNull();
+      expect(dataset.remoteExperimentEnabled).toBe(true);
+    },
+  );
+});

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -129,6 +129,38 @@ const resolveMetadata = (metadata: string | null | undefined) => {
   }
 };
 
+const validateRemoteExperimentUrl = async (urlString: string) => {
+  const trimmedUrl = urlString.trim();
+
+  let url: URL;
+  try {
+    url = new URL(trimmedUrl);
+  } catch {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid remote run URL: Invalid URL syntax",
+    });
+  }
+
+  if (url.protocol !== "https:") {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid remote run URL: Only HTTPS URLs are allowed",
+    });
+  }
+
+  try {
+    await validateWebhookURL(trimmedUrl);
+  } catch (error) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: `Invalid remote run URL: ${error instanceof Error ? error.message : "Unknown error"}`,
+    });
+  }
+
+  return trimmedUrl;
+};
+
 type GenerateDatasetQueryInput = {
   select: Prisma.Sql;
   projectId: string;
@@ -1667,10 +1699,12 @@ export const datasetRouter = createTRPCRouter({
         });
       }
 
+      const remoteExperimentUrl = await validateRemoteExperimentUrl(input.url);
+
       const updatedDataset = await updateDataset({
         input: {
           id: input.datasetId,
-          remoteExperimentUrl: input.url,
+          remoteExperimentUrl,
           remoteExperimentPayload: input.defaultPayload ?? {},
           remoteExperimentEnabled: input.enabled,
         },

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -129,38 +129,6 @@ const resolveMetadata = (metadata: string | null | undefined) => {
   }
 };
 
-const validateRemoteExperimentUrl = async (urlString: string) => {
-  const trimmedUrl = urlString.trim();
-
-  let url: URL;
-  try {
-    url = new URL(trimmedUrl);
-  } catch {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: "Invalid remote run URL: Invalid URL syntax",
-    });
-  }
-
-  if (url.protocol !== "https:") {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: "Invalid remote run URL: Only HTTPS URLs are allowed",
-    });
-  }
-
-  try {
-    await validateWebhookURL(trimmedUrl);
-  } catch (error) {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: `Invalid remote run URL: ${error instanceof Error ? error.message : "Unknown error"}`,
-    });
-  }
-
-  return trimmedUrl;
-};
-
 type GenerateDatasetQueryInput = {
   select: Prisma.Sql;
   projectId: string;
@@ -1699,12 +1667,19 @@ export const datasetRouter = createTRPCRouter({
         });
       }
 
-      const remoteExperimentUrl = await validateRemoteExperimentUrl(input.url);
+      try {
+        await validateWebhookURL(input.url);
+      } catch (error) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Invalid remote run URL: ${error instanceof Error ? error.message : "Unknown error"}`,
+        });
+      }
 
       const updatedDataset = await updateDataset({
         input: {
           id: input.datasetId,
-          remoteExperimentUrl,
+          remoteExperimentUrl: input.url,
           remoteExperimentPayload: input.defaultPayload ?? {},
           remoteExperimentEnabled: input.enabled,
         },


### PR DESCRIPTION
## Summary
- Validate remote experiment URLs at the upsert boundary before persisting them.
- Require HTTPS and reuse the shared webhook SSRF checks so invalid or internal targets are rejected early.
- Add regression coverage for blocked HTTP and loopback URLs, and verify rejected writes do not mutate the dataset record.

## Testing
- `pnpm exec dotenv -e ../.env.test -e ../.env -- vitest run --project server src/__tests__/server/datasets-remote-experiment.servertest.ts --maxWorkers=1 --no-file-parallelism`
- `pnpm --filter web run lint`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds URL validation to the `upsertRemoteExperiment` mutation, blocking non-HTTPS and SSRF-risky targets before any database write by reusing the existing `validateWebhookURL` utility.

- A new `validateRemoteExperimentUrl` helper enforces `https:` protocol and delegates SSRF checks (blocked IPs, loopback, private ranges) to the shared webhook validator; the guard is correctly placed before `updateDataset`.
- Regression tests verify that `http://` and loopback (`https://127.0.0.1`) URLs are rejected and that `remoteExperimentUrl`/`remoteExperimentPayload` remain `null` after rejection; the `remoteExperimentEnabled` assertion is vacuous because the schema default matches the test input (`true`), so it cannot detect a spurious write.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The production guard is correctly placed and the validation logic is sound; the only rough edge is a test assertion that cannot detect a partial write.

The `validateRemoteExperimentUrl` helper correctly gates the database write and the shared webhook SSRF checks are battle-tested. The test intended to prove non-mutation has a vacuous `remoteExperimentEnabled` assertion because the schema default and the test input are both `true`, meaning a spurious committed write would go undetected by that specific assertion.

web/src/__tests__/server/datasets-remote-experiment.servertest.ts — the `remoteExperimentEnabled` post-rejection assertion should be seeded differently to be meaningful.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant upsertRemoteExperiment
    participant validateRemoteExperimentUrl
    participant validateWebhookURL
    participant updateDataset

    Client->>upsertRemoteExperiment: "{url, payload, enabled}"
    upsertRemoteExperiment->>upsertRemoteExperiment: checkProjectAccess + findDataset
    upsertRemoteExperiment->>validateRemoteExperimentUrl: url string
    validateRemoteExperimentUrl->>validateRemoteExperimentUrl: parse URL, enforce https:
    validateRemoteExperimentUrl->>validateWebhookURL: trimmedUrl (SSRF check)
    alt invalid / blocked URL
        validateWebhookURL-->>validateRemoteExperimentUrl: throws Error
        validateRemoteExperimentUrl-->>upsertRemoteExperiment: throws TRPCError BAD_REQUEST
        upsertRemoteExperiment-->>Client: 400 BAD_REQUEST (no DB write)
    else valid URL
        validateWebhookURL-->>validateRemoteExperimentUrl: ok
        validateRemoteExperimentUrl-->>upsertRemoteExperiment: sanitised URL
        upsertRemoteExperiment->>updateDataset: "{remoteExperimentUrl, ...}"
        updateDataset-->>upsertRemoteExperiment: updatedDataset
        upsertRemoteExperiment-->>Client: updatedDataset
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/__tests__/server/datasets-remote-experiment.servertest.ts:114-116
The `remoteExperimentEnabled` assertion doesn't prove non-mutation. The schema defines `@default(true)` for `remoteExperimentEnabled`, and the test calls the procedure with `enabled: true`. Whether the write was blocked or actually committed, the value would be `true` in both cases — so this check cannot distinguish between the two scenarios. To make this assertion meaningful, the dataset should be seeded with `remoteExperimentEnabled: false` before the test so a spurious write would flip the value and be detectable.

```suggestion
      expect(dataset.remoteExperimentUrl).toBeNull();
      expect(dataset.remoteExperimentPayload).toBeNull();
      expect(dataset.remoteExperimentEnabled).toBe(false); // default is `true`, so seed it as false to detect a spurious write
```

### Issue 2 of 2
web/src/features/datasets/server/dataset-router.ts:143-159
**Implicit port 443-only restriction**

`validateWebhookURL` rejects any port other than 80 and 443. Since `validateRemoteExperimentUrl` already enforces `https:`, port 80 is the only other blocked port, and any non-standard HTTPS port (e.g. `8443`) will produce a generic "Only ports 80 and 443 are allowed" error. This behavior is inherited silently from the shared webhook validator and is not surfaced in the HTTPS-only error message shown to users. Documenting this constraint would prevent user confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Validate remote experiment URLs before s..."](https://github.com/langfuse/langfuse/commit/baf2ce95835b11125e35825f95b874836f568166) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31299415)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->