### PR TITLE
fix(web): gate eval config redirect behind session auth

### DIFF
--- a/web/src/__tests__/server/unit/eval-config-redirect.servertest.ts
+++ b/web/src/__tests__/server/unit/eval-config-redirect.servertest.ts
@@ -1,0 +1,111 @@
+import type { GetServerSidePropsContext } from "next";
+
+const mockGetServerAuthSession = vi.fn();
+const mockJobConfigurationFindUnique = vi.fn();
+
+vi.mock("@/src/server/auth", () => ({
+  getServerAuthSession: (...args: unknown[]) =>
+    mockGetServerAuthSession(...args),
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    jobConfiguration: {
+      findUnique: (...args: unknown[]) =>
+        mockJobConfigurationFindUnique(...args),
+    },
+  },
+}));
+
+import { getServerSideProps } from "../../../pages/project/[projectId]/evals/configs/[configId]";
+
+const projectId = "project-123";
+const evaluatorId = "eval-config-123";
+
+const createContext = (
+  params: GetServerSidePropsContext["params"] = {
+    projectId,
+    configId: evaluatorId,
+  },
+): GetServerSidePropsContext =>
+  ({
+    params,
+    query: params ?? {},
+    req: {},
+    res: {},
+    resolvedUrl: `/project/${projectId}/evals/configs/${evaluatorId}`,
+  }) as GetServerSidePropsContext;
+
+const createSession = (projects: Array<{ id: string }> = [{ id: projectId }]) =>
+  ({
+    user: {
+      id: "user-123",
+      email: "user@example.com",
+      admin: false,
+      organizations: [
+        {
+          id: "org-123",
+          projects,
+        },
+      ],
+    },
+  }) as Awaited<ReturnType<typeof mockGetServerAuthSession>>;
+
+describe("eval config redirect getServerSideProps", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns notFound without querying evaluator existence when unauthenticated", async () => {
+    mockGetServerAuthSession.mockResolvedValueOnce(null);
+    mockJobConfigurationFindUnique.mockResolvedValueOnce({ id: evaluatorId });
+
+    await expect(getServerSideProps(createContext())).resolves.toEqual({
+      notFound: true,
+    });
+
+    expect(mockJobConfigurationFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns notFound without querying evaluator existence for non-members", async () => {
+    mockGetServerAuthSession.mockResolvedValueOnce(createSession([]));
+    mockJobConfigurationFindUnique.mockResolvedValueOnce({ id: evaluatorId });
+
+    await expect(getServerSideProps(createContext())).resolves.toEqual({
+      notFound: true,
+    });
+
+    expect(mockJobConfigurationFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns notFound for project members when the evaluator is missing", async () => {
+    mockGetServerAuthSession.mockResolvedValueOnce(createSession());
+    mockJobConfigurationFindUnique.mockResolvedValueOnce(null);
+
+    await expect(getServerSideProps(createContext())).resolves.toEqual({
+      notFound: true,
+    });
+
+    expect(mockJobConfigurationFindUnique).toHaveBeenCalledWith({
+      where: {
+        id: evaluatorId,
+        projectId,
+      },
+      select: {
+        id: true,
+      },
+    });
+  });
+
+  it("redirects project members when the evaluator exists", async () => {
+    mockGetServerAuthSession.mockResolvedValueOnce(createSession());
+    mockJobConfigurationFindUnique.mockResolvedValueOnce({ id: evaluatorId });
+
+    await expect(getServerSideProps(createContext())).resolves.toEqual({
+      redirect: {
+        destination: `/project/${projectId}/evals/${evaluatorId}`,
+        permanent: false,
+      },
+    });
+  });
+});

--- a/web/src/pages/project/[projectId]/evals/configs/[configId].tsx
+++ b/web/src/pages/project/[projectId]/evals/configs/[configId].tsx
@@ -1,4 +1,6 @@
 import { prisma } from "@langfuse/shared/src/db";
+import { getServerAuthSession } from "@/src/server/auth";
+import { isProjectMemberOrAdmin } from "@/src/server/utils/checkProjectMembershipOrAdmin";
 import { type GetServerSideProps } from "next";
 import { useRouter } from "next/router";
 
@@ -13,17 +15,24 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const projectId = context.params.projectId as string;
   const evaluatorId = context.params.configId as string;
 
+  const session = await getServerAuthSession({
+    req: context.req,
+    res: context.res,
+  });
+
+  if (!isProjectMemberOrAdmin(session?.user, projectId)) {
+    return {
+      notFound: true,
+    };
+  }
+
   const evaluator = await prisma.jobConfiguration.findUnique({
     where: {
       id: evaluatorId,
       projectId,
     },
     select: {
-      project: {
-        select: {
-          id: true,
-        },
-      },
+      id: true,
     },
   });
 


### PR DESCRIPTION
## Summary
- Require a server session and project membership before resolving the deprecated eval config redirect.
- Return `notFound` for unauthenticated, unauthorized, and missing-config requests so the page no longer acts as an existence oracle.
- Add a focused server unit test covering the auth and lookup branches.

## Testing
- `pnpm --filter web exec vitest run --project server src/__tests__/server/unit/eval-config-redirect.servertest.ts`
- `pnpm --filter web run lint`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR secures a deprecated redirect page (`/project/[projectId]/evals/configs/[configId]`) that previously allowed unauthenticated users to probe for the existence of eval configs. It adds session authentication and project-membership checks before the database lookup, and cleans up the Prisma select to only fetch `id`.

- **Auth gate added**: `getServerAuthSession` and `isProjectMemberOrAdmin` are called before the DB query, returning `notFound` for unauthenticated or non-member callers — eliminating the existence-oracle vulnerability.
- **Query simplified**: the old `project: { select: { id: true } }` relation select (used only to confirm the record existed) is replaced with a minimal `id: true` select.
- **Tests added**: a focused unit test file covers all four branches — unauthenticated, non-member, missing config, and valid redirect — and asserts the DB is never reached in the auth-failure cases.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change tightens security on a deprecated redirect page with no regressions to existing functionality.

The auth gate is correctly placed before any DB access, the helper function handles null/undefined users, the Prisma query simplification is accurate, and the test suite validates every branch including that the DB is never touched on auth failures.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant getServerSideProps
    participant getServerAuthSession
    participant isProjectMemberOrAdmin
    participant prisma

    Client->>getServerSideProps: GET /project/:projectId/evals/configs/:configId
    getServerSideProps->>getServerAuthSession: req, res
    getServerAuthSession-->>getServerSideProps: "session | null"

    alt No session (unauthenticated)
        getServerSideProps-->>Client: notFound (404)
    else Session present
        getServerSideProps->>isProjectMemberOrAdmin: session.user, projectId
        isProjectMemberOrAdmin-->>getServerSideProps: "true | false"

        alt Not project member/admin
            getServerSideProps-->>Client: notFound (404)
        else Project member or admin
            getServerSideProps->>prisma: jobConfiguration.findUnique(id, projectId)
            prisma-->>getServerSideProps: "evaluator | null"

            alt Config not found
                getServerSideProps-->>Client: notFound (404)
            else Config found
                getServerSideProps-->>Client: redirect to /project/:projectId/evals/:configId
            end
        end
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Gate eval config redirect behind project..."](https://github.com/langfuse/langfuse/commit/a038b8ffcbafc68974f87fc0253e4fd148c07531) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31299775)</sub>

<!-- /greptile_comment -->