### PR TITLE
fix(web): refresh sso configs after domain verification

### DIFF
--- a/web/src/ee/features/verified-domains/components/VerifiedDomainsSettings.tsx
+++ b/web/src/ee/features/verified-domains/components/VerifiedDomainsSettings.tsx
@@ -187,6 +187,7 @@ function DomainRow({ orgId, row }: { orgId: string; row: DomainRowData }) {
   const verifyMutation = api.verifiedDomain.verify.useMutation({
     onSuccess: () => {
       void utils.verifiedDomain.list.invalidate({ orgId });
+      void utils.ssoConfig.get.invalidate({ orgId });
       showSuccessToast({
         title: "Domain verified",
         description: `${row.domain} is now verified.`,


### PR DESCRIPTION
### Motivation
- Verifying a domain that already had an SSO configuration did not cause the SSO settings UI to load the existing config immediately, forcing a manual page refresh.

### Description
- Invalidate the `ssoConfig.get` query in the `verifiedDomain.verify` `onSuccess` handler to force a refetch after domain verification in `web/src/ee/features/verified-domains/components/VerifiedDomainsSettings.tsx`.
- This ensures the `SsoSettings` table will show any existing SSO configuration for the domain immediately after verification.
- Modified file: `web/src/ee/features/verified-domains/components/VerifiedDomainsSettings.tsx`.

### Testing
- Running `pnpm --filter web run lint` in this environment failed due to an unrelated ESLint workspace plugin resolution issue (`@repo/eslint-plugin` build artifact) and not because of the code change.
- Local pre-commit verification executed `format:check` and the monorepo lint pipeline (`turbo run lint`) as part of automated checks and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fda39c57948333b43fed2b5614226f)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This fix adds a `ssoConfig.get` cache invalidation to the `verifiedDomain.verify` mutation's `onSuccess` handler, so the SSO settings UI refreshes automatically after a domain is verified without requiring a manual page reload.

- The `ssoConfig.get` tRPC endpoint accepts `{ orgId }` as its sole input, which matches the filter passed to `invalidate` exactly, so the targeted cache bust will work correctly.
- The pattern is consistent with the adjacent `verifiedDomain.list.invalidate` call already present in the same handler.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the single-line change adds a targeted cache invalidation that matches the endpoint's input schema exactly.

The added call invalidates ssoConfig.get with { orgId }, which is the exact input the router accepts. The pattern is already used for the adjacent verifiedDomain.list invalidation in the same handler, and the router was verified to use the same orgId key. No logic paths are altered and there are no side effects beyond triggering a refetch.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant UI as VerifiedDomainsSettings
    participant tRPC as verifiedDomain.verify
    participant Cache as tRPC Query Cache
    participant SSO as ssoConfig.get

    User->>UI: Click "Verify" button
    UI->>tRPC: "mutate({ orgId, id })"
    tRPC-->>UI: onSuccess()
    UI->>Cache: "invalidate verifiedDomain.list({ orgId })"
    UI->>Cache: "invalidate ssoConfig.get({ orgId }) ← new"
    Cache->>SSO: "refetch ssoConfig.get({ orgId })"
    SSO-->>UI: updated SSO config list
    UI-->>User: Show "Domain verified" toast + updated SSO table
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): refresh sso configs after doma..."](https://github.com/langfuse/langfuse/commit/a34b3d10002986cab9db1aa60498758204ee758b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31301375)</sub>

<!-- /greptile_comment -->