### PR TITLE
fix(web): improve SSO settings mobile table responsiveness

### DIFF
--- a/web/src/ee/features/sso-settings/components/SSOSettings.tsx
+++ b/web/src/ee/features/sso-settings/components/SSOSettings.tsx
@@ -203,28 +203,30 @@ function SsoConfigsTable({ orgId }: { orgId: string }) {
 
   return (
     <Card className="mb-4 overflow-hidden">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="text-primary pl-2.5">Domain</TableHead>
-            <TableHead className="text-primary">Provider</TableHead>
-            <TableHead className="text-primary hidden md:table-cell">
-              Updated
-            </TableHead>
-            <TableHead />
-          </TableRow>
-        </TableHeader>
-        <TableBody className="text-muted-foreground">
-          {verifiedDomains.map((row) => (
-            <SsoConfigRow
-              key={row.domain}
-              orgId={orgId}
-              domain={row.domain}
-              config={configByDomain.get(row.domain) ?? null}
-            />
-          ))}
-        </TableBody>
-      </Table>
+      <div className="overflow-x-auto">
+        <Table className="min-w-[640px] md:min-w-0">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="text-primary pl-2.5">Domain</TableHead>
+              <TableHead className="text-primary">Provider</TableHead>
+              <TableHead className="text-primary hidden md:table-cell">
+                Updated
+              </TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody className="text-muted-foreground">
+            {verifiedDomains.map((row) => (
+              <SsoConfigRow
+                key={row.domain}
+                orgId={orgId}
+                domain={row.domain}
+                config={configByDomain.get(row.domain) ?? null}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     </Card>
   );
 }
@@ -240,7 +242,7 @@ function SsoConfigRow({
 }) {
   return (
     <TableRow className="hover:bg-primary-foreground">
-      <TableCell density="comfortable" className="font-mono">
+      <TableCell density="comfortable" className="font-mono break-all">
         {domain}
       </TableCell>
       <TableCell density="comfortable">
@@ -253,14 +255,13 @@ function SsoConfigRow({
       <TableCell density="comfortable" className="hidden md:table-cell">
         {config ? config.updatedAt.toLocaleDateString() : "—"}
       </TableCell>
-      <TableCell
-        density="comfortable"
-        className="flex items-center justify-end gap-2"
-      >
-        <SsoConfigDialog orgId={orgId} domain={domain} existing={config} />
-        {config ? (
-          <DeleteSsoConfigButton orgId={orgId} domain={domain} />
-        ) : null}
+      <TableCell density="comfortable" className="text-right">
+        <div className="flex items-center justify-end gap-2">
+          <SsoConfigDialog orgId={orgId} domain={domain} existing={config} />
+          {config ? (
+            <DeleteSsoConfigButton orgId={orgId} domain={domain} />
+          ) : null}
+        </div>
       </TableCell>
     </TableRow>
   );
@@ -605,22 +606,24 @@ function CallbackUrlPanel({ callbackUrl }: { callbackUrl: string }) {
     <div>
       <p className="mb-2 text-sm font-medium">Callback URL</p>
       <Card className="overflow-hidden">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>URL</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            <TableRow>
-              <TableCellWithCopyButton
-                density="comfortable"
-                text={callbackUrl}
-                className="py-3 font-mono break-all"
-              />
-            </TableRow>
-          </TableBody>
-        </Table>
+        <div className="overflow-x-auto">
+          <Table className="min-w-[680px] md:min-w-0">
+            <TableHeader>
+              <TableRow>
+                <TableHead>URL</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCellWithCopyButton
+                  density="comfortable"
+                  text={callbackUrl}
+                  className="py-3 font-mono break-all"
+                />
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
       </Card>
       <p className="text-muted-foreground mt-2 text-xs">
         Add this URL as an authorized redirect URI in your identity provider.

--- a/web/src/ee/features/verified-domains/components/VerifiedDomainsSettings.tsx
+++ b/web/src/ee/features/verified-domains/components/VerifiedDomainsSettings.tsx
@@ -138,35 +138,37 @@ function DomainsTable({ orgId }: { orgId: string }) {
 
   return (
     <Card className="mb-4 overflow-hidden">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="text-primary pl-2.5">Domain</TableHead>
-            <TableHead className="text-primary">Status</TableHead>
-            <TableHead className="text-primary hidden md:table-cell">
-              Added
-            </TableHead>
-            <TableHead />
-          </TableRow>
-        </TableHeader>
-        <TableBody className="text-muted-foreground">
-          {query.data && query.data.length === 0 ? (
+      <div className="overflow-x-auto">
+        <Table className="min-w-[640px] md:min-w-0">
+          <TableHeader>
             <TableRow>
-              <TableCell
-                density="comfortable"
-                colSpan={4}
-                className="py-12 text-center text-sm"
-              >
-                No domains added yet
-              </TableCell>
+              <TableHead className="text-primary pl-2.5">Domain</TableHead>
+              <TableHead className="text-primary">Status</TableHead>
+              <TableHead className="text-primary hidden md:table-cell">
+                Added
+              </TableHead>
+              <TableHead />
             </TableRow>
-          ) : (
-            query.data?.map((row) => (
-              <DomainRow key={row.id} orgId={orgId} row={row} />
-            ))
-          )}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody className="text-muted-foreground">
+            {query.data && query.data.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  density="comfortable"
+                  colSpan={4}
+                  className="py-12 text-center text-sm"
+                >
+                  No domains added yet
+                </TableCell>
+              </TableRow>
+            ) : (
+              query.data?.map((row) => (
+                <DomainRow key={row.id} orgId={orgId} row={row} />
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
     </Card>
   );
 }
@@ -201,7 +203,7 @@ function DomainRow({ orgId, row }: { orgId: string; row: DomainRowData }) {
   return (
     <>
       <TableRow className="hover:bg-primary-foreground">
-        <TableCell density="comfortable" className="font-mono">
+        <TableCell density="comfortable" className="font-mono break-all">
           {!row.verifiedAt ? (
             <button
               type="button"
@@ -229,25 +231,24 @@ function DomainRow({ orgId, row }: { orgId: string; row: DomainRowData }) {
         <TableCell density="comfortable" className="hidden md:table-cell">
           {row.createdAt.toLocaleDateString()}
         </TableCell>
-        <TableCell
-          density="comfortable"
-          className="flex items-center justify-end gap-2"
-        >
-          {!row.verifiedAt && (
-            <Button
-              size="sm"
-              onClick={() => verifyMutation.mutate({ orgId, id: row.id })}
-              loading={verifyMutation.isPending}
-            >
-              Verify
-            </Button>
-          )}
-          <DeleteDomainButton
-            orgId={orgId}
-            id={row.id}
-            domain={row.domain}
-            verified={Boolean(row.verifiedAt)}
-          />
+        <TableCell density="comfortable" className="text-right">
+          <div className="flex items-center justify-end gap-2">
+            {!row.verifiedAt && (
+              <Button
+                size="sm"
+                onClick={() => verifyMutation.mutate({ orgId, id: row.id })}
+                loading={verifyMutation.isPending}
+              >
+                Verify
+              </Button>
+            )}
+            <DeleteDomainButton
+              orgId={orgId}
+              id={row.id}
+              domain={row.domain}
+              verified={Boolean(row.verifiedAt)}
+            />
+          </div>
         </TableCell>
       </TableRow>
       {!row.verifiedAt && expanded && (
@@ -277,32 +278,34 @@ function DnsInstructions({
         Add the following TXT record to your DNS provider:
       </p>
       <Card className="overflow-hidden">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-16">Type</TableHead>
-              <TableHead className="w-54">Host</TableHead>
-              <TableHead>Value</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            <TableRow>
-              <TableCell density="comfortable" className="w-16 font-mono">
-                TXT
-              </TableCell>
-              <TableCellWithCopyButton
-                density="comfortable"
-                text={recordHost}
-                className="w-54 py-3 font-mono break-all"
-              />
-              <TableCellWithCopyButton
-                density="comfortable"
-                text={recordValue}
-                className="py-3 font-mono break-all"
-              />
-            </TableRow>
-          </TableBody>
-        </Table>
+        <div className="overflow-x-auto">
+          <Table className="min-w-[680px] md:min-w-0">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-16">Type</TableHead>
+                <TableHead className="w-54">Host</TableHead>
+                <TableHead>Value</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell density="comfortable" className="w-16 font-mono">
+                  TXT
+                </TableCell>
+                <TableCellWithCopyButton
+                  density="comfortable"
+                  text={recordHost}
+                  className="w-54 py-3 font-mono break-all"
+                />
+                <TableCellWithCopyButton
+                  density="comfortable"
+                  text={recordValue}
+                  className="py-3 font-mono break-all"
+                />
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
       </Card>
       <p className="text-muted-foreground text-xs">
         DNS changes may take up to 24h to propagate. After adding the record,


### PR DESCRIPTION
### Motivation
- Mobile and tablet layouts for the Verified Domains and SSO Configuration flows were breaking at narrow breakpoints, making SSO setup unusable on iPhone X-class widths and at the 1024px breakpoint.

### Description
- Wrap table content in horizontal overflow containers and add `min-w-[...] md:min-w-0` guards so tables remain usable on small screens.
- Move flex layout into an inner wrapper and set the table cell to `text-right` to preserve table semantics and avoid action-column breakage on narrow viewports.
- Add `break-all` to domain/callback cells so long values wrap instead of overflowing off-screen.
- Apply the same responsive treatment to the DNS instructions and callback-URL tables and run code formatting fixes with Prettier.

### Testing
- Ran targeted ESLint for the modified files with `pnpm --filter web exec eslint src/ee/features/verified-domains/components/VerifiedDomainsSettings.tsx src/ee/features/sso-settings/components/SSOSettings.tsx`, which completed successfully after formatting fixes.
- Fixed formatting with `pnpm --filter web exec prettier --write <files>` and rebuilt the local `@repo/eslint-plugin` package to satisfy the linter resolution step, both of which succeeded.
- Attempted the full package lint `pnpm --filter web run lint`, but a workspace/environment toolchain mismatch initially blocked the pipeline in this environment, so full workspace lint is noted as attempted but unreliable here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fdb29778d883338e37d7929c60b0a5)