### PR TITLE
fix(sso): reduce multi-tenant SSO config cache TTL to 10 minutes

### DIFF
--- a/web/src/ee/features/multi-tenant-sso/utils.ts
+++ b/web/src/ee/features/multi-tenant-sso/utils.ts
@@ -38,7 +38,7 @@ let cachedSsoConfigs: {
 async function getSsoConfigs(): Promise<SsoProviderSchema[]> {
   if (!multiTenantSsoAvailable) return [];
 
-  const CACHE_TTL = 60 * 60 * 1000; // 1 hour
+  const CACHE_TTL = 10 * 60 * 1000; // 10 minutes
   const FAILEDTOFETCH_RETRY_AFTER = 60 * 1000; // 1 minute
   const DB_MAX_WAIT = 2 * 1000; // 2 seconds
   const DB_TIMEOUT = 3 * 1000; // 3 seconds


### PR DESCRIPTION
### Motivation
- Reduce the local cache lifetime for multi-tenant SSO configurations so changes to SSO setup (enable/disable/rotate) propagate faster and require less waiting for cache expiry.

### Description
- Update `CACHE_TTL` in `web/src/ee/features/multi-tenant-sso/utils.ts` from `60 * 60 * 1000` (1 hour) to `10 * 60 * 1000` (10 minutes) while keeping the failed-fetch retry interval (`FAILEDTOFETCH_RETRY_AFTER`) unchanged.

### Testing
- Ran pre-commit checks including `pnpm format:check` and `pnpm lint` (via the monorepo `turbo` lint run) which completed successfully; running `pnpm --filter web run lint` in isolation failed in this environment due to a missing built local `eslint-plugin` artifact rather than the code change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fdb263c35c83338f907570c06524d6)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces the in-memory cache TTL for multi-tenant SSO configurations from 1 hour to 10 minutes, allowing SSO configuration changes (enable/disable/rotate) to propagate to all running instances more quickly.

- The `CACHE_TTL` constant inside `getSsoConfigs()` is changed from `60 * 60 * 1000` to `10 * 60 * 1000`; the failed-fetch retry interval (`FAILEDTOFETCH_RETRY_AFTER = 60 * 1000`) is left unchanged.
- The cache is process-local (`let cachedSsoConfigs` module-level variable), so in multi-instance deployments each process will independently re-query the DB every 10 minutes rather than every hour.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single integer constant reduction with no logic alterations.

A single numeric constant is changed and nothing else. The cache logic, error handling, and all call-sites remain identical. The only operational effect is more frequent DB reads (at most once per 10 minutes per process), which the existing 2s/3s DB timeout guards against. No new code paths are introduced.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as Next.js Request
    participant Cache as Module-Level Cache (cachedSsoConfigs)
    participant DB as Database (Prisma)

    Client->>Cache: getSsoConfigs()
    alt "Cache is fresh (< 10 min old, was < 1 hr)"
        Cache-->>Client: return cached SsoProviderSchema[]
    else Cache expired or never populated
        Cache->>DB: prisma.$transaction(ssoConfig.findMany()) maxWait: 2s, timeout: 3s
        alt DB query succeeds
            DB-->>Cache: SsoConfig[]
            Cache->>Cache: parse + store with timestamp
            Cache-->>Client: return SsoProviderSchema[]
        else DB query fails
            DB-->>Cache: error
            Cache->>Cache: "store empty [] with failedToFetch=true, retry after 1 min"
            Cache-->>Client: return []
        end
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sso): reduce multi-tenant SSO config..."](https://github.com/langfuse/langfuse/commit/8a3ee26ba4a0572b09b5ea5f0e1218fc08650156) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31319086)</sub>

<!-- /greptile_comment -->