### PR TITLE
fix(auth): enforce AUTH_DOMAINS_WITH_SSO_ENFORCEMENT on the email-OTP path

### DIFF
--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -967,6 +967,20 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
 
           // Only allow sign in via email link if user is already in db as this is used for password reset
           if (account?.provider === "email") {
+            const blockedDomains = getSSOBlockedDomains();
+            if (userDomain && blockedDomains.includes(userDomain)) {
+              logger.info(
+                "Blocked email-OTP sign in for domain enforced via AUTH_DOMAINS_WITH_SSO_ENFORCEMENT",
+                { email },
+              );
+              const params = new URLSearchParams({
+                reason: "sso_enforced_domain",
+              });
+              if (email) params.set("email", email);
+              params.set("attemptedProvider", "email");
+              return `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/enterprise-sso-required?${params.toString()}`;
+            }
+
             const user = await prisma.user.findUnique({
               where: {
                 email: email,


### PR DESCRIPTION
The signIn callback consulted only the cloud-only multi-tenant SSO provider check, which is a no-op on self-hosted instances. This left the password-reset OTP path as an alternate authentication channel for users on domains that AUTH_DOMAINS_WITH_SSO_ENFORCEMENT was meant to lock down. Block the email provider for enforced domains the same way the credentials authorize() and signup handler do.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a security gap where `AUTH_DOMAINS_WITH_SSO_ENFORCEMENT` was not honored on the email-OTP (password-reset) path in the `signIn` callback — only the cloud multi-tenant SSO check was consulted there, leaving self-hosted instances without enforcement. The fix mirrors the same blocked-domain guard already applied in the credentials `authorize()` and signup handler.

- Adds `getSSOBlockedDomains()` call inside `if (account?.provider === "email")` in the `signIn` callback, redirecting enforced-domain users to `/auth/enterprise-sso-required` before any DB lookup.
- The `getSSOBlockedDomains` import was already present at the module level (line 65), satisfying the repo's import-at-top convention, and the redirect URL format is consistent with the existing multi-tenant SSO enforcement block above it.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a narrow, targeted addition to one branch of the signIn callback that mirrors the same pattern already used in the credentials authorize() and signup handler — safe to merge.

The fix is straightforward and consistent with existing enforcement patterns in the codebase. The getSSOBlockedDomains import was already at the module top, userDomain is already in scope, and the redirect URL format matches the existing multi-tenant SSO block. No existing tests or behaviors are altered outside the new guard.

web/src/server/auth.ts — the signIn callback is the only changed file; worth a quick read to confirm the new guard sits in the correct branch.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CB as NextAuth signIn callback
    participant EE as Multi-Tenant SSO Check (Cloud/EE)
    participant ENV as Blocked Domains Check (env var)
    participant DB as Database

    User->>CB: "Email OTP sign-in (provider = email)"
    CB->>CB: Validate email format
    CB->>CB: Extract userDomain from email
    CB->>EE: getSsoAuthProviderIdForDomain(userDomain)
    EE-->>CB: configured SSO provider or null
    alt SSO provider found and provider mismatch
        CB-->>User: Redirect to enterprise-sso-required page
    end
    CB->>ENV: getSSOBlockedDomains() [NEW CHECK]
    ENV-->>CB: list of enforced domains [NEW CHECK]
    alt userDomain is in blocked list [NEW CHECK]
        CB-->>User: Redirect to enterprise-sso-required page [NEW CHECK]
    end
    CB->>DB: Look up user by email
    alt user exists in database
        CB-->>User: Allow sign-in
    else user not found
        CB-->>User: Deny sign-in (with random delay)
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): enforce AUTH\_DOMAINS\_WITH\_SSO..."](https://github.com/langfuse/langfuse/commit/63373c94f509745a3d6c7c3d9e544d83f671637b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31330346)</sub>

<!-- /greptile_comment -->