### PR TITLE
fix(shared): handle Bedrock reasoning content

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -53,6 +53,13 @@ import { logger } from "../logger";
 import { LLMCompletionError } from "./errors";
 
 export type CompletionWithReasoning = { text: string; reasoning?: string };
+type AIMessageContent = AIMessage["content"];
+type AIMessageContentBlock = Exclude<AIMessageContent, string>[number];
+type SplitAIMessageContent = {
+  text: string;
+  contentWithoutThinking: AIMessageContent;
+  reasoning?: string;
+};
 
 const NON_RETRYABLE_LLM_ERROR_PATTERNS = [
   "Request timed out",
@@ -67,6 +74,7 @@ const isLangfuseCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 // Maps adapters to the content block types that represent "thinking".
 // Used to extract reasoning separately and strip thinking parts from parsed output.
 const THINKING_BLOCK_TYPES: Partial<Record<LLMAdapter, Set<string>>> = {
+  [LLMAdapter.Bedrock]: new Set(["reasoning_content"]),
   [LLMAdapter.VertexAI]: new Set(["reasoning"]),
   [LLMAdapter.GoogleAIStudio]: new Set(["reasoning"]),
 };
@@ -570,17 +578,15 @@ export async function fetchLLMCompletion(
             .invoke(finalMessages, runConfigWithTimeout),
       });
 
-      // For thinking adapters, strip reasoning blocks from content before parsing
-      // so ToolCallResponseSchema can validate. Extract reasoning separately.
       if (thinkingTypes != null && Array.isArray(result.content)) {
-        const reasoning = extractReasoning(result.content, thinkingTypes);
-        // mutates Langchain AIMessage in place, not ideal but safe because only used for parsing below
-        result.content = result.content.filter(
-          (block) =>
-            typeof block === "string" || !thinkingTypes.has(block.type),
+        const { contentWithoutThinking, reasoning } = splitAIMessageContent(
+          result.content,
+          thinkingTypes,
         );
-
-        const parsed = ToolCallResponseSchema.safeParse(result);
+        const parsed = ToolCallResponseSchema.safeParse({
+          content: contentWithoutThinking,
+          tool_calls: result.tool_calls,
+        });
         if (!parsed.success)
           throw Error("Failed to parse LLM tool call result");
 
@@ -603,7 +609,7 @@ export async function fetchLLMCompletion(
         abortController: runtimeTimeoutController,
         operation: () =>
           chatModel
-            .pipe(new BytesOutputParser())
+            .pipe(createBytesOutputParser(thinkingTypes))
             .stream(finalMessages, runConfigWithTimeout),
       });
 
@@ -616,7 +622,21 @@ export async function fetchLLMCompletion(
         abortController: runtimeTimeoutController,
         operation: () => chatModel.invoke(finalMessages, runConfigWithTimeout),
       });
-      return extractCompletionWithReasoning(aiMessage, thinkingTypes);
+      const completion = extractCompletionWithReasoning(
+        aiMessage,
+        thinkingTypes,
+      );
+
+      // Bedrock only returns reasoning blocks for selected models. Preserve the
+      // historical plain-string shape when the response contains no reasoning.
+      if (
+        modelParams.adapter === LLMAdapter.Bedrock &&
+        completion.reasoning == null
+      ) {
+        return completion.text;
+      }
+
+      return completion;
     }
 
     const completion = await executeWithRuntimeTimeout({
@@ -681,52 +701,91 @@ export async function fetchLLMCompletion(
   }
 }
 
-// extracts reasoning text from an array of content blocks.
-// returns concatenated reasoning or undefined if no reasoning blocks are found
-function extractReasoning(
-  content: AIMessage["content"],
-  thinkingBlockTypes: Set<string>,
-): string | undefined {
-  if (typeof content === "string" || !Array.isArray(content)) return undefined;
-  const parts: string[] = [];
-  for (const block of content) {
-    if (typeof block !== "string" && thinkingBlockTypes.has(block.type)) {
-      const text = (block as any).text ?? (block as any).reasoning;
-      if (typeof text === "string") parts.push(text);
-    }
-  }
-  return parts.length > 0 ? parts.join("") : undefined;
-}
-
-/**
- * Splits AIMessage content into text and reasoning parts.
- * Text parts are concatenated into `text`, thinking-type parts into `reasoning`.
- */
 function extractCompletionWithReasoning(
   message: AIMessage,
   thinkingBlockTypes: Set<string>,
 ): CompletionWithReasoning {
-  const { content } = message;
+  const { text, reasoning } = splitAIMessageContent(
+    message.content,
+    thinkingBlockTypes,
+  );
 
-  if (typeof content === "string") return { text: content };
-  if (!Array.isArray(content)) return { text: String(content) };
+  return {
+    text,
+    ...(reasoning ? { reasoning } : {}),
+  };
+}
 
-  const reasoning = extractReasoning(content, thinkingBlockTypes);
+function createBytesOutputParser(
+  thinkingBlockTypes: Set<string> | undefined,
+): BytesOutputParser {
+  return thinkingBlockTypes != null
+    ? new ThinkingBlockFilteringBytesOutputParser(thinkingBlockTypes)
+    : new BytesOutputParser();
+}
+
+class ThinkingBlockFilteringBytesOutputParser extends BytesOutputParser {
+  constructor(private readonly thinkingBlockTypes: Set<string>) {
+    super();
+  }
+
+  protected _baseMessageContentToString(
+    content: Exclude<AIMessageContent, string>,
+  ): string {
+    return splitAIMessageContent(content, this.thinkingBlockTypes).text;
+  }
+}
+
+function splitAIMessageContent(
+  content: AIMessageContent,
+  thinkingBlockTypes: Set<string>,
+): SplitAIMessageContent {
+  if (typeof content === "string") {
+    return { text: content, contentWithoutThinking: content };
+  }
+
+  if (!Array.isArray(content)) {
+    return { text: String(content), contentWithoutThinking: content };
+  }
 
   const textParts: string[] = [];
+  const reasoningParts: string[] = [];
+  const contentWithoutThinking: AIMessageContentBlock[] = [];
+
   for (const block of content) {
     if (typeof block === "string") {
       textParts.push(block);
-    } else if (!thinkingBlockTypes.has(block.type)) {
-      const text = (block as any).text ?? (block as any).reasoning;
+      contentWithoutThinking.push(block as AIMessageContentBlock);
+    } else if (thinkingBlockTypes.has(block.type)) {
+      const reasoning = extractReasoningBlockText(block);
+      if (typeof reasoning === "string") reasoningParts.push(reasoning);
+    } else {
+      const text = extractTextBlockText(block);
       if (typeof text === "string") textParts.push(text);
+      contentWithoutThinking.push(block);
     }
   }
 
   return {
     text: textParts.join(""),
-    ...(reasoning ? { reasoning } : {}),
+    contentWithoutThinking,
+    ...(reasoningParts.length > 0
+      ? { reasoning: reasoningParts.join("") }
+      : {}),
   };
+}
+
+function extractTextBlockText(block: AIMessageContentBlock) {
+  return (block as any).text ?? (block as any).reasoning;
+}
+
+function extractReasoningBlockText(block: AIMessageContentBlock) {
+  const reasoningText = (block as any).reasoningText;
+
+  if (typeof reasoningText === "string") return reasoningText;
+  if (typeof reasoningText?.text === "string") return reasoningText.text;
+
+  return extractTextBlockText(block);
 }
 
 /**

--- a/worker/src/__tests__/fetchLLMCompletionReasoning.test.ts
+++ b/worker/src/__tests__/fetchLLMCompletionReasoning.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+const streamMock = vi.fn();
+const pipeMock = vi.fn().mockImplementation((parser) => ({
+  invoke: invokeMock,
+  stream: (...args: any[]) => parser.transform(streamMock(...args), {}),
+}));
+const bindToolsInvokeMock = vi.fn();
+const bindToolsMock = vi.fn().mockReturnValue({
+  invoke: bindToolsInvokeMock,
+});
+const chatBedrockConverseConstructorMock = vi
+  .fn()
+  .mockImplementation(function () {
+    return {
+      invoke: invokeMock,
+      bindTools: bindToolsMock,
+      pipe: pipeMock,
+    };
+  });
+
+class MockLLMCompletionError extends Error {
+  responseStatusCode: number;
+  isRetryable: boolean;
+  blockReason: null;
+
+  constructor(params: {
+    message: string;
+    responseStatusCode?: number;
+    isRetryable?: boolean;
+  }) {
+    super(params.message);
+    this.name = "LLMCompletionError";
+    this.responseStatusCode = params.responseStatusCode ?? 500;
+    this.isRetryable = params.isRetryable ?? false;
+    this.blockReason = null;
+  }
+
+  shouldBlockConfig() {
+    return false;
+  }
+
+  getEvaluatorBlockReason() {
+    return null;
+  }
+}
+
+process.env.CLICKHOUSE_URL ??= "http://localhost:8123";
+process.env.CLICKHOUSE_USER ??= "default";
+process.env.CLICKHOUSE_PASSWORD ??= "password";
+process.env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET ??= "test-bucket";
+process.env.ENCRYPTION_KEY ??=
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("fetchLLMCompletion Bedrock reasoning blocks", () => {
+  let originalCloudRegion: string | undefined;
+  let encrypt: typeof import("../../../packages/shared/src/encryption").encrypt;
+  let fetchLLMCompletion: typeof import("../../../packages/shared/src/server/llm/fetchLLMCompletion").fetchLLMCompletion;
+
+  beforeEach(async () => {
+    invokeMock.mockReset();
+    streamMock.mockReset();
+    pipeMock.mockClear();
+    bindToolsInvokeMock.mockReset();
+    bindToolsMock.mockClear();
+    chatBedrockConverseConstructorMock.mockClear();
+    vi.resetModules();
+    originalCloudRegion = process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    delete process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    vi.doMock("../../../packages/shared/node_modules/@langchain/aws", () => ({
+      ChatBedrockConverse: chatBedrockConverseConstructorMock,
+    }));
+    vi.doMock("../../../packages/shared/src/server/llm/errors", () => ({
+      LLMCompletionError: MockLLMCompletionError,
+    }));
+
+    ({ encrypt } = await import("../../../packages/shared/src/encryption"));
+    ({ fetchLLMCompletion } =
+      await import("../../../packages/shared/src/server/llm/fetchLLMCompletion"));
+  });
+
+  afterEach(() => {
+    if (originalCloudRegion === undefined) {
+      delete process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    } else {
+      process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+    }
+  });
+
+  it("preserves plain string completions when Bedrock returns no reasoning", async () => {
+    invokeMock.mockResolvedValue({
+      content: "4",
+    });
+
+    const completion = await fetchLLMCompletion({
+      streaming: false,
+      messages: [
+        {
+          role: "user",
+          content: "What is 2+2? Answer only with the number.",
+          type: "public-api-created",
+        },
+      ],
+      modelParams: {
+        provider: "bedrock",
+        adapter: "bedrock",
+        model: "openai.gpt-oss-120b-1:0",
+        temperature: 0,
+        max_tokens: 10,
+      },
+      llmConnection: {
+        secretKey: encrypt(JSON.stringify({ apiKey: "test-api-key" })),
+        config: {
+          region: "us-east-1",
+        },
+      },
+    });
+
+    expect(completion).toBe("4");
+  });
+
+  it("returns Bedrock GPT OSS reasoning separately from text", async () => {
+    invokeMock.mockResolvedValue({
+      content: [
+        {
+          type: "reasoning_content",
+          reasoningText: { text: "Compute the arithmetic." },
+        },
+        { type: "text", text: "4" },
+      ],
+    });
+
+    const completion = await fetchLLMCompletion({
+      streaming: false,
+      messages: [
+        {
+          role: "user",
+          content: "What is 2+2? Answer only with the number.",
+          type: "public-api-created",
+        },
+      ],
+      modelParams: {
+        provider: "bedrock",
+        adapter: "bedrock",
+        model: "openai.gpt-oss-120b-1:0",
+        temperature: 0,
+        max_tokens: 10,
+      },
+      llmConnection: {
+        secretKey: encrypt(JSON.stringify({ apiKey: "test-api-key" })),
+        config: {
+          region: "us-east-1",
+        },
+      },
+    });
+
+    expect(completion).toEqual({
+      text: "4",
+      reasoning: "Compute the arithmetic.",
+    });
+  });
+
+  it("strips Bedrock reasoning blocks before parsing tool calls", async () => {
+    bindToolsInvokeMock.mockResolvedValue({
+      content: [
+        {
+          type: "reasoning_content",
+          reasoningText: { text: "Need the weather tool." },
+        },
+        { type: "text", text: "" },
+      ],
+      tool_calls: [
+        {
+          id: "tool-use-1",
+          name: "get_weather",
+          args: { location: "Paris" },
+        },
+      ],
+    });
+
+    const completion = await fetchLLMCompletion({
+      streaming: false,
+      messages: [
+        {
+          role: "user",
+          content: "What's the weather like in Paris?",
+          type: "public-api-created",
+        },
+      ],
+      modelParams: {
+        provider: "bedrock",
+        adapter: "bedrock",
+        model: "openai.gpt-oss-120b-1:0",
+        temperature: 0,
+        max_tokens: 100,
+      },
+      tools: [
+        {
+          name: "get_weather",
+          description: "Get the current weather for a location",
+          parameters: {
+            type: "object",
+            properties: {
+              location: { type: "string" },
+            },
+            required: ["location"],
+          },
+        },
+      ],
+      llmConnection: {
+        secretKey: encrypt(JSON.stringify({ apiKey: "test-api-key" })),
+        config: {
+          region: "us-east-1",
+        },
+      },
+    });
+
+    expect(completion).toEqual({
+      content: [{ type: "text", text: "" }],
+      tool_calls: [
+        {
+          id: "tool-use-1",
+          name: "get_weather",
+          args: { location: "Paris" },
+        },
+      ],
+      reasoning: "Need the weather tool.",
+    });
+  });
+
+  it("filters Bedrock reasoning blocks out of streaming output", async () => {
+    streamMock.mockImplementation(async function* () {
+      yield {
+        content: [
+          {
+            type: "reasoning_content",
+            reasoningText: { text: "Do not show this in the playground." },
+          },
+        ],
+      };
+      yield {
+        content: [{ type: "text", text: "Hello!" }],
+      };
+    } as any);
+
+    const stream = await fetchLLMCompletion({
+      streaming: true,
+      messages: [
+        {
+          role: "user",
+          content: "hi",
+          type: "public-api-created",
+        },
+      ],
+      modelParams: {
+        provider: "bedrock",
+        adapter: "bedrock",
+        model: "openai.gpt-oss-120b-1:0",
+        temperature: 0,
+        max_tokens: 100,
+      },
+      llmConnection: {
+        secretKey: encrypt(JSON.stringify({ apiKey: "test-api-key" })),
+        config: {
+          region: "us-east-1",
+        },
+      },
+    });
+
+    const decoder = new TextDecoder();
+    let text = "";
+    for await (const chunk of stream) {
+      text += decoder.decode(chunk);
+    }
+
+    expect(text).toBe("Hello!");
+  });
+});


### PR DESCRIPTION
## What

- Treat Bedrock `reasoning_content` message parts as thinking blocks in `fetchLLMCompletion`.
- Extract Bedrock GPT OSS reasoning from `reasoningText.text` while preserving response text separately.
- Strip Bedrock reasoning blocks before tool-call parsing.
- Add deterministic worker regression tests for plain Bedrock output, Bedrock GPT OSS reasoning output, and tool calls with reasoning blocks.

## Why

Bedrock Converse can return GPT OSS reasoning as LangChain `reasoning_content` blocks. The shared LLM wrapper only treated Gemini `reasoning` blocks as thinking content, so Bedrock non-streaming completions still went through `StringOutputParser`, which throws `Cannot coerce "reasoning_content" message part into a string.`

## Impacted packages

- `@langfuse/shared`
- `worker` tests

## Verification

- `pnpm --filter @langfuse/shared run lint`
- `pnpm --filter @langfuse/shared run typecheck`
- `pnpm --filter worker exec vitest run src/__tests__/fetchLLMCompletionTimeout.test.ts src/__tests__/fetchLLMCompletionReasoning.test.ts`
- `pnpm exec prettier --check packages/shared/src/server/llm/fetchLLMCompletion.ts worker/src/__tests__/fetchLLMCompletionReasoning.test.ts`
- Pre-commit hook: `pnpm run format:check` and `pnpm run lint`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash in `fetchLLMCompletion` when Bedrock Converse returns GPT OSS `reasoning_content` blocks, which previously caused `StringOutputParser` to throw `Cannot coerce "reasoning_content" message part into a string`. Bedrock is added to `THINKING_BLOCK_TYPES`, all three code paths (streaming, non-streaming, tool-call) are updated to strip or extract reasoning, and backward compatibility for non-reasoning Bedrock models is preserved by returning a plain string when no reasoning blocks are present.

- **Non-streaming path**: Bedrock now uses `chatModel.invoke()` + `extractCompletionWithReasoning`; a guard on `completion.reasoning == null` restores the historical plain-string return for non-reasoning models.
- **Streaming path**: A new `ThinkingBlockFilteringBytesOutputParser` subclass overrides `_baseMessageContentToString` to strip `reasoning_content` blocks before bytes are emitted.
- **Tool-call path**: Reasoning blocks are stripped from `result.content` before `ToolCallResponseSchema` validation, and extracted reasoning is attached to the result.
- Three deterministic vitest regression tests cover the plain Bedrock, GPT OSS reasoning, and tool-call-with-reasoning scenarios.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all three Bedrock execution paths are handled correctly and backward compatibility for non-reasoning models is preserved.

The logic across the streaming, non-streaming, and tool-call paths is sound and well-tested. The only concern is that the streaming filter depends on overriding `_baseMessageContentToString`, a protected LangChain internal; a future dependency bump could silently break the filter without any runtime error.

packages/shared/src/server/llm/fetchLLMCompletion.ts — specifically the ThinkingBlockFilteringBytesOutputParser override if @langchain/core is upgraded.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fetchLLMCompletion] --> B{tools?}
    B -- yes --> C[chatModel.bindTools.invoke]
    C --> D{thinkingTypes set AND content is array?}
    D -- yes --> E[extractReasoning + strip reasoning blocks]
    E --> F[ToolCallResponseSchema.safeParse]
    F --> G[Return ToolCallResponse + reasoning]
    D -- no --> H[ToolCallResponseSchema.safeParse]
    H --> I[Return ToolCallResponse]
    B -- no --> J{streaming?}
    J -- yes --> K{thinkingTypes set?}
    K -- yes --> M[ThinkingBlockFilteringBytesOutputParser filters reasoning_content]
    K -- no --> N[BytesOutputParser]
    M --> O[Return Uint8Array stream]
    N --> O
    J -- no --> P{thinkingTypes set?}
    P -- yes --> Q[chatModel.invoke direct]
    Q --> R[extractCompletionWithReasoning]
    R --> S{Bedrock AND no reasoning?}
    S -- yes --> T[Return plain string]
    S -- no --> U[Return CompletionWithReasoning]
    P -- no --> V[chatModel.pipe StringOutputParser .invoke]
    V --> W[Return string]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/llm/fetchLLMCompletion.ts:756-760
**Fragile override of a LangChain internal method**

`_baseMessageContentToString` is a protected implementation detail of `BytesOutputParser`, not a documented extension point. If LangChain renames, removes, or changes the call path for this method in a future release, the reasoning-block filter will silently stop working — reasoning text will pass through to the byte stream unfiltered, with no error or warning. The fix depends on a specific internal call chain (`transform → _transformStreamResults → parseResult → _baseMessageContentToString`). It may be worth adding a comment referencing the exact `@langchain/core` version this was validated against so future dependency bumps can trigger a re-check.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): handle Bedrock reasoning co..."](https://github.com/langfuse/langfuse/commit/ba5808f64b6ef2ab017175b99a512f3fe1b7ec68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31333158)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->