### PR TITLE
fix(scim): normalize userName casing in user POST flow

### DIFF
--- a/web/src/__tests__/server/scim-api.servertest.ts
+++ b/web/src/__tests__/server/scim-api.servertest.ts
@@ -644,6 +644,54 @@ describe("SCIM API", () => {
         expect(duplicateResult.status).toBe(409);
         expect(duplicateResult.body.detail).toContain("already exists");
       });
+
+      it("should return 409 when userName differs only by email case", async () => {
+        const localPart = `Mixed.Case.${randomUUID().substring(0, 8)}`;
+        const mixedCaseEmail = `${localPart}@Example.com`;
+        const lowerCaseEmail = `${localPart.toLowerCase()}@example.com`;
+
+        // Create with mixed-case userName
+        const createResponse = await makeAPICall(
+          "POST",
+          "/api/public/scim/Users",
+          {
+            userName: mixedCaseEmail,
+            name: {
+              formatted: "Test User",
+            },
+          },
+          createBasicAuthHeader(orgApiKey, orgSecretKey),
+        );
+        expect(createResponse.status).toBe(201);
+        testUserId = createResponse.body.id;
+
+        // The stored user email should be lowercased
+        const storedUser = await prisma.user.findUnique({
+          where: { id: testUserId },
+        });
+        expect(storedUser?.email).toBe(lowerCaseEmail);
+
+        // Re-POST with a case-variant userName: must be detected as duplicate
+        const duplicateResult = await makeAPICall(
+          "POST",
+          "/api/public/scim/Users",
+          {
+            userName: lowerCaseEmail,
+            name: {
+              formatted: "Another User",
+            },
+          },
+          createBasicAuthHeader(orgApiKey, orgSecretKey),
+        );
+        expect(duplicateResult.status).toBe(409);
+        expect(duplicateResult.body.detail).toContain("already exists");
+
+        // No duplicate org membership should have been created
+        const orgMemberships = await prisma.organizationMembership.findMany({
+          where: { userId: testUserId, orgId },
+        });
+        expect(orgMemberships.length).toBe(1);
+      });
     });
 
     describe("GET /api/public/scim/Users/{id}", () => {

--- a/web/src/pages/api/public/scim/Users/index.ts
+++ b/web/src/pages/api/public/scim/Users/index.ts
@@ -183,11 +183,15 @@ export default async function handler(
         role = parsedRoles.data[0];
       }
 
-      // Check if user already exists
+      // Check if user already exists. Normalize the email to lowercase to
+      // stay consistent with the upsert below; otherwise a case-variant
+      // userName slips past the duplicate check and the upsert can collide
+      // with an existing user row.
+      const normalizedEmail = userName.toLowerCase();
       const existingUser = await prisma.organizationMembership.findMany({
         where: {
           user: {
-            email: userName,
+            email: normalizedEmail,
           },
           orgId: authCheck.scope.orgId,
         },
@@ -207,10 +211,10 @@ export default async function handler(
       // Create the user
       const user = await prisma.user.upsert({
         where: {
-          email: userName.toLowerCase(),
+          email: normalizedEmail,
         },
         create: {
-          email: userName.toLowerCase(),
+          email: normalizedEmail,
           name: name?.formatted || displayName,
           password: password ? await hashPassword(password) : undefined,
         },


### PR DESCRIPTION
## Summary

- Fixes [INT-1320](https://linear.app/langfuse/issue/INT-1320). The SCIM `POST /api/public/scim/Users` flow checked for an existing user with the case-preserved `userName` but ran the upsert with a lowercased email. With case-sensitive uniqueness on `User.email`, a case-variant `userName` slipped past the duplicate check and could either link to an unrelated existing user or hit a unique-constraint error instead of returning a clean 409.
- Lowercase `userName` once at the top of the POST handler and reuse it for both the existing-user lookup and the upsert, so duplicate detection and user creation always agree on the email.

## Impacted packages

- `web` (only `web/src/pages/api/public/scim/Users/index.ts` and the SCIM server test)

## Verification

- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter web run typecheck` — only pre-existing errors on `main`, none in SCIM code or the new test
- [ ] `pnpm --filter web run test -- scim-api` — needs Postgres/Redis/ClickHouse from `bash scripts/codex/setup.sh`; new regression test added at `web/src/__tests__/server/scim-api.servertest.ts` covers a re-POST with a case-variant userName expecting 409 and a single org membership

## Test plan

- [ ] Bring up the local stack and run `pnpm --filter web run test -- scim-api` to confirm the new `should return 409 when userName differs only by email case` case passes and the existing SCIM tests still pass
- [ ] Smoke-test SCIM POST with a mixed-case email via an SSO provider; confirm subsequent re-POST with the lowercased variant returns 409

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a case-sensitivity mismatch in the SCIM `POST /api/public/scim/Users` handler where the duplicate-user lookup used the raw (case-preserved) `userName` while the `upsert` lowercased it, allowing a case-variant re-POST to slip past the 409 guard.

- **`web/src/pages/api/public/scim/Users/index.ts`**: Normalizes `userName` to lowercase once (`const normalizedEmail = userName.toLowerCase()`) immediately after role parsing, and reuses that value for both the `organizationMembership.findMany` duplicate check and the subsequent `user.upsert`, so the two operations always agree on the canonical email.
- **`web/src/__tests__/server/scim-api.servertest.ts`**: Adds a regression test that POSTs a mixed-case `userName`, verifies the stored email is lowercased, then re-POSTs with the fully-lowercased variant and expects a 409 with no duplicate org membership.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line normalization that closes a well-defined duplicate-detection gap, with a targeted regression test added alongside it.

The fix is minimal and surgical: one const normalizedEmail = userName.toLowerCase() replaces two separate inline .toLowerCase() calls and the previously un-normalized lookup. The duplicate-check and the upsert now share exactly the same value, so the mismatch that allowed case-variant emails to escape detection is closed. The new regression test exercises the exact failure scenario end-to-end and also verifies the stored email casing and org-membership count. No existing behavior changes outside this edge case.

No files require special attention. Both changed files are self-contained and the modification scope is narrow.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant IdP as Identity Provider
    participant SCIM as SCIM Handler (POST /Users)
    participant DB as Database (Prisma)

    IdP->>SCIM: "POST /api/public/scim/Users { userName: "User@Example.com" }"
    Note over SCIM: normalizedEmail = "user@example.com"
    SCIM->>DB: "organizationMembership.findMany(email: "user@example.com")"
    DB-->>SCIM: [] (no existing membership)
    SCIM->>DB: "user.upsert(where: { email: "user@example.com" })"
    DB-->>SCIM: "user { id, email: "user@example.com" }"
    SCIM->>DB: organizationMembership.create(userId, orgId, role)
    DB-->>SCIM: membership created
    SCIM-->>IdP: 201 Created

    IdP->>SCIM: "POST /api/public/scim/Users { userName: "user@example.com" }"
    Note over SCIM: normalizedEmail = "user@example.com"
    SCIM->>DB: "organizationMembership.findMany(email: "user@example.com")"
    DB-->>SCIM: [existing membership] (found!)
    SCIM-->>IdP: 409 Conflict "User with this userName already exists"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scim): normalize userName casing in ..."](https://github.com/langfuse/langfuse/commit/1ca30faf9911a37bf00b392b4c0b70ff8ba7a921) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31339618)</sub>

<!-- /greptile_comment -->