### PR TITLE
fix(security): rate limit org-admin REST endpoints

### DIFF
--- a/web/src/pages/api/public/organizations/apiKeys/index.ts
+++ b/web/src/pages/api/public/organizations/apiKeys/index.ts
@@ -2,6 +2,7 @@ import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
 import { prisma } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 import { handleGetApiKeys } from "@/src/ee/features/admin-api/server/organizations/apiKeys";
 
 import { type NextApiRequest, type NextApiResponse } from "next";
@@ -54,6 +55,14 @@ export default async function handler(
     return res.status(403).json({
       error: "This feature is not available on your current plan.",
     });
+  }
+
+  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
+    authCheck.scope,
+    "public-api",
+  );
+  if (rateLimitCheck?.isRateLimited()) {
+    return rateLimitCheck.sendRestResponseIfLimited(res);
   }
 
   // Route to the handler

--- a/web/src/pages/api/public/organizations/memberships/index.ts
+++ b/web/src/pages/api/public/organizations/memberships/index.ts
@@ -2,6 +2,7 @@ import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
 import { prisma } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 import {
   handleGetMemberships,
   handleUpdateMembership,
@@ -58,6 +59,14 @@ export default async function handler(
     return res.status(403).json({
       error: "This feature is not available on your current plan.",
     });
+  }
+
+  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
+    authCheck.scope,
+    "public-api",
+  );
+  if (rateLimitCheck?.isRateLimited()) {
+    return rateLimitCheck.sendRestResponseIfLimited(res);
   }
 
   // Route to the appropriate handler based on HTTP method

--- a/web/src/pages/api/public/organizations/projects/index.ts
+++ b/web/src/pages/api/public/organizations/projects/index.ts
@@ -2,6 +2,7 @@ import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
 import { prisma } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
+import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 import { handleGetProjects } from "@/src/ee/features/admin-api/server/projects";
 
 import { type NextApiRequest, type NextApiResponse } from "next";
@@ -54,6 +55,14 @@ export default async function handler(
     return res.status(403).json({
       error: "This feature is not available on your current plan.",
     });
+  }
+
+  const rateLimitCheck = await RateLimitService.getInstance().rateLimitRequest(
+    authCheck.scope,
+    "public-api",
+  );
+  if (rateLimitCheck?.isRateLimited()) {
+    return rateLimitCheck.sendRestResponseIfLimited(res);
   }
 
   // Route to the appropriate handler based on HTTP method


### PR DESCRIPTION
## Summary

- Adds `RateLimitService` checks (after auth + `admin-api` entitlement gates) to the three org-scoped admin handlers under `web/src/pages/api/public/organizations/{memberships,projects,apiKeys}/index.ts`, matching the pattern used by sibling project-scoped admin handlers.
- Caps unbounded `prisma.organizationMembership.upsert/deleteMany` writes and the unthrottled `prisma.user.findUnique` existence-oracle that a compromised org-scoped key could otherwise abuse.
- Resolves [INT-1270](https://linear.app/langfuse/issue/INT-1270).

## Impacted packages

- `web`

## Test plan

- [ ] `pnpm --filter web run lint`
- [ ] `pnpm --filter web run test -- src/__tests__/server/organizations-api.servertest.ts src/__tests__/server/memberships-api.servertest.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `RateLimitService` checks to the three org-scoped admin REST handlers (`apiKeys`, `memberships`, `projects`), mirroring the pattern already in place on sibling project-scoped endpoints. The rate-limit check is correctly inserted after both the auth guard and the `admin-api` entitlement gate, so it only counts requests from valid, entitled callers.

- All three handlers now call `RateLimitService.getInstance().rateLimitRequest(scope, \"public-api\")` and return a 429 when the bucket is exhausted, exactly matching the existing pattern in sibling handlers.
- The `RateLimitService` uses `scope.orgId` as the per-bucket key; because all three handlers already reject requests lacking a valid `orgId` before reaching this code, the key is always populated.
- The org-admin endpoints share the `\"public-api\"` rate-limit bucket with other public-API calls for the same org, which is consistent with the sibling handler pattern.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change adds a well-tested rate-limit guard using the same pattern already verified in sibling handlers.

The three handlers receive identical, minimal additions: one await RateLimitService call and a two-line guard. The placement (after auth and entitlement, before the database call) is correct. scope.orgId is guaranteed non-null by the earlier 403 check, and the public-api bucket is consistent with sibling handlers. No logic is removed or reordered.

No files require special attention — all three changed files follow the same well-established pattern.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP Request] --> B[CORS Middleware]
    B --> C{Valid HTTP Method?}
    C -- No --> D[405 Method Not Allowed]
    C -- Yes --> E[Verify API Key Scope]
    E --> F{Valid Org Key?}
    F -- No --> G[401 or 403 Error]
    F -- Yes --> H{admin-api Entitlement?}
    H -- No --> I[403 Forbidden]
    H -- Yes --> J[Rate Limit Check]
    J --> K{Limit Exceeded?}
    K -- Yes --> L[429 Too Many Requests]
    K -- No --> M[Route to Handler]
    M --> N[Return Response]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): rate limit org-admin REST..."](https://github.com/langfuse/langfuse/commit/3ed3d87828a6c24992deab7b7d8f9b9e02c5c3a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31339929)</sub>

<!-- /greptile_comment -->