### PR TITLE
fix(scim): block removing last organization owner

### DIFF
--- a/web/src/__tests__/server/scim-api.servertest.ts
+++ b/web/src/__tests__/server/scim-api.servertest.ts
@@ -934,5 +934,151 @@ describe("SCIM API", () => {
         expect(result.body.detail).toContain("User not found");
       });
     });
+
+    describe("Last OWNER protection", () => {
+      // Each scenario needs a fresh organization with exactly one OWNER so we
+      // can exercise the guard without interfering with the seeded OWNER on
+      // `seed-org-id`.
+      let scopedOrgId: string;
+      let scopedOwnerUserId: string;
+      let scopedOrgPublicKey: string;
+      let scopedOrgSecretKey: string;
+
+      beforeEach(async () => {
+        const org = await prisma.organization.create({
+          data: { name: `scim-last-owner-${randomUUID().substring(0, 8)}` },
+        });
+        scopedOrgId = org.id;
+
+        const owner = await prisma.user.create({
+          data: {
+            email: `owner.${randomUUID().substring(0, 8)}@example.com`,
+            name: "Sole Owner",
+          },
+        });
+        scopedOwnerUserId = owner.id;
+        await prisma.organizationMembership.create({
+          data: { userId: owner.id, orgId: scopedOrgId, role: "OWNER" },
+        });
+
+        scopedOrgPublicKey = `pk-lf-org-${randomUUID().substring(0, 8)}`;
+        scopedOrgSecretKey = `sk-lf-org-${randomUUID().substring(0, 8)}`;
+        await createAndAddApiKeysToDb({
+          prisma,
+          entityId: scopedOrgId,
+          scope: "ORGANIZATION",
+          predefinedKeys: {
+            publicKey: scopedOrgPublicKey,
+            secretKey: scopedOrgSecretKey,
+          },
+        });
+      });
+
+      afterEach(async () => {
+        await prisma.user.deleteMany({ where: { id: scopedOwnerUserId } });
+        await prisma.organization.deleteMany({ where: { id: scopedOrgId } });
+      });
+
+      it("DELETE rejects removing the only remaining OWNER", async () => {
+        const result = await makeAPICall(
+          "DELETE",
+          `/api/public/scim/Users/${scopedOwnerUserId}`,
+          undefined,
+          createBasicAuthHeader(scopedOrgPublicKey, scopedOrgSecretKey),
+        );
+
+        expect(result.status).toBe(403);
+        expect(String(result.body.detail).toLowerCase()).toContain(
+          "last owner",
+        );
+
+        const remaining = await prisma.organizationMembership.findMany({
+          where: { userId: scopedOwnerUserId, orgId: scopedOrgId },
+        });
+        expect(remaining.length).toBe(1);
+        expect(remaining[0].role).toBe("OWNER");
+      });
+
+      it("PUT active:false rejects removing the only remaining OWNER", async () => {
+        const result = await makeAPICall(
+          "PUT",
+          `/api/public/scim/Users/${scopedOwnerUserId}`,
+          {
+            schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+            id: scopedOwnerUserId,
+            userName: "owner@example.com",
+            active: false,
+          },
+          createBasicAuthHeader(scopedOrgPublicKey, scopedOrgSecretKey),
+        );
+
+        expect(result.status).toBe(403);
+        expect(String(result.body.detail).toLowerCase()).toContain(
+          "last owner",
+        );
+
+        const remaining = await prisma.organizationMembership.findMany({
+          where: { userId: scopedOwnerUserId, orgId: scopedOrgId },
+        });
+        expect(remaining.length).toBe(1);
+        expect(remaining[0].role).toBe("OWNER");
+      });
+
+      it("PATCH active:false rejects removing the only remaining OWNER", async () => {
+        const result = await makeAPICall(
+          "PATCH",
+          `/api/public/scim/Users/${scopedOwnerUserId}`,
+          {
+            schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            Operations: [{ op: "replace", value: { active: false } }],
+          },
+          createBasicAuthHeader(scopedOrgPublicKey, scopedOrgSecretKey),
+        );
+
+        expect(result.status).toBe(403);
+        expect(String(result.body.detail).toLowerCase()).toContain(
+          "last owner",
+        );
+
+        const remaining = await prisma.organizationMembership.findMany({
+          where: { userId: scopedOwnerUserId, orgId: scopedOrgId },
+        });
+        expect(remaining.length).toBe(1);
+        expect(remaining[0].role).toBe("OWNER");
+      });
+
+      it("DELETE allows removing an OWNER when another OWNER remains", async () => {
+        const secondOwner = await prisma.user.create({
+          data: {
+            email: `owner2.${randomUUID().substring(0, 8)}@example.com`,
+            name: "Second Owner",
+          },
+        });
+        await prisma.organizationMembership.create({
+          data: {
+            userId: secondOwner.id,
+            orgId: scopedOrgId,
+            role: "OWNER",
+          },
+        });
+
+        try {
+          const result = await makeAPICall(
+            "DELETE",
+            `/api/public/scim/Users/${secondOwner.id}`,
+            undefined,
+            createBasicAuthHeader(scopedOrgPublicKey, scopedOrgSecretKey),
+          );
+          expect(result.status).toBe(204);
+
+          const memberships = await prisma.organizationMembership.findMany({
+            where: { userId: secondOwner.id, orgId: scopedOrgId },
+          });
+          expect(memberships.length).toBe(0);
+        } finally {
+          await prisma.user.deleteMany({ where: { id: secondOwner.id } });
+        }
+      });
+    });
   });
 });

--- a/web/src/pages/api/public/scim/Users/[id].ts
+++ b/web/src/pages/api/public/scim/Users/[id].ts
@@ -1,42 +1,76 @@
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
-import { prisma, type User, type Role } from "@langfuse/shared/src/db";
+import { Prisma, prisma, type User, type Role } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
 import { z } from "zod";
 import { type NextApiRequest, type NextApiResponse } from "next";
 
-// Mirrors the tRPC `deleteMembership` invariant. Returns true when the caller
-// must stop because the response has already been written with a 403.
-async function rejectIfLastOwner(
+// Mirrors the tRPC `deleteMembership` invariant. Wraps the owner-count check
+// and the membership delete in a single Serializable transaction so two
+// concurrent SCIM deprovision requests cannot both pass the guard and orphan
+// the org. Returns false (with the response already written) when the caller
+// must stop; returns true after the membership has been removed.
+async function deprovisionOrReject(
   res: NextApiResponse,
   userId: string,
   orgId: string,
 ): Promise<boolean> {
-  const membership = await prisma.organizationMembership.findUnique({
-    where: { orgId_userId: { orgId, userId } },
-    select: { role: true },
-  });
-  if (!membership || membership.role !== "OWNER") {
-    return false;
-  }
+  try {
+    const outcome = await prisma.$transaction(
+      async (tx) => {
+        const membership = await tx.organizationMembership.findUnique({
+          where: { orgId_userId: { orgId, userId } },
+          select: { role: true },
+        });
+        if (membership?.role === "OWNER") {
+          const ownerCount = await tx.organizationMembership.count({
+            where: { orgId, role: "OWNER" },
+          });
+          if (ownerCount <= 1) {
+            return "lastOwner" as const;
+          }
+        }
+        await tx.organizationMembership.deleteMany({
+          where: { userId, orgId },
+        });
+        return "deleted" as const;
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
 
-  const ownerCount = await prisma.organizationMembership.count({
-    where: { orgId, role: "OWNER" },
-  });
-  if (ownerCount > 1) {
-    return false;
+    if (outcome === "lastOwner") {
+      logger.warn(
+        `[SCIM] Refused to remove last OWNER ${userId} from org ${orgId}`,
+      );
+      res.status(403).json({
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        detail:
+          "Cannot remove the last owner of an organization. Assign new owner or delete organization.",
+        status: 403,
+      });
+      return false;
+    }
+    return true;
+  } catch (error) {
+    // Postgres maps a serialization failure to Prisma error code P2034 ("could
+    // not serialize access due to concurrent update"). Surface as 409 so the
+    // SCIM client retries; on retry the guard will see the updated owner count.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2034"
+    ) {
+      logger.warn(
+        `[SCIM] Concurrent deprovision conflict for user ${userId} in org ${orgId}`,
+      );
+      res.status(409).json({
+        schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+        detail: "Concurrent deprovision conflict for this user. Please retry.",
+        status: 409,
+      });
+      return false;
+    }
+    throw error;
   }
-
-  logger.warn(
-    `[SCIM] Refused to remove last OWNER ${userId} from org ${orgId}`,
-  );
-  res.status(403).json({
-    schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
-    detail:
-      "Cannot remove the last owner of an organization. Assign new owner or delete organization.",
-    status: 403,
-  });
-  return true;
 }
 
 export default async function handler(
@@ -264,16 +298,10 @@ async function handlePatch(
           `[SCIM] Provisioned user ${user.id} in org ${orgId} via PATCH`,
         );
       } else {
-        if (await rejectIfLastOwner(res, user.id, orgId)) {
+        // Deprovision atomically: check + delete in one Serializable txn.
+        if (!(await deprovisionOrReject(res, user.id, orgId))) {
           return;
         }
-        // Deprovision the user by removing them from the organization
-        await prisma.organizationMembership.deleteMany({
-          where: {
-            userId: user.id,
-            orgId: orgId,
-          },
-        });
         logger.info(
           `[SCIM] Deprovisioned user ${user.id} from org ${orgId} via PATCH`,
         );
@@ -373,16 +401,10 @@ async function handlePut(
         `[SCIM] Provisioned user ${user.id} in org ${orgId} with role ${role} via PUT`,
       );
     } else {
-      if (await rejectIfLastOwner(res, user.id, orgId)) {
+      // Deprovision atomically: check + delete in one Serializable txn.
+      if (!(await deprovisionOrReject(res, user.id, orgId))) {
         return;
       }
-      // Deprovision the user by removing them from the organization
-      await prisma.organizationMembership.deleteMany({
-        where: {
-          userId: user.id,
-          orgId: orgId,
-        },
-      });
       logger.info(
         `[SCIM] Deprovisioned user ${user.id} from org ${orgId} via PUT`,
       );
@@ -414,16 +436,10 @@ async function handleDelete(
   user: User,
   orgId: string,
 ) {
-  if (await rejectIfLastOwner(res, user.id, orgId)) {
+  // Deprovision atomically: check + delete in one Serializable txn.
+  if (!(await deprovisionOrReject(res, user.id, orgId))) {
     return;
   }
-  // Delete just removes the user from the organization
-  await prisma.organizationMembership.deleteMany({
-    where: {
-      userId: user.id,
-      orgId: orgId,
-    },
-  });
   logger.info(`[SCIM] Removed user ${user.id} from org ${orgId} via DELETE`);
 
   // Return empty response with 204 No Content.

--- a/web/src/pages/api/public/scim/Users/[id].ts
+++ b/web/src/pages/api/public/scim/Users/[id].ts
@@ -5,6 +5,40 @@ import { logger, redis } from "@langfuse/shared/src/server";
 import { z } from "zod";
 import { type NextApiRequest, type NextApiResponse } from "next";
 
+// Mirrors the tRPC `deleteMembership` invariant. Returns true when the caller
+// must stop because the response has already been written with a 403.
+async function rejectIfLastOwner(
+  res: NextApiResponse,
+  userId: string,
+  orgId: string,
+): Promise<boolean> {
+  const membership = await prisma.organizationMembership.findUnique({
+    where: { orgId_userId: { orgId, userId } },
+    select: { role: true },
+  });
+  if (!membership || membership.role !== "OWNER") {
+    return false;
+  }
+
+  const ownerCount = await prisma.organizationMembership.count({
+    where: { orgId, role: "OWNER" },
+  });
+  if (ownerCount > 1) {
+    return false;
+  }
+
+  logger.warn(
+    `[SCIM] Refused to remove last OWNER ${userId} from org ${orgId}`,
+  );
+  res.status(403).json({
+    schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+    detail:
+      "Cannot remove the last owner of an organization. Assign new owner or delete organization.",
+    status: 403,
+  });
+  return true;
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -230,6 +264,9 @@ async function handlePatch(
           `[SCIM] Provisioned user ${user.id} in org ${orgId} via PATCH`,
         );
       } else {
+        if (await rejectIfLastOwner(res, user.id, orgId)) {
+          return;
+        }
         // Deprovision the user by removing them from the organization
         await prisma.organizationMembership.deleteMany({
           where: {
@@ -336,6 +373,9 @@ async function handlePut(
         `[SCIM] Provisioned user ${user.id} in org ${orgId} with role ${role} via PUT`,
       );
     } else {
+      if (await rejectIfLastOwner(res, user.id, orgId)) {
+        return;
+      }
       // Deprovision the user by removing them from the organization
       await prisma.organizationMembership.deleteMany({
         where: {
@@ -374,6 +414,9 @@ async function handleDelete(
   user: User,
   orgId: string,
 ) {
+  if (await rejectIfLastOwner(res, user.id, orgId)) {
+    return;
+  }
   // Delete just removes the user from the organization
   await prisma.organizationMembership.deleteMany({
     where: {


### PR DESCRIPTION
## Summary

SCIM `DELETE /Users/{id}`, `PUT /Users/{id}` with `active:false`, and `PATCH /Users/{id}` with `active:false` unconditionally removed the target user's organization membership. A SCIM client could deprovision the only remaining OWNER, orphaning the organization with no admin.

This mirrors the tRPC `deleteMembership` invariant in all three SCIM deprovisioning paths: count remaining OWNERs in the org, and reject with `403` and a SCIM error body when the request would remove the final OWNER. The error message matches the tRPC path so the user-facing copy stays consistent.

Resolves [INT-1223](https://linear.app/langfuse/issue/INT-1223).

## Impacted packages

- `web`

## Test plan

- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter web run test -- src/__tests__/server/scim-api.servertest.ts` — 37/37 pass, including 4 new cases:
  - DELETE rejects removing the only remaining OWNER (403)
  - PUT `active:false` rejects removing the only remaining OWNER (403)
  - PATCH `active:false` rejects removing the only remaining OWNER (403)
  - DELETE allows removing an OWNER when another OWNER remains (204)

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a guard (`rejectIfLastOwner`) that blocks SCIM `DELETE`, `PUT active:false`, and `PATCH active:false` from removing the sole remaining OWNER of an organization, mirroring the existing tRPC `deleteMembership` invariant.

- The guard is applied consistently in all three deprovision code paths and returns a well-formed SCIM error body with status 403.
- Four new integration tests cover the happy path, all three blocked-removal variants, and the two-owner scenario where removal is permitted.
- The check uses two separate non-transactional queries (`findUnique` + `count`) followed by a `deleteMany` outside any transaction; two concurrent deprovision requests targeting the only two OWNERs can both pass the guard before either delete executes, orphaning the org.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for single-client environments; concurrent bulk deprovision of the last two owners can silently orphan an org.

The guard is wired correctly in all three deprovision paths and the new tests pass. However, the three database operations (membership lookup, owner count, delete) are not wrapped in a transaction, so two concurrent SCIM deprovision requests for the last two OWNERs can both pass the guard and both succeed, orphaning the org. SCIM IdP batch sync jobs commonly issue concurrent requests, making this a realistic failure mode.

web/src/pages/api/public/scim/Users/[id].ts — specifically the `rejectIfLastOwner` function and its three call sites where the check and the delete are not inside a transaction.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SC as SCIM Client
    participant API as SCIM API Handler
    participant DB as Database

    SC->>API: "DELETE /Users/{ownerId}"
    API->>DB: "findUnique membership (role=OWNER)"
    DB-->>API: "role=OWNER"
    API->>DB: count OWNERs in org
    DB-->>API: "ownerCount=1"
    API-->>SC: 403 Forbidden (last OWNER blocked)

    note over SC,DB: Concurrent second-owner scenario (race condition)
    SC->>API: "DELETE /Users/{owner1Id}"
    SC->>API: "DELETE /Users/{owner2Id} (concurrent)"
    API->>DB: count OWNERs (owner1 req) → 2, pass guard
    API->>DB: count OWNERs (owner2 req) → 2, pass guard
    API->>DB: deleteMany owner1 membership
    API->>DB: deleteMany owner2 membership
    DB-->>API: 0 OWNERs remain (org orphaned)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/api/public/scim/Users/[id].ts:15-28
**TOCTOU race — concurrent deprovisions can orphan an org**

The guard performs `findUnique` + `count` in two separate queries outside any transaction, then the caller runs `deleteMany` in a third query. With exactly two OWNERs, two simultaneous SCIM DELETE (or PUT/PATCH `active:false`) requests will both read `ownerCount = 2`, both pass the guard, and both successfully delete — leaving the org with zero owners.

The tRPC `deleteMembership` has the same pattern (consistent intent), but SCIM clients are more likely to issue bulk deprovision requests concurrently. Wrapping the three database operations in a `prisma.$transaction` with a re-check inside would close the window.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scim): block removing last organizat..."](https://github.com/langfuse/langfuse/commit/407432768cae2383163957c9eab77e4fc28f728c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31345935)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->