### PR TITLE
fix(tool-parsing): ai sdk parsing of tools

### DIFF
--- a/packages/shared/src/server/ingestion/extractToolsBackend.ts
+++ b/packages/shared/src/server/ingestion/extractToolsBackend.ts
@@ -76,7 +76,7 @@ function flattenToolCall(call: unknown): {
   // Handle nested {function: {name, arguments}} format
   const func = c.function as Record<string, unknown> | undefined;
   const name = (func?.name ?? c.name ?? c.toolName) as string | undefined;
-  const rawArgs = func?.arguments ?? c.arguments ?? c.args;
+  const rawArgs = func?.arguments ?? c.arguments ?? c.args ?? c.input;
   const args =
     typeof rawArgs === "string" ? rawArgs : JSON.stringify(rawArgs ?? {});
 
@@ -127,6 +127,28 @@ function addToolArgument(args: ClickhouseToolArgument[], call: unknown): void {
     type: flattened.type,
     index: flattened.index,
   });
+}
+
+/**
+ * Helper to add a tool call from content-array parts.
+ * Handles Anthropic `tool_use` and AI SDK `tool-call` parts.
+ */
+function addToolArgumentFromContentPart(
+  args: ClickhouseToolArgument[],
+  part: Record<string, unknown>,
+): void {
+  if (part.type === "tool_use") {
+    addToolArgument(args, {
+      id: part.id,
+      name: part.name,
+      arguments: JSON.stringify(part.input ?? {}),
+      type: "tool_use",
+    });
+  }
+
+  if (part.type === "tool-call") {
+    addToolArgument(args, part);
+  }
 }
 
 /**
@@ -218,21 +240,17 @@ function extractToolCallsFromRawOutput(
     }
   }
 
-  // Anthropic tool_use in content array: {content: [{type: "tool_use", ...}]}
+  // Tool calls in content arrays: Anthropic `tool_use`, AI SDK `tool-call`
   if (Array.isArray(obj.content)) {
     for (const part of obj.content) {
       if (
         part &&
         typeof part === "object" &&
-        (part as Record<string, unknown>).type === "tool_use"
+        ["tool_use", "tool-call"].includes(
+          (part as Record<string, unknown>).type as string,
+        )
       ) {
-        const p = part as Record<string, unknown>;
-        addToolArgument(args, {
-          id: p.id,
-          name: p.name,
-          arguments: JSON.stringify(p.input ?? {}),
-          type: "tool_use",
-        });
+        addToolArgumentFromContentPart(args, part as Record<string, unknown>);
       }
     }
   }
@@ -261,21 +279,17 @@ function extractToolCallsFromMessage(
     }
   }
 
-  // Anthropic content array
+  // Tool calls in content arrays: Anthropic `tool_use`, AI SDK `tool-call`
   if (Array.isArray(msg.content)) {
     for (const part of msg.content) {
       if (
         part &&
         typeof part === "object" &&
-        (part as Record<string, unknown>).type === "tool_use"
+        ["tool_use", "tool-call"].includes(
+          (part as Record<string, unknown>).type as string,
+        )
       ) {
-        const p = part as Record<string, unknown>;
-        addToolArgument(args, {
-          id: p.id,
-          name: p.name,
-          arguments: JSON.stringify(p.input ?? {}),
-          type: "tool_use",
-        });
+        addToolArgumentFromContentPart(args, part as Record<string, unknown>);
       }
     }
   }

--- a/worker/src/__tests__/extractToolsBackend.test.ts
+++ b/worker/src/__tests__/extractToolsBackend.test.ts
@@ -294,6 +294,63 @@ describe("extractToolsFromObservation", () => {
       });
     });
 
+    it("extracts AI SDK tool-call content parts and input arguments from ingestion output", () => {
+      const output = [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I'll look that up." },
+            {
+              type: "tool-call",
+              toolCallId: "tooluse_123",
+              toolName: "getWeather",
+              input: {
+                location: "Berlin",
+                unit: "celsius",
+              },
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              type: "tool-call",
+              toolCallId: "tooluse_456",
+              toolName: "getForecast",
+              input: {
+                location: "San Francisco",
+                days: 3,
+              },
+            },
+          ],
+        },
+      ];
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toHaveLength(2);
+      expect(toolArguments[0]).toMatchObject({
+        id: "tooluse_123",
+        name: "getWeather",
+        arguments: JSON.stringify({
+          location: "Berlin",
+          unit: "celsius",
+        }),
+        type: "tool-call",
+      });
+      expect(toolArguments[1]).toMatchObject({
+        id: "tooluse_456",
+        name: "getForecast",
+        arguments: JSON.stringify({
+          location: "San Francisco",
+          days: 3,
+        }),
+        type: "tool-call",
+      });
+    });
+
     it("preserves index field for parallel tool calls", () => {
       const output = {
         tool_calls: [


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends tool-call parsing in `extractToolsBackend.ts` to support the AI SDK's `tool-call` content-part format alongside the existing Anthropic `tool_use` support.

- Adds a `c.input` fallback in `flattenToolCall` so objects that carry arguments in an `input` field (AI SDK format) are correctly serialized.
- Extracts a new `addToolArgumentFromContentPart` helper and expands the content-array scan in both `extractToolCallsFromRawOutput` and `extractToolCallsFromMessage` to recognize `tool-call` parts in addition to `tool_use`.
- Adds a test covering the AI SDK `tool-call` content-part path and `tool_calls` array with `input` arguments.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; it adds a new input-field fallback and a content-part helper without touching any existing happy paths.

Both extraction paths produce correct results, deduplication handles any edge-case double-processing, and the new test exercises both the content-part and tool_calls scenarios. The only finding is a minor redundancy in addToolArgumentFromContentPart where the tool_use branch constructs an intermediate object that the already-updated flattenToolCall could handle by receiving part directly.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Raw output] --> B{Array?}
    B -- Yes --> C[extractToolCallsFromMessage per message]
    B -- No --> D[extractToolCallsFromRawOutput]

    C --> E{msg.tool_calls?}
    E -- Yes --> F[addToolArgument for each call]
    C --> G{msg.content array?}
    G -- Yes --> H{part.type?}
    H -- tool_use --> I[addToolArgumentFromContentPart tool_use branch]
    H -- tool-call --> J[addToolArgumentFromContentPart tool-call branch]

    D --> K{obj.tool_calls?}
    K -- Yes --> F
    D --> L{obj.choices?}
    L -- Yes --> F
    D --> M{obj.content array?}
    M -- Yes --> H
    D --> N{obj.additional_kwargs?}
    N -- Yes --> F

    F --> O[flattenToolCall
id: c.id ?? c.toolCallId ?? c.call_id
name: c.name ?? c.toolName
rawArgs: c.arguments ?? c.args ?? c.input NEW]
    I --> O
    J --> O
    O --> P[ClickhouseToolArgument]
    P --> Q[Deduplicate by id]
    Q --> R[Return toolArguments]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/ingestion/extractToolsBackend.ts:140-151
The `tool_use` branch manually constructs a new object with `arguments: JSON.stringify(part.input ?? {})`, but `flattenToolCall` already handles the `input` field via the new `c.input` fallback added in this PR. Passing `part` directly (as the `tool-call` branch does) produces identical output and keeps the two branches consistent.

```suggestion
  if (part.type === "tool_use" || part.type === "tool-call") {
    addToolArgument(args, part);
  }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix parsing"](https://github.com/langfuse/langfuse/commit/f2673ea9a0e5aecfb987843a81c7327f98a3ecb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31361721)</sub>

<!-- /greptile_comment -->