### PR TITLE
chore(deps): bump fast-xml-builder to 1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
       "rollup@^4.0.0": "^4.22.4",
       "@types/node-fetch": "^2.6.13",
       "@types/react-dom": "19.2.3",
+      "fast-xml-builder": "1.1.7",
       "glob": "^10.5.0",
       "qs": "6.14.1",
       "path-to-regexp@0.1.12": "0.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   rollup@^4.0.0: ^4.22.4
   '@types/node-fetch': ^2.6.13
   '@types/react-dom': 19.2.3
+  fast-xml-builder: 1.1.7
   glob: ^10.5.0
   qs: 6.14.1
   path-to-regexp@0.1.12: 0.1.13
@@ -6899,8 +6900,8 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+  fast-xml-builder@1.1.7:
+    resolution: {integrity: sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==}
 
   fast-xml-parser@5.5.8:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
@@ -17808,13 +17809,13 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.4:
+  fast-xml-builder@1.1.7:
     dependencies:
       path-expression-matcher: 1.2.0
 
   fast-xml-parser@5.5.8:
     dependencies:
-      fast-xml-builder: 1.1.4
+      fast-xml-builder: 1.1.7
       path-expression-matcher: 1.2.0
       strnum: 2.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ minimumReleaseAgeExclude:
   - "@next/swc-win32-x64-msvc@16.2.6"
   - "eslint-config-next@16.2.6"
   - "@next/eslint-plugin-next@16.2.6"
+  - "fast-xml-builder@1.1.7"
 allowBuilds:
   "@prisma/client": true
   "@prisma/engines": true


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps the transitive dependency `fast-xml-builder` from `1.1.4` to `1.1.7` by adding an explicit pnpm override, and adds the new version to `minimumReleaseAgeExclude` to bypass the workspace's 5-day supply-chain gate.

- **`package.json` / `pnpm-lock.yaml`**: Adds `fast-xml-builder: 1.1.7` to `pnpm.overrides` and updates the resolution hash; `fast-xml-parser@5.5.8` continues to resolve against this overridden version.
- **`pnpm-workspace.yaml`**: Appends `fast-xml-builder@1.1.7` to `minimumReleaseAgeExclude`, which repurposes a list originally meant to prevent downgrading legacy packages; no inline comment explains the reason for this specific bypass.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This is a straightforward transitive-dependency pin with no logic changes; the only risk is the bypassed release-age gate for a package version whose motivation is not documented.

The override and lockfile update are mechanically correct. The one concern is that fast-xml-builder@1.1.7 is added to minimumReleaseAgeExclude without a comment explaining the urgency, making it unclear whether this is a security fix or a routine bump, and leaving no breadcrumb for future cleanup.

pnpm-workspace.yaml — the minimumReleaseAgeExclude entry for fast-xml-builder@1.1.7 should carry a comment or linked issue explaining why the 5-day gate is being bypassed.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm overrides in package.json] -->|pins| B[fast-xml-builder v1.1.7]
    C[fast-xml-parser v5.5.8] -->|depends on| B
    D[fast-xml-builder v1.1.4] -->|upgraded to| B
    E[minimumReleaseAgeExclude in pnpm-workspace.yaml] -->|bypasses 5-day gate for| B
    B -->|resolution hash updated in| F[pnpm-lock.yaml]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
pnpm-workspace.yaml:26
**Missing rationale for release-age bypass**

The `minimumReleaseAgeExclude` list was originally introduced to prevent the 5-day supply-chain gate from downgrading packages that were already installed before the policy was set (see the `TODO` comment above). Adding `fast-xml-builder@1.1.7` here serves a different purpose — explicitly fast-tracking an upgrade past that gate — without any inline comment explaining why (e.g. a CVE ID or linked issue). Without that context, a future reader has no way to tell whether this entry was intentional or accidental, and the `TODO` reminder to clean up the list becomes meaningless for this entry.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump fast-xml-builder to 1...."](https://github.com/langfuse/langfuse/commit/d7f7e6495208e9f278bcda7efe867732d9e172be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31363219)</sub>

<!-- /greptile_comment -->