### PR TITLE
fix(blobstorage-integration): add audit logs for validate and runNow

### DIFF
--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -1,0 +1,271 @@
+import type { Mock } from "vitest";
+import type { Session } from "next-auth";
+
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { encrypt } from "@langfuse/shared/encryption";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  BlobStorageIntegrationProcessingQueue,
+  createOrgProjectAndApiKey,
+  QueueJobs,
+  StorageServiceFactory,
+} from "@langfuse/shared/src/server";
+
+vi.mock("@langfuse/shared/src/server", async () => {
+  const actual = await vi.importActual("@langfuse/shared/src/server");
+  return {
+    ...actual,
+    BlobStorageIntegrationProcessingQueue: {
+      getInstance: vi.fn(),
+    },
+    StorageServiceFactory: {
+      getInstance: vi.fn(),
+    },
+  };
+});
+
+const __orgIds: string[] = [];
+
+const prepare = async () => {
+  const { project, org } = await createOrgProjectAndApiKey();
+
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: "user-1",
+      canCreateOrganizations: true,
+      name: "Demo User",
+      organizations: [
+        {
+          id: org.id,
+          name: org.name,
+          role: "OWNER",
+          plan: "cloud:hobby",
+          cloudConfig: undefined,
+          metadata: {},
+          projects: [
+            {
+              id: project.id,
+              role: "ADMIN",
+              retentionDays: 30,
+              deletedAt: null,
+              name: project.name,
+              metadata: {},
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+      },
+      admin: true,
+    },
+    environment: {
+      enableExperimentalFeatures: false,
+      selfHostedInstancePlan: "cloud:hobby",
+    },
+  };
+
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+  const caller = appRouter.createCaller({ ...ctx, prisma });
+
+  __orgIds.push(org.id);
+
+  return { project, org, session, ctx, caller };
+};
+
+const createIntegration = async ({
+  projectId,
+  enabled = true,
+}: {
+  projectId: string;
+  enabled?: boolean;
+}) =>
+  prisma.blobStorageIntegration.create({
+    data: {
+      projectId,
+      type: "S3",
+      bucketName: "test-bucket",
+      region: "us-east-1",
+      accessKeyId: "test-access-key",
+      secretAccessKey: encrypt("test-secret-key"),
+      prefix: "test/",
+      exportFrequency: "daily",
+      enabled,
+      forcePathStyle: false,
+      fileType: "JSONL",
+      exportMode: "FULL_HISTORY",
+    },
+  });
+
+const findAuditLog = async ({
+  projectId,
+  action,
+}: {
+  projectId: string;
+  action: string;
+}) =>
+  prisma.auditLog.findFirst({
+    where: {
+      projectId,
+      resourceType: "blobStorageIntegration",
+      resourceId: projectId,
+      action,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+const parseAuditLogAfter = (after: string | null) =>
+  after ? (JSON.parse(after) as Record<string, unknown>) : null;
+
+describe("Blob Storage Integration tRPC Router", () => {
+  afterAll(async () => {
+    await prisma.auditLog.deleteMany({
+      where: {
+        orgId: { in: __orgIds },
+      },
+    });
+    await prisma.organization.deleteMany({
+      where: {
+        id: { in: __orgIds },
+      },
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("runNow", () => {
+    it("creates a success audit log when a manual run is queued", async () => {
+      const add = vi.fn().mockResolvedValue(undefined);
+      (
+        BlobStorageIntegrationProcessingQueue.getInstance as Mock
+      ).mockReturnValue({ add });
+
+      const { caller, project } = await prepare();
+      await createIntegration({ projectId: project.id });
+
+      const result = await caller.blobStorageIntegration.runNow({
+        projectId: project.id,
+      });
+
+      expect(result.success).toBe(true);
+      expect(add).toHaveBeenCalledWith(
+        QueueJobs.BlobStorageIntegrationProcessingJob,
+        expect.objectContaining({
+          name: QueueJobs.BlobStorageIntegrationProcessingJob,
+          payload: {
+            projectId: project.id,
+          },
+        }),
+        expect.objectContaining({
+          jobId: result.jobId,
+        }),
+      );
+
+      const auditLog = await findAuditLog({
+        projectId: project.id,
+        action: "runNow",
+      });
+      expect(auditLog).toBeDefined();
+      expect(parseAuditLogAfter(auditLog?.after ?? null)).toMatchObject({
+        outcome: "success",
+        jobId: result.jobId,
+      });
+    });
+
+    it("creates a failure audit log when a manual run cannot be queued", async () => {
+      (
+        BlobStorageIntegrationProcessingQueue.getInstance as Mock
+      ).mockReturnValue(null);
+
+      const { caller, project } = await prepare();
+      await createIntegration({ projectId: project.id });
+
+      await expect(
+        caller.blobStorageIntegration.runNow({ projectId: project.id }),
+      ).rejects.toThrow();
+
+      const auditLog = await findAuditLog({
+        projectId: project.id,
+        action: "runNow",
+      });
+      expect(auditLog).toBeDefined();
+      expect(parseAuditLogAfter(auditLog?.after ?? null)).toMatchObject({
+        outcome: "failure",
+        error: "INTERNAL_SERVER_ERROR",
+      });
+    });
+  });
+
+  describe("validate", () => {
+    it("creates a success audit log when validation uploads a test file", async () => {
+      const uploadWithSignedUrl = vi.fn().mockResolvedValue({
+        signedUrl: "https://signed.example/upload",
+      });
+      (StorageServiceFactory.getInstance as Mock).mockReturnValue({
+        uploadWithSignedUrl,
+      });
+
+      const { caller, project } = await prepare();
+      await createIntegration({ projectId: project.id });
+
+      const result = await caller.blobStorageIntegration.validate({
+        projectId: project.id,
+      });
+
+      expect(result.success).toBe(true);
+      expect(uploadWithSignedUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileName: result.testFileName,
+          fileType: "text/plain",
+          expiresInSeconds: 3600,
+        }),
+      );
+
+      const auditLog = await findAuditLog({
+        projectId: project.id,
+        action: "validate",
+      });
+      expect(auditLog).toBeDefined();
+      const after = parseAuditLogAfter(auditLog?.after ?? null);
+      expect(after).toMatchObject({
+        outcome: "success",
+        testFileName: result.testFileName,
+      });
+      expect(JSON.stringify(after)).not.toContain("signed.example");
+    });
+
+    it("creates a failure audit log when validation upload fails", async () => {
+      (StorageServiceFactory.getInstance as Mock).mockReturnValue({
+        uploadWithSignedUrl: vi
+          .fn()
+          .mockRejectedValue(new Error("provider rejected the upload")),
+      });
+
+      const { caller, project } = await prepare();
+      await createIntegration({ projectId: project.id });
+
+      await expect(
+        caller.blobStorageIntegration.validate({ projectId: project.id }),
+      ).rejects.toThrow("Validation failed");
+
+      const auditLog = await findAuditLog({
+        projectId: project.id,
+        action: "validate",
+      });
+      expect(auditLog).toBeDefined();
+      const after = parseAuditLogAfter(auditLog?.after ?? null);
+      expect(after).toMatchObject({
+        outcome: "failure",
+        error: "Error",
+      });
+      expect(JSON.stringify(after)).not.toContain("provider rejected");
+    });
+  });
+});

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -136,7 +136,8 @@ describe("Blob Storage Integration tRPC Router", () => {
     });
   });
 
-  beforeEach(() => {
+  afterEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -200,6 +201,27 @@ describe("Blob Storage Integration tRPC Router", () => {
         outcome: "failure",
         error: "INTERNAL_SERVER_ERROR",
       });
+    });
+
+    it("does not fail a queued manual run when success audit logging fails", async () => {
+      const add = vi.fn().mockResolvedValue(undefined);
+      (
+        BlobStorageIntegrationProcessingQueue.getInstance as Mock
+      ).mockReturnValue({ add });
+      const auditLogCreateSpy = vi
+        .spyOn(prisma.auditLog, "create")
+        .mockRejectedValueOnce(new Error("audit log unavailable"));
+
+      const { caller, project } = await prepare();
+      await createIntegration({ projectId: project.id });
+
+      const result = await caller.blobStorageIntegration.runNow({
+        projectId: project.id,
+      });
+
+      expect(result.success).toBe(true);
+      expect(add).toHaveBeenCalledTimes(1);
+      expect(auditLogCreateSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -266,6 +288,29 @@ describe("Blob Storage Integration tRPC Router", () => {
         error: "Error",
       });
       expect(JSON.stringify(after)).not.toContain("provider rejected");
+    });
+
+    it("does not fail validation when success audit logging fails", async () => {
+      const uploadWithSignedUrl = vi.fn().mockResolvedValue({
+        signedUrl: "https://signed.example/upload",
+      });
+      (StorageServiceFactory.getInstance as Mock).mockReturnValue({
+        uploadWithSignedUrl,
+      });
+      const auditLogCreateSpy = vi
+        .spyOn(prisma.auditLog, "create")
+        .mockRejectedValueOnce(new Error("audit log unavailable"));
+
+      const { caller, project } = await prepare();
+      await createIntegration({ projectId: project.id });
+
+      const result = await caller.blobStorageIntegration.validate({
+        projectId: project.id,
+      });
+
+      expect(result.success).toBe(true);
+      expect(uploadWithSignedUrl).toHaveBeenCalledTimes(1);
+      expect(auditLogCreateSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -229,6 +229,11 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
             outcome: "success",
             jobId,
           },
+        }).catch((auditLogError) => {
+          logger.error(
+            `Failed to create audit log for blob storage integration run`,
+            auditLogError,
+          );
         });
 
         return { success: true, jobId };
@@ -347,6 +352,11 @@ This file can be safely deleted.`;
             outcome: "success",
             testFileName,
           },
+        }).catch((auditLogError) => {
+          logger.error(
+            `Failed to create audit log for blob storage integration validation`,
+            auditLogError,
+          );
         });
 
         return {

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -23,6 +23,16 @@ import {
   InvalidRequestError,
 } from "@langfuse/shared";
 
+const getAuditLogErrorType = (error: unknown) =>
+  error instanceof TRPCError
+    ? error.code
+    : error instanceof Error
+      ? error.name
+      : "UnknownError";
+
+const getErrorMessage = (error: unknown, fallback: string) =>
+  error instanceof Error ? error.message : fallback;
+
 export const blobStorageIntegrationRouter = createTRPCRouter({
   get: protectedProjectProcedure
     .input(z.object({ projectId: z.string() }))
@@ -210,9 +220,35 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           `Manual blob storage integration job queued for project ${input.projectId}`,
         );
 
+        await auditLog({
+          session: ctx.session,
+          action: "runNow",
+          resourceType: "blobStorageIntegration",
+          resourceId: input.projectId,
+          after: {
+            outcome: "success",
+            jobId,
+          },
+        });
+
         return { success: true, jobId };
       } catch (e) {
         logger.error(`Failed to trigger blob storage integration run`, e);
+        await auditLog({
+          session: ctx.session,
+          action: "runNow",
+          resourceType: "blobStorageIntegration",
+          resourceId: input.projectId,
+          after: {
+            outcome: "failure",
+            error: getAuditLogErrorType(e),
+          },
+        }).catch((auditLogError) => {
+          logger.error(
+            `Failed to create audit log for blob storage integration run`,
+            auditLogError,
+          );
+        });
         if (e instanceof TRPCError) {
           throw e;
         }
@@ -302,6 +338,17 @@ This file can be safely deleted.`;
           `Blob storage validation successful for project ${input.projectId}`,
         );
 
+        await auditLog({
+          session: ctx.session,
+          action: "validate",
+          resourceType: "blobStorageIntegration",
+          resourceId: input.projectId,
+          after: {
+            outcome: "success",
+            testFileName,
+          },
+        });
+
         return {
           success: true,
           message: "Validation successful! Test file uploaded.",
@@ -315,10 +362,26 @@ This file can be safely deleted.`;
         );
 
         // Extract meaningful error message
-        let errorMessage = "Unknown error occurred during validation";
-        if (e instanceof Error) {
-          errorMessage = e.message;
-        }
+        const errorMessage = getErrorMessage(
+          e,
+          "Unknown error occurred during validation",
+        );
+
+        await auditLog({
+          session: ctx.session,
+          action: "validate",
+          resourceType: "blobStorageIntegration",
+          resourceId: input.projectId,
+          after: {
+            outcome: "failure",
+            error: getAuditLogErrorType(e),
+          },
+        }).catch((auditLogError) => {
+          logger.error(
+            `Failed to create audit log for blob storage integration validation`,
+            auditLogError,
+          );
+        });
 
         if (e instanceof TRPCError) {
           throw e;


### PR DESCRIPTION
## Summary
- Add audit log entries for blob storage integration `validate` and `runNow` operations.
- Record success and failure outcomes without leaking signed URLs or raw provider error messages.
- Add server coverage for the new audit log behavior on both success and failure paths.

## Testing
- `pnpm --filter web run lint` passed.
- `pnpm --filter web exec dotenv -e ../.env.dev.example -e ../.env.test.example -- vitest run --project server src/__tests__/server/blob-storage-integration-trpc.servertest.ts` passed.
- `pnpm --filter web run typecheck` still reports existing unrelated repository-wide type errors.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds audit log entries to the `runNow` and `validate` tRPC mutations in the blob-storage integration router, recording success/failure outcomes while intentionally omitting signed URLs and raw provider error messages. New server tests cover all four paths (success/failure × runNow/validate).

- **Success-path audit logs are bare `await` calls** in both `runNow` and `validate`. If `auditLog` throws (e.g. a transient DB error), the exception propagates into the outer catch block, causing a successfully-completed operation to be returned as an error to the client and a spurious failure audit log entry to be written. The failure-path calls already use `.catch()` to prevent this.
- The `getAuditLogErrorType` helper correctly captures error type without leaking message content, and the tests verify the signed-URL and provider-message redaction.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core operations (job queuing and test-file upload) are unchanged, but a transient audit-log write failure in the success path would return an error to the client for an operation that actually completed, and would simultaneously corrupt the audit trail with a false failure entry.

Both runNow and validate have an unprotected await auditLog() on the success path. A DB hiccup during that write causes the exception to fall into the catch block, triggering a misleading error response to the caller and writing a failure audit log for a successful operation. The failure-path audit log calls right below already use .catch() — the fix is symmetric and straightforward, but until it lands the inconsistency is a real defect on an active code path.

web/src/features/blobstorage-integration/blobstorage-integration-router.ts — both success-path auditLog calls need .catch() protection
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Router as blobstorage-integration-router
    participant Queue as BlobStorageIntegrationProcessingQueue
    participant Storage as StorageServiceFactory
    participant AuditLog as auditLog

    Note over Router: runNow mutation
    Client->>Router: runNow(projectId)
    Router->>Queue: getInstance()
    Queue-->>Router: queue instance
    Router->>Queue: add(job, payload, jobId)
    Queue-->>Router: ok
    Router->>AuditLog: "auditLog(runNow, outcome=success)"
    alt auditLog succeeds
        AuditLog-->>Router: ok
        Router-->>Client: "success=true, jobId"
    else auditLog throws (unprotected)
        AuditLog-->>Router: throws
        Router->>AuditLog: "auditLog(runNow, outcome=failure) via catch"
        Router-->>Client: INTERNAL_SERVER_ERROR
    end

    Note over Router: validate mutation
    Client->>Router: validate(projectId)
    Router->>Storage: getInstance(config)
    Storage-->>Router: storageService
    Router->>Storage: uploadWithSignedUrl(testFileName)
    Storage-->>Router: signedUrl
    Router->>AuditLog: "auditLog(validate, outcome=success)"
    alt auditLog succeeds
        AuditLog-->>Router: ok
        Router-->>Client: "success=true, testFileName, signedUrl"
    else auditLog throws (unprotected)
        AuditLog-->>Router: throws
        Router->>AuditLog: "auditLog(validate, outcome=failure) via catch"
        Router-->>Client: BAD_REQUEST Validation failed
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/blobstorage-integration/blobstorage-integration-router.ts:223-234
If `auditLog` throws on the success path (e.g. a transient DB error), the exception bubbles into the outer `catch (e)` block. That block then logs a misleading "Failed to trigger blob storage integration run" error, writes a *failure* audit log for an operation that actually succeeded, and throws `INTERNAL_SERVER_ERROR` back to the client — even though the job was already enqueued. The failure-path `auditLog` already uses `.catch()` to prevent exactly this; the success path should do the same.

```suggestion
        await auditLog({
          session: ctx.session,
          action: "runNow",
          resourceType: "blobStorageIntegration",
          resourceId: input.projectId,
          after: {
            outcome: "success",
            jobId,
          },
        }).catch((auditLogError) => {
          logger.error(
            `Failed to create audit log for blob storage integration run`,
            auditLogError,
          );
        });

        return { success: true, jobId };
```

### Issue 2 of 2
web/src/features/blobstorage-integration/blobstorage-integration-router.ts:341-357
Same issue as in `runNow`: if `auditLog` throws here, the outer `catch` block receives an error originating from the audit log write — not from the upload. The client then gets `BAD_REQUEST: "Validation failed: <db error message>"` even though the test file was successfully uploaded, and a spurious failure audit log entry is written. Adding `.catch()` here keeps the pattern consistent with the failure path.

```suggestion
        await auditLog({
          session: ctx.session,
          action: "validate",
          resourceType: "blobStorageIntegration",
          resourceId: input.projectId,
          after: {
            outcome: "success",
            testFileName,
          },
        }).catch((auditLogError) => {
          logger.error(
            `Failed to create audit log for blob storage integration validation`,
            auditLogError,
          );
        });

        return {
          success: true,
          message: "Validation successful! Test file uploaded.",
          testFileName,
          signedUrl: result.signedUrl,
        };
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Log blob storage integration validate an..."](https://github.com/langfuse/langfuse/commit/97c31f6263e439e05f68d4d9d2fd9205f407c5ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31368864)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->