### PR TITLE
chore(deps): bump fast-uri to 3.1.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6897,8 +6897,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.1:
+    resolution: {integrity: sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==}
 
   fast-xml-builder@1.1.7:
     resolution: {integrity: sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==}
@@ -16243,7 +16243,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -17807,7 +17807,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.1: {}
 
   fast-xml-builder@1.1.7:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ minimumReleaseAgeExclude:
   - "eslint-config-next@16.2.6"
   - "@next/eslint-plugin-next@16.2.6"
   - "fast-xml-builder@1.1.7"
+  - "fast-uri@3.1.1"
 allowBuilds:
   "@prisma/client": true
   "@prisma/engines": true


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps the `fast-uri` dependency from version 3.1.0 to 3.1.1, a patch-level update, and adds the new version to the `minimumReleaseAgeExclude` list so it can be adopted immediately without waiting for the minimum release age policy window.

- `pnpm-lock.yaml`: Updates the resolved integrity hash for `fast-uri` to match 3.1.1 and updates its usage inside the `ajv@8.20.0` snapshot.
- `pnpm-workspace.yaml`: Adds `fast-uri@3.1.1` to `minimumReleaseAgeExclude`, following the same pattern used for previously pinned packages like `fast-xml-builder@1.1.7`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a patch-level lockfile bump with no logic changes.

The change updates a single transitive dependency (fast-uri) one patch version and pins it in the minimum release age exclusion list. Both the lockfile hash and the workspace config look correct and consistent with the established pattern in the repo.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump fast-uri to 3.1.1"](https://github.com/langfuse/langfuse/commit/ec6e65106fcf90147df109c27a3ec51c3b938ab7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31371470)</sub>

<!-- /greptile_comment -->