### PR TITLE
fix(rbac): restrict organization API key management to OWNER

### DIFF
--- a/web/src/__tests__/server/organizations-api-key-trpc.servertest.ts
+++ b/web/src/__tests__/server/organizations-api-key-trpc.servertest.ts
@@ -59,11 +59,40 @@ describe("organization API keys trpc", () => {
     environment: {} as any,
   };
 
+  const adminSession: Session = {
+    expires: "1",
+    user: {
+      id: "user-3",
+      canCreateOrganizations: true,
+      name: "Admin User",
+      organizations: [
+        {
+          id: organizationId,
+          name: "Test Organization",
+          role: "ADMIN",
+          plan: "cloud:hobby",
+          cloudConfig: undefined,
+          metadata: {},
+          projects: [],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+      },
+      admin: false,
+    },
+    environment: {} as any,
+  };
+
   const ownerCtx = createInnerTRPCContext({ session: ownerSession });
   const ownerCaller = appRouter.createCaller({ ...ownerCtx, prisma });
 
   const memberCtx = createInnerTRPCContext({ session: memberSession });
   const memberCaller = appRouter.createCaller({ ...memberCtx, prisma });
+
+  const adminCtx = createInnerTRPCContext({ session: adminSession });
+  const adminCaller = appRouter.createCaller({ ...adminCtx, prisma });
 
   const unAuthedCtx = createInnerTRPCContext({ session: null });
   const unAuthedCaller = appRouter.createCaller({ ...unAuthedCtx, prisma });
@@ -100,6 +129,14 @@ describe("organization API keys trpc", () => {
       ).rejects.toThrow(TRPCError);
     });
 
+    it("admin cannot fetch organization API keys", async () => {
+      await expect(
+        adminCaller.organizationApiKeys.byOrganizationId({
+          orgId: organizationId,
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+
     it("unauthenticated user cannot fetch organization API keys", async () => {
       await expect(
         unAuthedCaller.organizationApiKeys.byOrganizationId({
@@ -125,6 +162,15 @@ describe("organization API keys trpc", () => {
     it("regular member cannot create organization API keys", async () => {
       await expect(
         memberCaller.organizationApiKeys.create({
+          orgId: organizationId,
+          note: "Test API Key",
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it("admin cannot create organization API keys", async () => {
+      await expect(
+        adminCaller.organizationApiKeys.create({
           orgId: organizationId,
           note: "Test API Key",
         }),
@@ -182,6 +228,23 @@ describe("organization API keys trpc", () => {
         }),
       ).rejects.toThrow(TRPCError);
     });
+
+    it("admin cannot update API key note", async () => {
+      // Create a key as owner
+      const apiKeyResult = await ownerCaller.organizationApiKeys.create({
+        orgId: organizationId,
+        note: "Original Note",
+      });
+
+      // Try to update as admin
+      await expect(
+        adminCaller.organizationApiKeys.updateNote({
+          orgId: organizationId,
+          keyId: apiKeyResult.id,
+          note: "Updated Note",
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
   });
 
   describe("organizationApiKeys.delete", () => {
@@ -217,6 +280,22 @@ describe("organization API keys trpc", () => {
       // Try to delete as member
       await expect(
         memberCaller.organizationApiKeys.delete({
+          orgId: organizationId,
+          id: apiKeyResult.id,
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+
+    it("admin cannot delete API key", async () => {
+      // Create a key as owner
+      const apiKeyResult = await ownerCaller.organizationApiKeys.create({
+        orgId: organizationId,
+        note: "To Be Deleted",
+      });
+
+      // Try to delete as admin
+      await expect(
+        adminCaller.organizationApiKeys.delete({
           orgId: organizationId,
           id: apiKeyResult.id,
         }),

--- a/web/src/features/rbac/constants/organizationAccessRights.ts
+++ b/web/src/features/rbac/constants/organizationAccessRights.ts
@@ -32,7 +32,6 @@ export const organizationRoleAccessRights: Record<Role, OrganizationScope[]> = {
   ADMIN: [
     "projects:create",
     "projects:transfer_org",
-    "organization:CRUD_apiKeys",
     "organization:update",
     "organizationMembers:CUD",
     "organizationMembers:read",


### PR DESCRIPTION
## Summary

Removes `organization:CRUD_apiKeys` from the ADMIN role so only OWNERs can create, list, update, or delete organization-scoped API keys. Closes [INT-1222](https://linear.app/langfuse/issue/INT-1222).

## Why

INT-1222 documents an ADMIN -> OWNER privilege escalation: SCIM PUT (`web/src/pages/api/public/scim/Users/[id].ts`) does not enforce role hierarchy, and any holder of an org-scoped API key can therefore promote themselves to OWNER. Because both OWNER and ADMIN held `organization:CRUD_apiKeys`, an ADMIN could mint their own key and self-escalate.

This PR cuts that path at the key-creation boundary by restricting org API key management to OWNER. (A follow-up should still harden SCIM PUT itself with `throwIfHigherRole` + last-OWNER guard, but is out of scope here.)

## Changes

- `web/src/features/rbac/constants/organizationAccessRights.ts` — drop `organization:CRUD_apiKeys` from `ADMIN`.
- `web/src/__tests__/server/organizations-api-key-trpc.servertest.ts` — add ADMIN-role assertions for all four `organizationApiKeys` procedures (`byOrganizationId`, `create`, `updateNote`, `delete`).

The single monolithic scope already gates all four tRPC procedures and the corresponding UI gating in `CreateApiKeyButton.tsx` / `ApiKeyList.tsx`, so no other call sites needed updates.

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run lint` ✅
- Targeted server tests for `organizations-api-key-trpc.servertest.ts` should be run in CI.

## Test plan

- [ ] CI: web lint passes
- [ ] CI: `organizations-api-key-trpc.servertest.ts` passes, including new ADMIN cases
- [ ] Manual: as an ADMIN, "Organization API Keys" UI no longer shows the create/delete affordances and tRPC calls reject with FORBIDDEN
- [ ] Manual: as an OWNER, all four operations still work

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes an ADMIN→OWNER privilege escalation path by removing `organization:CRUD_apiKeys` from the ADMIN role, restricting org-scoped API key management to OWNER only. The change is a single-line permission table edit with four new server-side tests covering all tRPC procedures.

- **RBAC fix** (`organizationAccessRights.ts`): drops `organization:CRUD_apiKeys` from `ADMIN`; OWNER, MEMBER, VIEWER, and NONE are untouched. The scope gate in `organizationApiKeyRouter.ts` and the UI guards in `CreateApiKeyButton`/`ApiKeyList` all flow through the same constant, so no other call sites require changes.
- **New tests** (`organizations-api-key-trpc.servertest.ts`): adds `adminSession` (role `"ADMIN"`, `admin: false`) and asserts TRPCError for `byOrganizationId`, `create`, `updateNote`, and `delete` — correctly exercising the RBAC path. Note: the pre-existing positive "owner can X" tests use `admin: true`, so they pass via the superadmin bypass rather than through the OWNER role check; a regression to OWNER's scope list would not be caught by those tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the one-line RBAC change is minimal and correctly scoped, with no unintended side effects on other roles or call sites.

The core fix is a clean, targeted removal of a single permission entry. All four tRPC procedures and the UI components share the same scope constant, so the change propagates automatically. The new negative tests confirm ADMIN is blocked as expected. The main gap is that the pre-existing positive test cases rely on the system superadmin flag rather than the OWNER role, so a future accidental removal of this scope from OWNER would not be caught by the test suite.

The test file warrants a second look specifically around `ownerSession.user.admin = true` — changing it to `false` would make the positive test cases validate the RBAC path rather than the superadmin bypass.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User with ADMIN role] -->|Before this PR| B{Has organization:CRUD_apiKeys?}
    A -->|After this PR| C{Has organization:CRUD_apiKeys?}

    B -->|YES| D[Create org-scoped API key]
    D --> E[Call SCIM PUT /Users/id]
    E --> F[Set own role = OWNER]
    F --> G[Privilege Escalation!]

    C -->|NO - FORBIDDEN| H[Access Denied]

    I[User with OWNER role] -->|Before & After| J{Has organization:CRUD_apiKeys?}
    J -->|YES| K[Create / List / Update / Delete org API keys]

    style G fill:#f55,color:#fff
    style H fill:#5a5,color:#fff
    style K fill:#5a5,color:#fff
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/organizations-api-key-trpc.servertest.ts:10-34
**Positive test cases bypass RBAC via system-superadmin flag**

`ownerSession` sets `admin: true`, which causes `hasOrganizationAccess` to short-circuit and return `true` immediately — before checking the org role or scope list. This means the four "owner can X" tests validate superadmin access, not OWNER-role access. If `organization:CRUD_apiKeys` were accidentally removed from the OWNER entry in `organizationRoleAccessRights`, all four positive tests would still pass while real OWNER users would be blocked. Setting `admin: false` in `ownerSession` would make these tests exercise the actual RBAC path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rbac): restrict organization API key..."](https://github.com/langfuse/langfuse/commit/3cc39fb719971127bfe7dc2bcbf36194ec34c7bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31432860)</sub>

<!-- /greptile_comment -->