### PR TITLE
fix(web): hide org API keys tab without key access

### DIFF
--- a/web/src/__tests__/organization-settings-pages.clienttest.tsx
+++ b/web/src/__tests__/organization-settings-pages.clienttest.tsx
@@ -126,4 +126,15 @@ describe("useOrganizationSettingsPages", () => {
       true,
     );
   });
+
+  it("hides organization API key settings without admin-api entitlement", () => {
+    vi.mocked(useHasEntitlement).mockImplementation(() => false);
+    vi.mocked(useHasOrganizationAccess).mockReturnValue(true);
+
+    const { result } = renderHook(() => useOrganizationSettingsPages());
+
+    expect(result.current.find((page) => page.slug === "api-keys")?.show).toBe(
+      false,
+    );
+  });
 });

--- a/web/src/__tests__/organization-settings-pages.clienttest.tsx
+++ b/web/src/__tests__/organization-settings-pages.clienttest.tsx
@@ -1,0 +1,129 @@
+import { renderHook } from "@testing-library/react";
+
+import { useHasEntitlement, usePlan } from "@/src/features/entitlements/hooks";
+import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
+import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
+import { useIsCloudBillingAvailable } from "@/src/ee/features/billing/utils/isCloudBilling";
+import { useOrganizationSettingsPages } from "@/src/pages/organization/[organizationId]/settings";
+
+vi.mock("@/src/components/PagedSettingsContainer", () => ({
+  PagedSettingsContainer: () => null,
+}));
+
+vi.mock("@/src/components/layouts/header", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/src/features/rbac/components/MembershipInvitesPage", () => ({
+  MembershipInvitesPage: () => null,
+}));
+
+vi.mock("@/src/features/rbac/components/MembersTable", () => ({
+  MembersTable: () => null,
+}));
+
+vi.mock("@/src/components/ui/CodeJsonViewer", () => ({
+  JSONView: () => null,
+}));
+
+vi.mock("@/src/features/organizations/components/RenameOrganization", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/src/components/SettingsDangerZone", () => ({
+  SettingsDangerZone: () => null,
+}));
+
+vi.mock(
+  "@/src/features/organizations/components/DeleteOrganizationButton",
+  () => ({
+    DeleteOrganizationButton: () => null,
+  }),
+);
+
+vi.mock("@/src/ee/features/billing/components/BillingSettings", () => ({
+  BillingSettings: () => null,
+}));
+
+vi.mock("@/src/features/entitlements/hooks", () => ({
+  useHasEntitlement: vi.fn(),
+  usePlan: vi.fn(),
+}));
+
+vi.mock("@/src/ee/features/sso-settings/components/SSOSettings", () => ({
+  SSOSettings: () => null,
+}));
+
+vi.mock("@langfuse/shared", () => ({
+  isCloudPlan: vi.fn(() => false),
+}));
+
+vi.mock("@/src/features/projects/hooks", () => ({
+  useQueryProjectOrOrganization: vi.fn(),
+}));
+
+vi.mock("@/src/features/public-api/components/ApiKeyList", () => ({
+  ApiKeyList: () => null,
+}));
+
+vi.mock("@/src/features/organizations/components/AIFeatureSwitch", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/src/ee/features/billing/utils/isCloudBilling", () => ({
+  useIsCloudBillingAvailable: vi.fn(),
+}));
+
+vi.mock("@/src/ee/features/audit-log-viewer/OrgAuditLogsSettingsPage", () => ({
+  OrgAuditLogsSettingsPage: () => null,
+}));
+
+vi.mock("@/src/features/rbac/utils/checkOrganizationAccess", () => ({
+  useHasOrganizationAccess: vi.fn(),
+}));
+
+vi.mock("@/src/components/layouts/container-page", () => ({
+  default: () => null,
+}));
+
+const organization = {
+  id: "org-1",
+  name: "Org 1",
+  metadata: {},
+};
+
+describe("useOrganizationSettingsPages", () => {
+  beforeEach(() => {
+    vi.mocked(useQueryProjectOrOrganization).mockReturnValue({
+      organization,
+    } as ReturnType<typeof useQueryProjectOrOrganization>);
+    vi.mocked(useHasEntitlement).mockImplementation(
+      (entitlement) => entitlement === "admin-api",
+    );
+    vi.mocked(useHasOrganizationAccess).mockReturnValue(false);
+    vi.mocked(usePlan).mockReturnValue("oss");
+    vi.mocked(useIsCloudBillingAvailable).mockReturnValue(false);
+  });
+
+  it("hides organization API key settings without organization api key access", () => {
+    const { result } = renderHook(() => useOrganizationSettingsPages());
+
+    expect(useHasOrganizationAccess).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      scope: "organization:CRUD_apiKeys",
+    });
+    expect(result.current.find((page) => page.slug === "api-keys")?.show).toBe(
+      false,
+    );
+  });
+
+  it("shows organization API key settings with entitlement and access", () => {
+    vi.mocked(useHasOrganizationAccess).mockReturnValue(true);
+
+    const { result } = renderHook(() => useOrganizationSettingsPages());
+
+    expect(result.current.find((page) => page.slug === "api-keys")?.show).toBe(
+      true,
+    );
+  });
+});

--- a/web/src/pages/organization/[organizationId]/settings/index.tsx
+++ b/web/src/pages/organization/[organizationId]/settings/index.tsx
@@ -19,6 +19,7 @@ import AIFeatureSwitch from "@/src/features/organizations/components/AIFeatureSw
 import { useIsCloudBillingAvailable } from "@/src/ee/features/billing/utils/isCloudBilling";
 import { env } from "@/src/env.mjs";
 import { OrgAuditLogsSettingsPage } from "@/src/ee/features/audit-log-viewer/OrgAuditLogsSettingsPage";
+import { useHasOrganizationAccess } from "@/src/features/rbac/utils/checkOrganizationAccess";
 
 type OrganizationSettingsPage = {
   title: string;
@@ -30,7 +31,12 @@ type OrganizationSettingsPage = {
 export function useOrganizationSettingsPages(): OrganizationSettingsPage[] {
   const { organization } = useQueryProjectOrOrganization();
   const showBillingSettings = useHasEntitlement("cloud-billing");
-  const showOrgApiKeySettings = useHasEntitlement("admin-api");
+  const hasAdminApiEntitlement = useHasEntitlement("admin-api");
+  const hasOrgApiKeyAccess = useHasOrganizationAccess({
+    organizationId: organization?.id,
+    scope: "organization:CRUD_apiKeys",
+  });
+  const showOrgApiKeySettings = hasAdminApiEntitlement && hasOrgApiKeyAccess;
   const showAuditLogs = useHasEntitlement("audit-logs");
   const plan = usePlan();
   const isLangfuseCloud = isCloudPlan(plan) ?? false;


### PR DESCRIPTION
## Summary
- Hide the organization `API Keys` settings tab unless both the `admin-api` entitlement and `organization:CRUD_apiKeys` access are present.
- Add a regression test covering both the hidden and visible states for the organization settings pages.

## Testing
- `pnpm --filter web exec vitest run --project client src/__tests__/organization-settings-pages.clienttest.tsx`
- `pnpm --filter web run lint`
- Browser verification: local app booted, and protected org settings redirected to sign-in; exact tab visibility could not be exercised without a seeded authenticated org session.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens the visibility guard on the organization API Keys settings tab by requiring both the `admin-api` entitlement **and** the `organization:CRUD_apiKeys` RBAC scope, where previously only the entitlement was checked. A new Vitest suite is added to cover the hidden and visible states.

- `settings/index.tsx`: replaces the single `useHasEntitlement("admin-api")` flag with an AND of that entitlement and a new `useHasOrganizationAccess` call; the hook gracefully handles an undefined `organizationId` by returning `false`.
- `organization-settings-pages.clienttest.tsx`: two new tests verify the tab is hidden without RBAC access and visible when both conditions are met; the entitlement-absent branch of the AND-gate is not covered by any test case.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; it tightens an existing UI visibility guard and does not touch server-side auth or data access paths.

The logic change in settings/index.tsx is correct and well-scoped — useHasOrganizationAccess handles an undefined organizationId by returning false, and the AND-gate properly restricts tab visibility. The test file is missing a case for the entitlement-absent path, leaving one branch of the guard unverified.

The test file would benefit from an additional case covering the entitlement-absent path.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useOrganizationSettingsPages] --> B{useHasEntitlement
'admin-api'}
    A --> C{useHasOrganizationAccess
organization:CRUD_apiKeys}
    B -- true --> D{Both conditions?}
    B -- false --> E[showOrgApiKeySettings = false]
    C -- true --> D
    C -- false --> E
    D -- yes --> F[showOrgApiKeySettings = true]
    D -- no --> E
    E --> G[API Keys tab hidden]
    F --> H[API Keys tab visible]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/organization-settings-pages.clienttest.tsx:120-129
The `beforeEach` always mocks `useHasEntitlement` to return `true` for `"admin-api"`, so the test suite never exercises the case where a user has `organization:CRUD_apiKeys` access but lacks the entitlement. Without this third case, the entitlement half of the AND-gate is untested — a regression that accidentally dropped the entitlement check would not be caught.

```suggestion
  it("shows organization API key settings with entitlement and access", () => {
    vi.mocked(useHasOrganizationAccess).mockReturnValue(true);

    const { result } = renderHook(() => useOrganizationSettingsPages());

    expect(result.current.find((page) => page.slug === "api-keys")?.show).toBe(
      true,
    );
  });

  it("hides organization API key settings without admin-api entitlement", () => {
    vi.mocked(useHasEntitlement).mockImplementation(() => false);
    vi.mocked(useHasOrganizationAccess).mockReturnValue(true);

    const { result } = renderHook(() => useOrganizationSettingsPages());

    expect(result.current.find((page) => page.slug === "api-keys")?.show).toBe(
      false,
    );
  });
});
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Hide org API keys tab without access"](https://github.com/langfuse/langfuse/commit/31be819848ab609fab6cce314003ac67230275fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31498559)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->