### PR TITLE
docs(agents): add production regression triage skills

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -37,6 +37,12 @@ evaluating, and debugging AI applications.
 - Debugging a Linear issue, GitHub issue, or incident report using Datadog
   (APM, logs, metrics) to establish a root cause:
   [`skills/debug-issue-with-datadog/SKILL.md`](skills/debug-issue-with-datadog/SKILL.md)
+- Measured bug or regression evidence that needs Linear deduplication, evidence
+  comments, or Triage bug issue creation:
+  [`skills/linear-bug-triage/SKILL.md`](skills/linear-bug-triage/SKILL.md)
+- Proactive production regression sweeps across Datadog errors, logs, spans, and
+  API latency with Linear handoff:
+  [`skills/detect-prod-regressions/SKILL.md`](skills/detect-prod-regressions/SKILL.md)
 - Changelog drafting for completed feature branches:
   [`skills/changelog-writing/SKILL.md`](skills/changelog-writing/SKILL.md)
 - ClickHouse schema/query review:

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -72,6 +72,24 @@ Use for:
 
 Open: [code-review/SKILL.md](code-review/SKILL.md)
 
+### detect-prod-regressions
+
+Use for:
+- proactive Datadog sweeps across `prod-us`, `prod-eu`, `prod-hipaa`, and `prod-jp`
+- comparing recent production errors, logs, spans, and API latency to baselines
+- handing measured regressions to `linear-bug-triage` for Linear issues or comments
+
+Open: [detect-prod-regressions/SKILL.md](detect-prod-regressions/SKILL.md)
+
+### linear-bug-triage
+
+Use for:
+- deduplicating measured bug or regression evidence against Linear
+- creating new Linear bug issues in `Triage` with `bug` and related labels
+- adding concise evidence comments to related existing Linear issues
+
+Open: [linear-bug-triage/SKILL.md](linear-bug-triage/SKILL.md)
+
 ### changelog-writing
 
 Use for:

--- a/.agents/skills/detect-prod-regressions/SKILL.md
+++ b/.agents/skills/detect-prod-regressions/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: detect-prod-regressions
+description: |
+  Proactively detect production regressions in Langfuse by comparing recent
+  Datadog errors, error logs, error spans, and API route latency signals against
+  baseline benchmarks or traces across prod-us, prod-eu, prod-hipaa, and
+  prod-jp. Use when asked to sweep production for new bugs, catch regressions
+  early, catch low-occurrence coding bugs or edge cases, compare recent changes
+  to Datadog measurements, or hand measured production evidence to the
+  linear-bug-triage skill for Linear action.
+---
+
+# Detect Prod Regressions
+
+Run this skill as an evidence-first production sweep. The deliverable is a set
+of measured candidate bugs handed to
+[`linear-bug-triage`](../linear-bug-triage/SKILL.md) for Linear action, plus a
+short summary of what was checked.
+
+## Required Scope
+
+Always review all production environments unless the user explicitly narrows the
+scope:
+
+- `prod-us`
+- `prod-eu`
+- `prod-hipaa`
+- `prod-jp`
+
+Query both Datadog sites when needed. Default to the EU site for `prod-eu` and
+the US site for the other production envs, but verify by querying facets or
+running a small count query rather than assuming where a tag lives.
+
+## Measurement Rules
+
+- Ground every bug claim in a measurable signal: counts, rates, p50/p95/p99
+  duration, trace samples, flamegraphs, monitor thresholds, or benchmark
+  comparisons.
+- If a requested measurement is missing or unavailable, write exactly
+  "No measurements found" for that signal.
+- Treat a bug as new only when a recent window shows a new or materially worse
+  error cluster or latency regression versus a baseline.
+- Do not rely only on top-volume clusters. Also inspect new low-occurrence
+  errors that look like coding bugs or edge cases, such as invariant failures,
+  unexpected null/undefined values, validation surprises, unhandled promise
+  rejections, serialization failures, impossible enum states, or one-off 500s
+  on uncommon routes.
+- For latency, error-rate, throughput, saturation, or performance findings,
+  focus on how the signal worsened over time: recent versus preceding window,
+  recent versus same window 7 days earlier, and post-change versus pre-change
+  when deployment markers are available.
+- Prefer high-level aggregations before individual events; drill into example
+  logs, spans, traces, or flamegraphs only after a cluster is identified.
+- Do not infer customer impact, root cause, or severity beyond what the
+  measurements support.
+
+## Baseline Window
+
+Use the user's stated window when provided. Otherwise:
+
+1. Compare the most recent 24 hours with the preceding 24 hours.
+2. Add a same-day or same-hour historical baseline, usually the matching window
+   7 days earlier, when Datadog data is available.
+3. If release or deployment markers, service versions, git SHAs, or change
+   timestamps are visible, compare post-change versus pre-change windows.
+
+Include the recent window and baseline window in each handoff to
+`linear-bug-triage`.
+
+## Datadog Sweep
+
+Before querying Datadog, load the relevant Datadog MCP guidance for logs,
+traces, metrics, and visualizations. Use the existing
+[`debug-issue-with-datadog`](../debug-issue-with-datadog/SKILL.md) playbook
+when you need query syntax, repo mapping, or trace drill-down patterns.
+
+For each environment, check:
+
+1. **Datadog errors**
+   - Use Datadog Error Tracking to review error groups, new issues,
+     regressions, affected services, and occurrence timelines. Also check the
+     EU Datadog site equivalent when environment data is stored there.
+   - Aggregate error counts and rates by `env`, `service`, route/resource,
+     status code, `error.type`, and `error.message`.
+   - Compare recent counts/rates to the baseline.
+   - Include low-occurrence new error groups when the stack, message, route, or
+     affected code path suggests a coding bug or edge case, even if occurrence
+     counts are too small for top-N dashboards.
+
+2. **Datadog error logs**
+   - Aggregate `status:error` logs by service, route/resource, source,
+     `error.message`, tenant/project identifiers when present, and environment.
+   - Open representative logs only for clusters with measurable increase.
+
+3. **Datadog error spans**
+   - Aggregate error spans by `env`, `service`, `resource_name`, `http.route`,
+     `error.type`, and `error.message`.
+   - Fetch representative traces only after grouping identifies a candidate
+     regression.
+
+4. **API route latencies**
+   - Focus on `service:web` HTTP spans and metrics such as
+     `trace.http_request.duration` when available.
+   - Compare p50, p95, and p99 by route/resource and environment.
+   - Rank candidates by worsening over time, not only by absolute latency:
+     recent versus baseline deltas, slope, and newly introduced tail latency.
+   - Use trace samples or flamegraphs for routes whose latency materially
+     regressed.
+
+Keep Datadog links for every query, trace, dashboard, or flamegraph used as
+evidence.
+
+## Linear Handoff
+
+For every confirmed candidate bug, use
+[`linear-bug-triage`](../linear-bug-triage/SKILL.md) for Linear search,
+deduplication, evidence comments, Triage issue creation, labels, and ticket
+formatting. Treat that skill as the source of truth for Linear behavior.
+
+Hand off:
+
+- Recent window and baseline window.
+- Measured deltas or `No measurements found` for unavailable signals.
+- Affected environments, services, routes/resources, status codes, and top error
+  messages.
+- Datadog links for every query, trace, dashboard, metric graph, or flamegraph
+  used as evidence.
+
+## Final Response
+
+Summarize:
+
+- The windows compared and all prod environments checked.
+- New Linear issues created, with links.
+- Existing Linear issues commented on, with links.
+- Candidate signals skipped with "No measurements found".
+- A compact "no new bugs found" statement when no issue-worthy regressions were
+  measured.

--- a/.agents/skills/detect-prod-regressions/agents/openai.yaml
+++ b/.agents/skills/detect-prod-regressions/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Detect Prod Regressions"
+  short_description: "Datadog regression sweep with Linear handoff"
+  default_prompt: "Use $detect-prod-regressions to compare recent production Datadog signals against baselines across all prod environments and hand measured bugs to $linear-bug-triage."

--- a/.agents/skills/linear-bug-triage/SKILL.md
+++ b/.agents/skills/linear-bug-triage/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: linear-bug-triage
+description: |
+  Deduplicate measured bug or regression evidence against Linear, then either
+  add evidence comments to related existing issues or create concise Linear bug
+  issues in Triage. Use when Codex has confirmed evidence from Datadog,
+  benchmarks, traces, timings, flamegraphs, logs, or production measurements and
+  needs Linear search, comments, labels, Datadog links, or bug ticket creation
+  without fix suggestions.
+---
+
+# Linear Bug Triage
+
+Use this skill after a bug or regression candidate has measured evidence. This
+skill owns Linear search, deduplication, evidence comments, and ticket creation;
+the calling skill owns deciding whether the signal is issue-worthy.
+
+## Required Evidence
+
+For each candidate, gather:
+
+- Recent window and baseline window as absolute time ranges with timezone.
+- Measured signal: counts, rates, p50/p95/p99 latency, trace samples,
+  flamegraphs, monitor thresholds, or benchmark deltas.
+- Affected environments, services, routes/resources, status codes, and top error
+  messages.
+- Datadog links for logs, spans, traces, metrics, dashboards, or flamegraphs
+  used as evidence.
+- The exact text `No measurements found` for requested measurements that are
+  unavailable.
+
+Do not create or comment based on guesses, unsupported impact claims, or missing
+measurements alone.
+
+## Deduplication
+
+Before creating a new issue:
+
+1. Search Linear for related open issues using exact error text, route/resource,
+   service, environment, monitor name, and Datadog link keywords.
+2. Search recently closed or canceled issues if the error is recurring or the
+   wording is distinctive.
+3. If a related issue exists, add a concise evidence comment instead of creating
+   a duplicate.
+4. If no related issue exists, create one Linear issue in the `Triage` state for
+   each distinct bug cluster.
+
+## Existing Issue Comments
+
+For related existing issues, add only:
+
+- Recent window and baseline window.
+- Measured delta or `No measurements found` for unavailable signals.
+- Affected environments, services, routes/resources, and top error messages.
+- Datadog links.
+
+Do not add fix suggestions, root-cause guesses, implementation notes, owner
+assignments, or next steps.
+
+## New Issue Format
+
+Create new issues with:
+
+- State/status `Triage`; pass the Linear state explicitly on creation and do not
+  rely on workspace defaults.
+- Label `bug`.
+- Additional existing labels that match the evidence, such as affected service,
+  environment, API, ingestion, latency, ClickHouse, Postgres, integrations, or
+  observability labels. Query labels first and use the repository/team's exact
+  label names.
+- Concise title: `bug: <service or route> <measured symptom> in <envs>`.
+- Concise body, evidence-only:
+
+```markdown
+Recent window: <absolute time range and timezone>
+Baseline: <absolute time range and timezone>
+
+Signal:
+- <count/rate/latency delta with env/service/route>
+- <"No measurements found" for missing requested measurements>
+
+Evidence:
+- Datadog logs: <url>
+- Datadog spans/traces: <url>
+- Datadog metrics, dashboard, or latency graph: <url>
+
+Related Linear search:
+- <brief search terms used and result>
+```
+
+Do not include fix suggestions, root-cause guesses, implementation notes, owner
+assignments, or next steps unless the user explicitly asks outside the Linear
+issue or comment.

--- a/.agents/skills/linear-bug-triage/agents/openai.yaml
+++ b/.agents/skills/linear-bug-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Linear Bug Triage"
+  short_description: "Deduplicate and file Linear bug evidence"
+  default_prompt: "Use $linear-bug-triage to deduplicate measured bug evidence and create or comment Linear triage issues."


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two new agent skills for production regression triage: `detect-prod-regressions` (a Datadog sweep across all prod environments with Linear handoff) and `linear-bug-triage` (deduplication, evidence comments, and Triage issue creation in Linear). Both skills are registered in `AGENTS.md` and `README.md`.

- **`detect-prod-regressions/SKILL.md`**: Defines measurement rules, a four-signal Datadog sweep (errors, error logs, error spans, API latency), baseline-window logic, and a handoff protocol to `linear-bug-triage`. Cross-references to existing skills (`debug-issue-with-datadog`, `linear-bug-triage`) are valid.
- **`linear-bug-triage/SKILL.md`**: Defines deduplication steps, evidence comment format, and the new-issue template (Triage state, `bug` label, concise evidence-only body). Internally consistent but the frontmatter description hard-codes `Codex` as the only expected caller, which is overly specific given `detect-prod-regressions` and direct invocations are also valid entry points.
- **`AGENTS.md`**: The new entries list `linear-bug-triage` before `detect-prod-regressions`, the reverse of their dependency order; `README.md` lists them correctly (upstream first).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a documentation-only change adding agent skill definitions; no application code is modified.

All changed files are Markdown skill definitions and minimal YAML configs with no runtime code. The new skills are internally consistent, cross-references to existing skills resolve correctly, and the only findings are a listing-order inconsistency in AGENTS.md and an over-specific caller name in the linear-bug-triage frontmatter — neither affects behavior.

No files require special attention. The minor ordering issue in `.agents/AGENTS.md` is cosmetic.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant detect-prod-regressions
    participant Datadog
    participant linear-bug-triage
    participant Linear

    User->>detect-prod-regressions: sweep prod environments
    detect-prod-regressions->>Datadog: query errors, logs, spans, latency (prod-us/eu/hipaa/jp)
    Datadog-->>detect-prod-regressions: signals + measurements
    detect-prod-regressions->>detect-prod-regressions: compare recent vs baseline windows
    alt regression candidate found
        detect-prod-regressions->>linear-bug-triage: hand off (windows, deltas, env, Datadog links)
        linear-bug-triage->>Linear: search existing issues (dedup)
        alt related issue exists
            linear-bug-triage->>Linear: add evidence comment
        else no existing issue
            linear-bug-triage->>Linear: create Triage bug issue
        end
        Linear-->>linear-bug-triage: issue URL
        linear-bug-triage-->>detect-prod-regressions: Linear issue link
    end
    detect-prod-regressions-->>User: summary (windows, envs checked, Linear links, no-bug statement)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.agents/skills/linear-bug-triage/SKILL.md:4-9
The frontmatter description says "Use when Codex has confirmed evidence", tying this skill exclusively to the Codex agent. In practice this skill is also callable from `detect-prod-regressions` or directly by a user, so the hard-coded caller name is over-specific and could cause routing agents to skip this skill when the initiating agent is not named Codex.

```suggestion
  Deduplicate measured bug or regression evidence against Linear, then either
  add evidence comments to related existing issues or create concise Linear bug
  issues in Triage. Use when measured evidence from Datadog, benchmarks, traces,
  timings, flamegraphs, logs, or production measurements is available and Linear
  search, comments, labels, Datadog links, or bug ticket creation is needed
  without fix suggestions.
```

### Issue 2 of 2
.agents/AGENTS.md:40-45
The two new entries are listed in the reverse of their dependency order: `linear-bug-triage` (the downstream deduplication step) appears before `detect-prod-regressions` (the upstream orchestrating sweep). The `README.md` already lists them in the correct upstream-first order — AGENTS.md should match to avoid misleading agents scanning for the right entry point.

```suggestion
- Proactive production regression sweeps across Datadog errors, logs, spans, and
  API latency with Linear handoff:
  [`skills/detect-prod-regressions/SKILL.md`](skills/detect-prod-regressions/SKILL.md)
- Measured bug or regression evidence that needs Linear deduplication, evidence
  comments, or Triage bug issue creation:
  [`skills/linear-bug-triage/SKILL.md`](skills/linear-bug-triage/SKILL.md)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): add production regression ..."](https://github.com/langfuse/langfuse/commit/207b06670cd82305af5ff1cad8e232130917406d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31501050)</sub>

<!-- /greptile_comment -->