### PR TITLE
fix(agents): harden shared setup docs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -11,7 +11,7 @@ evaluating, and debugging AI applications.
 
 - `AGENTS.md` is a living document.
 - Keep this file concise and router-like. Push narrow or conditional workflows
-  into package-local `AGENTS.md` files or shared skills under `skills/`.
+  into package-local `AGENTS.md` files or shared skills under `.agents/skills/`.
 - Update this file in the same PR when monorepo-level architecture, workflows,
   dependency boundaries, mandatory verification commands, or release/security
   processes materially change.
@@ -24,38 +24,38 @@ evaluating, and debugging AI applications.
 ## Start Here By Task
 
 - Repo-wide agent setup, `.agents/**`, provider shims, or MCP/bootstrap config:
-  [`README.md`](README.md),
-  [`skills/agent-setup-maintenance/SKILL.md`](skills/agent-setup-maintenance/SKILL.md)
+  `.agents/README.md`,
+  `.agents/skills/agent-setup-maintenance/SKILL.md`
 - Backend/API work in `web/src/server/**`, `web/src/pages/api/public/**`,
   `worker/src/**`, or `packages/shared/src/**`:
-  [`skills/backend-dev-guidelines/SKILL.md`](skills/backend-dev-guidelines/SKILL.md)
+  `.agents/skills/backend-dev-guidelines/SKILL.md`
 - Model pricing work in `worker/src/constants/default-model-prices.json`,
   `packages/shared/src/server/llm/types.ts`, or related pricing files:
-  [`skills/add-model-price/SKILL.md`](skills/add-model-price/SKILL.md)
+  `.agents/skills/add-model-price/SKILL.md`
 - Code review tasks:
-  [`skills/code-review/SKILL.md`](skills/code-review/SKILL.md)
+  `.agents/skills/code-review/SKILL.md`
 - Debugging a Linear issue, GitHub issue, or incident report using Datadog
   (APM, logs, metrics) to establish a root cause:
-  [`skills/debug-issue-with-datadog/SKILL.md`](skills/debug-issue-with-datadog/SKILL.md)
+  `.agents/skills/debug-issue-with-datadog/SKILL.md`
 - Changelog drafting for completed feature branches:
-  [`skills/changelog-writing/SKILL.md`](skills/changelog-writing/SKILL.md)
+  `.agents/skills/changelog-writing/SKILL.md`
 - ClickHouse schema/query review:
-  [`skills/clickhouse-best-practices/SKILL.md`](skills/clickhouse-best-practices/SKILL.md)
+  `.agents/skills/clickhouse-best-practices/SKILL.md`
 - Monorepo/Turbo task graph changes:
-  [`skills/turborepo/SKILL.md`](skills/turborepo/SKILL.md)
+  `.agents/skills/turborepo/SKILL.md`
 - pnpm dependency upgrades, package-version bumps, or `minimumReleaseAgeExclude`
   decisions in `pnpm-workspace.yaml`:
-  [`skills/pnpm-upgrade-package/SKILL.md`](skills/pnpm-upgrade-package/SKILL.md)
+  `.agents/skills/pnpm-upgrade-package/SKILL.md`
 - User-visible frontend changes, Playwright review, or browser signoff:
-  [`skills/frontend-browser-review/SKILL.md`](skills/frontend-browser-review/SKILL.md)
+  `.agents/skills/frontend-browser-review/SKILL.md`
 - Web UI and frontend entry points:
-  `../web/AGENTS.md`
+  `web/AGENTS.md`
 - Worker queues and processors:
-  `../worker/AGENTS.md`
+  `worker/AGENTS.md`
 - Shared contracts, exports, schema, and migrations:
-  `../packages/shared/AGENTS.md`
+  `packages/shared/AGENTS.md`
 - EE-only work:
-  `../ee/AGENTS.md`
+  `ee/AGENTS.md`
 
 Read the minimal set required for the task. More-specific package guides and
 shared skills take precedence over this root file for their scoped areas.
@@ -87,7 +87,7 @@ langfuse/
     `packages/shared/clickhouse/migrations/{clustered,unclustered}/*.sql`
 - Architecture handbook:
   [langfuse.com/handbook/product-engineering/architecture](https://langfuse.com/handbook/product-engineering/architecture)
-  with source markdown in
+  with source markdown in the sibling docs checkout at
   `../langfuse-docs/content/handbook/product-engineering/architecture.mdx`
 
 ## Core Commands
@@ -135,7 +135,7 @@ Minimum verification matrix:
   bug.
 - For user-visible frontend changes in `web/**`, review the affected flow in a
   real browser with the Playwright MCP server before signoff. Use
-  `skills/frontend-browser-review/SKILL.md` and `../web/AGENTS.md` for the
+  `.agents/skills/frontend-browser-review/SKILL.md` and `web/AGENTS.md` for the
   browser-review loop.
 - Never commit secrets or credentials. Keep `.env*.example` files in sync with
   required env vars.
@@ -145,19 +145,19 @@ Minimum verification matrix:
 - `.agents/AGENTS.md` is the canonical root guide.
 - Root `AGENTS.md` is a symlink to `.agents/AGENTS.md`.
 - Root `CLAUDE.md` is a compatibility symlink to `AGENTS.md`.
-- Shared agent/tool config lives in `config.json` and shared skills live in
-  `skills/`.
+- Shared agent/tool config lives in `.agents/config.json` and shared skills
+  live in `.agents/skills/`.
 - Project-scoped provider discovery files are generated local artifacts. Edit
   the canonical files under `.agents/` instead of editing generated tool
   directories by hand.
-- If you change `.agents/config.json`, `skills/**`, or the shim-generation
-  workflow, run:
+- If you change `.agents/config.json`, `.agents/skills/**`, or the
+  shim-generation workflow, run:
   - `pnpm run agents:sync`
   - `pnpm run agents:check`
 - Do not commit generated provider config or shim outputs under `.claude/`,
   `.cursor/`, `.codex/`, `.vscode/`, or `.mcp.json`.
 - Durable cross-tool guidance belongs in root/package `AGENTS.md` files or
-  `skills/**`, not only in tool-specific config directories.
+  `.agents/skills/**`, not only in tool-specific config directories.
 
 ## Commit, PR, and Release Rules
 

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -38,15 +38,42 @@ Current shape:
     "playwright": {
       "transport": "stdio",
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest"]
+      "args": [
+        "-y",
+        "@playwright/mcp@latest",
+        "--isolated",
+        "--save-trace",
+        "--output-dir",
+        ".playwright-mcp",
+        "--test-id-attribute",
+        "data-testid"
+      ]
     },
-    "datadog": {
+    "langfuse-docs": {
       "transport": "http",
-      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+      "url": "https://langfuse.com/api/mcp"
+    },
+    "linear": {
+      "transport": "http",
+      "url": "https://mcp.linear.app/mcp"
     }
   },
   "claude": {
-    "settings": {}
+    "settings": {
+      "permissions": {
+        "allow": [
+          "Bash(find:*)",
+          "Bash(rg:*)",
+          "Bash(grep:*)",
+          "Bash(ls:*)",
+          "Bash(cat:*)",
+          "Bash(head:*)",
+          "Bash(tail:*)"
+        ],
+        "deny": []
+      },
+      "enableAllProjectMcpServers": true
+    }
   },
   "codex": {
     "environment": {

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -81,6 +81,24 @@ Use for:
 
 Open: [changelog-writing/SKILL.md](changelog-writing/SKILL.md)
 
+### clickhouse-best-practices
+
+Use for:
+- ClickHouse schema, query, or configuration review
+- ClickHouse migrations under `packages/shared/clickhouse/**`
+- applying the repo-specific ClickHouse rules layered on top of upstream best practices
+
+Open: [clickhouse-best-practices/SKILL.md](clickhouse-best-practices/SKILL.md)
+
+### debug-issue-with-datadog
+
+Use for:
+- root-causing Linear, GitHub, or incident reports with Datadog evidence
+- production debugging across APM spans, logs, metrics, and monitors
+- mapping observed error clusters back to Langfuse code paths
+
+Open: [debug-issue-with-datadog/SKILL.md](debug-issue-with-datadog/SKILL.md)
+
 ### pnpm-upgrade-package
 
 Use for:
@@ -91,6 +109,15 @@ Use for:
   current release-age gate
 
 Open: [pnpm-upgrade-package/SKILL.md](pnpm-upgrade-package/SKILL.md)
+
+### turborepo
+
+Use for:
+- `turbo.json` task graph, caching, filtering, or affected-run changes
+- root/package script organization for Turborepo workflows
+- monorepo package boundaries and shared-code layout decisions
+
+Open: [turborepo/SKILL.md](turborepo/SKILL.md)
 
 ## Adding a New Shared Skill
 

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -10,9 +10,10 @@ set -euo pipefail
 #
 # Root `postinstall` still runs during that pruned install step, but generating
 # agent shims is only useful in a full repo checkout. Skip cleanly when the
-# shared agent sync script is not available so Docker builds can continue.
-if [[ ! -f "scripts/agents/sync-agent-shims.mjs" ]]; then
-  echo "Skipping agent shim sync: scripts/agents/sync-agent-shims.mjs is not present in this install context."
+# shared agent sync script or config is not available so Docker builds can
+# continue.
+if [[ ! -f "scripts/agents/sync-agent-shims.mjs" || ! -f ".agents/config.json" ]]; then
+  echo "Skipping agent shim sync: scripts/agents/sync-agent-shims.mjs or .agents/config.json is not present in this install context."
   exit 0
 fi
 


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the agent setup documentation by standardising path references to be root-relative throughout `.agents/AGENTS.md`, updating the `config.json` documentation to reflect new MCP servers and Claude permissions, and tightening the `postinstall.sh` guard so Docker builds also skip gracefully when `.agents/config.json` is absent.

- **Path clean-up**: All skill and package `AGENTS.md` references in `.agents/AGENTS.md` now use root-relative paths (`.agents/skills/…`, `web/AGENTS.md`) instead of paths relative to the `.agents/` directory, making them consistent when the file is read via the root symlink.
- **Config update**: Playwright MCP gains richer flags (`--isolated`, `--save-trace`, `--output-dir`, `--test-id-attribute`); the Datadog MCP server is replaced by `langfuse-docs` and `linear` HTTP servers; Claude gets explicit bash-allow permissions and `enableAllProjectMcpServers: true`.
- **postinstall guard**: The early-exit condition in `scripts/postinstall.sh` now also checks for the absence of `.agents/config.json` alongside the sync script, preventing a runtime failure in Docker builds where config is absent.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with awareness of the two documentation mismatches noted in the comments.

The postinstall.sh guard and path normalisation changes are clean and low-risk. The main areas to watch are the removed Datadog MCP server (which may silently degrade agent debugging workflows that follow the debug-issue-with-datadog skill) and enableAllProjectMcpServers: true (which auto-approves any future MCP server added to the shared config). Neither prevents merging, but both warrant a deliberate decision by the team.

.agents/README.md — the config.json documentation block contains both the MCP server mismatch and the broad auto-trust setting that should be reviewed before teams start consuming the updated shims.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["pnpm install triggers postinstall.sh"] --> B{"scripts/agents/sync-agent-shims.mjs\npresent?"}
    B -- No --> D["Log skip message\nexit 0 (Docker-safe)"]
    B -- Yes --> C{".agents/config.json\npresent?"}
    C -- No --> D
    C -- Yes --> E["pnpm run agents:sync\n(write tool shims)"]
    E --> F["pnpm run agents:check\n(validate shims)"]
    F --> G["Done"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.agents/README.md:75
**`enableAllProjectMcpServers: true` auto-trusts future additions**

Setting `enableAllProjectMcpServers: true` means Claude will silently connect to every server that appears under `mcpServers` in `.agents/config.json` without prompting for confirmation. Any future `mcpServers` entry — even one added accidentally or via a supply-chain edit — gets full auto-approval. Since this config is committed to the repo, consider whether individual server opt-in (the default) is a safer posture, especially given that `linear` and `langfuse-docs` are HTTP servers that could change their behaviour independently of this repo.

### Issue 2 of 2
.agents/README.md:52-58
**Datadog MCP server removed while `debug-issue-with-datadog` skill is still documented**

The `datadog` MCP server entry (`https://mcp.datadoghq.com/api/unstable/mcp-server/mcp`) has been removed from `mcpServers`, but both `AGENTS.md` and `.agents/skills/README.md` still route agents to a `debug-issue-with-datadog` skill that promises APM/logs/metrics access via Datadog. Agents following that skill will not have a Datadog MCP connection in the generated shims, which may silently degrade the debugging workflow. If Datadog access is now expected to go through the browser or another channel, the skill's instructions should reflect that; if the MCP server is intentionally removed, the skill entry should note the missing integration.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agents): harden shared setup docs"](https://github.com/langfuse/langfuse/commit/faf30bcd35edabd9913ed3c460aad2680bc977d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31501258)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->