### PR TITLE
fix(tool-parsing): ai sdk handle stringified jsons as well

### DIFF
--- a/packages/shared/src/server/ingestion/extractToolsBackend.ts
+++ b/packages/shared/src/server/ingestion/extractToolsBackend.ts
@@ -152,6 +152,10 @@ function parseArrayIfString(data: unknown): unknown[] | undefined {
   }
 }
 
+/**
+ * Detects model-requested tool invocations in unlabelled output arrays.
+ * Excludes available tool definitions and tool result payloads.
+ */
 function isToolCallLike(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
 

--- a/packages/shared/src/server/ingestion/extractToolsBackend.ts
+++ b/packages/shared/src/server/ingestion/extractToolsBackend.ts
@@ -129,6 +129,63 @@ function addToolArgument(args: ClickhouseToolArgument[], call: unknown): void {
   });
 }
 
+function addToolArguments(
+  args: ClickhouseToolArgument[],
+  calls: unknown[] | undefined,
+): void {
+  if (!calls) return;
+
+  for (const call of calls) {
+    addToolArgument(args, call);
+  }
+}
+
+function parseArrayIfString(data: unknown): unknown[] | undefined {
+  if (Array.isArray(data)) return data;
+  if (typeof data !== "string") return undefined;
+
+  try {
+    const parsed = JSON.parse(data);
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isToolCallLike(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+
+  const call = value as Record<string, unknown>;
+  const functionCall = call.function as Record<string, unknown> | undefined;
+  const hasOpenAiShape = Boolean(functionCall?.name);
+  const hasAiSdkShape =
+    Boolean(call.toolName) &&
+    (["input", "args", "toolCallId"].some((key) => key in call) ||
+      call.type === "tool-call");
+  const hasResponsesShape = Boolean(call.call_id && call.name);
+  const hasArgumentsShape = ["arguments", "args", "input"].some((key) =>
+    key in call,
+  );
+  const hasKnownToolType = ["function", "tool-call", "tool_use"].includes(
+    String(call.type),
+  );
+  const hasNamedArguments =
+    Boolean(call.name) && (hasArgumentsShape || hasKnownToolType);
+
+  return (
+    hasOpenAiShape || hasAiSdkShape || hasResponsesShape || hasNamedArguments
+  );
+}
+
+function isMessageLike(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+
+  const message = value as Record<string, unknown>;
+  return ["role", "content", "tool_calls", "additional_kwargs"].some(
+    (key) => key in message,
+  );
+}
+
 /**
  * Helper to add a tool call from content-array parts.
  * Handles Anthropic `tool_use` and AI SDK `tool-call` parts.
@@ -207,9 +264,16 @@ function extractToolCallsFromRawOutput(
 
   // Array of messages
   if (Array.isArray(output)) {
-    for (const msg of output) {
-      if (msg && typeof msg === "object") {
-        extractToolCallsFromMessage(msg as Record<string, unknown>, args);
+    const isRawToolCallArray =
+      output.some(isToolCallLike) && !output.some(isMessageLike);
+
+    if (isRawToolCallArray) {
+      addToolArguments(args, output);
+    } else {
+      for (const msg of output) {
+        if (msg && typeof msg === "object") {
+          extractToolCallsFromMessage(msg as Record<string, unknown>, args);
+        }
       }
     }
     return;
@@ -219,11 +283,9 @@ function extractToolCallsFromRawOutput(
   const obj = output as Record<string, unknown>;
 
   // Direct tool_calls at top level
-  if (Array.isArray(obj.tool_calls)) {
-    for (const call of obj.tool_calls) {
-      addToolArgument(args, call);
-    }
-  }
+  const directToolCalls =
+    parseArrayIfString(obj.tool_calls) ?? parseArrayIfString(obj.toolCalls);
+  addToolArguments(args, directToolCalls);
 
   // OpenAI choices format: {choices: [{message: {tool_calls: [...]}}]}
   if (Array.isArray(obj.choices)) {
@@ -231,11 +293,10 @@ function extractToolCallsFromRawOutput(
       if (choice && typeof choice === "object") {
         const c = choice as Record<string, unknown>;
         const message = c.message as Record<string, unknown> | undefined;
-        if (message && Array.isArray(message.tool_calls)) {
-          for (const call of message.tool_calls) {
-            addToolArgument(args, call);
-          }
-        }
+        const messageToolCalls =
+          parseArrayIfString(message?.tool_calls) ??
+          parseArrayIfString(message?.toolCalls);
+        addToolArguments(args, messageToolCalls);
       }
     }
   }
@@ -259,11 +320,8 @@ function extractToolCallsFromRawOutput(
   const additionalKwargs = obj.additional_kwargs as
     | Record<string, unknown>
     | undefined;
-  if (additionalKwargs && Array.isArray(additionalKwargs.tool_calls)) {
-    for (const call of additionalKwargs.tool_calls) {
-      addToolArgument(args, call);
-    }
-  }
+  const additionalToolCalls = parseArrayIfString(additionalKwargs?.tool_calls);
+  addToolArguments(args, additionalToolCalls);
 }
 
 /**
@@ -273,11 +331,9 @@ function extractToolCallsFromMessage(
   msg: Record<string, unknown>,
   args: ClickhouseToolArgument[],
 ): void {
-  if (Array.isArray(msg.tool_calls)) {
-    for (const call of msg.tool_calls) {
-      addToolArgument(args, call);
-    }
-  }
+  const messageToolCalls =
+    parseArrayIfString(msg.tool_calls) ?? parseArrayIfString(msg.toolCalls);
+  addToolArguments(args, messageToolCalls);
 
   // Tool calls in content arrays: Anthropic `tool_use`, AI SDK `tool-call`
   if (Array.isArray(msg.content)) {

--- a/packages/shared/src/server/ingestion/extractToolsBackend.ts
+++ b/packages/shared/src/server/ingestion/extractToolsBackend.ts
@@ -163,8 +163,8 @@ function isToolCallLike(value: unknown): boolean {
     (["input", "args", "toolCallId"].some((key) => key in call) ||
       call.type === "tool-call");
   const hasResponsesShape = Boolean(call.call_id && call.name);
-  const hasArgumentsShape = ["arguments", "args", "input"].some((key) =>
-    key in call,
+  const hasArgumentsShape = ["arguments", "args", "input"].some(
+    (key) => key in call,
   );
   const hasKnownToolType = ["function", "tool-call", "tool_use"].includes(
     String(call.type),

--- a/packages/shared/src/server/ingestion/extractToolsBackend.ts
+++ b/packages/shared/src/server/ingestion/extractToolsBackend.ts
@@ -156,24 +156,37 @@ function isToolCallLike(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
 
   const call = value as Record<string, unknown>;
+  if (call.type === "tool-result") return false;
+
   const functionCall = call.function as Record<string, unknown> | undefined;
-  const hasOpenAiShape = Boolean(functionCall?.name);
-  const hasAiSdkShape =
+  const hasOpenAiShape = Boolean(
+    functionCall?.name && "arguments" in functionCall,
+  );
+  const hasAiSdkToolCallShape =
     Boolean(call.toolName) &&
-    (["input", "args", "toolCallId"].some((key) => key in call) ||
-      call.type === "tool-call");
-  const hasResponsesShape = Boolean(call.call_id && call.name);
-  const hasArgumentsShape = ["arguments", "args", "input"].some(
-    (key) => key in call,
+    (call.type === "tool-call" || ["input", "args"].some((key) => key in call));
+  const hasResponsesShape = Boolean(
+    call.call_id && call.name && "arguments" in call,
   );
-  const hasKnownToolType = ["function", "tool-call", "tool_use"].includes(
-    String(call.type),
+  const hasAnthropicToolUseShape = Boolean(
+    call.type === "tool_use" && call.name && "input" in call,
   );
-  const hasNamedArguments =
-    Boolean(call.name) && (hasArgumentsShape || hasKnownToolType);
+  const hasToolCallMarker =
+    "id" in call ||
+    "index" in call ||
+    ["function", "function_call", "tool-call", "tool_use"].includes(
+      String(call.type),
+    );
+  const hasFlatToolCallShape = Boolean(
+    call.name && "arguments" in call && hasToolCallMarker,
+  );
 
   return (
-    hasOpenAiShape || hasAiSdkShape || hasResponsesShape || hasNamedArguments
+    hasOpenAiShape ||
+    hasAiSdkToolCallShape ||
+    hasResponsesShape ||
+    hasAnthropicToolUseShape ||
+    hasFlatToolCallShape
   );
 }
 
@@ -264,15 +277,13 @@ function extractToolCallsFromRawOutput(
 
   // Array of messages
   if (Array.isArray(output)) {
-    const isRawToolCallArray =
-      output.some(isToolCallLike) && !output.some(isMessageLike);
-
-    if (isRawToolCallArray) {
-      addToolArguments(args, output);
-    } else {
-      for (const msg of output) {
-        if (msg && typeof msg === "object") {
-          extractToolCallsFromMessage(msg as Record<string, unknown>, args);
+    for (const item of output) {
+      if (item && typeof item === "object") {
+        const obj = item as Record<string, unknown>;
+        if (isToolCallLike(obj) && !isMessageLike(obj)) {
+          addToolArgument(args, obj);
+        } else {
+          extractToolCallsFromMessage(obj, args);
         }
       }
     }

--- a/worker/src/__tests__/extractToolsBackend.test.ts
+++ b/worker/src/__tests__/extractToolsBackend.test.ts
@@ -351,6 +351,77 @@ describe("extractToolsFromObservation", () => {
       });
     });
 
+    it("extracts AI SDK tool_calls when OTel stores the tool call array as a JSON string", () => {
+      const output = JSON.stringify({
+        role: "assistant",
+        content: "I'll check the weather.",
+        tool_calls: JSON.stringify([
+          {
+            toolCallId: "tooluse_weather",
+            toolName: "getWeather",
+            input: {
+              location: "Berlin",
+              unit: "celsius",
+            },
+          },
+        ]),
+      });
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toHaveLength(1);
+      expect(toolArguments[0]).toMatchObject({
+        id: "tooluse_weather",
+        name: "getWeather",
+        arguments: JSON.stringify({
+          location: "Berlin",
+          unit: "celsius",
+        }),
+      });
+    });
+
+    it("extracts raw AI SDK tool call arrays from ingestion output", () => {
+      const output = JSON.stringify([
+        {
+          toolCallId: "tooluse_forecast",
+          toolName: "getForecast",
+          input: {
+            location: "San Francisco",
+            days: 3,
+          },
+        },
+      ]);
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toHaveLength(1);
+      expect(toolArguments[0]).toMatchObject({
+        id: "tooluse_forecast",
+        name: "getForecast",
+        arguments: JSON.stringify({
+          location: "San Francisco",
+          days: 3,
+        }),
+      });
+    });
+
+    it("does not treat arbitrary output arrays with id and name fields as tool calls", () => {
+      const output = JSON.stringify([
+        {
+          id: "weather_station_1",
+          name: "Berlin weather station",
+        },
+        {
+          id: "weather_station_2",
+          name: "San Francisco weather station",
+        },
+      ]);
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toEqual([]);
+    });
+
     it("preserves index field for parallel tool calls", () => {
       const output = {
         tool_calls: [

--- a/worker/src/__tests__/extractToolsBackend.test.ts
+++ b/worker/src/__tests__/extractToolsBackend.test.ts
@@ -405,6 +405,35 @@ describe("extractToolsFromObservation", () => {
       });
     });
 
+    it("extracts mixed message and raw tool call arrays from ingestion output", () => {
+      const output = JSON.stringify([
+        {
+          role: "assistant",
+          content: "I'll check the weather.",
+        },
+        {
+          toolCallId: "tooluse_weather",
+          toolName: "getWeather",
+          input: {
+            location: "Berlin",
+            unit: "celsius",
+          },
+        },
+      ]);
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toHaveLength(1);
+      expect(toolArguments[0]).toMatchObject({
+        id: "tooluse_weather",
+        name: "getWeather",
+        arguments: JSON.stringify({
+          location: "Berlin",
+          unit: "celsius",
+        }),
+      });
+    });
+
     it("does not treat arbitrary output arrays with id and name fields as tool calls", () => {
       const output = JSON.stringify([
         {
@@ -414,6 +443,60 @@ describe("extractToolsFromObservation", () => {
         {
           id: "weather_station_2",
           name: "San Francisco weather station",
+        },
+      ]);
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toEqual([]);
+    });
+
+    it("does not treat AI SDK tool-result arrays as tool calls", () => {
+      // tool-result arrays are not treated as tool calls, they might not be caused
+      // because a model choose to call a tool, but might be externally caused
+      const output = JSON.stringify([
+        {
+          type: "tool-result",
+          toolCallId: "tooluse_weather",
+          toolName: "getWeather",
+          result: {
+            temperature: 19,
+          },
+        },
+      ]);
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toEqual([]);
+    });
+
+    it("does not treat function definition arrays as tool calls", () => {
+      const output = JSON.stringify([
+        {
+          type: "function",
+          function: {
+            name: "getWeather",
+            parameters: {
+              type: "object",
+              properties: {
+                location: { type: "string" },
+              },
+            },
+          },
+        },
+      ]);
+
+      const { toolArguments } = extractToolsFromObservation(null, output);
+
+      expect(toolArguments).toEqual([]);
+    });
+
+    it("does not treat arbitrary output arrays with name and input fields as tool calls", () => {
+      const output = JSON.stringify([
+        {
+          id: "review_1",
+          name: "Alice",
+          input: "Great weather forecast.",
         },
       ]);
 

--- a/worker/src/queues/__tests__/otelToObservationForEval.test.ts
+++ b/worker/src/queues/__tests__/otelToObservationForEval.test.ts
@@ -656,6 +656,91 @@ describe("OTEL to ObservationForEval Schema Validation", () => {
       expect(obs.input).toBe('[{"role":"user","content":"Say hello"}]');
       expect(obs.output).toBe("Hello! How can I help you today?");
     });
+
+    it("should extract AI SDK tool calls from stringified OTel toolCalls attributes", async () => {
+      const vercelAIToolCallSpan = {
+        resource: { attributes: [] },
+        scopeSpans: [
+          {
+            scope: { name: "ai" },
+            spans: [
+              {
+                traceId: createBufferId("a1e2d3c4b5a69788a1e2d3c4b5a69788"),
+                spanId: createBufferId("1122334455667799"),
+                name: "ai.generateText.doGenerate",
+                kind: 1,
+                startTimeUnixNano: createNanoTimestamp(
+                  BigInt(1738241387865000000),
+                ),
+                endTimeUnixNano: createNanoTimestamp(
+                  BigInt(1738241389310000000),
+                ),
+                attributes: [
+                  {
+                    key: "ai.model.id",
+                    value: { stringValue: "claude-opus-4-6" },
+                  },
+                  {
+                    key: "ai.operationId",
+                    value: { stringValue: "ai.generateText.doGenerate" },
+                  },
+                  {
+                    key: "ai.prompt.messages",
+                    value: {
+                      stringValue: JSON.stringify([
+                        {
+                          role: "user",
+                          content: "Check the weather in Berlin",
+                        },
+                      ]),
+                    },
+                  },
+                  {
+                    key: "ai.response.text",
+                    value: { stringValue: "I'll check the weather." },
+                  },
+                  {
+                    key: "ai.response.toolCalls",
+                    value: {
+                      stringValue: JSON.stringify([
+                        {
+                          toolCallId: "tooluse_weather",
+                          toolName: "getWeather",
+                          input: {
+                            location: "Berlin",
+                            unit: "celsius",
+                          },
+                        },
+                      ]),
+                    },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const observations =
+        await processOtelSpanToObservationForEval(vercelAIToolCallSpan);
+
+      expect(observations).toHaveLength(1);
+      const obs = observations[0];
+
+      const result = observationForEvalSchema.safeParse(obs);
+      expect(result.success).toBe(true);
+
+      expect(obs.tool_call_names).toEqual(["getWeather"]);
+      expect(obs.tool_calls).toHaveLength(1);
+      expect(JSON.parse(obs.tool_calls[0])).toMatchObject({
+        id: "tooluse_weather",
+        arguments: JSON.stringify({
+          location: "Berlin",
+          unit: "celsius",
+        }),
+      });
+    });
   });
 
   describe("Schema field coverage", () => {


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the tool-call extraction logic to handle AI SDK outputs where `tool_calls` (or `toolCalls`) is stored as a JSON-stringified array rather than a native array, and adds support for detecting raw top-level tool-call arrays emitted by the AI SDK's OTel integration.

- **`parseArrayIfString`** is added and applied wherever `tool_calls` / `toolCalls` fields are read, transparently supporting both native arrays and their stringified equivalents.
- **`isToolCallLike` / `isMessageLike` heuristics** gate a new code path that processes a top-level array as raw tool calls when every element looks like a call rather than a chat message; three new tests cover the main scenarios.
- The `isToolCallLike` check does not exclude AI SDK `tool-result` objects, which share the same `toolName` + `toolCallId` shape as tool calls, so arrays of tool results would be misidentified and produce phantom records with empty arguments.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The happy paths are well-tested and the string-parsing fallback is sound, but the `isToolCallLike` heuristic can misidentify AI SDK tool-result objects as tool calls, which would write phantom records to ClickHouse for anyone logging tool-result arrays as observation output.

The `isToolCallLike` function's `hasAiSdkShape` branch matches on `toolName + toolCallId` regardless of whether `type` is `"tool-call"` or `"tool-result"`. Because AI SDK emits tool results with the exact same identifying fields, an array of tool results would trigger the raw-tool-call path and produce empty-arguments entries in storage. This is a present defect on the newly added code path, not a theoretical future risk.

packages/shared/src/server/ingestion/extractToolsBackend.ts — specifically the `isToolCallLike` function and the `isRawToolCallArray` decision in `extractToolCallsFromRawOutput`.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractToolCallsFromRawOutput\noutput: unknown] --> B{Array.isArray?}
    B -- No --> C{typeof object?}
    C -- No --> Z[return]
    C -- Yes --> D[parseArrayIfString\nobj.tool_calls ?? obj.toolCalls]
    D --> E[addToolArguments]
    D --> F[choices loop → parseArrayIfString\nmessage.tool_calls ?? message.toolCalls]
    F --> E
    D --> G[additionalKwargs → parseArrayIfString\nadditionalKwargs.tool_calls]
    G --> E
    D --> H[content array →\naddToolArgumentFromContentPart]
    B -- Yes --> I{isRawToolCallArray?\nsome isToolCallLike\nAND none isMessageLike}
    I -- true --> J[addToolArguments\nentire array]
    I -- false --> K[per-msg loop\nextractToolCallsFromMessage]
    K --> L[parseArrayIfString\nmsg.tool_calls ?? msg.toolCalls]
    L --> E

    style I fill:#ffe0b2,stroke:#e65100
    style J fill:#ffe0b2,stroke:#e65100
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/ingestion/extractToolsBackend.ts:161-164
AI SDK `tool-result` objects share the same `toolName` + `toolCallId` fields as `tool-call` objects, so `hasAiSdkShape` fires for both. Any array of tool results (e.g. `[{type: "tool-result", toolCallId: "tc_1", toolName: "search", result: {...}}]`) would pass `isToolCallLike`, causing `isRawToolCallArray` to be `true` and producing phantom tool-call entries with empty `arguments: "{}"` written to ClickHouse.

```suggestion
  const hasAiSdkShape =
    Boolean(call.toolName) &&
    call.type !== "tool-result" &&
    (["input", "args", "toolCallId"].some((key) => key in call) ||
      call.type === "tool-call");
```

### Issue 2 of 2
packages/shared/src/server/ingestion/extractToolsBackend.ts:267-278
When an output array contains both message-like elements (e.g. `{role, content}`) and top-level tool-call-like elements, `isRawToolCallArray` evaluates to `false` because `output.some(isMessageLike)` is truthy. The branch then falls into the per-message loop and calls `extractToolCallsFromMessage` on each element, but the standalone tool-call objects lack `tool_calls`/`toolCalls` keys, so they are silently dropped. Consider processing elements individually based on their shape rather than making a binary all-or-nothing decision.

```suggestion
    const isRawToolCallArray =
      output.some(isToolCallLike) && !output.some(isMessageLike);

    if (isRawToolCallArray) {
      addToolArguments(args, output);
    } else {
      for (const msg of output) {
        if (msg && typeof msg === "object") {
          const item = msg as Record<string, unknown>;
          if (isToolCallLike(item) && !isMessageLike(item)) {
            addToolArgument(args, item);
          } else {
            extractToolCallsFromMessage(item, args);
          }
        }
      }
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix parse"](https://github.com/langfuse/langfuse/commit/c8f33b3ca192be688cfaafa8c4d95830af5b65cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31553034)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->