### PR TITLE
fix(shared): validate outbound fetch DNS at connection time

### DIFF
--- a/packages/shared/src/server/outbound-url/connection.ts
+++ b/packages/shared/src/server/outbound-url/connection.ts
@@ -1,0 +1,151 @@
+import dns from "node:dns";
+import { Agent } from "undici";
+import type { OutboundUrlValidationWhitelist } from "./validation";
+import { validateOutboundResolvedIp } from "./validation";
+
+// We currently expect only a few policy/context combinations in normal
+// operation, e.g. strict image URL validation and webhook/self-hosting env
+// validation. Keep the cap well above that to allow future static policies, but
+// low enough to catch accidental high-cardinality whitelists before they create
+// unbounded Agent pools.
+const OUTBOUND_AGENT_POLICY_LIMIT = 32;
+const DEFAULT_OUTBOUND_URL_VALIDATION_WHITELIST: OutboundUrlValidationWhitelist =
+  {
+    hosts: [],
+    ips: [],
+    ip_ranges: [],
+  };
+
+type DnsLookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address: string | dns.LookupAddress[],
+  family?: number,
+) => void;
+type DnsLookup = (
+  hostname: string,
+  options: dns.LookupOptions,
+  callback: DnsLookupCallback,
+) => void;
+
+export interface OutboundUrlConnectionValidationOptions {
+  whitelist?: OutboundUrlValidationWhitelist;
+  logContext?: string;
+}
+
+type RequestInitWithUndiciDispatcher = RequestInit & {
+  dispatcher?: Agent;
+};
+
+const secureOutboundDispatchersByPolicy = new Map<string, Agent>();
+
+export function addSecureOutboundConnectionValidation(
+  options: RequestInit,
+  validationOptions: OutboundUrlConnectionValidationOptions,
+): RequestInit {
+  return {
+    ...options,
+    dispatcher: getSecureOutboundDispatcher(validationOptions),
+  } as RequestInitWithUndiciDispatcher;
+}
+
+function createSecureOutboundLookup(
+  validationOptions: OutboundUrlConnectionValidationOptions,
+  lookup: typeof dns.lookup = dns.lookup,
+): DnsLookup {
+  return (hostname, options, callback) => {
+    lookup(hostname, options, (err, address, family) => {
+      if (err) {
+        callback(err, address, family);
+        return;
+      }
+
+      try {
+        validateConnectionTimeLookupResult(
+          hostname,
+          address,
+          validationOptions,
+        );
+      } catch (error) {
+        callback(error as NodeJS.ErrnoException, address, family);
+        return;
+      }
+
+      callback(null, address, family);
+    });
+  };
+}
+
+function getSecureOutboundDispatcher(
+  validationOptions: OutboundUrlConnectionValidationOptions,
+): Agent {
+  const policyKey = getConnectionValidationPolicyKey(validationOptions);
+  const existingDispatcher = secureOutboundDispatchersByPolicy.get(policyKey);
+  if (existingDispatcher) return existingDispatcher;
+
+  if (secureOutboundDispatchersByPolicy.size >= OUTBOUND_AGENT_POLICY_LIMIT) {
+    // Do not evict existing Agents: they own socket pools and may still have
+    // in-flight streaming responses. Evicting without closing leaks resources,
+    // while closing/destroying can break unrelated requests. Exceeding this
+    // small policy count is unexpected and should fail closed.
+    throw new Error(
+      `Maximum secure outbound connection policy count (${OUTBOUND_AGENT_POLICY_LIMIT}) exceeded`,
+    );
+  }
+
+  const dispatcher = new Agent({
+    connect: {
+      // This lookup runs at socket connection time, so DNS rebinding between
+      // the earlier URL validation and the actual HTTP connection is blocked.
+      lookup: createSecureOutboundLookup(validationOptions),
+    },
+  });
+
+  secureOutboundDispatchersByPolicy.set(policyKey, dispatcher);
+  return dispatcher;
+}
+
+function validateConnectionTimeLookupResult(
+  hostname: string,
+  address: string | dns.LookupAddress[],
+  validationOptions: OutboundUrlConnectionValidationOptions,
+): void {
+  const lookupAddresses = Array.isArray(address)
+    ? address
+    : [{ address, family: undefined }];
+
+  for (const lookupAddress of lookupAddresses) {
+    validateOutboundResolvedIp({
+      hostname,
+      ip: lookupAddress.address,
+      whitelist:
+        validationOptions.whitelist ??
+        DEFAULT_OUTBOUND_URL_VALIDATION_WHITELIST,
+      logContext: validationOptions.logContext ?? "Outbound URL",
+    });
+  }
+}
+
+function getConnectionValidationPolicyKey({
+  whitelist,
+  logContext,
+}: OutboundUrlConnectionValidationOptions): string {
+  // Keep separate Agent pools per whitelist. A single shared Agent could reuse
+  // a socket opened under a permissive policy for a later stricter request to
+  // the same origin without performing another DNS lookup. The lookup closure
+  // also captures logContext, so include it to avoid mislabeling connection-time
+  // block warnings when different flows share the same whitelist.
+  return JSON.stringify({
+    whitelist: normalizeWhitelist(whitelist),
+    logContext: logContext ?? "Outbound URL",
+  });
+}
+
+function normalizeWhitelist(
+  whitelist: OutboundUrlValidationWhitelist = DEFAULT_OUTBOUND_URL_VALIDATION_WHITELIST,
+): OutboundUrlValidationWhitelist {
+  return {
+    hosts: [...whitelist.hosts].sort(),
+    ips: [...whitelist.ips].sort(),
+    ip_ranges: [...whitelist.ip_ranges].sort(),
+  };
+}

--- a/packages/shared/src/server/outbound-url/fetch.ts
+++ b/packages/shared/src/server/outbound-url/fetch.ts
@@ -1,3 +1,4 @@
+import { addSecureOutboundConnectionValidation } from "./connection";
 import type { OutboundUrlValidationWhitelist } from "./validation";
 import { logger } from "../logger";
 
@@ -71,6 +72,7 @@ interface BaseRedirectOptions {
 interface RedirectValidationOptions {
   validateUrl: RedirectUrlValidator;
   whitelist?: OutboundUrlValidationWhitelist;
+  logContext?: string;
 }
 
 /**
@@ -131,11 +133,15 @@ export async function fetchWithSecureRedirects(
   let currentUrl = url;
   let redirectDepth = 0;
 
-  // Force manual redirect handling to prevent automatic following.
-  let fetchOptions: RequestInit = {
-    ...options,
-    redirect: "manual",
-  };
+  // Disable automatic redirects so every Location target is validated before
+  // following it, and attach connection-time DNS/IP validation for each fetch.
+  let fetchOptions: RequestInit = addConnectionTimeValidation(
+    {
+      ...options,
+      redirect: "manual",
+    },
+    redirectOptions,
+  );
 
   while (redirectDepth <= maxRedirects) {
     logger.debug("Fetching URL with manual redirect handling", {
@@ -272,6 +278,20 @@ export async function fetchWithSecureRedirects(
     ...redirectChain,
     currentUrl,
   ]);
+}
+
+function addConnectionTimeValidation(
+  options: RequestInit,
+  redirectOptions: RedirectOptions,
+): RequestInit {
+  if (redirectOptions.skipValidation === true) {
+    return options;
+  }
+
+  return addSecureOutboundConnectionValidation(options, {
+    whitelist: redirectOptions.redirectValidation.whitelist,
+    logContext: redirectOptions.redirectValidation.logContext,
+  });
 }
 
 function stripSensitiveRedirectHeaders(

--- a/packages/shared/src/server/outbound-url/validation.ts
+++ b/packages/shared/src/server/outbound-url/validation.ts
@@ -20,6 +20,13 @@ export interface ValidateOutboundUrlHostOptions {
   shouldSkipDnsCheckForLiteralIps: boolean;
 }
 
+interface ValidateOutboundResolvedIpOptions {
+  hostname: string;
+  ip: string;
+  whitelist: OutboundUrlValidationWhitelist;
+  logContext: string;
+}
+
 export async function resolveHost(hostname: string): Promise<string[]> {
   // Returns every A + AAAA address.
   const [v4, v6, lookup] = await Promise.allSettled([
@@ -93,12 +100,12 @@ export async function validateOutboundUrlHost({
   }
 
   if (isIPAddress(hostname)) {
-    if (isIPBlocked(hostname, whitelist.ips, whitelist.ip_ranges)) {
-      logger.warn(
-        `${logContext} validation blocked IP address in hostname: ${hostname}`,
-      );
-      throw new Error("Blocked IP address detected");
-    }
+    validateOutboundResolvedIp({
+      hostname,
+      ip: hostname,
+      whitelist,
+      logContext,
+    });
 
     if (shouldSkipDnsCheckForLiteralIps) return;
   }
@@ -110,12 +117,30 @@ export async function validateOutboundUrlHost({
   const ips = await resolveHost(hostname);
 
   for (const ip of ips) {
-    if (isIPBlocked(ip, whitelist.ips, whitelist.ip_ranges)) {
-      logger.warn(
-        `${logContext} validation blocked resolved IP address: ${ip} for hostname: ${hostname}`,
-      );
-      throw new Error("Blocked IP address detected");
-    }
+    validateOutboundResolvedIp({
+      hostname,
+      ip,
+      whitelist,
+      logContext,
+    });
+  }
+}
+
+export function validateOutboundResolvedIp({
+  hostname,
+  ip,
+  whitelist,
+  logContext,
+}: ValidateOutboundResolvedIpOptions): void {
+  if (whitelist.hosts.includes(hostname)) {
+    return;
+  }
+
+  if (isIPBlocked(ip, whitelist.ips, whitelist.ip_ranges)) {
+    logger.warn(
+      `${logContext} validation blocked resolved IP address: ${ip} for hostname: ${hostname}`,
+    );
+    throw new Error("Blocked IP address detected");
   }
 }
 

--- a/packages/shared/src/server/webhooks/validation.ts
+++ b/packages/shared/src/server/webhooks/validation.ts
@@ -9,6 +9,8 @@ import {
 export type WebhookValidationWhitelist = OutboundUrlValidationWhitelist;
 export { resolveHost };
 
+export const WEBHOOK_URL_VALIDATION_LOG_CONTEXT = "Webhook";
+
 export function whitelistFromEnv(): WebhookValidationWhitelist {
   return {
     hosts: env.LANGFUSE_WEBHOOK_WHITELISTED_HOST || [],
@@ -42,7 +44,7 @@ export async function validateWebhookURL(
   await validateOutboundUrlHost({
     url,
     whitelist,
-    logContext: "Webhook",
+    logContext: WEBHOOK_URL_VALIDATION_LOG_CONTEXT,
     // Preserve the existing webhook behavior: public IP literals must still
     // pass the same DNS-resolution path as hostname destinations.
     shouldSkipDnsCheckForLiteralIps: false,

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -67,6 +67,7 @@ import {
   escapeSqlLikePattern,
   fetchWithSecureRedirects,
   whitelistFromEnv,
+  WEBHOOK_URL_VALIDATION_LOG_CONTEXT,
 } from "@langfuse/shared/src/server";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 import {
@@ -1809,6 +1810,7 @@ export const datasetRouter = createTRPCRouter({
               redirectValidation: {
                 validateUrl: validateWebhookURL,
                 whitelist,
+                logContext: WEBHOOK_URL_VALIDATION_LOG_CONTEXT,
               },
             },
           );

--- a/web/src/server/api/routers/utilities.ts
+++ b/web/src/server/api/routers/utilities.ts
@@ -85,6 +85,8 @@ const fetchImageUrlWithSecureRedirects = async (
           );
         }
       },
+      whitelist: IMAGE_URL_VALIDATION_OPTIONS.whitelist,
+      logContext: IMAGE_URL_VALIDATION_OPTIONS.logContext,
     },
   });
 

--- a/worker/src/__tests__/outbound-connection-validation.test.ts
+++ b/worker/src/__tests__/outbound-connection-validation.test.ts
@@ -1,0 +1,145 @@
+import crypto from "node:crypto";
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../../../packages/shared/src/server/logger";
+import { fetchWithSecureRedirects } from "../../../packages/shared/src/server/outbound-url";
+
+const strictWhitelist = { hosts: [], ips: [], ip_ranges: [] };
+
+let server: Server | undefined;
+
+afterEach(async () => {
+  await closeServer();
+  vi.restoreAllMocks();
+});
+
+describe("fetchWithSecureRedirects connection-time validation", () => {
+  it("should reject DNS results that resolve to blocked IPs at connection time", async () => {
+    const url = await startLocalhostServer();
+
+    await expect(
+      fetchWithSecureRedirects(url, {}, validationOptions()),
+    ).rejects.toMatchObject({
+      message: "fetch failed",
+      cause: expect.objectContaining({
+        message: "Blocked IP address detected",
+      }),
+    });
+  });
+
+  it("should use the caller log context for connection-time blocks when whitelists match", async () => {
+    const warnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
+
+    await expect(
+      fetchWithSecureRedirects(
+        await startLocalhostServer(),
+        {},
+        validationOptions(strictWhitelist, "Webhook"),
+      ),
+    ).rejects.toMatchObject({ message: "fetch failed" });
+    await closeServer();
+
+    await expect(
+      fetchWithSecureRedirects(
+        await startLocalhostServer(),
+        {},
+        validationOptions(strictWhitelist, "Image URL"),
+      ),
+    ).rejects.toMatchObject({ message: "fetch failed" });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Webhook validation blocked resolved IP address"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Image URL validation blocked resolved IP address",
+      ),
+    );
+  });
+
+  it("should propagate DNS lookup errors from connection-time validation", async () => {
+    const hostname = `nonexistent-${crypto.randomUUID()}.invalid`;
+
+    await expect(
+      fetchWithSecureRedirects(
+        `http://${hostname}`,
+        {},
+        validationOptions({ hosts: [hostname], ips: [], ip_ranges: [] }),
+      ),
+    ).rejects.toMatchObject({
+      message: "fetch failed",
+      cause: expect.objectContaining({ code: "ENOTFOUND" }),
+    });
+  });
+
+  it("should preserve host whitelist behavior at connection time", async () => {
+    const url = await startLocalhostServer();
+
+    const result = await fetchWithSecureRedirects(
+      url,
+      {},
+      validationOptions({ hosts: ["localhost"], ips: [], ip_ranges: [] }),
+    );
+
+    expect(result.response.status).toBe(200);
+    await expect(result.response.text()).resolves.toBe("ok");
+  });
+
+  it("should preserve IP range whitelist behavior at connection time", async () => {
+    const url = await startLocalhostServer();
+
+    const result = await fetchWithSecureRedirects(
+      url,
+      {},
+      validationOptions({
+        hosts: [],
+        ips: [],
+        ip_ranges: ["127.0.0.0/8", "::1/128"],
+      }),
+    );
+
+    expect(result.response.status).toBe(200);
+    await expect(result.response.text()).resolves.toBe("ok");
+  });
+});
+
+async function startLocalhostServer(): Promise<string> {
+  server = createServer((_request, response) => {
+    response.end("ok");
+  });
+
+  await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", resolve));
+
+  const address = server.address() as AddressInfo;
+  return `http://localhost:${address.port}`;
+}
+
+async function closeServer(): Promise<void> {
+  if (!server) return;
+
+  await new Promise<void>((resolve, reject) => {
+    server?.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+  server = undefined;
+}
+
+function validationOptions(whitelist = strictWhitelist, logContext?: string) {
+  return {
+    maxRedirects: 0,
+    redirectValidation: {
+      validateUrl: async () => undefined,
+      whitelist,
+      logContext,
+    },
+  };
+}

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -17,6 +17,7 @@ import {
   validateWebhookURL,
   whitelistFromEnv,
   fetchWithSecureRedirects,
+  WEBHOOK_URL_VALIDATION_LOG_CONTEXT,
 } from "@langfuse/shared/src/server";
 import {
   TQueueJobTypes,
@@ -164,6 +165,7 @@ async function executeHttpAction({
                 redirectValidation: {
                   validateUrl: validateWebhookURL,
                   whitelist,
+                  logContext: WEBHOOK_URL_VALIDATION_LOG_CONTEXT,
                 },
                 additionalSensitiveHeaders,
               };


### PR DESCRIPTION
## Summary

- Hardened `fetchWithSecureRedirects` with connection-time DNS/IP validation so validated outbound fetches reject blocked/private/metadata IPs at socket connection time, not only during pre-fetch URL validation.
- Added a bounded, policy-keyed Undici Agent pool to preserve per-whitelist behavior while avoiding global dispatcher changes and per-request Agent leaks.
- Reused outbound resolved-IP validation for both pre-fetch DNS checks and connection-time lookup checks.
- Added worker regression coverage for blocked connection-time DNS results, DNS lookup error propagation, and host/IP-range whitelist behavior.

## Linear

- [INT-1617](https://linear.app/langfuse/issue/INT-1617)

## Major Decisions

- Chose policy-keyed singleton Undici Agents using `connect.lookup` instead of a DNS interceptor/cache or per-request Agents. This keeps the implementation close to Undici’s connection lifecycle, preserves Host/SNI behavior, avoids DNS cache/storage complexity, and prevents socket reuse across different whitelist policies.

## Review Focus

- Security behavior in `packages/shared/src/server/outbound-url/connection.ts`, especially blocked-IP rejection and whitelist preservation.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens `fetchWithSecureRedirects` against DNS-rebinding SSRF by attaching connection-time DNS/IP validation via a bounded pool of policy-keyed Undici Agents that run `validateOutboundResolvedIp` at socket creation time. It also removes the `shouldThrowIfDnsResolutionFails` flag, making DNS resolution failures a hard error for all outbound URL validation paths.

- A new `connection.ts` module manages a module-level `Map<string, Agent>` (capped at 32 policies) where each Agent's `connect.lookup` wraps the standard DNS lookup with IP-blocklist validation, preventing rebinding between the pre-fetch URL check and the actual TCP connection.
- `validateOutboundResolvedIp` is extracted as a shared, exported function and reused by both the pre-flight DNS check in `validateOutboundUrlHost` and the new connection-time lookup closure.
- `shouldThrowIfDnsResolutionFails` is removed entirely; DNS resolution failure now always throws, which closes the split-horizon bypass but is a breaking change for self-hosted users with gateways not yet resolvable at key-save time.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with awareness that self-hosted LLM gateway users who rely on saving a key before DNS is ready will now see hard failures and must add their hostname to the whitelist env var.

The core security logic in connection.ts is well-structured: the Agent pool is bounded, sockets are never reused across different policies, and the connection-time lookup correctly re-validates IPs for each new TCP connection. The `validateOutboundResolvedIp` extraction is clean and the test coverage for connection-time rejection, DNS error propagation, and whitelist pass-through is solid. The main concern is the silent behavioral break for self-hosted deployments where the LLM gateway hostname may be temporarily or permanently unresolvable — a very real scenario for users pointing at internal gateways — because the new hard-throw path offers no in-error guidance toward the whitelist env var.

packages/shared/src/server/llm/baseUrlValidation.ts — DNS now throws unconditionally; the error message should guide users to the whitelist env var. packages/shared/src/server/outbound-url/connection.ts — security-critical path; looks correct but worth a second pass on the callback error-passing convention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchWithSecureRedirects
    participant addConnectionTimeValidation
    participant UndiciAgent
    participant validateOutboundUrlHost
    participant validateOutboundResolvedIp
    participant DNS

    Caller->>fetchWithSecureRedirects: url, options, redirectOptions

    Note over fetchWithSecureRedirects,addConnectionTimeValidation: Pre-request setup
    fetchWithSecureRedirects->>addConnectionTimeValidation: options + whitelist
    addConnectionTimeValidation->>UndiciAgent: getSecureOutboundDispatcher(whitelist)
    Note over UndiciAgent: Singleton keyed by normalised whitelist JSON

    Note over fetchWithSecureRedirects,validateOutboundUrlHost: Pre-flight URL validation (per-redirect)
    fetchWithSecureRedirects->>validateOutboundUrlHost: url, whitelist
    validateOutboundUrlHost->>DNS: resolveHost(hostname)
    DNS-->>validateOutboundUrlHost: ips[]
    validateOutboundUrlHost->>validateOutboundResolvedIp: hostname, ip, whitelist
    validateOutboundResolvedIp-->>validateOutboundUrlHost: ok / throws

    Note over fetchWithSecureRedirects,DNS: Connection-time validation (per new socket)
    fetchWithSecureRedirects->>UndiciAgent: fetch(url, dispatcher)
    UndiciAgent->>DNS: custom lookup(hostname)
    DNS-->>UndiciAgent: address
    UndiciAgent->>validateOutboundResolvedIp: hostname, address, whitelist
    validateOutboundResolvedIp-->>UndiciAgent: ok / throws blocked error

    UndiciAgent-->>fetchWithSecureRedirects: HTTP Response
    fetchWithSecureRedirects-->>Caller: RedirectResult
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/llm/baseUrlValidation.ts:44-51
**Breaking DNS behavior change for self-hosted LLM gateways**

Removing `shouldThrowIfDnsResolutionFails: false` means `validateLlmConnectionBaseURL` now hard-throws on any DNS resolution failure via `resolveHost`. Previously, an unresolvable hostname would silently pass; now it blocks the save flow. Self-hosted users who save an LLM API key with a gateway URL like `https://my-llm-gateway.internal/v1` before that hostname is resolvable in DNS will see a `DNS lookup failed` error with no obvious path forward — the env-var solution (`LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST`) is only documented inside source-code comments and tests, not in user-facing docs or error messages. Consider enriching the thrown error message to explicitly tell users about the whitelist option (e.g., "DNS lookup failed for my-llm-gateway.internal — add the hostname to LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST to bypass DNS resolution").

### Issue 2 of 2
packages/shared/src/server/outbound-url/fetch.ts:282-293
**`logContext` not propagated to connection-time validation**

`addConnectionTimeValidation` passes only `whitelist` to `addSecureOutboundConnectionValidation`, so every connection-time blocked-IP log entry will read "Outbound URL" (the fallback in `validateConnectionTimeLookupResult`), regardless of whether the caller was a webhook, image URL, or LLM request. Since the `Agent` is a long-lived singleton keyed by policy, the `logContext` captured in its lookup closure is fixed at creation time. Adding `logContext` to `RedirectValidationOptions` and plumbing it through `addConnectionTimeValidation` would let production logs identify which feature triggered the block.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): validate outbound fetch DNS..."](https://github.com/langfuse/langfuse/commit/0607ab7010e3020b0d521058b8fefe54b2b52a8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31564452)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->