### PR TITLE
docs(agents): add cloud cost analysis skill

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -26,6 +26,9 @@ evaluating, and debugging AI applications.
 - Repo-wide agent setup, `.agents/**`, provider shims, or MCP/bootstrap config:
   `.agents/README.md`,
   `.agents/skills/agent-setup-maintenance/SKILL.md`
+- Langfuse Cloud cost structure, infra spend, AWS/ClickHouse cost splits, or
+  Metabase cost marts:
+  `.agents/skills/analyze-cloud-costs/SKILL.md`
 - Backend/API work in `web/src/server/**`, `web/src/pages/api/public/**`,
   `worker/src/**`, or `packages/shared/src/**`:
   `.agents/skills/backend-dev-guidelines/SKILL.md`

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -33,6 +33,16 @@ Use for:
 
 Open: [agent-setup-maintenance/SKILL.md](agent-setup-maintenance/SKILL.md)
 
+### analyze-cloud-costs
+
+Use for:
+- Langfuse Cloud infrastructure cost structure
+- AWS versus ClickHouse cost splits and cost drivers
+- Metabase infra cost dashboard and cost marts
+- daily cost per tracing event and cost regression analysis
+
+Open: [analyze-cloud-costs/SKILL.md](analyze-cloud-costs/SKILL.md)
+
 ### frontend-browser-review
 
 Use for:

--- a/.agents/skills/analyze-cloud-costs/SKILL.md
+++ b/.agents/skills/analyze-cloud-costs/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: analyze-cloud-costs
+description: |
+  Analyze Langfuse Cloud infrastructure cost structure using Metabase cost
+  marts. Use when asked about cloud spend, AWS versus ClickHouse cost splits,
+  cost drivers by provider/service/usage type/account, daily cost per tracing
+  event, infra cost dashboards, or cost regressions visible in Metabase.
+---
+
+# Analyze Cloud Costs
+
+## Overview
+
+Use this skill for evidence-backed Langfuse Cloud cost analysis. The primary
+source is the Metabase infra cost dashboard and its production cost marts; the
+deliverable should name the time window, query grain, top drivers, and caveats.
+
+## Workflow
+
+1. Clarify the question and choose the grain:
+   - Headline daily totals: total, AWS, ClickHouse, tracing events, and cost per
+     100k events.
+   - Cost structure: provider, service, usage type, operation, account, and day.
+   - Driver or regression analysis: compare a recent complete-day window against
+     a prior baseline.
+2. Load [`references/cost-marts.md`](references/cost-marts.md) for table IDs,
+   field IDs, query examples, and caveats.
+3. Use the Metabase MCP. If the Metabase tools are not visible, discover them
+   with tool search before falling back to manual interpretation.
+4. Prefer complete UTC days. Avoid treating current-day AWS cost as final
+   because AWS CUR rows can arrive late.
+5. Start broad, then drill down:
+   - Provider split.
+   - Service split within the dominant provider.
+   - Usage type, operation, and account split for the top services.
+   - Daily trend when explaining change over time.
+6. Report only what the queried data supports. If a requested slice is absent,
+   say that no rows were found for that slice instead of inventing a driver.
+
+## Query Rules
+
+- Use `mcp__metabase__.query` for quick reads. Use
+  `construct_query` plus `execute_query` when you need to inspect or reuse the
+  opaque query.
+- Pass `filters`, `aggregations`, `group_by`, and `fields` as JSON arrays. Some
+  tool schemas may display these as strings; if that happens, serialize the same
+  arrays without changing their shape.
+- Keep limits explicit and small enough for analysis. Use pagination only when
+  the continuation token is needed.
+- Include the Metabase dashboard link or query result context in the final
+  answer when useful.
+
+## Output Expectations
+
+Summarize:
+
+- Time window and whether it uses complete UTC days.
+- Total cost and provider split when relevant.
+- Top cost drivers by service, usage type, operation, or account.
+- Trend or baseline comparison when the user asks "why did this change?"
+- Caveats, especially incomplete current-day AWS data and ClickHouse credit
+  labeling in the unified mart.

--- a/.agents/skills/analyze-cloud-costs/agents/openai.yaml
+++ b/.agents/skills/analyze-cloud-costs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Analyze Cloud Costs"
+  short_description: "Analyze Langfuse Cloud cost structure"
+  default_prompt: "Use $analyze-cloud-costs to explain recent Langfuse Cloud cost drivers from Metabase."

--- a/.agents/skills/analyze-cloud-costs/references/cost-marts.md
+++ b/.agents/skills/analyze-cloud-costs/references/cost-marts.md
@@ -1,0 +1,137 @@
+# Langfuse Cloud Cost Marts
+
+Use this reference when querying or explaining Langfuse Cloud cost structure.
+
+Dashboard:
+
+- https://langfuse.metabaseapp.com/dashboard/22-infra-cost?account=&date=past90days&tab=20-tab-1
+
+## Primary Tables
+
+| Purpose | Table | ID |
+| --- | --- | --- |
+| Unified AWS and ClickHouse cost rows by provider, service, usage type, account, and day | `langfuse_prod.mart_daily_cost_chart` | `739` |
+| Daily headline totals plus tracing event counts and cost per 100k events | `langfuse_prod.mart_daily_cost_with_events` | `784` |
+| Detailed AWS CUR summary by product, operation, account, and usage type | `langfuse_prod.mart_aws_cost_daily_by_service` | `610` |
+| Detailed ClickHouse costs by entity and metric | `langfuse_prod.mart_clickhouse_daily_cost` | `689` |
+
+Prefer table `739` for structural breakdowns. Prefer table `784` for daily
+headline totals.
+
+## Field IDs
+
+### `mart_daily_cost_chart` (`739`)
+
+| Field ID | Field |
+| --- | --- |
+| `t739-0` | `usage_date` |
+| `t739-1` | `service_provider` |
+| `t739-2` | `service_name` |
+| `t739-3` | `operation` |
+| `t739-4` | `usage_type` |
+| `t739-5` | `account_name` |
+| `t739-6` | `cost_usd` |
+
+### `mart_daily_cost_with_events` (`784`)
+
+| Field ID | Field |
+| --- | --- |
+| `t784-0` | `usage_date` |
+| `t784-1` | `total_cost_usd` |
+| `t784-2` | `clickhouse_cost_usd` |
+| `t784-3` | `aws_cost_usd` |
+| `t784-5` | `s3_api_operations_cost_usd` |
+| `t784-6` | `total_tracing_events` |
+| `t784-7` | `total_cost_per_100k_events` |
+
+## Metabase MCP Patterns
+
+The Metabase MCP supports `query` for direct reads and
+`construct_query` plus `execute_query` for reusable opaque queries. In practice,
+pass `filters`, `aggregations`, `group_by`, and `fields` as JSON arrays:
+
+```json
+{
+  "table_id": 739,
+  "filters": [
+    {
+      "field_id": "t739-0",
+      "operation": "greater-than-or-equal",
+      "value": "2026-05-09"
+    }
+  ],
+  "aggregations": [
+    {
+      "function": "sum",
+      "field_id": "t739-6"
+    }
+  ],
+  "group_by": [
+    { "field_id": "t739-1" },
+    { "field_id": "t739-2" }
+  ],
+  "limit": "200"
+}
+```
+
+If a tool surface insists on strings for those parameters, serialize the same
+arrays as JSON strings.
+
+## Common Breakdowns
+
+Provider split:
+
+- Table `739`
+- Aggregate `sum(t739-6)`
+- Group by `t739-1`
+
+Service split:
+
+- Table `739`
+- Aggregate `sum(t739-6)`
+- Group by `t739-1`, `t739-2`
+
+Usage type split:
+
+- Table `739`
+- Aggregate `sum(t739-6)`
+- Group by `t739-1`, `t739-4`
+
+Environment/account split:
+
+- Table `739`
+- Aggregate `sum(t739-6)`
+- Group by `t739-1`, `t739-5`
+
+Daily headline totals:
+
+- Table `784`
+- Filter `t784-0` by date.
+- Read `total_cost_usd`, `clickhouse_cost_usd`, `aws_cost_usd`,
+  `total_tracing_events`, and `total_cost_per_100k_events`.
+
+Daily trend by provider:
+
+- Table `739`
+- Aggregate `sum(t739-6)`
+- Group by `t739-0`, `t739-1`
+
+Drilldown sequence for a cost spike:
+
+1. Compare total daily cost in table `784`.
+2. Split the same days by provider in table `739`.
+3. Split the dominant provider by service.
+4. Split the dominant service by usage type, operation, and account.
+
+## Caveats
+
+- Current-day AWS cost can be incomplete because AWS CUR data may not have
+  landed yet.
+- For stable recent analysis, prefer the last complete UTC days rather than
+  including today.
+- ClickHouse cost rows are labeled `cost_usd` in the unified mart, but the
+  source metric is ClickHouse credits. Mention this when precision or billing
+  interpretation matters.
+- Field IDs can change if Metabase models are rebuilt. If a query fails, search
+  Metabase for the table name and inspect the returned metadata before
+  changing the analysis.


### PR DESCRIPTION
## Summary

- Add `analyze-cloud-costs` as a shared Langfuse agent skill for Metabase-backed cloud cost analysis.
- Document the cost marts, table IDs, field IDs, query patterns, common breakdowns, and caveats for AWS/ClickHouse cost interpretation.
- Route cloud cost structure tasks from the root agent guide and shared skills index.

## Impacted Packages

- `.agents`

## Verification

- `python3 /Users/max/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/max/development/github.com/langfuse/langfuse-analyze-cloud-costs-pr/.agents/skills/analyze-cloud-costs`
- `pnpm run agents:sync`
- `pnpm run agents:check`

Note: `pnpm` emitted the existing engine warning because this shell is running Node `v25.9.0` while the repo expects Node `24`, but both agent commands completed successfully.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `analyze-cloud-costs` agent skill that documents Langfuse Cloud's Metabase-backed cost mart structure and routes cloud cost queries to it from the root agent guide and skills index.

- **New skill files** (`SKILL.md`, `agents/openai.yaml`, `references/cost-marts.md`) describe the Metabase tables, field IDs, query patterns, and caveats for AWS/ClickHouse cost analysis.
- **Routing updates** in `AGENTS.md` and `skills/README.md` direct cloud cost questions to the new skill.
- `cost-marts.md` contains a hardcoded internal Metabase dashboard URL committed to this public repository, a gap in the `mart_daily_cost_with_events` field ID table (`t784-4` is missing without explanation), and a string-typed `limit` value in the example JSON query where an integer is expected.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Documentation-only change, but it commits an internal production Metabase URL to a public repository.

All five changed files are documentation under `.agents/`; no application code is touched. The routing additions in `AGENTS.md` and `skills/README.md` are clean. The main concern is in `cost-marts.md`: it hard-codes a production Metabase dashboard URL into a public repo, which exposes the instance hostname and dashboard structure to anyone watching the repository. Additionally, a missing field ID (`t784-4`) and a string-typed `limit` in the example query could cause agent queries to behave unexpectedly. The URL issue in particular warrants a review conversation before merging into the public main branch.

.agents/skills/analyze-cloud-costs/references/cost-marts.md — contains the internal dashboard URL, missing field ID, and type inconsistency in the example query.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Information disclosure** (`cost-marts.md` line 7): The internal Metabase dashboard URL (`https://langfuse.metabaseapp.com/dashboard/22-infra-cost?...`) is committed to a public repository, exposing the hostname, dashboard ID, and tab structure of a production internal tooling instance. Although authentication is still required to view data, the URL makes the instance enumerable and is a stable phishing or credential-stuffing target.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent receives cloud cost query] --> B{Route via AGENTS.md}
    B --> C[Load analyze-cloud-costs/SKILL.md]
    C --> D[Load references/cost-marts.md]
    D --> E{Choose grain}
    E --> F[Headline totals\ntable 784]
    E --> G[Structural breakdown\ntable 739]
    E --> H[AWS detail\ntable 610]
    E --> I[ClickHouse detail\ntable 689]
    F --> J[Metabase MCP\nmcp__metabase__.query]
    G --> J
    H --> J
    I --> J
    J --> K[Format answer:\ntime window, drivers, caveats]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.agents/skills/analyze-cloud-costs/references/cost-marts.md:7
**Internal Metabase URL committed to public repository**

The dashboard URL `https://langfuse.metabaseapp.com/dashboard/22-infra-cost?...` is a direct link to an internal Metabase instance and is now visible in this public repository. While the URL itself does not carry credentials, it exposes the existence of `langfuse.metabaseapp.com`, the specific dashboard ID and tab structure, and acts as a stable enumeration target for anyone probing internal tooling. If the Metabase instance is internet-accessible (the `metabaseapp.com` subdomain suggests it is), this increases the attack surface for phishing or credential-stuffing attempts against that endpoint.

### Issue 2 of 3
.agents/skills/analyze-cloud-costs/references/cost-marts.md:55-63
**Missing field `t784-4` in field ID table**

The `mart_daily_cost_with_events` (table `784`) field listing jumps from `t784-3` to `t784-5`, silently skipping `t784-4`. If that field exists in the model, an agent querying sequentially or by index will miss it. If it was intentionally omitted (e.g., removed or unused), a brief note explaining the gap would prevent confusion — otherwise the documentation appears inconsistent and future maintainers may suspect a typo.

### Issue 3 of 3
.agents/skills/analyze-cloud-costs/references/cost-marts.md:73
The `limit` value is serialized as a string `"200"` instead of an integer. Most JSON-based query APIs treat these as distinct types, and passing a string where a number is expected can cause a type error at runtime. The surrounding prose uses `filters`, `aggregations`, etc. as JSON arrays (correct types), so the limit should follow the same pattern.

```suggestion
  "limit": 200
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): add cloud cost analysis sk..."](https://github.com/langfuse/langfuse/commit/9fb95091368f66b45c919b71d6f86478ce438dbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31566058)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->