### PR TITLE
docs(agents): route cross-repo context to navigator

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -25,6 +25,9 @@ evaluating, and debugging AI applications.
 
 - Architecture principles for high-scale observability and wide event data:
   `.agents/ARCHITECTURE_PRINCIPLES.md`
+- Langfuse org navigation, cross-repo context, or when context/skills from
+  other Langfuse codebases may be required:
+  use the `langfuse-codebase-navigator` skill.
 - Repo-wide agent setup, `.agents/**`, provider shims, or MCP/bootstrap config:
   `.agents/README.md`,
   `.agents/skills/agent-setup-maintenance/SKILL.md`


### PR DESCRIPTION
## Summary

- Add `langfuse-codebase-navigator` to the root agent task router for Langfuse org navigation and cross-repo context.
- Clarify that agents should use it when context or skills from other Langfuse codebases may be required.

## Impacted packages

- `.agents/AGENTS.md`

## Verification

- `pnpm run agents:sync`
- `pnpm run agents:check`

Both commands completed successfully. They emitted the existing local Node engine warning because this shell is running Node v25.9.0 while the repo requests Node 24.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a routing entry to the root `AGENTS.md` for the `langfuse-codebase-navigator` skill, directing agents to use it whenever cross-repo context or skills from other Langfuse codebases may be required.

- A new bullet is prepended to the \"Start Here By Task\" section mapping the \"Langfuse org navigation / cross-repo context\" trigger to the `langfuse-codebase-navigator` skill — the only routing entry in the section that does not include a repo-relative file path.
- The previous thread flagged a hardcoded developer-local path (`/Users/max/.codex/skills/…`); that path has been removed in this revision, leaving the skill referenced only by name without a location hint or installation pointer.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a three-line addition to an agent routing guide with no runtime code affected.

The only changed file is `.agents/AGENTS.md`, a documentation file consumed by AI agents at task-start time. The addition is additive and does not alter any existing routing entries. No production code, migrations, schemas, or build artifacts are touched.

No files require special attention beyond the routing entry in `.agents/AGENTS.md`.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent receives task] --> B{Check AGENTS.md\nStart Here By Task}
    B --> C{Cross-repo context\nor org navigation?}
    C -->|Yes| D[Use langfuse-codebase-navigator skill]
    C -->|No| E{Other task type?}
    E -->|Agent setup / .agents/**| F[.agents/skills/agent-setup-maintenance/SKILL.md]
    E -->|Backend / API work| G[.agents/skills/backend-dev-guidelines/SKILL.md]
    E -->|Code review| H[.agents/skills/code-review/SKILL.md]
    E -->|Frontend changes| I[.agents/skills/frontend-browser-review/SKILL.md]
    E -->|Other| J[Package-local AGENTS.md]
    D --> K[Navigate Langfuse org\ncross-repo resources]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(agents): route cross-repo context t..."](https://github.com/langfuse/langfuse/commit/7de673d06f659c6e1866600f65dd0397034df7dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31577008)</sub>

<!-- /greptile_comment -->