### PR TITLE
docs(agents): add architecture principles

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -23,6 +23,8 @@ evaluating, and debugging AI applications.
 
 ## Start Here By Task
 
+- Architecture principles for high-scale observability and wide event data:
+  `.agents/ARCHITECTURE_PRINCIPLES.md`
 - Repo-wide agent setup, `.agents/**`, provider shims, or MCP/bootstrap config:
   `.agents/README.md`,
   `.agents/skills/agent-setup-maintenance/SKILL.md`

--- a/.agents/ARCHITECTURE_PRINCIPLES.md
+++ b/.agents/ARCHITECTURE_PRINCIPLES.md
@@ -1,0 +1,49 @@
+# Underlying Architecture Principles
+
+Langfuse architecture should optimize for high-scale, exploratory observability
+on wide, structured event data. These principles are grounded in current
+production scale and the reference material below.
+
+## Reference Posts
+
+- [Simplifying Langfuse for Scale](https://langfuse.com/blog/2026-03-10-simplify-langfuse-for-scale)
+- [Charity Majors on Observability 2.0](https://charity.wtf/tag/observability-2-0/)
+- [All you need is Wide Events, not "Metrics, Logs and Traces"](https://isburmistrov.substack.com/p/all-you-need-is-wide-events-not-metrics)
+
+## Principles
+
+- Model observations as the primary analytical unit. A trace is a correlation
+  handle that links related observations, not the only useful entry point.
+- Prefer wide, richly attributed events over fragmented metrics, logs, and trace
+  records that require later reconstruction.
+- Preserve high-cardinality context so users can slice, group, filter, and debug
+  unknown unknowns without predefining every future question.
+- Favor immutable or append-oriented event records for high-volume telemetry.
+  Updates that force read-time deduplication create hidden query costs at scale.
+- Denormalize carefully when it removes hot-path joins and makes common filters
+  into direct column predicates.
+- Design storage and query paths around columnar access patterns: narrow field
+  selection, time-bounded scans, useful ordering keys, and data pruning.
+- Keep list, dashboard, and aggregate views on compact query-optimized
+  representations. Fetch large raw payloads only for focused detail views.
+- Make API contracts scale-aware: require time windows where needed, expose field
+  selection, use token pagination, and avoid defaults that can scan all history.
+- Treat cost and operational simplicity as architectural constraints. Extra
+  databases, queues, materialized views, and migrations must earn their long-term
+  operational burden.
+- Preserve real-time or near-real-time debugging workflows. Batch processing can
+  help, but it should not make fresh production behavior invisible.
+
+## Practical Defaults For Agents
+
+- Before adding a metric, ask whether the same question is better answered from
+  wide event data.
+- Before adding a join, ask whether the attribute should be propagated or
+  denormalized onto the observation path.
+- Before reading large fields, ask whether the view needs them or can defer them
+  until a single-record fetch.
+- Before adding an update-heavy design, ask whether immutable events plus
+  derived representations would be simpler at production scale.
+- Before documenting public behavior, separate stable public contracts from
+  private production topology, account details, secret names, and incident
+  runbooks.

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -10,6 +10,8 @@ or `.vscode/`.
 ## Layout
 
 - `AGENTS.md`: canonical shared root instructions
+- `ARCHITECTURE_PRINCIPLES.md`: architecture principles for high-scale
+  observability
 - `config.json`: shared bootstrap and MCP configuration used to generate
   tool-specific shims
 - `skills/`: shared, tool-neutral implementation guidance for recurring


### PR DESCRIPTION
## Summary

- Add `.agents/ARCHITECTURE_PRINCIPLES.md`, copied from the infrastructure repo's shared agent context.
- Link the new architecture principles doc from `.agents/AGENTS.md` and `.agents/README.md` so agents can discover it.

## Impacted packages

- `.agents` shared agent guidance only

## Verification

- `pnpm run agents:sync`
- `pnpm run agents:check`
- Confirmed `.agents/ARCHITECTURE_PRINCIPLES.md` matches `langfuse/infrastructure@main`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `.agents/ARCHITECTURE_PRINCIPLES.md`, a new agent-guidance document encoding Langfuse's high-level design philosophy around wide-event observability, and links it from the existing `.agents/AGENTS.md` and `.agents/README.md` discovery files. No production code is changed.

- **New file** – `.agents/ARCHITECTURE_PRINCIPLES.md` lists ten architectural principles (columnar access, immutable/append-oriented events, denormalization tradeoffs, scale-aware API contracts, etc.) plus four \"practical defaults for agents\" that shape how AI agents should reason about design decisions.
- **Discovery wiring** – The new file is surfaced as the first entry under \"Start Here By Task\" in `AGENTS.md` and added to the layout index in `README.md`, so agents and contributors can find it without prior knowledge of its existence.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no production code touched; safe to merge.

All three changed files are agent-guidance markdown documents. The new architecture principles are clearly written, internally consistent, and correctly wired into the existing discovery files. No code paths, schemas, or runtime behaviour are affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".agents/AGENTS.md\n(canonical root instructions)"] --> B[".agents/ARCHITECTURE_PRINCIPLES.md\n(NEW — design philosophy)"]
    A --> C[".agents/README.md\n(layout index)"]
    A --> D[".agents/skills/\n(implementation guidance)"]
    C --> B
    B --> E["Principles\n• Wide events\n• Immutable records\n• Columnar access\n• Scale-aware APIs"]
    B --> F["Practical Defaults for Agents\n• Metrics vs. wide events\n• Joins vs. denormalisation\n• Large-field deferral\n• Immutable event design"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/add-archi..."](https://github.com/langfuse/langfuse/commit/f7abbb2dca36c2851e0d2cb9e17b90b03443f035) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31578510)</sub>

<!-- /greptile_comment -->