### PR TITLE
fix(web): use prompt model config for experiments

### DIFF
--- a/web/src/features/evals/hooks/useEvaluationModel.ts
+++ b/web/src/features/evals/hooks/useEvaluationModel.ts
@@ -1,4 +1,5 @@
 import { api } from "@/src/utils/api";
+import { getEnabledModelParamState } from "@/src/utils/getFinalModelParams";
 import {
   type ModelParams,
   ZodModelConfig,
@@ -32,19 +33,9 @@ export function useEvaluationModel(
         return;
       }
 
-      const modelConfig = Object.entries(parsedModelParams.data).reduce(
-        (acc, [key, value]) => {
-          return {
-            ...acc,
-            [key]: { value, enabled: true },
-          };
-        },
-        {} as UIModelParams,
-      );
-
       setModelParams((prev: UIModelParams) => ({
         ...prev,
-        ...modelConfig,
+        ...getEnabledModelParamState(parsedModelParams.data),
         provider: { value: provider, enabled: true },
         model: { value: model, enabled: true },
       }));

--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { Form } from "@/src/components/ui/form";
 import {
@@ -28,7 +28,11 @@ import { useEvaluatorDefaults } from "@/src/features/experiments/hooks/useEvalua
 import { useExperimentEvaluatorData } from "@/src/features/experiments/hooks/useExperimentEvaluatorData";
 import { useExperimentNameValidation } from "@/src/features/experiments/hooks/useExperimentNameValidation";
 import { useExperimentPromptData } from "@/src/features/experiments/hooks/useExperimentPromptData";
-import { getFinalModelParams } from "@/src/utils/getFinalModelParams";
+import {
+  getDisabledModelParamState,
+  getEnabledModelParamState,
+  getFinalModelParams,
+} from "@/src/utils/getFinalModelParams";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import {
@@ -97,6 +101,7 @@ export const MultiStepExperimentForm = ({
   const [selectedSchemaName, setSelectedSchemaName] = useState<string | null>(
     null,
   );
+  const lastAppliedPromptConfigId = useRef<string | null>(null);
 
   const steps = [
     { id: "prompt", label: "Prompt & Model" },
@@ -176,19 +181,76 @@ export const MultiStepExperimentForm = ({
   });
 
   const {
+    promptId: promptIdFromHook,
+    promptsByName,
+    expectedColumns,
+    selectedPromptModelConfig,
+  } = useExperimentPromptData({
+    projectId,
+    form,
+  });
+
+  const {
     modelParams,
+    setModelParams,
     updateModelParamValue,
     setModelParamEnabled,
     availableModels,
     providerModelCombinations,
     availableProviders,
-  } = useModelParams();
+    resolveProviderForModel,
+  } = useModelParams(undefined, {
+    promptConfigModel: selectedPromptModelConfig
+      ? {
+          ...(selectedPromptModelConfig.provider
+            ? { provider: selectedPromptModelConfig.provider }
+            : {}),
+          model: selectedPromptModelConfig.model,
+        }
+      : null,
+  });
 
   useExperimentNameValidation({
     projectId,
     datasetId,
     form,
   });
+
+  useEffect(() => {
+    if (!promptIdFromHook || !selectedPromptModelConfig) return;
+    if (lastAppliedPromptConfigId.current === promptIdFromHook) return;
+
+    const promptProvider = resolveProviderForModel(selectedPromptModelConfig);
+    if (!promptProvider) return;
+
+    if (
+      modelParams.provider.value !== promptProvider ||
+      modelParams.model.value !== selectedPromptModelConfig.model
+    ) {
+      setModelParams((prev) => ({
+        ...prev,
+        provider: { value: promptProvider, enabled: true },
+        model: { value: selectedPromptModelConfig.model, enabled: true },
+      }));
+      return;
+    }
+
+    lastAppliedPromptConfigId.current = promptIdFromHook;
+    setModelParams((prev) => ({
+      ...prev,
+      ...getDisabledModelParamState(prev),
+      ...getEnabledModelParamState(selectedPromptModelConfig.modelParams),
+      provider: { value: promptProvider, enabled: true },
+      model: { value: selectedPromptModelConfig.model, enabled: true },
+    }));
+  }, [
+    modelParams.model.value,
+    modelParams.provider.value,
+    promptIdFromHook,
+    resolveProviderForModel,
+    selectedPromptModelConfig,
+    setModelParams,
+  ]);
 
   // Watch model config changes and update form
   useEffect(() => {
@@ -203,15 +265,6 @@ export const MultiStepExperimentForm = ({
       form.clearErrors("modelConfig");
     }
   }, [modelParams, form]);
-
-  const {
-    promptId: promptIdFromHook,
-    promptsByName,
-    expectedColumns,
-  } = useExperimentPromptData({
-    projectId,
-    form,
-  });
 
   const experimentMutation = api.experiments.createExperiment.useMutation({
     onSuccess: handleExperimentSuccess ?? (() => {}),

--- a/web/src/features/experiments/components/MultiStepExperimentForm.tsx
+++ b/web/src/features/experiments/components/MultiStepExperimentForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Button } from "@/src/components/ui/button";
 import { Form } from "@/src/components/ui/form";
 import {
@@ -28,11 +28,7 @@ import { useEvaluatorDefaults } from "@/src/features/experiments/hooks/useEvalua
 import { useExperimentEvaluatorData } from "@/src/features/experiments/hooks/useExperimentEvaluatorData";
 import { useExperimentNameValidation } from "@/src/features/experiments/hooks/useExperimentNameValidation";
 import { useExperimentPromptData } from "@/src/features/experiments/hooks/useExperimentPromptData";
-import {
-  getDisabledModelParamState,
-  getEnabledModelParamState,
-  getFinalModelParams,
-} from "@/src/utils/getFinalModelParams";
+import { getFinalModelParams } from "@/src/utils/getFinalModelParams";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import {
@@ -101,7 +97,6 @@ export const MultiStepExperimentForm = ({
   const [selectedSchemaName, setSelectedSchemaName] = useState<string | null>(
     null,
   );
-  const lastAppliedPromptConfigId = useRef<string | null>(null);
 
   const steps = [
     { id: "prompt", label: "Prompt & Model" },
@@ -192,16 +187,15 @@ export const MultiStepExperimentForm = ({
 
   const {
     modelParams,
-    setModelParams,
     updateModelParamValue,
     setModelParamEnabled,
     availableModels,
     providerModelCombinations,
     availableProviders,
-    resolveProviderForModel,
   } = useModelParams(undefined, {
     promptConfigModel: selectedPromptModelConfig
       ? {
+          selectionKey: promptIdFromHook,
           ...(selectedPromptModelConfig.provider
             ? { provider: selectedPromptModelConfig.provider }
             : {}),
@@ -215,42 +209,6 @@ export const MultiStepExperimentForm = ({
     datasetId,
     form,
   });
-
-  useEffect(() => {
-    if (!promptIdFromHook || !selectedPromptModelConfig) return;
-    if (lastAppliedPromptConfigId.current === promptIdFromHook) return;
-
-    const promptProvider = resolveProviderForModel(selectedPromptModelConfig);
-    if (!promptProvider) return;
-
-    if (
-      modelParams.provider.value !== promptProvider ||
-      modelParams.model.value !== selectedPromptModelConfig.model
-    ) {
-      setModelParams((prev) => ({
-        ...prev,
-        provider: { value: promptProvider, enabled: true },
-        model: { value: selectedPromptModelConfig.model, enabled: true },
-      }));
-      return;
-    }
-
-    lastAppliedPromptConfigId.current = promptIdFromHook;
-    setModelParams((prev) => ({
-      ...prev,
-      ...getDisabledModelParamState(prev),
-      ...getEnabledModelParamState(selectedPromptModelConfig.modelParams),
-      provider: { value: promptProvider, enabled: true },
-      model: { value: selectedPromptModelConfig.model, enabled: true },
-    }));
-  }, [
-    modelParams.model.value,
-    modelParams.provider.value,
-    promptIdFromHook,
-    resolveProviderForModel,
-    selectedPromptModelConfig,
-    setModelParams,
-  ]);
 
   // Watch model config changes and update form
   useEffect(() => {

--- a/web/src/features/experiments/hooks/useExperimentPromptData.ts
+++ b/web/src/features/experiments/hooks/useExperimentPromptData.ts
@@ -6,7 +6,6 @@ import {
   PromptType,
   extractPlaceholderNames,
   type PromptMessage,
-  type ModelConfig,
   ZodModelConfig,
 } from "@langfuse/shared";
 import { z } from "zod/v4";
@@ -19,7 +18,6 @@ type ExperimentPromptDataProps = {
 export type ExperimentPromptModelConfig = {
   provider?: string;
   model: string;
-  modelParams: ModelConfig;
 };
 
 export function useExperimentPromptData({
@@ -96,10 +94,9 @@ const getPromptModelConfig = (
 
   if (!parsedConfig.success) return null;
 
-  const { provider, model, ...modelParams } = parsedConfig.data;
+  const { provider, model } = parsedConfig.data;
   return {
     ...(provider ? { provider } : {}),
     model,
-    modelParams,
   };
 };

--- a/web/src/features/experiments/hooks/useExperimentPromptData.ts
+++ b/web/src/features/experiments/hooks/useExperimentPromptData.ts
@@ -6,11 +6,20 @@ import {
   PromptType,
   extractPlaceholderNames,
   type PromptMessage,
+  type ModelConfig,
+  ZodModelConfig,
 } from "@langfuse/shared";
+import { z } from "zod/v4";
 
 type ExperimentPromptDataProps = {
   projectId: string;
   form: UseFormReturn<any>;
+};
+
+export type ExperimentPromptModelConfig = {
+  provider?: string;
+  model: string;
+  modelParams: ModelConfig;
 };
 
 export function useExperimentPromptData({
@@ -62,9 +71,35 @@ export function useExperimentPromptData({
     [promptMeta.data],
   );
 
+  const selectedPromptModelConfig = useMemo(() => {
+    const prompt = promptMeta.data?.find((p) => p.id === promptId);
+    return getPromptModelConfig(prompt?.config);
+  }, [promptId, promptMeta.data]);
+
   return {
     expectedColumns,
     promptsByName,
     promptId,
+    selectedPromptModelConfig,
   };
 }
+
+const PromptConfigSchema = ZodModelConfig.extend({
+  provider: z.string().min(1).optional(),
+  model: z.string().min(1),
+});
+
+const getPromptModelConfig = (
+  config: unknown,
+): ExperimentPromptModelConfig | null => {
+  const parsedConfig = PromptConfigSchema.safeParse(config);
+
+  if (!parsedConfig.success) return null;
+
+  const { provider, model, ...modelParams } = parsedConfig.data;
+  return {
+    ...(provider ? { provider } : {}),
+    model,
+    modelParams,
+  };
+};

--- a/web/src/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/features/playground/page/hooks/useModelParams.ts
@@ -11,6 +11,22 @@ import {
 import { type ModelParamsContext } from "@/src/components/ModelParameters";
 import { getModelNameKey, getModelProviderKey } from "../storage/keys";
 
+type PromptConfigModel = {
+  provider?: string;
+  model: string;
+};
+
+type UseModelParamsOptions = {
+  promptConfigModel?: PromptConfigModel | null;
+};
+
+type AvailableLlmApiKey = {
+  provider: string;
+  adapter: LLMAdapter;
+  customModels: string[];
+  withDefaultModels: boolean;
+};
+
 /**
  * Hook for managing model parameters with window isolation support
  * Supports both single-window and multi-window scenarios through window-specific localStorage keys
@@ -18,7 +34,10 @@ import { getModelNameKey, getModelProviderKey } from "../storage/keys";
  * @param windowId - Optional window identifier for state isolation. Defaults to "default" for backward compatibility
  * @returns Object with model parameters state and management functions
  */
-export const useModelParams = (windowId?: string) => {
+export const useModelParams = (
+  windowId?: string,
+  options?: UseModelParamsOptions,
+) => {
   const [modelParams, setModelParams] = useState<UIModelParams>({
     ...getDefaultAdapterParams(LLMAdapter.OpenAI),
     provider: { value: "", enabled: true },
@@ -46,40 +65,78 @@ export const useModelParams = (windowId?: string) => {
     string | null
   >(modelProviderKey, null);
 
+  const llmApiKeys = useMemo(
+    () => availableLLMApiKeys.data?.data ?? [],
+    [availableLLMApiKeys.data?.data],
+  );
+
   const availableProviders = useMemo(() => {
-    const adapter = availableLLMApiKeys.data?.data ?? [];
+    return llmApiKeys.map((key) => key.provider);
+  }, [llmApiKeys]);
 
-    return adapter.map((key) => key.provider) ?? [];
-  }, [availableLLMApiKeys.data?.data]);
-
-  const selectedProviderApiKey = availableLLMApiKeys.data?.data.find(
+  const selectedProviderApiKey = llmApiKeys.find(
     (key) => key.provider === modelParams.provider.value,
   );
 
-  const providerModelCombinations =
-    availableLLMApiKeys.data?.data.reduce((acc, v) => {
-      if (v.withDefaultModels) {
-        acc.push(
-          ...supportedModels[v.adapter].map((m) => `${v.provider}: ${m}`),
-        );
-      }
-      acc.push(...v.customModels.map((m) => `${v.provider}: ${m}`));
+  const resolveProviderForModel = useCallback(
+    ({ provider: providerOrAdapter, model }: PromptConfigModel) => {
+      const matchingApiKey = providerOrAdapter
+        ? (llmApiKeys.find(({ provider }) => provider === providerOrAdapter) ??
+          llmApiKeys.find(({ adapter }) => adapter === providerOrAdapter))
+        : llmApiKeys.find((apiKey) =>
+            getAvailableModels(apiKey).includes(model),
+          );
 
-      return acc;
-    }, [] as string[]) ?? [];
-
-  const availableModels = useMemo(
-    () =>
-      !selectedProviderApiKey
-        ? []
-        : selectedProviderApiKey.withDefaultModels
-          ? [
-              ...selectedProviderApiKey.customModels,
-              ...supportedModels[selectedProviderApiKey.adapter],
-            ]
-          : selectedProviderApiKey.customModels,
-    [selectedProviderApiKey],
+      return matchingApiKey?.provider;
+    },
+    [llmApiKeys],
   );
+
+  const promptConfigProvider = options?.promptConfigModel?.provider;
+  const promptConfigModel = options?.promptConfigModel?.model;
+  const resolvedPromptConfigProvider = promptConfigModel
+    ? resolveProviderForModel({
+        ...(promptConfigProvider ? { provider: promptConfigProvider } : {}),
+        model: promptConfigModel,
+      })
+    : undefined;
+
+  const providerModelCombinations = useMemo(() => {
+    const combinations =
+      llmApiKeys.reduce((acc, v) => {
+        if (v.withDefaultModels) {
+          acc.push(
+            ...supportedModels[v.adapter].map((m) => `${v.provider}: ${m}`),
+          );
+        }
+        acc.push(...v.customModels.map((m) => `${v.provider}: ${m}`));
+
+        return acc;
+      }, [] as string[]) ?? [];
+
+    if (resolvedPromptConfigProvider && promptConfigModel) {
+      combinations.push(
+        `${resolvedPromptConfigProvider}: ${promptConfigModel}`,
+      );
+    }
+
+    return [...new Set(combinations)];
+  }, [llmApiKeys, promptConfigModel, resolvedPromptConfigProvider]);
+
+  const availableModels = useMemo(() => {
+    if (!selectedProviderApiKey) return [];
+
+    const baseModels = getAvailableModels(selectedProviderApiKey);
+
+    const shouldAddModelFromPromptConfig =
+      resolvedPromptConfigProvider === selectedProviderApiKey.provider &&
+      promptConfigModel &&
+      !baseModels.includes(promptConfigModel);
+
+    return shouldAddModelFromPromptConfig
+      ? [...baseModels, promptConfigModel]
+      : baseModels;
+  }, [promptConfigModel, resolvedPromptConfigProvider, selectedProviderApiKey]);
 
   const updateModelParamValue = useCallback<
     ModelParamsContext["updateModelParamValue"]
@@ -214,6 +271,7 @@ export const useModelParams = (windowId?: string) => {
     updateModelParamValue,
     setModelParamEnabled,
     providerModelCombinations,
+    resolveProviderForModel,
   };
 };
 
@@ -308,3 +366,8 @@ function getDefaultAdapterParams(
       };
   }
 }
+
+const getAvailableModels = (apiKey: AvailableLlmApiKey): string[] =>
+  apiKey.withDefaultModels
+    ? [...apiKey.customModels, ...supportedModels[apiKey.adapter]]
+    : apiKey.customModels;

--- a/web/src/features/playground/page/hooks/useModelParams.ts
+++ b/web/src/features/playground/page/hooks/useModelParams.ts
@@ -12,19 +12,13 @@ import { type ModelParamsContext } from "@/src/components/ModelParameters";
 import { getModelNameKey, getModelProviderKey } from "../storage/keys";
 
 type PromptConfigModel = {
+  selectionKey?: string;
   provider?: string;
   model: string;
 };
 
 type UseModelParamsOptions = {
   promptConfigModel?: PromptConfigModel | null;
-};
-
-type AvailableLlmApiKey = {
-  provider: string;
-  adapter: LLMAdapter;
-  customModels: string[];
-  withDefaultModels: boolean;
 };
 
 /**
@@ -65,68 +59,68 @@ export const useModelParams = (
     string | null
   >(modelProviderKey, null);
 
-  const llmApiKeys = useMemo(
-    () => availableLLMApiKeys.data?.data ?? [],
-    [availableLLMApiKeys.data?.data],
-  );
-
   const availableProviders = useMemo(() => {
-    return llmApiKeys.map((key) => key.provider);
-  }, [llmApiKeys]);
+    const adapter = availableLLMApiKeys.data?.data ?? [];
 
-  const selectedProviderApiKey = llmApiKeys.find(
+    return adapter.map((key) => key.provider) ?? [];
+  }, [availableLLMApiKeys.data?.data]);
+
+  const selectedProviderApiKey = availableLLMApiKeys.data?.data.find(
     (key) => key.provider === modelParams.provider.value,
   );
 
-  const resolveProviderForModel = useCallback(
-    ({ provider: providerOrAdapter, model }: PromptConfigModel) => {
-      const matchingApiKey = providerOrAdapter
-        ? (llmApiKeys.find(({ provider }) => provider === providerOrAdapter) ??
-          llmApiKeys.find(({ adapter }) => adapter === providerOrAdapter))
-        : llmApiKeys.find((apiKey) =>
-            getAvailableModels(apiKey).includes(model),
-          );
-
-      return matchingApiKey?.provider;
-    },
-    [llmApiKeys],
-  );
-
+  const promptConfigSelectionKey = options?.promptConfigModel?.selectionKey;
   const promptConfigProvider = options?.promptConfigModel?.provider;
   const promptConfigModel = options?.promptConfigModel?.model;
-  const resolvedPromptConfigProvider = promptConfigModel
-    ? resolveProviderForModel({
-        ...(promptConfigProvider ? { provider: promptConfigProvider } : {}),
-        model: promptConfigModel,
-      })
-    : undefined;
+  const resolvedPromptConfigProvider = useMemo(() => {
+    if (!promptConfigModel) return undefined;
 
-  const providerModelCombinations = useMemo(() => {
-    const combinations =
-      llmApiKeys.reduce((acc, v) => {
-        if (v.withDefaultModels) {
-          acc.push(
-            ...supportedModels[v.adapter].map((m) => `${v.provider}: ${m}`),
-          );
-        }
-        acc.push(...v.customModels.map((m) => `${v.provider}: ${m}`));
+    const apiKeys = availableLLMApiKeys.data?.data ?? [];
+    const matchingApiKey = promptConfigProvider
+      ? (apiKeys.find(({ provider }) => provider === promptConfigProvider) ??
+        apiKeys.find(({ adapter }) => adapter === promptConfigProvider))
+      : apiKeys.find(({ adapter, customModels, withDefaultModels }) =>
+          (withDefaultModels
+            ? customModels.concat(supportedModels[adapter])
+            : customModels
+          ).includes(promptConfigModel),
+        );
 
-        return acc;
-      }, [] as string[]) ?? [];
+    return matchingApiKey?.provider;
+  }, [availableLLMApiKeys.data?.data, promptConfigModel, promptConfigProvider]);
 
-    if (resolvedPromptConfigProvider && promptConfigModel) {
-      combinations.push(
-        `${resolvedPromptConfigProvider}: ${promptConfigModel}`,
-      );
-    }
+  const providerModelCombinations =
+    availableLLMApiKeys.data?.data.reduce((acc, v) => {
+      if (v.withDefaultModels) {
+        acc.push(
+          ...supportedModels[v.adapter].map((m) => `${v.provider}: ${m}`),
+        );
+      }
+      acc.push(...v.customModels.map((m) => `${v.provider}: ${m}`));
 
-    return [...new Set(combinations)];
-  }, [llmApiKeys, promptConfigModel, resolvedPromptConfigProvider]);
+      return acc;
+    }, [] as string[]) ?? [];
+
+  const promptConfigProviderModelCombination =
+    resolvedPromptConfigProvider && promptConfigModel
+      ? `${resolvedPromptConfigProvider}: ${promptConfigModel}`
+      : undefined;
+
+  if (
+    promptConfigProviderModelCombination &&
+    !providerModelCombinations.includes(promptConfigProviderModelCombination)
+  ) {
+    providerModelCombinations.push(promptConfigProviderModelCombination);
+  }
 
   const availableModels = useMemo(() => {
     if (!selectedProviderApiKey) return [];
 
-    const baseModels = getAvailableModels(selectedProviderApiKey);
+    const baseModels = selectedProviderApiKey.withDefaultModels
+      ? selectedProviderApiKey.customModels.concat(
+          supportedModels[selectedProviderApiKey.adapter],
+        )
+      : selectedProviderApiKey.customModels;
 
     const shouldAddModelFromPromptConfig =
       resolvedPromptConfigProvider === selectedProviderApiKey.provider &&
@@ -223,6 +217,26 @@ export const useModelParams = (
     persistedModelName,
   ]);
 
+  useEffect(() => {
+    if (
+      !promptConfigSelectionKey ||
+      !resolvedPromptConfigProvider ||
+      !promptConfigModel
+    ) {
+      return;
+    }
+
+    setModelParams((prev) => ({
+      ...prev,
+      provider: { value: resolvedPromptConfigProvider, enabled: true },
+      model: { value: promptConfigModel, enabled: true },
+    }));
+  }, [
+    promptConfigSelectionKey,
+    promptConfigModel,
+    resolvedPromptConfigProvider,
+  ]);
+
   // Update adapter, max temperature, temperature, max_tokens, top_p when provider changes
   useEffect(() => {
     if (selectedProviderApiKey?.adapter) {
@@ -271,7 +285,6 @@ export const useModelParams = (
     updateModelParamValue,
     setModelParamEnabled,
     providerModelCombinations,
-    resolveProviderForModel,
   };
 };
 
@@ -366,8 +379,3 @@ function getDefaultAdapterParams(
       };
   }
 }
-
-const getAvailableModels = (apiKey: AvailableLlmApiKey): string[] =>
-  apiKey.withDefaultModels
-    ? [...apiKey.customModels, ...supportedModels[apiKey.adapter]]
-    : apiKey.customModels;

--- a/web/src/features/prompts/server/routers/promptRouter.ts
+++ b/web/src/features/prompts/server/routers/promptRouter.ts
@@ -1158,6 +1158,7 @@ export const promptRouter = createTRPCRouter({
           version: true,
           type: true,
           prompt: true,
+          config: true,
           labels: true,
         },
         where: {

--- a/web/src/utils/getFinalModelParams.tsx
+++ b/web/src/utils/getFinalModelParams.tsx
@@ -27,18 +27,3 @@ export function getEnabledModelParamState(
     {},
   );
 }
-
-export function getDisabledModelParamState(
-  modelParams: UIModelParams,
-): Partial<UIModelParams> {
-  return {
-    max_tokens: { ...modelParams.max_tokens, enabled: false },
-    temperature: { ...modelParams.temperature, enabled: false },
-    top_p: { ...modelParams.top_p, enabled: false },
-    maxReasoningTokens: {
-      ...modelParams.maxReasoningTokens,
-      enabled: false,
-    },
-    providerOptions: { ...modelParams.providerOptions, enabled: false },
-  };
-}

--- a/web/src/utils/getFinalModelParams.tsx
+++ b/web/src/utils/getFinalModelParams.tsx
@@ -1,4 +1,8 @@
-import { type ModelParams, type UIModelParams } from "@langfuse/shared";
+import {
+  type ModelConfig,
+  type ModelParams,
+  type UIModelParams,
+} from "@langfuse/shared";
 
 export function getFinalModelParams(modelParams: UIModelParams): ModelParams {
   return Object.entries(modelParams)
@@ -7,4 +11,34 @@ export function getFinalModelParams(modelParams: UIModelParams): ModelParams {
       (params, [key, value]) => ({ ...params, [key]: value.value }),
       {} as ModelParams,
     );
+}
+
+export function getEnabledModelParamState(
+  modelParams: ModelConfig,
+): Partial<UIModelParams> {
+  return Object.entries(modelParams).reduce<Partial<UIModelParams>>(
+    (state, [key, value]) =>
+      value === undefined
+        ? state
+        : {
+            ...state,
+            [key]: { value, enabled: true },
+          },
+    {},
+  );
+}
+
+export function getDisabledModelParamState(
+  modelParams: UIModelParams,
+): Partial<UIModelParams> {
+  return {
+    max_tokens: { ...modelParams.max_tokens, enabled: false },
+    temperature: { ...modelParams.temperature, enabled: false },
+    top_p: { ...modelParams.top_p, enabled: false },
+    maxReasoningTokens: {
+      ...modelParams.maxReasoningTokens,
+      enabled: false,
+    },
+    providerOptions: { ...modelParams.providerOptions, enabled: false },
+  };
 }


### PR DESCRIPTION
## Summary

- Use prompt config model settings when configuring an experiment from a prompt, including newly released model names that are not yet in Langfuse's built-in model list.
- Resolve prompt config providers against stored LLM connection providers first, then adapters, and fall back to model-only matching when no provider is configured.
- Preserve prompt-config generation params when provider adapter defaults are applied.

## Linear

- [LFE-9509](https://linear.app/langfuse/issue/LFE-9509/bug-cannot-run-experiments-with-newly-released-models)

## Major Decisions

- Kept runtime semantics aligned with experiment execution: the UI stores the matched LLM connection provider, while the adapter still comes from the stored connection.
- Supported flat prompt config values so configs like `{ "model": "gpt-4.1", "temperature": 0.2 }` can preselect model settings.

## Review Focus

- Provider resolution order in experiment setup: provider match, adapter match, then model-only match.
- Interaction between prompt-config params and adapter default model params.
- Scope of `useModelParams` changes for adding prompt-config models to the selectable model list.

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes experiment setup so that newly released models (not yet in Langfuse's built-in list) can be used when a prompt's `config` field contains model settings. It also hardens SSRF protection by making DNS-resolution failure a hard error, closing the DNS-rebinding gap for LLM base URL and image URL validation.

- **Prompt config model pre-selection**: `allPromptMeta` now returns `config`; `useExperimentPromptData` parses it via `ZodModelConfig.extend`; `useModelParams` gains a `promptConfigModel` option that injects the model into the selectable list and resolves its provider via a three-step lookup (stored provider \u2192 adapter name \u2192 model scan); a `useEffect` in `MultiStepExperimentForm` applies the resolved values to the form.
- **Adapter-default preservation**: The form effect depends on `modelParams.adapter.value` to re-apply prompt-config params after the adapter defaults are written, but this same dependency causes user-initiated provider changes to be silently reverted (see inline comment).
- **SSRF hardening**: Removes `shouldThrowIfDnsResolutionFails` flag; DNS failures now always throw; self-hosted gateways must be explicitly allowlisted.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The experiment form can be used but users who select a prompt with model config and then try to manually override the provider/model will find their change silently reverted.

The core model-resolution logic and SSRF hardening are sound. The main concern is in MultiStepExperimentForm: the useEffect that re-applies prompt config after adapter defaults uses modelParams.adapter.value as a dependency. This fires on every manual provider change, overriding the user's explicit selection without feedback. A user who wants to run the experiment with a different model than the one in the prompt config cannot do so once a prompt with model config is selected.

web/src/features/experiments/components/MultiStepExperimentForm.tsx — the useEffect dependency list at lines 229-235 needs a closer look for the adapter-change override scenario.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant Form as MultiStepExperimentForm
    participant EPD as useExperimentPromptData
    participant UMP as useModelParams
    participant API as promptRouter

    U->>Form: Select prompt with model config
    Form->>EPD: watch(promptId)
    EPD->>API: allPromptMeta.useQuery (now includes config)
    API-->>EPD: prompt meta + config
    EPD->>EPD: getPromptModelConfig(config)
    EPD-->>Form: selectedPromptModelConfig

    Form->>UMP: "useModelParams(options={promptConfigModel})"
    UMP->>UMP: resolveProviderForModel(promptConfigModel)
    note over UMP: 1) match by stored provider name<br/>2) match by adapter name<br/>3) match by model in available models
    UMP-->>Form: resolvedPromptConfigProvider, expanded providerModelCombinations

    Form->>Form: useEffect fires [promptId/config changed]
    Form->>UMP: setModelParams(promptProvider, model, modelParams)
    UMP->>UMP: adapter effect fires, applies adapter defaults
    UMP-->>Form: modelParams.adapter.value changed
    Form->>Form: useEffect re-fires [adapter.value dep]
    Form->>UMP: setModelParams again (prompt config params override adapter defaults)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/experiments/components/MultiStepExperimentForm.tsx:217-235
**Adapter change re-fires effect and overrides manual provider selection**

`modelParams.adapter.value` is included as a dependency so that prompt-config params survive the adapter-defaults reset, but it has an unintended consequence: any manual provider change the user makes in the UI triggers an adapter update (via the adapter effect in `useModelParams`), which fires this effect again, which calls `setModelParams` with the *prompt's* provider/model — silently reverting the user's choice.

The failure path is: (1) Prompt with model config selected → effect pre-fills provider/model. (2) User manually picks a different provider → adapter effect fires → `modelParams.adapter.value` changes. (3) This effect re-runs with `promptIdFromHook` and `selectedPromptModelConfig` still set, resolves the same `promptProvider`, and overwrites the user's selection.

A narrower fix would be to track whether the current adapter is already consistent with the prompt config and skip the re-apply on subsequent adapter changes, or handle the adapter-default timing with a single-pass merge inside `useModelParams`.

### Issue 2 of 2
web/src/features/playground/page/hooks/useModelParams.ts:95-102
`resolvedPromptConfigProvider` is recomputed on every render by calling `resolveProviderForModel` inline. Since `resolveProviderForModel` performs a linear scan through `llmApiKeys`, wrapping this in `useMemo` avoids the repeated work and makes the dependency tracking explicit for `providerModelCombinations` and `availableModels`.

```suggestion
  const promptConfigProvider = options?.promptConfigModel?.provider;
  const promptConfigModel = options?.promptConfigModel?.model;
  const resolvedPromptConfigProvider = useMemo(
    () =>
      promptConfigModel
        ? resolveProviderForModel({
            ...(promptConfigProvider ? { provider: promptConfigProvider } : {}),
            model: promptConfigModel,
          })
        : undefined,
    [promptConfigModel, promptConfigProvider, resolveProviderForModel],
  );
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): use prompt model config for ex..."](https://github.com/langfuse/langfuse/commit/6ed0457b821069e4b18b6f9e86fef439a3209100) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31580819)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->