### PR TITLE
ci: add semgrep PR security scan

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,43 @@
+---
+name: Semgrep
+
+on:
+  pull_request:
+    branches:
+      - "**"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Security scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      image: semgrep/semgrep:1.162.0@sha256:9349edbadf90c3f3c0c3f55867625354e89680e6fa10d9034042af52fdb0e0d0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run Semgrep
+        env:
+          BASELINE_COMMIT: ${{ github.event.pull_request.base.sha }}
+          SEMGREP_SEND_METRICS: "off"
+        run: |
+          semgrep scan \
+            --config p/default \
+            --baseline-commit "$BASELINE_COMMIT" \
+            --error


### PR DESCRIPTION
## Summary
- Add a Semgrep GitHub Actions workflow for pull requests.
- Run Semgrep CE scans on PR open/reopen/ready-for-review and every `synchronize` event, so each new PR commit is checked.
- Use the PR base SHA as a Semgrep baseline so the job fails on newly introduced findings instead of all historical findings.
- Use the explicit `p/default` Semgrep ruleset so metrics can remain disabled.
- Pin the Semgrep container image by digest and keep checkout credentials disabled.

## Impacted packages
- CI only: `.github/workflows/semgrep.yml`

## Validation
- `git diff --check -- .github/workflows/semgrep.yml`
- `actionlint v1.7.12 .github/workflows/semgrep.yml`
- `docker run --rm -e SEMGREP_SEND_METRICS=off -v /private/tmp/langfuse-semgrep-validate:/src -w /src semgrep/semgrep:1.162.0@sha256:9349edbadf90c3f3c0c3f55867625354e89680e6fa10d9034042af52fdb0e0d0 semgrep scan --config p/default --baseline-commit HEAD^ --error`

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new GitHub Actions workflow that runs Semgrep CE security scans on every pull request commit, using the PR's base SHA as a baseline so only newly introduced findings cause a failure.

- The Semgrep container image is pinned by digest (`sha256:9349edba…`) and `actions/checkout` is pinned to a commit SHA with `persist-credentials: false`, matching the hardening pattern already applied in `codeql.yml` and `zizmor.yml`.
- Metrics are suppressed via `SEMGREP_SEND_METRICS: \"off\"` and the explicit `p/default` ruleset is used instead of the default cloud-connected config, keeping the scan fully offline-capable.
- `fetch-depth: 0` is correctly set so the full history (including the base commit) is available for the `--baseline-commit` comparison.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a clean additive CI workflow with no changes to application code.

The workflow follows the same hardening conventions already in use across the repo: container and action SHA/digest pinning, persist-credentials: false, and minimal contents: read permissions. The baseline-commit approach correctly scopes failures to newly introduced findings, and fetch-depth: 0 ensures the full git history needed for that comparison is available. No application code is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([PR event\nopened / reopened\nsynchronize / ready_for_review]) --> B[Trigger semgrep.yml]
    B --> C{concurrency check}
    C -- previous run in-progress --> D[Cancel previous run]
    C -- no conflict --> E[Spin up semgrep container\nsemgrep/semgrep:1.162.0]
    D --> E
    E --> F[actions/checkout\nfetch-depth 0\npersist-credentials false]
    F --> G[Resolve BASELINE_COMMIT\ngithub.event.pull_request.base.sha]
    G --> H[semgrep scan\n--config p/default\n--baseline-commit BASELINE_COMMIT\n--error]
    H --> I{New findings\nsince base SHA?}
    I -- Yes --> J[Job fails / Block PR merge]
    I -- No --> K[Job passes]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add semgrep PR security scan"](https://github.com/langfuse/langfuse/commit/e262861cd3491a2fcee6501497e3459c438a3365) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31583214)</sub>

<!-- /greptile_comment -->