### PR TITLE
chore: document max scores limit behaviour on scores v2 API route

### DIFF
--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -18,7 +18,7 @@ service:
             docs: Page number, starts at 1.
           limit:
             type: optional<integer>
-            docs: Limit of items per page. If you encounter api issues due to too large page sizes, try to reduce the limit.
+            docs: Limit of items per page. Maximum 100. Defaults to 50. Requests with a limit greater than 100 return HTTP 400. If you encounter api issues due to too large page sizes, try to reduce the limit.
           userId:
             type: optional<string>
             docs: Retrieve only scores with this userId associated to the trace.

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -5285,8 +5285,9 @@ paths:
         - name: limit
           in: query
           description: >-
-            Limit of items per page. If you encounter api issues due to too
-            large page sizes, try to reduce the limit.
+            Limit of items per page. Maximum 100. Defaults to 50. Requests with
+            a limit greater than 100 return HTTP 400. If you encounter api
+            issues due to too large page sizes, try to reduce the limit.
           required: false
           schema:
             type: integer

--- a/web/src/__tests__/server/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v2.servertest.ts
@@ -1166,6 +1166,31 @@ describe("/api/public/v2/scores API Endpoint", () => {
         });
       });
 
+      describe("should validate pagination", () => {
+        it("rejects limit > 100 with HTTP 400", async () => {
+          expect.assertions(5);
+          try {
+            await makeZodVerifiedAPICall(
+              z.object({
+                message: z.string(),
+                error: z.array(z.object({})),
+              }),
+              "GET",
+              `/api/public/v2/scores?limit=101`,
+              undefined,
+              authentication,
+            );
+          } catch (error) {
+            const msg = (error as Error).message;
+            expect(msg).toContain("status 400");
+            expect(msg).toContain('"message":"Invalid request data"');
+            expect(msg).toContain('"path":["limit"]');
+            expect(msg).toContain('"code":"too_big"');
+            expect(msg).toContain('"maximum":100');
+          }
+        });
+      });
+
       it("should filter scores by score IDs", async () => {
         const getScore = await makeZodVerifiedAPICall(
           GetScoresResponseV2,


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents the existing `limit` parameter constraints for the `GET /api/public/v2/scores` endpoint — specifically that the maximum is 100, the default is 50, and exceeding 100 returns HTTP 400. The change updates both the Fern API definition source and the generated OpenAPI spec, and backs the documentation with a new integration test.

- Updated `limit` parameter docs in `fern/apis/server/definition/scores.yml` and the generated `openapi.yml` to state the maximum, default, and error behavior.
- Added a server integration test (`scores-api-v2.servertest.ts`) asserting that `limit=101` returns a 400 with Zod `too_big` error details, matching the `lte(100)` constraint already enforced by `publicApiPaginationZod`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are additive documentation and a test; no production logic is modified.

The PR only adds documentation and a test that exercises an existing Zod validation constraint (lte(100).default(50) in publicApiPaginationZod). The documented behavior was verified against the actual implementation and is accurate. The new test is correctly structured with expect.assertions(5) to guard against silent success.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ScoresV2Route as GET /api/public/v2/scores
    participant GetScoresQueryV2 as Zod Schema (GetScoresQueryV2)
    participant ScoresApiService

    Client->>ScoresV2Route: "GET ?limit=101"
    ScoresV2Route->>GetScoresQueryV2: "parse({ limit: 101 })"
    GetScoresQueryV2-->>ScoresV2Route: "ZodError (too_big, max=100)"
    ScoresV2Route-->>Client: "HTTP 400 { message: Invalid request data }"

    Client->>ScoresV2Route: "GET ?limit=50"
    ScoresV2Route->>GetScoresQueryV2: "parse({ limit: 50 })"
    GetScoresQueryV2-->>ScoresV2Route: "{ limit: 50 } valid"
    ScoresV2Route->>ScoresApiService: generateScoresForPublicApi(...)
    ScoresApiService-->>ScoresV2Route: [items, count]
    ScoresV2Route-->>Client: "HTTP 200 { data: [...], meta: { limit: 50 } }"

    Client->>ScoresV2Route: GET (no limit)
    ScoresV2Route->>GetScoresQueryV2: "parse({})"
    GetScoresQueryV2-->>ScoresV2Route: "{ limit: 50 } default applied"
    ScoresV2Route->>ScoresApiService: generateScoresForPublicApi(...)
    ScoresApiService-->>ScoresV2Route: [items, count]
    ScoresV2Route-->>Client: "HTTP 200 { data: [...], meta: { limit: 50 } }"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: document max scores limit behavio..."](https://github.com/langfuse/langfuse/commit/7512ba2b7904b8e600d8ed96e20c8dcfb5cdb887) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31586671)</sub>

<!-- /greptile_comment -->