### PR TITLE
fix(web): Table row spacing consistency

### DIFF
--- a/web/src/components/level-counts-display.tsx
+++ b/web/src/components/level-counts-display.tsx
@@ -19,7 +19,13 @@ export function LevelCountsDisplay({
   counts,
   isLoading,
 }: LevelCountsDisplayProps) {
-  if (isLoading) return <Skeleton className="h-3 w-1/2" />;
+  if (isLoading) {
+    return (
+      <div className="flex min-h-6 items-center">
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+    );
+  }
 
   const nonZeroCounts = counts.filter((item) => item.count > 0);
 

--- a/web/src/components/table/types.ts
+++ b/web/src/components/table/types.ts
@@ -6,26 +6,26 @@ export type TableRowOptions = {
   options: { label: string; value: number; icon?: LucideIcon }[];
 };
 
-// extends tanstack ColumnDef to include additional properties
-type ExtendedColumnDef<TData extends RowData, TValue = unknown> = ColumnDef<
-  TData,
-  TValue
-> & {
-  defaultHidden?: boolean;
-  headerTooltip?: {
-    description: React.ReactNode;
-    href?: string;
-  };
-  isFixedPosition?: boolean; // if true, column cannot be reordered
-  isPinnedLeft?: boolean; // if true, column will be pinned to left side
-  loadingCell?: React.ReactNode | (() => React.ReactNode);
-};
+declare module "@tanstack/react-table" {
+  // extends tanstack ColumnDef to include additional properties
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnDefBase<TData extends RowData, TValue = unknown> {
+    defaultHidden?: boolean;
+    headerTooltip?: {
+      description: React.ReactNode;
+      href?: string;
+    };
+    isFixedPosition?: boolean; // if true, column cannot be reordered
+    isPinnedLeft?: boolean; // if true, column will be pinned to left side
+    loadingCell?: React.ReactNode | (() => React.ReactNode);
+  }
+}
 
 // limits types of defined tanstack ColumnDef properties to specific subset of tanstack type union
 export type LangfuseColumnDef<
   TData extends RowData,
   TValue = unknown,
-> = ExtendedColumnDef<TData, TValue> & {
+> = ColumnDef<TData, TValue> & {
   // Enforce langfuse columns to be of type 'AccessorKeyColumnDefBase' with 'accessorKey' property of type string
   accessorKey: string;
   // Enforce langfuse group columns to have children of type 'LangfuseColumnDef'

--- a/web/src/features/batch-actions/components/BatchActionsTable.tsx
+++ b/web/src/features/batch-actions/components/BatchActionsTable.tsx
@@ -206,6 +206,7 @@ export function BatchActionsTable(props: { projectId: string }) {
         onChange: setPaginationState,
         state: paginationState,
       }}
+      cellPadding="comfortable"
     />
   );
 }

--- a/web/src/features/batch-exports/components/BatchExportsTable.tsx
+++ b/web/src/features/batch-exports/components/BatchExportsTable.tsx
@@ -247,6 +247,7 @@ export function BatchExportsTable(props: { projectId: string }) {
           onChange: setPaginationState,
           state: paginationState,
         }}
+        cellPadding="comfortable"
       />
     </>
   );

--- a/web/src/features/dashboard/components/DashboardTable.tsx
+++ b/web/src/features/dashboard/components/DashboardTable.tsx
@@ -243,7 +243,7 @@ export function DashboardTable() {
           <div onClick={(e) => e.stopPropagation()}>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost">
+                <Button size="xs" variant="ghost">
                   <MoreVertical className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
@@ -312,6 +312,7 @@ export function DashboardTable() {
           `/project/${projectId}/dashboards/${encodeURIComponent(row.id)}`,
         );
       }}
+      cellPadding="comfortable"
     />
   );
 }

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -64,6 +64,11 @@ import {
   useEvaluatorTableData,
 } from "@/src/features/evals/hooks/useEvaluatorTableData";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import {
+  TableBadgeLoadingCell,
+  TableIconButtonLoadingCell,
+  TableTextLoadingCell,
+} from "@/src/components/table/loading-cells";
 
 function LegacyBadgeCell({ status }: { status: string }) {
   return (
@@ -189,6 +194,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       header: "Status",
       id: "status",
       size: 80,
+      loadingCell: <TableBadgeLoadingCell />,
       cell: (row) => {
         const status = row.getValue();
         return (
@@ -233,6 +239,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       header: "Logs",
       id: "logs",
       size: 150,
+      loadingCell: <Skeleton className="h-6 w-16 rounded-md" />,
       cell: ({ row }) => {
         const id = row.original.id;
         return (
@@ -257,6 +264,12 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       id: "template",
       header: "Referenced Evaluator",
       size: 200,
+      loadingCell: (
+        <div className="flex items-center gap-2">
+          <TableTextLoadingCell className="w-32" />
+          <TableBadgeLoadingCell className="w-6" />
+        </div>
+      ),
       cell: ({ row }) => {
         const template = row.original.template;
         if (!template) return "template not found";
@@ -287,6 +300,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       header: "Eval Version",
       size: 180,
       enableHiding: true,
+      loadingCell: <TableBadgeLoadingCell />,
       cell: (row) => {
         const targetObject = row.row.original.target;
         const status = row.row.original.rawStatus;
@@ -354,6 +368,7 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
       header: "Actions",
       id: "actions",
       size: 100,
+      loadingCell: <TableIconButtonLoadingCell />,
       cell: ({ row }) => {
         const id = row.original.id;
         return (

--- a/web/src/features/prompts/components/prompts-table.tsx
+++ b/web/src/features/prompts/components/prompts-table.tsx
@@ -479,6 +479,7 @@ export function PromptTable() {
                 onChange: setPaginationAndFolderState,
                 state: paginationState,
               }}
+              cellPadding="comfortable"
             />
           </div>
         </ResizableFilterLayout>

--- a/web/src/features/widgets/components/WidgetTable.tsx
+++ b/web/src/features/widgets/components/WidgetTable.tsx
@@ -247,6 +247,7 @@ export function DashboardWidgetTable() {
       }
       orderBy={orderByState}
       setOrderBy={setOrderByState}
+      cellPadding="comfortable"
       pagination={{
         totalCount: widgets.data?.totalCount ?? null,
         onChange: setPaginationState,

--- a/web/src/pages/project/[projectId]/users.tsx
+++ b/web/src/pages/project/[projectId]/users.tsx
@@ -479,6 +479,7 @@ const UsersTable = ({ isBetaEnabled }: { isBetaEnabled: boolean }) => {
           onChange: setPaginationState,
           state: paginationState,
         }}
+        cellPadding="comfortable"
       />
     </>
   );


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR standardizes table row spacing by introducing `cellPadding="comfortable"` across several tables and fixes loading skeleton inconsistencies to prevent row height jumps during data fetches.

- **`cellPadding="comfortable"` added** to BatchActions, BatchExports, Dashboard, Prompts, Widget, and Users tables — applying uniform vertical padding (`p-1`) to all cells.
- **`types.ts` refactored** from a local `ExtendedColumnDef` intersection type to idiomatic `declare module "@tanstack/react-table"` module augmentation, making custom column properties (`loadingCell`, `defaultHidden`, etc.) available on all column def variants without extra type casting.
- **Evaluator table** gains per-column `loadingCell` skeletons for Status, Logs, Referenced Evaluator, Eval Version, and Actions columns; the per-row `isCostLoading` skeleton in the Total Cost cell is removed, leaving that column without a row-level loading indicator while the costs query is in-flight.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge for most tables; the only concern is the evaluator table's cost column, which will silently show "–" while cost data is still being fetched asynchronously after the main query returns.

The `isCostLoading` guard was the only visual cue that distinguishes a pending lazy cost fetch from a row with zero/no cost. Removing it means the Total Cost column in the Evaluator table briefly (or permanently on slow networks) displays "–" when the second costs query is still in-flight, which could mislead users into thinking an evaluator has no cost data.

web/src/features/evals/components/evaluator-table.tsx — the `totalCost` cell no longer has any per-row loading indicator while `isCostLoading` is true.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as EvaluatorTable
    participant EQ as evals.allConfigs query
    participant CQ as evals.costByEvaluatorIds query
    participant LC as useLazyEvaluatorExecutionCounts

    UI->>EQ: fetch evaluators
    EQ-->>UI: evaluators.data (isLoading → false)
    UI->>CQ: fetch costs (enabled after EQ success)
    UI->>LC: fetch execution counts (enabled after EQ success)
    Note over CQ: costs.data = undefined<br/>isCostLoading = true<br/>totalCost cells show "–" (was: skeleton)
    CQ-->>UI: costs.data populated
    LC-->>UI: execution counts populated
    Note over UI: All cells fully rendered
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/evals/components/evaluator-table.tsx:212-218
**Per-row cost loading state no longer indicated**

The removal of the `isCostLoading` guard means that while the costs query is still in-flight (a separate async request that fires after the main evaluators query), `totalCost` will be `undefined` and the cell will display `"–"`. Users cannot distinguish between "cost is still loading" and "there is genuinely no cost for this evaluator." The table-level `loadingCell` only fires during the initial full-table load, not during this per-row lazy fetch. `isCostLoading` is still set in `useEvaluatorTableData` (`!costs.data`), so the intent to track that state appears to remain — it is just no longer surfaced in the cell.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Table row spacing consistency"](https://github.com/langfuse/langfuse/commit/7ba5577fc16a71005ed7b8b2ad911ed398483c8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31591473)</sub>

<!-- /greptile_comment -->