### PR TITLE
fix(filters): fallback to key input on empty key options

### DIFF
--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -601,6 +601,13 @@ function FilterBuilderForm({
                     (filter.column !== undefined &&
                       c.aliases?.includes(filter.column)),
                 );
+                const keyOptions =
+                  column?.type === "numberObject" ||
+                  column?.type === "stringObject"
+                    ? column.keyOptions?.filter(
+                        (o) => NonEmptyString.safeParse(o).success,
+                      )
+                    : undefined;
                 return (
                   <tr key={i}>
                     <td className="p-1 text-sm">{i === 0 ? "Where" : "And"}</td>
@@ -720,7 +727,7 @@ function FilterBuilderForm({
                         filter.type === "stringObject") &&
                       (column?.type === "numberObject" ||
                         column?.type === "stringObject") ? (
-                        column.keyOptions ? (
+                        keyOptions?.length ? (
                           // Case 1: object with keyOptions - selector of the key of the object
                           <Select
                             disabled={!filter.column}
@@ -733,15 +740,11 @@ function FilterBuilderForm({
                               <SelectValue placeholder="" />
                             </SelectTrigger>
                             <SelectContent>
-                              {column.keyOptions
-                                .filter(
-                                  (o) => NonEmptyString.safeParse(o).success,
-                                )
-                                .map((option) => (
-                                  <SelectItem key={option} value={option}>
-                                    {option}
-                                  </SelectItem>
-                                ))}
+                              {keyOptions.map((option) => (
+                                <SelectItem key={option} value={option}>
+                                  {option}
+                                </SelectItem>
+                              ))}
                             </SelectContent>
                           </Select>
                         ) : (


### PR DESCRIPTION
Extracted from https://github.com/langfuse/langfuse/pull/13449

<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a UI edge case where a `numberObject` or `stringObject` filter column with `keyOptions` that are all empty strings (or an empty `keyOptions` array) would render an empty dropdown selector instead of falling back to a free-text key input.

- The `keyOptions` filtering (stripping invalid `NonEmptyString` entries) is extracted into a variable computed once per filter row instead of inline inside the `SelectContent`, avoiding repetition.
- The branch condition is changed from `column.keyOptions ?` to `keyOptions?.length ?`, so an empty or all-invalid options list correctly falls back to Case 2 (text input for the key).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a small, self-contained fix that only affects the key-selector rendering path for object-type filter columns.

The fix is minimal: it hoists the NonEmptyString filter into a derived variable and tightens the branch guard from a truthiness check on the raw array reference to a length check on the filtered result. Both paths (dropdown vs. text input) already existed and are unchanged in behavior; the only difference is that an empty keyOptions array no longer renders an empty dropdown.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Filter row rendered] --> B{filter.type is numberObject or stringObject?}
    B -- No --> C[Render other filter type UI]
    B -- Yes --> D[Compute keyOptions: filter column.keyOptions to NonEmptyString only]
    D --> E{keyOptions?.length > 0?}
    E -- Yes --> F[Case 1: Render Select dropdown with valid key options]
    E -- No / undefined --> G[Case 2: Render free-text Input for key]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(filters): fallback to key input on e..."](https://github.com/langfuse/langfuse/commit/4d427991285fa40781f784ca686f8ce70fe95b8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31596290)</sub>

<!-- /greptile_comment -->