### PR TITLE
fix(otel): recognize OpenInference llm.token_count.prompt_details.cache_read/cache_write

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2505,12 +2505,14 @@ export class OtelIngestionProcessor {
       rawUsageDetails["cache_read.input_tokens"] ??
       rawUsageDetails["cache_read_tokens"] ??
       rawUsageDetails["details.cache_read_tokens"] ??
-      rawUsageDetails["details.cache_read_input_tokens"];
+      rawUsageDetails["details.cache_read_input_tokens"] ??
+      rawUsageDetails["prompt_details.cache_read"];
     const cacheCreationTokens =
       rawUsageDetails["cache_creation.input_tokens"] ??
       rawUsageDetails["cache_write_tokens"] ??
       rawUsageDetails["details.cache_write_tokens"] ??
-      rawUsageDetails["details.cache_creation_input_tokens"];
+      rawUsageDetails["details.cache_creation_input_tokens"] ??
+      rawUsageDetails["prompt_details.cache_write"];
 
     const normalizedUsageDetails = Object.entries(rawUsageDetails).reduce(
       (acc: Record<string, number>, [key, value]) => {
@@ -2528,10 +2530,12 @@ export class OtelIngestionProcessor {
             "cache_read_tokens",
             "details.cache_read_tokens",
             "details.cache_read_input_tokens",
+            "prompt_details.cache_read",
             "cache_creation.input_tokens",
             "cache_write_tokens",
             "details.cache_write_tokens",
             "details.cache_creation_input_tokens",
+            "prompt_details.cache_write",
           ].includes(key)
         ) {
           return acc;

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -1985,6 +1985,111 @@ describe("OTel Resource Span Mapping", () => {
       expect(observationEvent?.body.usageDetails.output_audio_tokens).toBe(7);
     });
 
+    it("should extract OpenInference llm.token_count.prompt_details.cache_read/cache_write into input_cached_tokens / input_cache_creation", async () => {
+      // OpenInference semantic conventions (used by openinference-instrumentation-{openai,anthropic,agno,...})
+      // emit cache token counts under llm.token_count.prompt_details.cache_read and
+      // llm.token_count.prompt_details.cache_write. Langfuse must recognize these
+      // canonical names alongside the existing details.cache_read_* / cache_creation_* aliases.
+      const traceId = "abcdef0123456789abcdef0123456789";
+
+      const openinferenceCacheSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "telemetry.sdk.language",
+              value: { stringValue: "python" },
+            },
+            {
+              key: "service.name",
+              value: { stringValue: "test-agno" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "openinference.instrumentation.agno",
+              version: "0.1.27",
+              attributes: [],
+            },
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("a1b2c3d4e5f60718", "hex"),
+                name: "openinference-cache-test",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "llm.token_count.prompt",
+                    value: {
+                      intValue: { low: 50000, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "llm.token_count.completion",
+                    value: {
+                      intValue: { low: 200, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "llm.token_count.prompt_details.cache_read",
+                    value: {
+                      intValue: { low: 40000, high: 0, unsigned: false },
+                    },
+                  },
+                  {
+                    key: "llm.token_count.prompt_details.cache_write",
+                    value: {
+                      intValue: { low: 5000, high: 0, unsigned: false },
+                    },
+                  },
+                ],
+                events: [],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        openinferenceCacheSpan,
+        new Set(),
+      );
+
+      const observationEvent = events.find((e) => e.type === "span-create");
+
+      expect(observationEvent).toBeDefined();
+      // input must be the uncached remainder: prompt - cache_read - cache_write
+      // = 50000 - 40000 - 5000 = 5000
+      expect(observationEvent?.body.usageDetails.input).toBe(5000);
+      expect(observationEvent?.body.usageDetails.output).toBe(200);
+      expect(observationEvent?.body.usageDetails.input_cached_tokens).toBe(
+        40000,
+      );
+      expect(observationEvent?.body.usageDetails.input_cache_creation).toBe(
+        5000,
+      );
+      // The raw OpenInference keys must NOT be passed through after normalization
+      // (otherwise they would double-count in the UI breakdown).
+      expect(
+        observationEvent?.body.usageDetails["prompt_details.cache_read"],
+      ).toBeUndefined();
+      expect(
+        observationEvent?.body.usageDetails["prompt_details.cache_write"],
+      ).toBeUndefined();
+    });
+
     it("should prepend gen_ai.system_instructions to pydantic_ai.all_messages input when system message is absent", async () => {
       const traceId = "9d7aa9a729def1eadc0b2063ca4ebeb4";
 


### PR DESCRIPTION
## Summary

Adds `prompt_details.cache_read` and `prompt_details.cache_write` to the cache token resolver in `extractGenericGenAiUsageDetails` so cache tokens emitted by **openinference-instrumentation-{openai,anthropic,agno,…}** are normalized into Langfuse's canonical `input_cached_tokens` / `input_cache_creation` `usage_details` keys instead of being passed through as opaque raw keys.

Fixes langfuse/langfuse#13571 (partially addresses langfuse/langfuse#12635 — the OpenInference subset).

## Problem

Langfuse's OTel ingestion processor (`packages/shared/src/server/otel/OtelIngestionProcessor.ts::extractGenericGenAiUsageDetails`) has an allow-list of recognized cache-token sub-keys under the `gen_ai.usage.*` and `llm.token_count.*` namespaces:

```
cache_read.input_tokens
cache_read_tokens
details.cache_read_tokens
details.cache_read_input_tokens
cache_creation.input_tokens
cache_write_tokens
details.cache_write_tokens
details.cache_creation_input_tokens
```

The **canonical OpenInference names** are missing from this list:

* `llm.token_count.prompt_details.cache_read`
* `llm.token_count.prompt_details.cache_write`

These are defined in [`openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py:115,119`](<https://github.com/Arize-ai/openinference/blob/main/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L115-L119>) and emitted by every OpenInference instrumentor that supports prompt caching — confirmed in [openai](<https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-openai/src/openinference/instrumentation/openai/_response_attributes_extractor.py#L236>), [anthropic](<https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-anthropic/src/openinference/instrumentation/anthropic/_wrappers.py#L707>), and [agno](<https://github.com/Arize-ai/openinference/blob/main/python/instrumentation/openinference-instrumentation-agno/src/openinference/instrumentation/agno/_model_wrapper.py#L335-L342>).

### Observed impact

On a live production Langfuse v3.169.0 with `agno==2.5.15` + `openinference-instrumentation-agno`:

* Cache tokens DO arrive — `usageDetails` ends up with raw keys `prompt_details.cache_read: 40024`, `prompt_details.cache_write: 168`
* But because the resolver doesn't recognize them:
  1. `input` is NOT reduced by the cached amount
  2. They are NOT normalized to `input_cached_tokens` / `input_cache_creation`
  3. The cost engine's cache-aware pricing tiers in `worker/src/constants/default-model-prices.json` do NOT match them
  4. Result: \~30% cost under-report per cache-heavy observation on `claude-opus-4-6`

### Why fix it in Langfuse, not upstream

`llm.token_count.prompt_details.cache_read` is the **documented OpenInference semantic-convention name**, used identically by Arize Phoenix, Datadog, Honeycomb, and other backends. Renaming upstream would break those integrations. Adding the name to Langfuse's resolver is the contract-preserving fix.

## Changes

### `packages/shared/src/server/otel/OtelIngestionProcessor.ts`

Three single-line additions to `extractGenericGenAiUsageDetails`:

1. `cacheReadTokens` resolver — recognize `prompt_details.cache_read` as a fallback alongside the existing `cache_read*` aliases.
2. `cacheCreationTokens` resolver — recognize `prompt_details.cache_write`.
3. **Dedup allow-list** — add both keys so they don't double-emit into the normalized `usageDetails`.

### `web/src/__tests__/server/api/otel/otelMapping.servertest.ts`

One new test `should extract OpenInference llm.token_count.prompt_details.cache_read/cache_write into input_cached_tokens / input_cache_creation` that:

* Builds a span with `llm.token_count.prompt: 50000`, `llm.token_count.completion: 200`, `prompt_details.cache_read: 40000`, `prompt_details.cache_write: 5000`.
* Asserts `input = 5000` (uncached remainder = 50000 − 40000 − 5000).
* Asserts `output = 200`.
* Asserts `input_cached_tokens = 40000`, `input_cache_creation = 5000` (canonical names).
* Asserts the raw `prompt_details.cache_read` / `cache_write` keys are NOT passed through (would double-count in the UI breakdown).

Pattern-matched to PR [#12248](<https://github.com/langfuse/langfuse/issues/12248>) which did the same shape of fix for pydantic-ai.

## Diff size

```
packages/shared/src/server/otel/OtelIngestionProcessor.ts      |   8 +-
web/src/__tests__/server/api/otel/otelMapping.servertest.ts    | 109 +++++++++++++++++++++
2 files changed, 115 insertions(+), 2 deletions(-)
```

Production code change is 4 net lines (2 alias additions + 2 dedup entries). No behavior change for any existing integration — only additive recognition.

## Test plan

* `pnpm --filter=web test -- otelMapping.servertest.ts` exercises the new test plus all surrounding cache-token tests (including the existing pydantic-ai and Anthropic provider-metadata cases). Existing assertions remain green; the new test asserts the previously-failing OpenInference path now works.
* Verified locally that the diff is structurally identical to the merged PR pattern of [#12248](<https://github.com/langfuse/langfuse/issues/12248>) (pydantic-ai cache token resolver fix), which adopted the same approach.

## Related

* langfuse/langfuse#13571 — issue this PR fixes
* langfuse/langfuse#12635 — broader umbrella issue ("Support cache_read_input_tokens / cache_creation_input_tokens in OTEL generation spans"); this PR addresses the OpenInference subset
* [#12248](<https://github.com/langfuse/langfuse/issues/12248>) — `fix(otel): correct pydantic-ai v0.7.x+ cache token attribute names` — same structural pattern for pydantic-ai
* langfuse/langfuse#12994 — inflated token counts with OpenTelemetry Anthropic instrumentor + streaming + images (different code path; not addressed here)

## **Disclaimer**: Experimental PR review

<details><summary>Greptile Summary</summary>

This PR adds `prompt_details.cache_read` and `prompt_details.cache_write` to the OpenTelemetry cache token resolver in `extractGenericGenAiUsageDetails`, so spans emitted by OpenInference instrumentors (`openinference-instrumentation-openai`, `-anthropic`, `-agno`, etc.) are correctly normalized into Langfuse's canonical `input_cached_tokens` / `input_cache_creation` keys and the uncached `input` count is computed properly.

* `OtelIngestionProcessor.ts`: Two alias additions in the `cacheReadTokens`/`cacheCreationTokens` resolver chains (using `??` fallback) and two corresponding entries in the dedup allow-list to prevent raw key pass-through.
* `otelMapping.servertest.ts`: One new end-to-end test that sends a span with 50 000 prompt tokens, 40 000 `cache_read`, and 5 000 `cache_write`; asserts `input = 5000`, `input_cached_tokens = 40000`, `input_cache_creation = 5000`, and that raw keys are absent from the normalized output.

</details>

<details><summary>Confidence Score: 5/5</summary>

Safe to merge — the change is purely additive, touches only the fallback resolver chain, and has no effect on any existing integration.

The production change is four net lines: two new ?? fallback entries and two dedup list entries. The pattern is identical to the already-merged pydantic-ai fix. The new test exercises the full normalization path, including the deduction from the uncached input count and the absence of raw keys in the output. No existing test coverage is disturbed.

No files require special attention.

</details>

<details><summary>Flowchart</summary>

%%{init: {'theme': 'neutral'}}%% flowchart TD A\["OTel span attributes"\] --> B\["Strip prefix\\ngen_ai.usage.\* or llm.token_count.\*\\n→ rawUsageDetails"\] B --> C{"cacheReadTokens\\nresolver (??)"} C --> C1\["cache_read.input_tokens"\] C --> C2\["cache_read_tokens"\] C --> C3\["details.cache_read_tokens"\] C --> C4\["details.cache_read_input_tokens"\] C --> C5\["prompt_details.cache_read NEW"\] B --> D{"cacheCreationTokens\\nresolver (??)"} D --> D1\["cache_creation.input_tokens"\] D --> D2\["cache_write_tokens"\] D --> D3\["details.cache_write_tokens"\] D --> D4\["details.cache_creation_input_tokens"\] D --> D5\["prompt_details.cache_write NEW"\] C5 & C1 & C2 & C3 & C4 --> E\["cacheReadTokens"\] D5 & D1 & D2 & D3 & D4 --> F\["cacheCreationTokens"\] E --> G\["input = max(inputTokens - cacheRead - cacheCreation, 0)"\] F --> G E --> H\["input_cached_tokens"\] F --> I\["input_cache_creation"\] G --> J\["normalizedUsageDetails\\n(raw keys excluded by allow-list)"\] H --> J I --> J

</details>

Reviews (1): Last reviewed commit: ["fix(otel): recognize OpenInference promp..."](<https://github.com/langfuse/langfuse/commit/8059b81b588ec13c4069eb3d2077ad14e9c0ef66>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=31597427>)