### PR TITLE
refactor(web): Migrate more icons to `Spinner`

### DIFF
--- a/web/src/components/BatchExportTableButton.tsx
+++ b/web/src/components/BatchExportTableButton.tsx
@@ -8,7 +8,8 @@ import {
   DropdownMenuLabel,
 } from "@/src/components/ui/dropdown-menu";
 import { Button } from "@/src/components/ui/button";
-import { Download, Loader, Info } from "lucide-react";
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { Download, Info } from "lucide-react";
 import {
   type BatchExportTableName,
   exportOptions,
@@ -98,7 +99,7 @@ export const BatchExportTableButton: React.FC<BatchExportTableButtonProps> = (
       <DropdownMenuTrigger asChild>
         <Button variant="outline" size="icon" title="Export">
           {isExporting ? (
-            <Loader className="h-4 w-4 animate-spin" />
+            <Spinner size="sm" />
           ) : (
             <Download className="h-4 w-4" />
           )}

--- a/web/src/components/layouts/breadcrumb.tsx
+++ b/web/src/components/layouts/breadcrumb.tsx
@@ -13,13 +13,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/src/components/ui/dropdown-menu";
-import {
-  ChevronDownIcon,
-  LoaderCircle,
-  PlusIcon,
-  Settings,
-  Slash,
-} from "lucide-react";
+import { ChevronDownIcon, PlusIcon, Settings, Slash } from "lucide-react";
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
 import { Button } from "@/src/components/ui/button";
 import { env } from "@/src/env.mjs";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
@@ -36,7 +31,10 @@ import { Badge } from "@/src/components/ui/badge";
 
 const LoadingMenuItem = () => (
   <DropdownMenuItem>
-    <LoaderCircle className="mr-1.5 h-4 w-4 animate-spin" /> Loading...
+    <span className="mr-1.5 inline-flex">
+      <Spinner size="sm" />
+    </span>
+    Loading...
   </DropdownMenuItem>
 );
 

--- a/web/src/components/table/data-table-pagination.tsx
+++ b/web/src/components/table/data-table-pagination.tsx
@@ -15,7 +15,7 @@ import {
   SelectValue,
 } from "@/src/components/ui/select";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { LoaderCircle } from "lucide-react";
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
 import { Input } from "@/src/components/ui/input";
 import { useEffect, useState } from "react";
 
@@ -150,7 +150,9 @@ export function DataTablePagination<TData>({
                 <span>
                   of{" "}
                   {isLoading ? (
-                    <LoaderCircle className="text-muted-foreground ml-1 inline-block h-3 w-3 animate-spin" />
+                    <span className="ml-1 inline-flex align-middle">
+                      <Spinner size="xxs" variant="muted" display="inline" />
+                    </span>
                   ) : (
                     1
                   )}

--- a/web/src/features/comments/CommentList.tsx
+++ b/web/src/features/comments/CommentList.tsx
@@ -30,7 +30,8 @@ import { getRelativeTimestampFromNow } from "@/src/utils/dates";
 import { cn } from "@/src/utils/tailwind";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { type CommentObjectType, CreateCommentData } from "@langfuse/shared";
-import { ArrowUpToLine, LoaderCircle, Search, Trash, X } from "lucide-react";
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { ArrowUpToLine, Search, Trash, X } from "lucide-react";
 import { useSession } from "next-auth/react";
 import React, {
   useCallback,
@@ -476,7 +477,9 @@ export function CommentList({
           className,
         )}
       >
-        <LoaderCircle className="text-muted-foreground mr-1.5 h-4 w-4 animate-spin" />
+        <span className="mr-1.5 inline-flex">
+          <Spinner size="sm" variant="muted" />
+        </span>
         <span className="text-muted-foreground text-sm opacity-60">
           Loading comments...
         </span>

--- a/web/src/features/comments/components/MentionAutocomplete.tsx
+++ b/web/src/features/comments/components/MentionAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { LoaderCircle } from "lucide-react";
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
 import { Avatar, AvatarFallback } from "@/src/components/ui/avatar";
 import {
   Command,
@@ -68,7 +68,7 @@ export function MentionAutocomplete({
               role="status"
               aria-live="polite"
             >
-              <LoaderCircle className="h-4 w-4 animate-spin" />
+              <Spinner size="sm" />
               <span className="sr-only">Loading users...</span>
             </div>
           )}

--- a/web/src/features/score-analytics/components/ScoreAnalyticsProvider.tsx
+++ b/web/src/features/score-analytics/components/ScoreAnalyticsProvider.tsx
@@ -231,7 +231,7 @@ export function ScoreAnalyticsProvider({
  * function StatisticsCard() {
  *   const { data, colors, isLoading } = useScoreAnalytics();
  *
- *   if (isLoading) return <Loader />;
+ *   if (isLoading) return <Spinner size="sm" />;
  *   if (!data) return null;
  *
  *   return <div>Mean: {data.statistics.score1.mean}</div>;

--- a/web/src/features/table/components/TableActionMenu.tsx
+++ b/web/src/features/table/components/TableActionMenu.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { Button } from "@/src/components/ui/button";
-import { X, Trash, LoaderCircle } from "lucide-react";
+import { X, Trash } from "lucide-react";
 import { Plus } from "lucide-react";
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
 import {
   type TableAction,
   type CustomDialogTableAction,
@@ -67,7 +68,7 @@ export function TableActionMenu({
             {selectedCount !== null ? (
               <span> {`${numberFormatter(selectedCount, 0)} selected`}</span>
             ) : (
-              <LoaderCircle className="h-4 w-4 animate-spin" />
+              <Spinner size="sm" />
             )}
           </div>
           <Button


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR continues the design-system migration by replacing `Loader` and `LoaderCircle` from lucide-react with the internal `Spinner` component across seven files. Where the previous icons were used inline alongside text, the authors correctly wrap `Spinner` in an `inline-flex` span to preserve layout given the component's default `block` display.

- **Icon replacement**: `Loader`/`LoaderCircle` removed from six component files; replaced with `<Spinner size="sm" />` (or `size="xxs"` where a smaller indicator was needed).
- **Inline layout handling**: Files with inline-text loading states (`breadcrumb.tsx`, `CommentList.tsx`, `data-table-pagination.tsx`) add a wrapper `<span className="inline-flex">` to maintain correct flow, matching the previous `inline-block` behavior.
- **Doc-only change**: `ScoreAnalyticsProvider.tsx` updates a JSDoc example to reference `Spinner` instead of the old `Loader` name.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely a visual component swap with no logic changes.

Every replacement correctly maps the original icon size (h-4/w-4 → `size="sm"`, h-3/w-3 → `size="xxs"`) and preserves colour intent via the `variant="muted"` prop where needed. Inline-text contexts are handled with wrapper spans. The only nit is two unconsolidated `lucide-react` imports in `TableActionMenu.tsx`.

web/src/features/table/components/TableActionMenu.tsx has a duplicate lucide-react import that could be merged.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Loading state triggered] --> B{Inline text context?}
    B -- Yes --> C["Wrap: span.inline-flex"]
    C --> D["Spinner size='sm|xxs' variant='muted'?"]
    B -- No --> E["Spinner size='sm' directly in block container"]
    D --> F[Spinner renders Loader2 from lucide-react]
    E --> F
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/table/components/TableActionMenu.tsx:3-4
Two separate `lucide-react` import statements exist side by side. With `LoaderCircle` removed in this PR, this is a clean opportunity to merge them into one.

```suggestion
import { X, Trash, Plus } from "lucide-react";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Migrate more icons to"](https://github.com/langfuse/langfuse/commit/ef90cbf1c8797a9f6001c3af215b8908802da4d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31597727)</sub>

<!-- /greptile_comment -->