### PR TITLE
fix(tracing): Disable score columns by default in events table

### DIFF
--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -501,6 +501,7 @@ export default function ObservationsEventsTable({
       projectId,
       filter: scoreFilters.forObservations(),
       fromTimestamp: dateRange?.from,
+      defaultHidden: true,
     });
   const { scoreColumns: traceScoreColumns, isLoading: isTraceColumnLoading } =
     useScoreColumns<EventsTableRow>({
@@ -509,6 +510,7 @@ export default function ObservationsEventsTable({
       filter: scoreFilters.forTraceLevel(),
       fromTimestamp: dateRange?.from,
       prefix: "Trace",
+      defaultHidden: true,
     });
 
   const { selectActionColumn } = TableSelectionManager<EventsTableRow>({


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `defaultHidden: true` to both `useScoreColumns` calls in `EventsTable.tsx` so that observation-level and trace-level score columns are hidden by default in the events table.

- Both `scoreColumns` (for observations) and `traceScoreColumns` (for trace-level scores) now pass `defaultHidden: true` to the `useScoreColumns` hook, which already supported this parameter and propagates it to the underlying `LangfuseColumnDef`.
- The existing `useColumnVisibility` hook respects stored user preferences — if a user has previously made score columns visible, that choice is preserved in `localStorage` and will not be overridden by this change.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a safe, minimal change that hides score columns by default in the events table without affecting user-saved preferences.

The two-line addition uses a well-established, already-tested defaultHidden property that threads correctly through useScoreColumns → createScoreColumns → LangfuseColumnDef → useColumnVisibility. Existing users with stored visibility preferences are unaffected because useColumnVisibility checks localStorage before applying defaults.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EventsTable mounts] --> B[useScoreColumns - observations\ndefaultHidden: true]
    A --> C[useScoreColumns - trace level\ndefaultHidden: true]
    B --> D[createScoreColumns\nsets defaultHidden on each LangfuseColumnDef]
    C --> D
    D --> E[useColumnVisibility]
    E --> F{Key already in\nlocalStorage?}
    F -- Yes --> G[Preserve user preference\ncolumn may be visible]
    F -- No --> H[Apply defaultHidden\ncolumn hidden by default]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tracing): Disable score columns by d..."](https://github.com/langfuse/langfuse/commit/e27bc7e700babaef12a0eb6198b5c53e604f3797) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31617919)</sub>

<!-- /greptile_comment -->