### PR TITLE
fix(annotation): introduce conditional read from events table for batch action

### DIFF
--- a/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
+++ b/web/src/features/annotation-queues/server/annotationQueueItemsRouter.ts
@@ -59,7 +59,10 @@ const MAP_OBJECT_TYPE_TO_ACTION_PROPS: Record<
   },
   [AnnotationQueueObjectType.OBSERVATION]: {
     actionId: ActionId.ObservationAddToAnnotationQueue,
-    tableName: BatchExportTableName.Observations,
+    tableName:
+      env.LANGFUSE_ENABLE_EVENTS_TABLE_UI === "true"
+        ? BatchExportTableName.Events
+        : BatchExportTableName.Observations,
   },
 };
 
@@ -296,10 +299,7 @@ export const queueItemRouter = createTRPCRouter({
       let createdCount = 0;
 
       if (input.isBatchAction && input.query) {
-        const actionProps =
-          MAP_OBJECT_TYPE_TO_ACTION_PROPS[
-            input.objectType as "TRACE" | "SESSION"
-          ];
+        const actionProps = MAP_OBJECT_TYPE_TO_ACTION_PROPS[input.objectType];
         if (!actionProps) {
           throw new TRPCError({
             code: "BAD_REQUEST",

--- a/worker/src/__tests__/batchAction.test.ts
+++ b/worker/src/__tests__/batchAction.test.ts
@@ -672,6 +672,122 @@ describe("select all test suite", () => {
       expect(jobs).toHaveLength(0);
     });
   });
+
+  it("should add traces to annotation queue", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId1 = uuidv4();
+    const traceId2 = uuidv4();
+    const traces = [
+      createTrace({
+        project_id: projectId,
+        id: traceId1,
+        timestamp: new Date("2024-01-01").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: traceId2,
+        timestamp: new Date("2024-01-01").getTime(),
+      }),
+    ];
+
+    await createTracesCh(traces);
+
+    const queueId = uuidv4();
+    await prisma.annotationQueue.create({
+      data: {
+        id: queueId,
+        projectId,
+        name: "test-queue",
+      },
+    });
+
+    await handleBatchActionJob({
+      id: uuidv4(),
+      timestamp: new Date(),
+      name: QueueJobs.BatchActionProcessingJob as const,
+      payload: {
+        projectId,
+        actionId: "trace-add-to-annotation-queue" as const,
+        tableName: BatchExportTableName.Traces,
+        cutoffCreatedAt: new Date("2024-01-02"),
+        targetId: queueId,
+        query: { filter: [], orderBy: { column: "timestamp", order: "DESC" } },
+        type: BatchActionType.Create,
+      },
+    });
+
+    const queueItems = await prisma.annotationQueueItem.findMany({
+      where: { queueId, projectId },
+    });
+
+    expect(queueItems).toHaveLength(2);
+    const objectIds = queueItems.map((item) => item.objectId);
+    expect(objectIds).toContain(traceId1);
+    expect(objectIds).toContain(traceId2);
+    expect(queueItems.every((item) => item.objectType === "TRACE")).toBe(true);
+  });
+
+  it("should add sessions to annotation queue", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const sessionId1 = uuidv4();
+    const sessionId2 = uuidv4();
+
+    // Create traces with sessions
+    const traces = [
+      createTrace({
+        project_id: projectId,
+        id: uuidv4(),
+        session_id: sessionId1,
+        timestamp: new Date("2024-01-01").getTime(),
+      }),
+      createTrace({
+        project_id: projectId,
+        id: uuidv4(),
+        session_id: sessionId2,
+        timestamp: new Date("2024-01-01").getTime(),
+      }),
+    ];
+
+    await createTracesCh(traces);
+
+    const queueId = uuidv4();
+    await prisma.annotationQueue.create({
+      data: {
+        id: queueId,
+        projectId,
+        name: "test-queue",
+      },
+    });
+
+    await handleBatchActionJob({
+      id: uuidv4(),
+      timestamp: new Date(),
+      name: QueueJobs.BatchActionProcessingJob as const,
+      payload: {
+        projectId,
+        actionId: "session-add-to-annotation-queue" as const,
+        tableName: BatchExportTableName.Sessions,
+        cutoffCreatedAt: new Date("2024-01-02"),
+        targetId: queueId,
+        query: { filter: [], orderBy: { column: "createdAt", order: "DESC" } },
+        type: BatchActionType.Create,
+      },
+    });
+
+    const queueItems = await prisma.annotationQueueItem.findMany({
+      where: { queueId, projectId },
+    });
+
+    expect(queueItems).toHaveLength(2);
+    const objectIds = queueItems.map((item) => item.objectId);
+    expect(objectIds).toContain(sessionId1);
+    expect(objectIds).toContain(sessionId2);
+    expect(queueItems.every((item) => item.objectType === "SESSION")).toBe(
+      true,
+    );
+  });
 });
 
 maybeDescribe("events table batch actions", () => {
@@ -813,8 +929,8 @@ maybeDescribe("events table batch actions", () => {
     const event = createEvent({
       project_id: projectId,
       trace_id: traceId,
-      input: eventInput,
-      output: eventOutput,
+      input: JSON.stringify(eventInput),
+      output: JSON.stringify(eventOutput),
       metadata_names: Object.keys(eventMetadata),
       metadata_values: Object.values(eventMetadata),
     });
@@ -934,5 +1050,69 @@ maybeDescribe("events table batch actions", () => {
     });
     expect(updatedBatchAction?.status).toBe(BatchActionStatus.Completed);
     expect(updatedBatchAction?.processedCount).toBe(1);
+  });
+
+  it("should add observations to annotation queue from events table", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const traceId = uuidv4();
+    const trace = createTrace({
+      project_id: projectId,
+      id: traceId,
+      timestamp: new Date().getTime(),
+    });
+    await createTracesCh([trace]);
+
+    const event1 = createEvent({
+      project_id: projectId,
+      trace_id: traceId,
+      input: JSON.stringify({ prompt: "Hello" }),
+      output: JSON.stringify({ response: "Hi" }),
+    });
+    const event2 = createEvent({
+      project_id: projectId,
+      trace_id: traceId,
+      input: JSON.stringify({ prompt: "Goodbye" }),
+      output: JSON.stringify({ response: "Bye" }),
+    });
+
+    await createEventsCh([event1, event2]);
+
+    // Create annotation queue
+    const queueId = uuidv4();
+    await prisma.annotationQueue.create({
+      data: {
+        id: queueId,
+        projectId,
+        name: "test-queue",
+      },
+    });
+
+    await handleBatchActionJob({
+      id: uuidv4(),
+      timestamp: new Date(),
+      name: QueueJobs.BatchActionProcessingJob as const,
+      payload: {
+        projectId,
+        actionId: "observation-add-to-annotation-queue" as const,
+        tableName: BatchTableNames.Events,
+        cutoffCreatedAt: new Date(),
+        targetId: queueId,
+        query: { filter: [], orderBy: null },
+        type: BatchActionType.Create,
+      },
+    });
+
+    const queueItems = await prisma.annotationQueueItem.findMany({
+      where: { queueId, projectId },
+    });
+
+    expect(queueItems).toHaveLength(2);
+
+    const eventSpanIds = [event1.span_id, event2.span_id];
+    for (const item of queueItems) {
+      expect(eventSpanIds).toContain(item.objectId);
+      expect(item.objectType).toBe("OBSERVATION");
+    }
   });
 });

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -34,6 +34,7 @@ import { getObservationStream } from "../database-read-stream/observation-stream
 import {
   getEventsStreamForEval,
   getEventsStreamForDataset,
+  getEventsStreamForAnnotationQueue,
 } from "../database-read-stream/event-stream";
 import { processAddObservationsToDataset } from "./processAddObservationsToDataset";
 import { ObservationAddToDatasetConfigSchema } from "@langfuse/shared";
@@ -173,33 +174,29 @@ export const handleBatchActionJob = async (
       throw new Error(`Target ID is required for create action`);
     }
 
+    const streamParams = {
+      projectId: projectId,
+      cutoffCreatedAt: new Date(cutoffCreatedAt),
+      filter: convertDatesInFiltersFromStrings(query.filter ?? []),
+      searchQuery: query.searchQuery ?? undefined,
+      searchType: query.searchType ?? ["id" as const],
+    };
+
     const dbReadStream =
       actionId === "trace-delete"
         ? await getTraceIdentifierStream({
-            projectId: projectId,
-            cutoffCreatedAt: new Date(cutoffCreatedAt),
-            filter: convertDatesInFiltersFromStrings(query.filter ?? []),
+            ...streamParams,
             orderBy: query.orderBy,
-            searchQuery: query.searchQuery ?? undefined,
-            searchType: query.searchType ?? ["id" as const],
           })
-        : tableName === BatchTableNames.Observations
-          ? await getObservationStream({
-              projectId: projectId,
-              cutoffCreatedAt: new Date(cutoffCreatedAt),
-              filter: convertDatesInFiltersFromStrings(query.filter ?? []),
-              searchQuery: query.searchQuery ?? undefined,
-              searchType: query.searchType ?? ["id" as const],
-            })
-          : await getDatabaseReadStreamPaginated({
-              projectId: projectId,
-              cutoffCreatedAt: new Date(cutoffCreatedAt),
-              filter: convertDatesInFiltersFromStrings(query.filter ?? []),
-              orderBy: query.orderBy,
-              tableName: tableName as BatchTableNames,
-              searchQuery: query.searchQuery ?? undefined,
-              searchType: query.searchType ?? ["id" as const],
-            });
+        : tableName === BatchTableNames.Events
+          ? await getEventsStreamForAnnotationQueue(streamParams)
+          : tableName === BatchTableNames.Observations
+            ? await getObservationStream(streamParams)
+            : await getDatabaseReadStreamPaginated({
+                ...streamParams,
+                orderBy: query.orderBy,
+                tableName: tableName as BatchTableNames,
+              });
 
     // Process stream in database-sized batches
     // 1. Read all records

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -602,3 +602,109 @@ export const getEventsStreamForDataset = async (props: {
     })(),
   );
 };
+
+/**
+ * Lightweight event stream for batch add-to-annotation-queue.
+ * Only fetches the fields needed for annotation queue item creation:
+ * id, traceId.
+ */
+export const getEventsStreamForAnnotationQueue = async (props: {
+  projectId: string;
+  cutoffCreatedAt: Date;
+  filter: FilterCondition[] | null;
+  searchQuery?: string;
+  searchType?: TracingSearchType[];
+  rowLimit?: number;
+}): Promise<Readable> => {
+  const {
+    projectId,
+    cutoffCreatedAt,
+    filter = [],
+    searchQuery,
+    searchType,
+    rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
+  } = props;
+
+  const eventOnlyFilters = (filter ?? []).filter((f) => {
+    const columnDef = eventsTableUiColumnDefinitions.find(
+      (col) => col.uiTableName === f.column || col.uiTableId === f.column,
+    );
+
+    return (
+      columnDef?.clickhouseTableName !== "scores" &&
+      columnDef?.clickhouseTableName !== "comments"
+    );
+  });
+
+  const eventsFilter = new FilterList(
+    createFilterFromFilterState(
+      [
+        ...eventOnlyFilters,
+        {
+          column: "startTime",
+          operator: "<" as const,
+          value: cutoffCreatedAt,
+          type: "datetime" as const,
+        },
+      ],
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
+  );
+
+  const appliedEventsFilter = eventsFilter.apply();
+
+  const search = clickhouseSearchCondition(searchQuery, searchType, "e", [
+    "span_id",
+    "name",
+    "trace_name",
+    "user_id",
+    "session_id",
+    "trace_id",
+  ]);
+
+  const eventsQuery = new EventsQueryBuilder({ projectId })
+    .selectFieldSet("core")
+    .where(appliedEventsFilter)
+    .where(search)
+    .whereRaw("e.is_deleted = 0")
+    .orderByDefault()
+    .limitBy("e.span_id", "e.project_id")
+    .limit(rowLimit);
+
+  const { query, params: queryParams } = eventsQuery.buildWithParams();
+
+  type AnnotationQueueEventRow = {
+    id: string;
+    trace_id: string;
+  };
+
+  const asyncGenerator = queryClickhouseStream<AnnotationQueueEventRow>({
+    query,
+    params: queryParams,
+    clickhouseConfigs: {
+      request_timeout: 180_000,
+      clickhouse_settings: {
+        http_send_timeout: 300,
+        http_receive_timeout: 300,
+      },
+    },
+    tags: {
+      feature: "batch-add-to-annotation-queue",
+      type: "event",
+      kind: "annotation",
+      projectId,
+    },
+  });
+
+  return Readable.from(
+    (async function* () {
+      for await (const row of asyncGenerator) {
+        yield {
+          id: row.id,
+          traceId: row.trace_id,
+        };
+      }
+    })(),
+  );
+};


### PR DESCRIPTION
<!-- greptile_comment -->

**Disclaimer**: Experimental PR review
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the batch \"add to annotation queue\" action for observations when the events-table UI flag is enabled, routing the worker to a new lightweight ClickHouse stream (`getEventsStreamForAnnotationQueue`) instead of the legacy observations table. It also removes an incorrect type cast that previously prevented the OBSERVATION object type from reaching the action dispatch.

- **New `getEventsStreamForAnnotationQueue`**: Reads `span_id` (aliased as `id`) and `trace_id` from the events table, applying the same cutoff/filter/search logic used by other event streams and deduplicating with `LIMIT BY span_id, project_id`.
- **Conditional tableName routing**: In `annotationQueueItemsRouter`, the OBSERVATION entry now selects `BatchExportTableName.Events` when `LANGFUSE_ENABLE_EVENTS_TABLE_UI === \"true\"`, falling back to the Observations table otherwise.
- **New integration tests**: Adds coverage for trace, session, and events-based observation batch add-to-queue flows; fixes a pre-existing `JSON.stringify` omission in `createEvent` helper calls.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge for its intended use case; the new events-table observation path works correctly end-to-end as confirmed by the new integration tests.

The core logic — selecting the right ClickHouse stream and writing annotation queue items with the correct span_id — is sound and well-tested. The main concern is that the events-table branch in handleBatchActionJob dispatches to getEventsStreamForAnnotationQueue based solely on tableName, without an actionId guard. Any future action added to that if-block that also uses the events table would silently receive observation rows.

The stream-selection ladder in worker/src/features/batchAction/handleBatchActionJob.ts (lines 185-199) deserves a second look to consider adding an explicit actionId guard alongside the tableName check.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Batch Action Job observation-add-to-annotation-queue] --> B{LANGFUSE_ENABLE_EVENTS_TABLE_UI?}
    B -->|true| C[tableName = Events]
    B -->|false| D[tableName = Observations]
    C --> E{tableName === Events?}
    D --> F{tableName === Observations?}
    E -->|yes| G[getEventsStreamForAnnotationQueue reads span_id as id from ClickHouse events table]
    F -->|yes| H[getObservationStream reads from ClickHouse observations table]
    G --> I[Stream rows with id and traceId]
    H --> J[Stream rows with id]
    I --> K[processActionChunk processAddObservationsToQueue chunkIds = row.id = span_id]
    J --> K
    K --> L[(Postgres annotationQueueItem objectId = span_id)]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/batchAction/handleBatchActionJob.ts:191-199
**Events-table routing is not guarded to observation-only actions**

The new `tableName === BatchTableNames.Events` branch routes to `getEventsStreamForAnnotationQueue` without first verifying that `actionId` is `observation-add-to-annotation-queue`. If a future action (e.g., `score-delete`) is ever invoked with `tableName === BatchTableNames.Events`, this branch will silently use the wrong stream — reading observation rows by `span_id` and handing those IDs to the wrong processor. The `trace-delete` case is already protected because it is checked by `actionId` first; the same pattern should apply here.

### Issue 2 of 2
worker/src/features/database-read-stream/event-stream.ts:700-708
**`traceId` is yielded but never consumed downstream**

`processActionChunk` calls `processAddObservationsToQueue` with only `batch.map((r) => r.id)` — the `traceId` field yielded here is never read. Emitting unused fields is harmless, but it adds unnecessary noise to the stream type and may mislead future readers into thinking `traceId` is required by the consumer.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["tests: add"](https://github.com/langfuse/langfuse/commit/e886f7716fccbcf9cfbb32308887fd6bb9bdb527) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31733445)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->