### PR TITLE
fix(worker): log + throw on dataset_run_item lookup miss instead of silent drop

### DIFF
--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -426,7 +426,22 @@ export class IngestionService {
               }),
             ]);
 
-            if (!runData || !itemData) return [];
+            if (!runData || !itemData) {
+              logger.warn(
+                "Dropping dataset_run_item event: Postgres lookup miss",
+                {
+                  projectId,
+                  runId: event.body.runId,
+                  datasetId: event.body.datasetId,
+                  datasetItemId: event.body.datasetItemId,
+                  hasRunData: !!runData,
+                  hasItemData: !!itemData,
+                },
+              );
+              throw new Error(
+                `dataset_run_item lookup miss: hasRun=${!!runData} hasItem=${!!itemData} runId=${event.body.runId} datasetItemId=${event.body.datasetItemId}`,
+              );
+            }
 
             const timestamp = event.body.createdAt
               ? new Date(event.body.createdAt).getTime()


### PR DESCRIPTION
## What does this PR do?

Fixes #13592.

The `if (!runData || !itemData) return []` branch in `IngestionService.processDatasetRunItemEventList` silently discarded `dataset_run_item` ingestion events whenever the parallel Postgres lookup for either the dataset run or the dataset item returned null. No warning was logged, no retry was attempted, and `mergeAndWrite` returned successfully so BullMQ marked the job done. This produced permanent data loss under any Postgres latency variance or a brief race where the `dataset_run` row was not yet committed when the worker dequeued the event.

Symptom: dataset run pages in the UI showed "No results" even though the experiment had completed and the LLM traces had landed in ClickHouse `traces`. Confirmed against a self-hosted deployment running against an external Postgres — 131 `dataset_run_item` blobs in `blob_storage_file_log` but 0 rows in `dataset_run_items_rmt` for the same project. The same flow against an in-cluster Postgres produced a 1:1 match.

This change:

- Replaces the silent `return []` with a `logger.warn` carrying `projectId`, `runId`, `datasetId`, `datasetItemId`, `hasRunData`, and `hasItemData` — matching the structured-context logging style used in `processScoreEventList` (per @dosu's review on the issue).
- Throws an `Error` so the caller in `worker/src/queues/ingestionQueue.ts` (which already wraps `mergeAndWrite` in `try/catch` and rethrows) propagates the failure to BullMQ. BullMQ retries via its existing exponential backoff, so the common race-against-uncommitted-row case self-heals on the next attempt. On max-attempt exhaustion the job lands in the failed queue with the lookup-miss reason in the error message, where it's operator-visible instead of disappearing.

No behavior change for the happy path — the `runData`/`itemData` are both present in every successful ingestion today. The change only affects events that were previously being silently lost.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent data-loss bug in `processDatasetRunItemEventList` where a null Postgres lookup caused the event to be silently discarded (returning `[]` with no log, no retry). The fix replaces the silent drop with a `logger.warn` and a thrown error, letting BullMQ's retry/backoff mechanism handle transient race conditions.

- Replaces `return []` with a structured `logger.warn` + `throw new Error` so the failure is visible and retriable.
- The new throw propagates through `mergeAndWrite` and the existing `try/catch` in `ingestionQueue.ts`, which rethrows to BullMQ for exponential-backoff retries.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change correctly converts a silent data-loss path into a retriable failure, but the whole-batch retry semantics introduce a coupling issue where a single lookup miss in a multi-event batch blocks all healthy sibling events from being written to ClickHouse.

The core fix is sound and addresses real data loss. The blocking concern is the per-batch throw: if a batch carries multiple dataset_run_item events and one permanently fails its Postgres lookup (deleted run, permanently absent item), all other healthy events in that batch will also be blocked and eventually dropped when the job hits max retries. This is a regression for multi-event batches compared to the old behavior where only the one bad event was silently skipped and the rest wrote successfully.

worker/src/services/IngestionService/index.ts — specifically the per-event error handling inside the Promise.all map.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/services/IngestionService/index.ts:430-432
The `logger.warn` message says "Dropping dataset_run_item event" but the event is no longer being dropped — it is now being retried by BullMQ. An operator watching logs would see "Dropping" and conclude data is being silently lost, which is exactly the symptom this PR is fixing. The message should reflect the new retry semantics.

```suggestion
              logger.warn(
                "dataset_run_item Postgres lookup miss, scheduling BullMQ retry",
                {
```

### Issue 2 of 2
worker/src/services/IngestionService/index.ts:400-443
**Whole-batch retry on single-item miss**

`processDatasetRunItemEventList` processes a list of events via `Promise.all`. Throwing inside one callback rejects the outer `Promise.all`, so if a batch contains N events and only one has a lookup miss, the entire batch is retried. ClickHouse writes for the successful N-1 events are also deferred until the retry. This means under a sustained lookup-miss scenario (e.g. the row is permanently absent), the healthy events in the same batch will also never be written — they keep riding along on each failed retry cycle until max-attempts exhaustion drops the whole job. Worth documenting this coupling, or handling the per-event error so only the failing event is retried.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): log + throw on dataset\_run\_..."](https://github.com/langfuse/langfuse/commit/c21f8fde280e4457abae4468d66eb3b50125ab81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31761498)</sub>

<!-- /greptile_comment -->