### PR TITLE
fix(llm-api-keys): scope update by project id

### DIFF
--- a/web/src/__tests__/server/llm-api-key.servertest.ts
+++ b/web/src/__tests__/server/llm-api-key.servertest.ts
@@ -572,6 +572,49 @@ describe("llmApiKey.all RPC", () => {
     expect(updatedKeys[0].withDefaultModels).toBe(newWithDefaultModels);
   });
 
+  it("should scope the llm api key update write by project id", async () => {
+    const secret = "test-secret";
+    const provider = "openai";
+    const adapter = LLMAdapter.OpenAI;
+
+    await caller.llmApiKey.create({
+      projectId,
+      secretKey: secret,
+      provider,
+      adapter,
+    });
+
+    const existingKey = await prisma.llmApiKeys.findFirstOrThrow({
+      where: {
+        projectId,
+        provider,
+      },
+    });
+
+    const updateSpy = vi.spyOn(prisma.llmApiKeys, "update");
+
+    try {
+      await caller.llmApiKey.update({
+        id: existingKey.id,
+        projectId,
+        secretKey: "new-test-secret",
+        provider,
+        adapter,
+      });
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            id: existingKey.id,
+            projectId,
+          },
+        }),
+      );
+    } finally {
+      updateSpy.mockRestore();
+    }
+  });
+
   it("should update a Bedrock Access key auth to a Bedrock API key", async () => {
     const provider = "bedrock";
 

--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -711,7 +711,10 @@ export const llmApiKeyRouter = createTRPCRouter({
         }
 
         const key = await ctx.prisma.llmApiKeys.update({
-          where: { id: input.id },
+          where: {
+            id: input.id,
+            projectId: input.projectId,
+          },
           data: {
             ...(input.secretKey ? { secretKey: encrypt(input.secretKey) } : {}),
             extraHeaders: extraHeaders


### PR DESCRIPTION
## Summary

- Scope the `llmApiKeys.update` Prisma write by both `id` and `projectId`.
- Add server coverage that asserts the update mutation sends the tenant-scoped `where` clause to Prisma.

## Root Cause

`llmApiKeys.update` first loaded the existing key with `{ id, projectId }`, but the final Prisma update used only `{ id }`. Random key IDs prevented a practical cross-tenant write today, but the write path still lacked the defense-in-depth tenant filter tracked in [INT-1295](https://linear.app/langfuse/issue/INT-1295).

## Validation

- `pnpm exec dotenv -e ../.env.test -e ../.env -- vitest run src/__tests__/server/llm-api-key.servertest.ts --project server` from `web/`
- `pnpm --filter web run lint`
- `pnpm --filter web run typecheck`

Notes: after rebasing onto the latest `origin/main`, I refreshed dependencies and rebuilt `@langfuse/shared` before rerunning the focused test/typecheck because the new upstream commit changed workspace dependencies and shared generated `dist` inputs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a tenant-isolation gap in `llmApiKeys.update` where the Prisma `update` call used only `{ id }` in its `where` clause despite the preceding `findUnique` already filtering by `{ id, projectId }`. The fix adds `projectId` to the `update` `where` clause, bringing it in line with how `delete` and `findUnique` are already scoped in the same router.

- `router.ts`: `where: { id }` → `where: { id, projectId }` in the Prisma `update` call — one-line change that makes the write path consistent with all other writes/reads in the file.
- `llm-api-key.servertest.ts`: Adds a spy-based test asserting that the `update` mutation sends the tenant-scoped `where` clause to Prisma; the test covers the positive path but not the cross-tenant rejection case.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a one-line addition of `projectId` to the Prisma `update` `where` clause that aligns the write path with the existing `delete` and `findUnique` calls already scoped the same way.

The router fix is correct and minimal, and the delete/findUnique calls already use the same `{ id, projectId }` pattern. The new test validates the mutation's `where` clause shape via a spy, though it only covers the positive path; a cross-tenant rejection test would give stronger behavioral confidence.

The test file would benefit from a negative case asserting that an update attempt with a mismatched `projectId` returns `NOT_FOUND`.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant tRPC Router
    participant Prisma

    Client->>tRPC Router: llmApiKey.update({ id, projectId, ... })
    tRPC Router->>tRPC Router: throwIfNoProjectAccess({ projectId, scope: "llmApiKeys:update" })
    tRPC Router->>Prisma: llmApiKeys.findUnique({ where: { id, projectId } })
    Prisma-->>tRPC Router: existingKey (or null → NOT_FOUND)
    tRPC Router->>tRPC Router: Validate provider/adapter unchanged, encrypt secrets
    tRPC Router->>Prisma: llmApiKeys.update({ where: { id, projectId }, data: {...} })
    Note over tRPC Router,Prisma: After fix: projectId scopes the write
    Prisma-->>tRPC Router: updated key
    tRPC Router->>tRPC Router: auditLog(...)
    tRPC Router-->>Client: updated key
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/llm-api-key.servertest.ts:575-616
**Missing negative/cross-tenant test case**

The test verifies that the correct `where` clause is passed to Prisma (white-box spy), but does not assert the actual isolation behavior: a caller supplying a mismatched `projectId` should receive `NOT_FOUND` rather than silently updating a key it doesn't own. Without an end-to-end cross-tenant test, a future regression (e.g. the `projectId` filter being accidentally removed from the `where` clause) would not be caught by this suite — the spy would simply not exist to verify it. Adding a second `it` block that creates a key under one project and then attempts to update it with a different project's ID (expecting a `NOT_FOUND` TRPC error) would give full behavioral coverage.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(llm-api-keys): scope update by proje..."](https://github.com/langfuse/langfuse/commit/e4de23891a5f62f87c88568af1d2f3649677dd68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31765203)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->