### PR TITLE
chore: remove skill

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
                 return `["staging"]`
               }
               if (context.ref === "refs/heads/production") {
-                return `["prod-eu", "prod-us", "prod-hipaa", "prod-jp"]`
+                return `["prod-eu", "prod-us", "prod-hipaa", "prod-jps"]`
               }
             }
             return "[]"


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR renames the Japan production environment identifier from `prod-jp` to `prod-jps` in the automatic push-deploy path of the `deploy.yml` workflow. The PR title ("chore: remove skill") and description do not describe the actual change.

- The `workflow_dispatch` input option for the `environment` field still lists `prod-jp` (line 27), while the `production` branch push path now emits `prod-jps` — these two must be consistent since both feed the same downstream ECS deploy job.
- The environment string is used verbatim as the GitHub Actions environment name, the ECS cluster name (`prod-jps-cluster`), ECS service names, and task definition family names, so any drift between the configured AWS/GitHub resources and this string will cause silent deployment failures for that region.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

The single-line change introduces a name mismatch between the auto-deploy path and the manual dispatch options, which will cause production deployments to the Japan region to target a non-existent or mis-named environment on every push to `production`.

The rename from `prod-jp` to `prod-jps` is applied only in the push-triggered deploy path, while the `workflow_dispatch` option, the GitHub environment configuration, and all downstream AWS resource names (cluster, services, task definitions) are still tied to `prod-jp`. A push to the `production` branch will attempt to deploy to `prod-jps-cluster` and `prod-jps-*` ECS services/task definitions that very likely do not exist, breaking Japan-region production deployments silently or with an AWS error.

.github/workflows/deploy.yml — the `workflow_dispatch` environment options and all AWS resource names must be reconciled with whatever the correct environment identifier is (`prod-jp` or `prod-jps`).
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to branch] --> B{Which branch?}
    B -->|main| C[environments: staging]
    B -->|production| D["environments: prod-eu, prod-us, prod-hipaa, prod-jps ← changed"]
    E[workflow_dispatch] --> F["environment input (options: prod-jp ← unchanged)"]
    C --> G[ecs-deploy matrix]
    D --> G
    F --> G
    G --> H["environment: matrix.environment"]
    H --> I["GitHub Actions environment lookup"]
    H --> J["ECS cluster: env-cluster"]
    H --> K["ECS service: env-service"]
    H --> L["Task def family: env-service"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/deploy.yml:87
**Environment name mismatch between auto-deploy and `workflow_dispatch` options**

The auto-deploy path for the `production` branch now targets `prod-jps`, but the `workflow_dispatch` input options (line 27) still list `prod-jp`. The environment string feeds directly into the GitHub Actions environment name (`environment: ${{ inputs.environment }}`), the ECS cluster (`${{ inputs.environment }}-cluster`), ECS service (`${{ inputs.environment }}-${{ inputs.service }}`), and task definition family (`${{ inputs.environment }}-${{ inputs.service }}`). If `prod-jps` does not match a configured GitHub environment and the corresponding AWS resources, every push to `production` will fail to deploy to this environment. Conversely, if this is the intended new name, the `workflow_dispatch` option at line 27 must be updated from `prod-jp` to `prod-jps` so manual deploys remain consistent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove skill"](https://github.com/langfuse/langfuse/commit/7a9a8165c61494bd585c1b4ab6c4836f0716c736) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31764423)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->