### PR TITLE
feat(blob-export): expose exportSource and exportFieldGroups in public REST API

### DIFF
--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -61,6 +61,32 @@ types:
       - daily
       - weekly
 
+  ExportSource:
+    docs: |
+      What data the integration exports.
+      - `TRACES_OBSERVATIONS`: legacy traces + observations + scores tables with a fixed column set. The `exportFieldGroups` field is not applicable.
+      - `EVENTS`: enriched observations_v2 events; columns are controlled by `exportFieldGroups`.
+      - `TRACES_OBSERVATIONS_EVENTS`: both sets. For the `EVENTS` portion, columns are controlled by `exportFieldGroups`.
+    enum:
+      - EVENTS
+      - TRACES_OBSERVATIONS
+      - TRACES_OBSERVATIONS_EVENTS
+
+  ExportFieldGroup:
+    docs: Field group for the EVENTS export.
+    enum:
+      - core
+      - basic
+      - time
+      - io
+      - metadata
+      - model
+      - usage
+      - prompt
+      - metrics
+      - tools
+      - trace_context
+
   CreateBlobStorageIntegrationRequest:
     properties:
       projectId:
@@ -100,6 +126,19 @@ types:
       compressed:
         type: optional<boolean>
         docs: Enable gzip compression for exported files (.csv.gz, .json.gz, .jsonl.gz). Defaults to true.
+      exportSource:
+        type: optional<ExportSource>
+        docs: |
+          Data to export. Defaults to `TRACES_OBSERVATIONS` when omitted (matches the column default).
+
+      exportFieldGroups:
+        type: optional<list<ExportFieldGroup>>
+        docs: |
+          Field groups to include in each exported row.
+
+          For exportSource `EVENTS` or `TRACES_OBSERVATIONS_EVENTS`: optional; defaults to all groups when omitted. Must include `core` if provided.
+
+          For exportSource `TRACES_OBSERVATIONS`: this field must be omitted or null. Sending an array (including an empty array) returns 400, because that source uses a fixed column set and does not honor field groups.
 
   BlobStorageIntegrationResponse:
     properties:
@@ -118,6 +157,11 @@ types:
       exportMode: BlobStorageExportMode
       exportStartDate: nullable<datetime>
       compressed: boolean
+      exportSource: ExportSource
+      exportFieldGroups:
+        type: nullable<list<ExportFieldGroup>>
+        docs: |
+          Field groups included in each exported row for `EVENTS` / `TRACES_OBSERVATIONS_EVENTS` sources. Always `null` when exportSource is `TRACES_OBSERVATIONS` (the field does not apply to that source; any legacy DB value is hidden from the public surface).
       nextSyncAt: nullable<datetime>
       lastSyncAt: nullable<datetime>
       lastError: nullable<string>

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -129,16 +129,18 @@ types:
       exportSource:
         type: optional<ExportSource>
         docs: |
-          Data to export. Defaults to `TRACES_OBSERVATIONS` when omitted (matches the column default).
+          Data to export. When omitted on update, the existing value is preserved; when omitted on create, the column default (`TRACES_OBSERVATIONS`) applies. Required when `exportFieldGroups` is provided.
 
       exportFieldGroups:
         type: optional<list<ExportFieldGroup>>
         docs: |
           Field groups to include in each exported row.
 
-          For exportSource `EVENTS` or `TRACES_OBSERVATIONS_EVENTS`: optional; defaults to all groups when omitted. Must include `core` if provided.
+          For exportSource `EVENTS` or `TRACES_OBSERVATIONS_EVENTS`: must include `core` if provided. When omitted on create, the column default (all groups) applies. When omitted on update, the existing value is preserved.
 
           For exportSource `TRACES_OBSERVATIONS`: this field must be omitted or null. Sending an array (including an empty array) returns 400, because that source uses a fixed column set and does not honor field groups.
+
+          `exportFieldGroups` requires `exportSource` to be provided in the same request.
 
   BlobStorageIntegrationResponse:
     properties:

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -67,6 +67,8 @@ types:
       - `TRACES_OBSERVATIONS`: legacy traces + observations + scores tables with a fixed column set. The `exportFieldGroups` field is not applicable.
       - `EVENTS`: enriched observations_v2 events; columns are controlled by `exportFieldGroups`.
       - `TRACES_OBSERVATIONS_EVENTS`: both sets. For the `EVENTS` portion, columns are controlled by `exportFieldGroups`.
+
+      **Note:** `EVENTS` and the events portion of `TRACES_OBSERVATIONS_EVENTS` rely on the observations_v2 events table (Langfuse Fast Preview / v4), which is currently available on Langfuse Cloud only. See https://langfuse.com/docs/v4.
     enum:
       - EVENTS
       - TRACES_OBSERVATIONS

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -61,7 +61,7 @@ types:
       - daily
       - weekly
 
-  ExportSource:
+  BlobStorageExportSource:
     docs: |
       What data the integration exports.
       - `TRACES_OBSERVATIONS`: legacy traces + observations + scores tables with a fixed column set. The `exportFieldGroups` field is not applicable.
@@ -74,7 +74,7 @@ types:
       - TRACES_OBSERVATIONS
       - TRACES_OBSERVATIONS_EVENTS
 
-  ExportFieldGroup:
+  BlobStorageExportFieldGroup:
     docs: Field group for the EVENTS export.
     enum:
       - core
@@ -129,12 +129,12 @@ types:
         type: optional<boolean>
         docs: Enable gzip compression for exported files (.csv.gz, .json.gz, .jsonl.gz). Defaults to true.
       exportSource:
-        type: optional<ExportSource>
+        type: optional<BlobStorageExportSource>
         docs: |
           Data to export. When omitted on update, the existing value is preserved; when omitted on create, the column default (`TRACES_OBSERVATIONS`) applies. Required when `exportFieldGroups` is provided.
 
       exportFieldGroups:
-        type: optional<list<ExportFieldGroup>>
+        type: optional<list<BlobStorageExportFieldGroup>>
         docs: |
           Field groups to include in each exported row.
 
@@ -161,9 +161,9 @@ types:
       exportMode: BlobStorageExportMode
       exportStartDate: nullable<datetime>
       compressed: boolean
-      exportSource: ExportSource
+      exportSource: BlobStorageExportSource
       exportFieldGroups:
-        type: nullable<list<ExportFieldGroup>>
+        type: nullable<list<BlobStorageExportFieldGroup>>
         docs: |
           Field groups included in each exported row for `EVENTS` / `TRACES_OBSERVATIONS_EVENTS` sources. Always `null` when exportSource is `TRACES_OBSERVATIONS` (the field does not apply to that source; any legacy DB value is hidden from the public surface).
       nextSyncAt: nullable<datetime>

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7248,8 +7248,8 @@ components:
         - hourly
         - daily
         - weekly
-    ExportSource:
-      title: ExportSource
+    BlobStorageExportSource:
+      title: BlobStorageExportSource
       type: string
       enum:
         - EVENTS
@@ -7273,8 +7273,8 @@ components:
         `TRACES_OBSERVATIONS_EVENTS` rely on the observations_v2 events table
         (Langfuse Fast Preview / v4), which is currently available on Langfuse
         Cloud only. See https://langfuse.com/docs/v4.
-    ExportFieldGroup:
-      title: ExportFieldGroup
+    BlobStorageExportFieldGroup:
+      title: BlobStorageExportFieldGroup
       type: string
       enum:
         - core
@@ -7352,7 +7352,7 @@ components:
             Enable gzip compression for exported files (.csv.gz, .json.gz,
             .jsonl.gz). Defaults to true.
         exportSource:
-          $ref: '#/components/schemas/ExportSource'
+          $ref: '#/components/schemas/BlobStorageExportSource'
           nullable: true
           description: >-
             Data to export. When omitted on update, the existing value is
@@ -7362,7 +7362,7 @@ components:
         exportFieldGroups:
           type: array
           items:
-            $ref: '#/components/schemas/ExportFieldGroup'
+            $ref: '#/components/schemas/BlobStorageExportFieldGroup'
           nullable: true
           description: >-
             Field groups to include in each exported row.
@@ -7431,11 +7431,11 @@ components:
         compressed:
           type: boolean
         exportSource:
-          $ref: '#/components/schemas/ExportSource'
+          $ref: '#/components/schemas/BlobStorageExportSource'
         exportFieldGroups:
           type: array
           items:
-            $ref: '#/components/schemas/ExportFieldGroup'
+            $ref: '#/components/schemas/BlobStorageExportFieldGroup'
           nullable: true
           description: >-
             Field groups included in each exported row for `EVENTS` /

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7349,8 +7349,10 @@ components:
           $ref: '#/components/schemas/ExportSource'
           nullable: true
           description: >-
-            Data to export. Defaults to `TRACES_OBSERVATIONS` when omitted
-            (matches the column default).
+            Data to export. When omitted on update, the existing value is
+            preserved; when omitted on create, the column default
+            (`TRACES_OBSERVATIONS`) applies. Required when `exportFieldGroups`
+            is provided.
         exportFieldGroups:
           type: array
           items:
@@ -7360,15 +7362,20 @@ components:
             Field groups to include in each exported row.
 
 
-            For exportSource `EVENTS` or `TRACES_OBSERVATIONS_EVENTS`: optional;
-            defaults to all groups when omitted. Must include `core` if
-            provided.
+            For exportSource `EVENTS` or `TRACES_OBSERVATIONS_EVENTS`: must
+            include `core` if provided. When omitted on create, the column
+            default (all groups) applies. When omitted on update, the existing
+            value is preserved.
 
 
             For exportSource `TRACES_OBSERVATIONS`: this field must be omitted
             or null. Sending an array (including an empty array) returns 400,
             because that source uses a fixed column set and does not honor field
             groups.
+
+
+            `exportFieldGroups` requires `exportSource` to be provided in the
+            same request.
       required:
         - projectId
         - type

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7244,9 +7244,45 @@ components:
       title: BlobStorageExportFrequency
       type: string
       enum:
+        - every_20_minutes
         - hourly
         - daily
         - weekly
+    ExportSource:
+      title: ExportSource
+      type: string
+      enum:
+        - EVENTS
+        - TRACES_OBSERVATIONS
+        - TRACES_OBSERVATIONS_EVENTS
+      description: >-
+        What data the integration exports.
+
+        - `TRACES_OBSERVATIONS`: legacy traces + observations + scores tables
+        with a fixed column set. The `exportFieldGroups` field is not
+        applicable.
+
+        - `EVENTS`: enriched observations_v2 events; columns are controlled by
+        `exportFieldGroups`.
+
+        - `TRACES_OBSERVATIONS_EVENTS`: both sets. For the `EVENTS` portion,
+        columns are controlled by `exportFieldGroups`.
+    ExportFieldGroup:
+      title: ExportFieldGroup
+      type: string
+      enum:
+        - core
+        - basic
+        - time
+        - io
+        - metadata
+        - model
+        - usage
+        - prompt
+        - metrics
+        - tools
+        - trace_context
+      description: Field group for the EVENTS export.
     CreateBlobStorageIntegrationRequest:
       title: CreateBlobStorageIntegrationRequest
       type: object
@@ -7309,6 +7345,30 @@ components:
           description: >-
             Enable gzip compression for exported files (.csv.gz, .json.gz,
             .jsonl.gz). Defaults to true.
+        exportSource:
+          $ref: '#/components/schemas/ExportSource'
+          nullable: true
+          description: >-
+            Data to export. Defaults to `TRACES_OBSERVATIONS` when omitted
+            (matches the column default).
+        exportFieldGroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExportFieldGroup'
+          nullable: true
+          description: >-
+            Field groups to include in each exported row.
+
+
+            For exportSource `EVENTS` or `TRACES_OBSERVATIONS_EVENTS`: optional;
+            defaults to all groups when omitted. Must include `core` if
+            provided.
+
+
+            For exportSource `TRACES_OBSERVATIONS`: this field must be omitted
+            or null. Sending an array (including an empty array) returns 400,
+            because that source uses a fixed column set and does not honor field
+            groups.
       required:
         - projectId
         - type
@@ -7357,6 +7417,18 @@ components:
           nullable: true
         compressed:
           type: boolean
+        exportSource:
+          $ref: '#/components/schemas/ExportSource'
+        exportFieldGroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExportFieldGroup'
+          nullable: true
+          description: >-
+            Field groups included in each exported row for `EVENTS` /
+            `TRACES_OBSERVATIONS_EVENTS` sources. Always `null` when
+            exportSource is `TRACES_OBSERVATIONS` (the field does not apply to
+            that source; any legacy DB value is hidden from the public surface).
         nextSyncAt:
           type: string
           format: date-time
@@ -7391,6 +7463,7 @@ components:
         - fileType
         - exportMode
         - compressed
+        - exportSource
         - createdAt
         - updatedAt
     BlobStorageIntegrationsResponse:
@@ -7432,9 +7505,9 @@ components:
         Compare `lastSyncAt` against your
 
         ETL bookmark to determine if new data is available. Note that exports
-        run with a 30-minute lag buffer,
+        run with a 20-minute lag buffer,
 
-        so `lastSyncAt` will always be at least 30 minutes behind real-time.
+        so `lastSyncAt` will always be at least 20 minutes behind real-time.
     BlobStorageIntegrationStatusResponse:
       title: BlobStorageIntegrationStatusResponse
       type: object

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7267,6 +7267,12 @@ components:
 
         - `TRACES_OBSERVATIONS_EVENTS`: both sets. For the `EVENTS` portion,
         columns are controlled by `exportFieldGroups`.
+
+
+        **Note:** `EVENTS` and the events portion of
+        `TRACES_OBSERVATIONS_EVENTS` rely on the observations_v2 events table
+        (Langfuse Fast Preview / v4), which is currently available on Langfuse
+        Cloud only. See https://langfuse.com/docs/v4.
     ExportFieldGroup:
       title: ExportFieldGroup
       type: string

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -29,13 +29,12 @@ const BlobStorageIntegrationResponseSchema = z.object({
   exportMode: z.enum(["FULL_HISTORY", "FROM_TODAY", "FROM_CUSTOM_DATE"]),
   exportStartDate: z.coerce.date().nullable(),
   compressed: z.boolean(),
-  exportSource: z
-    .enum(["TRACES_OBSERVATIONS", "TRACES_OBSERVATIONS_EVENTS", "EVENTS"])
-    .optional(),
-  exportFieldGroups: z
-    .array(z.enum(BLOB_EXPORT_FIELD_GROUPS))
-    .nullable()
-    .optional(),
+  exportSource: z.enum([
+    "TRACES_OBSERVATIONS",
+    "TRACES_OBSERVATIONS_EVENTS",
+    "EVENTS",
+  ]),
+  exportFieldGroups: z.array(z.enum(BLOB_EXPORT_FIELD_GROUPS)).nullable(),
   nextSyncAt: z.coerce.date().nullable(),
   lastSyncAt: z.coerce.date().nullable(),
   createdAt: z.coerce.date(),

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -9,6 +9,7 @@ import {
   createAndAddApiKeysToDb,
   createBasicAuthHeader,
 } from "@langfuse/shared/src/server";
+import { BLOB_EXPORT_FIELD_GROUPS } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 
 // Schemas based on Fern schema definition
@@ -28,6 +29,13 @@ const BlobStorageIntegrationResponseSchema = z.object({
   exportMode: z.enum(["FULL_HISTORY", "FROM_TODAY", "FROM_CUSTOM_DATE"]),
   exportStartDate: z.coerce.date().nullable(),
   compressed: z.boolean(),
+  exportSource: z
+    .enum(["TRACES_OBSERVATIONS", "TRACES_OBSERVATIONS_EVENTS", "EVENTS"])
+    .optional(),
+  exportFieldGroups: z
+    .array(z.enum(BLOB_EXPORT_FIELD_GROUPS))
+    .nullable()
+    .optional(),
   nextSyncAt: z.coerce.date().nullable(),
   lastSyncAt: z.coerce.date().nullable(),
   createdAt: z.coerce.date(),
@@ -617,6 +625,417 @@ describe("Blob Storage Integrations API", () => {
         where: { projectId: testProject1Id },
       });
       expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
+    });
+  });
+
+  describe("PUT/GET exportSource + exportFieldGroups behavior", () => {
+    afterEach(async () => {
+      await prisma.blobStorageIntegration.deleteMany({
+        where: {
+          projectId: { in: [testProject1Id, testProject2Id] },
+        },
+      });
+    });
+
+    // ---- EVENTS / TRACES_OBSERVATIONS_EVENTS path ----
+
+    it("EVENTS + exportFieldGroups=[core,io] -> 200 and GET returns same value", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "EVENTS" as const,
+        exportFieldGroups: ["core", "io"],
+      };
+
+      const putResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(putResponse.status).toBe(200);
+      expect(putResponse.body.exportSource).toBe("EVENTS");
+      expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
+
+      const getResponse = await makeZodVerifiedAPICall(
+        z.object({ data: z.array(BlobStorageIntegrationResponseSchema) }),
+        "GET",
+        "/api/public/integrations/blob-storage",
+        undefined,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+      const integration = getResponse.body.data.find(
+        (i) => i.projectId === testProject1Id,
+      );
+      expect(integration).toBeDefined();
+      expect(integration?.exportSource).toBe("EVENTS");
+      expect(integration?.exportFieldGroups).toStrictEqual(["core", "io"]);
+    });
+
+    it("EVENTS + exportFieldGroups=[io] (missing core) -> 400", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "EVENTS" as const,
+        exportFieldGroups: ["io"],
+      };
+
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(400);
+    });
+
+    it("EVENTS + exportFieldGroups omitted -> 200 and GET returns all 11 groups", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "EVENTS" as const,
+      };
+
+      const putResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(putResponse.status).toBe(200);
+
+      const getResponse = await makeZodVerifiedAPICall(
+        z.object({ data: z.array(BlobStorageIntegrationResponseSchema) }),
+        "GET",
+        "/api/public/integrations/blob-storage",
+        undefined,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+      const integration = getResponse.body.data.find(
+        (i) => i.projectId === testProject1Id,
+      );
+      expect(integration).toBeDefined();
+      expect(integration?.exportSource).toBe("EVENTS");
+      expect(integration?.exportFieldGroups).toBeDefined();
+      expect(integration?.exportFieldGroups).toHaveLength(
+        BLOB_EXPORT_FIELD_GROUPS.length,
+      );
+      expect(new Set(integration?.exportFieldGroups)).toStrictEqual(
+        new Set(BLOB_EXPORT_FIELD_GROUPS),
+      );
+    });
+
+    it("EVENTS + exportFieldGroups=null -> 200 and GET returns all 11 groups", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "EVENTS" as const,
+        exportFieldGroups: null,
+      };
+
+      const putResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(putResponse.status).toBe(200);
+
+      const getResponse = await makeZodVerifiedAPICall(
+        z.object({ data: z.array(BlobStorageIntegrationResponseSchema) }),
+        "GET",
+        "/api/public/integrations/blob-storage",
+        undefined,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+      const integration = getResponse.body.data.find(
+        (i) => i.projectId === testProject1Id,
+      );
+      expect(integration).toBeDefined();
+      expect(integration?.exportFieldGroups).toBeDefined();
+      expect(integration?.exportFieldGroups).toHaveLength(
+        BLOB_EXPORT_FIELD_GROUPS.length,
+      );
+      expect(new Set(integration?.exportFieldGroups)).toStrictEqual(
+        new Set(BLOB_EXPORT_FIELD_GROUPS),
+      );
+    });
+
+    // ---- TRACES_OBSERVATIONS path ----
+
+    it("TRACES_OBSERVATIONS + exportFieldGroups omitted -> 200; GET hides field groups", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "TRACES_OBSERVATIONS" as const,
+      };
+
+      const putResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(putResponse.status).toBe(200);
+
+      const getResponse = await makeZodVerifiedAPICall(
+        z.object({ data: z.array(BlobStorageIntegrationResponseSchema) }),
+        "GET",
+        "/api/public/integrations/blob-storage",
+        undefined,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+      const integration = getResponse.body.data.find(
+        (i) => i.projectId === testProject1Id,
+      );
+      expect(integration).toBeDefined();
+      expect(integration?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(integration?.exportFieldGroups).toBeNull();
+    });
+
+    it("TRACES_OBSERVATIONS + exportFieldGroups=null -> 200; GET hides field groups", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "TRACES_OBSERVATIONS" as const,
+        exportFieldGroups: null,
+      };
+
+      const putResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(putResponse.status).toBe(200);
+
+      const getResponse = await makeZodVerifiedAPICall(
+        z.object({ data: z.array(BlobStorageIntegrationResponseSchema) }),
+        "GET",
+        "/api/public/integrations/blob-storage",
+        undefined,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+      const integration = getResponse.body.data.find(
+        (i) => i.projectId === testProject1Id,
+      );
+      expect(integration).toBeDefined();
+      expect(integration?.exportFieldGroups).toBeNull();
+    });
+
+    it("TRACES_OBSERVATIONS + exportFieldGroups=[] -> 400 with 'not applicable'", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "TRACES_OBSERVATIONS" as const,
+        exportFieldGroups: [],
+      };
+
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(400);
+      const message = JSON.stringify(result.body);
+      expect(message.toLowerCase()).toContain("not applicable");
+    });
+
+    it("TRACES_OBSERVATIONS + exportFieldGroups=[core,io] -> 400 with 'not applicable'", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "TRACES_OBSERVATIONS" as const,
+        exportFieldGroups: ["core", "io"],
+      };
+
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(400);
+      const message = JSON.stringify(result.body);
+      expect(message.toLowerCase()).toContain("not applicable");
+    });
+
+    it("GET hides exportFieldGroups for legacy TRACES_OBSERVATIONS rows seeded via Prisma", async () => {
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject1Id,
+          type: "S3",
+          bucketName: "legacy-bucket",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportSource: "TRACES_OBSERVATIONS",
+          exportFieldGroups: ["core", "io", "metadata"],
+        },
+      });
+
+      const getResponse = await makeZodVerifiedAPICall(
+        z.object({ data: z.array(BlobStorageIntegrationResponseSchema) }),
+        "GET",
+        "/api/public/integrations/blob-storage",
+        undefined,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+
+      const integration = getResponse.body.data.find(
+        (i) => i.projectId === testProject1Id,
+      );
+      expect(integration).toBeDefined();
+      expect(integration?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(integration?.exportFieldGroups).toBeNull();
+    });
+
+    it("PUT TRACES_OBSERVATIONS preserves existing export_field_groups column in DB", async () => {
+      // Seed with a custom subset
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject1Id,
+          type: "S3",
+          bucketName: "initial-bucket",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportSource: "TRACES_OBSERVATIONS",
+          exportFieldGroups: ["core", "io"],
+        },
+      });
+
+      await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        {
+          ...validBlobStorageConfig,
+          projectId: testProject1Id,
+          exportSource: "TRACES_OBSERVATIONS" as const,
+          bucketName: "updated-bucket",
+        },
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+
+      const saved = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      });
+      expect(saved?.bucketName).toBe("updated-bucket");
+      // REST never overwrites export_field_groups for this source.
+      expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
+    });
+
+    // ---- Response shape ----
+
+    it("PUT response includes exportSource and exportFieldGroups (null for TRACES_OBSERVATIONS)", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "TRACES_OBSERVATIONS" as const,
+      };
+
+      const response = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty(
+        "exportSource",
+        "TRACES_OBSERVATIONS",
+      );
+      expect(response.body).toHaveProperty("exportFieldGroups");
+      expect(response.body.exportFieldGroups).toBeNull();
+    });
+
+    it("GET response includes exportSource always and exportFieldGroups with source-conditional null", async () => {
+      // Seed two integrations on different projects with different sources
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject1Id,
+          type: "S3",
+          bucketName: "bucket-1",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportSource: "TRACES_OBSERVATIONS",
+          exportFieldGroups: ["core", "io", "metadata"],
+        },
+      });
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject2Id,
+          type: "S3",
+          bucketName: "bucket-2",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportSource: "EVENTS",
+          exportFieldGroups: ["core", "io"],
+        },
+      });
+
+      const getResponse = await makeZodVerifiedAPICall(
+        z.object({ data: z.array(BlobStorageIntegrationResponseSchema) }),
+        "GET",
+        "/api/public/integrations/blob-storage",
+        undefined,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+
+      const tracesObsIntegration = getResponse.body.data.find(
+        (i) => i.projectId === testProject1Id,
+      );
+      const eventsIntegration = getResponse.body.data.find(
+        (i) => i.projectId === testProject2Id,
+      );
+      expect(tracesObsIntegration?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(tracesObsIntegration?.exportFieldGroups).toBeNull();
+      expect(eventsIntegration?.exportSource).toBe("EVENTS");
+      expect(eventsIntegration?.exportFieldGroups).toStrictEqual([
+        "core",
+        "io",
+      ]);
     });
   });
 

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -22,7 +22,7 @@ const BlobStorageIntegrationResponseSchema = z.object({
   region: z.string(),
   accessKeyId: z.string().nullable(),
   prefix: z.string(),
-  exportFrequency: z.enum(["hourly", "daily", "weekly"]),
+  exportFrequency: z.enum(["every_20_minutes", "hourly", "daily", "weekly"]),
   enabled: z.boolean(),
   forcePathStyle: z.boolean(),
   fileType: z.enum(["JSON", "CSV", "JSONL"]),
@@ -1082,6 +1082,53 @@ describe("Blob Storage Integrations API", () => {
       expect(saved?.exportSource).toBe("EVENTS");
       expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
       expect(saved?.bucketName).toBe("updated-bucket");
+    });
+
+    it("PUT exportSource=null preserves existing EVENTS source and field groups", async () => {
+      // Pre-seed an EVENTS row with a custom field-group subset
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject1Id,
+          type: "S3",
+          bucketName: "initial-bucket",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportSource: "EVENTS",
+          exportFieldGroups: ["core", "io"],
+        },
+      });
+
+      // PUT with exportSource explicitly null — mirrors what an OpenAPI/SDK
+      // client would emit for a not-provided value
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: null,
+        bucketName: "updated-bucket",
+      };
+      const putResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(putResponse.status).toBe(200);
+      expect(putResponse.body.exportSource).toBe("EVENTS");
+      expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
+
+      const saved = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      });
+      expect(saved?.exportSource).toBe("EVENTS");
+      expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
     it("PUT exportSource=EVENTS without exportFieldGroups on existing EVENTS row preserves field groups", async () => {

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -1037,6 +1037,117 @@ describe("Blob Storage Integrations API", () => {
         "io",
       ]);
     });
+
+    it("PUT without exportSource preserves existing EVENTS source and field groups", async () => {
+      // Pre-seed an EVENTS row with a custom field-group subset
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject1Id,
+          type: "S3",
+          bucketName: "initial-bucket",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportSource: "EVENTS",
+          exportFieldGroups: ["core", "io"],
+        },
+      });
+
+      // PUT update with exportSource and exportFieldGroups both omitted
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        bucketName: "updated-bucket",
+      };
+      const putResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(putResponse.status).toBe(200);
+      expect(putResponse.body.exportSource).toBe("EVENTS");
+      expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
+
+      // DB row preserved on both columns; bucket updated
+      const saved = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      });
+      expect(saved?.exportSource).toBe("EVENTS");
+      expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
+      expect(saved?.bucketName).toBe("updated-bucket");
+    });
+
+    it("PUT exportSource=EVENTS without exportFieldGroups on existing EVENTS row preserves field groups", async () => {
+      // Pre-seed an EVENTS row with a custom field-group subset
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject1Id,
+          type: "S3",
+          bucketName: "initial-bucket",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportSource: "EVENTS",
+          exportFieldGroups: ["core", "io"],
+        },
+      });
+
+      // PUT with explicit exportSource=EVENTS but exportFieldGroups omitted
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportSource: "EVENTS" as const,
+        bucketName: "updated-bucket",
+      };
+      const putResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(putResponse.status).toBe(200);
+      expect(putResponse.body.exportSource).toBe("EVENTS");
+      expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
+
+      const saved = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      });
+      expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
+      expect(saved?.bucketName).toBe("updated-bucket");
+    });
+
+    it("PUT with exportFieldGroups but no exportSource -> 400", async () => {
+      const requestBody = {
+        ...validBlobStorageConfig,
+        projectId: testProject1Id,
+        exportFieldGroups: ["core", "io"],
+      };
+
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        requestBody,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(400);
+      const message = JSON.stringify(result.body).toLowerCase();
+      expect(message).toContain("exportsource is required");
+    });
   });
 
   describe("DELETE /api/public/integrations/blob-storage/{id}", () => {

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -58,7 +58,7 @@ export const CreateBlobStorageIntegrationRequest = z
     exportMode: BlobStorageExportMode,
     exportStartDate: z.coerce.date().nullable().optional(),
     compressed: z.boolean().optional().default(true),
-    exportSource: BlobStorageExportSource.optional(),
+    exportSource: BlobStorageExportSource.nullable().optional(),
     exportFieldGroups: z
       .array(BlobStorageExportFieldGroup)
       .nullable()
@@ -77,7 +77,7 @@ export const CreateBlobStorageIntegrationRequest = z
   )
   .superRefine(validateAzureContainerName)
   .superRefine((data, ctx) => {
-    if (data.exportSource === undefined && data.exportFieldGroups != null) {
+    if (data.exportSource == null && data.exportFieldGroups != null) {
       ctx.addIssue({
         code: "custom",
         message: "exportSource is required when exportFieldGroups is provided",
@@ -98,7 +98,7 @@ export const CreateBlobStorageIntegrationRequest = z
       });
       return;
     }
-    if (data.exportFieldGroups != null && data.exportSource !== undefined) {
+    if (data.exportFieldGroups != null && data.exportSource != null) {
       validateExportFieldGroups(
         {
           exportSource: data.exportSource,

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -58,9 +58,7 @@ export const CreateBlobStorageIntegrationRequest = z
     exportMode: BlobStorageExportMode,
     exportStartDate: z.coerce.date().nullable().optional(),
     compressed: z.boolean().optional().default(true),
-    exportSource: BlobStorageExportSource.optional().default(
-      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-    ),
+    exportSource: BlobStorageExportSource.optional(),
     exportFieldGroups: z
       .array(BlobStorageExportFieldGroup)
       .nullable()
@@ -79,6 +77,14 @@ export const CreateBlobStorageIntegrationRequest = z
   )
   .superRefine(validateAzureContainerName)
   .superRefine((data, ctx) => {
+    if (data.exportSource === undefined && data.exportFieldGroups != null) {
+      ctx.addIssue({
+        code: "custom",
+        message: "exportSource is required when exportFieldGroups is provided",
+        path: ["exportSource"],
+      });
+      return;
+    }
     if (
       data.exportSource ===
         AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS &&
@@ -92,7 +98,7 @@ export const CreateBlobStorageIntegrationRequest = z
       });
       return;
     }
-    if (data.exportFieldGroups != null) {
+    if (data.exportFieldGroups != null && data.exportSource !== undefined) {
       validateExportFieldGroups(
         {
           exportSource: data.exportSource,

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
-import { validateAzureContainerName } from "@/src/features/blobstorage-integration/validation";
+import {
+  AnalyticsIntegrationExportSource,
+  BLOB_EXPORT_FIELD_GROUPS,
+} from "@langfuse/shared";
+import {
+  validateAzureContainerName,
+  validateExportFieldGroups,
+} from "@/src/features/blobstorage-integration/validation";
 
 /**
  * Enums
@@ -18,6 +25,10 @@ export const BlobStorageExportMode = z.enum([
   "FROM_TODAY",
   "FROM_CUSTOM_DATE",
 ]);
+
+export const BlobStorageExportSource = z.enum(AnalyticsIntegrationExportSource);
+
+export const BlobStorageExportFieldGroup = z.enum(BLOB_EXPORT_FIELD_GROUPS);
 
 /**
  * Request/Response Types
@@ -47,6 +58,13 @@ export const CreateBlobStorageIntegrationRequest = z
     exportMode: BlobStorageExportMode,
     exportStartDate: z.coerce.date().nullable().optional(),
     compressed: z.boolean().optional().default(true),
+    exportSource: BlobStorageExportSource.optional().default(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    ),
+    exportFieldGroups: z
+      .array(BlobStorageExportFieldGroup)
+      .nullable()
+      .optional(),
   })
   .strict()
   .refine(
@@ -59,7 +77,31 @@ export const CreateBlobStorageIntegrationRequest = z
       path: ["exportStartDate"],
     },
   )
-  .superRefine(validateAzureContainerName);
+  .superRefine(validateAzureContainerName)
+  .superRefine((data, ctx) => {
+    if (
+      data.exportSource ===
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS &&
+      data.exportFieldGroups != null
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "exportFieldGroups is not applicable when exportSource is TRACES_OBSERVATIONS",
+        path: ["exportFieldGroups"],
+      });
+      return;
+    }
+    if (data.exportFieldGroups != null) {
+      validateExportFieldGroups(
+        {
+          exportSource: data.exportSource,
+          exportFieldGroups: data.exportFieldGroups,
+        },
+        ctx,
+      );
+    }
+  });
 
 export const BlobStorageIntegrationResponse = z
   .object({
@@ -78,6 +120,8 @@ export const BlobStorageIntegrationResponse = z
     exportMode: BlobStorageExportMode,
     exportStartDate: z.coerce.date().nullable(),
     compressed: z.boolean(),
+    exportSource: BlobStorageExportSource,
+    exportFieldGroups: z.array(BlobStorageExportFieldGroup).nullable(),
     nextSyncAt: z.coerce.date().nullable(),
     lastSyncAt: z.coerce.date().nullable(),
     lastError: z.string().nullable(),

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -10,7 +10,6 @@ import {
 } from "@/src/features/public-api/types/blob-storage-integrations";
 import {
   AnalyticsIntegrationExportSource,
-  BLOB_EXPORT_FIELD_GROUPS,
   type BlobExportFieldGroup,
   LangfuseNotFoundError,
   UnauthorizedError,
@@ -184,11 +183,7 @@ async function handleUpsertBlobStorageIntegration(
       exportStartDate: validatedData.exportStartDate ?? null,
       compressed: validatedData.compressed,
       exportSource: validatedData.exportSource,
-      exportFieldGroups:
-        validatedData.exportSource ===
-        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
-          ? undefined
-          : (validatedData.exportFieldGroups ?? [...BLOB_EXPORT_FIELD_GROUPS]),
+      exportFieldGroups: validatedData.exportFieldGroups ?? undefined,
     },
   });
 

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -9,6 +9,9 @@ import {
   type BlobStorageIntegrationResponseType,
 } from "@/src/features/public-api/types/blob-storage-integrations";
 import {
+  AnalyticsIntegrationExportSource,
+  BLOB_EXPORT_FIELD_GROUPS,
+  type BlobExportFieldGroup,
   LangfuseNotFoundError,
   UnauthorizedError,
   ForbiddenError,
@@ -87,6 +90,12 @@ async function handleGetBlobStorageIntegrations(
       exportMode: integration.exportMode,
       exportStartDate: integration.exportStartDate,
       compressed: integration.compressed,
+      exportSource: integration.exportSource,
+      exportFieldGroups:
+        integration.exportSource ===
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
+          ? null
+          : (integration.exportFieldGroups as BlobExportFieldGroup[]),
       nextSyncAt: integration.nextSyncAt,
       lastSyncAt: integration.lastSyncAt,
       lastError: integration.lastError,
@@ -174,6 +183,12 @@ async function handleUpsertBlobStorageIntegration(
       exportMode: validatedData.exportMode,
       exportStartDate: validatedData.exportStartDate ?? null,
       compressed: validatedData.compressed,
+      exportSource: validatedData.exportSource,
+      exportFieldGroups:
+        validatedData.exportSource ===
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
+          ? undefined
+          : (validatedData.exportFieldGroups ?? [...BLOB_EXPORT_FIELD_GROUPS]),
     },
   });
 
@@ -194,6 +209,12 @@ async function handleUpsertBlobStorageIntegration(
     exportMode: integration.exportMode,
     exportStartDate: integration.exportStartDate,
     compressed: integration.compressed,
+    exportSource: integration.exportSource,
+    exportFieldGroups:
+      integration.exportSource ===
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
+        ? null
+        : (integration.exportFieldGroups as BlobExportFieldGroup[]),
     nextSyncAt: integration.nextSyncAt,
     lastSyncAt: integration.lastSyncAt,
     lastError: integration.lastError,

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -182,7 +182,7 @@ async function handleUpsertBlobStorageIntegration(
       exportMode: validatedData.exportMode,
       exportStartDate: validatedData.exportStartDate ?? null,
       compressed: validatedData.compressed,
-      exportSource: validatedData.exportSource,
+      exportSource: validatedData.exportSource ?? undefined,
       exportFieldGroups: validatedData.exportFieldGroups ?? undefined,
     },
   });


### PR DESCRIPTION
## Summary

[LFE-9456](https://linear.app/langfuse/issue/LFE-9456) — final part of the stack. Exposes `exportSource` and `exportFieldGroups` on the public REST API for blob storage integrations.

- **Request**: `CreateBlobStorageIntegrationRequest` now accepts `exportSource` (optional, defaults to `TRACES_OBSERVATIONS`) and `exportFieldGroups` (`nullable<list<ExportFieldGroup>>`, optional).
- **Response**: `BlobStorageIntegrationResponse` now returns `exportSource` (non-null) and `exportFieldGroups` (`nullable<list<…>>`).
- **Strict validation**: REST contract is intentionally stricter than tRPC:
  - `TRACES_OBSERVATIONS` + non-null `exportFieldGroups` → 400 ("not applicable"). Covers `[]`, partial arrays, full arrays alike.
  - `EVENTS` / `TRACES_OBSERVATIONS_EVENTS` + provided `exportFieldGroups` without `core` → 400 (delegates to existing shared `validateExportFieldGroups`).
- **Source-conditional handler**: `TRACES_OBSERVATIONS` writes `undefined` (Prisma preserves the column / applies default for new rows) and reads return `null` to hide any inert legacy value. `EVENTS` family defaults to all 11 groups when omitted/null.
- **Fern source updated** with new `ExportSource` / `ExportFieldGroup` enums, request and response field additions, and rule docstrings. OpenAPI spec regenerated.

### Why the REST/tRPC divergence is intentional

The UI's tRPC path still submits all 11 groups for `TRACES_OBSERVATIONS` because the form always carries them; the shared `validateExportFieldGroups` doesn't enforce `core` for that source. The worker ignores the column entirely for `TRACES_OBSERVATIONS` (uses fixed-column exports). The REST contract should not expose a knob that's inert at export time — so it rejects on write and hides on read.

### Drive-by

Includes `openapi.yml` regen sweep for #13126 (the `every_20_minutes` enum value was added to Fern source but never regenerated). Generated artifact only; no behavior change.

### Impacted packages

- `web` — Zod request/response types, GET list + PUT handlers, server tests, regenerated OpenAPI spec
- `fern` — Fern source definition

## Test plan

- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter web run typecheck`
- [x] `dotenv -e .env -- pnpm --filter web exec vitest run blob-storage-integration-api blob-storage-integration-trpc` — 50/50 passed (38 new REST + 12 tRPC regression)
- [x] `npx fern-api generate --api server` — Python SDK, TypeScript SDK, OpenAPI spec all regenerated cleanly
- [ ] Manual API client smoke test against staging once merged (verify SDK round-trip on EVENTS payload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes `exportSource` and `exportFieldGroups` on the public REST API for blob storage integrations, with strict validation rules (TRACES_OBSERVATIONS rejects non-null field groups; EVENTS/TRACES_OBSERVATIONS_EVENTS requires `core` when groups are provided) and source-conditional response masking.

- **PUT handler**: correctly defaults a null/omitted `exportFieldGroups` to all 11 groups for `EVENTS`/`TRACES_OBSERVATIONS_EVENTS`, and passes `undefined` for `TRACES_OBSERVATIONS` so Prisma preserves the existing DB column without overwriting it.
- **GET handler and PUT response block**: both cast the raw DB `exportFieldGroups` value without applying the same null-→-all-groups default that the write path uses, meaning legacy `EVENTS` rows with a null DB column return `null` in the response rather than the full group list.
- **Test schema**: local `BlobStorageIntegrationResponseSchema` marks `exportSource` as `.optional()`, which is weaker than the production contract; tests would not fail if the field were accidentally dropped from the response.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The write path is correct and well-tested, but the read path has an inconsistency: GET returns raw DB null for EVENTS integrations with an unset exportFieldGroups column, while PUT always writes the full default list. Any legacy EVENTS row would expose this gap to API consumers.

The write-side logic (defaulting, masking, validation) is solid and tests cover it well. The inconsistency lives in the GET handler and the PUT response builder, both of which skip the null-to-all-groups normalization that the write path applies. For organizations with legacy EVENTS integrations (created before exportFieldGroups was populated), the GET response would return null for a field that should carry the full 11-group list, which could mislead consumers and break SDK round-trips.

web/src/pages/api/public/integrations/blob-storage/index.ts — both response-building blocks (GET and PUT) need the same null-defaulting logic that the write path already has for EVENTS/TRACES_OBSERVATIONS_EVENTS sources.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PUT /integrations/blob-storage] --> B{Zod validation}
    B -->|exportSource = TRACES_OBSERVATIONS\nexportFieldGroups != null| C[400 not applicable]
    B -->|exportSource = EVENTS/TOE\nexportFieldGroups provided without 'core'| D[400 core required]
    B -->|valid| E{exportSource?}
    E -->|TRACES_OBSERVATIONS| F[pass exportFieldGroups: undefined\nPrisma skips column on update]
    E -->|EVENTS / TRACES_OBSERVATIONS_EVENTS| G[pass exportFieldGroups ?? all 11 groups]
    F --> H[upsertBlobStorageIntegration]
    G --> H
    H --> I{Build response}
    I -->|TRACES_OBSERVATIONS| J[exportFieldGroups: null]
    I -->|EVENTS/TOE| K[exportFieldGroups: DB value as-is\nno null → all-groups default]

    L[GET /integrations/blob-storage] --> M[fetch all org integrations]
    M --> N{for each integration}
    N -->|TRACES_OBSERVATIONS| O[exportFieldGroups: null]
    N -->|EVENTS/TOE| P[exportFieldGroups: DB value as-is\nno null → all-groups default]
    O --> Q[200 response array]
    P --> Q
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/api/public/integrations/blob-storage/index.ts:94-98
**GET doesn't normalize null `exportFieldGroups` for EVENTS sources**

The PUT handler defaults a null/omitted `exportFieldGroups` to all 11 groups for `EVENTS` and `TRACES_OBSERVATIONS_EVENTS` sources (`validatedData.exportFieldGroups ?? [...BLOB_EXPORT_FIELD_GROUPS]`). The GET handler here simply passes the raw DB value through, so a legacy `EVENTS` row where the column was never populated returns `null` instead of the full group list. A consumer reading the GET response on such a row sees `null`—indistinguishable from `TRACES_OBSERVATIONS`'s "not applicable" null—while a subsequent PUT would return the full list. The same cast-without-defaulting pattern repeats on the PUT response block at lines 213–217.

### Issue 2 of 2
web/src/__tests__/server/blob-storage-integration-api.servertest.ts:31-38
**Test schema marks `exportSource` optional — weaker than production contract**

The production `BlobStorageIntegrationResponse` schema requires `exportSource` as non-optional (it's always present in the response). Marking it `.optional()` in the test schema means the tests would pass even if the field were accidentally dropped from the API response, making the test suite weaker than intended for this new field.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(blob-export): expose exportSource a..."](https://github.com/langfuse/langfuse/commit/8601e56bd7e996def93d14761a4419b607b77923) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31769478)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->