### PR TITLE
fix(evals): surface evaluator status update errors

### DIFF
--- a/web/src/features/evals/components/deactivate-config.clienttest.tsx
+++ b/web/src/features/evals/components/deactivate-config.clienttest.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { toast } from "sonner";
+
+import { DeactivateEvalConfig } from "@/src/features/evals/components/deactivate-config";
+import { type RouterOutputs } from "@/src/utils/api";
+
+const mocks = vi.hoisted(() => ({
+  invalidate: vi.fn(),
+  capture: vi.fn(),
+  mutationOptions: undefined as
+    | {
+        onSuccess?: () => void;
+        onError?: (error: { message: string }) => void;
+      }
+    | undefined,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => mocks.capture,
+}));
+
+vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
+  useHasProjectAccess: () => true,
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    useUtils: () => ({
+      evals: {
+        invalidate: mocks.invalidate,
+      },
+    }),
+    evals: {
+      updateEvalJob: {
+        useMutation: vi.fn((options) => {
+          mocks.mutationOptions = options;
+          return {
+            isPending: false,
+            mutateAsync: vi.fn(),
+          };
+        }),
+      },
+    },
+  },
+}));
+
+describe("DeactivateEvalConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mutationOptions = undefined;
+  });
+
+  it("surfaces evaluator update failures via toast", () => {
+    const evalConfig = {
+      id: "eval-1",
+      status: "ACTIVE",
+      timeScope: ["NEW", "EXISTING"],
+    } as unknown as RouterOutputs["evals"]["configById"];
+
+    render(
+      <DeactivateEvalConfig projectId="project-1" evalConfig={evalConfig} />,
+    );
+
+    mocks.mutationOptions?.onError?.({
+      message:
+        "The evaluator ran on existing traces already. This cannot be changed anymore.",
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "The evaluator ran on existing traces already. This cannot be changed anymore.",
+    );
+  });
+
+  it("invalidates evaluator queries after successful status update", () => {
+    const evalConfig = {
+      id: "eval-1",
+      status: "ACTIVE",
+      timeScope: ["NEW"],
+    } as unknown as RouterOutputs["evals"]["configById"];
+
+    render(
+      <DeactivateEvalConfig projectId="project-1" evalConfig={evalConfig} />,
+    );
+
+    mocks.mutationOptions?.onSuccess?.();
+
+    expect(mocks.invalidate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/features/evals/components/deactivate-config.clienttest.tsx
+++ b/web/src/features/evals/components/deactivate-config.clienttest.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
 
 import { DeactivateEvalConfig } from "@/src/features/evals/components/deactivate-config";
@@ -8,6 +8,7 @@ import { type RouterOutputs } from "@/src/utils/api";
 const mocks = vi.hoisted(() => ({
   invalidate: vi.fn(),
   capture: vi.fn(),
+  mutateAsync: vi.fn(),
   mutationOptions: undefined as
     | {
         onSuccess?: () => void;
@@ -43,7 +44,7 @@ vi.mock("@/src/utils/api", () => ({
           mocks.mutationOptions = options;
           return {
             isPending: false,
-            mutateAsync: vi.fn(),
+            mutateAsync: mocks.mutateAsync,
           };
         }),
       },
@@ -54,6 +55,7 @@ vi.mock("@/src/utils/api", () => ({
 describe("DeactivateEvalConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.mutateAsync.mockResolvedValue(undefined);
     mocks.mutationOptions = undefined;
   });
 
@@ -93,4 +95,48 @@ describe("DeactivateEvalConfig", () => {
 
     expect(mocks.invalidate).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    {
+      currentStatus: "ACTIVE",
+      buttonName: "Deactivate",
+      nextStatus: "INACTIVE",
+      eventName: "eval_config:deactivate",
+    },
+    {
+      currentStatus: "INACTIVE",
+      buttonName: "Activate",
+      nextStatus: "ACTIVE",
+      eventName: "eval_config:activate",
+    },
+  ])(
+    "captures and closes the confirmation popover after a successful $buttonName action",
+    async ({ currentStatus, buttonName, nextStatus, eventName }) => {
+      const evalConfig = {
+        id: "eval-1",
+        status: currentStatus,
+        timeScope: ["NEW"],
+      } as unknown as RouterOutputs["evals"]["configById"];
+
+      render(
+        <DeactivateEvalConfig projectId="project-1" evalConfig={evalConfig} />,
+      );
+
+      fireEvent.click(screen.getByRole("switch"));
+      fireEvent.click(screen.getByRole("button", { name: buttonName }));
+
+      await waitFor(() =>
+        expect(mocks.mutateAsync).toHaveBeenCalledWith({
+          projectId: "project-1",
+          evalConfigId: "eval-1",
+          config: { status: nextStatus },
+        }),
+      );
+
+      expect(mocks.capture).toHaveBeenCalledWith(eventName);
+      await waitFor(() =>
+        expect(screen.queryByText("Please confirm")).not.toBeInTheDocument(),
+      );
+    },
+  );
 });

--- a/web/src/features/evals/components/deactivate-config.clienttest.tsx
+++ b/web/src/features/evals/components/deactivate-config.clienttest.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
 
 import { DeactivateEvalConfig } from "@/src/features/evals/components/deactivate-config";
@@ -8,6 +8,7 @@ import { type RouterOutputs } from "@/src/utils/api";
 const mocks = vi.hoisted(() => ({
   invalidate: vi.fn(),
   capture: vi.fn(),
+  mutateAsync: vi.fn(),
   mutationOptions: undefined as
     | {
         onSuccess?: () => void;
@@ -30,6 +31,10 @@ vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
   useHasProjectAccess: () => true,
 }));
 
+vi.mock("@/src/features/evals/hooks/useEvalCapabilities", () => ({
+  useEvalCapabilities: () => ({ allowLegacy: true }),
+}));
+
 vi.mock("@/src/utils/api", () => ({
   api: {
     useUtils: () => ({
@@ -43,7 +48,7 @@ vi.mock("@/src/utils/api", () => ({
           mocks.mutationOptions = options;
           return {
             isPending: false,
-            mutateAsync: vi.fn(),
+            mutateAsync: mocks.mutateAsync,
           };
         }),
       },
@@ -54,6 +59,7 @@ vi.mock("@/src/utils/api", () => ({
 describe("DeactivateEvalConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.mutateAsync.mockResolvedValue(undefined);
     mocks.mutationOptions = undefined;
   });
 
@@ -93,4 +99,48 @@ describe("DeactivateEvalConfig", () => {
 
     expect(mocks.invalidate).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    {
+      currentStatus: "ACTIVE",
+      buttonName: "Deactivate",
+      nextStatus: "INACTIVE",
+      eventName: "eval_config:deactivate",
+    },
+    {
+      currentStatus: "INACTIVE",
+      buttonName: "Activate",
+      nextStatus: "ACTIVE",
+      eventName: "eval_config:activate",
+    },
+  ])(
+    "captures and closes the confirmation popover after a successful $buttonName action",
+    async ({ currentStatus, buttonName, nextStatus, eventName }) => {
+      const evalConfig = {
+        id: "eval-1",
+        status: currentStatus,
+        timeScope: ["NEW"],
+      } as unknown as RouterOutputs["evals"]["configById"];
+
+      render(
+        <DeactivateEvalConfig projectId="project-1" evalConfig={evalConfig} />,
+      );
+
+      fireEvent.click(screen.getByRole("switch"));
+      fireEvent.click(screen.getByRole("button", { name: buttonName }));
+
+      await waitFor(() =>
+        expect(mocks.mutateAsync).toHaveBeenCalledWith({
+          projectId: "project-1",
+          evalConfigId: "eval-1",
+          config: { status: nextStatus },
+        }),
+      );
+
+      expect(mocks.capture).toHaveBeenCalledWith(eventName);
+      await waitFor(() =>
+        expect(screen.queryByText("Please confirm")).not.toBeInTheDocument(),
+      );
+    },
+  );
 });

--- a/web/src/features/evals/components/deactivate-config.tsx
+++ b/web/src/features/evals/components/deactivate-config.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/src/components/ui/popover";
 import { Button } from "@/src/components/ui/button";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
+import { toast } from "sonner";
 
 export function DeactivateEvalConfig({
   projectId,
@@ -28,9 +29,12 @@ export function DeactivateEvalConfig({
     onSuccess: () => {
       utils.evals.invalidate();
     },
+    onError: (error) => {
+      toast.error(error.message);
+    },
   });
 
-  const onClick = () => {
+  const onClick = async () => {
     if (!projectId) {
       console.error("Project ID is missing");
       return;
@@ -38,19 +42,23 @@ export function DeactivateEvalConfig({
 
     const prevStatus = evalConfig?.status;
 
-    mutEvaluator.mutateAsync({
-      projectId,
-      evalConfigId: evalConfig?.id ?? "",
-      config: {
-        status: isActive ? EvaluatorStatus.INACTIVE : EvaluatorStatus.ACTIVE,
-      },
-    });
-    capture(
-      prevStatus === EvaluatorStatus.ACTIVE
-        ? "eval_config:deactivate"
-        : "eval_config:activate",
-    );
-    setIsOpen(false);
+    try {
+      await mutEvaluator.mutateAsync({
+        projectId,
+        evalConfigId: evalConfig?.id ?? "",
+        config: {
+          status: isActive ? EvaluatorStatus.INACTIVE : EvaluatorStatus.ACTIVE,
+        },
+      });
+      capture(
+        prevStatus === EvaluatorStatus.ACTIVE
+          ? "eval_config:deactivate"
+          : "eval_config:activate",
+      );
+      setIsOpen(false);
+    } catch {
+      // onError surfaces the server-side rejection to the user.
+    }
   };
 
   return (

--- a/web/src/features/evals/components/deactivate-config.tsx
+++ b/web/src/features/evals/components/deactivate-config.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/src/components/ui/button";
 import { Switch } from "@/src/components/design-system/Switch/Switch";
 import { isLegacyEvalTarget } from "@/src/features/evals/utils/typeHelpers";
 import { useEvalCapabilities } from "@/src/features/evals/hooks/useEvalCapabilities";
+import { toast } from "sonner";
 
 export function DeactivateEvalConfig({
   projectId,
@@ -42,6 +43,9 @@ export function DeactivateEvalConfig({
     onSuccess: () => {
       utils.evals.invalidate();
     },
+    onError: (error) => {
+      toast.error(error.message);
+    },
   });
 
   const onClick = async () => {
@@ -66,8 +70,8 @@ export function DeactivateEvalConfig({
         },
       });
     } catch {
-      // The default mutation error toast reports the failure; the status is
-      // unchanged, so keep the popover open and skip the change callbacks.
+      // onError surfaces the server-side rejection; keep the popover open and
+      // skip callbacks because the status is unchanged.
       return;
     }
     capture(


### PR DESCRIPTION
## What does this PR do?

Surfaces server-side `updateEvalJob` failures from the evaluator activation/deactivation control instead of letting the promise rejection fail silently.

The evaluator status toggle already invalidated evaluator queries on success, but it did not handle mutation errors. When the server rejects an update, for example because an evaluator has already run on existing traces, users saw the popover close/revert with no toast or inline feedback.

This PR adds an `onError` toast for the mutation and awaits `mutateAsync` before closing the popover and emitting the analytics event. It also adds a client regression test for the error toast and success invalidation paths.

Fixes #13315

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Review follow-up

- [x] Addressed Greptile's success-path coverage note in `cce85bf` by asserting analytics capture and popover close after `mutateAsync` resolves.

## Testing

- [x] `pnpm.cmd --filter web exec dotenv -e ../.env.test -e ../.env -- vitest run --project client src/features/evals/components/deactivate-config.clienttest.tsx`
- [x] `pnpm.cmd --filter web run lint`
- [x] `pnpm.cmd --filter web run typecheck`
- [x] `pnpm.cmd exec prettier --check web/src/features/evals/components/deactivate-config.tsx web/src/features/evals/components/deactivate-config.clienttest.tsx --experimental-cli`
- [ ] Maintainer CI: waiting for protected fork workflow approval (`all-ci-passed`, spelling, `zizmor` are not reported yet)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent failure in the evaluator status toggle by adding an `onError` toast and awaiting `mutateAsync` so that server rejections are surfaced to users instead of being swallowed.

- `deactivate-config.tsx`: adds `onError` handler with `toast.error`, makes `onClick` async, wraps `mutateAsync` in try/catch so analytics capture and popover close only happen on success.
- `deactivate-config.clienttest.tsx`: new tests verifying the error toast fires and cache invalidation runs on success; the success path does not yet assert that `capture` and `setIsOpen` are called after `mutateAsync` resolves.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the production code change is small, correct, and follows the standard React Query error-handling pattern.

The component changes are straightforward: `onError` shows a toast, the try/catch suppresses the unhandled rejection that `mutateAsync` would otherwise surface, and the analytics event plus popover close are gated on success. The test file covers the error toast and `onSuccess` invalidation well, but the post-mutation `capture` and `setIsOpen` calls are not verified by any test case.

`deactivate-config.clienttest.tsx` — the success test only exercises the `onSuccess` callback directly and misses the `capture` / `setIsOpen` side-effects that live in the try-block.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Switch/Button
    participant onClick (async)
    participant mutateAsync
    participant tRPC Server
    participant onSuccess/onError
    participant Toast/Popover

    User->>Switch/Button: Click to toggle evaluator
    Switch/Button->>onClick (async): invoke
    onClick (async)->>mutateAsync: await mutateAsync({ status: toggle })
    mutateAsync->>tRPC Server: updateEvalJob request

    alt Success
        tRPC Server-->>mutateAsync: 200 OK
        mutateAsync-->>onClick (async): resolves
        onClick (async)->>onSuccess/onError: onSuccess fires
        onSuccess/onError->>Toast/Popover: utils.evals.invalidate()
        onClick (async)->>Toast/Popover: capture(analytics event)
        onClick (async)->>Toast/Popover: setIsOpen(false)
    else Error
        tRPC Server-->>mutateAsync: Error response
        mutateAsync-->>onClick (async): rejects
        onClick (async)->>onSuccess/onError: onError fires
        onSuccess/onError->>Toast/Popover: toast.error(error.message)
        Note over onClick (async): catch{} suppresses unhandled rejection
        Note over Toast/Popover: Popover stays open
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/evals/components/deactivate-config.clienttest.tsx:81-95
**Success path test gaps**

The success test only exercises the `onSuccess` mutation callback (verifying `invalidate` is called), but the actual `onClick` handler calls `capture(...)` and `setIsOpen(false)` in the try-block *after* `await mutateAsync` resolves — not inside `onSuccess`. Those two side-effects are entirely untested. If either were accidentally moved, removed, or broken in a future refactor, no test would catch it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): surface evaluator status upd..."](https://github.com/langfuse/langfuse/commit/a6264d331d6e4563287ee06d4df92e2531d39c9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31865264)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->