### PR TITLE
fix(otel): normalize OpenInference cache token details

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2505,12 +2505,14 @@ export class OtelIngestionProcessor {
       rawUsageDetails["cache_read.input_tokens"] ??
       rawUsageDetails["cache_read_tokens"] ??
       rawUsageDetails["details.cache_read_tokens"] ??
-      rawUsageDetails["details.cache_read_input_tokens"];
+      rawUsageDetails["details.cache_read_input_tokens"] ??
+      rawUsageDetails["prompt_details.cache_read"];
     const cacheCreationTokens =
       rawUsageDetails["cache_creation.input_tokens"] ??
       rawUsageDetails["cache_write_tokens"] ??
       rawUsageDetails["details.cache_write_tokens"] ??
-      rawUsageDetails["details.cache_creation_input_tokens"];
+      rawUsageDetails["details.cache_creation_input_tokens"] ??
+      rawUsageDetails["prompt_details.cache_write"];
 
     const normalizedUsageDetails = Object.entries(rawUsageDetails).reduce(
       (acc: Record<string, number>, [key, value]) => {
@@ -2528,10 +2530,12 @@ export class OtelIngestionProcessor {
             "cache_read_tokens",
             "details.cache_read_tokens",
             "details.cache_read_input_tokens",
+            "prompt_details.cache_read",
             "cache_creation.input_tokens",
             "cache_write_tokens",
             "details.cache_write_tokens",
             "details.cache_creation_input_tokens",
+            "prompt_details.cache_write",
           ].includes(key)
         ) {
           return acc;

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -6386,6 +6386,82 @@ describe("OTel Resource Span Mapping", () => {
       expect(observationEvent?.body.usageDetails.input_cache_creation).toBe(10);
       expect(observationEvent?.body.usageDetails.output_audio_tokens).toBe(5);
     });
+
+    it("should normalize OpenInference prompt detail cache tokens", async () => {
+      const traceId = "abcdef1234567890abcdef1234567893";
+
+      const openInferenceSpan = {
+        resource: {
+          attributes: [
+            {
+              key: "service.name",
+              value: { stringValue: "test-service" },
+            },
+          ],
+        },
+        scopeSpans: [
+          {
+            spans: [
+              {
+                traceId: Buffer.from(traceId, "hex"),
+                spanId: Buffer.from("1234567890abcdef", "hex"),
+                name: "openinference-generation",
+                kind: 1,
+                startTimeUnixNano: {
+                  low: 1000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                endTimeUnixNano: {
+                  low: 2000000,
+                  high: 406528574,
+                  unsigned: true,
+                },
+                attributes: [
+                  {
+                    key: "llm.token_count.prompt",
+                    value: { intValue: { low: 100, high: 0, unsigned: false } },
+                  },
+                  {
+                    key: "llm.token_count.completion",
+                    value: { intValue: { low: 25, high: 0, unsigned: false } },
+                  },
+                  {
+                    key: "llm.token_count.prompt_details.cache_read",
+                    value: { intValue: { low: 30, high: 0, unsigned: false } },
+                  },
+                  {
+                    key: "llm.token_count.prompt_details.cache_write",
+                    value: { intValue: { low: 10, high: 0, unsigned: false } },
+                  },
+                ],
+                status: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const events = await convertOtelSpanToIngestionEvent(
+        openInferenceSpan,
+        new Set(),
+      );
+      const observationEvent = events.find(
+        (e) => e.type === "generation-create" || e.type === "span-create",
+      );
+
+      expect(observationEvent).toBeDefined();
+      expect(observationEvent?.body.usageDetails.input).toBe(60);
+      expect(observationEvent?.body.usageDetails.output).toBe(25);
+      expect(observationEvent?.body.usageDetails.input_cached_tokens).toBe(30);
+      expect(observationEvent?.body.usageDetails.input_cache_creation).toBe(10);
+      expect(
+        observationEvent?.body.usageDetails["prompt_details.cache_read"],
+      ).toBeUndefined();
+      expect(
+        observationEvent?.body.usageDetails["prompt_details.cache_write"],
+      ).toBeUndefined();
+    });
   });
 
   describe("Vercel AI SDK Usage details", () => {


### PR DESCRIPTION
## What does this PR do?

Normalizes OpenInference prompt cache token attributes emitted under `llm.token_count.prompt_details.*` into Langfuse usage details.

Before this change, `llm.token_count.prompt_details.cache_read` and `llm.token_count.prompt_details.cache_write` were passed through as raw usage detail keys instead of being recognized as cache token fields. As a result, cached prompt tokens were not subtracted from input token counts and were not mapped into Langfuse canonical cache usage keys.

This PR maps:

- `prompt_details.cache_read` -> `input_cached_tokens`
- `prompt_details.cache_write` -> `input_cache_creation`

and excludes those raw OpenInference detail keys from the passthrough usage details.

Fixes #13571

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `pnpm.cmd --filter @langfuse/shared run lint`
- `pnpm.cmd --filter @langfuse/shared run typecheck`
- `pnpm.cmd --filter @langfuse/shared run build`
- `pnpm.cmd --filter web run lint`
- `pnpm.cmd --filter web run typecheck`
- `pnpm.cmd --filter web exec dotenv -e ../.env.test -e ../.env -- vitest run --project server src/__tests__/server/api/otel/otelMapping.servertest.ts -t 'OpenInference prompt detail cache tokens'`
- `pnpm.cmd exec prettier --check packages/shared/src/server/otel/OtelIngestionProcessor.ts web/src/__tests__/server/api/otel/otelMapping.servertest.ts --experimental-cli`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes OpenInference cache token handling in the OTEL ingestion pipeline by recognizing `llm.token_count.prompt_details.cache_read` and `llm.token_count.prompt_details.cache_write` attributes (which become `prompt_details.cache_read` / `prompt_details.cache_write` after prefix stripping) as canonical cache token fields rather than passing them through as raw usage details.

- Adds `prompt_details.cache_read` and `prompt_details.cache_write` to the cache-token lookup chains, mapping them to `input_cached_tokens` and `input_cache_creation` respectively, and subtracting them from the `input` token count.
- Adds both keys to the exclusion list in `normalizedUsageDetails` so they are not leaked as raw passthrough keys.
- Adds a dedicated test case that verifies all expected `usageDetails` values and confirms the raw keys are absent from the output.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted addition that mirrors an already-established pattern.

The fix adds two new key variants to an existing lookup chain and exclusion list following the exact same structure as the six keys already handled. The accompanying test validates token subtraction, canonical key mapping, and raw-key exclusion end-to-end. No existing behavior is altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["OTEL Span Attributes\nllm.token_count.*"] --> B["Strip prefix\nrawUsageDetails"]
    B --> C{"Is key a known\ncache token key?"}
    C -- "cache_read.input_tokens\ncache_read_tokens\ndetails.cache_read_tokens\ndetails.cache_read_input_tokens\nprompt_details.cache_read" --> D["cacheReadTokens"]
    C -- "cache_creation.input_tokens\ncache_write_tokens\ndetails.cache_write_tokens\ndetails.cache_creation_input_tokens\nprompt_details.cache_write" --> E["cacheCreationTokens"]
    C -- "other keys" --> F["normalizedUsageDetails\n(passthrough)"]
    D --> G["input_cached_tokens"]
    E --> H["input_cache_creation"]
    D & E --> I["input = prompt - cacheRead - cacheCreation"]
    F & G & H & I --> J["Final usageDetails"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): normalize openinference cache..."](https://github.com/langfuse/langfuse/commit/d08eb0e05effdb95574739a1fa45cd5678948c66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31865316)</sub>

<!-- /greptile_comment -->