### PR TITLE
fix(worker): filter Dify OTEL resource spans

### DIFF
--- a/worker/src/queues/__tests__/otelDirectEventWrite.test.ts
+++ b/worker/src/queues/__tests__/otelDirectEventWrite.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   checkHeaderBasedDirectWrite,
   checkSdkVersionRequirements,
+  filterDifyResourceSpans,
   getSdkInfoFromResourceSpans,
   type SdkInfo,
 } from "../otelIngestionQueue";
@@ -198,6 +199,55 @@ describe("checkSdkVersionRequirements (legacy fallback)", () => {
     },
   ])("$label → $expected", ({ sdkInfo, isExperiment, expected }) => {
     expect(checkSdkVersionRequirements(sdkInfo, isExperiment)).toBe(expected);
+  });
+});
+
+describe("filterDifyResourceSpans", () => {
+  it("drops resource spans with Dify service name and keeps the rest", () => {
+    const keepResourceSpan = {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "customer-service" } },
+        ],
+      },
+      scopeSpans: [{ spans: [{ name: "kept-span" }] }],
+    };
+    const dropResourceSpan = {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "langgenius/dify" } },
+        ],
+      },
+      scopeSpans: [{ spans: [{ name: "dify-span" }] }],
+    };
+    const keepSpanAttributeOnly = {
+      scopeSpans: [
+        {
+          spans: [
+            {
+              name: "span-level-service-name",
+              attributes: [
+                {
+                  key: "service.name",
+                  value: { stringValue: "langgenius/dify" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const resourceSpans = [
+      keepResourceSpan,
+      dropResourceSpan,
+      keepSpanAttributeOnly,
+    ] as unknown as Parameters<typeof filterDifyResourceSpans>[0];
+
+    expect(filterDifyResourceSpans(resourceSpans)).toEqual([
+      keepResourceSpan,
+      keepSpanAttributeOnly,
+    ]);
   });
 });
 

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -38,6 +38,9 @@ import {
   createObservationEvalSchedulerDeps,
 } from "../features/evaluation/observationEval";
 
+const DIFY_SERVICE_NAME = "langgenius/dify";
+const OTEL_SERVICE_NAME_ATTRIBUTE = "service.name";
+
 /**
  * Check if HTTP headers from the SDK request indicate the batch is eligible
  * for direct event writes.
@@ -103,6 +106,22 @@ function extractBaseSdkVersion(sdkVersion: string): string {
   }
 
   return version;
+}
+
+export function filterDifyResourceSpans(
+  resourceSpans: ResourceSpan[],
+): ResourceSpan[] {
+  if (!Array.isArray(resourceSpans)) {
+    return [];
+  }
+
+  return resourceSpans.filter((resourceSpan) => {
+    const serviceName = resourceSpan?.resource?.attributes?.find(
+      (attribute) => attribute.key === OTEL_SERVICE_NAME_ATTRIBUTE,
+    )?.value?.stringValue;
+
+    return serviceName !== DIFY_SERVICE_NAME;
+  });
 }
 
 /**
@@ -264,6 +283,22 @@ export const otelIngestionQueueProcessorBuilder = (
 
       // Parse spans from S3 download
       let parsedSpans = JSON.parse(resourceSpans);
+      const filteredSpans = filterDifyResourceSpans(parsedSpans);
+      const droppedResourceSpanCount =
+        parsedSpans.length - filteredSpans.length;
+
+      if (droppedResourceSpanCount > 0) {
+        recordIncrement(
+          "langfuse.ingestion.otel.dropped_resource_spans",
+          droppedResourceSpanCount,
+          { reason: "dify_service_name" },
+        );
+      }
+
+      parsedSpans = filteredSpans;
+      if (parsedSpans.length === 0) {
+        return;
+      }
 
       // Apply ingestion masking if enabled (EE feature)
       if (isIngestionMaskingEnabled()) {


### PR DESCRIPTION
## What changed

- Add a worker-side OTEL resource-span filter for resource-level `service.name = "langgenius/dify"`.
- Apply the filter immediately after loading the raw OTEL batch from S3, before ingestion masking and before both OTEL processor passes.
- Add a focused unit test that drops only resource-level Dify service spans and does not drop a span-level `service.name` attribute.

## Why

Dify emits OTEL spans under the `langgenius/dify` service name that should not be ingested. Filtering the parsed worker batch once keeps both downstream paths consistent: `processToIngestionEvents(...)` and `processToEvent(...)` both receive the same filtered input.

## Impact

Batches containing a mix of Dify and non-Dify resource spans continue processing the non-Dify spans. Batches containing only Dify resource spans exit early before masking, enrichment, event writes, eval scheduling, or ClickHouse writes.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run db:generate`
- `pnpm --filter @repo/eslint-plugin run build`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter worker run lint`
- `pnpm --filter worker exec vitest run src/queues/__tests__/otelDirectEventWrite.test.ts` with required dummy local env vars set
- `pnpm --filter worker run typecheck` with required dummy local env vars set
- Commit hook: repo `format:check` and `lint` passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a worker-side filter for OTEL resource spans emitted by `langgenius/dify`, dropping them before ingestion masking, enrichment, and any writes. Both the primary and secondary queue processors share the same `otelIngestionQueueProcessorBuilder`, so the filter is applied on both paths.

- `filterDifyResourceSpans` is exported and unit-tested; it correctly uses optional chaining so spans without a `resource` block (e.g. span-level `service.name` attributes) are never incorrectly filtered.
- An early return after filtering fires when the entire batch is Dify-only, saving all downstream work; a metric counter is emitted for observability but no structured log entry accompanies the silent discard.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the filter is applied before any writes and both queue processor paths share the same implementation.

The change is narrow and well-tested. The filter logic correctly handles missing resource blocks via optional chaining, the early return is positioned before masking and all downstream writes, and both the primary and secondary queue consumers reach the same code path. The only gap is the absence of a debug log when the all-Dify early return fires, which slightly reduces operational visibility but does not affect correctness.

No files require special attention beyond the minor observability note on the early-return path in otelIngestionQueue.ts.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BullMQ job received] --> B{Redirect to secondary queue?}
    B -- yes --> C[Enqueue to SecondaryOtelIngestionQueue]
    B -- no --> D[Download raw batch from S3]
    D --> E[JSON.parse parsedSpans]
    E --> F[filterDifyResourceSpans - new step]
    F --> G{droppedResourceSpanCount > 0?}
    G -- yes --> H[recordIncrement dropped_resource_spans]
    H --> I{parsedSpans.length === 0?}
    G -- no --> I
    I -- yes --> J[Early return — all spans were Dify]
    I -- no --> K{isIngestionMaskingEnabled?}
    K -- yes --> L[applyIngestionMasking]
    L --> M{maskingResult.success?}
    M -- no --> N[logger.warn + return]
    M -- yes --> O[processToIngestionEvents]
    K -- no --> O
    O --> P[Write observations and traces]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/queues/otelIngestionQueue.ts:298-301
**Missing debug log on silent early return**

When all resource spans belong to Dify and the batch is silently discarded, only the metric counter fires — there is no structured log entry. For most failure-mode early returns in this function (masking failure, secondary-queue redirect) a log line precedes the `return`. Without one here, operators who see a metric spike in `langfuse.ingestion.otel.dropped_resource_spans` have no correlated log to look up the affected `projectId` or `fileKey`.

Consider adding a `logger.debug(...)` with `{ projectId, fileKey, droppedResourceSpanCount }` before `return` so the batch can be identified in log-based investigations.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/filter-di..."](https://github.com/langfuse/langfuse/commit/57c3ffd9cfd06c2cbdfbcc1e69108dc663f5f099) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31924265)</sub>

<!-- /greptile_comment -->