### PR TITLE
fix(api): exclude deleted score versions from scores count

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2407,6 +2407,54 @@ export type ScoreQueryType = {
   advancedFilters?: FilterState;
 };
 
+const buildPublicApiScoresVersionedQuery = ({
+  selectClause,
+  needsTraceJoin,
+  scoreScope,
+  appliedScoresFilterQuery,
+  appliedTracesFilterQuery,
+  hasTraceFilters,
+}: {
+  selectClause: string;
+  needsTraceJoin: boolean;
+  scoreScope: "traces_only" | "all";
+  appliedScoresFilterQuery?: string;
+  appliedTracesFilterQuery?: string;
+  hasTraceFilters: boolean;
+}) => `
+      SELECT
+          ${selectClause}
+      FROM
+          scores s
+          ${needsTraceJoin ? "LEFT JOIN __TRACE_TABLE__ t ON s.trace_id = t.id AND s.project_id = t.project_id" : ""}
+      WHERE
+          s.project_id = {projectId: String}
+          AND (
+            ${scoreScope === "traces_only" ? "" : "s.trace_id IS NULL OR "}
+            (s.trace_id IS NOT NULL AND (${needsTraceJoin ? "t.id, t.project_id" : "s.trace_id, s.project_id"}) IN (
+              SELECT
+                ${needsTraceJoin ? "trace_id, project_id" : "s.trace_id, s.project_id"}
+              FROM
+                scores s
+              WHERE
+                s.project_id = {projectId: String}
+                ${appliedScoresFilterQuery ? `AND ${appliedScoresFilterQuery}` : ""}
+                ${scoreScope === "traces_only" ? "AND s.session_id IS NULL AND s.dataset_run_id IS NULL" : ""}
+              ORDER BY
+                s.timestamp desc, s.event_ts desc
+              LIMIT
+                1 BY s.id, s.project_id
+                ))
+          )
+          ${scoreScope === "traces_only" ? "AND s.session_id IS NULL AND s.dataset_run_id IS NULL" : ""}
+          ${appliedScoresFilterQuery ? `AND ${appliedScoresFilterQuery}` : ""}
+          ${hasTraceFilters && appliedTracesFilterQuery ? `AND ${appliedTracesFilterQuery}` : ""}
+      ORDER BY
+          s.timestamp desc, s.event_ts desc
+      LIMIT
+          1 BY s.id, s.project_id
+`;
+
 export const _handleGenerateScoresForPublicApi = async ({
   projectId,
   scoresFilter,
@@ -2427,12 +2475,14 @@ export const _handleGenerateScoresForPublicApi = async ({
   const appliedScoresFilter = scoresFilter.apply();
   const appliedTracesFilter = tracesFilter.apply();
 
-  const query = `
-      SELECT
+  const versionedScoresQuery = buildPublicApiScoresVersionedQuery({
+    selectClause: `
           ${needsTraceJoin ? "t.user_id as user_id, t.tags as tags, t.environment as trace_environment, t.session_id as trace_session_id," : ""}
           s.id as id,
           s.project_id as project_id,
           s.timestamp as timestamp,
+          s.event_ts as event_ts,
+          s.is_deleted as is_deleted,
           s.environment as environment,
           s.name as name,
           s.value as value,
@@ -2451,36 +2501,23 @@ export const _handleGenerateScoresForPublicApi = async ({
           s.trace_id as trace_id,
           s.observation_id as observation_id,
           s.session_id as session_id,
-          s.dataset_run_id as dataset_run_id
-      FROM
-          scores s
-          ${needsTraceJoin ? "LEFT JOIN __TRACE_TABLE__ t ON s.trace_id = t.id AND s.project_id = t.project_id" : ""}
+          s.dataset_run_id as dataset_run_id`,
+    needsTraceJoin,
+    scoreScope,
+    appliedScoresFilterQuery: appliedScoresFilter.query,
+    appliedTracesFilterQuery: appliedTracesFilter.query,
+    hasTraceFilters: tracesFilter.length() > 0,
+  });
+
+  const query = `
+      SELECT *
+      FROM (
+        ${versionedScoresQuery}
+      )
       WHERE
-          s.project_id = {projectId: String}
-          AND (
-            ${scoreScope === "traces_only" ? "" : "s.trace_id IS NULL OR "}
-            (s.trace_id IS NOT NULL AND (${needsTraceJoin ? "t.id, t.project_id" : "s.trace_id, s.project_id"}) IN (
-              SELECT
-                ${needsTraceJoin ? "trace_id, project_id" : "s.trace_id, s.project_id"}
-              FROM
-                scores s
-              WHERE
-                s.project_id = {projectId: String}
-                ${appliedScoresFilter.query ? `AND ${appliedScoresFilter.query}` : ""}
-                ${scoreScope === "traces_only" ? "AND s.session_id IS NULL AND s.dataset_run_id IS NULL" : ""}
-              ORDER BY
-                s.timestamp desc
-              LIMIT
-                1 BY s.id, s.project_id
-                ))
-          )
-          ${scoreScope === "traces_only" ? "AND s.session_id IS NULL AND s.dataset_run_id IS NULL" : ""}
-          ${appliedScoresFilter.query ? `AND ${appliedScoresFilter.query}` : ""}
-          ${tracesFilter.length() > 0 ? `AND ${appliedTracesFilter.query}` : ""}
+          is_deleted = 0
       ORDER BY
-          s.timestamp desc, s.event_ts desc
-      LIMIT
-          1 BY s.id, s.project_id
+          timestamp desc, event_ts desc
       ${pagination !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
       `;
 
@@ -2560,33 +2597,26 @@ export const _handleGetScoresCountForPublicApi = async ({
   const appliedScoresFilter = scoresFilter.apply();
   const appliedTracesFilter = tracesFilter.apply();
 
+  const versionedScoresQuery = buildPublicApiScoresVersionedQuery({
+    selectClause: `
+          s.id as id,
+          s.project_id as project_id,
+          s.is_deleted as is_deleted`,
+    needsTraceJoin,
+    scoreScope,
+    appliedScoresFilterQuery: appliedScoresFilter.query,
+    appliedTracesFilterQuery: appliedTracesFilter.query,
+    hasTraceFilters: tracesFilter.length() > 0,
+  });
+
   const query = `
       SELECT
         count() as count
-      FROM
-        scores s
-          ${needsTraceJoin ? "LEFT JOIN __TRACE_TABLE__ t ON s.trace_id = t.id AND s.project_id = t.project_id" : ""}
-      WHERE
-        s.project_id = {projectId: String}
-      AND (
-        ${scoreScope === "traces_only" ? "" : "s.trace_id IS NULL OR "}
-        (s.trace_id IS NOT NULL AND (${needsTraceJoin ? "t.id, t.project_id" : "s.trace_id, s.project_id"}) IN (
-          SELECT
-            ${needsTraceJoin ? "trace_id, project_id" : "s.trace_id, s.project_id"}
-          FROM
-            scores s
-          WHERE
-            s.project_id = {projectId: String}
-            ${appliedScoresFilter.query ? `AND ${appliedScoresFilter.query}` : ""}
-            ${scoreScope === "traces_only" ? "AND s.session_id IS NULL" : ""}
-          ORDER BY
-            s.timestamp desc
-          LIMIT
-            1 BY s.id, s.project_id
-        ))
+      FROM (
+        ${versionedScoresQuery}
       )
-      ${appliedScoresFilter.query ? `AND ${appliedScoresFilter.query}` : ""}
-      ${tracesFilter.length() > 0 ? `AND ${appliedTracesFilter.query}` : ""}
+      WHERE
+        is_deleted = 0
       `;
 
   return measureAndReturn({

--- a/web/src/__tests__/server/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v1.servertest.ts
@@ -1,5 +1,6 @@
 import {
   createObservation,
+  createDatasetRunScore,
   createTraceScore,
   createTrace,
   createSessionScore,
@@ -470,6 +471,7 @@ describe("/api/public/scores API Endpoint", () => {
       const scoreId_5 = v4();
       const scoreId_6 = v4();
       const scoreId_7 = v4();
+      const scoreId_8 = v4();
       const textScoreId_1 = v4();
       const textScoreId_2 = v4();
       let authentication: string;
@@ -618,6 +620,15 @@ describe("/api/public/scores API Endpoint", () => {
           data_type: "NUMERIC",
         });
 
+        const datasetRunScore = createDatasetRunScore({
+          id: scoreId_8,
+          project_id: newProjectId,
+          dataset_run_id: datasetRunId,
+          name: scoreName,
+          value: 100.5,
+          data_type: "NUMERIC",
+        });
+
         await createScoresCh([
           score1,
           score2,
@@ -628,6 +639,7 @@ describe("/api/public/scores API Endpoint", () => {
           textScore2,
           sessionScore1,
           sessionScore2,
+          datasetRunScore,
         ]);
       });
 
@@ -643,7 +655,7 @@ describe("/api/public/scores API Endpoint", () => {
         expect(getAllScore.body.meta).toMatchObject({
           page: 1,
           limit: 50,
-          totalItems: 7, // 9 scores in total, but only 7 are trace scores
+          totalItems: 7, // 10 scores in total, but only 7 are trace scores
           totalPages: 1,
         });
         for (const val of getAllScore.body.data) {

--- a/web/src/__tests__/server/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v2.servertest.ts
@@ -510,6 +510,76 @@ describe("/api/public/v2/scores API Endpoint", () => {
         );
       });
 
+      it("excludes soft-deleted score versions from data and totalItems", async () => {
+        const { projectId, auth } = await createOrgProjectAndApiKey();
+        const traceId = v4();
+        const visibleScoreId = v4();
+        const deletedScoreId = v4();
+        const baseTimestamp = Date.now();
+
+        await createTracesCh([
+          createTrace({
+            id: traceId,
+            project_id: projectId,
+          }),
+        ]);
+
+        const deletedScoreLiveVersion = createTraceScore({
+          id: deletedScoreId,
+          project_id: projectId,
+          trace_id: traceId,
+          name: "deleted-score",
+          timestamp: baseTimestamp,
+          event_ts: baseTimestamp,
+          value: 1,
+          data_type: "NUMERIC",
+        });
+
+        const deletedScoreTombstone = {
+          ...deletedScoreLiveVersion,
+          event_ts: baseTimestamp + 1,
+          is_deleted: 1 as const,
+        };
+
+        const visibleScore = createTraceScore({
+          id: visibleScoreId,
+          project_id: projectId,
+          trace_id: traceId,
+          name: "visible-score",
+          timestamp: baseTimestamp + 2,
+          event_ts: baseTimestamp + 2,
+          value: 2,
+          data_type: "NUMERIC",
+        });
+
+        await createScoresCh([
+          deletedScoreLiveVersion,
+          deletedScoreTombstone,
+          visibleScore,
+        ]);
+
+        const getScores = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores`,
+          undefined,
+          auth,
+        );
+
+        expect(getScores.status).toBe(200);
+        expect(getScores.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 1,
+          totalPages: 1,
+        });
+        expect(getScores.body.data).toHaveLength(1);
+        expect(getScores.body.data[0].id).toBe(visibleScoreId);
+        expect(
+          getScores.body.data.find((score) => score.id === deletedScoreId),
+        ).toBeUndefined();
+      });
+
       it("get all scores for config", async () => {
         const getAllScore = await makeZodVerifiedAPICall(
           GetScoresResponseV2,


### PR DESCRIPTION
## Summary

Fixes #13559.

This updates the public scores list/count query path to compute both `data` and `meta.totalItems` from the same latest-version score view:

- dedupe score versions with `ORDER BY s.timestamp desc, s.event_ts desc LIMIT 1 BY s.id, s.project_id`
- filter `is_deleted = 0` only after that dedupe step, so ReplacingMergeTree tombstones do not allow older live versions to reappear
- reuse the same versioned query shape for the data and count paths
- add regression coverage for a live score version followed by a tombstone, plus one visible score, asserting both response data and `meta.totalItems` exclude the deleted score

## Review follow-up

- [x] Addressed Greptile's `event_ts` tiebreaker note in `a32351f`.
- [x] Added v1 `traces_only` dataset-run score count coverage in `a32351f` to document the count/data alignment.

## Testing

- [x] `pnpm.cmd exec prettier --check web/src/features/public-api/server/scores.ts web/src/__tests__/server/scores-api-v2.servertest.ts`
- [x] `git diff --check`
- [x] `pnpm.cmd --filter web typecheck`
- [x] `pnpm.cmd --filter web lint`
- [ ] Targeted server test: blocked locally because another project is bound to `localhost:3000`, while the existing test helper hardcodes that port
- [ ] Maintainer CI: waiting for protected fork workflow approval (`all-ci-passed`, spelling, `zizmor` are not reported yet)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where soft-deleted scores (tombstoned via `is_deleted = 1`) could still appear in the public scores API when ClickHouse's background ReplacingMergeTree merge had not yet run. The fix wraps the score query in a subquery that first deduplicates rows with `ORDER BY timestamp desc, event_ts desc LIMIT 1 BY id, project_id`, then filters `is_deleted = 0` in the outer query — ensuring tombstones can never resurrect older live versions.

- `buildPublicApiScoresVersionedQuery` is extracted to share the same deduplicated view between the data and count code paths, replacing two structurally divergent queries.
- The `traces_only` count path silently gains a `dataset_run_id IS NULL` guard (the old count query had only `session_id IS NULL`), bringing count semantics in line with the data query.
- A regression test is added that inserts a live version followed by a tombstone for the same score ID, asserts the deleted score is absent from both `data` and `meta.totalItems`, and verifies the remaining visible score is returned correctly.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; it correctly addresses the tombstone resurrection bug and unifies the data and count query paths without introducing regressions in the primary score retrieval logic.

The core deduplication approach (subquery with LIMIT 1 BY followed by outer is_deleted = 0 filter) is correct for ClickHouse ReplacingMergeTree. The two observations — inner IN subquery lacking event_ts in its ORDER BY, and the silent behavioral change to traces_only count — are both non-blocking: the former is a pre-existing inconsistency that does not affect result correctness, and the latter is actually a bug fix that aligns count semantics with the data query. The regression test is logically sound but the PR author notes it could not be verified locally against the actual service due to a port conflict.

web/src/features/public-api/server/scores.ts warrants a close read on the traces_only count behavior change; callers that depend on dataset-run scores being included in that count will now see a different totalItems.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["API Request\n/api/public/v2/scores"] --> B["buildPublicApiScoresVersionedQuery\n(inner subquery)"]
    B --> C["SELECT cols FROM scores s\nLEFT JOIN traces t (if needed)\nWHERE project_id AND filters"]
    C --> D["ORDER BY timestamp desc, event_ts desc\nLIMIT 1 BY id, project_id\n(deduplicate — picks latest version)"]
    D --> E["Outer query wrapper"]
    E --> F["WHERE is_deleted = 0\n(filter tombstones after dedup)"]
    F --> G{"query type?"}
    G -->|"data"| H["ORDER BY timestamp desc, event_ts desc\nLIMIT n OFFSET m\n(paginate)"]
    G -->|"count"| I["SELECT count()"]
    H --> J["convertClickhouseScoreToDomain\n+ convertScoreToPublicApi"]
    I --> K["meta.totalItems"]
    J --> L["response.data"]

    style D fill:#f9f,stroke:#333
    style F fill:#9f9,stroke:#333
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/public-api/server/scores.ts:107-121
**Inner IN subquery deduplicates without `event_ts` tiebreaker**

The inner `SELECT … LIMIT 1 BY s.id, s.project_id` inside the `IN (…)` clause orders only by `s.timestamp desc`, omitting `s.event_ts desc`. The outer deduplication (line 127–129) uses both fields. When two versions of the same score share an identical `timestamp` but differ in `event_ts`, the inner and outer deduplications may pick different "latest" rows. Because the inner subquery only contributes `(trace_id, project_id)` to the `IN` set, and both versions share the same `trace_id`, correctness is preserved in all known cases — but the inconsistency is a latent gap if the semantics of the IN set are ever widened. This pattern was present before this PR.

### Issue 2 of 2
web/src/features/public-api/server/scores.ts:289-299
**`traces_only` count now also excludes `dataset_run_id IS NOT NULL` scores**

The old `_handleGetScoresCountForPublicApi` query applied only `AND s.session_id IS NULL` for the `traces_only` scope, while the data query applied `AND s.session_id IS NULL AND s.dataset_run_id IS NULL`. By sharing `buildPublicApiScoresVersionedQuery`, both paths now apply both conditions. This silently changes the count for callers using `scoreScope = "traces_only"` when dataset-run scores exist in the project. The change is more correct, but it is an undocumented behavioral delta that may shift `meta.totalItems` for existing integrations.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): exclude deleted score versions..."](https://github.com/langfuse/langfuse/commit/d2a3db188544e1f338823ae36af00cdc0534663a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31941164)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->