### PR TITLE
chore: add CODEOWNERS for GitHub config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Currently inactive
 # * @langfuse/maintainers
+
+# Require maintainer review for GitHub configuration changes
+.github/ @langfuse/maintainers


### PR DESCRIPTION
## Summary
- add/update `.github/CODEOWNERS` to require `@langfuse/maintainers` review for `.github/` changes

Linear: https://linear.app/langfuse/issue/LFE-9760/repo-owners-for-github-actions

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR activates a CODEOWNERS rule requiring `@langfuse/maintainers` approval for any changes under the `.github/` directory, including the CODEOWNERS file itself.

- Adds `.github/ @langfuse/maintainers` to enforce mandatory maintainer review on all GitHub configuration files (workflows, actions, issue templates, etc.).
- The previously present global ownership rule (`* @langfuse/maintainers`) remains commented out, so only the `.github/` path is actively gated.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a one-line config addition that enforces maintainer review on `.github/` changes going forward.

The change is minimal and self-contained: a single CODEOWNERS pattern with a clear, correct team assignment. The only note is that anchoring the pattern with a leading `/` would be more explicit, but has no practical effect in this repository.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened with changes] --> B{Files changed in `.github/` directory?}
    B -- Yes --> C[GitHub requests review from `@langfuse/maintainers`]
    B -- No --> D[Normal review process, no CODEOWNERS requirement]
    C --> E{Maintainer approves?}
    E -- Yes --> F[PR can be merged]
    E -- No --> G[PR blocked from merging]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/CODEOWNERS:5
The pattern `.github/` without a leading `/` follows `.gitignore` semantics and would match any directory named `.github/` anywhere in the repository tree. Using `/.github/` anchors the match to the root-level `.github/` directory specifically, which is the intended target.

```suggestion
/.github/ @langfuse/maintainers
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add codeowners for github config"](https://github.com/langfuse/langfuse/commit/37ec6ceb5bea731b1663d5b1946730b6b6f6a86b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31952259)</sub>

<!-- /greptile_comment -->