### PR TITLE
refactor(blob-export): split OBSERVATION_FIELD_GROUPS from BLOB_EXPORT_FIELD_GROUPS

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -298,6 +298,9 @@ types:
       totalCost:
         type: optional<nullable<double>>
         docs: The total cost of the observation in USD
+      usagePricingTierName:
+        type: optional<nullable<string>>
+        docs: The name of the pricing tier applied to this observation's usage costs
 
       # Prompt fields (field group: prompt)
       promptId:

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -22,7 +22,7 @@ service:
         - `io` - input, output
         - `metadata` - metadata (truncated to 200 chars by default, use `expandMetadata` to get full values)
         - `model` - providedModelName, internalModelId, modelParameters
-        - `usage` - usageDetails, costDetails, totalCost
+        - `usage` - usageDetails, costDetails, totalCost, usagePricingTierName
         - `prompt` - promptId, promptName, promptVersion
         - `metrics` - latency, timeToFirstToken
 

--- a/packages/shared/src/domain/index.ts
+++ b/packages/shared/src/domain/index.ts
@@ -1,3 +1,4 @@
+export * from "./observation-field-groups";
 export * from "./observations";
 export * from "./traces";
 export * from "./scores";

--- a/packages/shared/src/domain/observation-field-groups.ts
+++ b/packages/shared/src/domain/observation-field-groups.ts
@@ -1,0 +1,41 @@
+/**
+ * Vocabulary of observation field groups projected from the events repository.
+ *
+ * The events repository owns these definitions; features (the v2 public API,
+ * blob export, ...) consume them. Two sets exist because the v2 public API
+ * contract is deliberately narrower than the broader exporter surface:
+ *
+ * - OBSERVATION_FIELD_GROUPS_PUBLIC_API: v2 public API contract — the groups that the
+ *   v2 observations endpoint can return.
+ * - OBSERVATION_FIELD_GROUPS_FULL: the complete set of column groups the
+ *   events repository can project, including denormalized trace context and
+ *   tool fields that the public API does not currently expose.
+ *
+ * Defined in the client-safe domain layer (not inside the server-only
+ * repository file) so frontend forms and Zod enums can reference the values
+ * without pulling in repository runtime code.
+ */
+
+export const OBSERVATION_FIELD_GROUPS_PUBLIC_API = [
+  "core", // Always included: id, traceId, startTime, endTime, projectId, parentObservationId, type
+  "basic", // name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId
+  "time", // completionStartTime, createdAt, updatedAt
+  "io", // input, output
+  "metadata", // metadata
+  "model", // providedModelName, internalModelId, modelParameters
+  "usage", // usageDetails, costDetails, totalCost, usagePricingTierName
+  "prompt", // promptId, promptName, promptVersion
+  "metrics", // latency, timeToFirstToken
+] as const;
+
+export type ObservationFieldGroupPublicApi =
+  (typeof OBSERVATION_FIELD_GROUPS_PUBLIC_API)[number];
+
+export const OBSERVATION_FIELD_GROUPS_FULL = [
+  ...OBSERVATION_FIELD_GROUPS_PUBLIC_API,
+  "tools", // toolDefinitions, toolCalls, toolCallNames
+  "trace_context", // tags, release, traceName (denormalized trace metadata)
+] as const;
+
+export type ObservationFieldGroupFull =
+  (typeof OBSERVATION_FIELD_GROUPS_FULL)[number];

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -79,7 +79,7 @@ const EXPORT_FIELD_GROUP_LABELS = {
   usage: {
     label: "Usage",
     description:
-      "usage_details, cost_details, total_cost, input_price, output_price, total_price",
+      "usage_details, cost_details, total_cost, input_price, output_price, total_price, usage_pricing_tier_name",
   },
   prompt: {
     label: "Prompt",
@@ -95,7 +95,7 @@ const EXPORT_FIELD_GROUP_LABELS = {
   },
   trace_context: {
     label: "Trace Context",
-    description: "tags, release, trace_name, usage_pricing_tier_name",
+    description: "tags, release, trace_name",
   },
 } satisfies Record<
   BlobExportFieldGroup,

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -2,6 +2,10 @@
 // This is a client-safe file that can be imported from @langfuse/shared
 
 import { AnalyticsIntegrationExportSource } from "@prisma/client";
+import {
+  OBSERVATION_FIELD_GROUPS_FULL,
+  type ObservationFieldGroupFull,
+} from "../../domain/observation-field-groups";
 
 export const EXPORT_SOURCE_OPTIONS: Array<{
   value: AnalyticsIntegrationExportSource;
@@ -31,24 +35,8 @@ export const EXPORT_SOURCE_OPTIONS: Array<{
 export type ExportSourceOption = (typeof EXPORT_SOURCE_OPTIONS)[number];
 export type ExportSourceValue = ExportSourceOption["value"];
 
-export const BLOB_EXPORT_FIELD_GROUPS = [
-  "core",
-  "basic",
-  "time",
-  "io",
-  "metadata",
-  "model",
-  "usage",
-  "prompt",
-  "metrics",
-  "tools",
-  "trace_context",
-] as const;
-
-export type BlobExportFieldGroup = (typeof BLOB_EXPORT_FIELD_GROUPS)[number];
-
-// Keyed by BlobExportFieldGroup so TypeScript errors if a group is added to
-// BLOB_EXPORT_FIELD_GROUPS without a corresponding label/description here.
+// Keyed by ObservationFieldGroupFull so TypeScript errors if a group is added
+// to OBSERVATION_FIELD_GROUPS_FULL without a corresponding label/description here.
 const EXPORT_FIELD_GROUP_LABELS = {
   core: {
     label: "Core",
@@ -98,10 +86,10 @@ const EXPORT_FIELD_GROUP_LABELS = {
     description: "tags, release, trace_name",
   },
 } satisfies Record<
-  BlobExportFieldGroup,
+  ObservationFieldGroupFull,
   { label: string; description: string }
 >;
 
-export const EXPORT_FIELD_GROUP_OPTIONS = BLOB_EXPORT_FIELD_GROUPS.map(
+export const EXPORT_FIELD_GROUP_OPTIONS = OBSERVATION_FIELD_GROUPS_FULL.map(
   (value) => ({ value, ...EXPORT_FIELD_GROUP_LABELS[value] }),
 );

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -226,7 +226,7 @@ const FIELD_SETS = {
   io: ["input", "output"],
   metadata: ["metadata"],
   tools: ["toolDefinitions", "toolCalls", "toolCallNames"],
-  trace_context: ["tags", "release", "traceName", "usagePricingTierName"],
+  trace_context: ["tags", "release", "traceName"],
   model_export: ["providedModelName", "modelId", "modelParameters"],
   eventTs: ["eventTs"],
 
@@ -293,7 +293,7 @@ const FIELD_SETS = {
   ],
   time: ["completionStartTime", "createdAt", "updatedAt"],
   model: ["providedModelName", "internalModelId", "modelParameters"],
-  usage: ["usageDetails", "costDetails", "totalCost"],
+  usage: ["usageDetails", "costDetails", "totalCost", "usagePricingTierName"],
   prompt: ["promptId", "promptName", "promptVersion"],
   metrics: ["latency", "timeToFirstToken"],
 

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -50,6 +50,10 @@ import {
   RenderingProps,
 } from "../utils/rendering";
 import {
+  BLOB_EXPORT_FIELD_GROUPS,
+  type BlobExportFieldGroup,
+} from "../../features/analytics-integrations";
+import {
   commandClickhouse,
   parseClickhouseUTCDateTimeFormat,
   queryClickhouse,
@@ -862,6 +866,11 @@ export const getTraceByIdFromEventsTable = async ({
  *
  * - core: Always included (cursor-required fields)
  * - basic, time, io, metadata, model, usage, prompt, metrics: Optional groups
+ *
+ * Scoped to the observation contract. The blob exporter has a separate,
+ * broader set (`BLOB_EXPORT_FIELD_GROUPS`) that adds denormalized trace
+ * context and tool fields. Keep the two lists distinct so changes to the
+ * exporter cannot silently widen the public API contract.
  */
 export const OBSERVATION_FIELD_GROUPS = [
   "core", // Always included: id, traceId, startTime, endTime, projectId, parentObservationId, type
@@ -870,11 +879,9 @@ export const OBSERVATION_FIELD_GROUPS = [
   "io", // input, output
   "metadata", // metadata
   "model", // providedModelName, internalModelId, modelParameters
-  "usage", // usageDetails, costDetails, totalCost
+  "usage", // usageDetails, costDetails, totalCost, usagePricingTierName
   "prompt", // promptId, promptName, promptVersion
   "metrics", // latency, timeToFirstToken
-  "tools", // toolDefinitions, toolCalls, toolCallNames
-  "trace_context", // tags, release, traceName, usagePricingTierName
 ] as const;
 
 export type ObservationFieldGroup = (typeof OBSERVATION_FIELD_GROUPS)[number];
@@ -2984,14 +2991,14 @@ export const getEventsForBlobStorageExport = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-  fieldGroups: ObservationFieldGroup[] = [...OBSERVATION_FIELD_GROUPS],
+  fieldGroups: BlobExportFieldGroup[] = [...BLOB_EXPORT_FIELD_GROUPS],
 ) {
   const queryBuilder = new EventsQueryBuilder({ projectId });
 
   // core is always required (provides id, trace_id, start/end_time used for cursor and deduplication)
   const effectiveGroups = fieldGroups.includes("core")
     ? fieldGroups
-    : (["core", ...fieldGroups] as ObservationFieldGroup[]);
+    : (["core", ...fieldGroups] as BlobExportFieldGroup[]);
 
   // model_export must be selected whenever model or usage is requested:
   // - model group: include model identification fields in the output

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -50,9 +50,11 @@ import {
   RenderingProps,
 } from "../utils/rendering";
 import {
-  BLOB_EXPORT_FIELD_GROUPS,
-  type BlobExportFieldGroup,
-} from "../../features/analytics-integrations";
+  OBSERVATION_FIELD_GROUPS_PUBLIC_API,
+  OBSERVATION_FIELD_GROUPS_FULL,
+  type ObservationFieldGroupPublicApi,
+  type ObservationFieldGroupFull,
+} from "../../domain/observation-field-groups";
 import {
   commandClickhouse,
   parseClickhouseUTCDateTimeFormat,
@@ -125,7 +127,7 @@ async function enrichObservationsWithModelData(
   observationRecords: Array<ObservationsTableQueryResultWitouhtTraceFields>,
   projectId: string,
   parseIoAsJson: boolean,
-  requestedFields: ObservationFieldGroup[],
+  requestedFields: ObservationFieldGroupPublicApi[],
 ): Promise<Array<EventsObservationPublic>>;
 async function enrichObservationsWithModelData(
   observationRecords: Array<ObservationsTableQueryResultWitouhtTraceFields>,
@@ -137,7 +139,7 @@ async function enrichObservationsWithModelData(
   observationRecords: Array<ObservationsTableQueryResultWitouhtTraceFields>,
   projectId: string,
   parseIoAsJson: boolean,
-  requestedFields: ObservationFieldGroup[] | null,
+  requestedFields: ObservationFieldGroupPublicApi[] | null,
 ): Promise<
   Array<(EventsObservation & ObservationPriceFields) | EventsObservationPublic>
 > {
@@ -861,31 +863,6 @@ export const getTraceByIdFromEventsTable = async ({
   return res.shift();
 };
 
-/**
- * Field groups for selective field fetching in v2 observations API
- *
- * - core: Always included (cursor-required fields)
- * - basic, time, io, metadata, model, usage, prompt, metrics: Optional groups
- *
- * Scoped to the observation contract. The blob exporter has a separate,
- * broader set (`BLOB_EXPORT_FIELD_GROUPS`) that adds denormalized trace
- * context and tool fields. Keep the two lists distinct so changes to the
- * exporter cannot silently widen the public API contract.
- */
-export const OBSERVATION_FIELD_GROUPS = [
-  "core", // Always included: id, traceId, startTime, endTime, projectId, parentObservationId, type
-  "basic", // name, level, statusMessage, version, environment, bookmarked, public, userId, sessionId
-  "time", // completionStartTime, createdAt, updatedAt
-  "io", // input, output
-  "metadata", // metadata
-  "model", // providedModelName, internalModelId, modelParameters
-  "usage", // usageDetails, costDetails, totalCost, usagePricingTierName
-  "prompt", // promptId, promptName, promptVersion
-  "metrics", // latency, timeToFirstToken
-] as const;
-
-export type ObservationFieldGroup = (typeof OBSERVATION_FIELD_GROUPS)[number];
-
 type PublicApiObservationsQuery = {
   projectId: string;
   page: number;
@@ -907,7 +884,7 @@ type PublicApiObservationsQuery = {
     lastTraceId: string;
     lastId: string;
   };
-  fields?: ObservationFieldGroup[] | null;
+  fields?: ObservationFieldGroupPublicApi[] | null;
   /**
    * Metadata keys to expand (return full non-truncated values).
    * - null/undefined: use truncated metadata (default behavior)
@@ -1130,7 +1107,7 @@ export const getObservationsFromEventsTableForPublicApi = async (
     applyOrderByForObservationsQuery(buildObservationsQueryBase(opts)),
   );
 
-  OBSERVATION_FIELD_GROUPS.forEach((fieldGroup) => {
+  OBSERVATION_FIELD_GROUPS_PUBLIC_API.forEach((fieldGroup) => {
     queryBuilder.selectFieldSet(fieldGroup);
   });
 
@@ -1161,7 +1138,9 @@ export const getObservationsFromEventsTableForPublicApi = async (
  * This avoids expensive full-table scans on events_full.
  */
 export const getObservationsV2FromEventsTableForPublicApi = async (
-  opts: PublicApiObservationsQuery & { fields: ObservationFieldGroup[] },
+  opts: PublicApiObservationsQuery & {
+    fields: ObservationFieldGroupPublicApi[];
+  },
 ): Promise<Array<EventsObservationPublic>> => {
   const { projectId, expandMetadataKeys } = opts;
 
@@ -2991,14 +2970,14 @@ export const getEventsForBlobStorageExport = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
-  fieldGroups: BlobExportFieldGroup[] = [...BLOB_EXPORT_FIELD_GROUPS],
+  fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
 ) {
   const queryBuilder = new EventsQueryBuilder({ projectId });
 
   // core is always required (provides id, trace_id, start/end_time used for cursor and deduplication)
   const effectiveGroups = fieldGroups.includes("core")
     ? fieldGroups
-    : (["core", ...fieldGroups] as BlobExportFieldGroup[]);
+    : (["core", ...fieldGroups] as ObservationFieldGroupFull[]);
 
   // model_export must be selected whenever model or usage is requested:
   // - model group: include model identification fields in the output

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8081,6 +8081,12 @@ components:
           format: double
           nullable: true
           description: The total cost of the observation in USD
+        usagePricingTierName:
+          type: string
+          nullable: true
+          description: >-
+            The name of the pricing tier applied to this observation's usage
+            costs
         promptId:
           type: string
           nullable: true

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3127,7 +3127,7 @@ paths:
 
         - `model` - providedModelName, internalModelId, modelParameters
 
-        - `usage` - usageDetails, costDetails, totalCost
+        - `usage` - usageDetails, costDetails, totalCost, usagePricingTierName
 
         - `prompt` - promptId, promptName, promptVersion
 

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -7,7 +7,7 @@ import {
 } from "@/src/features/blobstorage-integration/types";
 import {
   AnalyticsIntegrationExportSource,
-  BLOB_EXPORT_FIELD_GROUPS,
+  OBSERVATION_FIELD_GROUPS_FULL,
   BlobStorageExportMode,
   BlobStorageIntegrationFileType,
   BlobStorageIntegrationType,
@@ -23,7 +23,7 @@ const VALID_BASE: BlobStorageIntegrationFormSchema = {
   fileType: BlobStorageIntegrationFileType.JSONL,
   exportMode: BlobStorageExportMode.FULL_HISTORY,
   exportSource: AnalyticsIntegrationExportSource.EVENTS,
-  exportFieldGroups: [...BLOB_EXPORT_FIELD_GROUPS],
+  exportFieldGroups: [...OBSERVATION_FIELD_GROUPS_FULL],
   compressed: true,
   endpoint: null,
   accessKeyId: "",

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -9,7 +9,7 @@ import {
   createAndAddApiKeysToDb,
   createBasicAuthHeader,
 } from "@langfuse/shared/src/server";
-import { BLOB_EXPORT_FIELD_GROUPS } from "@langfuse/shared";
+import { OBSERVATION_FIELD_GROUPS_FULL } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 
 // Schemas based on Fern schema definition
@@ -34,7 +34,7 @@ const BlobStorageIntegrationResponseSchema = z.object({
     "OBSERVATIONS_V2",
     "LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS",
   ]),
-  exportFieldGroups: z.array(z.enum(BLOB_EXPORT_FIELD_GROUPS)).nullable(),
+  exportFieldGroups: z.array(z.enum(OBSERVATION_FIELD_GROUPS_FULL)).nullable(),
   nextSyncAt: z.coerce.date().nullable(),
   lastSyncAt: z.coerce.date().nullable(),
   createdAt: z.coerce.date(),
@@ -721,10 +721,10 @@ describe("Blob Storage Integrations API", () => {
       expect(integration?.exportSource).toBe("OBSERVATIONS_V2");
       expect(integration?.exportFieldGroups).toBeDefined();
       expect(integration?.exportFieldGroups).toHaveLength(
-        BLOB_EXPORT_FIELD_GROUPS.length,
+        OBSERVATION_FIELD_GROUPS_FULL.length,
       );
       expect(new Set(integration?.exportFieldGroups)).toStrictEqual(
-        new Set(BLOB_EXPORT_FIELD_GROUPS),
+        new Set(OBSERVATION_FIELD_GROUPS_FULL),
       );
     });
 
@@ -759,10 +759,10 @@ describe("Blob Storage Integrations API", () => {
       expect(integration).toBeDefined();
       expect(integration?.exportFieldGroups).toBeDefined();
       expect(integration?.exportFieldGroups).toHaveLength(
-        BLOB_EXPORT_FIELD_GROUPS.length,
+        OBSERVATION_FIELD_GROUPS_FULL.length,
       );
       expect(new Set(integration?.exportFieldGroups)).toStrictEqual(
-        new Set(BLOB_EXPORT_FIELD_GROUPS),
+        new Set(OBSERVATION_FIELD_GROUPS_FULL),
       );
     });
 

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -11,7 +11,7 @@ import {
   QueueJobs,
   StorageServiceFactory,
 } from "@langfuse/shared/src/server";
-import { BLOB_EXPORT_FIELD_GROUPS } from "@langfuse/shared";
+import { OBSERVATION_FIELD_GROUPS_FULL } from "@langfuse/shared";
 
 vi.mock("@langfuse/shared/src/server", async () => {
   const actual = await vi.importActual("@langfuse/shared/src/server");
@@ -363,7 +363,7 @@ describe("Blob Storage Integration tRPC Router", () => {
         where: { projectId: project.id },
       });
       expect(stored?.exportFieldGroups).toStrictEqual([
-        ...BLOB_EXPORT_FIELD_GROUPS,
+        ...OBSERVATION_FIELD_GROUPS_FULL,
       ]);
     });
 

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -534,6 +534,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
       "usageDetails",
       "costDetails",
       "totalCost",
+      "usagePricingTierName",
       // prompt
       "promptId",
       "promptName",
@@ -572,6 +573,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
         model_parameters: '{"temperature":0.5}',
         usage_details: { input: 10, output: 20, total: 30 },
         cost_details: { input: 0.01, output: 0.02, total: 0.03 },
+        usage_pricing_tier_name: "contract-tier",
         prompt_id: randomUUID(),
         prompt_name: "contract-prompt",
         prompt_version: 2,
@@ -603,6 +605,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
       promptVersion: 2,
       input: "contract input",
       output: "contract output",
+      usagePricingTierName: "contract-tier",
     };
 
     const fieldsForGroup: Record<string, readonly string[]> = {
@@ -622,7 +625,12 @@ describe("/api/public/v2/observations API Endpoint", () => {
       metadata: ["metadata"],
       // "model" is the API response key for provided_model_name (see domain type)
       model: ["model", "internalModelId", "modelParameters"],
-      usage: ["usageDetails", "costDetails", "totalCost"],
+      usage: [
+        "usageDetails",
+        "costDetails",
+        "totalCost",
+        "usagePricingTierName",
+      ],
       prompt: ["promptId", "promptName", "promptVersion"],
       // latency and timeToFirstToken are always returned (computed from core start_time, completion_start_time,
       // end_time), but the metrics group is still defined for documentation and to verify these fields are indeed

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -5,7 +5,7 @@ import {
   InvalidRequestError,
   type BlobStorageIntegrationFileType,
   type AnalyticsIntegrationExportSource,
-  type BlobExportFieldGroup,
+  type ObservationFieldGroupFull,
 } from "@langfuse/shared";
 import { encrypt } from "@langfuse/shared/encryption";
 import { env } from "@/src/env.mjs";
@@ -25,7 +25,7 @@ type UpsertBlobStorageIntegrationInput = {
   exportMode: BlobStorageExportMode;
   exportStartDate: Date | null;
   exportSource?: AnalyticsIntegrationExportSource;
-  exportFieldGroups?: BlobExportFieldGroup[];
+  exportFieldGroups?: ObservationFieldGroupFull[];
   compressed?: boolean;
 };
 

--- a/web/src/features/blobstorage-integration/types.ts
+++ b/web/src/features/blobstorage-integration/types.ts
@@ -4,7 +4,7 @@ import {
   BlobStorageIntegrationFileType,
   BlobStorageExportMode,
   AnalyticsIntegrationExportSource,
-  BLOB_EXPORT_FIELD_GROUPS,
+  OBSERVATION_FIELD_GROUPS_FULL,
 } from "@langfuse/shared";
 import {
   validateAzureContainerName,
@@ -39,8 +39,8 @@ export const blobStorageIntegrationFormSchemaBase = z.object({
     .enum(AnalyticsIntegrationExportSource)
     .default(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
   exportFieldGroups: z
-    .array(z.enum(BLOB_EXPORT_FIELD_GROUPS))
-    .default([...BLOB_EXPORT_FIELD_GROUPS]),
+    .array(z.enum(OBSERVATION_FIELD_GROUPS_FULL))
+    .default([...OBSERVATION_FIELD_GROUPS_FULL]),
   compressed: z.boolean().default(true),
 });
 

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import {
   AnalyticsIntegrationExportSource,
-  BLOB_EXPORT_FIELD_GROUPS,
+  OBSERVATION_FIELD_GROUPS_FULL,
 } from "@langfuse/shared";
 import {
   validateAzureContainerName,
@@ -71,7 +71,9 @@ export const toPublicExportSource = (
 ): z.infer<typeof BlobStorageExportSource> =>
   INTERNAL_TO_PUBLIC_EXPORT_SOURCE[internalValue];
 
-export const BlobStorageExportFieldGroup = z.enum(BLOB_EXPORT_FIELD_GROUPS);
+export const BlobStorageExportFieldGroup = z.enum(
+  OBSERVATION_FIELD_GROUPS_FULL,
+);
 
 /**
  * Request/Response Types

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -12,14 +12,19 @@ import {
   reduceUsageOrCostDetails,
   stringDateTime,
   type ObservationPriceFields,
-  OBSERVATION_FIELD_GROUPS,
-  type ObservationFieldGroup,
 } from "@langfuse/shared/src/server";
+import {
+  OBSERVATION_FIELD_GROUPS_PUBLIC_API,
+  type ObservationFieldGroupPublicApi,
+} from "@langfuse/shared";
 import { z } from "zod";
 import { useEventsTableSchema } from "../../query/types";
 
 // Re-export for convenience
-export { OBSERVATION_FIELD_GROUPS, type ObservationFieldGroup };
+export {
+  OBSERVATION_FIELD_GROUPS_PUBLIC_API,
+  type ObservationFieldGroupPublicApi,
+};
 
 /**
  * Objects
@@ -315,11 +320,13 @@ export const GetObservationsV2Query = z.object({
       return v
         .split(",")
         .map((f) => f.trim())
-        .filter((f): f is ObservationFieldGroup =>
-          OBSERVATION_FIELD_GROUPS.includes(f as ObservationFieldGroup),
+        .filter((f): f is ObservationFieldGroupPublicApi =>
+          OBSERVATION_FIELD_GROUPS_PUBLIC_API.includes(
+            f as ObservationFieldGroupPublicApi,
+          ),
         );
     })
-    .pipe(z.array(z.enum(OBSERVATION_FIELD_GROUPS)).nullable()),
+    .pipe(z.array(z.enum(OBSERVATION_FIELD_GROUPS_PUBLIC_API)).nullable()),
   // Metadata expansion keys (optional)
   // Comma-separated list of metadata keys to return non-truncated: expandMetadata=transcript,steps
   expandMetadata: z

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -420,6 +420,7 @@ const APIObservationV2 = z
     usageDetails: z.record(z.string(), z.number().nonnegative()).optional(),
     costDetails: z.record(z.string(), z.number().nonnegative()).optional(),
     totalCost: z.number().nullable().optional(),
+    usagePricingTierName: z.string().nullable().optional(),
 
     // Prompt fields (field group: prompt)
     promptId: z.string().nullable().optional(),

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -12,7 +12,7 @@ import {
 } from "@/src/features/public-api/types/blob-storage-integrations";
 import {
   AnalyticsIntegrationExportSource,
-  type BlobExportFieldGroup,
+  type ObservationFieldGroupFull,
   LangfuseNotFoundError,
   UnauthorizedError,
   ForbiddenError,
@@ -96,7 +96,7 @@ async function handleGetBlobStorageIntegrations(
         integration.exportSource ===
         AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
           ? null
-          : (integration.exportFieldGroups as BlobExportFieldGroup[]),
+          : (integration.exportFieldGroups as ObservationFieldGroupFull[]),
       nextSyncAt: integration.nextSyncAt,
       lastSyncAt: integration.lastSyncAt,
       lastError: integration.lastError,
@@ -214,7 +214,7 @@ async function handleUpsertBlobStorageIntegration(
       integration.exportSource ===
       AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
         ? null
-        : (integration.exportFieldGroups as BlobExportFieldGroup[]),
+        : (integration.exportFieldGroups as ObservationFieldGroupFull[]),
     nextSyncAt: integration.nextSyncAt,
     lastSyncAt: integration.lastSyncAt,
     lastError: integration.lastError,

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -53,8 +53,8 @@ import {
   type BlobStorageIntegration,
   EXPORT_SOURCE_OPTIONS,
   EXPORT_FIELD_GROUP_OPTIONS,
-  BLOB_EXPORT_FIELD_GROUPS,
-  type BlobExportFieldGroup,
+  OBSERVATION_FIELD_GROUPS_FULL,
+  type ObservationFieldGroupFull,
 } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
@@ -265,8 +265,8 @@ const BlobStorageIntegrationSettingsForm = ({
           ? AnalyticsIntegrationExportSource.EVENTS
           : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
       exportFieldGroups:
-        (state?.exportFieldGroups as BlobExportFieldGroup[]) ?? [
-          ...BLOB_EXPORT_FIELD_GROUPS,
+        (state?.exportFieldGroups as ObservationFieldGroupFull[]) ?? [
+          ...OBSERVATION_FIELD_GROUPS_FULL,
         ],
       compressed: state?.compressed ?? true,
     },
@@ -299,8 +299,8 @@ const BlobStorageIntegrationSettingsForm = ({
           ? AnalyticsIntegrationExportSource.EVENTS
           : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
       exportFieldGroups:
-        (state?.exportFieldGroups as BlobExportFieldGroup[]) ?? [
-          ...BLOB_EXPORT_FIELD_GROUPS,
+        (state?.exportFieldGroups as ObservationFieldGroupFull[]) ?? [
+          ...OBSERVATION_FIELD_GROUPS_FULL,
         ],
       compressed: state?.compressed ?? true,
     });
@@ -778,7 +778,7 @@ const BlobStorageIntegrationSettingsForm = ({
                                           ? current
                                           : [...current, option.value]
                                         : current.filter(
-                                            (v: BlobExportFieldGroup) =>
+                                            (v: ObservationFieldGroupFull) =>
                                               v !== option.value,
                                           );
                                     field.onChange(next);

--- a/worker/src/__tests__/enrichObservationStream.unit.test.ts
+++ b/worker/src/__tests__/enrichObservationStream.unit.test.ts
@@ -18,7 +18,7 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
 });
 
 import { enrichObservationStream } from "../features/blobstorage/handleBlobStorageIntegrationProjectJob";
-import type { BlobExportFieldGroup } from "@langfuse/shared";
+import type { ObservationFieldGroupFull } from "@langfuse/shared";
 
 async function* rowStream(
   rows: Record<string, unknown>[],
@@ -64,7 +64,7 @@ describe("enrichObservationStream field group filtering", () => {
     const rows = [{ id: "obs-1", metadata: {} }];
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
-        "core" as BlobExportFieldGroup,
+        "core" as ObservationFieldGroupFull,
       ]),
     );
 
@@ -75,7 +75,7 @@ describe("enrichObservationStream field group filtering", () => {
     const rows = [{ id: "obs-1" }];
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
-        "core" as BlobExportFieldGroup,
+        "core" as ObservationFieldGroupFull,
       ]),
     );
 
@@ -99,8 +99,8 @@ describe("enrichObservationStream field group filtering", () => {
     ];
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
-        "core" as BlobExportFieldGroup,
-        "usage" as BlobExportFieldGroup,
+        "core" as ObservationFieldGroupFull,
+        "usage" as ObservationFieldGroupFull,
       ]),
     );
 
@@ -116,9 +116,9 @@ describe("enrichObservationStream field group filtering", () => {
     const rows = [{ id: "obs-1", model_id: "gpt-4" }];
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
-        "core" as BlobExportFieldGroup,
-        "model" as BlobExportFieldGroup,
-        "usage" as BlobExportFieldGroup,
+        "core" as ObservationFieldGroupFull,
+        "model" as ObservationFieldGroupFull,
+        "usage" as ObservationFieldGroupFull,
       ]),
     );
 

--- a/worker/src/__tests__/enrichObservationStream.unit.test.ts
+++ b/worker/src/__tests__/enrichObservationStream.unit.test.ts
@@ -18,7 +18,7 @@ vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
 });
 
 import { enrichObservationStream } from "../features/blobstorage/handleBlobStorageIntegrationProjectJob";
-import type { ObservationFieldGroup } from "@langfuse/shared/src/server";
+import type { BlobExportFieldGroup } from "@langfuse/shared";
 
 async function* rowStream(
   rows: Record<string, unknown>[],
@@ -64,7 +64,7 @@ describe("enrichObservationStream field group filtering", () => {
     const rows = [{ id: "obs-1", metadata: {} }];
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
-        "core" as ObservationFieldGroup,
+        "core" as BlobExportFieldGroup,
       ]),
     );
 
@@ -75,7 +75,7 @@ describe("enrichObservationStream field group filtering", () => {
     const rows = [{ id: "obs-1" }];
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
-        "core" as ObservationFieldGroup,
+        "core" as BlobExportFieldGroup,
       ]),
     );
 
@@ -99,8 +99,8 @@ describe("enrichObservationStream field group filtering", () => {
     ];
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
-        "core" as ObservationFieldGroup,
-        "usage" as ObservationFieldGroup,
+        "core" as BlobExportFieldGroup,
+        "usage" as BlobExportFieldGroup,
       ]),
     );
 
@@ -116,9 +116,9 @@ describe("enrichObservationStream field group filtering", () => {
     const rows = [{ id: "obs-1", model_id: "gpt-4" }];
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
-        "core" as ObservationFieldGroup,
-        "model" as ObservationFieldGroup,
-        "usage" as ObservationFieldGroup,
+        "core" as BlobExportFieldGroup,
+        "model" as BlobExportFieldGroup,
+        "usage" as BlobExportFieldGroup,
       ]),
     );
 

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -26,8 +26,8 @@ import {
   BlobStorageIntegrationType,
   BlobStorageIntegrationFileType,
   BlobStorageExportMode,
-  BLOB_EXPORT_FIELD_GROUPS,
-  type BlobExportFieldGroup,
+  OBSERVATION_FIELD_GROUPS_FULL,
+  type ObservationFieldGroupFull,
 } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 import { randomUUID } from "crypto";
@@ -40,7 +40,7 @@ export async function* enrichObservationStream(
   projectId: string,
   modelIdField: string,
   convertLatencyToSeconds: boolean,
-  fieldGroups?: BlobExportFieldGroup[],
+  fieldGroups?: ObservationFieldGroupFull[],
 ): AsyncGenerator<Record<string, unknown>> {
   const { getModel } = createModelCache(projectId);
 
@@ -225,7 +225,7 @@ const processBlobStorageExport = async (config: {
   fileType: BlobStorageIntegrationFileType;
   compressed: boolean;
   convertV4LatencyToSeconds: boolean;
-  exportFieldGroups?: BlobExportFieldGroup[];
+  exportFieldGroups?: ObservationFieldGroupFull[];
 }) => {
   logger.info(
     `[BLOB INTEGRATION] Processing ${config.table} export for project ${config.projectId}`,
@@ -265,7 +265,7 @@ const processBlobStorageExport = async (config: {
     const exportFieldGroups =
       config.exportFieldGroups && config.exportFieldGroups.length > 0
         ? config.exportFieldGroups
-        : [...BLOB_EXPORT_FIELD_GROUPS];
+        : [...OBSERVATION_FIELD_GROUPS_FULL];
 
     let dataStream: AsyncGenerator<Record<string, unknown>>;
 
@@ -457,7 +457,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
       compressed: blobStorageIntegration.compressed,
       convertV4LatencyToSeconds,
       exportFieldGroups:
-        blobStorageIntegration.exportFieldGroups as BlobExportFieldGroup[],
+        blobStorageIntegration.exportFieldGroups as ObservationFieldGroupFull[],
     };
 
     // Check if this project should only export traces (legacy behavior via env var)

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -13,8 +13,6 @@ import {
   getTracesForBlobStorageExport,
   getScoresForBlobStorageExport,
   getEventsForBlobStorageExport,
-  OBSERVATION_FIELD_GROUPS,
-  type ObservationFieldGroup,
   getCurrentSpan,
   BlobStorageIntegrationProcessingQueue,
   queryClickhouse,
@@ -28,6 +26,8 @@ import {
   BlobStorageIntegrationType,
   BlobStorageIntegrationFileType,
   BlobStorageExportMode,
+  BLOB_EXPORT_FIELD_GROUPS,
+  type BlobExportFieldGroup,
 } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 import { randomUUID } from "crypto";
@@ -40,7 +40,7 @@ export async function* enrichObservationStream(
   projectId: string,
   modelIdField: string,
   convertLatencyToSeconds: boolean,
-  fieldGroups?: ObservationFieldGroup[],
+  fieldGroups?: BlobExportFieldGroup[],
 ): AsyncGenerator<Record<string, unknown>> {
   const { getModel } = createModelCache(projectId);
 
@@ -225,7 +225,7 @@ const processBlobStorageExport = async (config: {
   fileType: BlobStorageIntegrationFileType;
   compressed: boolean;
   convertV4LatencyToSeconds: boolean;
-  exportFieldGroups?: ObservationFieldGroup[];
+  exportFieldGroups?: BlobExportFieldGroup[];
 }) => {
   logger.info(
     `[BLOB INTEGRATION] Processing ${config.table} export for project ${config.projectId}`,
@@ -265,7 +265,7 @@ const processBlobStorageExport = async (config: {
     const exportFieldGroups =
       config.exportFieldGroups && config.exportFieldGroups.length > 0
         ? config.exportFieldGroups
-        : [...OBSERVATION_FIELD_GROUPS];
+        : [...BLOB_EXPORT_FIELD_GROUPS];
 
     let dataStream: AsyncGenerator<Record<string, unknown>>;
 
@@ -457,7 +457,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
       compressed: blobStorageIntegration.compressed,
       convertV4LatencyToSeconds,
       exportFieldGroups:
-        blobStorageIntegration.exportFieldGroups as ObservationFieldGroup[],
+        blobStorageIntegration.exportFieldGroups as BlobExportFieldGroup[],
     };
 
     // Check if this project should only export traces (legacy behavior via env var)


### PR DESCRIPTION
## Summary

Follow-up to [#13598](https://github.com/langfuse/langfuse/pull/13598) / [LFE-9456](https://linear.app/langfuse/issue/LFE-9456).

`OBSERVATION_FIELD_GROUPS` was driving both the public `/v2/observations` API contract and the blob exporter's column selection. The blob exporter needs the broader set (`tools` + `trace_context`); keeping a single shared constant let exporter additions silently widen the public API. This PR decouples them.

- **Split**: `OBSERVATION_FIELD_GROUPS` stays narrow (9 groups) — drives `/v2/observations`. `BLOB_EXPORT_FIELD_GROUPS` owns the broader 11 groups — drives the blob exporter. Worker handler now imports `BLOB_EXPORT_FIELD_GROUPS` from `@langfuse/shared` (the analytics-integrations module) instead of the v2-API-scoped repository symbol.
- **Relocate**: `usagePricingTierName` moves from `trace_context` to `usage`. It's a pricing-tier attribute on the observation, not part of the parent trace's context. `/v2/observations` now exposes it under the `usage` group alongside `usageDetails`, `costDetails`, `totalCost`.
- **Docs**: Fern source and regenerated `openapi.yml` updated to match. `OBSERVATION_FIELD_GROUPS` gains a comment block explaining the separation invariant for future maintainers.

### Why split now

Caught by the LFE-9456 part-6 review. The two contracts were drifting (the blob exporter needed `tools` and `trace_context`, which were quietly added to `OBSERVATION_FIELD_GROUPS` and thereby to the public v2 API) without any review of the API impact. Going forward, blob-export-only field additions land in `BLOB_EXPORT_FIELD_GROUPS` only.

### Impacted packages

- `@langfuse/shared` — `OBSERVATION_FIELD_GROUPS` narrowed; field-set columns rebalanced (`usagePricingTierName` move)
- `worker` — handler imports `BLOB_EXPORT_FIELD_GROUPS` directly; fallback uses the broader set
- `web` — `/v2/observations` test asserts new `usagePricingTierName` placement under `usage`
- `fern` — observations endpoint docstring + regenerated `openapi.yml`

## Test plan

- [x] `pnpm --filter @langfuse/shared run typecheck`
- [x] `pnpm --filter web run typecheck`
- [x] `pnpm --filter worker run typecheck`
- [x] `dotenv -e .env -- pnpm --filter worker exec vitest run enrichObservationStream` — 7/7 passed
- [x] `dotenv -e .env -- pnpm --filter worker exec vitest run blobStorageIntegrationProcessing batchExport` — 79/79 passed
- [x] `dotenv -e .env -- pnpm --filter web exec vitest run observations-api-v2 blob-storage-integration-api blob-storage-integration-trpc` — 80/80 passed
- [ ] Manual: verify the regenerated SDK clients (Python, TypeScript) reflect the new `usage` group composition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR decouples the public `/v2/observations` API field contract from the blob exporter's field selection, preventing future exporter-only additions from silently widening the API surface. It also re-homes `usagePricingTierName` from the `trace_context` field set to `usage`, which is semantically correct.

- **Split**: `OBSERVATION_FIELD_GROUPS` is narrowed to 9 groups (drops `tools` and `trace_context`); `BLOB_EXPORT_FIELD_GROUPS` owns all 11 groups and drives the worker exporter. The worker now imports the broader constant from `@langfuse/shared` (analytics-integrations module).
- **Relocate `usagePricingTierName`**: Moved from `trace_context` to `usage` across `FIELD_SETS`, `EXPORT_FIELD_GROUP_LABELS`, the Fern/OpenAPI docs, and the API test fixture — all layers are consistent.
- **Fallback updated**: The `processBlobStorageExport` fallback now uses `BLOB_EXPORT_FIELD_GROUPS` instead of the old narrowed `OBSERVATION_FIELD_GROUPS`, preserving the full export set for unconfigured integrations.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The refactoring is clean, all changed layers (query builder, repository, worker handler, API tests, docs) are mutually consistent, and the runtime behavior of the blob exporter is preserved.

The split is mechanically straightforward: usagePricingTierName moves one field-set key with matching updates across FIELD_SETS, label descriptions, Fern docs, and the API test fixture. The type change from ObservationFieldGroup[] to BlobExportFieldGroup[] is correct because BlobExportFieldGroup is a superset, so no stored DB values become invalid and all FIELD_SETS entries exist for the broader type. The test plan covers all affected paths and passes.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph PublicAPI["Public API (/v2/observations)"]
        OFG["OBSERVATION_FIELD_GROUPS\n(9 groups: core, basic, time, io,\nmetadata, model, usage, prompt, metrics)"]
        OFG -->|usage group includes| UPN["usagePricingTierName"]
    end

    subgraph BlobExport["Blob Storage Exporter (worker)"]
        BEFG["BLOB_EXPORT_FIELD_GROUPS\n(11 groups: all above +\ntools, trace_context)"]
        BEFG -->|usage group includes| UPN2["usagePricingTierName"]
        BEFG -->|tools group| TC["toolDefinitions, toolCalls, toolCallNames"]
        BEFG -->|trace_context group| TCC["tags, release, traceName"]
    end

    subgraph SharedLib["@langfuse/shared"]
        OFG
        BEFG
    end

    Worker["worker/handleBlobStorageIntegrationProjectJob.ts"]
    WebAPI["web/observations v2 API handler"]
    EventsRepo["packages/shared/src/server/repositories/events.ts"]

    Worker -->|imports BLOB_EXPORT_FIELD_GROUPS| BEFG
    Worker -->|calls getEventsForBlobStorageExport| EventsRepo
    EventsRepo -->|default fieldGroups| BEFG
    WebAPI -->|uses ObservationFieldGroup| OFG
    EventsRepo -->|OBSERVATION_FIELD_GROUPS| OFG
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(blob-export): split OBSERVATION..."](https://github.com/langfuse/langfuse/commit/4a1bf1cadc24e9d8e7bd75a7163a8263d30d1e93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31973122)</sub>

<!-- /greptile_comment -->