### PR TITLE
refactor(blob-export): replace internal exportSource enum with public LEGACY_TRACES_OBSERVATIONS/OBSERVATIONS_V2/LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS

### DIFF
--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -64,18 +64,18 @@ types:
   BlobStorageExportSource:
     docs: |
       What data the integration exports.
-      - `LEGACY`: traces, observations, and scores tables with a fixed column set. The `exportFieldGroups` field is not applicable.
-      - `ENRICHED`: same data model as the `/api/public/v2/observations` endpoint, plus scores. Columns are controlled by `exportFieldGroups`.
-      - `LEGACY_AND_ENRICHED`: both sets. For the `ENRICHED` portion, columns are controlled by `exportFieldGroups`.
+      - `LEGACY_TRACES_OBSERVATIONS`: traces, observations, and scores tables with a fixed column set. The `exportFieldGroups` field is not applicable.
+      - `OBSERVATIONS_V2`: same data model as the `/api/public/v2/observations` endpoint, plus scores. Columns are controlled by `exportFieldGroups`.
+      - `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: both sets. For the `OBSERVATIONS_V2` portion, columns are controlled by `exportFieldGroups`.
 
-      **Note:** `ENRICHED` and the enriched-observations portion of `LEGACY_AND_ENRICHED` rely on the enriched observations table (Langfuse Fast Preview / v4), which is currently available on Langfuse Cloud only. See https://langfuse.com/docs/v4.
+      **Note:** `OBSERVATIONS_V2` and the enriched-observations portion of `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` rely on the enriched observations table (Langfuse Fast Preview / v4), which is currently available on Langfuse Cloud only. See https://langfuse.com/docs/v4.
     enum:
-      - LEGACY
-      - ENRICHED
-      - LEGACY_AND_ENRICHED
+      - LEGACY_TRACES_OBSERVATIONS
+      - OBSERVATIONS_V2
+      - LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS
 
   BlobStorageExportFieldGroup:
-    docs: Field group for the ENRICHED export.
+    docs: Field group for the OBSERVATIONS_V2 export.
     enum:
       - core
       - basic
@@ -131,16 +131,16 @@ types:
       exportSource:
         type: optional<BlobStorageExportSource>
         docs: |
-          Data to export. When omitted on update, the existing value is preserved; when omitted on create, the column default (`LEGACY`) applies. Required when `exportFieldGroups` is provided.
+          Data to export. When omitted on update, the existing value is preserved; when omitted on create, the column default (`LEGACY_TRACES_OBSERVATIONS`) applies. Required when `exportFieldGroups` is provided.
 
       exportFieldGroups:
         type: optional<list<BlobStorageExportFieldGroup>>
         docs: |
           Field groups to include in each exported row.
 
-          For exportSource `ENRICHED` or `LEGACY_AND_ENRICHED`: must include `core` if provided. When omitted on create, the column default (all groups) applies. When omitted on update, the existing value is preserved.
+          For exportSource `OBSERVATIONS_V2` or `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: must include `core` if provided. When omitted on create, the column default (all groups) applies. When omitted on update, the existing value is preserved.
 
-          For exportSource `LEGACY`: this field must be omitted or null. Sending an array (including an empty array) returns 400, because that source uses a fixed column set and does not honor field groups.
+          For exportSource `LEGACY_TRACES_OBSERVATIONS`: this field must be omitted or null. Sending an array (including an empty array) returns 400, because that source uses a fixed column set and does not honor field groups.
 
           `exportFieldGroups` requires `exportSource` to be provided in the same request.
 
@@ -165,7 +165,7 @@ types:
       exportFieldGroups:
         type: nullable<list<BlobStorageExportFieldGroup>>
         docs: |
-          Field groups included in each exported row for `ENRICHED` / `LEGACY_AND_ENRICHED` sources. Always `null` when exportSource is `LEGACY` (the field does not apply to that source; any legacy DB value is hidden from the public surface).
+          Field groups included in each exported row for `OBSERVATIONS_V2` / `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` sources. Always `null` when exportSource is `LEGACY_TRACES_OBSERVATIONS` (the field does not apply to that source; any legacy DB value is hidden from the public surface).
       nextSyncAt: nullable<datetime>
       lastSyncAt: nullable<datetime>
       lastError: nullable<string>

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -75,7 +75,7 @@ types:
       - LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS
 
   BlobStorageExportFieldGroup:
-    docs: Field group for the OBSERVATIONS_V2 export.
+    docs: Field group for the OBSERVATIONS_V2 and LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS export.
     enum:
       - core
       - basic

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -64,18 +64,18 @@ types:
   BlobStorageExportSource:
     docs: |
       What data the integration exports.
-      - `TRACES_OBSERVATIONS`: legacy traces + observations + scores tables with a fixed column set. The `exportFieldGroups` field is not applicable.
-      - `EVENTS`: enriched observations_v2 events; columns are controlled by `exportFieldGroups`.
-      - `TRACES_OBSERVATIONS_EVENTS`: both sets. For the `EVENTS` portion, columns are controlled by `exportFieldGroups`.
+      - `LEGACY`: traces, observations, and scores tables with a fixed column set. The `exportFieldGroups` field is not applicable.
+      - `ENRICHED`: same data model as the `/api/public/v2/observations` endpoint, plus scores. Columns are controlled by `exportFieldGroups`.
+      - `LEGACY_AND_ENRICHED`: both sets. For the `ENRICHED` portion, columns are controlled by `exportFieldGroups`.
 
-      **Note:** `EVENTS` and the events portion of `TRACES_OBSERVATIONS_EVENTS` rely on the observations_v2 events table (Langfuse Fast Preview / v4), which is currently available on Langfuse Cloud only. See https://langfuse.com/docs/v4.
+      **Note:** `ENRICHED` and the enriched-observations portion of `LEGACY_AND_ENRICHED` rely on the enriched observations table (Langfuse Fast Preview / v4), which is currently available on Langfuse Cloud only. See https://langfuse.com/docs/v4.
     enum:
-      - EVENTS
-      - TRACES_OBSERVATIONS
-      - TRACES_OBSERVATIONS_EVENTS
+      - LEGACY
+      - ENRICHED
+      - LEGACY_AND_ENRICHED
 
   BlobStorageExportFieldGroup:
-    docs: Field group for the EVENTS export.
+    docs: Field group for the ENRICHED export.
     enum:
       - core
       - basic
@@ -131,16 +131,16 @@ types:
       exportSource:
         type: optional<BlobStorageExportSource>
         docs: |
-          Data to export. When omitted on update, the existing value is preserved; when omitted on create, the column default (`TRACES_OBSERVATIONS`) applies. Required when `exportFieldGroups` is provided.
+          Data to export. When omitted on update, the existing value is preserved; when omitted on create, the column default (`LEGACY`) applies. Required when `exportFieldGroups` is provided.
 
       exportFieldGroups:
         type: optional<list<BlobStorageExportFieldGroup>>
         docs: |
           Field groups to include in each exported row.
 
-          For exportSource `EVENTS` or `TRACES_OBSERVATIONS_EVENTS`: must include `core` if provided. When omitted on create, the column default (all groups) applies. When omitted on update, the existing value is preserved.
+          For exportSource `ENRICHED` or `LEGACY_AND_ENRICHED`: must include `core` if provided. When omitted on create, the column default (all groups) applies. When omitted on update, the existing value is preserved.
 
-          For exportSource `TRACES_OBSERVATIONS`: this field must be omitted or null. Sending an array (including an empty array) returns 400, because that source uses a fixed column set and does not honor field groups.
+          For exportSource `LEGACY`: this field must be omitted or null. Sending an array (including an empty array) returns 400, because that source uses a fixed column set and does not honor field groups.
 
           `exportFieldGroups` requires `exportSource` to be provided in the same request.
 
@@ -165,7 +165,7 @@ types:
       exportFieldGroups:
         type: nullable<list<BlobStorageExportFieldGroup>>
         docs: |
-          Field groups included in each exported row for `EVENTS` / `TRACES_OBSERVATIONS_EVENTS` sources. Always `null` when exportSource is `TRACES_OBSERVATIONS` (the field does not apply to that source; any legacy DB value is hidden from the public surface).
+          Field groups included in each exported row for `ENRICHED` / `LEGACY_AND_ENRICHED` sources. Always `null` when exportSource is `LEGACY` (the field does not apply to that source; any legacy DB value is hidden from the public surface).
       nextSyncAt: nullable<datetime>
       lastSyncAt: nullable<datetime>
       lastError: nullable<string>

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7252,26 +7252,29 @@ components:
       title: BlobStorageExportSource
       type: string
       enum:
-        - LEGACY
-        - ENRICHED
-        - LEGACY_AND_ENRICHED
+        - LEGACY_TRACES_OBSERVATIONS
+        - OBSERVATIONS_V2
+        - LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS
       description: >-
         What data the integration exports.
 
-        - `LEGACY`: traces, observations, and scores tables with a fixed column
-        set. The `exportFieldGroups` field is not applicable.
+        - `LEGACY_TRACES_OBSERVATIONS`: traces, observations, and scores tables
+        with a fixed column set. The `exportFieldGroups` field is not
+        applicable.
 
-        - `ENRICHED`: same data model as the `/api/public/v2/observations`
-        endpoint, plus scores. Columns are controlled by `exportFieldGroups`.
+        - `OBSERVATIONS_V2`: same data model as the
+        `/api/public/v2/observations` endpoint, plus scores. Columns are
+        controlled by `exportFieldGroups`.
 
-        - `LEGACY_AND_ENRICHED`: both sets. For the `ENRICHED` portion, columns
-        are controlled by `exportFieldGroups`.
+        - `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: both sets. For the
+        `OBSERVATIONS_V2` portion, columns are controlled by
+        `exportFieldGroups`.
 
 
-        **Note:** `ENRICHED` and the enriched-observations portion of
-        `LEGACY_AND_ENRICHED` rely on the enriched observations table (Langfuse
-        Fast Preview / v4), which is currently available on Langfuse Cloud only.
-        See https://langfuse.com/docs/v4.
+        **Note:** `OBSERVATIONS_V2` and the enriched-observations portion of
+        `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` rely on the enriched
+        observations table (Langfuse Fast Preview / v4), which is currently
+        available on Langfuse Cloud only. See https://langfuse.com/docs/v4.
     BlobStorageExportFieldGroup:
       title: BlobStorageExportFieldGroup
       type: string
@@ -7287,7 +7290,7 @@ components:
         - metrics
         - tools
         - trace_context
-      description: Field group for the ENRICHED export.
+      description: Field group for the OBSERVATIONS_V2 export.
     CreateBlobStorageIntegrationRequest:
       title: CreateBlobStorageIntegrationRequest
       type: object
@@ -7355,8 +7358,9 @@ components:
           nullable: true
           description: >-
             Data to export. When omitted on update, the existing value is
-            preserved; when omitted on create, the column default (`LEGACY`)
-            applies. Required when `exportFieldGroups` is provided.
+            preserved; when omitted on create, the column default
+            (`LEGACY_TRACES_OBSERVATIONS`) applies. Required when
+            `exportFieldGroups` is provided.
         exportFieldGroups:
           type: array
           items:
@@ -7366,15 +7370,16 @@ components:
             Field groups to include in each exported row.
 
 
-            For exportSource `ENRICHED` or `LEGACY_AND_ENRICHED`: must include
-            `core` if provided. When omitted on create, the column default (all
-            groups) applies. When omitted on update, the existing value is
-            preserved.
+            For exportSource `OBSERVATIONS_V2` or
+            `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: must include `core` if
+            provided. When omitted on create, the column default (all groups)
+            applies. When omitted on update, the existing value is preserved.
 
 
-            For exportSource `LEGACY`: this field must be omitted or null.
-            Sending an array (including an empty array) returns 400, because
-            that source uses a fixed column set and does not honor field groups.
+            For exportSource `LEGACY_TRACES_OBSERVATIONS`: this field must be
+            omitted or null. Sending an array (including an empty array) returns
+            400, because that source uses a fixed column set and does not honor
+            field groups.
 
 
             `exportFieldGroups` requires `exportSource` to be provided in the
@@ -7435,10 +7440,11 @@ components:
             $ref: '#/components/schemas/BlobStorageExportFieldGroup'
           nullable: true
           description: >-
-            Field groups included in each exported row for `ENRICHED` /
-            `LEGACY_AND_ENRICHED` sources. Always `null` when exportSource is
-            `LEGACY` (the field does not apply to that source; any legacy DB
-            value is hidden from the public surface).
+            Field groups included in each exported row for `OBSERVATIONS_V2` /
+            `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` sources. Always `null`
+            when exportSource is `LEGACY_TRACES_OBSERVATIONS` (the field does
+            not apply to that source; any legacy DB value is hidden from the
+            public surface).
         nextSyncAt:
           type: string
           format: date-time

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7252,27 +7252,26 @@ components:
       title: BlobStorageExportSource
       type: string
       enum:
-        - EVENTS
-        - TRACES_OBSERVATIONS
-        - TRACES_OBSERVATIONS_EVENTS
+        - LEGACY
+        - ENRICHED
+        - LEGACY_AND_ENRICHED
       description: >-
         What data the integration exports.
 
-        - `TRACES_OBSERVATIONS`: legacy traces + observations + scores tables
-        with a fixed column set. The `exportFieldGroups` field is not
-        applicable.
+        - `LEGACY`: traces, observations, and scores tables with a fixed column
+        set. The `exportFieldGroups` field is not applicable.
 
-        - `EVENTS`: enriched observations_v2 events; columns are controlled by
-        `exportFieldGroups`.
+        - `ENRICHED`: same data model as the `/api/public/v2/observations`
+        endpoint, plus scores. Columns are controlled by `exportFieldGroups`.
 
-        - `TRACES_OBSERVATIONS_EVENTS`: both sets. For the `EVENTS` portion,
-        columns are controlled by `exportFieldGroups`.
+        - `LEGACY_AND_ENRICHED`: both sets. For the `ENRICHED` portion, columns
+        are controlled by `exportFieldGroups`.
 
 
-        **Note:** `EVENTS` and the events portion of
-        `TRACES_OBSERVATIONS_EVENTS` rely on the observations_v2 events table
-        (Langfuse Fast Preview / v4), which is currently available on Langfuse
-        Cloud only. See https://langfuse.com/docs/v4.
+        **Note:** `ENRICHED` and the enriched-observations portion of
+        `LEGACY_AND_ENRICHED` rely on the enriched observations table (Langfuse
+        Fast Preview / v4), which is currently available on Langfuse Cloud only.
+        See https://langfuse.com/docs/v4.
     BlobStorageExportFieldGroup:
       title: BlobStorageExportFieldGroup
       type: string
@@ -7288,7 +7287,7 @@ components:
         - metrics
         - tools
         - trace_context
-      description: Field group for the EVENTS export.
+      description: Field group for the ENRICHED export.
     CreateBlobStorageIntegrationRequest:
       title: CreateBlobStorageIntegrationRequest
       type: object
@@ -7356,9 +7355,8 @@ components:
           nullable: true
           description: >-
             Data to export. When omitted on update, the existing value is
-            preserved; when omitted on create, the column default
-            (`TRACES_OBSERVATIONS`) applies. Required when `exportFieldGroups`
-            is provided.
+            preserved; when omitted on create, the column default (`LEGACY`)
+            applies. Required when `exportFieldGroups` is provided.
         exportFieldGroups:
           type: array
           items:
@@ -7368,16 +7366,15 @@ components:
             Field groups to include in each exported row.
 
 
-            For exportSource `EVENTS` or `TRACES_OBSERVATIONS_EVENTS`: must
-            include `core` if provided. When omitted on create, the column
-            default (all groups) applies. When omitted on update, the existing
-            value is preserved.
+            For exportSource `ENRICHED` or `LEGACY_AND_ENRICHED`: must include
+            `core` if provided. When omitted on create, the column default (all
+            groups) applies. When omitted on update, the existing value is
+            preserved.
 
 
-            For exportSource `TRACES_OBSERVATIONS`: this field must be omitted
-            or null. Sending an array (including an empty array) returns 400,
-            because that source uses a fixed column set and does not honor field
-            groups.
+            For exportSource `LEGACY`: this field must be omitted or null.
+            Sending an array (including an empty array) returns 400, because
+            that source uses a fixed column set and does not honor field groups.
 
 
             `exportFieldGroups` requires `exportSource` to be provided in the
@@ -7438,10 +7435,10 @@ components:
             $ref: '#/components/schemas/BlobStorageExportFieldGroup'
           nullable: true
           description: >-
-            Field groups included in each exported row for `EVENTS` /
-            `TRACES_OBSERVATIONS_EVENTS` sources. Always `null` when
-            exportSource is `TRACES_OBSERVATIONS` (the field does not apply to
-            that source; any legacy DB value is hidden from the public surface).
+            Field groups included in each exported row for `ENRICHED` /
+            `LEGACY_AND_ENRICHED` sources. Always `null` when exportSource is
+            `LEGACY` (the field does not apply to that source; any legacy DB
+            value is hidden from the public surface).
         nextSyncAt:
           type: string
           format: date-time

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7290,7 +7290,9 @@ components:
         - metrics
         - tools
         - trace_context
-      description: Field group for the OBSERVATIONS_V2 export.
+      description: >-
+        Field group for the OBSERVATIONS_V2 and
+        LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS export.
     CreateBlobStorageIntegrationRequest:
       title: CreateBlobStorageIntegrationRequest
       type: object

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -29,11 +29,7 @@ const BlobStorageIntegrationResponseSchema = z.object({
   exportMode: z.enum(["FULL_HISTORY", "FROM_TODAY", "FROM_CUSTOM_DATE"]),
   exportStartDate: z.coerce.date().nullable(),
   compressed: z.boolean(),
-  exportSource: z.enum([
-    "TRACES_OBSERVATIONS",
-    "TRACES_OBSERVATIONS_EVENTS",
-    "EVENTS",
-  ]),
+  exportSource: z.enum(["LEGACY", "ENRICHED", "LEGACY_AND_ENRICHED"]),
   exportFieldGroups: z.array(z.enum(BLOB_EXPORT_FIELD_GROUPS)).nullable(),
   nextSyncAt: z.coerce.date().nullable(),
   lastSyncAt: z.coerce.date().nullable(),
@@ -642,7 +638,7 @@ describe("Blob Storage Integrations API", () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "EVENTS" as const,
+        exportSource: "ENRICHED" as const,
         exportFieldGroups: ["core", "io"],
       };
 
@@ -654,7 +650,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(putResponse.status).toBe(200);
-      expect(putResponse.body.exportSource).toBe("EVENTS");
+      expect(putResponse.body.exportSource).toBe("ENRICHED");
       expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
 
       const getResponse = await makeZodVerifiedAPICall(
@@ -669,7 +665,7 @@ describe("Blob Storage Integrations API", () => {
         (i) => i.projectId === testProject1Id,
       );
       expect(integration).toBeDefined();
-      expect(integration?.exportSource).toBe("EVENTS");
+      expect(integration?.exportSource).toBe("ENRICHED");
       expect(integration?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
@@ -677,7 +673,7 @@ describe("Blob Storage Integrations API", () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "EVENTS" as const,
+        exportSource: "ENRICHED" as const,
         exportFieldGroups: ["io"],
       };
 
@@ -694,7 +690,7 @@ describe("Blob Storage Integrations API", () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "EVENTS" as const,
+        exportSource: "ENRICHED" as const,
       };
 
       const putResponse = await makeZodVerifiedAPICall(
@@ -718,7 +714,7 @@ describe("Blob Storage Integrations API", () => {
         (i) => i.projectId === testProject1Id,
       );
       expect(integration).toBeDefined();
-      expect(integration?.exportSource).toBe("EVENTS");
+      expect(integration?.exportSource).toBe("ENRICHED");
       expect(integration?.exportFieldGroups).toBeDefined();
       expect(integration?.exportFieldGroups).toHaveLength(
         BLOB_EXPORT_FIELD_GROUPS.length,
@@ -732,7 +728,7 @@ describe("Blob Storage Integrations API", () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "EVENTS" as const,
+        exportSource: "ENRICHED" as const,
         exportFieldGroups: null,
       };
 
@@ -772,7 +768,7 @@ describe("Blob Storage Integrations API", () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "TRACES_OBSERVATIONS" as const,
+        exportSource: "LEGACY" as const,
       };
 
       const putResponse = await makeZodVerifiedAPICall(
@@ -796,7 +792,7 @@ describe("Blob Storage Integrations API", () => {
         (i) => i.projectId === testProject1Id,
       );
       expect(integration).toBeDefined();
-      expect(integration?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(integration?.exportSource).toBe("LEGACY");
       expect(integration?.exportFieldGroups).toBeNull();
     });
 
@@ -804,7 +800,7 @@ describe("Blob Storage Integrations API", () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "TRACES_OBSERVATIONS" as const,
+        exportSource: "LEGACY" as const,
         exportFieldGroups: null,
       };
 
@@ -836,7 +832,7 @@ describe("Blob Storage Integrations API", () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "TRACES_OBSERVATIONS" as const,
+        exportSource: "LEGACY" as const,
         exportFieldGroups: [],
       };
 
@@ -855,7 +851,7 @@ describe("Blob Storage Integrations API", () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "TRACES_OBSERVATIONS" as const,
+        exportSource: "LEGACY" as const,
         exportFieldGroups: ["core", "io"],
       };
 
@@ -903,7 +899,7 @@ describe("Blob Storage Integrations API", () => {
         (i) => i.projectId === testProject1Id,
       );
       expect(integration).toBeDefined();
-      expect(integration?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(integration?.exportSource).toBe("LEGACY");
       expect(integration?.exportFieldGroups).toBeNull();
     });
 
@@ -935,7 +931,7 @@ describe("Blob Storage Integrations API", () => {
         {
           ...validBlobStorageConfig,
           projectId: testProject1Id,
-          exportSource: "TRACES_OBSERVATIONS" as const,
+          exportSource: "LEGACY" as const,
           bucketName: "updated-bucket",
         },
         createBasicAuthHeader(testApiKey, testApiSecretKey),
@@ -955,7 +951,7 @@ describe("Blob Storage Integrations API", () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "TRACES_OBSERVATIONS" as const,
+        exportSource: "LEGACY" as const,
       };
 
       const response = await makeZodVerifiedAPICall(
@@ -966,10 +962,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty(
-        "exportSource",
-        "TRACES_OBSERVATIONS",
-      );
+      expect(response.body).toHaveProperty("exportSource", "LEGACY");
       expect(response.body).toHaveProperty("exportFieldGroups");
       expect(response.body.exportFieldGroups).toBeNull();
     });
@@ -1028,9 +1021,9 @@ describe("Blob Storage Integrations API", () => {
       const eventsIntegration = getResponse.body.data.find(
         (i) => i.projectId === testProject2Id,
       );
-      expect(tracesObsIntegration?.exportSource).toBe("TRACES_OBSERVATIONS");
+      expect(tracesObsIntegration?.exportSource).toBe("LEGACY");
       expect(tracesObsIntegration?.exportFieldGroups).toBeNull();
-      expect(eventsIntegration?.exportSource).toBe("EVENTS");
+      expect(eventsIntegration?.exportSource).toBe("ENRICHED");
       expect(eventsIntegration?.exportFieldGroups).toStrictEqual([
         "core",
         "io",
@@ -1072,7 +1065,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(putResponse.status).toBe(200);
-      expect(putResponse.body.exportSource).toBe("EVENTS");
+      expect(putResponse.body.exportSource).toBe("ENRICHED");
       expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
 
       // DB row preserved on both columns; bucket updated
@@ -1121,7 +1114,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(putResponse.status).toBe(200);
-      expect(putResponse.body.exportSource).toBe("EVENTS");
+      expect(putResponse.body.exportSource).toBe("ENRICHED");
       expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
 
       const saved = await prisma.blobStorageIntegration.findUnique({
@@ -1156,7 +1149,7 @@ describe("Blob Storage Integrations API", () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "EVENTS" as const,
+        exportSource: "ENRICHED" as const,
         bucketName: "updated-bucket",
       };
       const putResponse = await makeZodVerifiedAPICall(
@@ -1167,7 +1160,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(putResponse.status).toBe(200);
-      expect(putResponse.body.exportSource).toBe("EVENTS");
+      expect(putResponse.body.exportSource).toBe("ENRICHED");
       expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
 
       const saved = await prisma.blobStorageIntegration.findUnique({

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -29,7 +29,11 @@ const BlobStorageIntegrationResponseSchema = z.object({
   exportMode: z.enum(["FULL_HISTORY", "FROM_TODAY", "FROM_CUSTOM_DATE"]),
   exportStartDate: z.coerce.date().nullable(),
   compressed: z.boolean(),
-  exportSource: z.enum(["LEGACY", "ENRICHED", "LEGACY_AND_ENRICHED"]),
+  exportSource: z.enum([
+    "LEGACY_TRACES_OBSERVATIONS",
+    "OBSERVATIONS_V2",
+    "LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS",
+  ]),
   exportFieldGroups: z.array(z.enum(BLOB_EXPORT_FIELD_GROUPS)).nullable(),
   nextSyncAt: z.coerce.date().nullable(),
   lastSyncAt: z.coerce.date().nullable(),
@@ -632,13 +636,13 @@ describe("Blob Storage Integrations API", () => {
       });
     });
 
-    // ---- ENRICHED / LEGACY_AND_ENRICHED path ----
+    // ---- OBSERVATIONS_V2 / LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS path ----
 
-    it("ENRICHED + exportFieldGroups=[core,io] -> 200 and GET returns same value", async () => {
+    it("OBSERVATIONS_V2 + exportFieldGroups=[core,io] -> 200 and GET returns same value", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "ENRICHED" as const,
+        exportSource: "OBSERVATIONS_V2" as const,
         exportFieldGroups: ["core", "io"],
       };
 
@@ -650,7 +654,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(putResponse.status).toBe(200);
-      expect(putResponse.body.exportSource).toBe("ENRICHED");
+      expect(putResponse.body.exportSource).toBe("OBSERVATIONS_V2");
       expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
 
       const getResponse = await makeZodVerifiedAPICall(
@@ -665,15 +669,15 @@ describe("Blob Storage Integrations API", () => {
         (i) => i.projectId === testProject1Id,
       );
       expect(integration).toBeDefined();
-      expect(integration?.exportSource).toBe("ENRICHED");
+      expect(integration?.exportSource).toBe("OBSERVATIONS_V2");
       expect(integration?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
-    it("ENRICHED + exportFieldGroups=[io] (missing core) -> 400", async () => {
+    it("OBSERVATIONS_V2 + exportFieldGroups=[io] (missing core) -> 400", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "ENRICHED" as const,
+        exportSource: "OBSERVATIONS_V2" as const,
         exportFieldGroups: ["io"],
       };
 
@@ -686,11 +690,11 @@ describe("Blob Storage Integrations API", () => {
       expect(result.status).toBe(400);
     });
 
-    it("ENRICHED + exportFieldGroups omitted -> 200 and GET returns all 11 groups", async () => {
+    it("OBSERVATIONS_V2 + exportFieldGroups omitted -> 200 and GET returns all 11 groups", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "ENRICHED" as const,
+        exportSource: "OBSERVATIONS_V2" as const,
       };
 
       const putResponse = await makeZodVerifiedAPICall(
@@ -714,7 +718,7 @@ describe("Blob Storage Integrations API", () => {
         (i) => i.projectId === testProject1Id,
       );
       expect(integration).toBeDefined();
-      expect(integration?.exportSource).toBe("ENRICHED");
+      expect(integration?.exportSource).toBe("OBSERVATIONS_V2");
       expect(integration?.exportFieldGroups).toBeDefined();
       expect(integration?.exportFieldGroups).toHaveLength(
         BLOB_EXPORT_FIELD_GROUPS.length,
@@ -724,11 +728,11 @@ describe("Blob Storage Integrations API", () => {
       );
     });
 
-    it("ENRICHED + exportFieldGroups=null -> 200 and GET returns all 11 groups", async () => {
+    it("OBSERVATIONS_V2 + exportFieldGroups=null -> 200 and GET returns all 11 groups", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "ENRICHED" as const,
+        exportSource: "OBSERVATIONS_V2" as const,
         exportFieldGroups: null,
       };
 
@@ -762,13 +766,13 @@ describe("Blob Storage Integrations API", () => {
       );
     });
 
-    // ---- LEGACY path ----
+    // ---- LEGACY_TRACES_OBSERVATIONS path ----
 
-    it("LEGACY + exportFieldGroups omitted -> 200; GET hides field groups", async () => {
+    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups omitted -> 200; GET hides field groups", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "LEGACY" as const,
+        exportSource: "LEGACY_TRACES_OBSERVATIONS" as const,
       };
 
       const putResponse = await makeZodVerifiedAPICall(
@@ -792,15 +796,15 @@ describe("Blob Storage Integrations API", () => {
         (i) => i.projectId === testProject1Id,
       );
       expect(integration).toBeDefined();
-      expect(integration?.exportSource).toBe("LEGACY");
+      expect(integration?.exportSource).toBe("LEGACY_TRACES_OBSERVATIONS");
       expect(integration?.exportFieldGroups).toBeNull();
     });
 
-    it("LEGACY + exportFieldGroups=null -> 200; GET hides field groups", async () => {
+    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=null -> 200; GET hides field groups", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "LEGACY" as const,
+        exportSource: "LEGACY_TRACES_OBSERVATIONS" as const,
         exportFieldGroups: null,
       };
 
@@ -828,11 +832,11 @@ describe("Blob Storage Integrations API", () => {
       expect(integration?.exportFieldGroups).toBeNull();
     });
 
-    it("LEGACY + exportFieldGroups=[] -> 400 with 'not applicable'", async () => {
+    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=[] -> 400 with 'not applicable'", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "LEGACY" as const,
+        exportSource: "LEGACY_TRACES_OBSERVATIONS" as const,
         exportFieldGroups: [],
       };
 
@@ -847,11 +851,11 @@ describe("Blob Storage Integrations API", () => {
       expect(message.toLowerCase()).toContain("not applicable");
     });
 
-    it("LEGACY + exportFieldGroups=[core,io] -> 400 with 'not applicable'", async () => {
+    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=[core,io] -> 400 with 'not applicable'", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "LEGACY" as const,
+        exportSource: "LEGACY_TRACES_OBSERVATIONS" as const,
         exportFieldGroups: ["core", "io"],
       };
 
@@ -866,7 +870,7 @@ describe("Blob Storage Integrations API", () => {
       expect(message.toLowerCase()).toContain("not applicable");
     });
 
-    it("GET hides exportFieldGroups for legacy LEGACY rows seeded via Prisma", async () => {
+    it("GET hides exportFieldGroups for legacy LEGACY_TRACES_OBSERVATIONS rows seeded via Prisma", async () => {
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -899,11 +903,11 @@ describe("Blob Storage Integrations API", () => {
         (i) => i.projectId === testProject1Id,
       );
       expect(integration).toBeDefined();
-      expect(integration?.exportSource).toBe("LEGACY");
+      expect(integration?.exportSource).toBe("LEGACY_TRACES_OBSERVATIONS");
       expect(integration?.exportFieldGroups).toBeNull();
     });
 
-    it("PUT LEGACY preserves existing export_field_groups column in DB", async () => {
+    it("PUT LEGACY_TRACES_OBSERVATIONS preserves existing export_field_groups column in DB", async () => {
       // Seed with a custom subset
       await prisma.blobStorageIntegration.create({
         data: {
@@ -931,7 +935,7 @@ describe("Blob Storage Integrations API", () => {
         {
           ...validBlobStorageConfig,
           projectId: testProject1Id,
-          exportSource: "LEGACY" as const,
+          exportSource: "LEGACY_TRACES_OBSERVATIONS" as const,
           bucketName: "updated-bucket",
         },
         createBasicAuthHeader(testApiKey, testApiSecretKey),
@@ -947,11 +951,11 @@ describe("Blob Storage Integrations API", () => {
 
     // ---- Response shape ----
 
-    it("PUT response includes exportSource and exportFieldGroups (null for LEGACY)", async () => {
+    it("PUT response includes exportSource and exportFieldGroups (null for LEGACY_TRACES_OBSERVATIONS)", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "LEGACY" as const,
+        exportSource: "LEGACY_TRACES_OBSERVATIONS" as const,
       };
 
       const response = await makeZodVerifiedAPICall(
@@ -962,7 +966,10 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(response.status).toBe(200);
-      expect(response.body).toHaveProperty("exportSource", "LEGACY");
+      expect(response.body).toHaveProperty(
+        "exportSource",
+        "LEGACY_TRACES_OBSERVATIONS",
+      );
       expect(response.body).toHaveProperty("exportFieldGroups");
       expect(response.body.exportFieldGroups).toBeNull();
     });
@@ -1021,21 +1028,23 @@ describe("Blob Storage Integrations API", () => {
       const enrichedIntegration = getResponse.body.data.find(
         (i) => i.projectId === testProject2Id,
       );
-      expect(legacyIntegration?.exportSource).toBe("LEGACY");
+      expect(legacyIntegration?.exportSource).toBe(
+        "LEGACY_TRACES_OBSERVATIONS",
+      );
       expect(legacyIntegration?.exportFieldGroups).toBeNull();
-      expect(enrichedIntegration?.exportSource).toBe("ENRICHED");
+      expect(enrichedIntegration?.exportSource).toBe("OBSERVATIONS_V2");
       expect(enrichedIntegration?.exportFieldGroups).toStrictEqual([
         "core",
         "io",
       ]);
     });
 
-    it("GET response maps internal TRACES_OBSERVATIONS_EVENTS to public LEGACY_AND_ENRICHED", async () => {
+    it("GET response maps internal TRACES_OBSERVATIONS_EVENTS to public LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS", async () => {
       // Seed via Prisma with the third internal enum value to exercise the
-      // mapping for LEGACY_AND_ENRICHED through the public REST surface.
+      // mapping for LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS through the public REST surface.
       // satisfies-enforced exhaustiveness in INTERNAL_TO_PUBLIC_EXPORT_SOURCE
       // catches a missing key at compile time, but only a runtime assertion
-      // catches a copy-paste regression (e.g. "ENRICHED" written twice).
+      // catches a copy-paste regression (e.g. "OBSERVATIONS_V2" written twice).
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -1068,9 +1077,11 @@ describe("Blob Storage Integrations API", () => {
         (i) => i.projectId === testProject1Id,
       );
       expect(integration).toBeDefined();
-      expect(integration?.exportSource).toBe("LEGACY_AND_ENRICHED");
-      // exportFieldGroups is only masked to null for LEGACY — the
-      // LEGACY_AND_ENRICHED source returns the raw DB array.
+      expect(integration?.exportSource).toBe(
+        "LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS",
+      );
+      // exportFieldGroups is only masked to null for LEGACY_TRACES_OBSERVATIONS — the
+      // LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS source returns the raw DB array.
       expect(integration?.exportFieldGroups).toStrictEqual([
         "core",
         "io",
@@ -1078,8 +1089,8 @@ describe("Blob Storage Integrations API", () => {
       ]);
     });
 
-    it("PUT without exportSource preserves existing ENRICHED source and field groups", async () => {
-      // Pre-seed an ENRICHED row with a custom field-group subset
+    it("PUT without exportSource preserves existing OBSERVATIONS_V2 source and field groups", async () => {
+      // Pre-seed an OBSERVATIONS_V2 row with a custom field-group subset
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -1113,7 +1124,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(putResponse.status).toBe(200);
-      expect(putResponse.body.exportSource).toBe("ENRICHED");
+      expect(putResponse.body.exportSource).toBe("OBSERVATIONS_V2");
       expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
 
       // DB row preserved on both columns; bucket updated
@@ -1125,8 +1136,8 @@ describe("Blob Storage Integrations API", () => {
       expect(saved?.bucketName).toBe("updated-bucket");
     });
 
-    it("PUT exportSource=null preserves existing ENRICHED source and field groups", async () => {
-      // Pre-seed an ENRICHED row with a custom field-group subset
+    it("PUT exportSource=null preserves existing OBSERVATIONS_V2 source and field groups", async () => {
+      // Pre-seed an OBSERVATIONS_V2 row with a custom field-group subset
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -1162,7 +1173,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(putResponse.status).toBe(200);
-      expect(putResponse.body.exportSource).toBe("ENRICHED");
+      expect(putResponse.body.exportSource).toBe("OBSERVATIONS_V2");
       expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
 
       const saved = await prisma.blobStorageIntegration.findUnique({
@@ -1172,8 +1183,8 @@ describe("Blob Storage Integrations API", () => {
       expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
-    it("PUT exportSource=ENRICHED without exportFieldGroups on existing ENRICHED row preserves field groups", async () => {
-      // Pre-seed an ENRICHED row with a custom field-group subset
+    it("PUT exportSource=OBSERVATIONS_V2 without exportFieldGroups on existing OBSERVATIONS_V2 row preserves field groups", async () => {
+      // Pre-seed an OBSERVATIONS_V2 row with a custom field-group subset
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -1193,11 +1204,11 @@ describe("Blob Storage Integrations API", () => {
         },
       });
 
-      // PUT with explicit exportSource=ENRICHED but exportFieldGroups omitted
+      // PUT with explicit exportSource=OBSERVATIONS_V2 but exportFieldGroups omitted
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
-        exportSource: "ENRICHED" as const,
+        exportSource: "OBSERVATIONS_V2" as const,
         bucketName: "updated-bucket",
       };
       const putResponse = await makeZodVerifiedAPICall(
@@ -1208,7 +1219,7 @@ describe("Blob Storage Integrations API", () => {
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
       expect(putResponse.status).toBe(200);
-      expect(putResponse.body.exportSource).toBe("ENRICHED");
+      expect(putResponse.body.exportSource).toBe("OBSERVATIONS_V2");
       expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
 
       const saved = await prisma.blobStorageIntegration.findUnique({

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -632,9 +632,9 @@ describe("Blob Storage Integrations API", () => {
       });
     });
 
-    // ---- EVENTS / TRACES_OBSERVATIONS_EVENTS path ----
+    // ---- ENRICHED / LEGACY_AND_ENRICHED path ----
 
-    it("EVENTS + exportFieldGroups=[core,io] -> 200 and GET returns same value", async () => {
+    it("ENRICHED + exportFieldGroups=[core,io] -> 200 and GET returns same value", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -669,7 +669,7 @@ describe("Blob Storage Integrations API", () => {
       expect(integration?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
-    it("EVENTS + exportFieldGroups=[io] (missing core) -> 400", async () => {
+    it("ENRICHED + exportFieldGroups=[io] (missing core) -> 400", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -686,7 +686,7 @@ describe("Blob Storage Integrations API", () => {
       expect(result.status).toBe(400);
     });
 
-    it("EVENTS + exportFieldGroups omitted -> 200 and GET returns all 11 groups", async () => {
+    it("ENRICHED + exportFieldGroups omitted -> 200 and GET returns all 11 groups", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -724,7 +724,7 @@ describe("Blob Storage Integrations API", () => {
       );
     });
 
-    it("EVENTS + exportFieldGroups=null -> 200 and GET returns all 11 groups", async () => {
+    it("ENRICHED + exportFieldGroups=null -> 200 and GET returns all 11 groups", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -762,9 +762,9 @@ describe("Blob Storage Integrations API", () => {
       );
     });
 
-    // ---- TRACES_OBSERVATIONS path ----
+    // ---- LEGACY path ----
 
-    it("TRACES_OBSERVATIONS + exportFieldGroups omitted -> 200; GET hides field groups", async () => {
+    it("LEGACY + exportFieldGroups omitted -> 200; GET hides field groups", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -796,7 +796,7 @@ describe("Blob Storage Integrations API", () => {
       expect(integration?.exportFieldGroups).toBeNull();
     });
 
-    it("TRACES_OBSERVATIONS + exportFieldGroups=null -> 200; GET hides field groups", async () => {
+    it("LEGACY + exportFieldGroups=null -> 200; GET hides field groups", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -828,7 +828,7 @@ describe("Blob Storage Integrations API", () => {
       expect(integration?.exportFieldGroups).toBeNull();
     });
 
-    it("TRACES_OBSERVATIONS + exportFieldGroups=[] -> 400 with 'not applicable'", async () => {
+    it("LEGACY + exportFieldGroups=[] -> 400 with 'not applicable'", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -847,7 +847,7 @@ describe("Blob Storage Integrations API", () => {
       expect(message.toLowerCase()).toContain("not applicable");
     });
 
-    it("TRACES_OBSERVATIONS + exportFieldGroups=[core,io] -> 400 with 'not applicable'", async () => {
+    it("LEGACY + exportFieldGroups=[core,io] -> 400 with 'not applicable'", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -866,7 +866,7 @@ describe("Blob Storage Integrations API", () => {
       expect(message.toLowerCase()).toContain("not applicable");
     });
 
-    it("GET hides exportFieldGroups for legacy TRACES_OBSERVATIONS rows seeded via Prisma", async () => {
+    it("GET hides exportFieldGroups for legacy LEGACY rows seeded via Prisma", async () => {
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -903,7 +903,7 @@ describe("Blob Storage Integrations API", () => {
       expect(integration?.exportFieldGroups).toBeNull();
     });
 
-    it("PUT TRACES_OBSERVATIONS preserves existing export_field_groups column in DB", async () => {
+    it("PUT LEGACY preserves existing export_field_groups column in DB", async () => {
       // Seed with a custom subset
       await prisma.blobStorageIntegration.create({
         data: {
@@ -947,7 +947,7 @@ describe("Blob Storage Integrations API", () => {
 
     // ---- Response shape ----
 
-    it("PUT response includes exportSource and exportFieldGroups (null for TRACES_OBSERVATIONS)", async () => {
+    it("PUT response includes exportSource and exportFieldGroups (null for LEGACY)", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -1015,23 +1015,71 @@ describe("Blob Storage Integrations API", () => {
         200,
       );
 
-      const tracesObsIntegration = getResponse.body.data.find(
+      const legacyIntegration = getResponse.body.data.find(
         (i) => i.projectId === testProject1Id,
       );
-      const eventsIntegration = getResponse.body.data.find(
+      const enrichedIntegration = getResponse.body.data.find(
         (i) => i.projectId === testProject2Id,
       );
-      expect(tracesObsIntegration?.exportSource).toBe("LEGACY");
-      expect(tracesObsIntegration?.exportFieldGroups).toBeNull();
-      expect(eventsIntegration?.exportSource).toBe("ENRICHED");
-      expect(eventsIntegration?.exportFieldGroups).toStrictEqual([
+      expect(legacyIntegration?.exportSource).toBe("LEGACY");
+      expect(legacyIntegration?.exportFieldGroups).toBeNull();
+      expect(enrichedIntegration?.exportSource).toBe("ENRICHED");
+      expect(enrichedIntegration?.exportFieldGroups).toStrictEqual([
         "core",
         "io",
       ]);
     });
 
-    it("PUT without exportSource preserves existing EVENTS source and field groups", async () => {
-      // Pre-seed an EVENTS row with a custom field-group subset
+    it("GET response maps internal TRACES_OBSERVATIONS_EVENTS to public LEGACY_AND_ENRICHED", async () => {
+      // Seed via Prisma with the third internal enum value to exercise the
+      // mapping for LEGACY_AND_ENRICHED through the public REST surface.
+      // satisfies-enforced exhaustiveness in INTERNAL_TO_PUBLIC_EXPORT_SOURCE
+      // catches a missing key at compile time, but only a runtime assertion
+      // catches a copy-paste regression (e.g. "ENRICHED" written twice).
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject1Id,
+          type: "S3",
+          bucketName: "bucket-mixed",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportSource: "TRACES_OBSERVATIONS_EVENTS",
+          exportFieldGroups: ["core", "io", "metadata"],
+        },
+      });
+
+      const getResponse = await makeZodVerifiedAPICall(
+        z.object({ data: z.array(BlobStorageIntegrationResponseSchema) }),
+        "GET",
+        "/api/public/integrations/blob-storage",
+        undefined,
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+        200,
+      );
+
+      const integration = getResponse.body.data.find(
+        (i) => i.projectId === testProject1Id,
+      );
+      expect(integration).toBeDefined();
+      expect(integration?.exportSource).toBe("LEGACY_AND_ENRICHED");
+      // exportFieldGroups is only masked to null for LEGACY — the
+      // LEGACY_AND_ENRICHED source returns the raw DB array.
+      expect(integration?.exportFieldGroups).toStrictEqual([
+        "core",
+        "io",
+        "metadata",
+      ]);
+    });
+
+    it("PUT without exportSource preserves existing ENRICHED source and field groups", async () => {
+      // Pre-seed an ENRICHED row with a custom field-group subset
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -1077,8 +1125,8 @@ describe("Blob Storage Integrations API", () => {
       expect(saved?.bucketName).toBe("updated-bucket");
     });
 
-    it("PUT exportSource=null preserves existing EVENTS source and field groups", async () => {
-      // Pre-seed an EVENTS row with a custom field-group subset
+    it("PUT exportSource=null preserves existing ENRICHED source and field groups", async () => {
+      // Pre-seed an ENRICHED row with a custom field-group subset
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -1124,8 +1172,8 @@ describe("Blob Storage Integrations API", () => {
       expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
-    it("PUT exportSource=EVENTS without exportFieldGroups on existing EVENTS row preserves field groups", async () => {
-      // Pre-seed an EVENTS row with a custom field-group subset
+    it("PUT exportSource=ENRICHED without exportFieldGroups on existing ENRICHED row preserves field groups", async () => {
+      // Pre-seed an ENRICHED row with a custom field-group subset
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -1145,7 +1193,7 @@ describe("Blob Storage Integrations API", () => {
         },
       });
 
-      // PUT with explicit exportSource=EVENTS but exportFieldGroups omitted
+      // PUT with explicit exportSource=ENRICHED but exportFieldGroups omitted
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -34,15 +34,16 @@ export const BlobStorageExportMode = z.enum([
  * `toPublicExportSource`.
  */
 export const BlobStorageExportSource = z.enum([
-  "LEGACY",
-  "ENRICHED",
-  "LEGACY_AND_ENRICHED",
+  "LEGACY_TRACES_OBSERVATIONS",
+  "OBSERVATIONS_V2",
+  "LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS",
 ]);
 
 const PUBLIC_TO_INTERNAL_EXPORT_SOURCE = {
-  LEGACY: AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-  ENRICHED: AnalyticsIntegrationExportSource.EVENTS,
-  LEGACY_AND_ENRICHED:
+  LEGACY_TRACES_OBSERVATIONS:
+    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+  OBSERVATIONS_V2: AnalyticsIntegrationExportSource.EVENTS,
+  LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS:
     AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
 } as const satisfies Record<
   z.infer<typeof BlobStorageExportSource>,
@@ -50,10 +51,11 @@ const PUBLIC_TO_INTERNAL_EXPORT_SOURCE = {
 >;
 
 const INTERNAL_TO_PUBLIC_EXPORT_SOURCE = {
-  [AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS]: "LEGACY",
-  [AnalyticsIntegrationExportSource.EVENTS]: "ENRICHED",
+  [AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS]:
+    "LEGACY_TRACES_OBSERVATIONS",
+  [AnalyticsIntegrationExportSource.EVENTS]: "OBSERVATIONS_V2",
   [AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS]:
-    "LEGACY_AND_ENRICHED",
+    "LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS",
 } as const satisfies Record<
   AnalyticsIntegrationExportSource,
   z.infer<typeof BlobStorageExportSource>
@@ -126,11 +128,14 @@ export const CreateBlobStorageIntegrationRequest = z
       });
       return;
     }
-    if (data.exportSource === "LEGACY" && data.exportFieldGroups != null) {
+    if (
+      data.exportSource === "LEGACY_TRACES_OBSERVATIONS" &&
+      data.exportFieldGroups != null
+    ) {
       ctx.addIssue({
         code: "custom",
         message:
-          "exportFieldGroups is not applicable when exportSource is LEGACY",
+          "exportFieldGroups is not applicable when exportSource is LEGACY_TRACES_OBSERVATIONS",
         path: ["exportFieldGroups"],
       });
       return;

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -26,7 +26,48 @@ export const BlobStorageExportMode = z.enum([
   "FROM_CUSTOM_DATE",
 ]);
 
-export const BlobStorageExportSource = z.enum(AnalyticsIntegrationExportSource);
+/**
+ * Public REST enum for the blob-storage export source. Intentionally distinct
+ * from the internal `AnalyticsIntegrationExportSource` (Prisma): names here
+ * mirror the labels users see in the UI rather than the legacy internal
+ * identifiers. Maps to the internal enum via `toInternalExportSource` /
+ * `toPublicExportSource`.
+ */
+export const BlobStorageExportSource = z.enum([
+  "LEGACY",
+  "ENRICHED",
+  "LEGACY_AND_ENRICHED",
+]);
+
+const PUBLIC_TO_INTERNAL_EXPORT_SOURCE = {
+  LEGACY: AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+  ENRICHED: AnalyticsIntegrationExportSource.EVENTS,
+  LEGACY_AND_ENRICHED:
+    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+} as const satisfies Record<
+  z.infer<typeof BlobStorageExportSource>,
+  AnalyticsIntegrationExportSource
+>;
+
+const INTERNAL_TO_PUBLIC_EXPORT_SOURCE = {
+  [AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS]: "LEGACY",
+  [AnalyticsIntegrationExportSource.EVENTS]: "ENRICHED",
+  [AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS]:
+    "LEGACY_AND_ENRICHED",
+} as const satisfies Record<
+  AnalyticsIntegrationExportSource,
+  z.infer<typeof BlobStorageExportSource>
+>;
+
+export const toInternalExportSource = (
+  publicValue: z.infer<typeof BlobStorageExportSource>,
+): AnalyticsIntegrationExportSource =>
+  PUBLIC_TO_INTERNAL_EXPORT_SOURCE[publicValue];
+
+export const toPublicExportSource = (
+  internalValue: AnalyticsIntegrationExportSource,
+): z.infer<typeof BlobStorageExportSource> =>
+  INTERNAL_TO_PUBLIC_EXPORT_SOURCE[internalValue];
 
 export const BlobStorageExportFieldGroup = z.enum(BLOB_EXPORT_FIELD_GROUPS);
 
@@ -85,15 +126,11 @@ export const CreateBlobStorageIntegrationRequest = z
       });
       return;
     }
-    if (
-      data.exportSource ===
-        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS &&
-      data.exportFieldGroups != null
-    ) {
+    if (data.exportSource === "LEGACY" && data.exportFieldGroups != null) {
       ctx.addIssue({
         code: "custom",
         message:
-          "exportFieldGroups is not applicable when exportSource is TRACES_OBSERVATIONS",
+          "exportFieldGroups is not applicable when exportSource is LEGACY",
         path: ["exportFieldGroups"],
       });
       return;
@@ -101,7 +138,7 @@ export const CreateBlobStorageIntegrationRequest = z
     if (data.exportFieldGroups != null && data.exportSource != null) {
       validateExportFieldGroups(
         {
-          exportSource: data.exportSource,
+          exportSource: toInternalExportSource(data.exportSource),
           exportFieldGroups: data.exportFieldGroups,
         },
         ctx,

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -6,6 +6,8 @@ import { type NextApiRequest, type NextApiResponse } from "next";
 import { hasEntitlementBasedOnPlan } from "@/src/features/entitlements/server/hasEntitlement";
 import {
   CreateBlobStorageIntegrationRequest,
+  toInternalExportSource,
+  toPublicExportSource,
   type BlobStorageIntegrationResponseType,
 } from "@/src/features/public-api/types/blob-storage-integrations";
 import {
@@ -89,7 +91,7 @@ async function handleGetBlobStorageIntegrations(
       exportMode: integration.exportMode,
       exportStartDate: integration.exportStartDate,
       compressed: integration.compressed,
-      exportSource: integration.exportSource,
+      exportSource: toPublicExportSource(integration.exportSource),
       exportFieldGroups:
         integration.exportSource ===
         AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
@@ -182,7 +184,10 @@ async function handleUpsertBlobStorageIntegration(
       exportMode: validatedData.exportMode,
       exportStartDate: validatedData.exportStartDate ?? null,
       compressed: validatedData.compressed,
-      exportSource: validatedData.exportSource ?? undefined,
+      exportSource:
+        validatedData.exportSource != null
+          ? toInternalExportSource(validatedData.exportSource)
+          : undefined,
       exportFieldGroups: validatedData.exportFieldGroups ?? undefined,
     },
   });
@@ -204,7 +209,7 @@ async function handleUpsertBlobStorageIntegration(
     exportMode: integration.exportMode,
     exportStartDate: integration.exportStartDate,
     compressed: integration.compressed,
-    exportSource: integration.exportSource,
+    exportSource: toPublicExportSource(integration.exportSource),
     exportFieldGroups:
       integration.exportSource ===
       AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS


### PR DESCRIPTION
## Summary

Follow-up to [#13598](https://app.graphite.com/github/pr/langfuse/langfuse/13598) / [LFE-9456](https://linear.app/langfuse/issue/LFE-9456). Independent of [#13617](https://app.graphite.com/github/pr/langfuse/langfuse/13617) (no shared code paths beyond the regenerated `openapi.yml`, where the two PRs touch different regions).

The REST API was exposing `AnalyticsIntegrationExportSource` (a Prisma enum intended as an internal identifier) directly to public consumers. Its values — `TRACES_OBSERVATIONS`, `EVENTS`, `TRACES_OBSERVATIONS_EVENTS` — don't match the UI labels users see ("Enriched observations" etc.) and bake legacy internal naming into the public contract.

- **New public enum**: `LEGACY_TRACES_OBSERVATIONS`, `OBSERVATIONS_V2`, `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` mirroring UI labels.
- **Bidirectional mapping**: `toInternalExportSource` / `toPublicExportSource` helpers in `web/src/features/public-api/types/blob-storage-integrations.ts` with `satisfies Record<...>` for exhaustiveness.
- **Handler layering**: PUT maps public → internal before the Prisma upsert; GET maps internal → public on response.
- **Internal unchanged**: `AnalyticsIntegrationExportSource` (Prisma, tRPC, UI form) is untouched. The mapping is REST-only.
- **Docs**: Fern `OBSERVATIONS_V2` description references the existing `/api/public/v2/observations` endpoint as a concrete anchor for the data model.

### Why a hard break is acceptable

PR #13598 merged ~5 hours ago. No SDKs are believed to have been published or integrated against the previously-exposed internal values. Going forward, the REST contract uses the labels-matching enum.

### Impacted packages

- `web` — Zod request/response schemas, PUT/GET handlers, server tests
- `fern` — `BlobStorageExportSource` enum values + docstrings, regenerated `openapi.yml`

## Test plan

- [x] `pnpm --filter web run typecheck`
- [x] `dotenv -e .env -- pnpm --filter web exec vitest run blob-storage-integration-api blob-storage-integration-trpc` — 54/54 passed
- [ ] Manual: verify regenerated SDK clients (Python, TypeScript) reflect the new enum values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the directly-exposed Prisma enum `AnalyticsIntegrationExportSource` (`TRACES_OBSERVATIONS` / `EVENTS` / `TRACES_OBSERVATIONS_EVENTS`) in the public REST API with a new user-facing enum (`LEGACY_TRACES_OBSERVATIONS` / `OBSERVATIONS_V2` / `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`) that mirrors the UI labels. The internal Prisma enum, tRPC layer, and UI form are untouched; only the REST boundary changes.

- **Bidirectional mapping**: `PUBLIC_TO_INTERNAL_EXPORT_SOURCE` and `INTERNAL_TO_PUBLIC_EXPORT_SOURCE` lookup tables, both guarded with `satisfies Record<...>` for compile-time exhaustiveness, live in `blob-storage-integrations.ts`; exported as `toInternalExportSource` / `toPublicExportSource`.
- **Handler layering**: PUT applies `toInternalExportSource` before the Prisma upsert; both PUT and GET responses call `toPublicExportSource` before serialization. The `exportFieldGroups` masking logic continues to compare against the internal `TRACES_OBSERVATIONS` value correctly.
- **Test coverage**: A new server test exercises the `TRACES_OBSERVATIONS_EVENTS → LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` round-trip via a Prisma-seeded row, closing the gap that existed in the previous iteration.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The internal Prisma layer is entirely unchanged; only the REST boundary is affected, and both mapping directions are exhaustively checked at compile time via `satisfies Record<...>`.

The change is a well-scoped renaming at the API boundary. The `satisfies`-enforced lookup tables prevent an unmapped enum value from ever silently passing through, and the new runtime test for `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` closes the remaining coverage gap. No data-path logic has changed.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as PUT/GET Handler
    participant Mapping as toInternal/toPublic
    participant Prisma as Prisma (internal)

    Client->>Handler: "PUT {exportSource: "OBSERVATIONS_V2"}"
    Handler->>Mapping: toInternalExportSource("OBSERVATIONS_V2")
    Mapping-->>Handler: AnalyticsIntegrationExportSource.EVENTS
    Handler->>Prisma: "upsert({exportSource: EVENTS})"
    Prisma-->>Handler: "{exportSource: EVENTS, ...}"
    Handler->>Mapping: toPublicExportSource(EVENTS)
    Mapping-->>Handler: "OBSERVATIONS_V2"
    Handler-->>Client: "{exportSource: "OBSERVATIONS_V2", ...}"

    Client->>Handler: GET /integrations/blob-storage
    Handler->>Prisma: findMany(...)
    Prisma-->>Handler: "[{exportSource: TRACES_OBSERVATIONS_EVENTS}, ...]"
    Handler->>Mapping: toPublicExportSource(TRACES_OBSERVATIONS_EVENTS)
    Mapping-->>Handler: "LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS"
    Handler-->>Client: "[{exportSource: "LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS"}, ...]"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["updated API docs"](https://github.com/langfuse/langfuse/commit/c8f73481e3a587318c24f8c71a706a504ce43df2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31973118)</sub>

<!-- /greptile_comment -->