### PR TITLE
feat(observations-v2): expose trace_context field group in public API

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -326,6 +326,17 @@ types:
         type: optional<nullable<string>>
         docs: The matched model ID
 
+      # Trace context fields (field group: trace_context)
+      traceName:
+        type: optional<nullable<string>>
+        docs: The name of the parent trace
+      tags:
+        type: optional<nullable<list<string>>>
+        docs: Tags from the parent trace (denormalized onto the observation)
+      release:
+        type: optional<nullable<string>>
+        docs: The release version of the parent trace
+
   Usage:
     docs: (Deprecated. Use usageDetails and costDetails instead.) Standard interface for usage and cost
     properties:

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -25,6 +25,7 @@ service:
         - `usage` - usageDetails, costDetails, totalCost, usagePricingTierName
         - `prompt` - promptId, promptName, promptVersion
         - `metrics` - latency, timeToFirstToken
+        - `trace_context` - tags, release, traceName
 
         If not specified, `core` and `basic` field groups are returned.
 
@@ -40,7 +41,7 @@ service:
             type: optional<string>
             docs: |
               Comma-separated list of field groups to include in the response.
-              Available groups: core, basic, time, io, metadata, model, usage, prompt, metrics.
+              Available groups: core, basic, time, io, metadata, model, usage, prompt, metrics, trace_context.
               If not specified, `core` and `basic` field groups are returned.
               Example: "basic,usage,model"
           expandMetadata:

--- a/packages/shared/src/domain/observation-field-groups.ts
+++ b/packages/shared/src/domain/observation-field-groups.ts
@@ -8,8 +8,8 @@
  * - OBSERVATION_FIELD_GROUPS_PUBLIC_API: v2 public API contract — the groups that the
  *   v2 observations endpoint can return.
  * - OBSERVATION_FIELD_GROUPS_FULL: the complete set of column groups the
- *   events repository can project, including denormalized trace context and
- *   tool fields that the public API does not currently expose.
+ *   events repository can project, including tool fields that the public API
+ *   does not currently expose.
  *
  * Defined in the client-safe domain layer (not inside the server-only
  * repository file) so frontend forms and Zod enums can reference the values
@@ -26,6 +26,7 @@ export const OBSERVATION_FIELD_GROUPS_PUBLIC_API = [
   "usage", // usageDetails, costDetails, totalCost, usagePricingTierName
   "prompt", // promptId, promptName, promptVersion
   "metrics", // latency, timeToFirstToken
+  "trace_context", // tags, release, traceName (denormalized trace metadata)
 ] as const;
 
 export type ObservationFieldGroupPublicApi =
@@ -34,7 +35,6 @@ export type ObservationFieldGroupPublicApi =
 export const OBSERVATION_FIELD_GROUPS_FULL = [
   ...OBSERVATION_FIELD_GROUPS_PUBLIC_API,
   "tools", // toolDefinitions, toolCalls, toolCallNames
-  "trace_context", // tags, release, traceName (denormalized trace metadata)
 ] as const;
 
 export type ObservationFieldGroupFull =

--- a/packages/shared/src/domain/observations.ts
+++ b/packages/shared/src/domain/observations.ts
@@ -117,7 +117,7 @@ export const EventsObservationSchema = ObservationSchema.extend({
   sessionId: z.string().nullable(),
   traceName: z.string().nullable(),
   release: z.string().nullable().optional(),
-  tags: z.array(z.string()).optional(),
+  tags: z.array(z.string()).nullable().optional(),
   bookmarked: z.boolean().optional(),
   public: z.boolean().optional(),
 });

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -412,7 +412,7 @@ export function convertEventsObservation(
     sessionId: record.session_id ?? null,
     traceName: record.trace_name ?? null,
     release: record.release ?? null,
-    tags: record.tags ?? [],
+    tags: record.tags ?? null,
     bookmarked: record.bookmarked,
     public: record.public,
   };

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3133,6 +3133,8 @@ paths:
 
         - `metrics` - latency, timeToFirstToken
 
+        - `trace_context` - tags, release, traceName
+
 
         If not specified, `core` and `basic` field groups are returned.
 
@@ -3154,7 +3156,7 @@ paths:
             Comma-separated list of field groups to include in the response.
 
             Available groups: core, basic, time, io, metadata, model, usage,
-            prompt, metrics.
+            prompt, metrics, trace_context.
 
             If not specified, `core` and `basic` field groups are returned.
 

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8115,6 +8115,20 @@ components:
           type: string
           nullable: true
           description: The matched model ID
+        traceName:
+          type: string
+          nullable: true
+          description: The name of the parent trace
+        tags:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: Tags from the parent trace (denormalized onto the observation)
+        release:
+          type: string
+          nullable: true
+          description: The release version of the parent trace
       required:
         - id
         - startTime

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -539,6 +539,10 @@ describe("/api/public/v2/observations API Endpoint", () => {
       "promptId",
       "promptName",
       "promptVersion",
+      // trace_context
+      "traceName",
+      "tags",
+      "release",
     ] as const;
 
     let sharedObsId: string;

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -581,6 +581,9 @@ describe("/api/public/v2/observations API Endpoint", () => {
         output: "contract output",
         metadata_names: ["key"],
         metadata_values: ["val"],
+        trace_name: "contract-trace",
+        tags: ["tag-a", "tag-b"],
+        release: "1.2.3",
       });
 
       await createEventsCh([obs]);
@@ -605,6 +608,9 @@ describe("/api/public/v2/observations API Endpoint", () => {
       promptVersion: 2,
       input: "contract input",
       output: "contract output",
+      traceName: "contract-trace",
+      tags: ["tag-a", "tag-b"],
+      release: "1.2.3",
       usagePricingTierName: "contract-tier",
     };
 
@@ -636,6 +642,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
       // end_time), but the metrics group is still defined for documentation and to verify these fields are indeed
       // present
       metrics: ["latency", "timeToFirstToken"],
+      trace_context: ["traceName", "tags", "release"],
     };
 
     for (const [group, expectedFields] of Object.entries(fieldsForGroup)) {

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -156,6 +156,9 @@ export const transformDbToApiObservation = (
     // exclude trace name, this will only be available on events api
     traceName,
 
+    // exclude release, this will only be available on events api
+    release,
+
     // Exclude tags
     tags,
     traceTags,

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -440,6 +440,11 @@ const APIObservationV2 = z
 
     // Enrichment fields
     modelId: z.string().nullable().optional(),
+
+    // Trace context fields (field group: trace_context)
+    traceName: z.string().nullable().optional(),
+    tags: z.array(z.string()).nullable().optional(),
+    release: z.string().nullable().optional(),
   })
   .loose();
 


### PR DESCRIPTION
## Summary

Stacked on top of [#13617](https://app.graphite.com/github/pr/langfuse/langfuse/13617) (the `OBSERVATION_FIELD_GROUPS` / `BLOB_EXPORT_FIELD_GROUPS` split). Exposes `trace_context` on the public `/api/public/v2/observations` API after that split, restoring the group to the v2 contract with a documented surface (it had been incidentally available via the un-narrowed constant before #13617).

- Adds `trace_context` back to `OBSERVATION_FIELD_GROUPS` — the narrowed list of public v2 groups, distinct from `BLOB_EXPORT_FIELD_GROUPS`. `tools` stays only on the blob-export side as before.
- Fern source documents `trace_context` in both the field-selection list and the `Available groups` line on the `fields` query parameter. Regenerated `openapi.yml` propagates to the SDK clients.
- Columns exposed: `tags`, `release`, `traceName` (denormalized trace metadata). `usagePricingTierName` was moved to the `usage` group by #13617 and is documented there.

### How does this differ from pre-#13617 behavior?

Before #13617, `trace_context` was already accepted at runtime via the Zod filter against `OBSERVATION_FIELD_GROUPS` — but the Fern docstring listed only 9 of 11 groups, so it was undocumented. #13617 narrowed the constant for safety (separating v2 API from blob-export selection). This PR restores `trace_context` on the v2 side intentionally, with explicit Fern documentation, while leaving `tools` blob-export-only.

### Test coverage

Extends the parametrized `field group contract` loop in `observations-api-v2.servertest.ts` with a `trace_context` row that asserts the three denormalized fields flow through when `fields=trace_context` is requested. Uses fixture values for `tags`, `release`, `traceName` so a null regression is caught.

### Impacted packages

- `@langfuse/shared` — re-adds `trace_context` to `OBSERVATION_FIELD_GROUPS`; updates the docblock to reflect that only `tools` is now in the broader blob-export set
- `web` — extends servertest coverage; regenerated `openapi.yml`
- `fern` — observations endpoint docstring

## Test plan

- [x] `pnpm --filter web run typecheck`
- [x] `dotenv -e .env -- pnpm --filter web exec vitest run observations-api-v2` — 27/27 passed
- [ ] Manual: verify regenerated SDKs (Python, TypeScript) include `trace_context` as a valid `fields` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR re-adds `trace_context` to `OBSERVATION_FIELD_GROUPS` so that `tags`, `release`, and `traceName` are exposed on the public `/api/public/v2/observations` endpoint, and documents the group in both the Fern definition and the generated OpenAPI spec.

- **`packages/shared`**: `trace_context` is appended to `OBSERVATION_FIELD_GROUPS`; docblock updated to reflect `tools` is now the only blob-export-only group.
- **`fern` / `openapi.yml`**: `trace_context` and its three columns are added to the field-selection list and the `Available groups` doc line.
- **Server test**: parametrized contract test extended with a `trace_context` row and fixture values for `tags`, `release`, `traceName`, but `ALL_NON_CORE_FIELDS` (the sentinel list used for absence checks) is not updated, leaving a gap in isolation coverage.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation change itself is straightforward and isolated; the test gap means field-isolation regressions won't be caught by the existing suite.

Adding three fields to `ALL_NON_CORE_FIELDS` is the only change needed to complete the test contract — without it, the parametrized absence loop never fires for `traceName`, `tags`, or `release` when a different group is requested, so a future leak of `trace_context` data into unrelated group responses would go undetected in CI.

web/src/__tests__/server/observations-api-v2.servertest.ts — the `ALL_NON_CORE_FIELDS` constant needs to include `traceName`, `tags`, and `release`.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant PublicAPI as /api/public/v2/observations
    participant QueryBuilder as buildObservationsQueryComponents
    participant CH as ClickHouse (events table)
    participant Traces as traces CTE

    Client->>PublicAPI: "GET ?fields=trace_context&traceId=..."
    PublicAPI->>QueryBuilder: "fields=["trace_context"]"
    QueryBuilder->>QueryBuilder: Validates group in OBSERVATION_FIELD_GROUPS
    QueryBuilder->>Traces: JOIN traces CTE (tags, release, traceName)
    QueryBuilder->>CH: SELECT core + trace_context columns
    CH-->>PublicAPI: rows with tags, release, traceName
    PublicAPI-->>Client: "{ data: [{ id, traceId, ..., tags, release, traceName }] }"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/observations-api-v2.servertest.ts:538-542
The `ALL_NON_CORE_FIELDS` list is not updated with the three fields from the new `trace_context` group (`traceName`, `tags`, `release`). The absence-check loop only iterates over members of this list, so when any other group (e.g. `basic`, `io`, `usage`) is tested in isolation, the test never asserts that `traceName`, `tags`, and `release` are absent from the response. A regression that leaks `trace_context` fields into unrelated group responses would pass undetected.

```suggestion
      // prompt
      "promptId",
      "promptName",
      "promptVersion",
      // trace_context
      "traceName",
      "tags",
      "release",
    ] as const;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(observations-v2): expose trace\_cont..."](https://github.com/langfuse/langfuse/commit/ae0d5f26f2afb8019cb6a7aff75452d0184b08cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31989455)</sub>

<!-- /greptile_comment -->