### PR TITLE
feat(blob-export): gate legacy export sources for post-cutoff Cloud projects

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -62,6 +62,11 @@ NEXTAUTH_SECRET="secret"
 
 # Langfuse Cloud Environment
 NEXT_PUBLIC_LANGFUSE_CLOUD_REGION="DEV"
+# Dev-only: override the legacy blob-export cutoff date for local testing.
+# Set to a past date (e.g. 2020-01-01T00:00:00.000Z) to make every project
+# post-cutoff, or a future date (e.g. 2099-01-01T00:00:00.000Z) to grandfather
+# all projects. Must be a valid ISO 8601 datetime string. Leave unset in prod.
+# NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF=
 
 # Langfuse experimental features
 LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES="false"

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -133,6 +133,8 @@ types:
         docs: |
           Data to export. When omitted on update, the existing value is preserved; when omitted on create, the column default (`LEGACY_TRACES_OBSERVATIONS`) applies. Required when `exportFieldGroups` is provided.
 
+          **Cloud-only deprecation gate (effective 2026-05-20):** For projects created on or after 2026-05-20 on Langfuse Cloud, `LEGACY` and `LEGACY_AND_ENRICHED` are rejected with HTTP 400. Use `ENRICHED` for all new integrations. Projects created before 2026-05-20 and self-hosted deployments are unaffected.
+
       exportFieldGroups:
         type: optional<list<BlobStorageExportFieldGroup>>
         docs: |

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -131,9 +131,9 @@ types:
       exportSource:
         type: optional<BlobStorageExportSource>
         docs: |
-          Data to export. When omitted on update, the existing value is preserved; when omitted on create, the column default (`LEGACY_TRACES_OBSERVATIONS`) applies. Required when `exportFieldGroups` is provided.
+          Data to export. When omitted on update, the existing value is preserved. When omitted on create: pre-cutoff Cloud projects and self-hosted deployments fall back to `LEGACY_TRACES_OBSERVATIONS`; post-cutoff Cloud projects (created on or after 2026-05-20) auto-default to `OBSERVATIONS_V2`. Required when `exportFieldGroups` is provided.
 
-          **Cloud-only deprecation gate (effective 2026-05-20):** For projects created on or after 2026-05-20 on Langfuse Cloud, `LEGACY_TRACES_OBSERVATIONS` and `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP 400. Use `OBSERVATIONS_V2` for all new integrations. Projects created before 2026-05-20 and self-hosted deployments are unaffected.
+          **Cloud-only deprecation gate (effective 2026-05-20):** For projects created on or after 2026-05-20 on Langfuse Cloud, `LEGACY_TRACES_OBSERVATIONS` and `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP 400. Omitting `exportSource` on these projects silently defaults to `OBSERVATIONS_V2` rather than the schema column default. Use `OBSERVATIONS_V2` for all new integrations. Projects created before 2026-05-20 and self-hosted deployments are unaffected.
 
       exportFieldGroups:
         type: optional<list<BlobStorageExportFieldGroup>>

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -133,7 +133,7 @@ types:
         docs: |
           Data to export. When omitted on update, the existing value is preserved; when omitted on create, the column default (`LEGACY_TRACES_OBSERVATIONS`) applies. Required when `exportFieldGroups` is provided.
 
-          **Cloud-only deprecation gate (effective 2026-05-20):** For projects created on or after 2026-05-20 on Langfuse Cloud, `LEGACY` and `LEGACY_AND_ENRICHED` are rejected with HTTP 400. Use `ENRICHED` for all new integrations. Projects created before 2026-05-20 and self-hosted deployments are unaffected.
+          **Cloud-only deprecation gate (effective 2026-05-20):** For projects created on or after 2026-05-20 on Langfuse Cloud, `LEGACY_TRACES_OBSERVATIONS` and `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP 400. Use `OBSERVATIONS_V2` for all new integrations. Projects created before 2026-05-20 and self-hosted deployments are unaffected.
 
       exportFieldGroups:
         type: optional<list<BlobStorageExportFieldGroup>>

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -3,6 +3,10 @@ import { removeEmptyEnvVariables } from "./utils/environment";
 
 const EnvSchema = z.object({
   NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: z.string().optional(),
+  // Dev-only override: set to an ISO datetime string to shift the legacy blob
+  // export cutoff for local testing (e.g. "2020-01-01T00:00:00.000Z" makes
+  // every project post-cutoff; "2099-01-01T00:00:00.000Z" grandfathers all).
+  NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF: z.iso.datetime().optional(),
   NODE_ENV: z
     .enum(["development", "test", "production"])
     .default("development"),

--- a/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
@@ -13,9 +13,10 @@ export const LEGACY_BLOB_EXPORT_CUTOFF =
     ? _override
     : new Date("2026-05-20T00:00:00.000Z");
 
-// Internal enum values that are considered "legacy". satisfies ensures TypeScript
-// errors if a new AnalyticsIntegrationExportSource variant is added without
-// reconsidering whether it belongs here.
+// Internal enum values that are considered "legacy". satisfies ensures each
+// element remains a valid AnalyticsIntegrationExportSource — catches renames or
+// removals at compile time. Adding a new enum variant does NOT automatically
+// produce an error here; the list must be reviewed manually.
 export const LEGACY_BLOB_EXPORT_SOURCES = [
   AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
   AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,

--- a/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
@@ -20,7 +20,7 @@ export const LEGACY_BLOB_EXPORT_SOURCES = [
 
 /**
  * Returns true when a project may use legacy blob export sources.
- * False means the project is post-cutoff Cloud and must use ENRICHED only.
+ * False means the project is post-cutoff Cloud and must use OBSERVATIONS_V2 (internal: EVENTS) only.
  *
  * Shared by the server guard (throws when false + legacy source) and the UI
  * (hides legacy dropdown options when false) so the predicate lives once.

--- a/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
@@ -5,10 +5,13 @@ import { AnalyticsIntegrationExportSource } from "@prisma/client";
 
 // Cloud projects created on or after this instant cannot use legacy export sources.
 // NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF overrides the default for local dev testing.
-export const LEGACY_BLOB_EXPORT_CUTOFF = process.env
-  .NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF
+const _override = process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF
   ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF)
-  : new Date("2026-05-20T00:00:00.000Z");
+  : null;
+export const LEGACY_BLOB_EXPORT_CUTOFF =
+  _override && !isNaN(_override.getTime())
+    ? _override
+    : new Date("2026-05-20T00:00:00.000Z");
 
 // Internal enum values that are considered "legacy". satisfies ensures TypeScript
 // errors if a new AnalyticsIntegrationExportSource variant is added without

--- a/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
@@ -1,0 +1,34 @@
+// Business rules for the legacy blob export source deprecation gate.
+// This is a client-safe file that can be imported from @langfuse/shared.
+
+import { AnalyticsIntegrationExportSource } from "@prisma/client";
+
+// Cloud projects created on or after this instant cannot use legacy export sources.
+// NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF overrides the default for local dev testing.
+export const LEGACY_BLOB_EXPORT_CUTOFF = process.env
+  .NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF
+  ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF)
+  : new Date("2026-05-20T00:00:00.000Z");
+
+// Internal enum values that are considered "legacy". satisfies ensures TypeScript
+// errors if a new AnalyticsIntegrationExportSource variant is added without
+// reconsidering whether it belongs here.
+export const LEGACY_BLOB_EXPORT_SOURCES = [
+  AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+  AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+] as const satisfies ReadonlyArray<AnalyticsIntegrationExportSource>;
+
+/**
+ * Returns true when a project may use legacy blob export sources.
+ * False means the project is post-cutoff Cloud and must use ENRICHED only.
+ *
+ * Shared by the server guard (throws when false + legacy source) and the UI
+ * (hides legacy dropdown options when false) so the predicate lives once.
+ */
+export function isLegacyBlobExportAllowed(
+  projectCreatedAt: Date,
+  isCloud: boolean,
+): boolean {
+  if (!isCloud) return true;
+  return projectCreatedAt < LEGACY_BLOB_EXPORT_CUTOFF;
+}

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -7,6 +7,17 @@ import {
   type ObservationFieldGroupFull,
 } from "../../domain/observation-field-groups";
 
+// Cloud projects created on or after this instant cannot use legacy export sources.
+export const LEGACY_BLOB_EXPORT_CUTOFF = new Date("2026-05-20T00:00:00.000Z");
+
+// Internal enum values that are considered "legacy". satisfies ensures TypeScript
+// errors if a new AnalyticsIntegrationExportSource variant is added without
+// reconsidering whether it belongs here.
+export const LEGACY_BLOB_EXPORT_SOURCES = [
+  AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+  AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+] as const satisfies ReadonlyArray<AnalyticsIntegrationExportSource>;
+
 export const EXPORT_SOURCE_OPTIONS: Array<{
   value: AnalyticsIntegrationExportSource;
   label: string;

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -8,7 +8,11 @@ import {
 } from "../../domain/observation-field-groups";
 
 // Cloud projects created on or after this instant cannot use legacy export sources.
-export const LEGACY_BLOB_EXPORT_CUTOFF = new Date("2026-05-20T00:00:00.000Z");
+// NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF overrides the default for local dev testing.
+export const LEGACY_BLOB_EXPORT_CUTOFF = process.env
+  .NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF
+  ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF)
+  : new Date("2026-05-20T00:00:00.000Z");
 
 // Internal enum values that are considered "legacy". satisfies ensures TypeScript
 // errors if a new AnalyticsIntegrationExportSource variant is added without

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -7,35 +7,7 @@ import {
   type ObservationFieldGroupFull,
 } from "../../domain/observation-field-groups";
 
-// Cloud projects created on or after this instant cannot use legacy export sources.
-// NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF overrides the default for local dev testing.
-export const LEGACY_BLOB_EXPORT_CUTOFF = process.env
-  .NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF
-  ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF)
-  : new Date("2026-05-20T00:00:00.000Z");
-
-// Internal enum values that are considered "legacy". satisfies ensures TypeScript
-// errors if a new AnalyticsIntegrationExportSource variant is added without
-// reconsidering whether it belongs here.
-export const LEGACY_BLOB_EXPORT_SOURCES = [
-  AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-  AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
-] as const satisfies ReadonlyArray<AnalyticsIntegrationExportSource>;
-
-/**
- * Returns true when a project may use legacy blob export sources.
- * False means the project is post-cutoff Cloud and must use ENRICHED only.
- *
- * Shared by the server guard (throws when false + legacy source) and the UI
- * (hides legacy dropdown options when false) so the predicate lives once.
- */
-export function isLegacyBlobExportAllowed(
-  projectCreatedAt: Date,
-  isCloud: boolean,
-): boolean {
-  if (!isCloud) return true;
-  return projectCreatedAt < LEGACY_BLOB_EXPORT_CUTOFF;
-}
+export * from "./blob-export-gate";
 
 export const EXPORT_SOURCE_OPTIONS: Array<{
   value: AnalyticsIntegrationExportSource;

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -18,6 +18,21 @@ export const LEGACY_BLOB_EXPORT_SOURCES = [
   AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
 ] as const satisfies ReadonlyArray<AnalyticsIntegrationExportSource>;
 
+/**
+ * Returns true when a project may use legacy blob export sources.
+ * False means the project is post-cutoff Cloud and must use ENRICHED only.
+ *
+ * Shared by the server guard (throws when false + legacy source) and the UI
+ * (hides legacy dropdown options when false) so the predicate lives once.
+ */
+export function isLegacyBlobExportAllowed(
+  projectCreatedAt: Date,
+  isCloud: boolean,
+): boolean {
+  if (!isCloud) return true;
+  return projectCreatedAt < LEGACY_BLOB_EXPORT_CUTOFF;
+}
+
 export const EXPORT_SOURCE_OPTIONS: Array<{
   value: AnalyticsIntegrationExportSource;
   label: string;

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -238,7 +238,7 @@ export function convertObservationPartial(
 
     // Model fields
     ...(record.provided_model_name !== undefined && {
-      providedModelName: record.provided_model_name ?? null,
+      model: record.provided_model_name ?? null,
     }),
     ...(record.internal_model_id !== undefined && {
       internalModelId: record.internal_model_id ?? null,

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -238,7 +238,7 @@ export function convertObservationPartial(
 
     // Model fields
     ...(record.provided_model_name !== undefined && {
-      model: record.provided_model_name ?? null,
+      providedModelName: record.provided_model_name ?? null,
     }),
     ...(record.internal_model_id !== undefined && {
       internalModelId: record.internal_model_id ?? null,

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [".env"],
+  "globalEnv": ["NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF"],
   "envMode": "loose",
   "tasks": {
     "build": {

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7360,18 +7360,21 @@ components:
           nullable: true
           description: >-
             Data to export. When omitted on update, the existing value is
-            preserved; when omitted on create, the column default
-            (`LEGACY_TRACES_OBSERVATIONS`) applies. Required when
-            `exportFieldGroups` is provided.
+            preserved. When omitted on create: pre-cutoff Cloud projects and
+            self-hosted deployments fall back to `LEGACY_TRACES_OBSERVATIONS`;
+            post-cutoff Cloud projects (created on or after 2026-05-20)
+            auto-default to `OBSERVATIONS_V2`. Required when `exportFieldGroups`
+            is provided.
 
 
             **Cloud-only deprecation gate (effective 2026-05-20):** For projects
             created on or after 2026-05-20 on Langfuse Cloud,
             `LEGACY_TRACES_OBSERVATIONS` and
             `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP
-            400. Use `OBSERVATIONS_V2` for all new integrations. Projects
-            created before 2026-05-20 and self-hosted deployments are
-            unaffected.
+            400. Omitting `exportSource` on these projects silently defaults to
+            `OBSERVATIONS_V2` rather than the schema column default. Use
+            `OBSERVATIONS_V2` for all new integrations. Projects created before
+            2026-05-20 and self-hosted deployments are unaffected.
         exportFieldGroups:
           type: array
           items:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7363,6 +7363,15 @@ components:
             preserved; when omitted on create, the column default
             (`LEGACY_TRACES_OBSERVATIONS`) applies. Required when
             `exportFieldGroups` is provided.
+
+
+            **Cloud-only deprecation gate (effective 2026-05-20):** For projects
+            created on or after 2026-05-20 on Langfuse Cloud,
+            `LEGACY_TRACES_OBSERVATIONS` and
+            `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP
+            400. Use `OBSERVATIONS_V2` for all new integrations. Projects
+            created before 2026-05-20 and self-hosted deployments are
+            unaffected.
         exportFieldGroups:
           type: array
           items:

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -11,7 +11,6 @@ import {
 } from "@langfuse/shared/src/server";
 import { OBSERVATION_FIELD_GROUPS_FULL } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
-import { env } from "@/src/env.mjs";
 
 // Schemas based on Fern schema definition
 const BlobStorageIntegrationResponseSchema = z.object({
@@ -1452,9 +1451,13 @@ describe("Blob Storage Integrations API", () => {
       vi.restoreAllMocks();
     });
 
+    // All REST cutoff-gate tests rely on the CI server already running in Cloud
+    // mode (NEXT_PUBLIC_LANGFUSE_CLOUD_REGION is set in .env.dev.example). The
+    // makeAPICall goes over HTTP to a separate process whose env is frozen at
+    // boot, so any (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION mutation in
+    // the test process never reaches the server and would be dead code.
+
     it("Cloud + pre-cutoff project + LEGACY_TRACES_OBSERVATIONS → 200", async () => {
-      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       try {
         await prisma.project.update({
           where: { id: testProject1Id },
@@ -1472,7 +1475,6 @@ describe("Blob Storage Integrations API", () => {
         );
         expect(result.status).toBe(200);
       } finally {
-        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
         await prisma.blobStorageIntegration.deleteMany({
           where: { projectId: testProject1Id },
         });
@@ -1480,8 +1482,6 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("Cloud + post-cutoff project + LEGACY_TRACES_OBSERVATIONS → 400", async () => {
-      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       try {
         await prisma.project.update({
           where: { id: testProject1Id },
@@ -1500,7 +1500,6 @@ describe("Blob Storage Integrations API", () => {
         expect(result.status).toBe(400);
         expect(result.body.message).toContain("OBSERVATIONS_V2");
       } finally {
-        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
         await prisma.project.update({
           where: { id: testProject1Id },
           data: { createdAt: new Date() },
@@ -1509,8 +1508,6 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("Cloud + post-cutoff project + LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS → 400", async () => {
-      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       try {
         await prisma.project.update({
           where: { id: testProject1Id },
@@ -1529,7 +1526,6 @@ describe("Blob Storage Integrations API", () => {
         expect(result.status).toBe(400);
         expect(result.body.message).toContain("OBSERVATIONS_V2");
       } finally {
-        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
         await prisma.project.update({
           where: { id: testProject1Id },
           data: { createdAt: new Date() },
@@ -1538,8 +1534,6 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("Cloud + post-cutoff project + OBSERVATIONS_V2 → 200", async () => {
-      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       try {
         await prisma.project.update({
           where: { id: testProject1Id },
@@ -1557,7 +1551,6 @@ describe("Blob Storage Integrations API", () => {
         );
         expect(result.status).toBe(200);
       } finally {
-        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
         await prisma.project.update({
           where: { id: testProject1Id },
           data: { createdAt: new Date() },

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -9,8 +9,15 @@ import {
   createAndAddApiKeysToDb,
   createBasicAuthHeader,
 } from "@langfuse/shared/src/server";
-import { OBSERVATION_FIELD_GROUPS_FULL } from "@langfuse/shared";
+import {
+  OBSERVATION_FIELD_GROUPS_FULL,
+  LEGACY_BLOB_EXPORT_CUTOFF,
+} from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
+const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
 
 // Schemas based on Fern schema definition
 const BlobStorageIntegrationResponseSchema = z.object({
@@ -629,12 +636,13 @@ describe("Blob Storage Integrations API", () => {
 
   describe("PUT/GET exportSource + exportFieldGroups behavior", () => {
     // Pin projects to a pre-cutoff date so legacy-source tests remain valid
-    // after 2026-05-20 (when CI starts rejecting LEGACY_TRACES_OBSERVATIONS for
-    // projects created on or after the cutoff).
+    // once the clock crosses LEGACY_BLOB_EXPORT_CUTOFF (CI runs with
+    // NEXT_PUBLIC_LANGFUSE_CLOUD_REGION set, so the gate would otherwise
+    // reject LEGACY_TRACES_OBSERVATIONS for projects created at now()).
     beforeAll(async () => {
       await prisma.project.updateMany({
         where: { id: { in: [testProject1Id, testProject2Id] } },
-        data: { createdAt: new Date("2026-05-01T00:00:00.000Z") },
+        data: { createdAt: PRE_CUTOFF },
       });
     });
 
@@ -1445,9 +1453,6 @@ describe("Blob Storage Integrations API", () => {
   });
 
   describe("legacy blob export source cutoff gate", () => {
-    const PRE_CUTOFF = new Date("2026-05-19T12:00:00.000Z");
-    const POST_CUTOFF = new Date("2026-05-21T12:00:00.000Z");
-
     const basePayload = {
       type: "S3" as const,
       bucketName: "test-bucket",

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -1600,6 +1600,7 @@ describe("Blob Storage Integrations API", () => {
             type: "S3",
             bucketName: "test-bucket",
             region: "us-east-1",
+            prefix: "",
             exportFrequency: "daily",
             enabled: true,
             forcePathStyle: false,

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -1452,7 +1452,7 @@ describe("Blob Storage Integrations API", () => {
       vi.restoreAllMocks();
     });
 
-    it("Cloud + pre-cutoff project + LEGACY → 200", async () => {
+    it("Cloud + pre-cutoff project + LEGACY_TRACES_OBSERVATIONS → 200", async () => {
       const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       try {
@@ -1466,7 +1466,7 @@ describe("Blob Storage Integrations API", () => {
           {
             ...basePayload,
             projectId: testProject1Id,
-            exportSource: "TRACES_OBSERVATIONS",
+            exportSource: "LEGACY_TRACES_OBSERVATIONS",
           },
           createBasicAuthHeader(testApiKey, testApiSecretKey),
         );
@@ -1479,7 +1479,7 @@ describe("Blob Storage Integrations API", () => {
       }
     });
 
-    it("Cloud + post-cutoff project + LEGACY → 400", async () => {
+    it("Cloud + post-cutoff project + LEGACY_TRACES_OBSERVATIONS → 400", async () => {
       const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       try {
@@ -1493,12 +1493,12 @@ describe("Blob Storage Integrations API", () => {
           {
             ...basePayload,
             projectId: testProject1Id,
-            exportSource: "TRACES_OBSERVATIONS",
+            exportSource: "LEGACY_TRACES_OBSERVATIONS",
           },
           createBasicAuthHeader(testApiKey, testApiSecretKey),
         );
         expect(result.status).toBe(400);
-        expect(result.body.message).toContain("ENRICHED");
+        expect(result.body.message).toContain("OBSERVATIONS_V2");
       } finally {
         (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
         await prisma.project.update({
@@ -1508,7 +1508,7 @@ describe("Blob Storage Integrations API", () => {
       }
     });
 
-    it("Cloud + post-cutoff project + TRACES_OBSERVATIONS_EVENTS → 400", async () => {
+    it("Cloud + post-cutoff project + LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS → 400", async () => {
       const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       try {
@@ -1522,12 +1522,12 @@ describe("Blob Storage Integrations API", () => {
           {
             ...basePayload,
             projectId: testProject1Id,
-            exportSource: "TRACES_OBSERVATIONS_EVENTS",
+            exportSource: "LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS",
           },
           createBasicAuthHeader(testApiKey, testApiSecretKey),
         );
         expect(result.status).toBe(400);
-        expect(result.body.message).toContain("ENRICHED");
+        expect(result.body.message).toContain("OBSERVATIONS_V2");
       } finally {
         (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
         await prisma.project.update({
@@ -1537,7 +1537,7 @@ describe("Blob Storage Integrations API", () => {
       }
     });
 
-    it("Cloud + post-cutoff project + EVENTS → 200", async () => {
+    it("Cloud + post-cutoff project + OBSERVATIONS_V2 → 200", async () => {
       const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       try {
@@ -1548,7 +1548,11 @@ describe("Blob Storage Integrations API", () => {
         const result = await makeAPICall(
           "PUT",
           "/api/public/integrations/blob-storage",
-          { ...basePayload, projectId: testProject1Id, exportSource: "EVENTS" },
+          {
+            ...basePayload,
+            projectId: testProject1Id,
+            exportSource: "OBSERVATIONS_V2",
+          },
           createBasicAuthHeader(testApiKey, testApiSecretKey),
         );
         expect(result.status).toBe(200);
@@ -1564,7 +1568,7 @@ describe("Blob Storage Integrations API", () => {
       }
     });
 
-    it("self-hosted + post-cutoff project + LEGACY → 200 (bypass)", async () => {
+    it("self-hosted + post-cutoff project + LEGACY_TRACES_OBSERVATIONS → 200 (bypass)", async () => {
       const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
       try {
@@ -1578,7 +1582,7 @@ describe("Blob Storage Integrations API", () => {
           {
             ...basePayload,
             projectId: testProject1Id,
-            exportSource: "TRACES_OBSERVATIONS",
+            exportSource: "LEGACY_TRACES_OBSERVATIONS",
           },
           createBasicAuthHeader(testApiKey, testApiSecretKey),
         );

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -1567,5 +1567,31 @@ describe("Blob Storage Integrations API", () => {
         });
       }
     });
+    it("Cloud + post-cutoff project + no exportSource → defaults to OBSERVATIONS_V2", async () => {
+      // The server runs in Cloud mode in CI, so no env mutation is needed.
+      // Set createdAt to a past post-cutoff date so the gate applies.
+      try {
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: POST_CUTOFF },
+        });
+        const result = await makeAPICall(
+          "PUT",
+          "/api/public/integrations/blob-storage",
+          { ...basePayload, projectId: testProject1Id },
+          createBasicAuthHeader(testApiKey, testApiSecretKey),
+        );
+        expect(result.status).toBe(200);
+        expect(result.body.exportSource).toBe("OBSERVATIONS_V2");
+      } finally {
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: new Date() },
+        });
+        await prisma.blobStorageIntegration.deleteMany({
+          where: { projectId: testProject1Id },
+        });
+      }
+    });
   });
 });

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -1567,36 +1567,5 @@ describe("Blob Storage Integrations API", () => {
         });
       }
     });
-
-    it("self-hosted + post-cutoff project + LEGACY_TRACES_OBSERVATIONS → 200 (bypass)", async () => {
-      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
-      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
-      try {
-        await prisma.project.update({
-          where: { id: testProject1Id },
-          data: { createdAt: POST_CUTOFF },
-        });
-        const result = await makeAPICall(
-          "PUT",
-          "/api/public/integrations/blob-storage",
-          {
-            ...basePayload,
-            projectId: testProject1Id,
-            exportSource: "LEGACY_TRACES_OBSERVATIONS",
-          },
-          createBasicAuthHeader(testApiKey, testApiSecretKey),
-        );
-        expect(result.status).toBe(200);
-      } finally {
-        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
-        await prisma.project.update({
-          where: { id: testProject1Id },
-          data: { createdAt: new Date() },
-        });
-        await prisma.blobStorageIntegration.deleteMany({
-          where: { projectId: testProject1Id },
-        });
-      }
-    });
   });
 });

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -1560,13 +1560,53 @@ describe("Blob Storage Integrations API", () => {
         });
       }
     });
-    it("Cloud + post-cutoff project + no exportSource → defaults to OBSERVATIONS_V2", async () => {
-      // The server runs in Cloud mode in CI, so no env mutation is needed.
-      // Set createdAt to a past post-cutoff date so the gate applies.
+    it("Cloud + post-cutoff project + no exportSource + CREATE → defaults to OBSERVATIONS_V2", async () => {
+      // No existing row → CREATE path: handler forces EVENTS (OBSERVATIONS_V2).
       try {
         await prisma.project.update({
           where: { id: testProject1Id },
           data: { createdAt: POST_CUTOFF },
+        });
+        const result = await makeAPICall(
+          "PUT",
+          "/api/public/integrations/blob-storage",
+          { ...basePayload, projectId: testProject1Id },
+          createBasicAuthHeader(testApiKey, testApiSecretKey),
+        );
+        expect(result.status).toBe(200);
+        expect(result.body.exportSource).toBe("OBSERVATIONS_V2");
+      } finally {
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: new Date() },
+        });
+        await prisma.blobStorageIntegration.deleteMany({
+          where: { projectId: testProject1Id },
+        });
+      }
+    });
+
+    it("Cloud + post-cutoff project + no exportSource + UPDATE → preserves existing value", async () => {
+      // Existing row with OBSERVATIONS_V2 → UPDATE path: omitting exportSource
+      // must not overwrite the persisted value.
+      try {
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: POST_CUTOFF },
+        });
+        await prisma.blobStorageIntegration.create({
+          data: {
+            projectId: testProject1Id,
+            type: "S3",
+            bucketName: "test-bucket",
+            region: "us-east-1",
+            exportFrequency: "daily",
+            enabled: true,
+            forcePathStyle: false,
+            fileType: "JSONL",
+            exportMode: "FULL_HISTORY",
+            exportSource: "EVENTS",
+          },
         });
         const result = await makeAPICall(
           "PUT",

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -628,6 +628,23 @@ describe("Blob Storage Integrations API", () => {
   });
 
   describe("PUT/GET exportSource + exportFieldGroups behavior", () => {
+    // Pin projects to a pre-cutoff date so legacy-source tests remain valid
+    // after 2026-05-20 (when CI starts rejecting LEGACY_TRACES_OBSERVATIONS for
+    // projects created on or after the cutoff).
+    beforeAll(async () => {
+      await prisma.project.updateMany({
+        where: { id: { in: [testProject1Id, testProject2Id] } },
+        data: { createdAt: new Date("2026-05-01T00:00:00.000Z") },
+      });
+    });
+
+    afterAll(async () => {
+      await prisma.project.updateMany({
+        where: { id: { in: [testProject1Id, testProject2Id] } },
+        data: { createdAt: new Date() },
+      });
+    });
+
     afterEach(async () => {
       await prisma.blobStorageIntegration.deleteMany({
         where: {

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -11,6 +11,7 @@ import {
 } from "@langfuse/shared/src/server";
 import { OBSERVATION_FIELD_GROUPS_FULL } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
+import { env } from "@/src/env.mjs";
 
 // Schemas based on Fern schema definition
 const BlobStorageIntegrationResponseSchema = z.object({
@@ -1424,6 +1425,174 @@ describe("Blob Storage Integrations API", () => {
       );
       expect(result.status).toBe(405);
       expect(result.body.message).toContain("Method not allowed");
+    });
+  });
+
+  describe("legacy blob export source cutoff gate", () => {
+    const PRE_CUTOFF = new Date("2026-05-19T12:00:00.000Z");
+    const POST_CUTOFF = new Date("2026-05-21T12:00:00.000Z");
+
+    const basePayload = {
+      type: "S3" as const,
+      bucketName: "test-bucket",
+      endpoint: null,
+      region: "us-east-1",
+      accessKeyId: "AKIA123456789",
+      secretAccessKey: "secret123456789",
+      prefix: "exports/",
+      exportFrequency: "daily",
+      enabled: true,
+      forcePathStyle: false,
+      fileType: "JSONL",
+      exportMode: "FULL_HISTORY",
+      exportStartDate: null,
+    };
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("Cloud + pre-cutoff project + LEGACY → 200", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: PRE_CUTOFF },
+        });
+        const result = await makeAPICall(
+          "PUT",
+          "/api/public/integrations/blob-storage",
+          {
+            ...basePayload,
+            projectId: testProject1Id,
+            exportSource: "TRACES_OBSERVATIONS",
+          },
+          createBasicAuthHeader(testApiKey, testApiSecretKey),
+        );
+        expect(result.status).toBe(200);
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+        await prisma.blobStorageIntegration.deleteMany({
+          where: { projectId: testProject1Id },
+        });
+      }
+    });
+
+    it("Cloud + post-cutoff project + LEGACY → 400", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: POST_CUTOFF },
+        });
+        const result = await makeAPICall(
+          "PUT",
+          "/api/public/integrations/blob-storage",
+          {
+            ...basePayload,
+            projectId: testProject1Id,
+            exportSource: "TRACES_OBSERVATIONS",
+          },
+          createBasicAuthHeader(testApiKey, testApiSecretKey),
+        );
+        expect(result.status).toBe(400);
+        expect(result.body.message).toContain("ENRICHED");
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: new Date() },
+        });
+      }
+    });
+
+    it("Cloud + post-cutoff project + TRACES_OBSERVATIONS_EVENTS → 400", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: POST_CUTOFF },
+        });
+        const result = await makeAPICall(
+          "PUT",
+          "/api/public/integrations/blob-storage",
+          {
+            ...basePayload,
+            projectId: testProject1Id,
+            exportSource: "TRACES_OBSERVATIONS_EVENTS",
+          },
+          createBasicAuthHeader(testApiKey, testApiSecretKey),
+        );
+        expect(result.status).toBe(400);
+        expect(result.body.message).toContain("ENRICHED");
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: new Date() },
+        });
+      }
+    });
+
+    it("Cloud + post-cutoff project + EVENTS → 200", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: POST_CUTOFF },
+        });
+        const result = await makeAPICall(
+          "PUT",
+          "/api/public/integrations/blob-storage",
+          { ...basePayload, projectId: testProject1Id, exportSource: "EVENTS" },
+          createBasicAuthHeader(testApiKey, testApiSecretKey),
+        );
+        expect(result.status).toBe(200);
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: new Date() },
+        });
+        await prisma.blobStorageIntegration.deleteMany({
+          where: { projectId: testProject1Id },
+        });
+      }
+    });
+
+    it("self-hosted + post-cutoff project + LEGACY → 200 (bypass)", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      try {
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: POST_CUTOFF },
+        });
+        const result = await makeAPICall(
+          "PUT",
+          "/api/public/integrations/blob-storage",
+          {
+            ...basePayload,
+            projectId: testProject1Id,
+            exportSource: "TRACES_OBSERVATIONS",
+          },
+          createBasicAuthHeader(testApiKey, testApiSecretKey),
+        );
+        expect(result.status).toBe(200);
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+        await prisma.project.update({
+          where: { id: testProject1Id },
+          data: { createdAt: new Date() },
+        });
+        await prisma.blobStorageIntegration.deleteMany({
+          where: { projectId: testProject1Id },
+        });
+      }
     });
   });
 });

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -12,6 +12,7 @@ import {
   StorageServiceFactory,
 } from "@langfuse/shared/src/server";
 import { OBSERVATION_FIELD_GROUPS_FULL } from "@langfuse/shared";
+import { env } from "@/src/env.mjs";
 
 vi.mock("@langfuse/shared/src/server", async () => {
   const actual = await vi.importActual("@langfuse/shared/src/server");
@@ -428,6 +429,99 @@ describe("Blob Storage Integration tRPC Router", () => {
         "io",
         "metrics",
       ]);
+    });
+  });
+
+  describe("legacy blob export source cutoff gate", () => {
+    const PRE_CUTOFF = new Date("2026-05-19T12:00:00.000Z");
+    const POST_CUTOFF = new Date("2026-05-21T12:00:00.000Z");
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("Cloud + pre-cutoff project + legacy source → allow", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        const { caller, project } = await prepare();
+        await prisma.project.update({
+          where: { id: project.id },
+          data: { createdAt: PRE_CUTOFF },
+        });
+        await expect(
+          caller.blobStorageIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+            exportSource: "TRACES_OBSERVATIONS" as const,
+          }),
+        ).resolves.not.toThrow();
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      }
+    });
+
+    it("Cloud + post-cutoff project + legacy source → BAD_REQUEST", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        const { caller, project } = await prepare();
+        await prisma.project.update({
+          where: { id: project.id },
+          data: { createdAt: POST_CUTOFF },
+        });
+        await expect(
+          caller.blobStorageIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+            exportSource: "TRACES_OBSERVATIONS" as const,
+          }),
+        ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      }
+    });
+
+    it("Cloud + post-cutoff project + EVENTS → allow", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        const { caller, project } = await prepare();
+        await prisma.project.update({
+          where: { id: project.id },
+          data: { createdAt: POST_CUTOFF },
+        });
+        await expect(
+          caller.blobStorageIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+            exportSource: "EVENTS" as const,
+          }),
+        ).resolves.not.toThrow();
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      }
+    });
+
+    it("self-hosted + post-cutoff project + legacy source → allow (bypass)", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      try {
+        const { caller, project } = await prepare();
+        await prisma.project.update({
+          where: { id: project.id },
+          data: { createdAt: POST_CUTOFF },
+        });
+        await expect(
+          caller.blobStorageIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+            exportSource: "TRACES_OBSERVATIONS" as const,
+          }),
+        ).resolves.not.toThrow();
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      }
     });
   });
 });

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -11,8 +11,15 @@ import {
   QueueJobs,
   StorageServiceFactory,
 } from "@langfuse/shared/src/server";
-import { OBSERVATION_FIELD_GROUPS_FULL } from "@langfuse/shared";
+import {
+  OBSERVATION_FIELD_GROUPS_FULL,
+  LEGACY_BLOB_EXPORT_CUTOFF,
+} from "@langfuse/shared";
 import { env } from "@/src/env.mjs";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
+const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
 
 vi.mock("@langfuse/shared/src/server", async () => {
   const actual = await vi.importActual("@langfuse/shared/src/server");
@@ -384,7 +391,7 @@ describe("Blob Storage Integration tRPC Router", () => {
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },
-        data: { createdAt: new Date("2026-05-01T00:00:00.000Z") },
+        data: { createdAt: PRE_CUTOFF },
       });
 
       await expect(
@@ -401,7 +408,7 @@ describe("Blob Storage Integration tRPC Router", () => {
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },
-        data: { createdAt: new Date("2026-05-01T00:00:00.000Z") },
+        data: { createdAt: PRE_CUTOFF },
       });
 
       await expect(
@@ -441,9 +448,6 @@ describe("Blob Storage Integration tRPC Router", () => {
   });
 
   describe("legacy blob export source cutoff gate", () => {
-    const PRE_CUTOFF = new Date("2026-05-19T12:00:00.000Z");
-    const POST_CUTOFF = new Date("2026-05-21T12:00:00.000Z");
-
     afterEach(() => {
       vi.restoreAllMocks();
     });

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -382,6 +382,10 @@ describe("Blob Storage Integration tRPC Router", () => {
 
     it("rejects empty exportFieldGroups when exportSource is TRACES_OBSERVATIONS_EVENTS", async () => {
       const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: new Date("2026-05-01T00:00:00.000Z") },
+      });
 
       await expect(
         caller.blobStorageIntegration.update({
@@ -395,6 +399,10 @@ describe("Blob Storage Integration tRPC Router", () => {
 
     it("accepts empty exportFieldGroups when exportSource is TRACES_OBSERVATIONS", async () => {
       const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: new Date("2026-05-01T00:00:00.000Z") },
+      });
 
       await expect(
         caller.blobStorageIntegration.update({

--- a/web/src/__tests__/server/unit/assertLegacyBlobExportSourceAllowed.servertest.ts
+++ b/web/src/__tests__/server/unit/assertLegacyBlobExportSourceAllowed.servertest.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
-import { isLegacyBlobExportAllowed } from "@langfuse/shared";
+import {
+  isLegacyBlobExportAllowed,
+  LEGACY_BLOB_EXPORT_CUTOFF,
+} from "@langfuse/shared";
 
-const PRE_CUTOFF = new Date("2026-05-19T23:59:59.999Z");
-const AT_CUTOFF = new Date("2026-05-20T00:00:00.000Z");
-const POST_CUTOFF = new Date("2026-05-21T00:00:00.000Z");
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
+const AT_CUTOFF = LEGACY_BLOB_EXPORT_CUTOFF;
+const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
 
 describe("assertLegacyBlobExportSourceAllowed", () => {
   it("Cloud + EVENTS + pre-cutoff → allow", () => {

--- a/web/src/__tests__/server/unit/assertLegacyBlobExportSourceAllowed.servertest.ts
+++ b/web/src/__tests__/server/unit/assertLegacyBlobExportSourceAllowed.servertest.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
+import { isLegacyBlobExportAllowed } from "@langfuse/shared";
 
 const PRE_CUTOFF = new Date("2026-05-19T23:59:59.999Z");
 const AT_CUTOFF = new Date("2026-05-20T00:00:00.000Z");
@@ -94,5 +95,25 @@ describe("assertLegacyBlobExportSourceAllowed", () => {
         isCloud: true,
       }),
     ).toThrow();
+  });
+});
+
+describe("isLegacyBlobExportAllowed predicate", () => {
+  it("self-hosted always returns true", () => {
+    expect(isLegacyBlobExportAllowed(POST_CUTOFF, false)).toBe(true);
+    expect(isLegacyBlobExportAllowed(AT_CUTOFF, false)).toBe(true);
+    expect(isLegacyBlobExportAllowed(PRE_CUTOFF, false)).toBe(true);
+  });
+
+  it("Cloud + pre-cutoff → true (grandfathered)", () => {
+    expect(isLegacyBlobExportAllowed(PRE_CUTOFF, true)).toBe(true);
+  });
+
+  it("Cloud + post-cutoff → false", () => {
+    expect(isLegacyBlobExportAllowed(POST_CUTOFF, true)).toBe(false);
+  });
+
+  it("Cloud + exactly at cutoff → false (>= semantics)", () => {
+    expect(isLegacyBlobExportAllowed(AT_CUTOFF, true)).toBe(false);
   });
 });

--- a/web/src/__tests__/server/unit/assertLegacyBlobExportSourceAllowed.servertest.ts
+++ b/web/src/__tests__/server/unit/assertLegacyBlobExportSourceAllowed.servertest.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
+
+const PRE_CUTOFF = new Date("2026-05-19T23:59:59.999Z");
+const AT_CUTOFF = new Date("2026-05-20T00:00:00.000Z");
+const POST_CUTOFF = new Date("2026-05-21T00:00:00.000Z");
+
+describe("assertLegacyBlobExportSourceAllowed", () => {
+  it("Cloud + EVENTS + pre-cutoff → allow", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowed({
+        project: { createdAt: PRE_CUTOFF },
+        nextInternalExportSource: "EVENTS",
+        isCloud: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("Cloud + EVENTS + post-cutoff → allow", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowed({
+        project: { createdAt: POST_CUTOFF },
+        nextInternalExportSource: "EVENTS",
+        isCloud: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("Cloud + TRACES_OBSERVATIONS + pre-cutoff → allow (grandfathered)", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowed({
+        project: { createdAt: PRE_CUTOFF },
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("Cloud + TRACES_OBSERVATIONS + post-cutoff → reject", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowed({
+        project: { createdAt: POST_CUTOFF },
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: true,
+      }),
+    ).toThrow();
+  });
+
+  it("Cloud + TRACES_OBSERVATIONS_EVENTS + post-cutoff → reject", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowed({
+        project: { createdAt: POST_CUTOFF },
+        nextInternalExportSource: "TRACES_OBSERVATIONS_EVENTS",
+        isCloud: true,
+      }),
+    ).toThrow();
+  });
+
+  it("self-hosted + EVENTS + post-cutoff → allow (bypass)", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowed({
+        project: { createdAt: POST_CUTOFF },
+        nextInternalExportSource: "EVENTS",
+        isCloud: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("self-hosted + TRACES_OBSERVATIONS + pre-cutoff → allow (bypass)", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowed({
+        project: { createdAt: PRE_CUTOFF },
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("self-hosted + TRACES_OBSERVATIONS + post-cutoff → allow (bypass)", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowed({
+        project: { createdAt: POST_CUTOFF },
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("boundary: project.createdAt === cutoff → reject (>= semantics)", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowed({
+        project: { createdAt: AT_CUTOFF },
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: true,
+      }),
+    ).toThrow();
+  });
+});

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -482,6 +482,7 @@ export const env = createEnv({
     NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: z
       .enum(["US", "EU", "STAGING", "DEV", "HIPAA", "JP"])
       .optional(),
+    NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF: z.iso.datetime().optional(),
     NEXT_PUBLIC_DEMO_PROJECT_ID: z.string().optional(),
     NEXT_PUBLIC_DEMO_ORG_ID: z.string().optional(),
     NEXT_PUBLIC_SIGN_UP_DISABLED: z.enum(["true", "false"]).default("false"),
@@ -513,6 +514,8 @@ export const env = createEnv({
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     NEXT_PUBLIC_LANGFUSE_CLOUD_REGION:
       process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+    NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF:
+      process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF,
     NEXT_PUBLIC_SIGN_UP_DISABLED: process.env.NEXT_PUBLIC_SIGN_UP_DISABLED,
     LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES:
       process.env.LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES,

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -12,7 +12,9 @@ import {
   validateExportFieldGroups,
 } from "@/src/features/blobstorage-integration/validation";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
+import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
 import { TRPCError } from "@trpc/server";
+import { env } from "@/src/env.mjs";
 import {
   logger,
   BlobStorageIntegrationProcessingQueue,
@@ -83,6 +85,19 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           projectId: input.projectId,
           scope: "integrations:CRUD",
         });
+
+        if (input.exportSource) {
+          const project = await ctx.prisma.project.findUniqueOrThrow({
+            where: { id: input.projectId },
+            select: { createdAt: true },
+          });
+          assertLegacyBlobExportSourceAllowed({
+            project,
+            nextInternalExportSource: input.exportSource,
+            isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+          });
+        }
+
         await auditLog({
           session: ctx.session,
           action: "update",

--- a/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed.ts
+++ b/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed.ts
@@ -1,0 +1,34 @@
+import {
+  InvalidRequestError,
+  LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_BLOB_EXPORT_SOURCES,
+} from "@langfuse/shared";
+import { type AnalyticsIntegrationExportSource } from "@langfuse/shared/src/db";
+
+export function assertLegacyBlobExportSourceAllowed({
+  project,
+  nextInternalExportSource,
+  isCloud,
+}: {
+  project: { createdAt: Date };
+  nextInternalExportSource: AnalyticsIntegrationExportSource;
+  isCloud: boolean;
+}): void {
+  // Self-hosted deployments bypass the gate entirely.
+  if (!isCloud) return;
+
+  // EVENTS (ENRICHED) is always allowed.
+  if (
+    !(LEGACY_BLOB_EXPORT_SOURCES as ReadonlyArray<string>).includes(
+      nextInternalExportSource,
+    )
+  )
+    return;
+
+  // Projects created before the cutoff are grandfathered.
+  if (project.createdAt < LEGACY_BLOB_EXPORT_CUTOFF) return;
+
+  throw new InvalidRequestError(
+    "Legacy export sources (TRACES_OBSERVATIONS, TRACES_OBSERVATIONS_EVENTS) are not available for projects created on or after 2026-05-20. Use 'ENRICHED' ('EVENTS') instead.",
+  );
+}

--- a/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed.ts
+++ b/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed.ts
@@ -19,7 +19,7 @@ export function assertLegacyBlobExportSourceAllowed({
       nextInternalExportSource,
     )
   )
-    return; // OBSERVATIONS_V2 (ENRICHED) is always allowed.
+    return; // OBSERVATIONS_V2 (internal: EVENTS) is always allowed.
 
   if (isLegacyBlobExportAllowed(project.createdAt, isCloud)) return;
 

--- a/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed.ts
+++ b/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed.ts
@@ -1,6 +1,6 @@
 import {
   InvalidRequestError,
-  LEGACY_BLOB_EXPORT_CUTOFF,
+  isLegacyBlobExportAllowed,
   LEGACY_BLOB_EXPORT_SOURCES,
 } from "@langfuse/shared";
 import { type AnalyticsIntegrationExportSource } from "@langfuse/shared/src/db";
@@ -14,19 +14,14 @@ export function assertLegacyBlobExportSourceAllowed({
   nextInternalExportSource: AnalyticsIntegrationExportSource;
   isCloud: boolean;
 }): void {
-  // Self-hosted deployments bypass the gate entirely.
-  if (!isCloud) return;
-
-  // EVENTS (OBSERVATIONS_V2) is always allowed.
   if (
     !(LEGACY_BLOB_EXPORT_SOURCES as ReadonlyArray<string>).includes(
       nextInternalExportSource,
     )
   )
-    return;
+    return; // OBSERVATIONS_V2 (ENRICHED) is always allowed.
 
-  // Projects created before the cutoff are grandfathered.
-  if (project.createdAt < LEGACY_BLOB_EXPORT_CUTOFF) return;
+  if (isLegacyBlobExportAllowed(project.createdAt, isCloud)) return;
 
   throw new InvalidRequestError(
     "Legacy export sources (TRACES_OBSERVATIONS, TRACES_OBSERVATIONS_EVENTS) are not available for projects created on or after 2026-05-20. Use 'OBSERVATIONS_V2' ('EVENTS') instead.",

--- a/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed.ts
+++ b/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed.ts
@@ -24,6 +24,6 @@ export function assertLegacyBlobExportSourceAllowed({
   if (isLegacyBlobExportAllowed(project.createdAt, isCloud)) return;
 
   throw new InvalidRequestError(
-    "Legacy export sources (TRACES_OBSERVATIONS, TRACES_OBSERVATIONS_EVENTS) are not available for projects created on or after 2026-05-20. Use 'OBSERVATIONS_V2' ('EVENTS') instead.",
+    "Legacy export sources are not available for Cloud projects created on or after 2026-05-20. Use 'OBSERVATIONS_V2' instead.",
   );
 }

--- a/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed.ts
+++ b/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed.ts
@@ -17,7 +17,7 @@ export function assertLegacyBlobExportSourceAllowed({
   // Self-hosted deployments bypass the gate entirely.
   if (!isCloud) return;
 
-  // EVENTS (ENRICHED) is always allowed.
+  // EVENTS (OBSERVATIONS_V2) is always allowed.
   if (
     !(LEGACY_BLOB_EXPORT_SOURCES as ReadonlyArray<string>).includes(
       nextInternalExportSource,
@@ -29,6 +29,6 @@ export function assertLegacyBlobExportSourceAllowed({
   if (project.createdAt < LEGACY_BLOB_EXPORT_CUTOFF) return;
 
   throw new InvalidRequestError(
-    "Legacy export sources (TRACES_OBSERVATIONS, TRACES_OBSERVATIONS_EVENTS) are not available for projects created on or after 2026-05-20. Use 'ENRICHED' ('EVENTS') instead.",
+    "Legacy export sources (TRACES_OBSERVATIONS, TRACES_OBSERVATIONS_EVENTS) are not available for projects created on or after 2026-05-20. Use 'OBSERVATIONS_V2' ('EVENTS') instead.",
   );
 }

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -115,13 +115,18 @@ export async function upsertBlobStorageIntegration(params: {
       ? encrypt(data.secretAccessKey)
       : null;
 
-    // For CREATE only: when the caller signals that the project must not receive
-    // a legacy source default, substitute EVENTS for the column default.
-    // Evaluated here (inside the transaction) so the row-absence check that
-    // determines isCreate is atomic with the INSERT that follows.
+    // exportSource for the CREATE payload. The !existing guard was previously
+    // here, but it created a residual TOCTOU: READ COMMITTED isolation means
+    // tx.findUnique and tx.upsert take independent snapshots, so a concurrent
+    // DELETE between the two could leave createExportSource = undefined and let
+    // Postgres apply the @default(TRACES_OBSERVATIONS) column default on INSERT.
+    // Dropping the guard is safe: ON CONFLICT atomically decides CREATE vs UPDATE
+    // at INSERT time regardless of what findUnique saw. UPDATE uses
+    // writeData.exportSource (undefined → Prisma omits the column → preserves
+    // the existing value), so the caller intent is always honored on both paths.
     const createExportSource =
       data.exportSource ??
-      (!existing && params.forceEventsOnCreate
+      (params.forceEventsOnCreate
         ? AnalyticsIntegrationExportSource.EVENTS
         : undefined);
 

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -3,8 +3,8 @@ import {
   BlobStorageExportMode,
   BlobStorageIntegrationType,
   InvalidRequestError,
+  AnalyticsIntegrationExportSource,
   type BlobStorageIntegrationFileType,
-  type AnalyticsIntegrationExportSource,
   type ObservationFieldGroupFull,
 } from "@langfuse/shared";
 import { encrypt } from "@langfuse/shared/encryption";
@@ -52,6 +52,11 @@ export async function upsertBlobStorageIntegration(params: {
   prisma: PrismaClient;
   projectId: string;
   data: UpsertBlobStorageIntegrationInput;
+  // When true and no existing row is found inside the transaction, the CREATE
+  // branch uses EVENTS instead of the Prisma column default (TRACES_OBSERVATIONS).
+  // Evaluated inside the transaction so the row-state check and the INSERT are
+  // atomic — no TOCTOU window.
+  forceEventsOnCreate?: boolean;
 }) {
   const { prisma, projectId, data } = params;
 
@@ -110,10 +115,21 @@ export async function upsertBlobStorageIntegration(params: {
       ? encrypt(data.secretAccessKey)
       : null;
 
+    // For CREATE only: when the caller signals that the project must not receive
+    // a legacy source default, substitute EVENTS for the column default.
+    // Evaluated here (inside the transaction) so the row-absence check that
+    // determines isCreate is atomic with the INSERT that follows.
+    const createExportSource =
+      data.exportSource ??
+      (!existing && params.forceEventsOnCreate
+        ? AnalyticsIntegrationExportSource.EVENTS
+        : undefined);
+
     return tx.blobStorageIntegration.upsert({
       where: { projectId },
       create: {
         ...writeData,
+        exportSource: createExportSource,
         projectId,
         secretAccessKey: encryptedSecret,
       },

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -163,7 +163,9 @@ async function handleUpsertBlobStorageIntegration(
   if (validatedData.exportSource) {
     assertLegacyBlobExportSourceAllowed({
       project,
-      nextInternalExportSource: validatedData.exportSource,
+      nextInternalExportSource: toInternalExportSource(
+        validatedData.exportSource,
+      ),
       isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
     });
   }

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -18,7 +18,9 @@ import {
   ForbiddenError,
 } from "@langfuse/shared";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
+import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { env } from "@/src/env.mjs";
 
 export default withMiddlewares({
   GET: handleGetBlobStorageIntegrations,
@@ -152,10 +154,18 @@ async function handleUpsertBlobStorageIntegration(
   // Check if the project exists and belongs to the organization
   const project = await prisma.project.findUnique({
     where: { id: validatedData.projectId },
-    select: { id: true, orgId: true },
+    select: { id: true, orgId: true, createdAt: true },
   });
   if (!project || project.orgId !== authCheck.scope.orgId) {
     throw new LangfuseNotFoundError("Project not found");
+  }
+
+  if (validatedData.exportSource) {
+    assertLegacyBlobExportSourceAllowed({
+      project,
+      nextInternalExportSource: validatedData.exportSource,
+      isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+    });
   }
 
   await auditLog({

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -173,25 +173,6 @@ async function handleUpsertBlobStorageIntegration(
     });
   }
 
-  // Detect CREATE vs UPDATE so we can apply the correct default when
-  // exportSource is omitted.
-  const existingIntegration = await prisma.blobStorageIntegration.findUnique({
-    where: { projectId: validatedData.projectId },
-    select: { projectId: true },
-  });
-  const isCreate = existingIntegration === null;
-
-  // On UPDATE with no exportSource the existing value is preserved (pass
-  // undefined so the upsert leaves the column alone). On CREATE, post-cutoff
-  // Cloud projects must not fall back to the Prisma column default
-  // (TRACES_OBSERVATIONS — a legacy source); force EVENTS instead.
-  const exportSourceInternal =
-    validatedData.exportSource != null
-      ? toInternalExportSource(validatedData.exportSource)
-      : isCreate && !isLegacyBlobExportAllowed(project.createdAt, isCloud)
-        ? AnalyticsIntegrationExportSource.EVENTS
-        : undefined;
-
   await auditLog({
     action: "update",
     resourceType: "blobStorageIntegration",
@@ -203,6 +184,12 @@ async function handleUpsertBlobStorageIntegration(
   const integration = await upsertBlobStorageIntegration({
     prisma,
     projectId: validatedData.projectId,
+    // When exportSource is absent and the project is post-cutoff Cloud, have
+    // the service substitute EVENTS on CREATE inside its own transaction —
+    // eliminating the TOCTOU window that a pre-flight findUnique would create.
+    forceEventsOnCreate:
+      validatedData.exportSource == null &&
+      !isLegacyBlobExportAllowed(project.createdAt, isCloud),
     data: {
       type: validatedData.type,
       bucketName: validatedData.bucketName,
@@ -218,7 +205,10 @@ async function handleUpsertBlobStorageIntegration(
       exportMode: validatedData.exportMode,
       exportStartDate: validatedData.exportStartDate ?? null,
       compressed: validatedData.compressed,
-      exportSource: exportSourceInternal,
+      exportSource:
+        validatedData.exportSource != null
+          ? toInternalExportSource(validatedData.exportSource)
+          : undefined,
       exportFieldGroups: validatedData.exportFieldGroups ?? undefined,
     },
   });

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -16,6 +16,7 @@ import {
   LangfuseNotFoundError,
   UnauthorizedError,
   ForbiddenError,
+  isLegacyBlobExportAllowed,
 } from "@langfuse/shared";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
@@ -160,15 +161,27 @@ async function handleUpsertBlobStorageIntegration(
     throw new LangfuseNotFoundError("Project not found");
   }
 
+  const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
+
   if (validatedData.exportSource) {
     assertLegacyBlobExportSourceAllowed({
       project,
       nextInternalExportSource: toInternalExportSource(
         validatedData.exportSource,
       ),
-      isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+      isCloud,
     });
   }
+
+  // When exportSource is omitted, post-cutoff Cloud projects must not fall back
+  // to the Prisma column default (TRACES_OBSERVATIONS — a legacy source). Force
+  // EVENTS so the row is created with the correct non-legacy source.
+  const exportSourceInternal =
+    validatedData.exportSource != null
+      ? toInternalExportSource(validatedData.exportSource)
+      : !isLegacyBlobExportAllowed(project.createdAt, isCloud)
+        ? AnalyticsIntegrationExportSource.EVENTS
+        : undefined;
 
   await auditLog({
     action: "update",
@@ -196,10 +209,7 @@ async function handleUpsertBlobStorageIntegration(
       exportMode: validatedData.exportMode,
       exportStartDate: validatedData.exportStartDate ?? null,
       compressed: validatedData.compressed,
-      exportSource:
-        validatedData.exportSource != null
-          ? toInternalExportSource(validatedData.exportSource)
-          : undefined,
+      exportSource: exportSourceInternal,
       exportFieldGroups: validatedData.exportFieldGroups ?? undefined,
     },
   });

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -173,13 +173,22 @@ async function handleUpsertBlobStorageIntegration(
     });
   }
 
-  // When exportSource is omitted, post-cutoff Cloud projects must not fall back
-  // to the Prisma column default (TRACES_OBSERVATIONS — a legacy source). Force
-  // EVENTS so the row is created with the correct non-legacy source.
+  // Detect CREATE vs UPDATE so we can apply the correct default when
+  // exportSource is omitted.
+  const existingIntegration = await prisma.blobStorageIntegration.findUnique({
+    where: { projectId: validatedData.projectId },
+    select: { projectId: true },
+  });
+  const isCreate = existingIntegration === null;
+
+  // On UPDATE with no exportSource the existing value is preserved (pass
+  // undefined so the upsert leaves the column alone). On CREATE, post-cutoff
+  // Cloud projects must not fall back to the Prisma column default
+  // (TRACES_OBSERVATIONS — a legacy source); force EVENTS instead.
   const exportSourceInternal =
     validatedData.exportSource != null
       ? toInternalExportSource(validatedData.exportSource)
-      : !isLegacyBlobExportAllowed(project.createdAt, isCloud)
+      : isCreate && !isLegacyBlobExportAllowed(project.createdAt, isCloud)
         ? AnalyticsIntegrationExportSource.EVENTS
         : undefined;
 

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -248,16 +248,14 @@ const BlobStorageIntegrationSettingsForm = ({
     project?.createdAt != null &&
     !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
 
-  // Options shown in the dropdown. Legacy options are hidden for post-cutoff
-  // Cloud projects. Always include the currently-persisted value so the form
-  // stays consistent even if the project somehow ended up on a legacy source.
+  // Options shown in the dropdown. Legacy options are always hidden for
+  // post-cutoff Cloud projects, including any previously-persisted value.
   const availableExportSourceOptions = EXPORT_SOURCE_OPTIONS.filter(
     (opt) =>
       !isPostCutoffCloud ||
       !(LEGACY_BLOB_EXPORT_SOURCES as ReadonlyArray<string>).includes(
         opt.value,
-      ) ||
-      opt.value === state?.exportSource,
+      ),
   );
 
   const blobStorageForm = useForm({
@@ -280,11 +278,12 @@ const BlobStorageIntegrationSettingsForm = ({
       fileType: state?.fileType || BlobStorageIntegrationFileType.JSONL,
       exportMode: state?.exportMode || BlobStorageExportMode.FULL_HISTORY,
       exportStartDate: state?.exportStartDate || null,
-      exportSource:
-        state?.exportSource ||
-        (isPostCutoffCloud || isBetaEnabled
-          ? AnalyticsIntegrationExportSource.EVENTS
-          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      exportSource: isPostCutoffCloud
+        ? AnalyticsIntegrationExportSource.EVENTS
+        : state?.exportSource ||
+          (isBetaEnabled
+            ? AnalyticsIntegrationExportSource.EVENTS
+            : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
       exportFieldGroups:
         (state?.exportFieldGroups as ObservationFieldGroupFull[]) ?? [
           ...OBSERVATION_FIELD_GROUPS_FULL,
@@ -314,11 +313,12 @@ const BlobStorageIntegrationSettingsForm = ({
       fileType: state?.fileType || BlobStorageIntegrationFileType.JSONL,
       exportMode: state?.exportMode || BlobStorageExportMode.FULL_HISTORY,
       exportStartDate: state?.exportStartDate || null,
-      exportSource:
-        state?.exportSource ||
-        (isPostCutoffCloud || isBetaEnabled
-          ? AnalyticsIntegrationExportSource.EVENTS
-          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      exportSource: isPostCutoffCloud
+        ? AnalyticsIntegrationExportSource.EVENTS
+        : state?.exportSource ||
+          (isBetaEnabled
+            ? AnalyticsIntegrationExportSource.EVENTS
+            : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
       exportFieldGroups:
         (state?.exportFieldGroups as ObservationFieldGroupFull[]) ?? [
           ...OBSERVATION_FIELD_GROUPS_FULL,

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -55,8 +55,8 @@ import {
   EXPORT_FIELD_GROUP_OPTIONS,
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
-  LEGACY_BLOB_EXPORT_CUTOFF,
   LEGACY_BLOB_EXPORT_SOURCES,
+  isLegacyBlobExportAllowed,
 } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
@@ -245,9 +245,8 @@ const BlobStorageIntegrationSettingsForm = ({
 
   // Post-cutoff Cloud projects may only use OBSERVATIONS_V2 (EVENTS).
   const isPostCutoffCloud =
-    isLangfuseCloud &&
     project?.createdAt != null &&
-    new Date(project.createdAt) >= LEGACY_BLOB_EXPORT_CUTOFF;
+    !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
 
   // Options shown in the dropdown. Legacy options are hidden for post-cutoff
   // Cloud projects. Always include the currently-persisted value so the form

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -55,8 +55,11 @@ import {
   EXPORT_FIELD_GROUP_OPTIONS,
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
+  LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_BLOB_EXPORT_SOURCES,
 } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+import { useQueryProject } from "@/src/features/projects/hooks";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { Info, ExternalLink } from "lucide-react";
 
@@ -233,11 +236,30 @@ const BlobStorageIntegrationSettingsForm = ({
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const { isBetaEnabled } = useV4Beta();
+  const { project } = useQueryProject();
   const [integrationType, setIntegrationType] =
     useState<BlobStorageIntegrationType>(BlobStorageIntegrationType.S3);
 
   // Check if this is a self-hosted instance (no cloud region set)
   const isSelfHosted = !isLangfuseCloud;
+
+  // Post-cutoff Cloud projects may only use ENRICHED (EVENTS).
+  const isPostCutoffCloud =
+    isLangfuseCloud &&
+    project?.createdAt != null &&
+    new Date(project.createdAt) >= LEGACY_BLOB_EXPORT_CUTOFF;
+
+  // Options shown in the dropdown. Legacy options are hidden for post-cutoff
+  // Cloud projects. Always include the currently-persisted value so the form
+  // stays consistent even if the project somehow ended up on a legacy source.
+  const availableExportSourceOptions = EXPORT_SOURCE_OPTIONS.filter(
+    (opt) =>
+      !isPostCutoffCloud ||
+      !(LEGACY_BLOB_EXPORT_SOURCES as ReadonlyArray<string>).includes(
+        opt.value,
+      ) ||
+      opt.value === state?.exportSource,
+  );
 
   const blobStorageForm = useForm({
     resolver: zodResolver(blobStorageIntegrationFormSchema),
@@ -261,7 +283,7 @@ const BlobStorageIntegrationSettingsForm = ({
       exportStartDate: state?.exportStartDate || null,
       exportSource:
         state?.exportSource ||
-        (isBetaEnabled
+        (isPostCutoffCloud || isBetaEnabled
           ? AnalyticsIntegrationExportSource.EVENTS
           : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
       exportFieldGroups:
@@ -295,7 +317,7 @@ const BlobStorageIntegrationSettingsForm = ({
       exportStartDate: state?.exportStartDate || null,
       exportSource:
         state?.exportSource ||
-        (isBetaEnabled
+        (isPostCutoffCloud || isBetaEnabled
           ? AnalyticsIntegrationExportSource.EVENTS
           : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
       exportFieldGroups:
@@ -714,17 +736,25 @@ const BlobStorageIntegrationSettingsForm = ({
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {EXPORT_SOURCE_OPTIONS.map((option) => (
+                    {availableExportSourceOptions.map((option) => (
                       <SelectItem key={option.value} value={option.value}>
                         {option.label}
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
-                <FormDescription>
-                  Choose which data sources to export to blob storage. Scores
-                  are always included.
-                </FormDescription>
+                {isPostCutoffCloud ? (
+                  <FormDescription>
+                    Legacy export sources are not available for projects created
+                    on or after May 20, 2026. Use &quot;Enriched
+                    observations&quot; instead.
+                  </FormDescription>
+                ) : (
+                  <FormDescription>
+                    Choose which data sources to export to blob storage. Scores
+                    are always included.
+                  </FormDescription>
+                )}
                 <FormMessage />
               </FormItem>
             )}

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -243,7 +243,7 @@ const BlobStorageIntegrationSettingsForm = ({
   // Check if this is a self-hosted instance (no cloud region set)
   const isSelfHosted = !isLangfuseCloud;
 
-  // Post-cutoff Cloud projects may only use ENRICHED (EVENTS).
+  // Post-cutoff Cloud projects may only use OBSERVATIONS_V2 (EVENTS).
   const isPostCutoffCloud =
     isLangfuseCloud &&
     project?.createdAt != null &&

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -886,6 +886,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                                     string,
                                     unknown
                                   >) ?? {},
+                                createdAt: project.createdAt.toISOString(),
                               };
                             })
                             // Only include projects where the user has the required role

--- a/web/types/next-auth.d.ts
+++ b/web/types/next-auth.d.ts
@@ -53,6 +53,7 @@ declare module "next-auth" {
         hasTraces: PrismaProject["hasTraces"];
         metadata: Record<string, unknown>;
         role: Role; // include only projects where user has a role
+        createdAt: string; // iso datetime string — JWT does not support Date objects
       }[];
     }[];
     featureFlags: Flags;


### PR DESCRIPTION
## Summary

- Cloud projects created on or after **2026-05-20T00:00:00Z** can no longer use `LEGACY_TRACES_OBSERVATIONS` or `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`. Attempts via tRPC or the public REST API return `BAD_REQUEST` / HTTP 400.
- Self-hosted deployments and projects created before the cutoff are fully unaffected.
- Single shared helper (`assertLegacyBlobExportSourceAllowed`) enforces the rule identically on both write surfaces.
- Settings UI hides legacy options and defaults to `OBSERVATIONS_V2` for post-cutoff Cloud projects, with an inline message explaining the restriction.
- `project.createdAt` added to the NextAuth session so the UI can derive the gate without an extra DB round-trip.

**Assumption A1 (confirmed 2026-05-13):** the historic `events_full` backfill is complete across all Cloud regions (`prod-us`, `prod-eu`, `prod-hipaa`, `prod-jp`).

Stacked on: #13619 (public enum rename — direct prerequisite)
Related: [LFE-9688](https://linear.app/langfuse/issue/LFE-9688), [LFE-9456](https://linear.app/langfuse/issue/LFE-9456)

## Impacted packages

- `packages/shared` — new `LEGACY_BLOB_EXPORT_CUTOFF` / `LEGACY_BLOB_EXPORT_SOURCES` constants
- `web` — guard helper, tRPC router, REST handler, UI, session type, server + unit tests

## Verification

- `pnpm run lint` — passes (run via pre-commit hook)
- Unit tests: `pnpm --filter web run test -- src/__tests__/server/unit/assertLegacyBlobExportSourceAllowed.servertest.ts`
- Integration tests: `pnpm --filter web run test -- src/__tests__/server/blob-storage-integration-trpc.servertest.ts src/__tests__/server/blob-storage-integration-api.servertest.ts`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gates legacy blob export sources (`LEGACY_TRACES_OBSERVATIONS`, `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`) for Cloud projects created on or after 2026-05-20, while leaving self-hosted deployments and pre-cutoff Cloud projects fully unaffected. The implementation introduces a shared predicate (`isLegacyBlobExportAllowed`), a server-side throwing guard (`assertLegacyBlobExportSourceAllowed`), consistent enforcement on both the tRPC and REST API surfaces, and UI changes that hide legacy dropdown options and update the form default for post-cutoff projects.

- **New shared gate logic** (`blob-export-gate.ts`) exports `LEGACY_BLOB_EXPORT_CUTOFF`, `LEGACY_BLOB_EXPORT_SOURCES`, and `isLegacyBlobExportAllowed`; the constants use a `satisfies` check so TypeScript errors if a new enum variant is added without review.
- **Server enforcement** is added to both the tRPC `update` mutation and the REST `PUT` handler; `project.createdAt` is fetched alongside the existing project lookup to avoid a second round-trip.
- **Session type extended** with `createdAt: string` so the UI can derive the gate without an extra DB call; the settings form hides legacy options and defaults to `OBSERVATIONS_V2` for post-cutoff Cloud projects.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core gate logic is correct and well-tested, but a post-cutoff Cloud project can create a new integration via the REST API without specifying exportSource and silently receive the legacy TRACES_OBSERVATIONS column default, completely bypassing the guard.

The guard check on both the tRPC and REST surfaces is conditioned on if (input/validatedData.exportSource), which is falsy when the field is omitted. The Prisma schema default for the column is TRACES_OBSERVATIONS, so an omitted exportSource on a new-project create results in a legacy source being written without any gate enforcement — affecting exactly the case the PR is designed to prevent.

web/src/pages/api/public/integrations/blob-storage/index.ts and web/src/features/blobstorage-integration/blobstorage-integration-router.ts — the guard skips when exportSource is absent, and the DB default fills in a legacy value on insert.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Client: tRPC update / REST PUT] --> B{exportSource provided?}
    B -- No --> C[Skip gate — DB default TRACES_OBSERVATIONS applied on INSERT]
    B -- Yes --> D{Is Cloud?}
    D -- No --> E[Allow — self-hosted bypass]
    D -- Yes --> F{project.createdAt < cutoff?}
    F -- Yes pre-cutoff --> G[Allow — grandfathered]
    F -- No post-cutoff --> H{Is legacy source?}
    H -- No EVENTS --> I[Allow]
    H -- Yes --> J[Throw InvalidRequestError 400 BAD_REQUEST]
    C --> K[(DB upsert)]
    E --> K
    G --> K
    I --> K
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/pages/api/public/integrations/blob-storage/index.ts:163-171
**Gate bypass when `exportSource` is omitted on creation**

When a post-cutoff Cloud project creates a new integration without providing `exportSource` in the request body, the guard is skipped entirely (`if (validatedData.exportSource)` is falsy), and Prisma falls back to the column default of `TRACES_OBSERVATIONS` (confirmed in `schema.prisma:1100`). The integration is created with a legacy source that the gate was meant to block. The same pattern applies to the tRPC router. The fix is to also run the guard when `exportSource` is absent but the project is new (i.e., no existing integration row), using `TRACES_OBSERVATIONS` as the effective default source being applied.

### Issue 2 of 3
web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx:297-329
**Stale `isPostCutoffCloud` in `useEffect` due to missing dependency**

`isPostCutoffCloud` (derived from the session) and `isBetaEnabled` are both captured by the `useEffect` closure but are not listed as dependencies — only `[state]` is. The eslint disable comment suppresses the warning. If the session hasn't resolved by the time `state` first loads, the `reset` runs with `isPostCutoffCloud === false` and sets `exportSource` to `TRACES_OBSERVATIONS`. When the session subsequently resolves and `isPostCutoffCloud` flips to `true`, `state` hasn't changed so the effect never re-runs, leaving the form on the forbidden legacy value. The server guard will still reject the submit, but the user sees a confusing experience: the dropdown shows no legacy option yet the hidden field holds one.

### Issue 3 of 3
packages/shared/src/features/analytics-integrations/blob-export-gate.ts:8-11
**`LEGACY_BLOB_EXPORT_CUTOFF` reads `process.env` directly, bypassing schema validation**

The constant is evaluated once at module load using raw `process.env` access. The validated `env` object (from `packages/shared/src/env.ts`) is not used here, so if `NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF` is set to an unparseable string, `new Date(...)` silently produces `Invalid Date`. All comparisons against `Invalid Date` return `false`, so `projectCreatedAt < LEGACY_BLOB_EXPORT_CUTOFF` is always `false`, causing `isLegacyBlobExportAllowed` to return `false` for every project — gating even pre-cutoff Cloud projects. The startup-time Zod validation in `env.mjs` provides a second line of defence for the web server, but the shared package code could also be exercised in contexts (workers, tests with env stubs) that don't load `env.mjs` first.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fixup: align with renamed public exportS..."](https://github.com/langfuse/langfuse/commit/aecb1be2dbd25fc3ca675688a3cdf0993e145c64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32300145)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->