### PR TITLE
fix(datasets): guard prototype keys in dataset json

### DIFF
--- a/packages/shared/src/utils/json.ts
+++ b/packages/shared/src/utils/json.ts
@@ -2,7 +2,84 @@ import { JsonNested } from "./zod";
 import { parse, isSafeNumber, isNumber } from "lossless-json";
 
 // Dangerous keys that could lead to prototype pollution
-const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+export const DANGEROUS_JSON_KEYS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+const DANGEROUS_KEYS = DANGEROUS_JSON_KEYS;
+
+const appendPathSegment = (path: string, segment: string | number): string => {
+  if (typeof segment === "number") return `${path}[${segment}]`;
+  return path === "" ? segment : `${path}.${segment}`;
+};
+
+export const findDangerousJsonKeyPath = (
+  value: unknown,
+  path = "",
+): string | null => {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const dangerousPath = findDangerousJsonKeyPath(
+        value[i],
+        appendPathSegment(path, i),
+      );
+      if (dangerousPath) return dangerousPath;
+    }
+
+    return null;
+  }
+
+  if (typeof value !== "object" || value === null) return null;
+
+  for (const key of Object.keys(value)) {
+    const keyPath = appendPathSegment(path, key);
+    if (DANGEROUS_KEYS.has(key)) return keyPath;
+
+    const dangerousPath = findDangerousJsonKeyPath(
+      (value as Record<string, unknown>)[key],
+      keyPath,
+    );
+    if (dangerousPath) return dangerousPath;
+  }
+
+  return null;
+};
+
+export const stripDangerousJsonKeys = <T>(value: T): T => {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const sanitized = value.map((item) => {
+      const sanitizedItem = stripDangerousJsonKeys(item);
+      if (sanitizedItem !== item) changed = true;
+      return sanitizedItem;
+    });
+
+    return (changed ? sanitized : value) as T;
+  }
+
+  if (typeof value !== "object" || value === null) return value;
+
+  const entries = Object.entries(value);
+  if (entries.length === 0) return value;
+
+  let changed = false;
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, item] of entries) {
+    if (DANGEROUS_KEYS.has(key)) {
+      changed = true;
+      continue;
+    }
+
+    const sanitizedItem = stripDangerousJsonKeys(item);
+    if (sanitizedItem !== item) changed = true;
+    sanitized[key] = sanitizedItem;
+  }
+
+  return (changed ? sanitized : value) as T;
+};
 
 // attempts to parse Python dict/list string to JSON object
 // LangChain/LangGraph v1 tool calls are logged as python dicts for example

--- a/web/src/__tests__/server/datasets-trpc.servertest.ts
+++ b/web/src/__tests__/server/datasets-trpc.servertest.ts
@@ -3,6 +3,7 @@ import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { prisma } from "@langfuse/shared/src/db";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import type { Session } from "next-auth";
+import superjson from "superjson";
 import { v4 } from "uuid";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 
@@ -68,6 +69,88 @@ describe("datasets trpc", () => {
       where: {
         id: { in: orgIds },
       },
+    });
+  });
+
+  describe("datasets JSON prototype pollution guards", () => {
+    it("rejects dangerous keys in dataset metadata", async () => {
+      const { project, caller } = await prepare();
+
+      await expect(
+        caller.datasets.createDataset({
+          projectId: project.id,
+          name: `dangerous-metadata-${v4()}`,
+          metadata: JSON.stringify({
+            safe: true,
+            nested: JSON.parse('{"prototype":"polluted"}') as unknown,
+          }),
+        }),
+      ).rejects.toThrow(
+        /Dataset metadata contains unsupported key at nested\.prototype/,
+      );
+    });
+
+    it("rejects dangerous keys in dataset schemas", async () => {
+      const { project, caller } = await prepare();
+
+      await expect(
+        caller.datasets.createDataset({
+          projectId: project.id,
+          name: `dangerous-schema-${v4()}`,
+          inputSchema: {
+            type: "object",
+            properties: JSON.parse('{"prototype":{"type":"string"}}') as Record<
+              string,
+              unknown
+            >,
+          },
+        }),
+      ).rejects.toThrow(
+        /Dataset inputSchema contains unsupported key at properties\.prototype/,
+      );
+    });
+
+    it("strips dangerous keys from existing rows before allDatasets is serialized", async () => {
+      const { project, caller } = await prepare();
+      const datasetId = v4();
+
+      await prisma.dataset.create({
+        data: {
+          id: datasetId,
+          projectId: project.id,
+          name: `legacy-dangerous-row-${datasetId}`,
+          metadata: JSON.parse(
+            '{"safe":true,"nested":{"prototype":"polluted"}}',
+          ),
+          inputSchema: {
+            type: "object",
+            properties: JSON.parse(
+              '{"safe":{"type":"string"},"prototype":{"type":"string"}}',
+            ),
+          },
+        },
+      });
+
+      const result = await caller.datasets.allDatasets({
+        projectId: project.id,
+        searchQuery: "legacy-dangerous-row",
+        pathPrefix: "",
+        page: 0,
+        limit: 50,
+      });
+
+      expect(() => superjson.serialize(result)).not.toThrow();
+      expect(result.datasets).toHaveLength(1);
+      expect(result.datasets[0]?.metadata).toEqual({
+        safe: true,
+        nested: {},
+      });
+      expect(result.datasets[0]?.inputSchema).toEqual({
+        type: "object",
+        properties: {
+          safe: { type: "string" },
+        },
+      });
     });
   });
 

--- a/web/src/features/datasets/server/actions/createDataset.ts
+++ b/web/src/features/datasets/server/actions/createDataset.ts
@@ -1,5 +1,6 @@
 import {
   DatasetNameSchema,
+  findDangerousJsonKeyPath,
   InvalidRequestError,
   Prisma,
 } from "@langfuse/shared";
@@ -31,6 +32,28 @@ type UpdateDatasetInput = {
   expectedOutputSchema?: DatasetJson;
 };
 
+const assertNoDangerousDatasetJsonKeys = (
+  input: Pick<
+    UpsertDatasetInput & UpdateDatasetInput,
+    "metadata" | "inputSchema" | "expectedOutputSchema"
+  >,
+) => {
+  const fields = [
+    ["metadata", input.metadata],
+    ["inputSchema", input.inputSchema],
+    ["expectedOutputSchema", input.expectedOutputSchema],
+  ] as const;
+
+  for (const [field, value] of fields) {
+    const dangerousPath = findDangerousJsonKeyPath(value);
+    if (dangerousPath) {
+      throw new InvalidRequestError(
+        `Dataset ${field} contains unsupported key at ${dangerousPath}. Remove "__proto__", "constructor", and "prototype" keys before saving.`,
+      );
+    }
+  }
+};
+
 export const upsertDataset = async ({
   input,
   projectId,
@@ -44,6 +67,8 @@ export const upsertDataset = async ({
       "Dataset name not valid. " + validation.error.message,
     );
   }
+
+  assertNoDangerousDatasetJsonKeys(input);
 
   // Check if dataset exists (for UPDATE path)
   const existingDataset = await prisma.dataset.findUnique({
@@ -155,6 +180,8 @@ export const updateDataset = async ({
       );
     }
   }
+
+  assertNoDangerousDatasetJsonKeys(input);
 
   return await prisma.dataset.update({
     where: {

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -19,6 +19,7 @@ import {
   optionalPaginationZod,
   LangfuseConflictError,
   LangfuseNotFoundError,
+  stripDangerousJsonKeys,
 } from "@langfuse/shared";
 import { TRPCError } from "@trpc/server";
 import {
@@ -296,7 +297,7 @@ export const datasetRouter = createTRPCRouter({
   allDatasetMeta: protectedProjectProcedure
     .input(z.object({ projectId: z.string() }))
     .query(async ({ input, ctx }) => {
-      return ctx.prisma.dataset.findMany({
+      const datasets = await ctx.prisma.dataset.findMany({
         where: {
           projectId: input.projectId,
         },
@@ -307,6 +308,8 @@ export const datasetRouter = createTRPCRouter({
           expectedOutputSchema: true,
         },
       });
+
+      return stripDangerousJsonKeys(datasets);
     }),
   allDatasets: protectedProjectProcedure
     .input(
@@ -372,7 +375,7 @@ export const datasetRouter = createTRPCRouter({
       ]);
 
       return {
-        datasets,
+        datasets: stripDangerousJsonKeys(datasets),
         totalDatasets:
           datasetCount.length > 0 ? Number(datasetCount[0]?.totalCount) : 0,
       };


### PR DESCRIPTION
## Summary
- reject dangerous JSON keys in dataset metadata and schemas before writes
- strip dangerous keys from existing dataset rows before tRPC list responses are serialized
- add server tests for rejected writes and legacy-row serialization behavior

## Linear
- LFE-9780

## Verification
- git commit hook: pnpm run format:check && pnpm run lint

## Not run locally
- pnpm --filter web test src/__tests__/server/datasets-trpc.servertest.ts: blocked by missing local test env variables (DATABASE_URL, NEXTAUTH_URL, SALT, CLICKHOUSE_URL, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD).
- pnpm --filter web run typecheck: blocked in the fresh workspace before Prisma generation/shared build artifacts were available.

This replacement PR is based directly on main and contains only the dataset JSON guard commit.