### PR TITLE
fix(worker): stream core data prompt exports

### DIFF
--- a/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
+++ b/worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { Readable } from "node:stream";
+import { type StorageService } from "@langfuse/shared/src/server";
+import { uploadPromptsCoreDataJsonl } from "../coreDataS3ExportQueue";
+
+const readStream = async (stream: Readable): Promise<string> => {
+  const chunks: string[] = [];
+
+  for await (const chunk of stream) {
+    chunks.push(chunk.toString());
+  }
+
+  return chunks.join("");
+};
+
+describe("coreDataS3ExportQueue", () => {
+  it("streams prompt core data in pages", async () => {
+    const createdAt = new Date("2026-05-14T00:00:00.000Z");
+    const updatedAt = new Date("2026-05-14T01:00:00.000Z");
+    const pages = [
+      [
+        {
+          id: "prompt-1",
+          name: "first",
+          projectId: "project-1",
+          createdAt,
+          updatedAt,
+        },
+        {
+          id: "prompt-2",
+          name: "second",
+          projectId: "project-1",
+          createdAt,
+          updatedAt,
+        },
+      ],
+      [
+        {
+          id: "prompt-3",
+          name: "third",
+          projectId: "project-2",
+          createdAt,
+          updatedAt,
+        },
+      ],
+    ];
+
+    const fetchPromptPage = vi.fn(async ({ skip }: { skip: number }) => {
+      return pages[Math.floor(skip / 2)] ?? [];
+    });
+
+    const uploadFileBuffered = vi.fn(async ({ data }: { data: Readable }) => {
+      expect(await readStream(data)).toBe(
+        [
+          JSON.stringify(pages[0][0]),
+          JSON.stringify(pages[0][1]),
+          JSON.stringify(pages[1][0]),
+        ].join("\n"),
+      );
+    });
+
+    const s3Client = {
+      uploadFileBuffered,
+    } as unknown as StorageService;
+
+    await uploadPromptsCoreDataJsonl({
+      s3Client,
+      uploadPrefix: "core/",
+      pageSize: 2,
+      fetchPromptPage,
+    });
+
+    expect(fetchPromptPage).toHaveBeenCalledTimes(2);
+    expect(fetchPromptPage).toHaveBeenNthCalledWith(1, { skip: 0, take: 2 });
+    expect(fetchPromptPage).toHaveBeenNthCalledWith(2, { skip: 2, take: 2 });
+    expect(uploadFileBuffered).toHaveBeenCalledTimes(1);
+    expect(uploadFileBuffered).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: "core/prompts.jsonl",
+        fileType: "application/x-ndjson",
+        partSizeBytes: 100 * 1024 * 1024,
+      }),
+    );
+  });
+});

--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -1,11 +1,15 @@
 import { Processor } from "bullmq";
+import { Readable } from "node:stream";
 import {
   logger,
-  StorageService,
   StorageServiceFactory,
+  type StorageService,
 } from "@langfuse/shared/src/server";
 import { prisma } from "@langfuse/shared/src/db";
 import { env } from "../env";
+
+const PROMPT_EXPORT_PAGE_SIZE = 1_000;
+const PROMPT_EXPORT_PART_SIZE_BYTES = 100 * 1024 * 1024;
 
 let s3StorageServiceClient: StorageService;
 
@@ -24,6 +28,79 @@ const getS3StorageServiceClient = (bucketName: string): StorageService => {
     });
   }
   return s3StorageServiceClient;
+};
+
+type PromptCoreData = {
+  id: string;
+  name: string;
+  projectId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type FetchPromptPage = (args: {
+  skip: number;
+  take: number;
+}) => Promise<PromptCoreData[]>;
+
+async function* createPromptJsonlStream({
+  fetchPromptPage,
+  pageSize,
+}: {
+  fetchPromptPage: FetchPromptPage;
+  pageSize: number;
+}): AsyncGenerator<string> {
+  let skip = 0;
+  let isFirstRow = true;
+
+  while (true) {
+    const prompts = await fetchPromptPage({ skip, take: pageSize });
+
+    if (prompts.length === 0) {
+      break;
+    }
+
+    for (const prompt of prompts) {
+      yield `${isFirstRow ? "" : "\n"}${JSON.stringify(prompt)}`;
+      isFirstRow = false;
+    }
+
+    if (prompts.length < pageSize) {
+      break;
+    }
+
+    skip += prompts.length;
+  }
+}
+
+export const uploadPromptsCoreDataJsonl = async ({
+  s3Client,
+  uploadPrefix,
+  pageSize = PROMPT_EXPORT_PAGE_SIZE,
+  fetchPromptPage = (args) =>
+    prisma.prompt.findMany({
+      ...args,
+      orderBy: { id: "asc" },
+      select: {
+        id: true,
+        name: true,
+        projectId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
+}: {
+  s3Client: StorageService;
+  uploadPrefix: string;
+  pageSize?: number;
+  fetchPromptPage?: FetchPromptPage;
+}): Promise<void> => {
+  await s3Client.uploadFileBuffered({
+    fileName: `${uploadPrefix}prompts.jsonl`,
+    fileType: "application/x-ndjson",
+    data: Readable.from(createPromptJsonlStream({ fetchPromptPage, pageSize })),
+    partSizeBytes: PROMPT_EXPORT_PART_SIZE_BYTES,
+  });
 };
 
 export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
@@ -47,7 +124,6 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
     organizations,
     orgMemberships,
     projectMemberships,
-    prompts,
     billingMeterBackup,
     surveys,
   ] = await Promise.all([
@@ -100,15 +176,6 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
         updatedAt: true,
       },
     }),
-    prisma.prompt.findMany({
-      select: {
-        id: true,
-        name: true,
-        projectId: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    }),
     prisma.billingMeterBackup.findMany(),
     prisma.survey.findMany({
       select: {
@@ -131,7 +198,6 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
       organizations,
       orgMemberships,
       projectMemberships,
-      prompts,
       billingMeterBackup,
       surveys,
     }).map(async ([key, value]) =>
@@ -142,6 +208,11 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
       }),
     ),
   );
+
+  await uploadPromptsCoreDataJsonl({
+    s3Client,
+    uploadPrefix: env.LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX,
+  });
 
   logger.info("Finished core data S3 export");
 };


### PR DESCRIPTION
## What changed
- Move only the core data prompts export off the eager `prisma.prompt.findMany()` array path.
- Page prompt reads and stream `prompts.jsonl` into storage with `uploadFileBuffered`.
- Keep the other core data export tables on the existing path for now.
- Add a focused worker test validating paged prompt streaming and JSONL output.

## Why
The prod-us core data export is failing with `Invalid prisma.prompt.findMany() invocation: Failed to convert rust String into napi string`. This keeps the initial fix scoped to prompts while preserving existing behavior for the other core data tables.

## Verification
- `git diff --check`
- `pnpm --filter worker run test src/queues/__tests__/coreDataS3ExportQueue.test.ts` attempted locally, but this sandbox workspace cannot resolve `@langfuse/shared/src/server` in the worker test runtime.
- `pnpm --filter worker run lint` attempted locally, but this sandbox workspace cannot resolve the repo eslint plugin package path.
- Per request, relying on PR CI for full verification.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a production OOM failure in the core data S3 export by moving the prompts table off the eager `Promise.all` path and onto a paged async generator that streams JSONL to S3 via multipart upload (`uploadFileBuffered`). It also introduces `CLICKHOUSE_CLUSTER_ENABLED` to let single-node (self-hosted) ClickHouse deployments skip `clusterAllReplicas` wrapping in system-table queries, removes a completed experiment flag from event propagation, and ships a chain of five env-gated V4 background migrations for a historic data backfill.

- **Prompt streaming**: `createPromptJsonlStream` pages through `prisma.prompt.findMany` in 1,000-row increments, terminated by an empty page or a short page, and uploads as a 100 MB-part multipart upload — resolving the original OOM.
- **`CLICKHOUSE_CLUSTER_ENABLED` env var**: Added to `packages/shared/src/env.ts` with a default of `\"true\"` (preserving cluster behavior) and consumed in `queryTracking.ts`'s new `systemTableRef` helper.
- **V4 background migrations**: Five new env-gated migrations (`LANGFUSE_MIGRATION_V4_ENABLE_HISTORIC_BACKFILL`) ship dormant and cover root-span creation, observations rewrite, events_full backfill from observations and DRIs, and cleanup of old sorting tables.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The prompt-streaming fix is safe to merge: the core generator logic correctly handles both termination paths and the existing non-prompt tables are untouched. The env-gated V4 migrations ship dormant and activate only when operators set the flag.

The streaming implementation is correct, the test covers the most common execution path, and the paged DB access prevents the OOM that was occurring in production. The only notable gap is a missing test for the exact-multiple-of-pageSize edge case where an additional empty-page fetch terminates the loop.

The new background migration files (backfillEventsFullFromObservations.ts, backfillEventsFullFromDatasetRunItems.ts, createRootSpansFromTraces.ts, rewriteObservationsToPidTidSorting.ts) are large and complex — a secondary pass confirming their ClickHouse INSERT queries and cursor logic behaves correctly under concurrent workers would be worthwhile.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Processor as coreDataS3ExportProcessor
    participant PG as PostgreSQL (prisma.prompt)
    participant Gen as createPromptJsonlStream (AsyncGenerator)
    participant Stream as Readable.from(generator)
    participant S3 as S3 uploadFileBuffered

    Processor->>PG: findMany (projects, users, orgs, ...) [Promise.all]
    PG-->>Processor: all non-prompt tables in memory

    Processor->>S3: uploadFile (non-prompt tables as JSONL strings)
    S3-->>Processor: done

    Processor->>Stream: Readable.from(generator)
    Processor->>S3: "uploadFileBuffered({ data: Stream, partSizeBytes: 100MB })"

    loop "Pages (pageSize = 1000)"
        S3->>Stream: request data
        Stream->>Gen: iterate
        Gen->>PG: "fetchPromptPage({ skip, take: 1000 })"
        PG-->>Gen: prompts[]
        Gen-->>Stream: yield JSON lines
        Stream-->>S3: chunk
        alt last page (fewer than 1000 rows or empty)
            Gen-->>Stream: generator done
        end
    end

    S3-->>Processor: upload complete
    Processor->>Processor: logger.info(Finished core data S3 export)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/queues/__tests__/coreDataS3ExportQueue.test.ts:75-77
**Missing test for full-page termination path**

The test only exercises the early-break branch (`prompts.length < pageSize`). When the total record count is an exact multiple of `pageSize`, the generator instead terminates on an empty-page fetch — a third `fetchPromptPage({skip: 4, take: 2})` call returning `[]`. Adding a second test case with exactly four items would confirm the generator does not emit a duplicate or drop the final empty page silently.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): stream core data prompt exp..."](https://github.com/langfuse/langfuse/commit/0d161f5ba7a950fb7e8e0bbe4a8d40e84327373d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32106740)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->