### PR TITLE
test(clickhouse): seed nested metadata

### DIFF
--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -24,6 +24,21 @@ export class ClickHouseQueryBuilder {
     return str.replace(/'/g, "''");
   }
 
+  private buildNestedMetadataMapSql(
+    baseEntries: string[],
+    rowExpression: string = "number",
+  ): string {
+    return `map(
+          ${baseEntries.join(",\n          ")},
+          'customer.id', concat('customer_', toString(${rowExpression} % 100)),
+          'customer.plan', arrayElement(['free', 'pro', 'enterprise'], 1 + (${rowExpression} % 3)),
+          'customer.region.code', arrayElement(['eu-central-1', 'us-east-1', 'ap-south-1'], 1 + (${rowExpression} % 3)),
+          'routing.queue', arrayElement(['support-chat', 'sales-chat', 'ops-chat'], 1 + (${rowExpression} % 3)),
+          'routing.priority', arrayElement(['low', 'normal', 'high'], 1 + (${rowExpression} % 3)),
+          'flags.beta', if(${rowExpression} % 2 = 0, 'true', 'false')
+        )`;
+  }
+
   /**
    * Creates INSERT query for trace data using VALUES syntax.
    * Use for: Small datasets, detailed trace objects with all fields populated.
@@ -93,7 +108,7 @@ export class ClickHouseQueryBuilder {
         toDateTime(now() - randUniform(0, ${opts.numberOfDays} * 24 * 60 * 60)) AS timestamp,
         concat('trace-', toString(number % 10)) AS name,
         if(randUniform(0, 1) < 0.3, concat('user_', toString(rand() % 1000)), NULL) AS user_id,
-        map('generated', 'bulk') AS metadata,
+        ${this.buildNestedMetadataMapSql(["'generated'", "'bulk'"])} AS metadata,
         NULL AS release,
         NULL AS version,
         '${projectId}' AS project_id,
@@ -162,7 +177,7 @@ export class ClickHouseQueryBuilder {
           when type = 'SPAN' then concat('span-', toString(number % 10))
           else concat('event-', toString(number % 10))
         end AS name,
-        map('key', 'value') AS metadata,
+        ${this.buildNestedMetadataMapSql(["'key'", "'value'"])} AS metadata,
         if(randUniform(0, 1) < 0.85, 'DEFAULT', if(randUniform(0, 1) < 0.7, 'DEBUG', if(randUniform(0, 1) < 0.3, 'ERROR', 'WARNING'))) AS level,
         NULL AS status_message,
         NULL AS version,

--- a/packages/shared/scripts/seeder/utils/data-generators.ts
+++ b/packages/shared/scripts/seeder/utils/data-generators.ts
@@ -72,6 +72,28 @@ export class DataGenerator {
     return Math.floor(Math.random() * (max - min + 1)) + min;
   }
 
+  private buildNestedSeedMetadata(
+    source: string,
+    index: number,
+    overrides: Record<string, string> = {},
+  ): Record<string, string> {
+    const plans = ["free", "pro", "enterprise"];
+    const regions = ["eu-central-1", "us-east-1", "ap-south-1"];
+    const queues = ["support-chat", "sales-chat", "ops-chat"];
+    const priorities = ["low", "normal", "high"];
+
+    return {
+      source,
+      "customer.id": `customer_${index % 100}`,
+      "customer.plan": plans[index % plans.length],
+      "customer.region.code": regions[index % regions.length],
+      "routing.queue": queues[index % queues.length],
+      "routing.priority": priorities[index % priorities.length],
+      "flags.beta": index % 2 === 0 ? "true" : "false",
+      ...overrides,
+    };
+  }
+
   /**
    * Creates dataset run items for dataset runs.
    * Use for: Dataset experiment scenarios.
@@ -299,7 +321,9 @@ export class DataGenerator {
           ? `session_${this.randomInt(1, 100)}`
           : undefined,
         environment: "default",
-        metadata: { generated: "synthetic" },
+        metadata: this.buildNestedSeedMetadata("synthetic", i, {
+          generated: "synthetic",
+        }),
         tags: this.randomBoolean(0.3) ? ["production", "ai-agent"] : [],
         public: this.randomBoolean(0.8),
         bookmarked: this.randomBoolean(0.1),
@@ -549,6 +573,14 @@ export class DataGenerator {
                 ? "WARNING"
                 : "ERROR",
           environment: trace.environment,
+          metadata: this.buildNestedSeedMetadata(
+            "synthetic-observation",
+            traceIndex * observationsPerTrace + i,
+            {
+              "observation.type": obsType,
+              "workflow.step": String(i + 1),
+            },
+          ),
         });
 
         observations.push(observation);
@@ -1039,7 +1071,10 @@ export class DataGenerator {
       timestamp: now + index * 1000,
       name: "SupportChatSession",
       user_id: null,
-      metadata: { scenario: "support-chat" },
+      metadata: this.buildNestedSeedMetadata("support-chat", index, {
+        scenario: "support-chat",
+        "routing.queue": "membership-support",
+      }),
       release: null,
       version: null,
       project_id: projectId,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches the ClickHouse and TypeScript seeder paths with nested metadata keys (`customer.id`, `customer.plan`, `customer.region.code`, `routing.queue`, `routing.priority`, `flags.beta`) to make seed data more realistic for testing filtered queries and metadata exploration.

- `buildNestedMetadataMapSql` (ClickHouse SQL path) replaces flat single-entry maps with a richer `map()` call using ClickHouse `arrayElement` and modulo arithmetic; both bulk trace and bulk observation inserts are updated.
- `buildNestedSeedMetadata` (TypeScript path) produces the equivalent structure as a plain object and is applied to synthetic traces, synthetic observations, and the support-chat scenario, with per-call overrides that correctly shadow the base values.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are confined to test seeding utilities and do not touch production data paths.

Both helper methods are correct for their current callers. The one thing worth a follow-up is that buildNestedMetadataMapSql silently depends on baseEntries having an even element count to produce valid ClickHouse SQL, but this constraint is undocumented and unenforced — a future caller with an odd-length array would hit a runtime SQL error.

packages/shared/scripts/seeder/utils/clickhouse-builder.ts — the buildNestedMetadataMapSql helper's baseEntries parameter.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Seeder Entry Point] --> B{Data Volume}
    B -->|Large / Bulk| C[ClickHouseQueryBuilder]
    B -->|Small / Curated| D[DataGenerator]

    C --> E[buildBulkTracesInsert]
    C --> F[buildBulkObservationsInsert]
    E --> G[buildNestedMetadataMapSql\nbaseEntries + 6 nested k-v pairs]
    F --> G
    G --> H["map('generated','bulk',\n'customer.id', concat(...),\n'customer.plan', arrayElement(...),\n...)"]

    D --> I[generateSyntheticTraces]
    D --> J[generateSyntheticObservations]
    D --> K[Support-Chat Trace]
    I --> L[buildNestedSeedMetadata\nsource + index + overrides]
    J --> L
    K --> L
    L --> M["{ source, customer.id, customer.plan,\ncustomer.region.code, routing.queue,\nrouting.priority, flags.beta, ...overrides }"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/scripts/seeder/utils/clickhouse-builder.ts:27-40
**`baseEntries` must have an even count for valid `map()` syntax**

ClickHouse's `map()` function requires alternating key-value pairs, so the total argument count (all entries in `baseEntries` plus the 12 hardcoded key-value arguments) must be even. If a future caller passes an odd number of strings in `baseEntries`, the resulting SQL would fail at runtime with a ClickHouse type error. Both current callers happen to pass 2 items, so this is safe today, but there is no guard or documentation making the constraint explicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(clickhouse): seed nested metadata"](https://github.com/langfuse/langfuse/commit/10fc0c5e3357e66297975945a26c564b5e0ff1b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32108623)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->