### PR TITLE
chore: Update agent guidance for repo workflows

### DIFF
--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -240,9 +240,6 @@ export const addUserToSpan = (
     activeSpan.setAttribute("langfuse.org.plan", attributes.plan);
   }
   if (attributes.apiKeyId) {
-    baggage = baggage.setEntry("langfuse.api_key.id", {
-      value: attributes.apiKeyId,
-    });
     activeSpan.setAttribute("langfuse.api_key.id", attributes.apiKeyId);
   }
 

--- a/packages/shared/src/server/instrumentation/index.ts
+++ b/packages/shared/src/server/instrumentation/index.ts
@@ -194,6 +194,7 @@ export const addUserToSpan = (
     email?: string;
     orgId?: string;
     plan?: string;
+    apiKeyId?: string;
   },
   span?: opentelemetry.Span,
 ) => {
@@ -237,6 +238,12 @@ export const addUserToSpan = (
       value: attributes.plan,
     });
     activeSpan.setAttribute("langfuse.org.plan", attributes.plan);
+  }
+  if (attributes.apiKeyId) {
+    baggage = baggage.setEntry("langfuse.api_key.id", {
+      value: attributes.apiKeyId,
+    });
+    activeSpan.setAttribute("langfuse.api_key.id", attributes.apiKeyId);
   }
 
   return opentelemetry.propagation.setBaggage(ctx, baggage);

--- a/web/src/__tests__/server/unit/api-auth-span.servertest.ts
+++ b/web/src/__tests__/server/unit/api-auth-span.servertest.ts
@@ -1,0 +1,179 @@
+const {
+  addUserToSpanMock,
+  createShaHashMock,
+  fakeAuthSpan,
+  instrumentAsyncMock,
+} = vi.hoisted(() => {
+  const fakeAuthSpan = {
+    end: vi.fn(),
+    recordException: vi.fn(),
+    setAttribute: vi.fn(),
+    setAttributes: vi.fn(),
+    setStatus: vi.fn(),
+  };
+
+  return {
+    addUserToSpanMock: vi.fn(),
+    createShaHashMock: vi.fn(
+      (secretKey: string, salt: string) => `hashed:${salt}:${secretKey}`,
+    ),
+    fakeAuthSpan,
+    instrumentAsyncMock: vi.fn(async (_ctx, callback) =>
+      callback(fakeAuthSpan),
+    ),
+  };
+});
+
+vi.mock("@/src/env.mjs", () => ({
+  env: {
+    LANGFUSE_CACHE_API_KEY_ENABLED: "false",
+    LANGFUSE_CACHE_API_KEY_TTL_SECONDS: 60,
+    SALT: "test-salt",
+  },
+}));
+
+vi.mock("@/src/features/entitlements/server/getPlan", () => ({
+  getOrganizationPlanServerSide: () => "oss",
+}));
+
+vi.mock("@/src/utils/exceptions", () => ({
+  isPrismaException: () => false,
+}));
+
+vi.mock("@langfuse/shared", () => ({
+  CloudConfigSchema: {
+    parse: vi.fn((value) => value),
+  },
+  isPlan: vi.fn((plan) => typeof plan === "string"),
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  API_KEY_NON_EXISTENT: "api-key-non-existent",
+  CachedApiKey: {
+    safeParse: vi.fn((value) => ({ data: value, success: true })),
+  },
+  ClickHouseClientManager: {
+    getInstance: vi.fn(() => ({
+      closeAllConnections: vi.fn(),
+    })),
+  },
+  OrgEnrichedApiKey: {
+    parse: vi.fn((value) => value),
+  },
+  addUserToSpan: addUserToSpanMock,
+  createShaHash: createShaHashMock,
+  invalidateCachedApiKeys: vi.fn(),
+  invalidateCachedOrgApiKeys: vi.fn(),
+  invalidateCachedProjectApiKeys: vi.fn(),
+  instrumentAsync: instrumentAsyncMock,
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+  recordIncrement: vi.fn(),
+  redis: null,
+  verifySecretKey: vi.fn(),
+}));
+
+import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
+
+const createBasicAuthHeader = (publicKey: string, secretKey: string) =>
+  `Basic ${Buffer.from(`${publicKey}:${secretKey}`).toString("base64")}`;
+
+const createProjectApiKey = () => {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  const publicKey = "pk-lf-public";
+  const secretKey = "sk-lf-secret";
+  const projectId = "project-id";
+  const orgId = "org-id";
+
+  return {
+    apiKey: {
+      id: "api-key-id",
+      createdAt: now,
+      displaySecretKey: "sk-lf-...cret",
+      expiresAt: null,
+      fastHashedSecretKey: createShaHashMock(secretKey, "test-salt"),
+      hashedSecretKey: "legacy-hash",
+      lastUsedAt: null,
+      note: null,
+      organization: null,
+      project: {
+        id: projectId,
+        organization: {
+          id: orgId,
+          cloudConfig: null,
+          cloudFreeTierUsageThresholdState: null,
+          createdAt: now,
+          name: "Org",
+          updatedAt: now,
+        },
+      },
+      projectId,
+      publicKey,
+      scope: "PROJECT",
+    },
+    orgId,
+    projectId,
+    publicKey,
+    secretKey,
+  };
+};
+
+describe("ApiAuthService span metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds the api key id to the auth span for Basic auth", async () => {
+    const { apiKey, orgId, projectId, publicKey, secretKey } =
+      createProjectApiKey();
+    const prisma = {
+      apiKey: {
+        findUnique: vi.fn().mockResolvedValue(apiKey),
+      },
+    };
+
+    const result = await new ApiAuthService(
+      prisma as any,
+      null,
+    ).verifyAuthHeaderAndReturnScope(
+      createBasicAuthHeader(publicKey, secretKey),
+    );
+
+    expect(result.validKey).toBe(true);
+    expect(addUserToSpanMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKeyId: apiKey.id,
+        orgId,
+        projectId,
+      }),
+      fakeAuthSpan,
+    );
+  });
+
+  it("adds the api key id to the auth span for Bearer auth", async () => {
+    const { apiKey, orgId, projectId, publicKey } = createProjectApiKey();
+    const prisma = {
+      apiKey: {
+        findUnique: vi.fn().mockResolvedValue(apiKey),
+      },
+    };
+
+    const result = await new ApiAuthService(
+      prisma as any,
+      null,
+    ).verifyAuthHeaderAndReturnScope(`Bearer ${publicKey}`);
+
+    expect(result.validKey).toBe(true);
+    expect(addUserToSpanMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKeyId: apiKey.id,
+        orgId,
+        projectId,
+      }),
+      fakeAuthSpan,
+    );
+  });
+});

--- a/web/src/features/public-api/server/apiAuth.ts
+++ b/web/src/features/public-api/server/apiAuth.ts
@@ -88,7 +88,7 @@ export class ApiAuthService {
   ): Promise<AuthHeaderVerificationResult> {
     const result: AuthHeaderVerificationResult = await instrumentAsync(
       { name: "api-auth-verify" },
-      async () => {
+      async (span) => {
         if (!authHeader) {
           logger.debug("No authorization header");
           return {
@@ -172,11 +172,15 @@ export class ApiAuthService {
               throw new Error("Invalid credentials");
             }
 
-            addUserToSpan({
-              projectId: finalApiKey.projectId ?? undefined,
-              orgId: finalApiKey.orgId,
-              plan,
-            });
+            addUserToSpan(
+              {
+                projectId: finalApiKey.projectId ?? undefined,
+                orgId: finalApiKey.orgId,
+                plan,
+                apiKeyId: finalApiKey.id,
+              },
+              span,
+            );
 
             const accessLevel =
               finalApiKey.scope === "ORGANIZATION" ? "organization" : "project";
@@ -211,11 +215,15 @@ export class ApiAuthService {
             const { orgId, cloudConfig, cloudFreeTierUsageThresholdState } =
               this.extractOrgIdAndCloudConfig(dbKey);
 
-            addUserToSpan({
-              projectId: dbKey.projectId ?? undefined,
-              orgId,
-              plan: getOrganizationPlanServerSide(cloudConfig),
-            });
+            addUserToSpan(
+              {
+                projectId: dbKey.projectId ?? undefined,
+                orgId,
+                plan: getOrganizationPlanServerSide(cloudConfig),
+                apiKeyId: dbKey.id,
+              },
+              span,
+            );
 
             return {
               validKey: true,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the API key ID as an attribute to OpenTelemetry spans during API authentication, improving observability by recording which specific key was used for each request. The `instrumentAsync` callback in `verifyAuthHeaderAndReturnScope` now explicitly receives the span object and forwards it to `addUserToSpan`, rather than relying on `getCurrentSpan()` ambient lookup.

- `addUserToSpan` gains a new optional `apiKeyId` field that is written to both the active span and OTel baggage under the `langfuse.api_key.id` key, mirroring the existing pattern for `orgId`/`projectId`/`plan`.
- `verifyAuthHeaderAndReturnScope` is updated in both the Basic auth and Bearer auth code paths to pass the span explicitly and include `apiKeyId: finalApiKey.id` / `dbKey.id`.
- A new unit test file validates that `addUserToSpan` is called with the correct `apiKeyId` for both auth strategies.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge — it adds a non-sensitive internal identifier (API key UUID) to tracing spans and baggage, following the exact same pattern already used for orgId, projectId, and plan.

Both auth paths (Basic and Bearer) are updated consistently, the explicit span forwarding removes any ambiguity about which span receives the attributes, and the new tests confirm correct wiring for both flows. The apiKeyId is the database UUID, not the secret value, so there is no credential-exposure risk.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ApiAuthService
    participant instrumentAsync
    participant addUserToSpan
    participant OTelSpan

    Client->>ApiAuthService: verifyAuthHeaderAndReturnScope(authHeader)
    ApiAuthService->>instrumentAsync: "{ name: "api-auth-verify" }, async (span) => ..."
    instrumentAsync->>OTelSpan: startActiveSpan("api-auth-verify")
    OTelSpan-->>instrumentAsync: span

    alt Basic Auth
        instrumentAsync->>ApiAuthService: callback(span)
        ApiAuthService->>ApiAuthService: fetchApiKeyAndAddToRedis / prisma.findUnique
        ApiAuthService->>addUserToSpan: "{ projectId, orgId, plan, apiKeyId: finalApiKey.id }, span"
        addUserToSpan->>OTelSpan: setAttribute("langfuse.api_key.id", apiKeyId)
        addUserToSpan->>OTelSpan: setBaggage("langfuse.api_key.id", apiKeyId)
    else Bearer Auth
        instrumentAsync->>ApiAuthService: callback(span)
        ApiAuthService->>ApiAuthService: findDbKeyOrThrow(publicKey)
        ApiAuthService->>addUserToSpan: "{ projectId, orgId, plan, apiKeyId: dbKey.id }, span"
        addUserToSpan->>OTelSpan: setAttribute("langfuse.api_key.id", apiKeyId)
        addUserToSpan->>OTelSpan: setBaggage("langfuse.api_key.id", apiKeyId)
    end

    instrumentAsync-->>ApiAuthService: AuthHeaderVerificationResult
    ApiAuthService-->>Client: "{ validKey: true, scope: { apiKeyId, ... } }"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Update agent guidance for repo workflows"](https://github.com/langfuse/langfuse/commit/2da918e1a3b36b28b83aacc303d7962967f86d7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32164357)</sub>

<!-- /greptile_comment -->