### PR TITLE
feat(observations-v2): expose trace_context field group in public API

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -326,6 +326,17 @@ types:
         type: optional<nullable<string>>
         docs: The matched model ID
 
+      # Trace context fields (field group: trace_context)
+      traceName:
+        type: optional<nullable<string>>
+        docs: The name of the parent trace
+      tags:
+        type: optional<nullable<list<string>>>
+        docs: Tags from the parent trace (denormalized onto the observation)
+      release:
+        type: optional<nullable<string>>
+        docs: The release version of the parent trace
+
   Usage:
     docs: (Deprecated. Use usageDetails and costDetails instead.) Standard interface for usage and cost
     properties:

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -25,6 +25,7 @@ service:
         - `usage` - usageDetails, costDetails, totalCost, usagePricingTierName
         - `prompt` - promptId, promptName, promptVersion
         - `metrics` - latency, timeToFirstToken
+        - `trace_context` - tags, release, traceName
 
         If not specified, `core` and `basic` field groups are returned.
 
@@ -40,7 +41,7 @@ service:
             type: optional<string>
             docs: |
               Comma-separated list of field groups to include in the response.
-              Available groups: core, basic, time, io, metadata, model, usage, prompt, metrics.
+              Available groups: core, basic, time, io, metadata, model, usage, prompt, metrics, trace_context.
               If not specified, `core` and `basic` field groups are returned.
               Example: "basic,usage,model"
           expandMetadata:

--- a/packages/shared/src/domain/observation-field-groups.ts
+++ b/packages/shared/src/domain/observation-field-groups.ts
@@ -8,8 +8,8 @@
  * - OBSERVATION_FIELD_GROUPS_PUBLIC_API: v2 public API contract — the groups that the
  *   v2 observations endpoint can return.
  * - OBSERVATION_FIELD_GROUPS_FULL: the complete set of column groups the
- *   events repository can project, including denormalized trace context and
- *   tool fields that the public API does not currently expose.
+ *   events repository can project, including tool fields that the public API
+ *   does not currently expose.
  *
  * Defined in the client-safe domain layer (not inside the server-only
  * repository file) so frontend forms and Zod enums can reference the values
@@ -26,6 +26,7 @@ export const OBSERVATION_FIELD_GROUPS_PUBLIC_API = [
   "usage", // usageDetails, costDetails, totalCost, usagePricingTierName
   "prompt", // promptId, promptName, promptVersion
   "metrics", // latency, timeToFirstToken
+  "trace_context", // tags, release, traceName (denormalized trace metadata)
 ] as const;
 
 export type ObservationFieldGroupPublicApi =
@@ -34,7 +35,6 @@ export type ObservationFieldGroupPublicApi =
 export const OBSERVATION_FIELD_GROUPS_FULL = [
   ...OBSERVATION_FIELD_GROUPS_PUBLIC_API,
   "tools", // toolDefinitions, toolCalls, toolCallNames
-  "trace_context", // tags, release, traceName (denormalized trace metadata)
 ] as const;
 
 export type ObservationFieldGroupFull =

--- a/packages/shared/src/domain/observations.ts
+++ b/packages/shared/src/domain/observations.ts
@@ -117,7 +117,7 @@ export const EventsObservationSchema = ObservationSchema.extend({
   sessionId: z.string().nullable(),
   traceName: z.string().nullable(),
   release: z.string().nullable().optional(),
-  tags: z.array(z.string()).optional(),
+  tags: z.array(z.string()).nullable().optional(),
   bookmarked: z.boolean().optional(),
   public: z.boolean().optional(),
 });

--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -412,7 +412,7 @@ export function convertEventsObservation(
     sessionId: record.session_id ?? null,
     traceName: record.trace_name ?? null,
     release: record.release ?? null,
-    tags: record.tags ?? [],
+    tags: record.tags ?? null,
     bookmarked: record.bookmarked,
     public: record.public,
   };

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3133,6 +3133,8 @@ paths:
 
         - `metrics` - latency, timeToFirstToken
 
+        - `trace_context` - tags, release, traceName
+
 
         If not specified, `core` and `basic` field groups are returned.
 
@@ -3154,7 +3156,7 @@ paths:
             Comma-separated list of field groups to include in the response.
 
             Available groups: core, basic, time, io, metadata, model, usage,
-            prompt, metrics.
+            prompt, metrics, trace_context.
 
             If not specified, `core` and `basic` field groups are returned.
 

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8115,6 +8115,20 @@ components:
           type: string
           nullable: true
           description: The matched model ID
+        traceName:
+          type: string
+          nullable: true
+          description: The name of the parent trace
+        tags:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: Tags from the parent trace (denormalized onto the observation)
+        release:
+          type: string
+          nullable: true
+          description: The release version of the parent trace
       required:
         - id
         - startTime

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -539,6 +539,10 @@ describe("/api/public/v2/observations API Endpoint", () => {
       "promptId",
       "promptName",
       "promptVersion",
+      // trace_context
+      "traceName",
+      "tags",
+      "release",
     ] as const;
 
     let sharedObsId: string;

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -581,6 +581,9 @@ describe("/api/public/v2/observations API Endpoint", () => {
         output: "contract output",
         metadata_names: ["key"],
         metadata_values: ["val"],
+        trace_name: "contract-trace",
+        tags: ["tag-a", "tag-b"],
+        release: "1.2.3",
       });
 
       await createEventsCh([obs]);
@@ -605,6 +608,9 @@ describe("/api/public/v2/observations API Endpoint", () => {
       promptVersion: 2,
       input: "contract input",
       output: "contract output",
+      traceName: "contract-trace",
+      tags: ["tag-a", "tag-b"],
+      release: "1.2.3",
       usagePricingTierName: "contract-tier",
     };
 
@@ -636,6 +642,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
       // end_time), but the metrics group is still defined for documentation and to verify these fields are indeed
       // present
       metrics: ["latency", "timeToFirstToken"],
+      trace_context: ["traceName", "tags", "release"],
     };
 
     for (const [group, expectedFields] of Object.entries(fieldsForGroup)) {

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -440,6 +440,11 @@ const APIObservationV2 = z
 
     // Enrichment fields
     modelId: z.string().nullable().optional(),
+
+    // Trace context fields (field group: trace_context)
+    traceName: z.string().nullable().optional(),
+    tags: z.array(z.string()).nullable().optional(),
+    release: z.string().nullable().optional(),
   })
   .loose();
 


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes the `trace_context` field group in the v2 public observations API, allowing callers to opt into `traceName`, `tags`, and `release` fields via `?fields=trace_context`. It moves the group from the internal-only `OBSERVATION_FIELD_GROUPS_FULL` set into `OBSERVATION_FIELD_GROUPS_PUBLIC_API` and updates the Fern definition, generated OpenAPI spec, Zod schemas, and the ClickHouse converter.

- `trace_context` is now a first-class field group recognized by the `fields` query parameter parser, with the ClickHouse field set already defined (`tags`, `release`, `traceName`).
- The default for missing `tags` in `convertEventsObservation` changed from `[]` to `null`; all downstream callers that remap to `traceTags` already guard with `?? []`, so there is no behavioral regression.
- Test coverage adds a fixture with explicit tag/release/traceName values and asserts both field-group presence and absence contracts.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge. It adds a new opt-in field group to the V2 API and does not touch any existing default response fields.

The change is well-scoped: the ClickHouse field set for trace_context already existed, all downstream callers that remap tags to traceTags already guard against null, and the V1 API transformer explicitly strips these fields so it is unaffected. Tests cover both field presence and field-group isolation (absence) contracts.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ObservationsV2API
    participant EventsQueryBuilder
    participant ClickHouse
    participant EnrichObservations
    participant Converter

    Client->>ObservationsV2API: "GET /v2/observations?fields=trace_context"
    ObservationsV2API->>ObservationsV2API: Parse fields → ["trace_context"]
    ObservationsV2API->>EventsQueryBuilder: selectFieldSet("core") + selectFieldSet("trace_context")
    EventsQueryBuilder->>ClickHouse: SELECT id, trace_id, tags, release, trace_name FROM events_core
    ClickHouse-->>EventsQueryBuilder: rows
    EventsQueryBuilder-->>ObservationsV2API: ObservationsTableQueryResult[]
    ObservationsV2API->>EnrichObservations: enrichObservationsWithModelData(records, projectId, parseIo, requestedFields)
    EnrichObservations->>Converter: convertEventsObservation(record, props, false)
    Converter-->>EnrichObservations: "{ traceName, tags, release, ... }"
    EnrichObservations-->>ObservationsV2API: EventsObservationPublic[]
    ObservationsV2API-->>Client: "{ data: [{ traceName, tags, release, ... }] }"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(observations-v2): declare trace\_cont..."](https://github.com/langfuse/langfuse/commit/0fa70fddab05294cbda18c47643f3e747456ea62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32300669)</sub>

<!-- /greptile_comment -->