### PR TITLE
fix(fern): lift filter docs to endpoint level and fix column accuracy in observations/traces API

### DIFF
--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -129,12 +129,11 @@ service:
               - `statusMessage` (string) - Status message
               - `version` (string) - Version tag
               - `userId` (string) - User ID
-              - `sessionId` (string) - Session ID
 
               ### Trace-Related Fields
               - `traceName` (string) - Name of the parent trace
               - `traceTags` (arrayOptions) - Tags from the parent trace
-              - `tags` (arrayOptions) - Alias for traceTags
+              - `sessionId` (string) - Session ID (sourced from parent trace)
 
               ### Performance Metrics
               - `latency` (number) - Latency in seconds (calculated: end_time - start_time)

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -32,6 +32,98 @@ service:
         ## Filters
         Multiple filtering options are available via query parameters or the structured `filter` parameter.
         When using the `filter` parameter, it takes precedence over individual query parameter filters.
+
+        ### Filter Structure
+        Each filter condition has the following structure:
+        ```json
+        [
+          {
+            "type": "string",         // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": "name",         // Required. Column to filter on (see Available Columns below)
+            "operator": "=",          // Required. Operator based on type:
+                                      // - datetime: ">", "<", ">=", "<="
+                                      // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - stringOptions: "any of", "none of"
+                                      // - categoryOptions: "any of", "none of"
+                                      // - arrayOptions: "any of", "none of", "all of"
+                                      // - number: "=", ">", "<", ">=", "<="
+                                      // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - numberObject: "=", ">", "<", ">=", "<="
+                                      // - boolean: "=", "<>"
+                                      // - null: "is null", "is not null"
+            "value": "GENERATION",    // Required (except for null type). Type depends on filter type.
+            "key": "env"              // Required only for stringObject, numberObject, and categoryOptions when filtering nested fields like metadata.
+          }
+        ]
+        ```
+
+        ### Available Columns
+
+        #### Core Observation Fields
+        - `id` (string) - Observation ID
+        - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
+        - `name` (string) - Observation name
+        - `traceId` (string) - Associated trace ID
+        - `startTime` (datetime) - Observation start time
+        - `endTime` (datetime) - Observation end time
+        - `environment` (string) - Environment tag
+        - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
+        - `statusMessage` (string) - Status message
+        - `version` (string) - Version tag
+        - `userId` (string) - User ID
+
+        #### Trace-Related Fields
+        - `traceName` (string) - Name of the parent trace
+        - `traceTags` (arrayOptions) - Tags from the parent trace
+        - `sessionId` (string) - Session ID (sourced from parent trace)
+
+        #### Performance Metrics
+        - `latency` (number) - Latency in seconds (end_time − start_time)
+        - `timeToFirstToken` (number) - Time to first token in seconds
+        - `tokensPerSecond` (number) - Output tokens per second
+
+        #### Token Usage
+        - `inputTokens` (number) - Number of input tokens
+        - `outputTokens` (number) - Number of output tokens
+        - `totalTokens` (number) - Total tokens (alias: `tokens`)
+
+        #### Cost Metrics
+        - `inputCost` (number) - Input cost in USD
+        - `outputCost` (number) - Output cost in USD
+        - `totalCost` (number) - Total cost in USD
+
+        #### Model Information
+        - `model` (string) - Provided model name (alias: `providedModelName`)
+        - `promptName` (string) - Associated prompt name
+        - `promptVersion` (number) - Associated prompt version
+
+        #### Structured Data
+        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Requires the `key` parameter to target a specific metadata key.
+
+        ### Filter Examples
+        ```json
+        [
+          {
+            "type": "string",
+            "column": "type",
+            "operator": "=",
+            "value": "GENERATION"
+          },
+          {
+            "type": "number",
+            "column": "latency",
+            "operator": ">=",
+            "value": 2.5
+          },
+          {
+            "type": "stringObject",
+            "column": "metadata",
+            "key": "environment",
+            "operator": "=",
+            "value": "production"
+          }
+        ]
+        ```
       method: GET
       path: /v2/observations
       request:
@@ -89,99 +181,9 @@ service:
           filter:
             type: optional<string>
             docs: |
-              JSON string containing an array of filter conditions. When provided, this takes precedence over query parameter filters (userId, name, type, level, environment, fromStartTime, ...).
-
-              ## Filter Structure
-              Each filter condition has the following structure:
-              ```json
-              [
-                {
-                  "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-                  "column": string,         // Required. Column to filter on (see available columns below)
-                  "operator": string,       // Required. Operator based on type:
-                                            // - datetime: ">", "<", ">=", "<="
-                                            // - string: "=", "contains", "does not contain", "starts with", "ends with"
-                                            // - stringOptions: "any of", "none of"
-                                            // - categoryOptions: "any of", "none of"
-                                            // - arrayOptions: "any of", "none of", "all of"
-                                            // - number: "=", ">", "<", ">=", "<="
-                                            // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
-                                            // - numberObject: "=", ">", "<", ">=", "<="
-                                            // - boolean: "=", "<>"
-                                            // - null: "is null", "is not null"
-                  "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-                  "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
-                }
-              ]
-              ```
-
-              ## Available Columns
-
-              ### Core Observation Fields
-              - `id` (string) - Observation ID
-              - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
-              - `name` (string) - Observation name
-              - `traceId` (string) - Associated trace ID
-              - `startTime` (datetime) - Observation start time
-              - `endTime` (datetime) - Observation end time
-              - `environment` (string) - Environment tag
-              - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
-              - `statusMessage` (string) - Status message
-              - `version` (string) - Version tag
-              - `userId` (string) - User ID
-
-              ### Trace-Related Fields
-              - `traceName` (string) - Name of the parent trace
-              - `traceTags` (arrayOptions) - Tags from the parent trace
-              - `sessionId` (string) - Session ID (sourced from parent trace)
-
-              ### Performance Metrics
-              - `latency` (number) - Latency in seconds (calculated: end_time - start_time)
-              - `timeToFirstToken` (number) - Time to first token in seconds
-              - `tokensPerSecond` (number) - Output tokens per second
-
-              ### Token Usage
-              - `inputTokens` (number) - Number of input tokens
-              - `outputTokens` (number) - Number of output tokens
-              - `totalTokens` (number) - Total tokens (alias: `tokens`)
-
-              ### Cost Metrics
-              - `inputCost` (number) - Input cost in USD
-              - `outputCost` (number) - Output cost in USD
-              - `totalCost` (number) - Total cost in USD
-
-              ### Model Information
-              - `model` (string) - Provided model name (alias: `providedModelName`)
-              - `promptName` (string) - Associated prompt name
-              - `promptVersion` (number) - Associated prompt version
-
-              ### Structured Data
-              - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
-
-              ## Filter Examples
-              ```json
-              [
-                {
-                  "type": "string",
-                  "column": "type",
-                  "operator": "=",
-                  "value": "GENERATION"
-                },
-                {
-                  "type": "number",
-                  "column": "latency",
-                  "operator": ">=",
-                  "value": 2.5
-                },
-                {
-                  "type": "stringObject",
-                  "column": "metadata",
-                  "key": "environment",
-                  "operator": "=",
-                  "value": "production"
-                }
-              ]
-              ```
+              JSON-encoded array of filter conditions. Takes precedence over individual query-parameter filters
+              (userId, name, type, level, environment, fromStartTime, ...). See **Filter Structure**,
+              **Available Columns**, and **Filter Examples** in the endpoint description above.
       response: ObservationsV2Response
 
 types:

--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -31,7 +31,116 @@ service:
           docs: The unique langfuse identifier of the trace to delete
       response: DeleteTraceResponse
     list:
-      docs: Get list of traces
+      docs: |
+        Get list of traces.
+
+        ## Filters
+        Multiple filtering options are available via query parameters or the structured `filter` parameter.
+        When using the `filter` parameter, it takes precedence over individual query parameter filters.
+
+        ### Filter Structure
+        Each filter condition has the following structure:
+        ```json
+        [
+          {
+            "type": "string",         // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": "name",         // Required. Column to filter on (see Available Columns below)
+            "operator": "=",          // Required. Operator based on type:
+                                      // - datetime: ">", "<", ">=", "<="
+                                      // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - stringOptions: "any of", "none of"
+                                      // - categoryOptions: "any of", "none of"
+                                      // - arrayOptions: "any of", "none of", "all of"
+                                      // - number: "=", ">", "<", ">=", "<="
+                                      // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - numberObject: "=", ">", "<", ">=", "<="
+                                      // - boolean: "=", "<>"
+                                      // - null: "is null", "is not null"
+            "value": "production",    // Required (except for null type). Type depends on filter type.
+            "key": "env"              // Required only for stringObject, numberObject, and categoryOptions when filtering nested fields like metadata.
+          }
+        ]
+        ```
+
+        ### Available Columns
+
+        #### Core Trace Fields
+        - `id` (string) - Trace ID
+        - `name` (string) - Trace name
+        - `timestamp` (datetime) - Trace timestamp
+        - `userId` (string) - User ID
+        - `sessionId` (string) - Session ID
+        - `environment` (string) - Environment tag
+        - `version` (string) - Version tag
+        - `release` (string) - Release tag
+        - `tags` (arrayOptions) - Array of tags
+        - `bookmarked` (boolean) - Bookmark status
+
+        #### Structured Data
+        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Requires the `key` parameter to target a specific metadata key.
+
+        #### Aggregated Metrics (from observations)
+        These metrics are aggregated from all observations within the trace:
+        - `latency` (number) - Latency in seconds (time from first observation start to last observation end)
+        - `inputTokens` (number) - Total input tokens across all observations
+        - `outputTokens` (number) - Total output tokens across all observations
+        - `totalTokens` (number) - Total tokens (alias: `tokens`)
+        - `inputCost` (number) - Total input cost in USD
+        - `outputCost` (number) - Total output cost in USD
+        - `totalCost` (number) - Total cost in USD
+
+        #### Observation Level Aggregations
+        These fields aggregate observation levels within the trace:
+        - `level` (string) - Highest severity level (ERROR > WARNING > DEFAULT > DEBUG)
+        - `warningCount` (number) - Count of WARNING level observations
+        - `errorCount` (number) - Count of ERROR level observations
+        - `defaultCount` (number) - Count of DEFAULT level observations
+        - `debugCount` (number) - Count of DEBUG level observations
+
+        #### Scores (requires join with scores table)
+        - `scores_avg` (number) - Average of numeric scores (alias: `scores`)
+        - `score_categories` (categoryOptions) - Categorical score values
+
+        ### Filter Examples
+        ```json
+        [
+          {
+            "type": "datetime",
+            "column": "timestamp",
+            "operator": ">=",
+            "value": "2024-01-01T00:00:00Z"
+          },
+          {
+            "type": "string",
+            "column": "userId",
+            "operator": "=",
+            "value": "user-123"
+          },
+          {
+            "type": "number",
+            "column": "totalCost",
+            "operator": ">=",
+            "value": 0.01
+          },
+          {
+            "type": "arrayOptions",
+            "column": "tags",
+            "operator": "all of",
+            "value": ["production", "critical"]
+          },
+          {
+            "type": "stringObject",
+            "column": "metadata",
+            "key": "customer_tier",
+            "operator": "=",
+            "value": "enterprise"
+          }
+        ]
+        ```
+
+        ### Performance Notes
+        - Filtering on `userId`, `sessionId`, or `metadata` may enable skip indexes for better query performance.
+        - Score filters require a join with the scores table and may impact query performance.
       method: GET
       path: /traces
       request:
@@ -75,111 +184,9 @@ service:
           filter:
             type: optional<string>
             docs: |
-              JSON string containing an array of filter conditions. When provided, this takes precedence over query parameter filters (userId, name, sessionId, tags, version, release, environment, fromTimestamp, toTimestamp).
-
-              ## Filter Structure
-              Each filter condition has the following structure:
-              ```json
-              [
-                {
-                  "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-                  "column": string,         // Required. Column to filter on (see available columns below)
-                  "operator": string,       // Required. Operator based on type:
-                                            // - datetime: ">", "<", ">=", "<="
-                                            // - string: "=", "contains", "does not contain", "starts with", "ends with"
-                                            // - stringOptions: "any of", "none of"
-                                            // - categoryOptions: "any of", "none of"
-                                            // - arrayOptions: "any of", "none of", "all of"
-                                            // - number: "=", ">", "<", ">=", "<="
-                                            // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
-                                            // - numberObject: "=", ">", "<", ">=", "<="
-                                            // - boolean: "=", "<>"
-                                            // - null: "is null", "is not null"
-                  "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-                  "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
-                }
-              ]
-              ```
-
-              ## Available Columns
-
-              ### Core Trace Fields
-              - `id` (string) - Trace ID
-              - `name` (string) - Trace name
-              - `timestamp` (datetime) - Trace timestamp
-              - `userId` (string) - User ID
-              - `sessionId` (string) - Session ID
-              - `environment` (string) - Environment tag
-              - `version` (string) - Version tag
-              - `release` (string) - Release tag
-              - `tags` (arrayOptions) - Array of tags
-              - `bookmarked` (boolean) - Bookmark status
-
-              ### Structured Data
-              - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
-
-              ### Aggregated Metrics (from observations)
-              These metrics are aggregated from all observations within the trace:
-              - `latency` (number) - Latency in seconds (time from first observation start to last observation end)
-              - `inputTokens` (number) - Total input tokens across all observations
-              - `outputTokens` (number) - Total output tokens across all observations
-              - `totalTokens` (number) - Total tokens (alias: `tokens`)
-              - `inputCost` (number) - Total input cost in USD
-              - `outputCost` (number) - Total output cost in USD
-              - `totalCost` (number) - Total cost in USD
-
-              ### Observation Level Aggregations
-              These fields aggregate observation levels within the trace:
-              - `level` (string) - Highest severity level (ERROR > WARNING > DEFAULT > DEBUG)
-              - `warningCount` (number) - Count of WARNING level observations
-              - `errorCount` (number) - Count of ERROR level observations
-              - `defaultCount` (number) - Count of DEFAULT level observations
-              - `debugCount` (number) - Count of DEBUG level observations
-
-              ### Scores (requires join with scores table)
-              - `scores_avg` (number) - Average of numeric scores (alias: `scores`)
-              - `score_categories` (categoryOptions) - Categorical score values
-
-              ## Filter Examples
-              ```json
-              [
-                {
-                  "type": "datetime",
-                  "column": "timestamp",
-                  "operator": ">=",
-                  "value": "2024-01-01T00:00:00Z"
-                },
-                {
-                  "type": "string",
-                  "column": "userId",
-                  "operator": "=",
-                  "value": "user-123"
-                },
-                {
-                  "type": "number",
-                  "column": "totalCost",
-                  "operator": ">=",
-                  "value": 0.01
-                },
-                {
-                  "type": "arrayOptions",
-                  "column": "tags",
-                  "operator": "all of",
-                  "value": ["production", "critical"]
-                },
-                {
-                  "type": "stringObject",
-                  "column": "metadata",
-                  "key": "customer_tier",
-                  "operator": "=",
-                  "value": "enterprise"
-                }
-              ]
-              ```
-
-              ## Performance Notes
-              - Filtering on `userId`, `sessionId`, or `metadata` may enable skip indexes for better query performance
-              - Score filters require a join with the scores table and may impact query performance
+              JSON-encoded array of filter conditions. Takes precedence over individual query-parameter filters
+              (userId, name, sessionId, tags, version, release, environment, fromTimestamp, toTimestamp). See
+              **Filter Structure**, **Available Columns**, and **Filter Examples** in the endpoint description above.
       response: Traces
     deleteMultiple:
       docs: Delete multiple traces

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3146,6 +3146,144 @@ paths:
 
         When using the `filter` parameter, it takes precedence over individual
         query parameter filters.
+
+
+        ### Filter Structure
+
+        Each filter condition has the following structure:
+
+        ```json
+
+        [
+          {
+            "type": "string",         // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": "name",         // Required. Column to filter on (see Available Columns below)
+            "operator": "=",          // Required. Operator based on type:
+                                      // - datetime: ">", "<", ">=", "<="
+                                      // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - stringOptions: "any of", "none of"
+                                      // - categoryOptions: "any of", "none of"
+                                      // - arrayOptions: "any of", "none of", "all of"
+                                      // - number: "=", ">", "<", ">=", "<="
+                                      // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - numberObject: "=", ">", "<", ">=", "<="
+                                      // - boolean: "=", "<>"
+                                      // - null: "is null", "is not null"
+            "value": "GENERATION",    // Required (except for null type). Type depends on filter type.
+            "key": "env"              // Required only for stringObject, numberObject, and categoryOptions when filtering nested fields like metadata.
+          }
+        ]
+
+        ```
+
+
+        ### Available Columns
+
+
+        #### Core Observation Fields
+
+        - `id` (string) - Observation ID
+
+        - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
+
+        - `name` (string) - Observation name
+
+        - `traceId` (string) - Associated trace ID
+
+        - `startTime` (datetime) - Observation start time
+
+        - `endTime` (datetime) - Observation end time
+
+        - `environment` (string) - Environment tag
+
+        - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
+
+        - `statusMessage` (string) - Status message
+
+        - `version` (string) - Version tag
+
+        - `userId` (string) - User ID
+
+
+        #### Trace-Related Fields
+
+        - `traceName` (string) - Name of the parent trace
+
+        - `traceTags` (arrayOptions) - Tags from the parent trace
+
+        - `sessionId` (string) - Session ID (sourced from parent trace)
+
+
+        #### Performance Metrics
+
+        - `latency` (number) - Latency in seconds (end_time − start_time)
+
+        - `timeToFirstToken` (number) - Time to first token in seconds
+
+        - `tokensPerSecond` (number) - Output tokens per second
+
+
+        #### Token Usage
+
+        - `inputTokens` (number) - Number of input tokens
+
+        - `outputTokens` (number) - Number of output tokens
+
+        - `totalTokens` (number) - Total tokens (alias: `tokens`)
+
+
+        #### Cost Metrics
+
+        - `inputCost` (number) - Input cost in USD
+
+        - `outputCost` (number) - Output cost in USD
+
+        - `totalCost` (number) - Total cost in USD
+
+
+        #### Model Information
+
+        - `model` (string) - Provided model name (alias: `providedModelName`)
+
+        - `promptName` (string) - Associated prompt name
+
+        - `promptVersion` (number) - Associated prompt version
+
+
+        #### Structured Data
+
+        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
+        key-value pairs. Requires the `key` parameter to target a specific
+        metadata key.
+
+
+        ### Filter Examples
+
+        ```json
+
+        [
+          {
+            "type": "string",
+            "column": "type",
+            "operator": "=",
+            "value": "GENERATION"
+          },
+          {
+            "type": "number",
+            "column": "latency",
+            "operator": ">=",
+            "value": 2.5
+          },
+          {
+            "type": "stringObject",
+            "column": "metadata",
+            "key": "environment",
+            "operator": "=",
+            "value": "production"
+          }
+        ]
+
+        ```
       operationId: observations_getMany
       tags:
         - Observations
@@ -3286,151 +3424,14 @@ paths:
         - name: filter
           in: query
           description: >-
-            JSON string containing an array of filter conditions. When provided,
-            this takes precedence over query parameter filters (userId, name,
-            type, level, environment, fromStartTime, ...).
+            JSON-encoded array of filter conditions. Takes precedence over
+            individual query-parameter filters
 
+            (userId, name, type, level, environment, fromStartTime, ...). See
+            **Filter Structure**,
 
-            ## Filter Structure
-
-            Each filter condition has the following structure:
-
-            ```json
-
-            [
-              {
-                "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-                "column": string,         // Required. Column to filter on (see available columns below)
-                "operator": string,       // Required. Operator based on type:
-                                          // - datetime: ">", "<", ">=", "<="
-                                          // - string: "=", "contains", "does not contain", "starts with", "ends with"
-                                          // - stringOptions: "any of", "none of"
-                                          // - categoryOptions: "any of", "none of"
-                                          // - arrayOptions: "any of", "none of", "all of"
-                                          // - number: "=", ">", "<", ">=", "<="
-                                          // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
-                                          // - numberObject: "=", ">", "<", ">=", "<="
-                                          // - boolean: "=", "<>"
-                                          // - null: "is null", "is not null"
-                "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-                "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
-              }
-            ]
-
-            ```
-
-
-            ## Available Columns
-
-
-            ### Core Observation Fields
-
-            - `id` (string) - Observation ID
-
-            - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
-
-            - `name` (string) - Observation name
-
-            - `traceId` (string) - Associated trace ID
-
-            - `startTime` (datetime) - Observation start time
-
-            - `endTime` (datetime) - Observation end time
-
-            - `environment` (string) - Environment tag
-
-            - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
-
-            - `statusMessage` (string) - Status message
-
-            - `version` (string) - Version tag
-
-            - `userId` (string) - User ID
-
-            - `sessionId` (string) - Session ID
-
-
-            ### Trace-Related Fields
-
-            - `traceName` (string) - Name of the parent trace
-
-            - `traceTags` (arrayOptions) - Tags from the parent trace
-
-            - `tags` (arrayOptions) - Alias for traceTags
-
-
-            ### Performance Metrics
-
-            - `latency` (number) - Latency in seconds (calculated: end_time -
-            start_time)
-
-            - `timeToFirstToken` (number) - Time to first token in seconds
-
-            - `tokensPerSecond` (number) - Output tokens per second
-
-
-            ### Token Usage
-
-            - `inputTokens` (number) - Number of input tokens
-
-            - `outputTokens` (number) - Number of output tokens
-
-            - `totalTokens` (number) - Total tokens (alias: `tokens`)
-
-
-            ### Cost Metrics
-
-            - `inputCost` (number) - Input cost in USD
-
-            - `outputCost` (number) - Output cost in USD
-
-            - `totalCost` (number) - Total cost in USD
-
-
-            ### Model Information
-
-            - `model` (string) - Provided model name (alias:
-            `providedModelName`)
-
-            - `promptName` (string) - Associated prompt name
-
-            - `promptVersion` (number) - Associated prompt version
-
-
-            ### Structured Data
-
-            - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
-            key-value pairs. Use `key` parameter to filter on specific metadata
-            keys.
-
-
-            ## Filter Examples
-
-            ```json
-
-            [
-              {
-                "type": "string",
-                "column": "type",
-                "operator": "=",
-                "value": "GENERATION"
-              },
-              {
-                "type": "number",
-                "column": "latency",
-                "operator": ">=",
-                "value": 2.5
-              },
-              {
-                "type": "stringObject",
-                "column": "metadata",
-                "key": "environment",
-                "operator": "=",
-                "value": "production"
-              }
-            ]
-
-            ```
+            **Available Columns**, and **Filter Examples** in the endpoint
+            description above.
           required: false
           schema:
             type: string
@@ -5785,7 +5786,172 @@ paths:
         - BasicAuth: []
   /api/public/traces:
     get:
-      description: Get list of traces
+      description: >-
+        Get list of traces.
+
+
+        ## Filters
+
+        Multiple filtering options are available via query parameters or the
+        structured `filter` parameter.
+
+        When using the `filter` parameter, it takes precedence over individual
+        query parameter filters.
+
+
+        ### Filter Structure
+
+        Each filter condition has the following structure:
+
+        ```json
+
+        [
+          {
+            "type": "string",         // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": "name",         // Required. Column to filter on (see Available Columns below)
+            "operator": "=",          // Required. Operator based on type:
+                                      // - datetime: ">", "<", ">=", "<="
+                                      // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - stringOptions: "any of", "none of"
+                                      // - categoryOptions: "any of", "none of"
+                                      // - arrayOptions: "any of", "none of", "all of"
+                                      // - number: "=", ">", "<", ">=", "<="
+                                      // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - numberObject: "=", ">", "<", ">=", "<="
+                                      // - boolean: "=", "<>"
+                                      // - null: "is null", "is not null"
+            "value": "production",    // Required (except for null type). Type depends on filter type.
+            "key": "env"              // Required only for stringObject, numberObject, and categoryOptions when filtering nested fields like metadata.
+          }
+        ]
+
+        ```
+
+
+        ### Available Columns
+
+
+        #### Core Trace Fields
+
+        - `id` (string) - Trace ID
+
+        - `name` (string) - Trace name
+
+        - `timestamp` (datetime) - Trace timestamp
+
+        - `userId` (string) - User ID
+
+        - `sessionId` (string) - Session ID
+
+        - `environment` (string) - Environment tag
+
+        - `version` (string) - Version tag
+
+        - `release` (string) - Release tag
+
+        - `tags` (arrayOptions) - Array of tags
+
+        - `bookmarked` (boolean) - Bookmark status
+
+
+        #### Structured Data
+
+        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
+        key-value pairs. Requires the `key` parameter to target a specific
+        metadata key.
+
+
+        #### Aggregated Metrics (from observations)
+
+        These metrics are aggregated from all observations within the trace:
+
+        - `latency` (number) - Latency in seconds (time from first observation
+        start to last observation end)
+
+        - `inputTokens` (number) - Total input tokens across all observations
+
+        - `outputTokens` (number) - Total output tokens across all observations
+
+        - `totalTokens` (number) - Total tokens (alias: `tokens`)
+
+        - `inputCost` (number) - Total input cost in USD
+
+        - `outputCost` (number) - Total output cost in USD
+
+        - `totalCost` (number) - Total cost in USD
+
+
+        #### Observation Level Aggregations
+
+        These fields aggregate observation levels within the trace:
+
+        - `level` (string) - Highest severity level (ERROR > WARNING > DEFAULT >
+        DEBUG)
+
+        - `warningCount` (number) - Count of WARNING level observations
+
+        - `errorCount` (number) - Count of ERROR level observations
+
+        - `defaultCount` (number) - Count of DEFAULT level observations
+
+        - `debugCount` (number) - Count of DEBUG level observations
+
+
+        #### Scores (requires join with scores table)
+
+        - `scores_avg` (number) - Average of numeric scores (alias: `scores`)
+
+        - `score_categories` (categoryOptions) - Categorical score values
+
+
+        ### Filter Examples
+
+        ```json
+
+        [
+          {
+            "type": "datetime",
+            "column": "timestamp",
+            "operator": ">=",
+            "value": "2024-01-01T00:00:00Z"
+          },
+          {
+            "type": "string",
+            "column": "userId",
+            "operator": "=",
+            "value": "user-123"
+          },
+          {
+            "type": "number",
+            "column": "totalCost",
+            "operator": ">=",
+            "value": 0.01
+          },
+          {
+            "type": "arrayOptions",
+            "column": "tags",
+            "operator": "all of",
+            "value": ["production", "critical"]
+          },
+          {
+            "type": "stringObject",
+            "column": "metadata",
+            "key": "customer_tier",
+            "operator": "=",
+            "value": "enterprise"
+          }
+        ]
+
+        ```
+
+
+        ### Performance Notes
+
+        - Filtering on `userId`, `sessionId`, or `metadata` may enable skip
+        indexes for better query performance.
+
+        - Score filters require a join with the scores table and may impact
+        query performance.
       operationId: trace_list
       tags:
         - Trace
@@ -5904,168 +6070,14 @@ paths:
         - name: filter
           in: query
           description: >-
-            JSON string containing an array of filter conditions. When provided,
-            this takes precedence over query parameter filters (userId, name,
-            sessionId, tags, version, release, environment, fromTimestamp,
-            toTimestamp).
+            JSON-encoded array of filter conditions. Takes precedence over
+            individual query-parameter filters
 
+            (userId, name, sessionId, tags, version, release, environment,
+            fromTimestamp, toTimestamp). See
 
-            ## Filter Structure
-
-            Each filter condition has the following structure:
-
-            ```json
-
-            [
-              {
-                "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-                "column": string,         // Required. Column to filter on (see available columns below)
-                "operator": string,       // Required. Operator based on type:
-                                          // - datetime: ">", "<", ">=", "<="
-                                          // - string: "=", "contains", "does not contain", "starts with", "ends with"
-                                          // - stringOptions: "any of", "none of"
-                                          // - categoryOptions: "any of", "none of"
-                                          // - arrayOptions: "any of", "none of", "all of"
-                                          // - number: "=", ">", "<", ">=", "<="
-                                          // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
-                                          // - numberObject: "=", ">", "<", ">=", "<="
-                                          // - boolean: "=", "<>"
-                                          // - null: "is null", "is not null"
-                "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-                "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
-              }
-            ]
-
-            ```
-
-
-            ## Available Columns
-
-
-            ### Core Trace Fields
-
-            - `id` (string) - Trace ID
-
-            - `name` (string) - Trace name
-
-            - `timestamp` (datetime) - Trace timestamp
-
-            - `userId` (string) - User ID
-
-            - `sessionId` (string) - Session ID
-
-            - `environment` (string) - Environment tag
-
-            - `version` (string) - Version tag
-
-            - `release` (string) - Release tag
-
-            - `tags` (arrayOptions) - Array of tags
-
-            - `bookmarked` (boolean) - Bookmark status
-
-
-            ### Structured Data
-
-            - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
-            key-value pairs. Use `key` parameter to filter on specific metadata
-            keys.
-
-
-            ### Aggregated Metrics (from observations)
-
-            These metrics are aggregated from all observations within the trace:
-
-            - `latency` (number) - Latency in seconds (time from first
-            observation start to last observation end)
-
-            - `inputTokens` (number) - Total input tokens across all
-            observations
-
-            - `outputTokens` (number) - Total output tokens across all
-            observations
-
-            - `totalTokens` (number) - Total tokens (alias: `tokens`)
-
-            - `inputCost` (number) - Total input cost in USD
-
-            - `outputCost` (number) - Total output cost in USD
-
-            - `totalCost` (number) - Total cost in USD
-
-
-            ### Observation Level Aggregations
-
-            These fields aggregate observation levels within the trace:
-
-            - `level` (string) - Highest severity level (ERROR > WARNING >
-            DEFAULT > DEBUG)
-
-            - `warningCount` (number) - Count of WARNING level observations
-
-            - `errorCount` (number) - Count of ERROR level observations
-
-            - `defaultCount` (number) - Count of DEFAULT level observations
-
-            - `debugCount` (number) - Count of DEBUG level observations
-
-
-            ### Scores (requires join with scores table)
-
-            - `scores_avg` (number) - Average of numeric scores (alias:
-            `scores`)
-
-            - `score_categories` (categoryOptions) - Categorical score values
-
-
-            ## Filter Examples
-
-            ```json
-
-            [
-              {
-                "type": "datetime",
-                "column": "timestamp",
-                "operator": ">=",
-                "value": "2024-01-01T00:00:00Z"
-              },
-              {
-                "type": "string",
-                "column": "userId",
-                "operator": "=",
-                "value": "user-123"
-              },
-              {
-                "type": "number",
-                "column": "totalCost",
-                "operator": ">=",
-                "value": 0.01
-              },
-              {
-                "type": "arrayOptions",
-                "column": "tags",
-                "operator": "all of",
-                "value": ["production", "critical"]
-              },
-              {
-                "type": "stringObject",
-                "column": "metadata",
-                "key": "customer_tier",
-                "operator": "=",
-                "value": "enterprise"
-              }
-            ]
-
-            ```
-
-
-            ## Performance Notes
-
-            - Filtering on `userId`, `sessionId`, or `metadata` may enable skip
-            indexes for better query performance
-
-            - Score filters require a join with the scores table and may impact
-            query performance
+            **Filter Structure**, **Available Columns**, and **Filter Examples**
+            in the endpoint description above.
           required: false
           schema:
             type: string


### PR DESCRIPTION
## Summary

- **Fix `tags` column (invalid alias)**: the v2 observations endpoint uses `observationsTableUiColumnDefinitions` where only `traceTags` is a valid `uiTableId`; sending `"column":"tags"` would throw `InvalidRequestError`. The `tags` row is removed.
- **Fix `sessionId` classification**: it was listed under "Core Observation Fields" but routes to the traces table (via `observationsTableTraceUiColumnDefinitions`); moved to "Trace-Related Fields".
- **Lift filter docs to endpoint level** in both `observations.yml` and `trace.yml`: moved Filter Structure, Available Columns, and Filter Examples from the `filter` parameter's inline `docs` block up into the endpoint-level `## Filters` section. The parameter's docs now contain a single pointer sentence. This makes it unambiguous that the filter reference belongs to the endpoint, not the `filter` parameter alone.
- **Regenerate OpenAPI spec** via `fern generate --group local --api server`.

### Why
`##` headers inside a parameter `docs` block render at the same visual level as endpoint-level sections, making it unclear which content belongs to the `filter` parameter vs. the endpoint as a whole. See LFE-9794.

### Impacted packages
- `fern/apis/server/definition/` — source YAML (`observations.yml`, `trace.yml`)
- `web/public/generated/api/openapi.yml` — regenerated output

Closes [LFE-9794](https://linear.app/langfuse/issue/LFE-9794)

## Test plan
- [x] `fern generate --group local --api server` completes without errors
- [ ] Verify rendered docs at `/api-reference/observations/get-observations` show Filter Structure under the endpoint description, not under the `filter` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects API reference documentation for the observations and traces filter endpoints by moving filter documentation to the endpoint-level description and fixing two column categorization errors.

- **`sessionId` for observations** was previously listed under "Core Observation Fields" but is now correctly placed under "Trace-Related Fields" since it is sourced from the parent `traces` table (not the observation row itself), matching the backend's `observationsTableTraceUiColumnDefinitions`.
- **`tags` alias for observations** was removed from the documentation; the backend only accepts `traceTags` as a valid filter column name in the public API (the `tags`→`traceTags` remapping exists only in the frontend UI layer and is not exposed via the public API).
- Filter documentation is consolidated at the endpoint level to reduce duplication, with the query parameter `filter` field referencing it.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change correcting two inaccuracies in filter column listings; no functional code is touched.

All three changed files are documentation: two Fern definition YAMLs and one auto-generated OpenAPI YAML that mirrors them. The sessionId reclassification and tags alias removal were verified against the backend column definitions in mapObservationsTable.ts — both corrections accurately reflect how the API actually behaves.

No files require special attention; web/public/generated/api/openapi.yml is auto-generated and should not be edited directly.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(generated): regenerate OpenAPI spe..."](https://github.com/langfuse/langfuse/commit/3e4a2aaf48a112c8a5286f5f25442cc818196e3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32300672)</sub>

<!-- /greptile_comment -->