### PR TITLE
fix(pricing): add gemini-3.1-flash-lite pricing

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -4139,6 +4139,40 @@
     ]
   },
   {
+    "id": "167aed7d-1070-416b-bd24-611aa02adeee",
+    "modelName": "gemini-3.1-flash-lite",
+    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-flash-lite)$",
+    "createdAt": "2026-05-15T00:00:00.000Z",
+    "updatedAt": "2026-05-15T00:00:00.000Z",
+    "pricingTiers": [
+      {
+        "id": "167aed7d-1070-416b-bd24-611aa02adeee_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 0.25e-6,
+          "input_modality_1": 0.25e-6,
+          "input_text": 0.25e-6,
+          "prompt_token_count": 0.25e-6,
+          "promptTokenCount": 0.25e-6,
+          "input_cached_tokens": 0.025e-6,
+          "cached_content_token_count": 0.025e-6,
+          "output": 1.5e-6,
+          "output_text": 1.5e-6,
+          "output_modality_1": 1.5e-6,
+          "candidates_token_count": 1.5e-6,
+          "candidatesTokenCount": 1.5e-6,
+          "thoughtsTokenCount": 1.5e-6,
+          "thoughts_token_count": 1.5e-6,
+          "output_reasoning": 1.5e-6,
+          "input_audio_tokens": 0.5e-6
+        }
+      }
+    ]
+  },
+  {
     "id": "029e6695-ff24-47f0-b37b-7285fb2e5785",
     "modelName": "gemini-live-2.5-flash-native-audio",
     "matchPattern": "(?i)^(google\/)?(gemini-live-2.5-flash-native-audio)$",


### PR DESCRIPTION
## Summary

* add pricing for stable `gemini-3.1-flash-lite` in the worker pricing table
* expose `gemini-3.1-flash-lite` in Vertex AI and Google AI Studio shared model lists
* use the corrected output pricing of $1.5 per million tokens

## Verification

* node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs
* node .agents/skills/add-model-price/scripts/test-match-pattern.mjs --model gemini-3.1-flash-lite --accept gemini-3.1-flash-lite google/gemini-3.1-flash-lite googleai/gemini-3.1-flash-lite --reject gemini-3.1-flash-lite-preview gemini-3.1-flash gemini-3-flash-preview
* git commit hook: format:check
* git commit hook: turbo run lint

## Packages

* worker
* packages/shared

Fixes langfuse/langfuse#13650

<details><summary>Greptile Summary</summary>

This PR adds pricing support for the stable `gemini-3.1-flash-lite` model, mirroring the existing `gemini-3.1-flash-lite-preview` entry, and exposes the stable model name in both the Vertex AI and Google AI Studio shared model lists.

* `default-model-prices.json`: Adds a new pricing entry with a unique UUID, matching `gemini-3.1-flash-lite` (bare, `google/`, or `googleai/` prefixed) with input at $0.25/M tokens and output at $1.5/M tokens — identical to the preview tier.
* `types.ts`: Inserts `"gemini-3.1-flash-lite"` into both `vertexAIModels` and `googleAIStudioModels` arrays, sitting alongside its preview counterpart.

</details>

<details><summary>Confidence Score: 5/5</summary>

Safe to merge — additive-only change adding a new model and its pricing entry with no modifications to existing logic.

The change adds a single new pricing entry and two list entries. The regex anchors correctly with $ so it cannot accidentally match the preview variant. Pricing values are identical to the existing preview entry, the UUID is unique in the file, and the model is consistently added to both the Vertex AI and Google AI Studio model lists.

No files require special attention.

</details>

<details><summary>Flowchart</summary>

%%{init: {'theme': 'neutral'}}%% flowchart TD A\[Incoming model string\] --> B{Match against pricing patterns} B -->|gemini-3.1-flash-lite stable pattern| C\[gemini-3.1-flash-lite pricing tier\] B -->|preview pattern| D\[gemini-3.1-flash-lite-preview pricing\] B -->|other patterns| E\[Other model pricing\] C --> F\[input 0.25 per M tokens\] D --> G\[Same price schedule as stable\]

</details>

Reviews (1): Last reviewed commit: ["fix(pricing): add gemini-3.1-flash-lite ..."](<https://github.com/langfuse/langfuse/commit/f86e35e253c57cf643f18a0e410aabfffad6c66d>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=32306551>)