### PR TITLE
fix(events): tolerate non-JSON model_parameters in read path

### DIFF
--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_RENDERING_PROPS,
   applyInputOutputRendering,
 } from "../utils/rendering";
+import { parseJsonPrioritised } from "../../utils/json";
 import { logger } from "../logger";
 import { prisma } from "../../db";
 import type { Model, Price } from "@prisma/client";
@@ -244,9 +245,12 @@ export function convertObservationPartial(
       internalModelId: record.internal_model_id ?? null,
     }),
     ...(record.model_parameters !== undefined && {
+      // ClickHouse stores model_parameters as a free-form string; SDKs can
+      // write non-JSON sentinels here, so fall back to the raw value instead
+      // of throwing for the whole row.
       modelParameters: record.model_parameters
         ? ((typeof record.model_parameters === "string"
-            ? JSON.parse(record.model_parameters)
+            ? parseJsonPrioritised(record.model_parameters)
             : record.model_parameters) ?? null)
         : null,
     }),

--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -359,6 +359,47 @@ describe("Clickhouse Events Repository Test", () => {
       expect(resultWithIO[0]?.input).toBeDefined();
       expect(resultWithoutIO[0]?.output).toBeDefined();
     });
+
+    it("should not throw when model_parameters is not valid JSON", async () => {
+      const traceId = randomUUID();
+      const generationId = randomUUID();
+
+      const event = createEvent({
+        id: generationId,
+        span_id: generationId,
+        project_id: projectId,
+        trace_id: traceId,
+        type: "GENERATION",
+        name: "poisoned-model-parameters",
+        provided_model_name: "gpt-5-mini",
+        model_parameters: "<not serializable object of type: dict>",
+      });
+
+      await createEventsCh([event]);
+
+      const result = await getObservationsWithModelDataFromEventsTable({
+        projectId,
+        filter: [idFilter(generationId)],
+        limit: 1000,
+        offset: 0,
+        selectIOAndMetadata: true,
+      });
+
+      const observation = result.find((o) => o.id === generationId);
+      expect(observation).toBeDefined();
+      expect(observation?.modelParameters).toBe(
+        "<not serializable object of type: dict>",
+      );
+
+      const byId = await getObservationByIdFromEventsTable({
+        id: generationId,
+        projectId,
+        fetchWithInputOutput: true,
+      });
+      expect(byId?.modelParameters).toBe(
+        "<not serializable object of type: dict>",
+      );
+    });
   });
 
   maybe("getObservationsCountFromEventsTable", () => {


### PR DESCRIPTION
## Summary

Closes [LFE-9798](https://linear.app/langfuse/issue/LFE-9798/bug-eventsall-500-when-model-parameters-contains-not-serializable).

The `events.all` tRPC endpoint returned a 500 for any project whose `observations` table contained even a single row whose `model_parameters` field was not valid JSON. The Python SDK v4 writes the sentinel string `<not serializable object of type: dict>` when it encounters un-serializable values, which trips the bare `JSON.parse` in `convertObservationPartial` and propagates as an uncaught error all the way to the API response.

This PR addresses **work item 1 (read path mitigation)** from the issue:

- Route `model_parameters` through `parseJsonPrioritised` instead of `JSON.parse` in `convertObservationPartial`. On parse failure the helper returns the raw string, which is type-compatible with `Json` and matches how the existing metadata/IO rendering paths handle malformed payloads.
- Single-site change covers both `convertObservation` and `convertEventsObservation`, which share `convertObservationPartial`.
- Add a regression test in `event-repository.servertest.ts` that inserts an event with the exact Python-SDK sentinel and asserts both `getObservationsWithModelDataFromEventsTable` and `getObservationByIdFromEventsTable` return the raw string instead of throwing.

Out of scope (deferred — see issue):
- Work item 2: ingest-path normalization in `worker/src/services/event-processing/` (Python SDK fix is the primary mitigation there).
- Work item 3: ClickHouse backfill / cleanup of already-poisoned rows.

## Impacted packages

- `@langfuse/shared` — `packages/shared/src/server/repositories/observations_converters.ts`
- `web` — `web/src/__tests__/server/repositories/event-repository.servertest.ts`

## Test plan

- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter @langfuse/shared run typecheck`
- [x] `pnpm --filter @langfuse/shared run build`
- [x] Web typecheck reviewed: no new errors introduced by this change (pre-existing failures only)
- [ ] CI: targeted server tests including the new `should not throw when model_parameters is not valid JSON` regression test (gated on `LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a 500 error on the `events.all` tRPC endpoint caused by the Python SDK v4 writing non-JSON sentinel strings (e.g. `<not serializable object of type: dict>`) into the `model_parameters` field, which the bare `JSON.parse` in `convertObservationPartial` could not tolerate. The fix routes `model_parameters` through `parseJsonPrioritised`, which falls back to the raw string on parse failure instead of throwing.

- Replaces `JSON.parse` with `parseJsonPrioritised` for the `model_parameters` field in `convertObservationPartial`, covering both `convertObservation` and `convertEventsObservation` via the shared helper.
- Adds a regression test that inserts an event with the exact Python-SDK sentinel and asserts both `getObservationsWithModelDataFromEventsTable` and `getObservationByIdFromEventsTable` return the raw string without throwing.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-site, targeted swap from `JSON.parse` to the already-in-use `parseJsonPrioritised` helper, which itself swallows parse errors and returns the raw string rather than throwing.

The fix is minimal and well-scoped: one function call replaced, no new dependencies introduced, and `parseJsonPrioritised` already exists and is tested elsewhere. A regression test covers the exact failure scenario (Python-SDK sentinel) against both read-path queries. The import is placed correctly at the module top-level. No downstream type breakage — `parseJsonPrioritised` returns `JsonNested | string | undefined`, and the existing `?? null` guard handles the `undefined` case. The happy path (valid JSON) is identical to before.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[convertObservationPartial] --> B{model_parameters\ndefined?}
    B -- No --> C[skip field]
    B -- Yes --> D{model_parameters\ntruthy?}
    D -- No --> E[modelParameters = null]
    D -- Yes --> F{typeof === 'string'?}
    F -- No --> G[use object as-is]
    F -- Yes --> H[parseJsonPrioritised]
    H --> I{UNSAFE_NUMBER\n_PATTERN match?}
    I -- No --> J[JSON.parse]
    I -- Yes --> K[lossless-json parse]
    J -- success --> L[parsed JSON value]
    J -- throws --> M[return raw string]
    K -- success --> L
    K -- throws --> M
    G --> N["?? null"]
    L --> N
    M --> N
    N --> O[modelParameters = final value]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(events): tolerate non-JSON model\_par..."](https://github.com/langfuse/langfuse/commit/29a2f8fc4c70fec554aafadd506d229dd1d630ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32312327)</sub>

<!-- /greptile_comment -->