### PR TITLE
docs(agents): Add Storybook skill

### DIFF
--- a/.agents/skills/storybook/SKILL.md
+++ b/.agents/skills/storybook/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: storybook
+description: Use when writing or reviewing Storybook stories (`.stories.tsx`) for React components.
+---
+
+# Storybook Component Stories
+
+## Which Components Can Have Stories?
+
+Only create stories for components that **do not** do any of the following:
+
+- Depend on context.
+- Fetch data via any private API, including Langfuse’s own tRPC API.
+
+Stories should follow the `ComponentName.stories.tsx` filename pattern. Components covered by stories should have exactly one exported or public component.
+
+If this is not the case, suggest splitting up the file that includes the component to be covered first.
+
+Be mindful of the breadth a story covers. A story should show a component in isolation. Page-level compositions should be rare and intentional.
+
+## What to Do If a Component Violates the Criteria
+
+Suggest abstracting a presentational component that does not violate the criteria and receives relevant data via props.
+
+Make sure the props are well-defined using TypeScript.
+
+Keep the existing component, but update it to use the newly created component for rendering. These presentational components are easier to test and easier to reuse.
+
+## How Stories Should Be Written
+
+- Use "CSF Next" format by default.
+- Cover only the relevant component by default.
+- Avoid custom render functions by default.
+- Use `satisfies` and typed Storybook metadata so invalid args, decorators, and play functions are type-checked.
+- Use play functions to test user-relevant interactions after render, not to compensate for complex setup or hidden dependencies.
+- Name stories after the state they represent, not the implementation. Also do not include the component name in the story name.
+  - Prefer: `Default`, `Empty`, `WithLongName`, `Error`, `Disabled`, `Loading`
+  - Avoid: `Test1`, `CustomRenderExample`, `ButtonWithLongNameAndIcon`
+- Set callbacks up as Storybook Actions by default:
+
+  ```ts
+  import { fn } from "storybook/test";
+  ```
+
+- Avoid large fixtures.
+- Use the smallest meaningful data shape needed to render the state.
+- If fixtures are required and may be shared, check whether a reusable helper function exists. Otherwise, create one for defining the fixture.
+
+## Variant and Design Showcase Stories
+
+If a component has many variants, and the point of the story is to showcase the design of a component rather than its functionality, stories may render the component multiple times.
+
+For example, a `Button` with a `size: "sm" | "md" | "lg"` prop may have a story that shows three buttons side by side.
+
+If the button also has a `variant: "primary" | "secondary"` prop, consider using a matrix-like UI that showcases all possible combinations.
+
+These compositional stories **should not** contain Storybook play functions. They should also not allow the Storybook user to customize the predefined args, such as `size` and `variant`, via Storybook args. Having an arg for non-bound props, such as `text`, may be acceptable.
+
+## Additional Information
+
+- We do not use MSW and are not planning to add it.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces the first Storybook skill document at `.agents/skills/storybook/SKILL.md`, providing agent-readable guidance for writing component stories in this repo — covering eligibility criteria, CSF Next format conventions, naming, fixture sizing, and design-showcase patterns.

- The skill content is well-structured and technically accurate (correct `storybook/test` import path, appropriate MSW note, clear presentational-component abstraction pattern).
- Per the repo's own agent contract (`.agents/AGENTS.md`, `.agents/README.md`), adding a skill requires updating `.agents/AGENTS.md`'s "Start Here By Task" router and `.agents/skills/README.md`, then running `pnpm run agents:sync` + `pnpm run agents:check`. None of these follow-on steps were included in the PR.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge only after adding the AGENTS.md router entry and skills README update; without them the skill document is effectively unreachable by agents following the standard task-routing flow.

The skill content itself is accurate and well-written, but the AGENTS.md "Start Here By Task" section has no entry pointing to this skill, so agents handling Storybook requests will not load it. The repo explicitly requires this wiring step, plus a skills README update and an agents:sync run, none of which are present in the diff.

.agents/AGENTS.md needs a routing entry for the new storybook skill; .agents/skills/README.md also needs to be created or updated per the repo contract.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent asked to write\nStorybook stories] --> B{Consult AGENTS.md\nStart Here By Task}
    B -->|Entry exists| C[Load .agents/skills/storybook/SKILL.md]
    B -->|No entry — current state| D[Skill not discovered]
    C --> E{Does component violate\ncriteria?}
    E -->|No context / no private API| F[Write ComponentName.stories.tsx\nusing CSF Next format]
    E -->|Has context or tRPC dependency| G[Abstract presentational component\nreceiving data via typed props]
    G --> F
    F --> H{Many variants?}
    H -->|Yes – showcase story| I[Render all combos,\nno play functions]
    H -->|No| J[Add play functions\nfor user interactions]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.agents/skills/storybook/SKILL.md:1-6
**Skill not discoverable via AGENTS.md router**

The `.agents/AGENTS.md` "Start Here By Task" section lists every other skill with a routing entry (e.g., `frontend-browser-review`, `code-review`) so agents know when to reach for them. This skill has no corresponding entry, so an agent asked to "write Storybook stories for component X" will not be directed here. Per the repo contract in `.agents/AGENTS.md`: "keep skills concise with progressive disclosure, **update `.agents/skills/README.md`**, and run the shared agent verification below." Neither AGENTS.md nor the skills README was touched in this PR.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): Add Storybook skill"](https://github.com/langfuse/langfuse/commit/b09dcd3ff63819bed153a608ef78f2c224c241cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35164258)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->