### PR TITLE
fix(sso): strip openid scope on custom save when idToken is false

### DIFF
--- a/web/src/__tests__/server/ssoConfigRouter.servertest.ts
+++ b/web/src/__tests__/server/ssoConfigRouter.servertest.ts
@@ -430,6 +430,84 @@ describe("ssoConfigRouter.save", () => {
     );
   });
 
+  it("normalizes the stored scope when custom idToken is false", async () => {
+    // The self-service form doesn't surface `scope`, so a fresh custom config
+    // with idToken: false would otherwise inherit the runtime default
+    // `openid email profile` and fail at sign-in with
+    // "id_token detected in the response..." Persist a stripped scope.
+    const { org, caller } = await prepare();
+    const domain = `scope-strip-${uuidv4().slice(0, 8)}.com`;
+    await addVerifiedDomain(org.id, domain);
+
+    await caller.ssoConfig.save({
+      orgId: org.id,
+      payload: sampleCustomPayload(domain, false),
+    });
+
+    const stored = await prisma.ssoConfig.findUniqueOrThrow({
+      where: { domain },
+    });
+    expect((stored.authConfig as Record<string, unknown>).scope).toBe(
+      "email profile",
+    );
+  });
+
+  it("keeps the OIDC scope when custom idToken is true", async () => {
+    const { org, caller } = await prepare();
+    const domain = `scope-keep-${uuidv4().slice(0, 8)}.com`;
+    await addVerifiedDomain(org.id, domain);
+
+    await caller.ssoConfig.save({
+      orgId: org.id,
+      payload: sampleCustomPayload(domain, true),
+    });
+
+    const stored = await prisma.ssoConfig.findUniqueOrThrow({
+      where: { domain },
+    });
+    // No `scope` should be set; NextAuth falls back to the OIDC default at runtime.
+    expect(
+      (stored.authConfig as Record<string, unknown>).scope,
+    ).toBeUndefined();
+  });
+
+  it("strips openid from a preserved legacy scope when idToken is flipped to false", async () => {
+    // Mirrors the production trigger: a config first written via the legacy
+    // admin endpoint with `scope: "openid email profile"`, then re-saved
+    // through the self-service UI with idToken toggled off. The merge keeps
+    // the legacy scope, so the normalizer has to strip `openid` from it.
+    const { org, caller } = await prepare();
+    const domain = `legacy-merge-${uuidv4().slice(0, 8)}.com`;
+    await addVerifiedDomain(org.id, domain);
+
+    await prisma.ssoConfig.create({
+      data: {
+        domain,
+        authProvider: "custom",
+        authConfig: {
+          name: "Legacy Custom",
+          clientId: "legacy-client",
+          clientSecret: encrypt("legacy-secret"),
+          issuer: "https://example.okta.com",
+          scope: "openid email profile",
+          idToken: true,
+        },
+      },
+    });
+
+    await caller.ssoConfig.save({
+      orgId: org.id,
+      payload: sampleCustomPayload(domain, false),
+    });
+
+    const stored = await prisma.ssoConfig.findUniqueOrThrow({
+      where: { domain },
+    });
+    const cfg = stored.authConfig as Record<string, unknown>;
+    expect(cfg.idToken).toBe(false);
+    expect(cfg.scope).toBe("email profile");
+  });
+
   it("resets authConfig fields when the provider changes", async () => {
     // Switching providers is an explicit reset — Custom-only fields like
     // `name`/`scope` aren't valid in another provider's schema and shouldn't

--- a/web/src/ee/features/multi-tenant-sso/server/ssoConfigRouter.ts
+++ b/web/src/ee/features/multi-tenant-sso/server/ssoConfigRouter.ts
@@ -33,6 +33,23 @@ const maskAuthConfig = (
   return rest;
 };
 
+// Drop the OIDC `openid` token from a scope string and fall back to a baseline
+// OAuth2 scope when stripping would otherwise leave the IdP with no claims to
+// release. See the call site in `save` for the full rationale.
+const withOauth2Scope = (
+  authConfig: Record<string, unknown>,
+): Record<string, unknown> => {
+  const requestedScope =
+    typeof authConfig.scope === "string"
+      ? authConfig.scope
+      : "openid email profile";
+  const stripped = requestedScope
+    .split(/\s+/)
+    .filter((token) => token.length > 0 && token !== "openid")
+    .join(" ");
+  return { ...authConfig, scope: stripped || "email profile" };
+};
+
 export const ssoConfigRouter = createTRPCRouter({
   get: protectedOrganizationProcedure
     .input(z.object({ orgId: z.string() }))
@@ -135,11 +152,29 @@ export const ssoConfigRouter = createTRPCRouter({
             }
           : authConfig;
 
-      const encryptedAuthConfig = mergedAuthConfig
+      // NextAuth picks between client.callback() (OIDC) and
+      // client.oauthCallback() (OAuth2-only) based on the provider's
+      // `idToken` flag. openid-client's oauthCallback throws
+      //   "id_token detected in the response, you must use client.callback()
+      //    instead of client.oauthCallback()"
+      // mid-flow if the IdP returns an id_token — which any OIDC server does
+      // whenever `openid` is in scope. The self-service form only exposes
+      // `idToken` (not `scope`), so admins toggling `idToken: false` would
+      // otherwise pair it with our default `openid email profile` scope and
+      // hit this contradiction. Normalize the stored scope here so the
+      // runtime callback flow matches the IdP response shape.
+      const normalizedAuthConfig =
+        authProvider === "custom" &&
+        mergedAuthConfig &&
+        (mergedAuthConfig as { idToken?: unknown }).idToken === false
+          ? withOauth2Scope(mergedAuthConfig as Record<string, unknown>)
+          : mergedAuthConfig;
+
+      const encryptedAuthConfig = normalizedAuthConfig
         ? {
-            ...mergedAuthConfig,
+            ...normalizedAuthConfig,
             clientSecret: encrypt(
-              (mergedAuthConfig as { clientSecret: string }).clientSecret,
+              (normalizedAuthConfig as { clientSecret: string }).clientSecret,
             ),
           }
         : null;


### PR DESCRIPTION
## Summary

Custom-OIDC SSO configs saved through the self-service UI with `idToken: false` (the new toggle from #13647, intended for IdPs that release email only via userinfo) were failing mid-flow with:

> `[next-auth][error][OAUTH_CALLBACK_ERROR] id_token detected in the response, you must use client.callback() instead of client.oauthCallback()`

### Why

NextAuth picks the callback by `provider.idToken`:

- `true` → `client.callback()` (OIDC; accepts id_token)
- `false` → `client.oauthCallback()` (OAuth2-only; openid-client refuses any response carrying an id_token)

The form exposes `idToken` but **not** `scope` (scope was deliberately removed in #13647). So a fresh custom config with `idToken: false` inherits the runtime default scope `openid email profile` — and any OIDC IdP returns an id_token whenever `openid` is in scope, so openid-client throws.

### Fix

Normalize the stored scope at write time in `ssoConfigRouter.save`: when the saved provider is `custom` and `authConfig.idToken === false`, strip the `openid` token from the scope (falling back to `email profile` if stripping leaves it empty). The normalization runs after the merge with the existing stored config, so it also catches the case where a legacy `scope: "openid email profile"` field is preserved and the admin later toggles `idToken` off.

This keeps the fix on the UI-driven write path the user pointed to and avoids touching the runtime `CustomSSOProvider`, which is shared with single-tenant env-based config.

## Observed in production

Datadog `prod-us`, 2026-05-15, providerId `applause.com.custom` — 3 occurrences in a 15-minute window. Caller flow: `NextAuthApiHandler` → `AuthHandler` → `Object.callback` → `oAuthCallback` (`next-auth/core/lib/oauth/callback.js:29`).

## Impacted packages

- `web` (router + tests)

## Test plan

- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter @langfuse/shared run lint`
- [ ] `pnpm --filter web run test src/__tests__/server/ssoConfigRouter.servertest.ts` — three new cases added (skipped locally; needs a `db:reset:test` consent step on the dev machine that wasn't granted here):
  - `normalizes the stored scope when custom idToken is false`
  - `keeps the OIDC scope when custom idToken is true`
  - `strips openid from a preserved legacy scope when idToken is flipped to false`
- [ ] Manual: confirm `applause.com` sign-in succeeds after a DB fix (drop `openid` from their stored scope) and after this PR ships so the same misconfiguration can't recur via the UI.

## Notes for affected customers

Customers already stuck on this can be unblocked immediately by setting `authConfig.scope = "email profile"` on their `sso_configs` row (or removing `openid` from the existing scope value). After this PR, re-saving the config through the UI with `idToken: false` would have produced the same value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)