### PR TITLE
fix(observations-v2): omit trace_context keys from partial response when not in ClickHouse row

### DIFF
--- a/packages/shared/src/server/repositories/observations_converters.ts
+++ b/packages/shared/src/server/repositories/observations_converters.ts
@@ -401,24 +401,38 @@ export function convertEventsObservation(
   renderingProps: RenderingProps = DEFAULT_RENDERING_PROPS,
   complete: boolean,
 ): EventsObservation | PartialEventsObservation {
-  // Branch based on complete flag to use correct overload
-  const baseObservation = complete
-    ? convertObservationPartial(
-        record as ObservationRecordReadType,
-        renderingProps,
-        true,
-      )
-    : convertObservationPartial(record, renderingProps, false);
+  if (complete) {
+    const baseObservation = convertObservationPartial(
+      record as ObservationRecordReadType,
+      renderingProps,
+      true,
+    );
+    return {
+      ...baseObservation,
+      userId: record.user_id ?? null,
+      sessionId: record.session_id ?? null,
+      traceName: record.trace_name ?? null,
+      release: record.release ?? null,
+      tags: record.tags ?? null,
+      bookmarked: record.bookmarked!,
+      public: record.public!,
+    };
+  }
 
+  const baseObservation = convertObservationPartial(
+    record,
+    renderingProps,
+    false,
+  );
   return {
     ...baseObservation,
-    userId: record.user_id ?? null,
-    sessionId: record.session_id ?? null,
-    traceName: record.trace_name ?? null,
-    release: record.release ?? null,
-    tags: record.tags ?? null,
-    bookmarked: record.bookmarked,
-    public: record.public,
+    ...(record.user_id !== undefined && { userId: record.user_id }),
+    ...(record.session_id !== undefined && { sessionId: record.session_id }),
+    ...(record.trace_name !== undefined && { traceName: record.trace_name }),
+    ...(record.release !== undefined && { release: record.release }),
+    ...(record.tags !== undefined && { tags: record.tags }),
+    ...(record.bookmarked !== undefined && { bookmarked: record.bookmarked }),
+    ...(record.public !== undefined && { public: record.public }),
   };
 }
 

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -681,15 +681,14 @@ describe("/api/public/v2/observations API Endpoint", () => {
           }
         }
 
-        // Fields from other groups absent (null or undefined — API may serialize
-        // absent fields as null rather than omitting them from the JSON)
+        // Fields from other groups must be absent from the response
         const absentFields = ALL_NON_CORE_FIELDS.filter(
           (f) => !(expectedFields as readonly string[]).includes(f),
         );
         for (const field of absentFields) {
           expect(
-            obs[field] ?? undefined,
-            `expected field "${field}" to be null/undefined when only group "${group}" is requested`,
+            obs[field],
+            `expected field "${field}" to be absent when only group "${group}" is requested`,
           ).toBeUndefined();
         }
       });

--- a/web/src/__tests__/server/unit/observations-converters.servertest.ts
+++ b/web/src/__tests__/server/unit/observations-converters.servertest.ts
@@ -1,0 +1,154 @@
+// Mock env before any @langfuse/shared module is loaded to prevent parse failures
+// in environments without a .env file.
+vi.mock("@langfuse/shared/src/env", () => ({
+  env: new Proxy({} as Record<string, unknown>, { get: () => undefined }),
+  removeEmptyEnvVariables: (e: Record<string, string | undefined>) => e,
+}));
+
+// Prisma client creation is a module-level side effect; stub it out.
+vi.mock("@langfuse/shared/src/db", () => ({ prisma: {} }));
+
+import {
+  type EventsObservationRecordReadType,
+  convertEventsObservation,
+} from "@langfuse/shared/src/server/repositories/observations_converters";
+
+const TRACE_CONTEXT_FIELDS = [
+  "userId",
+  "sessionId",
+  "traceName",
+  "release",
+  "tags",
+  "bookmarked",
+  "public",
+] as const;
+
+/** Minimal complete record — all required ClickHouse columns present */
+function makeRecord(
+  overrides: Partial<EventsObservationRecordReadType> = {},
+): EventsObservationRecordReadType {
+  return {
+    id: "obs-1",
+    trace_id: "trace-1",
+    project_id: "proj-1",
+    type: "GENERATION",
+    environment: "default",
+    metadata: {},
+    is_deleted: 0,
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-01T00:00:00.000Z",
+    start_time: "2024-01-01T00:00:00.000Z",
+    event_ts: "2024-01-01T00:00:00.000Z",
+    provided_usage_details: {},
+    provided_cost_details: {},
+    usage_details: {},
+    cost_details: {},
+    user_id: null,
+    session_id: null,
+    trace_name: null,
+    release: null,
+    tags: [],
+    bookmarked: false,
+    public: false,
+    ...overrides,
+  };
+}
+
+describe("convertEventsObservation", () => {
+  describe("complete: false (V2 partial path)", () => {
+    it("omits trace_context keys that are absent from the ClickHouse row", () => {
+      const record: Partial<EventsObservationRecordReadType> = {
+        id: "obs-1",
+        trace_id: "trace-1",
+        project_id: "proj-1",
+        type: "GENERATION",
+        start_time: "2024-01-01T00:00:00.000Z",
+        // trace_context fields intentionally omitted — simulates a SELECT that
+        // did not request the trace_context field group
+      };
+
+      const result = convertEventsObservation(record, undefined, false);
+
+      for (const field of TRACE_CONTEXT_FIELDS) {
+        expect(
+          result,
+          `key "${field}" must be absent when not in the ClickHouse row`,
+        ).not.toHaveProperty(field);
+      }
+    });
+
+    it("includes trace_context keys that are present in the row, even when null", () => {
+      const record: Partial<EventsObservationRecordReadType> = {
+        id: "obs-1",
+        trace_id: "trace-1",
+        project_id: "proj-1",
+        type: "GENERATION",
+        start_time: "2024-01-01T00:00:00.000Z",
+        user_id: null,
+        session_id: null,
+        trace_name: null,
+        release: null,
+        tags: [],
+        bookmarked: false,
+        public: false,
+      };
+
+      const result = convertEventsObservation(record, undefined, false);
+
+      expect(result).toHaveProperty("userId", null);
+      expect(result).toHaveProperty("sessionId", null);
+      expect(result).toHaveProperty("traceName", null);
+      expect(result).toHaveProperty("release", null);
+      expect(result).toHaveProperty("tags", []);
+      expect(result).toHaveProperty("bookmarked", false);
+      expect(result).toHaveProperty("public", false);
+    });
+
+    it("passes through non-null trace_context values unchanged", () => {
+      const record: Partial<EventsObservationRecordReadType> = {
+        id: "obs-1",
+        trace_id: "trace-1",
+        project_id: "proj-1",
+        type: "GENERATION",
+        start_time: "2024-01-01T00:00:00.000Z",
+        user_id: "user-42",
+        session_id: "session-99",
+        trace_name: "my-trace",
+        release: "v1.2.3",
+        tags: ["alpha", "beta"],
+        bookmarked: true,
+        public: true,
+      };
+
+      const result = convertEventsObservation(record, undefined, false);
+
+      expect(result).toHaveProperty("userId", "user-42");
+      expect(result).toHaveProperty("sessionId", "session-99");
+      expect(result).toHaveProperty("traceName", "my-trace");
+      expect(result).toHaveProperty("release", "v1.2.3");
+      expect(result).toHaveProperty("tags", ["alpha", "beta"]);
+      expect(result).toHaveProperty("bookmarked", true);
+      expect(result).toHaveProperty("public", true);
+    });
+  });
+
+  describe("complete: true (V1 full path)", () => {
+    it("always includes all trace_context keys even when their values are null", () => {
+      const record = makeRecord({
+        user_id: null,
+        session_id: null,
+        trace_name: null,
+        release: null,
+        tags: null,
+      });
+
+      const result = convertEventsObservation(record, undefined, true);
+
+      expect(result).toHaveProperty("userId", null);
+      expect(result).toHaveProperty("sessionId", null);
+      expect(result).toHaveProperty("traceName", null);
+      expect(result).toHaveProperty("release", null);
+      expect(result).toHaveProperty("tags", null);
+    });
+  });
+});

--- a/web/src/__tests__/server/unit/observations-converters.servertest.ts
+++ b/web/src/__tests__/server/unit/observations-converters.servertest.ts
@@ -11,7 +11,7 @@ vi.mock("@langfuse/shared/src/db", () => ({ prisma: {} }));
 import {
   type EventsObservationRecordReadType,
   convertEventsObservation,
-} from "@langfuse/shared/src/server/repositories/observations_converters";
+} from "@langfuse/shared/src/server";
 
 const TRACE_CONTEXT_FIELDS = [
   "userId",


### PR DESCRIPTION
## What does this PR do?

Fixes a wire-format leak in the V2 observations endpoint where `traceName`, `tags`, `release`, `userId`, `sessionId`, `bookmarked`, and `public` appeared as `null` keys in responses even when the client did not request the `trace_context` field group.

**Root cause:** `convertEventsObservation` in `observations_converters.ts` used unconditional `record.x ?? null` assignments for those seven fields regardless of the `complete` flag. When ClickHouse omits a column from the projection (because the field group was not requested), the value is `undefined`, and `undefined ?? null === null` — so the key was always emitted. The peer converter `convertObservationPartial` already uses conditional spreads (`...(record.x !== undefined && { x: record.x })`) to enforce this discipline; `convertEventsObservation` deviated from that pattern.

**Fix:**
- Split the `complete`/partial branches in `convertEventsObservation`. The `complete: true` (V1) branch keeps the unconditional defaults since V1 always returns all fields. The `complete: false` (V2) branch gates each extra field on presence, matching `convertObservationPartial`.
- Tighten the contract test assertion in `observations-api-v2.servertest.ts`: removes the `?? undefined` softening that allowed `null` values to pass `toBeUndefined()`.
- Add a unit test for `convertEventsObservation` directly — no such test existed before.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impacted packages

- `packages/shared` — `observations_converters.ts`
- `web` — contract test + new unit test

## Verification

- `pnpm --filter @langfuse/shared run lint` ✓
- `pnpm --filter @langfuse/shared run typecheck` ✓
- CI green (tests-web, tests-worker, e2e)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a wire-format leak in the V2 observations endpoint where seven `trace_context` fields (`traceName`, `tags`, `release`, `userId`, `sessionId`, `bookmarked`, `public`) appeared as explicit `null` keys even when the client did not request that field group. The root cause was `undefined ?? null === null` in the single shared code path.

- **Core fix** (`observations_converters.ts`): Splits `convertEventsObservation` into separate `complete: true` (V1) and `complete: false` (V2) branches. The V1 path keeps unconditional `?? null` defaults; the V2 path gates each field on `!== undefined` using conditional spreads, matching the pattern already used in `convertObservationPartial`.
- **Contract test** (`observations-api-v2.servertest.ts`): Tightens the assertion from `obs[field] ?? undefined` (which let `null` pass `toBeUndefined()`) to a direct `obs[field]` check, so the test now correctly fails when a field leaks as `null`.
- **New unit test** (`observations-converters.servertest.ts`): Adds direct coverage for `convertEventsObservation` that was previously missing, testing both branches with absent, null, and non-null field values.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The production change to `observations_converters.ts` is safe: the fix is minimal, well-scoped, and the conditional-spread pattern it introduces for the V2 path already exists in the peer converter.

The converter change and the contract-test tightening are both correct. The new unit test has two TypeScript type incompatibilities (`tags: null` where only `string[] | undefined` is valid, and `undefined` passed for a required `RenderingProps` parameter). Both are caught only at type-check time — the PR description reports running typecheck only for `@langfuse/shared`, not for the `web` package where the new test lives. The issues don't affect runtime or production behaviour, but they leave the test file in a state that fails strict type-checking.

web/src/__tests__/server/unit/observations-converters.servertest.ts — two call-site type errors; all other files are clean.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/__tests__/server/unit/observations-converters.servertest.ts:137-143
The `makeRecord` override passes `tags: null`, but `tags` in `EventsObservationRecordReadType` is typed as `z.array(z.string()).optional()` — i.e. `string[] | undefined` — which is not nullable. Passing `null` here is a TypeScript type error that would surface under `tsc --noEmit` on the `web` package. The intent of the test (verifying `?? null` defaulting) is better expressed by omitting `tags` entirely (letting it be `undefined`) or by asserting that the complete path emits `null` when the field is absent rather than null in the row.

```suggestion
      const record = makeRecord({
        user_id: null,
        session_id: null,
        trace_name: null,
        release: null,
        // tags is omitted → undefined in the record; the converter defaults it to null
      });
```

### Issue 2 of 2
web/src/__tests__/server/unit/observations-converters.servertest.ts:70-72
The overload signatures for `convertEventsObservation` declare `renderingProps` as a required `RenderingProps` parameter (not `RenderingProps | undefined`). Passing `undefined` here works at runtime (the implementation has a default value), but TypeScript checks call sites against the overloads and will flag this as a type error. The same pattern appears at the other `convertEventsObservation` call sites in this file. Passing the exported `DEFAULT_RENDERING_PROPS` is the idiomatic fix and makes the intent explicit — note that the import for `DEFAULT_RENDERING_PROPS` from `@langfuse/shared/src/server` would also need to be added.

```suggestion
      const result = convertEventsObservation(record, DEFAULT_RENDERING_PROPS, false);

      for (const field of TRACE_CONTEXT_FIELDS) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): import convertEventsObservati..."](https://github.com/langfuse/langfuse/commit/5074fe72723a7812e8ff7f3b6ff0f9d0820ed316) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32323301)</sub>

<!-- /greptile_comment -->