### PR TITLE
fix(auth): redirect to /onboarding after initial password set on Cloud

### DIFF
--- a/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
+++ b/web/src/features/auth-credentials/components/ResetPasswordPage.tsx
@@ -26,6 +26,7 @@ import Link from "next/link";
 import { ErrorPage } from "@/src/components/error-page";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { passwordSchema } from "@/src/features/auth/lib/signupSchema";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 
 const resetPasswordSchema = z
   .object({
@@ -45,6 +46,7 @@ export function ResetPasswordPage({
 }) {
   const session = useSession();
   const router = useRouter();
+  const { isLangfuseCloud, region } = useLangfuseCloudRegion();
   const [formError, setFormError] = useState<string | null>(null);
   const [isSuccess, setIsSuccess] = useState(false);
   const [showResetPasswordEmailButton, setShowResetPasswordEmailButton] =
@@ -83,7 +85,11 @@ export function ResetPasswordPage({
       .then(() => {
         setIsSuccess(true);
         setTimeout(() => {
-          router.push("/");
+          const target =
+            isSetMode && isLangfuseCloud && region !== "DEV"
+              ? "/onboarding"
+              : "/";
+          router.push(target);
           setIsSuccess(false);
         }, 2000);
       })


### PR DESCRIPTION
PR body

  ## Summary

  - Fix post-signup redirect for the verified-email flow: after a brand-new user
    sets their first password at `/auth/setup-password`, they are now sent to
    `/onboarding` (where `onboarding.tsx`'s invite-cookie handler can route
    invited users to their org) instead of `/`.
  - Gate the new redirect behind `isSetMode && isLangfuseCloud && region !== "DEV"`,
    mirroring the existing Cloud-only redirect in `web/src/pages/auth/sign-up.tsx`.
  - Existing `/auth/reset-password` flow (`isSetMode === false`), self-hosted
    instances, and the DEV region are unchanged and continue to push to `/`.

  ## Impacted packages

  - `web`

  ## Files changed

  - `web/src/features/auth-credentials/components/ResetPasswordPage.tsx`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

After a new user sets their first password via the email-verification flow (`/auth/setup-password`), they are now redirected to `/onboarding` instead of `/` on Langfuse Cloud (excluding the DEV region). This mirrors the existing redirect in `sign-up.tsx` and ensures invited users reach the onboarding handler that can route them to their organisation.

- Adds `useLangfuseCloudRegion` hook to `ResetPasswordPage` and gates the new redirect with `isSetMode && isLangfuseCloud && region !== "DEV"`, leaving the reset-password flow, self-hosted instances, and DEV unchanged.
- The import is placed correctly at the module top, and the condition is consistent with the parallel pattern in `sign-up.tsx`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a small, focused redirect fix that only affects the Cloud set-password flow and leaves all other paths untouched.

The condition mirrors the existing Cloud redirect in sign-up.tsx, the import is correctly positioned at the module top, and the hook reads a static env var so there is no risk of stale or incorrect state during the 2-second redirect timer. Self-hosted, DEV-region, and the ordinary reset-password flow are all unaffected.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant SP as setup-password page
    participant RP as ResetPasswordPage
    participant API as resetPassword mutation
    participant OB as onboarding page
    participant Home as home page

    U->>SP: Navigate after email OTP verified
    SP->>RP: "Render with isSetMode=true"
    U->>RP: Submit new password
    RP->>API: mutateAsync
    API-->>RP: Success
    RP->>RP: setIsSuccess, start 2s timer
    RP->>RP: Evaluate redirect target
    alt Cloud non-DEV region and set mode
        RP->>OB: router.push /onboarding
    else Self-hosted or DEV or reset mode
        RP->>Home: router.push /
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["redirect net new users to onboarding sur..."](https://github.com/langfuse/langfuse/commit/a35ac6ac5629d81104063987fbe70d7f6b4a5a2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32330064)</sub>

<!-- /greptile_comment -->