### PR TITLE
fix(trace-ui): distinguish between trace and obs level scores on fp

### DIFF
--- a/web/src/components/grouped-score-badge.tsx
+++ b/web/src/components/grouped-score-badge.tsx
@@ -9,6 +9,7 @@ import {
   BracesIcon,
   MessageCircleMoreIcon,
   ExternalLinkIcon,
+  ListTreeIcon,
 } from "lucide-react";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import Link from "next/link";
@@ -46,6 +47,13 @@ const hasMetadata = (
   }
 };
 
+const TRACE_LEVEL_SCORE_TITLE =
+  "This score is attached to the trace, not the observation.";
+
+const isTraceLevelScore = (
+  score: WithStringifiedMetadata<ScoreDomain> | LastUserScore,
+) => Boolean(score.traceId) && score.observationId == null;
+
 const ScoreGroupBadge = <
   T extends WithStringifiedMetadata<ScoreDomain> | LastUserScore,
 >({
@@ -53,11 +61,13 @@ const ScoreGroupBadge = <
   scores,
   compact,
   badgeClassName,
+  showTraceLevelIcon,
 }: {
   name: string;
   scores: T[];
   compact?: boolean;
   badgeClassName?: string;
+  showTraceLevelIcon?: boolean;
 }) => {
   const projectId = useProjectIdFromURL();
 
@@ -74,49 +84,57 @@ const ScoreGroupBadge = <
         {name}:
       </div>
       <div className="flex min-w-0 items-center gap-1 text-nowrap">
-        {scores.map((s, i) => (
-          <span
-            key={i}
-            className="group/score ml-1 flex min-w-0 items-center gap-1 rounded-sm first:ml-0"
-          >
-            <span className="truncate">
-              {s.stringValue ?? s.value?.toFixed(2) ?? ""}
+        {scores.map((s, i) => {
+          const isTraceLevel = showTraceLevelIcon && isTraceLevelScore(s);
+
+          return (
+            <span
+              key={i}
+              title={isTraceLevel ? TRACE_LEVEL_SCORE_TITLE : undefined}
+              className="group/score ml-1 flex min-w-0 items-center gap-1 rounded-sm first:ml-0"
+            >
+              {isTraceLevel && (
+                <ListTreeIcon className="text-dark-green mb-0.25 size-3! shrink-0" />
+              )}
+              <span className="truncate">
+                {s.stringValue ?? s.value?.toFixed(2) ?? ""}
+              </span>
+              {s.comment && (
+                <HoverCard>
+                  <HoverCardTrigger className="inline-block shrink-0">
+                    <MessageCircleMoreIcon className="mb-0.25 size-3!" />
+                  </HoverCardTrigger>
+                  <HoverCardContent className="max-h-[50dvh] overflow-y-auto text-xs break-normal whitespace-normal">
+                    <p className="whitespace-pre-wrap">{s.comment}</p>
+                    {"executionTraceId" in s &&
+                      s.executionTraceId &&
+                      projectId && (
+                        <Link
+                          href={`/project/${projectId}/traces/${encodeURIComponent(s.executionTraceId)}`}
+                          className="mt-2 flex items-center gap-1 text-blue-600 hover:underline"
+                          target="_blank"
+                        >
+                          <ExternalLinkIcon className="h-3 w-3" />
+                          View execution trace
+                        </Link>
+                      )}
+                  </HoverCardContent>
+                </HoverCard>
+              )}
+              {hasMetadata(s) && (
+                <HoverCard>
+                  <HoverCardTrigger className="inline-block shrink-0">
+                    <BracesIcon className="mb-0.25 size-3!" />
+                  </HoverCardTrigger>
+                  <HoverCardContent className="max-h-[50dvh] overflow-y-auto rounded-md border-none p-0 text-xs break-normal whitespace-normal">
+                    <JSONView codeClassName="rounded-md!" json={s.metadata} />
+                  </HoverCardContent>
+                </HoverCard>
+              )}
+              <span className="group-last/score:hidden">,</span>
             </span>
-            {s.comment && (
-              <HoverCard>
-                <HoverCardTrigger className="inline-block shrink-0">
-                  <MessageCircleMoreIcon className="mb-0.25 size-3!" />
-                </HoverCardTrigger>
-                <HoverCardContent className="max-h-[50dvh] overflow-y-auto text-xs break-normal whitespace-normal">
-                  <p className="whitespace-pre-wrap">{s.comment}</p>
-                  {"executionTraceId" in s &&
-                    s.executionTraceId &&
-                    projectId && (
-                      <Link
-                        href={`/project/${projectId}/traces/${encodeURIComponent(s.executionTraceId)}`}
-                        className="mt-2 flex items-center gap-1 text-blue-600 hover:underline"
-                        target="_blank"
-                      >
-                        <ExternalLinkIcon className="h-3 w-3" />
-                        View execution trace
-                      </Link>
-                    )}
-                </HoverCardContent>
-              </HoverCard>
-            )}
-            {hasMetadata(s) && (
-              <HoverCard>
-                <HoverCardTrigger className="inline-block shrink-0">
-                  <BracesIcon className="mb-0.25 size-3!" />
-                </HoverCardTrigger>
-                <HoverCardContent className="max-h-[50dvh] overflow-y-auto rounded-md border-none p-0 text-xs break-normal whitespace-normal">
-                  <JSONView codeClassName="rounded-md!" json={s.metadata} />
-                </HoverCardContent>
-              </HoverCard>
-            )}
-            <span className="group-last/score:hidden">,</span>
-          </span>
-        ))}
+          );
+        })}
       </div>
     </Badge>
   );
@@ -129,11 +147,13 @@ export const GroupedScoreBadges = <
   maxVisible,
   compact,
   badgeClassName,
+  showTraceLevelIcon,
 }: {
   scores: T[];
   maxVisible?: number;
   compact?: boolean;
   badgeClassName?: string;
+  showTraceLevelIcon?: boolean;
 }) => {
   const groupedScores = scores.reduce<Record<string, T[]>>((acc, score) => {
     if (!acc[score.name] || !Array.isArray(acc[score.name])) {
@@ -158,6 +178,7 @@ export const GroupedScoreBadges = <
           scores={scores}
           compact={compact}
           badgeClassName={badgeClassName}
+          showTraceLevelIcon={showTraceLevelIcon}
         />
       ))}
       {Boolean(hiddenScores.length) && (
@@ -179,6 +200,7 @@ export const GroupedScoreBadges = <
                   scores={scores}
                   compact={compact}
                   badgeClassName={badgeClassName}
+                  showTraceLevelIcon={showTraceLevelIcon}
                 />
               ))}
             </div>

--- a/web/src/components/trace/components/SpanContent.tsx
+++ b/web/src/components/trace/components/SpanContent.tsx
@@ -93,6 +93,8 @@ export function SpanContent({
             (s) => s.observationId === node.id || s.observationId === null,
           )
         : mergedScores.filter((s) => s.observationId === node.id);
+  const showTraceLevelScoreIcon =
+    node.type !== "TRACE" && isTopLevelTreeNode && !hasTraceNode;
 
   return (
     <button
@@ -208,7 +210,11 @@ export function SpanContent({
         {/* Scores row */}
         {showScores && nodeScores.length > 0 && (
           <div className="flex flex-wrap gap-1">
-            <GroupedScoreBadges compact scores={nodeScores} />
+            <GroupedScoreBadges
+              compact
+              scores={nodeScores}
+              showTraceLevelIcon={showTraceLevelScoreIcon}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a visual indicator (`ListTreeIcon`) to distinguish trace-level scores from observation-level scores when both appear together on a top-level observation node in traces that lack an explicit TRACE root (the "rootless" v4 layout). The `showTraceLevelIcon` prop is opt-in, so all existing callers of `GroupedScoreBadges` are unaffected.

- **`grouped-score-badge.tsx`**: Adds `isTraceLevelScore` helper and `showTraceLevelIcon` prop; renders a tree icon with a native `title` tooltip on each score entry where `traceId` is set and `observationId` is `null`.
- **`SpanContent.tsx`**: Computes `showTraceLevelScoreIcon` (true only for non-TRACE top-level nodes in rootless trees) and passes it to `GroupedScoreBadges`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are isolated to the trace UI and are fully opt-in via a new prop.

Both files have narrow, well-scoped changes. The showTraceLevelIcon prop defaults to undefined, leaving all existing callers unmodified. The icon display condition mirrors the existing score-filtering logic in SpanContent, so the two cannot diverge. No data mutations, API changes, or side effects are involved.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SpanContent renders node] --> B{node.type === TRACE?}
    B -- Yes --> C[Show trace-level scores\nobservationId === null\nNo icon needed]
    B -- No --> D{isTopLevelTreeNode\nAND !hasTraceNode?}
    D -- No --> E[Show only node's own scores\nobservationId === node.id]
    D -- Yes --> F[Show trace-level + own scores\nshowTraceLevelIcon = true]
    F --> G[GroupedScoreBadges\nshowTraceLevelIcon=true]
    G --> H{per score:\nisTraceLevelScore?}
    H -- Yes\nobservationId == null --> I[Render ListTreeIcon\nwith tooltip]
    H -- No --> J[Render score value only]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace-ui): distinguish between trace..."](https://github.com/langfuse/langfuse/commit/d3ffffe9157bde0f56ddec3bec7eb3c66691d74f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32331805)</sub>

<!-- /greptile_comment -->