### PR TITLE
fix(score-analytics): normalize boolean time series category case for consistent chart colors

### DIFF
--- a/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.clienttest.tsx
+++ b/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.clienttest.tsx
@@ -43,6 +43,38 @@ function ScoreAnalyticsProbe({
   );
 }
 
+function ScoreAnalyticsTimeSeriesProbe({
+  includeScore2 = false,
+}: {
+  includeScore2?: boolean;
+}) {
+  const score1 = {
+    name: "metric_1",
+    dataType: "BOOLEAN" as const,
+    source: "ANNOTATION",
+  };
+  const score2 = {
+    name: "metric_11",
+    dataType: "BOOLEAN" as const,
+    source: "ANNOTATION",
+  };
+
+  const result = useScoreAnalyticsQuery({
+    projectId: "project-test",
+    score1,
+    ...(includeScore2 ? { score2 } : {}),
+    fromTimestamp: new Date("2026-02-01T00:00:00.000Z"),
+    toTimestamp: new Date("2026-02-02T00:00:00.000Z"),
+    interval: { count: 1, unit: "day" },
+  });
+
+  return (
+    <div data-testid="timeseries">
+      {JSON.stringify(result.data?.timeSeries.categorical ?? null)}
+    </div>
+  );
+}
+
 describe("useScoreAnalyticsQuery", () => {
   afterEach(() => {
     mockedUseQuery.mockReset();
@@ -179,5 +211,142 @@ describe("useScoreAnalyticsQuery", () => {
 
     expect(distribution.score1).toEqual(distribution.score2);
     expect(distribution.score2Categories).toEqual(["False", "True"]);
+  });
+
+  it("normalizes lowercase boolean category names in time series to Title-case", () => {
+    mockedUseQuery.mockReturnValue({
+      data: {
+        counts: { score1Total: 2, score2Total: 0, matchedCount: 0 },
+        heatmap: [],
+        confusionMatrix: [],
+        statistics: null,
+        timeSeries: [],
+        distribution1: [],
+        distribution2: [],
+        stackedDistribution: [],
+        stackedDistributionMatched: [],
+        score2Categories: [],
+        timeSeriesMatched: [],
+        distribution1Matched: [],
+        distribution2Matched: [],
+        distribution1Individual: [],
+        distribution2Individual: [],
+        timeSeriesCategorical1: [
+          {
+            timestamp: new Date("2026-02-01T12:00:00.000Z"),
+            category: "true",
+            count: 1,
+          },
+          {
+            timestamp: new Date("2026-02-01T13:00:00.000Z"),
+            category: "false",
+            count: 1,
+          },
+        ],
+        timeSeriesCategorical2: [],
+        timeSeriesCategorical1Matched: [],
+        timeSeriesCategorical2Matched: [],
+        samplingMetadata: {
+          isSampled: false,
+          samplingMethod: "none",
+          samplingRate: 1,
+          estimatedTotalMatches: 2,
+          actualSampleSize: 2,
+          samplingExpression: null,
+        },
+        metadata: { mode: "single", isSameScore: true, dataType: "BOOLEAN" },
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ScoreAnalyticsTimeSeriesProbe />);
+    const ts = JSON.parse(
+      screen.getByTestId("timeseries").textContent ?? "null",
+    );
+
+    const score1Categories = (ts.score1 as Array<{ category: string }>).map(
+      (item) => item.category,
+    );
+    expect(score1Categories).not.toContain("true");
+    expect(score1Categories).not.toContain("false");
+    expect(score1Categories).toContain("True");
+    expect(score1Categories).toContain("False");
+  });
+
+  it("normalizes boolean categories in two-score mode so namespaced color keys resolve correctly", () => {
+    mockedUseQuery.mockReturnValue({
+      data: {
+        counts: { score1Total: 2, score2Total: 2, matchedCount: 0 },
+        heatmap: [],
+        confusionMatrix: [],
+        statistics: null,
+        timeSeries: [],
+        distribution1: [],
+        distribution2: [],
+        stackedDistribution: [],
+        stackedDistributionMatched: [],
+        score2Categories: [],
+        timeSeriesMatched: [],
+        distribution1Matched: [],
+        distribution2Matched: [],
+        distribution1Individual: [],
+        distribution2Individual: [],
+        timeSeriesCategorical1: [
+          {
+            timestamp: new Date("2026-02-01T12:00:00.000Z"),
+            category: "true",
+            count: 1,
+          },
+          {
+            timestamp: new Date("2026-02-01T12:00:00.000Z"),
+            category: "false",
+            count: 1,
+          },
+        ],
+        timeSeriesCategorical2: [
+          {
+            timestamp: new Date("2026-02-01T12:00:00.000Z"),
+            category: "true",
+            count: 1,
+          },
+          {
+            timestamp: new Date("2026-02-01T12:00:00.000Z"),
+            category: "false",
+            count: 1,
+          },
+        ],
+        timeSeriesCategorical1Matched: [],
+        timeSeriesCategorical2Matched: [],
+        samplingMetadata: {
+          isSampled: false,
+          samplingMethod: "none",
+          samplingRate: 1,
+          estimatedTotalMatches: 2,
+          actualSampleSize: 2,
+          samplingExpression: null,
+        },
+        metadata: { mode: "two", isSameScore: false, dataType: "BOOLEAN" },
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ScoreAnalyticsTimeSeriesProbe includeScore2={true} />);
+    const ts = JSON.parse(
+      screen.getByTestId("timeseries").textContent ?? "null",
+    );
+
+    // "all" tab merges score1 and score2 with namespaced keys: "metric_1: True", "metric_11: True", etc.
+    const allCategories = (ts.all as Array<{ category: string }>).map(
+      (item) => item.category,
+    );
+    expect(allCategories).toContain("metric_1: True");
+    expect(allCategories).toContain("metric_1: False");
+    expect(allCategories).toContain("metric_11: True");
+    expect(allCategories).toContain("metric_11: False");
+    // No lowercase variants should be present
+    expect(allCategories).not.toContain("metric_1: true");
+    expect(allCategories).not.toContain("metric_11: false");
   });
 });

--- a/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts
+++ b/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts
@@ -270,6 +270,18 @@ export function useScoreAnalyticsQuery(
       return null;
     };
 
+    // Normalize boolean category values in a time series to "True"/"False".
+    // The DB can store boolean values in various forms ("true", "false", "1", "0")
+    // which would otherwise cause a case-mismatch with the color map keys and
+    // make all series fall back to the same fallback color.
+    const normalizeBooleanTimeSeries = (
+      series: Array<{ timestamp: Date; category: string; count: number }>,
+    ): Array<{ timestamp: Date; category: string; count: number }> =>
+      series.flatMap((item) => {
+        const normalized = normalizeBooleanCategory(item.category);
+        return normalized !== null ? [{ ...item, category: normalized }] : [];
+      });
+
     const buildBooleanDistribution = (
       timeSeries: Array<{ category: string; count: number }>,
       distributionCategories: string[],
@@ -533,33 +545,45 @@ export function useScoreAnalyticsQuery(
       });
     }
 
-    const categoricalTimeSeries1 = fillCategoricalTimeSeriesGaps(
+    const rawCategoricalTimeSeries1 = fillCategoricalTimeSeriesGaps(
       apiData.timeSeriesCategorical1,
       fromTimestamp,
       toTimestamp,
       interval,
     );
+    const categoricalTimeSeries1 = isBoolean
+      ? normalizeBooleanTimeSeries(rawCategoricalTimeSeries1)
+      : rawCategoricalTimeSeries1;
 
-    const categoricalTimeSeries2 = fillCategoricalTimeSeriesGaps(
+    const rawCategoricalTimeSeries2 = fillCategoricalTimeSeriesGaps(
       apiData.timeSeriesCategorical2,
       fromTimestamp,
       toTimestamp,
       interval,
     );
+    const categoricalTimeSeries2 = isBoolean
+      ? normalizeBooleanTimeSeries(rawCategoricalTimeSeries2)
+      : rawCategoricalTimeSeries2;
 
-    const categoricalTimeSeries1Matched = fillCategoricalTimeSeriesGaps(
+    const rawCategoricalTimeSeries1Matched = fillCategoricalTimeSeriesGaps(
       apiData.timeSeriesCategorical1Matched,
       fromTimestamp,
       toTimestamp,
       interval,
     );
+    const categoricalTimeSeries1Matched = isBoolean
+      ? normalizeBooleanTimeSeries(rawCategoricalTimeSeries1Matched)
+      : rawCategoricalTimeSeries1Matched;
 
-    const categoricalTimeSeries2Matched = fillCategoricalTimeSeriesGaps(
+    const rawCategoricalTimeSeries2Matched = fillCategoricalTimeSeriesGaps(
       apiData.timeSeriesCategorical2Matched,
       fromTimestamp,
       toTimestamp,
       interval,
     );
+    const categoricalTimeSeries2Matched = isBoolean
+      ? normalizeBooleanTimeSeries(rawCategoricalTimeSeries2Matched)
+      : rawCategoricalTimeSeries2Matched;
 
     // If same score selected twice, populate categorical2 with categorical1 data
     // This ensures UI can show data in "Score 2" tab when comparing a score to itself


### PR DESCRIPTION
## Summary

Fixes #13666

- Boolean score values in the DB can be stored as `"true"`, `"false"`, `"1"`, or `"0"`. `fillCategoricalTimeSeriesGaps` passes these through unchanged, but `buildColorMappings` keys its color map with Title-case `"True"`/`"False"`.
- This caused every `colors[category]` lookup in `ScoreTimeSeriesBooleanChart` to return `undefined` and fall back to `Object.values(colors)[0]` — the same single color for all series, making it impossible to distinguish `metric_1: True`, `metric_1: False`, `metric_11: True`, `metric_11: False`.
- Fix: apply the existing `normalizeBooleanCategory` helper to all four categorical time series arrays (`score1`, `score2`, and their `Matched` variants) right after gap-filling, when `dataType` is `BOOLEAN`. Categorical and numeric scores are unaffected.

## Changes

- `web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts` — added `normalizeBooleanTimeSeries` helper; wrapped the 4 `fillCategoricalTimeSeriesGaps` calls for boolean data
- `web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.clienttest.tsx` — two new tests: single-score normalization and two-score namespaced key correctness

## Verification

```
pnpm --filter web run test-client -- src/features/score-analytics/hooks/useScoreAnalyticsQuery.clienttest.tsx
# ✓ 4 tests pass (2 pre-existing + 2 new)

pnpm --filter web run typecheck
# clean
```

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a color-consistency bug in `ScoreTimeSeriesBooleanChart` where boolean score categories stored as `"true"`/`"false"`/`"1"`/`"0"` in the DB caused every series to resolve to the same fallback color because `buildColorMappings` keys on Title-case `"True"`/`"False"`.

- Introduces `normalizeBooleanTimeSeries`, a thin wrapper around the existing `normalizeBooleanCategory` helper, and applies it to all four categorical time-series arrays (`score1`, `score2`, and their `Matched` variants) immediately after gap-filling when `dataType` is `BOOLEAN`.
- Adds two new client tests covering single-score normalization and two-score namespaced key correctness, both passing alongside the two pre-existing tests.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix is narrow and well-tested, with no changes to downstream consumers or data persistence.

The normalization logic is correct and mirrors the already-proven buildBooleanDistribution approach. The only notable behaviour is that flatMap silently drops any category string that doesn't parse as a boolean, meaning corrupted or unexpected DB values disappear without a warning — acceptable given the boolean-only guard, but worth being aware of.

No files require special attention; both changed files are small and self-contained.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[apiData.timeSeriesCategoricalN] --> B[fillCategoricalTimeSeriesGaps]
    B --> C{isBoolean?}
    C -- Yes --> D[normalizeBooleanTimeSeries]
    D --> E{"normalizeBooleanCategory(category)"}
    E -- true / 1 --> F["Return 'True'"]
    E -- false / 0 --> G["Return 'False'"]
    E -- other --> H[Drop entry via flatMap]
    F & G --> I[categoricalTimeSeriesN]
    H --> I
    C -- No --> I
    I --> J[namespaceCategoricalTimeSeries - score prefix in two-score mode]
    J --> K[buildColorMappings - keys on Title-case True/False]
    K --> L[ScoreTimeSeriesBooleanChart - correct per-series color]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(score-analytics): normalize boolean ..."](https://github.com/langfuse/langfuse/commit/6e31c51846c38cda16389523447953bdee7f0416) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32439879)</sub>

<!-- /greptile_comment -->