### PR TITLE
fix(evals): normalize observation eval enum filters

### DIFF
--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -6,6 +6,7 @@ import { metadataArraysToRecord } from "../../server/utils/metadata_conversion";
 import { SingleValueOption } from "../../tableDefinitions";
 import { ColumnDefinition } from "../../tableDefinitions";
 import { formatColumnOptions } from "../../tableDefinitions/typeHelpers";
+import type { FilterCondition } from "../../types";
 
 const flexibleUsageCostSchema = z.record(
   z.string(),
@@ -376,6 +377,44 @@ export function experimentEvalFilterColsWithOptions(
   });
 }
 
+function findEventEvalFilterColumn(column: string) {
+  return eventsEvalFilterColumns.find(
+    (c) => c.id === column || c.name === column || c.aliases?.includes(column),
+  );
+}
+
+const normalizeEnumFilterValue = (
+  value: string,
+  column: ObservationEvalColumnDef,
+) => {
+  const options = "options" in column ? column.options : [];
+  const option = options.find(
+    (option) =>
+      "value" in option && option.value.toLowerCase() === value.toLowerCase(),
+  );
+
+  return option && "value" in option ? option.value : value;
+};
+
+export function normalizeEventEvalFilterCondition(
+  filter: FilterCondition,
+): FilterCondition {
+  const column = findEventEvalFilterColumn(filter.column);
+  if (
+    !column ||
+    filter.type !== "stringOptions" ||
+    (column.internal !== "type" && column.internal !== "level")
+  ) {
+    return filter;
+  }
+
+  return {
+    ...filter,
+    column: column.id,
+    value: filter.value.map((value) => normalizeEnumFilterValue(value, column)),
+  };
+}
+
 /**
  * Field mapper for observation eval filters.
  * Maps camelCase filter column IDs to snake_case observation fields.
@@ -389,9 +428,17 @@ export function mapEventEvalFilterColumnIdToField(
   observation: ObservationForEval,
   column: string,
 ) {
-  const columnMapping = eventsEvalFilterColumns.find((c) => c.id === column);
+  const columnMapping = findEventEvalFilterColumn(column);
   if (!columnMapping) {
     return undefined;
   }
-  return observation[columnMapping.internal];
+  const fieldValue = observation[columnMapping.internal];
+  if (
+    typeof fieldValue === "string" &&
+    (columnMapping.internal === "type" || columnMapping.internal === "level")
+  ) {
+    return normalizeEnumFilterValue(fieldValue, columnMapping);
+  }
+
+  return fieldValue;
 }

--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -400,12 +400,15 @@ export function normalizeEventEvalFilterCondition(
   filter: FilterCondition,
 ): FilterCondition {
   const column = findEventEvalFilterColumn(filter.column);
+  if (!column) {
+    return filter;
+  }
+
   if (
-    !column ||
     filter.type !== "stringOptions" ||
     (column.internal !== "type" && column.internal !== "level")
   ) {
-    return filter;
+    return { ...filter, column: column.id };
   }
 
   return {

--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -8,6 +8,7 @@ import { ColumnDefinition } from "../../tableDefinitions";
 import { formatColumnOptions } from "../../tableDefinitions/typeHelpers";
 import { parseJsonIfString } from "../../utils/json";
 import { isRootObservation } from "../../eventsTable";
+import type { FilterCondition } from "../../types";
 
 const flexibleUsageCostSchema = z.record(
   z.string(),
@@ -466,6 +467,44 @@ export function experimentEvalFilterColsWithOptions(
   });
 }
 
+function findEventEvalFilterColumn(column: string) {
+  return eventsEvalFilterColumns.find(
+    (c) => c.id === column || c.name === column || c.aliases?.includes(column),
+  );
+}
+
+const normalizeEnumFilterValue = (
+  value: string,
+  column: ObservationEvalColumnDef,
+) => {
+  const options = "options" in column ? column.options : [];
+  const option = options.find(
+    (option) =>
+      "value" in option && option.value.toLowerCase() === value.toLowerCase(),
+  );
+
+  return option && "value" in option ? option.value : value;
+};
+
+export function normalizeEventEvalFilterCondition(
+  filter: FilterCondition,
+): FilterCondition {
+  const column = findEventEvalFilterColumn(filter.column);
+  if (
+    !column ||
+    filter.type !== "stringOptions" ||
+    (column.internal !== "type" && column.internal !== "level")
+  ) {
+    return filter;
+  }
+
+  return {
+    ...filter,
+    column: column.id,
+    value: filter.value.map((value) => normalizeEnumFilterValue(value, column)),
+  };
+}
+
 /**
  * Field mapper for observation eval filters.
  * Maps camelCase filter column IDs to snake_case observation fields.
@@ -479,7 +518,7 @@ export function mapEventEvalFilterColumnIdToField(
   observation: ObservationForEval,
   column: string,
 ) {
-  const columnMapping = eventsEvalFilterColumns.find((c) => c.id === column);
+  const columnMapping = findEventEvalFilterColumn(column);
   if (!columnMapping) {
     return undefined;
   }
@@ -491,5 +530,13 @@ export function mapEventEvalFilterColumnIdToField(
     });
   }
 
-  return observation[columnMapping.internal];
+  const fieldValue = observation[columnMapping.internal];
+  if (
+    typeof fieldValue === "string" &&
+    (columnMapping.internal === "type" || columnMapping.internal === "level")
+  ) {
+    return normalizeEnumFilterValue(fieldValue, columnMapping);
+  }
+
+  return fieldValue;
 }

--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -490,12 +490,15 @@ export function normalizeEventEvalFilterCondition(
   filter: FilterCondition,
 ): FilterCondition {
   const column = findEventEvalFilterColumn(filter.column);
+  if (!column) {
+    return filter;
+  }
+
   if (
-    !column ||
     filter.type !== "stringOptions" ||
     (column.internal !== "type" && column.internal !== "level")
   ) {
-    return filter;
+    return { ...filter, column: column.id };
   }
 
   return {

--- a/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
@@ -288,6 +288,31 @@ describe("scheduleObservationEvals", () => {
       expect(schedulerDeps.enqueueEvalJob).toHaveBeenCalled();
     });
 
+    it("should process config when legacy lowercase level filter matches canonical observation level", async () => {
+      const schedulerDeps = createMockSchedulerDeps();
+      const observation = createMockObservation({ level: "DEFAULT" });
+
+      await scheduleObservationEvals({
+        observation,
+        configs: [
+          createMockConfig({
+            filter: [
+              {
+                column: "level",
+                type: "stringOptions",
+                operator: "any of",
+                value: ["default"],
+              },
+            ],
+          }),
+        ],
+        schedulerDeps,
+      });
+
+      expect(schedulerDeps.upsertJobExecution).toHaveBeenCalled();
+      expect(schedulerDeps.enqueueEvalJob).toHaveBeenCalled();
+    });
+
     it("should process config when filter is empty (matches all)", async () => {
       const schedulerDeps = createMockSchedulerDeps();
       const observation = createMockObservation();

--- a/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
@@ -200,7 +200,7 @@ describe("scheduleObservationEvals", () => {
                 column: "type",
                 type: "stringOptions",
                 operator: "any of",
-                value: ["generation"],
+                value: ["GENERATION"],
               },
             ],
           }),
@@ -215,7 +215,7 @@ describe("scheduleObservationEvals", () => {
 
     it("should process config when filter matches", async () => {
       const schedulerDeps = createMockSchedulerDeps();
-      const observation = createMockObservation({ type: "generation" });
+      const observation = createMockObservation();
 
       await scheduleObservationEvals({
         observation,
@@ -227,6 +227,56 @@ describe("scheduleObservationEvals", () => {
                 type: "stringOptions",
                 operator: "any of",
                 value: ["generation"],
+              },
+            ],
+          }),
+        ],
+        schedulerDeps,
+      });
+
+      expect(schedulerDeps.upsertJobExecution).toHaveBeenCalled();
+      expect(schedulerDeps.enqueueEvalJob).toHaveBeenCalled();
+    });
+
+    it("should process config when legacy lowercase type filter matches canonical observation type", async () => {
+      const schedulerDeps = createMockSchedulerDeps();
+      const observation = createMockObservation({ type: "GENERATION" });
+
+      await scheduleObservationEvals({
+        observation,
+        configs: [
+          createMockConfig({
+            filter: [
+              {
+                column: "type",
+                type: "stringOptions",
+                operator: "any of",
+                value: ["generation"],
+              },
+            ],
+          }),
+        ],
+        schedulerDeps,
+      });
+
+      expect(schedulerDeps.upsertJobExecution).toHaveBeenCalled();
+      expect(schedulerDeps.enqueueEvalJob).toHaveBeenCalled();
+    });
+
+    it("should process config when type filter uses the display column name", async () => {
+      const schedulerDeps = createMockSchedulerDeps();
+      const observation = createMockObservation({ type: "GENERATION" });
+
+      await scheduleObservationEvals({
+        observation,
+        configs: [
+          createMockConfig({
+            filter: [
+              {
+                column: "Type",
+                type: "stringOptions",
+                operator: "any of",
+                value: ["GENERATION"],
               },
             ],
           }),

--- a/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
@@ -238,7 +238,7 @@ describe("scheduleObservationEvals", () => {
                 column: "type",
                 type: "stringOptions",
                 operator: "any of",
-                value: ["generation"],
+                value: ["GENERATION"],
               },
             ],
           }),
@@ -253,7 +253,7 @@ describe("scheduleObservationEvals", () => {
 
     it("should process config when filter matches", async () => {
       const schedulerDeps = createMockSchedulerDeps();
-      const observation = createMockObservation({ type: "generation" });
+      const observation = createMockObservation();
 
       await scheduleObservationEvals({
         observation,
@@ -265,6 +265,56 @@ describe("scheduleObservationEvals", () => {
                 type: "stringOptions",
                 operator: "any of",
                 value: ["generation"],
+              },
+            ],
+          }),
+        ],
+        schedulerDeps,
+      });
+
+      expect(schedulerDeps.upsertJobExecution).toHaveBeenCalled();
+      expect(schedulerDeps.enqueueEvalJob).toHaveBeenCalled();
+    });
+
+    it("should process config when legacy lowercase type filter matches canonical observation type", async () => {
+      const schedulerDeps = createMockSchedulerDeps();
+      const observation = createMockObservation({ type: "GENERATION" });
+
+      await scheduleObservationEvals({
+        observation,
+        configs: [
+          createMockConfig({
+            filter: [
+              {
+                column: "type",
+                type: "stringOptions",
+                operator: "any of",
+                value: ["generation"],
+              },
+            ],
+          }),
+        ],
+        schedulerDeps,
+      });
+
+      expect(schedulerDeps.upsertJobExecution).toHaveBeenCalled();
+      expect(schedulerDeps.enqueueEvalJob).toHaveBeenCalled();
+    });
+
+    it("should process config when type filter uses the display column name", async () => {
+      const schedulerDeps = createMockSchedulerDeps();
+      const observation = createMockObservation({ type: "GENERATION" });
+
+      await scheduleObservationEvals({
+        observation,
+        configs: [
+          createMockConfig({
+            filter: [
+              {
+                column: "Type",
+                type: "stringOptions",
+                operator: "any of",
+                value: ["GENERATION"],
               },
             ],
           }),

--- a/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
@@ -326,6 +326,31 @@ describe("scheduleObservationEvals", () => {
       expect(schedulerDeps.enqueueEvalJob).toHaveBeenCalled();
     });
 
+    it("should process config when legacy lowercase level filter matches canonical observation level", async () => {
+      const schedulerDeps = createMockSchedulerDeps();
+      const observation = createMockObservation({ level: "DEFAULT" });
+
+      await scheduleObservationEvals({
+        observation,
+        configs: [
+          createMockConfig({
+            filter: [
+              {
+                column: "level",
+                type: "stringOptions",
+                operator: "any of",
+                value: ["default"],
+              },
+            ],
+          }),
+        ],
+        schedulerDeps,
+      });
+
+      expect(schedulerDeps.upsertJobExecution).toHaveBeenCalled();
+      expect(schedulerDeps.enqueueEvalJob).toHaveBeenCalled();
+    });
+
     it("should process config when filter is empty (matches all)", async () => {
       const schedulerDeps = createMockSchedulerDeps();
       const observation = createMockObservation();

--- a/worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts
+++ b/worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts
@@ -11,6 +11,7 @@ import {
   type FilterState,
   isJobConfigExecutable,
   mapEventEvalFilterColumnIdToField,
+  normalizeEventEvalFilterCondition,
 } from "@langfuse/shared";
 import { createW3CTraceId } from "../../utils";
 
@@ -177,12 +178,16 @@ function evaluateFilter(
   const fieldMapper = (obs: ObservationForEval, column: string) =>
     mapEventEvalFilterColumnIdToField(obs, column);
 
+  const normalizedFilterConditions = isEmptyFilter
+    ? []
+    : filterConditions.map(normalizeEventEvalFilterCondition);
+
   // Use InMemoryFilterService to evaluate filter if there are conditions
   const isFilterMatch = isEmptyFilter
     ? true
     : InMemoryFilterService.evaluateFilter(
         observation,
-        filterConditions,
+        normalizedFilterConditions,
         fieldMapper,
       );
 

--- a/worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts
+++ b/worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts
@@ -19,6 +19,7 @@ import {
   type JobConfigExecutionMode,
   isJobConfigExecutableForExecutionMode,
   mapEventEvalFilterColumnIdToField,
+  normalizeEventEvalFilterCondition,
 } from "@langfuse/shared";
 import { createW3CTraceId } from "../../utils";
 import { isInternalEvalEnvironment } from "../isEvalTargetEnvironmentAllowed";
@@ -247,12 +248,16 @@ function evaluateFilter(
   const fieldMapper = (obs: ObservationForEval, column: string) =>
     mapEventEvalFilterColumnIdToField(obs, column);
 
+  const normalizedFilterConditions = isEmptyFilter
+    ? []
+    : filterConditions.map(normalizeEventEvalFilterCondition);
+
   // Use InMemoryFilterService to evaluate filter if there are conditions
   const isFilterMatch = isEmptyFilter
     ? true
     : InMemoryFilterService.evaluateFilter(
         observation,
-        filterConditions,
+        normalizedFilterConditions,
         fieldMapper,
       );
 


### PR DESCRIPTION
## Summary
Observation eval filters are evaluated in memory after events are converted to `ObservationForEval`. Current records use enum values like `GENERATION`/`DEFAULT`, but older configs and a few tests can still carry lowercase values. The validator also accepts display column names such as `Type`, while the scheduler mapper only resolved stable ids.

This can make the preview find matching generations while the live scheduler skips the same rule.

This PR:
- resolves observation eval filter columns by id, display name, or alias
- canonicalizes `Type` and `Level` enum values before in-memory evaluation
- adds scheduler regressions for lowercase `generation` filters and display-name `Type` filters

Related to #13202.

## Testing
- `pnpm.cmd exec prisma generate --schema prisma/schema.prisma`
- `pnpm.cmd --filter @langfuse/shared build`
- `pnpm.cmd test src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts`
- `pnpm.cmd test src/features/evaluation/observationEval/__tests__/filterEvaluation.test.ts`
- `pnpm.cmd test src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts`
- `pnpm.cmd --filter worker typecheck`
- `pnpm.cmd --filter @langfuse/shared exec eslint src/features/evals/observationForEval.ts`
- `pnpm.cmd --filter worker exec eslint src/features/evaluation/observationEval/scheduleObservationEvals.ts --no-warn-ignored`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a mismatch in the observation eval scheduler where filter conditions saved with display column names (e.g. `"Type"`) or legacy lowercase enum values (e.g. `"generation"`) were not matched against canonical observation data (e.g. `"GENERATION"`), causing the scheduler to skip rules that the preview correctly identified as matching.

- Adds `normalizeEventEvalFilterCondition` to canonicalize `type`/`level` stringOptions filter conditions (column name → stable id, enum values → uppercase canonical form) before in-memory evaluation.
- Extends `mapEventEvalFilterColumnIdToField` to resolve filter columns by id, display name, or alias, and to normalize `type`/`level` observation field values to canonical form.
- Adds two scheduler regression tests covering a legacy lowercase type filter and a display-name `"Type"` filter.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly normalizes both the filter-condition side and the observation-field side before comparison, and the new tests confirm the two targeted regression scenarios.

The normalization logic and the in-memory comparison flow work correctly for all exercised cases. The main gap is that normalizeEventEvalFilterCondition only rewrites filter.column to the canonical id for type/level filters, leaving display-name columns like Environment passed through unchanged. This is safe today but could mislead a future caller expecting a fully canonical condition. There are also no tests for level column normalization.

The normalizeEventEvalFilterCondition function in packages/shared/src/features/evals/observationForEval.ts is worth a second look for its partial column-name canonicalization; the test file is missing a level-column coverage case.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[scheduleObservationEvals] --> B{filterConditions empty?}
    B -- yes --> C[isEmptyFilter = true / matches all]
    B -- no --> D[map each condition through normalizeEventEvalFilterCondition]
    D --> E{column found AND type=stringOptions AND internal=type or level?}
    E -- no --> F[return filter unchanged / column may be display name]
    E -- yes --> G[return filter with column=column.id / values normalized to canonical case]
    F --> H[InMemoryFilterService.evaluateFilter]
    G --> H
    H --> I[fieldMapper per condition: mapEventEvalFilterColumnIdToField]
    I --> J[findEventEvalFilterColumn by id OR name OR alias]
    J --> K{internal = type or level?}
    K -- yes --> L[normalizeEnumFilterValue on observation field value]
    K -- no --> M[return raw field value]
    L --> N[exact string match against normalized filter values]
    M --> N
    N --> O{all conditions match?}
    O -- yes --> P[evaluateFilter = true / schedule eval job]
    O -- no --> Q[evaluateFilter = false / skip observation]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/features/evals/observationForEval.ts:399-416
**Partial column canonicalization may surprise future callers**

`normalizeEventEvalFilterCondition` rewrites `filter.column` to `column.id` only when `column.internal` is `"type"` or `"level"`. For every other `stringOptions` column (e.g. a filter saved with the display name `"Environment"` instead of `"environment"`), the function returns the condition with the original display name still in `column`. The `InMemoryFilterService` path is safe today because `mapEventEvalFilterColumnIdToField` now also resolves by name, but a caller who normalizes conditions and then passes them to code that does strict id-equality lookup would silently get wrong results. Canonicalizing the `column` field unconditionally — whenever `findEventEvalFilterColumn` resolves the lookup — would make the exported contract easier to reason about.

### Issue 2 of 2
worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts:238-293
**`Level` column normalization is untested**

The new tests cover `type` with a legacy lowercase value and with the display column name `"Type"`, but there is no equivalent test for the `level` field. Both columns are handled by the same code path (`column.internal !== "type" && column.internal !== "level"`), so a regression in `level` normalization (e.g. filter `{ column: "level", value: ["default"] }` against an observation with `level: "DEFAULT"`) would go undetected. Adding a test case mirroring the lowercase-type test but for `level` would close this gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): normalize observation filter..."](https://github.com/langfuse/langfuse/commit/28c9facd6edcec9fbfc3cb43fadcc1e2ae2169a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32470246)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->