### PR TITLE
fix(web): link dataset source observations directly

### DIFF
--- a/web/src/features/datasets/components/DatasetItemDetailPage.tsx
+++ b/web/src/features/datasets/components/DatasetItemDetailPage.tsx
@@ -30,6 +30,7 @@ import { useDatasetVersion } from "@/src/features/datasets/hooks/useDatasetVersi
 import { toDatasetSchema } from "@/src/features/datasets/utils/datasetItemUtils";
 import { useExperimentAccess } from "@/src/features/experiments/hooks/useExperimentAccess";
 import { ExperimentsBetaSwitch } from "@/src/features/experiments/components/ExperimentsBetaSwitch";
+import { getSourceTraceHref } from "@/src/features/datasets/utils/sourceTraceHref";
 
 export const DatasetItemDetailPage = ({
   activeTab,
@@ -191,7 +192,11 @@ export const DatasetItemDetailPage = ({
             {item.data?.sourceTraceId && (
               <Button variant="ghost" size="icon-xs" asChild>
                 <Link
-                  href={`/project/${projectId}/traces/${item.data.sourceTraceId}`}
+                  href={getSourceTraceHref({
+                    projectId,
+                    sourceTraceId: item.data.sourceTraceId,
+                    sourceObservationId: item.data.sourceObservationId,
+                  })}
                   title={`View source ${item.data.sourceObservationId ? "observation" : "trace"}`}
                 >
                   <ListTree className="h-4 w-4" />

--- a/web/src/features/datasets/utils/sourceTraceHref.clienttest.ts
+++ b/web/src/features/datasets/utils/sourceTraceHref.clienttest.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { getSourceTraceHref } from "@/src/features/datasets/utils/sourceTraceHref";
+
+describe("getSourceTraceHref", () => {
+  it("links to the trace when no source observation is available", () => {
+    expect(
+      getSourceTraceHref({
+        projectId: "project-1",
+        sourceTraceId: "trace-1",
+      }),
+    ).toBe("/project/project-1/traces/trace-1");
+  });
+
+  it("links directly to the source observation when available", () => {
+    expect(
+      getSourceTraceHref({
+        projectId: "project-1",
+        sourceTraceId: "trace/1",
+        sourceObservationId: "observation/1",
+      }),
+    ).toBe("/project/project-1/traces/trace%2F1?observation=observation%2F1");
+  });
+});

--- a/web/src/features/datasets/utils/sourceTraceHref.ts
+++ b/web/src/features/datasets/utils/sourceTraceHref.ts
@@ -1,0 +1,15 @@
+export const getSourceTraceHref = ({
+  projectId,
+  sourceTraceId,
+  sourceObservationId,
+}: {
+  projectId: string;
+  sourceTraceId: string;
+  sourceObservationId?: string | null;
+}) => {
+  const traceHref = `/project/${projectId}/traces/${encodeURIComponent(sourceTraceId)}`;
+
+  return sourceObservationId
+    ? `${traceHref}?observation=${encodeURIComponent(sourceObservationId)}`
+    : traceHref;
+};


### PR DESCRIPTION
## What does this PR do?

Fixes #13544.

Updates the dataset item source link to include the source observation query parameter when `sourceObservationId` is available, so the "View source observation" action opens the specific observation instead of only the parent trace.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format` / lint)
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective
- [x] I have checked that the targeted test passes locally

## Verification

- `pnpm --dir web exec vitest run --project client src/features/datasets/utils/sourceTraceHref.clienttest.ts`
- `pnpm --dir web exec eslint src/features/datasets/components/DatasetItemDetailPage.tsx src/features/datasets/utils/sourceTraceHref.ts src/features/datasets/utils/sourceTraceHref.clienttest.ts --max-warnings 0`
- `pnpm --dir web exec prettier --check src/features/datasets/components/DatasetItemDetailPage.tsx src/features/datasets/utils/sourceTraceHref.ts src/features/datasets/utils/sourceTraceHref.clienttest.ts`
- `pnpm --filter web run lint`
- commit hook: `pnpm run format:check` + `turbo run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the "View source observation" link on dataset item detail pages so that when a `sourceObservationId` is present the link navigates directly to that observation (via `?observation=` query param) rather than only to the parent trace. A new `getSourceTraceHref` utility centralises URL construction with consistent `encodeURIComponent` encoding, matching the pattern already used in `DatasetRunItemsByRunTable`, `DatasetItemsTable`, and other dataset tables.

- `sourceTraceHref.ts`: new pure utility that builds the trace/observation href, handling `null`/`undefined` `sourceObservationId` correctly.
- `DatasetItemDetailPage.tsx`: swaps the hardcoded template literal for the new utility; the tooltip title was already correct.
- `sourceTraceHref.clienttest.ts`: adds two unit tests covering the trace-only and observation-present cases.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a small, well-tested URL construction fix with no side-effects beyond correcting the navigation target.

The utility function is simple, consistent with the codebase's existing URL-building pattern, and covered by tests. The only gap is a missing test for encoding the trace ID in the observation-absent branch, which is a minor omission and not a defect in the shipped code.

No files require special attention; sourceTraceHref.clienttest.ts could benefit from one additional encoding test.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant DatasetItemDetailPage
    participant getSourceTraceHref
    participant TraceDetailPage

    User->>DatasetItemDetailPage: Views dataset item
    DatasetItemDetailPage->>getSourceTraceHref: "{ projectId, sourceTraceId, sourceObservationId? }"
    alt sourceObservationId is present
        getSourceTraceHref-->>DatasetItemDetailPage: "/project/{id}/traces/{traceId}?observation={obsId}"
    else sourceObservationId is absent
        getSourceTraceHref-->>DatasetItemDetailPage: "/project/{id}/traces/{traceId}"
    end
    User->>DatasetItemDetailPage: Clicks "View source observation" button
    DatasetItemDetailPage->>TraceDetailPage: Navigates to URL with observation query param
    TraceDetailPage-->>User: Opens trace with observation selected
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/datasets/utils/sourceTraceHref.clienttest.ts:6-13
The trace-only branch test uses a plain UUID-style ID (`trace-1`) that is unchanged by `encodeURIComponent`. Adding a case with a special character in `sourceTraceId` (e.g. a slash) would confirm that the path segment is encoded even when no observation is present — the same guarantee the observation branch gets with its `trace/1` fixture.

```suggestion
  it("links to the trace when no source observation is available", () => {
    expect(
      getSourceTraceHref({
        projectId: "project-1",
        sourceTraceId: "trace-1",
      }),
    ).toBe("/project/project-1/traces/trace-1");
  });

  it("encodes special characters in sourceTraceId when no observation is available", () => {
    expect(
      getSourceTraceHref({
        projectId: "project-1",
        sourceTraceId: "trace/1",
      }),
    ).toBe("/project/project-1/traces/trace%2F1");
  });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): link dataset source observatio..."](https://github.com/langfuse/langfuse/commit/1366c02d67f71bd2eccb9f09f37f9436bc5cfcdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32476780)</sub>

<!-- /greptile_comment -->