### PR TITLE
fix(prompts): Align prompt variable handling in UI with SDK/compiler

### DIFF
--- a/packages/shared/src/utils/stringChecks.ts
+++ b/packages/shared/src/utils/stringChecks.ts
@@ -7,14 +7,15 @@ export function getIsCharOrUnderscore(value: string): boolean {
 // Regex for valid variable names (unicode letters, underscores, starting with letter)
 export const VARIABLE_REGEX = /^\p{L}[\p{L}\p{N}_]*$/u;
 
-// Regex to find variables in mustache syntax
-export const MUSTACHE_REGEX = /{{([^{}]*)}}+/g;
+// Regex to find variables in mustache syntax. Extra surrounding braces are
+// treated as literals by SDK/compiler behavior, e.g. {{{name}}} -> {value}.
+export const MUSTACHE_REGEX = /{{([^{}]*)}}/g;
 
 // Regex to find multiline variables
-export const MULTILINE_VARIABLE_REGEX = /{{[^}]*\n[^}]*}}/g;
+export const MULTILINE_VARIABLE_REGEX = /{{[^{}]*\n[^{}]*}}/g;
 
 // Regex to find unclosed variables
-export const UNCLOSED_VARIABLE_REGEX = /{{(?![^{]*}})/g;
+export const UNCLOSED_VARIABLE_REGEX = /{{(?!{)(?![^{]*}})/g;
 
 export function isValidVariableName(variable: string): boolean {
   return VARIABLE_REGEX.test(variable);

--- a/web/src/components/editor/CodeMirrorEditor.clienttest.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.clienttest.tsx
@@ -1,0 +1,18 @@
+import { getPromptVariableDiagnostics } from "@/src/components/editor/CodeMirrorEditor";
+
+describe("getPromptVariableDiagnostics", () => {
+  it("accepts triple-brace prompt variables as an inner variable with literal outer braces", () => {
+    expect(getPromptVariableDiagnostics("Use {{{placeholder}}} here")).toEqual(
+      [],
+    );
+  });
+
+  it("reports unclosed inner variables inside extra literal braces", () => {
+    expect(getPromptVariableDiagnostics("Use {{{placeholder} here")).toEqual([
+      expect.objectContaining({
+        from: 5,
+        message: "Unclosed variable brackets",
+      }),
+    ]);
+  });
+});

--- a/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.tsx
@@ -44,6 +44,12 @@ const promptLanguage = StreamLanguage.define({
       return "keyword";
     }
 
+    // Extra surrounding braces are literals; the inner {{variable}} compiles.
+    if (stream.match("{{{", false)) {
+      stream.next();
+      return null;
+    }
+
     // Highlight mustache variables
     if (stream.match("{{")) {
       const start = stream.pos;
@@ -57,10 +63,8 @@ const promptLanguage = StreamLanguage.define({
   },
 });
 
-// Linter for prompt variables
-const promptLinter = linter((view) => {
+export const getPromptVariableDiagnostics = (content: string): Diagnostic[] => {
   const diagnostics: Diagnostic[] = [];
-  const content = view.state.doc.toString();
 
   // Check for multiline variables
   for (const match of content.matchAll(MULTILINE_VARIABLE_REGEX)) {
@@ -128,7 +132,12 @@ const promptLinter = linter((view) => {
   }
 
   return diagnostics;
-});
+};
+
+// Linter for prompt variables
+const promptLinter = linter((view) =>
+  getPromptVariableDiagnostics(view.state.doc.toString()),
+);
 
 // Create a language support instance that combines the language and its configuration
 const promptSupport = new LanguageSupport(promptLanguage);

--- a/web/src/components/ui/PromptReferences.clienttest.tsx
+++ b/web/src/components/ui/PromptReferences.clienttest.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+import { extractVariables } from "@langfuse/shared";
+import { renderRichPromptContent } from "@/src/components/ui/PromptReferences";
+
+describe("renderRichPromptContent", () => {
+  it("preserves triple-brace prompt variable text in rich prompt rendering", () => {
+    const { container } = render(
+      <>{renderRichPromptContent("Use {{{placeholder}}} here")}</>,
+    );
+
+    expect(container.textContent).toBe("Use {{{placeholder}}} here");
+  });
+
+  it("extracts the inner variable from triple-brace prompt variables", () => {
+    expect(extractVariables("Use {{{placeholder}}} here")).toEqual([
+      "placeholder",
+    ]);
+  });
+});

--- a/web/src/components/ui/PromptReferences.tsx
+++ b/web/src/components/ui/PromptReferences.tsx
@@ -192,7 +192,7 @@ export const PromptReferenceButton = ({
   );
 };
 
-const PromptVar = ({ name, isValid }: { name: string; isValid: boolean }) => (
+const PromptVar = ({ text, isValid }: { text: string; isValid: boolean }) => (
   <span
     dir="ltr"
     style={{ unicodeBidi: "isolate" }}
@@ -201,7 +201,7 @@ const PromptVar = ({ name, isValid }: { name: string; isValid: boolean }) => (
       "whitespace-nowrap",
     )}
   >
-    {`{{${name}}}`}
+    {text}
   </span>
 );
 
@@ -253,7 +253,7 @@ export const renderRichPromptContent = (content: string): React.ReactNode[] => {
       const variable = match[2];
       parts.push(
         <React.Fragment key={`var-${index}-${variable}`}>
-          <PromptVar name={variable} isValid={isValidVariableName(variable)} />
+          <PromptVar text={fullMatch} isValid={isValidVariableName(variable)} />
         </React.Fragment>,
       );
     }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the handling of triple-brace Mustache variables (`{{{name}}}`) in the prompt UI so it aligns with the SDK/compiler semantics, where outer braces are treated as literals and only the inner `{{name}}` is the variable reference.

- **`stringChecks.ts`**: Tightens the three regexes — removes the `}}+` greedy quantifier in `MUSTACHE_REGEX` so it matches exactly `}}`, adds `(?!{)` to `UNCLOSED_VARIABLE_REGEX` so `{{{` is never flagged as unclosed, and tightens the character class in `MULTILINE_VARIABLE_REGEX` to exclude both `{` and `}`.
- **`CodeMirrorEditor.tsx`**: Adds a `{{{` peek-ahead in the stream tokenizer that advances past the leading literal brace, letting the normal `{{…}}` path highlight the inner variable; extracts `getPromptVariableDiagnostics` into a testable export.
- **`PromptReferences.tsx`**: Passes `fullMatch` (e.g., `{{name}}`) to `PromptVar` instead of reconstructing `{{name}}` from the captured group, so triple-brace content is rendered faithfully with the outer braces as surrounding plain-text nodes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are well-scoped to regex and tokenizer logic with new test coverage for the affected paths.

All three subsystems (variable extraction via MUSTACHE_REGEX, unclosed-bracket detection via UNCLOSED_VARIABLE_REGEX, and CodeMirror syntax highlighting) correctly handle the triple-brace case after the change, and edge cases like a genuinely unclosed inner variable are still caught. New client tests cover the happy path and the unclosed-inner-variable path. No logic regressions were identified.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Input prompt text"] --> B{Triple-brace syntax?}
    B -- Yes --> C["MUSTACHE_REGEX matches inner pair at offset+1"]
    B -- No --> D["MUSTACHE_REGEX matches double-brace pair normally"]
    C --> E["Leading brace becomes plain text node"]
    C --> F["fullMatch passed to PromptVar"]
    C --> G["Trailing brace becomes plain text node"]
    D --> H["fullMatch passed to PromptVar"]
    F --> I["PromptVar renders with variable styling"]
    H --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(prompts): Align prompt variable hand..."](https://github.com/langfuse/langfuse/commit/7526bf106591b8692696c4ca18289b60ef269d10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32611036)</sub>

<!-- /greptile_comment -->