### PR TITLE
feat(blob-export): hide Export Source field for post-cutoff Cloud projects

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -180,8 +180,14 @@ jobs:
           if git diff --quiet --exit-code --diff-filter=d "$BASE_SHA" HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' '*.css'; then
             echo "No JS/TS/CSS files changed - skipping prettier check"
           else
+            # --experimental-cli is intentionally omitted: its glob resolver treats bracket characters
+            # in Next.js dynamic-route paths (e.g. [projectId]) as glob character classes, causing
+            # "No files matching the given patterns were found" (exit 123) for any PR that touches a
+            # file inside a bracket-named directory. Standard prettier resolves explicit paths correctly.
+            # Parallelism and the ephemeral cache (the only extras --experimental-cli adds) provide no
+            # benefit when checking a handful of per-PR changed files.
             git diff --name-only -z --diff-filter=d "$BASE_SHA" HEAD -- '*.js' '*.jsx' '*.ts' '*.tsx' '*.css' \
-              | xargs -0 --no-run-if-empty pnpm prettier --check --experimental-cli --
+              | xargs -0 --no-run-if-empty pnpm prettier --check --
           fi
 
   tests-eslint-plugin:

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -55,7 +55,6 @@ import {
   EXPORT_FIELD_GROUP_OPTIONS,
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
-  LEGACY_BLOB_EXPORT_SOURCES,
   isLegacyBlobExportAllowed,
 } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
@@ -243,20 +242,13 @@ const BlobStorageIntegrationSettingsForm = ({
   // Check if this is a self-hosted instance (no cloud region set)
   const isSelfHosted = !isLangfuseCloud;
 
-  // Post-cutoff Cloud projects may only use OBSERVATIONS_V2 (EVENTS).
+  // Post-cutoff Cloud projects may only use OBSERVATIONS_V2 (EVENTS). The
+  // Export Source field is hidden in that case; the form value is pinned to
+  // EVENTS via the default below.
   const isPostCutoffCloud =
     project?.createdAt != null &&
     !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
-
-  // Options shown in the dropdown. Legacy options are always hidden for
-  // post-cutoff Cloud projects, including any previously-persisted value.
-  const availableExportSourceOptions = EXPORT_SOURCE_OPTIONS.filter(
-    (opt) =>
-      !isPostCutoffCloud ||
-      !(LEGACY_BLOB_EXPORT_SOURCES as ReadonlyArray<string>).includes(
-        opt.value,
-      ),
-  );
+  const showExportSourceField = isBetaEnabled && !isPostCutoffCloud;
 
   const blobStorageForm = useForm({
     resolver: zodResolver(blobStorageIntegrationFormSchema),
@@ -690,7 +682,7 @@ const BlobStorageIntegrationSettingsForm = ({
           )}
         />
 
-        {isBetaEnabled && (
+        {showExportSourceField && (
           <FormField
             control={blobStorageForm.control}
             name="exportSource"
@@ -735,25 +727,17 @@ const BlobStorageIntegrationSettingsForm = ({
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {availableExportSourceOptions.map((option) => (
+                    {EXPORT_SOURCE_OPTIONS.map((option) => (
                       <SelectItem key={option.value} value={option.value}>
                         {option.label}
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
-                {isPostCutoffCloud ? (
-                  <FormDescription>
-                    Legacy export sources are not available for projects created
-                    on or after May 20, 2026. Use &quot;Enriched
-                    observations&quot; instead.
-                  </FormDescription>
-                ) : (
-                  <FormDescription>
-                    Choose which data sources to export to blob storage. Scores
-                    are always included.
-                  </FormDescription>
-                )}
+                <FormDescription>
+                  Choose which data sources to export to blob storage. Scores
+                  are always included.
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}


### PR DESCRIPTION
## Summary

Follow-up to [LFE-9688](https://linear.app/langfuse/issue/LFE-9688) /
[#13627](https://app.graphite.com/github/pr/langfuse/langfuse/13627).
Tracked as [LFE-9830](https://linear.app/langfuse/issue/LFE-9830).

- After PR #13627 merged, post-cutoff Cloud projects saw a one-option Export Source dropdown. Team feedback: hide the field entirely.
- Wrap the FormField in `{showExportSourceField && (...)}` where `showExportSourceField = isBetaEnabled && !isPostCutoffCloud`. Composes with the existing `isPostCutoffCloud` derivation — `isLegacyBlobExportAllowed` is called exactly once per render.
- Form value stays pinned to `EVENTS` via the existing `defaultValues` / `reset` logic so submission is valid even with the field hidden (`react-hook-form` retains values of unmounted fields by default).
- Drops dead `availableExportSourceOptions` filter, the unreachable `isPostCutoffCloud` arm of `FormDescription`, and the unused `LEGACY_BLOB_EXPORT_SOURCES` import.

### Why no unit test

The rendering condition is a single-line AND of two existing booleans. The cutoff-bracket logic lives in `isLegacyBlobExportAllowed` (covered by its own tests in the shared package). Browser review of the affected page is the intended safety net — see the Test plan below.

### CI fix (fixup commit)

This PR also removes `--experimental-cli` from the `prettier-check` CI job (`pipeline.yml`). The flag's glob resolver treats bracket characters in Next.js dynamic-route paths (e.g. `[projectId]`) as glob character classes, causing exit 123 ("No files matching the given patterns were found") for any PR that touches a file under such a directory. `blobstorage.tsx` lives under `[projectId]`, which is what triggered the failure here. Standard prettier resolves explicit file paths correctly; the parallelism and ephemeral cache that `--experimental-cli` adds provide no practical benefit when checking a handful of changed files per PR.

### Impacted packages

- `web` — single page component, net 10+/26−.
- `.github/workflows/pipeline.yml` — CI prettier-check fix.

## Test plan

- [x] `pnpm --filter web run typecheck`
- [x] `pnpm --filter web exec vitest run --project=client src/__tests__/blob-storage-form-field-groups.clienttest.ts` — 5/5 passed (regression check on related form schema)
- [x] Reproduced prettier-check failure locally with the old command; confirmed fix passes with the new command.
- [ ] Browser review on Cloud with a seeded pre-cutoff and a seeded post-cutoff project (assert Export Source field hidden in the post-cutoff case, visible in the pre-cutoff case)
- [ ] Self-hosted parity check (`LANGFUSE_CLOUD_REGION` unset → field visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)