### PR TITLE
fix(agents): repair Playwright MCP by using --save-session

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -44,7 +44,7 @@ Current shape:
         "-y",
         "@playwright/mcp@latest",
         "--isolated",
-        "--save-trace",
+        "--save-session",
         "--output-dir",
         ".playwright-mcp",
         "--test-id-attribute",

--- a/.agents/config.json
+++ b/.agents/config.json
@@ -12,7 +12,7 @@
         "-y",
         "@playwright/mcp@latest",
         "--isolated",
-        "--save-trace",
+        "--save-session",
         "--output-dir",
         ".playwright-mcp",
         "--test-id-attribute",


### PR DESCRIPTION
## Summary

Upstream `@playwright/mcp` renamed `--save-trace` to `--save-session`. The current `latest` build (v0.0.75) rejects the old flag with `error: unknown option '--save-trace'` and the server exits immediately, so Claude Code (and any other MCP client launching the server via `.mcp.json`) reports `Failed to reconnect to playwright`. This blocks the `frontend-browser-review` skill end-to-end.

Swapping to `--save-session` is upstream's straight rename and keeps the same intent: Playwright MCP writes its session artifacts (including traces) under `--output-dir .playwright-mcp`, which is what the skill (`.agents/skills/frontend-browser-review/SKILL.md`) tells reviewers to inspect on failure.

## Impacted packages

- `.agents/config.json` — canonical MCP server config (source of truth)
- `.agents/README.md` — illustrative snippet kept in sync to avoid re-introducing the stale flag via copy-paste

Generated provider configs (`.mcp.json`, `.claude/`, `.codex/`, `.cursor/`, `.vscode/`) are regenerated by `pnpm run agents:sync` and remain gitignored per the agent-setup contract — no changes need committing there.

## Verification

- `pnpm run agents:sync` — regenerates all provider shims with the new flag
- `pnpm run agents:check` — clean
- Manual launch with the new args (`npx -y @playwright/mcp@latest --isolated --save-session --output-dir .playwright-mcp --test-id-attribute data-testid`) — process stays alive past handshake (old `--save-trace` exited with code 1)
- Live confirmation: with the fix applied locally, the Playwright MCP tools loaded successfully in my Claude Code session, whereas `/mcp` had previously reported `Failed to reconnect to playwright`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects the Playwright MCP flag in the agent configuration from `--save-trace` to `--save-session`, which is the correct flag for automatic session recording per the Playwright MCP documentation.

- Both `.agents/config.json` (the canonical source) and `.agents/README.md` (which embeds the current JSON shape inline) are updated consistently, keeping documentation and config in sync.
- Generated shim files (`.claude/settings.json`, `.cursor/mcp.json`, etc.) are not committed to the repo and are regenerated from `.agents/config.json` via `pnpm run agents:sync`, so no further changes are needed in this PR.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both changed files are updated consistently and the replacement flag is documented as correct by Playwright MCP.

The change swaps a single CLI flag in two files that are intentionally kept in sync (the canonical config and its embedded README snapshot). The flag --save-session is confirmed in the Playwright MCP documentation as the correct option for automatic session recording. Generated shim files are not committed and will pick up the corrected flag on the next pnpm install or agents:sync run.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".agents/config.json\n(canonical source)"] -->|pnpm run agents:sync| B["Generated Shim Files\n(.claude/settings.json\n.cursor/mcp.json\n.vscode/mcp.json\n.mcp.json etc.)"]
    A -->|inline snapshot| C[".agents/README.md\n(documentation)"]
    B --> D["Playwright MCP Server\nnpx @playwright/mcp@latest\n--isolated\n--save-session\n--output-dir .playwright-mcp\n--test-id-attribute data-testid"]
    style D fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agents): use --save-session for Play..."](https://github.com/langfuse/langfuse/commit/789bceb39b392e4a677e455c9d819ae864a17e8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32588333)</sub>

<!-- /greptile_comment -->