### PR TITLE
feat(analytics-integrations): extend legacy export source cutoff gate to PostHog and Mixpanel

### DIFF
--- a/web/src/__tests__/server/mixpanel-integration.servertest.ts
+++ b/web/src/__tests__/server/mixpanel-integration.servertest.ts
@@ -45,48 +45,7 @@ const buildSession = (orgId: string, projectId: string): Session => ({
   environment: {} as any,
 });
 
-describe("PostHog Integration SSRF Protection", () => {
-  const originalEncryptionKey = process.env.ENCRYPTION_KEY;
-  let projectId: string;
-  let orgId: string;
-  let caller: ReturnType<typeof appRouter.createCaller>;
-
-  beforeAll(() => {
-    // Set a test encryption key (64 hex characters = 32 bytes)
-    process.env.ENCRYPTION_KEY =
-      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-  });
-
-  afterAll(() => {
-    // Restore original environment
-    process.env.ENCRYPTION_KEY = originalEncryptionKey;
-  });
-
-  beforeEach(async () => {
-    const setup = await createOrgProjectAndApiKey();
-    projectId = setup.projectId;
-    orgId = setup.orgId;
-
-    const ctx = createInnerTRPCContext({
-      session: buildSession(orgId, projectId),
-      headers: {},
-    });
-    caller = appRouter.createCaller({ ...ctx, prisma });
-  });
-
-  it("should reject private IPs and localhost in PostHog hostname", async () => {
-    await expect(
-      caller.posthogIntegration.update({
-        projectId,
-        posthogHostname: "http://localhost",
-        posthogProjectApiKey: "phc_test_key_12345",
-        enabled: true,
-      }),
-    ).rejects.toThrow(/Invalid PostHog hostname.*Blocked/);
-  });
-});
-
-describe("PostHog Integration legacy export source cutoff gate", () => {
+describe("Mixpanel Integration legacy export source cutoff gate", () => {
   const originalEncryptionKey = process.env.ENCRYPTION_KEY;
 
   beforeAll(() => {
@@ -102,12 +61,9 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
     vi.restoreAllMocks();
   });
 
-  // PostHog uses webhook URL validation that rejects private IPs — including
-  // public DNS hosts the test container can reach is overkill for unit-testing
-  // the cutoff gate. We exercise the gate against a stable public hostname.
   const baseConfig = {
-    posthogHostname: "https://us.posthog.com",
-    posthogProjectApiKey: "phc_test_key_12345",
+    mixpanelRegion: "api" as const,
+    mixpanelProjectToken: "test_token_12345",
     enabled: true,
   };
 
@@ -131,7 +87,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         data: { createdAt: PRE_CUTOFF },
       });
       await expect(
-        caller.posthogIntegration.update({
+        caller.mixpanelIntegration.update({
           projectId: project.id,
           ...baseConfig,
           exportSource: "TRACES_OBSERVATIONS" as const,
@@ -152,7 +108,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         data: { createdAt: POST_CUTOFF },
       });
       await expect(
-        caller.posthogIntegration.update({
+        caller.mixpanelIntegration.update({
           projectId: project.id,
           ...baseConfig,
           exportSource: "TRACES_OBSERVATIONS" as const,
@@ -173,7 +129,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         data: { createdAt: POST_CUTOFF },
       });
       await expect(
-        caller.posthogIntegration.update({
+        caller.mixpanelIntegration.update({
           projectId: project.id,
           ...baseConfig,
           exportSource: "TRACES_OBSERVATIONS_EVENTS" as const,
@@ -194,7 +150,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         data: { createdAt: POST_CUTOFF },
       });
       await expect(
-        caller.posthogIntegration.update({
+        caller.mixpanelIntegration.update({
           projectId: project.id,
           ...baseConfig,
           exportSource: "EVENTS" as const,
@@ -215,7 +171,7 @@ describe("PostHog Integration legacy export source cutoff gate", () => {
         data: { createdAt: POST_CUTOFF },
       });
       await expect(
-        caller.posthogIntegration.update({
+        caller.mixpanelIntegration.update({
           projectId: project.id,
           ...baseConfig,
           exportSource: "TRACES_OBSERVATIONS" as const,

--- a/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
+++ b/web/src/features/mixpanel-integration/mixpanel-integration-router.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
   createTRPCRouter,
@@ -69,6 +70,21 @@ export const mixpanelIntegrationRouter = createTRPCRouter({
           });
         }
       }
+
+      // Post-cutoff Cloud projects may not select a legacy export source.
+      // Mirrors the blob-storage gate (LFE-9688); shares the same helper.
+      if (input.exportSource) {
+        const project = await ctx.prisma.project.findUniqueOrThrow({
+          where: { id: input.projectId },
+          select: { createdAt: true },
+        });
+        assertLegacyBlobExportSourceAllowed({
+          project,
+          nextInternalExportSource: input.exportSource,
+          isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+        });
+      }
+
       await auditLog({
         session: ctx.session,
         action: "update",

--- a/web/src/features/posthog-integration/posthog-integration-router.ts
+++ b/web/src/features/posthog-integration/posthog-integration-router.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
   createTRPCRouter,
@@ -80,6 +81,20 @@ export const posthogIntegrationRouter = createTRPCRouter({
             error instanceof Error
               ? `Invalid PostHog hostname: ${error.message}`
               : "Invalid PostHog hostname",
+        });
+      }
+
+      // Post-cutoff Cloud projects may not select a legacy export source.
+      // Mirrors the blob-storage gate (LFE-9688); shares the same helper.
+      if (input.exportSource) {
+        const project = await ctx.prisma.project.findUniqueOrThrow({
+          where: { id: input.projectId },
+          select: { createdAt: true },
+        });
+        assertLegacyBlobExportSourceAllowed({
+          project,
+          nextInternalExportSource: input.exportSource,
+          isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
         });
       }
 

--- a/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/mixpanel.tsx
@@ -35,8 +35,11 @@ import {
 import {
   AnalyticsIntegrationExportSource,
   EXPORT_SOURCE_OPTIONS,
+  isLegacyBlobExportAllowed,
 } from "@langfuse/shared";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+import { useQueryProject } from "@/src/features/projects/hooks";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
@@ -144,6 +147,17 @@ const MixpanelIntegrationSettingsForm = ({
 }) => {
   const capture = usePostHogClientCapture();
   const { isBetaEnabled } = useV4Beta();
+  const { isLangfuseCloud } = useLangfuseCloudRegion();
+  const { project } = useQueryProject();
+
+  // Post-cutoff Cloud projects may only use OBSERVATIONS_V2 (EVENTS). The
+  // Export Source field is hidden in that case; the form value is pinned to
+  // EVENTS via the default below. Mirrors blob-storage settings (LFE-9688 / 9830).
+  const isPostCutoffCloud =
+    project?.createdAt != null &&
+    !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
+  const showExportSourceField = isBetaEnabled && !isPostCutoffCloud;
+
   const mixpanelForm = useForm({
     resolver: zodResolver(mixpanelIntegrationFormSchema),
     defaultValues: {
@@ -152,11 +166,12 @@ const MixpanelIntegrationSettingsForm = ({
         MIXPANEL_REGIONS[0].subdomain,
       mixpanelProjectToken: state?.mixpanelProjectToken ?? "",
       enabled: state?.enabled ?? false,
-      exportSource:
-        state?.exportSource ??
-        (isBetaEnabled
-          ? AnalyticsIntegrationExportSource.EVENTS
-          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      exportSource: isPostCutoffCloud
+        ? AnalyticsIntegrationExportSource.EVENTS
+        : (state?.exportSource ??
+          (isBetaEnabled
+            ? AnalyticsIntegrationExportSource.EVENTS
+            : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS)),
     },
     disabled: isLoading,
   });
@@ -168,11 +183,12 @@ const MixpanelIntegrationSettingsForm = ({
         MIXPANEL_REGIONS[0].subdomain,
       mixpanelProjectToken: state?.mixpanelProjectToken ?? "",
       enabled: state?.enabled ?? false,
-      exportSource:
-        state?.exportSource ??
-        (isBetaEnabled
-          ? AnalyticsIntegrationExportSource.EVENTS
-          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      exportSource: isPostCutoffCloud
+        ? AnalyticsIntegrationExportSource.EVENTS
+        : (state?.exportSource ??
+          (isBetaEnabled
+            ? AnalyticsIntegrationExportSource.EVENTS
+            : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS)),
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
@@ -249,7 +265,7 @@ const MixpanelIntegrationSettingsForm = ({
             </FormItem>
           )}
         />
-        {isBetaEnabled && (
+        {showExportSourceField && (
           <FormField
             control={mixpanelForm.control}
             name="exportSource"

--- a/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/posthog.tsx
@@ -32,8 +32,11 @@ import { posthogIntegrationFormSchema } from "@/src/features/posthog-integration
 import {
   AnalyticsIntegrationExportSource,
   EXPORT_SOURCE_OPTIONS,
+  isLegacyBlobExportAllowed,
 } from "@langfuse/shared";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
+import { useQueryProject } from "@/src/features/projects/hooks";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { api } from "@/src/utils/api";
 import { type RouterOutput } from "@/src/utils/types";
@@ -141,17 +144,29 @@ const PostHogIntegrationSettings = ({
 }) => {
   const capture = usePostHogClientCapture();
   const { isBetaEnabled } = useV4Beta();
+  const { isLangfuseCloud } = useLangfuseCloudRegion();
+  const { project } = useQueryProject();
+
+  // Post-cutoff Cloud projects may only use OBSERVATIONS_V2 (EVENTS). The
+  // Export Source field is hidden in that case; the form value is pinned to
+  // EVENTS via the default below. Mirrors blob-storage settings (LFE-9688 / 9830).
+  const isPostCutoffCloud =
+    project?.createdAt != null &&
+    !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
+  const showExportSourceField = isBetaEnabled && !isPostCutoffCloud;
+
   const posthogForm = useForm({
     resolver: zodResolver(posthogIntegrationFormSchema),
     defaultValues: {
       posthogHostname: state?.posthogHostName ?? "",
       posthogProjectApiKey: state?.posthogApiKey ?? "",
       enabled: state?.enabled ?? false,
-      exportSource:
-        state?.exportSource ??
-        (isBetaEnabled
-          ? AnalyticsIntegrationExportSource.EVENTS
-          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      exportSource: isPostCutoffCloud
+        ? AnalyticsIntegrationExportSource.EVENTS
+        : (state?.exportSource ??
+          (isBetaEnabled
+            ? AnalyticsIntegrationExportSource.EVENTS
+            : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS)),
     },
     disabled: isLoading,
   });
@@ -161,11 +176,12 @@ const PostHogIntegrationSettings = ({
       posthogHostname: state?.posthogHostName ?? "",
       posthogProjectApiKey: state?.posthogApiKey ?? "",
       enabled: state?.enabled ?? false,
-      exportSource:
-        state?.exportSource ??
-        (isBetaEnabled
-          ? AnalyticsIntegrationExportSource.EVENTS
-          : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+      exportSource: isPostCutoffCloud
+        ? AnalyticsIntegrationExportSource.EVENTS
+        : (state?.exportSource ??
+          (isBetaEnabled
+            ? AnalyticsIntegrationExportSource.EVENTS
+            : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS)),
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
@@ -225,7 +241,7 @@ const PostHogIntegrationSettings = ({
             </FormItem>
           )}
         />
-        {isBetaEnabled && (
+        {showExportSourceField && (
           <FormField
             control={posthogForm.control}
             name="exportSource"


### PR DESCRIPTION
## Summary

Follow-up to [LFE-9688](https://linear.app/langfuse/issue/LFE-9688) /
[#13627](https://app.graphite.com/github/pr/langfuse/langfuse/13627),
which intentionally scoped the cutoff gate to blob-storage and listed
PostHog / Mixpanel under "Out of scope". Tracked as
[LFE-9838](https://linear.app/langfuse/issue/LFE-9838); planning doc:
`ideabox/Implementations/Proposed/2026-05-18 extend-cutoff-gate-to-posthog-mixpanel.md`.

- Post-cutoff Cloud projects (`createdAt >= 2026-05-20`) now see the Export Source field hidden in PostHog and Mixpanel settings pages (form value pinned to `EVENTS` via `defaultValues`).
- The matching tRPC `update` mutations reject any legacy `exportSource` (`TRACES_OBSERVATIONS`, `TRACES_OBSERVATIONS_EVENTS`) for post-cutoff Cloud projects with `BAD_REQUEST`.
- Pre-cutoff Cloud projects and self-hosted deployments keep full choice — no behavior change.
- Pure parity work: reuses the shared `isLegacyBlobExportAllowed` predicate and `assertLegacyBlobExportSourceAllowed` guard. No new constants, no shared-package edits, no public REST surface to gate (neither integration has one).
- The `LEGACY_BLOB_EXPORT_*` / `assertLegacyBlobExportSourceAllowed` names retain their "Blob" prefix; renaming is deferred to a separate cleanup PR (see planning doc, Decision #2).

### Impacted packages

- `web` — two settings pages, two routers, one extended servertest, one new servertest. No other package touched.

## Test plan

- [x] `pnpm --filter web run typecheck`
- [x] `pnpm --filter web exec vitest run --project=server src/__tests__/server/posthog-integration.servertest.ts src/__tests__/server/mixpanel-integration.servertest.ts` — 11/11 passed (PostHog 6, Mixpanel 5)
- [x] Browser review on dev (Playwright MCP): post-cutoff cloud projects (dev `.env` overrides cutoff to `2020-01-01`) — Export Source hidden on both PostHog and Mixpanel settings pages, Enabled switch + other form fields still render correctly
- [ ] Browser review with pre-cutoff Cloud (toggle `NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF` to a future date, restart dev server)
- [ ] Self-hosted parity check (`LANGFUSE_CLOUD_REGION` unset → field visible for any `createdAt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the legacy export source cutoff gate (originally applied to blob-storage in LFE-9688) to the PostHog and Mixpanel analytics integrations. Post-cutoff Cloud projects (`createdAt >= 2026-05-20`) can no longer save a legacy `exportSource` value; the field is hidden in the UI and pinned to `EVENTS`, while the tRPC `update` mutations enforce the same rule server-side.

- **Routers**: Both `posthogIntegrationRouter` and `mixpanelIntegrationRouter` gain the same `assertLegacyBlobExportSourceAllowed` guard that already protects the blob-storage router; the gate is correctly placed before the audit log and DB write.
- **UI pages**: Both settings pages derive `isPostCutoffCloud` from `useQueryProject` + `isLegacyBlobExportAllowed`, hide the Export Source `FormField` when that flag is true, and pin the form default to `EVENTS` — exactly mirroring the blob-storage page pattern.
- **Tests**: New `servertest` files (and an extended PostHog file) cover all five gate scenarios (pre-cutoff Cloud allow, two legacy-source rejections, `EVENTS` allow, self-hosted bypass) using a shared `buildSession` helper refactored from the existing SSRF test.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the server-side gate is correctly placed and always reachable, the UI correctly hides and pins the field, and tests cover all five gate scenarios for both integrations.

The change is tightly scoped: two routers gain the same guard already proven in blob-storage, two settings pages hide a single field for post-cutoff Cloud projects, and tests exercise every code branch. No new public API surface is added, and self-hosted / pre-cutoff behaviour is unchanged.

No files require special attention. The only observation is a duplicated buildSession helper in the two new test files, which is a maintenance concern rather than a functional one.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User submits PostHog / Mixpanel settings form] --> B{exportSource provided?}
    B -- "always truthy after Zod .default()" --> C[Fetch project.createdAt from DB]
    C --> D{Is legacy export source?}
    D -- No: EVENTS --> E[Allow — skip gate]
    D -- Yes: TRACES_OBSERVATIONS / TRACES_OBSERVATIONS_EVENTS --> F{isCloud AND project.createdAt >= cutoff?}
    F -- No: self-hosted OR pre-cutoff --> G[Allow]
    F -- Yes: post-cutoff Cloud --> H[Throw InvalidRequestError → BAD_REQUEST]
    E --> I[Audit log + DB upsert]
    G --> I
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/mixpanel-integration.servertest.ts:13-44
**Duplicated `buildSession` helper across test files**

The `buildSession` function in this file is byte-for-byte identical to the one added to `posthog-integration.servertest.ts`. If the session shape ever changes (e.g., a new required project field), both copies need updating in sync. Consider extracting it to a shared test utility (e.g., `web/src/__tests__/server/fixtures/session.ts`) so there is a single source of truth.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(analytics-integrations): extend leg..."](https://github.com/langfuse/langfuse/commit/6418f93afafa9dede9899f65747256c8e42fd309) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32589990)</sub>

<!-- /greptile_comment -->