### PR TITLE
fix: clear free-tier suspension state on Stripe subscription upgrade

### DIFF
--- a/web/src/__tests__/server/stripe-webhook-handler.servertest.ts
+++ b/web/src/__tests__/server/stripe-webhook-handler.servertest.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { v4 } from "uuid";
+import type Stripe from "stripe";
+import { prisma } from "@langfuse/shared/src/db";
+import { handleSubscriptionChanged } from "@/src/ee/features/billing/server/stripeWebhookHandler";
+import { env } from "@/src/env.mjs";
+
+const buildSubscription = (args: {
+  orgId: string;
+  status?: Stripe.Subscription.Status;
+}): Stripe.Subscription =>
+  ({
+    id: `sub_test_${v4()}`,
+    status: args.status ?? "active",
+    customer: `cus_test_${v4()}`,
+    metadata: {
+      orgId: args.orgId,
+      cloudRegion: env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
+    },
+    items: {
+      data: [
+        {
+          id: `si_test_${v4()}`,
+          price: {
+            id: `price_test_${v4()}`,
+            product: `prod_test_${v4()}`,
+            recurring: { usage_type: "licensed" },
+          },
+        },
+      ],
+    },
+  }) as unknown as Stripe.Subscription;
+
+describe("stripeWebhookHandler.handleSubscriptionChanged", () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    orgId = v4();
+    await prisma.organization.create({
+      data: {
+        id: orgId,
+        name: `test-org-${orgId}`,
+        cloudFreeTierUsageThresholdState: "BLOCKED",
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.organization.delete({ where: { id: orgId } }).catch(() => {});
+  });
+
+  it.each([["active"], ["trialing"]] as const)(
+    "clears cloudFreeTierUsageThresholdState when subscription.updated arrives with status=%s",
+    async (status) => {
+      const subscription = buildSubscription({ orgId, status });
+
+      await handleSubscriptionChanged(subscription, "updated");
+
+      const updated = await prisma.organization.findUniqueOrThrow({
+        where: { id: orgId },
+      });
+      expect(updated.cloudFreeTierUsageThresholdState).toBeNull();
+    },
+  );
+
+  it("clears cloudFreeTierUsageThresholdState when a paid subscription is created", async () => {
+    const subscription = buildSubscription({ orgId, status: "active" });
+
+    await handleSubscriptionChanged(subscription, "created");
+
+    const updated = await prisma.organization.findUniqueOrThrow({
+      where: { id: orgId },
+    });
+    expect(updated.cloudFreeTierUsageThresholdState).toBeNull();
+  });
+
+  it.each([
+    ["created", "incomplete"],
+    ["created", "incomplete_expired"],
+    ["updated", "past_due"],
+    ["updated", "unpaid"],
+  ] as const)(
+    "does NOT clear cloudFreeTierUsageThresholdState on subscription.%s with status=%s",
+    async (action, status) => {
+      const subscription = buildSubscription({ orgId, status });
+
+      await handleSubscriptionChanged(subscription, action);
+
+      const updated = await prisma.organization.findUniqueOrThrow({
+        where: { id: orgId },
+      });
+      // Side-effect assertion: subscriptionStatus is written unconditionally
+      // inside the same prisma update that contains the isPaidAndCurrent
+      // gate. Asserting it proves the gated branch actually ran, so the
+      // "still BLOCKED" check below cannot pass by an early return.
+      const stripe = (updated.cloudConfig as { stripe?: unknown } | null)
+        ?.stripe as
+        | { subscriptionStatus?: string; activeSubscriptionId?: string }
+        | undefined;
+      expect(stripe?.subscriptionStatus).toBe(status);
+      expect(stripe?.activeSubscriptionId).toBe(subscription.id);
+      expect(updated.cloudFreeTierUsageThresholdState).toBe("BLOCKED");
+    },
+  );
+});

--- a/web/src/ee/features/billing/server/stripeWebhookHandler.ts
+++ b/web/src/ee/features/billing/server/stripeWebhookHandler.ts
@@ -464,7 +464,7 @@ export async function createDefaultSpendAlerts({
   }
 }
 
-async function handleSubscriptionChanged(
+export async function handleSubscriptionChanged(
   subscription: Stripe.Subscription,
   action: "created" | "deleted" | "updated",
 ) {
@@ -632,12 +632,21 @@ async function handleSubscriptionChanged(
       },
     };
 
+    // Only clear free-tier suspension when payment is credibly current.
+    // Stripe fires subscription.created/updated for non-paying states too
+    // (incomplete, past_due, unpaid, ...); unblocking on those would let a
+    // failed-payment org resume ingestion. The worker's hourly threshold job
+    // remains the fallback that reconciles this column from usage + plan.
+    const isPaidAndCurrent =
+      subscription.status === "active" || subscription.status === "trialing";
+
     await prisma.organization.update({
       where: {
         id: parsedOrg.id,
       },
       data: {
         cloudConfig: updatedCloudConfig,
+        ...(isPaidAndCurrent ? { cloudFreeTierUsageThresholdState: null } : {}),
       },
     });
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a UX gap where organizations that upgrade from the free tier to a paid Stripe subscription remain ingestion-suspended until the next hourly threshold job run (up to ~1 hour). The fix clears `cloudFreeTierUsageThresholdState` to `null` immediately when a subscription is created or updated, alongside the existing `invalidateCachedOrgApiKeys` call that was already in that branch.

- **Core fix** (`stripeWebhookHandler.ts`): adds `cloudFreeTierUsageThresholdState: null` to the `prisma.organization.update` call inside the `created | updated` branch. The API key cache is already invalidated right afterward, so the full unblock happens atomically on the webhook.
- **Tests** (`stripe-webhook-handler.servertest.ts`): two new integration tests create a `BLOCKED` org, fire `handleSubscriptionChanged` with a synthetic subscription, and assert the field becomes `null`. The function is also exported for the first time to enable this testing.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge — it fixes a real unblock gap and the existing `invalidateCachedOrgApiKeys` call immediately following the update ensures Redis is flushed.

The core fix is minimal and correct: one new field in an existing Prisma update call, already inside the right conditional branch. The accompanying tests cover the two primary use cases. The only gap is that no test guards against the `deleted` action accidentally being changed to also clear the field, and non-`active` subscription statuses go untested. Neither is a present defect.

The test file would benefit from a `deleted`-action assertion and a non-`active` status case to lock in the intended boundaries of the fix.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant WebhookHandler as stripeWebhookHandler
    participant DB as Prisma / DB
    participant Redis as API Key Cache

    Stripe->>WebhookHandler: subscription.created / subscription.updated
    WebhookHandler->>WebhookHandler: "Validate cloud region & org lookup"
    WebhookHandler->>DB: "organization.update({cloudConfig, cloudFreeTierUsageThresholdState: null})"
    WebhookHandler->>Redis: invalidateCachedOrgApiKeys(orgId)
    Note over DB,Redis: Org is unblocked immediately
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/stripe-webhook-handler.servertest.ts:49-73
**Missing test for `deleted` action and non-`active` subscription status**

The test suite verifies that `created` and `updated` events clear the field, but there's no assertion that the `deleted` action does NOT clear `cloudFreeTierUsageThresholdState`. A regression that accidentally moved the `null` assignment outside the `if (action === "created" || action === "updated")` guard would go undetected. Similarly, the tests only exercise `status: "active"` — adding a case with `status: "past_due"` or `status: "incomplete"` would document whether the current "always clear on any update" behavior is intentional.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: clear free-tier suspension state on..."](https://github.com/langfuse/langfuse/commit/a833b59ca259061493b61b2c691ed09827636c86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32625343)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->