### PR TITLE
fix: lightweight updates/deletes interact incorrectly with lazy materialization in 25.10.

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -99,6 +99,12 @@ const EnvSchema = z.object({
   CLICKHOUSE_UPDATE_PARALLEL_MODE: z
     .enum(["sync", "async", "auto"])
     .default("auto"),
+  // Workaround for a 25.12 bug where lightweight updates/deletes interact
+  // incorrectly with lazy materialization. Remove after ClickHouse 26.4, or
+  // earlier if the fix is backported.
+  CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: z
+    .enum(["true", "false"])
+    .default("false"),
 
   LANGFUSE_INGESTION_QUEUE_DELAY_MS: z.coerce
     .number()

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -153,6 +153,12 @@ export class ClickHouseClientManager {
                 update_parallel_mode: env.CLICKHOUSE_UPDATE_PARALLEL_MODE,
               }
             : {}),
+          // Workaround for a 25.12 bug where lightweight updates/deletes
+          // interact incorrectly with lazy materialization. Remove after
+          // ClickHouse 26.4, or earlier if the fix is backported.
+          ...(env.CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION === "true"
+            ? { query_plan_optimize_lazy_materialization: 0 }
+            : {}),
           ...cloudOptions,
           ...opts.clickhouse_settings,
           async_insert: 1,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a targeted workaround for a ClickHouse bug (referenced as 25.10 in the title and 25.12 in code comments) where lightweight updates and deletes interact incorrectly with lazy materialization. The fix is gated behind a new `CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION` env var that defaults to `"true"`, injecting `query_plan_optimize_lazy_materialization: 0` into the global client settings.

- Adds `CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION` to `env.ts` using the existing `z.enum("true"/"false")` pattern; defaults to enabled so all deployments get the workaround without manual opt-in.
- Injects the ClickHouse setting before `cloudOptions` and `opts.clickhouse_settings`, so per-call or cloud overrides can still take precedence if needed.
- A minor inconsistency exists between the PR title ("25.10") and the in-code comments ("25.12"), which may cause confusion when evaluating whether the workaround can be removed.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a narrow, flag-gated workaround that follows established patterns and defaults to enabled so no manual operator action is required.

The logic is straightforward: a new boolean env var gates a single ClickHouse setting injected into the shared client builder. The setting is placed at the right priority level (before per-call overrides), and the default of "true" correctly applies the workaround to all existing deployments. The only rough edge is a version-number mismatch between the PR title ("25.10") and the in-code comments ("25.12"), which could make it harder to decide when to remove the code.

The version discrepancy is in both `packages/shared/src/server/clickhouse/client.ts` and `packages/shared/src/env.ts` — worth aligning before merging so the removal condition is unambiguous.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ClickHouseClientManager.getClient] --> B{Client already cached?}
    B -- Yes --> Z[Return cached client]
    B -- No --> C[Build clickhouse_settings]
    C --> D[Async insert tunables]
    D --> E{CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE != alter_update?}
    E -- Yes --> F[Add lightweight_delete_mode + update_parallel_mode]
    E -- No --> G
    F --> G{CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION == true?}
    G -- Yes --> H[Add query_plan_optimize_lazy_materialization: 0 - Workaround for CH 25.12 bug]
    G -- No --> I
    H --> I[Merge cloudOptions]
    I --> J[Merge per-call opts.clickhouse_settings]
    J --> K[Force async_insert + wait_for_async_insert]
    K --> L[Create & cache client]
    L --> Z
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/clickhouse/client.ts:156-161
**Version mismatch in comments vs PR title**

The PR title references "25.10" but the in-code comments (here and in `env.ts`) say "25.12 bug." Both describe the same workaround, so whichever version is wrong will mislead whoever comes back to evaluate whether the fix has been backported and this code can be removed. The removal condition ("ClickHouse 26.4 or earlier if backported") also differs from the env-var comment — the env comment says "26.4", which is consistent, but the version being fixed should be aligned throughout.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: lightweight updates/deletes interac..."](https://github.com/langfuse/langfuse/commit/2893cb6a07ef0ad6a449315b01058741b1132ca2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32641035)</sub>

<!-- /greptile_comment -->