### PR TITLE
feat(evals): add code eval execution queue

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -149,6 +149,10 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(1),
+  LANGFUSE_CODE_EVAL_EXECUTION_QUEUE_SHARD_COUNT: z.coerce
+    .number()
+    .positive()
+    .default(1),
   LANGFUSE_TRACE_UPSERT_QUEUE_SHARD_COUNT: z.coerce
     .number()
     .positive()

--- a/packages/shared/src/features/evals/types.ts
+++ b/packages/shared/src/features/evals/types.ts
@@ -39,6 +39,20 @@ export const assertLLMAsJudgeEvalTemplate = (
   }
 };
 
+export const assertCodeBasedEvalTemplate = (
+  template: EvalTemplate,
+): asserts template is EvalTemplateCodeBased => {
+  if (
+    template.type !== EvalTemplateType.CODE ||
+    template.prompt !== null ||
+    template.outputDefinition !== null ||
+    template.sourceCode === null ||
+    template.sourceCodeLanguage === null
+  ) {
+    throw new Error("Expected code-based evaluation template");
+  }
+};
+
 export const EvalTargetObject = {
   TRACE: "trace",
   DATASET: "dataset",

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -109,6 +109,7 @@ export * from "./utils/rendering";
 export * from "./utils/sqlLike";
 export * from "./redis/evalExecutionQueue";
 export * from "./redis/llmAsJudgeExecutionQueue";
+export * from "./redis/codeEvalExecutionQueue";
 export * from "./services/sessions-ui-table-service";
 export * from "./services/sessions-ui-table-events-service";
 export * from "./services/DashboardService";

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -99,8 +99,8 @@ export const EvalExecutionEvent = z.object({
   delay: z.number().nullish(),
 });
 
-// LLM-as-a-Judge execution for observation-based evals
-export const LLMAsJudgeExecutionEventSchema = z.object({
+// Observation-based eval execution payload shared by LLM-as-judge and code eval queues.
+export const ObservationEvalExecutionEventSchema = z.object({
   projectId: z.string(),
   jobExecutionId: z.string(),
   observationS3Path: z.string(),
@@ -284,8 +284,8 @@ export type DatasetRunItemUpsertEventType = z.infer<
   typeof DatasetRunItemUpsertEventSchema
 >;
 export type EvalExecutionEventType = z.infer<typeof EvalExecutionEvent>;
-export type LLMAsJudgeExecutionEventType = z.infer<
-  typeof LLMAsJudgeExecutionEventSchema
+export type ObservationEvalExecutionEventType = z.infer<
+  typeof ObservationEvalExecutionEventSchema
 >;
 export type IngestionEventQueueType = z.infer<typeof IngestionEvent>;
 export type OtelIngestionEventQueueType = z.infer<typeof OtelIngestionEvent>;
@@ -325,7 +325,8 @@ export enum QueueName {
   ProjectDelete = "project-delete",
   EvaluationExecution = "evaluation-execution-queue", // Worker executes Evals
   EvaluationExecutionSecondaryQueue = "secondary-evaluation-execution-queue", // Separates high-throughput eval projects from other projects.
-  LLMAsJudgeExecution = "llm-as-a-judge-execution-queue", // Observation-based eval execution
+  LLMAsJudgeExecution = "llm-as-a-judge-execution-queue", // Observation-based LLM-as-judge eval execution
+  CodeEvalExecution = "code-eval-execution-queue", // Observation-based code eval execution
   DatasetRunItemUpsert = "dataset-run-item-upsert-queue",
   BatchExport = "batch-export-queue",
   OtelIngestionQueue = "otel-ingestion-queue",
@@ -364,6 +365,7 @@ export enum QueueJobs {
   DatasetRunItemUpsert = "dataset-run-item-upsert",
   EvaluationExecution = "evaluation-execution-job",
   LLMAsJudgeExecution = "llm-as-a-judge-execution-job",
+  CodeEvalExecution = "code-eval-execution-job",
   BatchExportJob = "batch-export-job",
   CloudUsageMeteringJob = "cloud-usage-metering-job",
   CloudSpendAlertJob = "cloud-spend-alert-job",
@@ -447,8 +449,15 @@ export type TQueueJobTypes = {
   [QueueName.LLMAsJudgeExecution]: {
     timestamp: Date;
     id: string;
-    payload: LLMAsJudgeExecutionEventType;
+    payload: ObservationEvalExecutionEventType;
     name: QueueJobs.LLMAsJudgeExecution;
+    retryBaggage?: RetryBaggage;
+  };
+  [QueueName.CodeEvalExecution]: {
+    timestamp: Date;
+    id: string;
+    payload: ObservationEvalExecutionEventType;
+    name: QueueJobs.CodeEvalExecution;
     retryBaggage?: RetryBaggage;
   };
   [QueueName.BatchExport]: {

--- a/packages/shared/src/server/redis/codeEvalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/codeEvalExecutionQueue.ts
@@ -1,0 +1,92 @@
+import { Queue } from "bullmq";
+import { logger } from "../logger";
+import { TQueueJobTypes, QueueName } from "../queues";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  getQueuePrefix,
+} from "./redis";
+import { getShardIndex } from "./sharding";
+import { env } from "../../env";
+
+export class CodeEvalExecutionQueue {
+  private static instances: Map<
+    number,
+    Queue<TQueueJobTypes[QueueName.CodeEvalExecution]> | null
+  > = new Map();
+
+  public static getShardNames() {
+    return Array.from(
+      { length: env.LANGFUSE_CODE_EVAL_EXECUTION_QUEUE_SHARD_COUNT },
+      (_, i) => `${QueueName.CodeEvalExecution}${i > 0 ? `-${i}` : ""}`,
+    );
+  }
+
+  static getShardIndexFromShardName(
+    shardName: string | undefined,
+  ): number | null {
+    if (!shardName) return null;
+
+    const shardIndex =
+      shardName === QueueName.CodeEvalExecution
+        ? 0
+        : parseInt(
+            shardName.replace(`${QueueName.CodeEvalExecution}-`, ""),
+            10,
+          );
+
+    if (isNaN(shardIndex)) return null;
+    return shardIndex;
+  }
+
+  public static getInstance({
+    shardingKey,
+    shardName,
+  }: {
+    shardingKey?: string;
+    shardName?: string;
+  } = {}): Queue<TQueueJobTypes[QueueName.CodeEvalExecution]> | null {
+    const shardIndex =
+      CodeEvalExecutionQueue.getShardIndexFromShardName(shardName) ??
+      (env.REDIS_CLUSTER_ENABLED === "true" && shardingKey
+        ? getShardIndex(
+            shardingKey,
+            env.LANGFUSE_CODE_EVAL_EXECUTION_QUEUE_SHARD_COUNT,
+          )
+        : 0);
+
+    if (CodeEvalExecutionQueue.instances.has(shardIndex)) {
+      return CodeEvalExecutionQueue.instances.get(shardIndex) || null;
+    }
+
+    const newRedis = createNewRedisInstance({
+      enableOfflineQueue: false,
+      ...redisQueueRetryOptions,
+    });
+
+    const name = `${QueueName.CodeEvalExecution}${shardIndex > 0 ? `-${shardIndex}` : ""}`;
+    const queueInstance = newRedis
+      ? new Queue<TQueueJobTypes[QueueName.CodeEvalExecution]>(name, {
+          connection: newRedis,
+          prefix: getQueuePrefix(name),
+          defaultJobOptions: {
+            removeOnComplete: true,
+            removeOnFail: 10_000,
+            attempts: 10,
+            backoff: {
+              type: "exponential",
+              delay: 1000,
+            },
+          },
+        })
+      : null;
+
+    queueInstance?.on("error", (err) => {
+      logger.error(`CodeEvalExecutionQueue shard ${shardIndex} error`, err);
+    });
+
+    CodeEvalExecutionQueue.instances.set(shardIndex, queueInstance);
+
+    return queueInstance;
+  }
+}

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -38,6 +38,7 @@ export function getQueue(
     | QueueName.EvaluationExecution
     | QueueName.EvaluationExecutionSecondaryQueue
     | QueueName.LLMAsJudgeExecution
+    | QueueName.CodeEvalExecution
     | QueueName.TraceUpsert
     | QueueName.OtelIngestionQueue
     | QueueName.OtelIngestionSecondaryQueue

--- a/web/src/__tests__/test-utils.ts
+++ b/web/src/__tests__/test-utils.ts
@@ -1,6 +1,7 @@
 import { env } from "@/src/env.mjs";
 import { prisma } from "@langfuse/shared/src/db";
 import {
+  CodeEvalExecutionQueue,
   EvalExecutionQueue,
   LLMAsJudgeExecutionQueue,
   SecondaryEvalExecutionQueue,
@@ -94,6 +95,7 @@ export const getQueues = () => {
     ...EvalExecutionQueue.getShardNames(),
     ...SecondaryEvalExecutionQueue.getShardNames(),
     ...LLMAsJudgeExecutionQueue.getShardNames(),
+    ...CodeEvalExecutionQueue.getShardNames(),
     ...OtelIngestionQueue.getShardNames(),
     ...SecondaryOtelIngestionQueue.getShardNames(),
     ...TraceUpsertQueue.getShardNames(),
@@ -126,29 +128,36 @@ export const getQueues = () => {
                 ? LLMAsJudgeExecutionQueue.getInstance({
                     shardName: queueName,
                   })
-                : queueName.startsWith(QueueName.TraceUpsert)
-                  ? TraceUpsertQueue.getInstance({ shardName: queueName })
-                  : queueName.startsWith(QueueName.OtelIngestionSecondaryQueue)
-                    ? SecondaryOtelIngestionQueue.getInstance({
-                        shardName: queueName,
-                      })
-                    : queueName.startsWith(QueueName.OtelIngestionQueue)
-                      ? OtelIngestionQueue.getInstance({
+                : queueName.startsWith(QueueName.CodeEvalExecution)
+                  ? CodeEvalExecutionQueue.getInstance({
+                      shardName: queueName,
+                    })
+                  : queueName.startsWith(QueueName.TraceUpsert)
+                    ? TraceUpsertQueue.getInstance({ shardName: queueName })
+                    : queueName.startsWith(
+                          QueueName.OtelIngestionSecondaryQueue,
+                        )
+                      ? SecondaryOtelIngestionQueue.getInstance({
                           shardName: queueName,
                         })
-                      : getQueue(
-                          queueName as Exclude<
-                            QueueName,
-                            | QueueName.IngestionQueue
-                            | QueueName.IngestionSecondaryQueue
-                            | QueueName.EvaluationExecution
-                            | QueueName.EvaluationExecutionSecondaryQueue
-                            | QueueName.LLMAsJudgeExecution
-                            | QueueName.TraceUpsert
-                            | QueueName.OtelIngestionQueue
-                            | QueueName.OtelIngestionSecondaryQueue
-                          >,
-                        ),
+                      : queueName.startsWith(QueueName.OtelIngestionQueue)
+                        ? OtelIngestionQueue.getInstance({
+                            shardName: queueName,
+                          })
+                        : getQueue(
+                            queueName as Exclude<
+                              QueueName,
+                              | QueueName.IngestionQueue
+                              | QueueName.IngestionSecondaryQueue
+                              | QueueName.EvaluationExecution
+                              | QueueName.EvaluationExecutionSecondaryQueue
+                              | QueueName.LLMAsJudgeExecution
+                              | QueueName.CodeEvalExecution
+                              | QueueName.TraceUpsert
+                              | QueueName.OtelIngestionQueue
+                              | QueueName.OtelIngestionSecondaryQueue
+                            >,
+                          ),
     );
 };
 

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -1,6 +1,7 @@
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { z } from "zod";
 import {
+  CodeEvalExecutionQueue,
   EvalExecutionQueue,
   LLMAsJudgeExecutionQueue,
   SecondaryEvalExecutionQueue,
@@ -75,6 +76,7 @@ export default async function handler(
           ...EvalExecutionQueue.getShardNames(),
           ...SecondaryEvalExecutionQueue.getShardNames(),
           ...LLMAsJudgeExecutionQueue.getShardNames(),
+          ...CodeEvalExecutionQueue.getShardNames(),
           ...TraceUpsertQueue.getShardNames(),
           ...OtelIngestionQueue.getShardNames(),
           ...SecondaryOtelIngestionQueue.getShardNames(),
@@ -104,6 +106,10 @@ export default async function handler(
               queue = LLMAsJudgeExecutionQueue.getInstance({
                 shardName: queueName,
               });
+            } else if (queueName.startsWith(QueueName.CodeEvalExecution)) {
+              queue = CodeEvalExecutionQueue.getInstance({
+                shardName: queueName,
+              });
             } else if (queueName.startsWith(QueueName.TraceUpsert)) {
               queue = TraceUpsertQueue.getInstance({ shardName: queueName });
             } else if (
@@ -123,6 +129,7 @@ export default async function handler(
                   | QueueName.EvaluationExecution
                   | QueueName.EvaluationExecutionSecondaryQueue
                   | QueueName.LLMAsJudgeExecution
+                  | QueueName.CodeEvalExecution
                   | QueueName.TraceUpsert
                   | QueueName.OtelIngestionQueue
                   | QueueName.OtelIngestionSecondaryQueue
@@ -170,6 +177,10 @@ export default async function handler(
           queue = LLMAsJudgeExecutionQueue.getInstance({
             shardName: queueName,
           });
+        } else if (queueName.startsWith(QueueName.CodeEvalExecution)) {
+          queue = CodeEvalExecutionQueue.getInstance({
+            shardName: queueName,
+          });
         } else if (queueName.startsWith(QueueName.TraceUpsert)) {
           queue = TraceUpsertQueue.getInstance({ shardName: queueName });
         } else if (
@@ -189,6 +200,7 @@ export default async function handler(
               | QueueName.EvaluationExecution
               | QueueName.EvaluationExecutionSecondaryQueue
               | QueueName.LLMAsJudgeExecution
+              | QueueName.CodeEvalExecution
               | QueueName.TraceUpsert
               | QueueName.OtelIngestionQueue
               | QueueName.OtelIngestionSecondaryQueue
@@ -246,6 +258,10 @@ export default async function handler(
           queue = LLMAsJudgeExecutionQueue.getInstance({
             shardName: queueName,
           });
+        } else if (queueName.startsWith(QueueName.CodeEvalExecution)) {
+          queue = CodeEvalExecutionQueue.getInstance({
+            shardName: queueName,
+          });
         } else if (queueName.startsWith(QueueName.TraceUpsert)) {
           queue = TraceUpsertQueue.getInstance({ shardName: queueName });
         } else if (
@@ -265,6 +281,7 @@ export default async function handler(
               | QueueName.EvaluationExecution
               | QueueName.EvaluationExecutionSecondaryQueue
               | QueueName.LLMAsJudgeExecution
+              | QueueName.CodeEvalExecution
               | QueueName.TraceUpsert
               | QueueName.OtelIngestionQueue
               | QueueName.OtelIngestionSecondaryQueue

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -15,6 +15,7 @@ import {
   evalJobTraceCreatorQueueProcessor,
   llmAsJudgeExecutionQueueProcessorBuilder,
 } from "./queues/evalQueue";
+import { codeEvalExecutionQueueProcessorBuilder } from "./queues/codeEvalQueue";
 import { batchExportQueueProcessor } from "./queues/batchExportQueue";
 import { onShutdown } from "./utils/shutdown";
 import helmet from "helmet";
@@ -43,6 +44,7 @@ import {
   EvalExecutionQueue,
   SecondaryEvalExecutionQueue,
   LLMAsJudgeExecutionQueue,
+  CodeEvalExecutionQueue,
 } from "@langfuse/shared/src/server";
 import { env } from "./env";
 import { ingestionQueueProcessorBuilder } from "./queues/ingestionQueue";
@@ -263,6 +265,22 @@ if (env.QUEUE_CONSUMER_EVAL_EXECUTION_QUEUE_IS_ENABLED === "true") {
       llmAsJudgeExecutionQueueProcessorBuilder(shardName),
       {
         concurrency: env.LANGFUSE_LLM_AS_JUDGE_EXECUTION_WORKER_CONCURRENCY,
+        lockDuration: 60000,
+        stalledInterval: 120000,
+        maxStalledCount: 3,
+      },
+    );
+  });
+}
+
+if (env.QUEUE_CONSUMER_CODE_EVAL_EXECUTION_QUEUE_IS_ENABLED === "true") {
+  const codeEvalShardNames = CodeEvalExecutionQueue.getShardNames();
+  codeEvalShardNames.forEach((shardName) => {
+    WorkerManager.register(
+      shardName as QueueName,
+      codeEvalExecutionQueueProcessorBuilder(shardName),
+      {
+        concurrency: env.LANGFUSE_CODE_EVAL_EXECUTION_WORKER_CONCURRENCY,
         lockDuration: 60000,
         stalledInterval: 120000,
         maxStalledCount: 3,

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -132,6 +132,10 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(5),
+  LANGFUSE_CODE_EVAL_EXECUTION_WORKER_CONCURRENCY: z.coerce
+    .number()
+    .positive()
+    .default(5),
   LANGFUSE_EVAL_EXECUTION_SECONDARY_QUEUE_PROCESSING_CONCURRENCY: z.coerce
     .number()
     .positive()
@@ -204,6 +208,9 @@ const EnvSchema = z.object({
     .enum(["true", "false"])
     .default("true"),
   QUEUE_CONSUMER_EVAL_EXECUTION_SECONDARY_QUEUE_IS_ENABLED: z
+    .enum(["true", "false"])
+    .default("true"),
+  QUEUE_CONSUMER_CODE_EVAL_EXECUTION_QUEUE_IS_ENABLED: z
     .enum(["true", "false"])
     .default("true"),
   QUEUE_CONSUMER_TRACE_UPSERT_QUEUE_IS_ENABLED: z

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -400,6 +400,11 @@ export const handleBatchActionJob = async (
           id: true,
           projectId: true,
           evalTemplateId: true,
+          evalTemplate: {
+            select: {
+              type: true,
+            },
+          },
           scoreName: true,
           targetObject: true,
           variableMapping: true,
@@ -413,6 +418,7 @@ export const handleBatchActionJob = async (
       // sampling=1 to ensure every streamed observation is evaluated.
       evaluators = rawEvaluators.map((e) => ({
         ...e,
+        evalTemplate: e.evalTemplate!,
         filter: [] as [],
         sampling: new Decimal(1),
       }));

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -393,6 +393,7 @@ export const handleBatchActionJob = async (
         where: {
           id: { in: selectedEvaluatorIds },
           projectId,
+          evalTemplateId: { not: null },
           // Preserve the selected evaluators as-is. Executability is checked
           // later when each scheduling attempt runs.
         },

--- a/worker/src/features/batchAction/processBatchedObservationEval.test.ts
+++ b/worker/src/features/batchAction/processBatchedObservationEval.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
-import { EvalTargetObject, JobConfigState } from "@langfuse/shared";
+import {
+  EvalTargetObject,
+  EvalTemplateType,
+  JobConfigState,
+} from "@langfuse/shared";
 import { type ObservationEvalConfig } from "../evaluation/observationEval";
 
 vi.mock("@langfuse/shared/src/db", () => ({
@@ -38,6 +42,7 @@ describe("processBatchedObservationEval", () => {
         filter: [],
         sampling: { toNumber: () => 1 } as ObservationEvalConfig["sampling"],
         evalTemplateId: "template-1",
+        evalTemplate: { type: EvalTemplateType.LLM_AS_JUDGE },
         scoreName: "quality",
         targetObject: EvalTargetObject.EVENT,
         variableMapping: [],
@@ -96,6 +101,7 @@ describe("processBatchedObservationEval", () => {
         filter: [],
         sampling: { toNumber: () => 1 } as ObservationEvalConfig["sampling"],
         evalTemplateId: "template-1",
+        evalTemplate: { type: EvalTemplateType.LLM_AS_JUDGE },
         scoreName: "quality",
         targetObject: EvalTargetObject.EVENT,
         variableMapping: [],

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -1,0 +1,21 @@
+import { type JobConfiguration, type JobExecution } from "@prisma/client";
+import { type EvalTemplateCodeBased } from "@langfuse/shared";
+import { UnrecoverableError } from "../../../errors/UnrecoverableError";
+import { type EvalExecutionResult } from "../evalCompletion";
+import { type EvalExecutionDeps } from "../evalExecutionDeps";
+import { type ExtractedVariable } from "../observationEval/extractObservationVariables";
+
+export async function executeCodeBasedEvaluation(_params: {
+  projectId: string;
+  jobExecutionId: string;
+  job: JobExecution;
+  config: JobConfiguration;
+  template: EvalTemplateCodeBased;
+  extractedVariables: ExtractedVariable[];
+  environment: string;
+  deps?: EvalExecutionDeps;
+}): Promise<EvalExecutionResult> {
+  return Promise.reject(
+    new UnrecoverableError("Code-based eval execution is not implemented yet"),
+  );
+}

--- a/worker/src/features/evaluation/codeBased/index.ts
+++ b/worker/src/features/evaluation/codeBased/index.ts
@@ -1,0 +1,1 @@
+export { executeCodeBasedEvaluation } from "./executeCodeBasedEvaluation";

--- a/worker/src/features/evaluation/evalCompletion.ts
+++ b/worker/src/features/evaluation/evalCompletion.ts
@@ -1,0 +1,91 @@
+import { JobExecutionStatus } from "@prisma/client";
+import { logger, traceException } from "@langfuse/shared/src/server";
+import { type EvalOutputResult } from "@langfuse/shared";
+import { buildEvalScoreWritePayloads } from "./evalScoreEvent";
+import { type EvalExecutionDeps } from "./evalExecutionDeps";
+
+export type EvalExecutionResult = {
+  outputResult: EvalOutputResult;
+  primaryScoreId: string;
+  executionTraceId: string;
+  metadata: Record<string, string>;
+};
+
+export async function completeEvalExecution({
+  projectId,
+  jobExecutionId,
+  outputResult,
+  primaryScoreId,
+  traceId,
+  observationId,
+  scoreName,
+  environment,
+  executionTraceId,
+  metadata,
+  deps,
+}: {
+  projectId: string;
+  jobExecutionId: string;
+  outputResult: EvalOutputResult;
+  primaryScoreId: string;
+  traceId: string | null;
+  observationId: string | null;
+  scoreName: string;
+  environment: string;
+  executionTraceId: string;
+  metadata: Record<string, string>;
+  deps: EvalExecutionDeps;
+}): Promise<{ scoreCount: number }> {
+  const scoreWritePayloads = buildEvalScoreWritePayloads({
+    outputResult,
+    primaryScoreId,
+    traceId,
+    observationId,
+    scoreName,
+    environment,
+    executionTraceId,
+    metadata,
+  });
+
+  try {
+    await Promise.all(
+      scoreWritePayloads.map(async ({ scoreId, eventId, event }) => {
+        await deps.uploadScore({
+          projectId,
+          scoreId,
+          eventId,
+          event,
+        });
+
+        await deps.enqueueScoreIngestion({
+          projectId,
+          scoreId,
+          eventId,
+        });
+      }),
+    );
+  } catch (e) {
+    logger.error(`Failed to persist score: ${e}`, e);
+    traceException(e);
+    throw new Error(
+      `Failed to write score ${primaryScoreId} into IngestionQueue`,
+    );
+  }
+
+  logger.debug(
+    `Persisted ${scoreWritePayloads.length} score(s) for job ${jobExecutionId}`,
+  );
+
+  await deps.updateJobExecution({
+    id: jobExecutionId,
+    projectId,
+    data: {
+      status: JobExecutionStatus.COMPLETED,
+      endTime: new Date(),
+      jobOutputScoreId: primaryScoreId,
+      executionTraceId,
+    },
+  });
+
+  return { scoreCount: scoreWritePayloads.length };
+}

--- a/worker/src/features/evaluation/evalCompletion.ts
+++ b/worker/src/features/evaluation/evalCompletion.ts
@@ -8,7 +8,6 @@ export type EvalExecutionResult = {
   outputResult: EvalOutputResult;
   primaryScoreId: string;
   executionTraceId: string;
-  metadata: Record<string, string>;
 };
 
 export async function completeEvalExecution({

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -10,7 +10,6 @@ import {
   QueueJobs,
   QueueName,
   EvalExecutionEvent,
-  traceException,
   logger,
   EvalExecutionQueue,
   checkTraceExistsAndGetTimestamp,
@@ -74,7 +73,10 @@ import {
   buildEvalExecutionMetadata,
   getEnvironmentFromVariables,
 } from "./evalRuntime";
-import { buildEvalScoreWritePayloads } from "./evalScoreEvent";
+import {
+  completeEvalExecution,
+  type EvalExecutionResult,
+} from "./evalCompletion";
 import {
   type EvalExecutionDeps,
   createProductionEvalExecutionDeps,
@@ -711,8 +713,7 @@ export const createEvalJobs = async ({
  * It handles:
  * - Compiling the prompt with extracted variables
  * - Calling the LLM with structured output
- * - Persisting the score to S3 and queueing for ingestion
- * - Updating job execution status
+ * - Returning the validated eval output and completion metadata
  *
  * Note: Callers are responsible for:
  * - Fetching and validating job, config, and template
@@ -727,14 +728,13 @@ export const createEvalJobs = async ({
  * @param params.extractedVariables - Pre-extracted variables from trace/observation data
  * @param params.deps - Optional dependency injection for testing (defaults to production deps)
  */
-export async function executeLLMAsJudgeEvaluation({
+export async function runLLMAsJudgeEvaluation({
   projectId,
   jobExecutionId,
   job,
   config,
   template,
   extractedVariables,
-  environment,
   deps = createProductionEvalExecutionDeps(),
 }: {
   projectId: string;
@@ -745,7 +745,7 @@ export async function executeLLMAsJudgeEvaluation({
   extractedVariables: ExtractedVariable[];
   environment: string;
   deps?: EvalExecutionDeps;
-}): Promise<void> {
+}): Promise<EvalExecutionResult> {
   return instrumentAsync(
     { name: "eval.execute-llm-as-judge" },
     async (span) => {
@@ -950,63 +950,8 @@ export async function executeLLMAsJudgeEvaluation({
         }`,
       );
 
-      const scoreWritePayloads = buildEvalScoreWritePayloads({
-        outputResult: parsedLLMOutput.data,
-        primaryScoreId,
-        traceId: job.jobInputTraceId,
-        observationId: job.jobInputObservationId,
-        scoreName: config.scoreName,
-        environment,
-        executionTraceId,
-        metadata: executionMetadata,
-      });
-
-      span.setAttribute("eval.score.count", scoreWritePayloads.length);
-
-      // Write score to S3 and enqueue for ingestion
-      try {
-        await Promise.all(
-          scoreWritePayloads.map(async ({ scoreId, eventId, event }) => {
-            await deps.uploadScore({
-              projectId,
-              scoreId,
-              eventId,
-              event,
-            });
-
-            await deps.enqueueScoreIngestion({
-              projectId,
-              scoreId,
-              eventId,
-            });
-          }),
-        );
-      } catch (e) {
-        logger.error(`Failed to persist score: ${e}`, e);
-        traceException(e);
-        throw new Error(
-          `Failed to write score ${primaryScoreId} into IngestionQueue`,
-        );
-      }
-
       logger.debug(
-        `Persisted ${scoreWritePayloads.length} score(s) for job ${jobExecutionId}`,
-      );
-
-      // Update job execution status
-      await deps.updateJobExecution({
-        id: jobExecutionId,
-        projectId,
-        data: {
-          status: JobExecutionStatus.COMPLETED,
-          endTime: new Date(),
-          jobOutputScoreId: primaryScoreId,
-          executionTraceId,
-        },
-      });
-
-      logger.debug(
-        `Eval job ${job.id} completed with ${
+        `Eval job ${job.id} produced ${
           parsedLLMOutput.data.dataType === ScoreDataTypeEnum.NUMERIC
             ? `score ${parsedLLMOutput.data.score}`
             : parsedLLMOutput.data.dataType === ScoreDataTypeEnum.BOOLEAN
@@ -1014,8 +959,33 @@ export async function executeLLMAsJudgeEvaluation({
               : `matches ${parsedLLMOutput.data.matches.join(",")}`
         }`,
       );
+
+      return {
+        outputResult: parsedLLMOutput.data,
+        primaryScoreId,
+        executionTraceId,
+        metadata: executionMetadata,
+      };
     },
   );
+}
+
+export async function executeLLMAsJudgeEvaluation(
+  params: Parameters<typeof runLLMAsJudgeEvaluation>[0],
+): Promise<void> {
+  const deps = params.deps ?? createProductionEvalExecutionDeps();
+  const result = await runLLMAsJudgeEvaluation({ ...params, deps });
+
+  await completeEvalExecution({
+    projectId: params.projectId,
+    jobExecutionId: params.jobExecutionId,
+    traceId: params.job.jobInputTraceId,
+    observationId: params.job.jobInputObservationId,
+    scoreName: params.config.scoreName,
+    environment: params.environment,
+    deps,
+    ...result,
+  });
 }
 
 /**

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -735,7 +735,7 @@ export async function runLLMAsJudgeEvaluation({
   config,
   template,
   extractedVariables,
-  deps = createProductionEvalExecutionDeps(),
+  deps,
 }: {
   projectId: string;
   jobExecutionId: string;
@@ -744,7 +744,7 @@ export async function runLLMAsJudgeEvaluation({
   template: EvalTemplateLlmAsAJudge;
   extractedVariables: ExtractedVariable[];
   environment: string;
-  deps?: EvalExecutionDeps;
+  deps: EvalExecutionDeps;
 }): Promise<EvalExecutionResult> {
   return instrumentAsync(
     { name: "eval.execute-llm-as-judge" },
@@ -971,7 +971,9 @@ export async function runLLMAsJudgeEvaluation({
 }
 
 export async function executeLLMAsJudgeEvaluation(
-  params: Parameters<typeof runLLMAsJudgeEvaluation>[0],
+  params: Omit<Parameters<typeof runLLMAsJudgeEvaluation>[0], "deps"> & {
+    deps?: EvalExecutionDeps;
+  },
 ): Promise<void> {
   const deps = params.deps ?? createProductionEvalExecutionDeps();
   const result = await runLLMAsJudgeEvaluation({ ...params, deps });

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -735,6 +735,7 @@ export async function runLLMAsJudgeEvaluation({
   config,
   template,
   extractedVariables,
+  metadata,
   deps,
 }: {
   projectId: string;
@@ -744,6 +745,7 @@ export async function runLLMAsJudgeEvaluation({
   template: EvalTemplateLlmAsAJudge;
   extractedVariables: ExtractedVariable[];
   environment: string;
+  metadata: Record<string, string>;
   deps: EvalExecutionDeps;
 }): Promise<EvalExecutionResult> {
   return instrumentAsync(
@@ -856,14 +858,6 @@ export async function runLLMAsJudgeEvaluation({
       span.setAttribute("eval.score.id", primaryScoreId);
       const executionTraceId = createW3CTraceId(jobExecutionId);
 
-      const executionMetadata = buildEvalExecutionMetadata({
-        jobExecutionId,
-        jobConfigurationId: job.jobConfigurationId,
-        targetTraceId: job.jobInputTraceId,
-        targetObservationId: job.jobInputObservationId,
-        targetDatasetItemId: job.jobInputDatasetItemId,
-      });
-
       // Call LLM
       const llmOutput = await instrumentAsync(
         { name: "eval.call-llm" },
@@ -898,7 +892,7 @@ export async function runLLMAsJudgeEvaluation({
                 traceName: `Execute evaluator: ${template.name}`,
                 environment: LangfuseInternalTraceEnvironment.LLMJudge,
                 metadata: {
-                  ...executionMetadata,
+                  ...metadata,
                   score_id: primaryScoreId,
                 },
               },
@@ -964,19 +958,28 @@ export async function runLLMAsJudgeEvaluation({
         outputResult: parsedLLMOutput.data,
         primaryScoreId,
         executionTraceId,
-        metadata: executionMetadata,
       };
     },
   );
 }
 
 export async function executeLLMAsJudgeEvaluation(
-  params: Omit<Parameters<typeof runLLMAsJudgeEvaluation>[0], "deps"> & {
+  params: Omit<
+    Parameters<typeof runLLMAsJudgeEvaluation>[0],
+    "deps" | "metadata"
+  > & {
     deps?: EvalExecutionDeps;
   },
 ): Promise<void> {
   const deps = params.deps ?? createProductionEvalExecutionDeps();
-  const result = await runLLMAsJudgeEvaluation({ ...params, deps });
+  const metadata = buildEvalExecutionMetadata({
+    jobExecutionId: params.jobExecutionId,
+    jobConfigurationId: params.job.jobConfigurationId,
+    targetTraceId: params.job.jobInputTraceId,
+    targetObservationId: params.job.jobInputObservationId,
+    targetDatasetItemId: params.job.jobInputDatasetItemId,
+  });
+  const result = await runLLMAsJudgeEvaluation({ ...params, deps, metadata });
 
   await completeEvalExecution({
     projectId: params.projectId,
@@ -985,6 +988,7 @@ export async function executeLLMAsJudgeEvaluation(
     observationId: params.job.jobInputObservationId,
     scoreName: params.config.scoreName,
     environment: params.environment,
+    metadata,
     deps,
     ...result,
   });

--- a/worker/src/features/evaluation/observationEval/__tests__/createSchedulerDeps.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/createSchedulerDeps.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EvalTemplateType } from "@langfuse/shared/src/db";
+
+const addToLLMQueue = vi.fn();
+const addToCodeQueue = vi.fn();
+const getLLMQueueInstance = vi.fn(() => ({ add: addToLLMQueue }));
+const getCodeQueueInstance = vi.fn(() => ({ add: addToCodeQueue }));
+
+vi.mock("@langfuse/shared/src/server", async () => {
+  const actual = await vi.importActual("@langfuse/shared/src/server");
+
+  return {
+    ...actual,
+    LLMAsJudgeExecutionQueue: {
+      getInstance: getLLMQueueInstance,
+    },
+    CodeEvalExecutionQueue: {
+      getInstance: getCodeQueueInstance,
+    },
+  };
+});
+
+describe("createObservationEvalSchedulerDeps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("routes LLM-as-judge observation eval jobs to the LLM queue", async () => {
+    const { createObservationEvalSchedulerDeps } =
+      await import("../createSchedulerDeps");
+
+    await createObservationEvalSchedulerDeps().enqueueEvalJob({
+      projectId: "project-1",
+      jobExecutionId: "job-1",
+      observationS3Path: "evals/project-1/observations/obs-1.json",
+      delay: 10,
+      evalTemplateType: EvalTemplateType.LLM_AS_JUDGE,
+    });
+
+    expect(getLLMQueueInstance).toHaveBeenCalledWith({
+      shardingKey: "project-1-job-1",
+    });
+    expect(addToLLMQueue).toHaveBeenCalledWith(
+      "llm-as-a-judge-execution-queue",
+      expect.objectContaining({
+        name: "llm-as-a-judge-execution-job",
+        id: "job-1",
+      }),
+      { delay: 10 },
+    );
+    expect(getCodeQueueInstance).not.toHaveBeenCalled();
+  });
+
+  it("routes code observation eval jobs to the code eval queue", async () => {
+    const { createObservationEvalSchedulerDeps } =
+      await import("../createSchedulerDeps");
+
+    await createObservationEvalSchedulerDeps().enqueueEvalJob({
+      projectId: "project-1",
+      jobExecutionId: "job-2",
+      observationS3Path: "evals/project-1/observations/obs-1.json",
+      delay: 20,
+      evalTemplateType: EvalTemplateType.CODE,
+    });
+
+    expect(getCodeQueueInstance).toHaveBeenCalledWith({
+      shardingKey: "project-1-job-2",
+    });
+    expect(addToCodeQueue).toHaveBeenCalledWith(
+      "code-eval-execution-queue",
+      expect.objectContaining({
+        name: "code-eval-execution-job",
+        id: "job-2",
+      }),
+      { delay: 20 },
+    );
+    expect(getLLMQueueInstance).not.toHaveBeenCalled();
+  });
+});

--- a/worker/src/features/evaluation/observationEval/__tests__/fixtures.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/fixtures.ts
@@ -1,11 +1,12 @@
 import { vi, type Mock } from "vitest";
 import { randomUUID } from "crypto";
+import { type Prisma } from "@langfuse/shared/src/db";
 import {
   EvalTemplateSourceCodeLanguage,
   EvalTemplateType,
-  type Prisma,
-} from "@langfuse/shared/src/db";
-import { type ObservationForEval, EvalTargetObject } from "@langfuse/shared";
+  type ObservationForEval,
+  EvalTargetObject,
+} from "@langfuse/shared";
 import {
   type ObservationEvalConfig,
   type ObservationEvalSchedulerDeps,
@@ -28,6 +29,7 @@ type MockProcessorDeps = ObservationEvalProcessorDeps & {
   downloadObservationFromS3: Mock<
     ObservationEvalProcessorDeps["downloadObservationFromS3"]
   >;
+  evalExecutionDeps: EvalExecutionDeps;
 };
 
 /**
@@ -112,6 +114,7 @@ export function createTestEvalConfig(
     filter: [],
     sampling: { toNumber: () => 1 } as unknown as Prisma.Decimal,
     evalTemplateId: `template-${randomUUID()}`,
+    evalTemplate: { type: EvalTemplateType.LLM_AS_JUDGE },
     scoreName: "test-score",
     status: "ACTIVE",
     blockedAt: null,
@@ -165,6 +168,7 @@ export function createMockProcessorDeps(
     downloadObservationFromS3: Mock<
       ObservationEvalProcessorDeps["downloadObservationFromS3"]
     >;
+    evalExecutionDeps: EvalExecutionDeps;
   }> = {},
 ): MockProcessorDeps {
   const defaultObservation = createTestObservation();
@@ -175,6 +179,8 @@ export function createMockProcessorDeps(
       vi
         .fn<ObservationEvalProcessorDeps["downloadObservationFromS3"]>()
         .mockResolvedValue(JSON.stringify(defaultObservation)),
+    evalExecutionDeps:
+      overrides.evalExecutionDeps ?? createMockEvalExecutionDeps(),
   };
 }
 
@@ -359,18 +365,6 @@ export function createFullyMockedEvalPipeline(
       .mockResolvedValue(undefined),
   };
 
-  const processorDeps: MockProcessorDeps = {
-    downloadObservationFromS3: vi
-      .fn<ObservationEvalProcessorDeps["downloadObservationFromS3"]>()
-      .mockImplementation(async (path) => {
-        const data = uploadedData.get(path);
-        if (data) {
-          return JSON.stringify(data);
-        }
-        return JSON.stringify(observation);
-      }),
-  };
-
   const executionDeps: EvalExecutionDeps = createMockEvalExecutionDeps({
     callLLM: vi
       .fn()
@@ -390,6 +384,19 @@ export function createFullyMockedEvalPipeline(
     enqueueScoreIngestion: vi.fn().mockResolvedValue(undefined),
     updateJobExecution: vi.fn().mockResolvedValue(undefined),
   });
+
+  const processorDeps: MockProcessorDeps = {
+    downloadObservationFromS3: vi
+      .fn<ObservationEvalProcessorDeps["downloadObservationFromS3"]>()
+      .mockImplementation(async (path) => {
+        const data = uploadedData.get(path);
+        if (data) {
+          return JSON.stringify(data);
+        }
+        return JSON.stringify(observation);
+      }),
+    evalExecutionDeps: executionDeps,
+  };
 
   return {
     schedulerDeps,

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
@@ -13,7 +13,12 @@ import {
   createTestEvalConfig,
   createFullyMockedEvalPipeline,
 } from "./fixtures";
-import { EvalTargetObject } from "@langfuse/shared";
+import {
+  assertLLMAsJudgeEvalTemplate,
+  EvalTargetObject,
+  type EvalTemplate,
+  type EvalTemplateLlmAsAJudge,
+} from "@langfuse/shared";
 
 // Mock prisma for processObservationEval
 vi.mock("@langfuse/shared/src/db", () => ({
@@ -28,9 +33,9 @@ vi.mock("@langfuse/shared/src/db", () => ({
   },
 }));
 
-// Mock executeLLMAsJudgeEvaluation
+// Mock runLLMAsJudgeEvaluation
 vi.mock("../../evalService", () => ({
-  executeLLMAsJudgeEvaluation: vi.fn(),
+  runLLMAsJudgeEvaluation: vi.fn(),
 }));
 
 // Mock logger
@@ -49,13 +54,34 @@ vi.mock("@langfuse/shared/src/server", async () => {
 });
 
 import { prisma } from "@langfuse/shared/src/db";
-import { executeLLMAsJudgeEvaluation } from "../../evalService";
+import { runLLMAsJudgeEvaluation } from "../../evalService";
+
+const validateLLMAsJudgeTemplate = (
+  template: EvalTemplate,
+): EvalTemplateLlmAsAJudge => {
+  assertLLMAsJudgeEvalTemplate(template);
+  return template;
+};
+
+const mockEvalExecutionResult = {
+  outputResult: {
+    dataType: "NUMERIC" as const,
+    score: 0.85,
+    reasoning: "Good response",
+  },
+  primaryScoreId: "score-123",
+  executionTraceId: "trace-123",
+  metadata: {},
+};
 
 describe("Observation Eval E2E Pipeline", () => {
   const projectId = "test-project-123";
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (runLLMAsJudgeEvaluation as Mock).mockResolvedValue(
+      mockEvalExecutionResult,
+    );
   });
 
   describe("full pipeline: schedule → process → execute", () => {
@@ -207,6 +233,8 @@ describe("Observation Eval E2E Pipeline", () => {
           jobExecutionId: capturedJobExecutionId!,
           observationS3Path,
         },
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
         deps: pipeline.processorDeps,
       });
 
@@ -214,7 +242,7 @@ describe("Observation Eval E2E Pipeline", () => {
       expect(
         pipeline.processorDeps.downloadObservationFromS3,
       ).toHaveBeenCalledWith(observationS3Path);
-      expect(executeLLMAsJudgeEvaluation).toHaveBeenCalledWith(
+      expect(runLLMAsJudgeEvaluation).toHaveBeenCalledWith(
         expect.objectContaining({
           projectId,
           jobExecutionId: capturedJobExecutionId,
@@ -435,10 +463,12 @@ describe("Observation Eval E2E Pipeline", () => {
           jobExecutionId: "job-123",
           observationS3Path: "test-path",
         },
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
         deps: pipeline.processorDeps,
       });
 
-      expect(executeLLMAsJudgeEvaluation).toHaveBeenCalledWith(
+      expect(runLLMAsJudgeEvaluation).toHaveBeenCalledWith(
         expect.objectContaining({
           extractedVariables: expect.arrayContaining([
             expect.objectContaining({
@@ -538,10 +568,12 @@ describe("Observation Eval E2E Pipeline", () => {
           jobExecutionId: "job-123",
           observationS3Path: "test-path",
         },
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
         deps: pipeline.processorDeps,
       });
 
-      expect(executeLLMAsJudgeEvaluation).toHaveBeenCalledWith(
+      expect(runLLMAsJudgeEvaluation).toHaveBeenCalledWith(
         expect.objectContaining({
           extractedVariables: expect.arrayContaining([
             expect.objectContaining({

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
@@ -17,6 +17,19 @@ import {
 } from "./fixtures";
 import { UnrecoverableError } from "../../../../errors/UnrecoverableError";
 
+const validateLLMAsJudgeTemplate = vi.fn((template) => {
+  if (template.type !== EvalTemplateType.LLM_AS_JUDGE) {
+    throw new Error("Expected LLM-as-judge evaluation template");
+  }
+  return template;
+});
+const validateCodeBasedTemplate = vi.fn((template) => {
+  if (template.type !== EvalTemplateType.CODE) {
+    throw new Error("Expected code-based evaluation template");
+  }
+  return template;
+});
+
 // Mock prisma
 vi.mock("@langfuse/shared/src/db", async () => {
   const actual = await vi.importActual("@langfuse/shared/src/db");
@@ -35,9 +48,13 @@ vi.mock("@langfuse/shared/src/db", async () => {
   };
 });
 
-// Mock executeLLMAsJudgeEvaluation
+// Mock runLLMAsJudgeEvaluation
 vi.mock("../../evalService", () => ({
-  executeLLMAsJudgeEvaluation: vi.fn(),
+  runLLMAsJudgeEvaluation: vi.fn(),
+}));
+
+vi.mock("../../codeBased", () => ({
+  executeCodeBasedEvaluation: vi.fn(),
 }));
 
 // Mock logger
@@ -56,7 +73,23 @@ vi.mock("@langfuse/shared/src/server", async () => {
 });
 
 import { prisma } from "@langfuse/shared/src/db";
-import { executeLLMAsJudgeEvaluation } from "../../evalService";
+import { executeCodeBasedEvaluation } from "../../codeBased";
+import {
+  createMockEvalExecutionDeps,
+  type EvalExecutionDeps,
+} from "../../evalExecutionDeps";
+import { runLLMAsJudgeEvaluation } from "../../evalService";
+
+const mockEvalExecutionResult = {
+  outputResult: {
+    dataType: "NUMERIC" as const,
+    score: 0.5,
+    reasoning: "Mock eval result",
+  },
+  primaryScoreId: "score-123",
+  executionTraceId: "trace-123",
+  metadata: {},
+};
 
 describe("processObservationEval", () => {
   const projectId = "test-project-123";
@@ -71,6 +104,12 @@ describe("processObservationEval", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (executeCodeBasedEvaluation as Mock).mockResolvedValue(
+      mockEvalExecutionResult,
+    );
+    (runLLMAsJudgeEvaluation as Mock).mockResolvedValue(
+      mockEvalExecutionResult,
+    );
   });
 
   describe("job execution lookup", () => {
@@ -79,7 +118,12 @@ describe("processObservationEval", () => {
 
       const deps = createMockProcessorDeps();
 
-      await processObservationEval({ event: baseEvent, deps });
+      await processObservationEval({
+        event: baseEvent,
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
+        deps,
+      });
 
       expect(prisma.jobExecution.findFirst).toHaveBeenCalledWith({
         where: {
@@ -88,7 +132,7 @@ describe("processObservationEval", () => {
         },
       });
       expect(deps.downloadObservationFromS3).not.toHaveBeenCalled();
-      expect(executeLLMAsJudgeEvaluation).not.toHaveBeenCalled();
+      expect(runLLMAsJudgeEvaluation).not.toHaveBeenCalled();
     });
   });
 
@@ -106,10 +150,20 @@ describe("processObservationEval", () => {
       const deps = createMockProcessorDeps();
 
       await expect(
-        processObservationEval({ event: baseEvent, deps }),
+        processObservationEval({
+          event: baseEvent,
+          validateTemplate: validateLLMAsJudgeTemplate,
+          executor: runLLMAsJudgeEvaluation,
+          deps,
+        }),
       ).rejects.toThrow(UnrecoverableError);
       await expect(
-        processObservationEval({ event: baseEvent, deps }),
+        processObservationEval({
+          event: baseEvent,
+          validateTemplate: validateLLMAsJudgeTemplate,
+          executor: runLLMAsJudgeEvaluation,
+          deps,
+        }),
       ).rejects.toThrow("Job configuration or template not found");
     });
 
@@ -134,7 +188,12 @@ describe("processObservationEval", () => {
       const deps = createMockProcessorDeps();
 
       await expect(
-        processObservationEval({ event: baseEvent, deps }),
+        processObservationEval({
+          event: baseEvent,
+          validateTemplate: validateLLMAsJudgeTemplate,
+          executor: runLLMAsJudgeEvaluation,
+          deps,
+        }),
       ).rejects.toThrow(UnrecoverableError);
     });
 
@@ -156,7 +215,12 @@ describe("processObservationEval", () => {
 
       const deps = createMockProcessorDeps();
 
-      await processObservationEval({ event: baseEvent, deps });
+      await processObservationEval({
+        event: baseEvent,
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
+        deps,
+      });
 
       expect(prisma.jobExecution.update).toHaveBeenCalledWith({
         where: {
@@ -169,7 +233,7 @@ describe("processObservationEval", () => {
         },
       });
       expect(deps.downloadObservationFromS3).not.toHaveBeenCalled();
-      expect(executeLLMAsJudgeEvaluation).not.toHaveBeenCalled();
+      expect(runLLMAsJudgeEvaluation).not.toHaveBeenCalled();
     });
 
     it("should cancel blocked jobs before validating the evaluator template type", async () => {
@@ -197,7 +261,12 @@ describe("processObservationEval", () => {
 
       const deps = createMockProcessorDeps();
 
-      await processObservationEval({ event: baseEvent, deps });
+      await processObservationEval({
+        event: baseEvent,
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
+        deps,
+      });
 
       expect(prisma.jobExecution.update).toHaveBeenCalledWith({
         where: {
@@ -210,7 +279,53 @@ describe("processObservationEval", () => {
         },
       });
       expect(deps.downloadObservationFromS3).not.toHaveBeenCalled();
-      expect(executeLLMAsJudgeEvaluation).not.toHaveBeenCalled();
+      expect(runLLMAsJudgeEvaluation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("template type validation", () => {
+    it("should throw UnrecoverableError when the default LLM path receives a code template", async () => {
+      const job = createMockJobExecution({
+        id: jobExecutionId,
+        projectId,
+        status: JobExecutionStatus.PENDING,
+        jobConfigurationId: "config-123",
+      });
+      const config = createMockJobConfiguration({
+        id: "config-123",
+        projectId,
+        evalTemplate: createMockEvalTemplate({
+          type: EvalTemplateType.CODE,
+          prompt: null,
+          outputDefinition: null,
+          sourceCode: "def evaluate(): pass",
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.PYTHON,
+        }),
+      });
+
+      (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
+      (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
+
+      const deps = createMockProcessorDeps();
+
+      await expect(
+        processObservationEval({
+          event: baseEvent,
+          validateTemplate: validateLLMAsJudgeTemplate,
+          executor: runLLMAsJudgeEvaluation,
+          deps,
+        }),
+      ).rejects.toThrow(UnrecoverableError);
+      await expect(
+        processObservationEval({
+          event: baseEvent,
+          validateTemplate: validateLLMAsJudgeTemplate,
+          executor: runLLMAsJudgeEvaluation,
+          deps,
+        }),
+      ).rejects.toThrow("Expected LLM-as-judge evaluation template");
+      expect(deps.downloadObservationFromS3).not.toHaveBeenCalled();
+      expect(runLLMAsJudgeEvaluation).not.toHaveBeenCalled();
     });
   });
 
@@ -230,15 +345,20 @@ describe("processObservationEval", () => {
       (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
       (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
 
-      const deps: ObservationEvalProcessorDeps = {
+      const deps = createMockProcessorDeps({
         downloadObservationFromS3: vi
           .fn<ObservationEvalProcessorDeps["downloadObservationFromS3"]>()
           .mockRejectedValue(new Error("S3 connection failed")),
-      };
+      });
 
       // S3 connection errors should be retryable (not UnrecoverableError)
       await expect(
-        processObservationEval({ event: baseEvent, deps }),
+        processObservationEval({
+          event: baseEvent,
+          validateTemplate: validateLLMAsJudgeTemplate,
+          executor: runLLMAsJudgeEvaluation,
+          deps,
+        }),
       ).rejects.toThrow("Failed to download observation from S3");
     });
 
@@ -257,15 +377,20 @@ describe("processObservationEval", () => {
       (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
       (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
 
-      const deps: ObservationEvalProcessorDeps = {
+      const deps = createMockProcessorDeps({
         downloadObservationFromS3: vi
           .fn<ObservationEvalProcessorDeps["downloadObservationFromS3"]>()
           .mockResolvedValue("not valid json {"),
-      };
+      });
 
       // Invalid JSON is a permanent error - should be UnrecoverableError
       await expect(
-        processObservationEval({ event: baseEvent, deps }),
+        processObservationEval({
+          event: baseEvent,
+          validateTemplate: validateLLMAsJudgeTemplate,
+          executor: runLLMAsJudgeEvaluation,
+          deps,
+        }),
       ).rejects.toThrow(UnrecoverableError);
     });
 
@@ -286,21 +411,26 @@ describe("processObservationEval", () => {
 
       // Missing required fields - valid JSON but invalid schema
       const invalidObservation = { id: "obs-123", someField: "value" };
-      const deps: ObservationEvalProcessorDeps = {
+      const deps = createMockProcessorDeps({
         downloadObservationFromS3: vi
           .fn<ObservationEvalProcessorDeps["downloadObservationFromS3"]>()
           .mockResolvedValue(JSON.stringify(invalidObservation)),
-      };
+      });
 
       // Schema validation failures are permanent - should be UnrecoverableError
       await expect(
-        processObservationEval({ event: baseEvent, deps }),
+        processObservationEval({
+          event: baseEvent,
+          validateTemplate: validateLLMAsJudgeTemplate,
+          executor: runLLMAsJudgeEvaluation,
+          deps,
+        }),
       ).rejects.toThrow(UnrecoverableError);
     });
   });
 
   describe("successful execution", () => {
-    it("should call executeLLMAsJudgeEvaluation with correct parameters", async () => {
+    it("should call runLLMAsJudgeEvaluation with correct parameters", async () => {
       const job = createMockJobExecution({
         id: jobExecutionId,
         projectId,
@@ -340,9 +470,14 @@ describe("processObservationEval", () => {
           .mockResolvedValue(JSON.stringify(observation)),
       });
 
-      await processObservationEval({ event: baseEvent, deps });
+      await processObservationEval({
+        event: baseEvent,
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
+        deps,
+      });
 
-      expect(executeLLMAsJudgeEvaluation).toHaveBeenCalledWith(
+      expect(runLLMAsJudgeEvaluation).toHaveBeenCalledWith(
         expect.objectContaining({
           projectId,
           jobExecutionId,
@@ -358,6 +493,161 @@ describe("processObservationEval", () => {
           environment: "production",
         }),
       );
+    });
+
+    it("should complete eval execution with the executor result", async () => {
+      const job = createMockJobExecution({
+        id: jobExecutionId,
+        projectId,
+        status: JobExecutionStatus.PENDING,
+        jobConfigurationId: "config-123",
+        jobInputTraceId: "trace-abc",
+        jobInputObservationId: "obs-xyz",
+      });
+      const template = createMockEvalTemplate({
+        id: "template-456",
+        projectId,
+        prompt: "Evaluate: {{output}}",
+      });
+      const config = createMockJobConfiguration({
+        id: "config-123",
+        projectId,
+        evalTemplateId: "template-456",
+        variableMapping: [
+          { templateVariable: "output", selectedColumnId: "output" },
+        ],
+        evalTemplate: template,
+      });
+      const observation = createTestObservation({
+        span_id: "obs-xyz",
+        project_id: projectId,
+        trace_id: "trace-abc",
+        environment: "production",
+        output: '{"response": "test output"}',
+      });
+
+      (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
+      (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
+
+      const uploadScore = vi
+        .fn<EvalExecutionDeps["uploadScore"]>()
+        .mockResolvedValue(undefined);
+      const enqueueScoreIngestion = vi
+        .fn<EvalExecutionDeps["enqueueScoreIngestion"]>()
+        .mockResolvedValue(undefined);
+      const updateJobExecution = vi
+        .fn<EvalExecutionDeps["updateJobExecution"]>()
+        .mockResolvedValue(undefined);
+      const deps = createMockProcessorDeps({
+        downloadObservationFromS3: vi
+          .fn()
+          .mockResolvedValue(JSON.stringify(observation)),
+        evalExecutionDeps: createMockEvalExecutionDeps({
+          uploadScore,
+          enqueueScoreIngestion,
+          updateJobExecution,
+        }),
+      });
+
+      await processObservationEval({
+        event: baseEvent,
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
+        deps,
+      });
+
+      expect(uploadScore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId,
+          scoreId: mockEvalExecutionResult.primaryScoreId,
+        }),
+      );
+      expect(enqueueScoreIngestion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId,
+          scoreId: mockEvalExecutionResult.primaryScoreId,
+        }),
+      );
+      expect(updateJobExecution).toHaveBeenCalledWith({
+        id: jobExecutionId,
+        projectId,
+        data: expect.objectContaining({
+          status: JobExecutionStatus.COMPLETED,
+          jobOutputScoreId: mockEvalExecutionResult.primaryScoreId,
+          executionTraceId: mockEvalExecutionResult.executionTraceId,
+        }),
+      });
+    });
+
+    it("should call the code executor for code templates", async () => {
+      const job = createMockJobExecution({
+        id: jobExecutionId,
+        projectId,
+        status: JobExecutionStatus.PENDING,
+        jobConfigurationId: "config-123",
+        jobInputTraceId: "trace-abc",
+        jobInputObservationId: "obs-xyz",
+      });
+      const template = createMockEvalTemplate({
+        id: "template-456",
+        projectId,
+        type: EvalTemplateType.CODE,
+        prompt: null,
+        outputDefinition: null,
+        sourceCode: "def evaluate(): pass",
+        sourceCodeLanguage: EvalTemplateSourceCodeLanguage.PYTHON,
+      });
+      const config = createMockJobConfiguration({
+        id: "config-123",
+        projectId,
+        evalTemplateId: "template-456",
+        variableMapping: [
+          { templateVariable: "output", selectedColumnId: "output" },
+        ],
+        evalTemplate: template,
+      });
+      const observation = createTestObservation({
+        span_id: "obs-xyz",
+        project_id: projectId,
+        trace_id: "trace-abc",
+        environment: "production",
+        output: '{"response": "test output"}',
+      });
+
+      (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
+      (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
+
+      const deps = createMockProcessorDeps({
+        downloadObservationFromS3: vi
+          .fn()
+          .mockResolvedValue(JSON.stringify(observation)),
+      });
+
+      await processObservationEval({
+        event: baseEvent,
+        validateTemplate: validateCodeBasedTemplate,
+        executor: executeCodeBasedEvaluation,
+        deps,
+      });
+
+      expect(executeCodeBasedEvaluation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId,
+          jobExecutionId,
+          template: expect.objectContaining({
+            id: "template-456",
+            type: EvalTemplateType.CODE,
+          }),
+          extractedVariables: expect.arrayContaining([
+            expect.objectContaining({
+              var: "output",
+              value: '{"response": "test output"}',
+            }),
+          ]),
+          environment: "production",
+        }),
+      );
+      expect(runLLMAsJudgeEvaluation).not.toHaveBeenCalled();
     });
 
     it("should use default environment when observation environment is null", async () => {
@@ -386,9 +676,14 @@ describe("processObservationEval", () => {
           .mockResolvedValue(JSON.stringify(observation)),
       });
 
-      await processObservationEval({ event: baseEvent, deps });
+      await processObservationEval({
+        event: baseEvent,
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
+        deps,
+      });
 
-      expect(executeLLMAsJudgeEvaluation).toHaveBeenCalledWith(
+      expect(runLLMAsJudgeEvaluation).toHaveBeenCalledWith(
         expect.objectContaining({
           environment: "default",
         }),
@@ -425,9 +720,14 @@ describe("processObservationEval", () => {
           .mockResolvedValue(JSON.stringify(observation)),
       });
 
-      await processObservationEval({ event: baseEvent, deps });
+      await processObservationEval({
+        event: baseEvent,
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
+        deps,
+      });
 
-      expect(executeLLMAsJudgeEvaluation).toHaveBeenCalledWith(
+      expect(runLLMAsJudgeEvaluation).toHaveBeenCalledWith(
         expect.objectContaining({
           extractedVariables: expect.arrayContaining([
             expect.objectContaining({
@@ -464,7 +764,11 @@ describe("processObservationEval", () => {
 
       // Without injected deps, it will try to use real S3 which should fail
       await expect(
-        processObservationEval({ event: baseEvent }),
+        processObservationEval({
+          event: baseEvent,
+          validateTemplate: validateLLMAsJudgeTemplate,
+          executor: runLLMAsJudgeEvaluation,
+        }),
       ).rejects.toThrow();
     });
   });

--- a/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
@@ -8,6 +8,7 @@ import {
 import { type Prisma } from "@langfuse/shared/src/db";
 import {
   EvalTargetObject,
+  EvalTemplateType,
   JobConfigState,
   JobExecutionStatus,
 } from "@langfuse/shared";
@@ -82,6 +83,7 @@ describe("scheduleObservationEvals", () => {
     filter: [],
     sampling: { toNumber: () => 1 } as unknown as Prisma.Decimal,
     evalTemplateId: "template-1",
+    evalTemplate: { type: EvalTemplateType.LLM_AS_JUDGE },
     scoreName: "quality",
     variableMapping: [],
     targetObject: EvalTargetObject.EVENT,
@@ -340,7 +342,28 @@ describe("scheduleObservationEvals", () => {
         projectId: "project-789",
         observationS3Path: "observations/project-789/obs-123.json",
         delay: 0,
+        evalTemplateType: EvalTemplateType.LLM_AS_JUDGE,
       });
+    });
+
+    it("should pass code template type to the scheduler deps", async () => {
+      const schedulerDeps = createMockSchedulerDeps();
+      const observation = createMockObservation();
+      const config = createMockConfig({
+        evalTemplate: { type: EvalTemplateType.CODE },
+      });
+
+      await scheduleObservationEvals({
+        observation,
+        configs: [config],
+        schedulerDeps,
+      });
+
+      expect(schedulerDeps.enqueueEvalJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          evalTemplateType: EvalTemplateType.CODE,
+        }),
+      );
     });
   });
 

--- a/worker/src/features/evaluation/observationEval/createSchedulerDeps.ts
+++ b/worker/src/features/evaluation/observationEval/createSchedulerDeps.ts
@@ -1,5 +1,6 @@
-import { prisma } from "@langfuse/shared/src/db";
+import { EvalTemplateType, prisma } from "@langfuse/shared/src/db";
 import {
+  CodeEvalExecutionQueue,
   LLMAsJudgeExecutionQueue,
   QueueJobs,
   QueueName,
@@ -59,6 +60,31 @@ export function createObservationEvalSchedulerDeps(): ObservationEvalSchedulerDe
 
     enqueueEvalJob: async (params) => {
       const shardingKey = `${params.projectId}-${params.jobExecutionId}`;
+      const payload = {
+        projectId: params.projectId,
+        jobExecutionId: params.jobExecutionId,
+        observationS3Path: params.observationS3Path,
+      };
+
+      if (params.evalTemplateType === EvalTemplateType.CODE) {
+        const queue = CodeEvalExecutionQueue.getInstance({ shardingKey });
+        if (!queue) {
+          throw new Error("CodeEvalExecutionQueue is not initialized");
+        }
+
+        await queue.add(
+          QueueName.CodeEvalExecution,
+          {
+            name: QueueJobs.CodeEvalExecution,
+            id: params.jobExecutionId,
+            timestamp: new Date(),
+            payload,
+          },
+          { delay: params.delay },
+        );
+        return;
+      }
+
       const queue = LLMAsJudgeExecutionQueue.getInstance({ shardingKey });
       if (!queue) {
         throw new Error("LLMAsJudgeExecutionQueue is not initialized");
@@ -70,15 +96,9 @@ export function createObservationEvalSchedulerDeps(): ObservationEvalSchedulerDe
           name: QueueJobs.LLMAsJudgeExecution,
           id: params.jobExecutionId,
           timestamp: new Date(),
-          payload: {
-            projectId: params.projectId,
-            jobExecutionId: params.jobExecutionId,
-            observationS3Path: params.observationS3Path,
-          },
+          payload,
         },
-        {
-          delay: params.delay,
-        },
+        { delay: params.delay },
       );
     },
   };

--- a/worker/src/features/evaluation/observationEval/fetchObservationEvalConfigs.ts
+++ b/worker/src/features/evaluation/observationEval/fetchObservationEvalConfigs.ts
@@ -51,6 +51,11 @@ export async function fetchObservationEvalConfigs(
       blockedAt: true,
       targetObject: true,
       variableMapping: true,
+      evalTemplate: {
+        select: {
+          type: true,
+        },
+      },
     },
   });
 
@@ -68,5 +73,8 @@ export async function fetchObservationEvalConfigs(
     `Found ${configs.length} observation eval configs for project ${projectId}`,
   );
 
-  return configs;
+  return configs.map((config) => ({
+    ...config,
+    evalTemplate: config.evalTemplate!,
+  }));
 }

--- a/worker/src/features/evaluation/observationEval/fetchObservationEvalConfigs.ts
+++ b/worker/src/features/evaluation/observationEval/fetchObservationEvalConfigs.ts
@@ -39,6 +39,7 @@ export async function fetchObservationEvalConfigs(
       },
       status: JobConfigState.ACTIVE,
       blockedAt: null,
+      evalTemplateId: { not: null },
     },
     select: {
       id: true,

--- a/worker/src/features/evaluation/observationEval/index.ts
+++ b/worker/src/features/evaluation/observationEval/index.ts
@@ -4,7 +4,10 @@ export { createObservationEvalSchedulerDeps } from "./createSchedulerDeps";
 export {
   processObservationEval,
   createObservationEvalProcessorDeps,
+  type ObservationEvalExecutor,
+  type ObservationEvalExecutionParams,
   type ObservationEvalProcessorDeps,
+  type ObservationEvalTemplateValidator,
 } from "./observationEvalProcessor";
 export type {
   ObservationForEval,

--- a/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
+++ b/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
@@ -1,20 +1,31 @@
 import { z } from "zod";
 import {
   DEFAULT_TRACE_ENVIRONMENT,
-  LLMAsJudgeExecutionEventSchema,
+  ObservationEvalExecutionEventSchema,
   logger,
 } from "@langfuse/shared/src/server";
 import {
-  assertLLMAsJudgeEvalTemplate,
   observationForEvalSchema,
   observationVariableMappingList,
   isJobConfigExecutable,
+  type EvalTemplate,
   type ObservationVariableMapping,
 } from "@langfuse/shared";
+import { type JobConfiguration, type JobExecution } from "@prisma/client";
 import { prisma, JobExecutionStatus } from "@langfuse/shared/src/db";
 import { UnrecoverableError } from "../../../errors/UnrecoverableError";
-import { extractObservationVariables } from "./extractObservationVariables";
-import { executeLLMAsJudgeEvaluation } from "../evalService";
+import {
+  extractObservationVariables,
+  type ExtractedVariable,
+} from "./extractObservationVariables";
+import {
+  completeEvalExecution,
+  type EvalExecutionResult,
+} from "../evalCompletion";
+import {
+  createProductionEvalExecutionDeps,
+  type EvalExecutionDeps,
+} from "../evalExecutionDeps";
 import { getEvalS3StorageClient } from "../s3StorageClient";
 import { type ObservationForEval } from "./types";
 
@@ -22,8 +33,31 @@ import { type ObservationForEval } from "./types";
  * Dependencies for processing observation evals.
  * Allows S3 operations to be injected for testability.
  */
+export type ObservationEvalExecutionBaseParams = {
+  projectId: string;
+  jobExecutionId: string;
+  job: JobExecution;
+  config: JobConfiguration;
+  extractedVariables: ExtractedVariable[];
+  environment: string;
+};
+
+export type ObservationEvalExecutionParams<TTemplate extends EvalTemplate> =
+  ObservationEvalExecutionBaseParams & {
+    template: TTemplate;
+  };
+
+export type ObservationEvalExecutor<TTemplate extends EvalTemplate> = (
+  params: ObservationEvalExecutionParams<TTemplate>,
+) => Promise<EvalExecutionResult>;
+
+export type ObservationEvalTemplateValidator<TTemplate extends EvalTemplate> = (
+  template: EvalTemplate,
+) => TTemplate;
+
 export interface ObservationEvalProcessorDeps {
   downloadObservationFromS3: (path: string) => Promise<string>;
+  evalExecutionDeps: EvalExecutionDeps;
 }
 
 /**
@@ -36,25 +70,31 @@ export function createObservationEvalProcessorDeps(): ObservationEvalProcessorDe
 
       return s3Client.download(path);
     },
+    evalExecutionDeps: createProductionEvalExecutionDeps(),
   };
 }
 
 /**
- * Processes an observation-level LLM-as-a-judge evaluation job.
+ * Processes an observation-level evaluation job.
  *
  * This function:
  * 1. Fetches and validates job execution, config, and template
  * 2. Downloads observation data from S3 (stored during scheduling)
  * 3. Extracts variables from the observation
- * 4. Calls the shared executeLLMAsJudgeEvaluation() for LLM call and score persistence
+ * 4. Executes the evaluator-specific implementation
+ * 5. Completes the eval execution with shared score persistence
  */
-export async function processObservationEval({
-  event,
-  deps = createObservationEvalProcessorDeps(),
-}: {
-  event: z.infer<typeof LLMAsJudgeExecutionEventSchema>;
+type ProcessObservationEvalParams<TTemplate extends EvalTemplate> = {
+  event: z.infer<typeof ObservationEvalExecutionEventSchema>;
+  validateTemplate: ObservationEvalTemplateValidator<TTemplate>;
+  executor: ObservationEvalExecutor<TTemplate>;
   deps?: ObservationEvalProcessorDeps;
-}): Promise<void> {
+};
+
+export async function processObservationEval<TTemplate extends EvalTemplate>(
+  params: ProcessObservationEvalParams<TTemplate>,
+): Promise<void> {
+  const { event, deps = createObservationEvalProcessorDeps() } = params;
   logger.debug(
     `Processing observation eval job ${event.jobExecutionId} for project ${event.projectId}`,
   );
@@ -122,8 +162,9 @@ export async function processObservationEval({
     return;
   }
 
+  let evalTemplate: TTemplate;
   try {
-    assertLLMAsJudgeEvalTemplate(evalJobConfig.evalTemplate);
+    evalTemplate = params.validateTemplate(evalJobConfig.evalTemplate);
   } catch (e) {
     throw new UnrecoverableError(e instanceof Error ? e.message : String(e));
   }
@@ -172,14 +213,28 @@ export async function processObservationEval({
     `Extracted ${extractedVariables.length} variables for job ${job.id}`,
   );
 
-  // Execute the shared LLM-as-a-judge evaluation
-  await executeLLMAsJudgeEvaluation({
+  const executionParams = {
     projectId: event.projectId,
     jobExecutionId: event.jobExecutionId,
     job,
     config: evalJobConfig,
-    template: evalJobConfig.evalTemplate,
     extractedVariables,
     environment: observationData.environment ?? DEFAULT_TRACE_ENVIRONMENT,
+  };
+
+  const executionResult = await params.executor({
+    ...executionParams,
+    template: evalTemplate,
+  });
+
+  await completeEvalExecution({
+    projectId: executionParams.projectId,
+    jobExecutionId: executionParams.jobExecutionId,
+    traceId: executionParams.job.jobInputTraceId,
+    observationId: executionParams.job.jobInputObservationId,
+    scoreName: executionParams.config.scoreName,
+    environment: executionParams.environment,
+    deps: deps.evalExecutionDeps,
+    ...executionResult,
   });
 }

--- a/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
+++ b/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
@@ -18,6 +18,7 @@ import {
   extractObservationVariables,
   type ExtractedVariable,
 } from "./extractObservationVariables";
+import { buildEvalExecutionMetadata } from "../evalRuntime";
 import {
   completeEvalExecution,
   type EvalExecutionResult,
@@ -40,6 +41,7 @@ export type ObservationEvalExecutionBaseParams = {
   config: JobConfiguration;
   extractedVariables: ExtractedVariable[];
   environment: string;
+  metadata: Record<string, string>;
   deps: EvalExecutionDeps;
 };
 
@@ -221,6 +223,13 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     config: evalJobConfig,
     extractedVariables,
     environment: observationData.environment ?? DEFAULT_TRACE_ENVIRONMENT,
+    metadata: buildEvalExecutionMetadata({
+      jobExecutionId: event.jobExecutionId,
+      jobConfigurationId: job.jobConfigurationId,
+      targetTraceId: job.jobInputTraceId,
+      targetObservationId: job.jobInputObservationId,
+      targetDatasetItemId: job.jobInputDatasetItemId,
+    }),
     deps: deps.evalExecutionDeps,
   };
 
@@ -236,6 +245,7 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     observationId: executionParams.job.jobInputObservationId,
     scoreName: executionParams.config.scoreName,
     environment: executionParams.environment,
+    metadata: executionParams.metadata,
     deps: executionParams.deps,
     ...executionResult,
   });

--- a/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
+++ b/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
@@ -40,6 +40,7 @@ export type ObservationEvalExecutionBaseParams = {
   config: JobConfiguration;
   extractedVariables: ExtractedVariable[];
   environment: string;
+  deps: EvalExecutionDeps;
 };
 
 export type ObservationEvalExecutionParams<TTemplate extends EvalTemplate> =
@@ -220,6 +221,7 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     config: evalJobConfig,
     extractedVariables,
     environment: observationData.environment ?? DEFAULT_TRACE_ENVIRONMENT,
+    deps: deps.evalExecutionDeps,
   };
 
   const executionResult = await params.executor({
@@ -234,7 +236,7 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     observationId: executionParams.job.jobInputObservationId,
     scoreName: executionParams.config.scoreName,
     environment: executionParams.environment,
-    deps: deps.evalExecutionDeps,
+    deps: executionParams.deps,
     ...executionResult,
   });
 }

--- a/worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts
+++ b/worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts
@@ -144,6 +144,7 @@ async function processMatchingConfig(
     projectId: observation.project_id,
     observationS3Path,
     delay: 0,
+    evalTemplateType: matchingConfig.evalTemplate.type,
   });
 
   logger.debug("Scheduled observation eval job", {

--- a/worker/src/features/evaluation/observationEval/types.ts
+++ b/worker/src/features/evaluation/observationEval/types.ts
@@ -1,4 +1,9 @@
-import { JobConfiguration, JobExecutionStatus } from "@langfuse/shared/src/db";
+import {
+  EvalTemplate,
+  EvalTemplateType,
+  JobConfiguration,
+  JobExecutionStatus,
+} from "@langfuse/shared/src/db";
 
 /**
  * Re-export ObservationForEval as the canonical observation type for eval operations.
@@ -30,7 +35,9 @@ export type ObservationEvalConfig = Pick<
   | "variableMapping"
   | "status"
   | "blockedAt"
->;
+> & {
+  evalTemplate: Pick<EvalTemplate, "type">;
+};
 
 /**
  * Dependencies for scheduling observation evals.
@@ -61,5 +68,6 @@ export interface ObservationEvalSchedulerDeps {
     projectId: string;
     observationS3Path: string;
     delay: number;
+    evalTemplateType: EvalTemplateType;
   }) => Promise<void>;
 }

--- a/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
@@ -1,0 +1,168 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { Job } from "bullmq";
+import { UnrecoverableError } from "../../errors/UnrecoverableError";
+
+const QueueName = {
+  CodeEvalExecution: "code-eval-execution-queue",
+} as const;
+
+const JobExecutionStatus = {
+  ERROR: "ERROR",
+} as const;
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    jobExecution: {
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../../features/evaluation/observationEval", () => ({
+  processObservationEval: vi.fn(),
+}));
+
+vi.mock("../../features/evaluation/codeBased", () => ({
+  executeCodeBasedEvaluation: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  getCurrentSpan: vi.fn().mockReturnValue({
+    setAttribute: vi.fn(),
+  }),
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+  QueueName: {
+    CodeEvalExecution: "code-eval-execution-queue",
+  },
+  traceException: vi.fn(),
+}));
+
+vi.mock("../../features/utils", () => ({
+  createW3CTraceId: vi.fn().mockReturnValue("test-trace-id"),
+}));
+
+vi.mock("../../errors/UnrecoverableError", async () => {
+  const actual = await vi.importActual("../../errors/UnrecoverableError");
+  return {
+    ...actual,
+    isUnrecoverableError: vi.fn(),
+  };
+});
+
+import { prisma } from "@langfuse/shared/src/db";
+import { processObservationEval } from "../../features/evaluation/observationEval";
+import { traceException } from "@langfuse/shared/src/server";
+import { executeCodeBasedEvaluation } from "../../features/evaluation/codeBased";
+import { isUnrecoverableError } from "../../errors/UnrecoverableError";
+
+describe("codeEvalExecutionQueueProcessor", () => {
+  const projectId = "test-project-123";
+  const jobExecutionId = "job-exec-456";
+  const observationS3Path = "evals/test/observation.json";
+  const queueName = `${QueueName.CodeEvalExecution}-1`;
+  let codeEvalExecutionQueueProcessor: (job: Job<any>) => Promise<unknown>;
+
+  const createMockJob = (overrides: Record<string, unknown> = {}): Job<any> =>
+    ({
+      data: {
+        id: "queue-job-123",
+        name: "CodeEvalExecution",
+        timestamp: new Date(),
+        payload: {
+          projectId,
+          jobExecutionId,
+          observationS3Path,
+        },
+        retryBaggage: { attempt: 0 },
+        ...overrides,
+      },
+    }) as Job<any>;
+
+  beforeAll(async () => {
+    const { codeEvalExecutionQueueProcessorBuilder } =
+      await import("../codeEvalQueue");
+    codeEvalExecutionQueueProcessor =
+      codeEvalExecutionQueueProcessorBuilder(queueName);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (isUnrecoverableError as unknown as Mock).mockReturnValue(false);
+  });
+
+  it("should process code observation evals through the code template gate", async () => {
+    (processObservationEval as Mock).mockResolvedValue(undefined);
+
+    const result = await codeEvalExecutionQueueProcessor(createMockJob());
+
+    expect(result).toBe(true);
+    expect(processObservationEval).toHaveBeenCalledWith({
+      event: {
+        projectId,
+        jobExecutionId,
+        observationS3Path,
+      },
+      validateTemplate: expect.any(Function),
+      executor: executeCodeBasedEvaluation,
+    });
+  });
+
+  it("should mark unrecoverable skeleton errors as terminal", async () => {
+    const error = new UnrecoverableError(
+      "Code-based eval execution is not implemented yet",
+    );
+    (processObservationEval as Mock).mockRejectedValue(error);
+    (isUnrecoverableError as unknown as Mock).mockReturnValue(true);
+
+    const result = await codeEvalExecutionQueueProcessor(createMockJob());
+
+    expect(result).toBeUndefined();
+    expect(prisma.jobExecution.update).toHaveBeenCalledWith({
+      where: {
+        id: jobExecutionId,
+        projectId,
+      },
+      data: {
+        status: JobExecutionStatus.ERROR,
+        endTime: expect.any(Date),
+        error: "Code-based eval execution is not implemented yet",
+        executionTraceId: "test-trace-id",
+      },
+    });
+    expect(traceException).not.toHaveBeenCalled();
+  });
+
+  it("should rethrow unexpected errors after marking the job as errored", async () => {
+    const error = new Error("temporary dispatcher failure");
+    (processObservationEval as Mock).mockRejectedValue(error);
+
+    await expect(
+      codeEvalExecutionQueueProcessor(createMockJob()),
+    ).rejects.toThrow(error);
+
+    expect(prisma.jobExecution.update).toHaveBeenCalledWith({
+      where: {
+        id: jobExecutionId,
+        projectId,
+      },
+      data: {
+        status: JobExecutionStatus.ERROR,
+        endTime: expect.any(Date),
+        error: "An internal error occurred",
+        executionTraceId: "test-trace-id",
+      },
+    });
+    expect(traceException).toHaveBeenCalledWith(error);
+  });
+});

--- a/worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts
@@ -108,6 +108,7 @@ import {
   traceException,
 } from "@langfuse/shared/src/server";
 import { retryLLMRateLimitError } from "../../features/utils";
+import { runLLMAsJudgeEvaluation } from "../../features/evaluation/evalService";
 import { isUnrecoverableError } from "../../errors/UnrecoverableError";
 
 describe("llmAsJudgeExecutionQueueProcessor", () => {
@@ -152,8 +153,8 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (isLLMCompletionError as Mock).mockReturnValue(false);
-    (isUnrecoverableError as Mock).mockReturnValue(false);
+    vi.mocked(isLLMCompletionError).mockReturnValue(false);
+    vi.mocked(isUnrecoverableError).mockReturnValue(false);
   });
 
   describe("successful processing", () => {
@@ -170,6 +171,8 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
           jobExecutionId,
           observationS3Path,
         },
+        validateTemplate: expect.any(Function),
+        executor: runLLMAsJudgeEvaluation,
       });
     });
 
@@ -197,7 +200,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
     it("should schedule retry and set DELAYED status for retryable LLM errors", async () => {
       const rateLimitError = new Error("Rate limit exceeded");
       (processObservationEval as Mock).mockRejectedValue(rateLimitError);
-      (isLLMCompletionError as Mock).mockReturnValue(true);
+      vi.mocked(isLLMCompletionError).mockReturnValue(true);
       // Mark as retryable
       (rateLimitError as unknown as { isRetryable: boolean }).isRetryable =
         true;
@@ -237,7 +240,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
       (rateLimitError as unknown as { isRetryable: boolean }).isRetryable =
         true;
       (processObservationEval as Mock).mockRejectedValue(rateLimitError);
-      (isLLMCompletionError as Mock).mockReturnValue(true);
+      vi.mocked(isLLMCompletionError).mockReturnValue(true);
       (retryLLMRateLimitError as Mock).mockResolvedValue({
         outcome: "scheduled",
       });
@@ -253,7 +256,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
     it("should set ERROR when retryable LLM errors are not re-enqueued", async () => {
       const rateLimitError = new Error("Rate limit exceeded");
       (processObservationEval as Mock).mockRejectedValue(rateLimitError);
-      (isLLMCompletionError as Mock).mockReturnValue(true);
+      vi.mocked(isLLMCompletionError).mockReturnValue(true);
       (rateLimitError as unknown as { isRetryable: boolean }).isRetryable =
         true;
       (retryLLMRateLimitError as Mock).mockResolvedValue({
@@ -281,7 +284,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
     it("should set ERROR when the retry queue is unavailable", async () => {
       const rateLimitError = new Error("Rate limit exceeded");
       (processObservationEval as Mock).mockRejectedValue(rateLimitError);
-      (isLLMCompletionError as Mock).mockReturnValue(true);
+      vi.mocked(isLLMCompletionError).mockReturnValue(true);
       (rateLimitError as unknown as { isRetryable: boolean }).isRetryable =
         true;
       (retryLLMRateLimitError as Mock).mockResolvedValue({
@@ -311,7 +314,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
       const llmError = new Error("Invalid API key");
       (llmError as unknown as { isRetryable: boolean }).isRetryable = false;
       (processObservationEval as Mock).mockRejectedValue(llmError);
-      (isLLMCompletionError as Mock).mockReturnValue(true);
+      vi.mocked(isLLMCompletionError).mockReturnValue(true);
 
       const job = createMockJob();
       await llmAsJudgeExecutionQueueProcessor(job);
@@ -334,7 +337,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
       const llmError = new Error("Invalid API key");
       (llmError as unknown as { isRetryable: boolean }).isRetryable = false;
       (processObservationEval as Mock).mockRejectedValue(llmError);
-      (isLLMCompletionError as Mock).mockReturnValue(true);
+      vi.mocked(isLLMCompletionError).mockReturnValue(true);
 
       const job = createMockJob();
 
@@ -351,7 +354,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
         "Job configuration not found",
       );
       (processObservationEval as Mock).mockRejectedValue(unrecoverableError);
-      (isUnrecoverableError as Mock).mockReturnValue(true);
+      vi.mocked(isUnrecoverableError).mockReturnValue(true);
 
       const job = createMockJob();
       await llmAsJudgeExecutionQueueProcessor(job);
@@ -373,7 +376,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
     it("should not rethrow UnrecoverableError", async () => {
       const unrecoverableError = new UnrecoverableError("Config not found");
       (processObservationEval as Mock).mockRejectedValue(unrecoverableError);
-      (isUnrecoverableError as Mock).mockReturnValue(true);
+      vi.mocked(isUnrecoverableError).mockReturnValue(true);
 
       const job = createMockJob();
 
@@ -386,7 +389,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
     it("should not call traceException for UnrecoverableError", async () => {
       const unrecoverableError = new UnrecoverableError("Config not found");
       (processObservationEval as Mock).mockRejectedValue(unrecoverableError);
-      (isUnrecoverableError as Mock).mockReturnValue(true);
+      vi.mocked(isUnrecoverableError).mockReturnValue(true);
 
       const job = createMockJob();
       await llmAsJudgeExecutionQueueProcessor(job);
@@ -451,7 +454,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
     it("should generate deterministic trace ID from job execution ID", async () => {
       const error = new UnrecoverableError("Test error");
       (processObservationEval as Mock).mockRejectedValue(error);
-      (isUnrecoverableError as Mock).mockReturnValue(true);
+      vi.mocked(isUnrecoverableError).mockReturnValue(true);
 
       const { createW3CTraceId } = await import("../../features/utils");
 

--- a/worker/src/queues/codeEvalQueue.ts
+++ b/worker/src/queues/codeEvalQueue.ts
@@ -1,0 +1,90 @@
+import { Job, Processor } from "bullmq";
+import { JobExecutionStatus } from "@prisma/client";
+import {
+  assertCodeBasedEvalTemplate,
+  type EvalTemplate,
+  type EvalTemplateCodeBased,
+} from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  getCurrentSpan,
+  logger,
+  QueueName,
+  TQueueJobTypes,
+  traceException,
+} from "@langfuse/shared/src/server";
+import { executeCodeBasedEvaluation } from "../features/evaluation/codeBased";
+import { processObservationEval } from "../features/evaluation/observationEval";
+import { createW3CTraceId } from "../features/utils";
+import { isUnrecoverableError } from "../errors/UnrecoverableError";
+
+export const codeEvalExecutionQueueProcessorBuilder = (
+  _queueName: string,
+): Processor => {
+  return async (job: Job<TQueueJobTypes[QueueName.CodeEvalExecution]>) => {
+    try {
+      logger.debug("Executing Code Evaluation Observation Job", job.data);
+
+      const span = getCurrentSpan();
+
+      if (span) {
+        span.setAttribute(
+          "messaging.bullmq.job.input.jobExecutionId",
+          job.data.payload.jobExecutionId,
+        );
+        span.setAttribute(
+          "messaging.bullmq.job.input.projectId",
+          job.data.payload.projectId,
+        );
+        span.setAttribute(
+          "messaging.bullmq.job.input.retryBaggage.attempt",
+          job.data.retryBaggage?.attempt ?? 0,
+        );
+      }
+
+      await processObservationEval({
+        event: job.data.payload,
+        validateTemplate: validateCodeBasedTemplate,
+        executor: executeCodeBasedEvaluation,
+      });
+
+      return true;
+    } catch (e) {
+      const executionTraceId = createW3CTraceId(
+        job.data.payload.jobExecutionId,
+      );
+
+      const isTerminalError = isUnrecoverableError(e);
+
+      await prisma.jobExecution.update({
+        where: {
+          id: job.data.payload.jobExecutionId,
+          projectId: job.data.payload.projectId,
+        },
+        data: {
+          status: JobExecutionStatus.ERROR,
+          endTime: new Date(),
+          error: isTerminalError ? e.message : "An internal error occurred",
+          executionTraceId,
+        },
+      });
+
+      if (isTerminalError) return;
+
+      traceException(e);
+      logger.error(
+        `Failed code eval execution job for id ${job.data.payload.jobExecutionId}`,
+        e,
+      );
+
+      throw e;
+    }
+  };
+};
+
+const validateCodeBasedTemplate = (
+  template: EvalTemplate,
+): EvalTemplateCodeBased => {
+  assertCodeBasedEvalTemplate(template);
+  return template;
+};

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -1,5 +1,10 @@
 import { Job, Processor } from "bullmq";
-import { JobExecutionStatus } from "@langfuse/shared";
+import {
+  assertLLMAsJudgeEvalTemplate,
+  JobExecutionStatus,
+  type EvalTemplate,
+  type EvalTemplateLlmAsAJudge,
+} from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   QueueName,
@@ -13,7 +18,11 @@ import {
   getCurrentSpan,
   isLLMCompletionError,
 } from "@langfuse/shared/src/server";
-import { createEvalJobs, evaluate } from "../features/evaluation/evalService";
+import {
+  createEvalJobs,
+  evaluate,
+  runLLMAsJudgeEvaluation,
+} from "../features/evaluation/evalService";
 import { processObservationEval } from "../features/evaluation/observationEval";
 import { delayInMs } from "./utils/delays";
 import { createW3CTraceId, retryLLMRateLimitError } from "../features/utils";
@@ -296,7 +305,11 @@ export const llmAsJudgeExecutionQueueProcessorBuilder =
         );
       }
 
-      await processObservationEval({ event: job.data.payload });
+      await processObservationEval({
+        event: job.data.payload,
+        validateTemplate: validateLLMAsJudgeTemplate,
+        executor: runLLMAsJudgeEvaluation,
+      });
       return true;
     } catch (e) {
       const executionTraceId = createW3CTraceId(
@@ -359,3 +372,10 @@ export const llmAsJudgeExecutionQueueProcessorBuilder =
       throw e;
     }
   };
+
+const validateLLMAsJudgeTemplate = (
+  template: EvalTemplate,
+): EvalTemplateLlmAsAJudge => {
+  assertLLMAsJudgeEvalTemplate(template);
+  return template;
+};

--- a/worker/src/queues/shardedQueueRegistry.ts
+++ b/worker/src/queues/shardedQueueRegistry.ts
@@ -11,6 +11,7 @@ import {
   EvalExecutionQueue,
   SecondaryEvalExecutionQueue,
   LLMAsJudgeExecutionQueue,
+  CodeEvalExecutionQueue,
 } from "@langfuse/shared/src/server";
 
 export type ShardedQueueDef = {
@@ -66,6 +67,12 @@ export const SHARDED_QUEUES: ShardedQueueDef[] = [
     getInstance: (shard) =>
       LLMAsJudgeExecutionQueue.getInstance({ shardName: shard }),
   },
+  {
+    baseQueueName: QueueName.CodeEvalExecution,
+    getShardNames: () => CodeEvalExecutionQueue.getShardNames(),
+    getInstance: (shard) =>
+      CodeEvalExecutionQueue.getInstance({ shardName: shard }),
+  },
 ];
 
 export const SHARDED_QUEUE_BASE_NAMES = new Set<QueueName>(
@@ -92,6 +99,7 @@ export function resolveQueueInstance(queueName: string): Queue | null {
       | QueueName.EvaluationExecution
       | QueueName.EvaluationExecutionSecondaryQueue
       | QueueName.LLMAsJudgeExecution
+      | QueueName.CodeEvalExecution
       | QueueName.TraceUpsert
       | QueueName.OtelIngestionQueue
       | QueueName.OtelIngestionSecondaryQueue


### PR DESCRIPTION
## Summary

- Add a dedicated observation-level code-eval execution queue with independent worker flag, concurrency, shard-count configuration, and admin/test queue visibility.
- Keep LLM-as-judge behavior on the existing queue while routing observation eval jobs by evaluator template type.
- Refactor observation eval processing so evaluator-specific executors return execution results and shared completion persists scores/updates job executions.

## Linear

- [LFE-9833](https://linear.app/langfuse/issue/LFE-9833)

## Major Decisions

- Code eval execution uses a separate queue/consumer boundary for independent rollout, while sharing the observation eval payload and scheduler path.
- `processObservationEval` stays evaluator-agnostic by accepting a template validator and executor; queue processors own evaluator-specific validation/execution selection.
- Scheduler routing only selects `evalTemplate.type` to avoid fetching full templates or adding per-job lookups.

## Review Focus

- Queue contract/registration changes across shared, worker, and admin BullMQ visibility.
- Observation eval completion split between evaluator execution and shared score persistence.
- Scheduler routing for LLM-as-judge vs code-based templates, including historical/batch eval paths.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a dedicated `code-eval-execution-queue` alongside the existing LLM-as-judge queue for observation-based evals, enabling independent rollout, concurrency, and shard-count configuration. The `processObservationEval` function is refactored to accept injected `validateTemplate` and `executor` callbacks so each queue processor owns its type-gate and evaluation logic, while shared score persistence moves to a new `completeEvalExecution` helper.

- New `CodeEvalExecutionQueue` mirrors the `LLMAsJudgeExecutionQueue` structure with its own env flags, worker concurrency, and admin/BullMQ visibility registration.
- `scheduleObservationEvals` now passes `evalTemplateType` to `enqueueEvalJob`, routing LLM-as-judge jobs to the existing queue and code-based jobs to the new one; the batch eval path flows through the same scheduler deps unchanged.
- `runLLMAsJudgeEvaluation` is extracted from `executeLLMAsJudgeEvaluation` to return an `EvalExecutionResult` rather than write scores directly, with `completeEvalExecution` handling the score-write and job-status update for both evaluator types.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The queue boundary and routing changes are structurally sound; the code-based eval executor is a stub that immediately rejects, so no execution regressions are possible until that function is implemented.

The overall refactor is clean and well-tested. The scheduler routing, queue registration, and completion split all look correct. The main concern is the non-null assertion on evalTemplate in the config fetch and batch paths, which could produce an opaque TypeError if a template is ever deleted without cascading cleanup. The environment dead parameter and the missing deps forwarding to the executor are forward-looking issues rather than present bugs.

worker/src/features/evaluation/observationEval/fetchObservationEvalConfigs.ts (non-null assertion on evalTemplate) and worker/src/features/evaluation/evalService.ts (dead environment parameter in runLLMAsJudgeEvaluation type)
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Scheduler as scheduleObservationEvals
    participant Deps as createObservationEvalSchedulerDeps
    participant LLMQueue as LLMAsJudgeExecutionQueue
    participant CodeQueue as CodeEvalExecutionQueue
    participant LLMProc as llmAsJudgeExecutionQueueProcessor
    participant CodeProc as codeEvalExecutionQueueProcessor
    participant Processor as processObservationEval
    participant Executor as executor
    participant Complete as completeEvalExecution

    Scheduler->>Deps: "enqueueEvalJob({ evalTemplateType })"
    alt "evalTemplateType === CODE"
        Deps->>CodeQueue: queue.add(CodeEvalExecution job)
    else "evalTemplateType === LLM_AS_JUDGE"
        Deps->>LLMQueue: queue.add(LLMAsJudgeExecution job)
    end

    LLMQueue-->>LLMProc: job dequeued
    LLMProc->>Processor: processObservationEval with validateLLMAsJudge + runLLMAsJudgeEvaluation
    CodeQueue-->>CodeProc: job dequeued
    CodeProc->>Processor: processObservationEval with validateCodeBased + executeCodeBasedEvaluation

    Processor->>Processor: fetch job + config + template from DB
    Processor->>Processor: validateTemplate
    Processor->>Processor: download observation from S3
    Processor->>Processor: extract variables
    Processor->>Executor: executor params
    Executor-->>Processor: EvalExecutionResult
    Processor->>Complete: completeEvalExecution
    Complete->>Complete: uploadScore + enqueueScoreIngestion
    Complete->>Complete: updateJobExecution COMPLETED
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
worker/src/features/evaluation/evalService.ts:731-748
The `environment` parameter is declared in the type signature but never destructured or used inside `runLLMAsJudgeEvaluation`. Score writing (the only previous consumer of `environment`) was moved to `completeEvalExecution`, so the parameter is now dead. It is required by the `ObservationEvalExecutor` interface, but keeping it in the type while silently ignoring it is confusing. Either remove it from this function's own type and cast at the call site, or add a comment explaining it is accepted for interface compatibility only.

```suggestion
export async function runLLMAsJudgeEvaluation({
  projectId,
  jobExecutionId,
  job,
  config,
  template,
  extractedVariables,
  deps = createProductionEvalExecutionDeps(),
}: {
  projectId: string;
  jobExecutionId: string;
  job: JobExecution;
  config: JobConfiguration;
  template: EvalTemplateLlmAsAJudge;
  extractedVariables: ExtractedVariable[];
  // Accepted for ObservationEvalExecutor interface compatibility; score writing
  // uses the environment value via completeEvalExecution instead.
  environment?: string;
  deps?: EvalExecutionDeps;
}): Promise<EvalExecutionResult> {
```

### Issue 2 of 3
worker/src/features/evaluation/observationEval/observationEvalProcessor.ts:213-225
**`evalExecutionDeps` not forwarded to the executor**

`completeEvalExecution` receives `deps.evalExecutionDeps` for score persistence, but the `executor` call does not receive any `deps` at all. `runLLMAsJudgeEvaluation` silently falls back to `createProductionEvalExecutionDeps()` for its internal LLM work, which is fine now. However, when `executeCodeBasedEvaluation` is eventually implemented it will also need testable/injectable deps (e.g. a sandbox runner), and the current `ObservationEvalExecutor` type has no `deps` slot to carry them through. Wiring `deps.evalExecutionDeps` into the executor params or adding a `deps` field to `ObservationEvalExecutionBaseParams` before the code eval executor is fully implemented avoids a larger refactor later.

### Issue 3 of 3
worker/src/features/evaluation/observationEval/fetchObservationEvalConfigs.ts:76-79
The non-null assertion `config.evalTemplate!` silently passes `null` through the type system if a template has been deleted without cascading the deletion to its job configurations. Downstream code in `scheduleObservationEvals` would then throw `TypeError: Cannot read properties of null (reading 'type')` rather than a clear, debuggable error. Filtering out orphaned configs here gives a much cleaner failure mode. The same pattern exists in `handleBatchActionJob.ts` where `e.evalTemplate!` is used inside the evaluator mapping.

```suggestion
  return configs.flatMap((config) => {
    if (!config.evalTemplate) {
      logger.warn(
        `Skipping eval config ${config.id}: evalTemplate not found (template may have been deleted)`,
      );
      return [];
    }
    return [{ ...config, evalTemplate: config.evalTemplate }];
  });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): add code eval execution que..."](https://github.com/langfuse/langfuse/commit/ea2bc5a2bc0dd528a11832720af7f46c8084c805) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32682751)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->