### PR TITLE
chore(dx): Make turbo logs quieter by default

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "noUpdateNotifier": true,
   "globalDependencies": [".env"],
   "globalEnv": ["NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF"],
   "envMode": "loose",
@@ -7,7 +8,8 @@
     "build": {
       "dependsOn": ["db:generate", "^build"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
-      "cache": true
+      "cache": true,
+      "outputLogs": "errors-only"
     },
     "start": {
       "dependsOn": ["^start"]
@@ -52,20 +54,37 @@
       "cache": false,
       "dependsOn": ["^db:generate"]
     },
+    "@langfuse/shared#db:generate": {
+      "inputs": ["packages/shared/prisma/schema.prisma"],
+      "cache": false,
+      "dependsOn": ["^db:generate"],
+      "outputLogs": "errors-only"
+    },
+    "@langfuse/shared#db:seed": {
+      "cache": false,
+      "outputLogs": "errors-only"
+    },
+    "@langfuse/shared#db:seed:examples": {
+      "cache": false,
+      "outputLogs": "errors-only"
+    },
     "lint": {
       "dependsOn": ["@repo/eslint-plugin#build"],
       "cache": true,
+      "outputLogs": "errors-only",
       "outputs": []
     },
     "typecheck": {
       "dependsOn": ["db:generate", "^build"],
       "cache": true,
+      "outputLogs": "errors-only",
       "outputs": []
     },
     "build:check": {
       "dependsOn": ["db:generate", "^build"],
       "outputs": [".next-check/**", "!.next-check/cache/**"],
-      "cache": true
+      "cache": true,
+      "outputLogs": "errors-only"
     },
     "test": {
       "dependsOn": ["^test", "db:generate"],
@@ -74,7 +93,8 @@
     "@repo/eslint-plugin#build": {
       "dependsOn": [],
       "outputs": ["dist/**"],
-      "cache": true
+      "cache": true,
+      "outputLogs": "errors-only"
     },
     "worker#dev": {
       "cache": false,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes Turborepo logs quieter by setting `outputLogs: "errors-only"` on several tasks and adding `noUpdateNotifier: true` at the root level. It also adds package-specific task overrides for `@langfuse/shared` database tasks.

- `outputLogs: "errors-only"` is added to `build`, `lint`, `typecheck`, `build:check`, and `@repo/eslint-plugin#build` tasks, silencing stdout on successful runs.
- New package-scoped overrides are introduced for `@langfuse/shared#db:generate`, `@langfuse/shared#db:seed`, and `@langfuse/shared#db:seed:examples`, each with `cache: false` and `outputLogs: "errors-only"`.
- The `test` task is intentionally left unchanged (no output suppression), preserving test result visibility.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a Turborepo config-only change that reduces log verbosity on success without altering build logic or caching behaviour for any task that previously had it enabled.

All changes are additive config fields (`outputLogs`, `noUpdateNotifier`, package-scoped task overrides). No task cache behaviour is changed in a breaking way; `test` tasks deliberately retain full output. The only notable quirk is the redundant `inputs` field on a `cache: false` task, which is harmless.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Turbo Task Run] --> B{Task Type}
    B -->|build, lint, typecheck,\nbuild:check, eslint-plugin#build| C{Outcome}
    B -->|test| D[Full output always shown]
    B -->|dev tasks| E[Full output always shown]
    B -->|db:generate, db:seed,\ndb:seed:examples| F{Outcome}
    C -->|Success| G[Output suppressed\nerrors-only]
    C -->|Error| H[Output shown]
    F -->|Success| I[Output suppressed\nerrors-only]
    F -->|Error| J[Output shown]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
turbo.json:57-62
The `inputs` field on `@langfuse/shared#db:generate` has no effect because `cache: false` disables caching entirely. Turbo only uses `inputs` to compute the cache key, so specifying it here is a no-op and may cause confusion for future maintainers who expect it to change behaviour.

```suggestion
    "@langfuse/shared#db:generate": {
      "cache": false,
      "dependsOn": ["^db:generate"],
      "outputLogs": "errors-only"
    },
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Make turbo logs quiter by default"](https://github.com/langfuse/langfuse/commit/e8043268d6070215e164b034e0d17cc99efaa664) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32763801)</sub>

<!-- /greptile_comment -->