### PR TITLE
chore(dx): Make prisma quieter by default

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -61,7 +61,7 @@
     "db:reset:test": "if [ -f ../../.env.test ]; then dotenv -e ../../.env.test -e ../../.env -- npx prisma migrate reset --force; fi",
     "db:deploy": "dotenv -e ../../.env npx -- prisma migrate deploy",
     "db:seed": "dotenv -e ../../.env -- npx prisma db seed",
-    "db:generate": "dotenv -e ../../.env -- npx prisma generate",
+    "db:generate": "dotenv -e ../../.env -- npx prisma generate --no-hints",
     "db:seed:examples": "dotenv -e ../../.env -- npx prisma db seed -- --environment examples",
     "db:seed:load": "dotenv -e ../../.env -- npx prisma db seed -- --environment load",
     "ch:up": "bash clickhouse/scripts/up.sh",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the `--no-hints` flag to the `prisma generate` command in `packages/shared/package.json`, suppressing the informational hint messages Prisma prints during code generation.

- The `db:generate` script now runs `prisma generate --no-hints`, reducing noise in CI and local development logs without affecting generated output.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the only change is suppressing Prisma's informational hint messages during code generation, which has no effect on the generated client or any runtime behavior.

The change adds a single well-documented CLI flag (--no-hints) to one npm script. Generated Prisma client output is identical with or without the flag, so there is no risk to correctness, builds, or runtime behavior.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer / CI
    participant Script as pnpm db:generate
    participant Prisma as prisma generate

    Dev->>Script: run db:generate
    Script->>Prisma: npx prisma generate --no-hints
    Note over Prisma: Generates client code<br/>Hints/tips suppressed
    Prisma-->>Dev: Generated output (no hint noise)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Make prisma quieter by default"](https://github.com/langfuse/langfuse/commit/383a1251b9b343916db659b30633670fd3f307d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32763949)</sub>

<!-- /greptile_comment -->