### PR TITLE
fix(observations): restore release on v1 events-table path

### DIFF
--- a/web/src/__tests__/server/observations-api.servertest.ts
+++ b/web/src/__tests__/server/observations-api.servertest.ts
@@ -68,6 +68,7 @@ const createObservationData = (
       // Propagate trace-level fields to events
       user_id: trace?.user_id ?? null,
       tags: trace?.tags ?? [],
+      release: trace?.release ?? null,
     });
   } else {
     // For observations table: milliseconds, simpler structure
@@ -577,6 +578,50 @@ describe("/api/public/observations API Endpoint", () => {
     runTestSuite(true); // with events table
   }
   runTestSuite(false); // with observations table
+
+  // Regression: v1 events-table path must return `release` to callers.
+  // #13620 added `release` to the strip-list in `transformDbToApiObservation`,
+  // dropping the field from v1 responses on the events-table path. See LFE-9863.
+  if (env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true") {
+    describe("GET /api/public/observations with events table - release field", () => {
+      it("returns `release` on the v1 events-table path", async () => {
+        const traceId = randomUUID();
+        const timestamp = new Date();
+        const timeValue = timestamp.getTime() * 1000;
+
+        const createdTrace = createTrace({
+          id: traceId,
+          project_id: projectId,
+          timestamp: timestamp.getTime(),
+          release: "release-9863",
+        });
+
+        await createAndInsertObservations(true, createdTrace, [
+          {
+            trace_id: traceId,
+            project_id: projectId,
+            name: "release-observation",
+            type: "SPAN",
+            level: "DEFAULT",
+            start_time: timeValue,
+            end_time: timeValue + 1000 * 1000,
+          },
+        ]);
+
+        const response = await makeZodVerifiedAPICall(
+          GetObservationsV1Response,
+          "GET",
+          `/api/public/observations?useEventsTable=true&traceId=${traceId}`,
+          undefined,
+          auth,
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.length).toBe(1);
+        expect(response.body.data[0]?.release).toBe("release-9863");
+      });
+    });
+  }
 
   // Advanced Filtering Tests
   describe("Advanced Filtering", () => {

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -157,9 +157,6 @@ export const transformDbToApiObservation = (
     // exclude trace name, this will only be available on events api
     traceName,
 
-    // exclude release, this will only be available on events api
-    release,
-
     // Exclude tags
     tags,
     traceTags,


### PR DESCRIPTION
## Summary

Restore `release` on the v1 observations events-table path, fixing the regression introduced by #13620. Tracked in [LFE-9863](https://linear.app/langfuse/issue/LFE-9863).

`transformDbToApiObservation` had `release` added to its strip-list in #13620, which drops the field from v1 responses on the events-table path (`useEventsTable=true` or `LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS=true`). The v1 response schema (`APIObservation`) already declares `release` as `z.string().nullable().optional()`, and the legacy path was always unaffected (column never selected), so the fix is to remove the strip and let the field flow through `...rest`.

### Why this matters

This is a caller-visible v1 contract regression. v2 is unaffected — it uses `APIObservationV2` and exposes `release` via the `trace_context` field group, and does not call `transformDbToApiObservation`.

### Impacted packages

- `web` — `transformDbToApiObservation` (3 lines removed), plus regression test in `observations-api.servertest.ts`.

## Test plan

- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter web run typecheck`
- [x] `LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS=true pnpm --filter web exec vitest run src/__tests__/server/observations-api.servertest.ts` — 25/25 passed
- [x] `pnpm --filter web exec vitest run src/__tests__/server/observations-api.servertest.ts` (legacy path) — 25/25 passed
- [x] `pnpm --filter web exec vitest run src/__tests__/server/observations-api-v2.servertest.ts` — 27/27 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)