### PR TITLE
chore: propagate tags onto 422 errors

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -49,18 +49,27 @@ export class ClickHouseResourceError extends Error {
   static ERROR_ADVICE_MESSAGE = RESOURCE_LIMIT_ERROR_MESSAGE;
 
   public readonly errorType: ErrorType;
+  public readonly tags?: Record<string, string>;
 
-  constructor(errType: ErrorType, originalError: Error) {
+  constructor(
+    errType: ErrorType,
+    originalError: Error,
+    tags?: Record<string, string>,
+  ) {
     super(originalError.message, { cause: originalError });
     this.name = "ClickHouseResourceError";
     this.errorType = errType;
+    this.tags = tags;
     // Preserve the original stack trace if available
     if (originalError.stack) {
       this.stack = originalError.stack;
     }
   }
 
-  static wrapIfResourceError(originalError: Error): Error {
+  static wrapIfResourceError(
+    originalError: Error,
+    tags?: Record<string, string>,
+  ): Error {
     const errorMessage = originalError.message || "";
 
     for (const [type, config] of Object.entries(ERROR_TYPE_CONFIG) as Array<
@@ -74,7 +83,7 @@ export class ClickHouseResourceError extends Error {
       );
 
       if (hasDiscriminator) {
-        return new ClickHouseResourceError(type, originalError);
+        return new ClickHouseResourceError(type, originalError, tags);
       }
     }
 
@@ -239,7 +248,10 @@ export async function* queryClickhouseStream<T>(
         sendClickhouseQuery({ ...opts, format: "JSONEachRow", span }),
       )
       .catch((error) => {
-        throw ClickHouseResourceError.wrapIfResourceError(error as Error);
+        throw ClickHouseResourceError.wrapIfResourceError(
+          error as Error,
+          opts.tags,
+        );
       });
 
     for await (const rows of res.stream<T>()) {
@@ -249,7 +261,10 @@ export async function* queryClickhouseStream<T>(
     }
   } catch (error) {
     if (error instanceof ClickHouseResourceError) throw error;
-    throw ClickHouseResourceError.wrapIfResourceError(error as Error);
+    throw ClickHouseResourceError.wrapIfResourceError(
+      error as Error,
+      opts.tags,
+    );
   } finally {
     span.end();
   }
@@ -441,7 +456,10 @@ export async function queryClickhouse<T>(
           maxDelay: 100,
         },
       ).catch((error) => {
-        throw ClickHouseResourceError.wrapIfResourceError(error as Error);
+        throw ClickHouseResourceError.wrapIfResourceError(
+          error as Error,
+          opts.tags,
+        );
       });
     },
   );
@@ -474,7 +492,10 @@ export async function* queryClickhouseWithProgress<T>(
         }),
       )
       .catch((error) => {
-        throw ClickHouseResourceError.wrapIfResourceError(error as Error);
+        throw ClickHouseResourceError.wrapIfResourceError(
+          error as Error,
+          opts.tags,
+        );
       });
 
     for await (const rows of res.stream()) {
@@ -484,7 +505,10 @@ export async function* queryClickhouseWithProgress<T>(
     }
   } catch (error) {
     if (error instanceof ClickHouseResourceError) throw error;
-    throw ClickHouseResourceError.wrapIfResourceError(error as Error);
+    throw ClickHouseResourceError.wrapIfResourceError(
+      error as Error,
+      opts.tags,
+    );
   } finally {
     span.end();
   }

--- a/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
+++ b/web/src/__tests__/server/repositories/clickhouse-resource-errors.servertest.ts
@@ -16,6 +16,7 @@ describe("ClickHouse Resource Error Handling", () => {
             res = await queryClickhouse<any>({
               query: `SELECT throwIf(number >= 2, 'memory limit exceeded: would use 10.23 GiB') AS v FROM system.numbers LIMIT 2000`,
               clickhouseSettings: { max_block_size: `${blockSize}` },
+              tags: { test: "marker" },
             });
             fail(
               "Should have thrown an error, observed instead " +
@@ -24,6 +25,7 @@ describe("ClickHouse Resource Error Handling", () => {
           } catch (error: any) {
             expect(error).toBeInstanceOf(ClickHouseResourceError);
             expect(error.errorType).toBe("MEMORY_LIMIT");
+            expect(error.tags?.test).toBe("marker");
           }
         });
       });

--- a/web/src/__tests__/server/withMiddlewares.servertest.ts
+++ b/web/src/__tests__/server/withMiddlewares.servertest.ts
@@ -215,6 +215,39 @@ describe("withMiddlewares error handling", () => {
       expect(jsonData["error"]).toBe("Request timed out");
     });
 
+    it("should include tags from the error in the warn log", async () => {
+      const originalError = new Error("Memory limit exceeded");
+      const resourceError = new ClickHouseResourceError(
+        "MEMORY_LIMIT",
+        originalError,
+        { type: "events", kind: "publicApiRows" },
+      );
+
+      const handler = withMiddlewares({
+        GET: async () => {
+          throw resourceError;
+        },
+      });
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        headers: {
+          "x-langfuse-public-key": "test-key",
+        },
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(422);
+      expect(logger.warn).toHaveBeenCalledWith(
+        "ClickHouse resource limit exceeded",
+        expect.objectContaining({
+          errorType: "MEMORY_LIMIT",
+          tags: { type: "events", kind: "publicApiRows" },
+        }),
+      );
+    });
+
     it("should handle ClickHouseResourceError with custom advice", async () => {
       const originalError = new Error("Timeout exceeded");
       const resourceError = new ClickHouseResourceError(

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -148,6 +148,7 @@ export function withMiddlewares(
             errorType: resourceError.errorType,
             message: resourceError.message,
             suggestion: errorMessage,
+            tags: resourceError.tags,
           });
 
           return res.status(422).json({

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -170,6 +170,11 @@ const withErrorHandling = t.middleware(async ({ ctx, next }) => {
     if (res.error.cause instanceof ClickHouseResourceError) {
       // Surface ClickHouse errors using an advice message
       // which is supposed to provide a bit of guidance to the user.
+      logger.warn("ClickHouse resource limit exceeded", {
+        errorType: res.error.cause.errorType,
+        message: res.error.cause.message,
+        tags: res.error.cause.tags,
+      });
       logErrorByCode("UNPROCESSABLE_CONTENT", res.error);
       res.error = new TRPCError({
         code: "UNPROCESSABLE_CONTENT",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR propagates `tags` from `ClickhouseQueryOpts` through `ClickHouseResourceError` so that structured context (e.g. entity type, endpoint kind) is included in the `warn` log entries emitted on 422 responses, making resource-limit errors easier to triage in production.

- `ClickHouseResourceError` gains an optional `tags?: Record<string, string>` field, forwarded through `wrapIfResourceError` and every catch-site in `queryClickhouseStream`, `queryClickhouse`, and `queryClickhouseWithProgress`.
- Both the REST middleware (`withMiddlewares.ts`) and the tRPC error handler (`trpc.ts`) now include `tags` in their `logger.warn` payloads when a ClickHouse resource error is surfaced as a 422.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are additive, affecting only logging enrichment with no impact on error handling logic or response payloads.

The change only threads an optional field through existing error construction and log calls. Error matching, HTTP status codes, and client-facing response bodies are untouched. Both middleware paths are covered by tests, and the field is optional so callers that don't supply tags are unaffected.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant queryClickhouse/Stream/Progress
    participant ClickHouseResourceError
    participant withMiddlewares / tRPC

    Caller->>queryClickhouse/Stream/Progress: opts (query, tags, ...)
    queryClickhouse/Stream/Progress->>ClickHouseResourceError: wrapIfResourceError(error, opts.tags)
    ClickHouseResourceError-->>queryClickhouse/Stream/Progress: "new ClickHouseResourceError{errorType, tags}"
    queryClickhouse/Stream/Progress-->>withMiddlewares / tRPC: throw ClickHouseResourceError
    withMiddlewares / tRPC->>withMiddlewares / tRPC: logger.warn("ClickHouse resource limit exceeded", {errorType, tags})
    withMiddlewares / tRPC-->>Caller: HTTP 422 / TRPC UNPROCESSABLE_CONTENT
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: propagate tags onto 422 errors"](https://github.com/langfuse/langfuse/commit/013be0199bd85fd82af57286d89ba7934e6529a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32778008)</sub>

<!-- /greptile_comment -->