### PR TITLE
fix: observations v2 shouldn't be joining reconstructed traces for userId

### DIFF
--- a/packages/shared/src/server/queries/public-api-filter-builder.ts
+++ b/packages/shared/src/server/queries/public-api-filter-builder.ts
@@ -135,14 +135,28 @@ export function createPublicApiObservationsColumnMapping(
   tablePrefix: "e" | "o",
   parentFieldName: "parent_span_id" | "parent_observation_id",
 ): ApiColumnMapping[] {
+  // user_id is denormalized onto events_core/events_full, so the events_proto
+  // path filters directly without joining the traces CTE. The legacy
+  // observations table does not carry user_id, so that path still joins
+  // traces.
+  const userIdMapping: ApiColumnMapping =
+    tableName === "events_proto"
+      ? {
+          id: "userId",
+          clickhouseSelect: "user_id",
+          filterType: "StringFilter",
+          clickhouseTable: tableName,
+          clickhousePrefix: tablePrefix,
+        }
+      : {
+          id: "userId",
+          clickhouseSelect: "user_id",
+          filterType: "StringFilter",
+          clickhouseTable: "traces",
+          clickhousePrefix: "t",
+        };
   return [
-    {
-      id: "userId",
-      clickhouseSelect: "user_id",
-      filterType: "StringFilter",
-      clickhouseTable: "traces",
-      clickhousePrefix: "t",
-    },
+    userIdMapping,
     {
       id: "traceId",
       clickhouseSelect: "trace_id",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in the public API observations filter builder where filtering by `userId` on the v2 (events-based) observations path unnecessarily joined a reconstructed traces CTE, even though `user_id` is denormalized directly onto the `events_proto` table.

- For the `events_proto` path, `userId` filter now targets `e.user_id` directly, eliminating an unnecessary CTE join to the reconstructed `traces` aggregation.
- The legacy `observations` path is unchanged — it still joins `traces` to resolve `user_id`, as that column does not exist on the observations table.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted fix that eliminates an unnecessary CTE join when filtering by userId on the events-based observations path.

The fix correctly routes the userId filter directly to e.user_id on the events_proto table, avoiding an incorrect join to the reconstructed traces CTE. The legacy observations path is untouched, and the change integrates cleanly with the existing hasTraceFilter guard in buildObservationsQueryComponents.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createPublicApiObservationsColumnMapping called] --> B{tableName === 'events_proto'?}

    B -- YES --> C["userId mapping:\nclickhouseTable: 'events_proto'\nclickhousePrefix: 'e'"]
    B -- NO --> D["userId mapping:\nclickhouseTable: 'traces'\nclickhousePrefix: 't'"]

    C --> E[deriveFilters builds FilterList]
    D --> E

    E --> F{Any filter with\nclickhouseTable === 'traces'?}

    F -- NO --> G["No traces CTE created\ne.user_id = X applied directly\n(events_proto path, after fix)"]
    F -- YES --> H["eventsTracesAggregation CTE created\nJoins traces t ON t.id = e.trace_id\n(observations legacy path, unchanged)"]

    style G fill:#d4edda,stroke:#28a745
    style H fill:#fff3cd,stroke:#ffc107
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: observations v2 shouldn&#39;t be joinin..."](https://github.com/langfuse/langfuse/commit/a7f7b8c72da13bb8ec1e51b2d2061ed5567b4ec0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32780438)</sub>

<!-- /greptile_comment -->