### PR TITLE
refactor(fern): lift filter docs to endpoint level in traces API

### DIFF
--- a/fern/apis/server/definition/trace.yml
+++ b/fern/apis/server/definition/trace.yml
@@ -31,7 +31,116 @@ service:
           docs: The unique langfuse identifier of the trace to delete
       response: DeleteTraceResponse
     list:
-      docs: Get list of traces
+      docs: |
+        Get list of traces.
+
+        ## Filters
+        Multiple filtering options are available via query parameters or the structured `filter` parameter.
+        When using the `filter` parameter, it takes precedence over individual query parameter filters.
+
+        ### Filter Structure
+        Each filter condition has the following structure:
+        ```json
+        [
+          {
+            "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": string,         // Required. Column to filter on (see available columns below)
+            "operator": string,       // Required. Operator based on type:
+                                      // - datetime: ">", "<", ">=", "<="
+                                      // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - stringOptions: "any of", "none of"
+                                      // - categoryOptions: "any of", "none of"
+                                      // - arrayOptions: "any of", "none of", "all of"
+                                      // - number: "=", ">", "<", ">=", "<="
+                                      // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - numberObject: "=", ">", "<", ">=", "<="
+                                      // - boolean: "=", "<>"
+                                      // - null: "is null", "is not null"
+            "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
+            "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
+          }
+        ]
+        ```
+
+        ### Available Columns
+
+        #### Core Trace Fields
+        - `id` (string) - Trace ID
+        - `name` (string) - Trace name
+        - `timestamp` (datetime) - Trace timestamp
+        - `userId` (string) - User ID
+        - `sessionId` (string) - Session ID
+        - `environment` (string) - Environment tag
+        - `version` (string) - Version tag
+        - `release` (string) - Release tag
+        - `tags` (arrayOptions) - Array of tags
+        - `bookmarked` (boolean) - Bookmark status
+
+        #### Structured Data
+        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
+
+        #### Aggregated Metrics (from observations)
+        These metrics are aggregated from all observations within the trace:
+        - `latency` (number) - Latency in seconds (time from first observation start to last observation end)
+        - `inputTokens` (number) - Total input tokens across all observations
+        - `outputTokens` (number) - Total output tokens across all observations
+        - `totalTokens` (number) - Total tokens (alias: `tokens`)
+        - `inputCost` (number) - Total input cost in USD
+        - `outputCost` (number) - Total output cost in USD
+        - `totalCost` (number) - Total cost in USD
+
+        #### Observation Level Aggregations
+        These fields aggregate observation levels within the trace:
+        - `level` (string) - Highest severity level (ERROR > WARNING > DEFAULT > DEBUG)
+        - `warningCount` (number) - Count of WARNING level observations
+        - `errorCount` (number) - Count of ERROR level observations
+        - `defaultCount` (number) - Count of DEFAULT level observations
+        - `debugCount` (number) - Count of DEBUG level observations
+
+        #### Scores (requires join with scores table)
+        - `scores_avg` (number) - Average of numeric scores (alias: `scores`)
+        - `score_categories` (categoryOptions) - Categorical score values
+
+        ### Filter Examples
+        ```json
+        [
+          {
+            "type": "datetime",
+            "column": "timestamp",
+            "operator": ">=",
+            "value": "2024-01-01T00:00:00Z"
+          },
+          {
+            "type": "string",
+            "column": "userId",
+            "operator": "=",
+            "value": "user-123"
+          },
+          {
+            "type": "number",
+            "column": "totalCost",
+            "operator": ">=",
+            "value": 0.01
+          },
+          {
+            "type": "arrayOptions",
+            "column": "tags",
+            "operator": "all of",
+            "value": ["production", "critical"]
+          },
+          {
+            "type": "stringObject",
+            "column": "metadata",
+            "key": "customer_tier",
+            "operator": "=",
+            "value": "enterprise"
+          }
+        ]
+        ```
+
+        ### Performance Notes
+        - Filtering on `userId`, `sessionId`, or `metadata` may enable skip indexes for better query performance
+        - Score filters require a join with the scores table and may impact query performance
       method: GET
       path: /traces
       request:
@@ -75,111 +184,9 @@ service:
           filter:
             type: optional<string>
             docs: |
-              JSON string containing an array of filter conditions. When provided, this takes precedence over query parameter filters (userId, name, sessionId, tags, version, release, environment, fromTimestamp, toTimestamp).
-
-              ## Filter Structure
-              Each filter condition has the following structure:
-              ```json
-              [
-                {
-                  "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-                  "column": string,         // Required. Column to filter on (see available columns below)
-                  "operator": string,       // Required. Operator based on type:
-                                            // - datetime: ">", "<", ">=", "<="
-                                            // - string: "=", "contains", "does not contain", "starts with", "ends with"
-                                            // - stringOptions: "any of", "none of"
-                                            // - categoryOptions: "any of", "none of"
-                                            // - arrayOptions: "any of", "none of", "all of"
-                                            // - number: "=", ">", "<", ">=", "<="
-                                            // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
-                                            // - numberObject: "=", ">", "<", ">=", "<="
-                                            // - boolean: "=", "<>"
-                                            // - null: "is null", "is not null"
-                  "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-                  "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
-                }
-              ]
-              ```
-
-              ## Available Columns
-
-              ### Core Trace Fields
-              - `id` (string) - Trace ID
-              - `name` (string) - Trace name
-              - `timestamp` (datetime) - Trace timestamp
-              - `userId` (string) - User ID
-              - `sessionId` (string) - Session ID
-              - `environment` (string) - Environment tag
-              - `version` (string) - Version tag
-              - `release` (string) - Release tag
-              - `tags` (arrayOptions) - Array of tags
-              - `bookmarked` (boolean) - Bookmark status
-
-              ### Structured Data
-              - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
-
-              ### Aggregated Metrics (from observations)
-              These metrics are aggregated from all observations within the trace:
-              - `latency` (number) - Latency in seconds (time from first observation start to last observation end)
-              - `inputTokens` (number) - Total input tokens across all observations
-              - `outputTokens` (number) - Total output tokens across all observations
-              - `totalTokens` (number) - Total tokens (alias: `tokens`)
-              - `inputCost` (number) - Total input cost in USD
-              - `outputCost` (number) - Total output cost in USD
-              - `totalCost` (number) - Total cost in USD
-
-              ### Observation Level Aggregations
-              These fields aggregate observation levels within the trace:
-              - `level` (string) - Highest severity level (ERROR > WARNING > DEFAULT > DEBUG)
-              - `warningCount` (number) - Count of WARNING level observations
-              - `errorCount` (number) - Count of ERROR level observations
-              - `defaultCount` (number) - Count of DEFAULT level observations
-              - `debugCount` (number) - Count of DEBUG level observations
-
-              ### Scores (requires join with scores table)
-              - `scores_avg` (number) - Average of numeric scores (alias: `scores`)
-              - `score_categories` (categoryOptions) - Categorical score values
-
-              ## Filter Examples
-              ```json
-              [
-                {
-                  "type": "datetime",
-                  "column": "timestamp",
-                  "operator": ">=",
-                  "value": "2024-01-01T00:00:00Z"
-                },
-                {
-                  "type": "string",
-                  "column": "userId",
-                  "operator": "=",
-                  "value": "user-123"
-                },
-                {
-                  "type": "number",
-                  "column": "totalCost",
-                  "operator": ">=",
-                  "value": 0.01
-                },
-                {
-                  "type": "arrayOptions",
-                  "column": "tags",
-                  "operator": "all of",
-                  "value": ["production", "critical"]
-                },
-                {
-                  "type": "stringObject",
-                  "column": "metadata",
-                  "key": "customer_tier",
-                  "operator": "=",
-                  "value": "enterprise"
-                }
-              ]
-              ```
-
-              ## Performance Notes
-              - Filtering on `userId`, `sessionId`, or `metadata` may enable skip indexes for better query performance
-              - Score filters require a join with the scores table and may impact query performance
+              JSON-encoded array of filter conditions. Takes precedence over individual query-parameter filters
+              (userId, name, sessionId, tags, version, release, environment, fromTimestamp, toTimestamp). See
+              **Filter Structure**, **Available Columns**, and **Filter Examples** in the endpoint description above.
       response: Traces
     deleteMultiple:
       docs: Delete multiple traces

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -5785,7 +5785,172 @@ paths:
         - BasicAuth: []
   /api/public/traces:
     get:
-      description: Get list of traces
+      description: >-
+        Get list of traces.
+
+
+        ## Filters
+
+        Multiple filtering options are available via query parameters or the
+        structured `filter` parameter.
+
+        When using the `filter` parameter, it takes precedence over individual
+        query parameter filters.
+
+
+        ### Filter Structure
+
+        Each filter condition has the following structure:
+
+        ```json
+
+        [
+          {
+            "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": string,         // Required. Column to filter on (see available columns below)
+            "operator": string,       // Required. Operator based on type:
+                                      // - datetime: ">", "<", ">=", "<="
+                                      // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - stringOptions: "any of", "none of"
+                                      // - categoryOptions: "any of", "none of"
+                                      // - arrayOptions: "any of", "none of", "all of"
+                                      // - number: "=", ">", "<", ">=", "<="
+                                      // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - numberObject: "=", ">", "<", ">=", "<="
+                                      // - boolean: "=", "<>"
+                                      // - null: "is null", "is not null"
+            "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
+            "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
+          }
+        ]
+
+        ```
+
+
+        ### Available Columns
+
+
+        #### Core Trace Fields
+
+        - `id` (string) - Trace ID
+
+        - `name` (string) - Trace name
+
+        - `timestamp` (datetime) - Trace timestamp
+
+        - `userId` (string) - User ID
+
+        - `sessionId` (string) - Session ID
+
+        - `environment` (string) - Environment tag
+
+        - `version` (string) - Version tag
+
+        - `release` (string) - Release tag
+
+        - `tags` (arrayOptions) - Array of tags
+
+        - `bookmarked` (boolean) - Bookmark status
+
+
+        #### Structured Data
+
+        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
+        key-value pairs. Use `key` parameter to filter on specific metadata
+        keys.
+
+
+        #### Aggregated Metrics (from observations)
+
+        These metrics are aggregated from all observations within the trace:
+
+        - `latency` (number) - Latency in seconds (time from first observation
+        start to last observation end)
+
+        - `inputTokens` (number) - Total input tokens across all observations
+
+        - `outputTokens` (number) - Total output tokens across all observations
+
+        - `totalTokens` (number) - Total tokens (alias: `tokens`)
+
+        - `inputCost` (number) - Total input cost in USD
+
+        - `outputCost` (number) - Total output cost in USD
+
+        - `totalCost` (number) - Total cost in USD
+
+
+        #### Observation Level Aggregations
+
+        These fields aggregate observation levels within the trace:
+
+        - `level` (string) - Highest severity level (ERROR > WARNING > DEFAULT >
+        DEBUG)
+
+        - `warningCount` (number) - Count of WARNING level observations
+
+        - `errorCount` (number) - Count of ERROR level observations
+
+        - `defaultCount` (number) - Count of DEFAULT level observations
+
+        - `debugCount` (number) - Count of DEBUG level observations
+
+
+        #### Scores (requires join with scores table)
+
+        - `scores_avg` (number) - Average of numeric scores (alias: `scores`)
+
+        - `score_categories` (categoryOptions) - Categorical score values
+
+
+        ### Filter Examples
+
+        ```json
+
+        [
+          {
+            "type": "datetime",
+            "column": "timestamp",
+            "operator": ">=",
+            "value": "2024-01-01T00:00:00Z"
+          },
+          {
+            "type": "string",
+            "column": "userId",
+            "operator": "=",
+            "value": "user-123"
+          },
+          {
+            "type": "number",
+            "column": "totalCost",
+            "operator": ">=",
+            "value": 0.01
+          },
+          {
+            "type": "arrayOptions",
+            "column": "tags",
+            "operator": "all of",
+            "value": ["production", "critical"]
+          },
+          {
+            "type": "stringObject",
+            "column": "metadata",
+            "key": "customer_tier",
+            "operator": "=",
+            "value": "enterprise"
+          }
+        ]
+
+        ```
+
+
+        ### Performance Notes
+
+        - Filtering on `userId`, `sessionId`, or `metadata` may enable skip
+        indexes for better query performance
+
+        - Score filters require a join with the scores table and may impact
+        query performance
       operationId: trace_list
       tags:
         - Trace
@@ -5904,168 +6069,14 @@ paths:
         - name: filter
           in: query
           description: >-
-            JSON string containing an array of filter conditions. When provided,
-            this takes precedence over query parameter filters (userId, name,
-            sessionId, tags, version, release, environment, fromTimestamp,
-            toTimestamp).
+            JSON-encoded array of filter conditions. Takes precedence over
+            individual query-parameter filters
 
+            (userId, name, sessionId, tags, version, release, environment,
+            fromTimestamp, toTimestamp). See
 
-            ## Filter Structure
-
-            Each filter condition has the following structure:
-
-            ```json
-
-            [
-              {
-                "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-                "column": string,         // Required. Column to filter on (see available columns below)
-                "operator": string,       // Required. Operator based on type:
-                                          // - datetime: ">", "<", ">=", "<="
-                                          // - string: "=", "contains", "does not contain", "starts with", "ends with"
-                                          // - stringOptions: "any of", "none of"
-                                          // - categoryOptions: "any of", "none of"
-                                          // - arrayOptions: "any of", "none of", "all of"
-                                          // - number: "=", ">", "<", ">=", "<="
-                                          // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
-                                          // - numberObject: "=", ">", "<", ">=", "<="
-                                          // - boolean: "=", "<>"
-                                          // - null: "is null", "is not null"
-                "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-                "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
-              }
-            ]
-
-            ```
-
-
-            ## Available Columns
-
-
-            ### Core Trace Fields
-
-            - `id` (string) - Trace ID
-
-            - `name` (string) - Trace name
-
-            - `timestamp` (datetime) - Trace timestamp
-
-            - `userId` (string) - User ID
-
-            - `sessionId` (string) - Session ID
-
-            - `environment` (string) - Environment tag
-
-            - `version` (string) - Version tag
-
-            - `release` (string) - Release tag
-
-            - `tags` (arrayOptions) - Array of tags
-
-            - `bookmarked` (boolean) - Bookmark status
-
-
-            ### Structured Data
-
-            - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
-            key-value pairs. Use `key` parameter to filter on specific metadata
-            keys.
-
-
-            ### Aggregated Metrics (from observations)
-
-            These metrics are aggregated from all observations within the trace:
-
-            - `latency` (number) - Latency in seconds (time from first
-            observation start to last observation end)
-
-            - `inputTokens` (number) - Total input tokens across all
-            observations
-
-            - `outputTokens` (number) - Total output tokens across all
-            observations
-
-            - `totalTokens` (number) - Total tokens (alias: `tokens`)
-
-            - `inputCost` (number) - Total input cost in USD
-
-            - `outputCost` (number) - Total output cost in USD
-
-            - `totalCost` (number) - Total cost in USD
-
-
-            ### Observation Level Aggregations
-
-            These fields aggregate observation levels within the trace:
-
-            - `level` (string) - Highest severity level (ERROR > WARNING >
-            DEFAULT > DEBUG)
-
-            - `warningCount` (number) - Count of WARNING level observations
-
-            - `errorCount` (number) - Count of ERROR level observations
-
-            - `defaultCount` (number) - Count of DEFAULT level observations
-
-            - `debugCount` (number) - Count of DEBUG level observations
-
-
-            ### Scores (requires join with scores table)
-
-            - `scores_avg` (number) - Average of numeric scores (alias:
-            `scores`)
-
-            - `score_categories` (categoryOptions) - Categorical score values
-
-
-            ## Filter Examples
-
-            ```json
-
-            [
-              {
-                "type": "datetime",
-                "column": "timestamp",
-                "operator": ">=",
-                "value": "2024-01-01T00:00:00Z"
-              },
-              {
-                "type": "string",
-                "column": "userId",
-                "operator": "=",
-                "value": "user-123"
-              },
-              {
-                "type": "number",
-                "column": "totalCost",
-                "operator": ">=",
-                "value": 0.01
-              },
-              {
-                "type": "arrayOptions",
-                "column": "tags",
-                "operator": "all of",
-                "value": ["production", "critical"]
-              },
-              {
-                "type": "stringObject",
-                "column": "metadata",
-                "key": "customer_tier",
-                "operator": "=",
-                "value": "enterprise"
-              }
-            ]
-
-            ```
-
-
-            ## Performance Notes
-
-            - Filtering on `userId`, `sessionId`, or `metadata` may enable skip
-            indexes for better query performance
-
-            - Score filters require a join with the scores table and may impact
-            query performance
+            **Filter Structure**, **Available Columns**, and **Filter Examples**
+            in the endpoint description above.
           required: false
           schema:
             type: string


### PR DESCRIPTION
## Summary

- Moves Filter Structure, Available Columns, and Filter Examples from the `filter` parameter's inline `docs` block up into the endpoint-level `## Filters` section of the `GET /traces` list endpoint.
- The `filter` parameter's docs now contain a single pointer sentence referencing the endpoint description.

`##` headers inside a parameter `docs` block render at the same visual level as endpoint-level sections, making it unclear which content belongs to the `filter` parameter vs. the endpoint as a whole. See LFE-9794.

## Impacted packages

- `fern/apis/server/definition/trace.yml`
- `web/public/generated/api/openapi.yml` — regenerated via `fern generate --group local --api server`

## Verification

- [x] `fern generate --group local --api server` completes without errors
- [x] Lint passes
- [ ] Verify rendered docs at `/api-reference/traces/get-traces` show Filter Structure under the endpoint description, not under the `filter` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restructures the `GET /traces` API documentation by moving filter details (Filter Structure, Available Columns, Filter Examples, Performance Notes) from the `filter` query parameter's inline `docs` block into the endpoint-level description, so that Markdown headers render in the correct visual hierarchy.

- `fern/apis/server/definition/trace.yml` — endpoint `docs` block expanded with the full filter reference; `filter` parameter docs replaced with a single pointer sentence.
- `web/public/generated/api/openapi.yml` — regenerated output reflecting the above; `scores_avg` type corrected from `number` to `numberObject` in the endpoint description (more accurate since the field requires a `key` parameter), while `metadata` filter types were simplified from `stringObject/numberObject/categoryOptions` to only `stringObject`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are documentation-only with no runtime logic affected.

The restructuring is correct and the generated OpenAPI file matches the Fern source. The one notable content change is the narrowing of `metadata` filter types from `stringObject/numberObject/categoryOptions` to only `stringObject` in the new endpoint-level description; if the other two types are actually supported at runtime, their omission would leave users without documentation for a valid use case.

The `metadata` column entry in `fern/apis/server/definition/trace.yml` — specifically whether `numberObject` and `categoryOptions` should still be listed as valid filter types for that field.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (old structure)"]
        A["GET /traces\ndocs: 'Get list of traces'"] --> B["filter param docs\n(huge block: Filter Structure,\nAvailable Columns, Examples,\nPerformance Notes)"]
        B --> C["## headers render at same\nlevel as endpoint sections\n⚠ Confusing hierarchy"]
    end

    subgraph After["After (new structure)"]
        D["GET /traces docs block\n## Filters\n### Filter Structure\n### Available Columns\n### Filter Examples\n### Performance Notes"] --> E["filter param docs\n(short pointer sentence:\n'See Filter Structure...\nin endpoint description above')"]
        E --> F["## headers now correctly\nnested under endpoint description\n✓ Clear hierarchy"]
    end

    Before -->|"PR change"| After
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
fern/apis/server/definition/trace.yml:66-67
**Metadata filter type narrowed from three types to one**

The old docs listed `metadata` as `(stringObject/numberObject/categoryOptions)`, while the new endpoint-level description lists only `(stringObject)`. If users can actually filter metadata using `numberObject` (e.g., filtering a numeric metadata value like a price) or `categoryOptions`, those two types are now silently undocumented. Readers who relied on the old description to filter metadata numerically won't know the option exists.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(fern): lift filter docs to endpoint ..."](https://github.com/langfuse/langfuse/commit/32dd5d2385b1d5c7e0dad6fb93d1be360e8def14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32787716)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->