### PR TITLE
fix(fern): lift filter docs to endpoint level and fix column accuracy in observations API

### DIFF
--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -32,6 +32,108 @@ service:
         ## Filters
         Multiple filtering options are available via query parameters or the structured `filter` parameter.
         When using the `filter` parameter, it takes precedence over individual query parameter filters.
+
+        ### Filter Structure
+        Each filter condition has the following structure:
+        ```json
+        [
+          {
+            "type": "string",         // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": "name",         // Required. Column to filter on (see Available Columns below)
+            "operator": "=",          // Required. Operator based on type:
+                                      // - datetime: ">", "<", ">=", "<="
+                                      // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - stringOptions: "any of", "none of"
+                                      // - categoryOptions: "any of", "none of"
+                                      // - arrayOptions: "any of", "none of", "all of"
+                                      // - number: "=", ">", "<", ">=", "<="
+                                      // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - numberObject: "=", ">", "<", ">=", "<="
+                                      // - boolean: "=", "<>"
+                                      // - null: "is null", "is not null"
+            "value": "GENERATION",    // Required (except for null type). Type depends on filter type.
+            "key": "env"              // Required only for stringObject, numberObject, and categoryOptions when filtering nested fields like metadata.
+          }
+        ]
+        ```
+
+        ### Available Columns
+
+        #### Core Observation Fields
+        - `id` (string) - Observation ID
+        - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
+        - `name` (string) - Observation name
+        - `traceId` (string) - Associated trace ID
+        - `parentObservationId` (string) - Parent observation ID
+        - `startTime` (datetime) - Observation start time
+        - `endTime` (datetime) - Observation end time
+        - `environment` (string) - Environment tag
+        - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
+        - `statusMessage` (string) - Status message
+        - `version` (string) - Version tag
+
+        #### Trace-Related Fields
+        - `traceName` (string) - Name of the parent trace
+        - `traceEnvironment` (string) - Environment tag from the parent trace
+        - `traceTags` (arrayOptions) - Tags from the parent trace
+        - `tags` (arrayOptions) - Tags on the observation
+        - `userId` (string) - User ID
+        - `sessionId` (string) - Session ID
+
+        #### Performance Metrics
+        - `latency` (number) - Latency in seconds (end_time − start_time)
+        - `timeToFirstToken` (number) - Time to first token in seconds
+        - `tokensPerSecond` (number) - Output tokens per second
+
+        #### Token Usage
+        - `inputTokens` (number) - Number of input tokens
+        - `outputTokens` (number) - Number of output tokens
+        - `totalTokens` (number) - Total tokens (alias: `tokens`)
+
+        #### Cost Metrics
+        - `inputCost` (number) - Input cost in USD
+        - `outputCost` (number) - Output cost in USD
+        - `totalCost` (number) - Total cost in USD
+
+        #### Model Information
+        - `model` (string) - Provided model name (alias: `providedModelName`)
+        - `modelId` (stringOptions) - Internal model ID
+        - `promptName` (string) - Associated prompt name
+        - `promptVersion` (number) - Associated prompt version
+
+        #### Structured Data
+        - `metadata` (stringObject) - Metadata key-value pairs. Requires the `key` parameter to target a specific metadata key.
+
+        #### Tool Fields
+        - `toolDefinitions` (number) - Number of tool definitions
+        - `toolCalls` (number) - Number of tool calls
+        - `toolNames` (arrayOptions) - Names of defined tools
+        - `calledToolNames` (arrayOptions) - Names of tools that were called
+
+        ### Filter Examples
+        ```json
+        [
+          {
+            "type": "string",
+            "column": "type",
+            "operator": "=",
+            "value": "GENERATION"
+          },
+          {
+            "type": "number",
+            "column": "latency",
+            "operator": ">=",
+            "value": 2.5
+          },
+          {
+            "type": "stringObject",
+            "column": "metadata",
+            "key": "environment",
+            "operator": "=",
+            "value": "production"
+          }
+        ]
+        ```
       method: GET
       path: /v2/observations
       request:
@@ -89,100 +191,9 @@ service:
           filter:
             type: optional<string>
             docs: |
-              JSON string containing an array of filter conditions. When provided, this takes precedence over query parameter filters (userId, name, type, level, environment, fromStartTime, ...).
-
-              ## Filter Structure
-              Each filter condition has the following structure:
-              ```json
-              [
-                {
-                  "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-                  "column": string,         // Required. Column to filter on (see available columns below)
-                  "operator": string,       // Required. Operator based on type:
-                                            // - datetime: ">", "<", ">=", "<="
-                                            // - string: "=", "contains", "does not contain", "starts with", "ends with"
-                                            // - stringOptions: "any of", "none of"
-                                            // - categoryOptions: "any of", "none of"
-                                            // - arrayOptions: "any of", "none of", "all of"
-                                            // - number: "=", ">", "<", ">=", "<="
-                                            // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
-                                            // - numberObject: "=", ">", "<", ">=", "<="
-                                            // - boolean: "=", "<>"
-                                            // - null: "is null", "is not null"
-                  "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-                  "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
-                }
-              ]
-              ```
-
-              ## Available Columns
-
-              ### Core Observation Fields
-              - `id` (string) - Observation ID
-              - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
-              - `name` (string) - Observation name
-              - `traceId` (string) - Associated trace ID
-              - `startTime` (datetime) - Observation start time
-              - `endTime` (datetime) - Observation end time
-              - `environment` (string) - Environment tag
-              - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
-              - `statusMessage` (string) - Status message
-              - `version` (string) - Version tag
-              - `userId` (string) - User ID
-              - `sessionId` (string) - Session ID
-
-              ### Trace-Related Fields
-              - `traceName` (string) - Name of the parent trace
-              - `traceTags` (arrayOptions) - Tags from the parent trace
-              - `tags` (arrayOptions) - Alias for traceTags
-
-              ### Performance Metrics
-              - `latency` (number) - Latency in seconds (calculated: end_time - start_time)
-              - `timeToFirstToken` (number) - Time to first token in seconds
-              - `tokensPerSecond` (number) - Output tokens per second
-
-              ### Token Usage
-              - `inputTokens` (number) - Number of input tokens
-              - `outputTokens` (number) - Number of output tokens
-              - `totalTokens` (number) - Total tokens (alias: `tokens`)
-
-              ### Cost Metrics
-              - `inputCost` (number) - Input cost in USD
-              - `outputCost` (number) - Output cost in USD
-              - `totalCost` (number) - Total cost in USD
-
-              ### Model Information
-              - `model` (string) - Provided model name (alias: `providedModelName`)
-              - `promptName` (string) - Associated prompt name
-              - `promptVersion` (number) - Associated prompt version
-
-              ### Structured Data
-              - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
-
-              ## Filter Examples
-              ```json
-              [
-                {
-                  "type": "string",
-                  "column": "type",
-                  "operator": "=",
-                  "value": "GENERATION"
-                },
-                {
-                  "type": "number",
-                  "column": "latency",
-                  "operator": ">=",
-                  "value": 2.5
-                },
-                {
-                  "type": "stringObject",
-                  "column": "metadata",
-                  "key": "environment",
-                  "operator": "=",
-                  "value": "production"
-                }
-              ]
-              ```
+              JSON-encoded array of filter conditions. Takes precedence over individual query-parameter filters
+              (userId, name, type, level, environment, fromStartTime, ...). See **Filter Structure**,
+              **Available Columns**, and **Filter Examples** in the endpoint description above.
       response: ObservationsV2Response
 
 types:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3146,6 +3146,162 @@ paths:
 
         When using the `filter` parameter, it takes precedence over individual
         query parameter filters.
+
+
+        ### Filter Structure
+
+        Each filter condition has the following structure:
+
+        ```json
+
+        [
+          {
+            "type": "string",         // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": "name",         // Required. Column to filter on (see Available Columns below)
+            "operator": "=",          // Required. Operator based on type:
+                                      // - datetime: ">", "<", ">=", "<="
+                                      // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - stringOptions: "any of", "none of"
+                                      // - categoryOptions: "any of", "none of"
+                                      // - arrayOptions: "any of", "none of", "all of"
+                                      // - number: "=", ">", "<", ">=", "<="
+                                      // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - numberObject: "=", ">", "<", ">=", "<="
+                                      // - boolean: "=", "<>"
+                                      // - null: "is null", "is not null"
+            "value": "GENERATION",    // Required (except for null type). Type depends on filter type.
+            "key": "env"              // Required only for stringObject, numberObject, and categoryOptions when filtering nested fields like metadata.
+          }
+        ]
+
+        ```
+
+
+        ### Available Columns
+
+
+        #### Core Observation Fields
+
+        - `id` (string) - Observation ID
+
+        - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
+
+        - `name` (string) - Observation name
+
+        - `traceId` (string) - Associated trace ID
+
+        - `parentObservationId` (string) - Parent observation ID
+
+        - `startTime` (datetime) - Observation start time
+
+        - `endTime` (datetime) - Observation end time
+
+        - `environment` (string) - Environment tag
+
+        - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
+
+        - `statusMessage` (string) - Status message
+
+        - `version` (string) - Version tag
+
+
+        #### Trace-Related Fields
+
+        - `traceName` (string) - Name of the parent trace
+
+        - `traceEnvironment` (string) - Environment tag from the parent trace
+
+        - `traceTags` (arrayOptions) - Tags from the parent trace
+
+        - `tags` (arrayOptions) - Tags on the observation
+
+        - `userId` (string) - User ID
+
+        - `sessionId` (string) - Session ID
+
+
+        #### Performance Metrics
+
+        - `latency` (number) - Latency in seconds (end_time − start_time)
+
+        - `timeToFirstToken` (number) - Time to first token in seconds
+
+        - `tokensPerSecond` (number) - Output tokens per second
+
+
+        #### Token Usage
+
+        - `inputTokens` (number) - Number of input tokens
+
+        - `outputTokens` (number) - Number of output tokens
+
+        - `totalTokens` (number) - Total tokens (alias: `tokens`)
+
+
+        #### Cost Metrics
+
+        - `inputCost` (number) - Input cost in USD
+
+        - `outputCost` (number) - Output cost in USD
+
+        - `totalCost` (number) - Total cost in USD
+
+
+        #### Model Information
+
+        - `model` (string) - Provided model name (alias: `providedModelName`)
+
+        - `modelId` (stringOptions) - Internal model ID
+
+        - `promptName` (string) - Associated prompt name
+
+        - `promptVersion` (number) - Associated prompt version
+
+
+        #### Structured Data
+
+        - `metadata` (stringObject) - Metadata key-value pairs. Requires the
+        `key` parameter to target a specific metadata key.
+
+
+        #### Tool Fields
+
+        - `toolDefinitions` (number) - Number of tool definitions
+
+        - `toolCalls` (number) - Number of tool calls
+
+        - `toolNames` (arrayOptions) - Names of defined tools
+
+        - `calledToolNames` (arrayOptions) - Names of tools that were called
+
+
+        ### Filter Examples
+
+        ```json
+
+        [
+          {
+            "type": "string",
+            "column": "type",
+            "operator": "=",
+            "value": "GENERATION"
+          },
+          {
+            "type": "number",
+            "column": "latency",
+            "operator": ">=",
+            "value": 2.5
+          },
+          {
+            "type": "stringObject",
+            "column": "metadata",
+            "key": "environment",
+            "operator": "=",
+            "value": "production"
+          }
+        ]
+
+        ```
       operationId: observations_getMany
       tags:
         - Observations
@@ -3286,151 +3442,14 @@ paths:
         - name: filter
           in: query
           description: >-
-            JSON string containing an array of filter conditions. When provided,
-            this takes precedence over query parameter filters (userId, name,
-            type, level, environment, fromStartTime, ...).
+            JSON-encoded array of filter conditions. Takes precedence over
+            individual query-parameter filters
 
+            (userId, name, type, level, environment, fromStartTime, ...). See
+            **Filter Structure**,
 
-            ## Filter Structure
-
-            Each filter condition has the following structure:
-
-            ```json
-
-            [
-              {
-                "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-                "column": string,         // Required. Column to filter on (see available columns below)
-                "operator": string,       // Required. Operator based on type:
-                                          // - datetime: ">", "<", ">=", "<="
-                                          // - string: "=", "contains", "does not contain", "starts with", "ends with"
-                                          // - stringOptions: "any of", "none of"
-                                          // - categoryOptions: "any of", "none of"
-                                          // - arrayOptions: "any of", "none of", "all of"
-                                          // - number: "=", ">", "<", ">=", "<="
-                                          // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
-                                          // - numberObject: "=", ">", "<", ">=", "<="
-                                          // - boolean: "=", "<>"
-                                          // - null: "is null", "is not null"
-                "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-                "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
-              }
-            ]
-
-            ```
-
-
-            ## Available Columns
-
-
-            ### Core Observation Fields
-
-            - `id` (string) - Observation ID
-
-            - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
-
-            - `name` (string) - Observation name
-
-            - `traceId` (string) - Associated trace ID
-
-            - `startTime` (datetime) - Observation start time
-
-            - `endTime` (datetime) - Observation end time
-
-            - `environment` (string) - Environment tag
-
-            - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
-
-            - `statusMessage` (string) - Status message
-
-            - `version` (string) - Version tag
-
-            - `userId` (string) - User ID
-
-            - `sessionId` (string) - Session ID
-
-
-            ### Trace-Related Fields
-
-            - `traceName` (string) - Name of the parent trace
-
-            - `traceTags` (arrayOptions) - Tags from the parent trace
-
-            - `tags` (arrayOptions) - Alias for traceTags
-
-
-            ### Performance Metrics
-
-            - `latency` (number) - Latency in seconds (calculated: end_time -
-            start_time)
-
-            - `timeToFirstToken` (number) - Time to first token in seconds
-
-            - `tokensPerSecond` (number) - Output tokens per second
-
-
-            ### Token Usage
-
-            - `inputTokens` (number) - Number of input tokens
-
-            - `outputTokens` (number) - Number of output tokens
-
-            - `totalTokens` (number) - Total tokens (alias: `tokens`)
-
-
-            ### Cost Metrics
-
-            - `inputCost` (number) - Input cost in USD
-
-            - `outputCost` (number) - Output cost in USD
-
-            - `totalCost` (number) - Total cost in USD
-
-
-            ### Model Information
-
-            - `model` (string) - Provided model name (alias:
-            `providedModelName`)
-
-            - `promptName` (string) - Associated prompt name
-
-            - `promptVersion` (number) - Associated prompt version
-
-
-            ### Structured Data
-
-            - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
-            key-value pairs. Use `key` parameter to filter on specific metadata
-            keys.
-
-
-            ## Filter Examples
-
-            ```json
-
-            [
-              {
-                "type": "string",
-                "column": "type",
-                "operator": "=",
-                "value": "GENERATION"
-              },
-              {
-                "type": "number",
-                "column": "latency",
-                "operator": ">=",
-                "value": 2.5
-              },
-              {
-                "type": "stringObject",
-                "column": "metadata",
-                "key": "environment",
-                "operator": "=",
-                "value": "production"
-              }
-            ]
-
-            ```
+            **Available Columns**, and **Filter Examples** in the endpoint
+            description above.
           required: false
           schema:
             type: string


### PR DESCRIPTION
## Summary

- Moves Filter Structure, Available Columns, and Filter Examples from the `filter` parameter's inline `docs` block up into the endpoint-level `## Filters` section of `GET /v2/observations`. The `filter` parameter's docs now contain a single pointer sentence.
- Corrects the Available Columns list against `eventsTableNativeUiColumnDefinitions` — the actual runtime module for v2 (`/api/public/v2/observations` routes through `getObservationsV2FromEventsTableForPublicApi`, which passes `eventsTableNativeUiColumnDefinitions` to `deriveFilters`). The prior docs were audited against the wrong v1 module (`observationsTableUiColumnDefinitions`).

Column accuracy fixes:

| Change | Reason |
|--------|--------|
| Restore `tags` (arrayOptions) | `mapEventsTable.ts` has a distinct `uiTableId: 'tags'` → `e."tags"`, separate from `traceTags` |
| Restore `(alias: providedModelName)` on `model` | Both are valid `uiTableId`s in `eventsTableCols` |
| Remove "(sourced from parent trace)" from `userId`/`sessionId` | Both read from `events_proto` directly in v2 — no JOIN |
| Add `parentObservationId`, `traceEnvironment`, `modelId` | All registered in `eventsTableNativeUiColumnDefinitions`, omitted from prior docs |
| Add Tool Fields section | `toolDefinitions`, `toolCalls`, `toolNames`, `calledToolNames` all registered in `mapEventsTable.ts` |

## Impacted packages

- `fern/apis/server/definition/observations.yml`
- `web/public/generated/api/openapi.yml` — regenerated via `fern generate --group local --api server`

## Verification

- [x] `fern generate --group local --api server` completes without errors
- [x] Lint passes
- [ ] Verify rendered docs at `/api-reference/observations/get-observations` show Filter Structure under the endpoint description, not under the `filter` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the `GET /v2/observations` API documentation by moving the filter reference (structure, available columns, examples) from the `filter` query-parameter's inline `docs` block up to the endpoint-level `## Filters` section, and corrects the column list to reflect `eventsTableNativeUiColumnDefinitions` — the actual runtime module used by the v2 route — rather than the v1 `observationsTableUiColumnDefinitions`.

- **Structural lift**: Filter docs are now in the endpoint description; the `filter` parameter carries only a short pointer sentence. Both the Fern source (`observations.yml`) and the regenerated `openapi.yml` are updated consistently.
- **Column accuracy fixes**: `parentObservationId`, `traceEnvironment`, `modelId`, and the Tool Fields group (`toolDefinitions`, `toolCalls`, `toolNames`, `calledToolNames`) are added; stale "(sourced from parent trace)" annotations on `userId`/`sessionId` are removed; `tags` is restored as a distinct column.
- **Two documentation inaccuracies introduced**: `tags` and `traceTags` both map to the same ClickHouse column (`e."tags"`) in the source, but are now described as semantically distinct fields; and `metadata`'s supported filter types were narrowed from `stringObject/numberObject/categoryOptions` to only `stringObject`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are documentation-only with no runtime code touched.

The structural refactor (lifting filter docs to endpoint level) is clean and consistent between the Fern source and the regenerated OpenAPI file. Two documentation accuracy issues remain: `tags` is now described as semantically distinct from `traceTags` even though both resolve to the same ClickHouse column, which could mislead users; and `metadata`'s supported filter types were silently narrowed. Neither affects runtime behavior, but they represent a step backward in accuracy compared to the previous docs for those specific fields.

Both changed files warrant a second look around the `tags`/`traceTags` description and the `metadata` type list in `fern/apis/server/definition/observations.yml` (and the corresponding section in `web/public/generated/api/openapi.yml`).
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["GET /v2/observations\n(request)"] --> B{filter param\nprovided?}
    B -- Yes --> C["Parse JSON filter array"]
    B -- No --> D["Use individual query params\n(userId, name, type, level,\nenvironment, fromStartTime, …)"]
    C --> E["deriveFilters()\npassed eventsTableNativeUiColumnDefinitions"]
    E --> F["Resolve uiTableId → ClickHouse column\ne.g. tags → e.tags\ntraceTags → e.tags\nenvironment → e.environment\ntraceEnvironment → e.environment"]
    F --> G["Build ClickHouse WHERE clause"]
    D --> G
    G --> H["Query events_proto table"]
    H --> I["Return ObservationsV2Response"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
fern/apis/server/definition/observations.yml:72-74
**`tags` and `traceTags` map to the same underlying column**

In `mapEventsTable.ts`, both `traceTags` (`uiTableId: "traceTags"`) and `tags` (`uiTableId: "tags"`) resolve to exactly the same ClickHouse expression: `e."tags"`. The new docs describe them as different things — "Tags from the parent trace" vs "Tags on the observation" — but since they hit the same column, a filter on `tags` and a filter on `traceTags` will produce identical results. The old docs were actually more accurate by labeling `tags` as "Alias for traceTags." Giving them different semantic descriptions may mislead users into believing they can filter for observation-level tags independently of trace tags.

### Issue 2 of 3
fern/apis/server/definition/observations.yml:104-105
**`metadata` filter type narrowed from three to one — `numberObject` support silently dropped**

The old docs correctly listed `metadata (stringObject/numberObject/categoryOptions)` to reflect that metadata key-value pairs can be filtered numerically as well. The new text documents only `stringObject`. If the filter engine still accepts `numberObject` for metadata (which the `deriveFilters` implementation suggests it does, since the column mapping itself carries no type restriction), this narrowing will mislead users who need to write numeric range filters against metadata fields.

```suggestion
        #### Structured Data
        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Requires the `key` parameter to target a specific metadata key.
```

### Issue 3 of 3
fern/apis/server/definition/observations.yml:38-42
**Several filterable columns are absent from the docs**

`eventsTableNativeUiColumnDefinitions` registers `input`, `output`, `hasParentObservation` (boolean), and the experiment family (`experimentDatasetId`, `experimentId`, `experimentName`, `isExperimentItemRootSpan`) — all are valid targets for the structured `filter` parameter but are undocumented. If these are intentionally omitted (e.g., considered internal), a brief note would prevent confused support requests; otherwise they should be listed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(fern): lift filter docs to endpoint ..."](https://github.com/langfuse/langfuse/commit/887e18cb80a5be52207c984c744376e197105d4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32787724)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->