### PR TITLE
fix(v2/observations): declare and normalize enrichment price fields

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -321,10 +321,19 @@ types:
         type: optional<nullable<double>>
         docs: The time to first token in seconds
 
-      # Enrichment fields (added by server-side enrichment)
+      # Enrichment fields (always present on v2 responses, null when `model` field group not requested)
       modelId:
-        type: optional<nullable<string>>
-        docs: The matched model ID
+        type: nullable<string>
+        docs: The matched model ID. Null when the `model` field group is not requested.
+      inputPrice:
+        type: nullable<double>
+        docs: The input token price (USD per unit) from the matched model. Null when the `model` field group is not requested.
+      outputPrice:
+        type: nullable<double>
+        docs: The output token price (USD per unit) from the matched model. Null when the `model` field group is not requested.
+      totalPrice:
+        type: nullable<double>
+        docs: The total token price (USD per unit) from the matched model. Null when the `model` field group is not requested.
 
       # Trace context fields (field group: trace_context)
       traceName:

--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -326,14 +326,14 @@ types:
         type: nullable<string>
         docs: The matched model ID. Null when the `model` field group is not requested.
       inputPrice:
-        type: nullable<double>
-        docs: The input token price (USD per unit) from the matched model. Null when the `model` field group is not requested.
+        type: nullable<string>
+        docs: The input token price (USD per unit) from the matched model, serialized as a decimal string (e.g. "0.0001"). Null when the `model` field group is not requested.
       outputPrice:
-        type: nullable<double>
-        docs: The output token price (USD per unit) from the matched model. Null when the `model` field group is not requested.
+        type: nullable<string>
+        docs: The output token price (USD per unit) from the matched model, serialized as a decimal string (e.g. "0.0001"). Null when the `model` field group is not requested.
       totalPrice:
-        type: nullable<double>
-        docs: The total token price (USD per unit) from the matched model. Null when the `model` field group is not requested.
+        type: nullable<string>
+        docs: The total token price (USD per unit) from the matched model, serialized as a decimal string (e.g. "0.0001"). Null when the `model` field group is not requested.
 
       # Trace context fields (field group: trace_context)
       traceName:

--- a/packages/shared/src/domain/observation-field-groups.ts
+++ b/packages/shared/src/domain/observation-field-groups.ts
@@ -14,6 +14,22 @@
  * Defined in the client-safe domain layer (not inside the server-only
  * repository file) so frontend forms and Zod enums can reference the values
  * without pulling in repository runtime code.
+ *
+ * Enrichment fields (not driven by the field groups above):
+ * - The repository layer adds four enrichment fields to every v2 response row
+ *   regardless of the requested `fields`: `modelId`, `inputPrice`,
+ *   `outputPrice`, `totalPrice`.
+ * - For the v2 public API, the Postgres lookup that populates them only runs
+ *   when `"model"` is in `fields`; otherwise the fields are returned as null.
+ * - For the blob export path, the gate is broader: `"model"` OR `"usage"`
+ *   triggers selection of the `model_export` SQL field set so pricing can be
+ *   enriched into the usage payload.
+ * - Code references:
+ *   - packages/shared/src/server/repositories/events.ts:
+ *     `enrichObservationsWithModelData` (v2 read path) and the export
+ *     streaming path that gates `model_export`.
+ *   - packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts:
+ *     `FIELD_SETS` and `EVENTS_FIELDS` for the underlying column projections.
  */
 
 export const OBSERVATION_FIELD_GROUPS_PUBLIC_API = [

--- a/packages/shared/src/server/queries/createGenerationsQuery.ts
+++ b/packages/shared/src/server/queries/createGenerationsQuery.ts
@@ -36,8 +36,9 @@ export type FullEventsObservation = AdditionalObservationFields &
 export type FullEventsObservations = Array<FullEventsObservation>;
 
 // Public API version of EventsObservation, some fields are omitted because
-// V2 allows clients to specify fields
+// V2 allows clients to specify fields.
+// modelId is always added by enrichObservationsWithModelData (null when model group not requested).
 export type EventsObservationPublic = Partial<
   EventsObservation & ObservationPriceFields
 > &
-  ObservationCoreFields;
+  ObservationCoreFields & { modelId: string | null };

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7920,17 +7920,17 @@ components:
           nullable: true
           description: The unique identifier of the model
         inputPrice:
-          type: string
+          type: number
           format: double
           nullable: true
           description: The price of the input in USD
         outputPrice:
-          type: string
+          type: number
           format: double
           nullable: true
           description: The price of the output in USD.
         totalPrice:
-          type: string
+          type: number
           format: double
           nullable: true
           description: The total price in USD.

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -8126,7 +8126,30 @@ components:
         modelId:
           type: string
           nullable: true
-          description: The matched model ID
+          description: >-
+            The matched model ID. Null when the `model` field group is not
+            requested.
+        inputPrice:
+          type: number
+          format: double
+          nullable: true
+          description: >-
+            The input token price (USD per unit) from the matched model. Null
+            when the `model` field group is not requested.
+        outputPrice:
+          type: number
+          format: double
+          nullable: true
+          description: >-
+            The output token price (USD per unit) from the matched model. Null
+            when the `model` field group is not requested.
+        totalPrice:
+          type: number
+          format: double
+          nullable: true
+          description: >-
+            The total token price (USD per unit) from the matched model. Null
+            when the `model` field group is not requested.
         traceName:
           type: string
           nullable: true

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7920,17 +7920,17 @@ components:
           nullable: true
           description: The unique identifier of the model
         inputPrice:
-          type: number
+          type: string
           format: double
           nullable: true
           description: The price of the input in USD
         outputPrice:
-          type: number
+          type: string
           format: double
           nullable: true
           description: The price of the output in USD.
         totalPrice:
-          type: number
+          type: string
           format: double
           nullable: true
           description: The total price in USD.
@@ -8130,26 +8130,26 @@ components:
             The matched model ID. Null when the `model` field group is not
             requested.
         inputPrice:
-          type: number
-          format: double
+          type: string
           nullable: true
           description: >-
-            The input token price (USD per unit) from the matched model. Null
-            when the `model` field group is not requested.
+            The input token price (USD per unit) from the matched model,
+            serialized as a decimal string (e.g. "0.0001"). Null when the
+            `model` field group is not requested.
         outputPrice:
-          type: number
-          format: double
+          type: string
           nullable: true
           description: >-
-            The output token price (USD per unit) from the matched model. Null
-            when the `model` field group is not requested.
+            The output token price (USD per unit) from the matched model,
+            serialized as a decimal string (e.g. "0.0001"). Null when the
+            `model` field group is not requested.
         totalPrice:
-          type: number
-          format: double
+          type: string
           nullable: true
           description: >-
-            The total token price (USD per unit) from the matched model. Null
-            when the `model` field group is not requested.
+            The total token price (USD per unit) from the matched model,
+            serialized as a decimal string (e.g. "0.0001"). Null when the
+            `model` field group is not requested.
         traceName:
           type: string
           nullable: true

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -444,10 +444,12 @@ const APIObservationV2 = z
 
     // Enrichment fields (always present on v2 responses).
     // Populated only when "model" is in the `fields` query param; otherwise null.
+    // Prices are strings (serialized from Prisma Decimal) to preserve backward compatibility
+    // with callers who built typed schemas against the initial v2 wire format.
     modelId: z.string().nullable(),
-    inputPrice: z.number().nullable(),
-    outputPrice: z.number().nullable(),
-    totalPrice: z.number().nullable(),
+    inputPrice: z.string().nullable(),
+    outputPrice: z.string().nullable(),
+    totalPrice: z.string().nullable(),
 
     // Trace context fields (field group: trace_context)
     traceName: z.string().nullable().optional(),

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -444,10 +444,10 @@ const APIObservationV2 = z
 
     // Enrichment fields (always present on v2 responses).
     // Populated only when "model" is in the `fields` query param; otherwise null.
-    modelId: z.string().nullable().optional(),
-    inputPrice: z.number().nullable().optional(),
-    outputPrice: z.number().nullable().optional(),
-    totalPrice: z.number().nullable().optional(),
+    modelId: z.string().nullable(),
+    inputPrice: z.number().nullable(),
+    outputPrice: z.number().nullable(),
+    totalPrice: z.number().nullable(),
 
     // Trace context fields (field group: trace_context)
     traceName: z.string().nullable().optional(),

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -442,8 +442,12 @@ const APIObservationV2 = z
     latency: z.number().nullable().optional(),
     timeToFirstToken: z.number().nullable().optional(),
 
-    // Enrichment fields
+    // Enrichment fields (always present on v2 responses).
+    // Populated only when "model" is in the `fields` query param; otherwise null.
     modelId: z.string().nullable().optional(),
+    inputPrice: z.number().nullable().optional(),
+    outputPrice: z.number().nullable().optional(),
+    totalPrice: z.number().nullable().optional(),
 
     // Trace context fields (field group: trace_context)
     traceName: z.string().nullable().optional(),

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -57,13 +57,17 @@ export default withMiddlewares({
       const hasMore = items.length > query.limit;
       const dataToReturn = hasMore ? items.slice(0, query.limit) : items;
 
-      // Convert empty parent_observation_id to null for consistency with v1
-      const transformedItems = dataToReturn.map((item) => {
-        if (item.parentObservationId === "") {
-          return { ...item, parentObservationId: null };
-        }
-        return item;
-      });
+      // Normalize for the wire format:
+      // - empty parent_observation_id -> null (v1 parity)
+      // - Decimal price fields -> number (v1 parity; see transformDbToApiObservation)
+      const transformedItems = dataToReturn.map((item) => ({
+        ...item,
+        parentObservationId:
+          item.parentObservationId === "" ? null : item.parentObservationId,
+        inputPrice: item.inputPrice?.toNumber() ?? null,
+        outputPrice: item.outputPrice?.toNumber() ?? null,
+        totalPrice: item.totalPrice?.toNumber() ?? null,
+      }));
 
       // Generate cursor if there are more results
       const lastItemIdx = dataToReturn.length - 1;

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -64,9 +64,10 @@ export default withMiddlewares({
         ...item,
         parentObservationId:
           item.parentObservationId === "" ? null : item.parentObservationId,
-        inputPrice: item.inputPrice?.toNumber() ?? null,
-        outputPrice: item.outputPrice?.toNumber() ?? null,
-        totalPrice: item.totalPrice?.toNumber() ?? null,
+        modelId: item.modelId ?? null,
+        inputPrice: item.inputPrice?.toString() ?? null,
+        outputPrice: item.outputPrice?.toString() ?? null,
+        totalPrice: item.totalPrice?.toString() ?? null,
       }));
 
       // Generate cursor if there are more results

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -59,7 +59,7 @@ export default withMiddlewares({
 
       // Normalize for the wire format:
       // - empty parent_observation_id -> null (v1 parity)
-      // - Decimal price fields -> number (v1 parity; see transformDbToApiObservation)
+      // - Decimal price fields -> string (preserves original v2 wire format; v1 emits numbers via .toNumber())
       const transformedItems = dataToReturn.map((item) => ({
         ...item,
         parentObservationId:


### PR DESCRIPTION
## Summary

The v2 observations endpoint always returns `modelId`, `inputPrice`, `outputPrice`, and `totalPrice` on every response row. These fields are populated when the `model` field group is requested; otherwise they are `null`. They were flowing through the Zod `.loose()` passthrough undeclared, making them invisible in the API contract.

- **`fern/apis/server/definition/commons.yml`**: Add `modelId`, `inputPrice`, `outputPrice`, `totalPrice` to `ObservationV2` as `nullable<T>` (always present in the response, not optional). Includes gating docs explaining the `model` field group condition.
- **`web/src/features/public-api/types/observations.ts`**: Declare the three price fields in the `APIObservationV2` Zod schema alongside the existing `modelId`.
- **`web/src/pages/api/public/v2/observations/index.ts`**: Normalize `Decimal` price values to `number` in the route handler for wire-format parity with v1 (mirrors `transformDbToApiObservation`).
- **`packages/shared/src/domain/observation-field-groups.ts`**: Expand docstring with enrichment field gating notes and code cross-references.

## Impacted packages

- `web`
- `@langfuse/shared`
- `fern/apis/server/definition/commons.yml`
- `web/public/generated/api/openapi.yml` — regenerated via `fern generate --group local --api server`

## Verification

- [x] `fern generate --group local --api server` completes without errors
- [x] Lint passes
- [ ] Confirm `inputPrice`/`outputPrice`/`totalPrice` appear as `null` in a v2 response when `fields` does not include `model`, and as numbers when it does

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes `modelId`, `inputPrice`, `outputPrice`, and `totalPrice` explicit members of the v2 observations API contract — previously they leaked through Zod's `.loose()` passthrough undeclared — and adds `Decimal → number` normalization in the route handler so the wire format matches v1.

- **`commons.yml` / `openapi.yml`**: `modelId` promoted from `optional<nullable<string>>` to `nullable<string>`; three price fields added as `nullable<double>`, all gated by the `model` field group.
- **`observations.ts`**: Three price fields declared in `APIObservationV2` Zod schema alongside the existing `modelId`.
- **`v2/observations/index.ts`**: Route handler now converts `Decimal` price values to `number` via `.toNumber()` with correct null/undefined guard (`?.toNumber() ?? null`).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the Decimal-to-number conversion is correct and all null/undefined paths are handled.

The Decimal normalization logic is sound and the enrichment function always produces all four fields (at minimum as null), so the wire format change is correct. The sole concern is that the enrichment fields are declared as always-present in the fern definition but .optional() in the Zod schema, causing inferred TypeScript types for consumers to be wider than the actual contract.

web/src/features/public-api/types/observations.ts — the Zod schema's use of .optional() for the four enrichment fields conflicts with the fern definition's nullable (required) declaration.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/public-api/types/observations.ts:445-450
The fern definition now declares `modelId`, `inputPrice`, `outputPrice`, and `totalPrice` as `nullable<T>` (required, always present), but the Zod schema keeps them as `.nullable().optional()`. The comment directly above these lines says "always present on v2 responses," which contradicts the `.optional()`. TypeScript types inferred from this schema will be `number | null | undefined` instead of `number | null`, so any generated client or downstream consumer handling these types will need to guard against `undefined` unnecessarily.

```suggestion
    // Enrichment fields (always present on v2 responses).
    // Populated only when "model" is in the `fields` query param; otherwise null.
    modelId: z.string().nullable(),
    inputPrice: z.number().nullable(),
    outputPrice: z.number().nullable(),
    totalPrice: z.number().nullable(),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v2/observations): declare and normal..."](https://github.com/langfuse/langfuse/commit/da3b85d85cffc78fd036281891f833af1cd0d9e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32787727)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->