### PR TITLE
refactor(fern): lift filter docs to endpoint level in observations API

### DIFF
--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -32,6 +32,99 @@ service:
         ## Filters
         Multiple filtering options are available via query parameters or the structured `filter` parameter.
         When using the `filter` parameter, it takes precedence over individual query parameter filters.
+
+        ### Filter Structure
+        Each filter condition has the following structure:
+        ```json
+        [
+          {
+            "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": string,         // Required. Column to filter on (see available columns below)
+            "operator": string,       // Required. Operator based on type:
+                                      // - datetime: ">", "<", ">=", "<="
+                                      // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - stringOptions: "any of", "none of"
+                                      // - categoryOptions: "any of", "none of"
+                                      // - arrayOptions: "any of", "none of", "all of"
+                                      // - number: "=", ">", "<", ">=", "<="
+                                      // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - numberObject: "=", ">", "<", ">=", "<="
+                                      // - boolean: "=", "<>"
+                                      // - null: "is null", "is not null"
+            "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
+            "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
+          }
+        ]
+        ```
+
+        ### Available Columns
+
+        #### Core Observation Fields
+        - `id` (string) - Observation ID
+        - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
+        - `name` (string) - Observation name
+        - `traceId` (string) - Associated trace ID
+        - `startTime` (datetime) - Observation start time
+        - `endTime` (datetime) - Observation end time
+        - `environment` (string) - Environment tag
+        - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
+        - `statusMessage` (string) - Status message
+        - `version` (string) - Version tag
+        - `userId` (string) - User ID
+        - `sessionId` (string) - Session ID
+
+        #### Trace-Related Fields
+        - `traceName` (string) - Name of the parent trace
+        - `traceTags` (arrayOptions) - Tags from the parent trace
+        - `tags` (arrayOptions) - Alias for traceTags
+
+        #### Performance Metrics
+        - `latency` (number) - Latency in seconds (calculated: end_time - start_time)
+        - `timeToFirstToken` (number) - Time to first token in seconds
+        - `tokensPerSecond` (number) - Output tokens per second
+
+        #### Token Usage
+        - `inputTokens` (number) - Number of input tokens
+        - `outputTokens` (number) - Number of output tokens
+        - `totalTokens` (number) - Total tokens (alias: `tokens`)
+
+        #### Cost Metrics
+        - `inputCost` (number) - Input cost in USD
+        - `outputCost` (number) - Output cost in USD
+        - `totalCost` (number) - Total cost in USD
+
+        #### Model Information
+        - `model` (string) - Provided model name (alias: `providedModelName`)
+        - `promptName` (string) - Associated prompt name
+        - `promptVersion` (number) - Associated prompt version
+
+        #### Structured Data
+        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
+
+        ### Filter Examples
+        ```json
+        [
+          {
+            "type": "string",
+            "column": "type",
+            "operator": "=",
+            "value": "GENERATION"
+          },
+          {
+            "type": "number",
+            "column": "latency",
+            "operator": ">=",
+            "value": 2.5
+          },
+          {
+            "type": "stringObject",
+            "column": "metadata",
+            "key": "environment",
+            "operator": "=",
+            "value": "production"
+          }
+        ]
+        ```
       method: GET
       path: /v2/observations
       request:
@@ -89,100 +182,9 @@ service:
           filter:
             type: optional<string>
             docs: |
-              JSON string containing an array of filter conditions. When provided, this takes precedence over query parameter filters (userId, name, type, level, environment, fromStartTime, ...).
-
-              ## Filter Structure
-              Each filter condition has the following structure:
-              ```json
-              [
-                {
-                  "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-                  "column": string,         // Required. Column to filter on (see available columns below)
-                  "operator": string,       // Required. Operator based on type:
-                                            // - datetime: ">", "<", ">=", "<="
-                                            // - string: "=", "contains", "does not contain", "starts with", "ends with"
-                                            // - stringOptions: "any of", "none of"
-                                            // - categoryOptions: "any of", "none of"
-                                            // - arrayOptions: "any of", "none of", "all of"
-                                            // - number: "=", ">", "<", ">=", "<="
-                                            // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
-                                            // - numberObject: "=", ">", "<", ">=", "<="
-                                            // - boolean: "=", "<>"
-                                            // - null: "is null", "is not null"
-                  "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-                  "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
-                }
-              ]
-              ```
-
-              ## Available Columns
-
-              ### Core Observation Fields
-              - `id` (string) - Observation ID
-              - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
-              - `name` (string) - Observation name
-              - `traceId` (string) - Associated trace ID
-              - `startTime` (datetime) - Observation start time
-              - `endTime` (datetime) - Observation end time
-              - `environment` (string) - Environment tag
-              - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
-              - `statusMessage` (string) - Status message
-              - `version` (string) - Version tag
-              - `userId` (string) - User ID
-              - `sessionId` (string) - Session ID
-
-              ### Trace-Related Fields
-              - `traceName` (string) - Name of the parent trace
-              - `traceTags` (arrayOptions) - Tags from the parent trace
-              - `tags` (arrayOptions) - Alias for traceTags
-
-              ### Performance Metrics
-              - `latency` (number) - Latency in seconds (calculated: end_time - start_time)
-              - `timeToFirstToken` (number) - Time to first token in seconds
-              - `tokensPerSecond` (number) - Output tokens per second
-
-              ### Token Usage
-              - `inputTokens` (number) - Number of input tokens
-              - `outputTokens` (number) - Number of output tokens
-              - `totalTokens` (number) - Total tokens (alias: `tokens`)
-
-              ### Cost Metrics
-              - `inputCost` (number) - Input cost in USD
-              - `outputCost` (number) - Output cost in USD
-              - `totalCost` (number) - Total cost in USD
-
-              ### Model Information
-              - `model` (string) - Provided model name (alias: `providedModelName`)
-              - `promptName` (string) - Associated prompt name
-              - `promptVersion` (number) - Associated prompt version
-
-              ### Structured Data
-              - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
-
-              ## Filter Examples
-              ```json
-              [
-                {
-                  "type": "string",
-                  "column": "type",
-                  "operator": "=",
-                  "value": "GENERATION"
-                },
-                {
-                  "type": "number",
-                  "column": "latency",
-                  "operator": ">=",
-                  "value": 2.5
-                },
-                {
-                  "type": "stringObject",
-                  "column": "metadata",
-                  "key": "environment",
-                  "operator": "=",
-                  "value": "production"
-                }
-              ]
-              ```
+              JSON-encoded array of filter conditions. Takes precedence over individual query-parameter filters
+              (userId, name, type, level, environment, fromStartTime, ...). See **Filter Structure**,
+              **Available Columns**, and **Filter Examples** in the endpoint description above.
       response: ObservationsV2Response
 
 types:

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3146,6 +3146,147 @@ paths:
 
         When using the `filter` parameter, it takes precedence over individual
         query parameter filters.
+
+
+        ### Filter Structure
+
+        Each filter condition has the following structure:
+
+        ```json
+
+        [
+          {
+            "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": string,         // Required. Column to filter on (see available columns below)
+            "operator": string,       // Required. Operator based on type:
+                                      // - datetime: ">", "<", ">=", "<="
+                                      // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - stringOptions: "any of", "none of"
+                                      // - categoryOptions: "any of", "none of"
+                                      // - arrayOptions: "any of", "none of", "all of"
+                                      // - number: "=", ">", "<", ">=", "<="
+                                      // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                      // - numberObject: "=", ">", "<", ">=", "<="
+                                      // - boolean: "=", "<>"
+                                      // - null: "is null", "is not null"
+            "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
+            "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
+          }
+        ]
+
+        ```
+
+
+        ### Available Columns
+
+
+        #### Core Observation Fields
+
+        - `id` (string) - Observation ID
+
+        - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
+
+        - `name` (string) - Observation name
+
+        - `traceId` (string) - Associated trace ID
+
+        - `startTime` (datetime) - Observation start time
+
+        - `endTime` (datetime) - Observation end time
+
+        - `environment` (string) - Environment tag
+
+        - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
+
+        - `statusMessage` (string) - Status message
+
+        - `version` (string) - Version tag
+
+        - `userId` (string) - User ID
+
+        - `sessionId` (string) - Session ID
+
+
+        #### Trace-Related Fields
+
+        - `traceName` (string) - Name of the parent trace
+
+        - `traceTags` (arrayOptions) - Tags from the parent trace
+
+        - `tags` (arrayOptions) - Alias for traceTags
+
+
+        #### Performance Metrics
+
+        - `latency` (number) - Latency in seconds (calculated: end_time -
+        start_time)
+
+        - `timeToFirstToken` (number) - Time to first token in seconds
+
+        - `tokensPerSecond` (number) - Output tokens per second
+
+
+        #### Token Usage
+
+        - `inputTokens` (number) - Number of input tokens
+
+        - `outputTokens` (number) - Number of output tokens
+
+        - `totalTokens` (number) - Total tokens (alias: `tokens`)
+
+
+        #### Cost Metrics
+
+        - `inputCost` (number) - Input cost in USD
+
+        - `outputCost` (number) - Output cost in USD
+
+        - `totalCost` (number) - Total cost in USD
+
+
+        #### Model Information
+
+        - `model` (string) - Provided model name (alias: `providedModelName`)
+
+        - `promptName` (string) - Associated prompt name
+
+        - `promptVersion` (number) - Associated prompt version
+
+
+        #### Structured Data
+
+        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
+        key-value pairs. Use `key` parameter to filter on specific metadata
+        keys.
+
+
+        ### Filter Examples
+
+        ```json
+
+        [
+          {
+            "type": "string",
+            "column": "type",
+            "operator": "=",
+            "value": "GENERATION"
+          },
+          {
+            "type": "number",
+            "column": "latency",
+            "operator": ">=",
+            "value": 2.5
+          },
+          {
+            "type": "stringObject",
+            "column": "metadata",
+            "key": "environment",
+            "operator": "=",
+            "value": "production"
+          }
+        ]
+
+        ```
       operationId: observations_getMany
       tags:
         - Observations
@@ -3286,151 +3427,14 @@ paths:
         - name: filter
           in: query
           description: >-
-            JSON string containing an array of filter conditions. When provided,
-            this takes precedence over query parameter filters (userId, name,
-            type, level, environment, fromStartTime, ...).
+            JSON-encoded array of filter conditions. Takes precedence over
+            individual query-parameter filters
 
+            (userId, name, type, level, environment, fromStartTime, ...). See
+            **Filter Structure**,
 
-            ## Filter Structure
-
-            Each filter condition has the following structure:
-
-            ```json
-
-            [
-              {
-                "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-                "column": string,         // Required. Column to filter on (see available columns below)
-                "operator": string,       // Required. Operator based on type:
-                                          // - datetime: ">", "<", ">=", "<="
-                                          // - string: "=", "contains", "does not contain", "starts with", "ends with"
-                                          // - stringOptions: "any of", "none of"
-                                          // - categoryOptions: "any of", "none of"
-                                          // - arrayOptions: "any of", "none of", "all of"
-                                          // - number: "=", ">", "<", ">=", "<="
-                                          // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
-                                          // - numberObject: "=", ">", "<", ">=", "<="
-                                          // - boolean: "=", "<>"
-                                          // - null: "is null", "is not null"
-                "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-                "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
-              }
-            ]
-
-            ```
-
-
-            ## Available Columns
-
-
-            ### Core Observation Fields
-
-            - `id` (string) - Observation ID
-
-            - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
-
-            - `name` (string) - Observation name
-
-            - `traceId` (string) - Associated trace ID
-
-            - `startTime` (datetime) - Observation start time
-
-            - `endTime` (datetime) - Observation end time
-
-            - `environment` (string) - Environment tag
-
-            - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
-
-            - `statusMessage` (string) - Status message
-
-            - `version` (string) - Version tag
-
-            - `userId` (string) - User ID
-
-            - `sessionId` (string) - Session ID
-
-
-            ### Trace-Related Fields
-
-            - `traceName` (string) - Name of the parent trace
-
-            - `traceTags` (arrayOptions) - Tags from the parent trace
-
-            - `tags` (arrayOptions) - Alias for traceTags
-
-
-            ### Performance Metrics
-
-            - `latency` (number) - Latency in seconds (calculated: end_time -
-            start_time)
-
-            - `timeToFirstToken` (number) - Time to first token in seconds
-
-            - `tokensPerSecond` (number) - Output tokens per second
-
-
-            ### Token Usage
-
-            - `inputTokens` (number) - Number of input tokens
-
-            - `outputTokens` (number) - Number of output tokens
-
-            - `totalTokens` (number) - Total tokens (alias: `tokens`)
-
-
-            ### Cost Metrics
-
-            - `inputCost` (number) - Input cost in USD
-
-            - `outputCost` (number) - Output cost in USD
-
-            - `totalCost` (number) - Total cost in USD
-
-
-            ### Model Information
-
-            - `model` (string) - Provided model name (alias:
-            `providedModelName`)
-
-            - `promptName` (string) - Associated prompt name
-
-            - `promptVersion` (number) - Associated prompt version
-
-
-            ### Structured Data
-
-            - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
-            key-value pairs. Use `key` parameter to filter on specific metadata
-            keys.
-
-
-            ## Filter Examples
-
-            ```json
-
-            [
-              {
-                "type": "string",
-                "column": "type",
-                "operator": "=",
-                "value": "GENERATION"
-              },
-              {
-                "type": "number",
-                "column": "latency",
-                "operator": ">=",
-                "value": 2.5
-              },
-              {
-                "type": "stringObject",
-                "column": "metadata",
-                "key": "environment",
-                "operator": "=",
-                "value": "production"
-              }
-            ]
-
-            ```
+            **Available Columns**, and **Filter Examples** in the endpoint
+            description above.
           required: false
           schema:
             type: string


### PR DESCRIPTION
## Summary

Moves Filter Structure, Available Columns, and Filter Examples from the `filter` parameter's inline `docs` block up into the endpoint-level `## Filters` section of `GET /v2/observations`. Adjusts heading levels (`##` → `###`, `###` → `####`) so the hierarchy sits correctly under the endpoint-level section. The `filter` parameter's docs now contain a single pointer sentence.

**No column content is changed** — this is a pure structural move. Column accuracy corrections follow in a stacked PR.

## Why

`##` headers inside a parameter `docs` block render at the same visual level as endpoint-level sections, making it unclear which content belongs to the `filter` parameter vs. the endpoint as a whole. See LFE-9794.

## Impacted packages

- `fern/apis/server/definition/observations.yml`
- `web/public/generated/api/openapi.yml` — regenerated via `fern generate --group local --api server`

## Verification

- [x] `fern generate --group local --api server` completes without errors
- [x] Lint passes
- [ ] Verify rendered docs show Filter Structure under the endpoint description, not under the `filter` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves the Filter Structure, Available Columns, and Filter Examples documentation from the `filter` query parameter's inline `docs` block up into the endpoint-level `## Filters` section of `GET /v2/observations`, adjusting heading levels accordingly. The `filter` parameter description is reduced to a single pointer sentence, and `web/public/generated/api/openapi.yml` is regenerated to reflect these changes.

- **Documentation restructured**: The substantial filter documentation block (Filter Structure, Available Columns, Filter Examples) is lifted to endpoint-level, fixing heading hierarchy so `##` headers no longer appear at the same visual level as top-level endpoint sections.
- **Minor content change**: The filter structure template changed from pseudo-typed placeholders (`\"type\": string`, `\"value\": any`) to concrete example values (`\"type\": \"string\"`, `\"value\": \"GENERATION\"`). The PR description claims this is a pure structural move, but the template format did change, which is worth noting for reviewers comparing before/after.
- **`openapi.yml` regenerated**: The generated file consistently reflects the YAML source changes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — documentation-only change with no runtime behaviour affected.

The change is confined to documentation structure in observations.yml and its regenerated openapi.yml. The only noteworthy detail is that the filter structure template quietly shifted from pseudo-typed placeholders to concrete example values, which the PR description characterises as a pure structural move. This is a minor discrepancy worth acknowledging but poses no risk to API consumers.

No files require special attention beyond the noted template format change in fern/apis/server/definition/observations.yml.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
fern/apis/server/definition/observations.yml:35-46
**Filter structure template changed from pseudo-code to JSON example**

The PR description states "No column content is changed — this is a pure structural move," but the filter structure template itself was modified. The old version used pseudo-typed placeholders (`"type": string`, `"value": any`, `"key": string`) to describe the expected types, while the new version uses concrete example values (`"type": "string"`, `"value": "GENERATION"`, `"key": "env"`). Although the new format is arguably clearer (the old placeholders were not valid JSON), the change subtly shifts the template from a type-description style to an example style, which may confuse readers who were relying on the type hints rather than example values to understand expected field types.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(fern): lift filter docs to endp..."](https://github.com/langfuse/langfuse/commit/a6d865c20e61e5654c1f63316bb702069e6f767c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32788947)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->