### PR TITLE
fix(fern): correct v2 observations filter column docs

### DIFF
--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -38,9 +38,9 @@ service:
         ```json
         [
           {
-            "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-            "column": string,         // Required. Column to filter on (see available columns below)
-            "operator": string,       // Required. Operator based on type:
+            "type": "string",         // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": "name",         // Required. Column to filter on (see Available Columns below)
+            "operator": "=",          // Required. Operator based on type:
                                       // - datetime: ">", "<", ">=", "<="
                                       // - string: "=", "contains", "does not contain", "starts with", "ends with"
                                       // - stringOptions: "any of", "none of"
@@ -51,8 +51,8 @@ service:
                                       // - numberObject: "=", ">", "<", ">=", "<="
                                       // - boolean: "=", "<>"
                                       // - null: "is null", "is not null"
-            "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-            "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
+            "value": "GENERATION",    // Required (except for null type). Type depends on filter type.
+            "key": "env"              // Required only for stringObject, numberObject, and categoryOptions when filtering nested fields like metadata.
           }
         ]
         ```
@@ -64,22 +64,24 @@ service:
         - `type` (string) - Observation type (SPAN, GENERATION, EVENT)
         - `name` (string) - Observation name
         - `traceId` (string) - Associated trace ID
+        - `parentObservationId` (string) - Parent observation ID
         - `startTime` (datetime) - Observation start time
         - `endTime` (datetime) - Observation end time
         - `environment` (string) - Environment tag
         - `level` (string) - Log level (DEBUG, DEFAULT, WARNING, ERROR)
         - `statusMessage` (string) - Status message
         - `version` (string) - Version tag
-        - `userId` (string) - User ID
-        - `sessionId` (string) - Session ID
 
         #### Trace-Related Fields
         - `traceName` (string) - Name of the parent trace
+        - `traceEnvironment` (string) - Environment tag from the parent trace
         - `traceTags` (arrayOptions) - Tags from the parent trace
-        - `tags` (arrayOptions) - Alias for traceTags
+        - `tags` (arrayOptions) - Tags on the observation
+        - `userId` (string) - User ID
+        - `sessionId` (string) - Session ID
 
         #### Performance Metrics
-        - `latency` (number) - Latency in seconds (calculated: end_time - start_time)
+        - `latency` (number) - Latency in seconds (end_time − start_time)
         - `timeToFirstToken` (number) - Time to first token in seconds
         - `tokensPerSecond` (number) - Output tokens per second
 
@@ -95,11 +97,18 @@ service:
 
         #### Model Information
         - `model` (string) - Provided model name (alias: `providedModelName`)
+        - `modelId` (stringOptions) - Internal model ID
         - `promptName` (string) - Associated prompt name
         - `promptVersion` (number) - Associated prompt version
 
         #### Structured Data
-        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
+        - `metadata` (stringObject) - Metadata key-value pairs. Requires the `key` parameter to target a specific metadata key.
+
+        #### Tool Fields
+        - `toolDefinitions` (number) - Number of tool definitions
+        - `toolCalls` (number) - Number of tool calls
+        - `toolNames` (arrayOptions) - Names of defined tools
+        - `calledToolNames` (arrayOptions) - Names of tools that were called
 
         ### Filter Examples
         ```json

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3156,9 +3156,9 @@ paths:
 
         [
           {
-            "type": string,           // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
-            "column": string,         // Required. Column to filter on (see available columns below)
-            "operator": string,       // Required. Operator based on type:
+            "type": "string",         // Required. One of: "datetime", "string", "number", "stringOptions", "categoryOptions", "arrayOptions", "stringObject", "numberObject", "boolean", "null"
+            "column": "name",         // Required. Column to filter on (see Available Columns below)
+            "operator": "=",          // Required. Operator based on type:
                                       // - datetime: ">", "<", ">=", "<="
                                       // - string: "=", "contains", "does not contain", "starts with", "ends with"
                                       // - stringOptions: "any of", "none of"
@@ -3169,8 +3169,8 @@ paths:
                                       // - numberObject: "=", ">", "<", ">=", "<="
                                       // - boolean: "=", "<>"
                                       // - null: "is null", "is not null"
-            "value": any,             // Required (except for null type). Value to compare against. Type depends on filter type
-            "key": string             // Required only for stringObject, numberObject, and categoryOptions types when filtering on nested fields like metadata
+            "value": "GENERATION",    // Required (except for null type). Type depends on filter type.
+            "key": "env"              // Required only for stringObject, numberObject, and categoryOptions when filtering nested fields like metadata.
           }
         ]
 
@@ -3190,6 +3190,8 @@ paths:
 
         - `traceId` (string) - Associated trace ID
 
+        - `parentObservationId` (string) - Parent observation ID
+
         - `startTime` (datetime) - Observation start time
 
         - `endTime` (datetime) - Observation end time
@@ -3202,24 +3204,25 @@ paths:
 
         - `version` (string) - Version tag
 
-        - `userId` (string) - User ID
-
-        - `sessionId` (string) - Session ID
-
 
         #### Trace-Related Fields
 
         - `traceName` (string) - Name of the parent trace
 
+        - `traceEnvironment` (string) - Environment tag from the parent trace
+
         - `traceTags` (arrayOptions) - Tags from the parent trace
 
-        - `tags` (arrayOptions) - Alias for traceTags
+        - `tags` (arrayOptions) - Tags on the observation
+
+        - `userId` (string) - User ID
+
+        - `sessionId` (string) - Session ID
 
 
         #### Performance Metrics
 
-        - `latency` (number) - Latency in seconds (calculated: end_time -
-        start_time)
+        - `latency` (number) - Latency in seconds (end_time − start_time)
 
         - `timeToFirstToken` (number) - Time to first token in seconds
 
@@ -3248,6 +3251,8 @@ paths:
 
         - `model` (string) - Provided model name (alias: `providedModelName`)
 
+        - `modelId` (stringOptions) - Internal model ID
+
         - `promptName` (string) - Associated prompt name
 
         - `promptVersion` (number) - Associated prompt version
@@ -3255,9 +3260,19 @@ paths:
 
         #### Structured Data
 
-        - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
-        key-value pairs. Use `key` parameter to filter on specific metadata
-        keys.
+        - `metadata` (stringObject) - Metadata key-value pairs. Requires the
+        `key` parameter to target a specific metadata key.
+
+
+        #### Tool Fields
+
+        - `toolDefinitions` (number) - Number of tool definitions
+
+        - `toolCalls` (number) - Number of tool calls
+
+        - `toolNames` (arrayOptions) - Names of defined tools
+
+        - `calledToolNames` (arrayOptions) - Names of tools that were called
 
 
         ### Filter Examples


### PR DESCRIPTION
## Summary

Corrects the Available Columns list in `GET /v2/observations` against `eventsTableNativeUiColumnDefinitions` — the actual runtime module for v2. The prior docs were audited against the wrong v1 module (`observationsTableUiColumnDefinitions`); `/api/public/v2/observations` routes through `getObservationsV2FromEventsTableForPublicApi`, which passes `eventsTableNativeUiColumnDefinitions` to `deriveFilters`.

Stacked on top of the structural refactor PR.

## Column accuracy changes

| Change | Reason |
|--------|--------|
| Add `parentObservationId` (string) | Valid `uiTableId` in `mapEventsTable.ts`; also a top-level query param on this endpoint |
| Add `traceEnvironment` (string) | Valid `uiTableId` in `mapEventsTable.ts`; was in v1 legacy docs |
| Change `tags` from "Alias for traceTags" → "Tags on the observation" | `mapEventsTable.ts` has a distinct `uiTableId: 'tags'` → `e."tags"`, not an alias |
| Move `userId`/`sessionId` from Core → Trace-Related | Read from `events_proto` denormalized fields, consistent with placement of `traceName`/`traceTags` |
| Add `modelId` (stringOptions) to Model Information | Distinct from `model` (`e."model_id"` vs `e."provided_model_name"`) |
| Add Tool Fields section | `toolDefinitions`, `toolCalls`, `toolNames`, `calledToolNames` all registered `uiTableId`s in `mapEventsTable.ts` |
| Tighten `metadata` description | `stringObject` only (not all three filter types) |

## Impacted packages

- `fern/apis/server/definition/observations.yml`
- `web/public/generated/api/openapi.yml` — regenerated via `fern generate --group local --api server`

## Verification

- [x] `fern generate --group local --api server` completes without errors
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects the Available Columns documentation for `GET /v2/observations` to reflect the actual runtime filter module (`eventsTableNativeUiColumnDefinitions` in `mapEventsTable.ts`) rather than the v1 module. The regenerated `openapi.yml` is a direct output of the corrected Fern source.

- Adds `parentObservationId`, `traceEnvironment`, and `modelId` — all verified as registered `uiTableId`s in `mapEventsTable.ts` and `eventsTable.ts`. Type labels (`string`, `stringOptions`) are confirmed accurate against the `ColumnDefinition` entries.
- Adds a Tool Fields section (`toolDefinitions`, `toolCalls`, `toolNames`, `calledToolNames`) and tightens `metadata` to `stringObject` only — all verified against `eventsTable.ts` column definitions.
- Note: `tags` and `traceTags` both resolve to `e.\"tags\"` at query time; the new \"Tags on the observation\" description may mislead users into expecting distinct data from the two columns.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are documentation only, with no runtime logic affected.

All added and modified column entries are backed by matching uiTableId entries in mapEventsTable.ts and matching ColumnDefinition types in eventsTable.ts. The one minor concern is the tags description implying distinct data from traceTags, when both map to the same e.tags column at query time.

Only fern/apis/server/definition/observations.yml needs attention for the tags vs traceTags description clarity.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["GET /v2/observations\n(query.filter)"] --> B["deriveFilters()"]
    B --> C["createFilterFromFilterState()\nwith eventsTableNativeUiColumnDefinitions\n(mapEventsTable.ts)"]
    B --> D["convertApiProvidedFilterToClickhouseFilter()\nwith simple params e.g. traceId, parentObservationId"]
    C --> E["matchAndVerifyTracesUiColumn()\nlookup by uiTableId"]
    E --> F{columnDefinitions\npassed?}
    F -->|Yes: check eventsTableCols| G["COMPATIBLE_FILTER_TYPES\nvalidation"]
    F -->|No entry found| H["Skip type check\ne.g. parentObservationId,\ntraceEnvironment, tags"]
    G --> I["ClickHouse Filter\nBuilt"]
    H --> I
    D --> I
    I --> J["events_proto query\nvia getObservationsV2FromEventsTableForPublicApi"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
fern/apis/server/definition/observations.yml:74-75
`tags` and `traceTags` map to identical data

In `mapEventsTable.ts`, both `tags` and `traceTags` use `clickhouseSelect: 'e."tags"'` — the same underlying column. The new description "Tags on the observation" implies distinct content from `traceTags` ("Tags from the parent trace"), but filtering by either column produces identical query results. A user reading the docs may pass `tags` expecting observation-level tags and `traceTags` expecting trace-level tags, and be surprised they're equivalent. Adding a brief note like "(same underlying field as `traceTags` in the v2 events table)" would prevent this confusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(fern): correct v2 observations filte..."](https://github.com/langfuse/langfuse/commit/06935420ea471cfe1badf2b414a19d861f070188) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32788952)</sub>

<!-- /greptile_comment -->