### PR TITLE
fix: multienv queries for observations v2

### DIFF
--- a/packages/shared/src/server/queries/public-api-filter-builder.ts
+++ b/packages/shared/src/server/queries/public-api-filter-builder.ts
@@ -218,7 +218,7 @@ export function createPublicApiObservationsColumnMapping(
     {
       id: "environment",
       clickhouseSelect: "environment",
-      filterType: "StringFilter",
+      filterType: "StringOptionsFilter",
       clickhouseTable: tableName,
       clickhousePrefix: tablePrefix,
     },

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -225,6 +225,94 @@ describe("/api/public/v2/observations API Endpoint", () => {
       expect(obs?.level).toBe("WARNING");
     });
 
+    it("should filter by multiple environment query params (any-of semantics)", async () => {
+      const traceId = randomUUID();
+      const envA = `env-a-${randomUUID()}`;
+      const envB = `env-b-${randomUUID()}`;
+      const envC = `env-c-${randomUUID()}`;
+      const observationIdA = randomUUID();
+      const observationIdB = randomUUID();
+      const observationIdC = randomUUID();
+      const timestamp = new Date();
+      const timeValue = timestamp.getTime() * 1000;
+
+      const buildObservation = (
+        id: string,
+        environment: string,
+        offsetMicros: number,
+      ) =>
+        createEvent({
+          id,
+          span_id: id,
+          trace_id: traceId,
+          project_id: projectId,
+          name: `env-filter-obs-${environment}`,
+          type: "GENERATION",
+          level: "DEFAULT",
+          environment,
+          start_time: timeValue + offsetMicros,
+          end_time: timeValue + offsetMicros + 1000 * 1000,
+        });
+
+      await createEventsCh([
+        buildObservation(observationIdA, envA, 0),
+        buildObservation(observationIdB, envB, 1000 * 1000),
+        buildObservation(observationIdC, envC, 2000 * 1000),
+      ]);
+
+      await waitForExpect(
+        async () => {
+          const result = await queryClickhouse<{ count: string }>({
+            query: `SELECT count() as count FROM events_core WHERE project_id = {projectId: String} AND span_id IN ({ids: Array(String)})`,
+            params: {
+              projectId,
+              ids: [observationIdA, observationIdB, observationIdC],
+            },
+          });
+          expect(Number(result[0]?.count)).toBeGreaterThanOrEqual(3);
+        },
+        5000,
+        10,
+      );
+
+      const response = await getObservations(
+        `/api/public/v2/observations?fields=basic&traceId=${traceId}&environment=${encodeURIComponent(envA)}&environment=${encodeURIComponent(envB)}`,
+      );
+
+      expect(response.status).toBe(200);
+      const returnedIds = response.body.data
+        .map((obs: any) => obs.id)
+        .filter((id: string) =>
+          [observationIdA, observationIdB, observationIdC].includes(id),
+        );
+      expect(returnedIds.sort()).toEqual(
+        [observationIdA, observationIdB].sort(),
+      );
+
+      for (const obs of response.body.data) {
+        expect([envA, envB]).toContain(obs.environment);
+      }
+
+      // Backwards-compat: single environment value (scalar string) must still
+      // behave as exact-match equality (previously `environment = 'foo'`, now
+      // `environment IN ('foo')`).
+      const singleEnvResponse = await getObservations(
+        `/api/public/v2/observations?fields=basic&traceId=${traceId}&environment=${encodeURIComponent(envA)}`,
+      );
+
+      expect(singleEnvResponse.status).toBe(200);
+      const singleEnvReturnedIds = singleEnvResponse.body.data
+        .map((obs: any) => obs.id)
+        .filter((id: string) =>
+          [observationIdA, observationIdB, observationIdC].includes(id),
+        );
+      expect(singleEnvReturnedIds).toEqual([observationIdA]);
+
+      for (const obs of singleEnvResponse.body.data) {
+        expect(obs.environment).toBe(envA);
+      }
+    });
+
     it("should support filter parameter on various columns without SQL crashes", async () => {
       const traceId = randomUUID();
       const observationId1 = randomUUID();


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent filter-bypass bug on the `environment` parameter for the public observations API (v1 and v2). When multiple `environment=` query params were passed, the underlying `StringFilter` silently dropped the filter (it only handles `typeof value === "string"`, not arrays), so all environments were returned instead of the requested ones.

- **`public-api-filter-builder.ts`**: Changes the `filterType` for `environment` in `createPublicApiObservationsColumnMapping` from `"StringFilter"` to `"StringOptionsFilter"`, aligning it with the existing trace and sessions column definitions. `StringOptionsFilter` correctly handles both arrays (multi-value params) and single strings, using `IN (...)` / "any of" semantics.
- **`observations-api-v2.servertest.ts`**: Adds a server integration test that verifies multi-environment filtering returns only observations matching any of the specified environments, and confirms single-value backward-compat still works.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a minimal one-line fix with a matching integration test that confirms both multi-value and single-value semantics.

The change targets only the observations column mapping and brings it in line with how traces and sessions already handle the same field. The test covers the previously broken multi-env path and validates backward compatibility for single-env usage. No other paths are touched.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: multienv queries for observations v..."](https://github.com/langfuse/langfuse/commit/9e763a42a31cb0d8e1699eab3868c69ac9cf862d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32791463)</sub>

<!-- /greptile_comment -->