### PR TITLE
refactor(blob-export): gate pricing fields on model group, not usage

### DIFF
--- a/packages/shared/src/domain/observation-field-groups.ts
+++ b/packages/shared/src/domain/observation-field-groups.ts
@@ -21,9 +21,8 @@
  *   `outputPrice`, `totalPrice`.
  * - For the v2 public API, the Postgres lookup that populates them only runs
  *   when `"model"` is in `fields`; otherwise the fields are returned as null.
- * - For the blob export path, the gate is broader: `"model"` OR `"usage"`
- *   triggers selection of the `model_export` SQL field set so pricing can be
- *   enriched into the usage payload.
+ * - For the blob export path `"model"` triggers selection of the `model_export`
+ *   SQL field set so pricing can be enriched into the usage payload.
  * - Code references:
  *   - packages/shared/src/server/repositories/events.ts:
  *     `enrichObservationsWithModelData` (v2 read path) and the export

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -70,7 +70,7 @@ const EXPORT_FIELD_GROUP_LABELS = {
   usage: {
     label: "Usage",
     description:
-      "usage_details, cost_details, total_cost, usage_pricing_tier_name",
+      "usage_details, cost_details, total_cost, usage_pricing_tier_id, usage_pricing_tier_name",
   },
   prompt: {
     label: "Prompt",

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -64,12 +64,13 @@ const EXPORT_FIELD_GROUP_LABELS = {
   },
   model: {
     label: "Model",
-    description: "provided_model_name, model_id, model_parameters",
+    description:
+      "provided_model_name, model_id, model_parameters, input_price, output_price, total_price",
   },
   usage: {
     label: "Usage",
     description:
-      "usage_details, cost_details, total_cost, input_price, output_price, total_price, usage_pricing_tier_name",
+      "usage_details, cost_details, total_cost, usage_pricing_tier_name",
   },
   prompt: {
     label: "Prompt",

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3015,22 +3015,14 @@ export const getEventsForBlobStorageExport = function (
     ? fieldGroups
     : (["core", ...fieldGroups] as ObservationFieldGroupFull[]);
 
-  // model_export must be selected when the model group is requested.
-  // It provides model_id (needed for the pricing lookup), provided_model_name,
-  // and model_parameters. Pricing fields are only enriched when model is selected.
-  const needsModelFields = fieldGroups.includes("model");
-
   for (const group of effectiveGroups) {
     if (group === "io") {
       queryBuilder.selectIO(false); // Full I/O, no truncation
-    } else if (group !== "model") {
-      // model_export is selected below via needsModelFields to avoid double-selecting
-      queryBuilder.selectFieldSet(group);
+    } else if (group === "model") {
+      queryBuilder.selectFieldSet("model_export"); // "model_export" is the SQL field set name for the "model" group
+    } else {
+      queryBuilder.selectFieldSet(group as FieldSetName);
     }
-  }
-
-  if (needsModelFields) {
-    queryBuilder.selectFieldSet("model_export");
   }
 
   queryBuilder

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3021,7 +3021,7 @@ export const getEventsForBlobStorageExport = function (
     } else if (group === "model") {
       queryBuilder.selectFieldSet("model_export"); // "model_export" is the SQL field set name for the "model" group
     } else {
-      queryBuilder.selectFieldSet(group as FieldSetName);
+      queryBuilder.selectFieldSet(group);
     }
   }
 

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -3015,12 +3015,10 @@ export const getEventsForBlobStorageExport = function (
     ? fieldGroups
     : (["core", ...fieldGroups] as ObservationFieldGroupFull[]);
 
-  // model_export must be selected whenever model or usage is requested:
-  // - model group: include model identification fields in the output
-  // - usage group (without model): pricing enrichment needs model_id for the
-  //   lookup; the field is dropped afterward by enrichObservationStream
-  const needsModelFields =
-    fieldGroups.includes("model") || fieldGroups.includes("usage");
+  // model_export must be selected when the model group is requested.
+  // It provides model_id (needed for the pricing lookup), provided_model_name,
+  // and model_parameters. Pricing fields are only enriched when model is selected.
+  const needsModelFields = fieldGroups.includes("model");
 
   for (const group of effectiveGroups) {
     if (group === "io") {

--- a/worker/src/__tests__/enrichObservationStream.unit.test.ts
+++ b/worker/src/__tests__/enrichObservationStream.unit.test.ts
@@ -71,7 +71,7 @@ describe("enrichObservationStream field group filtering", () => {
     expect(results[0]).not.toHaveProperty("metadata");
   });
 
-  it("does not add pricing fields when usage group is not selected", async () => {
+  it("does not add pricing fields when model group is not selected", async () => {
     const rows = [{ id: "obs-1" }];
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
@@ -85,10 +85,26 @@ describe("enrichObservationStream field group filtering", () => {
     expect(results[0]).not.toHaveProperty("total_price");
   });
 
-  it("adds pricing fields but drops all model_export columns when usage is selected without model", async () => {
-    // ClickHouse fetches model_export (model_id, provided_model_name,
-    // model_parameters) whenever usage is requested so the pricing lookup has
-    // data. All three must be removed from the output when model is not selected.
+  it("does not add pricing fields when usage is selected without model", async () => {
+    // model_export columns are not fetched when only usage is requested,
+    // so there is no model_id to look up and no pricing to enrich.
+    const rows = [{ id: "obs-1" }];
+    const results = await collect(
+      enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
+        "core" as ObservationFieldGroupFull,
+        "usage" as ObservationFieldGroupFull,
+      ]),
+    );
+
+    expect(results[0]).not.toHaveProperty("model_id");
+    expect(results[0]).not.toHaveProperty("provided_model_name");
+    expect(results[0]).not.toHaveProperty("model_parameters");
+    expect(results[0]).not.toHaveProperty("input_price");
+    expect(results[0]).not.toHaveProperty("output_price");
+    expect(results[0]).not.toHaveProperty("total_price");
+  });
+
+  it("adds pricing fields and preserves model_export columns when model group is selected", async () => {
     const rows = [
       {
         id: "obs-1",
@@ -100,19 +116,19 @@ describe("enrichObservationStream field group filtering", () => {
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [
         "core" as ObservationFieldGroupFull,
-        "usage" as ObservationFieldGroupFull,
+        "model" as ObservationFieldGroupFull,
       ]),
     );
 
-    expect(results[0]).not.toHaveProperty("model_id");
-    expect(results[0]).not.toHaveProperty("provided_model_name");
-    expect(results[0]).not.toHaveProperty("model_parameters");
+    expect(results[0]).toHaveProperty("model_id");
+    expect(results[0]).toHaveProperty("provided_model_name");
+    expect(results[0]).toHaveProperty("model_parameters");
     expect(results[0]).toHaveProperty("input_price");
     expect(results[0]).toHaveProperty("output_price");
     expect(results[0]).toHaveProperty("total_price");
   });
 
-  it("preserves model_id when both model and usage groups are selected", async () => {
+  it("adds pricing fields when both model and usage groups are selected", async () => {
     const rows = [{ id: "obs-1", model_id: "gpt-4" }];
     const results = await collect(
       enrichObservationStream(rowStream(rows), "project-1", "model_id", false, [

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -58,13 +58,6 @@ export async function* enrichObservationStream(
       enriched.input_price = pricing.inputPrice;
       enriched.output_price = pricing.outputPrice;
       enriched.total_price = pricing.totalPrice;
-    } else {
-      // model_export columns (provided_model_name, model_id, model_parameters)
-      // are only fetched when model is requested. Drop them when the model
-      // group was not selected so they don't leak into the output.
-      delete enriched[modelIdField];
-      delete enriched.provided_model_name;
-      delete enriched.model_parameters;
     }
 
     // ClickHouse returns {} for Map columns even when not SELECTed — drop it

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -46,26 +46,22 @@ export async function* enrichObservationStream(
 ): AsyncGenerator<Record<string, unknown>> {
   const { getModel } = createModelCache(projectId);
 
-  const includePricing = !fieldGroups || fieldGroups.includes("usage");
   const includeModelId = !fieldGroups || fieldGroups.includes("model");
 
   for await (const row of stream) {
     const enriched: Record<string, unknown> = { ...row };
 
-    if (includePricing) {
+    if (includeModelId) {
       const modelId = row[modelIdField] as string | null | undefined;
       const model = await getModel(modelId);
       const pricing = enrichObservationWithModelData(model);
       enriched.input_price = pricing.inputPrice;
       enriched.output_price = pricing.outputPrice;
       enriched.total_price = pricing.totalPrice;
-    }
-
-    // model_export (provided_model_name, model_id, model_parameters) is fetched
-    // whenever usage OR model is requested — usage needs model_id for the
-    // pricing lookup. Drop all three when the model group was not requested so
-    // they don't leak into a usage-only export.
-    if (!includeModelId) {
+    } else {
+      // model_export columns (provided_model_name, model_id, model_parameters)
+      // are only fetched when model is requested. Drop them when the model
+      // group was not selected so they don't leak into the output.
       delete enriched[modelIdField];
       delete enriched.provided_model_name;
       delete enriched.model_parameters;


### PR DESCRIPTION
## Summary

Move model pricing fields (`input_price`, `output_price`, `total_price`) from the `usage` field group to the `model` field group in the blob exporter.

### Why

The previous design was asymmetric: `usage` produced cost/usage maps *and* triggered a Postgres pricing lookup, while `model` covered identification fields only. This meant:
- Selecting `usage` without `model` fetched model data from ClickHouse, enriched prices, then silently deleted the model columns before writing — wasted work.
- Users reading the UI description for `usage` saw pricing fields listed there, which was counterintuitive.
- P2 inconsistency noted in LFE-9859: the exporter gated pricing on `model || usage` while the v2 read API gated it on `model` only.

After this change `model` owns everything model-related — identification fields and prices. `usage` is purely cost/usage data with no model lookup.

### Behaviour change

| Selection | Before | After |
|---|---|---|
| `usage` only | `input_price`, `output_price`, `total_price` present | not present |
| `model` only | prices absent | prices present |
| `model` + `usage` | prices present | prices present (unchanged) |
| all groups (default) | prices present | prices present (unchanged) |

Customers explicitly selecting only `usage` and relying on price columns will see them disappear. Customers on the default (all groups) are unaffected.

### Impacted packages

- `worker` — `enrichObservationStream`: `includePricing` gate collapsed into `includeModelId`; unit tests updated.
- `packages/shared` — `getEventsForBlobStorageExport`: `needsModelFields` drops the `|| usage` branch; `analytics-integrations` field group descriptions updated (prices moved from usage → model label).

## Test plan

- [x] `pnpm --filter worker exec vitest run src/__tests__/enrichObservationStream.unit.test.ts` — 8/8 passed
- [x] `pnpm --filter worker run typecheck`
- [x] `pnpm run lint`
- [ ] Integration test `blobStorageIntegrationProcessing.test.ts` — uses default field groups (all groups); pricing assertions unaffected. Requires live infra (Minio, ClickHouse).
- [ ] Browser: verify `model` checkbox in blob storage settings now shows pricing fields in description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves `input_price`, `output_price`, and `total_price` from the `usage` field group to the `model` field group in the blob exporter, aligning the exporter's behavior with the v2 read API and eliminating wasted work where model data was fetched and immediately discarded.

- **`getEventsForBlobStorageExport`** (`events.ts`): removes the `needsModelFields` flag that forced `model_export` selection whenever `usage` was requested; `model_export` is now selected only when `model` is in the groups.
- **`enrichObservationStream`** (`handleBlobStorageIntegrationProjectJob.ts`): replaces the separate `includePricing` flag (keyed on `usage`) with the existing `includeModelId` flag (keyed on `model`), and drops the now-unnecessary post-fetch deletion of model columns from usage-only rows.
- Tests are updated to cover the new "model-only" pricing trigger and the new "usage-only ⇒ no prices" behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is a clean gate-transfer from `usage` to `model` with no shared mutable state and consistent handling of the legacy `fieldGroups=undefined` path.

All four changed files are internally consistent: the ClickHouse query now only selects `model_export` when the `model` group is active, and `enrichObservationStream` applies pricing enrichment under the same condition. The legacy v3 `observations` path (no fieldGroups) is unaffected. Unit tests cover every combination. The only externally visible difference is intentional and documented: users who configured `usage`-only without `model` will no longer receive price columns.

No files require special attention. The `getEventsForBlobStorageExport` simplification in `events.ts` is the most consequential change, but the logic is straightforward and covered by updated tests.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Field groups configured by user] --> B{Includes 'model'?}
    B -- Yes --> C[selectFieldSet model_export in ClickHouse query]
    B -- No --> D[Skip model_export selection]
    C --> E[enrichObservationStream]
    D --> E
    E --> F{includeModelId?}
    F -- Yes --> G[Postgres pricing lookup via model_id]
    G --> H[Attach input_price, output_price, total_price]
    F -- No --> I[No pricing enrichment]
    H --> J[Yield enriched row]
    I --> J
    E --> K{Includes 'usage'?}
    K -- Yes --> L[usage_details, cost_details, total_cost from ClickHouse]
    K -- No --> M[Skip usage fields]
    L --> J
    M --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(blob-export): remove dead model..."](https://github.com/langfuse/langfuse/commit/6a855c395c53326e4ac14c8cc25de6a2882060ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32815014)</sub>

<!-- /greptile_comment -->