### PR TITLE
feat(automations): add Monitor event source to triggers and webhook envelope

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -806,6 +806,7 @@ jobs:
         lint,
         prettier-check,
         tests-eslint-plugin,
+        tests-shared,
         tests-web,
         tests-worker,
         test-worker-llm-connections,

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -222,6 +222,7 @@ jobs:
         run: pnpm --filter @repo/eslint-plugin run test
 
   tests-shared:
+    timeout-minutes: 15
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
@@ -230,9 +231,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
         with:
-          version: 10.33.0
+          version: 11.1.3
       - name: Use Node.js ${{ env.NODE_VERSION }} without cache
         if: env.CI_CACHE_ALLOWED != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -221,6 +221,42 @@ jobs:
       - name: run eslint-plugin tests
         run: pnpm --filter @repo/eslint-plugin run test
 
+  tests-shared:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        with:
+          version: 10.33.0
+      - name: Use Node.js ${{ env.NODE_VERSION }} without cache
+        if: env.CI_CACHE_ALLOWED != 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-cache: false
+      - name: Use Node.js ${{ env.NODE_VERSION }} with pnpm cache
+        if: env.CI_CACHE_ALLOWED == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # zizmor: ignore[cache-poisoning] shared test dependency cache only; no published artifacts are built from this cached state
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+      - name: install dependencies
+        run: |
+          pnpm install
+      - name: Load default env (for prisma generate)
+        run: |
+          cp .env.dev.example .env
+      - name: generate prisma client
+        run: pnpm --filter=shared run db:generate
+      - name: run shared tests
+        run: pnpm --filter @langfuse/shared run test
+
   test-docker-build:
     timeout-minutes: 20
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -56,6 +56,9 @@ Use root [AGENTS.md](../../AGENTS.md) for monorepo-level rules.
 - `@langfuse/shared/encryption` via `src/encryption/index.ts`: encryption and
   signature helpers for secrets and signed payloads.
 - `@langfuse/shared/query` via `src/features/query/index.ts`: dashboard query feature.
+- `@langfuse/shared/monitor` via `src/features/monitor/index.ts`: Monitor
+  domain schemas (`MonitorSchema`, queue/alert/webhook payloads), tier
+  constants, and the Handlebars template validator.
 - Narrower exported subpaths also exist for targeted imports:
   `@langfuse/shared/src/server/auth/apiKeys`,
   `@langfuse/shared/src/server/ee/ingestionMasking`, and

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -118,6 +118,7 @@
     "dd-trace": "5.97.0",
     "decimal.js": "^10.4.3",
     "exponential-backoff": "^3.1.2",
+    "handlebars": "^4.7.9",
     "ioredis": "^5.10.1",
     "ipaddr.js": "^2.2.0",
     "jsonpath-plus": "10.3.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -54,6 +54,10 @@
     "./query/server": {
       "import": "./dist/src/features/query/server/index.js",
       "require": "./dist/src/features/query/server/index.js"
+    },
+    "./monitor": {
+      "import": "./dist/src/features/monitor/index.js",
+      "require": "./dist/src/features/monitor/index.js"
     }
   },
   "scripts": {
@@ -63,6 +67,7 @@
     "dev": "tsc --watch",
     "lint": "eslint . --cache --cache-location dist/.eslintcache --max-warnings 0",
     "lint:fix": "eslint . --cache --cache-location dist/.eslintcache --fix",
+    "test": "vitest run",
     "db:migrate": "DISABLE_ERD=false dotenv -e ../../.env -- npx prisma migrate dev",
     "db:push": "DISABLE_ERD=false dotenv -e ../../.env -- npx prisma db push",
     "db:reset": "dotenv -e ../../.env npx -- prisma migrate reset",
@@ -144,7 +149,8 @@
     "prisma": "^6.19.3",
     "ts-node": "^10.9.2",
     "tsc-watch": "^6.2.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.4"
   },
   "peerDependencies": {
     "@types/react": "~19.2.14",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -58,6 +58,10 @@
     "./monitor": {
       "import": "./dist/src/features/monitor/index.js",
       "require": "./dist/src/features/monitor/index.js"
+    },
+    "./monitor/server": {
+      "import": "./dist/src/features/monitor/server/index.js",
+      "require": "./dist/src/features/monitor/server/index.js"
     }
   },
   "scripts": {

--- a/packages/shared/src/domain/automations.test.ts
+++ b/packages/shared/src/domain/automations.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  AvailableWebhookApiSchema,
+  TriggerEventSource,
+  TriggerEventSourceSchema,
+  TriggerInputSchema,
+} from "./automations";
+
+describe("TriggerEventSourceSchema", () => {
+  it("accepts the prompt event source", () => {
+    expect(TriggerEventSourceSchema.safeParse("prompt").success).toBe(true);
+  });
+
+  it("accepts the monitor event source", () => {
+    expect(TriggerEventSourceSchema.safeParse("monitor").success).toBe(true);
+  });
+
+  it("rejects unknown event sources", () => {
+    expect(TriggerEventSourceSchema.safeParse("bogus").success).toBe(false);
+  });
+});
+
+describe("AvailableWebhookApiSchema", () => {
+  it("accepts the prompt v1 entry", () => {
+    expect(AvailableWebhookApiSchema.safeParse({ prompt: "v1" }).success).toBe(
+      true,
+    );
+  });
+
+  it("accepts the monitor v1 entry", () => {
+    expect(AvailableWebhookApiSchema.safeParse({ monitor: "v1" }).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects unknown event source keys", () => {
+    expect(AvailableWebhookApiSchema.safeParse({ bogus: "v1" }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("TriggerInputSchema", () => {
+  it("parses a prompt variant with an empty filter", () => {
+    const result = TriggerInputSchema.safeParse({
+      eventSource: TriggerEventSource.Prompt,
+      filter: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("parses a monitor variant with an empty filter", () => {
+    const result = TriggerInputSchema.safeParse({
+      eventSource: TriggerEventSource.Monitor,
+      filter: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("defaults filter to [] when omitted", () => {
+    const result = TriggerInputSchema.safeParse({
+      eventSource: TriggerEventSource.Monitor,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.filter).toEqual([]);
+    }
+  });
+
+  it("rejects an unknown event source", () => {
+    expect(
+      TriggerInputSchema.safeParse({ eventSource: "bogus", filter: [] })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/domain/automations.ts
+++ b/packages/shared/src/domain/automations.ts
@@ -1,16 +1,42 @@
 import { Action, Trigger } from "@prisma/client";
 import { FilterState } from "../types";
+import { singleFilter } from "../interfaces/filters";
 import { z } from "zod";
 
 export enum TriggerEventSource {
   Prompt = "prompt",
+  Monitor = "monitor",
 }
 
 export const EventActionSchema = z.enum(["created", "updated", "deleted"]);
 
 export type TriggerEventAction = z.infer<typeof EventActionSchema>;
 
-export const TriggerEventSourceSchema = z.enum([TriggerEventSource.Prompt]);
+export const TriggerEventSourceSchema = z.enum([
+  TriggerEventSource.Prompt,
+  TriggerEventSource.Monitor,
+]);
+
+const PromptTriggerInputSchema = z.object({
+  eventSource: z.literal(TriggerEventSource.Prompt),
+  filter: z.array(singleFilter).default([]),
+});
+
+const MonitorTriggerInputSchema = z.object({
+  eventSource: z.literal(TriggerEventSource.Monitor),
+  filter: z.array(singleFilter).default([]),
+});
+
+/**
+ * TriggerInputSchema is the per-eventSource shape that defines when a
+ * Trigger fires. Variants share `filter` today; downstream tickets will
+ * tighten the allowed filter columns per variant.
+ */
+export const TriggerInputSchema = z.discriminatedUnion("eventSource", [
+  PromptTriggerInputSchema,
+  MonitorTriggerInputSchema,
+]);
+export type TriggerInput = z.infer<typeof TriggerInputSchema>;
 
 export type TriggerDomain = Omit<
   Trigger,
@@ -38,8 +64,8 @@ export type ActionDomainWithSecrets = Omit<Action, "config"> & {
 
 export const ActionTypeSchema = z.enum(["WEBHOOK", "SLACK", "GITHUB_DISPATCH"]);
 
-export const AvailableWebhookApiSchema = z.record(
-  z.enum(["prompt"]),
+export const AvailableWebhookApiSchema = z.partialRecord(
+  z.enum(["prompt", "monitor"]),
   z.enum(["v1"]),
 );
 

--- a/packages/shared/src/domain/webhooks.test.ts
+++ b/packages/shared/src/domain/webhooks.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+
+import { MonitorWindow } from "../features/monitor";
+import { MonitorAlertWebhookOutboundSchema } from "./webhooks";
+
+describe("MonitorAlertWebhookOutboundSchema", () => {
+  const validOutbound = {
+    id: "exe_01",
+    timestamp: new Date("2026-05-18T12:01:00.000Z"),
+    type: "monitor-alert" as const,
+    apiVersion: "v1" as const,
+    payload: {
+      monitorId: "mon_01",
+      projectId: "proj_01",
+      severity: "ALERT" as const,
+      permalink: "https://cloud.langfuse.com/project/proj_01/monitors/mon_01",
+      timestamp: new Date("2026-05-18T12:01:00.000Z"),
+      message: { title: "High error rate", body: "errors > 100" },
+      view: "OBSERVATIONS" as const,
+      filters: [],
+      window: MonitorWindow.FIVE_MIN,
+    },
+  };
+
+  it("round-trips a valid outbound payload", () => {
+    const parsed = MonitorAlertWebhookOutboundSchema.safeParse(validOutbound);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.type).toBe("monitor-alert");
+      expect(parsed.data.apiVersion).toBe("v1");
+      expect(parsed.data.payload.monitorId).toBe("mon_01");
+    }
+  });
+
+  it("rejects a wrong type discriminator", () => {
+    expect(
+      MonitorAlertWebhookOutboundSchema.safeParse({
+        ...validOutbound,
+        type: "prompt-version",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a wrong apiVersion", () => {
+    expect(
+      MonitorAlertWebhookOutboundSchema.safeParse({
+        ...validOutbound,
+        apiVersion: "v2",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/domain/webhooks.test.ts
+++ b/packages/shared/src/domain/webhooks.test.ts
@@ -32,6 +32,17 @@ describe("MonitorAlertWebhookOutboundSchema", () => {
     }
   });
 
+  it("stringifies the bigint window for JSON serialization", () => {
+    const parsed = MonitorAlertWebhookOutboundSchema.safeParse(validOutbound);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.payload.window).toBe(
+        MonitorWindow.FIVE_MIN.toString(),
+      );
+      expect(() => JSON.stringify(parsed.data)).not.toThrow();
+    }
+  });
+
   it("rejects a wrong type discriminator", () => {
     expect(
       MonitorAlertWebhookOutboundSchema.safeParse({

--- a/packages/shared/src/domain/webhooks.ts
+++ b/packages/shared/src/domain/webhooks.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { jsonSchema } from "../utils/zod";
-import { MonitorAlertSchema } from "../features/monitor";
 import { EventActionSchema } from "./automations";
 
 export const WebhookDefaultHeaders = {
@@ -51,21 +50,4 @@ export const GitHubDispatchWebhookOutboundSchema = z.object({
 
 export type GitHubDispatchWebhookOutput = z.infer<
   typeof GitHubDispatchWebhookOutboundSchema
->;
-
-// `payload.window` is stringified here because the rest of the system
-// keeps `window` as a `bigint` (cheap arithmetic, exact ms) and `bigint`
-// has no JSON representation.
-export const MonitorAlertWebhookOutboundSchema = z.object({
-  id: z.string(),
-  timestamp: z.coerce.date(),
-  type: z.literal("monitor-alert"),
-  apiVersion: z.literal("v1"),
-  payload: MonitorAlertSchema.omit({ window: true }).extend({
-    window: z.bigint().transform((v) => v.toString()),
-  }),
-});
-
-export type MonitorAlertWebhookOutput = z.infer<
-  typeof MonitorAlertWebhookOutboundSchema
 >;

--- a/packages/shared/src/domain/webhooks.ts
+++ b/packages/shared/src/domain/webhooks.ts
@@ -53,12 +53,21 @@ export type GitHubDispatchWebhookOutput = z.infer<
   typeof GitHubDispatchWebhookOutboundSchema
 >;
 
+// `apiVersion` (not `version`) matches PromptWebhookOutboundSchema —
+// `version` on MonitorWebhookQueueEventSchema is the queue-envelope
+// version and is intentionally separate from the outbound API version.
+//
+// `payload.window` is stringified here because the rest of the system
+// keeps `window` as a `bigint` (cheap arithmetic, exact ms) and `bigint`
+// has no JSON representation.
 export const MonitorAlertWebhookOutboundSchema = z.object({
   id: z.string(),
   timestamp: z.coerce.date(),
   type: z.literal("monitor-alert"),
   apiVersion: z.literal("v1"),
-  payload: MonitorAlertSchema,
+  payload: MonitorAlertSchema.omit({ window: true }).extend({
+    window: z.bigint().transform((v) => v.toString()),
+  }),
 });
 
 export type MonitorAlertWebhookOutput = z.infer<

--- a/packages/shared/src/domain/webhooks.ts
+++ b/packages/shared/src/domain/webhooks.ts
@@ -53,10 +53,6 @@ export type GitHubDispatchWebhookOutput = z.infer<
   typeof GitHubDispatchWebhookOutboundSchema
 >;
 
-// `apiVersion` (not `version`) matches PromptWebhookOutboundSchema —
-// `version` on MonitorWebhookQueueEventSchema is the queue-envelope
-// version and is intentionally separate from the outbound API version.
-//
 // `payload.window` is stringified here because the rest of the system
 // keeps `window` as a `bigint` (cheap arithmetic, exact ms) and `bigint`
 // has no JSON representation.

--- a/packages/shared/src/domain/webhooks.ts
+++ b/packages/shared/src/domain/webhooks.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { jsonSchema } from "../utils/zod";
+import { MonitorAlertSchema } from "../features/monitor";
 import { EventActionSchema } from "./automations";
 
 export const WebhookDefaultHeaders = {
@@ -50,4 +51,16 @@ export const GitHubDispatchWebhookOutboundSchema = z.object({
 
 export type GitHubDispatchWebhookOutput = z.infer<
   typeof GitHubDispatchWebhookOutboundSchema
+>;
+
+export const MonitorAlertWebhookOutboundSchema = z.object({
+  id: z.string(),
+  timestamp: z.coerce.date(),
+  type: z.literal("monitor-alert"),
+  apiVersion: z.literal("v1"),
+  payload: MonitorAlertSchema,
+});
+
+export type MonitorAlertWebhookOutput = z.infer<
+  typeof MonitorAlertWebhookOutboundSchema
 >;

--- a/packages/shared/src/features/monitor/index.ts
+++ b/packages/shared/src/features/monitor/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/packages/shared/src/features/monitor/index.ts
+++ b/packages/shared/src/features/monitor/index.ts
@@ -1,1 +1,2 @@
 export * from "./types";
+export * from "./template";

--- a/packages/shared/src/features/monitor/internal.ts
+++ b/packages/shared/src/features/monitor/internal.ts
@@ -6,7 +6,7 @@
 export const SECOND = 1000n;
 
 /**
- * MINUTE one minute in milliseconds.
+ * MINUTE is one minute in milliseconds.
  */
 export const MINUTE = 60n * SECOND;
 

--- a/packages/shared/src/features/monitor/internal.ts
+++ b/packages/shared/src/features/monitor/internal.ts
@@ -1,4 +1,4 @@
-/* internal.ts is internal to the monitor implementation. Do export from the package barrel. */
+/* internal.ts is internal to the monitor implementation. Do NOT export from the package barrel. */
 
 /**
  * SECOND is one second in milliseconds.

--- a/packages/shared/src/features/monitor/internal.ts
+++ b/packages/shared/src/features/monitor/internal.ts
@@ -1,0 +1,26 @@
+/* internal.ts is internal to the monitor implementation. Do export from the package barrel. */
+
+/**
+ * SECOND is one second in milliseconds.
+ */
+export const SECOND = 1000n;
+
+/**
+ * MINUTE one minute in milliseconds.
+ */
+export const MINUTE = 60n * SECOND;
+
+/**
+ * HOUR is one hour in milliseconds.
+ */
+export const HOUR = 60n * MINUTE;
+
+/**
+ * DAY is one day in milliseconds.
+ */
+export const DAY = 24n * HOUR;
+
+/**
+ * WEEK is one week in milliseconds.
+ */
+export const WEEK = 7n * DAY;

--- a/packages/shared/src/features/monitor/server/index.ts
+++ b/packages/shared/src/features/monitor/server/index.ts
@@ -1,0 +1,1 @@
+export * from "./queue-processor";

--- a/packages/shared/src/features/monitor/server/queue-processor.test.ts
+++ b/packages/shared/src/features/monitor/server/queue-processor.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from "vitest";
 
-import { MonitorWindow } from "../features/monitor";
-import { MonitorAlertWebhookOutboundSchema } from "./webhooks";
+import { MonitorWindow } from "../types";
+import {
+  MonitorAlertWebhookOutboundSchema,
+  MonitorAlertWebhookPublishInputSchema,
+} from "./queue-processor";
+
+const validAlertPayload = {
+  monitorId: "mon_01",
+  projectId: "proj_01",
+  severity: "ALERT" as const,
+  permalink: "https://cloud.langfuse.com/project/proj_01/monitors/mon_01",
+  timestamp: new Date("2026-05-18T12:01:00.000Z"),
+  message: { title: "High error rate", body: "errors > 100" },
+  view: "OBSERVATIONS" as const,
+  filters: [],
+  window: MonitorWindow.FIVE_MIN,
+};
 
 describe("MonitorAlertWebhookOutboundSchema", () => {
   const validOutbound = {
@@ -9,17 +24,7 @@ describe("MonitorAlertWebhookOutboundSchema", () => {
     timestamp: new Date("2026-05-18T12:01:00.000Z"),
     type: "monitor-alert" as const,
     apiVersion: "v1" as const,
-    payload: {
-      monitorId: "mon_01",
-      projectId: "proj_01",
-      severity: "ALERT" as const,
-      permalink: "https://cloud.langfuse.com/project/proj_01/monitors/mon_01",
-      timestamp: new Date("2026-05-18T12:01:00.000Z"),
-      message: { title: "High error rate", body: "errors > 100" },
-      view: "OBSERVATIONS" as const,
-      filters: [],
-      window: MonitorWindow.FIVE_MIN,
-    },
+    payload: validAlertPayload,
   };
 
   it("round-trips a valid outbound payload", () => {
@@ -57,6 +62,35 @@ describe("MonitorAlertWebhookOutboundSchema", () => {
       MonitorAlertWebhookOutboundSchema.safeParse({
         ...validOutbound,
         apiVersion: "v2",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("MonitorAlertWebhookPublishInputSchema", () => {
+  const validPublishInput = {
+    projectId: "proj_01",
+    automationId: "auto_01",
+    executionId: "exe_01",
+    payload: {
+      type: "monitor-alert" as const,
+      apiVersion: "v1" as const,
+      payload: validAlertPayload,
+    },
+  };
+
+  it("parses a valid publish input", () => {
+    expect(
+      MonitorAlertWebhookPublishInputSchema.safeParse(validPublishInput)
+        .success,
+    ).toBe(true);
+  });
+
+  it("rejects a publish input with a non-monitor-alert envelope", () => {
+    expect(
+      MonitorAlertWebhookPublishInputSchema.safeParse({
+        ...validPublishInput,
+        payload: { ...validPublishInput.payload, type: "prompt-version" },
       }).success,
     ).toBe(false);
   });

--- a/packages/shared/src/features/monitor/server/queue-processor.ts
+++ b/packages/shared/src/features/monitor/server/queue-processor.ts
@@ -1,0 +1,50 @@
+/**
+ * DTOs and ports for the future Monitor Queue Processor.
+ *
+ * The processor reads `MonitorQueueEvent` batches, evaluates each Monitor
+ * against ClickHouse, and publishes a `MonitorAlertWebhookPublishInput` to
+ * the WebhookQueue for every Monitor that crossed a threshold. The outbound
+ * HTTP payload posted to a customer-configured webhook URL is shaped by
+ * `MonitorAlertWebhookOutboundSchema`.
+ */
+import { z } from "zod";
+
+import { MonitorAlertSchema, MonitorWebhookQueueEventSchema } from "../types";
+
+/**
+ * MonitorAlertWebhookOutboundSchema is the JSON payload posted to a
+ * customer-configured webhook URL when a Monitor alerts. `payload.window`
+ * is stringified because the rest of the system carries `window` as a
+ * `bigint` (cheap arithmetic, exact ms) and `bigint` has no JSON
+ * representation.
+ */
+export const MonitorAlertWebhookOutboundSchema = z.object({
+  id: z.string(),
+  timestamp: z.coerce.date(),
+  type: z.literal("monitor-alert"),
+  apiVersion: z.literal("v1"),
+  payload: MonitorAlertSchema.omit({ window: true }).extend({
+    window: z.bigint().transform((v) => v.toString()),
+  }),
+});
+
+export type MonitorAlertWebhookOutput = z.infer<
+  typeof MonitorAlertWebhookOutboundSchema
+>;
+
+/**
+ * MonitorAlertWebhookPublishInputSchema is the DTO the Monitor Queue
+ * Processor pushes onto the WebhookQueue for each Monitor that fired.
+ * It matches `WebhookInputSchema` narrowed to the `monitor-alert` variant
+ * so the existing webhook worker can consume it without a separate queue.
+ */
+export const MonitorAlertWebhookPublishInputSchema = z.object({
+  projectId: z.string(),
+  automationId: z.string(),
+  executionId: z.string(),
+  payload: MonitorWebhookQueueEventSchema,
+});
+
+export type MonitorAlertWebhookPublishInput = z.infer<
+  typeof MonitorAlertWebhookPublishInputSchema
+>;

--- a/packages/shared/src/features/monitor/template.test.ts
+++ b/packages/shared/src/features/monitor/template.test.ts
@@ -74,4 +74,25 @@ describe("validateMonitorTemplate", () => {
   it("rejects malformed handlebars", () => {
     expect(validateMonitorTemplate("{{value")).toBe(false);
   });
+
+  it.each(["{{@is_alert}}", "{{@value}}", "{{@threshold}}", "{{@root}}"])(
+    "rejects an @-prefixed data reference: %s",
+    (template) => {
+      expect(validateMonitorTemplate(template)).toBe(false);
+    },
+  );
+
+  it.each(["{{../value}}", "{{../is_alert}}"])(
+    "rejects a parent-context reference: %s",
+    (template) => {
+      expect(validateMonitorTemplate(template)).toBe(false);
+    },
+  );
+
+  it.each(["{{tags.0}}", "{{value.length}}", "{{window.constructor}}"])(
+    "rejects a sub-property reference: %s",
+    (template) => {
+      expect(validateMonitorTemplate(template)).toBe(false);
+    },
+  );
 });

--- a/packages/shared/src/features/monitor/template.test.ts
+++ b/packages/shared/src/features/monitor/template.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+
+import { validateMonitorTemplate } from "./template";
+
+describe("validateMonitorTemplate", () => {
+  it("accepts the empty string", () => {
+    expect(validateMonitorTemplate("")).toBe(true);
+  });
+
+  it("accepts plain text without any handlebars", () => {
+    expect(validateMonitorTemplate("hello world")).toBe(true);
+  });
+
+  it.each([
+    "value",
+    "threshold",
+    "warningThreshold",
+    "operator",
+    "window",
+    "permalink",
+    "tags",
+    "is_ok",
+    "is_warning",
+    "is_alert",
+    "is_no_data",
+    "is_fired",
+    "is_resolved",
+    "is_crossed",
+  ])("accepts {{%s}}", (key) => {
+    expect(validateMonitorTemplate(`x {{${key}}} y`)).toBe(true);
+  });
+
+  it("accepts a mix of text and multiple variables", () => {
+    expect(
+      validateMonitorTemplate(
+        "Alert {{value}} crossed {{threshold}} in {{window}}",
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a handlebars comment", () => {
+    expect(validateMonitorTemplate("{{! a comment }}hi {{value}}")).toBe(true);
+  });
+
+  it("rejects a template referencing an unknown variable", () => {
+    expect(validateMonitorTemplate("{{foo}}")).toBe(false);
+  });
+
+  it("rejects unescaped {{{value}}}", () => {
+    expect(validateMonitorTemplate("{{{value}}}")).toBe(false);
+  });
+
+  it.each([
+    "{{#if is_alert}}x{{/if}}",
+    "{{#unless is_ok}}x{{/unless}}",
+    "{{#each tags}}x{{/each}}",
+    "{{#with value}}x{{/with}}",
+  ])("rejects a block helper: %s", (template) => {
+    expect(validateMonitorTemplate(template)).toBe(false);
+  });
+
+  it("rejects an inline helper invocation", () => {
+    expect(validateMonitorTemplate("{{lookup tags 0}}")).toBe(false);
+  });
+
+  it("rejects a partial", () => {
+    expect(validateMonitorTemplate("{{> myPartial}}")).toBe(false);
+  });
+
+  it("rejects a sub-expression argument", () => {
+    expect(validateMonitorTemplate("{{value (lookup tags 0)}}")).toBe(false);
+  });
+
+  it("rejects malformed handlebars", () => {
+    expect(validateMonitorTemplate("{{value")).toBe(false);
+  });
+});

--- a/packages/shared/src/features/monitor/template.ts
+++ b/packages/shared/src/features/monitor/template.ts
@@ -1,0 +1,86 @@
+/** template.ts contains Monitor message template validation */
+import Handlebars from "handlebars";
+
+/**
+ * MonitorMessageContext is the allowlisted context passed to a Monitor
+ * message template at render time. Templates may only reference these
+ * top-level keys.
+ */
+export type MonitorMessageContext = {
+  value: string;
+  threshold: string;
+  warningThreshold: string | null;
+  operator: ">" | ">=" | "<" | "<=" | "==" | "!=";
+  window: string;
+  permalink: string;
+  tags: string[];
+
+  is_ok: boolean;
+  is_warning: boolean;
+  is_alert: boolean;
+  is_no_data: boolean;
+
+  is_fired: boolean;
+  is_resolved: boolean;
+  is_crossed: boolean;
+};
+
+const monitorMessageContextKeys = new Set<string>([
+  "value",
+  "threshold",
+  "warningThreshold",
+  "operator",
+  "window",
+  "permalink",
+  "tags",
+  "is_ok",
+  "is_warning",
+  "is_alert",
+  "is_no_data",
+  "is_fired",
+  "is_resolved",
+  "is_crossed",
+] satisfies (keyof MonitorMessageContext)[]);
+
+/**
+ * validateMonitorTemplate returns true when `source` is a Handlebars
+ * template whose AST only references `MonitorMessageContext` keys and
+ * does not invoke helpers, partials, decorators, or sub-expressions, and
+ * does not use unescaped output (`{{{x}}}`).
+ */
+export const validateMonitorTemplate = (source: string): boolean => {
+  let ast: hbs.AST.Program;
+  try {
+    ast = Handlebars.parse(source);
+  } catch {
+    return false;
+  }
+  return ast.body.every(isAllowedStatement);
+};
+
+const isAllowedStatement = (node: hbs.AST.Statement): boolean => {
+  switch (node.type) {
+    case "ContentStatement":
+    case "CommentStatement":
+      return true;
+    case "MustacheStatement": {
+      const m = node as hbs.AST.MustacheStatement;
+      if (m.escaped === false) return false;
+      if (m.params.length > 0) return false;
+      if (m.hash) return false;
+      return isAllowedPath(m.path);
+    }
+    default:
+      return false;
+  }
+};
+
+const isAllowedPath = (
+  path: hbs.AST.PathExpression | hbs.AST.Literal,
+): boolean => {
+  if (path.type !== "PathExpression") return false;
+  const p = path as hbs.AST.PathExpression;
+  const head = p.parts[0];
+  if (typeof head !== "string") return false;
+  return monitorMessageContextKeys.has(head);
+};

--- a/packages/shared/src/features/monitor/template.ts
+++ b/packages/shared/src/features/monitor/template.ts
@@ -80,6 +80,9 @@ const isAllowedPath = (
 ): boolean => {
   if (path.type !== "PathExpression") return false;
   const p = path as hbs.AST.PathExpression;
+  if (p.data) return false;
+  if (p.depth !== 0) return false;
+  if (p.parts.length !== 1) return false;
   const head = p.parts[0];
   if (typeof head !== "string") return false;
   return monitorMessageContextKeys.has(head);

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -1,0 +1,542 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  MonitorWindow,
+  isValidMonitorWindow,
+  monitorWindowCadenceMs,
+  MonitorRenotifySchema,
+  MonitorNoDataSchema,
+  MonitorTemplateSchema,
+  MonitorSchema,
+  MonitorQueueEventSchema,
+  MonitorAlertSchema,
+  MonitorWebhookQueueEventSchema,
+  validateWarningAlertOrdering,
+} from "./types";
+
+// Minimal valid domain object. Tests override one field at a time.
+const validMonitorBase = {
+  id: "mon_01",
+  createdAt: new Date("2026-05-18T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-18T00:00:00.000Z"),
+  createdBy: null,
+  updatedBy: null,
+  projectId: "proj_01",
+
+  view: "OBSERVATIONS" as const,
+  filters: [],
+  metric: { measure: "count", aggregation: "count" as const },
+
+  window: MonitorWindow.FIVE_MIN,
+  thresholdOperator: "GT" as const,
+  alertThreshold: 100,
+  warningThreshold: null,
+
+  severity: "UNKNOWN" as const,
+  severityChangedAt: null,
+
+  noData: { mode: "SILENT" as const },
+  renotify: { mode: "OFF" as const },
+
+  status: "ACTIVE" as const,
+  nextRunAt: new Date("2026-05-18T00:01:00.000Z"),
+  lastPublishedRunAt: null,
+  lastCompletedRunAt: null,
+
+  name: "High error rate",
+  message: "",
+  tags: [],
+  alertedAt: null,
+};
+
+// Local readability aliases. The production module keeps these internal.
+const MINUTE_MS = 60_000n;
+const HOUR_MS = 60n * MINUTE_MS;
+const DAY_MS = 24n * HOUR_MS;
+const WEEK_MS = 7n * DAY_MS;
+
+describe("MonitorWindow tier map", () => {
+  it("exposes the 10 RFC tiers with BigInt millisecond values", () => {
+    expect(MonitorWindow.FIVE_MIN).toBe(5n * 60_000n);
+    expect(MonitorWindow.TEN_MIN).toBe(10n * 60_000n);
+    expect(MonitorWindow.FIFTEEN_MIN).toBe(15n * 60_000n);
+    expect(MonitorWindow.THIRTY_MIN).toBe(30n * 60_000n);
+    expect(MonitorWindow.ONE_HOUR).toBe(60n * 60_000n);
+    expect(MonitorWindow.TWO_HOUR).toBe(2n * 60n * 60_000n);
+    expect(MonitorWindow.FOUR_HOUR).toBe(4n * 60n * 60_000n);
+    expect(MonitorWindow.ONE_DAY).toBe(24n * 60n * 60_000n);
+    expect(MonitorWindow.TWO_DAY).toBe(2n * 24n * 60n * 60_000n);
+    expect(MonitorWindow.ONE_WEEK).toBe(7n * 24n * 60n * 60_000n);
+  });
+});
+
+describe("isValidMonitorWindow", () => {
+  it("accepts every MonitorWindow tier value", () => {
+    for (const tier of Object.values(MonitorWindow)) {
+      expect(isValidMonitorWindow(tier)).toBe(true);
+    }
+  });
+
+  it("rejects a bigint that isn't a known tier", () => {
+    expect(isValidMonitorWindow(123n)).toBe(false);
+  });
+});
+
+describe("monitorWindowCadenceMs", () => {
+  it("returns 1 minute for sub-day windows", () => {
+    expect(monitorWindowCadenceMs(MonitorWindow.FIVE_MIN)).toBe(MINUTE_MS);
+    expect(monitorWindowCadenceMs(MonitorWindow.FOUR_HOUR)).toBe(MINUTE_MS);
+    expect(monitorWindowCadenceMs(DAY_MS - 1n)).toBe(MINUTE_MS);
+  });
+
+  it("returns 30 minutes for day-to-week windows", () => {
+    expect(monitorWindowCadenceMs(MonitorWindow.ONE_DAY)).toBe(30n * MINUTE_MS);
+    expect(monitorWindowCadenceMs(DAY_MS + 1n)).toBe(30n * MINUTE_MS);
+    expect(monitorWindowCadenceMs(MonitorWindow.TWO_DAY)).toBe(30n * MINUTE_MS);
+    expect(monitorWindowCadenceMs(WEEK_MS - 1n)).toBe(30n * MINUTE_MS);
+  });
+
+  it("returns 48 hours for week-and-up windows", () => {
+    expect(monitorWindowCadenceMs(MonitorWindow.ONE_WEEK)).toBe(48n * HOUR_MS);
+    expect(monitorWindowCadenceMs(WEEK_MS + 1n)).toBe(48n * HOUR_MS);
+  });
+});
+
+describe("MonitorRenotifySchema", () => {
+  it("accepts the OFF variant", () => {
+    expect(MonitorRenotifySchema.safeParse({ mode: "OFF" }).success).toBe(true);
+  });
+
+  it("accepts the EVERY variant with a valid interval", () => {
+    const result = MonitorRenotifySchema.safeParse({
+      mode: "EVERY",
+      intervalMinutes: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects EVERY without intervalMinutes", () => {
+    expect(MonitorRenotifySchema.safeParse({ mode: "EVERY" }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects intervalMinutes below 1", () => {
+    expect(
+      MonitorRenotifySchema.safeParse({ mode: "EVERY", intervalMinutes: 0 })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects intervalMinutes above one week", () => {
+    expect(
+      MonitorRenotifySchema.safeParse({
+        mode: "EVERY",
+        intervalMinutes: 60 * 24 * 7 + 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown discriminator", () => {
+    expect(
+      MonitorRenotifySchema.safeParse({
+        mode: "BOGUS",
+        intervalMinutes: 5,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("MonitorNoDataSchema", () => {
+  it("accepts the SILENT variant", () => {
+    expect(MonitorNoDataSchema.safeParse({ mode: "SILENT" }).success).toBe(
+      true,
+    );
+  });
+
+  it("accepts the NOTIFY variant with a valid interval", () => {
+    const result = MonitorNoDataSchema.safeParse({
+      mode: "NOTIFY",
+      intervalMinutes: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects NOTIFY without intervalMinutes", () => {
+    expect(MonitorNoDataSchema.safeParse({ mode: "NOTIFY" }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects intervalMinutes below 1", () => {
+    expect(
+      MonitorNoDataSchema.safeParse({ mode: "NOTIFY", intervalMinutes: 0 })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects intervalMinutes above one day", () => {
+    expect(
+      MonitorNoDataSchema.safeParse({
+        mode: "NOTIFY",
+        intervalMinutes: 60 * 24 + 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown discriminator", () => {
+    expect(
+      MonitorNoDataSchema.safeParse({
+        mode: "BOGUS",
+        intervalMinutes: 5,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("MonitorTemplateSchema", () => {
+  it("accepts the empty string", () => {
+    expect(MonitorTemplateSchema.safeParse("").success).toBe(true);
+  });
+
+  it("accepts a typical short template", () => {
+    expect(
+      MonitorTemplateSchema.safeParse("Alert: {{value}} crossed {{threshold}}")
+        .success,
+    ).toBe(true);
+  });
+
+  it("accepts exactly 4000 characters", () => {
+    expect(MonitorTemplateSchema.safeParse("x".repeat(4000)).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects a string longer than 4000 characters", () => {
+    expect(MonitorTemplateSchema.safeParse("x".repeat(4001)).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects non-string input", () => {
+    expect(MonitorTemplateSchema.safeParse(123).success).toBe(false);
+    expect(MonitorTemplateSchema.safeParse(null).success).toBe(false);
+  });
+});
+
+describe("validateWarningAlertOrdering", () => {
+  it.each(["GT", "GTE"] as const)("%s requires warning < alert", (op) => {
+    expect(
+      validateWarningAlertOrdering({
+        thresholdOperator: op,
+        alertThreshold: 100,
+        warningThreshold: 50,
+      }),
+    ).toBe(true);
+    expect(
+      validateWarningAlertOrdering({
+        thresholdOperator: op,
+        alertThreshold: 100,
+        warningThreshold: 100,
+      }),
+    ).toBe(false);
+  });
+
+  it.each(["LT", "LTE"] as const)("%s requires warning > alert", (op) => {
+    expect(
+      validateWarningAlertOrdering({
+        thresholdOperator: op,
+        alertThreshold: 100,
+        warningThreshold: 200,
+      }),
+    ).toBe(true);
+    expect(
+      validateWarningAlertOrdering({
+        thresholdOperator: op,
+        alertThreshold: 100,
+        warningThreshold: 100,
+      }),
+    ).toBe(false);
+  });
+
+  it.each(["EQ", "NEQ"] as const)(
+    "%s always passes regardless of ordering",
+    (op) => {
+      for (const warning of [50, 100, 200]) {
+        expect(
+          validateWarningAlertOrdering({
+            thresholdOperator: op,
+            alertThreshold: 100,
+            warningThreshold: warning,
+          }),
+        ).toBe(true);
+      }
+    },
+  );
+
+  it.each(["GT", "GTE", "LT", "LTE", "EQ", "NEQ"] as const)(
+    "%s passes with null warningThreshold",
+    (op) => {
+      expect(
+        validateWarningAlertOrdering({
+          thresholdOperator: op,
+          alertThreshold: 100,
+          warningThreshold: null,
+        }),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("MonitorSchema", () => {
+  it("parses a minimally valid Monitor", () => {
+    const result = MonitorSchema.safeParse(validMonitorBase);
+    expect(result.success).toBe(true);
+  });
+
+  describe("warning/alert threshold ordering refinement", () => {
+    it.each(["GT", "GTE"] as const)(
+      "%s rejects warningThreshold >= alertThreshold",
+      (op) => {
+        const result = MonitorSchema.safeParse({
+          ...validMonitorBase,
+          thresholdOperator: op,
+          alertThreshold: 100,
+          warningThreshold: 100, // equal → must reject
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues[0].path).toEqual(["warningThreshold"]);
+        }
+
+        const tooHigh = MonitorSchema.safeParse({
+          ...validMonitorBase,
+          thresholdOperator: op,
+          alertThreshold: 100,
+          warningThreshold: 200,
+        });
+        expect(tooHigh.success).toBe(false);
+      },
+    );
+
+    it.each(["GT", "GTE"] as const)(
+      "%s accepts warningThreshold < alertThreshold",
+      (op) => {
+        expect(
+          MonitorSchema.safeParse({
+            ...validMonitorBase,
+            thresholdOperator: op,
+            alertThreshold: 100,
+            warningThreshold: 50,
+          }).success,
+        ).toBe(true);
+      },
+    );
+
+    it.each(["LT", "LTE"] as const)(
+      "%s rejects warningThreshold <= alertThreshold",
+      (op) => {
+        const result = MonitorSchema.safeParse({
+          ...validMonitorBase,
+          thresholdOperator: op,
+          alertThreshold: 100,
+          warningThreshold: 100,
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues[0].path).toEqual(["warningThreshold"]);
+        }
+
+        const tooLow = MonitorSchema.safeParse({
+          ...validMonitorBase,
+          thresholdOperator: op,
+          alertThreshold: 100,
+          warningThreshold: 50,
+        });
+        expect(tooLow.success).toBe(false);
+      },
+    );
+
+    it.each(["LT", "LTE"] as const)(
+      "%s accepts warningThreshold > alertThreshold",
+      (op) => {
+        expect(
+          MonitorSchema.safeParse({
+            ...validMonitorBase,
+            thresholdOperator: op,
+            alertThreshold: 100,
+            warningThreshold: 200,
+          }).success,
+        ).toBe(true);
+      },
+    );
+
+    it.each(["EQ", "NEQ"] as const)(
+      "%s accepts any warningThreshold/alertThreshold ordering",
+      (op) => {
+        for (const warning of [50, 100, 200]) {
+          expect(
+            MonitorSchema.safeParse({
+              ...validMonitorBase,
+              thresholdOperator: op,
+              alertThreshold: 100,
+              warningThreshold: warning,
+            }).success,
+          ).toBe(true);
+        }
+      },
+    );
+
+    it.each(["GT", "GTE", "LT", "LTE", "EQ", "NEQ"] as const)(
+      "%s accepts a null warningThreshold regardless of alertThreshold",
+      (op) => {
+        expect(
+          MonitorSchema.safeParse({
+            ...validMonitorBase,
+            thresholdOperator: op,
+            alertThreshold: 100,
+            warningThreshold: null,
+          }).success,
+        ).toBe(true);
+      },
+    );
+  });
+});
+
+describe("MonitorQueueEventSchema", () => {
+  const validQueueEvent = {
+    projectId: "proj_01",
+    schedulerBatchId: 42n,
+    scheduledAt: new Date("2026-05-18T12:00:00.000Z"),
+    view: "OBSERVATIONS" as const,
+    filters: [],
+    window: MonitorWindow.FIVE_MIN,
+    monitors: [
+      {
+        monitorId: "mon_01",
+        metric: { measure: "count", aggregation: "count" as const },
+      },
+    ],
+  };
+
+  it("parses a representative queue event", () => {
+    const result = MonitorQueueEventSchema.safeParse(validQueueEvent);
+    expect(result.success).toBe(true);
+  });
+
+  it("coerces a string scheduledAt to a Date", () => {
+    const result = MonitorQueueEventSchema.safeParse({
+      ...validQueueEvent,
+      scheduledAt: "2026-05-18T12:00:00.000Z",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.scheduledAt).toBeInstanceOf(Date);
+  });
+
+  it("rejects a non-bigint schedulerBatchId", () => {
+    expect(
+      MonitorQueueEventSchema.safeParse({
+        ...validQueueEvent,
+        schedulerBatchId: 42,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a window outside the MonitorWindow tier set", () => {
+    expect(
+      MonitorQueueEventSchema.safeParse({
+        ...validQueueEvent,
+        window: 123n,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts an empty monitors array", () => {
+    // Scheduler may publish with zero monitors if everything in the batch was
+    // filtered out — schema should not block; downstream worker handles it.
+    expect(
+      MonitorQueueEventSchema.safeParse({ ...validQueueEvent, monitors: [] })
+        .success,
+    ).toBe(true);
+  });
+});
+
+describe("MonitorAlertSchema", () => {
+  const validAlert = {
+    monitorId: "mon_01",
+    projectId: "proj_01",
+    severity: "ALERT" as const,
+    permalink: "https://cloud.langfuse.com/project/proj_01/monitors/mon_01",
+    timestamp: new Date("2026-05-18T12:01:00.000Z"),
+    message: { title: "High error rate", body: "errors > 100" },
+    view: "OBSERVATIONS" as const,
+    filters: [],
+    window: MonitorWindow.FIVE_MIN,
+  };
+
+  it("parses a representative alert", () => {
+    expect(MonitorAlertSchema.safeParse(validAlert).success).toBe(true);
+  });
+
+  it("rejects a non-URL permalink", () => {
+    expect(
+      MonitorAlertSchema.safeParse({ ...validAlert, permalink: "not-a-url" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown severity", () => {
+    expect(
+      MonitorAlertSchema.safeParse({ ...validAlert, severity: "BOGUS" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects a window outside the MonitorWindow tier set", () => {
+    expect(
+      MonitorAlertSchema.safeParse({ ...validAlert, window: 123n }).success,
+    ).toBe(false);
+  });
+});
+
+describe("MonitorWebhookQueueEventSchema", () => {
+  const validEnvelope = {
+    type: "monitor-alert" as const,
+    version: "v1" as const,
+    payload: {
+      monitorId: "mon_01",
+      projectId: "proj_01",
+      severity: "ALERT" as const,
+      permalink: "https://cloud.langfuse.com/project/proj_01/monitors/mon_01",
+      timestamp: new Date("2026-05-18T12:01:00.000Z"),
+      message: { title: "High error rate", body: "errors > 100" },
+      view: "OBSERVATIONS" as const,
+      filters: [],
+      window: MonitorWindow.FIVE_MIN,
+    },
+  };
+
+  it("parses a valid envelope", () => {
+    expect(
+      MonitorWebhookQueueEventSchema.safeParse(validEnvelope).success,
+    ).toBe(true);
+  });
+
+  it("rejects a wrong type discriminator", () => {
+    expect(
+      MonitorWebhookQueueEventSchema.safeParse({
+        ...validEnvelope,
+        type: "prompt-version",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a wrong version literal", () => {
+    expect(
+      MonitorWebhookQueueEventSchema.safeParse({
+        ...validEnvelope,
+        version: "v2",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -419,13 +419,23 @@ describe("MonitorQueueEventSchema", () => {
     if (result.success) expect(result.data.scheduledAt).toBeInstanceOf(Date);
   });
 
-  it("rejects a non-bigint schedulerBatchId", () => {
-    expect(
-      MonitorQueueEventSchema.safeParse({
-        ...validQueueEvent,
-        schedulerBatchId: 42,
-      }).success,
-    ).toBe(false);
+  it("coerces a string schedulerBatchId to a bigint", () => {
+    const result = MonitorQueueEventSchema.safeParse({
+      ...validQueueEvent,
+      schedulerBatchId: "42",
+    });
+    expect(result.success).toBe(true);
+    if (result.success)
+      expect(typeof result.data.schedulerBatchId).toBe("bigint");
+  });
+
+  it("coerces a string window to a bigint", () => {
+    const result = MonitorQueueEventSchema.safeParse({
+      ...validQueueEvent,
+      window: MonitorWindow.FIVE_MIN.toString(),
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(typeof result.data.window).toBe("bigint");
   });
 
   it("rejects a window outside the MonitorWindow tier set", () => {
@@ -491,6 +501,15 @@ describe("MonitorAlertSchema", () => {
     });
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.timestamp).toBeInstanceOf(Date);
+  });
+
+  it("coerces a string window to a bigint", () => {
+    const result = MonitorAlertSchema.safeParse({
+      ...validAlert,
+      window: MonitorWindow.FIVE_MIN.toString(),
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(typeof result.data.window).toBe("bigint");
   });
 });
 

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -516,7 +516,7 @@ describe("MonitorAlertSchema", () => {
 describe("MonitorWebhookQueueEventSchema", () => {
   const validEnvelope = {
     type: "monitor-alert" as const,
-    version: "v1" as const,
+    apiVersion: "v1" as const,
     payload: {
       monitorId: "mon_01",
       projectId: "proj_01",
@@ -545,11 +545,11 @@ describe("MonitorWebhookQueueEventSchema", () => {
     ).toBe(false);
   });
 
-  it("rejects a wrong version literal", () => {
+  it("rejects a wrong apiVersion literal", () => {
     expect(
       MonitorWebhookQueueEventSchema.safeParse({
         ...validEnvelope,
-        version: "v2",
+        apiVersion: "v2",
       }).success,
     ).toBe(false);
   });

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -6,7 +6,6 @@ import {
   monitorWindowCadenceMs,
   MonitorRenotifySchema,
   MonitorNoDataSchema,
-  MonitorTemplateSchema,
   MonitorSchema,
   MonitorQueueEventSchema,
   MonitorAlertSchema,
@@ -194,36 +193,6 @@ describe("MonitorNoDataSchema", () => {
   });
 });
 
-describe("MonitorTemplateSchema", () => {
-  it("accepts the empty string", () => {
-    expect(MonitorTemplateSchema.safeParse("").success).toBe(true);
-  });
-
-  it("accepts a typical short template", () => {
-    expect(
-      MonitorTemplateSchema.safeParse("Alert: {{value}} crossed {{threshold}}")
-        .success,
-    ).toBe(true);
-  });
-
-  it("accepts exactly 4000 characters", () => {
-    expect(MonitorTemplateSchema.safeParse("x".repeat(4000)).success).toBe(
-      true,
-    );
-  });
-
-  it("rejects a string longer than 4000 characters", () => {
-    expect(MonitorTemplateSchema.safeParse("x".repeat(4001)).success).toBe(
-      false,
-    );
-  });
-
-  it("rejects non-string input", () => {
-    expect(MonitorTemplateSchema.safeParse(123).success).toBe(false);
-    expect(MonitorTemplateSchema.safeParse(null).success).toBe(false);
-  });
-});
-
 describe("validateWarningAlertOrdering", () => {
   it.each(["GT", "GTE"] as const)("%s requires warning < alert", (op) => {
     expect(
@@ -292,6 +261,22 @@ describe("MonitorSchema", () => {
   it("parses a minimally valid Monitor", () => {
     const result = MonitorSchema.safeParse(validMonitorBase);
     expect(result.success).toBe(true);
+  });
+
+  it("rejects a message longer than 2000 characters", () => {
+    const result = MonitorSchema.safeParse({
+      ...validMonitorBase,
+      message: "x".repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a message with an invalid handlebars template", () => {
+    const result = MonitorSchema.safeParse({
+      ...validMonitorBase,
+      message: "{{unknown}}",
+    });
+    expect(result.success).toBe(false);
   });
 
   describe("warning/alert threshold ordering refinement", () => {

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
 
+import { DAY, HOUR, MINUTE, WEEK } from "./internal";
 import {
   MonitorWindow,
   isValidMonitorWindow,
-  monitorWindowCadenceMs,
+  calculateMonitorWindowCadenceMillis,
   MonitorRenotifySchema,
   MonitorNoDataSchema,
   MonitorSchema,
@@ -48,12 +49,6 @@ const validMonitorBase = {
   alertedAt: null,
 };
 
-// Local readability aliases. The production module keeps these internal.
-const MINUTE_MS = 60_000n;
-const HOUR_MS = 60n * MINUTE_MS;
-const DAY_MS = 24n * HOUR_MS;
-const WEEK_MS = 7n * DAY_MS;
-
 describe("MonitorWindow tier map", () => {
   it("exposes the 10 RFC tiers with BigInt millisecond values", () => {
     expect(MonitorWindow.FIVE_MIN).toBe(5n * 60_000n);
@@ -81,23 +76,33 @@ describe("isValidMonitorWindow", () => {
   });
 });
 
-describe("monitorWindowCadenceMs", () => {
+describe("calculateMonitorWindowCadenceMillis", () => {
   it("returns 1 minute for sub-day windows", () => {
-    expect(monitorWindowCadenceMs(MonitorWindow.FIVE_MIN)).toBe(MINUTE_MS);
-    expect(monitorWindowCadenceMs(MonitorWindow.FOUR_HOUR)).toBe(MINUTE_MS);
-    expect(monitorWindowCadenceMs(DAY_MS - 1n)).toBe(MINUTE_MS);
+    expect(calculateMonitorWindowCadenceMillis(MonitorWindow.FIVE_MIN)).toBe(
+      MINUTE,
+    );
+    expect(calculateMonitorWindowCadenceMillis(MonitorWindow.FOUR_HOUR)).toBe(
+      MINUTE,
+    );
+    expect(calculateMonitorWindowCadenceMillis(DAY - 1n)).toBe(MINUTE);
   });
 
   it("returns 30 minutes for day-to-week windows", () => {
-    expect(monitorWindowCadenceMs(MonitorWindow.ONE_DAY)).toBe(30n * MINUTE_MS);
-    expect(monitorWindowCadenceMs(DAY_MS + 1n)).toBe(30n * MINUTE_MS);
-    expect(monitorWindowCadenceMs(MonitorWindow.TWO_DAY)).toBe(30n * MINUTE_MS);
-    expect(monitorWindowCadenceMs(WEEK_MS - 1n)).toBe(30n * MINUTE_MS);
+    expect(calculateMonitorWindowCadenceMillis(MonitorWindow.ONE_DAY)).toBe(
+      30n * MINUTE,
+    );
+    expect(calculateMonitorWindowCadenceMillis(DAY + 1n)).toBe(30n * MINUTE);
+    expect(calculateMonitorWindowCadenceMillis(MonitorWindow.TWO_DAY)).toBe(
+      30n * MINUTE,
+    );
+    expect(calculateMonitorWindowCadenceMillis(WEEK - 1n)).toBe(30n * MINUTE);
   });
 
   it("returns 48 hours for week-and-up windows", () => {
-    expect(monitorWindowCadenceMs(MonitorWindow.ONE_WEEK)).toBe(48n * HOUR_MS);
-    expect(monitorWindowCadenceMs(WEEK_MS + 1n)).toBe(48n * HOUR_MS);
+    expect(calculateMonitorWindowCadenceMillis(MonitorWindow.ONE_WEEK)).toBe(
+      48n * HOUR,
+    );
+    expect(calculateMonitorWindowCadenceMillis(WEEK + 1n)).toBe(48n * HOUR);
   });
 });
 
@@ -396,12 +401,8 @@ describe("MonitorQueueEventSchema", () => {
     view: "OBSERVATIONS" as const,
     filters: [],
     window: MonitorWindow.FIVE_MIN,
-    monitors: [
-      {
-        monitorId: "mon_01",
-        metric: { measure: "count", aggregation: "count" as const },
-      },
-    ],
+    metrics: [{ measure: "count", aggregation: "count" as const }],
+    monitors: [{ monitorId: "mon_01", metricName: "count_count" }],
   };
 
   it("parses a representative queue event", () => {

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -483,6 +483,15 @@ describe("MonitorAlertSchema", () => {
       MonitorAlertSchema.safeParse({ ...validAlert, window: 123n }).success,
     ).toBe(false);
   });
+
+  it("coerces a string timestamp to a Date", () => {
+    const result = MonitorAlertSchema.safeParse({
+      ...validAlert,
+      timestamp: "2026-05-18T12:01:00.000Z",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.timestamp).toBeInstanceOf(Date);
+  });
 });
 
 describe("MonitorWebhookQueueEventSchema", () => {

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { singleFilter } from "../../interfaces/filters";
 import { metric as MetricSchema } from "../query/types";
 import { DAY, HOUR, MINUTE, WEEK } from "./internal";
+import { validateMonitorTemplate } from "./template";
 
 /**
  * ErrorInvalidMonitorWindow is emitted when a `window`
@@ -23,6 +24,14 @@ export const ErrorInvalidMonitorWindow =
  */
 export const ErrorInvalidWarningAlertOrdering =
   "warningThreshold must be less severe than alertThreshold for ordered operators";
+
+/**
+ * ErrorInvalidMonitorTemplate is emitted when a message template references
+ * unknown variables, uses helpers, partials, decorators, sub-expressions, or
+ * unescaped `{{{x}}}` output, or fails to parse as Handlebars.
+ */
+export const ErrorInvalidMonitorTemplate =
+  "template is not formatted correctly";
 
 /**
  * MonitorWindow contains a the list of allowed Monitor evaluation windows.
@@ -94,10 +103,6 @@ export const MonitorNoDataSchema = z.discriminatedUnion("mode", [
 ]);
 export type MonitorNoData = z.infer<typeof MonitorNoDataSchema>;
 
-/** MonitorTemplateSchema is the Monitor message template source (Handlebars). Size-limited; AST validation layered elsewhere. */
-export const MonitorTemplateSchema = z.string().max(4000);
-export type MonitorTemplate = z.infer<typeof MonitorTemplateSchema>;
-
 /**
  * validateWarningAlertOrdering enforces that warning must cross before alert
  * for ordered operators; null warning and unordered operators (EQ/NEQ) always
@@ -155,8 +160,16 @@ export const MonitorSchema = z
     renotify: MonitorRenotifySchema.default({ mode: "OFF" }),
 
     // MonitorAlert Config
-    name: MonitorTemplateSchema.min(1).max(200),
-    message: MonitorTemplateSchema.default(""),
+    name: z
+      .string()
+      .min(1)
+      .max(200)
+      .refine(validateMonitorTemplate, ErrorInvalidMonitorTemplate),
+    message: z
+      .string()
+      .max(2000)
+      .refine(validateMonitorTemplate, ErrorInvalidMonitorTemplate)
+      .default(""),
     tags: z.array(z.string().max(60)).max(20).default([]),
 
     // Monitor State

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -198,7 +198,7 @@ export const MonitorSchema = z
 export const MonitorQueueEventSchema = z.object({
   projectId: z.string(),
   // Fingerprint of (projectId, view, filters, window)
-  schedulerBatchId: z.bigint(),
+  schedulerBatchId: z.coerce.bigint(),
 
   // Scheduler tick time
   scheduledAt: z.coerce.date(),
@@ -206,7 +206,9 @@ export const MonitorQueueEventSchema = z.object({
   // Shared query primitives — every monitor in this batch agrees on these.
   view: z.enum(MonitorView),
   filters: z.array(singleFilter),
-  window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
+  window: z.coerce
+    .bigint()
+    .refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
   metrics: z.array(MetricSchema),
 
   // Monitors map to metricNames returned by the above query params
@@ -230,7 +232,9 @@ export const MonitorAlertSchema = z.object({
   timestamp: z.coerce.date(),
   view: z.enum(MonitorView),
   filters: z.array(singleFilter),
-  window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
+  window: z.coerce
+    .bigint()
+    .refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
 });
 export type MonitorAlert = z.infer<typeof MonitorAlertSchema>;
 

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -1,4 +1,4 @@
-/** types.ts contains all entitiy models and logic */
+/** types.ts contains all entity models and logic */
 import {
   MonitorSeverity,
   MonitorStatus,
@@ -34,7 +34,7 @@ export const ErrorInvalidMonitorTemplate =
   "template is not formatted correctly";
 
 /**
- * MonitorWindow contains a the list of allowed Monitor evaluation windows.
+ * MonitorWindow contains the list of allowed Monitor evaluation windows.
  * Adding a tier requires updating `monitorWindowCadenceMs`.
  */
 export const MonitorWindow = {
@@ -217,7 +217,7 @@ export const MonitorQueueEventSchema = z.object({
 export type MonitorQueueEvent = z.infer<typeof MonitorQueueEventSchema>;
 
 /**
- * MonitorAlertSchema is emmitted when a monitor alerts.
+ * MonitorAlertSchema is emitted when a monitor alerts.
  * It carries the query shape (`view` / `filters` / `window`) alongside the
  * rendered message so that recipients can reconstruct the underlying observations / scores query.
  */
@@ -227,7 +227,7 @@ export const MonitorAlertSchema = z.object({
   permalink: z.url(),
   message: z.object({ title: z.string(), body: z.string() }),
   severity: z.enum(MonitorSeverity),
-  timestamp: z.date(),
+  timestamp: z.coerce.date(),
   view: z.enum(MonitorView),
   filters: z.array(singleFilter),
   window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -35,7 +35,7 @@ export const ErrorInvalidMonitorTemplate =
 
 /**
  * MonitorWindow contains the list of allowed Monitor evaluation windows.
- * Adding a tier requires updating `monitorWindowCadenceMs`.
+ * Adding a tier requires updating `calculateMonitorWindowCadenceMillis`.
  */
 export const MonitorWindow = {
   FIVE_MIN: 5n * MINUTE,
@@ -51,7 +51,7 @@ export const MonitorWindow = {
 } as const;
 
 /**
- * calculateMonitorWindowCadenceMs derives a Monitor's scheduler cadence from its evaluation window.
+ * calculateMonitorWindowCadenceMillis derives a Monitor's scheduler cadence from its evaluation window.
  */
 export function calculateMonitorWindowCadenceMillis(
   windowMillis: bigint,

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -1,0 +1,235 @@
+/** types.ts contains all entitiy models and logic */
+import {
+  MonitorSeverity,
+  MonitorStatus,
+  MonitorThresholdOperator,
+  MonitorView,
+} from "@prisma/client";
+import { z } from "zod";
+import { singleFilter } from "../../interfaces/filters";
+import { metric as MetricSchema } from "../query/types";
+import { DAY, HOUR, MINUTE, WEEK } from "./internal";
+
+/**
+ * ErrorInvalidMonitorWindow is emitted when a `window`
+ * value does not match any `MonitorWindow.*` tier.
+ */
+export const ErrorInvalidMonitorWindow =
+  "window must be one of the MonitorWindow.* tiers";
+
+/**
+ * ErrorInvalidWarningAlertOrdering is emitted when `warningThreshold` is more severe
+ * than `alertThreshold` for a given `thresholdOperator`.
+ */
+export const ErrorInvalidWarningAlertOrdering =
+  "warningThreshold must be less severe than alertThreshold for ordered operators";
+
+/**
+ * MonitorWindow contains a the list of allowed Monitor evaluation windows.
+ * Adding a tier requires updating `monitorWindowCadenceMs`.
+ */
+export const MonitorWindow = {
+  FIVE_MIN: 5n * MINUTE,
+  TEN_MIN: 10n * MINUTE,
+  FIFTEEN_MIN: 15n * MINUTE,
+  THIRTY_MIN: 30n * MINUTE,
+  ONE_HOUR: HOUR,
+  TWO_HOUR: 2n * HOUR,
+  FOUR_HOUR: 4n * HOUR,
+  ONE_DAY: DAY,
+  TWO_DAY: 2n * DAY,
+  ONE_WEEK: WEEK,
+} as const;
+
+/**
+ * calculateMonitorWindowCadenceMs derives a Monitor's scheduler cadence from its evaluation window.
+ */
+export function calculateMonitorWindowCadenceMillis(
+  windowMillis: bigint,
+): bigint {
+  if (windowMillis >= WEEK) return 48n * HOUR;
+  if (windowMillis >= DAY) return 30n * MINUTE;
+  return MINUTE; // default cadence
+}
+
+/**
+ * isValidMonitorWindow returns true when `v` matches one of the `MonitorWindow.*` tiers.
+ */
+export const isValidMonitorWindow = (v: bigint): boolean =>
+  (Object.values(MonitorWindow) as bigint[]).includes(v);
+
+/**
+ * MonitorRenotifySchema describes renotify behavior for a sustained severity.
+ * `OFF` is edge-only; `EVERY` re-emits every `intervalMinutes` while the
+ * severity persists.
+ */
+export const MonitorRenotifySchema = z.discriminatedUnion("mode", [
+  z.object({ mode: z.literal("OFF") }),
+  z.object({
+    mode: z.literal("EVERY"),
+    intervalMinutes: z
+      .number()
+      .int()
+      .min(1)
+      .max(60 * 24 * 7),
+  }),
+]);
+export type MonitorRenotify = z.infer<typeof MonitorRenotifySchema>;
+
+/**
+ * MonitorNoDataSchema describes behavior when a Monitor query returns no rows.
+ * `SILENT` only alerts on recovery; `NOTIFY` also alerts after
+ * `intervalMinutes` of sustained NO_DATA.
+ */
+export const MonitorNoDataSchema = z.discriminatedUnion("mode", [
+  z.object({ mode: z.literal("SILENT") }),
+  z.object({
+    mode: z.literal("NOTIFY"),
+    intervalMinutes: z
+      .number()
+      .int()
+      .min(1)
+      .max(60 * 24),
+  }),
+]);
+export type MonitorNoData = z.infer<typeof MonitorNoDataSchema>;
+
+/** MonitorTemplateSchema is the Monitor message template source (Handlebars). Size-limited; AST validation layered elsewhere. */
+export const MonitorTemplateSchema = z.string().max(4000);
+export type MonitorTemplate = z.infer<typeof MonitorTemplateSchema>;
+
+/**
+ * validateWarningAlertOrdering enforces that warning must cross before alert
+ * for ordered operators; null warning and unordered operators (EQ/NEQ) always
+ * pass.
+ */
+export function validateWarningAlertOrdering(monitor: {
+  thresholdOperator: MonitorThresholdOperator;
+  alertThreshold: number;
+  warningThreshold: number | null;
+}): boolean {
+  if (monitor.warningThreshold == null) return true;
+  switch (monitor.thresholdOperator) {
+    case "GT":
+    case "GTE":
+      return monitor.warningThreshold < monitor.alertThreshold;
+    case "LT":
+    case "LTE":
+      return monitor.warningThreshold > monitor.alertThreshold;
+    case "EQ":
+    case "NEQ":
+      return true;
+  }
+}
+
+/**
+ * MonitorSchema is the canonical Monitor object. Mirrors the Prisma `Monitor`
+ * row.
+ *
+ * `cadenceMs` is derived from `window` on write and intentionally not
+ * exposed here.
+ *
+ * The Prisma column `windowMs` maps to this schema's `window`
+ * at the service boundary.
+ */
+export const MonitorSchema = z
+  .object({
+    id: z.string(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+    createdBy: z.string().nullable(),
+    updatedBy: z.string().nullable(),
+    projectId: z.string(),
+
+    // Query Config
+    view: z.enum(MonitorView),
+    filters: z.array(singleFilter),
+    metric: MetricSchema,
+
+    // Monitor Config
+    window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
+    thresholdOperator: z.enum(MonitorThresholdOperator),
+    alertThreshold: z.number(),
+    warningThreshold: z.number().nullable(),
+    noData: MonitorNoDataSchema.default({ mode: "SILENT" }),
+    renotify: MonitorRenotifySchema.default({ mode: "OFF" }),
+
+    // MonitorAlert Config
+    name: MonitorTemplateSchema.min(1).max(200),
+    message: MonitorTemplateSchema.default(""),
+    tags: z.array(z.string().max(60)).max(20).default([]),
+
+    // Monitor State
+    severity: z.enum(MonitorSeverity).default("UNKNOWN"),
+    severityChangedAt: z.date().nullable(),
+    alertedAt: z.date().nullable(),
+
+    // MonitorScheduler State
+    status: z.enum(MonitorStatus).default("ACTIVE"),
+    nextRunAt: z.date(),
+    lastPublishedRunAt: z.date().nullable(),
+    lastCompletedRunAt: z.date().nullable(),
+  })
+  .refine(validateWarningAlertOrdering, {
+    message: ErrorInvalidWarningAlertOrdering,
+    path: ["warningThreshold"],
+  });
+
+/**
+ * MonitorQueueEventSchema represents a batch of monitors that can be evaluated
+ * together using the same set of parameters.
+ *
+ * All monitors in `monitors[]` share `view` / `filters` /
+ * `window`, so the worker runs one ClickHouse query for the whole batch.
+ */
+export const MonitorQueueEventSchema = z.object({
+  projectId: z.string(),
+  // Fingerprint of (projectId, view, filters, window)
+  schedulerBatchId: z.bigint(),
+
+  // Scheduler tick time
+  scheduledAt: z.coerce.date(),
+
+  // Shared query primitives — every monitor in this batch agrees on these.
+  view: z.enum(MonitorView),
+  filters: z.array(singleFilter),
+  window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
+  metrics: z.array(MetricSchema),
+
+  // Monitors map to metricNames returned by the above query params
+  monitors: z.array(
+    z.object({ monitorId: z.string(), metricName: z.string() }),
+  ),
+});
+export type MonitorQueueEvent = z.infer<typeof MonitorQueueEventSchema>;
+
+/**
+ * MonitorAlertSchema is emmitted when a monitor alerts.
+ * It carries the query shape (`view` / `filters` / `window`) alongside the
+ * rendered message so that recipients can reconstruct the underlying observations / scores query.
+ */
+export const MonitorAlertSchema = z.object({
+  monitorId: z.string(),
+  projectId: z.string(),
+  permalink: z.url(),
+  message: z.object({ title: z.string(), body: z.string() }),
+  severity: z.enum(MonitorSeverity),
+  timestamp: z.date(),
+  view: z.enum(MonitorView),
+  filters: z.array(singleFilter),
+  window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
+});
+export type MonitorAlert = z.infer<typeof MonitorAlertSchema>;
+
+/**
+ * MonitorWebhookQueueEventSchema is the transport envelope wrapping
+ * `MonitorAlertSchema` for the `WebhookQueue`.
+ */
+export const MonitorWebhookQueueEventSchema = z.object({
+  type: z.literal("monitor-alert"),
+  version: z.literal("v1"),
+  payload: MonitorAlertSchema,
+});
+export type MonitorWebhookQueueEvent = z.infer<
+  typeof MonitorWebhookQueueEventSchema
+>;

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -244,7 +244,7 @@ export type MonitorAlert = z.infer<typeof MonitorAlertSchema>;
  */
 export const MonitorWebhookQueueEventSchema = z.object({
   type: z.literal("monitor-alert"),
-  version: z.literal("v1"),
+  apiVersion: z.literal("v1"),
   payload: MonitorAlertSchema,
 });
 export type MonitorWebhookQueueEvent = z.infer<

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -104,3 +104,6 @@ export * from "./features/analytics-integrations";
 export * from "./features/query/types";
 export * from "./features/query/dataModel";
 export * from "./features/query/validateQuery";
+
+// monitor (Monitor schemas, queue contracts, template validator)
+export * from "./features/monitor";

--- a/packages/shared/src/server/queues.test.ts
+++ b/packages/shared/src/server/queues.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+
+import { MonitorWindow } from "../features/monitor";
+import { WebhookOutboundEnvelopeSchema } from "./queues";
+
+describe("WebhookOutboundEnvelopeSchema", () => {
+  const validPromptEnvelope = {
+    type: "prompt-version" as const,
+    action: "created" as const,
+    prompt: {
+      id: "p_01",
+      name: "faq-bot",
+      version: 1,
+      createdAt: new Date("2026-05-18T00:00:00.000Z"),
+      updatedAt: new Date("2026-05-18T00:00:00.000Z"),
+      createdBy: "u_01",
+      isActive: true,
+      tags: [],
+      labels: [],
+      prompt: null,
+      config: null,
+      projectId: "proj_01",
+      commitMessage: null,
+    },
+  };
+
+  const validMonitorEnvelope = {
+    type: "monitor-alert" as const,
+    version: "v1" as const,
+    payload: {
+      monitorId: "mon_01",
+      projectId: "proj_01",
+      severity: "ALERT" as const,
+      permalink: "https://cloud.langfuse.com/project/proj_01/monitors/mon_01",
+      timestamp: new Date("2026-05-18T12:01:00.000Z"),
+      message: { title: "High error rate", body: "errors > 100" },
+      view: "OBSERVATIONS" as const,
+      filters: [],
+      window: MonitorWindow.FIVE_MIN,
+    },
+  };
+
+  it("parses a valid prompt-version envelope", () => {
+    const parsed = WebhookOutboundEnvelopeSchema.safeParse(validPromptEnvelope);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.type).toBe("prompt-version");
+    }
+  });
+
+  it("parses a valid monitor-alert envelope", () => {
+    const parsed =
+      WebhookOutboundEnvelopeSchema.safeParse(validMonitorEnvelope);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.type).toBe("monitor-alert");
+    }
+  });
+
+  it("rejects an envelope with an unknown type", () => {
+    expect(
+      WebhookOutboundEnvelopeSchema.safeParse({
+        ...validPromptEnvelope,
+        type: "bogus",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/server/queues.test.ts
+++ b/packages/shared/src/server/queues.test.ts
@@ -26,7 +26,7 @@ describe("WebhookOutboundEnvelopeSchema", () => {
 
   const validMonitorEnvelope = {
     type: "monitor-alert" as const,
-    version: "v1" as const,
+    apiVersion: "v1" as const,
     payload: {
       monitorId: "mon_01",
       projectId: "proj_01",

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -8,6 +8,7 @@ import {
 import { BatchTableNames } from "../interfaces/tableNames";
 import { EventActionSchema } from "../domain";
 import { PromptDomainSchema } from "../domain/prompts";
+import { MonitorWebhookQueueEventSchema } from "../features/monitor";
 import { ObservationAddToDatasetConfigSchema } from "../features/batchAction/addToDatasetTypes";
 import { EvalTargetObjectSchema } from "../features/evals/types";
 
@@ -230,10 +231,10 @@ export const NotificationEventSchema = z.discriminatedUnion("type", [
   // Future notification types can be added here
 ]);
 
-export const WebhookOutboundEnvelopeSchema = z.object({
+export const PromptVersionWebhookEnvelopeSchema = z.object({
+  type: z.literal("prompt-version"),
   prompt: PromptDomainSchema,
   action: EventActionSchema,
-  type: z.literal("prompt-version"),
   user: z
     .object({
       id: z.string(),
@@ -242,6 +243,11 @@ export const WebhookOutboundEnvelopeSchema = z.object({
     })
     .optional(),
 });
+
+export const WebhookOutboundEnvelopeSchema = z.discriminatedUnion("type", [
+  PromptVersionWebhookEnvelopeSchema,
+  MonitorWebhookQueueEventSchema,
+]);
 
 export const WebhookInputSchema = z.object({
   projectId: z.string(),

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    dir: "./src",
+    include: ["**/*.test.ts"],
+    pool: "forks",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.2
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(msw@2.6.5(@types/node@24.3.0)(typescript@5.9.2))(vite@7.0.5(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.20.5)(yaml@2.8.4))
 
   web:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       exponential-backoff:
         specifier: ^3.1.2
         version: 3.1.2
+      handlebars:
+        specifier: ^4.7.9
+        version: 4.7.9
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
@@ -7365,6 +7368,11 @@ packages:
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -10185,6 +10193,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -10598,6 +10611,9 @@ packages:
   winston@3.15.0:
     resolution: {integrity: sha512-RhruH2Cj0bV0WgNL+lOfoUBI4DVfdUNjVnJGVovWZmrcKtrFTTRzgXYK2O9cymSGjrERCtaAeHwMNnUWXlwZow==}
     engines: {node: '>= 12.0.0'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -18148,6 +18164,15 @@ snapshots:
 
   hachure-fill@0.5.2: {}
 
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -21433,6 +21458,9 @@ snapshots:
 
   typescript@5.9.2: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -21885,6 +21913,8 @@ snapshots:
       stack-trace: 0.0.10
       triple-beam: 1.4.1
       winston-transport: 4.7.1
+
+  wordwrap@1.0.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/worker/src/features/slack/slackMessageBuilder.ts
+++ b/worker/src/features/slack/slackMessageBuilder.ts
@@ -18,7 +18,9 @@ export class SlackMessageBuilder {
   /**
    * Build Block Kit message for prompt version events
    */
-  static buildPromptVersionMessage(payload: WebhookInput["payload"]): any[] {
+  static buildPromptVersionMessage(
+    payload: Extract<WebhookInput["payload"], { type: "prompt-version" }>,
+  ): any[] {
     const { action, prompt } = payload;
 
     // Determine action emoji and color
@@ -110,12 +112,14 @@ export class SlackMessageBuilder {
    * Build a simple fallback message for unsupported event types
    */
   static buildFallbackMessage(payload: WebhookInput["payload"]): any[] {
+    const detail =
+      payload.type === "prompt-version" ? payload.action : "notification";
     return [
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `*Langfuse Notification*\n${payload.type} event: *${payload.action}*`,
+          text: `*Langfuse Notification*\n${payload.type} event: *${detail}*`,
         },
       },
     ];

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -362,6 +362,12 @@ async function executeWebhookAction({
     );
   }
 
+  if (input.payload.type !== "prompt-version") {
+    throw new InternalServerError(
+      `Unsupported webhook payload type ${input.payload.type}`,
+    );
+  }
+
   const webhookConfig = actionConfig.config;
   const webhookUser = input.payload.user
     ? {
@@ -470,6 +476,12 @@ async function executeGitHubDispatchAction({
   if (!isGitHubDispatchAction(actionConfig)) {
     throw new InternalServerError(
       "Action config is not a valid GitHub dispatch configuration",
+    );
+  }
+
+  if (input.payload.type !== "prompt-version") {
+    throw new InternalServerError(
+      `Unsupported webhook payload type ${input.payload.type}`,
     );
   }
 

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -591,6 +591,12 @@ async function executeSlackAction({
       );
     }
 
+    if (input.payload.type !== "prompt-version") {
+      throw new InternalServerError(
+        `Unsupported webhook payload type ${input.payload.type}`,
+      );
+    }
+
     const slackConfig = actionConfig.config;
 
     // Build message blocks using predefined formats or custom template


### PR DESCRIPTION
## Summary
`Trigger`, `AvailableWebhookApi`, and `WebhookOutboundEnvelope` only knew about prompt-version events, so [Monitor alerts](https://linear.app/langfuse/document/rfc-monitoring-and-alerting-653cc4349c29) could not ride the existing webhook pipeline without every consumer special-casing the event source.

To achieve this we:
- Added `Monitor` to `TriggerEventSource` and introduced `TriggerInputSchema` as a `discriminatedUnion("eventSource")` so each source can declare its own filter column set.
- Added `"monitor": "v1"` to `AvailableWebhookApiSchema` (switched to `z.partialRecord` so one webhook config carries only its source's apiVersion).
- Promoted `WebhookOutboundEnvelopeSchema` to a `discriminatedUnion("type")` of `prompt-version` and `monitor-alert` variants, and added `MonitorAlertWebhookOutboundSchema` for the outbound JSON payload.
- Narrowed the worker webhook/GitHub-dispatch executors and `SlackMessageBuilder` to gate prompt-only fields on `payload.type === "prompt-version"`, leaving the existing flow regression-free.

**Note**: `WebhookOutboundSchema` (the unifying `safeParse` for both types) and the actual `monitor-alert` dispatch + Slack builder are deferred to [LFE-9816](https://linear.app/langfuse/issue/LFE-9816). Per-eventSource filter-column tightening inside `TriggerInputSchema` is deferred to [LFE-9820](https://linear.app/langfuse/issue/LFE-9820).

Fixes [LFE-9809](https://linear.app/langfuse/issue/LFE-9809/add-monitor-event-source-to-triggers-and-webhook-envelope)

## Verification

- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter worker run lint`
- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter @langfuse/shared run test src/domain/automations.test.ts src/domain/webhooks.test.ts src/server/queues.test.ts` (16/16)
- [x] `pnpm --filter worker run test src/__tests__/webhooks.test.ts` (16/16)
- [x] `pnpm --filter worker run test src/__tests__/slack-processor.test.ts` (6/6)

## Test plan

- [ ] Existing prompt-version automations continue to dispatch via webhook, GitHub Dispatch, and Slack actions unchanged.
- [ ] A `WebhookOutboundEnvelopeSchema.safeParse` against either a `prompt-version` or `monitor-alert` payload round-trips.
- [ ] `automation_action.config.apiVersion = { monitor: "v1" }` records validate against `AvailableWebhookApiSchema`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the automations/webhook pipeline to be aware of `monitor-alert` as a first-class event source alongside the existing `prompt-version` events, laying the schema groundwork for the upcoming monitor-alert dispatch work (LFE-9816).

- **Schema changes**: `TriggerEventSource` gains a `Monitor` variant; `TriggerInputSchema` becomes a `discriminatedUnion`; `AvailableWebhookApiSchema` switches to `z.partialRecord`; `WebhookOutboundEnvelopeSchema` becomes a `discriminatedUnion` of `PromptVersionWebhookEnvelopeSchema` and `MonitorWebhookQueueEventSchema`; and `MonitorAlertWebhookOutboundSchema` is introduced for the future HTTP payload shape.
- **Worker guards**: `executeWebhookAction` and `executeGitHubDispatchAction` now throw `InternalServerError` for non-`prompt-version` payloads, keeping existing flows regression-free while deferring actual monitor-alert dispatch to LFE-9816.
- **Slack builder**: `buildPromptVersionMessage` is narrowed to only accept `prompt-version` payloads; `buildFallbackMessage` correctly branches on the type discriminant before accessing action-specific fields.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The existing prompt-version automation path is unchanged and properly guarded. The new monitor-alert schema definitions are safe to merge for schema registration, but MonitorAlertWebhookOutboundSchema embeds a bigint field that will cause JSON serialization failures when the actual dispatch is implemented in LFE-9816.

All changed code paths for prompt-version remain correct and the new type guards prevent monitor-alert events from reaching any HTTP dispatch logic. The concern is in packages/shared/src/domain/webhooks.ts: MonitorAlertWebhookOutboundSchema embeds MonitorAlertSchema whose window field is a bigint. Since JSON.stringify(bigint) throws, any executor using this schema to build a real HTTP body will fail immediately — the tests don't catch this because they only call safeParse, not JSON.stringify.

packages/shared/src/domain/webhooks.ts — the MonitorAlertWebhookOutboundSchema payload type needs the window field coerced to a serializable type before LFE-9816 builds on it.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Q[WebhookQueue Job]
    Q --> P{payload.type?}
    P -- prompt-version --> WH[executeWebhookAction]
    P -- monitor-alert --> WH2[executeWebhookAction]
    P -- prompt-version --> GH[executeGitHubDispatchAction]
    P -- monitor-alert --> GH2[executeGitHubDispatchAction]
    P -- prompt-version --> SL[executeSlackAction]
    P -- monitor-alert --> SL2[executeSlackAction]
    WH --> CHK1{type check}
    CHK1 -- prompt-version --> BUILD1[PromptWebhookOutboundSchema validate + sign + POST]
    CHK1 -- monitor-alert --> ERR1[throw InternalServerError blocked until LFE-9816]
    WH2 --> CHK1
    GH --> CHK2{type check}
    CHK2 -- prompt-version --> BUILD2[GitHubDispatch payload validate + sign + POST]
    CHK2 -- monitor-alert --> ERR2[throw InternalServerError blocked until LFE-9816]
    SL --> BUILD3[SlackMessageBuilder.buildMessage]
    SL2 --> BUILD3
    BUILD3 -- prompt-version --> MSG1[buildPromptVersionMessage full message]
    BUILD3 -- monitor-alert --> MSG2[buildFallbackMessage generic notification deferred to LFE-9816]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/src/domain/webhooks.ts:52-63
**`bigint` field makes the outbound schema non-JSON-serializable**

`MonitorAlertWebhookOutboundSchema` embeds `MonitorAlertSchema`, which carries `window: z.bigint()`. Any executor that validates an outbound payload with this schema and then calls `JSON.stringify` on the result will throw `TypeError: Do not know how to serialize a BigInt` — the same `JSON.stringify` call used by the existing `executeWebhookAction` / `executeGitHubDispatchAction`. The tests only exercise `safeParse`, so this failure won't surface until LFE-9816 attempts actual dispatch. The `window` field should be coerced to a number or string at the outbound boundary (e.g. `z.bigint().transform(v => v.toString())`) so the schema is serializable from day one.

### Issue 2 of 3
packages/shared/src/server/queues.ts:244-250
**`version` vs `apiVersion` field naming inconsistency**

`MonitorWebhookQueueEventSchema` (the queue envelope) uses `version: "v1"`, but `MonitorAlertWebhookOutboundSchema` (the HTTP payload) uses `apiVersion: "v1"`. When LFE-9816 maps the queue event to the outbound payload, the executor will need to translate between these two field names — a silent mismatch that won't be caught by TypeScript since both are `z.literal("v1")`. Aligning the names (or adding a comment that explicitly documents the intentional difference) reduces the chance of a dropped or wrong-named field in the next PR.

### Issue 3 of 3
worker/src/queues/webhooks.ts:365-369
**`executeSlackAction` silently processes `monitor-alert` events while WEBHOOK and GITHUB_DISPATCH throw**

`executeWebhookAction` and `executeGitHubDispatchAction` both now throw `InternalServerError` for non-`prompt-version` payloads, but `executeSlackAction` has no equivalent guard. A `monitor-alert` payload routed to the Slack action will reach `SlackMessageBuilder.buildMessage`, fall through to `buildFallbackMessage`, and successfully send a bare `"monitor-alert event: *notification*"` Slack message — rather than failing visibly. If this asymmetry is deliberate (Slack deferred to LFE-9816), a brief comment here would clarify the intent and prevent a future reviewer from adding the guard in a conflicting way.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(automations): add Monitor event sou..."](https://github.com/langfuse/langfuse/commit/4dfbdf5d076dd06d2f915fd10123c437d1de65d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32808415)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->