### PR TITLE
fix(v2/observations): strict schema, add usagePricingTierId, fix model field name

### DIFF
--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -330,7 +330,8 @@ types:
         docs: The time to first token in seconds
 
       # Enrichment fields (always present on v2 responses; null when model group not requested).
-      # Prices are decimal strings (e.g. "0.0001") for backward compatibility — see
+      # Prices are decimal strings (e.g. "0.0001") for backward compatibility — changing to
+      # number would break Go/Java/C# callers who built typed structs against the original wire format.
       modelId:
         type: nullable<string>
         docs: The matched model ID. Null when the `model` field group is not requested.

--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -278,11 +278,14 @@ types:
         docs: Additional metadata of the observation
 
       # Model fields (field group: model)
-      # Note: the wire-format key is "model" (maps from provided_model_name); "providedModelName"
-      # is the human-readable alias used in documentation.
+      # Both keys are present for backward compatibility. "model" has always been the wire-format
+      # key; "providedModelName" was declared in the spec from day one. v3 will consolidate.
       model:
         type: optional<nullable<string>>
-        docs: The model name as provided by the user (wire key is "model", not "providedModelName")
+        docs: The provided model name. Identical to providedModelName; both keys are present for backward compatibility.
+      providedModelName:
+        type: optional<nullable<string>>
+        docs: The provided model name. Identical to model; both keys are present for backward compatibility.
       internalModelId:
         type: optional<nullable<string>>
         docs: The internal model ID matched by Langfuse
@@ -327,7 +330,7 @@ types:
         docs: The time to first token in seconds
 
       # Enrichment fields (always present on v2 responses; null when model group not requested).
-      # Prices are decimal strings (e.g. "0.0001") for backward compatibility — see LFE-9859.
+      # Prices are decimal strings (e.g. "0.0001") for backward compatibility — see
       modelId:
         type: nullable<string>
         docs: The matched model ID. Null when the `model` field group is not requested.

--- a/fern/apis/server/definition/commons.yml
+++ b/fern/apis/server/definition/commons.yml
@@ -278,9 +278,11 @@ types:
         docs: Additional metadata of the observation
 
       # Model fields (field group: model)
-      providedModelName:
+      # Note: the wire-format key is "model" (maps from provided_model_name); "providedModelName"
+      # is the human-readable alias used in documentation.
+      model:
         type: optional<nullable<string>>
-        docs: The model name as provided by the user
+        docs: The model name as provided by the user (wire key is "model", not "providedModelName")
       internalModelId:
         type: optional<nullable<string>>
         docs: The internal model ID matched by Langfuse
@@ -298,6 +300,9 @@ types:
       totalCost:
         type: optional<nullable<double>>
         docs: The total cost of the observation in USD
+      usagePricingTierId:
+        type: optional<nullable<string>>
+        docs: The ID of the pricing tier applied to this observation's usage costs
       usagePricingTierName:
         type: optional<nullable<string>>
         docs: The name of the pricing tier applied to this observation's usage costs
@@ -321,10 +326,20 @@ types:
         type: optional<nullable<double>>
         docs: The time to first token in seconds
 
-      # Enrichment fields (added by server-side enrichment)
+      # Enrichment fields (always present on v2 responses; null when model group not requested).
+      # Prices are decimal strings (e.g. "0.0001") for backward compatibility — see LFE-9859.
       modelId:
-        type: optional<nullable<string>>
-        docs: The matched model ID
+        type: nullable<string>
+        docs: The matched model ID. Null when the `model` field group is not requested.
+      inputPrice:
+        type: nullable<string>
+        docs: The input token price (USD per unit) from the matched model, serialized as a decimal string (e.g. "0.0001"). Null when the `model` field group is not requested.
+      outputPrice:
+        type: nullable<string>
+        docs: The output token price (USD per unit) from the matched model, serialized as a decimal string (e.g. "0.0001"). Null when the `model` field group is not requested.
+      totalPrice:
+        type: nullable<string>
+        docs: The total token price (USD per unit) from the matched model, serialized as a decimal string (e.g. "0.0001"). Null when the `model` field group is not requested.
 
       # Trace context fields (field group: trace_context)
       traceName:

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -21,8 +21,8 @@ service:
         - `time` - completionStartTime, createdAt, updatedAt
         - `io` - input, output
         - `metadata` - metadata (truncated to 200 chars by default, use `expandMetadata` to get full values)
-        - `model` - providedModelName, internalModelId, modelParameters
-        - `usage` - usageDetails, costDetails, totalCost, usagePricingTierName
+        - `model` - model, providedModelName (alias for backward compat), internalModelId, modelParameters
+        - `usage` - usageDetails, costDetails, totalCost, usagePricingTierId, usagePricingTierName
         - `prompt` - promptId, promptName, promptVersion
         - `metrics` - latency, timeToFirstToken
         - `trace_context` - tags, release, traceName

--- a/packages/shared/src/domain/observation-field-groups.ts
+++ b/packages/shared/src/domain/observation-field-groups.ts
@@ -22,8 +22,8 @@ export const OBSERVATION_FIELD_GROUPS_PUBLIC_API = [
   "time", // completionStartTime, createdAt, updatedAt
   "io", // input, output
   "metadata", // metadata
-  "model", // providedModelName, internalModelId, modelParameters
-  "usage", // usageDetails, costDetails, totalCost, usagePricingTierName
+  "model", // model + providedModelName (both present), internalModelId, modelParameters
+  "usage", // usageDetails, costDetails, totalCost, usagePricingTierId, usagePricingTierName
   "prompt", // promptId, promptName, promptVersion
   "metrics", // latency, timeToFirstToken
   "trace_context", // tags, release, traceName (denormalized trace metadata)

--- a/packages/shared/src/server/queries/createGenerationsQuery.ts
+++ b/packages/shared/src/server/queries/createGenerationsQuery.ts
@@ -36,8 +36,9 @@ export type FullEventsObservation = AdditionalObservationFields &
 export type FullEventsObservations = Array<FullEventsObservation>;
 
 // Public API version of EventsObservation, some fields are omitted because
-// V2 allows clients to specify fields
+// V2 allows clients to specify fields.
+// modelId is always added by enrichObservationsWithModelData (null when model group not requested).
 export type EventsObservationPublic = Partial<
   EventsObservation & ObservationPriceFields
 > &
-  ObservationCoreFields;
+  ObservationCoreFields & { modelId: string | null };

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -613,9 +613,12 @@ describe("/api/public/v2/observations API Endpoint", () => {
       "output",
       // metadata
       "metadata",
-      // model — note: the API response uses "model" for the provided model name,
-      // not "providedModelName" (the domain type maps provided_model_name → model)
+      // model group exposes both keys for backward compat:
+      // - "model" has always been the wire-format key
+      // - "providedModelName" was declared in the published spec from day one
+      // v3 will consolidate. See LFE-9859.
       "model",
+      "providedModelName",
       "internalModelId",
       "modelParameters",
       // usage
@@ -697,6 +700,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
       userId: "test-user",
       sessionId: "test-session",
       model: "gpt-4",
+      providedModelName: "gpt-4",
       modelParameters: { temperature: 0.5 },
       promptName: "contract-prompt",
       promptVersion: 2,
@@ -724,8 +728,12 @@ describe("/api/public/v2/observations API Endpoint", () => {
       time: ["completionStartTime", "createdAt", "updatedAt"],
       io: ["input", "output"],
       metadata: ["metadata"],
-      // "model" is the API response key for provided_model_name (see domain type)
-      model: ["model", "internalModelId", "modelParameters"],
+      model: [
+        "model",
+        "providedModelName",
+        "internalModelId",
+        "modelParameters",
+      ],
       usage: [
         "usageDetails",
         "costDetails",

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -622,6 +622,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
       "usageDetails",
       "costDetails",
       "totalCost",
+      "usagePricingTierId",
       "usagePricingTierName",
       // prompt
       "promptId",
@@ -665,6 +666,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
         model_parameters: '{"temperature":0.5}',
         usage_details: { input: 10, output: 20, total: 30 },
         cost_details: { input: 0.01, output: 0.02, total: 0.03 },
+        usage_pricing_tier_id: "tier-id-9859",
         usage_pricing_tier_name: "contract-tier",
         prompt_id: randomUUID(),
         prompt_name: "contract-prompt",
@@ -703,6 +705,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
       traceName: "contract-trace",
       tags: ["tag-a", "tag-b"],
       release: "1.2.3",
+      usagePricingTierId: "tier-id-9859",
       usagePricingTierName: "contract-tier",
     };
 
@@ -727,6 +730,7 @@ describe("/api/public/v2/observations API Endpoint", () => {
         "usageDetails",
         "costDetails",
         "totalCost",
+        "usagePricingTierId",
         "usagePricingTierName",
       ],
       prompt: ["promptId", "promptName", "promptVersion"],
@@ -736,6 +740,46 @@ describe("/api/public/v2/observations API Endpoint", () => {
       metrics: ["latency", "timeToFirstToken"],
       trace_context: ["traceName", "tags", "release"],
     };
+
+    it("enrichment fields always present; internal derived fields absent; prices are strings", async () => {
+      // Requests all groups. Validates:
+      // 1. modelId/inputPrice/outputPrice/totalPrice are always in the response.
+      // 2. Prices are strings (Decimal serialisation, v2 backward compat).
+      // 3. Internal converter fields (inputUsage etc.) are stripped.
+      // 4. Response passes the strict GetObservationsV2Response Zod schema.
+      const response = await getObservations(
+        `/api/public/v2/observations?fields=core,basic,time,io,metadata,model,usage,prompt,metrics,trace_context&traceId=${sharedTraceId}`,
+      );
+
+      expect(response.status).toBe(200);
+      const obs = response.body.data.find((o: any) => o.id === sharedObsId);
+      expect(obs).toBeDefined();
+      if (!obs) return;
+
+      // Enrichment fields — always present as own keys (null when not resolved)
+      expect(obs).toHaveProperty("modelId");
+      expect(obs).toHaveProperty("inputPrice");
+      expect(obs).toHaveProperty("outputPrice");
+      expect(obs).toHaveProperty("totalPrice");
+
+      // Prices are strings on v2 (Prisma Decimal.toString()), never numbers
+      if (obs.inputPrice !== null) expect(typeof obs.inputPrice).toBe("string");
+      if (obs.outputPrice !== null)
+        expect(typeof obs.outputPrice).toBe("string");
+      if (obs.totalPrice !== null) expect(typeof obs.totalPrice).toBe("string");
+
+      // usagePricingTierId present and correct when usage group requested
+      expect(obs.usagePricingTierId).toBe("tier-id-9859");
+
+      // Internal derived fields must never appear in the v2 response
+      expect(obs).not.toHaveProperty("inputUsage");
+      expect(obs).not.toHaveProperty("outputUsage");
+      expect(obs).not.toHaveProperty("totalUsage");
+      expect(obs).not.toHaveProperty("inputCost");
+      expect(obs).not.toHaveProperty("outputCost");
+      expect(obs).not.toHaveProperty("providedUsageDetails");
+      expect(obs).not.toHaveProperty("providedCostDetails");
+    });
 
     for (const [group, expectedFields] of Object.entries(fieldsForGroup)) {
       it(`field group contract: ${group}`, async () => {

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -422,9 +422,13 @@ const APIObservationV2 = z
     metadata: z.any().optional(),
 
     // Model fields (field group: model)
-    // Note: the wire-format key is "model" (maps from provided_model_name in ClickHouse),
-    // matching the domain Observation type. "providedModelName" is the Fern/docs alias.
+    // Both keys are present for backward compatibility:
+    // - "model" has always been the actual wire-format key (domain type maps provided_model_name → model)
+    // - "providedModelName" was declared in the published openapi/Fern spec from the start;
+    //   it was never in the JSON before (always undefined), but SDK clients were typed against it.
+    // v3 should consolidate to one name
     model: z.string().nullable().optional(),
+    providedModelName: z.string().nullable().optional(),
     internalModelId: z.string().nullable().optional(),
     modelParameters: z.any().optional(),
 
@@ -447,7 +451,7 @@ const APIObservationV2 = z
     // Enrichment fields (always present on v2 responses; null when model group not requested).
     // Prices are strings (Prisma Decimal serialisation) to preserve backward compatibility —
     // statically-typed language clients (Go, Java, C#) built structs against the original
-    // string wire format and cannot safely migrate to numbers on v2. See LFE-9859.
+    // string wire format and cannot safely migrate to numbers on v2
     modelId: z.string().nullable(),
     inputPrice: z.string().nullable(),
     outputPrice: z.string().nullable(),

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -385,7 +385,7 @@ export const GetObservationsV2Query = z.object({
 /**
  * Typed observation schema for v2 API responses.
  * Core fields are always present; other fields are optional depending on requested field groups.
- * Uses .loose() to allow server enrichment fields not explicitly listed.
+ * Uses .strict() to ensure the schema exactly matches what the server returns.
  */
 const APIObservationV2 = z
   .object({
@@ -422,7 +422,9 @@ const APIObservationV2 = z
     metadata: z.any().optional(),
 
     // Model fields (field group: model)
-    providedModelName: z.string().nullable().optional(),
+    // Note: the wire-format key is "model" (maps from provided_model_name in ClickHouse),
+    // matching the domain Observation type. "providedModelName" is the Fern/docs alias.
+    model: z.string().nullable().optional(),
     internalModelId: z.string().nullable().optional(),
     modelParameters: z.any().optional(),
 
@@ -430,6 +432,7 @@ const APIObservationV2 = z
     usageDetails: z.record(z.string(), z.number().nonnegative()).optional(),
     costDetails: z.record(z.string(), z.number().nonnegative()).optional(),
     totalCost: z.number().nullable().optional(),
+    usagePricingTierId: z.string().nullable().optional(),
     usagePricingTierName: z.string().nullable().optional(),
 
     // Prompt fields (field group: prompt)
@@ -441,15 +444,21 @@ const APIObservationV2 = z
     latency: z.number().nullable().optional(),
     timeToFirstToken: z.number().nullable().optional(),
 
-    // Enrichment fields
-    modelId: z.string().nullable().optional(),
+    // Enrichment fields (always present on v2 responses; null when model group not requested).
+    // Prices are strings (Prisma Decimal serialisation) to preserve backward compatibility —
+    // statically-typed language clients (Go, Java, C#) built structs against the original
+    // string wire format and cannot safely migrate to numbers on v2. See LFE-9859.
+    modelId: z.string().nullable(),
+    inputPrice: z.string().nullable(),
+    outputPrice: z.string().nullable(),
+    totalPrice: z.string().nullable(),
 
     // Trace context fields (field group: trace_context)
     traceName: z.string().nullable().optional(),
     tags: z.array(z.string()).nullable().optional(),
     release: z.string().nullable().optional(),
   })
-  .loose();
+  .strict();
 
 export const GetObservationsV2Response = z
   .object({

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -57,12 +57,38 @@ export default withMiddlewares({
       const hasMore = items.length > query.limit;
       const dataToReturn = hasMore ? items.slice(0, query.limit) : items;
 
-      // Convert empty parent_observation_id to null for consistency with v1
+      // Normalize for the wire format and strip internal derived fields not
+      // part of the public v2 contract.
       const transformedItems = dataToReturn.map((item) => {
-        if (item.parentObservationId === "") {
-          return { ...item, parentObservationId: null };
-        }
-        return item;
+        // Strip internal derived fields that the converter produces from
+        // usageDetails / costDetails but are not declared in the public schema.
+        const {
+          inputUsage: _iu,
+          outputUsage: _ou,
+          totalUsage: _tu,
+          inputCost: _ic,
+          outputCost: _oc,
+          ...publicFields
+        } = item as typeof item & {
+          inputUsage?: number;
+          outputUsage?: number;
+          totalUsage?: number;
+          inputCost?: number | null;
+          outputCost?: number | null;
+        };
+
+        return {
+          ...publicFields,
+          parentObservationId:
+            item.parentObservationId === "" ? null : item.parentObservationId,
+          // Enrichment fields: always present (null when model group not requested).
+          // Prices serialised as strings (Decimal.toString()) for backward compat — v2
+          // wire format has always been string; see LFE-9859.
+          modelId: item.modelId ?? null,
+          inputPrice: item.inputPrice?.toString() ?? null,
+          outputPrice: item.outputPrice?.toString() ?? null,
+          totalPrice: item.totalPrice?.toString() ?? null,
+        };
       });
 
       // Generate cursor if there are more results

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -81,20 +81,20 @@ export default withMiddlewares({
           ...publicFields,
           parentObservationId:
             item.parentObservationId === "" ? null : item.parentObservationId,
-          // Enrichment fields: always present (null when model group not requested).
-          // Prices serialised as strings (Decimal.toString()) for backward compat — v2
-          // wire format has always been string; see
-          // Both "model" and "providedModelName" are exposed when the model group is requested.
-          // "model" has always been the actual wire-format key (domain type maps
-          // provided_model_name → model). "providedModelName" was declared in the published
-          // Fern/openapi spec from day one so SDK clients built against it; expose both for
-          // backward compat. Only set when the model group was selected (undefined otherwise).
+          // Both "model" and "providedModelName" are exposed when the model group is
+          // requested. "model" has always been the actual wire-format key (domain type
+          // maps provided_model_name → model). "providedModelName" was declared in the
+          // published Fern/openapi spec from day one so SDK clients built against it;
+          // expose both for backward compat. Only set when model group is selected.
           ...((item as typeof item & { model?: string | null }).model !==
             undefined && {
             model: (item as typeof item & { model?: string | null }).model,
             providedModelName: (item as typeof item & { model?: string | null })
               .model,
           }),
+          // Enrichment fields: always present (null when model group not requested).
+          // Prices serialised as strings (Decimal.toString()) — v2 wire format has
+          // always been string; changing to number would break Go/Java/C# callers.
           modelId: item.modelId ?? null,
           inputPrice: item.inputPrice?.toString() ?? null,
           outputPrice: item.outputPrice?.toString() ?? null,

--- a/web/src/pages/api/public/v2/observations/index.ts
+++ b/web/src/pages/api/public/v2/observations/index.ts
@@ -83,7 +83,18 @@ export default withMiddlewares({
             item.parentObservationId === "" ? null : item.parentObservationId,
           // Enrichment fields: always present (null when model group not requested).
           // Prices serialised as strings (Decimal.toString()) for backward compat — v2
-          // wire format has always been string; see LFE-9859.
+          // wire format has always been string; see
+          // Both "model" and "providedModelName" are exposed when the model group is requested.
+          // "model" has always been the actual wire-format key (domain type maps
+          // provided_model_name → model). "providedModelName" was declared in the published
+          // Fern/openapi spec from day one so SDK clients built against it; expose both for
+          // backward compat. Only set when the model group was selected (undefined otherwise).
+          ...((item as typeof item & { model?: string | null }).model !==
+            undefined && {
+            model: (item as typeof item & { model?: string | null }).model,
+            providedModelName: (item as typeof item & { model?: string | null })
+              .model,
+          }),
           modelId: item.modelId ?? null,
           inputPrice: item.inputPrice?.toString() ?? null,
           outputPrice: item.outputPrice?.toString() ?? null,


### PR DESCRIPTION
## Summary

Switches `APIObservationV2` from `.loose()` to `.strict()` and brings the schema into full agreement with what the server actually returns. Fixes two undeclared fields that were silently leaking to callers, corrects a field name mismatch, and adds a test that locks the exact response shape. Tracked in [LFE-9859](https://linear.app/langfuse/issue/LFE-9859).

### Why `.loose()` was a problem

The `.loose()` passthrough allowed any ClickHouse field-set column to reach callers without a schema declaration. This caused two real incidents:
1. **`usagePricingTierId`** — selected by the `usage` FieldSet, returned in every usage response, but undeclared. Callers could not rely on it in SDKs.
2. **Price fields as strings** — `inputPrice`/`outputPrice`/`totalPrice` leaked through as Prisma Decimal strings. By the time we declared them, the string type was live and we could not fix it to `number` without breaking Go/Java/C# clients (see LFE-9859).

### Schema changes (`APIObservationV2`)

| Change | Before | After | Reason |
|---|---|---|---|
| `.loose()` → `.strict()` | undeclared fields pass through | unknown fields are rejected | prevents future leaks |
| `providedModelName` → `model` | wrong name, never in responses | matches wire format | domain type maps `provided_model_name → model` |
| `usagePricingTierId` | missing | `z.string().nullable().optional()` | was in `usage` FieldSet, always returned |
| `modelId`, price fields | optional or absent | `z.string().nullable()` (required) | always set by enrichment; prices are strings for compat |

### Route handler changes (`index.ts`)

- Explicit `modelId`/`inputPrice`/`outputPrice`/`totalPrice` mapping so TypeScript verifies they are always present.
- Strips `inputUsage`, `outputUsage`, `totalUsage`, `inputCost`, `outputCost` — internal derived values produced by the converter from `usageDetails`/`costDetails`; not part of the public contract.

### Risk assessment

| Area | Risk | Notes |
|---|---|---|
| Callers using `providedModelName` | Low | The field was never in the response — callers already got `undefined`. The field name `model` has always been the wire format. Renaming in the schema corrects, not changes, what callers receive. |
| Callers receiving `usagePricingTierId` | None | Additive — field was already in the response. Now formally declared. |
| Callers relying on `inputUsage` etc. | Low | These fields were undocumented and technically never contracted. Callers on statically-typed SDKs never saw them (not in the schema). Raw-REST callers who built against these fields may break, but these are internal derived values with no documentation precedent. |
| `.strict()` validation errors in dev | Informational | The response schema is only validated in `NODE_ENV=development` (logged, not thrown). Prod responses are unaffected. |

### Impacted packages

- `web` — `APIObservationV2` schema (strict, corrected fields), `index.ts` (explicit enrichment fields, strip internals), servertest (new field-contract test, usagePricingTierId)
- `packages/shared` — `EventsObservationPublic` gains `modelId: string | null` so TypeScript can verify the explicit mapping
- `fern/apis/server/definition/commons.yml` — `ObservationV2` updated: `model` field, `usagePricingTierId`, enrichment price fields

## Test plan

- [x] `pnpm --filter web run typecheck`
- [x] `pnpm run lint`
- [x] `LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS=true pnpm --filter web exec vitest run src/__tests__/server/observations-api-v2.servertest.ts` — 29/29 passed
  - New test: "enrichment fields always present; internal derived fields absent; prices are strings"
  - Field group contract loop updated with `usagePricingTierId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the `APIObservationV2` Zod schema by switching from `.loose()` to `.strict()`, corrects the field name `providedModelName` → `model` to match the actual wire format, adds the previously-undeclared `usagePricingTierId`, and promotes enrichment price fields to required-nullable strings for backward compatibility with statically-typed language clients.

- **Schema tightening**: `.strict()` replaces `.loose()`; the `index.ts` handler now explicitly strips internal converter fields (`inputUsage`, `outputUsage`, `totalUsage`, `inputCost`, `outputCost`) and serialises `inputPrice`/`outputPrice`/`totalPrice` as decimal strings, guaranteeing the response always passes the strict schema.
- **Field corrections**: `model` (wire key) replaces `providedModelName` (old schema alias that was never actually in responses); `modelId` and price fields are promoted from optional to required-nullable since enrichment always populates them.
- **Test coverage**: A new server test validates enrichment field presence, string type for prices, `usagePricingTierId` round-trip, and confirms internal fields are stripped — covering the field-group contract for all groups.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the wire format is unchanged for existing callers and all 29 tests pass.

The logic is sound: enrichment always produces modelId/price fields, the explicit stripping in index.ts is correct, and providedUsageDetails/providedCostDetails can't leak because the V2 ClickHouse field sets don't select those columns. The only findings are stale inline comments and a public-docs string that carries an internal migration note — neither affects runtime behavior.

The inline comments in packages/shared/src/domain/observation-field-groups.ts and the docs string in fern/apis/server/definition/commons.yml for the model field are worth a quick look before merge.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
fern/apis/server/definition/commons.yml:283-285
The `docs` string leaks an internal migration note into the public API documentation generated from this Fern spec. Callers reading generated SDK docs will see "wire key is 'model', not 'providedModelName'" which is meaningless context for them. The comment above already captures this for maintainers; the `docs` field only needs the user-facing description.

```suggestion
      model:
        type: optional<nullable<string>>
        docs: The model name as provided by the user
```

### Issue 2 of 3
packages/shared/src/domain/observation-field-groups.ts:25-26
Two inline comments are stale after this PR's changes: the `model` group comment still says `providedModelName` (the old schema name that was never the wire key), and the `usage` group comment omits the newly-added `usagePricingTierId`. Developers reading this file to understand which fields each group returns will get incorrect information.

```suggestion
  "model", // model (provided_model_name), internalModelId, modelParameters
  "usage", // usageDetails, costDetails, totalCost, usagePricingTierId, usagePricingTierName
```

### Issue 3 of 3
fern/apis/server/definition/commons.yml:281-283
The YAML comment says `"providedModelName" is the human-readable alias used in documentation`, but this PR removes `providedModelName` from the Fern spec entirely and replaces it with `model`. The comment now describes the opposite of the current state and will mislead future maintainers.

```suggestion
      # Note: the wire-format key is "model" (maps from ClickHouse provided_model_name).
      # The previous Fern alias "providedModelName" has been removed; "model" is now canonical.
      model:
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(v2/observations): strict schema, add..."](https://github.com/langfuse/langfuse/commit/4a9582307d1d0b139443745373b3d4631ac047af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32828237)</sub>

<!-- /greptile_comment -->