### PR TITLE
feat(evals): implement local and AWS Lambda code eval dispatchers

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -146,6 +146,8 @@ NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT="false"
 # Override Lambda function names if your deployment uses non-default names:
 # LANGFUSE_CODE_EVAL_AWS_LAMBDA_NODE_FUNCTION_NAME=code-based-eval-executor-node
 # LANGFUSE_CODE_EVAL_AWS_LAMBDA_PYTHON_FUNCTION_NAME=code-based-eval-executor-python
+# Override the local dispatcher execution timeout (default: 2000ms):
+# LANGFUSE_CODE_EVAL_LOCAL_TIMEOUT_MS=2000
 
 # Slack credentials for development
 SLACK_CLIENT_ID=your_slack_client_id

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -139,6 +139,14 @@ NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT="false"
 # LANGFUSE_EVAL_EXECUTION_WORKER_CONCURRENCY=5
 # LANGFUSE_LLM_AS_JUDGE_EXECUTION_WORKER_CONCURRENCY=5
 
+# Code-based eval dispatchers. Local dev defaults to the in-process dispatcher.
+# To test the AWS Lambda dispatcher against Floci, set:
+# LANGFUSE_CODE_EVAL_DISPATCHER=aws-lambda
+# LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT=http://localhost:4566
+# Override Lambda function names if your deployment uses non-default names:
+# LANGFUSE_CODE_EVAL_AWS_LAMBDA_NODE_FUNCTION_NAME=code-based-eval-executor-node
+# LANGFUSE_CODE_EVAL_AWS_LAMBDA_PYTHON_FUNCTION_NAME=code-based-eval-executor-python
+
 # Slack credentials for development
 SLACK_CLIENT_ID=your_slack_client_id
 SLACK_CLIENT_SECRET=your_slack_client_secret

--- a/.env.dev.example
+++ b/.env.dev.example
@@ -139,7 +139,9 @@ NEXT_PUBLIC_LANGFUSE_RUN_NEXT_INIT="false"
 # LANGFUSE_EVAL_EXECUTION_WORKER_CONCURRENCY=5
 # LANGFUSE_LLM_AS_JUDGE_EXECUTION_WORKER_CONCURRENCY=5
 
-# Code-based eval dispatchers. Local dev defaults to the in-process dispatcher.
+# Code-based eval dispatchers. Local dev defaults to the insecure in-process dispatcher.
+# To explicitly use the local dispatcher, set:
+# LANGFUSE_CODE_EVAL_DISPATCHER=insecure-local
 # To test the AWS Lambda dispatcher against Floci, set:
 # LANGFUSE_CODE_EVAL_DISPATCHER=aws-lambda
 # LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT=http://localhost:4566

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -504,17 +504,6 @@ jobs:
         run: pnpm --filter=worker run test:exclude-llm-connections
         env:
           LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT: ${{ matrix.deploy-mode == '' && 'http://localhost:4566' || '' }}
-      - name: Dump Floci diagnostics on worker test failure
-        if: failure() && matrix.deploy-mode == ''
-        run: |
-          docker compose -f docker-compose.dev.yml ps floci || true
-          docker compose -f docker-compose.dev.yml logs --no-color --timestamps floci || true
-          floci_container_id="$(docker compose -f docker-compose.dev.yml ps -q floci)"
-          if [ -n "$floci_container_id" ]; then
-            docker inspect "$floci_container_id" || true
-          fi
-          docker ps -a --filter "name=code-based-eval" || true
-
   test-worker-llm-connections:
     timeout-minutes: 20
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -504,6 +504,16 @@ jobs:
         run: pnpm --filter=worker run test:exclude-llm-connections
         env:
           LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT: ${{ matrix.deploy-mode == '' && 'http://localhost:4566' || '' }}
+      - name: Dump Floci diagnostics on worker test failure
+        if: failure() && matrix.deploy-mode == ''
+        run: |
+          docker compose -f docker-compose.dev.yml ps floci || true
+          docker compose -f docker-compose.dev.yml logs --no-color --timestamps floci || true
+          floci_container_id="$(docker compose -f docker-compose.dev.yml ps -q floci)"
+          if [ -n "$floci_container_id" ]; then
+            docker inspect "$floci_container_id" || true
+          fi
+          docker ps -a --filter "name=code-based-eval" || true
 
   test-worker-llm-connections:
     timeout-minutes: 20

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -471,6 +471,8 @@ jobs:
         run: |
           docker compose -f docker-compose.dev${{ matrix.deploy-mode }}.yml up -d --wait --wait-timeout 180
           docker compose ps
+        env:
+          COMPOSE_PROFILES: ${{ matrix.deploy-mode == '' && 'worker-tests' || '' }}
       - name: Ensure no unhealthy status
         run: |
           if docker compose ps | grep "(unhealthy)"; then
@@ -500,6 +502,8 @@ jobs:
         run: pnpm --filter=worker... run build
       - name: run tests
         run: pnpm --filter=worker run test:exclude-llm-connections
+        env:
+          LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT: ${{ matrix.deploy-mode == '' && 'http://localhost:4566' || '' }}
 
   test-worker-llm-connections:
     timeout-minutes: 20

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 
+# python
+__pycache__/
+*.py[cod]
+
 /generated
 
 # openapi spec that is copied during build

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,6 @@
+# Code-eval runners are Lambda handler test fixtures (Node + Python). They
+# intentionally execute user-supplied evaluator source via `exec` / dynamic
+# `import` and talk to a locally-provisioned Floci endpoint from
+# `urllib.request.urlopen`. Both are by design and inherent to the runner
+# contract — scanning them produces noise, not signal.
+scripts/code-eval-runners/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,6 +50,8 @@ services:
       - default
 
   floci:
+    profiles:
+      - worker-tests
     image: docker.io/floci/floci:1.5.17-compat
     container_name: ${FLOCI_CONTAINER_NAME:-langfuse-floci}
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,6 +49,22 @@ services:
     networks:
       - default
 
+  floci:
+    image: docker.io/floci/floci:1.5.17-compat
+    container_name: ${FLOCI_CONTAINER_NAME:-langfuse-floci}
+    environment:
+      FLOCI_HOSTNAME: floci
+      FLOCI_INIT_HOOKS_TIMEOUT_SECONDS: 120
+    ports:
+      - ${HOST_IP:-127.0.0.1}:${FLOCI_PORT:-4566}:4566
+    volumes:
+      - langfuse_floci_data:/app/data
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./scripts/code-eval-runners:/opt/code-eval-runners:ro
+      - ./scripts/code-eval-runners/bootstrap-floci.py:/etc/floci/init/ready.d/01-bootstrap-code-eval-runners.py:ro
+    networks:
+      - default
+
   redis:
     image: docker.io/redis:7.2.4
     container_name: ${REDIS_CONTAINER_NAME:-langfuse-redis}
@@ -96,6 +112,9 @@ volumes:
     driver: local
   langfuse_minio_data:
     name: ${MINIO_VOLUME_NAME:-langfuse_minio_data}
+    driver: local
+  langfuse_floci_data:
+    name: ${FLOCI_VOLUME_NAME:-langfuse_floci_data}
     driver: local
 
 networks:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,6 +53,7 @@ services:
     profiles:
       - worker-tests
     image: docker.io/floci/floci:1.5.17-compat
+    user: "0"
     container_name: ${FLOCI_CONTAINER_NAME:-langfuse-floci}
     environment:
       FLOCI_HOSTNAME: floci

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -78,6 +78,7 @@
   "dependencies": {
     "@anthropic-ai/tokenizer": "^0.0.4",
     "@aws-sdk/client-cloudwatch": "^3.1013.0",
+    "@aws-sdk/client-lambda": "^3.1046.0",
     "@aws-sdk/client-s3": "^3.1013.0",
     "@aws-sdk/lib-storage": "^3.1013.0",
     "@aws-sdk/s3-request-presigner": "^3.1013.0",

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -134,7 +134,9 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(1),
-  LANGFUSE_CODE_EVAL_DISPATCHER: z.enum(["local", "aws-lambda"]).optional(),
+  LANGFUSE_CODE_EVAL_DISPATCHER: z
+    .enum(["insecure-local", "aws-lambda"])
+    .optional(),
   LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT: z.string().optional(),
   LANGFUSE_CODE_EVAL_AWS_LAMBDA_NODE_FUNCTION_NAME: z
     .string()

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -134,6 +134,14 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(1),
+  LANGFUSE_CODE_EVAL_DISPATCHER: z.enum(["local", "aws-lambda"]).optional(),
+  LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT: z.string().optional(),
+  LANGFUSE_CODE_EVAL_AWS_LAMBDA_NODE_FUNCTION_NAME: z
+    .string()
+    .default("code-based-eval-executor-node"),
+  LANGFUSE_CODE_EVAL_AWS_LAMBDA_PYTHON_FUNCTION_NAME: z
+    .string()
+    .default("code-based-eval-executor-python"),
   LANGFUSE_TRACE_UPSERT_QUEUE_SHARD_COUNT: z.coerce
     .number()
     .positive()

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -142,6 +142,11 @@ const EnvSchema = z.object({
   LANGFUSE_CODE_EVAL_AWS_LAMBDA_PYTHON_FUNCTION_NAME: z
     .string()
     .default("code-based-eval-executor-python"),
+  LANGFUSE_CODE_EVAL_LOCAL_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(2_000),
   LANGFUSE_TRACE_UPSERT_QUEUE_SHARD_COUNT: z.coerce
     .number()
     .positive()

--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -63,7 +63,6 @@ export const observationForEvalSchema = z.object({
   experiment_dataset_id: z.string().nullish(),
   experiment_item_id: z.string().nullish(),
   experiment_item_expected_output: z.string().nullish(),
-  experiment_item_metadata: z.record(z.string(), z.unknown()).default({}),
   experiment_item_root_span_id: z.string().nullish(),
 
   // Data - accepts any type (string, array, object) from different OTEL SDKs
@@ -82,18 +81,10 @@ export function convertEventRecordToObservationForEval(
     record.metadata_values,
   );
 
-  const experimentItemMetadata = Object.fromEntries(
-    record.experiment_item_metadata_names.map((name, index) => [
-      name,
-      record.experiment_item_metadata_values[index] ?? null,
-    ]),
-  );
-
   const toolCallNames = record.tool_call_names ?? [];
   return observationForEvalSchema.parse({
     ...record,
     metadata,
-    experiment_item_metadata: experimentItemMetadata,
     tool_call_count: toolCallNames.length,
   });
 }
@@ -120,11 +111,7 @@ export type ObservationEvalFilterColumnInternal =
 
 export type ObservationEvalMappingColumnInternal = keyof Pick<
   ObservationForEval,
-  | "input"
-  | "output"
-  | "metadata"
-  | "experiment_item_expected_output"
-  | "experiment_item_metadata"
+  "input" | "output" | "metadata" | "experiment_item_expected_output"
 >;
 
 export interface ObservationEvalVariableColumn {
@@ -171,13 +158,6 @@ export const observationEvalVariableColumns: ObservationEvalVariableColumn[] = [
     name: "Expected Output",
     description: "Expected output from experiment item",
     internal: "experiment_item_expected_output",
-  },
-  {
-    id: "experimentItemMetadata",
-    name: "Experiment Item Metadata",
-    description: "Metadata from experiment item",
-    type: "stringObject",
-    internal: "experiment_item_metadata",
   },
 ];
 

--- a/packages/shared/src/features/evals/observationForEval.ts
+++ b/packages/shared/src/features/evals/observationForEval.ts
@@ -63,6 +63,7 @@ export const observationForEvalSchema = z.object({
   experiment_dataset_id: z.string().nullish(),
   experiment_item_id: z.string().nullish(),
   experiment_item_expected_output: z.string().nullish(),
+  experiment_item_metadata: z.record(z.string(), z.unknown()).default({}),
   experiment_item_root_span_id: z.string().nullish(),
 
   // Data - accepts any type (string, array, object) from different OTEL SDKs
@@ -81,10 +82,18 @@ export function convertEventRecordToObservationForEval(
     record.metadata_values,
   );
 
+  const experimentItemMetadata = Object.fromEntries(
+    record.experiment_item_metadata_names.map((name, index) => [
+      name,
+      record.experiment_item_metadata_values[index] ?? null,
+    ]),
+  );
+
   const toolCallNames = record.tool_call_names ?? [];
   return observationForEvalSchema.parse({
     ...record,
     metadata,
+    experiment_item_metadata: experimentItemMetadata,
     tool_call_count: toolCallNames.length,
   });
 }
@@ -111,7 +120,11 @@ export type ObservationEvalFilterColumnInternal =
 
 export type ObservationEvalMappingColumnInternal = keyof Pick<
   ObservationForEval,
-  "input" | "output" | "metadata" | "experiment_item_expected_output"
+  | "input"
+  | "output"
+  | "metadata"
+  | "experiment_item_expected_output"
+  | "experiment_item_metadata"
 >;
 
 export interface ObservationEvalVariableColumn {
@@ -158,6 +171,13 @@ export const observationEvalVariableColumns: ObservationEvalVariableColumn[] = [
     name: "Expected Output",
     description: "Expected output from experiment item",
     internal: "experiment_item_expected_output",
+  },
+  {
+    id: "experimentItemMetadata",
+    name: "Experiment Item Metadata",
+    description: "Metadata from experiment item",
+    type: "stringObject",
+    internal: "experiment_item_metadata",
   },
 ];
 

--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -109,3 +109,24 @@ export function extractValueFromObject(
 
   return { value: jsonSelectedColumn, error };
 }
+
+/**
+ * Backwards-compatible extraction for UI prompt previews and LLM prompt
+ * rendering. `extractValueFromObject` preserves typed values for code eval;
+ * this wrapper keeps the previous string-only behavior for prompt surfaces.
+ */
+export function extractValueFromObjectAsString(
+  obj: Record<string, unknown>,
+  selectedColumnId: string,
+  jsonSelector?: string,
+  parseJson?: (selectedColumn: unknown, jsonSelector: string) => unknown,
+): { value: string; error: Error | null } {
+  const { value, error } = extractValueFromObject(
+    obj,
+    selectedColumnId,
+    jsonSelector,
+    parseJson,
+  );
+
+  return { value: parseUnknownToString(value), error };
+}

--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -78,7 +78,7 @@ export function extractValueFromObject(
   selectedColumnId: string,
   jsonSelector?: string,
   parseJson?: (selectedColumn: unknown, jsonSelector: string) => unknown,
-): { value: string; error: Error | null } {
+): { value: unknown; error: Error | null } {
   const selectedColumn = obj[selectedColumnId];
 
   const jsonParser = parseJson || parseJsonDefault;
@@ -107,8 +107,5 @@ export function extractValueFromObject(
     jsonSelectedColumn = selectedColumn;
   }
 
-  return {
-    value: parseUnknownToString(jsonSelectedColumn),
-    error,
-  };
+  return { value: jsonSelectedColumn, error };
 }

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -61,13 +61,19 @@ const AWS_ERROR_CLASSIFICATION_BY_NAME: Record<
   // a single code regardless of which layer caught them.
   RequestTooLargeException: { code: "PAYLOAD_TOO_LARGE" },
   ResourceNotFoundException: { code: "LAMBDA_CONFIGURATION_ERROR" },
-  ECONNRESET: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
-  ETIMEDOUT: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
   ResourceConflictException: {
     code: "LAMBDA_INVOCATION_ERROR",
     retryable: true,
   },
   ServiceException: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+};
+
+const AWS_ERROR_CLASSIFICATION_BY_CODE: Record<
+  string,
+  CodeEvalDispatcherErrorClassification
+> = {
+  ECONNRESET: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+  ETIMEDOUT: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
 };
 
 // `.strict()` ensures a runner that returns a valid dispatch result alongside
@@ -278,8 +284,13 @@ function classifyAwsLambdaError(
     return { code: "LAMBDA_INVOCATION_ERROR", retryable: true };
   }
 
+  const errorCode = (error as { code?: unknown }).code;
+
   return (
-    AWS_ERROR_CLASSIFICATION_BY_NAME[error.name] ?? {
+    AWS_ERROR_CLASSIFICATION_BY_NAME[error.name] ??
+    (typeof errorCode === "string"
+      ? AWS_ERROR_CLASSIFICATION_BY_CODE[errorCode]
+      : undefined) ?? {
       code: "LAMBDA_INVOCATION_ERROR",
       retryable: true,
     }

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -1,0 +1,327 @@
+import {
+  InvokeCommand,
+  LambdaClient,
+  type InvokeCommandInput,
+} from "@aws-sdk/client-lambda";
+import { z } from "zod";
+import { logger } from "../logger";
+import {
+  assertDispatchInputWithinLimits,
+  assertDispatchResultWithinByteLimit,
+  CodeEvalDispatcherError,
+  CodeEvalDispatcherErrorCode,
+  parseDispatchResult,
+  type CodeEvalDispatcher,
+  type CodeEvalRuntimeLanguage,
+  type DispatchInput,
+  type DispatchResult,
+} from "./codeEvalDispatcherTypes";
+
+export const DEFAULT_LAMBDA_FUNCTION_BY_LANGUAGE = {
+  PYTHON: "code-based-eval-executor-python",
+  TYPESCRIPT: "code-based-eval-executor-node",
+} satisfies Record<CodeEvalRuntimeLanguage, string>;
+
+type CodeEvalDispatcherErrorClassification = {
+  code: CodeEvalDispatcherErrorCode;
+  retryable?: boolean;
+};
+
+// Defensive: today our runners only emit non-retryable user-code codes, so
+// this is only consulted if a future runner surfaces one of them via the
+// user-code-error envelope.
+const RETRYABLE_ERROR_CODES = new Set<CodeEvalDispatcherErrorCode>([
+  "TIMEOUT",
+  "LAMBDA_CONCURRENCY_LIMIT",
+  "LAMBDA_INVOCATION_ERROR",
+]);
+
+// Skipped from warn-level logging so routine user failures don't drown out
+// infrastructure issues in Datadog.
+const USER_ERROR_CODES = new Set<CodeEvalDispatcherErrorCode>([
+  "INVALID_RESULT",
+  "INVALID_SOURCE",
+  "PAYLOAD_TOO_LARGE",
+  "RESULT_TOO_LARGE",
+  "SOURCE_TOO_LARGE",
+  "USER_CODE_ERROR",
+]);
+
+const AWS_ERROR_CLASSIFICATION_BY_NAME: Record<
+  string,
+  CodeEvalDispatcherErrorClassification
+> = {
+  TooManyRequestsException: {
+    code: "LAMBDA_CONCURRENCY_LIMIT",
+    retryable: true,
+  },
+  AccessDeniedException: { code: "LAMBDA_CONFIGURATION_ERROR" },
+  InvalidParameterValueException: { code: "LAMBDA_CONFIGURATION_ERROR" },
+  // Unified with the local pre-check so "payload too large" failures share
+  // a single code regardless of which layer caught them.
+  RequestTooLargeException: { code: "PAYLOAD_TOO_LARGE" },
+  ResourceNotFoundException: { code: "LAMBDA_CONFIGURATION_ERROR" },
+  ECONNRESET: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+  ETIMEDOUT: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+  ResourceConflictException: {
+    code: "LAMBDA_INVOCATION_ERROR",
+    retryable: true,
+  },
+  ServiceException: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+};
+
+// `.strict()` ensures a runner that returns a valid dispatch result alongside
+// an `error` field (e.g. `{ scores: [...], error: { code, message } }`) cannot
+// match here — defense in depth for the user-code envelope.
+const UserCodeErrorFieldsSchema = z
+  .object({
+    code: CodeEvalDispatcherErrorCode,
+    message: z.string(),
+  })
+  .strict();
+
+const UserCodeErrorSchema = z.union([
+  z
+    .object({ error: UserCodeErrorFieldsSchema })
+    .strict()
+    .transform(({ error }) => error),
+  UserCodeErrorFieldsSchema,
+]);
+
+type UserCodeError = z.infer<typeof UserCodeErrorSchema>;
+
+export class AwsLambdaCodeEvalDispatcher implements CodeEvalDispatcher {
+  public readonly name = "aws-lambda";
+  private readonly lambdaClient: LambdaClient;
+  private readonly functionNameByLanguage: Record<
+    CodeEvalRuntimeLanguage,
+    string
+  >;
+
+  constructor(params?: {
+    lambdaClient?: LambdaClient;
+    endpoint?: string;
+    functionNameByLanguage?: Partial<Record<CodeEvalRuntimeLanguage, string>>;
+  }) {
+    this.lambdaClient =
+      params?.lambdaClient ??
+      new LambdaClient(params?.endpoint ? { endpoint: params.endpoint } : {});
+    this.functionNameByLanguage = {
+      ...DEFAULT_LAMBDA_FUNCTION_BY_LANGUAGE,
+      ...params?.functionNameByLanguage,
+    };
+  }
+
+  async dispatch(input: DispatchInput): Promise<DispatchResult> {
+    const serializedPayload = assertDispatchInputWithinLimits(input);
+    const functionName = this.functionNameByLanguage[input.runtime.language];
+
+    try {
+      const commandInput: InvokeCommandInput = {
+        FunctionName: functionName,
+        InvocationType: "RequestResponse",
+        Payload: Buffer.from(serializedPayload),
+        TenantId: `${input.scope.organizationId}:${input.scope.projectId}`,
+      };
+
+      const response = await this.lambdaClient.send(
+        new InvokeCommand(commandInput),
+      );
+
+      // Lambda function errors come back as HTTP 200 with `FunctionError`
+      // set; the SDK does NOT throw for these. SDK service exceptions
+      // (throttling, auth, etc.) hit the outer catch instead.
+      // https://docs.aws.amazon.com/lambda/latest/dg/invocation-errors.html
+      if (response.FunctionError) {
+        throw classifyLambdaFunctionError({
+          functionName,
+          functionError: response.FunctionError,
+          payload: response.Payload,
+        });
+      }
+
+      if (!response.Payload) {
+        throw new CodeEvalDispatcherError(
+          `Code eval Lambda ${functionName} returned an empty response`,
+          { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+        );
+      }
+
+      return parseLambdaResponsePayload({
+        functionName,
+        payload: response.Payload,
+      });
+    } catch (error) {
+      if (error instanceof CodeEvalDispatcherError) {
+        logDispatcherError({ functionName, error });
+        throw error;
+      }
+
+      const awsError = classifyAwsLambdaError(error);
+      const dispatcherError = new CodeEvalDispatcherError(
+        `Failed to invoke code eval Lambda ${functionName}: ${error instanceof Error ? error.message : String(error)}`,
+        { ...awsError, cause: error },
+      );
+      logDispatcherError({ functionName, error: dispatcherError });
+      throw dispatcherError;
+    }
+  }
+}
+
+// Warn on non-user errors only, so infrastructure issues surface in Datadog
+// without drowning the channel in routine user-template failures.
+function logDispatcherError(params: {
+  functionName: string;
+  error: CodeEvalDispatcherError;
+}): void {
+  if (USER_ERROR_CODES.has(params.error.code)) return;
+
+  logger.warn(
+    `Code eval Lambda ${params.functionName} dispatcher failed: ${params.error.message}`,
+    {
+      code: params.error.code,
+      retryable: params.error.retryable,
+    },
+  );
+}
+
+function classifyLambdaFunctionError(params: {
+  functionName: string;
+  functionError: string;
+  payload: Uint8Array | undefined;
+}): CodeEvalDispatcherError {
+  const errorPayload = parseLambdaErrorPayload(params.payload);
+
+  // Our runners emit `{ error: { code, message } }` on user-code failures.
+  const userCodeError = parseUserCodeError(errorPayload);
+  if (userCodeError) {
+    return createCodeEvalDispatcherErrorFromUserCodeError(userCodeError);
+  }
+
+  // AWS-runtime error envelope: `{ errorMessage, errorType, stackTrace? }`.
+  const record = isRecord(errorPayload) ? errorPayload : null;
+  const errorType =
+    typeof record?.errorType === "string" ? record.errorType : null;
+  const errorMessage =
+    typeof record?.errorMessage === "string" ? record.errorMessage : null;
+  const composedMessage =
+    errorType && errorMessage
+      ? `${errorType}: ${errorMessage}`
+      : (errorMessage ?? errorType ?? "");
+
+  if (
+    errorType === "Function.TimedOut" ||
+    errorType === "Sandbox.Timedout" ||
+    (errorMessage && isTimeoutErrorMessage(errorMessage))
+  ) {
+    return new CodeEvalDispatcherError(
+      composedMessage || "Lambda task timed out",
+      { code: "TIMEOUT", retryable: true },
+    );
+  }
+
+  // Abnormal runtime exit (OOM kill, segfault, process.exit, SIGKILL).
+  // Retrying never recovers from these.
+  if (errorType === "Runtime.ExitError") {
+    return new CodeEvalDispatcherError(
+      composedMessage || "Lambda runtime exited abnormally",
+      { code: "LAMBDA_CONFIGURATION_ERROR", retryable: false },
+    );
+  }
+
+  // The managed runtime caught a user-code exception and populated
+  // errorType + errorMessage with the language-specific class and message.
+  if (params.functionError === "Handled") {
+    return new CodeEvalDispatcherError(
+      composedMessage || "Evaluator code threw an uncaught exception",
+      { code: "USER_CODE_ERROR", retryable: false },
+    );
+  }
+
+  // Unknown failure — default retryable so a flake doesn't burn the job.
+  return new CodeEvalDispatcherError(
+    composedMessage ||
+      `Code eval Lambda ${params.functionName} failed with ${params.functionError}`,
+    { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+  );
+}
+
+function createCodeEvalDispatcherErrorFromUserCodeError(
+  userCodeError: UserCodeError,
+): CodeEvalDispatcherError {
+  return new CodeEvalDispatcherError(userCodeError.message, {
+    code: userCodeError.code,
+    retryable: RETRYABLE_ERROR_CODES.has(userCodeError.code),
+  });
+}
+
+function classifyAwsLambdaError(
+  error: unknown,
+): CodeEvalDispatcherErrorClassification {
+  if (!(error instanceof Error)) {
+    return { code: "LAMBDA_INVOCATION_ERROR", retryable: true };
+  }
+
+  return (
+    AWS_ERROR_CLASSIFICATION_BY_NAME[error.name] ?? {
+      code: "LAMBDA_INVOCATION_ERROR",
+      retryable: true,
+    }
+  );
+}
+
+function parseLambdaResponsePayload(params: {
+  functionName: string;
+  payload: Uint8Array;
+}): DispatchResult {
+  assertDispatchResultWithinByteLimit(params.payload.byteLength);
+
+  const responseBody = Buffer.from(params.payload).toString("utf8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(responseBody) as unknown;
+  } catch (error) {
+    throw new CodeEvalDispatcherError(
+      `Code eval Lambda ${params.functionName} returned invalid JSON`,
+      { code: "INVALID_RESULT", cause: error },
+    );
+  }
+
+  // Try the success shape first so a runner can't smuggle an `error`
+  // envelope alongside valid scores to force a retry or mask the outcome.
+  try {
+    return parseDispatchResult(parsed);
+  } catch (dispatchError) {
+    const userCodeError = parseUserCodeError(parsed);
+    if (userCodeError) {
+      throw createCodeEvalDispatcherErrorFromUserCodeError(userCodeError);
+    }
+    throw dispatchError;
+  }
+}
+
+function parseUserCodeError(payload: unknown): UserCodeError | null {
+  return UserCodeErrorSchema.safeParse(payload).data ?? null;
+}
+
+function parseLambdaErrorPayload(payload: Uint8Array | undefined): unknown {
+  if (!payload) return null;
+
+  try {
+    return JSON.parse(Buffer.from(payload).toString("utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function isTimeoutErrorMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("task timed out") || normalized.includes("timeout")
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -10,6 +10,7 @@ import {
   assertDispatchResultWithinByteLimit,
   CodeEvalDispatcherError,
   CodeEvalDispatcherErrorCode,
+  CodeEvalDispatcherErrorCodes,
   parseDispatchResult,
   type CodeEvalDispatcher,
   type CodeEvalRuntimeLanguage,
@@ -31,20 +32,20 @@ type CodeEvalDispatcherErrorClassification = {
 // this is only consulted if a future runner surfaces one of them via the
 // user-code-error envelope.
 const RETRYABLE_ERROR_CODES = new Set<CodeEvalDispatcherErrorCode>([
-  "TIMEOUT",
-  "LAMBDA_CONCURRENCY_LIMIT",
-  "LAMBDA_INVOCATION_ERROR",
+  CodeEvalDispatcherErrorCodes.TIMEOUT,
+  CodeEvalDispatcherErrorCodes.LAMBDA_CONCURRENCY_LIMIT,
+  CodeEvalDispatcherErrorCodes.LAMBDA_INVOCATION_ERROR,
 ]);
 
 // Skipped from warn-level logging so routine user failures don't drown out
 // infrastructure issues in Datadog.
 const USER_ERROR_CODES = new Set<CodeEvalDispatcherErrorCode>([
-  "INVALID_RESULT",
-  "INVALID_SOURCE",
-  "PAYLOAD_TOO_LARGE",
-  "RESULT_TOO_LARGE",
-  "SOURCE_TOO_LARGE",
-  "USER_CODE_ERROR",
+  CodeEvalDispatcherErrorCodes.INVALID_RESULT,
+  CodeEvalDispatcherErrorCodes.INVALID_SOURCE,
+  CodeEvalDispatcherErrorCodes.PAYLOAD_TOO_LARGE,
+  CodeEvalDispatcherErrorCodes.RESULT_TOO_LARGE,
+  CodeEvalDispatcherErrorCodes.SOURCE_TOO_LARGE,
+  CodeEvalDispatcherErrorCodes.USER_CODE_ERROR,
 ]);
 
 const AWS_ERROR_CLASSIFICATION_BY_NAME: Record<
@@ -52,28 +53,45 @@ const AWS_ERROR_CLASSIFICATION_BY_NAME: Record<
   CodeEvalDispatcherErrorClassification
 > = {
   TooManyRequestsException: {
-    code: "LAMBDA_CONCURRENCY_LIMIT",
+    code: CodeEvalDispatcherErrorCodes.LAMBDA_CONCURRENCY_LIMIT,
     retryable: true,
   },
-  AccessDeniedException: { code: "LAMBDA_CONFIGURATION_ERROR" },
-  InvalidParameterValueException: { code: "LAMBDA_CONFIGURATION_ERROR" },
+  AccessDeniedException: {
+    code: CodeEvalDispatcherErrorCodes.LAMBDA_CONFIGURATION_ERROR,
+  },
+  InvalidParameterValueException: {
+    code: CodeEvalDispatcherErrorCodes.LAMBDA_CONFIGURATION_ERROR,
+  },
   // Unified with the local pre-check so "payload too large" failures share
   // a single code regardless of which layer caught them.
-  RequestTooLargeException: { code: "PAYLOAD_TOO_LARGE" },
-  ResourceNotFoundException: { code: "LAMBDA_CONFIGURATION_ERROR" },
+  RequestTooLargeException: {
+    code: CodeEvalDispatcherErrorCodes.PAYLOAD_TOO_LARGE,
+  },
+  ResourceNotFoundException: {
+    code: CodeEvalDispatcherErrorCodes.LAMBDA_CONFIGURATION_ERROR,
+  },
   ResourceConflictException: {
-    code: "LAMBDA_INVOCATION_ERROR",
+    code: CodeEvalDispatcherErrorCodes.LAMBDA_INVOCATION_ERROR,
     retryable: true,
   },
-  ServiceException: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+  ServiceException: {
+    code: CodeEvalDispatcherErrorCodes.LAMBDA_INVOCATION_ERROR,
+    retryable: true,
+  },
 };
 
 const AWS_ERROR_CLASSIFICATION_BY_CODE: Record<
   string,
   CodeEvalDispatcherErrorClassification
 > = {
-  ECONNRESET: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
-  ETIMEDOUT: { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+  ECONNRESET: {
+    code: CodeEvalDispatcherErrorCodes.LAMBDA_INVOCATION_ERROR,
+    retryable: true,
+  },
+  ETIMEDOUT: {
+    code: CodeEvalDispatcherErrorCodes.LAMBDA_INVOCATION_ERROR,
+    retryable: true,
+  },
 };
 
 // `.strict()` ensures a runner that returns a valid dispatch result alongside
@@ -165,7 +183,10 @@ export class AwsLambdaCodeEvalDispatcher implements CodeEvalDispatcher {
       if (!response.Payload) {
         throw new CodeEvalDispatcherError(
           `Code eval Lambda ${functionName} returned an empty response`,
-          { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+          {
+            code: CodeEvalDispatcherErrorCodes.LAMBDA_INVOCATION_ERROR,
+            retryable: true,
+          },
         );
       }
 
@@ -238,7 +259,7 @@ function classifyLambdaFunctionError(params: {
   ) {
     return new CodeEvalDispatcherError(
       composedMessage || "Lambda task timed out",
-      { code: "TIMEOUT", retryable: true },
+      { code: CodeEvalDispatcherErrorCodes.TIMEOUT, retryable: true },
     );
   }
 
@@ -247,7 +268,10 @@ function classifyLambdaFunctionError(params: {
   if (errorType === "Runtime.ExitError") {
     return new CodeEvalDispatcherError(
       composedMessage || "Lambda runtime exited abnormally",
-      { code: "LAMBDA_CONFIGURATION_ERROR", retryable: false },
+      {
+        code: CodeEvalDispatcherErrorCodes.LAMBDA_CONFIGURATION_ERROR,
+        retryable: false,
+      },
     );
   }
 
@@ -256,7 +280,7 @@ function classifyLambdaFunctionError(params: {
   if (params.functionError === "Handled") {
     return new CodeEvalDispatcherError(
       composedMessage || "Evaluator code threw an uncaught exception",
-      { code: "USER_CODE_ERROR", retryable: false },
+      { code: CodeEvalDispatcherErrorCodes.USER_CODE_ERROR, retryable: false },
     );
   }
 
@@ -264,7 +288,10 @@ function classifyLambdaFunctionError(params: {
   return new CodeEvalDispatcherError(
     composedMessage ||
       `Code eval Lambda ${params.functionName} failed with ${params.functionError}`,
-    { code: "LAMBDA_INVOCATION_ERROR", retryable: true },
+    {
+      code: CodeEvalDispatcherErrorCodes.LAMBDA_INVOCATION_ERROR,
+      retryable: true,
+    },
   );
 }
 
@@ -281,7 +308,10 @@ function classifyAwsLambdaError(
   error: unknown,
 ): CodeEvalDispatcherErrorClassification {
   if (!(error instanceof Error)) {
-    return { code: "LAMBDA_INVOCATION_ERROR", retryable: true };
+    return {
+      code: CodeEvalDispatcherErrorCodes.LAMBDA_INVOCATION_ERROR,
+      retryable: true,
+    };
   }
 
   const errorCode = (error as { code?: unknown }).code;
@@ -291,7 +321,7 @@ function classifyAwsLambdaError(
     (typeof errorCode === "string"
       ? AWS_ERROR_CLASSIFICATION_BY_CODE[errorCode]
       : undefined) ?? {
-      code: "LAMBDA_INVOCATION_ERROR",
+      code: CodeEvalDispatcherErrorCodes.LAMBDA_INVOCATION_ERROR,
       retryable: true,
     }
   );
@@ -311,7 +341,7 @@ function parseLambdaResponsePayload(params: {
   } catch (error) {
     throw new CodeEvalDispatcherError(
       `Code eval Lambda ${params.functionName} returned invalid JSON`,
-      { code: "INVALID_RESULT", cause: error },
+      { code: CodeEvalDispatcherErrorCodes.INVALID_RESULT, cause: error },
     );
   }
 

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -90,6 +90,23 @@ const UserCodeErrorSchema = z.union([
 
 type UserCodeError = z.infer<typeof UserCodeErrorSchema>;
 
+// Process-singleton client so the AWS SDK's Keep-Alive connection pool is
+// reused across all dispatcher instances. In practice the process sees one
+// endpoint for its lifetime (real AWS or the Floci dev endpoint); the
+// endpoint-mismatch guard exists so a future caller that passes a different
+// endpoint without injecting a client doesn't silently get a stale one.
+let sharedLambdaClient: LambdaClient | undefined;
+let sharedLambdaClientEndpoint: string | undefined;
+
+function getSharedLambdaClient(endpoint?: string): LambdaClient {
+  if (sharedLambdaClient && sharedLambdaClientEndpoint === endpoint) {
+    return sharedLambdaClient;
+  }
+  sharedLambdaClient = new LambdaClient(endpoint ? { endpoint } : {});
+  sharedLambdaClientEndpoint = endpoint;
+  return sharedLambdaClient;
+}
+
 export class AwsLambdaCodeEvalDispatcher implements CodeEvalDispatcher {
   public readonly name = "aws-lambda";
   private readonly lambdaClient: LambdaClient;
@@ -104,8 +121,7 @@ export class AwsLambdaCodeEvalDispatcher implements CodeEvalDispatcher {
     functionNameByLanguage?: Partial<Record<CodeEvalRuntimeLanguage, string>>;
   }) {
     this.lambdaClient =
-      params?.lambdaClient ??
-      new LambdaClient(params?.endpoint ? { endpoint: params.endpoint } : {});
+      params?.lambdaClient ?? getSharedLambdaClient(params?.endpoint);
     this.functionNameByLanguage = {
       ...DEFAULT_LAMBDA_FUNCTION_BY_LANGUAGE,
       ...params?.functionNameByLanguage,

--- a/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
@@ -16,11 +16,15 @@ export type CodeEvalScope = {
 };
 
 export type CodeEvalPayload = {
-  input: unknown;
-  output: unknown;
-  observationMetadata: unknown;
-  experimentExpectedOutput: unknown;
-  experimentItemMetadata: unknown;
+  observation: {
+    input: unknown;
+    output: unknown;
+    metadata: unknown;
+  };
+  experiment?: {
+    expectedOutput: unknown;
+    itemMetadata: unknown;
+  };
 };
 
 export type DispatchInput = {

--- a/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
@@ -146,7 +146,7 @@ export class CodeEvalDispatcherError extends Error {
   }
 }
 
-export type CodeEvalDispatcherName = "local" | "aws-lambda";
+export type CodeEvalDispatcherName = "insecure-local" | "aws-lambda";
 
 export function assertDispatchInputWithinLimits(input: DispatchInput): string {
   const sourceBytes = Buffer.byteLength(input.code.source, "utf8");

--- a/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
@@ -126,6 +126,7 @@ export const CodeEvalDispatcherErrorCode = z.enum([
 export type CodeEvalDispatcherErrorCode = z.infer<
   typeof CodeEvalDispatcherErrorCode
 >;
+export const CodeEvalDispatcherErrorCodes = CodeEvalDispatcherErrorCode.enum;
 
 export class CodeEvalDispatcherError extends Error {
   public readonly code: CodeEvalDispatcherErrorCode;
@@ -153,7 +154,7 @@ export function assertDispatchInputWithinLimits(input: DispatchInput): string {
   if (sourceBytes > CODE_EVAL_SOURCE_MAX_BYTES) {
     throw new CodeEvalDispatcherError(
       `Code eval source exceeds the ${CODE_EVAL_SOURCE_MAX_BYTES} byte limit`,
-      { code: "SOURCE_TOO_LARGE" },
+      { code: CodeEvalDispatcherErrorCodes.SOURCE_TOO_LARGE },
     );
   }
 
@@ -162,7 +163,7 @@ export function assertDispatchInputWithinLimits(input: DispatchInput): string {
   if (payloadBytes > CODE_EVAL_DISPATCH_PAYLOAD_MAX_BYTES) {
     throw new CodeEvalDispatcherError(
       `Code eval dispatch payload exceeds the ${CODE_EVAL_DISPATCH_PAYLOAD_MAX_BYTES} byte limit`,
-      { code: "PAYLOAD_TOO_LARGE" },
+      { code: CodeEvalDispatcherErrorCodes.PAYLOAD_TOO_LARGE },
     );
   }
 
@@ -181,7 +182,7 @@ export function assertDispatchResultWithinByteLimit(byteSize: number): void {
   if (byteSize > CODE_EVAL_DISPATCH_RESULT_MAX_BYTES) {
     throw new CodeEvalDispatcherError(
       `Code eval result exceeds the ${CODE_EVAL_DISPATCH_RESULT_MAX_BYTES} byte limit`,
-      { code: "RESULT_TOO_LARGE" },
+      { code: CodeEvalDispatcherErrorCodes.RESULT_TOO_LARGE },
     );
   }
 }
@@ -192,7 +193,7 @@ export function parseDispatchResult(result: unknown): DispatchResult {
   if (!parsed.success) {
     throw new CodeEvalDispatcherError(
       `Invalid code eval result: ${parsed.error.message}`,
-      { code: "INVALID_RESULT" },
+      { code: CodeEvalDispatcherErrorCodes.INVALID_RESULT },
     );
   }
 

--- a/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
@@ -1,0 +1,196 @@
+import { z } from "zod";
+import { ScoreDataTypeEnum, TEXT_SCORE_MAX_LENGTH } from "../../domain/scores";
+
+export const CODE_EVAL_SOURCE_MAX_BYTES = 256 * 1024;
+export const CODE_EVAL_DISPATCH_PAYLOAD_MAX_BYTES = 5.5 * 1024 * 1024;
+export const CODE_EVAL_DISPATCH_RESULT_MAX_BYTES = 256 * 1024;
+
+export const CodeEvalRuntimeLanguage = z.enum(["PYTHON", "TYPESCRIPT"]);
+export type CodeEvalRuntimeLanguage = z.infer<typeof CodeEvalRuntimeLanguage>;
+
+export type CodeEvalScope = {
+  organizationId: string;
+  projectId: string;
+  evaluatorId: string;
+  environment: string;
+};
+
+export type CodeEvalPayload = {
+  input: unknown;
+  output: unknown;
+  observationMetadata: unknown;
+  experimentExpectedOutput: unknown;
+  experimentItemMetadata: unknown;
+};
+
+export type DispatchInput = {
+  scope: CodeEvalScope;
+  runtime: { language: CodeEvalRuntimeLanguage };
+  execution: {
+    jobExecutionId: string;
+  };
+  code: {
+    source: string;
+  };
+  payload: CodeEvalPayload;
+};
+
+const codeEvalScoreBase = {
+  name: z.string().min(1).optional(),
+  comment: z.string().nullish(),
+  configId: z.string().nullish(),
+};
+
+const CodeEvalScoreSchema = z.union([
+  z.object({
+    ...codeEvalScoreBase,
+    value: z.number(),
+    dataType: z.literal(ScoreDataTypeEnum.NUMERIC),
+  }),
+  z.object({
+    ...codeEvalScoreBase,
+    value: z.string(),
+    dataType: z.literal(ScoreDataTypeEnum.CATEGORICAL),
+  }),
+  z.object({
+    ...codeEvalScoreBase,
+    // BOOLEAN explicitly signals intent, so accept the values users most
+    // commonly return — native booleans, 0/1, and string forms ("true"/
+    // "false"/"1"/"0", case-insensitive) — and normalize to the 0/1 wire
+    // encoding the score ingestion expects.
+    value: z
+      .union([z.literal(0), z.literal(1), z.boolean(), z.string()])
+      .transform((v, ctx): 0 | 1 => {
+        if (v === 0 || v === 1) return v;
+        if (typeof v === "boolean") return v ? 1 : 0;
+
+        const normalized = v.trim().toLowerCase();
+        if (normalized === "true" || normalized === "1") return 1;
+        if (normalized === "false" || normalized === "0") return 0;
+
+        ctx.addIssue({
+          code: "custom",
+          message: `Invalid boolean value: ${JSON.stringify(v)}`,
+        });
+        return z.NEVER;
+      }),
+    dataType: z.literal(ScoreDataTypeEnum.BOOLEAN),
+  }),
+  z.object({
+    ...codeEvalScoreBase,
+    // Mirror the public ingestion `ScoreBody` cap on TEXT score length so that
+    // an oversized TEXT value fails fast as a non-retryable `INVALID_RESULT`
+    // at the dispatcher, instead of being silently dropped later by the
+    // ingestion consumer after the `JobExecution` is already marked
+    // COMPLETED.
+    value: z.string().min(1).max(TEXT_SCORE_MAX_LENGTH),
+    dataType: z.literal(ScoreDataTypeEnum.TEXT),
+  }),
+  z.object({
+    ...codeEvalScoreBase,
+    value: z.union([z.string(), z.number()]),
+    dataType: z.undefined().optional(),
+  }),
+]);
+
+const CodeEvalDispatchResultSchema = z.object({
+  scores: z.array(CodeEvalScoreSchema).min(1),
+});
+
+export type CodeEvalScore = z.infer<typeof CodeEvalScoreSchema>;
+export type CodeEvalScoreWithName = CodeEvalScore & { name: string };
+export type DispatchResult = z.infer<typeof CodeEvalDispatchResultSchema>;
+
+export interface CodeEvalDispatcher {
+  name: string;
+  dispatch(input: DispatchInput): Promise<DispatchResult>;
+}
+
+export const CodeEvalDispatcherErrorCode = z.enum([
+  "INVALID_RESULT",
+  "INVALID_SOURCE",
+  "PAYLOAD_TOO_LARGE",
+  "RESULT_TOO_LARGE",
+  "SOURCE_TOO_LARGE",
+  "TIMEOUT",
+  "UNSUPPORTED_RUNTIME",
+  "USER_CODE_ERROR",
+  "LAMBDA_CONCURRENCY_LIMIT",
+  "LAMBDA_CONFIGURATION_ERROR",
+  "LAMBDA_INVOCATION_ERROR",
+]);
+export type CodeEvalDispatcherErrorCode = z.infer<
+  typeof CodeEvalDispatcherErrorCode
+>;
+
+export class CodeEvalDispatcherError extends Error {
+  public readonly code: CodeEvalDispatcherErrorCode;
+  public readonly retryable: boolean;
+
+  constructor(
+    message: string,
+    options: {
+      code: CodeEvalDispatcherErrorCode;
+      retryable?: boolean;
+      cause?: unknown;
+    },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "CodeEvalDispatcherError";
+    this.code = options.code;
+    this.retryable = options.retryable ?? false;
+  }
+}
+
+export type CodeEvalDispatcherName = "local" | "aws-lambda";
+
+export function assertDispatchInputWithinLimits(input: DispatchInput): string {
+  const sourceBytes = Buffer.byteLength(input.code.source, "utf8");
+  if (sourceBytes > CODE_EVAL_SOURCE_MAX_BYTES) {
+    throw new CodeEvalDispatcherError(
+      `Code eval source exceeds the ${CODE_EVAL_SOURCE_MAX_BYTES} byte limit`,
+      { code: "SOURCE_TOO_LARGE" },
+    );
+  }
+
+  const serializedInput = JSON.stringify(input);
+  const payloadBytes = Buffer.byteLength(serializedInput, "utf8");
+  if (payloadBytes > CODE_EVAL_DISPATCH_PAYLOAD_MAX_BYTES) {
+    throw new CodeEvalDispatcherError(
+      `Code eval dispatch payload exceeds the ${CODE_EVAL_DISPATCH_PAYLOAD_MAX_BYTES} byte limit`,
+      { code: "PAYLOAD_TOO_LARGE" },
+    );
+  }
+
+  return serializedInput;
+}
+
+/**
+ * Guard against malicious or runaway evaluator output that would blow up
+ * downstream score ingestion and ClickHouse writes. Each dispatcher is
+ * expected to call this with the byte size at its cheapest representation:
+ * Lambda has the raw response bytes (`response.Payload.byteLength`) so the
+ * check is free; the local dispatcher must serialize the in-memory result
+ * because there is no wire payload.
+ */
+export function assertDispatchResultWithinByteLimit(byteSize: number): void {
+  if (byteSize > CODE_EVAL_DISPATCH_RESULT_MAX_BYTES) {
+    throw new CodeEvalDispatcherError(
+      `Code eval result exceeds the ${CODE_EVAL_DISPATCH_RESULT_MAX_BYTES} byte limit`,
+      { code: "RESULT_TOO_LARGE" },
+    );
+  }
+}
+
+export function parseDispatchResult(result: unknown): DispatchResult {
+  const parsed = CodeEvalDispatchResultSchema.safeParse(result);
+
+  if (!parsed.success) {
+    throw new CodeEvalDispatcherError(
+      `Invalid code eval result: ${parsed.error.message}`,
+      { code: "INVALID_RESULT" },
+    );
+  }
+
+  return parsed.data;
+}

--- a/packages/shared/src/server/evals/codeEvalDispatchers.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatchers.ts
@@ -1,4 +1,5 @@
 import { env } from "../../env";
+import { logger } from "../logger";
 import { AwsLambdaCodeEvalDispatcher } from "./awsLambdaCodeEvalDispatcher";
 import { LocalCodeEvalDispatcher } from "./localCodeEvalDispatcher";
 import type { CodeEvalDispatcher } from "./codeEvalDispatcherTypes";
@@ -7,14 +8,24 @@ export * from "./awsLambdaCodeEvalDispatcher";
 export * from "./codeEvalDispatcherTypes";
 export * from "./localCodeEvalDispatcher";
 
+let hasLoggedInsecureLocalWarning = false;
+
 export function resolveConfiguredCodeEvalDispatcher(): CodeEvalDispatcher | null {
   const dispatcherName =
     env.LANGFUSE_CODE_EVAL_DISPATCHER ??
-    (env.NODE_ENV === "development" ? "local" : undefined);
+    (env.NODE_ENV === "development" ? "insecure-local" : undefined);
 
   if (!dispatcherName) return null;
 
-  if (dispatcherName === "local") return new LocalCodeEvalDispatcher();
+  if (dispatcherName === "insecure-local") {
+    if (!hasLoggedInsecureLocalWarning) {
+      logger.warn(
+        "LANGFUSE_CODE_EVAL_DISPATCHER is set to `insecure-local`. Code evals will execute user-provided code in the worker process. Only use this with trusted code or for local development.",
+      );
+      hasLoggedInsecureLocalWarning = true;
+    }
+    return new LocalCodeEvalDispatcher();
+  }
 
   if (dispatcherName === "aws-lambda") {
     return new AwsLambdaCodeEvalDispatcher({

--- a/packages/shared/src/server/evals/codeEvalDispatchers.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatchers.ts
@@ -20,7 +20,7 @@ export function resolveConfiguredCodeEvalDispatcher(): CodeEvalDispatcher | null
   if (dispatcherName === "insecure-local") {
     if (!hasLoggedInsecureLocalWarning) {
       logger.warn(
-        "LANGFUSE_CODE_EVAL_DISPATCHER is set to `insecure-local`. Code evals will execute user-provided code in the worker process. Only use this with trusted code or for local development.",
+        "Using the `insecure-local` code-eval dispatcher. Code evals will execute user-provided code in the worker process. Only use this with trusted code or for local development.",
       );
       hasLoggedInsecureLocalWarning = true;
     }

--- a/packages/shared/src/server/evals/codeEvalDispatchers.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatchers.ts
@@ -15,6 +15,7 @@ export function resolveConfiguredCodeEvalDispatcher(): CodeEvalDispatcher | null
   if (!dispatcherName) return null;
 
   if (dispatcherName === "local") return new LocalCodeEvalDispatcher();
+
   if (dispatcherName === "aws-lambda") {
     return new AwsLambdaCodeEvalDispatcher({
       endpoint: env.LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT,

--- a/packages/shared/src/server/evals/codeEvalDispatchers.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatchers.ts
@@ -1,0 +1,29 @@
+import { env } from "../../env";
+import { AwsLambdaCodeEvalDispatcher } from "./awsLambdaCodeEvalDispatcher";
+import { LocalCodeEvalDispatcher } from "./localCodeEvalDispatcher";
+import type { CodeEvalDispatcher } from "./codeEvalDispatcherTypes";
+
+export * from "./awsLambdaCodeEvalDispatcher";
+export * from "./codeEvalDispatcherTypes";
+export * from "./localCodeEvalDispatcher";
+
+export function resolveConfiguredCodeEvalDispatcher(): CodeEvalDispatcher | null {
+  const dispatcherName =
+    env.LANGFUSE_CODE_EVAL_DISPATCHER ??
+    (env.NODE_ENV === "development" ? "local" : undefined);
+
+  if (!dispatcherName) return null;
+
+  if (dispatcherName === "local") return new LocalCodeEvalDispatcher();
+  if (dispatcherName === "aws-lambda") {
+    return new AwsLambdaCodeEvalDispatcher({
+      endpoint: env.LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT,
+      functionNameByLanguage: {
+        PYTHON: env.LANGFUSE_CODE_EVAL_AWS_LAMBDA_PYTHON_FUNCTION_NAME,
+        TYPESCRIPT: env.LANGFUSE_CODE_EVAL_AWS_LAMBDA_NODE_FUNCTION_NAME,
+      },
+    });
+  }
+
+  return null;
+}

--- a/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
@@ -1,0 +1,62 @@
+import { stripTypeScriptTypes } from "node:module";
+import {
+  CodeEvalDispatcherError,
+  parseDispatchResult,
+  type CodeEvalDispatcher,
+  type DispatchInput,
+  type DispatchResult,
+} from "./codeEvalDispatcherTypes";
+
+export class LocalCodeEvalDispatcher implements CodeEvalDispatcher {
+  public readonly name = "local";
+
+  async dispatch(input: DispatchInput): Promise<DispatchResult> {
+    if (input.runtime.language !== "TYPESCRIPT") {
+      throw new CodeEvalDispatcherError(
+        "Local code eval dispatcher only supports TypeScript/JavaScript evaluators",
+        { code: "UNSUPPORTED_RUNTIME" },
+      );
+    }
+
+    let source: string;
+    try {
+      source = stripTypeScriptTypes(input.code.source, { mode: "strip" });
+    } catch (error) {
+      throw new CodeEvalDispatcherError(
+        `Failed to strip TypeScript syntax: ${error instanceof Error ? error.message : String(error)}`,
+        { code: "INVALID_SOURCE", cause: error },
+      );
+    }
+
+    let evaluate: unknown;
+    try {
+      const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}#${input.execution.jobExecutionId}-${Date.now()}`;
+      const module = (await import(moduleUrl)) as { evaluate?: unknown };
+      evaluate = module.evaluate;
+    } catch (error) {
+      throw new CodeEvalDispatcherError(
+        `Failed to load evaluator source: ${error instanceof Error ? error.message : String(error)}`,
+        { code: "INVALID_SOURCE", cause: error },
+      );
+    }
+
+    if (typeof evaluate !== "function") {
+      throw new CodeEvalDispatcherError(
+        "Evaluator source must export an evaluate(ctx) function",
+        { code: "INVALID_SOURCE" },
+      );
+    }
+
+    let result: unknown;
+    try {
+      result = await evaluate(input.payload);
+    } catch (error) {
+      throw new CodeEvalDispatcherError(
+        `Evaluator execution failed: ${error instanceof Error ? error.message : String(error)}`,
+        { code: "USER_CODE_ERROR", cause: error },
+      );
+    }
+
+    return parseDispatchResult(result);
+  }
+}

--- a/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
@@ -1,11 +1,70 @@
 import { stripTypeScriptTypes } from "node:module";
+import { Worker } from "node:worker_threads";
 import {
   CodeEvalDispatcherError,
   parseDispatchResult,
   type CodeEvalDispatcher,
+  type CodeEvalDispatcherErrorCode,
   type DispatchInput,
   type DispatchResult,
 } from "./codeEvalDispatcherTypes";
+
+// Each dispatch runs the evaluator in a fresh worker thread so that Node's
+// ESM loader registry (which has no public eviction API) is GC'd with the
+// worker on termination, instead of leaking the user-supplied source +
+// parsed module on every invocation.
+const WORKER_SOURCE = `
+const { parentPort, workerData } = require("node:worker_threads");
+
+(async () => {
+  const moduleUrl =
+    "data:text/javascript;base64," +
+    Buffer.from(workerData.source).toString("base64");
+
+  let mod;
+  try {
+    mod = await import(moduleUrl);
+  } catch (error) {
+    parentPort.postMessage({
+      ok: false,
+      code: "INVALID_SOURCE",
+      message: "Failed to load evaluator source: " + (error && error.message ? error.message : String(error)),
+    });
+    return;
+  }
+
+  if (typeof mod.evaluate !== "function") {
+    parentPort.postMessage({
+      ok: false,
+      code: "INVALID_SOURCE",
+      message: "Evaluator source must export an evaluate(ctx) function",
+    });
+    return;
+  }
+
+  try {
+    const result = await mod.evaluate(workerData.payload);
+    parentPort.postMessage({ ok: true, result });
+  } catch (error) {
+    parentPort.postMessage({
+      ok: false,
+      code: "USER_CODE_ERROR",
+      message: error && error.message ? error.message : String(error),
+    });
+  }
+})();
+`;
+
+type WorkerSuccess = { ok: true; result: unknown };
+type WorkerFailure = {
+  ok: false;
+  code: Extract<
+    CodeEvalDispatcherErrorCode,
+    "INVALID_SOURCE" | "USER_CODE_ERROR"
+  >;
+  message: string;
+};
+type WorkerMessage = WorkerSuccess | WorkerFailure;
 
 export class LocalCodeEvalDispatcher implements CodeEvalDispatcher {
   public readonly name = "local";
@@ -28,35 +87,59 @@ export class LocalCodeEvalDispatcher implements CodeEvalDispatcher {
       );
     }
 
-    let evaluate: unknown;
-    try {
-      const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}#${input.execution.jobExecutionId}-${Date.now()}`;
-      const module = (await import(moduleUrl)) as { evaluate?: unknown };
-      evaluate = module.evaluate;
-    } catch (error) {
-      throw new CodeEvalDispatcherError(
-        `Failed to load evaluator source: ${error instanceof Error ? error.message : String(error)}`,
-        { code: "INVALID_SOURCE", cause: error },
-      );
+    const message = await runInWorker({ source, payload: input.payload });
+
+    if (!message.ok) {
+      throw new CodeEvalDispatcherError(message.message, {
+        code: message.code,
+      });
     }
 
-    if (typeof evaluate !== "function") {
-      throw new CodeEvalDispatcherError(
-        "Evaluator source must export an evaluate(ctx) function",
-        { code: "INVALID_SOURCE" },
-      );
-    }
-
-    let result: unknown;
-    try {
-      result = await evaluate(input.payload);
-    } catch (error) {
-      throw new CodeEvalDispatcherError(
-        `Evaluator execution failed: ${error instanceof Error ? error.message : String(error)}`,
-        { code: "USER_CODE_ERROR", cause: error },
-      );
-    }
-
-    return parseDispatchResult(result);
+    return parseDispatchResult(message.result);
   }
+}
+
+function runInWorker(workerData: {
+  source: string;
+  payload: unknown;
+}): Promise<WorkerMessage> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(WORKER_SOURCE, { eval: true, workerData });
+    let settled = false;
+
+    const cleanup = () => {
+      settled = true;
+      void worker.terminate();
+    };
+
+    worker.once("message", (msg: WorkerMessage) => {
+      cleanup();
+      resolve(msg);
+    });
+
+    // Worker-level error: worker startup or unhandled rejection escaping
+    // the IIFE. The in-worker try/catch above covers the common paths, so
+    // hitting this branch usually means the runtime itself crashed.
+    worker.once("error", (error) => {
+      cleanup();
+      reject(
+        new CodeEvalDispatcherError(
+          `Local code eval worker crashed: ${error.message}`,
+          { code: "INVALID_SOURCE", cause: error },
+        ),
+      );
+    });
+
+    // Worker exits without posting a message (e.g. user code calls
+    // process.exit()). Surface as a user-code error rather than hanging.
+    worker.once("exit", (exitCode) => {
+      if (settled) return;
+      reject(
+        new CodeEvalDispatcherError(
+          `Local code eval worker exited with code ${exitCode} before returning a result`,
+          { code: "USER_CODE_ERROR" },
+        ),
+      );
+    });
+  });
 }

--- a/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
@@ -3,6 +3,7 @@ import { Worker } from "node:worker_threads";
 import { env } from "../../env";
 import {
   CodeEvalDispatcherError,
+  CodeEvalDispatcherErrorCodes,
   parseDispatchResult,
   type CodeEvalDispatcher,
   type CodeEvalDispatcherErrorCode,
@@ -61,7 +62,8 @@ type WorkerFailure = {
   ok: false;
   code: Extract<
     CodeEvalDispatcherErrorCode,
-    "INVALID_SOURCE" | "USER_CODE_ERROR"
+    | typeof CodeEvalDispatcherErrorCodes.INVALID_SOURCE
+    | typeof CodeEvalDispatcherErrorCodes.USER_CODE_ERROR
   >;
   message: string;
 };
@@ -80,7 +82,7 @@ export class LocalCodeEvalDispatcher implements CodeEvalDispatcher {
     if (input.runtime.language !== "TYPESCRIPT") {
       throw new CodeEvalDispatcherError(
         "Local code eval dispatcher only supports TypeScript/JavaScript evaluators",
-        { code: "UNSUPPORTED_RUNTIME" },
+        { code: CodeEvalDispatcherErrorCodes.UNSUPPORTED_RUNTIME },
       );
     }
 
@@ -90,7 +92,7 @@ export class LocalCodeEvalDispatcher implements CodeEvalDispatcher {
     } catch (error) {
       throw new CodeEvalDispatcherError(
         `Failed to strip TypeScript syntax: ${error instanceof Error ? error.message : String(error)}`,
-        { code: "INVALID_SOURCE", cause: error },
+        { code: CodeEvalDispatcherErrorCodes.INVALID_SOURCE, cause: error },
       );
     }
 
@@ -125,7 +127,7 @@ function runInWorker(
       cleanup();
       reject(
         new CodeEvalDispatcherError("Local code eval execution timed out", {
-          code: "TIMEOUT",
+          code: CodeEvalDispatcherErrorCodes.TIMEOUT,
           retryable: true,
         }),
       );
@@ -152,7 +154,7 @@ function runInWorker(
       reject(
         new CodeEvalDispatcherError(
           `Local code eval worker crashed: ${error.message}`,
-          { code: "INVALID_SOURCE", cause: error },
+          { code: CodeEvalDispatcherErrorCodes.INVALID_SOURCE, cause: error },
         ),
       );
     });
@@ -165,7 +167,7 @@ function runInWorker(
       reject(
         new CodeEvalDispatcherError(
           `Local code eval worker exited with code ${exitCode} before returning a result`,
-          { code: "USER_CODE_ERROR" },
+          { code: CodeEvalDispatcherErrorCodes.USER_CODE_ERROR },
         ),
       );
     });

--- a/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
@@ -1,5 +1,6 @@
 import { stripTypeScriptTypes } from "node:module";
 import { Worker } from "node:worker_threads";
+import { env } from "../../env";
 import {
   CodeEvalDispatcherError,
   parseDispatchResult,
@@ -68,6 +69,12 @@ type WorkerMessage = WorkerSuccess | WorkerFailure;
 
 export class LocalCodeEvalDispatcher implements CodeEvalDispatcher {
   public readonly name = "local";
+  private readonly timeoutMs: number;
+
+  constructor(params?: { timeoutMs?: number }) {
+    this.timeoutMs =
+      params?.timeoutMs ?? env.LANGFUSE_CODE_EVAL_LOCAL_TIMEOUT_MS;
+  }
 
   async dispatch(input: DispatchInput): Promise<DispatchResult> {
     if (input.runtime.language !== "TYPESCRIPT") {
@@ -87,7 +94,10 @@ export class LocalCodeEvalDispatcher implements CodeEvalDispatcher {
       );
     }
 
-    const message = await runInWorker({ source, payload: input.payload });
+    const message = await runInWorker(
+      { source, payload: input.payload },
+      this.timeoutMs,
+    );
 
     if (!message.ok) {
       throw new CodeEvalDispatcherError(message.message, {
@@ -99,20 +109,36 @@ export class LocalCodeEvalDispatcher implements CodeEvalDispatcher {
   }
 }
 
-function runInWorker(workerData: {
-  source: string;
-  payload: unknown;
-}): Promise<WorkerMessage> {
+function runInWorker(
+  workerData: {
+    source: string;
+    payload: unknown;
+  },
+  timeoutMs: number,
+): Promise<WorkerMessage> {
   return new Promise((resolve, reject) => {
     const worker = new Worker(WORKER_SOURCE, { eval: true, workerData });
     let settled = false;
 
+    const timer = setTimeout(() => {
+      if (settled) return;
+      cleanup();
+      reject(
+        new CodeEvalDispatcherError("Local code eval execution timed out", {
+          code: "TIMEOUT",
+          retryable: true,
+        }),
+      );
+    }, timeoutMs);
+
     const cleanup = () => {
       settled = true;
+      clearTimeout(timer);
       void worker.terminate();
     };
 
     worker.once("message", (msg: WorkerMessage) => {
+      if (settled) return;
       cleanup();
       resolve(msg);
     });
@@ -121,6 +147,7 @@ function runInWorker(workerData: {
     // the IIFE. The in-worker try/catch above covers the common paths, so
     // hitting this branch usually means the runtime itself crashed.
     worker.once("error", (error) => {
+      if (settled) return;
       cleanup();
       reject(
         new CodeEvalDispatcherError(
@@ -134,6 +161,7 @@ function runInWorker(workerData: {
     // process.exit()). Surface as a user-code error rather than hanging.
     worker.once("exit", (exitCode) => {
       if (settled) return;
+      cleanup();
       reject(
         new CodeEvalDispatcherError(
           `Local code eval worker exited with code ${exitCode} before returning a result`,

--- a/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
@@ -68,7 +68,7 @@ type WorkerFailure = {
 type WorkerMessage = WorkerSuccess | WorkerFailure;
 
 export class LocalCodeEvalDispatcher implements CodeEvalDispatcher {
-  public readonly name = "local";
+  public readonly name = "insecure-local";
   private readonly timeoutMs: number;
 
   constructor(params?: { timeoutMs?: number }) {

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -19,6 +19,7 @@ export * from "./services/commentFilterService";
 export * from "./datasets/schemaValidation";
 export * from "./datasets/schemaTypes";
 export * from "./evalJobConfigCache";
+export * from "./evals/codeEvalDispatchers";
 export * from "./auth/apiKeys";
 export * from "./auth/invalidateApiKeys";
 export * from "./auth/customSsoProvider";

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -536,6 +536,7 @@ export type LLMApiKey =
 export enum LangfuseInternalTraceEnvironment {
   PromptExperiments = "langfuse-prompt-experiment",
   LLMJudge = "langfuse-llm-as-a-judge",
+  CodeEval = "langfuse-code-eval",
 }
 
 export type ProcessedTraceEvent = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@aws-sdk/client-cloudwatch':
         specifier: ^3.1013.0
         version: 3.1024.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3.1046.0
+        version: 3.1046.0
       '@aws-sdk/client-s3':
         specifier: ^3.1013.0
         version: 3.1024.0
@@ -1102,6 +1105,10 @@ packages:
     resolution: {integrity: sha512-KYd1SYF+WaZinfzg4rsfprZQ3X1qboaJnHtjppd82JG3YSO/LVkenOkFIIsREPnXMoy6Dy6Xx+BXh4Y9A+a1zQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-lambda@3.1046.0':
+    resolution: {integrity: sha512-g997Ks9pIxUWrc+BRlbkEXCIsYiW60lVSvSt38UXu50XG6DAH63l+ALiwzBk47TA2XlFO7z/IufklQCnCBaQnQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-s3@3.1024.0':
     resolution: {integrity: sha512-8qdO5aLCzaf9l0RdrSBW1iIroRKP2QBqtZ6lkrtHKiaaH0B18xEn+lrEgiN/eCf3uRAYk4cqbnI2XcWzm+7dDQ==}
     engines: {node: '>=20.0.0'}
@@ -1109,6 +1116,11 @@ packages:
   '@aws-sdk/core@3.973.26':
     resolution: {integrity: sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==}
     engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.9':
+    resolution: {integrity: sha512-bXxosFunr+v/kqNb99r1NRkrVBha7CG036fRSpWGbC1A/e363XFQN6wcZMx7MYTdRr1tYwNnkrWX2xc1rT3BCQ==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Deprecated due to an error deserialization bug in JSON 1.0 protocol services, see https://github.com/aws/aws-sdk-js-v3/pull/8031. Newer version available.
 
   '@aws-sdk/crc64-nvme@3.972.5':
     resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
@@ -1118,32 +1130,64 @@ packages:
     resolution: {integrity: sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.35':
+    resolution: {integrity: sha512-WkFQ8BedszVomhh/Zzs8WwnE/XBmTqZjoQVB8u/4zH6kZCjouXZpPpb93gD8m0EZmzAl7dxHE/y+yDpuKzNCMw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.26':
     resolution: {integrity: sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.37':
+    resolution: {integrity: sha512-ylx0ZJTU+2eNcvXQ69VNR3TVSYa/ibpvdK717/NxqR9aXRMn2QRWZaiI8aa5yY/fOWZ5mknSmxGaVxxtdwv3EA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.28':
     resolution: {integrity: sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.39':
+    resolution: {integrity: sha512-QhRSrdkk+Gq0AFIylpiI0N6lcJqFYV9Jtr4Luz5FpYOYbjJSfyTG6iLhnK/UPIgN1Jnon8WAmSC//16XYGvwkA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.28':
     resolution: {integrity: sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.39':
+    resolution: {integrity: sha512-1hU0NtC04QbFIuoBuF4aQ2A97GsSE5/A0ZJpDijwexsBREIQ4KPRYl3v/FfKCPBYsaTeGjkOFx5nLhWHY24LOw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.29':
     resolution: {integrity: sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.40':
+    resolution: {integrity: sha512-ZgrQaGkpyTlVSCCsffzijVg+KgftTAWYvI5Otc36J/4jNiHb+7MmBiJIR0a5AHLvifC92PiYHt5pijP0dswd1w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.24':
     resolution: {integrity: sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.35':
+    resolution: {integrity: sha512-hNj1rAwZWT1vfz54BwH8FUWxZuqStrM25Q5LEIwn2erHPMRVAjLlpZqEbCEEqS99eEEOhdeetnS0WeNa3iYeEQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.28':
     resolution: {integrity: sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.39':
+    resolution: {integrity: sha512-mwIPNPldyCZkvHozb6E0X/vuQLN1UCjcA6MwUf1gaO7EwghCmuNZXatq0L3zptKFvPC4Nds7+WFUkifI1XmbSw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.28':
     resolution: {integrity: sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.39':
+    resolution: {integrity: sha512-b9HT8CnpyPVn1hU14Q7ihjwSPlRzToYmRYJxRd5jNHEZ43lrIhoLaTT8JmfQQt5j5M8rTX1iN1X8mvu0SM1dXA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/eventstream-handler-node@3.972.11':
@@ -1172,6 +1216,10 @@ packages:
     resolution: {integrity: sha512-YckB8k1ejbyCg/g36gUMFLNzE4W5cERIa4MtsdO+wpTmJEP0+TB7okWIt7d8TDOvnb7SwvxJ21E4TGOBxFpSWQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-host-header@3.972.11':
+    resolution: {integrity: sha512-CBC6+tVYaOJo7QXgN1zJ4Ba2f3/Cpy4eRViYFimXW/O5Mn8hBmgXXzHu4vy4ubT80YWnp8aCFygr7dTOa14yQg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-host-header@3.972.8':
     resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
     engines: {node: '>=20.0.0'}
@@ -1180,8 +1228,16 @@ packages:
     resolution: {integrity: sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-logger@3.972.8':
     resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.12':
+    resolution: {integrity: sha512-5eltYxKB4MfdQv7/VhWxRbAVQKow5dz9votRFigTYrWJHMQXwLMltlbk7KFWSZh5NDBySfmjT7Jv/DWfYCmDng==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-recursion-detection@3.972.9':
@@ -1200,6 +1256,10 @@ packages:
     resolution: {integrity: sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-user-agent@3.972.39':
+    resolution: {integrity: sha512-MlNSvNsSVlMKKWaCzA0GP1nS4Cuq3WCXUN1vmMvd+Ctztib5kmRcpmTtKx9kikN8szAc+gcdp7uqJJervV2nQg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-websocket@3.972.13':
     resolution: {integrity: sha512-Gp6EWIqHX5wmsOR5ZxWyyzEU8P0xBdSxkm6VHEwXwBqScKZ7QWRoj6ZmHpr+S44EYb5tuzGya4ottsogSu2W3A==}
     engines: {node: '>= 14.0.0'}
@@ -1208,8 +1268,16 @@ packages:
     resolution: {integrity: sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.7':
+    resolution: {integrity: sha512-jT2AXOODobQfTYGC2SChMSnZ/voIcRV/LHlY1suyhY1bdgP/voKkhEg8Ci1jiGQ4lBiaso5BEAV3ZWWpPTfmYA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.10':
     resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.14':
+    resolution: {integrity: sha512-VuLXVmm7+lKVxqFcOItPkXhjbJ02iUfxkxheRu41SfWf6/xrZup2A2SwHZos/LeQGu3SBHeqTQht80Uo3ienPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.1024.0':
@@ -1220,6 +1288,10 @@ packages:
     resolution: {integrity: sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.26':
+    resolution: {integrity: sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1013.0':
     resolution: {integrity: sha512-IL1c54UvbuERrs9oLm5rvkzMciwhhpn1FL0SlC3XUMoLlFhdBsWJgQKK8O5fsQLxbFVqjbjFx9OBkrn44X9PHw==}
     engines: {node: '>=20.0.0'}
@@ -1228,8 +1300,16 @@ packages:
     resolution: {integrity: sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1046.0':
+    resolution: {integrity: sha512-9je8nZt+ntB8IjhpGNayU/AkBgvq/f4aFO2bH1LSNC5JX6K8zY4LUnr/ymqunePrwq+B5OVBpL7ILjYzMFSZAw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.6':
     resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -1240,6 +1320,10 @@ packages:
     resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/util-endpoints@3.996.9':
+    resolution: {integrity: sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/util-format-url@3.972.8':
     resolution: {integrity: sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==}
     engines: {node: '>=20.0.0'}
@@ -1247,6 +1331,9 @@ packages:
   '@aws-sdk/util-locate-window@3.568.0':
     resolution: {integrity: sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==}
     engines: {node: '>=16.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.11':
+    resolution: {integrity: sha512-kq3RS6XQtHMrLFShbkem6h+8fxazB3jEIsbMC6aaSInOciRGE+eGAqTgJ+obO7Euo/pjM8thVqLiLISEH9X9DA==}
 
   '@aws-sdk/util-user-agent-browser@3.972.8':
     resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
@@ -1260,8 +1347,21 @@ packages:
       aws-crt:
         optional: true
 
+  '@aws-sdk/util-user-agent-node@3.973.25':
+    resolution: {integrity: sha512-066hKH/0nvV7x4ofV/iK9kz8r/qNfcR6rzuEOFqI2vQL/fcTTsDAbTw0jmXkyMzANK8ltQdALj19ns3zuOJiUw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
   '@aws-sdk/xml-builder@3.972.16':
     resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.23':
+    resolution: {integrity: sha512-A0YmgYFv+hTI9c17Ntvd2hSehm9bmJfkb+ggADBwVKA8H/3+Jx94SzR2qOB9bAA9WFeDqnfz9PKKQ+D+YAKomA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -2441,6 +2541,9 @@ packages:
   '@noble/hashes@1.7.1':
     resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4275,8 +4378,16 @@ packages:
     resolution: {integrity: sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.2':
+    resolution: {integrity: sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.2':
+    resolution: {integrity: sha512-iYr9ekBjmZ+FwkiHEopqGscBbl78X62cq3p5Dd0eC+gNd7fybNZFQQdDuOQjTVmFymleuA8YRWZnuXWZ8B3kKA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.12':
@@ -4301,6 +4412,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.15':
     resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.2':
+    resolution: {integrity: sha512-3wF40g8OOCA5BnwQUvwtzZqYBbWWftDjpAlWIUo6Yld3ZzJaMAKqg7MWQBPjE8oLaqvZQUE7tVGlZPsae6A4bQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -4363,6 +4478,10 @@ packages:
     resolution: {integrity: sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.2':
+    resolution: {integrity: sha512-EdksTZ8UXYxGUgQ4mpIKrHoaj9WVGsp66TpZuixLAz1Jex8YDLnS4RH9ktGED5aOpN0OJlEtrsC9IGt76go1eA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.12':
     resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
     engines: {node: '>=18.0.0'}
@@ -4391,12 +4510,20 @@ packages:
     resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.4.2':
+    resolution: {integrity: sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.8':
     resolution: {integrity: sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.13.1':
     resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.12':
@@ -6715,6 +6842,10 @@ packages:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
     hasBin: true
 
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
@@ -8468,6 +8599,10 @@ packages:
     resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
     engines: {node: '>=14.0.0'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -9419,6 +9554,9 @@ packages:
   strnum@2.2.1:
     resolution: {integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
@@ -10259,7 +10397,7 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
@@ -10282,7 +10420,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/util-locate-window': 3.568.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -10290,7 +10428,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -10299,7 +10437,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.8
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -10492,6 +10630,29 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-lambda@3.1046.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/credential-provider-node': 3.972.40
+      '@aws-sdk/middleware-host-header': 3.972.11
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.12
+      '@aws-sdk/middleware-user-agent': 3.972.39
+      '@aws-sdk/region-config-resolver': 3.972.14
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.9
+      '@aws-sdk/util-user-agent-browser': 3.972.11
+      '@aws-sdk/util-user-agent-node': 3.973.25
+      '@smithy/core': 3.24.2
+      '@smithy/fetch-http-handler': 5.4.2
+      '@smithy/node-http-handler': 4.7.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-s3@3.1024.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
@@ -10568,6 +10729,15 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.23
+      '@smithy/core': 3.24.2
+      '@smithy/signature-v4': 5.4.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.5':
     dependencies:
       '@smithy/types': 4.13.1
@@ -10581,6 +10751,14 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.35':
+    dependencies:
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.26':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -10592,6 +10770,16 @@ snapshots:
       '@smithy/smithy-client': 4.12.8
       '@smithy/types': 4.13.1
       '@smithy/util-stream': 4.5.21
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/fetch-http-handler': 5.4.2
+      '@smithy/node-http-handler': 4.7.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.28':
@@ -10613,6 +10801,24 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/credential-provider-env': 3.972.35
+      '@aws-sdk/credential-provider-http': 3.972.37
+      '@aws-sdk/credential-provider-login': 3.972.39
+      '@aws-sdk/credential-provider-process': 3.972.35
+      '@aws-sdk/credential-provider-sso': 3.972.39
+      '@aws-sdk/credential-provider-web-identity': 3.972.39
+      '@aws-sdk/nested-clients': 3.997.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/credential-provider-imds': 4.3.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-login@3.972.28':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -10622,6 +10828,17 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/nested-clients': 3.997.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -10643,6 +10860,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.40':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.35
+      '@aws-sdk/credential-provider-http': 3.972.37
+      '@aws-sdk/credential-provider-ini': 3.972.39
+      '@aws-sdk/credential-provider-process': 3.972.35
+      '@aws-sdk/credential-provider-sso': 3.972.39
+      '@aws-sdk/credential-provider-web-identity': 3.972.39
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/credential-provider-imds': 4.3.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-process@3.972.24':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -10650,6 +10883,14 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.35':
+    dependencies:
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.28':
@@ -10665,6 +10906,18 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/nested-clients': 3.997.7
+      '@aws-sdk/token-providers': 3.1046.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-web-identity@3.972.28':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -10673,6 +10926,17 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/nested-clients': 3.997.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -10737,6 +11001,13 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-host-header@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-host-header@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -10750,10 +11021,24 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-logger@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.12':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.972.9':
@@ -10796,6 +11081,15 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-retry': 4.2.13
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.9
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-websocket@3.972.13':
@@ -10856,12 +11150,42 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.7':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/middleware-host-header': 3.972.11
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.12
+      '@aws-sdk/middleware-user-agent': 3.972.39
+      '@aws-sdk/region-config-resolver': 3.972.14
+      '@aws-sdk/signature-v4-multi-region': 3.996.26
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.9
+      '@aws-sdk/util-user-agent-browser': 3.972.11
+      '@aws-sdk/util-user-agent-node': 3.973.25
+      '@smithy/core': 3.24.2
+      '@smithy/fetch-http-handler': 5.4.2
+      '@smithy/node-http-handler': 4.7.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/region-config-resolver@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@smithy/config-resolver': 4.4.13
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/region-config-resolver@3.972.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/s3-request-presigner@3.1024.0':
@@ -10882,6 +11206,14 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/signature-v4': 5.3.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.26':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/signature-v4': 5.4.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1013.0':
@@ -10908,9 +11240,25 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.1046.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.9
+      '@aws-sdk/nested-clients': 3.997.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/types@3.973.6':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -10925,6 +11273,13 @@ snapshots:
       '@smithy/util-endpoints': 3.3.3
       tslib: 2.8.1
 
+  '@aws-sdk/util-endpoints@3.996.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/util-format-url@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -10934,6 +11289,13 @@ snapshots:
 
   '@aws-sdk/util-locate-window@3.568.0':
     dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-browser@3.972.8':
@@ -10952,10 +11314,25 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/util-user-agent-node@3.973.25':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.39
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.972.16':
     dependencies:
       '@smithy/types': 4.13.1
       fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.23':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.2
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -12172,6 +12549,8 @@ snapshots:
     optional: true
 
   '@noble/hashes@1.7.1': {}
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -14132,12 +14511,24 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.2':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.12':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.2':
+    dependencies:
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.12':
@@ -14176,6 +14567,12 @@ snapshots:
       '@smithy/querystring-builder': 4.2.12
       '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.2':
+    dependencies:
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -14285,6 +14682,12 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.2':
+    dependencies:
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
@@ -14326,6 +14729,12 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.4.2':
+    dependencies:
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.8':
     dependencies:
       '@smithy/core': 3.23.13
@@ -14337,6 +14746,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.13.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
     dependencies:
       tslib: 2.8.1
 
@@ -17006,6 +17419,13 @@ snapshots:
       path-expression-matcher: 1.2.0
       strnum: 2.2.1
 
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.7
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+
   fastest-levenshtein@1.0.16: {}
 
   fastq@1.20.1:
@@ -19050,6 +19470,8 @@ snapshots:
 
   path-expression-matcher@1.2.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -20150,6 +20572,8 @@ snapshots:
       '@types/node': 24.3.0
 
   strnum@2.2.1: {}
+
+  strnum@2.3.0: {}
 
   stubs@3.0.0: {}
 

--- a/scripts/code-eval-runners/bootstrap-floci.py
+++ b/scripts/code-eval-runners/bootstrap-floci.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+import base64
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+ENDPOINT = os.environ.get("FLOCI_ENDPOINT", "http://localhost:4566").rstrip("/")
+RUNNERS_DIR = Path(os.environ.get("CODE_EVAL_RUNNERS_DIR", "/opt/code-eval-runners"))
+BUILD_DIR = Path(os.environ.get("CODE_EVAL_RUNNERS_BUILD_DIR", "/tmp/code-eval-runners"))
+ROLE_ARN = "arn:aws:iam::000000000000:role/code-eval-floci-role"
+NODE_FUNCTION = "code-based-eval-executor-node"
+PYTHON_FUNCTION = "code-based-eval-executor-python"
+
+
+def main() -> None:
+    wait_for_floci()
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+
+    node_zip = BUILD_DIR / "node.zip"
+    python_zip = BUILD_DIR / "python.zip"
+
+    node_handler_file = "code-based-eval-handler.mjs"
+    python_handler_file = "code_based_eval_handler.py"
+
+    with ZipFile(node_zip, "w", ZIP_DEFLATED) as zf:
+        zf.write(RUNNERS_DIR / "node" / node_handler_file, node_handler_file)
+
+    with ZipFile(python_zip, "w", ZIP_DEFLATED) as zf:
+        zf.write(
+            RUNNERS_DIR / "python" / python_handler_file, python_handler_file
+        )
+
+    upsert_lambda(
+        NODE_FUNCTION, "nodejs24.x", "code-based-eval-handler.handler", node_zip
+    )
+    upsert_lambda(
+        PYTHON_FUNCTION,
+        "python3.13",
+        "code_based_eval_handler.handler",
+        python_zip,
+    )
+
+    print("Code eval Floci Lambda runners are ready.", flush=True)
+
+
+def wait_for_floci() -> None:
+    for _ in range(60):
+        try:
+            request("GET", "/2015-03-31/functions")
+            return
+        except Exception:
+            time.sleep(1)
+
+    raise RuntimeError(f"Timed out waiting for Floci at {ENDPOINT}")
+
+
+def upsert_lambda(
+    function_name: str,
+    runtime: str,
+    handler: str,
+    zip_path: Path,
+) -> None:
+    encoded_zip = base64.b64encode(zip_path.read_bytes()).decode("ascii")
+
+    if function_exists(function_name):
+        request(
+            "PUT",
+            f"/2015-03-31/functions/{function_name}/code",
+            {"ZipFile": encoded_zip},
+        )
+        return
+
+    request(
+        "POST",
+        "/2015-03-31/functions",
+        {
+            "FunctionName": function_name,
+            "Runtime": runtime,
+            "Handler": handler,
+            "Role": ROLE_ARN,
+            "Timeout": 2,
+            "MemorySize": 128,
+            "Code": {"ZipFile": encoded_zip},
+        },
+    )
+
+
+def function_exists(function_name: str) -> bool:
+    try:
+        request("GET", f"/2015-03-31/functions/{function_name}")
+        return True
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return False
+        raise
+
+
+def request(method: str, path: str, payload=None) -> bytes:
+    data = None
+    headers = {"Content-Type": "application/json"}
+
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+
+    req = urllib.request.Request(
+        f"{ENDPOINT}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+
+    with urllib.request.urlopen(req, timeout=10) as response:
+        return response.read()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/code-eval-runners/bootstrap-floci.py
+++ b/scripts/code-eval-runners/bootstrap-floci.py
@@ -113,9 +113,6 @@ def request(method: str, path: str, payload=None) -> bytes:
         method=method,
     )
 
-    # Dev infra: ENDPOINT is operator-supplied (default localhost Floci),
-    # not user input.
-    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
     with urllib.request.urlopen(req, timeout=10) as response:
         return response.read()
 

--- a/scripts/code-eval-runners/bootstrap-floci.py
+++ b/scripts/code-eval-runners/bootstrap-floci.py
@@ -113,6 +113,9 @@ def request(method: str, path: str, payload=None) -> bytes:
         method=method,
     )
 
+    # Dev infra: ENDPOINT is operator-supplied (default localhost Floci),
+    # not user input.
+    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
     with urllib.request.urlopen(req, timeout=10) as response:
         return response.read()
 

--- a/scripts/code-eval-runners/node/code-based-eval-handler.mjs
+++ b/scripts/code-eval-runners/node/code-based-eval-handler.mjs
@@ -1,0 +1,69 @@
+import { stripTypeScriptTypes } from "node:module";
+
+export async function handler(event) {
+  let source;
+  try {
+    source = stripTypeScriptTypes(event.code.source, { mode: "strip" });
+  } catch (error) {
+    return runnerError(
+      "INVALID_SOURCE",
+      `Failed to strip TypeScript syntax: ${formatError(error)}`,
+    );
+  }
+
+  let evaluate;
+  try {
+    const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}#${event.execution.jobExecutionId}-${Date.now()}`;
+    const module = await import(moduleUrl);
+    evaluate = module.evaluate;
+  } catch (error) {
+    return runnerError(
+      "INVALID_SOURCE",
+      `Failed to load evaluator source: ${formatError(error)}`,
+    );
+  }
+
+  if (typeof evaluate !== "function") {
+    return runnerError(
+      "INVALID_SOURCE",
+      "Evaluator source must export an evaluate(ctx) function",
+    );
+  }
+
+  let result;
+  try {
+    result = await evaluate(event.payload);
+  } catch (error) {
+    return runnerError("USER_CODE_ERROR", formatError(error));
+  }
+
+  return normalizeResult(result);
+}
+
+function normalizeResult(result) {
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    !Array.isArray(result.scores)
+  ) {
+    return runnerError(
+      "INVALID_RESULT",
+      "Evaluator must return an object shaped like { scores: [...] }",
+    );
+  }
+
+  return result;
+}
+
+function runnerError(code, message) {
+  return {
+    error: {
+      code,
+      message,
+    },
+  };
+}
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/scripts/code-eval-runners/node/code-based-eval-handler.mjs
+++ b/scripts/code-eval-runners/node/code-based-eval-handler.mjs
@@ -1,4 +1,52 @@
 import { stripTypeScriptTypes } from "node:module";
+import { Worker } from "node:worker_threads";
+
+const WORKER_SOURCE = `
+import { parentPort, workerData } from "node:worker_threads";
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+(async () => {
+  const moduleUrl =
+    "data:text/javascript;base64," +
+    Buffer.from(workerData.source).toString("base64");
+
+  let evaluate;
+  try {
+    const module = await import(moduleUrl);
+    evaluate = module.evaluate;
+  } catch (error) {
+    parentPort.postMessage({
+      ok: false,
+      code: "INVALID_SOURCE",
+      message: "Failed to load evaluator source: " + formatError(error),
+    });
+    return;
+  }
+
+  if (typeof evaluate !== "function") {
+    parentPort.postMessage({
+      ok: false,
+      code: "INVALID_SOURCE",
+      message: "Evaluator source must export an evaluate(ctx) function",
+    });
+    return;
+  }
+
+  try {
+    const result = await evaluate(workerData.payload);
+    parentPort.postMessage({ ok: true, result });
+  } catch (error) {
+    parentPort.postMessage({
+      ok: false,
+      code: "USER_CODE_ERROR",
+      message: formatError(error),
+    });
+  }
+})();
+`;
 
 export async function handler(event) {
   let source;
@@ -11,33 +59,54 @@ export async function handler(event) {
     );
   }
 
-  let evaluate;
+  let message;
   try {
-    const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}#${event.execution.jobExecutionId}-${Date.now()}`;
-    const module = await import(moduleUrl);
-    evaluate = module.evaluate;
-  } catch (error) {
-    return runnerError(
-      "INVALID_SOURCE",
-      `Failed to load evaluator source: ${formatError(error)}`,
-    );
-  }
-
-  if (typeof evaluate !== "function") {
-    return runnerError(
-      "INVALID_SOURCE",
-      "Evaluator source must export an evaluate(ctx) function",
-    );
-  }
-
-  let result;
-  try {
-    result = await evaluate(event.payload);
+    message = await runInWorker({ source, payload: event.payload });
   } catch (error) {
     return runnerError("USER_CODE_ERROR", formatError(error));
   }
 
-  return normalizeResult(result);
+  if (!message.ok) {
+    return runnerError(message.code, message.message);
+  }
+
+  return normalizeResult(message.result);
+}
+
+function runInWorker(workerData) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL(
+        `data:text/javascript;base64,${Buffer.from(WORKER_SOURCE).toString("base64")}`,
+      ),
+      { workerData },
+    );
+    let settled = false;
+
+    const cleanup = () => {
+      settled = true;
+      void worker.terminate();
+    };
+
+    worker.once("message", (message) => {
+      cleanup();
+      resolve(message);
+    });
+
+    worker.once("error", (error) => {
+      cleanup();
+      reject(error);
+    });
+
+    worker.once("exit", (exitCode) => {
+      if (settled) return;
+      reject(
+        new Error(
+          `Code eval worker exited with code ${exitCode} before returning a result`,
+        ),
+      );
+    });
+  });
 }
 
 function normalizeResult(result) {

--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -60,6 +60,10 @@ def handler(event, context):
     }
 
     try:
+        # Executing user-supplied evaluator code is the entire purpose of this
+        # runner; isolation is provided by the per-invocation Lambda sandbox,
+        # not by avoiding `exec`.
+        # nosemgrep: python.aws-lambda.security.tainted-code-exec.tainted-code-exec,python.lang.security.audit.exec-detected.exec-detected
         exec(event["code"]["source"], namespace)
     except Exception as error:
         return runner_error(

--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -14,8 +14,8 @@ class ObservationContext:
 
 @dataclass
 class ExperimentContext:
-    expectedOutput: Any = None
-    itemMetadata: Any = None
+    expected_output: Any = None
+    item_metadata: Any = None
 
 
 @dataclass
@@ -34,8 +34,8 @@ class EvaluationContext:
                 metadata=observation.get("metadata"),
             ),
             experiment=ExperimentContext(
-                expectedOutput=experiment.get("expectedOutput"),
-                itemMetadata=experiment.get("itemMetadata"),
+                expected_output=experiment.get("expectedOutput"),
+                item_metadata=experiment.get("itemMetadata"),
             )
             if isinstance(experiment, dict)
             else None,

--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -132,6 +132,9 @@ def to_jsonable(value):
     if isinstance(value, list):
         return [to_jsonable(item) for item in value]
 
+    if isinstance(value, dict):
+        return {key: to_jsonable(item) for key, item in value.items()}
+
     try:
         json.dumps(value)
         return value

--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -60,10 +60,6 @@ def handler(event, context):
     }
 
     try:
-        # Executing user-supplied evaluator code is the entire purpose of this
-        # runner; isolation is provided by the per-invocation Lambda sandbox,
-        # not by avoiding `exec`.
-        # nosemgrep: python.aws-lambda.security.tainted-code-exec.tainted-code-exec,python.lang.security.audit.exec-detected.exec-detected
         exec(event["code"]["source"], namespace)
     except Exception as error:
         return runner_error(

--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -5,22 +5,41 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
-class EvaluationContext:
-    def __init__(self, payload: dict[str, Any]):
-        self.input = payload.get("input")
-        self.output = payload.get("output")
-        self.observation_metadata = payload.get("observationMetadata")
-        self.experiment_expected_output = payload.get("experimentExpectedOutput")
-        self.experiment_item_metadata = payload.get("experimentItemMetadata")
+@dataclass
+class ObservationContext:
+    input: Any = None
+    output: Any = None
+    metadata: Any = None
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "input": self.input,
-            "output": self.output,
-            "observation_metadata": self.observation_metadata,
-            "experiment_expected_output": self.experiment_expected_output,
-            "experiment_item_metadata": self.experiment_item_metadata,
-        }
+
+@dataclass
+class ExperimentContext:
+    expectedOutput: Any = None
+    itemMetadata: Any = None
+
+
+@dataclass
+class EvaluationContext:
+    observation: ObservationContext
+    experiment: ExperimentContext | None = None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]):
+        observation = payload.get("observation") or {}
+        experiment = payload.get("experiment")
+        return cls(
+            observation=ObservationContext(
+                input=observation.get("input"),
+                output=observation.get("output"),
+                metadata=observation.get("metadata"),
+            ),
+            experiment=ExperimentContext(
+                expectedOutput=experiment.get("expectedOutput"),
+                itemMetadata=experiment.get("itemMetadata"),
+            )
+            if isinstance(experiment, dict)
+            else None,
+        )
 
 
 # Public dataclasses exposed to user evaluator code. Field names are Pythonic
@@ -33,7 +52,6 @@ class Score:
     data_type: str | None = None
     name: str | None = None
     comment: str | None = None
-    metadata: Any | None = None
     config_id: str | None = None
 
 
@@ -73,7 +91,7 @@ def handler(event, context):
         )
 
     try:
-        result = evaluate(EvaluationContext(event.get("payload", {})))
+        result = evaluate(EvaluationContext.from_payload(event.get("payload", {})))
         if asyncio.iscoroutine(result):
             result = asyncio.run(result)
     except Exception as error:

--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -1,0 +1,125 @@
+import asyncio
+import dataclasses
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class EvaluationContext:
+    def __init__(self, payload: dict[str, Any]):
+        self.input = payload.get("input")
+        self.output = payload.get("output")
+        self.observation_metadata = payload.get("observationMetadata")
+        self.experiment_expected_output = payload.get("experimentExpectedOutput")
+        self.experiment_item_metadata = payload.get("experimentItemMetadata")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "input": self.input,
+            "output": self.output,
+            "observation_metadata": self.observation_metadata,
+            "experiment_expected_output": self.experiment_expected_output,
+            "experiment_item_metadata": self.experiment_item_metadata,
+        }
+
+
+# Public dataclasses exposed to user evaluator code. Field names are Pythonic
+# (snake_case); they are translated to the camelCase wire format (`dataType`,
+# `configId`) by `to_jsonable` so users can return an `EvaluationResult`
+# directly without manual key mangling.
+@dataclass
+class Score:
+    value: Any
+    data_type: str | None = None
+    name: str | None = None
+    comment: str | None = None
+    metadata: Any | None = None
+    config_id: str | None = None
+
+
+@dataclass
+class EvaluationResult:
+    scores: list[Score] = field(default_factory=list)
+
+
+# Mapping from dataclass snake_case field names to the camelCase keys expected
+# by the dispatcher wire schema. Kept as an explicit allowlist so that user
+# metadata payloads (which may legitimately contain snake_case keys) are never
+# rewritten — only dataclass field names are translated.
+_DATACLASS_FIELD_NAME_OVERRIDES: dict[str, str] = {
+    "data_type": "dataType",
+    "config_id": "configId",
+}
+
+
+def handler(event, context):
+    namespace = {
+        "EvaluationContext": EvaluationContext,
+        "EvaluationResult": EvaluationResult,
+        "Score": Score,
+    }
+
+    try:
+        exec(event["code"]["source"], namespace)
+    except Exception as error:
+        return runner_error(
+            "INVALID_SOURCE", f"Failed to load evaluator source: {error}"
+        )
+
+    evaluate = namespace.get("evaluate")
+    if not callable(evaluate):
+        return runner_error(
+            "INVALID_SOURCE", "Evaluator source must define an evaluate(ctx) function"
+        )
+
+    try:
+        result = evaluate(EvaluationContext(event.get("payload", {})))
+        if asyncio.iscoroutine(result):
+            result = asyncio.run(result)
+    except Exception as error:
+        return runner_error("USER_CODE_ERROR", str(error))
+
+    return normalize_result(result)
+
+
+def normalize_result(result):
+    normalized = to_jsonable(result)
+
+    if not isinstance(normalized, dict) or not isinstance(
+        normalized.get("scores"), list
+    ):
+        return runner_error(
+            "INVALID_RESULT",
+            "Evaluator must return an object shaped like { scores: [...] }",
+        )
+
+    return normalized
+
+
+def to_jsonable(value):
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        # Translate snake_case dataclass field names to the camelCase wire
+        # format and drop None-valued optional fields so that the result
+        # matches the union variants in the TypeScript schema (e.g. the
+        # `dataType: undefined` variant).
+        result = {}
+        for f in dataclasses.fields(value):
+            raw = getattr(value, f.name)
+            if raw is None:
+                continue
+            key = _DATACLASS_FIELD_NAME_OVERRIDES.get(f.name, f.name)
+            result[key] = to_jsonable(raw)
+        return result
+
+    if isinstance(value, list):
+        return [to_jsonable(item) for item in value]
+
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        return str(value)
+
+
+def runner_error(code: str, message: str):
+    return {"error": {"code": code, "message": message}}

--- a/web/src/features/evals/components/evaluation-prompt-preview.tsx
+++ b/web/src/features/evals/components/evaluation-prompt-preview.tsx
@@ -100,7 +100,7 @@ const ColoredPromptView = ({
                 fragment.content
               ) : (
                 <ColoredVariable
-                  value={fragment.value || ""}
+                  value={fragment.value ?? ""}
                   index={fragment.colorIndex || 0}
                 />
               )}
@@ -173,7 +173,7 @@ export const EvaluationPromptPreview = ({
       // Add variable
       const variableName = match[1];
       const variableValue =
-        extractedVariables.find((v) => v.variable === variableName)?.value ||
+        extractedVariables.find((v) => v.variable === variableName)?.value ??
         "";
 
       fragments.push({

--- a/web/src/features/evals/hooks/useExtractVariables.ts
+++ b/web/src/features/evals/hooks/useExtractVariables.ts
@@ -2,7 +2,10 @@ import { type PreviewData } from "@/src/features/evals/hooks/usePreviewData";
 import { type VariableMapping } from "@/src/features/evals/utils/evaluator-form-utils";
 import { api } from "@/src/utils/api";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { EvalTargetObject, extractValueFromObject } from "@langfuse/shared";
+import {
+  EvalTargetObject,
+  extractValueFromObjectAsString,
+} from "@langfuse/shared";
 import { useEffect, useState, useRef } from "react";
 
 /**
@@ -20,7 +23,7 @@ function getObservationByName(
 
 type ExtractedVariable = {
   variable: string;
-  value: unknown;
+  value: string;
 };
 
 type ExtractionError =
@@ -158,7 +161,7 @@ export function useExtractVariables({
         return { variable, value: "n/a" };
       }
 
-      const { value, error } = extractValueFromObject(
+      const { value, error } = extractValueFromObjectAsString(
         object,
         mapping.selectedColumnId,
         mapping.jsonSelector ?? undefined,

--- a/web/src/features/evals/utils/evaluator-constants.ts
+++ b/web/src/features/evals/utils/evaluator-constants.ts
@@ -40,6 +40,7 @@ export const OUTPUT_MAPPING = [
 
 export const INTERNAL_ENVIRONMENTS = [
   LangfuseInternalTraceEnvironment.LLMJudge,
+  LangfuseInternalTraceEnvironment.CodeEval,
   "langfuse-prompt-experiment",
   "langfuse-evaluation",
   "sdk-experiment",

--- a/web/src/features/filters/constants/internal-environments.ts
+++ b/web/src/features/filters/constants/internal-environments.ts
@@ -3,6 +3,7 @@ import { LangfuseInternalTraceEnvironment } from "@langfuse/shared";
 export const DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS = [
   LangfuseInternalTraceEnvironment.PromptExperiments,
   LangfuseInternalTraceEnvironment.LLMJudge,
+  LangfuseInternalTraceEnvironment.CodeEval,
   "langfuse-evaluation",
   "sdk-experiment",
 ] as const;

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -2403,11 +2403,11 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
       expect(result).toEqual([
         {
-          value: '{"input":"This is a great prompt"}',
+          value: { input: "This is a great prompt" },
           var: "input",
         },
         {
-          value: '{"expected_output":"This is a great response"}',
+          value: { expected_output: "This is a great response" },
           var: "output",
         },
       ]);
@@ -2451,12 +2451,12 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
       expect(result).toEqual([
         {
-          value: '{"input":"This is a great prompt"}',
+          value: { input: "This is a great prompt" },
           var: "input",
           environment: "production",
         },
         {
-          value: '{"output":"This is a great response"}',
+          value: { output: "This is a great response" },
           var: "output",
           environment: "production",
         },
@@ -2516,12 +2516,12 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
       expect(result).toEqual([
         {
-          value: '{"huhu":"This is a great prompt"}',
+          value: { huhu: "This is a great prompt" },
           var: "input",
           environment: "production",
         },
         {
-          value: '{"haha":"This is a great response"}',
+          value: { haha: "This is a great response" },
           var: "output",
           environment: "production",
         },
@@ -2613,12 +2613,12 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
       expect(result).toEqual([
         {
           environment: "default",
-          value: "",
+          value: null,
           var: "input",
         },
         {
           environment: "default",
-          value: "",
+          value: null,
           var: "output",
         },
       ]);
@@ -2694,12 +2694,12 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
       expect(result).toEqual([
         {
           environment: "default",
-          value: '{"huhu":"This is a great prompt again"}',
+          value: { huhu: "This is a great prompt again" },
           var: "input",
         },
         {
           environment: "default",
-          value: '{"haha":"This is a great response again"}',
+          value: { haha: "This is a great response again" },
           var: "output",
         },
       ]);
@@ -2764,12 +2764,12 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
         expect(result).toEqual([
           {
-            value: '{"huhu":"This is a great prompt"}',
+            value: { huhu: "This is a great prompt" },
             var: "input",
             environment: "production",
           },
           {
-            value: '{"haha":"This is a great response"}',
+            value: { haha: "This is a great response" },
             var: "output",
             environment: "production",
           },
@@ -2852,7 +2852,7 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
       expect(resultV1).toEqual([
         {
-          value: '{"expected_output":"v1 expected output"}',
+          value: { expected_output: "v1 expected output" },
           var: "output",
         },
       ]);
@@ -2868,7 +2868,7 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
 
       expect(resultLatest).toEqual([
         {
-          value: '{"expected_output":"v2 expected output"}',
+          value: { expected_output: "v2 expected output" },
           var: "output",
         },
       ]);

--- a/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
+++ b/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { extractValueFromObject } from "@langfuse/shared";
+import {
+  extractValueFromObjectAsString,
+  extractValueFromObject,
+} from "@langfuse/shared";
 
 describe("extractValueFromObject", () => {
   describe("JSONPath slice expressions returning multiple elements", () => {
@@ -152,6 +155,30 @@ describe("extractValueFromObject", () => {
       const result = extractValueFromObject(obj, "data", "$.name");
       expect(result.value).toBe("Alice");
       expect(result.error).toBeNull();
+    });
+  });
+
+  describe("extractValueFromObjectAsString", () => {
+    it("should preserve string extraction behavior for prompt previews", () => {
+      const obj = {
+        object: { key: "value", count: 42 },
+        array: ["a", "b"],
+        zero: 0,
+        falseValue: false,
+        missing: null,
+      };
+
+      expect(extractValueFromObjectAsString(obj, "object").value).toBe(
+        '{"key":"value","count":42}',
+      );
+      expect(extractValueFromObjectAsString(obj, "array").value).toBe(
+        '["a","b"]',
+      );
+      expect(extractValueFromObjectAsString(obj, "zero").value).toBe("0");
+      expect(extractValueFromObjectAsString(obj, "falseValue").value).toBe(
+        "false",
+      );
+      expect(extractValueFromObjectAsString(obj, "missing").value).toBe("");
     });
   });
 });

--- a/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
+++ b/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
@@ -13,9 +13,7 @@ describe("extractValueFromObject", () => {
       };
 
       const result = extractValueFromObject(obj, "data", "$[1:]");
-      expect(result.value).toBe(
-        JSON.stringify([{ role: "ai" }, { role: "human" }]),
-      );
+      expect(result.value).toEqual([{ role: "ai" }, { role: "human" }]);
       expect(result.error).toBeNull();
     });
 
@@ -29,7 +27,7 @@ describe("extractValueFromObject", () => {
       };
 
       const result = extractValueFromObject(obj, "data", "$[*].role");
-      expect(result.value).toBe(JSON.stringify(["human", "ai", "human"]));
+      expect(result.value).toEqual(["human", "ai", "human"]);
       expect(result.error).toBeNull();
     });
 
@@ -39,7 +37,7 @@ describe("extractValueFromObject", () => {
       };
 
       const result = extractValueFromObject(obj, "data", "$[0:2]");
-      expect(result.value).toBe(JSON.stringify(["a", "b"]));
+      expect(result.value).toEqual(["a", "b"]);
       expect(result.error).toBeNull();
     });
   });
@@ -71,27 +69,27 @@ describe("extractValueFromObject", () => {
       };
 
       const result = extractValueFromObject(obj, "data", "$.nested");
-      expect(result.value).toBe(JSON.stringify({ key: "value" }));
+      expect(result.value).toEqual({ key: "value" });
       expect(result.error).toBeNull();
     });
   });
 
   describe("empty result handling", () => {
-    it("should return empty string for non-matching JSONPath", () => {
+    it("should return undefined for non-matching JSONPath", () => {
       const obj = {
         data: JSON.stringify({ name: "Alice" }),
       };
 
       const result = extractValueFromObject(obj, "data", "$.nonexistent");
-      expect(result.value).toBe("");
+      expect(result.value).toBeUndefined();
       expect(result.error).toBeNull();
     });
 
-    it("should return empty string when column does not exist", () => {
+    it("should return undefined when column does not exist", () => {
       const obj = { other: "value" };
 
       const result = extractValueFromObject(obj, "missing");
-      expect(result.value).toBe("");
+      expect(result.value).toBeUndefined();
       expect(result.error).toBeNull();
     });
   });
@@ -111,19 +109,19 @@ describe("extractValueFromObject", () => {
       const obj = { data: 42 };
 
       const result = extractValueFromObject(obj, "data", "$.field");
-      expect(result.value).toBe("42");
+      expect(result.value).toBe(42);
       expect(result.error).toBeNull();
     });
   });
 
   describe("no JSON selector", () => {
-    it("should return stringified object when no selector is provided", () => {
+    it("should return object as-is when no selector is provided", () => {
       const obj = {
         data: { key: "value" },
       };
 
       const result = extractValueFromObject(obj, "data");
-      expect(result.value).toBe(JSON.stringify({ key: "value" }));
+      expect(result.value).toEqual({ key: "value" });
       expect(result.error).toBeNull();
     });
 
@@ -135,11 +133,11 @@ describe("extractValueFromObject", () => {
       expect(result.error).toBeNull();
     });
 
-    it("should return number as string", () => {
+    it("should return number as-is", () => {
       const obj = { data: 42 };
 
       const result = extractValueFromObject(obj, "data");
-      expect(result.value).toBe("42");
+      expect(result.value).toBe(42);
       expect(result.error).toBeNull();
     });
   });

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
@@ -83,7 +83,7 @@ def evaluate(ctx):
             {"name": "output-contains-input-int", "value": 1 if contains else 0, "dataType": "BOOLEAN"},
             {"name": "output-contains-input-str", "value": "true" if contains else "false", "dataType": "BOOLEAN"},
             {"name": ctx.observation.metadata["topic"], "value": ctx.experiment.itemMetadata["item"], "dataType": "NUMERIC"},
-            {"name": "expected-output", "value": ctx.experiment.expectedOutput, "dataType": "TEXT"},
+            Score(name="expected-output", value=ctx.experiment.expectedOutput, data_type="TEXT"),
             {"name": "rating", "value": "good", "dataType": "CATEGORICAL"},
         ],
     }

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
@@ -24,11 +24,15 @@ const baseInput: DispatchInput = {
   execution: { jobExecutionId: "job-floci-integration" },
   code: { source: "export function evaluate() {}" },
   payload: {
-    input: "hello",
-    output: "hello world",
-    observationMetadata: { topic: "integration" },
-    experimentExpectedOutput: "hello world",
-    experimentItemMetadata: { item: 42 },
+    observation: {
+      input: "hello",
+      output: "hello world",
+      metadata: { topic: "integration" },
+    },
+    experiment: {
+      expectedOutput: "hello world",
+      itemMetadata: { item: 42 },
+    },
   },
 };
 
@@ -47,20 +51,24 @@ const expectedScores = [
 const sources: Record<CodeEvalRuntimeLanguage, string> = {
   TYPESCRIPT: `
 export function evaluate(ctx: {
-  input: string;
-  output: string;
-  observationMetadata: { topic: string };
-  experimentExpectedOutput: string;
-  experimentItemMetadata: { item: number };
+  observation: {
+    input: string;
+    output: string;
+    metadata: { topic: string };
+  };
+  experiment: {
+    expectedOutput: string;
+    itemMetadata: { item: number };
+  } | undefined;
 }) {
-  const contains = ctx.output.includes(ctx.input);
+  const contains = ctx.observation.output.includes(ctx.observation.input);
   return {
     scores: [
       { name: "output-contains-input-bool", value: contains, dataType: "BOOLEAN" },
       { name: "output-contains-input-int", value: contains ? 1 : 0, dataType: "BOOLEAN" },
       { name: "output-contains-input-str", value: contains ? "True" : "False", dataType: "BOOLEAN" },
-      { name: ctx.observationMetadata.topic, value: ctx.experimentItemMetadata.item, dataType: "NUMERIC" },
-      { name: "expected-output", value: ctx.experimentExpectedOutput, dataType: "TEXT" },
+      { name: ctx.observation.metadata.topic, value: ctx.experiment?.itemMetadata.item ?? 0, dataType: "NUMERIC" },
+      { name: "expected-output", value: ctx.experiment?.expectedOutput ?? "", dataType: "TEXT" },
       { name: "rating", value: "good", dataType: "CATEGORICAL" },
     ],
   };
@@ -68,14 +76,14 @@ export function evaluate(ctx: {
 `,
   PYTHON: `
 def evaluate(ctx):
-    contains = ctx.input in ctx.output
+    contains = ctx.observation.input in ctx.observation.output
     return {
         "scores": [
             {"name": "output-contains-input-bool", "value": contains, "dataType": "BOOLEAN"},
             {"name": "output-contains-input-int", "value": 1 if contains else 0, "dataType": "BOOLEAN"},
             {"name": "output-contains-input-str", "value": "true" if contains else "false", "dataType": "BOOLEAN"},
-            {"name": ctx.observation_metadata["topic"], "value": ctx.experiment_item_metadata["item"], "dataType": "NUMERIC"},
-            {"name": "expected-output", "value": ctx.experiment_expected_output, "dataType": "TEXT"},
+            {"name": ctx.observation.metadata["topic"], "value": ctx.experiment.itemMetadata["item"], "dataType": "NUMERIC"},
+            {"name": "expected-output", "value": ctx.experiment.expectedOutput, "dataType": "TEXT"},
             {"name": "rating", "value": "good", "dataType": "CATEGORICAL"},
         ],
     }

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
@@ -82,8 +82,8 @@ def evaluate(ctx):
             {"name": "output-contains-input-bool", "value": contains, "dataType": "BOOLEAN"},
             {"name": "output-contains-input-int", "value": 1 if contains else 0, "dataType": "BOOLEAN"},
             {"name": "output-contains-input-str", "value": "true" if contains else "false", "dataType": "BOOLEAN"},
-            {"name": ctx.observation.metadata["topic"], "value": ctx.experiment.itemMetadata["item"], "dataType": "NUMERIC"},
-            Score(name="expected-output", value=ctx.experiment.expectedOutput, data_type="TEXT"),
+            {"name": ctx.observation.metadata["topic"], "value": ctx.experiment.item_metadata["item"], "dataType": "NUMERIC"},
+            Score(name="expected-output", value=ctx.experiment.expected_output, data_type="TEXT"),
             {"name": "rating", "value": "good", "dataType": "CATEGORICAL"},
         ],
     }

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  AwsLambdaCodeEvalDispatcher,
+  CodeEvalDispatcherError,
+  type CodeEvalRuntimeLanguage,
+  type DispatchInput,
+} from "@langfuse/shared/src/server";
+
+const endpoint = process.env.LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT;
+const describeWithFloci = endpoint ? describe : describe.skip;
+
+process.env.AWS_ACCESS_KEY_ID ??= "test";
+process.env.AWS_SECRET_ACCESS_KEY ??= "test";
+process.env.AWS_REGION ??= "us-east-1";
+
+const baseInput: DispatchInput = {
+  scope: {
+    organizationId: "org-floci-integration",
+    projectId: "project-floci-integration",
+    evaluatorId: "evaluator-floci-integration",
+    environment: "code-based-eval",
+  },
+  runtime: { language: "TYPESCRIPT" },
+  execution: { jobExecutionId: "job-floci-integration" },
+  code: { source: "export function evaluate() {}" },
+  payload: {
+    input: "hello",
+    output: "hello world",
+    observationMetadata: { topic: "integration" },
+    experimentExpectedOutput: "hello world",
+    experimentItemMetadata: { item: 42 },
+  },
+};
+
+// Each runner returns the same logical scores so we can share assertions.
+// BOOLEAN variants cover every accepted input shape: native boolean,
+// already-encoded 0/1, and string form ("true"). All normalize to 1.
+const expectedScores = [
+  { name: "output-contains-input-bool", value: 1, dataType: "BOOLEAN" },
+  { name: "output-contains-input-int", value: 1, dataType: "BOOLEAN" },
+  { name: "output-contains-input-str", value: 1, dataType: "BOOLEAN" },
+  { name: "integration", value: 42, dataType: "NUMERIC" },
+  { name: "expected-output", value: "hello world", dataType: "TEXT" },
+  { name: "rating", value: "good", dataType: "CATEGORICAL" },
+] as const;
+
+const sources: Record<CodeEvalRuntimeLanguage, string> = {
+  TYPESCRIPT: `
+export function evaluate(ctx: {
+  input: string;
+  output: string;
+  observationMetadata: { topic: string };
+  experimentExpectedOutput: string;
+  experimentItemMetadata: { item: number };
+}) {
+  const contains = ctx.output.includes(ctx.input);
+  return {
+    scores: [
+      { name: "output-contains-input-bool", value: contains, dataType: "BOOLEAN" },
+      { name: "output-contains-input-int", value: contains ? 1 : 0, dataType: "BOOLEAN" },
+      { name: "output-contains-input-str", value: contains ? "True" : "False", dataType: "BOOLEAN" },
+      { name: ctx.observationMetadata.topic, value: ctx.experimentItemMetadata.item, dataType: "NUMERIC" },
+      { name: "expected-output", value: ctx.experimentExpectedOutput, dataType: "TEXT" },
+      { name: "rating", value: "good", dataType: "CATEGORICAL" },
+    ],
+  };
+}
+`,
+  PYTHON: `
+def evaluate(ctx):
+    contains = ctx.input in ctx.output
+    return {
+        "scores": [
+            {"name": "output-contains-input-bool", "value": contains, "dataType": "BOOLEAN"},
+            {"name": "output-contains-input-int", "value": 1 if contains else 0, "dataType": "BOOLEAN"},
+            {"name": "output-contains-input-str", "value": "true" if contains else "false", "dataType": "BOOLEAN"},
+            {"name": ctx.observation_metadata["topic"], "value": ctx.experiment_item_metadata["item"], "dataType": "NUMERIC"},
+            {"name": "expected-output", "value": ctx.experiment_expected_output, "dataType": "TEXT"},
+            {"name": "rating", "value": "good", "dataType": "CATEGORICAL"},
+        ],
+    }
+`,
+};
+
+describeWithFloci("AwsLambdaCodeEvalDispatcher Floci integration", () => {
+  const dispatcher = new AwsLambdaCodeEvalDispatcher({ endpoint });
+
+  it.each<CodeEvalRuntimeLanguage>(["TYPESCRIPT", "PYTHON"])(
+    "passes the payload and returns all score types for the %s runner",
+    async (language) => {
+      await expect(
+        dispatcher.dispatch({
+          ...baseInput,
+          runtime: { language },
+          code: { source: sources[language] },
+        }),
+      ).resolves.toEqual({ scores: expectedScores });
+    },
+  );
+
+  it("preserves runner error classifications", async () => {
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "TYPESCRIPT" },
+        code: {
+          source: `export function evaluate() { throw new Error("boom") }`,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "USER_CODE_ERROR",
+      message: "boom",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+});

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
@@ -16,11 +16,11 @@ const baseInput: DispatchInput = {
   execution: { jobExecutionId: "job-1" },
   code: { source: "export function evaluate() {}" },
   payload: {
-    input: null,
-    output: null,
-    observationMetadata: null,
-    experimentExpectedOutput: null,
-    experimentItemMetadata: null,
+    observation: {
+      input: null,
+      output: null,
+      metadata: null,
+    },
   },
 };
 
@@ -52,6 +52,38 @@ describe("AwsLambdaCodeEvalDispatcher", () => {
 
     await dispatcher.dispatch(baseInput);
     expect(send.mock.calls[0][0].input.TenantId).toBe("org-1:project-1");
+  });
+
+  it("sends the nested evaluation context payload to Lambda", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Payload: Buffer.from(
+        JSON.stringify({ scores: [{ value: 1, dataType: "NUMERIC" }] }),
+      ),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+    const input: DispatchInput = {
+      ...baseInput,
+      payload: {
+        observation: {
+          input: { question: "2+2" },
+          output: "4",
+          metadata: { source: "test" },
+        },
+        experiment: {
+          expectedOutput: "4",
+          itemMetadata: { difficulty: "easy" },
+        },
+      },
+    };
+
+    await dispatcher.dispatch(input);
+
+    const lambdaPayload = JSON.parse(
+      Buffer.from(send.mock.calls[0][0].input.Payload).toString("utf8"),
+    );
+    expect(lambdaPayload.payload).toEqual(input.payload);
   });
 
   it("prefers a valid dispatch result over an injected error envelope", async () => {

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AwsLambdaCodeEvalDispatcher,
+  CodeEvalDispatcherError,
+  type DispatchInput,
+} from "@langfuse/shared/src/server";
+
+const baseInput: DispatchInput = {
+  scope: {
+    organizationId: "org-1",
+    projectId: "project-1",
+    evaluatorId: "evaluator-1",
+    environment: "code-based-eval",
+  },
+  runtime: { language: "TYPESCRIPT" },
+  execution: { jobExecutionId: "job-1" },
+  code: { source: "export function evaluate() {}" },
+  payload: {
+    input: null,
+    output: null,
+    observationMetadata: null,
+    experimentExpectedOutput: null,
+    experimentItemMetadata: null,
+  },
+};
+
+describe("AwsLambdaCodeEvalDispatcher", () => {
+  it("returns successful Lambda scores", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Payload: Buffer.from(
+        JSON.stringify({ scores: [{ value: 1, dataType: "NUMERIC" }] }),
+      ),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).resolves.toEqual({
+      scores: [{ value: 1, dataType: "NUMERIC" }],
+    });
+  });
+
+  it("propagates TenantId derived from scope.organizationId:projectId", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Payload: Buffer.from(
+        JSON.stringify({ scores: [{ value: 1, dataType: "NUMERIC" }] }),
+      ),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await dispatcher.dispatch(baseInput);
+    expect(send.mock.calls[0][0].input.TenantId).toBe("org-1:project-1");
+  });
+
+  it("prefers a valid dispatch result over an injected error envelope", async () => {
+    // Defense in depth against runners that try to smuggle an `error`
+    // envelope alongside valid scores to force a retry or mask the
+    // outcome with a masked LAMBDA_* code.
+    const send = vi.fn().mockResolvedValue({
+      Payload: Buffer.from(
+        JSON.stringify({
+          scores: [{ value: 1, dataType: "NUMERIC" }],
+          error: {
+            code: "LAMBDA_CONCURRENCY_LIMIT",
+            message: "attacker-controlled",
+          },
+        }),
+      ),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).resolves.toEqual({
+      scores: [{ value: 1, dataType: "NUMERIC" }],
+    });
+  });
+
+  it("uses configured function names per runtime", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Payload: Buffer.from(
+        JSON.stringify({ scores: [{ value: 1, dataType: "NUMERIC" }] }),
+      ),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+      functionNameByLanguage: {
+        PYTHON: "custom-python-fn",
+        TYPESCRIPT: "custom-node-fn",
+      },
+    });
+
+    await dispatcher.dispatch(baseInput);
+    expect(send.mock.calls[0][0].input.FunctionName).toBe("custom-node-fn");
+
+    await dispatcher.dispatch({
+      ...baseInput,
+      runtime: { language: "PYTHON" },
+    });
+    expect(send.mock.calls[1][0].input.FunctionName).toBe("custom-python-fn");
+  });
+
+  it("classifies typed user-code runner errors as non-retryable", async () => {
+    const send = vi.fn().mockResolvedValue({
+      FunctionError: "Handled",
+      Payload: Buffer.from(
+        JSON.stringify({
+          error: { code: "USER_CODE_ERROR", message: "ReferenceError: x" },
+        }),
+      ),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "USER_CODE_ERROR",
+      message: "ReferenceError: x",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("classifies successful runner error envelopes", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Payload: Buffer.from(
+        JSON.stringify({
+          error: { code: "USER_CODE_ERROR", message: "ReferenceError: x" },
+        }),
+      ),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "USER_CODE_ERROR",
+      message: "ReferenceError: x",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("classifies timeouts via errorType Function.TimedOut as retryable", async () => {
+    // Envelope shape captured empirically from Floci probes.
+    const send = vi.fn().mockResolvedValue({
+      FunctionError: "Unhandled",
+      Payload: Buffer.from(
+        JSON.stringify({
+          errorMessage: "Task timed out after 30 seconds",
+          errorType: "Function.TimedOut",
+        }),
+      ),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "TIMEOUT",
+      message: "Function.TimedOut: Task timed out after 30 seconds",
+      retryable: true,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("classifies timeouts via errorMessage substring as retryable", async () => {
+    // Defensive fallback for runtimes that don't populate errorType.
+    const send = vi.fn().mockResolvedValue({
+      FunctionError: "Unhandled",
+      Payload: Buffer.from(JSON.stringify({ errorMessage: "Task timed out" })),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "TIMEOUT",
+      retryable: true,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("classifies Runtime.ExitError as non-retryable LAMBDA_CONFIGURATION_ERROR", async () => {
+    // Documented Lambda RIC errorType for abnormal runtime termination
+    // (OOM kill, segfault, process.exit). Retrying never recovers.
+    const send = vi.fn().mockResolvedValue({
+      FunctionError: "Unhandled",
+      Payload: Buffer.from(
+        JSON.stringify({
+          errorMessage:
+            "RequestId: abc Error: Runtime exited with error: signal: killed",
+          errorType: "Runtime.ExitError",
+        }),
+      ),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "LAMBDA_CONFIGURATION_ERROR",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("classifies FunctionError=Handled without runner envelope as USER_CODE_ERROR", async () => {
+    // Managed runtime caught a user-code exception that escaped our
+    // handler's try/catch (e.g. async unhandled rejection). The envelope
+    // carries the language-specific exception type+message.
+    const send = vi.fn().mockResolvedValue({
+      FunctionError: "Handled",
+      Payload: Buffer.from(
+        JSON.stringify({
+          errorMessage: "x is not defined",
+          errorType: "ReferenceError",
+        }),
+      ),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "USER_CODE_ERROR",
+      message: "ReferenceError: x is not defined",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("classifies concurrency throttling as retryable", async () => {
+    const error = new Error("Rate exceeded");
+    error.name = "TooManyRequestsException";
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send: vi.fn().mockRejectedValue(error) } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "LAMBDA_CONCURRENCY_LIMIT",
+      retryable: true,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("classifies Lambda configuration errors as non-retryable", async () => {
+    const error = new Error("Function not found");
+    error.name = "ResourceNotFoundException";
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send: vi.fn().mockRejectedValue(error) } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "LAMBDA_CONFIGURATION_ERROR",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("classifies AWS-side payload-too-large rejection as PAYLOAD_TOO_LARGE", async () => {
+    // If a request slips past our local `assertDispatchInputWithinLimits`
+    // (5.5 MB) and AWS still rejects it at the 6 MB sync-invocation limit,
+    // the failure should surface under the same `PAYLOAD_TOO_LARGE` code as
+    // the local pre-check — same cause, same fix, same non-retryability.
+    const error = new Error("Payload exceeds maximum allowed size");
+    error.name = "RequestTooLargeException";
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send: vi.fn().mockRejectedValue(error) } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "PAYLOAD_TOO_LARGE",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("rejects Lambda responses that exceed the wire byte-size limit", async () => {
+    // Build a response payload larger than the 256 KiB result cap. The
+    // guard inspects `response.Payload.byteLength` before any JSON parsing,
+    // so it should fail fast as a non-retryable `RESULT_TOO_LARGE` without
+    // ever allocating the parsed object.
+    const oversizedBody = JSON.stringify({
+      scores: [{ value: "a".repeat(512 * 1024), dataType: "CATEGORICAL" }],
+    });
+    const send = vi.fn().mockResolvedValue({
+      Payload: Buffer.from(oversizedBody),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "RESULT_TOO_LARGE",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+});

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
@@ -271,6 +271,20 @@ describe("AwsLambdaCodeEvalDispatcher", () => {
     } satisfies Partial<CodeEvalDispatcherError>);
   });
 
+  it("classifies Node network timeout error codes as retryable invocation errors", async () => {
+    const error = Object.assign(new Error("connect ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send: vi.fn().mockRejectedValue(error) } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "LAMBDA_INVOCATION_ERROR",
+      retryable: true,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
   it("classifies Lambda configuration errors as non-retryable", async () => {
     const error = new Error("Function not found");
     error.name = "ResourceNotFoundException";

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -87,9 +87,15 @@ describe("executeCodeBasedEvaluation", () => {
       { name: "extra-score", value: "good", dataType: "CATEGORICAL" },
     ]);
     const expectedPayload = expect.objectContaining({
-      input: { question: "2+2" },
-      output: "4",
-      experimentExpectedOutput: "4",
+      observation: {
+        input: { question: "2+2" },
+        output: "4",
+        metadata: null,
+      },
+      experiment: {
+        expectedOutput: "4",
+        itemMetadata: null,
+      },
     });
     expect(mocks.dispatcher.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -152,6 +158,13 @@ describe("executeCodeBasedEvaluation", () => {
       { name: "default-score", value: 1, dataType: "BOOLEAN" },
       { name: "default-score", value: "good", dataType: "CATEGORICAL" },
     ]);
+    expect(mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          observation: { input: null, output: null, metadata: null },
+        },
+      }),
+    );
   });
 
   it("passes extracted variable values through to the dispatcher payload as-is", async () => {
@@ -191,9 +204,15 @@ describe("executeCodeBasedEvaluation", () => {
     expect(mocks.dispatcher.dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
-          output: "true",
-          observationMetadata: "42",
-          experimentExpectedOutput: "null",
+          observation: {
+            input: null,
+            output: "true",
+            metadata: "42",
+          },
+          experiment: {
+            expectedOutput: "null",
+            itemMetadata: null,
+          },
         }),
       }),
     );

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -218,6 +218,44 @@ describe("executeCodeBasedEvaluation", () => {
     );
   });
 
+  it("continues successful execution when writing the internal trace fails", async () => {
+    mocks.dispatcher.dispatch.mockResolvedValue({
+      scores: [{ name: "score", value: 1, dataType: "NUMERIC" }],
+    });
+    mocks.writeInternalTrace.mockRejectedValue(new Error("trace write failed"));
+
+    await expect(
+      executeCodeBasedEvaluation({
+        projectId: "project-1",
+        jobExecutionId: "job-1",
+        job: {
+          id: "job-1",
+          jobConfigurationId: "config-1",
+          jobInputTraceId: "trace-1",
+          jobInputObservationId: "obs-1",
+          jobInputDatasetItemId: null,
+        } as any,
+        config: { id: "config-1", scoreName: "default-score" } as any,
+        template: {
+          id: "template-1",
+          name: "Code evaluator",
+          type: EvalTemplateType.CODE,
+          version: 1,
+          sourceCode: "export function evaluate() {}",
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+          prompt: null,
+          outputDefinition: null,
+        } as any,
+        extractedVariables: [{ var: "input", value: "prompt" }],
+        environment: "default",
+        metadata: { job_execution_id: "job-1" },
+      }),
+    ).resolves.toMatchObject({
+      scores: [{ name: "score", value: 1, dataType: "NUMERIC" }],
+      metadata: expect.objectContaining({ dispatcher_name: "test-dispatcher" }),
+    });
+  });
+
   it("writes an error internal trace when code eval execution fails and rethrows", async () => {
     const error = Object.assign(new Error("runner exploded"), {
       code: "USER_CODE_ERROR",

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -25,7 +25,7 @@ vi.mock("@langfuse/shared/src/server", () => ({
   INTERNAL_TRACE_EVENT_SOURCE: "test-source",
   LangfuseInternalTraceEnvironment: { CodeEval: "langfuse-code-eval" },
   instrumentAsync: vi.fn(async (_options, fn) => fn({ setAttribute: vi.fn() })),
-  logger: { debug: vi.fn() },
+  logger: { debug: vi.fn(), warn: vi.fn() },
   resolveConfiguredCodeEvalDispatcher: vi.fn(() => mocks.dispatcher),
 }));
 
@@ -214,6 +214,79 @@ describe("executeCodeBasedEvaluation", () => {
             itemMetadata: null,
           },
         }),
+      }),
+    );
+  });
+
+  it("writes an error internal trace when code eval execution fails and rethrows", async () => {
+    const error = Object.assign(new Error("runner exploded"), {
+      code: "USER_CODE_ERROR",
+      retryable: false,
+    });
+    mocks.dispatcher.dispatch.mockRejectedValue(error);
+
+    await expect(
+      executeCodeBasedEvaluation({
+        projectId: "project-1",
+        jobExecutionId: "job-1",
+        job: {
+          id: "job-1",
+          jobConfigurationId: "config-1",
+          jobInputTraceId: "trace-1",
+          jobInputObservationId: "obs-1",
+          jobInputDatasetItemId: null,
+        } as any,
+        config: { id: "config-1", scoreName: "default-score" } as any,
+        template: {
+          id: "template-1",
+          name: "Code evaluator",
+          type: EvalTemplateType.CODE,
+          version: 1,
+          sourceCode: "export function evaluate() {}",
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+          prompt: null,
+          outputDefinition: null,
+        } as any,
+        extractedVariables: [{ var: "input", value: "prompt" }],
+        environment: "default",
+        metadata: { job_execution_id: "job-1" },
+      }),
+    ).rejects.toBe(error);
+
+    expect(mocks.writeInternalTrace).toHaveBeenCalledTimes(1);
+    expect(mocks.writeInternalTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventInputs: [
+          expect.objectContaining({
+            projectId: "project-1",
+            traceName: "Execute evaluator: Code evaluator",
+            name: "Execute evaluator: Code evaluator",
+            type: "SPAN",
+            environment: "langfuse-code-eval",
+            level: "ERROR",
+            statusMessage: "Code eval execution failed: runner exploded",
+            input: JSON.stringify({
+              observation: { input: "prompt", output: null, metadata: null },
+            }),
+            output: JSON.stringify({
+              error: {
+                name: "Error",
+                message: "runner exploded",
+                code: "USER_CODE_ERROR",
+                retryable: false,
+              },
+            }),
+            metadata: expect.objectContaining({
+              dispatcher_name: "test-dispatcher",
+              code_eval_runtime: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+              job_execution_id: "job-1",
+              error_name: "Error",
+              error_message: "runner exploded",
+              error_code: "USER_CODE_ERROR",
+              error_retryable: false,
+            }),
+          }),
+        ],
       }),
     );
   });

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -74,9 +74,9 @@ describe("executeCodeBasedEvaluation", () => {
         outputDefinition: null,
       } as any,
       extractedVariables: [
-        { var: "input", value: '{"question":"2+2"}' },
-        { var: "output", value: '"4"' },
-        { var: "experimentExpectedOutput", value: '"4"' },
+        { var: "input", value: { question: "2+2" } },
+        { var: "output", value: "4" },
+        { var: "experimentExpectedOutput", value: "4" },
       ],
       environment: "default",
       metadata: { job_execution_id: "job-1" },
@@ -152,5 +152,50 @@ describe("executeCodeBasedEvaluation", () => {
       { name: "default-score", value: 1, dataType: "BOOLEAN" },
       { name: "default-score", value: "good", dataType: "CATEGORICAL" },
     ]);
+  });
+
+  it("passes extracted variable values through to the dispatcher payload as-is", async () => {
+    mocks.dispatcher.dispatch.mockResolvedValue({
+      scores: [{ value: 1, dataType: "BOOLEAN" }],
+    });
+
+    await executeCodeBasedEvaluation({
+      projectId: "project-1",
+      jobExecutionId: "job-1",
+      job: {
+        id: "job-1",
+        jobConfigurationId: "config-1",
+        jobInputTraceId: "trace-1",
+        jobInputObservationId: "obs-1",
+        jobInputDatasetItemId: null,
+      } as any,
+      config: { id: "config-1", scoreName: "default-score" } as any,
+      template: {
+        id: "template-1",
+        type: EvalTemplateType.CODE,
+        version: 1,
+        sourceCode: "export function evaluate() {}",
+        sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        prompt: null,
+        outputDefinition: null,
+      } as any,
+      extractedVariables: [
+        { var: "output", value: "true" },
+        { var: "observationMetadata", value: "42" },
+        { var: "experimentExpectedOutput", value: "null" },
+      ],
+      environment: "default",
+      metadata: { job_execution_id: "job-1" },
+    });
+
+    expect(mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          output: "true",
+          observationMetadata: "42",
+          experimentExpectedOutput: "null",
+        }),
+      }),
+    );
   });
 });

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import {
+  EvalTemplateSourceCodeLanguage,
+  EvalTemplateType,
+} from "@prisma/client";
+
+const mocks = vi.hoisted(() => ({
+  dispatcher: {
+    name: "test-dispatcher",
+    dispatch: vi.fn(),
+  },
+  projectFindUnique: vi.fn(),
+  writeInternalTrace: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    project: {
+      findUnique: mocks.projectFindUnique,
+    },
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  INTERNAL_TRACE_EVENT_SOURCE: "test-source",
+  LangfuseInternalTraceEnvironment: { CodeEval: "langfuse-code-eval" },
+  instrumentAsync: vi.fn(async (_options, fn) => fn({ setAttribute: vi.fn() })),
+  logger: { debug: vi.fn() },
+  resolveConfiguredCodeEvalDispatcher: vi.fn(() => mocks.dispatcher),
+}));
+
+vi.mock("../../internal-tracing/createInternalEventsWriter", () => ({
+  createInternalEventsWriter: () => ({ write: mocks.writeInternalTrace }),
+}));
+
+import { executeCodeBasedEvaluation } from "./executeCodeBasedEvaluation";
+
+describe("executeCodeBasedEvaluation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.projectFindUnique.mockResolvedValue({ orgId: "org-1" });
+  });
+
+  it("defaults the first missing score name to the score config name and keeps additional names", async () => {
+    mocks.dispatcher.dispatch.mockResolvedValue({
+      scores: [
+        { value: 1, dataType: "BOOLEAN", metadata: { user: "value" } },
+        { name: "extra-score", value: "good", dataType: "CATEGORICAL" },
+      ],
+    });
+
+    const result = await executeCodeBasedEvaluation({
+      projectId: "project-1",
+      jobExecutionId: "job-1",
+      job: {
+        id: "job-1",
+        jobConfigurationId: "config-1",
+        jobInputTraceId: "trace-1",
+        jobInputObservationId: "obs-1",
+        jobInputDatasetItemId: null,
+      } as any,
+      config: {
+        id: "config-1",
+        scoreName: "default-score",
+      } as any,
+      template: {
+        id: "template-1",
+        name: "Code evaluator",
+        type: EvalTemplateType.CODE,
+        version: 1,
+        sourceCode: "export function evaluate() {}",
+        sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        prompt: null,
+        outputDefinition: null,
+      } as any,
+      extractedVariables: [
+        { var: "input", value: '{"question":"2+2"}' },
+        { var: "output", value: '"4"' },
+        { var: "experimentExpectedOutput", value: '"4"' },
+      ],
+      environment: "default",
+      metadata: { job_execution_id: "job-1" },
+    });
+
+    expect(result.scores).toMatchObject([
+      { name: "default-score", value: 1, dataType: "BOOLEAN" },
+      { name: "extra-score", value: "good", dataType: "CATEGORICAL" },
+    ]);
+    const expectedPayload = expect.objectContaining({
+      input: { question: "2+2" },
+      output: "4",
+      experimentExpectedOutput: "4",
+    });
+    expect(mocks.dispatcher.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: expect.objectContaining({ organizationId: "org-1" }),
+        payload: expectedPayload,
+      }),
+    );
+    expect(mocks.writeInternalTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventInputs: [
+          expect.objectContaining({
+            projectId: "project-1",
+            traceName: "Execute evaluator: Code evaluator",
+            name: "Execute evaluator: Code evaluator",
+            type: "SPAN",
+            environment: "langfuse-code-eval",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("defaults every unnamed score to the score config name", async () => {
+    mocks.dispatcher.dispatch.mockResolvedValue({
+      scores: [
+        { value: 1, dataType: "BOOLEAN" },
+        { value: "good", dataType: "CATEGORICAL" },
+      ],
+    });
+
+    const result = await executeCodeBasedEvaluation({
+      projectId: "project-1",
+      jobExecutionId: "job-1",
+      job: {
+        id: "job-1",
+        jobConfigurationId: "config-1",
+        jobInputTraceId: "trace-1",
+        jobInputObservationId: "obs-1",
+        jobInputDatasetItemId: null,
+      } as any,
+      config: {
+        id: "config-1",
+        scoreName: "default-score",
+      } as any,
+      template: {
+        id: "template-1",
+        type: EvalTemplateType.CODE,
+        version: 1,
+        sourceCode: "export function evaluate() {}",
+        sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        prompt: null,
+        outputDefinition: null,
+      } as any,
+      extractedVariables: [],
+      environment: "default",
+      metadata: { job_execution_id: "job-1" },
+    });
+
+    expect(result.scores).toMatchObject([
+      { name: "default-score", value: 1, dataType: "BOOLEAN" },
+      { name: "default-score", value: "good", dataType: "CATEGORICAL" },
+    ]);
+  });
+});

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -137,16 +137,13 @@ export async function executeCodeBasedEvaluation(params: {
 }
 
 // The frontend maps user-facing template variables to a fixed, known set of
-// payload field names; we only need to look each one up once.
+// payload field names; we only need to look each one up once. Values are
+// already typed (the upstream extractor preserves the original shape), so
+// no per-field parsing is needed here.
 function buildCodeEvalPayload(
   extractedVariables: ExtractedVariable[],
 ): CodeEvalPayload {
-  const byName = new Map(
-    extractedVariables.map((v) => [
-      v.var,
-      parseExtractedVariableValue(v.value),
-    ]),
-  );
+  const byName = new Map(extractedVariables.map((v) => [v.var, v.value]));
   return {
     input: byName.get("input") ?? null,
     output: byName.get("output") ?? null,
@@ -154,15 +151,6 @@ function buildCodeEvalPayload(
     experimentExpectedOutput: byName.get("experimentExpectedOutput") ?? null,
     experimentItemMetadata: byName.get("experimentItemMetadata") ?? null,
   };
-}
-
-function parseExtractedVariableValue(value: string): unknown {
-  if (value === "") return null;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
 }
 
 function normalizeCodeEvalScores(params: {

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -78,49 +78,85 @@ export async function executeCodeBasedEvaluation(params: {
 
       const payload = buildCodeEvalPayload(params.extractedVariables);
       const traceStartTime = new Date();
-      const dispatchResult = await dispatcher.dispatch({
-        scope: {
-          organizationId: project.orgId,
-          projectId: params.projectId,
-          evaluatorId: params.template.id,
-          environment: CODE_EVAL_SCOPE_ENVIRONMENT,
-        },
-        runtime: { language: params.template.sourceCodeLanguage },
-        execution: { jobExecutionId: params.jobExecutionId },
-        code: { source: params.template.sourceCode },
-        payload,
-      });
-
-      const scores = normalizeCodeEvalScores({
-        scores: dispatchResult.scores,
-        defaultScoreName: params.config.scoreName,
-      });
-
-      // LLM-as-judge gets this trace from fetchLLMCompletion's traceSinkParams;
-      // the code-eval dispatcher returns no trace data, so synthesize a SPAN.
       const traceName = `Execute evaluator: ${params.template.name}`;
-      await createInternalEventsWriter().write({
-        rootSpanId: executionTraceId,
-        eventInputs: [
-          {
+      let dispatchResult: { scores: CodeEvalScore[] } | undefined;
+      let scores: CodeEvalScoreWithName[];
+
+      try {
+        dispatchResult = await dispatcher.dispatch({
+          scope: {
+            organizationId: project.orgId,
             projectId: params.projectId,
-            traceId: executionTraceId,
-            spanId: executionTraceId,
-            startTimeISO: traceStartTime.toISOString(),
-            endTimeISO: new Date().toISOString(),
-            name: traceName,
+            evaluatorId: params.template.id,
+            environment: CODE_EVAL_SCOPE_ENVIRONMENT,
+          },
+          runtime: { language: params.template.sourceCodeLanguage },
+          execution: { jobExecutionId: params.jobExecutionId },
+          code: { source: params.template.sourceCode },
+          payload,
+        });
+
+        scores = normalizeCodeEvalScores({
+          scores: dispatchResult.scores,
+          defaultScoreName: params.config.scoreName,
+        });
+      } catch (error) {
+        const errorDetails = serializeCodeEvalError(error);
+
+        try {
+          await writeCodeEvalTrace({
+            projectId: params.projectId,
+            executionTraceId,
+            traceStartTime,
             traceName,
-            type: "SPAN",
-            environment: LangfuseInternalTraceEnvironment.CodeEval,
-            input: stringifyValue(payload),
-            output: stringifyValue(dispatchResult),
+            payload,
+            output: {
+              ...(dispatchResult ? { result: dispatchResult } : {}),
+              error: errorDetails,
+            },
             metadata: {
               ...executionMetadata,
               score_id: primaryScoreId,
+              error_name: errorDetails.name,
+              error_message: errorDetails.message,
+              ...(errorDetails.code ? { error_code: errorDetails.code } : {}),
+              ...(typeof errorDetails.retryable === "boolean"
+                ? { error_retryable: errorDetails.retryable }
+                : {}),
             },
-            source: INTERNAL_TRACE_EVENT_SOURCE,
-          },
-        ],
+            level: "ERROR",
+            statusMessage: `Code eval execution failed: ${errorDetails.message}`,
+          });
+        } catch (traceError) {
+          logger.warn(
+            "Failed to write internal trace for failed code eval execution",
+            {
+              projectId: params.projectId,
+              executionTraceId,
+              error:
+                traceError instanceof Error
+                  ? traceError.message
+                  : String(traceError),
+            },
+          );
+        }
+
+        throw error;
+      }
+
+      // LLM-as-judge gets this trace from fetchLLMCompletion's traceSinkParams;
+      // the code-eval dispatcher returns no trace data, so synthesize a SPAN.
+      await writeCodeEvalTrace({
+        projectId: params.projectId,
+        executionTraceId,
+        traceStartTime,
+        traceName,
+        payload,
+        output: dispatchResult,
+        metadata: {
+          ...executionMetadata,
+          score_id: primaryScoreId,
+        },
       });
 
       span.setAttribute("eval.result.count", scores.length);
@@ -164,6 +200,67 @@ function buildCodeEvalPayload(
   }
 
   return payload;
+}
+
+async function writeCodeEvalTrace(params: {
+  projectId: string;
+  executionTraceId: string;
+  traceStartTime: Date;
+  traceName: string;
+  payload: CodeEvalPayload;
+  output: unknown;
+  metadata: Record<string, unknown>;
+  level?: string;
+  statusMessage?: string;
+}) {
+  await createInternalEventsWriter().write({
+    rootSpanId: params.executionTraceId,
+    eventInputs: [
+      {
+        projectId: params.projectId,
+        traceId: params.executionTraceId,
+        spanId: params.executionTraceId,
+        startTimeISO: params.traceStartTime.toISOString(),
+        endTimeISO: new Date().toISOString(),
+        name: params.traceName,
+        traceName: params.traceName,
+        type: "SPAN",
+        environment: LangfuseInternalTraceEnvironment.CodeEval,
+        ...(params.level ? { level: params.level } : {}),
+        ...(params.statusMessage
+          ? { statusMessage: params.statusMessage }
+          : {}),
+        input: stringifyValue(params.payload),
+        output: stringifyValue(params.output),
+        metadata: params.metadata,
+        source: INTERNAL_TRACE_EVENT_SOURCE,
+      },
+    ],
+  });
+}
+
+function serializeCodeEvalError(error: unknown): {
+  name: string;
+  message: string;
+  code?: string;
+  retryable?: boolean;
+} {
+  const base =
+    error instanceof Error
+      ? { name: error.name, message: error.message }
+      : { name: "Error", message: String(error) };
+
+  if (!error || typeof error !== "object") return base;
+
+  const errorRecord = error as Record<string, unknown>;
+
+  return {
+    ...base,
+    ...(typeof errorRecord.code === "string" ? { code: errorRecord.code } : {}),
+    ...(typeof errorRecord.retryable === "boolean"
+      ? { retryable: errorRecord.retryable }
+      : {}),
+  };
 }
 
 function normalizeCodeEvalScores(params: {

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -180,9 +180,7 @@ function buildCodeEvalPayload(
   extractedVariables: ExtractedVariable[],
 ): CodeEvalPayload {
   const byName = new Map(extractedVariables.map((v) => [v.var, v.value]));
-  const hasExperiment =
-    byName.has("experimentExpectedOutput") ||
-    byName.has("experimentItemMetadata");
+  const hasExperiment = byName.has("experimentExpectedOutput");
 
   const payload: CodeEvalPayload = {
     observation: {
@@ -195,7 +193,7 @@ function buildCodeEvalPayload(
   if (hasExperiment) {
     payload.experiment = {
       expectedOutput: byName.get("experimentExpectedOutput") ?? null,
-      itemMetadata: byName.get("experimentItemMetadata") ?? null,
+      itemMetadata: null,
     };
   }
 

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -144,13 +144,26 @@ function buildCodeEvalPayload(
   extractedVariables: ExtractedVariable[],
 ): CodeEvalPayload {
   const byName = new Map(extractedVariables.map((v) => [v.var, v.value]));
-  return {
-    input: byName.get("input") ?? null,
-    output: byName.get("output") ?? null,
-    observationMetadata: byName.get("observationMetadata") ?? null,
-    experimentExpectedOutput: byName.get("experimentExpectedOutput") ?? null,
-    experimentItemMetadata: byName.get("experimentItemMetadata") ?? null,
+  const hasExperiment =
+    byName.has("experimentExpectedOutput") ||
+    byName.has("experimentItemMetadata");
+
+  const payload: CodeEvalPayload = {
+    observation: {
+      input: byName.get("input") ?? null,
+      output: byName.get("output") ?? null,
+      metadata: byName.get("observationMetadata") ?? null,
+    },
   };
+
+  if (hasExperiment) {
+    payload.experiment = {
+      expectedOutput: byName.get("experimentExpectedOutput") ?? null,
+      itemMetadata: byName.get("experimentItemMetadata") ?? null,
+    };
+  }
+
+  return payload;
 }
 
 function normalizeCodeEvalScores(params: {

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -1,11 +1,27 @@
+import { randomUUID } from "crypto";
 import { type JobConfiguration, type JobExecution } from "@prisma/client";
-import { type EvalTemplateCodeBased } from "@langfuse/shared";
+import { stringifyValue, type EvalTemplateCodeBased } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  instrumentAsync,
+  INTERNAL_TRACE_EVENT_SOURCE,
+  LangfuseInternalTraceEnvironment,
+  logger,
+  resolveConfiguredCodeEvalDispatcher,
+  type CodeEvalScore,
+  type CodeEvalScoreWithName,
+  type CodeEvalPayload,
+} from "@langfuse/shared/src/server";
 import { UnrecoverableError } from "../../../errors/UnrecoverableError";
+import { createW3CTraceId } from "../../utils";
+import { createInternalEventsWriter } from "../../internal-tracing/createInternalEventsWriter";
 import { type EvalExecutionResult } from "../evalCompletion";
 import { type EvalExecutionDeps } from "../evalExecutionDeps";
 import { type ExtractedVariable } from "../observationEval/extractObservationVariables";
 
-export async function executeCodeBasedEvaluation(_params: {
+const CODE_EVAL_SCOPE_ENVIRONMENT = "code-based-eval";
+
+export async function executeCodeBasedEvaluation(params: {
   projectId: string;
   jobExecutionId: string;
   job: JobExecution;
@@ -13,9 +29,149 @@ export async function executeCodeBasedEvaluation(_params: {
   template: EvalTemplateCodeBased;
   extractedVariables: ExtractedVariable[];
   environment: string;
+  metadata: Record<string, string>;
+  // Unused; present for ObservationEvalExecutor interface symmetry.
   deps?: EvalExecutionDeps;
 }): Promise<EvalExecutionResult> {
-  return Promise.reject(
-    new UnrecoverableError("Code-based eval execution is not implemented yet"),
+  return instrumentAsync(
+    { name: "eval.execute-code-based-eval" },
+    async (span) => {
+      const dispatcher = resolveConfiguredCodeEvalDispatcher();
+
+      if (!dispatcher) {
+        throw new UnrecoverableError("Code eval dispatcher is not configured");
+      }
+
+      const project = await prisma.project.findUnique({
+        where: { id: params.projectId },
+        select: { orgId: true },
+      });
+
+      if (!project) {
+        throw new UnrecoverableError(
+          `Project ${params.projectId} not found for code eval execution`,
+        );
+      }
+
+      const executionTraceId = createW3CTraceId(params.jobExecutionId);
+      const primaryScoreId = randomUUID();
+      const executionMetadata = {
+        ...params.metadata,
+        dispatcher_name: dispatcher.name,
+        code_eval_runtime: params.template.sourceCodeLanguage,
+      };
+
+      span.setAttribute("langfuse.project.id", params.projectId);
+      span.setAttribute("eval.job_execution.id", params.jobExecutionId);
+      span.setAttribute("eval.job_configuration.id", params.config.id);
+      span.setAttribute("eval.template.id", params.template.id);
+      span.setAttribute("eval.template.version", params.template.version);
+      span.setAttribute("eval.dispatcher.name", dispatcher.name);
+      span.setAttribute(
+        "eval.runner.language",
+        params.template.sourceCodeLanguage,
+      );
+
+      logger.debug(
+        `Executing code-based evaluation for job ${params.jobExecutionId} in project ${params.projectId}`,
+      );
+
+      const payload = buildCodeEvalPayload(params.extractedVariables);
+      const traceStartTime = new Date();
+      const dispatchResult = await dispatcher.dispatch({
+        scope: {
+          organizationId: project.orgId,
+          projectId: params.projectId,
+          evaluatorId: params.template.id,
+          environment: CODE_EVAL_SCOPE_ENVIRONMENT,
+        },
+        runtime: { language: params.template.sourceCodeLanguage },
+        execution: { jobExecutionId: params.jobExecutionId },
+        code: { source: params.template.sourceCode },
+        payload,
+      });
+
+      const scores = normalizeCodeEvalScores({
+        scores: dispatchResult.scores,
+        defaultScoreName: params.config.scoreName,
+      });
+
+      // LLM-as-judge gets this trace from fetchLLMCompletion's traceSinkParams;
+      // the code-eval dispatcher returns no trace data, so synthesize a SPAN.
+      const traceName = `Execute evaluator: ${params.template.name}`;
+      await createInternalEventsWriter().write({
+        rootSpanId: executionTraceId,
+        eventInputs: [
+          {
+            projectId: params.projectId,
+            traceId: executionTraceId,
+            spanId: executionTraceId,
+            startTimeISO: traceStartTime.toISOString(),
+            endTimeISO: new Date().toISOString(),
+            name: traceName,
+            traceName,
+            type: "SPAN",
+            environment: LangfuseInternalTraceEnvironment.CodeEval,
+            input: stringifyValue(payload),
+            output: stringifyValue(dispatchResult),
+            metadata: {
+              ...executionMetadata,
+              score_id: primaryScoreId,
+            },
+            source: INTERNAL_TRACE_EVENT_SOURCE,
+          },
+        ],
+      });
+
+      span.setAttribute("eval.result.count", scores.length);
+      span.setAttribute("eval.score.id", primaryScoreId);
+
+      return {
+        scores,
+        primaryScoreId,
+        executionTraceId,
+        metadata: executionMetadata,
+      };
+    },
+  );
+}
+
+// The frontend maps user-facing template variables to a fixed, known set of
+// payload field names; we only need to look each one up once.
+function buildCodeEvalPayload(
+  extractedVariables: ExtractedVariable[],
+): CodeEvalPayload {
+  const byName = new Map(
+    extractedVariables.map((v) => [
+      v.var,
+      parseExtractedVariableValue(v.value),
+    ]),
+  );
+  return {
+    input: byName.get("input") ?? null,
+    output: byName.get("output") ?? null,
+    observationMetadata: byName.get("observationMetadata") ?? null,
+    experimentExpectedOutput: byName.get("experimentExpectedOutput") ?? null,
+    experimentItemMetadata: byName.get("experimentItemMetadata") ?? null,
+  };
+}
+
+function parseExtractedVariableValue(value: string): unknown {
+  if (value === "") return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeCodeEvalScores(params: {
+  scores: CodeEvalScore[];
+  defaultScoreName: string;
+}): CodeEvalScoreWithName[] {
+  return params.scores.map((score) =>
+    score.name
+      ? (score as CodeEvalScoreWithName)
+      : { ...score, name: params.defaultScoreName },
   );
 }

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -103,8 +103,12 @@ export async function executeCodeBasedEvaluation(params: {
       } catch (error) {
         const errorDetails = serializeCodeEvalError(error);
 
-        try {
-          await writeCodeEvalTrace({
+        await writeCodeEvalTraceBestEffort({
+          failureMessage:
+            "Failed to write internal trace for failed code eval execution",
+          projectId: params.projectId,
+          executionTraceId,
+          traceParams: {
             projectId: params.projectId,
             executionTraceId,
             traceStartTime,
@@ -126,36 +130,30 @@ export async function executeCodeBasedEvaluation(params: {
             },
             level: "ERROR",
             statusMessage: `Code eval execution failed: ${errorDetails.message}`,
-          });
-        } catch (traceError) {
-          logger.warn(
-            "Failed to write internal trace for failed code eval execution",
-            {
-              projectId: params.projectId,
-              executionTraceId,
-              error:
-                traceError instanceof Error
-                  ? traceError.message
-                  : String(traceError),
-            },
-          );
-        }
+          },
+        });
 
         throw error;
       }
 
       // LLM-as-judge gets this trace from fetchLLMCompletion's traceSinkParams;
       // the code-eval dispatcher returns no trace data, so synthesize a SPAN.
-      await writeCodeEvalTrace({
+      await writeCodeEvalTraceBestEffort({
+        failureMessage:
+          "Failed to write internal trace for completed code eval execution",
         projectId: params.projectId,
         executionTraceId,
-        traceStartTime,
-        traceName,
-        payload,
-        output: dispatchResult,
-        metadata: {
-          ...executionMetadata,
-          score_id: primaryScoreId,
+        traceParams: {
+          projectId: params.projectId,
+          executionTraceId,
+          traceStartTime,
+          traceName,
+          payload,
+          output: dispatchResult,
+          metadata: {
+            ...executionMetadata,
+            score_id: primaryScoreId,
+          },
         },
       });
 
@@ -200,7 +198,7 @@ function buildCodeEvalPayload(
   return payload;
 }
 
-async function writeCodeEvalTrace(params: {
+type WriteCodeEvalTraceParams = {
   projectId: string;
   executionTraceId: string;
   traceStartTime: Date;
@@ -210,7 +208,27 @@ async function writeCodeEvalTrace(params: {
   metadata: Record<string, unknown>;
   level?: string;
   statusMessage?: string;
+};
+
+async function writeCodeEvalTraceBestEffort(params: {
+  failureMessage: string;
+  projectId: string;
+  executionTraceId: string;
+  traceParams: WriteCodeEvalTraceParams;
 }) {
+  try {
+    await writeCodeEvalTrace(params.traceParams);
+  } catch (traceError) {
+    logger.warn(params.failureMessage, {
+      projectId: params.projectId,
+      executionTraceId: params.executionTraceId,
+      error:
+        traceError instanceof Error ? traceError.message : String(traceError),
+    });
+  }
+}
+
+async function writeCodeEvalTrace(params: WriteCodeEvalTraceParams) {
   await createInternalEventsWriter().write({
     rootSpanId: params.executionTraceId,
     eventInputs: [

--- a/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
@@ -17,11 +17,15 @@ const baseInput: Omit<DispatchInput, "runtime" | "code"> = {
     jobExecutionId: "job-1",
   },
   payload: {
-    input: { question: "2+2" },
-    output: "4",
-    observationMetadata: { source: "test" },
-    experimentExpectedOutput: "4",
-    experimentItemMetadata: { difficulty: "easy" },
+    observation: {
+      input: { question: "2+2" },
+      output: "4",
+      metadata: { source: "test" },
+    },
+    experiment: {
+      expectedOutput: "4",
+      itemMetadata: { difficulty: "easy" },
+    },
   },
 };
 
@@ -34,10 +38,13 @@ describe("LocalCodeEvalDispatcher", () => {
       runtime: { language: "TYPESCRIPT" },
       code: {
         source: `
-          type EvaluationContext = { output: string; experimentExpectedOutput: string };
+          type EvaluationContext = {
+            observation: { output: string };
+            experiment: { expectedOutput: string } | undefined;
+          };
           export async function evaluate(ctx: EvaluationContext) {
             return {
-              scores: [{ value: ctx.output === ctx.experimentExpectedOutput ? 1 : 0, dataType: "BOOLEAN" }],
+              scores: [{ value: ctx.observation.output === ctx.experiment?.expectedOutput ? 1 : 0, dataType: "BOOLEAN" }],
             };
           }
         `,

--- a/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  CodeEvalDispatcherError,
+  LocalCodeEvalDispatcher,
+  type DispatchInput,
+} from "@langfuse/shared/src/server";
+import { TEXT_SCORE_MAX_LENGTH } from "../../../../../packages/shared/src/domain/scores";
+
+const baseInput: Omit<DispatchInput, "runtime" | "code"> = {
+  scope: {
+    organizationId: "org-1",
+    projectId: "project-1",
+    evaluatorId: "evaluator-1",
+    environment: "default",
+  },
+  execution: {
+    jobExecutionId: "job-1",
+  },
+  payload: {
+    input: { question: "2+2" },
+    output: "4",
+    observationMetadata: { source: "test" },
+    experimentExpectedOutput: "4",
+    experimentItemMetadata: { difficulty: "easy" },
+  },
+};
+
+describe("LocalCodeEvalDispatcher", () => {
+  it("executes TS-lite evaluate(ctx) functions in process", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    const result = await dispatcher.dispatch({
+      ...baseInput,
+      runtime: { language: "TYPESCRIPT" },
+      code: {
+        source: `
+          type EvaluationContext = { output: string; experimentExpectedOutput: string };
+          export async function evaluate(ctx: EvaluationContext) {
+            return {
+              scores: [{ value: ctx.output === ctx.experimentExpectedOutput ? 1 : 0, dataType: "BOOLEAN" }],
+            };
+          }
+        `,
+      },
+    });
+
+    expect(result).toEqual({ scores: [{ value: 1, dataType: "BOOLEAN" }] });
+  });
+
+  it("rejects sources with TypeScript syntax errors", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "TYPESCRIPT" },
+        // Deliberate stray token that `stripTypeScriptTypes` cannot parse.
+        code: { source: "export function evaluate(@@@) {}" },
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_SOURCE",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("rejects sources whose module throws at top level", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "TYPESCRIPT" },
+        code: { source: `throw new Error("top-level boom");` },
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_SOURCE",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("rejects sources missing an exported evaluate function", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "TYPESCRIPT" },
+        code: { source: `export const evaluate = 42;` },
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_SOURCE",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("surfaces evaluator runtime throws as USER_CODE_ERROR", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "TYPESCRIPT" },
+        code: {
+          source: `export function evaluate() { throw new Error("boom"); }`,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "USER_CODE_ERROR",
+      retryable: false,
+      message: expect.stringContaining("boom"),
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("rejects Python evaluators", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "PYTHON" },
+        code: { source: "def evaluate(ctx): pass" },
+      }),
+    ).rejects.toThrow(CodeEvalDispatcherError);
+  });
+
+  it("accepts TEXT scores within the public ingestion length cap", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    const source = `
+      export async function evaluate() {
+        return {
+          scores: [{
+            value: "reasoning fits within the limit",
+            dataType: "TEXT",
+            name: "judge-rationale",
+          }],
+        };
+      }
+    `;
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "TYPESCRIPT" },
+        code: { source },
+      }),
+    ).resolves.toEqual({
+      scores: [
+        {
+          value: "reasoning fits within the limit",
+          dataType: "TEXT",
+          name: "judge-rationale",
+        },
+      ],
+    });
+  });
+
+  it("rejects TEXT scores that exceed the public ingestion length cap", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    // Produce a TEXT value just over the public 500-char ingestion cap. The
+    // dispatcher must surface this as a non-retryable INVALID_RESULT so the
+    // job execution fails clearly instead of completing and then having the
+    // score silently dropped by the ingestion consumer.
+    const source = `
+      export async function evaluate() {
+        return {
+          scores: [{
+            value: "a".repeat(${TEXT_SCORE_MAX_LENGTH + 1}),
+            dataType: "TEXT",
+          }],
+        };
+      }
+    `;
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "TYPESCRIPT" },
+        code: { source },
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_RESULT",
+      retryable: false,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+});

--- a/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
@@ -118,6 +118,23 @@ describe("LocalCodeEvalDispatcher", () => {
     } satisfies Partial<CodeEvalDispatcherError>);
   });
 
+  it("times out runaway evaluators and terminates the worker", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher({ timeoutMs: 50 });
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "TYPESCRIPT" },
+        code: {
+          source: `export function evaluate() { while (true) {} }`,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "TIMEOUT",
+      retryable: true,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
   it("rejects Python evaluators", async () => {
     const dispatcher = new LocalCodeEvalDispatcher();
 

--- a/worker/src/features/evaluation/evalCompletion.ts
+++ b/worker/src/features/evaluation/evalCompletion.ts
@@ -1,49 +1,49 @@
 import { JobExecutionStatus } from "@prisma/client";
-import { logger, traceException } from "@langfuse/shared/src/server";
-import { type EvalOutputResult } from "@langfuse/shared";
+import {
+  logger,
+  traceException,
+  type CodeEvalScoreWithName,
+} from "@langfuse/shared/src/server";
 import { buildEvalScoreWritePayloads } from "./evalScoreEvent";
 import { type EvalExecutionDeps } from "./evalExecutionDeps";
 
+/**
+ * Common result returned by every evaluator executor (LLM-as-judge,
+ * code-based, future executors). The first entry of `scores` is the primary
+ * score and is persisted on `JobExecution.jobOutputScoreId`.
+ */
 export type EvalExecutionResult = {
-  outputResult: EvalOutputResult;
+  scores: CodeEvalScoreWithName[];
   primaryScoreId: string;
   executionTraceId: string;
+  metadata: Record<string, string>;
 };
 
 export async function completeEvalExecution({
   projectId,
   jobExecutionId,
-  outputResult,
-  primaryScoreId,
+  result,
   traceId,
   observationId,
-  scoreName,
   environment,
-  executionTraceId,
-  metadata,
   deps,
 }: {
   projectId: string;
   jobExecutionId: string;
-  outputResult: EvalOutputResult;
-  primaryScoreId: string;
+  result: EvalExecutionResult;
   traceId: string | null;
   observationId: string | null;
-  scoreName: string;
   environment: string;
-  executionTraceId: string;
-  metadata: Record<string, string>;
   deps: EvalExecutionDeps;
 }): Promise<{ scoreCount: number }> {
   const scoreWritePayloads = buildEvalScoreWritePayloads({
-    outputResult,
-    primaryScoreId,
+    scores: result.scores,
+    primaryScoreId: result.primaryScoreId,
     traceId,
     observationId,
-    scoreName,
     environment,
-    executionTraceId,
-    metadata,
+    executionTraceId: result.executionTraceId,
+    executionMetadata: result.metadata,
   });
 
   try {
@@ -67,7 +67,7 @@ export async function completeEvalExecution({
     logger.error(`Failed to persist score: ${e}`, e);
     traceException(e);
     throw new Error(
-      `Failed to write score ${primaryScoreId} into IngestionQueue`,
+      `Failed to write score ${result.primaryScoreId} into IngestionQueue`,
     );
   }
 
@@ -81,8 +81,8 @@ export async function completeEvalExecution({
     data: {
       status: JobExecutionStatus.COMPLETED,
       endTime: new Date(),
-      jobOutputScoreId: primaryScoreId,
-      executionTraceId,
+      jobOutputScoreId: result.primaryScoreId,
+      executionTraceId: result.executionTraceId,
     },
   });
 

--- a/worker/src/features/evaluation/evalRuntime.ts
+++ b/worker/src/features/evaluation/evalRuntime.ts
@@ -1,4 +1,8 @@
-import { ChatMessageRole, ChatMessageType } from "@langfuse/shared";
+import {
+  ChatMessageRole,
+  ChatMessageType,
+  parseUnknownToString,
+} from "@langfuse/shared";
 import { compileTemplateString } from "../utils";
 import { ExtractedVariable } from "./observationEval/extractObservationVariables";
 
@@ -8,8 +12,14 @@ export interface CompileEvalPromptParams {
 }
 
 export function compileEvalPrompt(params: CompileEvalPromptParams): string {
+  // Stringify extracted values here (LLM-judge's consumption boundary) so
+  // the upstream extractor can preserve original shapes for code-eval and
+  // template substitution still gets a flat string per variable.
   const variableMap = Object.fromEntries(
-    params.variables.map(({ var: key, value }) => [key, value]),
+    params.variables.map(({ var: key, value }) => [
+      key,
+      parseUnknownToString(value),
+    ]),
   );
 
   return compileTemplateString(params.templatePrompt, variableMap);

--- a/worker/src/features/evaluation/evalScoreEvent.ts
+++ b/worker/src/features/evaluation/evalScoreEvent.ts
@@ -1,73 +1,10 @@
 import { randomUUID } from "crypto";
+import { ScoreSourceEnum } from "@langfuse/shared";
 import {
-  type EvalOutputResult,
-  ScoreDataTypeEnum,
-  ScoreSourceEnum,
-} from "@langfuse/shared";
-import { eventTypes, ScoreEventType } from "@langfuse/shared/src/server";
-
-type BuildScoreEventBase = {
-  eventId: string;
-  scoreId: string;
-  traceId: string | null;
-  observationId: string | null;
-  scoreName: string;
-  reasoning: string;
-  environment: string;
-  executionTraceId: string;
-  metadata: Record<string, string>;
-};
-
-export type BuildScoreEventParams = BuildScoreEventBase &
-  (
-    | {
-        dataType: typeof ScoreDataTypeEnum.NUMERIC;
-        scoreValue: number;
-      }
-    | {
-        dataType: typeof ScoreDataTypeEnum.BOOLEAN;
-        scoreValue: 0 | 1;
-      }
-    | {
-        dataType: typeof ScoreDataTypeEnum.CATEGORICAL;
-        scoreValue: string;
-      }
-  );
-
-type BuildScoreWritePayloadParams =
-  | Omit<
-      Extract<
-        BuildScoreEventParams,
-        { dataType: typeof ScoreDataTypeEnum.NUMERIC }
-      >,
-      "eventId"
-    >
-  | Omit<
-      Extract<
-        BuildScoreEventParams,
-        { dataType: typeof ScoreDataTypeEnum.BOOLEAN }
-      >,
-      "eventId"
-    >
-  | Omit<
-      Extract<
-        BuildScoreEventParams,
-        { dataType: typeof ScoreDataTypeEnum.CATEGORICAL }
-      >,
-      "eventId"
-    >;
-
-function createScoreEventEnvelope(params: {
-  eventId: string;
-  body: ScoreEventType["body"];
-}): ScoreEventType {
-  return {
-    id: params.eventId,
-    timestamp: new Date().toISOString(),
-    type: eventTypes.SCORE_CREATE,
-    body: params.body,
-  };
-}
+  eventTypes,
+  ScoreEventType,
+  type CodeEvalScoreWithName,
+} from "@langfuse/shared/src/server";
 
 export type EvalScoreWritePayload = {
   eventId: string;
@@ -75,142 +12,41 @@ export type EvalScoreWritePayload = {
   event: ScoreEventType;
 };
 
-export function buildScoreEvent(params: BuildScoreEventParams): ScoreEventType {
-  const bodyBase = {
-    id: params.scoreId,
-    traceId: params.traceId,
-    observationId: params.observationId,
-    name: params.scoreName,
-    comment: params.reasoning,
-    source: ScoreSourceEnum.EVAL,
-    environment: params.environment,
-    executionTraceId: params.executionTraceId,
-    metadata: params.metadata,
-  };
-
-  if (params.dataType === ScoreDataTypeEnum.CATEGORICAL) {
-    return createScoreEventEnvelope({
-      eventId: params.eventId,
-      body: {
-        ...bodyBase,
-        value: params.scoreValue,
-        dataType: ScoreDataTypeEnum.CATEGORICAL,
-      },
-    });
-  }
-
-  if (params.dataType === ScoreDataTypeEnum.BOOLEAN) {
-    return createScoreEventEnvelope({
-      eventId: params.eventId,
-      body: {
-        ...bodyBase,
-        value: params.scoreValue,
-        dataType: ScoreDataTypeEnum.BOOLEAN,
-      },
-    });
-  }
-
-  return createScoreEventEnvelope({
-    eventId: params.eventId,
-    body: {
-      ...bodyBase,
-      value: params.scoreValue,
-      dataType: ScoreDataTypeEnum.NUMERIC,
-    },
-  });
-}
-
-function buildScoreWritePayload(
-  params: BuildScoreWritePayloadParams,
-): EvalScoreWritePayload {
-  const eventId = randomUUID();
-
-  if (params.dataType === ScoreDataTypeEnum.CATEGORICAL) {
-    return {
-      eventId,
-      scoreId: params.scoreId,
-      event: buildScoreEvent({
-        ...params,
-        eventId,
-        dataType: ScoreDataTypeEnum.CATEGORICAL,
-        scoreValue: params.scoreValue,
-      }),
-    };
-  }
-
-  if (params.dataType === ScoreDataTypeEnum.BOOLEAN) {
-    return {
-      eventId,
-      scoreId: params.scoreId,
-      event: buildScoreEvent({
-        ...params,
-        eventId,
-        dataType: ScoreDataTypeEnum.BOOLEAN,
-        scoreValue: params.scoreValue,
-      }),
-    };
-  }
-
-  return {
-    eventId,
-    scoreId: params.scoreId,
-    event: buildScoreEvent({
-      ...params,
-      eventId,
-      dataType: ScoreDataTypeEnum.NUMERIC,
-      scoreValue: params.scoreValue,
-    }),
-  };
-}
-
 export function buildEvalScoreWritePayloads(params: {
-  outputResult: EvalOutputResult;
+  scores: CodeEvalScoreWithName[];
   primaryScoreId: string;
   traceId: string | null;
   observationId: string | null;
-  scoreName: string;
   environment: string;
   executionTraceId: string;
-  metadata: Record<string, string>;
+  executionMetadata: Record<string, string>;
 }): EvalScoreWritePayload[] {
-  const commonParams = {
-    traceId: params.traceId,
-    observationId: params.observationId,
-    scoreName: params.scoreName,
-    reasoning: params.outputResult.reasoning,
-    environment: params.environment,
-    executionTraceId: params.executionTraceId,
-    metadata: params.metadata,
-  };
+  return params.scores.map((score, index) => {
+    const eventId = randomUUID();
+    const scoreId = index === 0 ? params.primaryScoreId : randomUUID();
 
-  if (params.outputResult.dataType === ScoreDataTypeEnum.NUMERIC) {
-    return [
-      buildScoreWritePayload({
-        ...commonParams,
-        scoreId: params.primaryScoreId,
-        scoreValue: params.outputResult.score,
-        dataType: ScoreDataTypeEnum.NUMERIC,
-      }),
-    ];
-  }
-
-  if (params.outputResult.dataType === ScoreDataTypeEnum.BOOLEAN) {
-    return [
-      buildScoreWritePayload({
-        ...commonParams,
-        scoreId: params.primaryScoreId,
-        scoreValue: params.outputResult.score ? 1 : 0,
-        dataType: ScoreDataTypeEnum.BOOLEAN,
-      }),
-    ];
-  }
-
-  return params.outputResult.matches.map((scoreValue, index) =>
-    buildScoreWritePayload({
-      ...commonParams,
-      scoreId: index === 0 ? params.primaryScoreId : randomUUID(),
-      scoreValue,
-      dataType: ScoreDataTypeEnum.CATEGORICAL,
-    }),
-  );
+    return {
+      eventId,
+      scoreId,
+      event: {
+        id: eventId,
+        timestamp: new Date().toISOString(),
+        type: eventTypes.SCORE_CREATE,
+        body: {
+          id: scoreId,
+          traceId: params.traceId,
+          observationId: params.observationId,
+          name: score.name,
+          comment: score.comment,
+          metadata: params.executionMetadata,
+          configId: score.configId,
+          source: ScoreSourceEnum.EVAL,
+          environment: params.environment,
+          executionTraceId: params.executionTraceId,
+          value: score.value,
+          dataType: score.dataType,
+        } as ScoreEventType["body"],
+      },
+    };
+  });
 }

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -1174,13 +1174,13 @@ export async function extractVariablesFromTracingData({
   traceTimestamp?: Date;
   datasetItemId?: string;
   datasetItemValidFrom?: Date;
-}): Promise<{ var: string; value: string; environment?: string }[]> {
+}): Promise<ExtractedVariable[]> {
   // Internal cache for this function call to avoid duplicate database lookups.
   // We do not cache dataset items as Postgres is cheaper than ClickHouse.
   const traceCache = new Map<string, TraceDomain | null>();
   const observationCache = new Map<string, Observation | null>();
 
-  const results: { var: string; value: string; environment?: string }[] = [];
+  const results: ExtractedVariable[] = [];
 
   // We run through this list sequentially to make use of caching.
   // The performance improvement by parallel execution should be less than the improvement we gain by caching.
@@ -1244,7 +1244,7 @@ export async function extractVariablesFromTracingData({
 
       results.push({
         var: variable,
-        value: parseDatabaseRowToString(datasetItem, mapping),
+        value: parseDatabaseRowValue(datasetItem, mapping),
       });
       continue;
     }
@@ -1289,7 +1289,7 @@ export async function extractVariablesFromTracingData({
 
       results.push({
         var: variable,
-        value: parseDatabaseRowToString(trace, mapping),
+        value: parseDatabaseRowValue(trace, mapping),
         environment: trace.environment,
       });
       continue;
@@ -1350,7 +1350,7 @@ export async function extractVariablesFromTracingData({
 
       results.push({
         var: variable,
-        value: parseDatabaseRowToString(observation, mapping),
+        value: parseDatabaseRowValue(observation, mapping),
         environment: observation.environment,
       });
       continue;
@@ -1365,10 +1365,13 @@ export async function extractVariablesFromTracingData({
 const snakeToCamel = (s: string) =>
   s.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
 
-export const parseDatabaseRowToString = (
+// Returns the typed value extracted from a database row. LLM-as-judge
+// stringifies at template-substitution time via `compileEvalPrompt`; code-
+// based evaluators consume the typed value directly.
+export const parseDatabaseRowValue = (
   dbRow: Record<string, unknown>,
   mapping: z.infer<typeof variableMapping>,
-): string => {
+): unknown => {
   // Prisma returns camelCase keys, but selectedColumnId may be snake_case
   const selectedColumn =
     dbRow[mapping.selectedColumnId] ??

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -32,6 +32,7 @@ import {
   isLLMCompletionError,
   blockEvaluatorConfigs,
   EvaluatorBlockSource,
+  type CodeEvalScoreWithName,
 } from "@langfuse/shared/src/server";
 import {
   mapTraceFilterColumn,
@@ -59,6 +60,7 @@ import {
   PersistedEvalOutputDefinitionSchema,
   ScoreDataTypeEnum,
   validateEvalOutputResult,
+  type EvalOutputResult,
   extractValueFromObject,
   validateEvaluatorFiltersForTarget,
 } from "@langfuse/shared";
@@ -955,12 +957,53 @@ export async function runLLMAsJudgeEvaluation({
       );
 
       return {
-        outputResult: parsedLLMOutput.data,
+        scores: toNormalizedScores({
+          outputResult: parsedLLMOutput.data,
+          scoreName: config.scoreName,
+        }),
         primaryScoreId,
         executionTraceId,
+        metadata,
       };
     },
   );
+}
+
+function toNormalizedScores(params: {
+  outputResult: EvalOutputResult;
+  scoreName: string;
+}): CodeEvalScoreWithName[] {
+  const { outputResult, scoreName } = params;
+  const baseFields = {
+    name: scoreName,
+    comment: outputResult.reasoning,
+  };
+
+  if (outputResult.dataType === ScoreDataTypeEnum.NUMERIC) {
+    return [
+      {
+        ...baseFields,
+        dataType: ScoreDataTypeEnum.NUMERIC,
+        value: outputResult.score,
+      },
+    ];
+  }
+
+  if (outputResult.dataType === ScoreDataTypeEnum.BOOLEAN) {
+    return [
+      {
+        ...baseFields,
+        dataType: ScoreDataTypeEnum.BOOLEAN,
+        value: outputResult.score ? 1 : 0,
+      },
+    ];
+  }
+
+  return outputResult.matches.map((value) => ({
+    ...baseFields,
+    dataType: ScoreDataTypeEnum.CATEGORICAL,
+    value,
+  }));
 }
 
 export async function executeLLMAsJudgeEvaluation(
@@ -986,11 +1029,9 @@ export async function executeLLMAsJudgeEvaluation(
     jobExecutionId: params.jobExecutionId,
     traceId: params.job.jobInputTraceId,
     observationId: params.job.jobInputObservationId,
-    scoreName: params.config.scoreName,
     environment: params.environment,
-    metadata,
     deps,
-    ...result,
+    result,
   });
 }
 

--- a/worker/src/features/evaluation/evaluationHelpers.test.ts
+++ b/worker/src/features/evaluation/evaluationHelpers.test.ts
@@ -70,6 +70,33 @@ describe("evaluation helpers", () => {
       const result = compileEvalPrompt(params);
       expect(result).toBe('Data: {"key": "value", "count": 42}');
     });
+
+    it("stringifies non-string variable values via parseUnknownToString", () => {
+      // Regression guard for the upstream refactor that made
+      // `ExtractedVariable.value: unknown`. A naive `String(value)` would
+      // render `"[object Object]"` for object inputs and the comma-joined
+      // form for arrays — both useless to an LLM.
+      const params = {
+        templatePrompt:
+          "meta={{meta}} tools={{tools}} score={{score}} flag={{flag}} missing={{missing}}",
+        variables: [
+          { var: "meta", value: { key: "value", count: 42 } },
+          { var: "tools", value: ["get_weather", "search_web"] },
+          { var: "score", value: 0.85 },
+          { var: "flag", value: true },
+          { var: "missing", value: null },
+        ] as ExtractedVariable[],
+      };
+
+      const result = compileEvalPrompt(params);
+
+      expect(result).toContain('meta={"key":"value","count":42}');
+      expect(result).not.toContain("[object Object]");
+      expect(result).toContain('tools=["get_weather","search_web"]');
+      expect(result).toContain("score=0.85");
+      expect(result).toContain("flag=true");
+      expect(result).toContain("missing=");
+    });
   });
 
   describe("buildEvalOutputResultSchema", () => {

--- a/worker/src/features/evaluation/evaluationHelpers.test.ts
+++ b/worker/src/features/evaluation/evaluationHelpers.test.ts
@@ -18,7 +18,7 @@ import {
   compileEvalPrompt,
   getEnvironmentFromVariables,
 } from "./evalRuntime";
-import { buildEvalScoreWritePayloads, buildScoreEvent } from "./evalScoreEvent";
+import { buildEvalScoreWritePayloads } from "./evalScoreEvent";
 
 describe("evaluation helpers", () => {
   describe("compileEvalPrompt", () => {
@@ -353,113 +353,23 @@ describe("evaluation helpers", () => {
     });
   });
 
-  describe("buildScoreEvent", () => {
-    it("should build complete score event", () => {
-      const params = {
-        eventId: "event-123",
-        scoreId: "score-456",
-        traceId: "trace-789",
-        observationId: null,
-        scoreName: "accuracy",
-        scoreValue: 0.85,
-        reasoning: "High accuracy observed",
-        environment: "production",
-        executionTraceId: "exec-trace-abc",
-        metadata: { job_execution_id: "exec-123" },
-        dataType: ScoreDataTypeEnum.NUMERIC,
-      };
-
-      const result = buildScoreEvent(params);
-
-      expect(result.id).toBe("event-123");
-      expect(result.type).toBe("score-create");
-      expect(result.body.id).toBe("score-456");
-      expect(result.body.traceId).toBe("trace-789");
-      expect(result.body.observationId).toBeNull();
-      expect(result.body.name).toBe("accuracy");
-      expect(result.body.value).toBe(0.85);
-      expect(result.body.comment).toBe("High accuracy observed");
-      expect(result.body.source).toBe("EVAL");
-      expect(result.body.environment).toBe("production");
-      expect(result.body.executionTraceId).toBe("exec-trace-abc");
-      expect(result.body.metadata).toEqual({ job_execution_id: "exec-123" });
-      expect(result.body.dataType).toBe("NUMERIC");
-    });
-
-    it("should include observation ID when provided", () => {
-      const params = {
-        eventId: "event-123",
-        scoreId: "score-456",
-        traceId: "trace-789",
-        observationId: "obs-abc",
-        scoreName: "relevance",
-        scoreValue: 0.9,
-        reasoning: "Highly relevant",
-        environment: "default",
-        executionTraceId: "exec-trace-def",
-        metadata: {},
-        dataType: ScoreDataTypeEnum.NUMERIC,
-      };
-
-      const result = buildScoreEvent(params);
-
-      expect(result.body.observationId).toBe("obs-abc");
-    });
-
-    it("should build categorical score events", () => {
-      const result = buildScoreEvent({
-        eventId: "event-123",
-        scoreId: "score-456",
-        traceId: "trace-789",
-        observationId: null,
-        scoreName: "factuality",
-        scoreValue: "correct",
-        reasoning: "The answer is fully supported.",
-        environment: "production",
-        executionTraceId: "exec-trace-abc",
-        metadata: { job_execution_id: "exec-123" },
-        dataType: ScoreDataTypeEnum.CATEGORICAL,
-      });
-
-      expect(result.body.value).toBe("correct");
-      expect(result.body.dataType).toBe("CATEGORICAL");
-    });
-
-    it("should build boolean score events", () => {
-      const result = buildScoreEvent({
-        eventId: "event-123",
-        scoreId: "score-456",
-        traceId: "trace-789",
-        observationId: null,
-        scoreName: "correctness",
-        scoreValue: 1,
-        reasoning: "The answer meets the criteria.",
-        environment: "production",
-        executionTraceId: "exec-trace-abc",
-        metadata: { job_execution_id: "exec-123" },
-        dataType: ScoreDataTypeEnum.BOOLEAN,
-      });
-
-      expect(result.body.value).toBe(1);
-      expect(result.body.dataType).toBe("BOOLEAN");
-    });
-  });
-
   describe("buildEvalScoreWritePayloads", () => {
     it("should build a single numeric score payload", () => {
       const result = buildEvalScoreWritePayloads({
-        outputResult: {
-          dataType: ScoreDataTypeEnum.NUMERIC,
-          score: 0.85,
-          reasoning: "High accuracy observed",
-        },
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.NUMERIC,
+            value: 0.85,
+            name: "accuracy",
+            comment: "High accuracy observed",
+          },
+        ],
         primaryScoreId: "score-123",
         traceId: "trace-456",
         observationId: null,
-        scoreName: "accuracy",
         environment: "production",
         executionTraceId: "exec-trace-789",
-        metadata: { job_execution_id: "job-1" },
+        executionMetadata: { job_execution_id: "job-1" },
       });
 
       expect(result).toHaveLength(1);
@@ -477,18 +387,20 @@ describe("evaluation helpers", () => {
 
     it("should build a single boolean score payload", () => {
       const result = buildEvalScoreWritePayloads({
-        outputResult: {
-          dataType: ScoreDataTypeEnum.BOOLEAN,
-          score: true,
-          reasoning: "The answer satisfies the criteria",
-        },
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.BOOLEAN,
+            value: 1,
+            name: "correctness",
+            comment: "The answer satisfies the criteria",
+          },
+        ],
         primaryScoreId: "score-123",
         traceId: "trace-456",
         observationId: null,
-        scoreName: "correctness",
         environment: "production",
         executionTraceId: "exec-trace-789",
-        metadata: { job_execution_id: "job-1" },
+        executionMetadata: { job_execution_id: "job-1" },
       });
 
       expect(result).toHaveLength(1);
@@ -506,18 +418,26 @@ describe("evaluation helpers", () => {
 
     it("should build one categorical payload per match while preserving shared metadata", () => {
       const result = buildEvalScoreWritePayloads({
-        outputResult: {
-          dataType: ScoreDataTypeEnum.CATEGORICAL,
-          matches: ["correct", "partial"],
-          reasoning: "Both categories apply",
-        },
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "correct",
+            name: "accuracy",
+            comment: "Both categories apply",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "partial",
+            name: "accuracy",
+            comment: "Both categories apply",
+          },
+        ],
         primaryScoreId: "score-123",
         traceId: "trace-456",
         observationId: "obs-789",
-        scoreName: "accuracy",
         environment: "production",
         executionTraceId: "exec-trace-789",
-        metadata: { job_execution_id: "job-1" },
+        executionMetadata: { job_execution_id: "job-1" },
       });
 
       expect(result).toHaveLength(2);

--- a/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
@@ -393,6 +393,30 @@ describe("extractObservationVariables", () => {
 
       expect(result[0].value).toBe(mockObservation.input);
     });
+
+    it("keeps raw value for no-selector mapping when selector sibling uses the same JSON string column", () => {
+      const variableMapping: ObservationVariableMapping[] = [
+        {
+          templateVariable: "rawInput",
+          selectedColumnId: "input",
+        },
+        {
+          templateVariable: "prompt",
+          selectedColumnId: "input",
+          jsonSelector: "$.prompt",
+        },
+      ];
+
+      const result = extractObservationVariables({
+        observation: mockObservation,
+        variableMapping,
+      });
+
+      expect(result).toEqual([
+        { var: "rawInput", value: mockObservation.input },
+        { var: "prompt", value: "Hello, how are you?" },
+      ]);
+    });
   });
 
   describe("edge cases", () => {

--- a/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/extractObservationVariables.test.ts
@@ -123,7 +123,7 @@ describe("extractObservationVariables", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].var).toBe("meta");
-      expect(result[0].value).toBe(JSON.stringify(mockObservation.metadata));
+      expect(result[0].value).toEqual(mockObservation.metadata);
     });
 
     it("should extract multiple variables", () => {
@@ -166,7 +166,7 @@ describe("extractObservationVariables", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].var).toBe("tools");
-      expect(result[0].value).toBe(JSON.stringify(mockObservation.tool_calls));
+      expect(result[0].value).toEqual(mockObservation.tool_calls);
     });
 
     it("should extract toolDefinitions variable", () => {
@@ -187,9 +187,7 @@ describe("extractObservationVariables", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].var).toBe("definitions");
-      expect(result[0].value).toBe(
-        JSON.stringify(mockObservation.tool_definitions),
-      );
+      expect(result[0].value).toEqual(mockObservation.tool_definitions);
     });
   });
 
@@ -270,9 +268,7 @@ describe("extractObservationVariables", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].var).toBe("usage");
-      expect(result[0].value).toBe(
-        JSON.stringify(mockObservation.usage_details),
-      );
+      expect(result[0].value).toEqual(mockObservation.usage_details);
     });
 
     it("should extract costDetails variable", () => {
@@ -290,9 +286,7 @@ describe("extractObservationVariables", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].var).toBe("cost");
-      expect(result[0].value).toBe(
-        JSON.stringify(mockObservation.cost_details),
-      );
+      expect(result[0].value).toEqual(mockObservation.cost_details);
     });
   });
 
@@ -363,9 +357,7 @@ describe("extractObservationVariables", () => {
         variableMapping,
       });
 
-      expect(result[0].value).toBe(
-        JSON.stringify(["get_weather", "search_web"]),
-      );
+      expect(result[0].value).toEqual(["get_weather", "search_web"]);
     });
 
     it("should handle null jsonSelector by returning full value", () => {
@@ -433,8 +425,8 @@ describe("extractObservationVariables", () => {
         availableObservationEvalVariableColumns as ObservationEvalVariableColumn[],
       );
 
-      expect(result[0].value).toBe("");
-      expect(result[1].value).toBe("");
+      expect(result[0].value).toBeNull();
+      expect(result[1].value).toBeUndefined();
     });
 
     it("should handle invalid JSON selector gracefully", () => {
@@ -454,8 +446,8 @@ describe("extractObservationVariables", () => {
         availableObservationEvalVariableColumns as ObservationEvalVariableColumn[],
       );
 
-      // Non-matching JSONPath returns empty string
-      expect(result[0].value).toBe("");
+      // Non-matching JSONPath returns undefined
+      expect(result[0].value).toBeUndefined();
     });
 
     it("should handle non-JSON string column with JSON selector", () => {
@@ -528,7 +520,7 @@ describe("extractObservationVariables", () => {
         variableMapping,
       });
 
-      expect(result[0].value).toBe(JSON.stringify(mockObservation.metadata));
+      expect(result[0].value).toEqual(mockObservation.metadata);
     });
   });
 });

--- a/worker/src/features/evaluation/observationEval/__tests__/fixtures.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/fixtures.ts
@@ -91,7 +91,6 @@ export function createTestObservation(
     experiment_dataset_id: null,
     experiment_item_id: null,
     experiment_item_expected_output: null,
-    experiment_item_metadata: {},
     experiment_item_root_span_id: null,
 
     // Data fields

--- a/worker/src/features/evaluation/observationEval/__tests__/fixtures.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/fixtures.ts
@@ -91,6 +91,7 @@ export function createTestObservation(
     experiment_dataset_id: null,
     experiment_item_id: null,
     experiment_item_expected_output: null,
+    experiment_item_metadata: {},
     experiment_item_root_span_id: null,
 
     // Data fields

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import {
+  EvalTemplateSourceCodeLanguage,
   EvalTemplateType,
   JobExecutionStatus,
   type Prisma,
@@ -12,13 +13,23 @@ import {
   createTestObservation,
   createTestEvalConfig,
   createFullyMockedEvalPipeline,
+  createMockEvalTemplate,
+  createMockJobConfiguration,
+  createMockJobExecution,
 } from "./fixtures";
 import {
+  assertCodeBasedEvalTemplate,
   assertLLMAsJudgeEvalTemplate,
   EvalTargetObject,
   type EvalTemplate,
+  type EvalTemplateCodeBased,
   type EvalTemplateLlmAsAJudge,
+  type ObservationVariableMapping,
 } from "@langfuse/shared";
+
+const mocks = vi.hoisted(() => ({
+  writeInternalTrace: vi.fn(),
+}));
 
 // Mock prisma for processObservationEval
 vi.mock("@langfuse/shared/src/db", () => ({
@@ -30,6 +41,9 @@ vi.mock("@langfuse/shared/src/db", () => ({
     jobConfiguration: {
       findFirst: vi.fn(),
     },
+    project: {
+      findUnique: vi.fn(),
+    },
   },
 }));
 
@@ -38,9 +52,15 @@ vi.mock("../../evalService", () => ({
   runLLMAsJudgeEvaluation: vi.fn(),
 }));
 
+vi.mock("../../../internal-tracing/createInternalEventsWriter", () => ({
+  createInternalEventsWriter: () => ({ write: mocks.writeInternalTrace }),
+}));
+
 // Mock logger
 vi.mock("@langfuse/shared/src/server", async () => {
-  const actual = await vi.importActual("@langfuse/shared/src/server");
+  const actual = await vi.importActual<
+    typeof import("@langfuse/shared/src/server")
+  >("@langfuse/shared/src/server");
   return {
     ...actual,
     logger: {
@@ -50,16 +70,27 @@ vi.mock("@langfuse/shared/src/server", async () => {
       error: vi.fn(),
     },
     DEFAULT_TRACE_ENVIRONMENT: "default",
+    resolveConfiguredCodeEvalDispatcher: vi.fn(
+      () => new actual.LocalCodeEvalDispatcher(),
+    ),
   };
 });
 
 import { prisma } from "@langfuse/shared/src/db";
+import { executeCodeBasedEvaluation } from "../../codeBased";
 import { runLLMAsJudgeEvaluation } from "../../evalService";
 
 const validateLLMAsJudgeTemplate = (
   template: EvalTemplate,
 ): EvalTemplateLlmAsAJudge => {
   assertLLMAsJudgeEvalTemplate(template);
+  return template;
+};
+
+const validateCodeBasedTemplate = (
+  template: EvalTemplate,
+): EvalTemplateCodeBased => {
+  assertCodeBasedEvalTemplate(template);
   return template;
 };
 
@@ -82,6 +113,7 @@ describe("Observation Eval E2E Pipeline", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (prisma.project.findUnique as Mock).mockResolvedValue({ orgId: "org-1" });
     (runLLMAsJudgeEvaluation as Mock).mockResolvedValue(
       mockEvalExecutionResult,
     );
@@ -256,6 +288,145 @@ describe("Observation Eval E2E Pipeline", () => {
             }),
           ]),
           environment: "production",
+        }),
+      );
+    });
+
+    it("should process a code-based eval through execution and score persistence", async () => {
+      const observation = createTestObservation({
+        project_id: projectId,
+        input: { question: "2+2" },
+        output: { answer: "4" },
+        metadata: { rubric: "math" },
+        experiment_item_expected_output: "4",
+        experiment_item_metadata: { difficulty: "easy" },
+        environment: "production",
+      });
+      const variableMapping: ObservationVariableMapping[] = [
+        { templateVariable: "input", selectedColumnId: "input" },
+        { templateVariable: "output", selectedColumnId: "output" },
+        {
+          templateVariable: "observationMetadata",
+          selectedColumnId: "metadata",
+        },
+        {
+          templateVariable: "experimentExpectedOutput",
+          selectedColumnId: "experimentItemExpectedOutput",
+        },
+        {
+          templateVariable: "experimentItemMetadata",
+          selectedColumnId: "experimentItemMetadata",
+        },
+      ];
+      const config = createTestEvalConfig({
+        id: `config-${randomUUID()}`,
+        projectId,
+        scoreName: "code-score",
+        variableMapping,
+      });
+      const pipeline = createFullyMockedEvalPipeline({ observation });
+      const job = createMockJobExecution({
+        id: `job-exec-${randomUUID()}`,
+        projectId,
+        jobConfigurationId: config.id,
+        jobInputTraceId: observation.trace_id,
+        jobInputObservationId: observation.span_id,
+      });
+      const template = createMockEvalTemplate({
+        id: config.evalTemplateId,
+        projectId,
+        name: "Code nested context evaluator",
+        type: EvalTemplateType.CODE,
+        prompt: null,
+        outputDefinition: null,
+        sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        sourceCode: `
+          export function evaluate(ctx) {
+            const matched =
+              ctx.observation.input.question === "2+2" &&
+              ctx.observation.output.answer === ctx.experiment?.expectedOutput &&
+              ctx.observation.metadata.rubric === "math" &&
+              ctx.experiment?.itemMetadata.difficulty === "easy";
+
+            return {
+              scores: [
+                {
+                  name: "nested-context-score",
+                  value: matched ? 1 : 0,
+                  dataType: "BOOLEAN",
+                  comment: ctx.experiment?.itemMetadata.difficulty,
+                },
+              ],
+            };
+          }
+        `,
+      });
+      const mockConfig = createMockJobConfiguration({
+        id: config.id,
+        projectId,
+        evalTemplateId: config.evalTemplateId,
+        scoreName: config.scoreName,
+        variableMapping,
+        evalTemplate: template,
+      });
+
+      (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
+      (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(mockConfig);
+
+      await processObservationEval({
+        event: {
+          projectId,
+          jobExecutionId: job.id,
+          observationS3Path: "test-path",
+        },
+        validateTemplate: validateCodeBasedTemplate,
+        executor: executeCodeBasedEvaluation,
+        deps: pipeline.processorDeps,
+      });
+
+      expect(
+        pipeline.processorDeps.downloadObservationFromS3,
+      ).toHaveBeenCalledWith("test-path");
+      expect(pipeline.executionDeps.uploadScore).toHaveBeenCalledTimes(1);
+      expect(
+        pipeline.executionDeps.enqueueScoreIngestion,
+      ).toHaveBeenCalledTimes(1);
+      expect(pipeline.executionDeps.updateJobExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: job.id,
+          projectId,
+          data: expect.objectContaining({
+            status: JobExecutionStatus.COMPLETED,
+            executionTraceId: expect.any(String),
+            jobOutputScoreId: expect.any(String),
+          }),
+        }),
+      );
+      expect(pipeline.executionDeps.uploadScore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId,
+          event: expect.objectContaining({
+            body: expect.objectContaining({
+              traceId: observation.trace_id,
+              observationId: observation.span_id,
+              name: "nested-context-score",
+              value: 1,
+              dataType: "BOOLEAN",
+              comment: "easy",
+              environment: "production",
+              source: "EVAL",
+            }),
+          }),
+        }),
+      );
+      expect(mocks.writeInternalTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventInputs: [
+            expect.objectContaining({
+              input: expect.stringContaining('"observation"'),
+              output: expect.stringContaining('"nested-context-score"'),
+            }),
+          ],
         }),
       );
     });

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
@@ -299,7 +299,6 @@ describe("Observation Eval E2E Pipeline", () => {
         output: { answer: "4" },
         metadata: { rubric: "math" },
         experiment_item_expected_output: "4",
-        experiment_item_metadata: { difficulty: "easy" },
         environment: "production",
       });
       const variableMapping: ObservationVariableMapping[] = [
@@ -312,10 +311,6 @@ describe("Observation Eval E2E Pipeline", () => {
         {
           templateVariable: "experimentExpectedOutput",
           selectedColumnId: "experimentItemExpectedOutput",
-        },
-        {
-          templateVariable: "experimentItemMetadata",
-          selectedColumnId: "experimentItemMetadata",
         },
       ];
       const config = createTestEvalConfig({
@@ -345,8 +340,7 @@ describe("Observation Eval E2E Pipeline", () => {
             const matched =
               ctx.observation.input.question === "2+2" &&
               ctx.observation.output.answer === ctx.experiment?.expectedOutput &&
-              ctx.observation.metadata.rubric === "math" &&
-              ctx.experiment?.itemMetadata.difficulty === "easy";
+              ctx.observation.metadata.rubric === "math";
 
             return {
               scores: [
@@ -354,7 +348,7 @@ describe("Observation Eval E2E Pipeline", () => {
                   name: "nested-context-score",
                   value: matched ? 1 : 0,
                   dataType: "BOOLEAN",
-                  comment: ctx.experiment?.itemMetadata.difficulty,
+                  comment: ctx.experiment?.expectedOutput,
                 },
               ],
             };
@@ -412,7 +406,7 @@ describe("Observation Eval E2E Pipeline", () => {
               name: "nested-context-score",
               value: 1,
               dataType: "BOOLEAN",
-              comment: "easy",
+              comment: "4",
               environment: "production",
               source: "EVAL",
             }),

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
@@ -64,11 +64,14 @@ const validateLLMAsJudgeTemplate = (
 };
 
 const mockEvalExecutionResult = {
-  outputResult: {
-    dataType: "NUMERIC" as const,
-    score: 0.85,
-    reasoning: "Good response",
-  },
+  scores: [
+    {
+      dataType: "NUMERIC" as const,
+      value: 0.85,
+      name: "test-score",
+      comment: "Good response",
+    },
+  ],
   primaryScoreId: "score-123",
   executionTraceId: "trace-123",
   metadata: {},

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
@@ -81,11 +81,14 @@ import {
 import { runLLMAsJudgeEvaluation } from "../../evalService";
 
 const mockEvalExecutionResult = {
-  outputResult: {
-    dataType: "NUMERIC" as const,
-    score: 0.5,
-    reasoning: "Mock eval result",
-  },
+  scores: [
+    {
+      dataType: "NUMERIC" as const,
+      value: 0.5,
+      name: "test-score",
+      comment: "Mock eval result",
+    },
+  ],
   primaryScoreId: "score-123",
   executionTraceId: "trace-123",
   metadata: {},

--- a/worker/src/features/evaluation/observationEval/__tests__/observationForEvalSchema.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationForEvalSchema.test.ts
@@ -99,7 +99,6 @@ describe("observationForEvalSchema", () => {
       experiment_dataset_id: "dataset-123",
       experiment_item_id: "item-123",
       experiment_item_expected_output: "expected output",
-      experiment_item_metadata: {},
       input: '{"prompt": "Hello"}',
       output: '{"response": "World"}',
       metadata: { key: "value" },

--- a/worker/src/features/evaluation/observationEval/__tests__/observationForEvalSchema.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationForEvalSchema.test.ts
@@ -99,6 +99,7 @@ describe("observationForEvalSchema", () => {
       experiment_dataset_id: "dataset-123",
       experiment_item_id: "item-123",
       experiment_item_expected_output: "expected output",
+      experiment_item_metadata: {},
       input: '{"prompt": "Hello"}',
       output: '{"response": "World"}',
       metadata: { key: "value" },

--- a/worker/src/features/evaluation/observationEval/extractObservationVariables.ts
+++ b/worker/src/features/evaluation/observationEval/extractObservationVariables.ts
@@ -12,7 +12,7 @@ import { logger } from "@langfuse/shared/src/server";
  */
 export interface ExtractedVariable {
   var: string;
-  value: string;
+  value: unknown;
   environment?: string;
 }
 
@@ -77,7 +77,7 @@ export function extractObservationVariables(
       );
       variables.push({
         var: mapping.templateVariable,
-        value: "",
+        value: null,
       });
       continue;
     }

--- a/worker/src/features/evaluation/observationEval/extractObservationVariables.ts
+++ b/worker/src/features/evaluation/observationEval/extractObservationVariables.ts
@@ -82,10 +82,12 @@ export function extractObservationVariables(
       continue;
     }
 
-    // Use pre-parsed value if this field was parsed, otherwise use raw value
-    const fieldValue = parsedFields.has(mapping.selectedColumnId)
-      ? parsedFields.get(mapping.selectedColumnId)
-      : observation[internal];
+    // Use pre-parsed value only for mappings that requested a selector,
+    // otherwise keep the raw column value even if a sibling mapping parsed it.
+    const fieldValue =
+      mapping.jsonSelector && parsedFields.has(mapping.selectedColumnId)
+        ? parsedFields.get(mapping.selectedColumnId)
+        : observation[internal];
 
     // Build a single-key object so extractValueFromObject can look it up
     const { value, error } = extractValueFromObject(

--- a/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
+++ b/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
@@ -243,10 +243,8 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     jobExecutionId: executionParams.jobExecutionId,
     traceId: executionParams.job.jobInputTraceId,
     observationId: executionParams.job.jobInputObservationId,
-    scoreName: executionParams.config.scoreName,
     environment: executionParams.environment,
-    metadata: executionParams.metadata,
     deps: executionParams.deps,
-    ...executionResult,
+    result: executionResult,
   });
 }

--- a/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
@@ -34,7 +34,27 @@ vi.mock("../../features/evaluation/codeBased", () => ({
   executeCodeBasedEvaluation: vi.fn(),
 }));
 
+const { FakeCodeEvalDispatcherError } = vi.hoisted(() => {
+  class FakeCodeEvalDispatcherError extends Error {
+    public readonly code: string;
+    public readonly retryable: boolean;
+
+    constructor(
+      message: string,
+      options: { code: string; retryable?: boolean },
+    ) {
+      super(message);
+      this.name = "CodeEvalDispatcherError";
+      this.code = options.code;
+      this.retryable = options.retryable ?? false;
+    }
+  }
+
+  return { FakeCodeEvalDispatcherError };
+});
+
 vi.mock("@langfuse/shared/src/server", () => ({
+  CodeEvalDispatcherError: FakeCodeEvalDispatcherError,
   getCurrentSpan: vi.fn().mockReturnValue({
     setAttribute: vi.fn(),
   }),
@@ -73,7 +93,13 @@ describe("codeEvalExecutionQueueProcessor", () => {
   const queueName = `${QueueName.CodeEvalExecution}-1`;
   let codeEvalExecutionQueueProcessor: (job: Job<any>) => Promise<unknown>;
 
-  const createMockJob = (overrides: Record<string, unknown> = {}): Job<any> =>
+  const createMockJob = (
+    overrides: {
+      data?: Record<string, unknown>;
+      attemptsMade?: number;
+      opts?: { attempts?: number };
+    } = {},
+  ): Job<any> =>
     ({
       data: {
         id: "queue-job-123",
@@ -85,8 +111,10 @@ describe("codeEvalExecutionQueueProcessor", () => {
           observationS3Path,
         },
         retryBaggage: { attempt: 0 },
-        ...overrides,
+        ...overrides.data,
       },
+      attemptsMade: overrides.attemptsMade ?? 0,
+      opts: overrides.opts ?? { attempts: 10 },
     }) as Job<any>;
 
   beforeAll(async () => {
@@ -118,6 +146,49 @@ describe("codeEvalExecutionQueueProcessor", () => {
     });
   });
 
+  it("should treat non-retryable dispatcher errors as terminal and show the dispatcher message", async () => {
+    const error = new FakeCodeEvalDispatcherError(
+      "Evaluator returned invalid result",
+      { code: "INVALID_RESULT", retryable: false },
+    );
+    (processObservationEval as Mock).mockRejectedValue(error);
+
+    const result = await codeEvalExecutionQueueProcessor(createMockJob());
+
+    expect(result).toBeUndefined();
+    expect(prisma.jobExecution.update).toHaveBeenCalledWith({
+      where: { id: jobExecutionId, projectId },
+      data: {
+        status: JobExecutionStatus.ERROR,
+        endTime: expect.any(Date),
+        error: "Evaluator returned invalid result",
+        executionTraceId: "test-trace-id",
+      },
+    });
+    expect(traceException).not.toHaveBeenCalled();
+  });
+
+  it("should mask internal lambda error codes when finalizing on the last attempt", async () => {
+    const error = new FakeCodeEvalDispatcherError(
+      "Function not found: code-based-eval-executor-node",
+      { code: "LAMBDA_CONFIGURATION_ERROR", retryable: false },
+    );
+    (processObservationEval as Mock).mockRejectedValue(error);
+
+    const result = await codeEvalExecutionQueueProcessor(createMockJob());
+
+    expect(result).toBeUndefined();
+    expect(prisma.jobExecution.update).toHaveBeenCalledWith({
+      where: { id: jobExecutionId, projectId },
+      data: {
+        status: JobExecutionStatus.ERROR,
+        endTime: expect.any(Date),
+        error: "An internal error occurred",
+        executionTraceId: "test-trace-id",
+      },
+    });
+  });
+
   it("should mark unrecoverable skeleton errors as terminal", async () => {
     const error = new UnrecoverableError(
       "Code-based eval execution is not implemented yet",
@@ -143,12 +214,26 @@ describe("codeEvalExecutionQueueProcessor", () => {
     expect(traceException).not.toHaveBeenCalled();
   });
 
-  it("should rethrow unexpected errors after marking the job as errored", async () => {
+  it("should rethrow retryable errors without writing ERROR while retries remain", async () => {
     const error = new Error("temporary dispatcher failure");
     (processObservationEval as Mock).mockRejectedValue(error);
 
     await expect(
       codeEvalExecutionQueueProcessor(createMockJob()),
+    ).rejects.toThrow(error);
+
+    expect(prisma.jobExecution.update).not.toHaveBeenCalled();
+    expect(traceException).toHaveBeenCalledWith(error);
+  });
+
+  it("should mark the job as ERROR on the final retry attempt", async () => {
+    const error = new Error("temporary dispatcher failure");
+    (processObservationEval as Mock).mockRejectedValue(error);
+
+    await expect(
+      codeEvalExecutionQueueProcessor(
+        createMockJob({ attemptsMade: 9, opts: { attempts: 10 } }),
+      ),
     ).rejects.toThrow(error);
 
     expect(prisma.jobExecution.update).toHaveBeenCalledWith({
@@ -159,7 +244,7 @@ describe("codeEvalExecutionQueueProcessor", () => {
       data: {
         status: JobExecutionStatus.ERROR,
         endTime: expect.any(Date),
-        error: "An internal error occurred",
+        error: "temporary dispatcher failure",
         executionTraceId: "test-trace-id",
       },
     });

--- a/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
@@ -226,7 +226,7 @@ describe("codeEvalExecutionQueueProcessor", () => {
     expect(traceException).toHaveBeenCalledWith(error);
   });
 
-  it("should mark the job as ERROR on the final retry attempt", async () => {
+  it("should mark the job as ERROR with a masked message on the final retry attempt", async () => {
     const error = new Error("temporary dispatcher failure");
     (processObservationEval as Mock).mockRejectedValue(error);
 
@@ -244,7 +244,7 @@ describe("codeEvalExecutionQueueProcessor", () => {
       data: {
         status: JobExecutionStatus.ERROR,
         endTime: expect.any(Date),
-        error: "temporary dispatcher failure",
+        error: "An internal error occurred",
         executionTraceId: "test-trace-id",
       },
     });

--- a/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
@@ -55,6 +55,13 @@ const { FakeCodeEvalDispatcherError } = vi.hoisted(() => {
 
 vi.mock("@langfuse/shared/src/server", () => ({
   CodeEvalDispatcherError: FakeCodeEvalDispatcherError,
+  CodeEvalDispatcherErrorCode: {
+    enum: {
+      LAMBDA_CONCURRENCY_LIMIT: "LAMBDA_CONCURRENCY_LIMIT",
+      LAMBDA_CONFIGURATION_ERROR: "LAMBDA_CONFIGURATION_ERROR",
+      LAMBDA_INVOCATION_ERROR: "LAMBDA_INVOCATION_ERROR",
+    },
+  },
   getCurrentSpan: vi.fn().mockReturnValue({
     setAttribute: vi.fn(),
   }),

--- a/worker/src/queues/codeEvalQueue.ts
+++ b/worker/src/queues/codeEvalQueue.ts
@@ -8,12 +8,12 @@ import {
 import { prisma } from "@langfuse/shared/src/db";
 import {
   CodeEvalDispatcherError,
+  CodeEvalDispatcherErrorCode,
   getCurrentSpan,
   logger,
   QueueName,
   TQueueJobTypes,
   traceException,
-  type CodeEvalDispatcherErrorCode,
 } from "@langfuse/shared/src/server";
 import { executeCodeBasedEvaluation } from "../features/evaluation/codeBased";
 import { processObservationEval } from "../features/evaluation/observationEval";
@@ -103,9 +103,9 @@ const validateCodeBasedTemplate = (
 const INTERNAL_ERROR_MESSAGE = "An internal error occurred";
 
 const INTERNAL_CODE_EVAL_ERROR_CODES = new Set<CodeEvalDispatcherErrorCode>([
-  "LAMBDA_CONCURRENCY_LIMIT",
-  "LAMBDA_CONFIGURATION_ERROR",
-  "LAMBDA_INVOCATION_ERROR",
+  CodeEvalDispatcherErrorCode.enum.LAMBDA_CONCURRENCY_LIMIT,
+  CodeEvalDispatcherErrorCode.enum.LAMBDA_CONFIGURATION_ERROR,
+  CodeEvalDispatcherErrorCode.enum.LAMBDA_INVOCATION_ERROR,
 ]);
 
 // Returns a user-visible message for JobExecution.error. Dispatcher errors

--- a/worker/src/queues/codeEvalQueue.ts
+++ b/worker/src/queues/codeEvalQueue.ts
@@ -7,11 +7,13 @@ import {
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
+  CodeEvalDispatcherError,
   getCurrentSpan,
   logger,
   QueueName,
   TQueueJobTypes,
   traceException,
+  type CodeEvalDispatcherErrorCode,
 } from "@langfuse/shared/src/server";
 import { executeCodeBasedEvaluation } from "../features/evaluation/codeBased";
 import { processObservationEval } from "../features/evaluation/observationEval";
@@ -54,20 +56,29 @@ export const codeEvalExecutionQueueProcessorBuilder = (
         job.data.payload.jobExecutionId,
       );
 
-      const isTerminalError = isUnrecoverableError(e);
+      const isTerminalError =
+        isUnrecoverableError(e) ||
+        (e instanceof CodeEvalDispatcherError && !e.retryable);
+      const totalAttempts = job.opts.attempts ?? 1;
+      const isFinalAttempt = job.attemptsMade + 1 >= totalAttempts;
 
-      await prisma.jobExecution.update({
-        where: {
-          id: job.data.payload.jobExecutionId,
-          projectId: job.data.payload.projectId,
-        },
-        data: {
-          status: JobExecutionStatus.ERROR,
-          endTime: new Date(),
-          error: isTerminalError ? e.message : "An internal error occurred",
-          executionTraceId,
-        },
-      });
+      // Only persist the terminal ERROR state when there will be no more
+      // retries; otherwise observationEvalProcessor would short-circuit the
+      // retry attempts because it skips jobs already in ERROR status.
+      if (isTerminalError || isFinalAttempt) {
+        await prisma.jobExecution.update({
+          where: {
+            id: job.data.payload.jobExecutionId,
+            projectId: job.data.payload.projectId,
+          },
+          data: {
+            status: JobExecutionStatus.ERROR,
+            endTime: new Date(),
+            error: getJobExecutionErrorMessage(e),
+            executionTraceId,
+          },
+        });
+      }
 
       if (isTerminalError) return;
 
@@ -88,3 +99,26 @@ const validateCodeBasedTemplate = (
   assertCodeBasedEvalTemplate(template);
   return template;
 };
+
+const INTERNAL_ERROR_MESSAGE = "An internal error occurred";
+
+const INTERNAL_CODE_EVAL_ERROR_CODES = new Set<CodeEvalDispatcherErrorCode>([
+  "LAMBDA_CONCURRENCY_LIMIT",
+  "LAMBDA_CONFIGURATION_ERROR",
+  "LAMBDA_INVOCATION_ERROR",
+]);
+
+// Returns a user-visible message for JobExecution.error. Dispatcher errors
+// with internal lambda codes are masked to avoid exposing infra details;
+// other dispatcher errors and UnrecoverableError messages are surfaced as-is.
+function getJobExecutionErrorMessage(e: unknown): string {
+  if (e instanceof CodeEvalDispatcherError) {
+    return INTERNAL_CODE_EVAL_ERROR_CODES.has(e.code)
+      ? INTERNAL_ERROR_MESSAGE
+      : e.message;
+  }
+
+  if (e instanceof Error) return e.message;
+
+  return INTERNAL_ERROR_MESSAGE;
+}

--- a/worker/src/queues/codeEvalQueue.ts
+++ b/worker/src/queues/codeEvalQueue.ts
@@ -118,7 +118,7 @@ function getJobExecutionErrorMessage(e: unknown): string {
       : e.message;
   }
 
-  if (e instanceof Error) return e.message;
+  if (isUnrecoverableError(e)) return e.message;
 
   return INTERNAL_ERROR_MESSAGE;
 }


### PR DESCRIPTION
## Summary

- Implement `LocalCodeEvalDispatcher` (in-process TS-lite execution) and `AwsLambdaCodeEvalDispatcher` (synchronous Lambda Invoke with `TenantId` propagation) behind the `CodeEvalDispatcher` interface.
- Env-driven selector: `LANGFUSE_CODE_EVAL_DISPATCHER=local|aws-lambda`; unset/empty disables. Local dev defaults to `local`. Lambda function names are env-configurable.
- Harmonize executor result shape: both LLM-as-judge and code-eval return `{ scores, primaryScoreId, executionTraceId, metadata }`. Removes the union in `evalCompletion.ts` and lets one builder handle both paths.
- Fix code-eval queue retry semantics: `JobExecution.status = ERROR` is now only persisted on terminal errors or the final BullMQ attempt. Previously the first retryable failure short-circuited every subsequent attempt via the status check in `observationEvalProcessor`.
- Mask only the three LAMBDA_* infra codes as `"An internal error occurred"`; other dispatcher messages surface as-is.
- Accept BOOLEAN values as `0|1|true|false` plus stringy forms (`"true"`, `"1"`, etc., case-insensitive); normalize to `0`/`1` in the schema.
- Add Node + Python Lambda runner sources under `scripts/code-eval-runners/` and a Floci-based dev infra path (`docker-compose.dev.yml` + ready-init hook) so the AWS dispatcher can be tested end-to-end locally. Opt-in for tests via `LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT`.

## Linear

- [LFE-9834](https://linear.app/langfuse/issue/LFE-9834/code-based-evals-implement-local-and-aws-lambda-dispatchers)
- Stacked on #13696 — base branch is `feature/lfe-9833-code-eval-queue-boundary-stacked`.

## Major Decisions

- **Harmonize at the executor edge.** Each executor normalizes its own output (`toNormalizedScores` for LLM-judge, `normalizeCodeEvalScores` for code-eval), so `evalCompletion.ts` and `evalScoreEvent.ts` stay shape-agnostic and one `buildEvalScoreWritePayloads` handles both paths.
- **Parse dispatch result before user-code error envelope.** A runner returning `{ scores: [valid], error: { code: "LAMBDA_*", message: "x" } }` could otherwise force a retry or mask the outcome. Combined with `.strict()` on the error envelope schema.
- **Build the shared execution metadata in `processObservationEval`.** Each executor spreads it and adds executor-specific keys, avoiding duplicated `buildEvalExecutionMetadata` calls.

## Review Focus

- `parseLambdaResponsePayload` order — dispatch-result-first matters for the retry/mask attack surface.
- `getJobExecutionErrorMessage` masking list — confirm the three masked LAMBDA codes match desired UX (everything else, incl. `USER_CODE_ERROR` / `TIMEOUT` / `INVALID_*`, surfaces verbatim).
- Retry-finalization gate in `codeEvalQueue.ts`. The same pattern exists in `evalQueue.ts` (LLM-judge) and is intentionally untouched here.
- BOOLEAN coercion in `codeEvalDispatcherTypes.ts` — accepted forms vs strict rejections.
- Floci dev infra additions in `docker-compose.dev.yml` + `scripts/code-eval-runners/` — adds services to `pnpm run infra:dev:up`, but the AWS dispatcher itself is opt-in via env.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements two code eval dispatchers — `LocalCodeEvalDispatcher` (in-process TypeScript via `data:` URL imports) and `AwsLambdaCodeEvalDispatcher` (synchronous Lambda Invoke with tenant scoping) — selected by the `LANGFUSE_CODE_EVAL_DISPATCHER` env var. It also harmonizes the LLM-as-judge and code-eval executor result shapes into a single `EvalExecutionResult` type, fixes a retry short-circuit bug in `codeEvalQueue.ts` where any error would mark `JobExecution.status = ERROR` and block all subsequent BullMQ retries, and adds Node.js and Python Lambda runner scripts with a Floci-based local dev path.

- **Dispatchers**: `LocalCodeEvalDispatcher` runs TypeScript evaluators in-process (dev-only default); `AwsLambdaCodeEvalDispatcher` invokes a named Lambda synchronously, parses success shape first to prevent error-envelope smuggling, and maps AWS SDK errors to typed `CodeEvalDispatcherError` codes.
- **Retry fix**: `codeEvalQueue.ts` now only persists `ERROR` status on terminal errors or the final BullMQ attempt, preventing `observationEvalProcessor`'s status check from short-circuiting retries.
- **Python runner**: Exposes user-facing `Score` and `EvaluationResult` dataclasses; `Score.metadata` is serialized by `to_jsonable` but has no corresponding field in the TypeScript `CodeEvalScoreSchema`, so per-score metadata set by Python evaluators is silently dropped at parse time.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge in terms of correctness for the Lambda and local dispatchers, but the Python Score.metadata field creates a misleading public API that will confuse evaluator authors whose per-score metadata silently disappears.

The retry-finalization gate fix and the dispatch-result-first parsing are well-reasoned and tested. The main concern is that the Score dataclass advertised to Python evaluator authors includes a metadata field that to_jsonable will serialize, but the TypeScript CodeEvalScoreSchema has no matching field — Zod strips it without error. Any Python evaluator that sets score.metadata will ship with a no-op field and no indication it was dropped. The LambdaClient per-job construction is a secondary concern around connection reuse under load.

scripts/code-eval-runners/python/code_based_eval_handler.py (Score.metadata vs TypeScript schema mismatch) and worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts (dispatcher instantiation per job).
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Q as BullMQ codeEvalQueue
    participant P as observationEvalProcessor
    participant E as executeCodeBasedEvaluation
    participant R as resolveConfiguredCodeEvalDispatcher
    participant D as Dispatcher (Local | Lambda)
    participant L as AWS Lambda / In-Process
    participant C as completeEvalExecution
    participant I as IngestionQueue

    Q->>P: processObservationEval(job)
    P->>E: executeCodeBasedEvaluation(params)
    E->>R: resolveConfiguredCodeEvalDispatcher()
    R-->>E: "LocalCodeEvalDispatcher | AwsLambdaCodeEvalDispatcher | null"
    E->>D: dispatcher.dispatch(DispatchInput)
    alt aws-lambda
        D->>L: LambdaClient.send(InvokeCommand)
        L-->>D: "Payload (scores[] | error envelope)"
        D->>D: parseLambdaResponsePayload (success first, then user-code error)
    else local
        D->>L: "import(data:base64 URL) -> evaluate(payload)"
        L-->>D: unknown result
        D->>D: parseDispatchResult(result)
    end
    D-->>E: "DispatchResult { scores[] }"
    E->>E: normalizeCodeEvalScores (fill defaultScoreName)
    E->>I: createInternalEventsWriter().write (execution span)
    E-->>P: "EvalExecutionResult { scores, primaryScoreId, executionTraceId, metadata }"
    P->>C: completeEvalExecution(result)
    C->>I: "buildEvalScoreWritePayloads -> IngestionQueue"
    C->>C: prisma.jobExecution.update(COMPLETED)

    note over Q,C: On error: persist ERROR only on terminal or final BullMQ attempt
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/code-eval-runners/python/code_based_eval_handler.py:33-39
**`Score.metadata` is silently dropped by the TypeScript schema**

The `Score` dataclass exposes `metadata: Any | None = None` as a user-facing field, and `to_jsonable` will serialize it when set. However, the TypeScript `CodeEvalScoreSchema`/`codeEvalScoreBase` has no `metadata` field — Zod strips unrecognized keys by default, so any per-score metadata a Python evaluator sets is silently discarded before the score reaches ingestion. Users who write `score.metadata = {"key": "val"}` will see no error and no persisted metadata.

### Issue 2 of 2
worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts:39
**New `LambdaClient` created on every job execution**

`resolveConfiguredCodeEvalDispatcher()` constructs a fresh `AwsLambdaCodeEvalDispatcher` — and therefore a new `LambdaClient` — on every call. The AWS SDK v3 client manages an internal HTTP connection pool per instance, so creating a new client per job means no Keep-Alive connection reuse across jobs, adding a TLS-handshake roundtrip to every Lambda invocation under load. A module-level singleton (or a constructor-injected instance) would share the pool across all job executions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): run local code eval dispatch..."](https://github.com/langfuse/langfuse/commit/851f66d1a413a20d95940a0de411c2d48fa864e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32831407)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->