### PR TITLE
feat(monitors): render handlebars message templates with LRU-cached compiles

### DIFF
--- a/packages/shared/src/features/monitor/__snapshots__/template.test.ts.snap
+++ b/packages/shared/src/features/monitor/__snapshots__/template.test.ts.snap
@@ -1,0 +1,92 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MonitorTemplateRenderer > snapshots per scenario (covers every flag) > renders a fresh alert (OK → ALERT) 1`] = `
+"value=5,432ms
+threshold=100ms
+warn_threshold=50ms
+comparator=>
+window=last 5 minutes
+permalink=https://cloud.langfuse.com/project/proj_01/monitors/mon_01
+is_ok=false is_alert=true is_warning=false is_no_data=false is_unknown=false
+was_ok=true was_alert=false was_warning=false was_no_data=false was_unknown=false
+is_recovery=false is_escalation=true is_renotify=false
+last_triggered_at=2026-05-19T12:00:00.000Z last_triggered_at_epoch=1779192000000"
+`;
+
+exports[`MonitorTemplateRenderer > snapshots per scenario (covers every flag) > renders a fresh no-data (OK → NO_DATA) 1`] = `
+"value=5,432ms
+threshold=100ms
+warn_threshold=50ms
+comparator=>
+window=last 5 minutes
+permalink=https://cloud.langfuse.com/project/proj_01/monitors/mon_01
+is_ok=false is_alert=false is_warning=false is_no_data=true is_unknown=false
+was_ok=true was_alert=false was_warning=false was_no_data=false was_unknown=false
+is_recovery=false is_escalation=true is_renotify=false
+last_triggered_at=2026-05-19T12:00:00.000Z last_triggered_at_epoch=1779192000000"
+`;
+
+exports[`MonitorTemplateRenderer > snapshots per scenario (covers every flag) > renders a fresh warning (OK → WARNING) 1`] = `
+"value=5,432ms
+threshold=100ms
+warn_threshold=50ms
+comparator=>
+window=last 5 minutes
+permalink=https://cloud.langfuse.com/project/proj_01/monitors/mon_01
+is_ok=false is_alert=false is_warning=true is_no_data=false is_unknown=false
+was_ok=true was_alert=false was_warning=false was_no_data=false was_unknown=false
+is_recovery=false is_escalation=true is_renotify=false
+last_triggered_at=2026-05-19T12:00:00.000Z last_triggered_at_epoch=1779192000000"
+`;
+
+exports[`MonitorTemplateRenderer > snapshots per scenario (covers every flag) > renders a recovery (ALERT → OK) 1`] = `
+"value=5,432ms
+threshold=100ms
+warn_threshold=50ms
+comparator=>
+window=last 5 minutes
+permalink=https://cloud.langfuse.com/project/proj_01/monitors/mon_01
+is_ok=true is_alert=false is_warning=false is_no_data=false is_unknown=false
+was_ok=false was_alert=true was_warning=false was_no_data=false was_unknown=false
+is_recovery=true is_escalation=false is_renotify=false
+last_triggered_at=2026-05-19T12:00:00.000Z last_triggered_at_epoch=1779192000000"
+`;
+
+exports[`MonitorTemplateRenderer > snapshots per scenario (covers every flag) > renders a sustained-alert renotify 1`] = `
+"value=5,432ms
+threshold=100ms
+warn_threshold=50ms
+comparator=>
+window=last 5 minutes
+permalink=https://cloud.langfuse.com/project/proj_01/monitors/mon_01
+is_ok=false is_alert=true is_warning=false is_no_data=false is_unknown=false
+was_ok=false was_alert=true was_warning=false was_no_data=false was_unknown=false
+is_recovery=false is_escalation=false is_renotify=true
+last_triggered_at=2026-05-19T12:00:00.000Z last_triggered_at_epoch=1779192000000"
+`;
+
+exports[`MonitorTemplateRenderer > snapshots per scenario (covers every flag) > renders a warning → alert escalation 1`] = `
+"value=5,432ms
+threshold=100ms
+warn_threshold=50ms
+comparator=>
+window=last 5 minutes
+permalink=https://cloud.langfuse.com/project/proj_01/monitors/mon_01
+is_ok=false is_alert=true is_warning=false is_no_data=false is_unknown=false
+was_ok=false was_alert=false was_warning=true was_no_data=false was_unknown=false
+is_recovery=false is_escalation=true is_renotify=false
+last_triggered_at=2026-05-19T12:00:00.000Z last_triggered_at_epoch=1779192000000"
+`;
+
+exports[`MonitorTemplateRenderer > snapshots per scenario (covers every flag) > renders the initial unknown state (from=null, to=UNKNOWN) 1`] = `
+"value=5,432ms
+threshold=100ms
+warn_threshold=50ms
+comparator=>
+window=last 5 minutes
+permalink=https://cloud.langfuse.com/project/proj_01/monitors/mon_01
+is_ok=false is_alert=false is_warning=false is_no_data=false is_unknown=true
+was_ok=false was_alert=false was_warning=false was_no_data=false was_unknown=false
+is_recovery=false is_escalation=false is_renotify=false
+last_triggered_at= last_triggered_at_epoch="
+`;

--- a/packages/shared/src/features/monitor/template.test.ts
+++ b/packages/shared/src/features/monitor/template.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
 
-import { validateMonitorTemplate } from "./template";
+import {
+  DEFAULT_MONITOR_TEMPLATE_CACHE_SIZE,
+  MonitorTemplateRenderer,
+  validateMonitorTemplate,
+} from "./template";
+import { MonitorWindow } from "./types";
+import type { Monitor } from "./types";
 
 describe("validateMonitorTemplate", () => {
   it("accepts the empty string", () => {
@@ -14,18 +20,25 @@ describe("validateMonitorTemplate", () => {
   it.each([
     "value",
     "threshold",
-    "warningThreshold",
-    "operator",
+    "warn_threshold",
+    "comparator",
     "window",
     "permalink",
-    "tags",
     "is_ok",
-    "is_warning",
     "is_alert",
+    "is_warning",
     "is_no_data",
-    "is_fired",
-    "is_resolved",
-    "is_crossed",
+    "is_unknown",
+    "was_ok",
+    "was_alert",
+    "was_warning",
+    "was_no_data",
+    "was_unknown",
+    "is_recovery",
+    "is_escalation",
+    "is_renotify",
+    "last_triggered_at",
+    "last_triggered_at_epoch",
   ])("accepts {{%s}}", (key) => {
     expect(validateMonitorTemplate(`x {{${key}}} y`)).toBe(true);
   });
@@ -53,14 +66,14 @@ describe("validateMonitorTemplate", () => {
   it.each([
     "{{#if is_alert}}x{{/if}}",
     "{{#unless is_ok}}x{{/unless}}",
-    "{{#each tags}}x{{/each}}",
+    "{{#each value}}x{{/each}}",
     "{{#with value}}x{{/with}}",
-  ])("rejects a block helper: %s", (template) => {
+  ])("rejects a non-allowlisted block helper: %s", (template) => {
     expect(validateMonitorTemplate(template)).toBe(false);
   });
 
   it("rejects an inline helper invocation", () => {
-    expect(validateMonitorTemplate("{{lookup tags 0}}")).toBe(false);
+    expect(validateMonitorTemplate("{{lookup value 0}}")).toBe(false);
   });
 
   it("rejects a partial", () => {
@@ -68,7 +81,7 @@ describe("validateMonitorTemplate", () => {
   });
 
   it("rejects a sub-expression argument", () => {
-    expect(validateMonitorTemplate("{{value (lookup tags 0)}}")).toBe(false);
+    expect(validateMonitorTemplate("{{value (lookup value 0)}}")).toBe(false);
   });
 
   it("rejects malformed handlebars", () => {
@@ -89,10 +102,480 @@ describe("validateMonitorTemplate", () => {
     },
   );
 
-  it.each(["{{tags.0}}", "{{value.length}}", "{{window.constructor}}"])(
+  it.each(["{{value.length}}", "{{window.constructor}}"])(
     "rejects a sub-property reference: %s",
     (template) => {
       expect(validateMonitorTemplate(template)).toBe(false);
     },
   );
+
+  describe("{{#and}} / {{#or}} block helpers", () => {
+    it("accepts {{#and is_alert was_warning}}x{{/and}}", () => {
+      expect(
+        validateMonitorTemplate("{{#and is_alert was_warning}}x{{/and}}"),
+      ).toBe(true);
+    });
+
+    it("accepts {{#or is_alert is_warning}}x{{/or}}", () => {
+      expect(
+        validateMonitorTemplate("{{#or is_alert is_warning}}x{{/or}}"),
+      ).toBe(true);
+    });
+
+    it("accepts a nested (or ...) sub-expression inside {{#and}}", () => {
+      expect(
+        validateMonitorTemplate(
+          "{{#and is_alert (or is_renotify was_alert)}}x{{/and}}",
+        ),
+      ).toBe(true);
+    });
+
+    it("accepts an {{else}} inverse branch inside {{#and}}", () => {
+      expect(
+        validateMonitorTemplate(
+          "{{#and is_alert was_warning}}HIT{{else}}MISS{{/and}}",
+        ),
+      ).toBe(true);
+    });
+
+    it("accepts a {{value}} mustache inside the block body", () => {
+      expect(
+        validateMonitorTemplate(
+          "{{#and is_alert was_warning}}{{value}}{{/and}}",
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects a forbidden sub-expression argument", () => {
+      expect(
+        validateMonitorTemplate("{{#and (lookup value 0) is_alert}}x{{/and}}"),
+      ).toBe(false);
+    });
+
+    it("rejects an unknown variable as a block argument", () => {
+      expect(validateMonitorTemplate("{{#and is_alert foo}}x{{/and}}")).toBe(
+        false,
+      );
+    });
+
+    it("rejects {{#and}} with no arguments", () => {
+      expect(validateMonitorTemplate("{{#and}}x{{/and}}")).toBe(false);
+    });
+  });
+});
+
+// --- MonitorTemplateRenderer ---
+
+const baseUrl = "https://cloud.langfuse.com";
+
+const buildMonitor = (overrides: Partial<Monitor> = {}): Monitor =>
+  ({
+    id: "mon_01",
+    createdAt: new Date("2026-05-19T00:00:00.000Z"),
+    updatedAt: new Date("2026-05-19T00:00:00.000Z"),
+    createdBy: null,
+    updatedBy: null,
+    projectId: "proj_01",
+
+    view: "OBSERVATIONS",
+    filters: [],
+    metric: { measure: "count", aggregation: "count" },
+
+    window: MonitorWindow.FIVE_MIN,
+    thresholdOperator: "GT",
+    alertThreshold: 100,
+    warningThreshold: 50,
+
+    noData: { mode: "SILENT" },
+    renotify: { mode: "OFF" },
+
+    name: "Title",
+    message: "Body",
+    tags: [],
+
+    severity: "OK",
+    severityChangedAt: null,
+    alertedAt: null,
+
+    status: "ACTIVE",
+    nextRunAt: new Date("2026-05-19T00:01:00.000Z"),
+    lastPublishedRunAt: null,
+    lastCompletedRunAt: null,
+
+    ...overrides,
+  }) as Monitor;
+
+const FULL_CONTEXT_TEMPLATE =
+  "value={{value}}\n" +
+  "threshold={{threshold}}\n" +
+  "warn_threshold={{warn_threshold}}\n" +
+  "comparator={{comparator}}\n" +
+  "window={{window}}\n" +
+  "permalink={{permalink}}\n" +
+  "is_ok={{is_ok}} is_alert={{is_alert}} is_warning={{is_warning}} is_no_data={{is_no_data}} is_unknown={{is_unknown}}\n" +
+  "was_ok={{was_ok}} was_alert={{was_alert}} was_warning={{was_warning}} was_no_data={{was_no_data}} was_unknown={{was_unknown}}\n" +
+  "is_recovery={{is_recovery}} is_escalation={{is_escalation}} is_renotify={{is_renotify}}\n" +
+  "last_triggered_at={{last_triggered_at}} last_triggered_at_epoch={{last_triggered_at_epoch}}";
+
+describe("MonitorTemplateRenderer", () => {
+  describe("snapshots per scenario (covers every flag)", () => {
+    const aggregation = { value: 5432, type: "millisecond" } as const;
+
+    it("renders a fresh alert (OK → ALERT)", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const from = buildMonitor({ severity: "OK" });
+      const to = buildMonitor({
+        severity: "ALERT",
+        alertedAt: new Date("2026-05-19T12:00:00.000Z"),
+      });
+      expect(
+        renderer.render({
+          template: FULL_CONTEXT_TEMPLATE,
+          from,
+          to,
+          aggregation,
+        }),
+      ).toMatchSnapshot();
+    });
+
+    it("renders a fresh warning (OK → WARNING)", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const from = buildMonitor({ severity: "OK" });
+      const to = buildMonitor({
+        severity: "WARNING",
+        alertedAt: new Date("2026-05-19T12:00:00.000Z"),
+      });
+      expect(
+        renderer.render({
+          template: FULL_CONTEXT_TEMPLATE,
+          from,
+          to,
+          aggregation,
+        }),
+      ).toMatchSnapshot();
+    });
+
+    it("renders a fresh no-data (OK → NO_DATA)", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const from = buildMonitor({ severity: "OK" });
+      const to = buildMonitor({
+        severity: "NO_DATA",
+        alertedAt: new Date("2026-05-19T12:00:00.000Z"),
+      });
+      expect(
+        renderer.render({
+          template: FULL_CONTEXT_TEMPLATE,
+          from,
+          to,
+          aggregation,
+        }),
+      ).toMatchSnapshot();
+    });
+
+    it("renders the initial unknown state (from=null, to=UNKNOWN)", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const to = buildMonitor({ severity: "UNKNOWN" });
+      expect(
+        renderer.render({
+          template: FULL_CONTEXT_TEMPLATE,
+          from: null,
+          to,
+          aggregation,
+        }),
+      ).toMatchSnapshot();
+    });
+
+    it("renders a recovery (ALERT → OK)", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const from = buildMonitor({
+        severity: "ALERT",
+        alertedAt: new Date("2026-05-19T11:00:00.000Z"),
+      });
+      const to = buildMonitor({
+        severity: "OK",
+        alertedAt: new Date("2026-05-19T12:00:00.000Z"),
+      });
+      expect(
+        renderer.render({
+          template: FULL_CONTEXT_TEMPLATE,
+          from,
+          to,
+          aggregation,
+        }),
+      ).toMatchSnapshot();
+    });
+
+    it("renders a warning → alert escalation", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const from = buildMonitor({
+        severity: "WARNING",
+        alertedAt: new Date("2026-05-19T11:00:00.000Z"),
+      });
+      const to = buildMonitor({
+        severity: "ALERT",
+        alertedAt: new Date("2026-05-19T12:00:00.000Z"),
+      });
+      expect(
+        renderer.render({
+          template: FULL_CONTEXT_TEMPLATE,
+          from,
+          to,
+          aggregation,
+        }),
+      ).toMatchSnapshot();
+    });
+
+    it("renders a sustained-alert renotify", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const from = buildMonitor({
+        severity: "ALERT",
+        alertedAt: new Date("2026-05-19T11:00:00.000Z"),
+      });
+      const to = buildMonitor({
+        severity: "ALERT",
+        alertedAt: new Date("2026-05-19T12:00:00.000Z"),
+      });
+      expect(
+        renderer.render({
+          template: FULL_CONTEXT_TEMPLATE,
+          from,
+          to,
+          aggregation,
+        }),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe("LRU cache", () => {
+    const monitor = buildMonitor();
+    const aggregation = { value: 1, type: "" } as const;
+
+    it("caches compiled templates by source string", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      renderer.render({
+        template: "{{value}}",
+        from: null,
+        to: monitor,
+        aggregation,
+      });
+      expect(renderer.size).toBe(1);
+
+      // Same source — cache hit, size unchanged.
+      renderer.render({
+        template: "{{value}}",
+        from: null,
+        to: monitor,
+        aggregation,
+      });
+      expect(renderer.size).toBe(1);
+
+      // Different source — cache miss, new entry.
+      renderer.render({
+        template: "{{threshold}}",
+        from: null,
+        to: monitor,
+        aggregation,
+      });
+      expect(renderer.size).toBe(2);
+    });
+
+    it("evicts least-recently-used entries past max", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl, max: 2 });
+      for (const t of ["A {{value}}", "B {{value}}", "C {{value}}"]) {
+        renderer.render({
+          template: t,
+          from: null,
+          to: monitor,
+          aggregation,
+        });
+      }
+      expect(renderer.size).toBe(2);
+    });
+
+    it("re-renders correctly after an entry is evicted", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl, max: 2 });
+      renderer.render({
+        template: "A {{value}}",
+        from: null,
+        to: monitor,
+        aggregation,
+      });
+      renderer.render({
+        template: "B {{value}}",
+        from: null,
+        to: monitor,
+        aggregation,
+      });
+      renderer.render({
+        template: "C {{value}}",
+        from: null,
+        to: monitor,
+        aggregation,
+      });
+      // "A …" is now evicted; re-rendering it should still produce the
+      // correct output (forced recompile).
+      const output = renderer.render({
+        template: "A {{value}}",
+        from: null,
+        to: monitor,
+        aggregation: { value: 42, type: "" },
+      });
+      expect(output).toBe("A 42");
+      expect(renderer.size).toBe(2);
+    });
+
+    it("defaults to DEFAULT_MONITOR_TEMPLATE_CACHE_SIZE when max is omitted", () => {
+      // Just a smoke check that the constant is exported and a renderer
+      // built with the default behaves sanely.
+      expect(DEFAULT_MONITOR_TEMPLATE_CACHE_SIZE).toBeGreaterThan(0);
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      renderer.render({
+        template: "x {{value}}",
+        from: null,
+        to: monitor,
+        aggregation,
+      });
+      expect(renderer.size).toBe(1);
+    });
+  });
+
+  describe("comparator + window mapping", () => {
+    const aggregation = { value: 0, type: "" } as const;
+
+    it.each([
+      ["GT", ">"],
+      ["GTE", ">="],
+      ["LT", "<"],
+      ["LTE", "<="],
+      ["EQ", "=="],
+      ["NEQ", "!="],
+    ] as const)(
+      "renders comparator for thresholdOperator=%s",
+      (op, expected) => {
+        const renderer = new MonitorTemplateRenderer({ baseUrl });
+        const to = buildMonitor({ thresholdOperator: op });
+        const output = renderer.render({
+          template: "{{comparator}}",
+          from: null,
+          to,
+          aggregation,
+        });
+        expect(output).toBe(expected);
+      },
+    );
+
+    it.each([
+      [MonitorWindow.FIVE_MIN, "last 5 minutes"],
+      [MonitorWindow.ONE_HOUR, "last 1 hour"],
+      [MonitorWindow.TWO_HOUR, "last 2 hours"],
+      [MonitorWindow.ONE_DAY, "last 1 day"],
+      [MonitorWindow.TWO_DAY, "last 2 days"],
+      [MonitorWindow.ONE_WEEK, "last 1 week"],
+    ])("renders window for %s ms", (windowMs, expected) => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const to = buildMonitor({ window: windowMs });
+      const output = renderer.render({
+        template: "{{window}}",
+        from: null,
+        to,
+        aggregation,
+      });
+      expect(output).toBe(expected);
+    });
+  });
+
+  describe("aggregation.type value formatter", () => {
+    const monitor = buildMonitor({
+      alertThreshold: 1000,
+      warningThreshold: 500,
+    });
+
+    it.each([
+      ["millisecond", 5432, "5,432ms", "1,000ms"],
+      ["USD", 1234.567, "$1,234.57", "$1,000.00"],
+      ["tokens", 5432, "5,432 tokens", "1,000 tokens"],
+      ["tokens/s", 5432, "5,432 tokens/s", "1,000 tokens/s"],
+      ["traces", 5432, "5,432", "1,000"],
+      ["observations", 5432, "5,432", "1,000"],
+      ["scores", 5432, "5,432", "1,000"],
+      ["users", 5432, "5,432", "1,000"],
+      ["sessions", 5432, "5,432", "1,000"],
+      ["calls", 5432, "5,432", "1,000"],
+      ["tools", 5432, "5,432", "1,000"],
+      ["unknown-unit", 5432, "5,432", "1,000"],
+    ] as const)(
+      "formats type=%s value=%s as %s / threshold %s",
+      (type, value, expectedValue, expectedThreshold) => {
+        const renderer = new MonitorTemplateRenderer({ baseUrl });
+        const output = renderer.render({
+          template: "{{value}} / {{threshold}}",
+          from: null,
+          to: monitor,
+          aggregation: { value, type },
+        });
+        expect(output).toBe(`${expectedValue} / ${expectedThreshold}`);
+      },
+    );
+
+    it("renders warn_threshold null as empty string", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const to = buildMonitor({ warningThreshold: null });
+      const output = renderer.render({
+        template: "[{{warn_threshold}}]",
+        from: null,
+        to,
+        aggregation: { value: 0, type: "millisecond" },
+      });
+      expect(output).toBe("[]");
+    });
+  });
+
+  describe("{{#and}} / {{#or}} block rendering", () => {
+    const monitor = buildMonitor();
+    const aggregation = { value: 0, type: "" } as const;
+
+    it("{{#and a b}} renders body only when both args are truthy", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const from = buildMonitor({ severity: "WARNING" });
+      const to = buildMonitor({ severity: "ALERT" });
+      const hit = renderer.render({
+        template: "{{#and is_alert was_warning}}YES{{/and}}",
+        from,
+        to,
+        aggregation,
+      });
+      expect(hit).toBe("YES");
+
+      const miss = renderer.render({
+        template: "{{#and is_alert was_warning}}YES{{/and}}",
+        from: buildMonitor({ severity: "OK" }),
+        to,
+        aggregation,
+      });
+      expect(miss).toBe("");
+    });
+
+    it("{{#or a b}} renders body when either arg is truthy", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const to = buildMonitor({ severity: "WARNING" });
+      const output = renderer.render({
+        template: "{{#or is_alert is_warning}}DEGRADED{{/or}}",
+        from: null,
+        to,
+        aggregation,
+      });
+      expect(output).toBe("DEGRADED");
+    });
+
+    it("renders the {{else}} inverse branch when the predicate is false", () => {
+      const renderer = new MonitorTemplateRenderer({ baseUrl });
+      const output = renderer.render({
+        template: "{{#and is_alert is_warning}}HIT{{else}}MISS{{/and}}",
+        from: null,
+        to: monitor,
+        aggregation,
+      });
+      expect(output).toBe("MISS");
+    });
+  });
 });

--- a/packages/shared/src/features/monitor/template.ts
+++ b/packages/shared/src/features/monitor/template.ts
@@ -1,57 +1,105 @@
-/** template.ts contains Monitor message template validation */
+/** template.ts contains Monitor message template validation and rendering. */
+import type { MonitorSeverity, MonitorThresholdOperator } from "@prisma/client";
 import Handlebars from "handlebars";
+import { LRUCache } from "lru-cache";
+import { DAY, HOUR, MINUTE, WEEK } from "./internal";
+import type { Monitor } from "./types";
 
 /**
  * MonitorMessageContext is the allowlisted context passed to a Monitor
  * message template at render time. Templates may only reference these
- * top-level keys.
+ * top-level keys. Names mirror Datadog's monitor variables
+ * (https://docs.datadoghq.com/monitors/notify/variables/).
  */
 export type MonitorMessageContext = {
   value: string;
   threshold: string;
-  warningThreshold: string | null;
-  operator: ">" | ">=" | "<" | "<=" | "==" | "!=";
+  warn_threshold: string | null;
+  comparator: ">" | ">=" | "<" | "<=" | "==" | "!=";
   window: string;
   permalink: string;
-  tags: string[];
 
   is_ok: boolean;
-  is_warning: boolean;
   is_alert: boolean;
+  is_warning: boolean;
   is_no_data: boolean;
+  is_unknown: boolean;
 
-  is_fired: boolean;
-  is_resolved: boolean;
-  is_crossed: boolean;
+  was_ok: boolean;
+  was_alert: boolean;
+  was_warning: boolean;
+  was_no_data: boolean;
+  was_unknown: boolean;
+
+  is_recovery: boolean;
+  is_escalation: boolean;
+  is_renotify: boolean;
+
+  last_triggered_at: string;
+  last_triggered_at_epoch: string;
 };
 
 const monitorMessageContextKeys = new Set<string>([
   "value",
   "threshold",
-  "warningThreshold",
-  "operator",
+  "warn_threshold",
+  "comparator",
   "window",
   "permalink",
-  "tags",
   "is_ok",
-  "is_warning",
   "is_alert",
+  "is_warning",
   "is_no_data",
-  "is_fired",
-  "is_resolved",
-  "is_crossed",
+  "is_unknown",
+  "was_ok",
+  "was_alert",
+  "was_warning",
+  "was_no_data",
+  "was_unknown",
+  "is_recovery",
+  "is_escalation",
+  "is_renotify",
+  "last_triggered_at",
+  "last_triggered_at_epoch",
 ] satisfies (keyof MonitorMessageContext)[]);
 
 /**
+ * ALLOWED_BLOCK_HELPERS is the closed set of block helpers a Monitor
+ * template may use. `if`/`unless`/`each`/`with` stay rejected.
+ */
+const ALLOWED_BLOCK_HELPERS = new Set(["and", "or"]);
+
+/**
+ * monitorHandlebars is a sandboxed Handlebars instance with the `and`
+ * and `or` block helpers registered. Both validator parse and renderer
+ * compile go through it so AST allowlist and runtime stay in lock-step.
+ */
+export const monitorHandlebars = Handlebars.create();
+monitorHandlebars.registerHelper(
+  "and",
+  function (this: unknown, ...args: unknown[]) {
+    const options = args.pop() as Handlebars.HelperOptions;
+    return args.every(Boolean) ? options.fn(this) : options.inverse(this);
+  },
+);
+monitorHandlebars.registerHelper(
+  "or",
+  function (this: unknown, ...args: unknown[]) {
+    const options = args.pop() as Handlebars.HelperOptions;
+    return args.some(Boolean) ? options.fn(this) : options.inverse(this);
+  },
+);
+
+/**
  * validateMonitorTemplate returns true when `source` is a Handlebars
- * template whose AST only references `MonitorMessageContext` keys and
- * does not invoke helpers, partials, decorators, or sub-expressions, and
- * does not use unescaped output (`{{{x}}}`).
+ * template whose AST only references `MonitorMessageContext` keys, uses
+ * only the `{{#and}}` / `{{#or}}` block helpers (recursively), and does
+ * not invoke other helpers, partials, decorators, or unescaped output.
  */
 export const validateMonitorTemplate = (source: string): boolean => {
   let ast: hbs.AST.Program;
   try {
-    ast = Handlebars.parse(source);
+    ast = monitorHandlebars.parse(source);
   } catch {
     return false;
   }
@@ -70,6 +118,20 @@ const isAllowedStatement = (node: hbs.AST.Statement): boolean => {
       if (m.hash) return false;
       return isAllowedPath(m.path);
     }
+    case "BlockStatement": {
+      const b = node as hbs.AST.BlockStatement;
+      if (b.path.type !== "PathExpression") return false;
+      const head = (b.path as hbs.AST.PathExpression).parts[0];
+      if (typeof head !== "string" || !ALLOWED_BLOCK_HELPERS.has(head)) {
+        return false;
+      }
+      if (b.hash) return false;
+      if (b.params.length === 0) return false;
+      if (!b.params.every(isAllowedParam)) return false;
+      if (!b.program.body.every(isAllowedStatement)) return false;
+      if (b.inverse && !b.inverse.body.every(isAllowedStatement)) return false;
+      return true;
+    }
     default:
       return false;
   }
@@ -86,4 +148,183 @@ const isAllowedPath = (
   const head = p.parts[0];
   if (typeof head !== "string") return false;
   return monitorMessageContextKeys.has(head);
+};
+
+const isAllowedParam = (node: hbs.AST.Expression): boolean => {
+  if (node.type === "PathExpression") return isAllowedPath(node);
+  if (node.type === "SubExpression") {
+    const sub = node as hbs.AST.SubExpression;
+    if (sub.path.type !== "PathExpression") return false;
+    const head = (sub.path as hbs.AST.PathExpression).parts[0];
+    if (typeof head !== "string" || !ALLOWED_BLOCK_HELPERS.has(head)) {
+      return false;
+    }
+    if (sub.hash) return false;
+    if (sub.params.length === 0) return false;
+    return sub.params.every(isAllowedParam);
+  }
+  return false;
+};
+
+/**
+ * DEFAULT_MONITOR_TEMPLATE_CACHE_SIZE bounds the LRU cache of compiled
+ * templates inside `MonitorTemplateRenderer`.
+ */
+export const DEFAULT_MONITOR_TEMPLATE_CACHE_SIZE = 1000;
+
+/**
+ * MonitorTemplateRenderer compiles Monitor message templates and caches
+ * the compiled functions in an LRU keyed by template source.
+ *
+ * `baseUrl` is the deployment URL used to build `{{permalink}}`. On the
+ * worker, pass `env.NEXTAUTH_URL`.
+ */
+export class MonitorTemplateRenderer {
+  private readonly cache: LRUCache<string, HandlebarsTemplateDelegate>;
+  private readonly baseUrl: string;
+
+  constructor(opts: { baseUrl: string; max?: number }) {
+    this.baseUrl = opts.baseUrl;
+    this.cache = new LRUCache({
+      max: opts.max ?? DEFAULT_MONITOR_TEMPLATE_CACHE_SIZE,
+    });
+  }
+
+  render(params: {
+    template: string;
+    from: Monitor | null;
+    to: Monitor;
+    aggregation: { value: number; type: string };
+  }): string {
+    let compiled = this.cache.get(params.template);
+    if (!compiled) {
+      compiled = monitorHandlebars.compile(params.template, {
+        noEscape: true,
+      });
+      this.cache.set(params.template, compiled);
+    }
+    return compiled(toMonitorMessageContext(params, this.baseUrl));
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+}
+
+const toMonitorMessageContext = (
+  p: {
+    from: Monitor | null;
+    to: Monitor;
+    aggregation: { value: number; type: string };
+  },
+  baseUrl: string,
+): MonitorMessageContext => {
+  const { from, to, aggregation } = p;
+  const cur = to.severity;
+  const prev = from?.severity ?? null;
+
+  return {
+    value: formatAggregationValue(aggregation.value, aggregation.type),
+    threshold: formatAggregationValue(
+      Number(to.alertThreshold),
+      aggregation.type,
+    ),
+    warn_threshold:
+      to.warningThreshold === null
+        ? null
+        : formatAggregationValue(Number(to.warningThreshold), aggregation.type),
+    comparator: thresholdOperatorToSymbol(to.thresholdOperator),
+    window: windowMsToHumanString(to.window),
+    permalink: `${baseUrl}/project/${to.projectId}/monitors/${to.id}`,
+
+    is_ok: cur === "OK",
+    is_alert: cur === "ALERT",
+    is_warning: cur === "WARNING",
+    is_no_data: cur === "NO_DATA",
+    is_unknown: cur === "UNKNOWN",
+
+    was_ok: prev === "OK",
+    was_alert: prev === "ALERT",
+    was_warning: prev === "WARNING",
+    was_no_data: prev === "NO_DATA",
+    was_unknown: prev === "UNKNOWN",
+
+    is_recovery: cur === "OK" && prev !== null && prev !== "OK",
+    is_escalation:
+      from !== null && severityRank(cur) > severityRank(from.severity),
+
+    is_renotify:
+      from !== null &&
+      from.severity === to.severity &&
+      to.alertedAt !== null &&
+      (from.alertedAt === null ||
+        from.alertedAt.getTime() !== to.alertedAt.getTime()),
+
+    last_triggered_at: to.alertedAt?.toISOString() ?? "",
+    last_triggered_at_epoch: to.alertedAt ? String(to.alertedAt.getTime()) : "",
+  };
+};
+
+const thresholdOperatorToSymbol = (
+  op: MonitorThresholdOperator,
+): MonitorMessageContext["comparator"] => {
+  switch (op) {
+    case "GT":
+      return ">";
+    case "GTE":
+      return ">=";
+    case "LT":
+      return "<";
+    case "LTE":
+      return "<=";
+    case "EQ":
+      return "==";
+    case "NEQ":
+      return "!=";
+  }
+};
+
+const windowMsToHumanString = (ms: bigint): string => {
+  if (ms >= WEEK) {
+    const weeks = ms / WEEK;
+    return `last ${weeks} week${weeks === 1n ? "" : "s"}`;
+  }
+  if (ms >= DAY) {
+    const days = ms / DAY;
+    return `last ${days} day${days === 1n ? "" : "s"}`;
+  }
+  if (ms >= HOUR) {
+    const hours = ms / HOUR;
+    return `last ${hours} hour${hours === 1n ? "" : "s"}`;
+  }
+  const minutes = ms / MINUTE;
+  return `last ${minutes} minute${minutes === 1n ? "" : "s"}`;
+};
+
+const SEVERITY_RANK: Record<MonitorSeverity, number> = {
+  OK: 0,
+  UNKNOWN: 1,
+  NO_DATA: 2,
+  WARNING: 3,
+  ALERT: 4,
+};
+
+const severityRank = (s: MonitorSeverity): number => SEVERITY_RANK[s];
+
+const formatAggregationValue = (value: number, type: string): string => {
+  switch (type) {
+    case "millisecond":
+      return `${value.toLocaleString("en-US")}ms`;
+    case "USD":
+      return `$${value.toLocaleString("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`;
+    case "tokens":
+      return `${value.toLocaleString("en-US")} tokens`;
+    case "tokens/s":
+      return `${value.toLocaleString("en-US")} tokens/s`;
+    default:
+      return value.toLocaleString("en-US");
+  }
 };

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -187,6 +187,7 @@ export const MonitorSchema = z
     message: ErrorInvalidWarningAlertOrdering,
     path: ["warningThreshold"],
   });
+export type Monitor = z.infer<typeof MonitorSchema>;
 
 /**
  * MonitorQueueEventSchema represents a batch of monitors that can be evaluated


### PR DESCRIPTION
## Summary

The Monitor execution loop renders two Handlebars templates per surviving monitor inside the `MonitorQueueProcessor` (name → alert title, message → alert body), and `Handlebars.compile` is the expensive step — running it per render would burn CPU on every batch.

To achieve this we:
- Added a `MonitorTemplateRenderer` class that compiles templates lazily and caches the compiled functions in an LRU keyed by template source.
- Realigned `MonitorMessageContext` to mirror [Datadog's monitor variables](https://docs.datadoghq.com/monitors/notify/variables/) by name (`comparator`, `warn_threshold`, full `is_*`/`was_*` severity pairs, plus convenience flags `is_recovery`, `is_escalation`, `is_renotify`).
- Derived every flag from a `(from, to)` Monitor pair so transitions and renotifies fall out of the data without extra params.
- Opened up `{{#and}}` and `{{#or}}` block helpers on a sandboxed `Handlebars.create()` instance — the validator allows them recursively, everything else (`if`/`unless`/`each`/`with`/`lookup`) stays rejected.
- Switched the value/threshold formatter on the metric's measure unit string (`millisecond`/`USD`/`tokens`/count types) so worker callers don't pre-format numbers.

**Note**: integration into the `MonitorQueueProcessor` is out of scope — this ticket only ships the renderer + tests. Wiring tracked separately in the monitor execution tickets.

Fixes [LFE-9811](https://linear.app/langfuse/issue/lfe-9811-add-handlebars-template-render)

## Verification

- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter @langfuse/shared run typecheck`
- [x] `pnpm --filter @langfuse/shared exec vitest run src/features/monitor` (154 tests passing, 7 snapshots)

## Test plan

- [ ] Confirm the snapshot fixtures in `__snapshots__/template.test.ts.snap` cover every severity flag (`is_*`/`was_*`), `is_recovery`, `is_escalation`, and `is_renotify`.
- [ ] Compile a representative monitor template using `{{#and is_alert was_warning}}…{{/and}}` and verify the validator accepts it; verify `{{#if is_alert}}…{{/if}}` and `{{#each tags}}…{{/each}}` are still rejected.
- [ ] Spot-check the value formatter against each measure unit (`millisecond`, `USD`, `tokens`, count types) by rendering `{{value}} / {{threshold}}` with a 5,432 / 1,000 fixture.
