### PR TITLE
feat(monitors): add MonitorScheduler with slot-based batching

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -222,6 +222,7 @@ jobs:
         run: pnpm --filter @repo/eslint-plugin run test
 
   tests-shared:
+    timeout-minutes: 15
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - pre-job
@@ -230,9 +231,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
         with:
-          version: 10.33.0
+          version: 11.1.3
       - name: Use Node.js ${{ env.NODE_VERSION }} without cache
         if: env.CI_CACHE_ALLOWED != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -221,6 +221,42 @@ jobs:
       - name: run eslint-plugin tests
         run: pnpm --filter @repo/eslint-plugin run test
 
+  tests-shared:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - pre-job
+    if: needs.pre-job.outputs.should_skip != 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        with:
+          version: 10.33.0
+      - name: Use Node.js ${{ env.NODE_VERSION }} without cache
+        if: env.CI_CACHE_ALLOWED != 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-cache: false
+      - name: Use Node.js ${{ env.NODE_VERSION }} with pnpm cache
+        if: env.CI_CACHE_ALLOWED == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # zizmor: ignore[cache-poisoning] shared test dependency cache only; no published artifacts are built from this cached state
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+      - name: install dependencies
+        run: |
+          pnpm install
+      - name: Load default env (for prisma generate)
+        run: |
+          cp .env.dev.example .env
+      - name: generate prisma client
+        run: pnpm --filter=shared run db:generate
+      - name: run shared tests
+        run: pnpm --filter @langfuse/shared run test
+
   test-docker-build:
     timeout-minutes: 20
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -118,6 +118,7 @@
     "dd-trace": "5.97.0",
     "decimal.js": "^10.4.3",
     "exponential-backoff": "^3.1.2",
+    "handlebars": "^4.7.9",
     "ioredis": "^5.10.1",
     "ipaddr.js": "^2.2.0",
     "jsonpath-plus": "10.3.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -54,6 +54,10 @@
     "./query/server": {
       "import": "./dist/src/features/query/server/index.js",
       "require": "./dist/src/features/query/server/index.js"
+    },
+    "./monitor": {
+      "import": "./dist/src/features/monitor/index.js",
+      "require": "./dist/src/features/monitor/index.js"
     }
   },
   "scripts": {
@@ -63,6 +67,7 @@
     "dev": "tsc --watch",
     "lint": "eslint . --cache --cache-location dist/.eslintcache --max-warnings 0",
     "lint:fix": "eslint . --cache --cache-location dist/.eslintcache --fix",
+    "test": "vitest run",
     "db:migrate": "DISABLE_ERD=false dotenv -e ../../.env -- npx prisma migrate dev",
     "db:push": "DISABLE_ERD=false dotenv -e ../../.env -- npx prisma db push",
     "db:reset": "dotenv -e ../../.env npx -- prisma migrate reset",
@@ -144,7 +149,8 @@
     "prisma": "^6.19.3",
     "ts-node": "^10.9.2",
     "tsc-watch": "^6.2.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^4.1.4"
   },
   "peerDependencies": {
     "@types/react": "~19.2.14",

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -128,6 +128,7 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(1),
+  LANGFUSE_MONITOR_QUEUE_SHARD_COUNT: z.coerce.number().positive().default(1),
   LANGFUSE_OTEL_INGESTION_QUEUE_SHARD_COUNT: z.coerce
     .number()
     .positive()

--- a/packages/shared/src/features/monitor/index.ts
+++ b/packages/shared/src/features/monitor/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/packages/shared/src/features/monitor/internal.ts
+++ b/packages/shared/src/features/monitor/internal.ts
@@ -1,4 +1,4 @@
-/* internal.ts is internal to the monitor implementation. Do export from the package barrel. */
+/* internal.ts is internal to the monitor implementation. Do NOT export from the package barrel. */
 
 /**
  * SECOND is one second in milliseconds.

--- a/packages/shared/src/features/monitor/internal.ts
+++ b/packages/shared/src/features/monitor/internal.ts
@@ -1,0 +1,26 @@
+/* internal.ts is internal to the monitor implementation. Do export from the package barrel. */
+
+/**
+ * SECOND is one second in milliseconds.
+ */
+export const SECOND = 1000n;
+
+/**
+ * MINUTE one minute in milliseconds.
+ */
+export const MINUTE = 60n * SECOND;
+
+/**
+ * HOUR is one hour in milliseconds.
+ */
+export const HOUR = 60n * MINUTE;
+
+/**
+ * DAY is one day in milliseconds.
+ */
+export const DAY = 24n * HOUR;
+
+/**
+ * WEEK is one week in milliseconds.
+ */
+export const WEEK = 7n * DAY;

--- a/packages/shared/src/features/monitor/server/index.ts
+++ b/packages/shared/src/features/monitor/server/index.ts
@@ -1,0 +1,1 @@
+export * from "./scheduler";

--- a/packages/shared/src/features/monitor/server/scheduler.ts
+++ b/packages/shared/src/features/monitor/server/scheduler.ts
@@ -1,0 +1,171 @@
+import { Prisma } from "../../../db";
+import type { PrismaClient } from "../../../db";
+import type { singleFilter } from "../../../interfaces/filters";
+import type { metric as MetricSchema } from "../../query/types";
+import type { MonitorQueueEvent } from "../types";
+import type { z } from "zod";
+
+type Metric = z.infer<typeof MetricSchema>;
+type FilterState = z.infer<typeof singleFilter>[];
+
+type PublishMonitorEvents = (events: MonitorQueueEvent[]) => Promise<void>;
+
+/**
+ * MonitorScheduler claims due monitor rows for its slot, advances `nextRunAt`
+ * for every claimed row, gate-publishes ACTIVE rows that aren't already
+ * pending evaluation (or that crossed the 5-minute TTL), groups the published
+ * rows by `schedulerBatchId`, and emits one `MonitorQueueEvent` per group via
+ * the injected `publish` callback.
+ */
+export class MonitorScheduler {
+  private readonly schedulerId: number;
+  private readonly totalSchedulers: number;
+  private readonly db: PrismaClient;
+  private readonly publish: PublishMonitorEvents;
+
+  constructor(deps: {
+    schedulerId: number;
+    totalSchedulers: number;
+    db: PrismaClient;
+    publish: PublishMonitorEvents;
+  }) {
+    this.schedulerId = deps.schedulerId;
+    this.totalSchedulers = deps.totalSchedulers;
+    this.db = deps.db;
+    this.publish = deps.publish;
+  }
+
+  async tick(scheduledAt: Date): Promise<number> {
+    const rows = await this.db.$queryRaw<MonitorBatchRow[]>(
+      buildTickQuery({
+        tick: scheduledAt,
+        schedulerId: this.schedulerId,
+        totalSchedulers: this.totalSchedulers,
+      }),
+    );
+
+    if (rows.length === 0) return 0;
+
+    const events = rows.map(toMonitorQueueEvent);
+    await this.publish(events);
+    return events.length;
+  }
+}
+
+type MonitorBatchRow = {
+  project_id: string;
+  scheduler_batch_id: bigint;
+  scheduled_at: Date;
+  view: string;
+  filters: FilterState;
+  window_ms: bigint;
+  metrics: Metric[];
+  monitors: { monitorId: string; metricName: string }[];
+};
+
+function toMonitorQueueEvent(row: MonitorBatchRow): MonitorQueueEvent {
+  return {
+    projectId: row.project_id,
+    schedulerBatchId: row.scheduler_batch_id,
+    scheduledAt: row.scheduled_at,
+    view: row.view as MonitorQueueEvent["view"],
+    filters: row.filters,
+    window: row.window_ms,
+    metrics: row.metrics,
+    monitors: row.monitors,
+  };
+}
+
+/**
+ * Two-stage CTE per RFC §Example SQL, collapsed to one UPDATE because
+ * Postgres forbids modifying the same row twice in a single statement
+ * (advance_schedule + publish would both touch `monitors.id`). Equivalent
+ * semantics — advance always, publish only when the gate passes:
+ *   - `due`: SELECT FOR UPDATE SKIP LOCKED claims this slot's due rows
+ *   - `updated`: single UPDATE that advances `next_run_at` for every claimed
+ *     row and conditionally stamps `last_published_run_at` for rows that pass
+ *     the ACTIVE + (first-run OR prior-run-done OR 5-min-TTL) gate. The
+ *     `was_published` boolean is echoed back so the final SELECT can filter.
+ * Final SELECT groups by `(project_id, scheduler_batch_id)`.
+ */
+function buildTickQuery({
+  tick,
+  schedulerId,
+  totalSchedulers,
+}: {
+  tick: Date;
+  schedulerId: number;
+  totalSchedulers: number;
+}): Prisma.Sql {
+  const publishGate = Prisma.sql`
+    due.status = 'ACTIVE'
+    AND (
+      due.last_published_run_at IS NULL
+      OR due.last_completed_run_at >= due.last_published_run_at
+      OR ${tick}::timestamptz - due.last_published_run_at > interval '5 minutes'
+    )
+  `;
+
+  return Prisma.sql`
+    WITH due AS (
+      SELECT
+        id,
+        project_id,
+        scheduler_batch_id,
+        next_run_at AS scheduled_at,
+        cadence_ms,
+        view,
+        filters,
+        window_ms,
+        metric,
+        last_published_run_at,
+        last_completed_run_at,
+        status
+      FROM monitors
+      WHERE next_run_at <= ${tick}
+        AND (scheduler_batch_id % ${totalSchedulers}::bigint) = ${schedulerId}::bigint
+      ORDER BY next_run_at ASC
+      FOR UPDATE SKIP LOCKED
+    ),
+    updated AS (
+      UPDATE monitors
+      SET
+        next_run_at = monitors.next_run_at + (due.cadence_ms * interval '1 millisecond'),
+        last_published_run_at = CASE
+          WHEN ${publishGate} THEN due.scheduled_at
+          ELSE monitors.last_published_run_at
+        END
+      FROM due
+      WHERE monitors.id = due.id
+      RETURNING
+        monitors.id,
+        due.project_id,
+        due.scheduler_batch_id,
+        due.scheduled_at,
+        due.view,
+        due.filters,
+        due.window_ms,
+        due.metric,
+        (${publishGate}) AS was_published
+    )
+    SELECT
+      project_id,
+      scheduler_batch_id,
+      MAX(scheduled_at)            AS scheduled_at,
+      (array_agg(view::text))[1]   AS view,
+      (array_agg(filters))[1]      AS filters,
+      (array_agg(window_ms))[1]    AS window_ms,
+      array_agg(DISTINCT metric)   AS metrics,
+      array_agg(
+        jsonb_build_object(
+          'monitorId', id,
+          'metricName', concat(metric->>'aggregation', '_', metric->>'measure')
+        )
+        ORDER BY id
+      ) AS monitors
+    FROM updated
+    WHERE was_published = true
+    GROUP BY project_id, scheduler_batch_id
+    ORDER BY MAX(scheduled_at) ASC
+  `;
+}

--- a/packages/shared/src/features/monitor/template.test.ts
+++ b/packages/shared/src/features/monitor/template.test.ts
@@ -74,4 +74,25 @@ describe("validateMonitorTemplate", () => {
   it("rejects malformed handlebars", () => {
     expect(validateMonitorTemplate("{{value")).toBe(false);
   });
+
+  it.each(["{{@is_alert}}", "{{@value}}", "{{@threshold}}", "{{@root}}"])(
+    "rejects an @-prefixed data reference: %s",
+    (template) => {
+      expect(validateMonitorTemplate(template)).toBe(false);
+    },
+  );
+
+  it.each(["{{../value}}", "{{../is_alert}}"])(
+    "rejects a parent-context reference: %s",
+    (template) => {
+      expect(validateMonitorTemplate(template)).toBe(false);
+    },
+  );
+
+  it.each(["{{tags.0}}", "{{value.length}}", "{{window.constructor}}"])(
+    "rejects a sub-property reference: %s",
+    (template) => {
+      expect(validateMonitorTemplate(template)).toBe(false);
+    },
+  );
 });

--- a/packages/shared/src/features/monitor/template.test.ts
+++ b/packages/shared/src/features/monitor/template.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+
+import { validateMonitorTemplate } from "./template";
+
+describe("validateMonitorTemplate", () => {
+  it("accepts the empty string", () => {
+    expect(validateMonitorTemplate("")).toBe(true);
+  });
+
+  it("accepts plain text without any handlebars", () => {
+    expect(validateMonitorTemplate("hello world")).toBe(true);
+  });
+
+  it.each([
+    "value",
+    "threshold",
+    "warningThreshold",
+    "operator",
+    "window",
+    "permalink",
+    "tags",
+    "is_ok",
+    "is_warning",
+    "is_alert",
+    "is_no_data",
+    "is_fired",
+    "is_resolved",
+    "is_crossed",
+  ])("accepts {{%s}}", (key) => {
+    expect(validateMonitorTemplate(`x {{${key}}} y`)).toBe(true);
+  });
+
+  it("accepts a mix of text and multiple variables", () => {
+    expect(
+      validateMonitorTemplate(
+        "Alert {{value}} crossed {{threshold}} in {{window}}",
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a handlebars comment", () => {
+    expect(validateMonitorTemplate("{{! a comment }}hi {{value}}")).toBe(true);
+  });
+
+  it("rejects a template referencing an unknown variable", () => {
+    expect(validateMonitorTemplate("{{foo}}")).toBe(false);
+  });
+
+  it("rejects unescaped {{{value}}}", () => {
+    expect(validateMonitorTemplate("{{{value}}}")).toBe(false);
+  });
+
+  it.each([
+    "{{#if is_alert}}x{{/if}}",
+    "{{#unless is_ok}}x{{/unless}}",
+    "{{#each tags}}x{{/each}}",
+    "{{#with value}}x{{/with}}",
+  ])("rejects a block helper: %s", (template) => {
+    expect(validateMonitorTemplate(template)).toBe(false);
+  });
+
+  it("rejects an inline helper invocation", () => {
+    expect(validateMonitorTemplate("{{lookup tags 0}}")).toBe(false);
+  });
+
+  it("rejects a partial", () => {
+    expect(validateMonitorTemplate("{{> myPartial}}")).toBe(false);
+  });
+
+  it("rejects a sub-expression argument", () => {
+    expect(validateMonitorTemplate("{{value (lookup tags 0)}}")).toBe(false);
+  });
+
+  it("rejects malformed handlebars", () => {
+    expect(validateMonitorTemplate("{{value")).toBe(false);
+  });
+});

--- a/packages/shared/src/features/monitor/template.ts
+++ b/packages/shared/src/features/monitor/template.ts
@@ -1,0 +1,86 @@
+/** template.ts contains Monitor message template validation */
+import Handlebars from "handlebars";
+
+/**
+ * MonitorMessageContext is the allowlisted context passed to a Monitor
+ * message template at render time. Templates may only reference these
+ * top-level keys.
+ */
+export type MonitorMessageContext = {
+  value: string;
+  threshold: string;
+  warningThreshold: string | null;
+  operator: ">" | ">=" | "<" | "<=" | "==" | "!=";
+  window: string;
+  permalink: string;
+  tags: string[];
+
+  is_ok: boolean;
+  is_warning: boolean;
+  is_alert: boolean;
+  is_no_data: boolean;
+
+  is_fired: boolean;
+  is_resolved: boolean;
+  is_crossed: boolean;
+};
+
+const monitorMessageContextKeys = new Set<string>([
+  "value",
+  "threshold",
+  "warningThreshold",
+  "operator",
+  "window",
+  "permalink",
+  "tags",
+  "is_ok",
+  "is_warning",
+  "is_alert",
+  "is_no_data",
+  "is_fired",
+  "is_resolved",
+  "is_crossed",
+] satisfies (keyof MonitorMessageContext)[]);
+
+/**
+ * validateMonitorTemplate returns true when `source` is a Handlebars
+ * template whose AST only references `MonitorMessageContext` keys and
+ * does not invoke helpers, partials, decorators, or sub-expressions, and
+ * does not use unescaped output (`{{{x}}}`).
+ */
+export const validateMonitorTemplate = (source: string): boolean => {
+  let ast: hbs.AST.Program;
+  try {
+    ast = Handlebars.parse(source);
+  } catch {
+    return false;
+  }
+  return ast.body.every(isAllowedStatement);
+};
+
+const isAllowedStatement = (node: hbs.AST.Statement): boolean => {
+  switch (node.type) {
+    case "ContentStatement":
+    case "CommentStatement":
+      return true;
+    case "MustacheStatement": {
+      const m = node as hbs.AST.MustacheStatement;
+      if (m.escaped === false) return false;
+      if (m.params.length > 0) return false;
+      if (m.hash) return false;
+      return isAllowedPath(m.path);
+    }
+    default:
+      return false;
+  }
+};
+
+const isAllowedPath = (
+  path: hbs.AST.PathExpression | hbs.AST.Literal,
+): boolean => {
+  if (path.type !== "PathExpression") return false;
+  const p = path as hbs.AST.PathExpression;
+  const head = p.parts[0];
+  if (typeof head !== "string") return false;
+  return monitorMessageContextKeys.has(head);
+};

--- a/packages/shared/src/features/monitor/template.ts
+++ b/packages/shared/src/features/monitor/template.ts
@@ -80,6 +80,9 @@ const isAllowedPath = (
 ): boolean => {
   if (path.type !== "PathExpression") return false;
   const p = path as hbs.AST.PathExpression;
+  if (p.data) return false;
+  if (p.depth !== 0) return false;
+  if (p.parts.length !== 1) return false;
   const head = p.parts[0];
   if (typeof head !== "string") return false;
   return monitorMessageContextKeys.has(head);

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -1,0 +1,542 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  MonitorWindow,
+  isValidMonitorWindow,
+  monitorWindowCadenceMs,
+  MonitorRenotifySchema,
+  MonitorNoDataSchema,
+  MonitorTemplateSchema,
+  MonitorSchema,
+  MonitorQueueEventSchema,
+  MonitorAlertSchema,
+  MonitorWebhookQueueEventSchema,
+  validateWarningAlertOrdering,
+} from "./types";
+
+// Minimal valid domain object. Tests override one field at a time.
+const validMonitorBase = {
+  id: "mon_01",
+  createdAt: new Date("2026-05-18T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-18T00:00:00.000Z"),
+  createdBy: null,
+  updatedBy: null,
+  projectId: "proj_01",
+
+  view: "OBSERVATIONS" as const,
+  filters: [],
+  metric: { measure: "count", aggregation: "count" as const },
+
+  window: MonitorWindow.FIVE_MIN,
+  thresholdOperator: "GT" as const,
+  alertThreshold: 100,
+  warningThreshold: null,
+
+  severity: "UNKNOWN" as const,
+  severityChangedAt: null,
+
+  noData: { mode: "SILENT" as const },
+  renotify: { mode: "OFF" as const },
+
+  status: "ACTIVE" as const,
+  nextRunAt: new Date("2026-05-18T00:01:00.000Z"),
+  lastPublishedRunAt: null,
+  lastCompletedRunAt: null,
+
+  name: "High error rate",
+  message: "",
+  tags: [],
+  alertedAt: null,
+};
+
+// Local readability aliases. The production module keeps these internal.
+const MINUTE_MS = 60_000n;
+const HOUR_MS = 60n * MINUTE_MS;
+const DAY_MS = 24n * HOUR_MS;
+const WEEK_MS = 7n * DAY_MS;
+
+describe("MonitorWindow tier map", () => {
+  it("exposes the 10 RFC tiers with BigInt millisecond values", () => {
+    expect(MonitorWindow.FIVE_MIN).toBe(5n * 60_000n);
+    expect(MonitorWindow.TEN_MIN).toBe(10n * 60_000n);
+    expect(MonitorWindow.FIFTEEN_MIN).toBe(15n * 60_000n);
+    expect(MonitorWindow.THIRTY_MIN).toBe(30n * 60_000n);
+    expect(MonitorWindow.ONE_HOUR).toBe(60n * 60_000n);
+    expect(MonitorWindow.TWO_HOUR).toBe(2n * 60n * 60_000n);
+    expect(MonitorWindow.FOUR_HOUR).toBe(4n * 60n * 60_000n);
+    expect(MonitorWindow.ONE_DAY).toBe(24n * 60n * 60_000n);
+    expect(MonitorWindow.TWO_DAY).toBe(2n * 24n * 60n * 60_000n);
+    expect(MonitorWindow.ONE_WEEK).toBe(7n * 24n * 60n * 60_000n);
+  });
+});
+
+describe("isValidMonitorWindow", () => {
+  it("accepts every MonitorWindow tier value", () => {
+    for (const tier of Object.values(MonitorWindow)) {
+      expect(isValidMonitorWindow(tier)).toBe(true);
+    }
+  });
+
+  it("rejects a bigint that isn't a known tier", () => {
+    expect(isValidMonitorWindow(123n)).toBe(false);
+  });
+});
+
+describe("monitorWindowCadenceMs", () => {
+  it("returns 1 minute for sub-day windows", () => {
+    expect(monitorWindowCadenceMs(MonitorWindow.FIVE_MIN)).toBe(MINUTE_MS);
+    expect(monitorWindowCadenceMs(MonitorWindow.FOUR_HOUR)).toBe(MINUTE_MS);
+    expect(monitorWindowCadenceMs(DAY_MS - 1n)).toBe(MINUTE_MS);
+  });
+
+  it("returns 30 minutes for day-to-week windows", () => {
+    expect(monitorWindowCadenceMs(MonitorWindow.ONE_DAY)).toBe(30n * MINUTE_MS);
+    expect(monitorWindowCadenceMs(DAY_MS + 1n)).toBe(30n * MINUTE_MS);
+    expect(monitorWindowCadenceMs(MonitorWindow.TWO_DAY)).toBe(30n * MINUTE_MS);
+    expect(monitorWindowCadenceMs(WEEK_MS - 1n)).toBe(30n * MINUTE_MS);
+  });
+
+  it("returns 48 hours for week-and-up windows", () => {
+    expect(monitorWindowCadenceMs(MonitorWindow.ONE_WEEK)).toBe(48n * HOUR_MS);
+    expect(monitorWindowCadenceMs(WEEK_MS + 1n)).toBe(48n * HOUR_MS);
+  });
+});
+
+describe("MonitorRenotifySchema", () => {
+  it("accepts the OFF variant", () => {
+    expect(MonitorRenotifySchema.safeParse({ mode: "OFF" }).success).toBe(true);
+  });
+
+  it("accepts the EVERY variant with a valid interval", () => {
+    const result = MonitorRenotifySchema.safeParse({
+      mode: "EVERY",
+      intervalMinutes: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects EVERY without intervalMinutes", () => {
+    expect(MonitorRenotifySchema.safeParse({ mode: "EVERY" }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects intervalMinutes below 1", () => {
+    expect(
+      MonitorRenotifySchema.safeParse({ mode: "EVERY", intervalMinutes: 0 })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects intervalMinutes above one week", () => {
+    expect(
+      MonitorRenotifySchema.safeParse({
+        mode: "EVERY",
+        intervalMinutes: 60 * 24 * 7 + 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown discriminator", () => {
+    expect(
+      MonitorRenotifySchema.safeParse({
+        mode: "BOGUS",
+        intervalMinutes: 5,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("MonitorNoDataSchema", () => {
+  it("accepts the SILENT variant", () => {
+    expect(MonitorNoDataSchema.safeParse({ mode: "SILENT" }).success).toBe(
+      true,
+    );
+  });
+
+  it("accepts the NOTIFY variant with a valid interval", () => {
+    const result = MonitorNoDataSchema.safeParse({
+      mode: "NOTIFY",
+      intervalMinutes: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects NOTIFY without intervalMinutes", () => {
+    expect(MonitorNoDataSchema.safeParse({ mode: "NOTIFY" }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects intervalMinutes below 1", () => {
+    expect(
+      MonitorNoDataSchema.safeParse({ mode: "NOTIFY", intervalMinutes: 0 })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects intervalMinutes above one day", () => {
+    expect(
+      MonitorNoDataSchema.safeParse({
+        mode: "NOTIFY",
+        intervalMinutes: 60 * 24 + 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown discriminator", () => {
+    expect(
+      MonitorNoDataSchema.safeParse({
+        mode: "BOGUS",
+        intervalMinutes: 5,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("MonitorTemplateSchema", () => {
+  it("accepts the empty string", () => {
+    expect(MonitorTemplateSchema.safeParse("").success).toBe(true);
+  });
+
+  it("accepts a typical short template", () => {
+    expect(
+      MonitorTemplateSchema.safeParse("Alert: {{value}} crossed {{threshold}}")
+        .success,
+    ).toBe(true);
+  });
+
+  it("accepts exactly 4000 characters", () => {
+    expect(MonitorTemplateSchema.safeParse("x".repeat(4000)).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects a string longer than 4000 characters", () => {
+    expect(MonitorTemplateSchema.safeParse("x".repeat(4001)).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects non-string input", () => {
+    expect(MonitorTemplateSchema.safeParse(123).success).toBe(false);
+    expect(MonitorTemplateSchema.safeParse(null).success).toBe(false);
+  });
+});
+
+describe("validateWarningAlertOrdering", () => {
+  it.each(["GT", "GTE"] as const)("%s requires warning < alert", (op) => {
+    expect(
+      validateWarningAlertOrdering({
+        thresholdOperator: op,
+        alertThreshold: 100,
+        warningThreshold: 50,
+      }),
+    ).toBe(true);
+    expect(
+      validateWarningAlertOrdering({
+        thresholdOperator: op,
+        alertThreshold: 100,
+        warningThreshold: 100,
+      }),
+    ).toBe(false);
+  });
+
+  it.each(["LT", "LTE"] as const)("%s requires warning > alert", (op) => {
+    expect(
+      validateWarningAlertOrdering({
+        thresholdOperator: op,
+        alertThreshold: 100,
+        warningThreshold: 200,
+      }),
+    ).toBe(true);
+    expect(
+      validateWarningAlertOrdering({
+        thresholdOperator: op,
+        alertThreshold: 100,
+        warningThreshold: 100,
+      }),
+    ).toBe(false);
+  });
+
+  it.each(["EQ", "NEQ"] as const)(
+    "%s always passes regardless of ordering",
+    (op) => {
+      for (const warning of [50, 100, 200]) {
+        expect(
+          validateWarningAlertOrdering({
+            thresholdOperator: op,
+            alertThreshold: 100,
+            warningThreshold: warning,
+          }),
+        ).toBe(true);
+      }
+    },
+  );
+
+  it.each(["GT", "GTE", "LT", "LTE", "EQ", "NEQ"] as const)(
+    "%s passes with null warningThreshold",
+    (op) => {
+      expect(
+        validateWarningAlertOrdering({
+          thresholdOperator: op,
+          alertThreshold: 100,
+          warningThreshold: null,
+        }),
+      ).toBe(true);
+    },
+  );
+});
+
+describe("MonitorSchema", () => {
+  it("parses a minimally valid Monitor", () => {
+    const result = MonitorSchema.safeParse(validMonitorBase);
+    expect(result.success).toBe(true);
+  });
+
+  describe("warning/alert threshold ordering refinement", () => {
+    it.each(["GT", "GTE"] as const)(
+      "%s rejects warningThreshold >= alertThreshold",
+      (op) => {
+        const result = MonitorSchema.safeParse({
+          ...validMonitorBase,
+          thresholdOperator: op,
+          alertThreshold: 100,
+          warningThreshold: 100, // equal → must reject
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues[0].path).toEqual(["warningThreshold"]);
+        }
+
+        const tooHigh = MonitorSchema.safeParse({
+          ...validMonitorBase,
+          thresholdOperator: op,
+          alertThreshold: 100,
+          warningThreshold: 200,
+        });
+        expect(tooHigh.success).toBe(false);
+      },
+    );
+
+    it.each(["GT", "GTE"] as const)(
+      "%s accepts warningThreshold < alertThreshold",
+      (op) => {
+        expect(
+          MonitorSchema.safeParse({
+            ...validMonitorBase,
+            thresholdOperator: op,
+            alertThreshold: 100,
+            warningThreshold: 50,
+          }).success,
+        ).toBe(true);
+      },
+    );
+
+    it.each(["LT", "LTE"] as const)(
+      "%s rejects warningThreshold <= alertThreshold",
+      (op) => {
+        const result = MonitorSchema.safeParse({
+          ...validMonitorBase,
+          thresholdOperator: op,
+          alertThreshold: 100,
+          warningThreshold: 100,
+        });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues[0].path).toEqual(["warningThreshold"]);
+        }
+
+        const tooLow = MonitorSchema.safeParse({
+          ...validMonitorBase,
+          thresholdOperator: op,
+          alertThreshold: 100,
+          warningThreshold: 50,
+        });
+        expect(tooLow.success).toBe(false);
+      },
+    );
+
+    it.each(["LT", "LTE"] as const)(
+      "%s accepts warningThreshold > alertThreshold",
+      (op) => {
+        expect(
+          MonitorSchema.safeParse({
+            ...validMonitorBase,
+            thresholdOperator: op,
+            alertThreshold: 100,
+            warningThreshold: 200,
+          }).success,
+        ).toBe(true);
+      },
+    );
+
+    it.each(["EQ", "NEQ"] as const)(
+      "%s accepts any warningThreshold/alertThreshold ordering",
+      (op) => {
+        for (const warning of [50, 100, 200]) {
+          expect(
+            MonitorSchema.safeParse({
+              ...validMonitorBase,
+              thresholdOperator: op,
+              alertThreshold: 100,
+              warningThreshold: warning,
+            }).success,
+          ).toBe(true);
+        }
+      },
+    );
+
+    it.each(["GT", "GTE", "LT", "LTE", "EQ", "NEQ"] as const)(
+      "%s accepts a null warningThreshold regardless of alertThreshold",
+      (op) => {
+        expect(
+          MonitorSchema.safeParse({
+            ...validMonitorBase,
+            thresholdOperator: op,
+            alertThreshold: 100,
+            warningThreshold: null,
+          }).success,
+        ).toBe(true);
+      },
+    );
+  });
+});
+
+describe("MonitorQueueEventSchema", () => {
+  const validQueueEvent = {
+    projectId: "proj_01",
+    schedulerBatchId: 42n,
+    scheduledAt: new Date("2026-05-18T12:00:00.000Z"),
+    view: "OBSERVATIONS" as const,
+    filters: [],
+    window: MonitorWindow.FIVE_MIN,
+    monitors: [
+      {
+        monitorId: "mon_01",
+        metric: { measure: "count", aggregation: "count" as const },
+      },
+    ],
+  };
+
+  it("parses a representative queue event", () => {
+    const result = MonitorQueueEventSchema.safeParse(validQueueEvent);
+    expect(result.success).toBe(true);
+  });
+
+  it("coerces a string scheduledAt to a Date", () => {
+    const result = MonitorQueueEventSchema.safeParse({
+      ...validQueueEvent,
+      scheduledAt: "2026-05-18T12:00:00.000Z",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.scheduledAt).toBeInstanceOf(Date);
+  });
+
+  it("rejects a non-bigint schedulerBatchId", () => {
+    expect(
+      MonitorQueueEventSchema.safeParse({
+        ...validQueueEvent,
+        schedulerBatchId: 42,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a window outside the MonitorWindow tier set", () => {
+    expect(
+      MonitorQueueEventSchema.safeParse({
+        ...validQueueEvent,
+        window: 123n,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts an empty monitors array", () => {
+    // Scheduler may publish with zero monitors if everything in the batch was
+    // filtered out — schema should not block; downstream worker handles it.
+    expect(
+      MonitorQueueEventSchema.safeParse({ ...validQueueEvent, monitors: [] })
+        .success,
+    ).toBe(true);
+  });
+});
+
+describe("MonitorAlertSchema", () => {
+  const validAlert = {
+    monitorId: "mon_01",
+    projectId: "proj_01",
+    severity: "ALERT" as const,
+    permalink: "https://cloud.langfuse.com/project/proj_01/monitors/mon_01",
+    timestamp: new Date("2026-05-18T12:01:00.000Z"),
+    message: { title: "High error rate", body: "errors > 100" },
+    view: "OBSERVATIONS" as const,
+    filters: [],
+    window: MonitorWindow.FIVE_MIN,
+  };
+
+  it("parses a representative alert", () => {
+    expect(MonitorAlertSchema.safeParse(validAlert).success).toBe(true);
+  });
+
+  it("rejects a non-URL permalink", () => {
+    expect(
+      MonitorAlertSchema.safeParse({ ...validAlert, permalink: "not-a-url" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown severity", () => {
+    expect(
+      MonitorAlertSchema.safeParse({ ...validAlert, severity: "BOGUS" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects a window outside the MonitorWindow tier set", () => {
+    expect(
+      MonitorAlertSchema.safeParse({ ...validAlert, window: 123n }).success,
+    ).toBe(false);
+  });
+});
+
+describe("MonitorWebhookQueueEventSchema", () => {
+  const validEnvelope = {
+    type: "monitor-alert" as const,
+    version: "v1" as const,
+    payload: {
+      monitorId: "mon_01",
+      projectId: "proj_01",
+      severity: "ALERT" as const,
+      permalink: "https://cloud.langfuse.com/project/proj_01/monitors/mon_01",
+      timestamp: new Date("2026-05-18T12:01:00.000Z"),
+      message: { title: "High error rate", body: "errors > 100" },
+      view: "OBSERVATIONS" as const,
+      filters: [],
+      window: MonitorWindow.FIVE_MIN,
+    },
+  };
+
+  it("parses a valid envelope", () => {
+    expect(
+      MonitorWebhookQueueEventSchema.safeParse(validEnvelope).success,
+    ).toBe(true);
+  });
+
+  it("rejects a wrong type discriminator", () => {
+    expect(
+      MonitorWebhookQueueEventSchema.safeParse({
+        ...validEnvelope,
+        type: "prompt-version",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a wrong version literal", () => {
+    expect(
+      MonitorWebhookQueueEventSchema.safeParse({
+        ...validEnvelope,
+        version: "v2",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -419,13 +419,23 @@ describe("MonitorQueueEventSchema", () => {
     if (result.success) expect(result.data.scheduledAt).toBeInstanceOf(Date);
   });
 
-  it("rejects a non-bigint schedulerBatchId", () => {
-    expect(
-      MonitorQueueEventSchema.safeParse({
-        ...validQueueEvent,
-        schedulerBatchId: 42,
-      }).success,
-    ).toBe(false);
+  it("coerces a string schedulerBatchId to a bigint", () => {
+    const result = MonitorQueueEventSchema.safeParse({
+      ...validQueueEvent,
+      schedulerBatchId: "42",
+    });
+    expect(result.success).toBe(true);
+    if (result.success)
+      expect(typeof result.data.schedulerBatchId).toBe("bigint");
+  });
+
+  it("coerces a string window to a bigint", () => {
+    const result = MonitorQueueEventSchema.safeParse({
+      ...validQueueEvent,
+      window: MonitorWindow.FIVE_MIN.toString(),
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(typeof result.data.window).toBe("bigint");
   });
 
   it("rejects a window outside the MonitorWindow tier set", () => {
@@ -491,6 +501,15 @@ describe("MonitorAlertSchema", () => {
     });
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.timestamp).toBeInstanceOf(Date);
+  });
+
+  it("coerces a string window to a bigint", () => {
+    const result = MonitorAlertSchema.safeParse({
+      ...validAlert,
+      window: MonitorWindow.FIVE_MIN.toString(),
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(typeof result.data.window).toBe("bigint");
   });
 });
 

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -6,7 +6,6 @@ import {
   monitorWindowCadenceMs,
   MonitorRenotifySchema,
   MonitorNoDataSchema,
-  MonitorTemplateSchema,
   MonitorSchema,
   MonitorQueueEventSchema,
   MonitorAlertSchema,
@@ -194,36 +193,6 @@ describe("MonitorNoDataSchema", () => {
   });
 });
 
-describe("MonitorTemplateSchema", () => {
-  it("accepts the empty string", () => {
-    expect(MonitorTemplateSchema.safeParse("").success).toBe(true);
-  });
-
-  it("accepts a typical short template", () => {
-    expect(
-      MonitorTemplateSchema.safeParse("Alert: {{value}} crossed {{threshold}}")
-        .success,
-    ).toBe(true);
-  });
-
-  it("accepts exactly 4000 characters", () => {
-    expect(MonitorTemplateSchema.safeParse("x".repeat(4000)).success).toBe(
-      true,
-    );
-  });
-
-  it("rejects a string longer than 4000 characters", () => {
-    expect(MonitorTemplateSchema.safeParse("x".repeat(4001)).success).toBe(
-      false,
-    );
-  });
-
-  it("rejects non-string input", () => {
-    expect(MonitorTemplateSchema.safeParse(123).success).toBe(false);
-    expect(MonitorTemplateSchema.safeParse(null).success).toBe(false);
-  });
-});
-
 describe("validateWarningAlertOrdering", () => {
   it.each(["GT", "GTE"] as const)("%s requires warning < alert", (op) => {
     expect(
@@ -292,6 +261,22 @@ describe("MonitorSchema", () => {
   it("parses a minimally valid Monitor", () => {
     const result = MonitorSchema.safeParse(validMonitorBase);
     expect(result.success).toBe(true);
+  });
+
+  it("rejects a message longer than 2000 characters", () => {
+    const result = MonitorSchema.safeParse({
+      ...validMonitorBase,
+      message: "x".repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a message with an invalid handlebars template", () => {
+    const result = MonitorSchema.safeParse({
+      ...validMonitorBase,
+      message: "{{unknown}}",
+    });
+    expect(result.success).toBe(false);
   });
 
   describe("warning/alert threshold ordering refinement", () => {

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
 
+import { DAY, HOUR, MINUTE, WEEK } from "./internal";
 import {
   MonitorWindow,
   isValidMonitorWindow,
-  monitorWindowCadenceMs,
+  calculateMonitorWindowCadenceMillis,
   MonitorRenotifySchema,
   MonitorNoDataSchema,
   MonitorSchema,
@@ -48,12 +49,6 @@ const validMonitorBase = {
   alertedAt: null,
 };
 
-// Local readability aliases. The production module keeps these internal.
-const MINUTE_MS = 60_000n;
-const HOUR_MS = 60n * MINUTE_MS;
-const DAY_MS = 24n * HOUR_MS;
-const WEEK_MS = 7n * DAY_MS;
-
 describe("MonitorWindow tier map", () => {
   it("exposes the 10 RFC tiers with BigInt millisecond values", () => {
     expect(MonitorWindow.FIVE_MIN).toBe(5n * 60_000n);
@@ -81,23 +76,33 @@ describe("isValidMonitorWindow", () => {
   });
 });
 
-describe("monitorWindowCadenceMs", () => {
+describe("calculateMonitorWindowCadenceMillis", () => {
   it("returns 1 minute for sub-day windows", () => {
-    expect(monitorWindowCadenceMs(MonitorWindow.FIVE_MIN)).toBe(MINUTE_MS);
-    expect(monitorWindowCadenceMs(MonitorWindow.FOUR_HOUR)).toBe(MINUTE_MS);
-    expect(monitorWindowCadenceMs(DAY_MS - 1n)).toBe(MINUTE_MS);
+    expect(calculateMonitorWindowCadenceMillis(MonitorWindow.FIVE_MIN)).toBe(
+      MINUTE,
+    );
+    expect(calculateMonitorWindowCadenceMillis(MonitorWindow.FOUR_HOUR)).toBe(
+      MINUTE,
+    );
+    expect(calculateMonitorWindowCadenceMillis(DAY - 1n)).toBe(MINUTE);
   });
 
   it("returns 30 minutes for day-to-week windows", () => {
-    expect(monitorWindowCadenceMs(MonitorWindow.ONE_DAY)).toBe(30n * MINUTE_MS);
-    expect(monitorWindowCadenceMs(DAY_MS + 1n)).toBe(30n * MINUTE_MS);
-    expect(monitorWindowCadenceMs(MonitorWindow.TWO_DAY)).toBe(30n * MINUTE_MS);
-    expect(monitorWindowCadenceMs(WEEK_MS - 1n)).toBe(30n * MINUTE_MS);
+    expect(calculateMonitorWindowCadenceMillis(MonitorWindow.ONE_DAY)).toBe(
+      30n * MINUTE,
+    );
+    expect(calculateMonitorWindowCadenceMillis(DAY + 1n)).toBe(30n * MINUTE);
+    expect(calculateMonitorWindowCadenceMillis(MonitorWindow.TWO_DAY)).toBe(
+      30n * MINUTE,
+    );
+    expect(calculateMonitorWindowCadenceMillis(WEEK - 1n)).toBe(30n * MINUTE);
   });
 
   it("returns 48 hours for week-and-up windows", () => {
-    expect(monitorWindowCadenceMs(MonitorWindow.ONE_WEEK)).toBe(48n * HOUR_MS);
-    expect(monitorWindowCadenceMs(WEEK_MS + 1n)).toBe(48n * HOUR_MS);
+    expect(calculateMonitorWindowCadenceMillis(MonitorWindow.ONE_WEEK)).toBe(
+      48n * HOUR,
+    );
+    expect(calculateMonitorWindowCadenceMillis(WEEK + 1n)).toBe(48n * HOUR);
   });
 });
 
@@ -396,12 +401,8 @@ describe("MonitorQueueEventSchema", () => {
     view: "OBSERVATIONS" as const,
     filters: [],
     window: MonitorWindow.FIVE_MIN,
-    monitors: [
-      {
-        monitorId: "mon_01",
-        metric: { measure: "count", aggregation: "count" as const },
-      },
-    ],
+    metrics: [{ measure: "count", aggregation: "count" as const }],
+    monitors: [{ monitorId: "mon_01", metricName: "count_count" }],
   };
 
   it("parses a representative queue event", () => {

--- a/packages/shared/src/features/monitor/types.test.ts
+++ b/packages/shared/src/features/monitor/types.test.ts
@@ -483,6 +483,15 @@ describe("MonitorAlertSchema", () => {
       MonitorAlertSchema.safeParse({ ...validAlert, window: 123n }).success,
     ).toBe(false);
   });
+
+  it("coerces a string timestamp to a Date", () => {
+    const result = MonitorAlertSchema.safeParse({
+      ...validAlert,
+      timestamp: "2026-05-18T12:01:00.000Z",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.timestamp).toBeInstanceOf(Date);
+  });
 });
 
 describe("MonitorWebhookQueueEventSchema", () => {

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { singleFilter } from "../../interfaces/filters";
 import { metric as MetricSchema } from "../query/types";
 import { DAY, HOUR, MINUTE, WEEK } from "./internal";
+import { validateMonitorTemplate } from "./template";
 
 /**
  * ErrorInvalidMonitorWindow is emitted when a `window`
@@ -23,6 +24,14 @@ export const ErrorInvalidMonitorWindow =
  */
 export const ErrorInvalidWarningAlertOrdering =
   "warningThreshold must be less severe than alertThreshold for ordered operators";
+
+/**
+ * ErrorInvalidMonitorTemplate is emitted when a message template references
+ * unknown variables, uses helpers, partials, decorators, sub-expressions, or
+ * unescaped `{{{x}}}` output, or fails to parse as Handlebars.
+ */
+export const ErrorInvalidMonitorTemplate =
+  "template is not formatted correctly";
 
 /**
  * MonitorWindow contains a the list of allowed Monitor evaluation windows.
@@ -94,10 +103,6 @@ export const MonitorNoDataSchema = z.discriminatedUnion("mode", [
 ]);
 export type MonitorNoData = z.infer<typeof MonitorNoDataSchema>;
 
-/** MonitorTemplateSchema is the Monitor message template source (Handlebars). Size-limited; AST validation layered elsewhere. */
-export const MonitorTemplateSchema = z.string().max(4000);
-export type MonitorTemplate = z.infer<typeof MonitorTemplateSchema>;
-
 /**
  * validateWarningAlertOrdering enforces that warning must cross before alert
  * for ordered operators; null warning and unordered operators (EQ/NEQ) always
@@ -155,8 +160,16 @@ export const MonitorSchema = z
     renotify: MonitorRenotifySchema.default({ mode: "OFF" }),
 
     // MonitorAlert Config
-    name: MonitorTemplateSchema.min(1).max(200),
-    message: MonitorTemplateSchema.default(""),
+    name: z
+      .string()
+      .min(1)
+      .max(200)
+      .refine(validateMonitorTemplate, ErrorInvalidMonitorTemplate),
+    message: z
+      .string()
+      .max(2000)
+      .refine(validateMonitorTemplate, ErrorInvalidMonitorTemplate)
+      .default(""),
     tags: z.array(z.string().max(60)).max(20).default([]),
 
     // Monitor State

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -198,7 +198,7 @@ export const MonitorSchema = z
 export const MonitorQueueEventSchema = z.object({
   projectId: z.string(),
   // Fingerprint of (projectId, view, filters, window)
-  schedulerBatchId: z.bigint(),
+  schedulerBatchId: z.coerce.bigint(),
 
   // Scheduler tick time
   scheduledAt: z.coerce.date(),
@@ -206,7 +206,9 @@ export const MonitorQueueEventSchema = z.object({
   // Shared query primitives — every monitor in this batch agrees on these.
   view: z.enum(MonitorView),
   filters: z.array(singleFilter),
-  window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
+  window: z.coerce
+    .bigint()
+    .refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
   metrics: z.array(MetricSchema),
 
   // Monitors map to metricNames returned by the above query params
@@ -230,7 +232,9 @@ export const MonitorAlertSchema = z.object({
   timestamp: z.coerce.date(),
   view: z.enum(MonitorView),
   filters: z.array(singleFilter),
-  window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
+  window: z.coerce
+    .bigint()
+    .refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
 });
 export type MonitorAlert = z.infer<typeof MonitorAlertSchema>;
 

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -1,4 +1,4 @@
-/** types.ts contains all entitiy models and logic */
+/** types.ts contains all entity models and logic */
 import {
   MonitorSeverity,
   MonitorStatus,
@@ -34,7 +34,7 @@ export const ErrorInvalidMonitorTemplate =
   "template is not formatted correctly";
 
 /**
- * MonitorWindow contains a the list of allowed Monitor evaluation windows.
+ * MonitorWindow contains the list of allowed Monitor evaluation windows.
  * Adding a tier requires updating `monitorWindowCadenceMs`.
  */
 export const MonitorWindow = {
@@ -217,7 +217,7 @@ export const MonitorQueueEventSchema = z.object({
 export type MonitorQueueEvent = z.infer<typeof MonitorQueueEventSchema>;
 
 /**
- * MonitorAlertSchema is emmitted when a monitor alerts.
+ * MonitorAlertSchema is emitted when a monitor alerts.
  * It carries the query shape (`view` / `filters` / `window`) alongside the
  * rendered message so that recipients can reconstruct the underlying observations / scores query.
  */
@@ -227,7 +227,7 @@ export const MonitorAlertSchema = z.object({
   permalink: z.url(),
   message: z.object({ title: z.string(), body: z.string() }),
   severity: z.enum(MonitorSeverity),
-  timestamp: z.date(),
+  timestamp: z.coerce.date(),
   view: z.enum(MonitorView),
   filters: z.array(singleFilter),
   window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),

--- a/packages/shared/src/features/monitor/types.ts
+++ b/packages/shared/src/features/monitor/types.ts
@@ -1,0 +1,235 @@
+/** types.ts contains all entitiy models and logic */
+import {
+  MonitorSeverity,
+  MonitorStatus,
+  MonitorThresholdOperator,
+  MonitorView,
+} from "@prisma/client";
+import { z } from "zod";
+import { singleFilter } from "../../interfaces/filters";
+import { metric as MetricSchema } from "../query/types";
+import { DAY, HOUR, MINUTE, WEEK } from "./internal";
+
+/**
+ * ErrorInvalidMonitorWindow is emitted when a `window`
+ * value does not match any `MonitorWindow.*` tier.
+ */
+export const ErrorInvalidMonitorWindow =
+  "window must be one of the MonitorWindow.* tiers";
+
+/**
+ * ErrorInvalidWarningAlertOrdering is emitted when `warningThreshold` is more severe
+ * than `alertThreshold` for a given `thresholdOperator`.
+ */
+export const ErrorInvalidWarningAlertOrdering =
+  "warningThreshold must be less severe than alertThreshold for ordered operators";
+
+/**
+ * MonitorWindow contains a the list of allowed Monitor evaluation windows.
+ * Adding a tier requires updating `monitorWindowCadenceMs`.
+ */
+export const MonitorWindow = {
+  FIVE_MIN: 5n * MINUTE,
+  TEN_MIN: 10n * MINUTE,
+  FIFTEEN_MIN: 15n * MINUTE,
+  THIRTY_MIN: 30n * MINUTE,
+  ONE_HOUR: HOUR,
+  TWO_HOUR: 2n * HOUR,
+  FOUR_HOUR: 4n * HOUR,
+  ONE_DAY: DAY,
+  TWO_DAY: 2n * DAY,
+  ONE_WEEK: WEEK,
+} as const;
+
+/**
+ * calculateMonitorWindowCadenceMs derives a Monitor's scheduler cadence from its evaluation window.
+ */
+export function calculateMonitorWindowCadenceMillis(
+  windowMillis: bigint,
+): bigint {
+  if (windowMillis >= WEEK) return 48n * HOUR;
+  if (windowMillis >= DAY) return 30n * MINUTE;
+  return MINUTE; // default cadence
+}
+
+/**
+ * isValidMonitorWindow returns true when `v` matches one of the `MonitorWindow.*` tiers.
+ */
+export const isValidMonitorWindow = (v: bigint): boolean =>
+  (Object.values(MonitorWindow) as bigint[]).includes(v);
+
+/**
+ * MonitorRenotifySchema describes renotify behavior for a sustained severity.
+ * `OFF` is edge-only; `EVERY` re-emits every `intervalMinutes` while the
+ * severity persists.
+ */
+export const MonitorRenotifySchema = z.discriminatedUnion("mode", [
+  z.object({ mode: z.literal("OFF") }),
+  z.object({
+    mode: z.literal("EVERY"),
+    intervalMinutes: z
+      .number()
+      .int()
+      .min(1)
+      .max(60 * 24 * 7),
+  }),
+]);
+export type MonitorRenotify = z.infer<typeof MonitorRenotifySchema>;
+
+/**
+ * MonitorNoDataSchema describes behavior when a Monitor query returns no rows.
+ * `SILENT` only alerts on recovery; `NOTIFY` also alerts after
+ * `intervalMinutes` of sustained NO_DATA.
+ */
+export const MonitorNoDataSchema = z.discriminatedUnion("mode", [
+  z.object({ mode: z.literal("SILENT") }),
+  z.object({
+    mode: z.literal("NOTIFY"),
+    intervalMinutes: z
+      .number()
+      .int()
+      .min(1)
+      .max(60 * 24),
+  }),
+]);
+export type MonitorNoData = z.infer<typeof MonitorNoDataSchema>;
+
+/** MonitorTemplateSchema is the Monitor message template source (Handlebars). Size-limited; AST validation layered elsewhere. */
+export const MonitorTemplateSchema = z.string().max(4000);
+export type MonitorTemplate = z.infer<typeof MonitorTemplateSchema>;
+
+/**
+ * validateWarningAlertOrdering enforces that warning must cross before alert
+ * for ordered operators; null warning and unordered operators (EQ/NEQ) always
+ * pass.
+ */
+export function validateWarningAlertOrdering(monitor: {
+  thresholdOperator: MonitorThresholdOperator;
+  alertThreshold: number;
+  warningThreshold: number | null;
+}): boolean {
+  if (monitor.warningThreshold == null) return true;
+  switch (monitor.thresholdOperator) {
+    case "GT":
+    case "GTE":
+      return monitor.warningThreshold < monitor.alertThreshold;
+    case "LT":
+    case "LTE":
+      return monitor.warningThreshold > monitor.alertThreshold;
+    case "EQ":
+    case "NEQ":
+      return true;
+  }
+}
+
+/**
+ * MonitorSchema is the canonical Monitor object. Mirrors the Prisma `Monitor`
+ * row.
+ *
+ * `cadenceMs` is derived from `window` on write and intentionally not
+ * exposed here.
+ *
+ * The Prisma column `windowMs` maps to this schema's `window`
+ * at the service boundary.
+ */
+export const MonitorSchema = z
+  .object({
+    id: z.string(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+    createdBy: z.string().nullable(),
+    updatedBy: z.string().nullable(),
+    projectId: z.string(),
+
+    // Query Config
+    view: z.enum(MonitorView),
+    filters: z.array(singleFilter),
+    metric: MetricSchema,
+
+    // Monitor Config
+    window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
+    thresholdOperator: z.enum(MonitorThresholdOperator),
+    alertThreshold: z.number(),
+    warningThreshold: z.number().nullable(),
+    noData: MonitorNoDataSchema.default({ mode: "SILENT" }),
+    renotify: MonitorRenotifySchema.default({ mode: "OFF" }),
+
+    // MonitorAlert Config
+    name: MonitorTemplateSchema.min(1).max(200),
+    message: MonitorTemplateSchema.default(""),
+    tags: z.array(z.string().max(60)).max(20).default([]),
+
+    // Monitor State
+    severity: z.enum(MonitorSeverity).default("UNKNOWN"),
+    severityChangedAt: z.date().nullable(),
+    alertedAt: z.date().nullable(),
+
+    // MonitorScheduler State
+    status: z.enum(MonitorStatus).default("ACTIVE"),
+    nextRunAt: z.date(),
+    lastPublishedRunAt: z.date().nullable(),
+    lastCompletedRunAt: z.date().nullable(),
+  })
+  .refine(validateWarningAlertOrdering, {
+    message: ErrorInvalidWarningAlertOrdering,
+    path: ["warningThreshold"],
+  });
+
+/**
+ * MonitorQueueEventSchema represents a batch of monitors that can be evaluated
+ * together using the same set of parameters.
+ *
+ * All monitors in `monitors[]` share `view` / `filters` /
+ * `window`, so the worker runs one ClickHouse query for the whole batch.
+ */
+export const MonitorQueueEventSchema = z.object({
+  projectId: z.string(),
+  // Fingerprint of (projectId, view, filters, window)
+  schedulerBatchId: z.bigint(),
+
+  // Scheduler tick time
+  scheduledAt: z.coerce.date(),
+
+  // Shared query primitives — every monitor in this batch agrees on these.
+  view: z.enum(MonitorView),
+  filters: z.array(singleFilter),
+  window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
+  metrics: z.array(MetricSchema),
+
+  // Monitors map to metricNames returned by the above query params
+  monitors: z.array(
+    z.object({ monitorId: z.string(), metricName: z.string() }),
+  ),
+});
+export type MonitorQueueEvent = z.infer<typeof MonitorQueueEventSchema>;
+
+/**
+ * MonitorAlertSchema is emmitted when a monitor alerts.
+ * It carries the query shape (`view` / `filters` / `window`) alongside the
+ * rendered message so that recipients can reconstruct the underlying observations / scores query.
+ */
+export const MonitorAlertSchema = z.object({
+  monitorId: z.string(),
+  projectId: z.string(),
+  permalink: z.url(),
+  message: z.object({ title: z.string(), body: z.string() }),
+  severity: z.enum(MonitorSeverity),
+  timestamp: z.date(),
+  view: z.enum(MonitorView),
+  filters: z.array(singleFilter),
+  window: z.bigint().refine(isValidMonitorWindow, ErrorInvalidMonitorWindow),
+});
+export type MonitorAlert = z.infer<typeof MonitorAlertSchema>;
+
+/**
+ * MonitorWebhookQueueEventSchema is the transport envelope wrapping
+ * `MonitorAlertSchema` for the `WebhookQueue`.
+ */
+export const MonitorWebhookQueueEventSchema = z.object({
+  type: z.literal("monitor-alert"),
+  version: z.literal("v1"),
+  payload: MonitorAlertSchema,
+});
+export type MonitorWebhookQueueEvent = z.infer<
+  typeof MonitorWebhookQueueEventSchema
+>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -104,3 +104,6 @@ export * from "./features/analytics-integrations";
 export * from "./features/query/types";
 export * from "./features/query/dataModel";
 export * from "./features/query/validateQuery";
+
+// monitor (Monitor schemas, queue contracts, template validator)
+export * from "./features/monitor";

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -81,6 +81,8 @@ export * from "./redis/dataRetentionProcessingQueue";
 export * from "./redis/coreDataS3ExportQueue";
 export * from "./redis/meteringDataPostgresExportQueue";
 export * from "./redis/notificationQueue";
+export * from "./redis/monitorQueue";
+export * from "../features/monitor/server";
 export * from "./webhooks/validation";
 export * from "./webhooks/ipBlocking";
 export * from "./redis/experimentCreateQueue";

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -10,6 +10,7 @@ import { EventActionSchema } from "../domain";
 import { PromptDomainSchema } from "../domain/prompts";
 import { ObservationAddToDatasetConfigSchema } from "../features/batchAction/addToDatasetTypes";
 import { EvalTargetObjectSchema } from "../features/evals/types";
+import type { MonitorQueueEvent } from "../features/monitor/types";
 
 export const IngestionEvent = z.object({
   data: z.object({
@@ -355,6 +356,7 @@ export enum QueueName {
   EntityChangeQueue = "entity-change-queue",
   EventPropagationQueue = "event-propagation-queue",
   NotificationQueue = "notification-queue",
+  MonitorQueue = "monitor-queue",
 }
 
 export enum QueueJobs {
@@ -390,6 +392,7 @@ export enum QueueJobs {
   EntityChangeJob = "entity-change-job",
   EventPropagationJob = "event-propagation-job",
   NotificationJob = "notification-job",
+  MonitorJob = "monitor-job",
 }
 
 export type TQueueJobTypes = {
@@ -563,5 +566,11 @@ export type TQueueJobTypes = {
     id: string;
     payload: NotificationEventType;
     name: QueueJobs.NotificationJob;
+  };
+  [QueueName.MonitorQueue]: {
+    timestamp: Date;
+    id: string;
+    payload: MonitorQueueEvent;
+    name: QueueJobs.MonitorJob;
   };
 };

--- a/packages/shared/src/server/redis/getQueue.ts
+++ b/packages/shared/src/server/redis/getQueue.ts
@@ -41,6 +41,7 @@ export function getQueue(
     | QueueName.TraceUpsert
     | QueueName.OtelIngestionQueue
     | QueueName.OtelIngestionSecondaryQueue
+    | QueueName.MonitorQueue
   >,
 ): Queue | null {
   switch (queueName) {

--- a/packages/shared/src/server/redis/monitorQueue.ts
+++ b/packages/shared/src/server/redis/monitorQueue.ts
@@ -1,0 +1,93 @@
+import { Queue } from "bullmq";
+import { QueueName, TQueueJobTypes } from "../queues";
+import {
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  getQueuePrefix,
+} from "./redis";
+import { logger } from "../logger";
+import { getShardIndex } from "./sharding";
+import { env } from "../../env";
+
+export class MonitorQueue {
+  private static instances: Map<
+    number,
+    Queue<TQueueJobTypes[QueueName.MonitorQueue]> | null
+  > = new Map();
+
+  public static getShardNames() {
+    return Array.from(
+      { length: env.LANGFUSE_MONITOR_QUEUE_SHARD_COUNT },
+      (_, i) => `${QueueName.MonitorQueue}${i > 0 ? `-${i}` : ""}`,
+    );
+  }
+
+  static getShardIndexFromShardName(
+    shardName: string | undefined,
+  ): number | null {
+    if (!shardName) return null;
+
+    const shardIndex =
+      shardName === QueueName.MonitorQueue
+        ? 0
+        : parseInt(shardName.replace(`${QueueName.MonitorQueue}-`, ""), 10);
+
+    if (isNaN(shardIndex)) return null;
+    return shardIndex;
+  }
+
+  /**
+   * Get the monitor queue instance for the given sharding key or shard name.
+   * @param shardingKey - Hashed and randomly allocated to a shard. Should be
+   *   `${projectId}-${schedulerBatchId}` so all events for a given batch land
+   *   on the same shard.
+   * @param shardName - Name of the shard (e.g. `monitor-queue-2`).
+   */
+  public static getInstance({
+    shardingKey,
+    shardName,
+  }: {
+    shardingKey?: string;
+    shardName?: string;
+  } = {}): Queue<TQueueJobTypes[QueueName.MonitorQueue]> | null {
+    const shardIndex =
+      MonitorQueue.getShardIndexFromShardName(shardName) ??
+      (env.REDIS_CLUSTER_ENABLED === "true" && shardingKey
+        ? getShardIndex(shardingKey, env.LANGFUSE_MONITOR_QUEUE_SHARD_COUNT)
+        : 0);
+
+    if (MonitorQueue.instances.has(shardIndex)) {
+      return MonitorQueue.instances.get(shardIndex) || null;
+    }
+
+    const newRedis = createNewRedisInstance({
+      enableOfflineQueue: false,
+      ...redisQueueRetryOptions,
+    });
+
+    const name = `${QueueName.MonitorQueue}${shardIndex > 0 ? `-${shardIndex}` : ""}`;
+    const queueInstance = newRedis
+      ? new Queue<TQueueJobTypes[QueueName.MonitorQueue]>(name, {
+          connection: newRedis,
+          prefix: getQueuePrefix(name),
+          defaultJobOptions: {
+            removeOnComplete: true,
+            removeOnFail: 100_000,
+            attempts: 6,
+            backoff: {
+              type: "exponential",
+              delay: 5000,
+            },
+          },
+        })
+      : null;
+
+    queueInstance?.on("error", (err) => {
+      logger.error(`MonitorQueue shard ${shardIndex} error`, err);
+    });
+
+    MonitorQueue.instances.set(shardIndex, queueInstance);
+
+    return queueInstance;
+  }
+}

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    dir: "./src",
+    include: ["**/*.test.ts"],
+    pool: "forks",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.2
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(msw@2.6.5(@types/node@24.3.0)(typescript@5.9.2))(vite@7.0.5(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.20.5)(yaml@2.8.4))
 
   web:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       exponential-backoff:
         specifier: ^3.1.2
         version: 3.1.2
+      handlebars:
+        specifier: ^4.7.9
+        version: 4.7.9
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
@@ -7365,6 +7368,11 @@ packages:
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -10185,6 +10193,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -10598,6 +10611,9 @@ packages:
   winston@3.15.0:
     resolution: {integrity: sha512-RhruH2Cj0bV0WgNL+lOfoUBI4DVfdUNjVnJGVovWZmrcKtrFTTRzgXYK2O9cymSGjrERCtaAeHwMNnUWXlwZow==}
     engines: {node: '>= 12.0.0'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -18148,6 +18164,15 @@ snapshots:
 
   hachure-fill@0.5.2: {}
 
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -21433,6 +21458,9 @@ snapshots:
 
   typescript@5.9.2: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -21885,6 +21913,8 @@ snapshots:
       stack-trace: 0.0.10
       triple-beam: 1.4.1
       winston-transport: 4.7.1
+
+  wordwrap@1.0.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/web/src/pages/api/admin/bullmq/index.ts
+++ b/web/src/pages/api/admin/bullmq/index.ts
@@ -13,6 +13,7 @@ import {
   IngestionEvent,
   OtelIngestionQueue,
   SecondaryOtelIngestionQueue,
+  MonitorQueue,
 } from "@langfuse/shared/src/server";
 import { AdminApiAuthService } from "@/src/ee/features/admin-api/server/adminApiAuth";
 
@@ -78,6 +79,7 @@ export default async function handler(
           ...TraceUpsertQueue.getShardNames(),
           ...OtelIngestionQueue.getShardNames(),
           ...SecondaryOtelIngestionQueue.getShardNames(),
+          ...MonitorQueue.getShardNames(),
         ]),
       );
       const queueCounts = await Promise.all(
@@ -114,6 +116,8 @@ export default async function handler(
               });
             } else if (queueName.startsWith(QueueName.OtelIngestionQueue)) {
               queue = OtelIngestionQueue.getInstance({ shardName: queueName });
+            } else if (queueName.startsWith(QueueName.MonitorQueue)) {
+              queue = MonitorQueue.getInstance({ shardName: queueName });
             } else {
               queue = getQueue(
                 queueName as Exclude<
@@ -126,6 +130,7 @@ export default async function handler(
                   | QueueName.TraceUpsert
                   | QueueName.OtelIngestionQueue
                   | QueueName.OtelIngestionSecondaryQueue
+                  | QueueName.MonitorQueue
                 >,
               );
             }
@@ -180,6 +185,8 @@ export default async function handler(
           });
         } else if (queueName.startsWith(QueueName.OtelIngestionQueue)) {
           queue = OtelIngestionQueue.getInstance({ shardName: queueName });
+        } else if (queueName.startsWith(QueueName.MonitorQueue)) {
+          queue = MonitorQueue.getInstance({ shardName: queueName });
         } else {
           queue = getQueue(
             queueName as Exclude<
@@ -192,6 +199,7 @@ export default async function handler(
               | QueueName.TraceUpsert
               | QueueName.OtelIngestionQueue
               | QueueName.OtelIngestionSecondaryQueue
+              | QueueName.MonitorQueue
             >,
           );
         }
@@ -256,6 +264,8 @@ export default async function handler(
           });
         } else if (queueName.startsWith(QueueName.OtelIngestionQueue)) {
           queue = OtelIngestionQueue.getInstance({ shardName: queueName });
+        } else if (queueName.startsWith(QueueName.MonitorQueue)) {
+          queue = MonitorQueue.getInstance({ shardName: queueName });
         } else {
           queue = getQueue(
             queueName as Exclude<
@@ -268,6 +278,7 @@ export default async function handler(
               | QueueName.TraceUpsert
               | QueueName.OtelIngestionQueue
               | QueueName.OtelIngestionSecondaryQueue
+              | QueueName.MonitorQueue
             >,
           );
         }

--- a/worker/src/__tests__/monitorScheduler.test.ts
+++ b/worker/src/__tests__/monitorScheduler.test.ts
@@ -1,0 +1,458 @@
+import { expect, describe, it, afterEach, beforeEach } from "vitest";
+import { Queue } from "bullmq";
+import {
+  createOrgProjectAndApiKey,
+  createNewRedisInstance,
+  redisQueueRetryOptions,
+  getQueuePrefix,
+  redis,
+  QueueName,
+  QueueJobs,
+  TQueueJobTypes,
+  MonitorScheduler,
+} from "@langfuse/shared/src/server";
+import type { MonitorQueueEvent } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  MonitorSchedulerRunner,
+  MONITOR_SCHEDULER_LOCK_PREFIX,
+} from "../features/monitor-scheduler";
+
+const MINUTE_MS = 60 * 1000;
+
+type SeedOverrides = Partial<{
+  id: string;
+  projectId: string;
+  schedulerBatchId: bigint;
+  windowMs: bigint;
+  cadenceMs: bigint;
+  nextRunAt: Date;
+  lastPublishedRunAt: Date | null;
+  lastCompletedRunAt: Date | null;
+  status: "ACTIVE" | "PAUSED" | "ERROR_BAD_QUERY";
+  view: "OBSERVATIONS" | "SCORES_NUMERIC" | "SCORES_CATEGORICAL";
+  filters: unknown;
+  metric: { measure: string; aggregation: string };
+  alertThreshold: number;
+}>;
+
+async function seedMonitor(projectId: string, overrides: SeedOverrides = {}) {
+  const id =
+    overrides.id ??
+    `mon_${Math.random().toString(36).slice(2, 10)}_${Date.now()}`;
+  return prisma.monitor.create({
+    data: {
+      id,
+      projectId,
+      view: overrides.view ?? "OBSERVATIONS",
+      filters: (overrides.filters as object) ?? [],
+      metric: overrides.metric ?? { measure: "count", aggregation: "count" },
+      windowMs: overrides.windowMs ?? BigInt(5 * MINUTE_MS),
+      cadenceMs: overrides.cadenceMs ?? BigInt(MINUTE_MS),
+      thresholdOperator: "GT",
+      alertThreshold: overrides.alertThreshold ?? 100,
+      noData: { mode: "SILENT" },
+      renotify: { mode: "OFF" },
+      name: "Test Monitor",
+      message: "",
+      tags: [],
+      status: overrides.status ?? "ACTIVE",
+      schedulerBatchId: overrides.schedulerBatchId ?? 0n,
+      nextRunAt: overrides.nextRunAt ?? new Date(Date.now() - 1000),
+      lastPublishedRunAt: overrides.lastPublishedRunAt ?? null,
+      lastCompletedRunAt: overrides.lastCompletedRunAt ?? null,
+    },
+  });
+}
+
+async function withIsolatedMonitorQueue<T>(
+  fn: (queue: Queue<TQueueJobTypes[QueueName.MonitorQueue]>) => Promise<T>,
+): Promise<T> {
+  const queueName = `${QueueName.MonitorQueue}-test-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+  const conn = createNewRedisInstance({
+    enableOfflineQueue: false,
+    ...redisQueueRetryOptions,
+  });
+  if (!conn) throw new Error("Redis is not initialized");
+
+  const queue = new Queue<TQueueJobTypes[QueueName.MonitorQueue]>(queueName, {
+    connection: conn,
+    prefix: getQueuePrefix(queueName),
+  });
+
+  try {
+    return await fn(queue);
+  } finally {
+    try {
+      await queue.obliterate({ force: true });
+    } finally {
+      try {
+        await queue.close();
+      } finally {
+        conn.disconnect();
+      }
+    }
+  }
+}
+
+function fakePublisher() {
+  const events: MonitorQueueEvent[] = [];
+  return {
+    events,
+    publish: async (es: MonitorQueueEvent[]) => {
+      events.push(...es);
+    },
+  };
+}
+
+describe("MonitorScheduler.tick", () => {
+  let projectId: string;
+
+  beforeEach(async () => {
+    ({ projectId } = await createOrgProjectAndApiKey());
+  });
+
+  afterEach(async () => {
+    await prisma.monitor.deleteMany({ where: { projectId } });
+  });
+
+  it("publishes one event per schedulerBatchId and groups monitors by id", async () => {
+    const tick = new Date();
+    const past = new Date(tick.getTime() - 1000);
+
+    // Three monitors in batch A (one shared metric for two of them, one different)
+    await seedMonitor(projectId, {
+      id: "mon_a3",
+      schedulerBatchId: 100n,
+      nextRunAt: past,
+      metric: { measure: "count", aggregation: "count" },
+    });
+    await seedMonitor(projectId, {
+      id: "mon_a1",
+      schedulerBatchId: 100n,
+      nextRunAt: past,
+      metric: { measure: "count", aggregation: "count" },
+    });
+    await seedMonitor(projectId, {
+      id: "mon_a2",
+      schedulerBatchId: 100n,
+      nextRunAt: past,
+      metric: { measure: "value", aggregation: "avg" },
+    });
+    // One monitor in batch B
+    await seedMonitor(projectId, {
+      id: "mon_b1",
+      schedulerBatchId: 200n,
+      nextRunAt: past,
+      metric: { measure: "value", aggregation: "p95" },
+    });
+
+    const pub = fakePublisher();
+    const scheduler = new MonitorScheduler({
+      schedulerId: 0,
+      totalSchedulers: 1,
+      db: prisma,
+      publish: pub.publish,
+    });
+
+    const published = await scheduler.tick(tick);
+    expect(published).toBe(2);
+    expect(pub.events).toHaveLength(2);
+
+    const byBatch = new Map(pub.events.map((e) => [e.schedulerBatchId, e]));
+    const batchA = byBatch.get(100n);
+    const batchB = byBatch.get(200n);
+    expect(batchA).toBeDefined();
+    expect(batchB).toBeDefined();
+
+    expect(batchA?.monitors.map((m) => m.monitorId)).toEqual([
+      "mon_a1",
+      "mon_a2",
+      "mon_a3",
+    ]);
+    expect(batchA?.monitors.map((m) => m.metricName).sort()).toEqual(
+      ["avg_value", "count_count", "count_count"].sort(),
+    );
+    expect(batchA?.metrics).toHaveLength(2);
+    expect(batchA?.view).toBe("OBSERVATIONS");
+    expect(batchA?.window).toBe(BigInt(5 * MINUTE_MS));
+
+    expect(batchB?.monitors).toHaveLength(1);
+    expect(batchB?.monitors[0]).toEqual({
+      monitorId: "mon_b1",
+      metricName: "p95_value",
+    });
+  });
+
+  it("advances nextRunAt for inactive monitors but never publishes them", async () => {
+    const tick = new Date();
+    const past = new Date(tick.getTime() - 5000);
+    const inactive = await seedMonitor(projectId, {
+      id: "mon_paused",
+      schedulerBatchId: 1n,
+      status: "PAUSED",
+      nextRunAt: past,
+      cadenceMs: BigInt(MINUTE_MS),
+    });
+
+    const pub = fakePublisher();
+    const scheduler = new MonitorScheduler({
+      schedulerId: 0,
+      totalSchedulers: 1,
+      db: prisma,
+      publish: pub.publish,
+    });
+
+    const published = await scheduler.tick(tick);
+    expect(published).toBe(0);
+    expect(pub.events).toHaveLength(0);
+
+    const after = await prisma.monitor.findUniqueOrThrow({
+      where: { id: inactive.id },
+    });
+    expect(after.lastPublishedRunAt).toBeNull();
+    expect(after.nextRunAt.getTime()).toBe(past.getTime() + MINUTE_MS);
+  });
+
+  it("re-publishes pending monitors past the 5-minute TTL", async () => {
+    const tick = new Date();
+    const past = new Date(tick.getTime() - 1000);
+    const sixMinAgo = new Date(tick.getTime() - 6 * MINUTE_MS);
+
+    await seedMonitor(projectId, {
+      id: "mon_stuck",
+      schedulerBatchId: 7n,
+      nextRunAt: past,
+      lastPublishedRunAt: sixMinAgo,
+      lastCompletedRunAt: null,
+    });
+
+    const pub = fakePublisher();
+    const scheduler = new MonitorScheduler({
+      schedulerId: 0,
+      totalSchedulers: 1,
+      db: prisma,
+      publish: pub.publish,
+    });
+
+    const published = await scheduler.tick(tick);
+    expect(published).toBe(1);
+    expect(pub.events[0]?.monitors[0]?.monitorId).toBe("mon_stuck");
+  });
+
+  it("skips pending monitors still within the 5-minute TTL", async () => {
+    const tick = new Date();
+    const past = new Date(tick.getTime() - 1000);
+    const twoMinAgo = new Date(tick.getTime() - 2 * MINUTE_MS);
+
+    const m = await seedMonitor(projectId, {
+      id: "mon_recent_pending",
+      schedulerBatchId: 8n,
+      nextRunAt: past,
+      lastPublishedRunAt: twoMinAgo,
+      lastCompletedRunAt: null,
+    });
+
+    const pub = fakePublisher();
+    const scheduler = new MonitorScheduler({
+      schedulerId: 0,
+      totalSchedulers: 1,
+      db: prisma,
+      publish: pub.publish,
+    });
+
+    const published = await scheduler.tick(tick);
+    expect(published).toBe(0);
+
+    const after = await prisma.monitor.findUniqueOrThrow({
+      where: { id: m.id },
+    });
+    expect(after.nextRunAt.getTime()).toBe(past.getTime() + MINUTE_MS);
+    expect(after.lastPublishedRunAt?.getTime()).toBe(twoMinAgo.getTime());
+  });
+
+  it("only claims monitors whose schedulerBatchId % totalSchedulers matches schedulerId", async () => {
+    const tick = new Date();
+    const past = new Date(tick.getTime() - 1000);
+
+    await seedMonitor(projectId, {
+      id: "mon_slot0_a",
+      schedulerBatchId: 0n,
+      nextRunAt: past,
+    });
+    await seedMonitor(projectId, {
+      id: "mon_slot0_b",
+      schedulerBatchId: 2n,
+      nextRunAt: past,
+    });
+    await seedMonitor(projectId, {
+      id: "mon_slot1",
+      schedulerBatchId: 1n,
+      nextRunAt: past,
+    });
+
+    const pub = fakePublisher();
+    const scheduler = new MonitorScheduler({
+      schedulerId: 0,
+      totalSchedulers: 2,
+      db: prisma,
+      publish: pub.publish,
+    });
+
+    const published = await scheduler.tick(tick);
+    expect(published).toBe(2);
+    const ids = pub.events.flatMap((e) => e.monitors.map((m) => m.monitorId));
+    expect(ids.sort()).toEqual(["mon_slot0_a", "mon_slot0_b"]);
+
+    const slot1 = await prisma.monitor.findUniqueOrThrow({
+      where: { id: "mon_slot1" },
+    });
+    expect(slot1.nextRunAt.getTime()).toBe(past.getTime()); // untouched
+  });
+
+  it("threads all required fields onto the MonitorQueueEvent payload", async () => {
+    const tick = new Date(Date.UTC(2026, 4, 18, 12, 0, 0));
+    const past = new Date(tick.getTime() - 1000);
+    const filters = [
+      { column: "level", operator: "=", value: "ERROR", type: "string" },
+    ];
+
+    await seedMonitor(projectId, {
+      id: "mon_threaded",
+      schedulerBatchId: 999n,
+      nextRunAt: past,
+      view: "SCORES_NUMERIC",
+      filters,
+      windowMs: BigInt(15 * MINUTE_MS),
+      metric: { measure: "value", aggregation: "p95" },
+    });
+
+    const pub = fakePublisher();
+    const scheduler = new MonitorScheduler({
+      schedulerId: 0,
+      totalSchedulers: 1,
+      db: prisma,
+      publish: pub.publish,
+    });
+
+    await scheduler.tick(tick);
+    expect(pub.events).toHaveLength(1);
+    const event = pub.events[0]!;
+    expect(event.projectId).toBe(projectId);
+    expect(event.schedulerBatchId).toBe(999n);
+    expect(event.scheduledAt.getTime()).toBe(past.getTime()); // echoes original next_run_at
+    expect(event.view).toBe("SCORES_NUMERIC");
+    expect(event.filters).toEqual(filters);
+    expect(event.window).toBe(BigInt(15 * MINUTE_MS));
+    expect(event.metrics).toEqual([{ measure: "value", aggregation: "p95" }]);
+    expect(event.monitors[0]?.metricName).toBe("p95_value");
+  });
+
+  it("publishes to the real MonitorQueue with a deterministic jobId so repeat ticks dedupe", async () => {
+    const tick = new Date();
+    const past = new Date(tick.getTime() - 1000);
+
+    await seedMonitor(projectId, {
+      id: "mon_dedupe",
+      schedulerBatchId: 42n,
+      nextRunAt: past,
+      lastPublishedRunAt: new Date(tick.getTime() - 6 * MINUTE_MS), // republishable
+      lastCompletedRunAt: null,
+    });
+
+    await withIsolatedMonitorQueue(async (queue) => {
+      const publish = async (events: MonitorQueueEvent[]) => {
+        await queue.addBulk(
+          events.map((event) => {
+            const jobId = `${event.schedulerBatchId}-${event.scheduledAt.getTime()}`;
+            // BullMQ JSON-encodes payloads; serialize bigints to strings on
+            // the wire (the schema's z.coerce.bigint() reparses them on read).
+            const wire: MonitorQueueEvent = {
+              ...event,
+              schedulerBatchId:
+                event.schedulerBatchId.toString() as unknown as bigint,
+              window: event.window.toString() as unknown as bigint,
+            };
+            return {
+              name: QueueJobs.MonitorJob,
+              data: {
+                timestamp: new Date(),
+                id: jobId,
+                payload: wire,
+                name: QueueJobs.MonitorJob,
+              },
+              opts: { jobId },
+            };
+          }),
+        );
+      };
+
+      const scheduler = new MonitorScheduler({
+        schedulerId: 0,
+        totalSchedulers: 1,
+        db: prisma,
+        publish,
+      });
+
+      // First tick — publishes 1 event
+      await scheduler.tick(tick);
+      // Reset monitor row so a second tick would publish the same scheduledAt again
+      await prisma.monitor.update({
+        where: { id: "mon_dedupe" },
+        data: {
+          nextRunAt: past,
+          lastPublishedRunAt: new Date(tick.getTime() - 6 * MINUTE_MS),
+          lastCompletedRunAt: null,
+        },
+      });
+      await scheduler.tick(tick);
+
+      const counts = await queue.getJobCounts(
+        "waiting",
+        "delayed",
+        "active",
+        "completed",
+        "failed",
+      );
+      const total =
+        counts.waiting +
+        counts.delayed +
+        counts.active +
+        counts.completed +
+        counts.failed;
+      expect(total).toBe(1); // dedupe via jobId
+    });
+  });
+});
+
+describe("MonitorSchedulerRunner", () => {
+  afterEach(async () => {
+    if (redis) {
+      const keys = await redis.keys(`${MONITOR_SCHEDULER_LOCK_PREFIX}:*`);
+      if (keys.length > 0) await redis.del(...keys);
+    }
+  });
+
+  it("two runners sharing a schedulerId — exactly one acquires the lock when contended", async () => {
+    if (!redis) throw new Error("Redis not initialized");
+
+    // Pre-acquire the lock to simulate another live runner holding the slot.
+    // Without this, both calls run in rapid succession (lock releases between
+    // ticks) and both appear to "win" — the lock guarantees mutual exclusion
+    // during a tick, not across release boundaries.
+    const lockKey = `${MONITOR_SCHEDULER_LOCK_PREFIX}:0`;
+    await redis.set(lockKey, "external-holder", "EX", 30, "NX");
+
+    const runner = new MonitorSchedulerRunner(0, 1);
+    const result = await runner.processBatch();
+    expect(result).toBeUndefined(); // lock denied → scheduler did not run
+
+    // Release the lock; a follow-up call now succeeds, returning the number of
+    // published events (0 because no monitors are seeded).
+    await redis.del(lockKey);
+    const second = await runner.processBatch();
+    expect(typeof second).toBe("number");
+  });
+});

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -92,6 +92,7 @@ import { BatchTraceDeletionCleaner } from "./features/batch-trace-deletion-clean
 import { BatchProjectMediaCleaner } from "./features/batch-project-media-cleaner";
 import { BatchProjectBlobCleaner } from "./features/batch-project-blob-cleaner";
 import { QueueMetricsRunner } from "./features/queue-metrics-runner";
+import { MonitorSchedulerRunner } from "./features/monitor-scheduler";
 
 const app = express();
 
@@ -693,6 +694,16 @@ export let queueMetricsRunner: QueueMetricsRunner | null = null;
 if (env.LANGFUSE_QUEUE_METRICS_ENABLED === "true") {
   queueMetricsRunner = new QueueMetricsRunner();
   queueMetricsRunner.start();
+}
+
+// Monitor schedulers: per-slot leader-elected runners that tick every second
+// and publish `MonitorQueueEvent`s to the sharded `MonitorQueue`.
+export const monitorSchedulers: MonitorSchedulerRunner[] = [];
+
+for (let i = 0; i < env.LANGFUSE_MONITOR_SCHEDULERS; i++) {
+  const runner = new MonitorSchedulerRunner(i, env.LANGFUSE_MONITOR_SCHEDULERS);
+  monitorSchedulers.push(runner);
+  runner.start();
 }
 
 process.on("SIGINT", () => onShutdown("SIGINT"));

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -459,6 +459,7 @@ const EnvSchema = z.object({
     .default(0.3), // Probability for recording sharded queue depth metrics
   LANGFUSE_QUEUE_METRICS_INTERVAL_MS: z.coerce.number().min(100).default(1000),
   LANGFUSE_QUEUE_METRICS_ENABLED: z.enum(["true", "false"]).default("true"),
+  LANGFUSE_MONITOR_SCHEDULERS: z.coerce.number().int().min(0).default(0),
 });
 
 export const env: z.infer<typeof EnvSchema> =

--- a/worker/src/features/monitor-scheduler/index.ts
+++ b/worker/src/features/monitor-scheduler/index.ts
@@ -1,0 +1,113 @@
+import {
+  MonitorQueue,
+  MonitorScheduler,
+  QueueJobs,
+  logger,
+} from "@langfuse/shared/src/server";
+import type { MonitorQueueEvent } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import { PeriodicExclusiveRunner } from "../../utils/PeriodicExclusiveRunner";
+
+export const MONITOR_SCHEDULER_LOCK_PREFIX = "langfuse:monitor-scheduler";
+
+const TICK_INTERVAL_MS = 1000;
+const LOCK_TTL_SECONDS = 30;
+
+/**
+ * MonitorSchedulerRunner ticks every second under a per-slot Redis lock,
+ * delegating the actual claim/advance/publish work to the shared
+ * `MonitorScheduler`. Multiple pods compete for the same lock key per slot;
+ * exactly one wins per tick. `LANGFUSE_MONITOR_SCHEDULERS` controls how many
+ * slots exist.
+ */
+export class MonitorSchedulerRunner extends PeriodicExclusiveRunner {
+  private readonly scheduler: MonitorScheduler;
+
+  protected get defaultIntervalMs(): number {
+    return TICK_INTERVAL_MS;
+  }
+
+  constructor(schedulerId: number, totalSchedulers: number) {
+    super({
+      name: `MonitorScheduler(${schedulerId}/${totalSchedulers})`,
+      lockKey: `${MONITOR_SCHEDULER_LOCK_PREFIX}:${schedulerId}`,
+      lockTtlSeconds: LOCK_TTL_SECONDS,
+      onUnavailable: "fail",
+    });
+
+    this.scheduler = new MonitorScheduler({
+      schedulerId,
+      totalSchedulers,
+      db: prisma,
+      publish: publishToMonitorQueue,
+    });
+  }
+
+  public override start(): void {
+    logger.info(`Starting ${this.instanceName}`);
+    super.start();
+  }
+
+  public override async processBatch(): Promise<number | void> {
+    const tickerTime = new Date(Math.floor(Date.now() / 1000) * 1000);
+    return this.withLock(() => this.scheduler.tick(tickerTime));
+  }
+
+  protected async execute(): Promise<void> {
+    // execute() drives the PeriodicRunner cadence — return void so the runner
+    // doesn't treat the published count as a next-delay override. The lock
+    // result is exposed via processBatch() for tests.
+    await this.processBatch();
+  }
+}
+
+/**
+ * Routes each event to the correct MonitorQueue shard via the
+ * `${projectId}-${schedulerBatchId}` sharding key so all jobs for a batch
+ * land on the same shard.
+ */
+async function publishToMonitorQueue(
+  events: MonitorQueueEvent[],
+): Promise<void> {
+  await Promise.all(
+    events.map(async (event) => {
+      const shardingKey = `${event.projectId}-${event.schedulerBatchId}`;
+      const queue = MonitorQueue.getInstance({ shardingKey });
+      if (!queue) {
+        logger.warn(
+          `MonitorQueue unavailable for shardingKey ${shardingKey}; dropping event`,
+        );
+        return;
+      }
+
+      // BullMQ custom job IDs cannot contain ":", so we use epoch ms.
+      // Dedupe semantics are unchanged: (schedulerBatchId, scheduledAt) is
+      // unique per tick.
+      const jobId = `${event.schedulerBatchId}-${event.scheduledAt.getTime()}`;
+      const wire = toWirePayload(event);
+      await queue.add(
+        QueueJobs.MonitorJob,
+        {
+          timestamp: new Date(),
+          id: jobId,
+          payload: wire,
+          name: QueueJobs.MonitorJob,
+        },
+        { jobId },
+      );
+    }),
+  );
+}
+
+/**
+ * BullMQ JSON-encodes the job data; bigints throw on serialization, so the
+ * wire form sends `schedulerBatchId` and `window` as strings. The schema
+ * already declares `z.coerce.bigint()` so consumers parse them back on read.
+ */
+function toWirePayload(event: MonitorQueueEvent): MonitorQueueEvent {
+  return {
+    ...event,
+    schedulerBatchId: event.schedulerBatchId.toString() as unknown as bigint,
+    window: event.window.toString() as unknown as bigint,
+  };
+}

--- a/worker/src/queues/shardedQueueRegistry.ts
+++ b/worker/src/queues/shardedQueueRegistry.ts
@@ -11,6 +11,7 @@ import {
   EvalExecutionQueue,
   SecondaryEvalExecutionQueue,
   LLMAsJudgeExecutionQueue,
+  MonitorQueue,
 } from "@langfuse/shared/src/server";
 
 export type ShardedQueueDef = {
@@ -66,6 +67,11 @@ export const SHARDED_QUEUES: ShardedQueueDef[] = [
     getInstance: (shard) =>
       LLMAsJudgeExecutionQueue.getInstance({ shardName: shard }),
   },
+  {
+    baseQueueName: QueueName.MonitorQueue,
+    getShardNames: () => MonitorQueue.getShardNames(),
+    getInstance: (shard) => MonitorQueue.getInstance({ shardName: shard }),
+  },
 ];
 
 export const SHARDED_QUEUE_BASE_NAMES = new Set<QueueName>(
@@ -95,6 +101,7 @@ export function resolveQueueInstance(queueName: string): Queue | null {
       | QueueName.TraceUpsert
       | QueueName.OtelIngestionQueue
       | QueueName.OtelIngestionSecondaryQueue
+      | QueueName.MonitorQueue
     >,
   );
 }


### PR DESCRIPTION
## Summary

Monitor evaluation needs a scheduler that ticks every second, claims due
monitor rows for its slot, and emits one `MonitorQueueEvent` per
`schedulerBatchId` group onto a sharded `MonitorQueue` for the downstream
processor.

To achieve this we:
- Added the sharded `MonitorQueue` Redis class + `QueueName.MonitorQueue` / `QueueJobs.MonitorJob` registration so the scheduler has a publish target (deferred from [LFE-9808](https://linear.app/langfuse/issue/LFE-9808/add-monitor-shared-zod-and-queue-schemas)).
- Added `MonitorScheduler` in `@langfuse/shared` with dependency-inverted Prisma + publish hooks; its `tick(scheduledAt)` runs a `SELECT FOR UPDATE SKIP LOCKED` claim, a single combined `UPDATE` that advances `next_run_at` for every claimed row and gate-publishes ACTIVE rows on first-run / prior-run-done / 5-minute-TTL, and a `GROUP BY scheduler_batch_id` final select.
- Added `MonitorSchedulerRunner` in `worker` that extends `PeriodicExclusiveRunner` for per-slot leader election (lock key `langfuse:monitor-scheduler:<slot>`, `onUnavailable: "fail"`), uses a 1s cadence, and routes each event to the correct `MonitorQueue` shard via `${projectId}-${schedulerBatchId}`.
- Wired `LANGFUSE_MONITOR_SCHEDULERS` (default `0` — opt-in) and instantiated one runner per slot in `worker/src/app.ts`.

**Note**: The RFC's three-stage CTE collapses into one combined `UPDATE` because Postgres forbids updating the same row twice in a single statement. Semantics are unchanged. The RFC's `jobId = "${schedulerBatchId}:${scheduledAt}"` becomes `${schedulerBatchId}-${scheduledAt.getTime()}` because BullMQ custom job IDs cannot contain `:`; dedupe semantics are identical.

**Note**: The downstream `MonitorQueueProcessor` (consumer side) is tracked separately.

Fixes [LFE-9812](https://linear.app/langfuse/issue/LFE-9812/add-monitorscheduler-with-slot-based-batching)
Related to [LFE-9808](https://linear.app/langfuse/issue/LFE-9808/add-monitor-shared-zod-and-queue-schemas)

## Verification

- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter @langfuse/shared run test` (101 tests pass)
- [x] `pnpm --filter worker run lint`
- [x] `pnpm --filter worker run test monitorScheduler.test` (8 tests pass)
- [x] `pnpm --filter web run lint`
- [x] `pnpm exec turbo run typecheck --filter=web --filter=worker --filter=@langfuse/shared --force`

## Test plan

- [ ] Set `LANGFUSE_MONITOR_SCHEDULERS=2` on a worker, seed a few monitor rows across slots, confirm both slots tick independently and publish jobs land on the expected shards
- [ ] Run two worker pods with the same `LANGFUSE_MONITOR_SCHEDULERS=1`, verify only one publishes per tick (other reports lock miss)
- [ ] Pause a monitor and confirm `next_run_at` still advances but `last_published_run_at` never moves
- [ ] Stall a monitor's `last_completed_run_at` for >5 min and confirm the scheduler re-publishes
