### PR TITLE
feat(models): add new Gemini models

### DIFF
--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -456,7 +456,9 @@ export const anthropicModels = [
 export const vertexAIModels = [
   "gemini-2.5-flash",
   "gemini-2.5-pro",
+  "gemini-3.5-flash",
   "gemini-3.1-pro-preview",
+  "gemini-3.1-flash-lite",
   "gemini-3.1-flash-lite-preview",
   "gemini-3-pro-preview",
   "gemini-3-flash-preview",
@@ -477,7 +479,9 @@ export const vertexAIModels = [
 export const googleAIStudioModels = [
   "gemini-2.5-flash",
   "gemini-2.5-pro",
+  "gemini-3.5-flash",
   "gemini-3.1-pro-preview",
+  "gemini-3.1-flash-lite",
   "gemini-3.1-flash-lite-preview",
   "gemini-3-pro-preview",
   "gemini-3-flash-preview",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -4005,6 +4005,39 @@
     ]
   },
   {
+    "id": "6ed696e7-5f3a-4113-a233-019155fb3ff0",
+    "modelName": "gemini-3.5-flash",
+    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.5-flash)$",
+    "createdAt": "2026-05-20T00:00:00.000Z",
+    "updatedAt": "2026-05-20T00:00:00.000Z",
+    "pricingTiers": [
+      {
+        "id": "6ed696e7-5f3a-4113-a233-019155fb3ff0_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 1.5e-6,
+          "input_modality_1": 1.5e-6,
+          "input_text": 1.5e-6,
+          "prompt_token_count": 1.5e-6,
+          "promptTokenCount": 1.5e-6,
+          "input_cached_tokens": 0.15e-6,
+          "cached_content_token_count": 0.15e-6,
+          "output": 9e-6,
+          "output_text": 9e-6,
+          "output_modality_1": 9e-6,
+          "candidates_token_count": 9e-6,
+          "candidatesTokenCount": 9e-6,
+          "thoughtsTokenCount": 9e-6,
+          "thoughts_token_count": 9e-6,
+          "output_reasoning": 9e-6
+        }
+      }
+    ]
+  },
+  {
     "id": "cmjfoeykl000004l8ffzra8c7",
     "modelName": "gemini-3-flash-preview",
     "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3-flash-preview)$",
@@ -4033,6 +4066,40 @@
           "thoughtsTokenCount": 3e-6,
           "thoughts_token_count": 3e-6,
           "output_reasoning": 3e-6
+        }
+      }
+    ]
+  },
+  {
+    "id": "79f4d62c-22fb-4ec3-82e1-6e56cdd5e23c",
+    "modelName": "gemini-3.1-flash-lite",
+    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-flash-lite)$",
+    "createdAt": "2026-05-20T00:00:00.000Z",
+    "updatedAt": "2026-05-20T00:00:00.000Z",
+    "pricingTiers": [
+      {
+        "id": "79f4d62c-22fb-4ec3-82e1-6e56cdd5e23c_tier_default",
+        "name": "Standard",
+        "isDefault": true,
+        "priority": 0,
+        "conditions": [],
+        "prices": {
+          "input": 0.25e-6,
+          "input_modality_1": 0.25e-6,
+          "input_text": 0.25e-6,
+          "prompt_token_count": 0.25e-6,
+          "promptTokenCount": 0.25e-6,
+          "input_cached_tokens": 0.025e-6,
+          "cached_content_token_count": 0.025e-6,
+          "output": 1.5e-6,
+          "output_text": 1.5e-6,
+          "output_modality_1": 1.5e-6,
+          "candidates_token_count": 1.5e-6,
+          "candidatesTokenCount": 1.5e-6,
+          "thoughtsTokenCount": 1.5e-6,
+          "thoughts_token_count": 1.5e-6,
+          "output_reasoning": 1.5e-6,
+          "input_audio_tokens": 0.5e-6
         }
       }
     ]


### PR DESCRIPTION
## What changed

- Added `gemini-3.5-flash` and stable `gemini-3.1-flash-lite` to the Vertex AI and Google AI Studio supported model lists.
- Added default pricing entries for both models with Google/Gemini usage-detail aliases and provider-prefixed match patterns.

## Why

Google added new Gemini models to the Gemini API / Vertex AI model lineup. Langfuse should recognize these model IDs for LLM API key model selection and automatic cost calculation.

## Validation

- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
- `node .agents/skills/add-model-price/scripts/test-match-pattern.mjs --model gemini-3.5-flash --accept gemini-3.5-flash google/gemini-3.5-flash googleai/gemini-3.5-flash --reject gemini-3-flash-preview gemini-3.5-flash-preview`
- `node .agents/skills/add-model-price/scripts/test-match-pattern.mjs --model gemini-3.1-flash-lite --accept gemini-3.1-flash-lite google/gemini-3.1-flash-lite googleai/gemini-3.1-flash-lite --reject gemini-3.1-flash-lite-preview gemini-2.5-flash-lite`
- `pnpm --filter worker test pricing-tier-matcher.test.ts`
- `pnpm --filter @langfuse/shared run lint`
- `pnpm --filter worker run lint`
- `pnpm --filter web run lint`
- pre-commit: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli` and `turbo run lint`
- post-rebase: `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`