### PR TITLE
fix(worker): truncate oversized GitHub dispatch payloads

### DIFF
--- a/worker/src/__tests__/webhooks.test.ts
+++ b/worker/src/__tests__/webhooks.test.ts
@@ -108,6 +108,9 @@ class WebhookTestServer {
 }
 
 const webhookServer = new WebhookTestServer();
+const GITHUB_REPOSITORY_DISPATCH_TRUNCATION_MARKER =
+  "[TRUNCATED: GitHub repository_dispatch payload exceeded size limit]";
+const GITHUB_REPOSITORY_DISPATCH_MAX_PAYLOAD_BYTES = 64 * 1024;
 
 describe("Webhook Integration Tests", () => {
   let projectId: string;
@@ -1490,6 +1493,109 @@ describe("Webhook Integration Tests", () => {
       });
       expect(payload.client_payload.user.id).toBeUndefined();
       // Verify prompt is still the last field in client_payload
+      const clientPayloadKeys = Object.keys(payload.client_payload);
+      expect(clientPayloadKeys[clientPayloadKeys.length - 1]).toBe("prompt");
+    });
+
+    it("should truncate oversized GitHub dispatch prompt fields", async () => {
+      const fullPrompt = await prisma.prompt.findUnique({
+        where: { id: promptId },
+      });
+      if (!fullPrompt) {
+        throw new Error("Prompt not found");
+      }
+
+      const testUser = {
+        id: "user-456",
+        name: "GitHub User",
+        email: "github@example.com",
+      };
+
+      const ghActionId = v4();
+      await prisma.action.create({
+        data: {
+          id: ghActionId,
+          projectId,
+          type: "GITHUB_DISPATCH",
+          config: {
+            type: "GITHUB_DISPATCH",
+            url: "https://webhook.example.com/dispatches",
+            eventType: "prompt-update",
+            githubToken: encrypt("ghp_test_token"),
+            displayGitHubToken: "ghp_...n",
+          },
+        },
+      });
+
+      const ghAutomationId = v4();
+      await prisma.automation.create({
+        data: {
+          id: ghAutomationId,
+          projectId,
+          triggerId,
+          actionId: ghActionId,
+          name: "GitHub Dispatch Automation",
+        },
+      });
+
+      const ghExecutionId = v4();
+      await prisma.automationExecution.create({
+        data: {
+          id: ghExecutionId,
+          projectId,
+          triggerId,
+          automationId: ghAutomationId,
+          actionId: ghActionId,
+          status: ActionExecutionStatus.PENDING,
+          sourceId: promptId,
+          input: {},
+        },
+      });
+
+      const webhookInput: WebhookInput = {
+        projectId,
+        automationId: ghAutomationId,
+        executionId: ghExecutionId,
+        payload: {
+          prompt: PromptDomainSchema.parse({
+            ...fullPrompt,
+            prompt: {
+              content: "a".repeat(GITHUB_REPOSITORY_DISPATCH_MAX_PAYLOAD_BYTES),
+            },
+            config: {
+              schema: {
+                content: "b".repeat(
+                  GITHUB_REPOSITORY_DISPATCH_MAX_PAYLOAD_BYTES,
+                ),
+              },
+            },
+          }),
+          action: "created",
+          type: "prompt-version",
+          user: testUser,
+        },
+      };
+
+      await executeWebhook(webhookInput, { skipValidation: true });
+
+      const requests = webhookServer.getReceivedRequests();
+      expect(requests).toHaveLength(1);
+      expect(Buffer.byteLength(requests[0].body, "utf8")).toBeLessThan(
+        GITHUB_REPOSITORY_DISPATCH_MAX_PAYLOAD_BYTES,
+      );
+
+      const payload = JSON.parse(requests[0].body);
+      expect(payload.event_type).toBe("prompt-update");
+      expect(Object.keys(payload.client_payload)).toHaveLength(8);
+      expect(payload.client_payload.truncation).toEqual({
+        payloadTruncated: true,
+        truncatedFields: ["prompt.prompt", "prompt.config"],
+      });
+      expect(payload.client_payload.prompt.prompt).toBe(
+        GITHUB_REPOSITORY_DISPATCH_TRUNCATION_MARKER,
+      );
+      expect(payload.client_payload.prompt.config).toEqual({});
+
       const clientPayloadKeys = Object.keys(payload.client_payload);
       expect(clientPayloadKeys[clientPayloadKeys.length - 1]).toBe("prompt");
     });

--- a/worker/src/queues/webhooks.ts
+++ b/worker/src/queues/webhooks.ts
@@ -35,6 +35,16 @@ import { backOff } from "exponential-backoff";
 import { env } from "../env";
 import { SlackMessageBuilder } from "../features/slack/slackMessageBuilder";
 
+// GitHub repository_dispatch client_payload: max 10 top-level properties and <64KB.
+// https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event
+const GITHUB_REPOSITORY_DISPATCH_MAX_PAYLOAD_BYTES = 64 * 1024;
+const GITHUB_REPOSITORY_DISPATCH_TRUNCATION_MARKER =
+  "[TRUNCATED: GitHub repository_dispatch payload exceeded size limit]";
+const GITHUB_REPOSITORY_DISPATCH_TRUNCATED_FIELDS = [
+  "prompt.prompt",
+  "prompt.config",
+];
+
 // Handles both webhook and slack actions
 export const webhookProcessor: Processor = async (
   job: Job<TQueueJobTypes[QueueName.WebhookQueue]>,
@@ -503,7 +513,7 @@ async function executeGitHubDispatchAction({
 
   // Transform to GitHub dispatch format
   const { prompt, user, ...otherFields } = validatedPayload.data;
-  const githubPayload = JSON.stringify({
+  const fullGithubPayload = JSON.stringify({
     event_type: eventType,
     client_payload: {
       ...otherFields,
@@ -511,6 +521,26 @@ async function executeGitHubDispatchAction({
       prompt,
     },
   });
+  const githubPayload =
+    Buffer.byteLength(fullGithubPayload, "utf8") <
+    GITHUB_REPOSITORY_DISPATCH_MAX_PAYLOAD_BYTES
+      ? fullGithubPayload
+      : JSON.stringify({
+          event_type: eventType,
+          client_payload: {
+            ...otherFields,
+            ...(user ? { user } : {}),
+            truncation: {
+              payloadTruncated: true,
+              truncatedFields: GITHUB_REPOSITORY_DISPATCH_TRUNCATED_FIELDS,
+            },
+            prompt: {
+              ...prompt,
+              prompt: GITHUB_REPOSITORY_DISPATCH_TRUNCATION_MARKER,
+              config: {},
+            },
+          },
+        });
 
   // Prepare headers with GitHub token
   const requestHeaders: Record<string, string> = {};


### PR DESCRIPTION
## Summary

- Fixes GitHub repository dispatch automations failing for large prompts by falling back to a compact payload only when the full request would exceed GitHub's documented payload limit.
- The fallback keeps the existing envelope and prompt metadata, replaces `prompt.prompt` with a truncation marker, clears `prompt.config`, and exposes the omitted fields under one `truncation` key to stay below GitHub's 10 top-level `client_payload` property limit.

## Linear

- [LFE-9891](https://linear.app/langfuse/issue/LFE-9891/github-actions-automation-trigger-fails-for-large-prompts)

## Review Focus

- Please check the fallback payload shape for GitHub Actions consumers and the regression test that asserts the serialized payload stays under the limit.