### PR TITLE
test(web): scope projects api cleanup to seed org

### DIFF
--- a/web/src/__tests__/server/projects-api.servertest.ts
+++ b/web/src/__tests__/server/projects-api.servertest.ts
@@ -175,6 +175,7 @@ describe("Projects API", () => {
       // Delete any test projects created during tests
       await prisma.project.deleteMany({
         where: {
+          orgId: "seed-org-id",
           name: {
             startsWith: "Test Project",
           },


### PR DESCRIPTION
## What
- Scope the Projects API test cleanup to `seed-org-id` so it only deletes projects owned by that test fixture.

## Why
- The failed CI job on PR #13685 showed `organizations-api.servertest.ts` sometimes returning no organization projects, followed by a project API key FK failure.
- Root cause: `projects-api.servertest.ts` deleted every project whose name starts with `Test Project`, which could remove projects created by the organizations API tests while leaving related org/API-key state behind.
- This keeps the existing cleanup intent while avoiding cross-test data deletion.

## Verification
- `npx prettier --check src/__tests__/server/organizations-api.servertest.ts src/__tests__/server/projects-api.servertest.ts`
- `npx dotenv -e ../.env -- eslint src/__tests__/server/organizations-api.servertest.ts src/__tests__/server/projects-api.servertest.ts --max-warnings 0`
- Commit hook: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli`
- Commit hook: `turbo run lint`

Note: I did not rerun the affected server tests locally because the direct run requires the web app to be serving on localhost:3000; the earlier direct attempt failed with ECONNREFUSED.