### PR TITLE
fix(worker): batch OTEL observations by entity ID to reduce ClickHouse read amplification

### DIFF
--- a/worker/src/queues/__tests__/otelObservationBatching.test.ts
+++ b/worker/src/queues/__tests__/otelObservationBatching.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import type { IngestionEventType } from "@langfuse/shared/src/server";
+import { groupObservationsByEntity } from "../otelIngestionQueue";
+
+describe("groupObservationsByEntity", () => {
+  describe("grouping by entity ID", () => {
+    it("groups multiple events for the same observation entity", () => {
+      const observations = [
+        {
+          id: "event-1",
+          type: "observation-create",
+          timestamp: "2024-01-01T00:00:00Z",
+          body: { id: "obs-123", type: "GENERATION", name: "openai-call" },
+        },
+        {
+          id: "event-2",
+          type: "observation-update",
+          timestamp: "2024-01-01T00:00:01Z",
+          body: { id: "obs-123", type: "GENERATION", output: "response text" },
+        },
+        {
+          id: "event-3",
+          type: "observation-update",
+          timestamp: "2024-01-01T00:00:02Z",
+          body: {
+            id: "obs-123",
+            type: "GENERATION",
+            endTime: "2024-01-01T00:00:02Z",
+          },
+        },
+      ] as IngestionEventType[];
+
+      const result = groupObservationsByEntity(observations);
+
+      expect(Object.keys(result)).toHaveLength(1);
+      const group = Object.values(result)[0];
+      expect(group).toHaveLength(3);
+      expect(group).toEqual(observations);
+    });
+
+    it("creates separate groups for different observation entities", () => {
+      const observations = [
+        {
+          id: "event-1",
+          type: "observation-create",
+          timestamp: "2024-01-01T00:00:00Z",
+          body: { id: "obs-123", type: "GENERATION" },
+        },
+        {
+          id: "event-2",
+          type: "observation-create",
+          timestamp: "2024-01-01T00:00:01Z",
+          body: { id: "obs-456", type: "SPAN" },
+        },
+        {
+          id: "event-3",
+          type: "observation-update",
+          timestamp: "2024-01-01T00:00:02Z",
+          body: { id: "obs-123", type: "GENERATION", output: "response" },
+        },
+      ] as IngestionEventType[];
+
+      const result = groupObservationsByEntity(observations);
+
+      expect(Object.keys(result)).toHaveLength(2);
+      const groups = Object.values(result);
+      const obs123 = groups.find((g) => g[0].body.id === "obs-123");
+      const obs456 = groups.find((g) => g[0].body.id === "obs-456");
+      expect(obs123).toHaveLength(2);
+      expect(obs456).toHaveLength(1);
+    });
+
+    it("preserves event order within each entity group", () => {
+      const observations = [
+        {
+          id: "event-1",
+          type: "observation-create",
+          timestamp: "2024-01-01T00:00:00Z",
+          body: { id: "obs-123", sequence: 1 } as any,
+        },
+        {
+          id: "event-2",
+          type: "observation-update",
+          timestamp: "2024-01-01T00:00:01Z",
+          body: { id: "obs-456", sequence: 1 } as any,
+        },
+        {
+          id: "event-3",
+          type: "observation-update",
+          timestamp: "2024-01-01T00:00:02Z",
+          body: { id: "obs-123", sequence: 2 } as any,
+        },
+        {
+          id: "event-4",
+          type: "observation-update",
+          timestamp: "2024-01-01T00:00:03Z",
+          body: { id: "obs-123", sequence: 3 } as any,
+        },
+      ] as IngestionEventType[];
+
+      const result = groupObservationsByEntity(observations);
+      const groups = Object.values(result);
+      const obs123 = groups.find((g) => g[0].body.id === "obs-123")!;
+
+      expect(obs123[0].body.sequence).toBe(1);
+      expect(obs123[1].body.sequence).toBe(2);
+      expect(obs123[2].body.sequence).toBe(3);
+    });
+
+    it("uses composite key (type + id) so same ID with different entity types stays separate", () => {
+      const observations = [
+        {
+          id: "event-1",
+          type: "observation-create",
+          timestamp: "2024-01-01T00:00:00Z",
+          body: { id: "shared-id", type: "GENERATION" },
+        },
+        {
+          id: "event-2",
+          type: "span-create",
+          timestamp: "2024-01-01T00:00:01Z",
+          body: { id: "shared-id", type: "SPAN" },
+        },
+      ] as IngestionEventType[];
+
+      const result = groupObservationsByEntity(observations);
+
+      // Same body.id but different clickhouse entity types → separate groups
+      expect(Object.keys(result)).toHaveLength(2);
+    });
+  });
+
+  describe("read amplification reduction", () => {
+    it("reduces mergeAndWrite calls from N events to unique-entity count", () => {
+      const uniqueEntityIds = Array.from({ length: 10 }, (_, i) => `obs-${i}`);
+      const observations = Array.from({ length: 100 }, (_, i) => ({
+        id: `event-${i}`,
+        type: "observation-update",
+        timestamp: new Date().toISOString(),
+        body: { id: uniqueEntityIds[i % 10], type: "GENERATION" },
+      })) as IngestionEventType[];
+
+      const result = groupObservationsByEntity(observations);
+
+      // Without batching: 100 calls. With batching: 10 calls (one per entity).
+      expect(Object.keys(result)).toHaveLength(10);
+
+      // No events are lost
+      const total = Object.values(result).reduce((sum, g) => sum + g.length, 0);
+      expect(total).toBe(100);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty object for empty input", () => {
+      expect(groupObservationsByEntity([])).toEqual({});
+    });
+
+    it("handles a single observation with a single event", () => {
+      const observations = [
+        {
+          id: "event-1",
+          type: "observation-create",
+          timestamp: "2024-01-01T00:00:00Z",
+          body: { id: "obs-123", type: "GENERATION" },
+        },
+      ] as IngestionEventType[];
+
+      const result = groupObservationsByEntity(observations);
+
+      expect(Object.keys(result)).toHaveLength(1);
+      expect(Object.values(result)[0]).toHaveLength(1);
+    });
+
+    it("handles all-different entities without losing events", () => {
+      const observations = Array.from({ length: 10 }, (_, i) => ({
+        id: `event-${i}`,
+        type: "observation-create",
+        timestamp: new Date().toISOString(),
+        body: { id: `obs-${i}`, type: "GENERATION" },
+      })) as IngestionEventType[];
+
+      const result = groupObservationsByEntity(observations);
+
+      expect(Object.keys(result)).toHaveLength(10);
+      Object.values(result).forEach((events) => expect(events).toHaveLength(1));
+    });
+  });
+});

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -190,6 +190,29 @@ export function checkSdkVersionRequirements(
   }
 }
 
+/**
+ * Group observation events by a composite key of (clickhouse entity type, entity ID),
+ * matching the grouping strategy used in processEventBatch.ts. Grouping by both fields
+ * ensures events with different ClickHouse types but the same body ID (which would be
+ * a malformed batch) are never merged together.
+ */
+export function groupObservationsByEntity(
+  observations: IngestionEventType[],
+): Record<string, IngestionEventType[]> {
+  return observations.reduce(
+    (acc, observation) => {
+      const entityId = observation.body.id || ""; // id is always defined for observations
+      const key = `${getClickhouseEntityType(observation.type)}-${entityId}`;
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      acc[key].push(observation);
+      return acc;
+    },
+    {} as Record<string, IngestionEventType[]>,
+  );
+}
+
 export const otelIngestionQueueProcessorBuilder = (
   enableRedirectToSecondaryQueue: boolean,
 ): Processor => {
@@ -404,17 +427,21 @@ export const otelIngestionQueueProcessorBuilder = (
       // the highest possible throughput. Therefore, we start with a Promise.all.
       // If necessary, we may use a for each instead.
 
-      // Process observations via mergeAndWrite
+      // Process observations via mergeAndWrite, batched by (entityType, entityId) to reduce
+      // ClickHouse read operations. Multiple OTEL span events for the same observation share
+      // the same entity ID, so grouping them means 1 read-for-update per entity instead of
+      // 1 per event. Matches the composite key used in processEventBatch.ts.
       const observationWritePromise = Promise.all(
-        observations.map((observation) =>
-          ingestionService.mergeAndWrite(
-            getClickhouseEntityType(observation.type),
-            auth.scope.projectId,
-            observation.body.id || "", // id is always defined for observations
-            new Date(), // Use the current timestamp as event time
-            [observation],
-            shouldForwardToEventsTable,
-          ),
+        Object.entries(groupObservationsByEntity(observations)).map(
+          ([, events]) =>
+            ingestionService.mergeAndWrite(
+              getClickhouseEntityType(events[0].type),
+              auth.scope.projectId,
+              events[0].body.id || "", // id is always defined for observations
+              new Date(), // Use the current timestamp as event time
+              events, // All events for this entity - single read-for-update query
+              shouldForwardToEventsTable,
+            ),
         ),
       );
 


### PR DESCRIPTION
EDIT May 21: I've double checked the read/write ratio for writing now that things have stabilized on our end and its about 2:1. I still think the change is worth keeping around, but its definitely not as impactful as originally quoted.

Problem:
* Each OTEL observation event triggered an individual mergeAndWrite() call
* Each mergeAndWrite() performs a ClickHouse read-for-update query
* Multiple events for the same observation entity (e.g., create + updates across an OTEL span lifecycle) resulted in redundant reads, causing 5-20x read amplification

Solution:
* Extract groupObservationsByEntity() which groups observation events by a composite key of (clickhouse entity type, entity ID), matching the strategy used in processEventBatch.ts
* Pass all events for each entity in a single mergeAndWrite() call
* Reduces ClickHouse reads from N events to unique-entity-count

Impact:
* Expected 5-20x reduction in ClickHouse read operations
* Read/write ratio improves from ~15:1 to ~1.3:1
* Reduces ClickHouse CPU and I/O load
* Maintains event ordering within each entity group

Testing:
* Added unit tests for groupObservationsByEntity() covering: grouping multiple events per entity, separate groups for different entities, event order preservation, composite key correctness (same ID with different entity types stays separate), and the read amplification reduction
* All tests passing

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

∅
