### PR TITLE
ci: adjust zizmor advanced security handling

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,18 +26,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run zizmor (fork PR - fail on findings)
-        # Fork PRs don't get security-events: write on GITHUB_TOKEN, so SARIF
-        # upload isn't possible. Fail the job on findings instead so contributors
-        # see the error directly in the PR check.
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
-
-      - name: Run zizmor (trusted - upload SARIF)
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
-          # Means that the action will only report issues, but not fail the workflow.
-          # Blocking merges are handled by rulesets:
-          # https://docs.github.com/en/code-security/concepts/code-scanning/about-code-scanning-alerts#pull-request-check-failures-for-code-scanning-alerts
-          advanced-security: true
+          advanced-security: ${{ github.event_name == 'push' && 'true' || 'false' }}
+          min-severity: low


### PR DESCRIPTION
## What changed

- Run `zizmor-action` with `advanced-security: false` for non-`push` events, including pull requests and merge queue runs.
- Keep Advanced Security/SARIF uploads enabled on `push` events.
- Set `min-severity: low` for the zizmor scan.

## Why

Fork pull requests cannot upload code scanning results to GitHub Advanced Security, so requiring zizmor code scanning results blocks community PRs. This keeps the check usable for fork PRs while preserving SARIF upload on trusted pushes.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/zizmor.yml"); puts "yaml ok"'`
- `git diff --check -- .github/workflows/zizmor.yml`
- pre-commit: Prettier check
- pre-commit: `turbo run lint`