### PR TITLE
fix(evals): stabilize eval score ids

### DIFF
--- a/packages/shared/src/server/evals/evalScoreIds.ts
+++ b/packages/shared/src/server/evals/evalScoreIds.ts
@@ -1,0 +1,38 @@
+import { v5 } from "uuid";
+import type { CodeEvalScoreWithName } from "./codeEvalDispatcherTypes";
+
+const EVAL_SCORE_ID_NAMESPACE = "52b93de0-1d6c-4fb3-9f65-e5173184b1cb";
+
+export function createDeterministicEvalScoreId(params: {
+  jobExecutionId: string;
+  scoreName: string;
+  occurrenceIndex: number;
+}): string {
+  return v5(
+    JSON.stringify([
+      "eval-score",
+      params.jobExecutionId,
+      params.scoreName,
+      params.occurrenceIndex,
+    ]),
+    EVAL_SCORE_ID_NAMESPACE,
+  );
+}
+
+export function buildDeterministicEvalScoreIds(params: {
+  scores: CodeEvalScoreWithName[];
+  jobExecutionId: string;
+}): string[] {
+  const occurrenceByScoreName = new Map<string, number>();
+
+  return params.scores.map((score) => {
+    const occurrenceIndex = occurrenceByScoreName.get(score.name) ?? 0;
+    occurrenceByScoreName.set(score.name, occurrenceIndex + 1);
+
+    return createDeterministicEvalScoreId({
+      jobExecutionId: params.jobExecutionId,
+      scoreName: score.name,
+      occurrenceIndex,
+    });
+  });
+}

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -21,6 +21,7 @@ export * from "./datasets/schemaTypes";
 export * from "./evalJobConfigCache";
 export * from "./evals/codeEvalDispatchers";
 export * from "./evals/codeEvalExecution";
+export * from "./evals/evalScoreIds";
 export * from "./evals/extractObservationVariables";
 export * from "./utils/traceId";
 export * from "./auth/apiKeys";

--- a/web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts
+++ b/web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts
@@ -233,10 +233,26 @@ maybe("evals.testRunCodeEval", () => {
     });
   });
 
-  it("persists an internal trace for the test run", async () => {
+  it("passes experiment context to test runs", async () => {
     const { project, caller } = await prepare();
     const observationId = randomUUID();
-    const template = await createCodeTemplate(project.id);
+    const expectedOutput = "expected answer";
+    const template = await createCodeTemplate(
+      project.id,
+      `
+        export function evaluate(ctx) {
+          if (!ctx.experiment) {
+            throw new Error("missing experiment context");
+          }
+
+          const matched =
+            ctx.observation.output === ctx.experiment.expectedOutput &&
+            ctx.experiment.itemMetadata.difficulty === "easy";
+
+          return { scores: [{ value: matched ? 1 : 0, dataType: "BOOLEAN" }] };
+        }
+      `,
+    );
 
     await createEventsCh([
       createEvent({
@@ -244,23 +260,55 @@ maybe("evals.testRunCodeEval", () => {
         trace_id: randomUUID(),
         span_id: observationId,
         id: observationId,
+        output: expectedOutput,
+        experiment_id: randomUUID(),
+        experiment_item_expected_output: expectedOutput,
+        experiment_item_metadata_names: ["difficulty"],
+        experiment_item_metadata_values: ["easy"],
       }),
     ]);
 
     const response = await caller.evals.testRunCodeEval({
       projectId: project.id,
       evalTemplateId: template.id,
-      target: EvalTargetObject.EVENT,
-      scoreName: "unsaved-score",
+      target: EvalTargetObject.EXPERIMENT,
+      scoreName: "experiment-score",
       observationId,
-      mapping: [],
+      mapping: [
+        {
+          templateVariable: "output",
+          selectedColumnId: "output",
+          jsonSelector: null,
+        },
+        {
+          templateVariable: "experimentExpectedOutput",
+          selectedColumnId: "experimentItemExpectedOutput",
+          jsonSelector: null,
+        },
+        {
+          templateVariable: "experimentItemMetadata",
+          selectedColumnId: "experimentItemMetadata",
+          jsonSelector: null,
+        },
+      ],
+    });
+
+    expect(response).toEqual({
+      success: true,
+      result: {
+        scores: [
+          {
+            value: 1,
+            dataType: "BOOLEAN",
+          },
+        ],
+      },
+      executionTraceId: expect.stringMatching(/^[0-9a-f]{32}$/),
     });
 
     if (!response.success) {
       throw new Error("Expected successful test run");
     }
-
-    const executionTraceId = response.executionTraceId;
 
     const findTrace = async () => {
       const rows = await queryClickhouse<{
@@ -268,7 +316,7 @@ maybe("evals.testRunCodeEval", () => {
         sourceCode: string;
       }>({
         query: `SELECT environment, metadata['code_eval_source_code'] as sourceCode FROM traces WHERE project_id = {projectId: String} AND id = {traceId: String} LIMIT 1`,
-        params: { projectId: project.id, traceId: executionTraceId },
+        params: { projectId: project.id, traceId: response.executionTraceId },
         tags: {
           feature: "evals",
           type: "traces",

--- a/web/src/features/evals/server/codeEvalTestRun.ts
+++ b/web/src/features/evals/server/codeEvalTestRun.ts
@@ -126,6 +126,7 @@ export async function runCodeEvalTest(params: {
     template: codeTemplate,
     scoreName: params.scoreName,
     extractedVariables,
+    hasExperimentContext: Boolean(observation.experiment_id),
     traceName,
     metadata: executionMetadata,
     maskErrorsInTrace: true,

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -3181,9 +3181,7 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
         job_execution_id: jobExecutionId,
         job_configuration_id: configId,
         target_trace_id: traceId,
-        score_id: capturedTraceSinkParams.metadata.score_id,
       });
-      expect(capturedTraceSinkParams.metadata.score_id).toBeDefined();
     }, 15_000);
   });
 

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "crypto";
 import { type JobConfiguration, type JobExecution } from "@prisma/client";
 import { type EvalTemplateCodeBased } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
@@ -49,13 +48,11 @@ export async function executeCodeBasedEvaluation(params: {
       }
 
       const executionTraceId = createW3CTraceId(params.jobExecutionId);
-      const primaryScoreId = randomUUID();
       const executionMetadata = {
         ...params.metadata,
         dispatcher_name: dispatcher.name,
         code_eval_runtime: params.template.sourceCodeLanguage,
       };
-
       span.setAttribute("langfuse.project.id", params.projectId);
       span.setAttribute("eval.job_execution.id", params.jobExecutionId);
       span.setAttribute("eval.job_configuration.id", params.config.id);
@@ -82,10 +79,7 @@ export async function executeCodeBasedEvaluation(params: {
         extractedVariables: params.extractedVariables,
         hasExperimentContext: params.hasExperimentContext ?? false,
         traceName: `Execute evaluator: ${params.template.name}`,
-        metadata: {
-          ...executionMetadata,
-          score_id: primaryScoreId,
-        },
+        metadata: executionMetadata,
         maskErrorsInTrace: true,
         writeTrace: (trace) => createInternalEventsWriter().write(trace),
       });
@@ -96,11 +90,9 @@ export async function executeCodeBasedEvaluation(params: {
 
       span.setAttribute("eval.result.count", dispatchOutcome.scores.length);
       span.setAttribute("eval.score.count", dispatchOutcome.scores.length);
-      span.setAttribute("eval.score.id", primaryScoreId);
 
       return {
         scores: dispatchOutcome.scores,
-        primaryScoreId,
         executionTraceId,
         metadata: executionMetadata,
       };

--- a/worker/src/features/evaluation/evalCompletion.ts
+++ b/worker/src/features/evaluation/evalCompletion.ts
@@ -9,12 +9,11 @@ import { type EvalExecutionDeps } from "./evalExecutionDeps";
 
 /**
  * Common result returned by every evaluator executor (LLM-as-judge,
- * code-based, future executors). The first entry of `scores` is the primary
- * score and is persisted on `JobExecution.jobOutputScoreId`.
+ * code-based, future executors). The first persisted score payload is treated
+ * as primary and is persisted on `JobExecution.jobOutputScoreId`.
  */
 export type EvalExecutionResult = {
   scores: CodeEvalScoreWithName[];
-  primaryScoreId: string;
   executionTraceId: string;
   metadata: Record<string, string>;
 };
@@ -38,13 +37,19 @@ export async function completeEvalExecution({
 }): Promise<{ scoreCount: number }> {
   const scoreWritePayloads = buildEvalScoreWritePayloads({
     scores: result.scores,
-    primaryScoreId: result.primaryScoreId,
+    jobExecutionId,
     traceId,
     observationId,
     environment,
     executionTraceId: result.executionTraceId,
     executionMetadata: result.metadata,
   });
+  const [firstScorePayload] = scoreWritePayloads;
+
+  if (!firstScorePayload) {
+    throw new Error(`Evaluation job ${jobExecutionId} returned no scores`);
+  }
+  const jobOutputScoreId = firstScorePayload.scoreId;
 
   try {
     await Promise.all(
@@ -67,7 +72,7 @@ export async function completeEvalExecution({
     logger.error(`Failed to persist score: ${e}`, e);
     traceException(e);
     throw new Error(
-      `Failed to write score ${result.primaryScoreId} into IngestionQueue`,
+      `Failed to write score ${jobOutputScoreId} into IngestionQueue`,
     );
   }
 
@@ -81,7 +86,7 @@ export async function completeEvalExecution({
     data: {
       status: JobExecutionStatus.COMPLETED,
       endTime: new Date(),
-      jobOutputScoreId: result.primaryScoreId,
+      jobOutputScoreId,
       executionTraceId: result.executionTraceId,
     },
   });

--- a/worker/src/features/evaluation/evalScoreEvent.ts
+++ b/worker/src/features/evaluation/evalScoreEvent.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { ScoreSourceEnum } from "@langfuse/shared";
 import {
+  buildDeterministicEvalScoreIds,
   eventTypes,
   ScoreEventType,
   type CodeEvalScoreWithName,
@@ -14,16 +15,21 @@ export type EvalScoreWritePayload = {
 
 export function buildEvalScoreWritePayloads(params: {
   scores: CodeEvalScoreWithName[];
-  primaryScoreId: string;
+  jobExecutionId: string;
   traceId: string | null;
   observationId: string | null;
   environment: string;
   executionTraceId: string;
   executionMetadata: Record<string, string>;
 }): EvalScoreWritePayload[] {
+  const scoreIds = buildDeterministicEvalScoreIds({
+    scores: params.scores,
+    jobExecutionId: params.jobExecutionId,
+  });
+
   return params.scores.map((score, index) => {
     const eventId = randomUUID();
-    const scoreId = index === 0 ? params.primaryScoreId : randomUUID();
+    const scoreId = scoreIds[index]!;
 
     return {
       eventId,

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -855,8 +855,6 @@ export async function runLLMAsJudgeEvaluation({
       // Prepare LLM call
       const messages = buildEvalMessages(prompt);
 
-      const primaryScoreId = randomUUID();
-      span.setAttribute("eval.score.id", primaryScoreId);
       const executionTraceId = createW3CTraceId(jobExecutionId);
 
       // Call LLM
@@ -894,7 +892,6 @@ export async function runLLMAsJudgeEvaluation({
                 environment: LangfuseInternalTraceEnvironment.LLMJudge,
                 metadata: {
                   ...metadata,
-                  score_id: primaryScoreId,
                 },
               },
             });
@@ -964,7 +961,6 @@ export async function runLLMAsJudgeEvaluation({
 
       return {
         scores,
-        primaryScoreId,
         executionTraceId,
         metadata,
       };

--- a/worker/src/features/evaluation/evaluationHelpers.test.ts
+++ b/worker/src/features/evaluation/evaluationHelpers.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@langfuse/shared";
 import { type ExtractedVariable } from "@langfuse/shared/src/server";
 import { parseDispatchResult } from "../../../../packages/shared/src/server/evals/codeEvalDispatcherTypes";
+import { createDeterministicEvalScoreId } from "../../../../packages/shared/src/server/evals/evalScoreIds";
 import {
   buildEvalExecutionMetadata,
   buildEvalMessages,
@@ -416,7 +417,148 @@ describe("evaluation helpers", () => {
   });
 
   describe("buildEvalScoreWritePayloads", () => {
+    it("should build stable code eval score IDs when different score names reorder", () => {
+      const originalPayloads = buildEvalScoreWritePayloads({
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.NUMERIC,
+            value: 0.9,
+            name: "accuracy",
+          },
+          {
+            dataType: ScoreDataTypeEnum.NUMERIC,
+            value: 0.7,
+            name: "fluency",
+          },
+        ],
+        jobExecutionId: "job-1",
+        traceId: "trace-456",
+        observationId: "obs-789",
+        environment: "production",
+        executionTraceId: "exec-trace-789",
+        executionMetadata: { job_execution_id: "job-1" },
+      });
+      const reorderedPayloads = buildEvalScoreWritePayloads({
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.NUMERIC,
+            value: 0.7,
+            name: "fluency",
+          },
+          {
+            dataType: ScoreDataTypeEnum.NUMERIC,
+            value: 0.9,
+            name: "accuracy",
+          },
+        ],
+        jobExecutionId: "job-1",
+        traceId: "trace-456",
+        observationId: "obs-789",
+        environment: "production",
+        executionTraceId: "exec-trace-789",
+        executionMetadata: { job_execution_id: "job-1" },
+      });
+
+      expect(originalPayloads[0].scoreId).toBe(reorderedPayloads[1].scoreId);
+      expect(originalPayloads[1].scoreId).toBe(reorderedPayloads[0].scoreId);
+    });
+
+    it("should build distinct deterministic code eval score IDs for duplicate score names", () => {
+      const result = buildEvalScoreWritePayloads({
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "correct",
+            name: "accuracy",
+          },
+          {
+            dataType: ScoreDataTypeEnum.NUMERIC,
+            value: 0.7,
+            name: "fluency",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "partial",
+            name: "accuracy",
+          },
+        ],
+        jobExecutionId: "job-1",
+        traceId: "trace-456",
+        observationId: "obs-789",
+        environment: "production",
+        executionTraceId: "exec-trace-789",
+        executionMetadata: { job_execution_id: "job-1" },
+      });
+      const scoreIds = result.map((payload) => payload.scoreId);
+
+      expect(new Set(scoreIds).size).toBe(3);
+      expect(scoreIds).toEqual([
+        createDeterministicEvalScoreId({
+          jobExecutionId: "job-1",
+          scoreName: "accuracy",
+          occurrenceIndex: 0,
+        }),
+        createDeterministicEvalScoreId({
+          jobExecutionId: "job-1",
+          scoreName: "fluency",
+          occurrenceIndex: 0,
+        }),
+        createDeterministicEvalScoreId({
+          jobExecutionId: "job-1",
+          scoreName: "accuracy",
+          occurrenceIndex: 1,
+        }),
+      ]);
+    });
+
+    it("should build deterministic score IDs as part of payload creation", () => {
+      const expectedScoreIds = [
+        createDeterministicEvalScoreId({
+          jobExecutionId: "job-1",
+          scoreName: "accuracy",
+          occurrenceIndex: 0,
+        }),
+        createDeterministicEvalScoreId({
+          jobExecutionId: "job-1",
+          scoreName: "accuracy",
+          occurrenceIndex: 1,
+        }),
+      ];
+      const result = buildEvalScoreWritePayloads({
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "correct",
+            name: "accuracy",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "partial",
+            name: "accuracy",
+          },
+        ],
+        jobExecutionId: "job-1",
+        traceId: "trace-456",
+        observationId: "obs-789",
+        environment: "production",
+        executionTraceId: "exec-trace-789",
+        executionMetadata: { job_execution_id: "job-1" },
+      });
+
+      expect(result.map((payload) => payload.scoreId)).toEqual(
+        expectedScoreIds,
+      );
+      expect(result.map((payload) => payload.event.body.id)).toEqual(
+        expectedScoreIds,
+      );
+    });
+
     it("should build a single numeric score payload", () => {
+      const scoreId = createDeterministicEvalScoreId({
+        jobExecutionId: "job-1",
+        scoreName: "accuracy",
+        occurrenceIndex: 0,
+      });
       const result = buildEvalScoreWritePayloads({
         scores: [
           {
@@ -426,7 +568,7 @@ describe("evaluation helpers", () => {
             comment: "High accuracy observed",
           },
         ],
-        primaryScoreId: "score-123",
+        jobExecutionId: "job-1",
         traceId: "trace-456",
         observationId: null,
         environment: "production",
@@ -437,7 +579,7 @@ describe("evaluation helpers", () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
         eventId: expect.any(String),
-        scoreId: "score-123",
+        scoreId,
         event: expect.objectContaining({
           body: expect.objectContaining({
             value: 0.85,
@@ -448,6 +590,11 @@ describe("evaluation helpers", () => {
     });
 
     it("should build a single boolean score payload", () => {
+      const scoreId = createDeterministicEvalScoreId({
+        jobExecutionId: "job-1",
+        scoreName: "correctness",
+        occurrenceIndex: 0,
+      });
       const result = buildEvalScoreWritePayloads({
         scores: [
           {
@@ -457,7 +604,7 @@ describe("evaluation helpers", () => {
             comment: "The answer satisfies the criteria",
           },
         ],
-        primaryScoreId: "score-123",
+        jobExecutionId: "job-1",
         traceId: "trace-456",
         observationId: null,
         environment: "production",
@@ -468,7 +615,7 @@ describe("evaluation helpers", () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
         eventId: expect.any(String),
-        scoreId: "score-123",
+        scoreId,
         event: expect.objectContaining({
           body: expect.objectContaining({
             value: 1,
@@ -479,6 +626,16 @@ describe("evaluation helpers", () => {
     });
 
     it("should build one categorical payload per match while preserving shared metadata", () => {
+      const firstScoreId = createDeterministicEvalScoreId({
+        jobExecutionId: "job-1",
+        scoreName: "accuracy",
+        occurrenceIndex: 0,
+      });
+      const secondScoreId = createDeterministicEvalScoreId({
+        jobExecutionId: "job-1",
+        scoreName: "accuracy",
+        occurrenceIndex: 1,
+      });
       const result = buildEvalScoreWritePayloads({
         scores: [
           {
@@ -494,7 +651,7 @@ describe("evaluation helpers", () => {
             comment: "Both categories apply",
           },
         ],
-        primaryScoreId: "score-123",
+        jobExecutionId: "job-1",
         traceId: "trace-456",
         observationId: "obs-789",
         environment: "production",
@@ -503,8 +660,8 @@ describe("evaluation helpers", () => {
       });
 
       expect(result).toHaveLength(2);
-      expect(result[0].scoreId).toBe("score-123");
-      expect(result[1].scoreId).not.toBe("score-123");
+      expect(result[0].scoreId).toBe(firstScoreId);
+      expect(result[1].scoreId).toBe(secondScoreId);
       expect(result[0].event.body.value).toBe("correct");
       expect(result[1].event.body.value).toBe("partial");
       expect(result[0].event.body.comment).toBe("Both categories apply");
@@ -536,7 +693,7 @@ describe("evaluation helpers", () => {
             name: "fluency",
           },
         ],
-        primaryScoreId: "score-123",
+        jobExecutionId: "job-1",
         traceId: "trace-456",
         observationId: "obs-789",
         environment: "production",

--- a/worker/src/features/evaluation/executeLLMAsJudgeEvaluation.test.ts
+++ b/worker/src/features/evaluation/executeLLMAsJudgeEvaluation.test.ts
@@ -453,7 +453,6 @@ describe("executeLLMAsJudgeEvaluation", () => {
               job_execution_id: jobExecutionId,
               job_configuration_id: mockJobExecution.jobConfigurationId,
               target_trace_id: mockJobExecution.jobInputTraceId,
-              score_id: expect.any(String),
             }),
           }),
         }),

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
@@ -103,7 +103,6 @@ const mockEvalExecutionResult = {
       comment: "Good response",
     },
   ],
-  primaryScoreId: "score-123",
   executionTraceId: "trace-123",
   metadata: {},
 };

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
@@ -82,6 +82,13 @@ import {
   type EvalExecutionDeps,
 } from "../../evalExecutionDeps";
 import { runLLMAsJudgeEvaluation } from "../../evalService";
+import { createDeterministicEvalScoreId } from "../../../../../../packages/shared/src/server/evals/evalScoreIds";
+
+const mockScoreId = createDeterministicEvalScoreId({
+  jobExecutionId: "job-exec-456",
+  scoreName: "test-score",
+  occurrenceIndex: 0,
+});
 
 const mockEvalExecutionResult = {
   scores: [
@@ -92,7 +99,6 @@ const mockEvalExecutionResult = {
       comment: "Mock eval result",
     },
   ],
-  primaryScoreId: "score-123",
   executionTraceId: "trace-123",
   metadata: {},
 };
@@ -567,13 +573,13 @@ describe("processObservationEval", () => {
       expect(uploadScore).toHaveBeenCalledWith(
         expect.objectContaining({
           projectId,
-          scoreId: mockEvalExecutionResult.primaryScoreId,
+          scoreId: mockScoreId,
         }),
       );
       expect(enqueueScoreIngestion).toHaveBeenCalledWith(
         expect.objectContaining({
           projectId,
-          scoreId: mockEvalExecutionResult.primaryScoreId,
+          scoreId: mockScoreId,
         }),
       );
       expect(updateJobExecution).toHaveBeenCalledWith({
@@ -581,7 +587,7 @@ describe("processObservationEval", () => {
         projectId,
         data: expect.objectContaining({
           status: JobExecutionStatus.COMPLETED,
-          jobOutputScoreId: mockEvalExecutionResult.primaryScoreId,
+          jobOutputScoreId: mockScoreId,
           executionTraceId: mockEvalExecutionResult.executionTraceId,
         }),
       });


### PR DESCRIPTION
## Summary

- Stabilizes evaluator score IDs by deriving them from job execution ID, score name, and occurrence index when score payloads are built.
- Removes precomputed score IDs from evaluator execution trace metadata and keeps code eval test runs experiment-aware, including experiment item metadata.

## Major Decisions

- Score IDs are generated only at score persistence time to avoid duplicating ID policy across evaluator dispatch paths.

## Review Focus

- Deterministic score ID semantics for repeated score names and retry behavior.
- Test-run experiment context and internal trace persistence coverage.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes evaluator score IDs by deriving them deterministically from `(jobExecutionId, scoreName, occurrenceIndex)` via UUIDv5, replacing the previous mix of a pre-generated primary UUID and random UUIDs for secondary scores. It also removes `primaryScoreId` from the `EvalExecutionResult` type, propagates experiment context to code-eval test runs, and drops the `score_id` field from internal trace metadata.

- **New `evalScoreIds.ts`**: Introduces `createDeterministicEvalScoreId` and `buildDeterministicEvalScoreIds`, both keyed by job execution ID and score name, with occurrence tracking to handle duplicate score names.
- **`evalCompletion.ts`**: `jobOutputScoreId` is now derived from the first built score payload rather than a pre-allocated field; an explicit guard throws when no scores are produced.
- **Test updates**: The server test for code-eval test runs is replaced with a fuller experiment-context integration test; unit tests are updated to assert against computed deterministic IDs.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the primary code-based evaluator path; the deterministic ID scheme works correctly for deterministic evaluators and single-score LLM-as-judge runs.

The core change is well-reasoned and cleanly implemented. The one non-trivial edge case is multi-match CATEGORICAL LLM-as-judge evaluations on retry: if the LLM returns matches in a different order, occurrence-index-based IDs map the same ID to a different match value, potentially overwriting correct scores with stale data.

worker/src/features/evaluation/evalScoreEvent.ts — the occurrence-index ID assignment for multi-match categorical scores is the one place where the determinism guarantee breaks down on retry with a different match ordering.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Executor as Evaluator Executor
    participant Completion as completeEvalExecution
    participant ScoreEvent as buildEvalScoreWritePayloads
    participant ScoreIds as buildDeterministicEvalScoreIds
    participant Ingestion as IngestionQueue / DB

    Executor->>Completion: "EvalExecutionResult { scores[], executionTraceId, metadata }"
    Completion->>ScoreEvent: scores, jobExecutionId, traceId, ...
    ScoreEvent->>ScoreIds: scores, jobExecutionId
    ScoreIds-->>ScoreEvent: scoreIds[] (v5 UUID per name+occurrenceIndex)
    ScoreEvent-->>Completion: "EvalScoreWritePayload[] (scoreId = scoreIds[i])"
    Completion->>Completion: "jobOutputScoreId = payloads[0].scoreId"
    Completion->>Ingestion: uploadScore + enqueueScoreIngestion (for each payload)
    Completion->>Ingestion: updateJobExecution(jobOutputScoreId, COMPLETED)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
worker/src/features/evaluation/evalScoreEvent.ts:30-32
**Occurrence-index IDs can collide on retry for multi-match categorical evals**

For LLM-as-judge evaluations that use `shouldAllowMultipleMatches = true`, the LLM may return matches in a different order on retry. Because `buildDeterministicEvalScoreIds` assigns IDs by occurrence index within the array, a reordering on retry maps `occurrenceIndex: 0` to a semantically different match value than the first run. The upsert will silently overwrite the score ID that previously held value A with value B, leaving stale data for the ID that held B. This only affects multi-match categorical evaluations; single-score paths (numeric, boolean, single-category) are fully stable.

### Issue 2 of 3
worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts:85
Using a deep relative path to import `createDeterministicEvalScoreId` is fragile — the function is now exported from `@langfuse/shared/src/server`, which is the consistent pattern used by all other imports in this file. Same applies to the relative import in `evaluationHelpers.test.ts`.

```suggestion
import { createDeterministicEvalScoreId } from "@langfuse/shared/src/server";
```

### Issue 3 of 3
worker/src/features/evaluation/evaluationHelpers.test.ts:16
Same deep relative import issue: `createDeterministicEvalScoreId` is now re-exported from `@langfuse/shared/src/server`, which matches the existing import pattern in this file.

```suggestion
import { createDeterministicEvalScoreId } from "@langfuse/shared/src/server";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): stabilize eval score ids"](https://github.com/langfuse/langfuse/commit/a109c24e0f2eac26af1965ad8a90d3a7f4e09bf3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33224632)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->