### PR TITLE
refactor(evals): wrap up review comments

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -478,6 +478,7 @@ jobs:
           docker compose -f docker-compose.dev${{ matrix.deploy-mode }}.yml up -d --wait --wait-timeout 180
           docker compose ps
         env:
+          # Only start the extra floci container for default worker tests to avoid overhead elsewhere.
           COMPOSE_PROFILES: ${{ matrix.deploy-mode == '' && 'worker-tests' || '' }}
       - name: Ensure no unhealthy status
         run: |

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,8 +61,10 @@ services:
     ports:
       - ${HOST_IP:-127.0.0.1}:${FLOCI_PORT:-4566}:4566
     volumes:
-      - langfuse_floci_data:/app/data
+      # Floci Lambda starts real Docker containers for function invocations.
+      # See: https://floci.io/floci/services/lambda/
       - /var/run/docker.sock:/var/run/docker.sock
+      # The init hook packages these local runner sources into Lambda ZIPs on startup.
       - ./scripts/code-eval-runners:/opt/code-eval-runners:ro
       - ./scripts/code-eval-runners/bootstrap-floci.py:/etc/floci/init/ready.d/01-bootstrap-code-eval-runners.py:ro
     networks:
@@ -115,9 +117,6 @@ volumes:
     driver: local
   langfuse_minio_data:
     name: ${MINIO_VOLUME_NAME:-langfuse_minio_data}
-    driver: local
-  langfuse_floci_data:
-    name: ${FLOCI_VOLUME_NAME:-langfuse_floci_data}
     driver: local
 
 networks:

--- a/packages/shared/src/features/evals/types.ts
+++ b/packages/shared/src/features/evals/types.ts
@@ -25,20 +25,6 @@ export type EvalTemplateWithType =
   | EvalTemplateLlmAsAJudge
   | EvalTemplateCodeBased;
 
-export const assertCodeBasedEvalTemplate = (
-  template: EvalTemplate,
-): asserts template is EvalTemplateCodeBased => {
-  if (
-    template.type !== EvalTemplateType.CODE ||
-    template.prompt !== null ||
-    template.outputDefinition !== null ||
-    template.sourceCode === null ||
-    template.sourceCodeLanguage === null
-  ) {
-    throw new Error("Expected code-based evaluation template");
-  }
-};
-
 export const EvalTargetObject = {
   TRACE: "trace",
   DATASET: "dataset",

--- a/packages/shared/src/features/evals/types.ts
+++ b/packages/shared/src/features/evals/types.ts
@@ -25,20 +25,6 @@ export type EvalTemplateWithType =
   | EvalTemplateLlmAsAJudge
   | EvalTemplateCodeBased;
 
-export const assertLLMAsJudgeEvalTemplate = (
-  template: EvalTemplate,
-): asserts template is EvalTemplateLlmAsAJudge => {
-  if (
-    template.type !== EvalTemplateType.LLM_AS_JUDGE ||
-    template.prompt === null ||
-    template.outputDefinition === null ||
-    template.sourceCode != null ||
-    template.sourceCodeLanguage != null
-  ) {
-    throw new Error("Expected LLM-as-judge evaluation template");
-  }
-};
-
 export const assertCodeBasedEvalTemplate = (
   template: EvalTemplate,
 ): asserts template is EvalTemplateCodeBased => {

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -23,7 +23,8 @@ export const DEFAULT_LAMBDA_FUNCTION_BY_LANGUAGE = {
   TYPESCRIPT: "code-based-eval-executor-node",
 } satisfies Record<CodeEvalRuntimeLanguage, string>;
 
-const LAMBDA_INVOKE_REQUEST_TIMEOUT_MS = 3_000;
+// Synchronous Lambda invokes hold the HTTP request open through cold starts and user code execution.
+const LAMBDA_INVOKE_REQUEST_TIMEOUT_MS = 10_000;
 
 type CodeEvalDispatcherErrorClassification = {
   code: CodeEvalDispatcherErrorCode;

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -23,6 +23,8 @@ export const DEFAULT_LAMBDA_FUNCTION_BY_LANGUAGE = {
   TYPESCRIPT: "code-based-eval-executor-node",
 } satisfies Record<CodeEvalRuntimeLanguage, string>;
 
+const LAMBDA_INVOKE_REQUEST_TIMEOUT_MS = 3_000;
+
 type CodeEvalDispatcherErrorClassification = {
   code: CodeEvalDispatcherErrorCode;
   retryable?: boolean;
@@ -126,7 +128,13 @@ function getSharedLambdaClient(endpoint?: string): LambdaClient {
   if (sharedLambdaClient && sharedLambdaClientEndpoint === endpoint) {
     return sharedLambdaClient;
   }
-  sharedLambdaClient = new LambdaClient(endpoint ? { endpoint } : {});
+  sharedLambdaClient = new LambdaClient({
+    ...(endpoint ? { endpoint } : {}),
+    requestHandler: {
+      requestTimeout: LAMBDA_INVOKE_REQUEST_TIMEOUT_MS,
+      throwOnRequestTimeout: true,
+    },
+  });
   sharedLambdaClientEndpoint = endpoint;
   return sharedLambdaClient;
 }

--- a/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
@@ -12,7 +12,6 @@ export type CodeEvalScope = {
   organizationId: string;
   projectId: string;
   evaluatorId: string;
-  environment: string;
 };
 
 export type CodeEvalPayload = {

--- a/packages/shared/src/server/evals/codeEvalExecution.ts
+++ b/packages/shared/src/server/evals/codeEvalExecution.ts
@@ -21,7 +21,6 @@ import {
 } from "./codeEvalDispatcherTypes";
 import type { ExtractedVariable } from "./extractObservationVariables";
 
-const CODE_EVAL_SCOPE_ENVIRONMENT = "code-based-eval";
 const INTERNAL_CODE_EVAL_ERROR_MESSAGE = "An internal error occurred";
 
 const INTERNAL_CODE_EVAL_ERROR_CODES = new Set<CodeEvalDispatcherErrorCode>([
@@ -168,7 +167,6 @@ export async function runCodeBasedEvaluationDispatch(params: {
         organizationId: params.organizationId,
         projectId: params.projectId,
         evaluatorId: params.template.id,
-        environment: CODE_EVAL_SCOPE_ENVIRONMENT,
       },
       runtime: { language: params.template.sourceCodeLanguage },
       execution: { jobExecutionId: params.jobExecutionId },

--- a/packages/shared/src/server/redis/codeEvalExecutionQueue.ts
+++ b/packages/shared/src/server/redis/codeEvalExecutionQueue.ts
@@ -72,7 +72,7 @@ export class CodeEvalExecutionQueue {
           defaultJobOptions: {
             removeOnComplete: true,
             removeOnFail: 10_000,
-            attempts: 10,
+            attempts: 3,
             backoff: {
               type: "exponential",
               delay: 1000,

--- a/web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts
+++ b/web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts
@@ -92,6 +92,7 @@ maybe("evals.testRunCodeEval", () => {
     const { project, caller } = await prepare();
     const observationId = randomUUID();
     const traceId = randomUUID();
+    const startTime = new Date();
     const savedSource = `
       export function evaluate(ctx) {
         const matched =
@@ -122,6 +123,7 @@ maybe("evals.testRunCodeEval", () => {
         trace_id: traceId,
         span_id: observationId,
         id: observationId,
+        start_time: startTime.getTime() * 1000,
         input: JSON.stringify({ question: "2+2" }),
         output: "4",
         metadata_names: ["quality"],
@@ -142,6 +144,8 @@ maybe("evals.testRunCodeEval", () => {
       target: EvalTargetObject.EVENT,
       scoreName: "unsaved-score",
       observationId,
+      traceId,
+      startTime,
       mapping: [
         {
           templateVariable: "input",
@@ -198,6 +202,8 @@ maybe("evals.testRunCodeEval", () => {
   it("returns user-code dispatcher failures as structured failures", async () => {
     const { project, caller } = await prepare();
     const observationId = randomUUID();
+    const traceId = randomUUID();
+    const startTime = new Date();
     const template = await createCodeTemplate(
       project.id,
       `export function evaluate() {
@@ -208,9 +214,10 @@ maybe("evals.testRunCodeEval", () => {
     await createEventsCh([
       createEvent({
         project_id: project.id,
-        trace_id: randomUUID(),
+        trace_id: traceId,
         span_id: observationId,
         id: observationId,
+        start_time: startTime.getTime() * 1000,
       }),
     ]);
 
@@ -220,6 +227,8 @@ maybe("evals.testRunCodeEval", () => {
       target: EvalTargetObject.EVENT,
       scoreName: "unsaved-score",
       observationId,
+      traceId,
+      startTime,
       mapping: [],
     });
 
@@ -236,14 +245,17 @@ maybe("evals.testRunCodeEval", () => {
   it("persists an internal trace for the test run", async () => {
     const { project, caller } = await prepare();
     const observationId = randomUUID();
+    const traceId = randomUUID();
+    const startTime = new Date();
     const template = await createCodeTemplate(project.id);
 
     await createEventsCh([
       createEvent({
         project_id: project.id,
-        trace_id: randomUUID(),
+        trace_id: traceId,
         span_id: observationId,
         id: observationId,
+        start_time: startTime.getTime() * 1000,
       }),
     ]);
 
@@ -253,6 +265,8 @@ maybe("evals.testRunCodeEval", () => {
       target: EvalTargetObject.EVENT,
       scoreName: "unsaved-score",
       observationId,
+      traceId,
+      startTime,
       mapping: [],
     });
 
@@ -297,12 +311,15 @@ maybe("evals.testRunCodeEval", () => {
     const template = await createCodeTemplate(callerProject.id);
 
     const otherProjectObservationId = randomUUID();
+    const otherProjectTraceId = randomUUID();
+    const otherProjectStartTime = new Date();
     await createEventsCh([
       createEvent({
         project_id: otherProject.id,
-        trace_id: randomUUID(),
+        trace_id: otherProjectTraceId,
         span_id: otherProjectObservationId,
         id: otherProjectObservationId,
+        start_time: otherProjectStartTime.getTime() * 1000,
       }),
     ]);
 
@@ -313,6 +330,8 @@ maybe("evals.testRunCodeEval", () => {
         target: EvalTargetObject.EVENT,
         scoreName: "unsaved-score",
         observationId: otherProjectObservationId,
+        traceId: otherProjectTraceId,
+        startTime: otherProjectStartTime,
         mapping: [],
       }),
     ).rejects.toThrow(/Observation not found/);
@@ -322,15 +341,18 @@ maybe("evals.testRunCodeEval", () => {
     const { project: callerProject, caller } = await prepare();
     const { project: otherProject } = await prepare();
     const observationId = randomUUID();
+    const traceId = randomUUID();
+    const startTime = new Date();
 
     const otherProjectTemplate = await createCodeTemplate(otherProject.id);
 
     await createEventsCh([
       createEvent({
         project_id: callerProject.id,
-        trace_id: randomUUID(),
+        trace_id: traceId,
         span_id: observationId,
         id: observationId,
+        start_time: startTime.getTime() * 1000,
       }),
     ]);
 
@@ -341,6 +363,8 @@ maybe("evals.testRunCodeEval", () => {
         target: EvalTargetObject.EVENT,
         scoreName: "unsaved-score",
         observationId,
+        traceId,
+        startTime,
         mapping: [],
       }),
     ).rejects.toThrow(/Evaluator template not found/);

--- a/web/src/features/evals/server/codeEvalTestRun.ts
+++ b/web/src/features/evals/server/codeEvalTestRun.ts
@@ -245,7 +245,7 @@ async function writeTraceViaIngestion(trace: InternalTraceWriteInput) {
   }
 }
 
-function getInternalEvalEnvironment(environment: string) {
+function getInternalEvalEnvironment(environment: string | undefined) {
   return environment === LangfuseInternalTraceEnvironment.CodeEval
     ? LangfuseInternalTraceEnvironment.CodeEval
     : LangfuseInternalTraceEnvironment.LLMJudge;

--- a/web/src/features/evals/server/codeEvalTestRun.ts
+++ b/web/src/features/evals/server/codeEvalTestRun.ts
@@ -13,14 +13,13 @@ import {
 import { TRPCError } from "@trpc/server";
 
 import {
-  assertCodeBasedEvalTemplate,
   observationForEvalSchema,
   type EvalTargetObject,
   type EvalTemplateCodeBased,
   type ObservationForEval,
   type ObservationVariableMapping,
 } from "@langfuse/shared";
-import type { PrismaClient } from "@langfuse/shared/src/db";
+import { EvalTemplateType, type PrismaClient } from "@langfuse/shared/src/db";
 
 export type CodeEvalTestRunResult =
   | {
@@ -39,6 +38,7 @@ export type CodeEvalTestRunResult =
 
 export async function runCodeEvalTest(params: {
   prisma: PrismaClient;
+  orgId: string;
   projectId: string;
   evalTemplateId: string;
   target: EvalTargetObject;
@@ -55,44 +55,20 @@ export async function runCodeEvalTest(params: {
     });
   }
 
-  const [project, template] = await Promise.all([
-    params.prisma.project.findUnique({
-      where: { id: params.projectId },
-      select: { orgId: true },
-    }),
-    params.prisma.evalTemplate.findFirst({
-      where: {
-        id: params.evalTemplateId,
-        OR: [{ projectId: params.projectId }, { projectId: null }],
-      },
-    }),
-  ]);
+  const codeTemplate = (await params.prisma.evalTemplate.findFirst({
+    where: {
+      id: params.evalTemplateId,
+      type: EvalTemplateType.CODE,
+      sourceCode: { not: null },
+      sourceCodeLanguage: { not: null },
+      OR: [{ projectId: params.projectId }, { projectId: null }],
+    },
+  })) as EvalTemplateCodeBased | null;
 
-  if (!project) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "Project not found",
-    });
-  }
-
-  if (!template) {
+  if (!codeTemplate) {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Evaluator template not found",
-    });
-  }
-
-  let codeTemplate: EvalTemplateCodeBased;
-  try {
-    assertCodeBasedEvalTemplate(template);
-    codeTemplate = template;
-  } catch (error) {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message:
-        error instanceof Error
-          ? error.message
-          : "Evaluator template is not a code-based template",
     });
   }
 
@@ -119,7 +95,7 @@ export async function runCodeEvalTest(params: {
 
   const dispatchOutcome = await runCodeBasedEvaluationDispatch({
     dispatcher,
-    organizationId: project.orgId,
+    organizationId: params.orgId,
     projectId: params.projectId,
     executionTraceId,
     jobExecutionId: executionTraceId,

--- a/web/src/features/evals/server/codeEvalTestRun.ts
+++ b/web/src/features/evals/server/codeEvalTestRun.ts
@@ -45,6 +45,8 @@ export async function runCodeEvalTest(params: {
   mapping: ObservationVariableMapping[];
   scoreName: string;
   observationId: string;
+  traceId: string;
+  startTime: Date;
 }): Promise<CodeEvalTestRunResult> {
   const dispatcher = resolveConfiguredCodeEvalDispatcher();
 
@@ -75,6 +77,8 @@ export async function runCodeEvalTest(params: {
   const observation = await getObservationForEvalById({
     projectId: params.projectId,
     id: params.observationId,
+    traceId: params.traceId,
+    startTime: params.startTime,
   });
   const extractedVariables = extractObservationVariables({
     observation,
@@ -126,10 +130,32 @@ export async function runCodeEvalTest(params: {
 async function getObservationForEvalById(params: {
   projectId: string;
   id: string;
+  traceId: string;
+  startTime: Date;
 }): Promise<ObservationForEval> {
+  const startTimeUpperBound = new Date(params.startTime.getTime() + 1);
+
   const stream = await getEventsStreamForEval({
     projectId: params.projectId,
     filter: [
+      {
+        type: "string",
+        column: "traceId",
+        operator: "=",
+        value: params.traceId,
+      },
+      {
+        type: "datetime",
+        column: "startTime",
+        operator: ">=",
+        value: params.startTime,
+      },
+      {
+        type: "datetime",
+        column: "startTime",
+        operator: "<",
+        value: startTimeUpperBound,
+      },
       {
         type: "stringOptions",
         column: "id",

--- a/web/src/features/evals/server/codeEvalTestRun.ts
+++ b/web/src/features/evals/server/codeEvalTestRun.ts
@@ -13,6 +13,7 @@ import {
 import { TRPCError } from "@trpc/server";
 
 import {
+  LangfuseInternalTraceEnvironment,
   observationForEvalSchema,
   type EvalTargetObject,
   type EvalTemplateCodeBased,
@@ -193,7 +194,7 @@ async function writeTraceViaIngestion(trace: InternalTraceWriteInput) {
       id: rootEventInput.traceId,
       timestamp: rootEventInput.startTimeISO,
       name: rootEventInput.traceName ?? rootEventInput.name,
-      environment: rootEventInput.environment,
+      environment: getInternalEvalEnvironment(rootEventInput.environment),
       input: rootEventInput.input,
       output: rootEventInput.output,
       metadata: rootEventInput.metadata,
@@ -214,7 +215,7 @@ async function writeTraceViaIngestion(trace: InternalTraceWriteInput) {
       id: eventInput.spanId,
       traceId: eventInput.traceId,
       name: eventInput.name,
-      environment: eventInput.environment,
+      environment: getInternalEvalEnvironment(eventInput.environment),
       startTime: eventInput.startTimeISO,
       endTime: eventInput.endTimeISO,
       input: eventInput.input,
@@ -242,4 +243,10 @@ async function writeTraceViaIngestion(trace: InternalTraceWriteInput) {
   if (result.errors.length > 0) {
     throw new Error(result.errors[0]?.error ?? "Failed to write trace");
   }
+}
+
+function getInternalEvalEnvironment(environment: string) {
+  return environment === LangfuseInternalTraceEnvironment.CodeEval
+    ? LangfuseInternalTraceEnvironment.CodeEval
+    : LangfuseInternalTraceEnvironment.LLMJudge;
 }

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -881,6 +881,7 @@ export const evalRouter = createTRPCRouter({
 
       return runCodeEvalTest({
         prisma: ctx.prisma,
+        orgId: ctx.session.orgId,
         projectId: input.projectId,
         evalTemplateId: input.evalTemplateId,
         target: input.target,

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -183,6 +183,8 @@ const CodeEvalTestRunSchema = z.object({
   mapping: z.array(observationVariableMapping),
   scoreName: z.string().min(1),
   observationId: z.string(),
+  traceId: z.string(),
+  startTime: z.coerce.date(),
 });
 
 const UpdateEvalJobSchema = z.object({
@@ -888,6 +890,8 @@ export const evalRouter = createTRPCRouter({
         mapping: input.mapping,
         scoreName: input.scoreName,
         observationId: input.observationId,
+        traceId: input.traceId,
+        startTime: input.startTime,
       });
     }),
   createTemplate: protectedProjectProcedure

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
@@ -18,7 +18,6 @@ const baseInput: DispatchInput = {
     organizationId: "org-floci-integration",
     projectId: "project-floci-integration",
     evaluatorId: "evaluator-floci-integration",
-    environment: "code-based-eval",
   },
   runtime: { language: "TYPESCRIPT" },
   execution: { jobExecutionId: "job-floci-integration" },

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
@@ -10,7 +10,6 @@ const baseInput: DispatchInput = {
     organizationId: "org-1",
     projectId: "project-1",
     evaluatorId: "evaluator-1",
-    environment: "code-based-eval",
   },
   runtime: { language: "TYPESCRIPT" },
   execution: { jobExecutionId: "job-1" },

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -89,7 +89,6 @@ describe("executeCodeBasedEvaluation", () => {
         { var: "experimentExpectedOutput", value: "4" },
       ],
       hasExperimentContext: true,
-      environment: "default",
       executionMetadata: { job_execution_id: "job-1" },
     });
 
@@ -172,7 +171,6 @@ describe("executeCodeBasedEvaluation", () => {
         outputDefinition: null,
       } as any,
       extractedVariables: [],
-      environment: "default",
       executionMetadata: { job_execution_id: "job-1" },
     });
 
@@ -217,7 +215,6 @@ describe("executeCodeBasedEvaluation", () => {
       } as any,
       extractedVariables: [],
       hasExperimentContext: true,
-      environment: "default",
       executionMetadata: { job_execution_id: "job-1" },
     });
 
@@ -262,7 +259,6 @@ describe("executeCodeBasedEvaluation", () => {
       } as any,
       extractedVariables: [{ var: "experimentExpectedOutput", value: "4" }],
       hasExperimentContext: false,
-      environment: "default",
       executionMetadata: { job_execution_id: "job-1" },
     });
 
@@ -307,7 +303,6 @@ describe("executeCodeBasedEvaluation", () => {
         { var: "experimentExpectedOutput", value: "null" },
       ],
       hasExperimentContext: true,
-      environment: "default",
       executionMetadata: { job_execution_id: "job-1" },
     });
 
@@ -361,7 +356,6 @@ describe("executeCodeBasedEvaluation", () => {
         },
       ],
       hasExperimentContext: true,
-      environment: "default",
       executionMetadata: { job_execution_id: "job-1" },
     });
 
@@ -412,7 +406,6 @@ describe("executeCodeBasedEvaluation", () => {
           outputDefinition: null,
         } as any,
         extractedVariables: [{ var: "input", value: "prompt" }],
-        environment: "default",
         executionMetadata: { job_execution_id: "job-1" },
       }),
     ).resolves.toMatchObject({
@@ -452,7 +445,6 @@ describe("executeCodeBasedEvaluation", () => {
           outputDefinition: null,
         } as any,
         extractedVariables: [{ var: "input", value: "prompt" }],
-        environment: "default",
         executionMetadata: { job_execution_id: "job-1" },
       }),
     ).rejects.toBe(error);
@@ -530,7 +522,6 @@ describe("executeCodeBasedEvaluation", () => {
           outputDefinition: null,
         } as any,
         extractedVariables: [{ var: "input", value: "prompt" }],
-        environment: "default",
         executionMetadata: { job_execution_id: "job-1" },
       }),
     ).rejects.toBe(error);

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -61,7 +61,6 @@ describe("executeCodeBasedEvaluation", () => {
     const result = await executeCodeBasedEvaluation({
       projectId: "project-1",
       organizationId: "org-1",
-      jobExecutionId: "job-1",
       job: {
         id: "job-1",
         jobConfigurationId: "config-1",
@@ -149,7 +148,6 @@ describe("executeCodeBasedEvaluation", () => {
     const result = await executeCodeBasedEvaluation({
       projectId: "project-1",
       organizationId: "org-1",
-      jobExecutionId: "job-1",
       job: {
         id: "job-1",
         jobConfigurationId: "config-1",
@@ -195,7 +193,6 @@ describe("executeCodeBasedEvaluation", () => {
     await executeCodeBasedEvaluation({
       projectId: "project-1",
       organizationId: "org-1",
-      jobExecutionId: "job-1",
       job: {
         id: "job-1",
         jobConfigurationId: "config-1",
@@ -239,7 +236,6 @@ describe("executeCodeBasedEvaluation", () => {
     await executeCodeBasedEvaluation({
       projectId: "project-1",
       organizationId: "org-1",
-      jobExecutionId: "job-1",
       job: {
         id: "job-1",
         jobConfigurationId: "config-1",
@@ -279,7 +275,6 @@ describe("executeCodeBasedEvaluation", () => {
     await executeCodeBasedEvaluation({
       projectId: "project-1",
       organizationId: "org-1",
-      jobExecutionId: "job-1",
       job: {
         id: "job-1",
         jobConfigurationId: "config-1",
@@ -331,7 +326,6 @@ describe("executeCodeBasedEvaluation", () => {
     await executeCodeBasedEvaluation({
       projectId: "project-1",
       organizationId: "org-1",
-      jobExecutionId: "job-1",
       job: {
         id: "job-1",
         jobConfigurationId: "config-1",
@@ -386,7 +380,6 @@ describe("executeCodeBasedEvaluation", () => {
       executeCodeBasedEvaluation({
         projectId: "project-1",
         organizationId: "org-1",
-        jobExecutionId: "job-1",
         job: {
           id: "job-1",
           jobConfigurationId: "config-1",
@@ -425,7 +418,6 @@ describe("executeCodeBasedEvaluation", () => {
       executeCodeBasedEvaluation({
         projectId: "project-1",
         organizationId: "org-1",
-        jobExecutionId: "job-1",
         job: {
           id: "job-1",
           jobConfigurationId: "config-1",
@@ -502,7 +494,6 @@ describe("executeCodeBasedEvaluation", () => {
       executeCodeBasedEvaluation({
         projectId: "project-1",
         organizationId: "org-1",
-        jobExecutionId: "job-1",
         job: {
           id: "job-1",
           jobConfigurationId: "config-1",

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -90,7 +90,7 @@ describe("executeCodeBasedEvaluation", () => {
       ],
       hasExperimentContext: true,
       environment: "default",
-      metadata: { job_execution_id: "job-1" },
+      executionMetadata: { job_execution_id: "job-1" },
     });
 
     expect(result.scores).toMatchObject([
@@ -173,7 +173,7 @@ describe("executeCodeBasedEvaluation", () => {
       } as any,
       extractedVariables: [],
       environment: "default",
-      metadata: { job_execution_id: "job-1" },
+      executionMetadata: { job_execution_id: "job-1" },
     });
 
     expect(result.scores).toMatchObject([
@@ -218,7 +218,7 @@ describe("executeCodeBasedEvaluation", () => {
       extractedVariables: [],
       hasExperimentContext: true,
       environment: "default",
-      metadata: { job_execution_id: "job-1" },
+      executionMetadata: { job_execution_id: "job-1" },
     });
 
     expect(mocks.dispatcher.dispatch).toHaveBeenCalledWith(
@@ -263,7 +263,7 @@ describe("executeCodeBasedEvaluation", () => {
       extractedVariables: [{ var: "experimentExpectedOutput", value: "4" }],
       hasExperimentContext: false,
       environment: "default",
-      metadata: { job_execution_id: "job-1" },
+      executionMetadata: { job_execution_id: "job-1" },
     });
 
     expect(mocks.dispatcher.dispatch).toHaveBeenCalledWith(
@@ -308,7 +308,7 @@ describe("executeCodeBasedEvaluation", () => {
       ],
       hasExperimentContext: true,
       environment: "default",
-      metadata: { job_execution_id: "job-1" },
+      executionMetadata: { job_execution_id: "job-1" },
     });
 
     expect(mocks.dispatcher.dispatch).toHaveBeenCalledWith(
@@ -362,7 +362,7 @@ describe("executeCodeBasedEvaluation", () => {
       ],
       hasExperimentContext: true,
       environment: "default",
-      metadata: { job_execution_id: "job-1" },
+      executionMetadata: { job_execution_id: "job-1" },
     });
 
     expect(mocks.dispatcher.dispatch).toHaveBeenCalledWith(
@@ -413,7 +413,7 @@ describe("executeCodeBasedEvaluation", () => {
         } as any,
         extractedVariables: [{ var: "input", value: "prompt" }],
         environment: "default",
-        metadata: { job_execution_id: "job-1" },
+        executionMetadata: { job_execution_id: "job-1" },
       }),
     ).resolves.toMatchObject({
       scores: [{ name: "score", value: 1, dataType: "NUMERIC" }],
@@ -453,7 +453,7 @@ describe("executeCodeBasedEvaluation", () => {
         } as any,
         extractedVariables: [{ var: "input", value: "prompt" }],
         environment: "default",
-        metadata: { job_execution_id: "job-1" },
+        executionMetadata: { job_execution_id: "job-1" },
       }),
     ).rejects.toBe(error);
 
@@ -531,7 +531,7 @@ describe("executeCodeBasedEvaluation", () => {
         } as any,
         extractedVariables: [{ var: "input", value: "prompt" }],
         environment: "default",
-        metadata: { job_execution_id: "job-1" },
+        executionMetadata: { job_execution_id: "job-1" },
       }),
     ).rejects.toBe(error);
 

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -13,19 +13,10 @@ const mocks = vi.hoisted(() => ({
     name: "test-dispatcher",
     dispatch: vi.fn(),
   },
-  projectFindUnique: vi.fn(),
   writeInternalTrace: vi.fn(),
   createW3CTraceId: vi.fn(() => "execution-trace-1"),
   span: {
     setAttribute: vi.fn(),
-  },
-}));
-
-vi.mock("@langfuse/shared/src/db", () => ({
-  prisma: {
-    project: {
-      findUnique: mocks.projectFindUnique,
-    },
   },
 }));
 
@@ -56,7 +47,6 @@ import { executeCodeBasedEvaluation } from "./executeCodeBasedEvaluation";
 describe("executeCodeBasedEvaluation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.projectFindUnique.mockResolvedValue({ orgId: "org-1" });
     mocks.writeInternalTrace.mockResolvedValue(undefined);
   });
 
@@ -70,6 +60,7 @@ describe("executeCodeBasedEvaluation", () => {
 
     const result = await executeCodeBasedEvaluation({
       projectId: "project-1",
+      organizationId: "org-1",
       jobExecutionId: "job-1",
       job: {
         id: "job-1",
@@ -158,6 +149,7 @@ describe("executeCodeBasedEvaluation", () => {
 
     const result = await executeCodeBasedEvaluation({
       projectId: "project-1",
+      organizationId: "org-1",
       jobExecutionId: "job-1",
       job: {
         id: "job-1",
@@ -204,6 +196,7 @@ describe("executeCodeBasedEvaluation", () => {
 
     await executeCodeBasedEvaluation({
       projectId: "project-1",
+      organizationId: "org-1",
       jobExecutionId: "job-1",
       job: {
         id: "job-1",
@@ -248,6 +241,7 @@ describe("executeCodeBasedEvaluation", () => {
 
     await executeCodeBasedEvaluation({
       projectId: "project-1",
+      organizationId: "org-1",
       jobExecutionId: "job-1",
       job: {
         id: "job-1",
@@ -288,6 +282,7 @@ describe("executeCodeBasedEvaluation", () => {
 
     await executeCodeBasedEvaluation({
       projectId: "project-1",
+      organizationId: "org-1",
       jobExecutionId: "job-1",
       job: {
         id: "job-1",
@@ -340,6 +335,7 @@ describe("executeCodeBasedEvaluation", () => {
 
     await executeCodeBasedEvaluation({
       projectId: "project-1",
+      organizationId: "org-1",
       jobExecutionId: "job-1",
       job: {
         id: "job-1",
@@ -395,6 +391,7 @@ describe("executeCodeBasedEvaluation", () => {
     await expect(
       executeCodeBasedEvaluation({
         projectId: "project-1",
+        organizationId: "org-1",
         jobExecutionId: "job-1",
         job: {
           id: "job-1",
@@ -434,6 +431,7 @@ describe("executeCodeBasedEvaluation", () => {
     await expect(
       executeCodeBasedEvaluation({
         projectId: "project-1",
+        organizationId: "org-1",
         jobExecutionId: "job-1",
         job: {
           id: "job-1",
@@ -511,6 +509,7 @@ describe("executeCodeBasedEvaluation", () => {
     await expect(
       executeCodeBasedEvaluation({
         projectId: "project-1",
+        organizationId: "org-1",
         jobExecutionId: "job-1",
         job: {
           id: "job-1",

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -23,7 +23,7 @@ export async function executeCodeBasedEvaluation(params: {
   extractedVariables: ExtractedVariable[];
   hasExperimentContext?: boolean;
   executionMetadata: Record<string, string>;
-  // Unused; present for ObservationEvalExecutor interface symmetry.
+  // Unused by code-based eval; the shared observation processor passes it.
   deps?: EvalExecutionDeps;
 }): Promise<EvalExecutionResult> {
   return instrumentAsync(

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -17,7 +17,6 @@ import { type EvalExecutionDeps } from "../evalExecutionDeps";
 export async function executeCodeBasedEvaluation(params: {
   projectId: string;
   organizationId: string;
-  jobExecutionId: string;
   job: JobExecution;
   config: JobConfiguration;
   template: EvalTemplateCodeBased;
@@ -31,12 +30,13 @@ export async function executeCodeBasedEvaluation(params: {
     { name: "eval.execute-code-based-eval" },
     async (span) => {
       const dispatcher = resolveConfiguredCodeEvalDispatcher();
+      const jobExecutionId = params.job.id;
 
       if (!dispatcher) {
         throw new UnrecoverableError("Code eval dispatcher is not configured");
       }
 
-      const executionTraceId = createW3CTraceId(params.jobExecutionId);
+      const executionTraceId = createW3CTraceId(jobExecutionId);
       const primaryScoreId = randomUUID();
       const executionMetadata = {
         ...params.executionMetadata,
@@ -45,7 +45,7 @@ export async function executeCodeBasedEvaluation(params: {
       };
 
       span.setAttribute("langfuse.project.id", params.projectId);
-      span.setAttribute("eval.job_execution.id", params.jobExecutionId);
+      span.setAttribute("eval.job_execution.id", jobExecutionId);
       span.setAttribute("eval.job_configuration.id", params.config.id);
       span.setAttribute("eval.template.id", params.template.id);
       span.setAttribute("eval.template.version", params.template.version);
@@ -56,7 +56,7 @@ export async function executeCodeBasedEvaluation(params: {
       );
 
       logger.debug(
-        `Executing code-based evaluation for job ${params.jobExecutionId} in project ${params.projectId}`,
+        `Executing code-based evaluation for job ${jobExecutionId} in project ${params.projectId}`,
       );
 
       const dispatchOutcome = await runCodeBasedEvaluationDispatch({
@@ -64,7 +64,7 @@ export async function executeCodeBasedEvaluation(params: {
         organizationId: params.organizationId,
         projectId: params.projectId,
         executionTraceId,
-        jobExecutionId: params.jobExecutionId,
+        jobExecutionId,
         template: params.template,
         scoreName: params.config.scoreName,
         extractedVariables: params.extractedVariables,

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "crypto";
 import { type JobConfiguration, type JobExecution } from "@prisma/client";
 import { type EvalTemplateCodeBased } from "@langfuse/shared";
-import { prisma } from "@langfuse/shared/src/db";
 import {
   instrumentAsync,
   logger,
@@ -17,6 +16,7 @@ import { type EvalExecutionDeps } from "../evalExecutionDeps";
 
 export async function executeCodeBasedEvaluation(params: {
   projectId: string;
+  organizationId: string;
   jobExecutionId: string;
   job: JobExecution;
   config: JobConfiguration;
@@ -35,17 +35,6 @@ export async function executeCodeBasedEvaluation(params: {
 
       if (!dispatcher) {
         throw new UnrecoverableError("Code eval dispatcher is not configured");
-      }
-
-      const project = await prisma.project.findUnique({
-        where: { id: params.projectId },
-        select: { orgId: true },
-      });
-
-      if (!project) {
-        throw new UnrecoverableError(
-          `Project ${params.projectId} not found for code eval execution`,
-        );
       }
 
       const executionTraceId = createW3CTraceId(params.jobExecutionId);
@@ -73,7 +62,7 @@ export async function executeCodeBasedEvaluation(params: {
 
       const dispatchOutcome = await runCodeBasedEvaluationDispatch({
         dispatcher,
-        organizationId: project.orgId,
+        organizationId: params.organizationId,
         projectId: params.projectId,
         executionTraceId,
         jobExecutionId: params.jobExecutionId,
@@ -94,7 +83,6 @@ export async function executeCodeBasedEvaluation(params: {
         throw dispatchOutcome.cause;
       }
 
-      span.setAttribute("eval.result.count", dispatchOutcome.scores.length);
       span.setAttribute("eval.score.count", dispatchOutcome.scores.length);
       span.setAttribute("eval.score.id", primaryScoreId);
 

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -24,7 +24,7 @@ export async function executeCodeBasedEvaluation(params: {
   extractedVariables: ExtractedVariable[];
   hasExperimentContext?: boolean;
   environment: string;
-  metadata: Record<string, string>;
+  executionMetadata: Record<string, string>;
   // Unused; present for ObservationEvalExecutor interface symmetry.
   deps?: EvalExecutionDeps;
 }): Promise<EvalExecutionResult> {
@@ -40,7 +40,7 @@ export async function executeCodeBasedEvaluation(params: {
       const executionTraceId = createW3CTraceId(params.jobExecutionId);
       const primaryScoreId = randomUUID();
       const executionMetadata = {
-        ...params.metadata,
+        ...params.executionMetadata,
         dispatcher_name: dispatcher.name,
         code_eval_runtime: params.template.sourceCodeLanguage,
       };

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.ts
@@ -23,7 +23,6 @@ export async function executeCodeBasedEvaluation(params: {
   template: EvalTemplateCodeBased;
   extractedVariables: ExtractedVariable[];
   hasExperimentContext?: boolean;
-  environment: string;
   executionMetadata: Record<string, string>;
   // Unused; present for ObservationEvalExecutor interface symmetry.
   deps?: EvalExecutionDeps;

--- a/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
@@ -11,7 +11,6 @@ const baseInput: Omit<DispatchInput, "runtime" | "code"> = {
     organizationId: "org-1",
     projectId: "project-1",
     evaluatorId: "evaluator-1",
-    environment: "default",
   },
   execution: {
     jobExecutionId: "job-1",

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -728,6 +728,7 @@ export const createEvalJobs = async ({
  * @param params.config - Pre-fetched job configuration
  * @param params.template - Pre-fetched eval template
  * @param params.extractedVariables - Pre-extracted variables from trace/observation data
+ * @param params.executionMetadata - Metadata identifying this eval execution
  * @param params.deps - Optional dependency injection for testing (defaults to production deps)
  */
 export async function runLLMAsJudgeEvaluation({
@@ -737,7 +738,7 @@ export async function runLLMAsJudgeEvaluation({
   config,
   template,
   extractedVariables,
-  metadata,
+  executionMetadata,
   deps,
 }: {
   projectId: string;
@@ -746,7 +747,7 @@ export async function runLLMAsJudgeEvaluation({
   config: JobConfiguration;
   template: EvalTemplateLlmAsAJudge;
   extractedVariables: ExtractedVariable[];
-  metadata: Record<string, string>;
+  executionMetadata: Record<string, string>;
   deps: EvalExecutionDeps;
 }): Promise<EvalExecutionResult> {
   return instrumentAsync(
@@ -893,7 +894,7 @@ export async function runLLMAsJudgeEvaluation({
                 traceName: `Execute evaluator: ${template.name}`,
                 environment: LangfuseInternalTraceEnvironment.LLMJudge,
                 metadata: {
-                  ...metadata,
+                  ...executionMetadata,
                   score_id: primaryScoreId,
                 },
               },
@@ -966,7 +967,7 @@ export async function runLLMAsJudgeEvaluation({
         scores,
         primaryScoreId,
         executionTraceId,
-        metadata,
+        metadata: executionMetadata,
       };
     },
   );
@@ -1012,21 +1013,25 @@ function toNormalizedScores(params: {
 export async function executeLLMAsJudgeEvaluation(
   params: Omit<
     Parameters<typeof runLLMAsJudgeEvaluation>[0],
-    "deps" | "metadata"
+    "deps" | "executionMetadata"
   > & {
     environment: string;
     deps?: EvalExecutionDeps;
   },
 ): Promise<void> {
   const deps = params.deps ?? createProductionEvalExecutionDeps();
-  const metadata = buildEvalExecutionMetadata({
+  const executionMetadata = buildEvalExecutionMetadata({
     jobExecutionId: params.jobExecutionId,
     jobConfigurationId: params.job.jobConfigurationId,
     targetTraceId: params.job.jobInputTraceId,
     targetObservationId: params.job.jobInputObservationId,
     targetDatasetItemId: params.job.jobInputDatasetItemId,
   });
-  const result = await runLLMAsJudgeEvaluation({ ...params, deps, metadata });
+  const result = await runLLMAsJudgeEvaluation({
+    ...params,
+    deps,
+    executionMetadata,
+  });
 
   await completeEvalExecution({
     projectId: params.projectId,

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { z } from "zod";
 import {
+  EvalTemplateType,
   JobConfigState,
   JobExecutionStatus,
   type JobExecution,
@@ -52,7 +53,6 @@ import {
   Observation,
   EvalTargetObject,
   EvaluatorBlockReason,
-  assertLLMAsJudgeEvalTemplate,
   getEvaluatorBlockMetadata,
   getBlockReasonForInvalidModelConfig,
   isJobConfigExecutable,
@@ -1118,6 +1118,7 @@ export const evaluate = async ({
   const template = await prisma.evalTemplate.findFirst({
     where: {
       id: config.evalTemplateId,
+      type: EvalTemplateType.LLM_AS_JUDGE,
       OR: [{ projectId: event.projectId }, { projectId: null }],
     },
   });
@@ -1126,11 +1127,6 @@ export const evaluate = async ({
     throw new UnrecoverableError(
       `Evaluation template ${config.evalTemplateId} not found`,
     );
-  }
-  try {
-    assertLLMAsJudgeEvalTemplate(template);
-  } catch (e) {
-    throw new UnrecoverableError(e instanceof Error ? e.message : String(e));
   }
 
   // Extract variables from tracing data
@@ -1158,7 +1154,7 @@ export const evaluate = async ({
     jobExecutionId: event.jobExecutionId,
     job,
     config,
-    template,
+    template: template as EvalTemplateLlmAsAJudge,
     extractedVariables,
     environment:
       getEnvironmentFromVariables(extractedVariables) ??

--- a/worker/src/features/evaluation/observationEval/__tests__/createSchedulerDeps.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/createSchedulerDeps.test.ts
@@ -45,6 +45,7 @@ describe("createObservationEvalSchedulerDeps", () => {
       expect.objectContaining({
         name: "llm-as-a-judge-execution-job",
         id: "job-1",
+        payload: expect.objectContaining({ projectId: "project-1" }),
       }),
       { delay: 10 },
     );
@@ -71,6 +72,7 @@ describe("createObservationEvalSchedulerDeps", () => {
       expect.objectContaining({
         name: "code-eval-execution-job",
         id: "job-2",
+        payload: expect.objectContaining({ projectId: "project-1" }),
       }),
       { delay: 20 },
     );

--- a/worker/src/features/evaluation/observationEval/__tests__/fixtures.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/fixtures.ts
@@ -279,6 +279,7 @@ export function createMockJobConfiguration(
       overrides.evalTemplate !== undefined
         ? overrides.evalTemplate
         : createMockEvalTemplate({ id: templateId, projectId }),
+    project: { orgId: "test-org-123" },
   };
 }
 

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
@@ -18,12 +18,7 @@ import {
   createMockJobExecution,
 } from "./fixtures";
 import {
-  assertCodeBasedEvalTemplate,
-  assertLLMAsJudgeEvalTemplate,
   EvalTargetObject,
-  type EvalTemplate,
-  type EvalTemplateCodeBased,
-  type EvalTemplateLlmAsAJudge,
   type ObservationVariableMapping,
 } from "@langfuse/shared";
 
@@ -74,22 +69,7 @@ vi.mock("@langfuse/shared/src/server", async () => {
 });
 
 import { prisma } from "@langfuse/shared/src/db";
-import { executeCodeBasedEvaluation } from "../../codeBased";
 import { runLLMAsJudgeEvaluation } from "../../evalService";
-
-const validateLLMAsJudgeTemplate = (
-  template: EvalTemplate,
-): EvalTemplateLlmAsAJudge => {
-  assertLLMAsJudgeEvalTemplate(template);
-  return template;
-};
-
-const validateCodeBasedTemplate = (
-  template: EvalTemplate,
-): EvalTemplateCodeBased => {
-  assertCodeBasedEvalTemplate(template);
-  return template;
-};
 
 const mockEvalExecutionResult = {
   scores: [
@@ -265,8 +245,7 @@ describe("Observation Eval E2E Pipeline", () => {
           jobExecutionId: capturedJobExecutionId!,
           observationS3Path,
         },
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
         deps: pipeline.processorDeps,
       });
 
@@ -372,8 +351,7 @@ describe("Observation Eval E2E Pipeline", () => {
           jobExecutionId: job.id,
           observationS3Path: "test-path",
         },
-        validateTemplate: validateCodeBasedTemplate,
-        executor: executeCodeBasedEvaluation,
+        executionType: EvalTemplateType.CODE,
         deps: pipeline.processorDeps,
       });
 
@@ -631,8 +609,7 @@ describe("Observation Eval E2E Pipeline", () => {
           jobExecutionId: "job-123",
           observationS3Path: "test-path",
         },
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
         deps: pipeline.processorDeps,
       });
 
@@ -737,8 +714,7 @@ describe("Observation Eval E2E Pipeline", () => {
           jobExecutionId: "job-123",
           observationS3Path: "test-path",
         },
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
         deps: pipeline.processorDeps,
       });
 

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEval.e2e.test.ts
@@ -41,9 +41,6 @@ vi.mock("@langfuse/shared/src/db", () => ({
     jobConfiguration: {
       findFirst: vi.fn(),
     },
-    project: {
-      findUnique: vi.fn(),
-    },
   },
 }));
 
@@ -113,7 +110,6 @@ describe("Observation Eval E2E Pipeline", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (prisma.project.findUnique as Mock).mockResolvedValue({ orgId: "org-1" });
     (runLLMAsJudgeEvaluation as Mock).mockResolvedValue(
       mockEvalExecutionResult,
     );
@@ -256,6 +252,7 @@ describe("Observation Eval E2E Pipeline", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         evalTemplate: mockTemplate,
+        project: { orgId: "test-org-123" },
       };
 
       (prisma.jobExecution.findFirst as Mock).mockResolvedValue(mockJob);
@@ -280,6 +277,7 @@ describe("Observation Eval E2E Pipeline", () => {
       expect(runLLMAsJudgeEvaluation).toHaveBeenCalledWith(
         expect.objectContaining({
           projectId,
+          organizationId: "test-org-123",
           jobExecutionId: capturedJobExecutionId,
           extractedVariables: expect.arrayContaining([
             expect.objectContaining({
@@ -621,6 +619,7 @@ describe("Observation Eval E2E Pipeline", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         evalTemplate: mockTemplate,
+        project: { orgId: "test-org-123" },
       };
 
       (prisma.jobExecution.findFirst as Mock).mockResolvedValue(mockJob);
@@ -726,6 +725,7 @@ describe("Observation Eval E2E Pipeline", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
         evalTemplate: mockTemplate,
+        project: { orgId: "test-org-123" },
       };
 
       (prisma.jobExecution.findFirst as Mock).mockResolvedValue(mockJob);

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
@@ -487,6 +487,7 @@ describe("processObservationEval", () => {
       expect(runLLMAsJudgeEvaluation).toHaveBeenCalledWith(
         expect.objectContaining({
           projectId,
+          organizationId: "test-org-123",
           jobExecutionId,
           job: expect.objectContaining({ id: jobExecutionId }),
           config: expect.objectContaining({ id: "config-123" }),
@@ -641,6 +642,7 @@ describe("processObservationEval", () => {
       expect(executeCodeBasedEvaluation).toHaveBeenCalledWith(
         expect.objectContaining({
           projectId,
+          organizationId: "test-org-123",
           jobExecutionId,
           template: expect.objectContaining({
             id: "template-456",

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
@@ -17,19 +17,6 @@ import {
 } from "./fixtures";
 import { UnrecoverableError } from "../../../../errors/UnrecoverableError";
 
-const validateLLMAsJudgeTemplate = vi.fn((template) => {
-  if (template.type !== EvalTemplateType.LLM_AS_JUDGE) {
-    throw new Error("Expected LLM-as-judge evaluation template");
-  }
-  return template;
-});
-const validateCodeBasedTemplate = vi.fn((template) => {
-  if (template.type !== EvalTemplateType.CODE) {
-    throw new Error("Expected code-based evaluation template");
-  }
-  return template;
-});
-
 // Mock prisma
 vi.mock("@langfuse/shared/src/db", async () => {
   const actual = await vi.importActual("@langfuse/shared/src/db");
@@ -126,8 +113,7 @@ describe("processObservationEval", () => {
 
       await processObservationEval({
         event: baseEvent,
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
         deps,
       });
 
@@ -158,16 +144,14 @@ describe("processObservationEval", () => {
       await expect(
         processObservationEval({
           event: baseEvent,
-          validateTemplate: validateLLMAsJudgeTemplate,
-          executor: runLLMAsJudgeEvaluation,
+          executionType: EvalTemplateType.LLM_AS_JUDGE,
           deps,
         }),
       ).rejects.toThrow(UnrecoverableError);
       await expect(
         processObservationEval({
           event: baseEvent,
-          validateTemplate: validateLLMAsJudgeTemplate,
-          executor: runLLMAsJudgeEvaluation,
+          executionType: EvalTemplateType.LLM_AS_JUDGE,
           deps,
         }),
       ).rejects.toThrow("Job configuration or template not found");
@@ -196,8 +180,7 @@ describe("processObservationEval", () => {
       await expect(
         processObservationEval({
           event: baseEvent,
-          validateTemplate: validateLLMAsJudgeTemplate,
-          executor: runLLMAsJudgeEvaluation,
+          executionType: EvalTemplateType.LLM_AS_JUDGE,
           deps,
         }),
       ).rejects.toThrow(UnrecoverableError);
@@ -223,54 +206,7 @@ describe("processObservationEval", () => {
 
       await processObservationEval({
         event: baseEvent,
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
-        deps,
-      });
-
-      expect(prisma.jobExecution.update).toHaveBeenCalledWith({
-        where: {
-          id: job.id,
-          projectId,
-        },
-        data: {
-          status: JobExecutionStatus.CANCELLED,
-          endTime: expect.any(Date),
-        },
-      });
-      expect(deps.downloadObservationFromS3).not.toHaveBeenCalled();
-      expect(runLLMAsJudgeEvaluation).not.toHaveBeenCalled();
-    });
-
-    it("should cancel blocked jobs before validating the evaluator template type", async () => {
-      const job = createMockJobExecution({
-        id: jobExecutionId,
-        projectId,
-        status: JobExecutionStatus.PENDING,
-        jobConfigurationId: "config-123",
-      });
-      const config = createMockJobConfiguration({
-        id: "config-123",
-        projectId,
-        blockedAt: new Date(),
-        evalTemplate: createMockEvalTemplate({
-          type: EvalTemplateType.CODE,
-          prompt: null,
-          outputDefinition: null,
-          sourceCode: "def evaluate(): pass",
-          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.PYTHON,
-        }),
-      });
-
-      (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
-      (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
-
-      const deps = createMockProcessorDeps();
-
-      await processObservationEval({
-        event: baseEvent,
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
         deps,
       });
 
@@ -289,47 +225,38 @@ describe("processObservationEval", () => {
     });
   });
 
-  describe("template type validation", () => {
-    it("should throw UnrecoverableError when the default LLM path receives a code template", async () => {
+  describe("template type filtering", () => {
+    it("should throw UnrecoverableError when no template matches the requested execution type", async () => {
       const job = createMockJobExecution({
         id: jobExecutionId,
         projectId,
         status: JobExecutionStatus.PENDING,
         jobConfigurationId: "config-123",
       });
-      const config = createMockJobConfiguration({
-        id: "config-123",
-        projectId,
-        evalTemplate: createMockEvalTemplate({
-          type: EvalTemplateType.CODE,
-          prompt: null,
-          outputDefinition: null,
-          sourceCode: "def evaluate(): pass",
-          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.PYTHON,
-        }),
-      });
 
       (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
-      (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
+      (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(null);
 
       const deps = createMockProcessorDeps();
 
       await expect(
         processObservationEval({
           event: baseEvent,
-          validateTemplate: validateLLMAsJudgeTemplate,
-          executor: runLLMAsJudgeEvaluation,
+          executionType: EvalTemplateType.LLM_AS_JUDGE,
           deps,
         }),
       ).rejects.toThrow(UnrecoverableError);
-      await expect(
-        processObservationEval({
-          event: baseEvent,
-          validateTemplate: validateLLMAsJudgeTemplate,
-          executor: runLLMAsJudgeEvaluation,
-          deps,
+      expect(prisma.jobConfiguration.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            evalTemplate: {
+              is: {
+                type: EvalTemplateType.LLM_AS_JUDGE,
+              },
+            },
+          }),
         }),
-      ).rejects.toThrow("Expected LLM-as-judge evaluation template");
+      );
       expect(deps.downloadObservationFromS3).not.toHaveBeenCalled();
       expect(runLLMAsJudgeEvaluation).not.toHaveBeenCalled();
     });
@@ -361,8 +288,7 @@ describe("processObservationEval", () => {
       await expect(
         processObservationEval({
           event: baseEvent,
-          validateTemplate: validateLLMAsJudgeTemplate,
-          executor: runLLMAsJudgeEvaluation,
+          executionType: EvalTemplateType.LLM_AS_JUDGE,
           deps,
         }),
       ).rejects.toThrow("Failed to download observation from S3");
@@ -393,8 +319,7 @@ describe("processObservationEval", () => {
       await expect(
         processObservationEval({
           event: baseEvent,
-          validateTemplate: validateLLMAsJudgeTemplate,
-          executor: runLLMAsJudgeEvaluation,
+          executionType: EvalTemplateType.LLM_AS_JUDGE,
           deps,
         }),
       ).rejects.toThrow(UnrecoverableError);
@@ -427,8 +352,7 @@ describe("processObservationEval", () => {
       await expect(
         processObservationEval({
           event: baseEvent,
-          validateTemplate: validateLLMAsJudgeTemplate,
-          executor: runLLMAsJudgeEvaluation,
+          executionType: EvalTemplateType.LLM_AS_JUDGE,
           deps,
         }),
       ).rejects.toThrow(UnrecoverableError);
@@ -479,11 +403,21 @@ describe("processObservationEval", () => {
 
       await processObservationEval({
         event: baseEvent,
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
         deps,
       });
 
+      expect(prisma.jobConfiguration.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            evalTemplate: {
+              is: {
+                type: EvalTemplateType.LLM_AS_JUDGE,
+              },
+            },
+          }),
+        }),
+      );
       expect(runLLMAsJudgeEvaluation).toHaveBeenCalledWith(
         expect.objectContaining({
           projectId,
@@ -559,8 +493,7 @@ describe("processObservationEval", () => {
 
       await processObservationEval({
         event: baseEvent,
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
         deps,
       });
 
@@ -638,8 +571,7 @@ describe("processObservationEval", () => {
 
       await processObservationEval({
         event: baseEvent,
-        validateTemplate: validateCodeBasedTemplate,
-        executor: executeCodeBasedEvaluation,
+        executionType: EvalTemplateType.CODE,
         deps,
       });
 
@@ -697,8 +629,7 @@ describe("processObservationEval", () => {
 
       await processObservationEval({
         event: baseEvent,
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
         deps,
       });
 
@@ -745,8 +676,7 @@ describe("processObservationEval", () => {
 
       await processObservationEval({
         event: baseEvent,
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
         deps,
       });
 
@@ -789,8 +719,7 @@ describe("processObservationEval", () => {
       await expect(
         processObservationEval({
           event: baseEvent,
-          validateTemplate: validateLLMAsJudgeTemplate,
-          executor: runLLMAsJudgeEvaluation,
+          executionType: EvalTemplateType.LLM_AS_JUDGE,
         }),
       ).rejects.toThrow();
     });

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
@@ -499,7 +499,6 @@ describe("processObservationEval", () => {
             }),
           ]),
           hasExperimentContext: true,
-          environment: "production",
         }),
       );
     });
@@ -569,6 +568,11 @@ describe("processObservationEval", () => {
         expect.objectContaining({
           projectId,
           scoreId: mockEvalExecutionResult.primaryScoreId,
+          event: expect.objectContaining({
+            body: expect.objectContaining({
+              environment: "production",
+            }),
+          }),
         }),
       );
       expect(enqueueScoreIngestion).toHaveBeenCalledWith(
@@ -654,13 +658,12 @@ describe("processObservationEval", () => {
               value: '{"response": "test output"}',
             }),
           ]),
-          environment: "production",
         }),
       );
       expect(runLLMAsJudgeEvaluation).not.toHaveBeenCalled();
     });
 
-    it("should use default environment when observation environment is null", async () => {
+    it("should use default environment for persisted scores when observation environment is null", async () => {
       const job = createMockJobExecution({
         id: jobExecutionId,
         projectId,
@@ -680,10 +683,16 @@ describe("processObservationEval", () => {
       (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
       (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
 
+      const uploadScore = vi
+        .fn<EvalExecutionDeps["uploadScore"]>()
+        .mockResolvedValue(undefined);
       const deps = createMockProcessorDeps({
         downloadObservationFromS3: vi
           .fn()
           .mockResolvedValue(JSON.stringify(observation)),
+        evalExecutionDeps: createMockEvalExecutionDeps({
+          uploadScore,
+        }),
       });
 
       await processObservationEval({
@@ -693,9 +702,13 @@ describe("processObservationEval", () => {
         deps,
       });
 
-      expect(runLLMAsJudgeEvaluation).toHaveBeenCalledWith(
+      expect(uploadScore).toHaveBeenCalledWith(
         expect.objectContaining({
-          environment: "default",
+          event: expect.objectContaining({
+            body: expect.objectContaining({
+              environment: "default",
+            }),
+          }),
         }),
       );
     });

--- a/worker/src/features/evaluation/observationEval/fetchObservationEvalConfigs.ts
+++ b/worker/src/features/evaluation/observationEval/fetchObservationEvalConfigs.ts
@@ -74,8 +74,16 @@ export async function fetchObservationEvalConfigs(
     `Found ${configs.length} observation eval configs for project ${projectId}`,
   );
 
-  return configs.map((config) => ({
-    ...config,
-    evalTemplate: config.evalTemplate!,
-  }));
+  return configs.map((config) => {
+    if (!config.evalTemplate) {
+      throw new Error(
+        `Observation eval config ${config.id} has no eval template`,
+      );
+    }
+
+    return {
+      ...config,
+      evalTemplate: config.evalTemplate,
+    };
+  });
 }

--- a/worker/src/features/evaluation/observationEval/index.ts
+++ b/worker/src/features/evaluation/observationEval/index.ts
@@ -4,10 +4,7 @@ export { createObservationEvalSchedulerDeps } from "./createSchedulerDeps";
 export {
   processObservationEval,
   createObservationEvalProcessorDeps,
-  type ObservationEvalExecutor,
-  type ObservationEvalExecutionParams,
   type ObservationEvalProcessorDeps,
-  type ObservationEvalTemplateValidator,
 } from "./observationEvalProcessor";
 export type {
   ObservationForEval,

--- a/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
+++ b/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
@@ -10,10 +10,15 @@ import {
   observationForEvalSchema,
   observationVariableMappingList,
   isJobConfigExecutable,
-  type EvalTemplate,
+  type EvalTemplateCodeBased,
+  type EvalTemplateLlmAsAJudge,
   type ObservationVariableMapping,
 } from "@langfuse/shared";
-import { type JobConfiguration, type JobExecution } from "@prisma/client";
+import {
+  EvalTemplateType,
+  type JobConfiguration,
+  type JobExecution,
+} from "@prisma/client";
 import { prisma, JobExecutionStatus } from "@langfuse/shared/src/db";
 import { UnrecoverableError } from "../../../errors/UnrecoverableError";
 import { buildEvalExecutionMetadata } from "../evalRuntime";
@@ -25,6 +30,8 @@ import {
   createProductionEvalExecutionDeps,
   type EvalExecutionDeps,
 } from "../evalExecutionDeps";
+import { runLLMAsJudgeEvaluation } from "../evalService";
+import { executeCodeBasedEvaluation } from "../codeBased";
 import { getEvalS3StorageClient } from "../s3StorageClient";
 import { type ObservationForEval } from "./types";
 
@@ -40,22 +47,10 @@ export type ObservationEvalExecutionBaseParams = {
   config: JobConfiguration;
   extractedVariables: ExtractedVariable[];
   hasExperimentContext: boolean;
+  environment: string;
   executionMetadata: Record<string, string>;
   deps: EvalExecutionDeps;
 };
-
-export type ObservationEvalExecutionParams<TTemplate extends EvalTemplate> =
-  ObservationEvalExecutionBaseParams & {
-    template: TTemplate;
-  };
-
-export type ObservationEvalExecutor<TTemplate extends EvalTemplate> = (
-  params: ObservationEvalExecutionParams<TTemplate>,
-) => Promise<EvalExecutionResult>;
-
-export type ObservationEvalTemplateValidator<TTemplate extends EvalTemplate> = (
-  template: EvalTemplate,
-) => TTemplate;
 
 export interface ObservationEvalProcessorDeps {
   downloadObservationFromS3: (path: string) => Promise<string>;
@@ -80,21 +75,24 @@ export function createObservationEvalProcessorDeps(): ObservationEvalProcessorDe
  * Processes an observation-level evaluation job.
  *
  * This function:
- * 1. Fetches and validates job execution, config, and template
+ * 1. Fetches job execution, config, and the expected template type
  * 2. Downloads observation data from S3 (stored during scheduling)
  * 3. Extracts variables from the observation
  * 4. Executes the evaluator-specific implementation
  * 5. Completes the eval execution with shared score persistence
  */
-type ProcessObservationEvalParams<TTemplate extends EvalTemplate> = {
+type ObservationEvalExecutionType =
+  | typeof EvalTemplateType.LLM_AS_JUDGE
+  | typeof EvalTemplateType.CODE;
+
+type ProcessObservationEvalParams = {
   event: z.infer<typeof ObservationEvalExecutionEventSchema>;
-  validateTemplate: ObservationEvalTemplateValidator<TTemplate>;
-  executor: ObservationEvalExecutor<TTemplate>;
+  executionType: ObservationEvalExecutionType;
   deps?: ObservationEvalProcessorDeps;
 };
 
-export async function processObservationEval<TTemplate extends EvalTemplate>(
-  params: ProcessObservationEvalParams<TTemplate>,
+export async function processObservationEval(
+  params: ProcessObservationEvalParams,
 ): Promise<void> {
   const { event, deps = createObservationEvalProcessorDeps() } = params;
   logger.debug(
@@ -133,6 +131,11 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     where: {
       id: job.jobConfigurationId,
       projectId: event.projectId,
+      evalTemplate: {
+        is: {
+          type: params.executionType,
+        },
+      },
     },
     include: {
       evalTemplate: true,
@@ -167,13 +170,6 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     });
 
     return;
-  }
-
-  let evalTemplate: TTemplate;
-  try {
-    evalTemplate = params.validateTemplate(evalJobConfig.evalTemplate);
-  } catch (e) {
-    throw new UnrecoverableError(e instanceof Error ? e.message : String(e));
   }
 
   // Download observation data from S3
@@ -228,6 +224,7 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     config: evalJobConfig,
     extractedVariables,
     hasExperimentContext: Boolean(observationData.experiment_id),
+    environment: observationData.environment ?? DEFAULT_TRACE_ENVIRONMENT,
     executionMetadata: buildEvalExecutionMetadata({
       jobExecutionId: event.jobExecutionId,
       jobConfigurationId: job.jobConfigurationId,
@@ -238,17 +235,30 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     deps: deps.evalExecutionDeps,
   };
 
-  const executionResult = await params.executor({
-    ...executionParams,
-    template: evalTemplate,
-  });
+  // The config query filters evalTemplate.type, but Prisma does not narrow the
+  // nullable template fields from that relation predicate.
+  let executionResult: EvalExecutionResult;
+  switch (params.executionType) {
+    case EvalTemplateType.LLM_AS_JUDGE:
+      executionResult = await runLLMAsJudgeEvaluation({
+        ...executionParams,
+        template: evalJobConfig.evalTemplate as EvalTemplateLlmAsAJudge,
+      });
+      break;
+    case EvalTemplateType.CODE:
+      executionResult = await executeCodeBasedEvaluation({
+        ...executionParams,
+        template: evalJobConfig.evalTemplate as EvalTemplateCodeBased,
+      });
+      break;
+  }
 
   await completeEvalExecution({
     projectId: executionParams.projectId,
     jobExecutionId: executionParams.jobExecutionId,
     traceId: executionParams.job.jobInputTraceId,
     observationId: executionParams.job.jobInputObservationId,
-    environment: observationData.environment ?? DEFAULT_TRACE_ENVIRONMENT,
+    environment: executionParams.environment,
     deps: executionParams.deps,
     result: executionResult,
   });

--- a/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
+++ b/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
@@ -40,7 +40,6 @@ export type ObservationEvalExecutionBaseParams = {
   config: JobConfiguration;
   extractedVariables: ExtractedVariable[];
   hasExperimentContext: boolean;
-  environment: string;
   executionMetadata: Record<string, string>;
   deps: EvalExecutionDeps;
 };
@@ -229,7 +228,6 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     config: evalJobConfig,
     extractedVariables,
     hasExperimentContext: Boolean(observationData.experiment_id),
-    environment: observationData.environment ?? DEFAULT_TRACE_ENVIRONMENT,
     executionMetadata: buildEvalExecutionMetadata({
       jobExecutionId: event.jobExecutionId,
       jobConfigurationId: job.jobConfigurationId,
@@ -250,7 +248,7 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     jobExecutionId: executionParams.jobExecutionId,
     traceId: executionParams.job.jobInputTraceId,
     observationId: executionParams.job.jobInputObservationId,
-    environment: executionParams.environment,
+    environment: observationData.environment ?? DEFAULT_TRACE_ENVIRONMENT,
     deps: executionParams.deps,
     result: executionResult,
   });

--- a/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
+++ b/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
@@ -41,7 +41,7 @@ export type ObservationEvalExecutionBaseParams = {
   extractedVariables: ExtractedVariable[];
   hasExperimentContext: boolean;
   environment: string;
-  metadata: Record<string, string>;
+  executionMetadata: Record<string, string>;
   deps: EvalExecutionDeps;
 };
 
@@ -230,7 +230,7 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     extractedVariables,
     hasExperimentContext: Boolean(observationData.experiment_id),
     environment: observationData.environment ?? DEFAULT_TRACE_ENVIRONMENT,
-    metadata: buildEvalExecutionMetadata({
+    executionMetadata: buildEvalExecutionMetadata({
       jobExecutionId: event.jobExecutionId,
       jobConfigurationId: job.jobConfigurationId,
       targetTraceId: job.jobInputTraceId,

--- a/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
+++ b/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
@@ -34,6 +34,7 @@ import { type ObservationForEval } from "./types";
  */
 export type ObservationEvalExecutionBaseParams = {
   projectId: string;
+  organizationId: string;
   jobExecutionId: string;
   job: JobExecution;
   config: JobConfiguration;
@@ -136,6 +137,11 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
     },
     include: {
       evalTemplate: true,
+      project: {
+        select: {
+          orgId: true,
+        },
+      },
     },
   });
 
@@ -217,6 +223,7 @@ export async function processObservationEval<TTemplate extends EvalTemplate>(
 
   const executionParams = {
     projectId: event.projectId,
+    organizationId: evalJobConfig.project.orgId,
     jobExecutionId: event.jobExecutionId,
     job,
     config: evalJobConfig,

--- a/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
@@ -8,6 +8,7 @@ import {
   type Mock,
 } from "vitest";
 import { Job } from "bullmq";
+import { EvalTemplateType } from "@prisma/client";
 import { UnrecoverableError } from "../../errors/UnrecoverableError";
 
 const QueueName = {
@@ -89,7 +90,6 @@ vi.mock("../../errors/UnrecoverableError", async () => {
 import { prisma } from "@langfuse/shared/src/db";
 import { processObservationEval } from "../../features/evaluation/observationEval";
 import { traceException } from "@langfuse/shared/src/server";
-import { executeCodeBasedEvaluation } from "../../features/evaluation/codeBased";
 import { isUnrecoverableError } from "../../errors/UnrecoverableError";
 
 describe("codeEvalExecutionQueueProcessor", () => {
@@ -147,8 +147,7 @@ describe("codeEvalExecutionQueueProcessor", () => {
         jobExecutionId,
         observationS3Path,
       },
-      validateTemplate: expect.any(Function),
-      executor: executeCodeBasedEvaluation,
+      executionType: EvalTemplateType.CODE,
     });
   });
 

--- a/worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/llmAsJudgeExecutionQueueProcessor.test.ts
@@ -27,6 +27,9 @@ const JobExecutionStatus = {
 
 vi.mock("@langfuse/shared", () => ({
   removeEmptyEnvVariables: <T>(value: T) => value,
+  EvalTemplateType: {
+    LLM_AS_JUDGE: "LLM_AS_JUDGE",
+  },
   JobExecutionStatus: {
     DELAYED: "DELAYED",
     ERROR: "ERROR",
@@ -108,7 +111,6 @@ import {
   traceException,
 } from "@langfuse/shared/src/server";
 import { retryLLMRateLimitError } from "../../features/utils";
-import { runLLMAsJudgeEvaluation } from "../../features/evaluation/evalService";
 import { isUnrecoverableError } from "../../errors/UnrecoverableError";
 
 describe("llmAsJudgeExecutionQueueProcessor", () => {
@@ -171,8 +173,7 @@ describe("llmAsJudgeExecutionQueueProcessor", () => {
           jobExecutionId,
           observationS3Path,
         },
-        validateTemplate: expect.any(Function),
-        executor: runLLMAsJudgeEvaluation,
+        executionType: "LLM_AS_JUDGE",
       });
     });
 

--- a/worker/src/queues/codeEvalQueue.ts
+++ b/worker/src/queues/codeEvalQueue.ts
@@ -1,10 +1,5 @@
 import { Job, Processor } from "bullmq";
-import { JobExecutionStatus } from "@prisma/client";
-import {
-  assertCodeBasedEvalTemplate,
-  type EvalTemplate,
-  type EvalTemplateCodeBased,
-} from "@langfuse/shared";
+import { EvalTemplateType, JobExecutionStatus } from "@prisma/client";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   CodeEvalDispatcherError,
@@ -15,7 +10,6 @@ import {
   TQueueJobTypes,
   traceException,
 } from "@langfuse/shared/src/server";
-import { executeCodeBasedEvaluation } from "../features/evaluation/codeBased";
 import { processObservationEval } from "../features/evaluation/observationEval";
 import { createW3CTraceId } from "../features/utils";
 import { isUnrecoverableError } from "../errors/UnrecoverableError";
@@ -46,8 +40,7 @@ export const codeEvalExecutionQueueProcessorBuilder = (
 
       await processObservationEval({
         event: job.data.payload,
-        validateTemplate: validateCodeBasedTemplate,
-        executor: executeCodeBasedEvaluation,
+        executionType: EvalTemplateType.CODE,
       });
 
       return true;
@@ -91,13 +84,6 @@ export const codeEvalExecutionQueueProcessorBuilder = (
       throw e;
     }
   };
-};
-
-const validateCodeBasedTemplate = (
-  template: EvalTemplate,
-): EvalTemplateCodeBased => {
-  assertCodeBasedEvalTemplate(template);
-  return template;
 };
 
 // Returns a user-visible message for JobExecution.error. Dispatcher errors

--- a/worker/src/queues/evalQueue.ts
+++ b/worker/src/queues/evalQueue.ts
@@ -1,10 +1,5 @@
 import { Job, Processor } from "bullmq";
-import {
-  assertLLMAsJudgeEvalTemplate,
-  JobExecutionStatus,
-  type EvalTemplate,
-  type EvalTemplateLlmAsAJudge,
-} from "@langfuse/shared";
+import { EvalTemplateType, JobExecutionStatus } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   QueueName,
@@ -18,11 +13,7 @@ import {
   getCurrentSpan,
   isLLMCompletionError,
 } from "@langfuse/shared/src/server";
-import {
-  createEvalJobs,
-  evaluate,
-  runLLMAsJudgeEvaluation,
-} from "../features/evaluation/evalService";
+import { createEvalJobs, evaluate } from "../features/evaluation/evalService";
 import { processObservationEval } from "../features/evaluation/observationEval";
 import { delayInMs } from "./utils/delays";
 import { createW3CTraceId, retryLLMRateLimitError } from "../features/utils";
@@ -307,8 +298,7 @@ export const llmAsJudgeExecutionQueueProcessorBuilder =
 
       await processObservationEval({
         event: job.data.payload,
-        validateTemplate: validateLLMAsJudgeTemplate,
-        executor: runLLMAsJudgeEvaluation,
+        executionType: EvalTemplateType.LLM_AS_JUDGE,
       });
       return true;
     } catch (e) {
@@ -372,10 +362,3 @@ export const llmAsJudgeExecutionQueueProcessorBuilder =
       throw e;
     }
   };
-
-const validateLLMAsJudgeTemplate = (
-  template: EvalTemplate,
-): EvalTemplateLlmAsAJudge => {
-  assertLLMAsJudgeEvalTemplate(template);
-  return template;
-};


### PR DESCRIPTION
## Summary

- Simplifies code-eval execution plumbing by passing organization context through the dispatch path, deriving execution IDs in the worker, and removing the now-unused environment/template assertion surface.
- Tightens eval-template routing for code eval test runs and observation eval processing so LLM-as-judge and code-based evals stay on their typed execution paths.
- Hardens Lambda-backed code eval dispatch by increasing the invoke timeout, bounding queue retry behavior, and keeping code eval test traces internal.
- Reduces local and CI overhead by trimming floci compose mounts and only enabling the floci profile for the default worker-test stack.

## Linear

- [LFE-9832](https://linear.app/langfuse/issue/LFE-9832/code-based-evals-add-backend-data-model)

## Major Decisions

- Centralized observation eval dispatch around explicit execution types so LLM-as-judge and code-based evals share scheduling flow while keeping execution-specific runners isolated.
- Removed configurable code-eval execution environments from the runtime surface; execution now follows the configured dispatcher and queue path directly.
- Kept the Lambda invoke request timeout above the function timeout to avoid client-side timeouts causing duplicate concurrent Lambda executions.

## Review Focus

- Worker observation-eval dispatch and queue retry behavior, especially routing between LLM-as-judge and code-based evals.
- Code eval test-run visibility and internal trace scoping.
- Lambda dispatcher timeout behavior and the floci compose changes used by local and CI worker tests.