### PR TITLE
fix(shared): bound S3 key segment length

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.s3KeySegments.test.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.s3KeySegments.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+
+const uploadedPaths: string[] = [];
+
+vi.mock("../../env", () => ({
+  env: {
+    LANGFUSE_S3_EVENT_UPLOAD_PREFIX: "events/",
+    LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse",
+    LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: "minio",
+    LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: "miniosecret",
+    LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: "http://localhost:9000",
+    LANGFUSE_S3_EVENT_UPLOAD_REGION: "auto",
+    LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true",
+    LANGFUSE_S3_EVENT_UPLOAD_SSE: null,
+    LANGFUSE_S3_EVENT_UPLOAD_SSE_KMS_KEY_ID: null,
+    LANGFUSE_INGESTION_QUEUE_DELAY_MS: 0,
+    LANGFUSE_SKIP_S3_LIST_FOR_OBSERVATIONS_PROJECT_IDS: undefined,
+  },
+}));
+
+vi.mock("../instrumentation", () => ({
+  getCurrentSpan: () => ({
+    setAttribute: vi.fn(),
+  }),
+  instrumentAsync: (_opts: unknown, fn: () => Promise<unknown>) => fn(),
+  recordDistribution: vi.fn(),
+  recordIncrement: vi.fn(),
+  traceException: vi.fn(),
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../redis/s3SlowdownTracking", () => ({
+  isS3SlowDownError: () => false,
+  markProjectS3Slowdown: vi.fn(),
+}));
+
+vi.mock("../services/StorageService", () => ({
+  StorageService: class StorageService {},
+  StorageServiceFactory: {
+    getInstance: () => ({
+      uploadJson: async (path: string) => {
+        uploadedPaths.push(path);
+        throw new Error("boom");
+      },
+    }),
+  },
+}));
+
+vi.mock("./types", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./types")>();
+  const { z } = await import("zod");
+
+  const minimalSchema = z
+    .object({
+      id: z.string(),
+      type: z.string(),
+      timestamp: z.string(),
+      body: z.object({ id: z.string() }).loose(),
+    })
+    .loose();
+
+  return {
+    ...actual,
+    createIngestionEventSchema: () => minimalSchema,
+  };
+});
+
+describe("processEventBatch S3 key segmentation", () => {
+  it("keeps every S3 key path segment <= 255 bytes", async () => {
+    const { processEventBatch } = await import("./processEventBatch");
+    const { eventTypes } = await import("./types");
+
+    const longId = `resp_${"a".repeat(300)}`;
+    const now = new Date().toISOString();
+
+    await expect(
+      processEventBatch(
+        [
+          {
+            id: "evt_1",
+            type: eventTypes.TRACE_CREATE,
+            timestamp: now,
+            body: { id: longId },
+          },
+        ],
+        {
+          validKey: true,
+          scope: {
+            projectId: "proj_123",
+            accessLevel: "project",
+          },
+        } as any,
+      ),
+    ).rejects.toThrow("Failed to upload events to blob storage");
+
+    expect(uploadedPaths).toHaveLength(1);
+
+    const segments = uploadedPaths[0].split("/").filter(Boolean);
+    for (const segment of segments) {
+      expect(Buffer.byteLength(segment, "utf8")).toBeLessThanOrEqual(255);
+    }
+  });
+});

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { z } from "zod";
 
 import { env } from "../../env";
@@ -36,6 +36,42 @@ import {
 } from "../redis/s3SlowdownTracking";
 
 let s3StorageServiceClient: StorageService;
+
+const S3_OBJECT_KEY_SEGMENT_MAX_BYTES = 255;
+
+const safeS3ObjectKeySegment = (
+  segment: string,
+  maxBytes = S3_OBJECT_KEY_SEGMENT_MAX_BYTES,
+) => {
+  if (Buffer.byteLength(segment, "utf8") <= maxBytes) {
+    return segment;
+  }
+
+  const hash = createHash("sha256").update(segment).digest("hex").slice(0, 16);
+  const suffix = `_${hash}`;
+  const suffixBytes = Buffer.byteLength(suffix, "utf8");
+  const prefixMaxBytes = Math.max(0, maxBytes - suffixBytes);
+
+  const prefixBuf = Buffer.from(segment, "utf8").subarray(0, prefixMaxBytes);
+  let prefix = prefixBuf.toString("utf8");
+  while (
+    Buffer.byteLength(prefix, "utf8") > prefixMaxBytes &&
+    prefix.length > 0
+  ) {
+    prefix = prefix.slice(0, -1);
+  }
+
+  return `${prefix}${suffix}`;
+};
+
+const safeS3ObjectKeyFileName = (baseName: string, extension: string) => {
+  const extensionBytes = Buffer.byteLength(extension, "utf8");
+  const safeBase = safeS3ObjectKeySegment(
+    baseName,
+    Math.max(0, S3_OBJECT_KEY_SEGMENT_MAX_BYTES - extensionBytes),
+  );
+  return `${safeBase}${extension}`;
+};
 
 const getS3StorageServiceClient = (bucketName: string): StorageService => {
   if (!s3StorageServiceClient) {
@@ -234,7 +270,9 @@ export const processEventBatch = async (
         // That way we batch updates from the same invocation into a single file and reduce
         // write operations on S3.
         const { data, key, type, eventBodyId } = sortedBatchByEventBodyId[id];
-        const bucketPath = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${authCheck.scope.projectId}/${getClickhouseEntityType(type)}/${eventBodyId}/${key}.json`;
+        const safeEventBodyId = safeS3ObjectKeySegment(eventBodyId);
+        const safeFileName = safeS3ObjectKeyFileName(key, ".json");
+        const bucketPath = `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${authCheck.scope.projectId}/${getClickhouseEntityType(type)}/${safeEventBodyId}/${safeFileName}`;
         return getS3StorageServiceClient(
           env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET,
         ).uploadJson(bucketPath, data);


### PR DESCRIPTION
Fixes #13476.

MinIO running on ext4 rejects object keys with path segments >255 bytes. We currently embed `event.body.id` into both the directory segment and the file name for S3 event uploads, which can exceed that limit for long provider-generated IDs.

This change bounds each S3 key segment to <=255 bytes by truncating and appending a stable hash.

Tests:
- pnpm --filter @langfuse/shared run lint
- pnpm --filter @langfuse/shared run db:generate
- pnpm --filter @langfuse/shared run test
- pnpm --filter web run lint
- pnpm --filter worker run lint

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bounds S3 object-key path segments to ≤255 bytes by truncating long `eventBodyId` values (such as provider-generated IDs like `resp_aaa…`) and appending a 16-char SHA-256 hash before the upload, fixing MinIO/ext4 rejections.

- **Write side fixed, read side not updated**: The upload path in `processEventBatch.ts` correctly uses the truncated `safeEventBodyId`, but the raw `eventBodyId` is still enqueued in the Redis job payload. The worker (`worker/src/queues/ingestionQueue.ts`, line 161) rebuilds the S3 prefix directly from `job.data.payload.data.eventBodyId` without any truncation, so when an ID exceeds 255 bytes the worker constructs a path that was never written — causing a silent S3 list/download miss and dropping all events for that entity.
- The `BlobStorageFileLog` entry (line 75 of the same worker file) records the same raw `eventBodyId` in `bucket_path`, so retention and deletion operations would target a non-existent path.
- The accompanying test validates the upload path correctly but does not cover the worker's reconstruction logic.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The upload side is fixed, but the worker still reads using the untransformed eventBodyId, so any event whose body ID exceeds 255 bytes will be silently lost after this change ships.

The truncation logic itself is sound and the test for the write path is well-structured. The gap is that worker/src/queues/ingestionQueue.ts reconstructs the S3 prefix from the raw queue payload without applying the same transformation, turning a previously-rejected upload into a silently-dropped event. This is not a theoretical risk — it is the normal code path for any ingestion event whose provider-generated ID is longer than 255 characters.

worker/src/queues/ingestionQueue.ts (lines 75 and 161) needs to apply the same segment-length transformation when reconstructing S3 paths from the queue payload.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API as API (processEventBatch.ts)
    participant S3 as S3 / MinIO
    participant Queue as Redis IngestionQueue
    participant Worker as Worker (ingestionQueue.ts)

    API->>API: "safeEventBodyId = safeS3ObjectKeySegment(eventBodyId)"
    Note over API: truncates to ≤255 bytes + hash suffix
    API->>S3: "upload to .../{safeEventBodyId}/{safeFileName}.json"
    API->>Queue: "enqueue { eventBodyId: rawEventBodyId, fileKey: rawKey }"
    Note over Queue: raw (un-truncated) eventBodyId stored

    Worker->>Queue: dequeue job
    Worker->>Worker: build prefix using raw eventBodyId
    Note over Worker: .../{rawEventBodyId}/ DOES NOT MATCH S3 path
    Worker->>S3: "listFiles(.../{rawEventBodyId}/)"
    S3-->>Worker: [] (no files found — wrong directory)
    Worker->>Worker: log warning No events found, return
    Note over Worker: Events silently dropped
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/ingestion/processEventBatch.ts:359-385
**Worker–producer path mismatch on long `eventBodyId`**

The queue payload carries the raw `eventBodyId: eventData.eventBodyId` (potentially >255 bytes), but `worker/src/queues/ingestionQueue.ts` (line 161) reconstructs the S3 prefix with that same raw value — `…/${job.data.payload.data.eventBodyId}/` — without applying `safeS3ObjectKeySegment`. When `eventBodyId` exceeds 255 bytes, the file is uploaded to `${safeEventBodyId}/…` but the worker reads from `${rawEventBodyId}/…`, returning zero files from S3 and silently dropping all events for that entity. The same raw value is also logged in `bucket_path` of the `BlobStorageFileLog` entry (line 75 of `ingestionQueue.ts`), so retention/deletion records will point to a path that does not exist.

The fix requires either exporting `safeS3ObjectKeySegment` from the shared package and calling it in the worker's prefix construction, or including the truncated form as a separate field in the queue payload.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): bound S3 key segment length"](https://github.com/langfuse/langfuse/commit/5f8335e8b6fe7edca1e03cbce93c3013b79ef23c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33239946)</sub>

<!-- /greptile_comment -->