### PR TITLE
chore: bump clickhouse client to 1.18.5

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -91,7 +91,7 @@
     "@aws-sdk/lib-storage": "^3.1013.0",
     "@aws-sdk/s3-request-presigner": "^3.1013.0",
     "@azure/storage-blob": "^12.26.0",
-    "@clickhouse/client": "^1.13.0",
+    "@clickhouse/client": "^1.18.5",
     "@google-cloud/storage": "^7.19.0",
     "@langchain/anthropic": "^1.3.26",
     "@langchain/aws": "^1.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^12.26.0
         version: 12.26.0
       '@clickhouse/client':
-        specifier: ^1.13.0
-        version: 1.13.0
+        specifier: ^1.18.5
+        version: 1.18.5
       '@google-cloud/storage':
         specifier: ^7.19.0
         version: 7.19.0
@@ -1552,11 +1552,11 @@ packages:
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
-  '@clickhouse/client-common@1.13.0':
-    resolution: {integrity: sha512-QlGUMd3EaKkIRLCv0WW8Rw9cOlqhwQPT+ucNWY8eC4UALsMhJLpa0H7Cd7MYc9CEtTv/xlr3IcYw5Tdho4Hr2g==}
+  '@clickhouse/client-common@1.18.5':
+    resolution: {integrity: sha512-g9LwcS1dvkatKDsIjT1PwUHldsiYzwdKAB0nXfd9APLd+t4PrNJa+my+dXcqJdmcWyhWjKLP/2/ztBwgxp+sbQ==}
 
-  '@clickhouse/client@1.13.0':
-    resolution: {integrity: sha512-uK+zqPaJnAoq3QIOvUNbHtbWUhyg2A/aSbdJtrY2+kawp4SMBLcfIbB9ucRv5Yht1CAa3b24CiUlypkmgarukg==}
+  '@clickhouse/client@1.18.5':
+    resolution: {integrity: sha512-4FfoyMkFWhsdNMuXsoEL6l3c12svA63BBJBtDo9SrxRZ14RdmN6jLr/rF3f84BK8cFoxETZCSeKlsbk6NNYebw==}
     engines: {node: '>=16'}
 
   '@codemirror/autocomplete@6.17.0':
@@ -11804,11 +11804,11 @@ snapshots:
 
   '@chevrotain/types@11.1.2': {}
 
-  '@clickhouse/client-common@1.13.0': {}
+  '@clickhouse/client-common@1.18.5': {}
 
-  '@clickhouse/client@1.13.0':
+  '@clickhouse/client@1.18.5':
     dependencies:
-      '@clickhouse/client-common': 1.13.0
+      '@clickhouse/client-common': 1.18.5
 
   '@codemirror/autocomplete@6.17.0(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.42.0)(@lezer/common@1.5.1)':
     dependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps the `@clickhouse/client` package (and its peer `@clickhouse/client-common`) from `1.13.0` to `1.18.5` in `packages/shared`. Both `package.json` and `pnpm-lock.yaml` are updated consistently.

- The version specifier in `package.json` is updated from `^1.13.0` to `^1.18.5`, and the lock file snapshots are updated to match the new resolved versions with their correct integrity hashes.
- `@clickhouse/client-common` is co-versioned with the client and is correctly bumped to `1.18.5` as well.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a routine minor-version dependency update with no application logic changes.

Both package.json and pnpm-lock.yaml are updated consistently with correct integrity hashes. The bump spans minor releases (1.13→1.18), meaning the client's published semver guarantees no breaking API changes. No application code is modified.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump clickhouse client to 1.18.5"](https://github.com/langfuse/langfuse/commit/fbf603b0e770043cf85877fb03ab8f5000ef8c9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33240056)</sub>

<!-- /greptile_comment -->