### PR TITLE
fix(tracing): sanitize external urls wholistically

### DIFF
--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -344,7 +344,8 @@ function MarkdownRenderer({
               );
             },
             img({ src, alt }) {
-              const safeSrc = getSafeImageUrl(src);
+              const safeSrc =
+                typeof src === "string" ? getSafeImageUrl(src) : null;
               return safeSrc ? (
                 <ResizableImage src={safeSrc} alt={alt} />
               ) : null;
@@ -553,28 +554,26 @@ export function MarkdownView({
             }
 
             if (isOpenAIImageContentPart(content)) {
-              const safeImageUrl = OpenAIUrlImageUrl.safeParse(
-                content.image_url.url,
-              ).success
-                ? getSafeImageUrl(content.image_url.url)
-                : null;
+              const imageUrl = content.image_url.url;
+              const safeImageUrl =
+                typeof imageUrl === "string" &&
+                OpenAIUrlImageUrl.safeParse(imageUrl).success
+                  ? getSafeImageUrl(imageUrl)
+                  : null;
 
               return safeImageUrl ? (
                 <div key={index}>
                   <ResizableImage src={safeImageUrl} />
                 </div>
-              ) : MediaReferenceStringSchema.safeParse(content.image_url.url)
-                  .success ? (
-                <LangfuseMediaView
-                  mediaReferenceString={content.image_url.url}
-                />
+              ) : MediaReferenceStringSchema.safeParse(imageUrl).success ? (
+                <LangfuseMediaView mediaReferenceString={imageUrl} />
               ) : (
                 <div className="grid grid-cols-[auto_1fr] items-center gap-2">
                   <span title="<Base64 data URI>" className="h-4 w-4">
                     <ImageOff className="h-4 w-4" />
                   </span>
                   <span className="truncate text-sm">
-                    {content.image_url.url.toString()}
+                    {imageUrl.toString()}
                   </span>
                 </div>
               );

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -35,10 +35,10 @@ import { type MediaReturnType } from "@/src/features/media/validation";
 import { JSONView } from "@/src/components/ui/CodeJsonViewer";
 import { MarkdownJsonViewHeader } from "@/src/components/ui/MarkdownJsonView";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
-import DOMPurify from "dompurify";
 import { MENTION_USER_PREFIX } from "@/src/features/comments/lib/mentionParser";
 import { useCollapsibleSystemPrompt } from "@/src/hooks/useCollapsibleSystemPrompt";
 import { Button } from "@/src/components/ui/button";
+import { getSafeImageUrl, getSafeLinkUrl } from "@/src/components/ui/safe-url";
 import {
   getPromptReferenceMarkdownHref,
   getPromptReferenceMarkdownLabel,
@@ -62,33 +62,6 @@ type ReactMarkdownNodeChildren = Exclude<
 // ReactMarkdown does not render raw HTML by default for security reasons, to prevent XSS (Cross-Site Scripting) attacks.
 // html is rendered as plain text by default.
 const MemoizedReactMarkdown: FC<Options> = memo(ReactMarkdown);
-
-const getSafeUrl = (href: string | undefined | null): string | null => {
-  if (!href || typeof href !== "string") return null;
-
-  // DOMPurify's default sanitization is quite permissive but safe
-  // It blocks javascript:, data: with scripts, vbscript:, etc.
-  // But allows http:, https:, ftp:, mailto:, tel:, and many others
-  try {
-    const sanitized = DOMPurify.sanitize(href, {
-      // ALLOWED_TAGS: An array of HTML tags that are explicitly permitted in the output.
-      // Setting this to an empty array means that no HTML tags are allowed.
-      // Any HTML tag found within the 'href' string would be stripped out.
-      ALLOWED_TAGS: [],
-
-      // ALLOWED_ATTR: An array of HTML attributes that are explicitly permitted on allowed tags.
-      // Setting this to an empty array means that no HTML attributes are allowed.
-      // Similar to ALLOWED_TAGS, this ensures that if any attributes are somehow
-      // embedded within the URL string (e.g., malformed or attempting injection),
-      // they will be removed by DOMPurify. We only expect a pure URL string.
-      ALLOWED_ATTR: [],
-    });
-
-    return sanitized || null;
-  } catch {
-    return null;
-  }
-};
 
 const isTextElement = (
   child: ReactNode,
@@ -285,7 +258,7 @@ function MarkdownRenderer({
               }
 
               // Handle regular links
-              const safeHref = getSafeUrl(href);
+              const safeHref = getSafeLinkUrl(href);
               if (safeHref) {
                 return (
                   <Link
@@ -371,8 +344,9 @@ function MarkdownRenderer({
               );
             },
             img({ src, alt }) {
-              return src && typeof src === "string" ? (
-                <ResizableImage src={src} alt={alt} />
+              const safeSrc = getSafeImageUrl(src);
+              return safeSrc ? (
+                <ResizableImage src={safeSrc} alt={alt} />
               ) : null;
             },
             hr() {
@@ -566,18 +540,28 @@ export function MarkdownView({
           )
         ) : (
           // content parts (multi-modal)
-          (markdown ?? []).map((content, index) =>
-            isOpenAITextContentPart(content) ? (
-              <MarkdownRenderer
-                key={index}
-                markdown={content.text}
-                theme={theme}
-                customCodeHeaderClassName={customCodeHeaderClassName}
-              />
-            ) : isOpenAIImageContentPart(content) ? (
-              OpenAIUrlImageUrl.safeParse(content.image_url.url).success ? (
+          (markdown ?? []).map((content, index) => {
+            if (isOpenAITextContentPart(content)) {
+              return (
+                <MarkdownRenderer
+                  key={index}
+                  markdown={content.text}
+                  theme={theme}
+                  customCodeHeaderClassName={customCodeHeaderClassName}
+                />
+              );
+            }
+
+            if (isOpenAIImageContentPart(content)) {
+              const safeImageUrl = OpenAIUrlImageUrl.safeParse(
+                content.image_url.url,
+              ).success
+                ? getSafeImageUrl(content.image_url.url)
+                : null;
+
+              return safeImageUrl ? (
                 <div key={index}>
-                  <ResizableImage src={content.image_url.url.toString()} />
+                  <ResizableImage src={safeImageUrl} />
                 </div>
               ) : MediaReferenceStringSchema.safeParse(content.image_url.url)
                   .success ? (
@@ -593,13 +577,15 @@ export function MarkdownView({
                     {content.image_url.url.toString()}
                   </span>
                 </div>
-              )
-            ) : content.type === "input_audio" ? (
+              );
+            }
+
+            return content.type === "input_audio" ? (
               <LangfuseMediaView
                 mediaReferenceString={content.input_audio.data}
               />
-            ) : null,
-          )
+            ) : null;
+          })
         )}
         {audio ? (
           <>

--- a/web/src/components/ui/resizable-image.tsx
+++ b/web/src/components/ui/resizable-image.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from "@/src/components/ui/skeleton";
 import { captureException } from "@sentry/nextjs";
 import { useSession } from "next-auth/react";
 import { buildResizableImageSrc } from "./resizable-image.utils";
+import { getSafeImageUrl } from "@/src/components/ui/safe-url";
 
 /**
  * Implemented customLoader as we cannot whitelist user provided image domains
@@ -31,16 +32,29 @@ const ImageErrorDisplay = ({
 }: {
   src: string;
   displayError: string;
-}) => (
-  <div className="grid grid-cols-[auto_1fr] items-center gap-2">
-    <span title={displayError} className="h-4 w-4">
-      <ImageOff className="h-4 w-4" />
-    </span>
-    <Link href={src} className="truncate text-sm underline" target="_blank">
-      {src}
-    </Link>
-  </div>
-);
+}) => {
+  const safeSrc = getSafeImageUrl(src);
+
+  return (
+    <div className="grid grid-cols-[auto_1fr] items-center gap-2">
+      <span title={displayError} className="h-4 w-4">
+        <ImageOff className="h-4 w-4" />
+      </span>
+      {safeSrc ? (
+        <Link
+          href={safeSrc}
+          className="truncate text-sm underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {src}
+        </Link>
+      ) : (
+        <span className="truncate text-sm">{src}</span>
+      )}
+    </div>
+  );
+};
 
 export const ResizableImage = ({
   src,
@@ -53,13 +67,15 @@ export const ResizableImage = ({
   isDefaultVisible?: boolean;
   shouldValidateImageSource?: boolean;
 }) => {
+  const safeSrc = getSafeImageUrl(src);
   const [isZoomedIn, setIsZoomedIn] = useState(true);
   const [hasFetchError, setHasFetchError] = useState(false);
   const [isImageVisible, setIsImageVisible] = useState(isDefaultVisible);
   const session = useSession();
-  const isValidImage = api.utilities.validateImgUrl.useQuery(src, {
+  const isValidImage = api.utilities.validateImgUrl.useQuery(safeSrc ?? "", {
     enabled:
       session.status === "authenticated" &&
+      Boolean(safeSrc) &&
       isImageVisible &&
       shouldValidateImageSource,
     initialData: shouldValidateImageSource ? undefined : { isValid: true },
@@ -95,16 +111,16 @@ export const ResizableImage = ({
             isZoomedIn ? "h-1/2 w-1/2" : "h-full w-full",
           )}
         >
-          {isImageVisible && isValidImage.data?.isValid ? (
+          {isImageVisible && safeSrc && isValidImage.data?.isValid ? (
             <>
               <Image
                 loader={customLoader}
-                src={src}
+                src={safeSrc}
                 alt={alt ?? `Markdown Image-${Math.random()}`}
                 loading="lazy"
                 width={0}
                 height={0}
-                title={src}
+                title={safeSrc ?? src}
                 className="h-full w-full rounded border object-contain"
                 onError={(error) => {
                   setHasFetchError(true);
@@ -133,18 +149,26 @@ export const ResizableImage = ({
                 size="sm"
                 variant="secondary"
                 onClick={() => setIsImageVisible(!isImageVisible)}
+                disabled={!safeSrc}
               >
                 Load Image
               </Button>
               <div className="flex min-w-0 flex-1 items-center overflow-hidden">
-                <Link
-                  href={src}
-                  title={src}
-                  className="truncate underline"
-                  target="_blank"
-                >
-                  {src}
-                </Link>
+                {safeSrc ? (
+                  <Link
+                    href={safeSrc}
+                    title={src}
+                    className="truncate underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {src}
+                  </Link>
+                ) : (
+                  <span title={src} className="truncate">
+                    {src}
+                  </span>
+                )}
               </div>
             </div>
           )}

--- a/web/src/components/ui/safe-url.clienttest.ts
+++ b/web/src/components/ui/safe-url.clienttest.ts
@@ -1,0 +1,42 @@
+import { getSafeImageUrl, getSafeLinkUrl } from "@/src/components/ui/safe-url";
+
+describe("safe URL helpers", () => {
+  it.each([
+    "javascript:alert(1)",
+    "JaVaScRiPt:alert(1)",
+    "jav\nascript:alert(1)",
+    "vbscript:msgbox(1)",
+    "data:text/html,<svg/onload=alert(1)>",
+    "ftp://example.com/file.txt",
+    "//attacker.example.com/path",
+    "relative/path",
+  ])("blocks unsafe link URL %s", (url) => {
+    expect(getSafeLinkUrl(url)).toBeNull();
+  });
+
+  it.each([
+    ["https://example.com/path?q=1", "https://example.com/path?q=1"],
+    ["http://example.com/image.png", "http://example.com/image.png"],
+    ["mailto:security@example.com", "mailto:security@example.com"],
+    ["tel:+49123456789", "tel:+49123456789"],
+    ["/project/abc/traces/def", "/project/abc/traces/def"],
+    ["#section", "#section"],
+  ])("allows safe link URL %s", (url, expected) => {
+    expect(getSafeLinkUrl(url)).toBe(expected);
+  });
+
+  it.each(["mailto:security@example.com", "tel:+49123456789", "#section"])(
+    "blocks non-image URL %s for image sources",
+    (url) => {
+      expect(getSafeImageUrl(url)).toBeNull();
+    },
+  );
+
+  it.each([
+    ["https://example.com/image.png", "https://example.com/image.png"],
+    ["http://example.com/image.png", "http://example.com/image.png"],
+    ["/api/media/image.png", "/api/media/image.png"],
+  ])("allows safe image URL %s", (url, expected) => {
+    expect(getSafeImageUrl(url)).toBe(expected);
+  });
+});

--- a/web/src/components/ui/safe-url.clienttest.ts
+++ b/web/src/components/ui/safe-url.clienttest.ts
@@ -7,8 +7,11 @@ describe("safe URL helpers", () => {
     "jav\nascript:alert(1)",
     "vbscript:msgbox(1)",
     "data:text/html,<svg/onload=alert(1)>",
+    "data:image/png;base64,iVBORw0KGgo=",
     "ftp://example.com/file.txt",
     "//attacker.example.com/path",
+    "/\\attacker.example.com/path",
+    "/\\\\attacker.example.com/path",
     "relative/path",
   ])("blocks unsafe link URL %s", (url) => {
     expect(getSafeLinkUrl(url)).toBeNull();
@@ -16,6 +19,9 @@ describe("safe URL helpers", () => {
 
   it.each([
     ["https://example.com/path?q=1", "https://example.com/path?q=1"],
+    ["HTTPS://EXAMPLE.COM/path", "https://example.com/path"],
+    ["https://example.com/foo\tbar", "https://example.com/foobar"],
+    ["https://example.com/foo bar", "https://example.com/foo%20bar"],
     ["http://example.com/image.png", "http://example.com/image.png"],
     ["mailto:security@example.com", "mailto:security@example.com"],
     ["tel:+49123456789", "tel:+49123456789"],
@@ -25,15 +31,21 @@ describe("safe URL helpers", () => {
     expect(getSafeLinkUrl(url)).toBe(expected);
   });
 
-  it.each(["mailto:security@example.com", "tel:+49123456789", "#section"])(
-    "blocks non-image URL %s for image sources",
-    (url) => {
-      expect(getSafeImageUrl(url)).toBeNull();
-    },
-  );
+  it.each([
+    "mailto:security@example.com",
+    "tel:+49123456789",
+    "#section",
+    "data:image/png;base64,iVBORw0KGgo=",
+    "//attacker.example.com/path",
+    "/\\attacker.example.com/path",
+    "/\\\\attacker.example.com/path",
+  ])("blocks non-image URL %s for image sources", (url) => {
+    expect(getSafeImageUrl(url)).toBeNull();
+  });
 
   it.each([
     ["https://example.com/image.png", "https://example.com/image.png"],
+    ["HTTPS://EXAMPLE.COM/image.png", "https://example.com/image.png"],
     ["http://example.com/image.png", "http://example.com/image.png"],
     ["/api/media/image.png", "/api/media/image.png"],
   ])("allows safe image URL %s", (url, expected) => {

--- a/web/src/components/ui/safe-url.clienttest.ts
+++ b/web/src/components/ui/safe-url.clienttest.ts
@@ -12,7 +12,8 @@ describe("safe URL helpers", () => {
     "//attacker.example.com/path",
     "/\\attacker.example.com/path",
     "/\\\\attacker.example.com/path",
-    "relative/path",
+    "\\attacker.example.com/path",
+    "relative\\path",
   ])("blocks unsafe link URL %s", (url) => {
     expect(getSafeLinkUrl(url)).toBeNull();
   });
@@ -23,9 +24,16 @@ describe("safe URL helpers", () => {
     ["https://example.com/foo\tbar", "https://example.com/foobar"],
     ["https://example.com/foo bar", "https://example.com/foo%20bar"],
     ["http://example.com/image.png", "http://example.com/image.png"],
+    ["irc://irc.example.com/langfuse", "irc://irc.example.com/langfuse"],
+    ["ircs://irc.example.com/langfuse", "ircs://irc.example.com/langfuse"],
     ["mailto:security@example.com", "mailto:security@example.com"],
     ["tel:+49123456789", "tel:+49123456789"],
+    ["xmpp:security@example.com", "xmpp:security@example.com"],
     ["/project/abc/traces/def", "/project/abc/traces/def"],
+    ["relative/path", "relative/path"],
+    ["./relative/path", "./relative/path"],
+    ["../relative/path", "../relative/path"],
+    ["?tab=foo", "?tab=foo"],
     ["#section", "#section"],
   ])("allows safe link URL %s", (url, expected) => {
     expect(getSafeLinkUrl(url)).toBe(expected);
@@ -39,6 +47,8 @@ describe("safe URL helpers", () => {
     "//attacker.example.com/path",
     "/\\attacker.example.com/path",
     "/\\\\attacker.example.com/path",
+    "\\attacker.example.com/path",
+    "relative\\path",
   ])("blocks non-image URL %s for image sources", (url) => {
     expect(getSafeImageUrl(url)).toBeNull();
   });
@@ -48,6 +58,9 @@ describe("safe URL helpers", () => {
     ["HTTPS://EXAMPLE.COM/image.png", "https://example.com/image.png"],
     ["http://example.com/image.png", "http://example.com/image.png"],
     ["/api/media/image.png", "/api/media/image.png"],
+    ["relative/image.png", "relative/image.png"],
+    ["./relative/image.png", "./relative/image.png"],
+    ["../relative/image.png", "../relative/image.png"],
   ])("allows safe image URL %s", (url, expected) => {
     expect(getSafeImageUrl(url)).toBe(expected);
   });

--- a/web/src/components/ui/safe-url.ts
+++ b/web/src/components/ui/safe-url.ts
@@ -1,6 +1,10 @@
 const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
 const SAFE_IMAGE_PROTOCOLS = new Set(["http:", "https:"]);
 
+// The old DOMPurify helper used ALLOWED_TAGS: [] and ALLOWED_ATTR: [], which is
+// correct for stripping HTML tags/attributes from a string. It does not validate
+// URL protocols when the input is already plain text: "javascript:alert(1)" has
+// no markup to remove, so URL safety has to be protocol allowlist based here.
 const getSafeUrl = (
   value: string | undefined | null,
   {
@@ -22,10 +26,12 @@ const getSafeUrl = (
     const parsed = new URL(trimmed);
     return allowedProtocols.has(parsed.protocol) ? trimmed : null;
   } catch {
+    // Markdown links may point to anchors inside the rendered content.
     if (allowHash && trimmed.startsWith("#")) {
       return trimmed;
     }
 
+    // Allow same-origin app paths, but block protocol-relative URLs.
     if (
       allowAbsolutePath &&
       trimmed.startsWith("/") &&

--- a/web/src/components/ui/safe-url.ts
+++ b/web/src/components/ui/safe-url.ts
@@ -1,0 +1,54 @@
+const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+const SAFE_IMAGE_PROTOCOLS = new Set(["http:", "https:"]);
+
+const getSafeUrl = (
+  value: string | undefined | null,
+  {
+    allowedProtocols,
+    allowHash = false,
+    allowAbsolutePath = true,
+  }: {
+    allowedProtocols: Set<string>;
+    allowHash?: boolean;
+    allowAbsolutePath?: boolean;
+  },
+): string | null => {
+  if (!value || typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = new URL(trimmed);
+    return allowedProtocols.has(parsed.protocol) ? trimmed : null;
+  } catch {
+    if (allowHash && trimmed.startsWith("#")) {
+      return trimmed;
+    }
+
+    if (
+      allowAbsolutePath &&
+      trimmed.startsWith("/") &&
+      !trimmed.startsWith("//")
+    ) {
+      return trimmed;
+    }
+
+    return null;
+  }
+};
+
+export const getSafeLinkUrl = (
+  value: string | undefined | null,
+): string | null =>
+  getSafeUrl(value, {
+    allowedProtocols: SAFE_LINK_PROTOCOLS,
+    allowHash: true,
+  });
+
+export const getSafeImageUrl = (
+  value: string | undefined | null,
+): string | null =>
+  getSafeUrl(value, {
+    allowedProtocols: SAFE_IMAGE_PROTOCOLS,
+  });

--- a/web/src/components/ui/safe-url.ts
+++ b/web/src/components/ui/safe-url.ts
@@ -1,4 +1,12 @@
-const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+const SAFE_LINK_PROTOCOLS = new Set([
+  "http:",
+  "https:",
+  "irc:",
+  "ircs:",
+  "mailto:",
+  "tel:",
+  "xmpp:",
+]);
 const SAFE_IMAGE_PROTOCOLS = new Set(["http:", "https:"]);
 const SAME_ORIGIN_URL_BASE = "https://langfuse.local";
 
@@ -15,11 +23,13 @@ const getSafeUrl = (
   {
     allowedProtocols,
     allowHash = false,
-    allowAbsolutePath = true,
+    allowSearch = false,
+    allowRelativePath = true,
   }: {
     allowedProtocols: Set<string>;
     allowHash?: boolean;
-    allowAbsolutePath?: boolean;
+    allowSearch?: boolean;
+    allowRelativePath?: boolean;
   },
 ): string | null => {
   if (!value || typeof value !== "string") return null;
@@ -36,25 +46,34 @@ const getSafeUrl = (
       return trimmed;
     }
 
-    // Allow same-origin app paths, but block protocol-relative and
-    // backslash-normalized URLs that browsers can resolve to another host.
-    if (
-      allowAbsolutePath &&
-      trimmed.startsWith("/") &&
-      !trimmed.startsWith("//") &&
-      !trimmed.includes("\\")
-    ) {
-      try {
-        const parsedPath = new URL(trimmed, SAME_ORIGIN_URL_BASE);
-        return parsedPath.origin === SAME_ORIGIN_URL_BASE
-          ? `${parsedPath.pathname}${parsedPath.search}${parsedPath.hash}`
-          : null;
-      } catch {
-        return null;
-      }
+    if (allowSearch && trimmed.startsWith("?")) {
+      return isSafeSameOriginReference(trimmed) ? trimmed : null;
+    }
+
+    if (allowRelativePath && isRelativePathReference(trimmed)) {
+      return isSafeSameOriginReference(trimmed) ? trimmed : null;
     }
 
     return null;
+  }
+};
+
+const isRelativePathReference = (value: string): boolean =>
+  value.startsWith("/") ||
+  value.startsWith("./") ||
+  value.startsWith("../") ||
+  /^[^/?#]/.test(value);
+
+const isSafeSameOriginReference = (value: string): boolean => {
+  // Block protocol-relative and backslash-normalized URLs. Browsers can resolve
+  // values like "/\\attacker.example/x" to another host for http(s) documents.
+  if (value.startsWith("//") || value.includes("\\")) return false;
+
+  try {
+    const parsed = new URL(value, SAME_ORIGIN_URL_BASE);
+    return parsed.origin === SAME_ORIGIN_URL_BASE;
+  } catch {
+    return false;
   }
 };
 
@@ -64,6 +83,7 @@ export const getSafeLinkUrl = (
   getSafeUrl(value, {
     allowedProtocols: SAFE_LINK_PROTOCOLS,
     allowHash: true,
+    allowSearch: true,
   });
 
 export const getSafeImageUrl = (

--- a/web/src/components/ui/safe-url.ts
+++ b/web/src/components/ui/safe-url.ts
@@ -1,5 +1,10 @@
 const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
 const SAFE_IMAGE_PROTOCOLS = new Set(["http:", "https:"]);
+const SAME_ORIGIN_URL_BASE = "https://langfuse.local";
+
+// Markdown image URLs intentionally stay limited to fetchable http(s) URLs and
+// same-origin paths. Do not add data: here; inline base64 media needs separate
+// handling from clickable/fetchable markdown URLs.
 
 // The old DOMPurify helper used ALLOWED_TAGS: [] and ALLOWED_ATTR: [], which is
 // correct for stripping HTML tags/attributes from a string. It does not validate
@@ -24,20 +29,29 @@ const getSafeUrl = (
 
   try {
     const parsed = new URL(trimmed);
-    return allowedProtocols.has(parsed.protocol) ? trimmed : null;
+    return allowedProtocols.has(parsed.protocol) ? parsed.href : null;
   } catch {
     // Markdown links may point to anchors inside the rendered content.
     if (allowHash && trimmed.startsWith("#")) {
       return trimmed;
     }
 
-    // Allow same-origin app paths, but block protocol-relative URLs.
+    // Allow same-origin app paths, but block protocol-relative and
+    // backslash-normalized URLs that browsers can resolve to another host.
     if (
       allowAbsolutePath &&
       trimmed.startsWith("/") &&
-      !trimmed.startsWith("//")
+      !trimmed.startsWith("//") &&
+      !trimmed.includes("\\")
     ) {
-      return trimmed;
+      try {
+        const parsedPath = new URL(trimmed, SAME_ORIGIN_URL_BASE);
+        return parsedPath.origin === SAME_ORIGIN_URL_BASE
+          ? `${parsedPath.pathname}${parsedPath.search}${parsedPath.hash}`
+          : null;
+      } catch {
+        return null;
+      }
     }
 
     return null;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the DOMPurify-based URL sanitisation in `MarkdownViewer` with a new `safe-url.ts` module (`getSafeLinkUrl` / `getSafeImageUrl`) that uses the WHATWG `new URL()` parser for protocol validation. `ResizableImage` is updated to call the new helpers so every link and image source is validated at the point of use before it reaches the DOM.

- **`safe-url.ts`**: New lightweight URL allow-listing module using `URL` parsing; supports safe protocols (`http:`, `https:`, `mailto:`, `tel:`), fragment-only, and same-origin absolute paths.
- **`MarkdownViewer.tsx` / `resizable-image.tsx`**: All link `href` and image `src` values are now passed through the new helpers before rendering; unsafe URLs are silently dropped and shown as plain text instead.
- **`safe-url.clienttest.ts`**: Client-side unit tests covering XSS vectors (`javascript:`, `vbscript:`, `data:`, `//` protocol-relative, relative paths) and allowed cases.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change moves URL sanitisation in the right direction and is safe to merge; the issues found are code-quality concerns rather than exploitable vulnerabilities.

The core allow-list logic is sound and the major XSS vectors are correctly blocked. The main concern is that getSafeUrl returns the raw trimmed input rather than the WHATWG-normalised parsed.href, creating a subtle mismatch between what is validated and what is returned. Additionally, blocking data:image/… URIs is an undocumented behaviour change from the previous DOMPurify approach with no test coverage.

safe-url.ts (return value normalisation) and safe-url.clienttest.ts (missing data URI and protocol-relative coverage for image URLs)
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Raw URL string\n(from Markdown / OpenAI content)"] --> B["getSafeLinkUrl / getSafeImageUrl"]
    B --> C["trim whitespace"]
    C --> D["new URL(trimmed)"]
    D -->|"throws (relative / fragment)"| E{"allowHash or\nallowAbsolutePath?"}
    D -->|"succeeds"| F{"parsed.protocol\nin allowedProtocols?"}
    F -->|"yes"| G["return trimmed ✓"]
    F -->|"no (javascript:, data:, ftp:, …)"| H["return null ✗"]
    E -->|"yes + starts with # or /"| I["return trimmed ✓"]
    E -->|"no"| J["return null ✗"]
    G --> K["Link href / Image src / ResizableImage"]
    I --> K
    H --> L["Render as plain text or null"]
    J --> L
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/ui/safe-url.ts:22-23
The function validates `parsed.protocol` but returns the original `trimmed` string rather than `parsed.href`. The WHATWG URL parser silently strips `	`, `
`, and `
` from URLs before processing, so a value like `"https://example.com/foo	bar"` would pass the protocol check and be returned with the tab still embedded. Using `parsed.href` returns the fully-normalised form and guarantees that what is checked equals what is returned downstream.

```suggestion
    const parsed = new URL(trimmed);
    return allowedProtocols.has(parsed.protocol) ? parsed.href : null;
```

### Issue 2 of 3
web/src/components/ui/resizable-image.tsx:123
`safeSrc` is already guaranteed to be truthy at this point in the render tree (the surrounding condition is `isImageVisible && safeSrc && isValidImage.data?.isValid`), so the `?? src` fallback is dead code and never evaluates.

```suggestion
                title={safeSrc}
```

### Issue 3 of 3
web/src/components/ui/safe-url.clienttest.ts:35-41
**Missing test for `data:image/…` URLs in `getSafeImageUrl`**

The previous DOMPurify implementation permitted `data:image/png;base64,…` URIs for `<img>` tags (DOMPurify allows `data:image` on image elements by default). The new `SAFE_IMAGE_PROTOCOLS` set contains only `"http:"` and `"https:"`, so base64-encoded images embedded directly in AI-generated content will silently stop rendering. Adding an explicit test case — and a comment in `safe-url.ts` — would document this intentional behaviour change and prevent future regressions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tracing): sanitize external urls who..."](https://github.com/langfuse/langfuse/commit/ca2fa104247433defbbf665cd602ca2865ceb1f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33424024)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->