### PR TITLE
fix: route more queries to readonly pools

### DIFF
--- a/packages/shared/src/features/query/server/queryExecutor.ts
+++ b/packages/shared/src/features/query/server/queryExecutor.ts
@@ -6,7 +6,6 @@ import { measureAndReturn } from "../../../server/clickhouse/measureAndReturn";
 import { type PreferredClickhouseService } from "../../../server/clickhouse/client";
 import { QueryBuilder } from "./queryBuilder";
 import { type QueryType, type ViewVersion } from "../types";
-import { getViewDeclaration } from "../dataModel";
 import { env } from "../../../env";
 
 export type PreparedQuery = {
@@ -44,8 +43,13 @@ export async function prepareExecuteQuery(opts: {
       env.LANGFUSE_ENABLE_SINGLE_LEVEL_QUERY_OPTIMIZATION === "true",
   );
 
-  const view = getViewDeclaration(query.view, version);
-  const preferredClickhouseService = view.baseCte.includes("events_")
+  // v2 score views are score-based, but can add events_core joins for
+  // trace/observation dimensions. Route based on the compiled query so only
+  // generated queries that actually touch events use the events readonly pool.
+  const usesEventsTable =
+    compiledQuery.includes("events_core") ||
+    compiledQuery.includes("events_full");
+  const preferredClickhouseService = usesEventsTable
     ? ("EventsReadOnly" as const)
     : undefined;
 

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -849,7 +849,8 @@ export const getTraceByIdFromEventsTable = async ({
         query,
         params: input.params,
         tags: input.tags,
-        preferredClickhouseService,
+        preferredClickhouseService:
+          preferredClickhouseService ?? "EventsReadOnly",
       });
     },
   });
@@ -2571,6 +2572,7 @@ export async function getAgentGraphDataFromEventsTable(params: {
         query,
         params: input.params,
         tags: input.tags,
+        preferredClickhouseService: "EventsReadOnly",
       });
     },
   });
@@ -2824,6 +2826,7 @@ export const getUsersFromEventsTable = async (
       kind: "analytic",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 };
 
@@ -2868,6 +2871,7 @@ export const getUsersCountFromEventsTable = async (
       kind: "analytic",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 };
 
@@ -2950,6 +2954,7 @@ export const getUserMetricsFromEventsTable = async (
       kind: "analytic",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   return rows.map((row) => ({
@@ -3050,6 +3055,7 @@ export const getEventsForBlobStorageExport = function (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 };
 
@@ -3102,6 +3108,7 @@ export const getEventsForAnalyticsIntegrations = async function* (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   const baseUrl = env.NEXTAUTH_URL?.replace("/api/auth", "");
@@ -3216,6 +3223,7 @@ export const getTraceMetadataByIdsFromEvents = async (props: {
         query,
         params: input.params,
         tags: input.tags,
+        preferredClickhouseService: "EventsReadOnly",
       }),
   });
 };
@@ -3261,6 +3269,7 @@ export const getAvgCostByEvaluatorIds = async (
       kind: "analytic",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   return rows.map((row) => ({
@@ -3303,6 +3312,7 @@ export const getSessionMetricsFromEvents = async (props: {
         query,
         params: input.params,
         tags: input.tags,
+        preferredClickhouseService: "EventsReadOnly",
       }),
   });
 

--- a/packages/shared/src/server/repositories/experiments.ts
+++ b/packages/shared/src/server/repositories/experiments.ts
@@ -199,6 +199,7 @@ export const getExperimentMetricsFromEvents = async (props: {
         query,
         params: input.params,
         tags: input.tags,
+        preferredClickhouseService: "EventsReadOnly",
       });
     },
   });
@@ -362,6 +363,7 @@ const getExperimentsFromEventsGeneric = async <T>(
         query: finalQuery,
         params: input.params,
         tags: input.tags,
+        preferredClickhouseService: "EventsReadOnly",
       });
     },
   });
@@ -468,6 +470,7 @@ export const getExperimentItemsCountFromEvents = async (
       type: "experiment-items-count",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   return rows.length > 0 ? Number(rows[0].count) : 0;
@@ -730,6 +733,7 @@ export const getExperimentItemsFromEvents = async (
       type: "experiment-items-filter",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   const itemIds = itemIdsResult.map((r) => r.item_id);
@@ -774,6 +778,7 @@ export const getExperimentItemsFromEvents = async (
       type: "experiment-items-data",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   // Group by item_id, preserving pagination order
@@ -881,6 +886,7 @@ export const getExperimentItemsBatchIO = async (props: {
       type: "experiment-items-batch-io",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   // Group by item_id
@@ -964,6 +970,7 @@ export const getExperimentNamesFromEvents = async (props: {
       kind: "analytic",
       projectId: props.projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   return res;

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -1865,6 +1865,7 @@ export const getObservationsForBlobStorageExport = function (
     clickhouseConfigs: {
       request_timeout: env.LANGFUSE_CLICKHOUSE_DATA_EXPORT_REQUEST_TIMEOUT_MS,
     },
+    preferredClickhouseService: "ReadOnly",
   });
 
   return records;

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -480,6 +480,7 @@ export const getScoresForExperimentItems = async (
       kind: "list",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   const includeMetadataPayload = false;
@@ -844,7 +845,9 @@ export const getScoresGroupedByNameSourceType = async ({
       kind: "list",
       projectId,
     },
-    preferredClickhouseService: "ReadOnly",
+    preferredClickhouseService: hasEventsFilters
+      ? "EventsReadOnly"
+      : "ReadOnly",
   });
 
   return rows.map((row) => ({
@@ -1432,6 +1435,9 @@ const getScoresUiGenericFromEvents = async <T>(props: {
         params: input.params,
         tags: input.tags,
         clickhouseConfigs,
+        preferredClickhouseService: needsTracesCTE
+          ? "EventsReadOnly"
+          : undefined,
       });
     },
   });

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1437,7 +1437,7 @@ const getScoresUiGenericFromEvents = async <T>(props: {
         clickhouseConfigs,
         preferredClickhouseService: needsTracesCTE
           ? "EventsReadOnly"
-          : undefined,
+          : "ReadOnly",
       });
     },
   });

--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -95,6 +95,7 @@ export const getSessionTracesFromEvents = async (props: {
         query,
         params: input.params,
         tags: input.tags,
+        preferredClickhouseService: "EventsReadOnly",
       });
     },
   });
@@ -300,6 +301,7 @@ const getSessionsTableFromEventsGeneric = async <T>(
         params: input.params,
         tags: input.tags,
         clickhouseConfigs,
+        preferredClickhouseService: "EventsReadOnly",
       });
     },
   });

--- a/worker/src/features/database-read-stream/event-stream.ts
+++ b/worker/src/features/database-read-stream/event-stream.ts
@@ -210,6 +210,7 @@ export const getEventsStream = async (props: {
       kind: "export",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   // Helper function to process a single event row
@@ -473,6 +474,7 @@ export const getEventsStreamForEval = async (props: {
       kind: "eval",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   // Remap ClickHouse aliases to schema field names.
@@ -587,6 +589,7 @@ export const getEventsStreamForDataset = async (props: {
       kind: "dataset",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   return Readable.from(
@@ -696,6 +699,7 @@ export const getEventsStreamForAnnotationQueue = async (props: {
       kind: "annotation",
       projectId,
     },
+    preferredClickhouseService: "EventsReadOnly",
   });
 
   return Readable.from(


### PR DESCRIPTION
## Summary
- Routes legacy observation exports to `ReadOnly`
- Routes event analytics, exports, and event-backed dashboard queries to `EventsReadOnly` at the explicit callsites.
- Keeps preflight reads that gate `DELETE`/`UPDATE`-style operations on `ReadWrite` so they see the same replica path as the mutation.
- Preserves generated query routing for v2 dashboard views by checking the compiled query when it actually touches `events_core` or `events_full`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR routes more ClickHouse read queries to the `EventsReadOnly` (and `ReadOnly`) pool by adding explicit `preferredClickhouseService` annotations at individual callsites across the events, experiments, observations, scores, sessions, and worker stream repositories.

- The dashboard query executor (`queryExecutor.ts`) switches from declaration-based routing (checking `view.baseCte`) to compiled-query inspection, so v2 score views that optionally JOIN events tables are only routed to `EventsReadOnly` when the compiled SQL actually contains `events_core` or `events_full`.
- `getTraceByIdFromEventsTable` now defaults to `EventsReadOnly` (via `?? "EventsReadOnly"`) while still respecting an explicit caller-supplied service, preserving the ability for future mutation-preflight callers to pin to `ReadWrite`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all changes are additive routing hints with no mutation-path impact.

The PR is a straightforward set of routing annotations. Every function that reads exclusively from events tables now explicitly targets the EventsReadOnly pool, and the dashboard query executor's new compiled-query inspection correctly handles v2 score views. The one gap is `getScoresUiGenericFromEvents` when no events CTE is needed — that branch passes `undefined`, silently falling back to the ReadWrite pool for a pure scores read that should go to ReadOnly. It matches pre-existing behaviour rather than being a new regression, but it is a missed opportunity the PR could have closed while touching this function.

packages/shared/src/server/repositories/scores.ts — the `getScoresUiGenericFromEvents` non-events branch still routes to ReadWrite.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Query] --> B{Query Type}

    B -->|Dashboard / prepareExecuteQuery| C{Compiled SQL contains\nevents_core or events_full?}
    C -->|Yes| D[EventsReadOnly pool]
    C -->|No| E[undefined → ReadWrite pool]

    B -->|Events repo reads| F{caller passes\npreferredClickhouseService?}
    F -->|Yes| G[Use caller-provided service]
    F -->|No| D

    B -->|Scores UI getScoresUiGenericFromEvents| H{needsTracesCTE?}
    H -->|Yes – events JOIN present| D
    H -->|No – scores FINAL only| E

    B -->|getScoresGroupedByNameSourceType| I{hasEventsFilters?}
    I -->|Yes| D
    I -->|No| J[ReadOnly pool]

    B -->|Observations blob export| J

    B -->|Worker event streams| D
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/repositories/scores.ts:1438-1440
When `needsTracesCTE` is false the scores UI table query reads only from `scores s final` with no events join, so it routes to the ReadWrite pool via the `undefined` fallback. A `"ReadOnly"` service would be more appropriate here since this is a pure read with no mutation relationship.

```suggestion
        preferredClickhouseService: needsTracesCTE
          ? "EventsReadOnly"
          : "ReadOnly",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: route most event table queries to..."](https://github.com/langfuse/langfuse/commit/3bdeb7f7c772f90cc5cd8e7d051769e48ce27dcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33430635)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->