### PR TITLE
feat(mcp): Handle numeric colums in `getObservationFilterValues`

### DIFF
--- a/packages/shared/src/eventsTable.ts
+++ b/packages/shared/src/eventsTable.ts
@@ -357,6 +357,18 @@ export const eventsTableCols =
 
 type EventsTableColumnId = (typeof eventsTableColsDefinition)[number]["id"];
 
+export type NumericEventsTableColumnId = Extract<
+  (typeof eventsTableColsDefinition)[number],
+  { type: "number" }
+>["id"];
+
+export const isNumericEventsTableColumnId = (
+  column: EventsTableColumnId,
+): column is NumericEventsTableColumnId =>
+  eventsTableColsDefinition.some(
+    (col) => col.id === column && col.type === "number",
+  );
+
 // Subset of columns that are allowed to be used as filters in the MCP observations API
 const OBSERVATION_MCP_ALLOWED_EVENTS_TABLE_FILTER_COLUMN_IDS = [
   "id",

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -100,6 +100,7 @@ import {
   eventsTableCols,
   eventsTableHasParentObservationSql,
   eventsTableIsRootObservationSql,
+  type NumericEventsTableColumnId,
 } from "../../eventsTable";
 import {
   findUiColumnMapping,
@@ -2226,6 +2227,71 @@ export const getEventsGroupedByVersion = async (
     preferredClickhouseService: "EventsReadOnly",
   });
   return res;
+};
+
+export const getEventsNumericStatsByFilterColumn = async (
+  projectId: string,
+  filter: FilterState,
+  columnId: Exclude<
+    NumericEventsTableColumnId,
+    "inputTokens" | "outputTokens" | "inputCost" | "outputCost"
+  >,
+) => {
+  const column = eventsTableCols.find((col) => col.id === columnId);
+
+  if (!column || column.type !== "number") {
+    throw new Error(`Column ${columnId} is not supported for numeric stats`);
+  }
+
+  const eventsFilter = new FilterList(
+    createFilterFromFilterState(
+      filter,
+      eventsTableUiColumnDefinitions,
+      eventsTableCols,
+    ),
+  );
+
+  const valueExpression = column.internal;
+  const appliedEventsFilter = eventsFilter.apply();
+
+  const queryBuilder = new EventsAggQueryBuilder({
+    projectId,
+    groupByColumn: "tuple()",
+    selectExpression: `min(${valueExpression}) as min, max(${valueExpression}) as max, avg(${valueExpression}) as avg, count(${valueExpression}) as count`,
+  })
+    .where(appliedEventsFilter)
+    .whereRaw(`isNotNull(${valueExpression})`);
+
+  const { query, params } = queryBuilder.buildWithParams();
+
+  const res = await queryClickhouse<{
+    min: number | null;
+    max: number | null;
+    avg: number | null;
+    count: number;
+  }>({
+    query,
+    params,
+    tags: {
+      feature: "tracing",
+      type: "events",
+      kind: "analytic",
+      projectId,
+    },
+    preferredClickhouseService: "EventsReadOnly",
+  });
+  const range = res[0];
+
+  if (
+    !range ||
+    range.min === null ||
+    range.max === null ||
+    range.avg === null
+  ) {
+    return null;
+  }
+
+  return range;
 };
 
 /**

--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -1482,6 +1482,61 @@ describe("MCP Read Tools", () => {
       expect(result.meta).toBeDefined();
     });
 
+    it("should return string examples and numeric ranges for filter columns", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const uniqueSessionId = `mcp-session-${nanoid()}`;
+      const lowTotalCost = 0.1;
+      const highTotalCost = 0.3;
+
+      await createEventsCh([
+        createObservationEvent({
+          projectId,
+          name: `mcp-filter-examples-${nanoid()}`,
+          sessionId: uniqueSessionId,
+          totalCost: lowTotalCost,
+        }),
+        createObservationEvent({
+          projectId,
+          name: `mcp-filter-examples-${nanoid()}`,
+          sessionId: uniqueSessionId,
+          totalCost: highTotalCost,
+        }),
+      ]);
+
+      const sessionResult = await handleGetObservationFilterValues(
+        { column: "sessionId", limit: 100 },
+        context,
+      );
+
+      expect(sessionResult).toEqual(
+        expect.objectContaining({
+          type: "VALUES",
+          column: "sessionId",
+          values: expect.arrayContaining([
+            expect.objectContaining({ value: uniqueSessionId, count: 2 }),
+          ]),
+        }),
+      );
+
+      const costResult = await handleGetObservationFilterValues(
+        { column: "totalCost", limit: 100 },
+        context,
+      );
+
+      expect(costResult).toEqual(
+        expect.objectContaining({
+          type: "RANGE",
+          column: "totalCost",
+          range: expect.objectContaining({
+            count: 2,
+            min: expect.closeTo(lowTotalCost),
+            max: expect.closeTo(highTotalCost),
+            avg: expect.closeTo(0.2),
+          }),
+        }),
+      );
+    });
+
     it("should map public tags column to traceTags option source", async () => {
       const { context, projectId } = await createMcpTestSetup();
       const uniqueTag = `mcp-tag-${nanoid()}`;

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -2,6 +2,7 @@ import { type z } from "zod";
 import {
   type FilterCondition,
   LISTABLE_SCORE_TYPES,
+  type NumericEventsTableColumnId,
   filterAndValidateDbScoreList,
 } from "@langfuse/shared";
 import {
@@ -17,6 +18,7 @@ import {
   getEventsGroupedByType,
   getEventsGroupedByUserId,
   getEventsGroupedByVersion,
+  getEventsNumericStatsByFilterColumn,
   getEventsGroupedBySessionId,
   getEventsGroupedByLevel,
   getEventsGroupedByEnvironment,
@@ -462,6 +464,20 @@ export async function getEventFilterValuePage(
   }
 
   return assertUnreachable(column);
+}
+
+export async function getEventFilterNumericRange(
+  params: GetObservationsFilterOptionsParams & {
+    column: Exclude<
+      NumericEventsTableColumnId,
+      "inputTokens" | "outputTokens" | "inputCost" | "outputCost"
+    >;
+  },
+) {
+  const { projectId, column } = params;
+  const { eventsFilter } = getEventFilterOptionsScope(params);
+
+  return getEventsNumericStatsByFilterColumn(projectId, eventsFilter, column);
 }
 
 /**

--- a/web/src/features/mcp/features/observations/tools/getObservationFilterValues.ts
+++ b/web/src/features/mcp/features/observations/tools/getObservationFilterValues.ts
@@ -1,10 +1,14 @@
 import {
   InvalidRequestError,
   ObservationTypeDomain,
+  isNumericEventsTableColumnId,
   type timeFilter,
 } from "@langfuse/shared";
 import { z } from "zod";
-import { getEventFilterValuePage } from "@/src/features/events/server/eventsService";
+import {
+  getEventFilterNumericRange,
+  getEventFilterValuePage,
+} from "@/src/features/events/server/eventsService";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import {
@@ -22,13 +26,20 @@ const OBSERVATION_MCP_FILTER_VALUE_COLUMNS = [
   "traceName",
   "level",
   "promptName",
+  "promptVersion",
   "modelId",
   "providedModelName",
+  "totalCost",
+  "totalTokens",
+  "latency",
+  "timeToFirstToken",
   "tags",
   "hasParentObservation",
 ] as const satisfies readonly ObservationMcpFilterColumn[];
 
 const FilterValueColumnSchema = z.enum(OBSERVATION_MCP_FILTER_VALUE_COLUMNS);
+
+type FilterValueColumn = z.infer<typeof FilterValueColumnSchema>;
 
 const GetObservationFilterValuesBaseSchema = z.object({
   column: FilterValueColumnSchema,
@@ -74,7 +85,7 @@ const buildStartTimeFilter = (params: {
 
 const normalizeFilterOptions = (
   values: unknown[],
-  column: z.infer<typeof FilterValueColumnSchema>,
+  column: FilterValueColumn,
 ): FilterOption[] => {
   const normalizeValue = (value: unknown): string | boolean | null => {
     if (typeof value === "string") {
@@ -149,7 +160,7 @@ export const [
 ] = defineTool({
   name: "getObservationFilterValues",
   description:
-    "List available values for an observation filter field, such as names, types, levels, environments, model names, tags, users, or sessions. Use the returned cursor to page through long value lists.",
+    "List example values for a string or boolean observation filter field, such as names, types, levels, environments, model names, tags, users, or sessions. For numeric metric fields, returns a range with min, max, avg, and count. Use the returned cursor to page through long value lists.",
   baseSchema: GetObservationFilterValuesBaseSchema,
   inputSchema: GetObservationFilterValuesBaseSchema,
   handler: async (input, context) => {
@@ -166,11 +177,27 @@ export const [
           toStartTime: input.toStartTime,
         });
 
-        const offset = decodeObservationFilterValueCursor(input.cursor);
-
-        // The `tags` column is stored in the database as `traceTags`
         const eventsColumn =
           input.column === "tags" ? "traceTags" : input.column;
+
+        if (isNumericEventsTableColumnId(eventsColumn)) {
+          const range = await getEventFilterNumericRange({
+            column: eventsColumn,
+            projectId: context.projectId,
+            startTimeFilter,
+            hasParentObservation: input.hasParentObservation,
+            observationType: input.observationType,
+          });
+
+          return {
+            type: "RANGE",
+            column: input.column,
+            range: range ?? null,
+            meta: {},
+          };
+        }
+
+        const offset = decodeObservationFilterValueCursor(input.cursor);
 
         const page = await getEventFilterValuePage({
           column: eventsColumn,
@@ -194,6 +221,7 @@ export const [
         );
 
         return {
+          type: "VALUES",
           column: input.column,
           values: normalizedValues,
           meta:


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the MCP `getObservationFilterValues` tool to handle numeric columns (`totalCost`, `totalTokens`, `latency`, `timeToFirstToken`, `promptVersion`) by returning a `{ min, max, avg, count }` range instead of paginated string values. It also adds `promptVersion` as a newly queryable filter column.

- **New ClickHouse query** (`getEventsNumericStatsByFilterColumn`): correctly uses `isNotNull(expression)` to filter rows, aggregates into a single bucket with `GROUP BY tuple()`, and maps a ClickHouse empty-result `NULL` aggregate to `null` in TypeScript before returning to the caller.
- **Dispatch logic**: `isNumericEventsTableColumnId` type-guards `eventsColumn` in the handler, routing numeric columns to the RANGE path and narrowing the type so non-numeric columns still satisfy `getEventFilterValuePage`'s explicit column union.
- **`inputTokens`, `outputTokens`, `inputCost`, `outputCost` correctly excluded**: their `arraySum`-based expressions always return `0` rather than `NULL`, making the `isNotNull` filter a no-op; the type-level exclusion prevents them from reaching the new query.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the new numeric range query path is well-guarded and the previously concerning null-aggregate edge case is handled correctly.

The dispatch logic, TypeScript narrowing, and null-handling for empty ClickHouse results are all correct. The four arraySum columns that would silently return wrong results are excluded at the type level. The only gap is that commentCount and tokensPerSecond remain reachable via the function type signature, but no current code passes them.

No files require special attention for merging.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Tool as getObservationFilterValues
    participant Service as eventsService
    participant Repo as events.ts (ClickHouse)

    Client->>Tool: "{ column: "totalCost", ... }"
    Tool->>Tool: isNumericEventsTableColumnId("totalCost") true
    Tool->>Service: "getEventFilterNumericRange({ column: "totalCost", ... })"
    Service->>Repo: getEventsNumericStatsByFilterColumn(projectId, filter, "totalCost")
    Repo->>Repo: SELECT min(if(...)), max(...), avg(...), count(...) WHERE isNotNull(...)
    Repo-->>Service: "[{min, max, avg, count}] or []"
    Service-->>Tool: "{min, max, avg, count} or null"
    Tool-->>Client: "{type: RANGE, column: totalCost, range: {...} or null}"

    Client->>Tool: "{ column: "sessionId", ... }"
    Tool->>Tool: isNumericEventsTableColumnId("sessionId") false
    Tool->>Service: "getEventFilterValuePage({ column: "sessionId", limit, offset })"
    Service->>Repo: "getEventsGroupedBySessionId(projectId, filter, {limit, offset})"
    Repo-->>Service: "[{sessionId, count}, ...]"
    Service-->>Tool: "{values: [...], nextOffset?}"
    Tool-->>Client: "{type: VALUES, column: sessionId, values: [...], meta: {cursor?}}"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/repositories/events.ts:1989-1996
`commentCount` has `internal: ""` (empty string) and `tokensPerSecond` references `start_time`/`end_time` without the `e.` table alias. Both are `NumericEventsTableColumnId` but are not excluded from `getEventsNumericStatsByFilterColumn`'s type signature the way `inputTokens` etc. are. If either column ID is ever added to a caller's column list, the generated SQL will be malformed (`min() as min` or an unresolved column reference). Extending the exclusion union to cover these prevents a silent footgun.

```suggestion
export const getEventsNumericStatsByFilterColumn = async (
  projectId: string,
  filter: FilterState,
  columnId: Exclude<
    NumericEventsTableColumnId,
    | "inputTokens"
    | "outputTokens"
    | "inputCost"
    | "outputCost"
    | "commentCount"
    | "tokensPerSecond"
  >,
) => {
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(mcp): Handle numeric colums in \`get..."](https://github.com/langfuse/langfuse/commit/4f8ed95bee97d2ef327d9b6b88194cb1650dcd65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33439642)</sub>

<!-- /greptile_comment -->