### PR TITLE
test(ingestion): cover S3 event key segment sanitizer

### DIFF
--- a/packages/shared/src/server/services/safeBlobKeySegment.test.ts
+++ b/packages/shared/src/server/services/safeBlobKeySegment.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { safeBlobFilenameStem, safeBlobKeySegment } from "./safeBlobKeySegment";
+import { env } from "../../env";
+
+describe("safeBlobKeySegment", () => {
+  it("returns already-safe segments unchanged", () => {
+    expect(safeBlobKeySegment("time-12-54-37-476491_resp_abc123")).toBe(
+      "time-12-54-37-476491_resp_abc123",
+    );
+  });
+
+  it("replaces path separators and appends a stable hash suffix", () => {
+    const raw = "resp_bGl0ZWxsbTphYmM+Lz0=/child";
+    const safe = safeBlobKeySegment(raw, 255);
+
+    expect(safe).not.toContain("/");
+    expect(safe).not.toContain("\\");
+    expect(safe).toMatch(/_[0-9a-f]{16}$/);
+    expect(Buffer.byteLength(safe, "utf8")).toBeLessThanOrEqual(255);
+
+    expect(safeBlobKeySegment(raw, 255)).toBe(safe);
+  });
+
+  it("bounds long segments to the configured per-segment byte limit", () => {
+    const raw = `resp_${"a".repeat(400)}`;
+    const safe = safeBlobKeySegment(raw, 255);
+
+    expect(Buffer.byteLength(safe, "utf8")).toBeLessThanOrEqual(255);
+    expect(safe).toMatch(/_[0-9a-f]{16}$/);
+  });
+
+  it("does not split multi-byte characters when truncating", () => {
+    const raw = `resp_${"測".repeat(400)}`;
+    const safe = safeBlobKeySegment(raw, 255);
+
+    expect(Buffer.byteLength(safe, "utf8")).toBeLessThanOrEqual(255);
+    expect(safe).toMatch(/_[0-9a-f]{16}$/);
+    expect(safe).not.toContain("\uFFFD");
+  });
+
+  it("reserves filename suffix bytes when sanitizing event file stems", () => {
+    const budget = env.LANGFUSE_S3_EVENT_KEY_MAX_SEGMENT_BYTES;
+    const safeStem = safeBlobFilenameStem(
+      `${"a".repeat(budget + 10)}/child`,
+      ".json",
+    );
+    const fileName = `${safeStem}.json`;
+
+    expect(safeStem).not.toContain("/");
+    expect(Buffer.byteLength(fileName, "utf8")).toBeLessThanOrEqual(budget);
+  });
+});


### PR DESCRIPTION
### What changed
- Add regression coverage for `safeBlobKeySegment` and `safeBlobFilenameStem`.
- Cover pass-through IDs, path separators, deterministic hash suffixes, long ASCII IDs, UTF-8 truncation boundaries, and filename suffix budgeting.

### Context
- The original production fix has since landed on `main` in #14090 while this branch was open.
- This rebase narrows the PR to the missing coverage only; it no longer changes ingestion, replay, queue payload, or worker runtime paths.

### Tests
- `..\..\node_modules\.bin\dotenv.CMD -e ..\..\.env -- node_modules\.bin\vitest.CMD run src/server/services/safeBlobKeySegment.test.ts`