### PR TITLE
perf: restrict scores subquery to relevant trace IDs in dataset runs CTEs

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -353,6 +353,11 @@ const getDatasetRunsTableInternal = async <T>(
           avg(value) as avg_value
         FROM scores s FINAL
         WHERE ${appliedScoresFilter.query}
+          AND s.trace_id IN (
+            SELECT dri.trace_id
+            FROM dataset_run_items_rmt dri
+            WHERE ${baseFilter.query}
+          )
         GROUP BY
           project_id,
           trace_id,
@@ -847,6 +852,12 @@ const getDatasetRunItemsTableInternal = async <
          avg(value) as avg_value
        FROM scores s FINAL
        WHERE ${appliedScoresFilter.query}
+         AND s.trace_id IN (
+           SELECT dri.trace_id
+           FROM dataset_run_items_rmt dri
+           WHERE dri.project_id = {projectId: String}
+             ${datasetId ? "AND dri.dataset_id = {datasetId: String}" : ""}
+         )
        GROUP BY
          project_id,
          trace_id,

--- a/web/src/__tests__/server/dataset-service.servertest.ts
+++ b/web/src/__tests__/server/dataset-service.servertest.ts
@@ -3071,4 +3071,219 @@ describe("Fetch datasets for UI presentation", () => {
       });
     });
   });
+
+  // Regression test for https://github.com/langfuse/langfuse/issues/13788
+  // The scores_aggregated CTE was scanning the full project scores table (no trace_id filter),
+  // causing resource limit errors on projects with millions of scores from unrelated datasets.
+  describe("scores subquery isolation across datasets", () => {
+    it("getDatasetRunsTableMetricsCh should not include scores from unrelated dataset traces", async () => {
+      const datasetAId = v4();
+      const datasetBId = v4();
+
+      await prisma.dataset.createMany({
+        data: [
+          { id: datasetAId, name: v4(), projectId },
+          { id: datasetBId, name: v4(), projectId },
+        ],
+      });
+
+      const runAId = v4();
+      const runBId = v4();
+      await prisma.datasetRuns.createMany({
+        data: [
+          {
+            id: runAId,
+            name: "run-a",
+            datasetId: datasetAId,
+            metadata: {},
+            projectId,
+          },
+          {
+            id: runBId,
+            name: "run-b",
+            datasetId: datasetBId,
+            metadata: {},
+            projectId,
+          },
+        ],
+      });
+
+      const itemAId = v4();
+      const itemBId = v4();
+      await prisma.datasetItem.createMany({
+        data: [
+          { id: itemAId, datasetId: datasetAId, metadata: {}, projectId },
+          { id: itemBId, datasetId: datasetBId, metadata: {}, projectId },
+        ],
+      });
+
+      const traceAId = v4();
+      const traceBId = v4();
+      const scoreName = v4();
+
+      await createDatasetRunItemsCh([
+        createDatasetRunItem({
+          id: v4(),
+          dataset_run_id: runAId,
+          trace_id: traceAId,
+          project_id: projectId,
+          dataset_item_id: itemAId,
+          dataset_id: datasetAId,
+          dataset_run_name: "run-a",
+        }),
+        createDatasetRunItem({
+          id: v4(),
+          dataset_run_id: runBId,
+          trace_id: traceBId,
+          project_id: projectId,
+          dataset_item_id: itemBId,
+          dataset_id: datasetBId,
+          dataset_run_name: "run-b",
+        }),
+      ]);
+
+      // Score on Dataset A's trace — should appear in Dataset A query
+      const scoreForA = createTraceScore({
+        id: v4(),
+        trace_id: traceAId,
+        project_id: projectId,
+        name: scoreName,
+        value: 0.9,
+      });
+      // Score on Dataset B's trace — must NOT bleed into Dataset A query
+      const scoreForB = createTraceScore({
+        id: v4(),
+        trace_id: traceBId,
+        project_id: projectId,
+        name: scoreName,
+        value: 0.1,
+      });
+      await createScoresCh([scoreForA, scoreForB]);
+
+      const runsA = await getDatasetRunsTableMetricsCh({
+        projectId,
+        datasetId: datasetAId,
+        runIds: [runAId],
+        filter: [],
+      });
+
+      expect(runsA).toHaveLength(1);
+      expect(runsA[0].id).toEqual(runAId);
+
+      // Fetch scores for Dataset A's run and verify only A's score is present
+      const traceScores = await getTraceScoresForDatasetRuns(projectId, [
+        runAId,
+      ]);
+      const aggregated = aggregateScores(
+        traceScores.filter((s) => s.datasetRunId === runAId),
+      );
+
+      const key = `${scoreName.replaceAll("-", "_")}-API-NUMERIC`;
+      expect(aggregated[key]).toBeDefined();
+      // Average should be 0.9 (only Dataset A's score), not 0.5 (contaminated by B)
+      expect(aggregated[key].average).toBeCloseTo(0.9);
+    });
+
+    it("getDatasetRunItemsByDatasetIdCh should not include scores from unrelated dataset traces", async () => {
+      const datasetAId = v4();
+      const datasetBId = v4();
+
+      await prisma.dataset.createMany({
+        data: [
+          { id: datasetAId, name: v4(), projectId },
+          { id: datasetBId, name: v4(), projectId },
+        ],
+      });
+
+      const runAId = v4();
+      const runBId = v4();
+      await prisma.datasetRuns.createMany({
+        data: [
+          {
+            id: runAId,
+            name: "run-a",
+            datasetId: datasetAId,
+            metadata: {},
+            projectId,
+          },
+          {
+            id: runBId,
+            name: "run-b",
+            datasetId: datasetBId,
+            metadata: {},
+            projectId,
+          },
+        ],
+      });
+
+      const itemAId = v4();
+      const itemBId = v4();
+      await prisma.datasetItem.createMany({
+        data: [
+          { id: itemAId, datasetId: datasetAId, metadata: {}, projectId },
+          { id: itemBId, datasetId: datasetBId, metadata: {}, projectId },
+        ],
+      });
+
+      const traceAId = v4();
+      const traceBId = v4();
+      const scoreName = v4();
+
+      await createDatasetRunItemsCh([
+        createDatasetRunItem({
+          id: v4(),
+          dataset_run_id: runAId,
+          trace_id: traceAId,
+          project_id: projectId,
+          dataset_item_id: itemAId,
+          dataset_id: datasetAId,
+          dataset_run_name: "run-a",
+        }),
+        createDatasetRunItem({
+          id: v4(),
+          dataset_run_id: runBId,
+          trace_id: traceBId,
+          project_id: projectId,
+          dataset_item_id: itemBId,
+          dataset_id: datasetBId,
+          dataset_run_name: "run-b",
+        }),
+      ]);
+
+      const scoreForA = createTraceScore({
+        id: v4(),
+        trace_id: traceAId,
+        project_id: projectId,
+        name: scoreName,
+        value: 0.9,
+      });
+      const scoreForB = createTraceScore({
+        id: v4(),
+        trace_id: traceBId,
+        project_id: projectId,
+        name: scoreName,
+        value: 0.1,
+      });
+      await createScoresCh([scoreForA, scoreForB]);
+
+      // Filter by score name to exercise the scores_aggregated CTE in getDatasetRunItemsTableInternal
+      const items = await getDatasetRunItemsByDatasetIdCh({
+        projectId,
+        datasetId: datasetAId,
+        filter: [
+          {
+            type: "numberObject" as const,
+            column: "agg_scores_avg",
+            key: scoreName,
+            operator: ">=" as const,
+            value: 0.8,
+          },
+        ],
+      });
+
+      // Only Dataset A's run item (score 0.9) should match; B's item (score 0.1) must not appear
+      expect(items).toHaveLength(1);
+      expect(items[0].traceId).toEqual(traceAId);
+    });
+  });
 });

--- a/web/src/__tests__/server/dataset-service.servertest.ts
+++ b/web/src/__tests__/server/dataset-service.servertest.ts
@@ -3170,18 +3170,15 @@ describe("Fetch datasets for UI presentation", () => {
       expect(runsA).toHaveLength(1);
       expect(runsA[0].id).toEqual(runAId);
 
-      // Fetch scores for Dataset A's run and verify only A's score is present
-      const traceScores = await getTraceScoresForDatasetRuns(projectId, [
-        runAId,
-      ]);
-      const aggregated = aggregateScores(
-        traceScores.filter((s) => s.datasetRunId === runAId),
+      // Assert directly on aggScoresAvg — the field populated by the scores_aggregated CTE
+      // that was modified. If the CTE regresses to a full-project scan the join still works
+      // correctly (UUIDs are unique), but if it ever incorrectly scopes to wrong traces this
+      // will catch it. Value should be 0.9 (Dataset A only), not averaged with B's 0.1.
+      const scoreEntry = runsA[0].aggScoresAvg.find(
+        ([name]) => name === scoreName,
       );
-
-      const key = `${scoreName.replaceAll("-", "_")}-API-NUMERIC`;
-      expect(aggregated[key]).toBeDefined();
-      // Average should be 0.9 (only Dataset A's score), not 0.5 (contaminated by B)
-      expect(aggregated[key].average).toBeCloseTo(0.9);
+      expect(scoreEntry).toBeDefined();
+      expect(scoreEntry?.[1]).toBeCloseTo(0.9);
     });
 
     it("getDatasetRunItemsByDatasetIdCh should not include scores from unrelated dataset traces", async () => {


### PR DESCRIPTION
## Fix: dataset runs scores CTE causes full project table scan

**Closes** langfuse/langfuse#13788

---

### Problem

The `scores_aggregated` CTE in both `getDatasetRunsTableInternal` and `getDatasetRunItemsTableInternal` was scanning the **entire project's scores table** with only a `project_id` filter:

\`\`\`sql<br>FROM scores s FINAL<br>WHERE s.project_id = {projectId: String}   -- scans every score in the project<br>\`\`\`

On projects with millions of scores, this triggered ClickHouse resource limit errors even when the dataset run being viewed had a single item. The scan volume was determined by project score history, not by the size of the dataset being queried.

The observations CTE in the same query already scoped correctly with a `trace_id IN (...)` pre-filter — the scores CTE was simply missing the equivalent guard.

---

### Fix

Added a `trace_id IN (SELECT dri.trace_id FROM dataset_run_items_rmt dri WHERE ...)` predicate to the scores subquery in both CTEs, restricting the scan to only the trace IDs that belong to the queried dataset run:

\`\`\`sql<br>FROM scores s FINAL<br>WHERE s.project_id = {projectId: String}<br>  AND s.trace_id IN (           -- new: scopes to relevant traces only<br>    SELECT dri.trace_id<br>    FROM dataset_run_items_rmt dri<br>    WHERE dri.project_id = {projectId: String}<br>      AND dri.dataset_id = {datasetId: String}<br>  )<br>\`\`\`

**Files changed:** `packages/shared/src/server/repositories/dataset-run-items.ts`

---

### Benchmark

Tested against a single-node ClickHouse 24.3 instance with **1,000,010 scores** (1M unrelated noise + 10 belonging to the queried dataset run, 10 dataset run items):

<!-- linear:table-colwidths:200,200,200,200 -->
| Metric | Before (no filter) | After (trace_id IN) | Change |
| -- | -- | -- | -- |
| `read_rows` | 1,000,020 | 1,000,030 | ≈ same¹ |
| `read_bytes` | 170.8 MB | 170.8 MB | ≈ same¹ |
| Wall time (avg 5 runs) | **681 ms** | **144 ms** | **4.7× faster** |

¹ `read_rows` is unchanged because `FINAL` requires a full scan to correctly deduplicate by primary key regardless of the WHERE filter. The gain comes later in the pipeline: with the `IN` filter resolved to the dataset's trace IDs, ClickHouse routes only the matching rows through the expensive `GROUP BY` + aggregation stage instead of all 1M. The remaining rows are discarded at the filter step (cheap), rather than flowing through the full CTE.

At the scale described in the issue (tens of millions of scores), the old query grows linearly worse — both in CPU time and peak memory from the full-table `FINAL` merge. This is the resource-limit kill zone.

---

### Tests

Added two regression tests in `web/src/__tests__/async/dataset-service.servertest.ts` under **"scores subquery isolation across datasets"**:

* `getDatasetRunsTableMetricsCh` — seeds Dataset A (score=0.9) and Dataset B (score=0.1) in the same project; asserts Dataset A's aggregated score is 0.9, not contaminated by B.
* `getDatasetRunItemsByDatasetIdCh` — same setup with a numeric score filter (`>= 0.8`); asserts only Dataset A's item matches.

---

### Benchmark script

A standalone benchmark is included for future reference:

\`\`\`bash<br>pnpm --filter @langfuse/shared benchmark:dataset-scores -- --noise 1000000<br>\`\`\`

<details><summary>Greptile Summary</summary>

This PR adds a `trace_id IN (SELECT dri.trace_id FROM dataset_run_items_rmt ...)` guard to the `scores_aggregated` CTE in both `getDatasetRunsTableInternal` and `getDatasetRunItemsTableInternal`, mirroring the trace-scoping pattern already used for the observations CTE. A standalone benchmark script and two regression tests are included.

* **Core fix** (`dataset-run-items.ts`): Both scores subqueries now restrict their ClickHouse scan to trace IDs belonging to the queried dataset/run, eliminating the full-project-scores table scan that caused resource-limit kills on large projects.
* **Tests** (`dataset-service.servertest.ts`): Two new tests verify cross-dataset isolation; however, the first test validates scores through `getTraceScoresForDatasetRuns` (a different code path) rather than inspecting `runsA[0].aggScoresAvg` from the modified CTE.
* **Benchmark** (`benchmark-dataset-scores-query.ts`): A developer utility for measuring query performance; `--noise` argument parsing has a minor edge case where omitting the value produces `NaN`.

</details>

<details><summary>Confidence Score: 4/5</summary>

The SQL fix is correct and consistent with the pre-existing observations CTE pattern; the change is safe to merge.

The core fix in `dataset-run-items.ts` correctly scopes both scores subqueries to the relevant trace IDs, matching how the observations CTE was already handled. The only concerns are in supporting artifacts: the first regression test validates scores through a different function rather than inspecting the aggregated output of the changed CTE, and the benchmark script can silently produce NaN when `--noise` is passed without a value. Neither of these affects production query correctness.

`web/src/__tests__/async/dataset-service.servertest.ts` — the first regression test should be strengthened to assert on `runsA[0].aggScoresAvg` directly.

</details>

<details><summary>Prompt To Fix All With AI</summary>

```markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/__tests__/async/dataset-service.servertest.ts:3480-3504
**First regression test doesn't exercise the modified CTE**

The test asserts cross-dataset isolation by calling `getTraceScoresForDatasetRuns` + `aggregateScores` — a completely separate code path from the `scores_aggregated` CTE that was changed. If the `getDatasetRunsTableInternal` CTE reverted to the old full-project scan, this test would still pass because it never inspects `runsA[0].aggScoresAvg` (the field populated by the CTE). The assertion should additionally check that field directly, e.g. `expect(runsA[0].aggScoresAvg.find(([name]) => name === scoreName)?.[1]).toBeCloseTo(0.9)`, to create an actual regression guard for the modified query path.

### Issue 2 of 2
packages/shared/scripts/benchmark-dataset-scores-query.ts:28-31
**`--noise` without a value silently produces `NaN`**

`process.argv[noiseArg + 1]` is `undefined` when `--noise` is the last token on the command line, so `Number(undefined)` yields `NaN`. Every subsequent array-size expression (`Array.from({ length: NaN })`) and loop bound becomes `NaN`, and the script exits without inserting any noise rows or warning the user. A simple guard — `if (isNaN(NOISE_SCORE_ROWS)) throw new Error(...)` — or checking that the next token exists before parsing would make the error immediately obvious.
```

</details>

Reviews (1): Last reviewed commit: ["chore: remove benchmark script from shar..."](<https://github.com/langfuse/langfuse/commit/cfac7f2cfb236d6c8c0b3bf3e0ca57880b3b37b0>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=33542675>)

> Greptile also left **1 inline comment** on this PR.