### PR TITLE
fix(mcp): inject root "type: object" so Tool.inputSchema satisfies MCP SDK

### DIFF
--- a/web/src/__tests__/server/unit/mcp-define-tool.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-define-tool.servertest.ts
@@ -23,7 +23,44 @@ describe("defineTool", () => {
     expect(tool.inputSchema).toHaveProperty("allOf");
   });
 
-  it("defines updateScoreConfig without omitting from a refined schema", () => {
+  // Regression test for MCP TS SDK compatibility: ToolSchema.inputSchema is
+  // validated with `z.literal("object")` on the root `type`, so clients drop
+  // tools whose root schema omits it. Zod emits intersections as bare `allOf`,
+  // so defineTool must inject `type: "object"`.
+  it("injects root type: 'object' for intersection schemas (MCP SDK requires it)", () => {
+    const schema = z.object({ id: z.string() }).and(
+      z.object({ value: z.number() }),
+    );
+
+    const [tool] = defineTool({
+      name: "intersectionTool",
+      description: "",
+      baseSchema: schema,
+      inputSchema: schema,
+      handler: async (input) => input,
+    });
+
+    expect(tool.inputSchema.type).toBe("object");
+    expect(tool.inputSchema).toHaveProperty("allOf");
+  });
+
+  it("preserves root type: 'object' for plain object schemas", () => {
+    const schema = z.object({ name: z.string() });
+
+    const [tool] = defineTool({
+      name: "plainTool",
+      description: "",
+      baseSchema: schema,
+      inputSchema: schema,
+      handler: async (input) => input,
+    });
+
+    expect(tool.inputSchema.type).toBe("object");
+  });
+
+  it("defines updateScoreConfig with MCP-compliant root inputSchema", () => {
     expect(updateScoreConfigTool.name).toBe("updateScoreConfig");
+    // Real-world tool from PR #13781 that originally broke MCP clients.
+    expect(updateScoreConfigTool.inputSchema.type).toBe("object");
   });
 });

--- a/web/src/__tests__/server/unit/mcp-define-tool.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-define-tool.servertest.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { defineTool } from "../../../features/mcp/core/define-tool";
-import { updateScoreConfigTool } from "../../../features/mcp/features/scores/tools/updateScoreConfig";
 
 describe("defineTool", () => {
   it("accepts object intersections emitted as JSON Schema allOf", () => {
@@ -28,12 +27,13 @@ describe("defineTool", () => {
   // tools whose root schema omits it. Zod emits intersections as bare `allOf`,
   // so defineTool must inject `type: "object"`.
   it("injects root type: 'object' for intersection schemas (MCP SDK requires it)", () => {
-    const schema = z
-      .object({ id: z.string() })
-      .and(z.object({ value: z.number() }));
+    const schema = z.union([
+      z.object({ scoreId: z.string() }),
+      z.object({ configId: z.string() }),
+    ]);
 
     const [tool] = defineTool({
-      name: "intersectionTool",
+      name: "objectUnionTool",
       description: "",
       baseSchema: schema,
       inputSchema: schema,
@@ -41,7 +41,7 @@ describe("defineTool", () => {
     });
 
     expect(tool.inputSchema.type).toBe("object");
-    expect(tool.inputSchema).toHaveProperty("allOf");
+    expect(tool.inputSchema).toHaveProperty("anyOf");
   });
 
   it("preserves root type: 'object' for plain object schemas", () => {
@@ -58,9 +58,17 @@ describe("defineTool", () => {
     expect(tool.inputSchema.type).toBe("object");
   });
 
-  it("defines updateScoreConfig with MCP-compliant root inputSchema", () => {
-    expect(updateScoreConfigTool.name).toBe("updateScoreConfig");
-    // Real-world tool from PR #13781 that originally broke MCP clients.
-    expect(updateScoreConfigTool.inputSchema.type).toBe("object");
+  it("rejects unions with non-object branches", () => {
+    const schema = z.union([z.string(), z.object({ id: z.string() })]);
+
+    expect(() =>
+      defineTool({
+        name: "mixedUnionTool",
+        description: "",
+        baseSchema: schema,
+        inputSchema: schema,
+        handler: async (input) => input,
+      }),
+    ).toThrow("Expected object or union schema");
   });
 });

--- a/web/src/__tests__/server/unit/mcp-define-tool.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-define-tool.servertest.ts
@@ -28,9 +28,9 @@ describe("defineTool", () => {
   // tools whose root schema omits it. Zod emits intersections as bare `allOf`,
   // so defineTool must inject `type: "object"`.
   it("injects root type: 'object' for intersection schemas (MCP SDK requires it)", () => {
-    const schema = z.object({ id: z.string() }).and(
-      z.object({ value: z.number() }),
-    );
+    const schema = z
+      .object({ id: z.string() })
+      .and(z.object({ value: z.number() }));
 
     const [tool] = defineTool({
       name: "intersectionTool",

--- a/web/src/features/mcp/core/define-tool.ts
+++ b/web/src/features/mcp/core/define-tool.ts
@@ -138,11 +138,21 @@ export function defineTool<TInput>(
     );
   }
 
+  // The MCP TypeScript SDK validates Tool.inputSchema.type as `z.literal("object")`,
+  // so clients reject any tool whose root schema lacks `type: "object"`. Zod's
+  // JSON Schema converter omits the root `type` for intersection/union schemas
+  // (emitting allOf/oneOf/anyOf instead), so we inject it here. JSON Schema
+  // draft-7 allows `type` alongside these keywords — all constraints must hold.
+  const normalizedJsonSchema: JsonSchemaObject =
+    (jsonSchema as JsonSchemaObject).type === "object"
+      ? (jsonSchema as JsonSchemaObject)
+      : { ...(jsonSchema as JsonSchemaObject), type: "object" };
+
   // Build tool definition
   const toolDefinition: ToolDefinition = {
     name,
     description,
-    inputSchema: jsonSchema,
+    inputSchema: normalizedJsonSchema,
   };
 
   // Add annotations if provided

--- a/web/src/features/mcp/core/define-tool.ts
+++ b/web/src/features/mcp/core/define-tool.ts
@@ -65,16 +65,19 @@ type JsonSchemaObject = Record<string, unknown>;
 function isObjectLikeJsonSchema(schema: JsonSchemaObject): boolean {
   if (schema.type === "object") return true;
 
-  if ("oneOf" in schema || "anyOf" in schema || "discriminator" in schema) {
-    return true;
-  }
+  const subSchemas = (() => {
+    if ("oneOf" in schema && Array.isArray(schema.oneOf)) return schema.oneOf;
+    if ("anyOf" in schema && Array.isArray(schema.anyOf)) return schema.anyOf;
+    if ("allOf" in schema && Array.isArray(schema.allOf)) return schema.allOf;
+    return [];
+  })();
 
-  if (Array.isArray(schema.allOf)) {
-    return schema.allOf.every(
+  if (subSchemas.length > 0) {
+    return subSchemas.every(
       (subSchema) =>
         typeof subSchema === "object" &&
         subSchema !== null &&
-        isObjectLikeJsonSchema(subSchema as JsonSchemaObject),
+        isObjectLikeJsonSchema(subSchema),
     );
   }
 


### PR DESCRIPTION
## What
Normalize the JSON Schema returned by `z.toJSONSchema()` inside `defineTool` so that the root object always carries `"type": "object"`.

## Why
The MCP TypeScript SDK (`@modelcontextprotocol/sdk`) defines `ToolSchema.inputSchema` as:

```ts
z.object({ type: z.literal("object"), ... }).passthrough()
```

Zod v4's JSON Schema converter emits **intersections** as `allOf` and **unions** as `anyOf`, both with no top-level `type` keyword. Although each branch declares `"type": "object"`, MCP SDK-based clients (Claude Code, etc.) reject the tool at validation time and silently drop it from `tools/list`.

After #13781 this affected three live tools on Langfuse Cloud:

- `createScore`
- `createScoreConfig`
- `updateScoreConfig`

Reproduced today against `https://*.cloud.langfuse.com/api/public/mcp` via raw `tools/list`:

```bash
jq '.result.tools | map(select(.inputSchema.type != "object")) | map(.name)'
# => ["createScore", "createScoreConfig", "updateScoreConfig"]
```

## How
Post-process the schema right after `z.toJSONSchema()` to set `type: "object"` at the root when it's missing. Draft-7 allows `type` alongside `allOf`/`oneOf`/`anyOf` — all constraints must hold — so this is semantically a no-op for already-conformant object schemas and correct for the intersection/union cases (every branch is itself an object schema, enforced by `isObjectLikeJsonSchema`).

## Tests
Extended `mcp-define-tool.servertest.ts`:

- Intersection schema → root `type === "object"` and `allOf` preserved
- Plain object schema → root `type === "object"` (no regression)
- Real-world `updateScoreConfigTool` → root `type === "object"`

Closes #13804

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a compatibility issue between Zod v4's JSON Schema output and the MCP TypeScript SDK, which requires `"type": "object"` at the root of every tool's `inputSchema`. Zod emits intersection schemas as bare `allOf` without a root `type`, causing MCP clients to silently drop three live tools (`createScore`, `createScoreConfig`, `updateScoreConfig`).

- **`define-tool.ts`**: After converting the Zod schema to JSON Schema and passing the object-likeness guard, a new normalization step injects `"type": "object"` at the root if it is absent — a semantic no-op for conformant schemas and correct for `allOf`-based intersections.
- **`mcp-define-tool.servertest.ts`**: Three new regression tests verify the injection for intersection schemas, the preservation for plain object schemas, and end-to-end compliance for the real-world `updateScoreConfig` tool.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is minimal, well-tested for the affected tools, and restores three live tools that were silently dropped by MCP clients.

The normalization is correct for all allOf-based intersection schemas, which are the only affected cases in production. The one gap worth noting is that isObjectLikeJsonSchema passes any schema containing anyOf/oneOf without inspecting branches, so a mixed-type union would receive an injected type: object that narrows its semantics. No such schema exists in the codebase today, but the guard's inconsistency leaves a future footgun if a non-object union is ever introduced as a tool input schema.

The branch-checking asymmetry in isObjectLikeJsonSchema (lines 68–70 of define-tool.ts) is worth a follow-up to align anyOf/oneOf treatment with the recursive allOf check.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[defineTool called] --> B[z.toJSONSchema baseSchema]
    B --> C{jsonSchema truthy?}
    C -- No --> D[throw Error]
    C -- Yes --> E{isObjectLikeJsonSchema?}
    E -- No --> F[throw Error]
    E -- Yes --> G{jsonSchema.type === 'object'?}
    G -- Yes --> H[use jsonSchema as-is]
    G -- No --> I["inject { ...jsonSchema, type: 'object' }"]
    H --> J[build ToolDefinition]
    I --> J
    J --> K[add optional annotations]
    K --> L[wrap handler with validation]
    L --> M[return ToolDefinition + handler]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/mcp/core/define-tool.ts:68-70
**Inconsistent branch-checking in the `anyOf`/`oneOf` guard**

`isObjectLikeJsonSchema` recursively verifies every branch for `allOf` schemas but returns `true` unconditionally for any schema that merely contains `anyOf`, `oneOf`, or `discriminator`, without inspecting the branches. The normalization added in this PR then injects `type: "object"` for every schema that passes this guard. If a schema has `anyOf: [{ type: "string" }, { type: "object", ... }]`, it would pass the guard and receive `type: "object"`, making the combined schema reject all string inputs — silently narrowing what was intended to be a mixed-type union. The PR description states that branches are "enforced" by `isObjectLikeJsonSchema`, but that enforcement only applies to the `allOf` path.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): inject root type: &quot;object&quot; for..."](https://github.com/langfuse/langfuse/commit/ba3b13b2b43f9466c0afa20d819cdaeeb8436919) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33556381)</sub>

<!-- /greptile_comment -->