### PR TITLE
fix(time-picker): make period Select controlled to prevent stale AM/PM

### DIFF
--- a/web/src/components/ui/time-period-select.tsx
+++ b/web/src/components/ui/time-period-select.tsx
@@ -46,7 +46,7 @@ export const TimePeriodSelect = React.forwardRef<
           new Date(date),
           hours.toString(),
           "12hours",
-          period === "AM" ? "PM" : "AM",
+          value,
         ),
       );
     }
@@ -55,7 +55,7 @@ export const TimePeriodSelect = React.forwardRef<
   return (
     <div className="flex h-7 items-center">
       <Select
-        defaultValue={period}
+        value={period}
         onValueChange={(value: Period) => handleValueChange(value)}
       >
         <SelectTrigger


### PR DESCRIPTION
## Problem

The `TimePeriodSelect` component uses Radix `Select` with `defaultValue={period}` (uncontrolled). When the `period` prop is updated externally — for example when `TimePicker`'s `useEffect` recomputes the period from a newly received `date` prop (e.g. after a preset like "Past 30 min" is selected) — the Select dropdown does not re-render to reflect the new period.

This causes a visual/state desync:
- The Select shows "AM" (stale `defaultValue`)
- The internal `period` state is "PM" (updated by the effect)

When the user subsequently types into the hour input, `TimePickerInput` passes the stale `period="PM"` to `setDateByType`, so entering "02" with apparent "AM" calls `convert12HourTo24Hour(2, "PM")` = 14. The time is stored as 14:00 (2 PM) while the picker displays "02 AM".

A secondary issue: in `handleValueChange`, the period was computed as `period === "AM" ? "PM" : "AM"` — the negation of the current state — rather than using `value` directly. When the stale state desyncs, this logic inverts the wrong period.

Fixes #13687.

## Solution

1. Changed `defaultValue={period}` → `value={period}` in `Select` to make `TimePeriodSelect` a fully controlled component. The Select now always reflects the current `period` prop.
2. Changed `period === "AM" ? "PM" : "AM"` → `value` in `handleValueChange` to use the newly selected period directly instead of negating the (potentially stale) previous state.

## Testing

1. Open the Traces view and select a named time preset (e.g. "Past 30 min") that resolves to a PM start time.
2. Switch to the custom calendar picker.
3. Verify the time picker displays the correct PM period instead of showing AM.
4. Enter a time (e.g. "02") and confirm the stored time matches what is displayed (e.g. 2 PM = 14:00, not 2 AM = 02:00).
5. Toggle between AM and PM — verify the stored time updates correctly in both directions.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a state desync in the 12-hour time picker by converting `TimePeriodSelect` from an uncontrolled to a controlled component. When an external preset updated the `period` prop, the Radix `Select` kept rendering the stale `defaultValue`; this also caused `handleValueChange` to invert the wrong period.

- `defaultValue={period}` → `value={period}` so the dropdown always reflects the current `period` prop, eliminating visual desync when presets recompute the period.
- `period === \"AM\" ? \"PM\" : \"AM\"` → `value` so `handleValueChange` directly uses the newly selected period instead of negating potentially stale state, which could previously set the wrong period when prop and internal state diverged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — two targeted, correct changes that resolve a documented desync between the displayed AM/PM value and the internally tracked period state.

Both changes are minimal, well-reasoned, and directly address the root causes described in the PR. Switching to a controlled value prop ensures the Radix Select always reflects external prop updates, and replacing the inversion logic with the direct value parameter eliminates the double-flip bug when state was stale. No new edge cases are introduced.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(time-picker): make period Select con..."](https://github.com/langfuse/langfuse/commit/55257e9c7ea71a9a3a5a82603f46f75b97798102) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33556459)</sub>

<!-- /greptile_comment -->