### PR TITLE
fix(public-api): count v2 score IDs consistently

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2560,9 +2560,9 @@ export const _handleGetScoresCountForPublicApi = async ({
   const appliedScoresFilter = scoresFilter.apply();
   const appliedTracesFilter = tracesFilter.apply();
 
-  const query = `
+  const scoreIdsQuery = `
       SELECT
-        count() as count
+        s.id as id
       FROM
         scores s
           ${needsTraceJoin ? "LEFT JOIN __TRACE_TABLE__ t ON s.trace_id = t.id AND s.project_id = t.project_id" : ""}
@@ -2578,15 +2578,27 @@ export const _handleGetScoresCountForPublicApi = async ({
           WHERE
             s.project_id = {projectId: String}
             ${appliedScoresFilter.query ? `AND ${appliedScoresFilter.query}` : ""}
-            ${scoreScope === "traces_only" ? "AND s.session_id IS NULL" : ""}
+            ${scoreScope === "traces_only" ? "AND s.session_id IS NULL AND s.dataset_run_id IS NULL" : ""}
           ORDER BY
             s.timestamp desc
           LIMIT
             1 BY s.id, s.project_id
         ))
       )
+      ${scoreScope === "traces_only" ? "AND s.session_id IS NULL AND s.dataset_run_id IS NULL" : ""}
       ${appliedScoresFilter.query ? `AND ${appliedScoresFilter.query}` : ""}
       ${tracesFilter.length() > 0 ? `AND ${appliedTracesFilter.query}` : ""}
+      ORDER BY
+        s.timestamp desc, s.event_ts desc
+      LIMIT
+        1 BY s.id, s.project_id
+      `;
+
+  const query = `
+      SELECT
+        count() as count
+      FROM
+        (${scoreIdsQuery})
       `;
 
   return measureAndReturn({

--- a/web/src/__tests__/server/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v2.servertest.ts
@@ -510,6 +510,64 @@ describe("/api/public/v2/scores API Endpoint", () => {
         );
       });
 
+      it("counts unique score IDs when multiple score versions exist", async () => {
+        const { projectId, auth } = await createOrgProjectAndApiKey();
+        const traceId = v4();
+        const scoreId = v4();
+
+        await createTracesCh([
+          createTrace({ id: traceId, project_id: projectId }),
+        ]);
+
+        const oldScore = createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          trace_id: traceId,
+          name: "versioned-score",
+          value: 1,
+          data_type: "NUMERIC",
+          timestamp: 1,
+          event_ts: 1,
+          created_at: 1,
+          updated_at: 1,
+        });
+        const newScore = createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          trace_id: traceId,
+          name: "versioned-score",
+          value: 2,
+          data_type: "NUMERIC",
+          timestamp: 2,
+          event_ts: 2,
+          created_at: 2,
+          updated_at: 2,
+        });
+
+        await createScoresCh([oldScore, newScore]);
+
+        const getScores = await makeZodVerifiedAPICall(
+          GetScoresResponseV2,
+          "GET",
+          `/api/public/v2/scores?scoreIds=${scoreId}`,
+          undefined,
+          auth,
+        );
+
+        expect(getScores.status).toBe(200);
+        expect(getScores.body.meta).toMatchObject({
+          page: 1,
+          limit: 50,
+          totalItems: 1,
+          totalPages: 1,
+        });
+        expect(getScores.body.data).toHaveLength(1);
+        expect(getScores.body.data[0]).toMatchObject({
+          id: scoreId,
+          value: 2,
+        });
+      });
+
       it("get all scores for config", async () => {
         const getAllScore = await makeZodVerifiedAPICall(
           GetScoresResponseV2,


### PR DESCRIPTION
Fixes langfuse/langfuse#13559.

`GET /api/public/v2/scores` returns one row per score ID (via `LIMIT 1 BY s.id`), but `meta.totalItems` was counting raw rows and could overcount when multiple score versions exist.

This updates `_handleGetScoresCountForPublicApi` to count the same `LIMIT 1 BY s.id` result set, and adds a regression test covering duplicate score rows.

Verification:
- pnpm.cmd --filter web run lint

Local server tests couldn’t run here because the Postgres test DB credentials in `.env.test` aren’t configured on this machine.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a count discrepancy in `GET /api/public/v2/scores` where `meta.totalItems` overcounted when multiple versions of the same score ID existed in ClickHouse. The fix restructures `_handleGetScoresCountForPublicApi` to first collect deduplicated score IDs (using the same `LIMIT 1 BY s.id, s.project_id` logic as the data query) and then wraps that result in an outer `count()`.

- **Count query refactor**: replaces the flat `SELECT count()` with a two-level query — an inner `scoreIdsQuery` that mirrors the deduplication logic of the data query, wrapped by an outer `SELECT count() FROM (...)`.
- **Consistency fix for `traces_only` scope**: the count query's inner subquery was only guarding `s.session_id IS NULL`, omitting `s.dataset_run_id IS NULL`; this PR adds the missing clause to match the data query.
- **Regression test**: adds a server test that inserts two rows sharing the same score ID (simulating a versioned score) and asserts that `totalItems` is 1 and the returned `value` matches the newer row.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change fixes a real count inflation bug and the new query logic precisely mirrors the deduplication already applied to the data fetch path.

Both the count and data queries now apply the same LIMIT 1 BY s.id, s.project_id deduplication, eliminating the mismatch. The additional dataset_run_id IS NULL guard in the traces_only scope aligns the count path with the existing data path. A focused regression test covers the core scenario. No functional regressions or logic gaps were identified.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(public-api): count v2 score IDs cons..."](https://github.com/langfuse/langfuse/commit/6f987cceef68a7a02750061b7754cf63d2f1ba6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33609460)</sub>

<!-- /greptile_comment -->