### PR TITLE
fix(datasets): add stable orderBy id tiebreaker to listDatasets and listDatasetRuns

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -117,6 +117,12 @@ import {
   updateScoreConfigTool,
   handleUpdateScoreConfig,
 } from "@/src/features/mcp/features/scores/tools/updateScoreConfig";
+import {
+  listDatasetsTool,
+  handleListDatasets,
+  listDatasetRunsTool,
+  handleListDatasetRuns,
+} from "@/src/features/mcp/features/datasets/tools";
 
 const maybeEventsTable =
   env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true"
@@ -2722,6 +2728,113 @@ describe("MCP Read Tools", () => {
       expect(result.prompt[0].content).toContain(
         "@@@langfusePrompt:name=system-base|label=production@@@",
       );
+    });
+  });
+
+  describe("listDatasets tool", () => {
+    it("should have readOnlyHint annotation", () => {
+      verifyToolAnnotations(listDatasetsTool, { readOnlyHint: true });
+    });
+
+    it("returns stable, non-overlapping pages when datasets share identical createdAt timestamps", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const sharedCreatedAt = new Date("2024-01-01T00:00:00.000Z");
+
+      // Insert 6 datasets with identical createdAt to stress-test the id tiebreaker.
+      // Without a secondary sort key, PostgreSQL can return different orderings across
+      // page fetches, causing an agent to miss a dataset or process the same one twice.
+      await prisma.dataset.createMany({
+        data: Array.from({ length: 6 }, (_, i) => ({
+          id: randomUUID(),
+          name: `stable-test-dataset-${i}-${nanoid()}`,
+          projectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        })),
+      });
+
+      const page1 = (await handleListDatasets(
+        { page: 1, limit: 3 },
+        context,
+      )) as { data: Array<{ id: string }>; meta: { totalItems: number } };
+
+      const page2 = (await handleListDatasets(
+        { page: 2, limit: 3 },
+        context,
+      )) as { data: Array<{ id: string }> };
+
+      const ids1 = page1.data.map((d) => d.id);
+      const ids2 = page2.data.map((d) => d.id);
+
+      // Pages must not overlap
+      expect(ids1.filter((id) => ids2.includes(id))).toHaveLength(0);
+
+      // Together they cover all 6 datasets — no gaps
+      expect(ids1.length + ids2.length).toBe(6);
+
+      // Page 1 is stable across repeated calls
+      const page1Repeat = (await handleListDatasets(
+        { page: 1, limit: 3 },
+        context,
+      )) as { data: Array<{ id: string }> };
+
+      expect(page1Repeat.data.map((d) => d.id)).toEqual(ids1);
+    });
+  });
+
+  describe("listDatasetRuns tool", () => {
+    it("returns stable, non-overlapping pages when dataset runs share identical createdAt timestamps", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const sharedCreatedAt = new Date("2024-01-01T00:00:00.000Z");
+      const datasetName = `stable-test-runs-${nanoid()}`;
+
+      const dataset = await prisma.dataset.create({
+        data: {
+          id: randomUUID(),
+          name: datasetName,
+          projectId,
+        },
+      });
+
+      // Insert 6 runs with identical createdAt to stress-test the id tiebreaker.
+      // Concurrent eval execution can easily produce same-millisecond createdAt values.
+      await prisma.datasetRuns.createMany({
+        data: Array.from({ length: 6 }, (_, i) => ({
+          id: randomUUID(),
+          name: `run-${i}-${nanoid()}`,
+          datasetId: dataset.id,
+          projectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        })),
+      });
+
+      const page1 = (await handleListDatasetRuns(
+        { name: datasetName, page: 1, limit: 3 },
+        context,
+      )) as { data: Array<{ id: string }> };
+
+      const page2 = (await handleListDatasetRuns(
+        { name: datasetName, page: 2, limit: 3 },
+        context,
+      )) as { data: Array<{ id: string }> };
+
+      const ids1 = page1.data.map((r) => r.id);
+      const ids2 = page2.data.map((r) => r.id);
+
+      // Pages must not overlap
+      expect(ids1.filter((id) => ids2.includes(id))).toHaveLength(0);
+
+      // Together they cover all 6 runs — no gaps
+      expect(ids1.length + ids2.length).toBe(6);
+
+      // Page 1 is stable across repeated calls
+      const page1Repeat = (await handleListDatasetRuns(
+        { name: datasetName, page: 1, limit: 3 },
+        context,
+      )) as { data: Array<{ id: string }> };
+
+      expect(page1Repeat.data.map((r) => r.id)).toEqual(ids1);
     });
   });
 });

--- a/web/src/features/mcp/features/datasets/tools.ts
+++ b/web/src/features/mcp/features/datasets/tools.ts
@@ -162,7 +162,7 @@ export const [listDatasetsTool, handleListDatasets] = defineTool({
               id: true,
             },
             where: { projectId: context.projectId },
-            orderBy: { createdAt: "desc" },
+            orderBy: [{ createdAt: "desc" }, { id: "asc" }],
             take: input.limit,
             skip: (input.page - 1) * input.limit,
           }),
@@ -650,7 +650,7 @@ export const [listDatasetRunsTool, handleListDatasetRuns] = defineTool({
               where: { projectId: context.projectId },
               take: input.limit,
               skip: (input.page - 1) * input.limit,
-              orderBy: { createdAt: "desc" },
+              orderBy: [{ createdAt: "desc" }, { id: "asc" }],
             },
           },
         });

--- a/web/src/pages/api/public/datasets/[name]/runs/index.ts
+++ b/web/src/pages/api/public/datasets/[name]/runs/index.ts
@@ -24,9 +24,7 @@ export default withMiddlewares({
           datasetRuns: {
             take: query.limit,
             skip: (query.page - 1) * query.limit,
-            orderBy: {
-              createdAt: "desc",
-            },
+            orderBy: [{ createdAt: "desc" }, { id: "asc" }],
           },
         },
       });

--- a/web/src/pages/api/public/datasets/index.ts
+++ b/web/src/pages/api/public/datasets/index.ts
@@ -84,9 +84,7 @@ export default withMiddlewares({
         where: {
           projectId: auth.scope.projectId,
         },
-        orderBy: {
-          createdAt: "desc",
-        },
+        orderBy: [{ createdAt: "desc" }, { id: "asc" }],
         take: limit,
         skip: (page - 1) * limit,
       });


### PR DESCRIPTION
## What does this PR do?

Adds `{ id: "asc" }` as a secondary sort key to four paginated `findMany` calls that were ordering by `createdAt: "desc"` alone — two in the MCP dataset tools and two in the public REST API.

## Why

When multiple rows share the same `createdAt` timestamp, PostgreSQL does not guarantee a stable order within that group. Paginated `OFFSET`/`LIMIT` queries against an unstable sort can return overlapping or skipped records across page fetches. Agents or scripts that iterate through dataset runs to compare experiments may miss a run or process the same one twice — especially when runs are created concurrently during parallel eval execution, which is exactly when same-millisecond timestamps occur.

Same class of issue as open PR #13813 (`listComments`). The annotation queue MCP tools added in the same PR (#13783) already use compound `createdAt, id` ordering; this brings datasets and dataset-run endpoints in line.

Fixes #13816.

**Affected files:**

- `web/src/features/mcp/features/datasets/tools.ts` — `listDatasets` and `listDatasetRuns` handlers
- `web/src/pages/api/public/datasets/index.ts` — `GET /api/public/datasets`
- `web/src/pages/api/public/datasets/[name]/runs/index.ts` — `GET /api/public/datasets/[name]/runs`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] Added pagination-stability tests for `listDatasets` and `listDatasetRuns`: inserts 6 records with identical `createdAt` timestamps, then asserts that pages 1 and 2 produce no overlap, no gaps, and identical page 1 results on repeated calls.
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a pagination-stability bug across four `findMany` calls in the dataset and dataset-run listing endpoints by adding `{ id: "asc" }` as a secondary sort key alongside the existing `createdAt: "desc"` ordering. Without this tiebreaker, rows sharing the same millisecond timestamp could be returned in an arbitrary order, causing OFFSET-based pagination to produce overlapping or missing records.

- **MCP tools** (`tools.ts`): `listDatasets` and `listDatasetRuns` handlers now use compound `[{ createdAt: "desc" }, { id: "asc" }]` ordering, consistent with other MCP tools added in the same feature area.
- **Public REST API** (`datasets/index.ts`, `[name]/runs/index.ts`): Both GET endpoints receive the same compound ordering fix.
- **Tests** (`mcp-tools-read.servertest.ts`): New pagination-stability tests insert 6 records with identical `createdAt` values and verify that two pages produce no overlap, no gaps, and stable repeated first-page results.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge — it narrows scope to four targeted orderBy array replacements with no logic changes outside of sort ordering.

The four pagination fixes are correct and match the pattern already used elsewhere in the codebase. The one gap is the nested datasetRuns sub-relation inside GET /api/public/datasets, which still uses a single createdAt: desc — its run-name list can be non-deterministic when timestamps collide, though it does not affect page-level pagination. New tests are well-structured but the listDatasetRuns describe-block is missing the symmetrical readOnlyHint annotation check present for listDatasets.

web/src/pages/api/public/datasets/index.ts — the nested datasetRuns.orderBy inside the same findMany call was not updated alongside the top-level fix.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as REST/MCP API
    participant DB as PostgreSQL

    Client->>API: "GET /datasets?page=1&limit=3"
    API->>DB: findMany ORDER BY createdAt DESC, id ASC LIMIT 3 OFFSET 0
    DB-->>API: rows 1-3 (stable)
    API-->>Client: page 1 data

    Client->>API: "GET /datasets?page=2&limit=3"
    API->>DB: findMany ORDER BY createdAt DESC, id ASC LIMIT 3 OFFSET 3
    DB-->>API: rows 4-6 (stable, no overlap)
    API-->>Client: page 2 data

    Note over DB: Without id tiebreaker: rows with same createdAt can shift between pages
    Note over DB: With id tiebreaker: deterministic order across all page fetches
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/api/public/datasets/index.ts:75-82
The nested `datasetRuns` relation inside the same `findMany` call still uses only `{ createdAt: "desc" }` without the `id` tiebreaker. While this sub-relation isn't paginated (no OFFSET), its ordering is still non-deterministic when two runs share a timestamp, so the `runs` name-list returned in each dataset object can differ across calls. Aligning it with the pattern used everywhere else in this PR keeps the response stable.

```suggestion
          datasetRuns: {
            select: {
              name: true,
            },
            orderBy: [{ createdAt: "desc" }, { id: "asc" }],
          },
```

### Issue 2 of 2
web/src/__tests__/server/mcp-tools-read.servertest.ts:2785-2786
The `listDatasets` describe-block includes a `readOnlyHint` annotation check, but the `listDatasetRuns` describe-block has no equivalent. Since `listDatasetRunsTool` is also exported and annotated, a symmetrical annotation assertion here would catch any future accidental regression.

```suggestion
  describe("listDatasetRuns tool", () => {
    it("should have readOnlyHint annotation", () => {
      verifyToolAnnotations(listDatasetRunsTool, { readOnlyHint: true });
    });

    it("returns stable, non-overlapping pages when dataset runs share identical createdAt timestamps", async () => {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(datasets): add pagination-stability..."](https://github.com/langfuse/langfuse/commit/b420f993d8f5a77f0efb16ec80e9e49bfd0e17e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33652780)</sub>

<!-- /greptile_comment -->