### PR TITLE
fix(datasets): stabilize pagination when createdAt ties

### DIFF
--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -1413,6 +1413,78 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     expect(mergedIds).toEqual(expect.arrayContaining(datasetIds));
   });
 
+  it("should paginate v2 datasets deterministically when createdAt timestamps tie", async () => {
+    const authAndProject = await createOrgProjectAndApiKey();
+    const localAuth = authAndProject.auth;
+    const localProjectId = authAndProject.projectId;
+    const sharedCreatedAt = new Date("2025-01-01T00:00:00.000Z");
+    const datasetIds = [v4(), v4(), v4()];
+
+    await prisma.dataset.createMany({
+      data: [
+        {
+          id: datasetIds[0],
+          name: `dataset-v2-tie-a-${v4()}`,
+          projectId: localProjectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+        {
+          id: datasetIds[1],
+          name: `dataset-v2-tie-b-${v4()}`,
+          projectId: localProjectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+        {
+          id: datasetIds[2],
+          name: `dataset-v2-tie-c-${v4()}`,
+          projectId: localProjectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+      ],
+    });
+
+    const page1 = await makeZodVerifiedAPICall(
+      GetDatasetsV2Response,
+      "GET",
+      "/api/public/v2/datasets?page=1&limit=2",
+      undefined,
+      localAuth,
+    );
+    const page2 = await makeZodVerifiedAPICall(
+      GetDatasetsV2Response,
+      "GET",
+      "/api/public/v2/datasets?page=2&limit=2",
+      undefined,
+      localAuth,
+    );
+    const page1Repeat = await makeZodVerifiedAPICall(
+      GetDatasetsV2Response,
+      "GET",
+      "/api/public/v2/datasets?page=1&limit=2",
+      undefined,
+      localAuth,
+    );
+
+    expect(page1.status).toBe(200);
+    expect(page2.status).toBe(200);
+    expect(page1Repeat.status).toBe(200);
+
+    const page1Ids = page1.body.data.map((dataset) => dataset.id);
+    const page2Ids = page2.body.data.map((dataset) => dataset.id);
+    const page1RepeatIds = page1Repeat.body.data.map((dataset) => dataset.id);
+
+    expect(page1Ids).toEqual(page1RepeatIds);
+    page2Ids.forEach((id) => {
+      expect(page1Ids).not.toContain(id);
+    });
+
+    const mergedIds = [...page1Ids, ...page2Ids];
+    expect(mergedIds).toEqual(expect.arrayContaining(datasetIds));
+  });
+
   it("should paginate dataset runs deterministically when createdAt timestamps tie", async () => {
     const authAndProject = await createOrgProjectAndApiKey();
     const localAuth = authAndProject.auth;

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -1346,25 +1346,26 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     const localAuth = authAndProject.auth;
     const localProjectId = authAndProject.projectId;
     const sharedCreatedAt = new Date("2025-01-01T00:00:00.000Z");
+    const datasetIds = [v4(), v4(), v4()];
 
     await prisma.dataset.createMany({
       data: [
         {
-          id: "dataset-tie-a",
+          id: datasetIds[0],
           name: `dataset-tie-a-${v4()}`,
           projectId: localProjectId,
           createdAt: sharedCreatedAt,
           updatedAt: sharedCreatedAt,
         },
         {
-          id: "dataset-tie-b",
+          id: datasetIds[1],
           name: `dataset-tie-b-${v4()}`,
           projectId: localProjectId,
           createdAt: sharedCreatedAt,
           updatedAt: sharedCreatedAt,
         },
         {
-          id: "dataset-tie-c",
+          id: datasetIds[2],
           name: `dataset-tie-c-${v4()}`,
           projectId: localProjectId,
           createdAt: sharedCreatedAt,
@@ -1409,9 +1410,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
 
     const mergedIds = [...page1Ids, ...page2Ids];
-    expect(mergedIds).toEqual(
-      expect.arrayContaining(["dataset-tie-a", "dataset-tie-b", "dataset-tie-c"]),
-    );
+    expect(mergedIds).toEqual(expect.arrayContaining(datasetIds));
   });
 
   it("should paginate dataset runs deterministically when createdAt timestamps tie", async () => {
@@ -1420,6 +1419,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     const localProjectId = authAndProject.projectId;
     const datasetName = `dataset-runs-tie-${v4()}`;
     const sharedCreatedAt = new Date("2025-01-02T00:00:00.000Z");
+    const runIds = [v4(), v4(), v4()];
 
     const dataset = await prisma.dataset.create({
       data: {
@@ -1434,7 +1434,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     await prisma.datasetRuns.createMany({
       data: [
         {
-          id: "run-tie-a",
+          id: runIds[0],
           datasetId: dataset.id,
           name: `run-tie-a-${v4()}`,
           projectId: localProjectId,
@@ -1443,7 +1443,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
           updatedAt: sharedCreatedAt,
         },
         {
-          id: "run-tie-b",
+          id: runIds[1],
           datasetId: dataset.id,
           name: `run-tie-b-${v4()}`,
           projectId: localProjectId,
@@ -1452,7 +1452,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
           updatedAt: sharedCreatedAt,
         },
         {
-          id: "run-tie-c",
+          id: runIds[2],
           datasetId: dataset.id,
           name: `run-tie-c-${v4()}`,
           projectId: localProjectId,
@@ -1499,9 +1499,7 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     });
 
     const mergedIds = [...page1Ids, ...page2Ids];
-    expect(mergedIds).toEqual(
-      expect.arrayContaining(["run-tie-a", "run-tie-b", "run-tie-c"]),
-    );
+    expect(mergedIds).toEqual(expect.arrayContaining(runIds));
   });
 
   it("dataset-run-items should fail when neither trace nor observation provided", async () => {

--- a/web/src/__tests__/server/datasets-api.servertest.ts
+++ b/web/src/__tests__/server/datasets-api.servertest.ts
@@ -1341,6 +1341,169 @@ describe("/api/public/datasets and /api/public/dataset-items API Endpoints", () 
     }, 30000);
   }, 90000);
 
+  it("should paginate datasets deterministically when createdAt timestamps tie", async () => {
+    const authAndProject = await createOrgProjectAndApiKey();
+    const localAuth = authAndProject.auth;
+    const localProjectId = authAndProject.projectId;
+    const sharedCreatedAt = new Date("2025-01-01T00:00:00.000Z");
+
+    await prisma.dataset.createMany({
+      data: [
+        {
+          id: "dataset-tie-a",
+          name: `dataset-tie-a-${v4()}`,
+          projectId: localProjectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+        {
+          id: "dataset-tie-b",
+          name: `dataset-tie-b-${v4()}`,
+          projectId: localProjectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+        {
+          id: "dataset-tie-c",
+          name: `dataset-tie-c-${v4()}`,
+          projectId: localProjectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+      ],
+    });
+
+    const page1 = await makeZodVerifiedAPICall(
+      GetDatasetsV1Response,
+      "GET",
+      "/api/public/datasets?page=1&limit=2",
+      undefined,
+      localAuth,
+    );
+    const page2 = await makeZodVerifiedAPICall(
+      GetDatasetsV1Response,
+      "GET",
+      "/api/public/datasets?page=2&limit=2",
+      undefined,
+      localAuth,
+    );
+    const page1Repeat = await makeZodVerifiedAPICall(
+      GetDatasetsV1Response,
+      "GET",
+      "/api/public/datasets?page=1&limit=2",
+      undefined,
+      localAuth,
+    );
+
+    expect(page1.status).toBe(200);
+    expect(page2.status).toBe(200);
+    expect(page1Repeat.status).toBe(200);
+
+    const page1Ids = page1.body.data.map((dataset) => dataset.id);
+    const page2Ids = page2.body.data.map((dataset) => dataset.id);
+    const page1RepeatIds = page1Repeat.body.data.map((dataset) => dataset.id);
+
+    expect(page1Ids).toEqual(page1RepeatIds);
+    page2Ids.forEach((id) => {
+      expect(page1Ids).not.toContain(id);
+    });
+
+    const mergedIds = [...page1Ids, ...page2Ids];
+    expect(mergedIds).toEqual(
+      expect.arrayContaining(["dataset-tie-a", "dataset-tie-b", "dataset-tie-c"]),
+    );
+  });
+
+  it("should paginate dataset runs deterministically when createdAt timestamps tie", async () => {
+    const authAndProject = await createOrgProjectAndApiKey();
+    const localAuth = authAndProject.auth;
+    const localProjectId = authAndProject.projectId;
+    const datasetName = `dataset-runs-tie-${v4()}`;
+    const sharedCreatedAt = new Date("2025-01-02T00:00:00.000Z");
+
+    const dataset = await prisma.dataset.create({
+      data: {
+        id: `dataset-runs-tie-id-${v4()}`,
+        name: datasetName,
+        projectId: localProjectId,
+        createdAt: sharedCreatedAt,
+        updatedAt: sharedCreatedAt,
+      },
+    });
+
+    await prisma.datasetRuns.createMany({
+      data: [
+        {
+          id: "run-tie-a",
+          datasetId: dataset.id,
+          name: `run-tie-a-${v4()}`,
+          projectId: localProjectId,
+          metadata: {},
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+        {
+          id: "run-tie-b",
+          datasetId: dataset.id,
+          name: `run-tie-b-${v4()}`,
+          projectId: localProjectId,
+          metadata: {},
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+        {
+          id: "run-tie-c",
+          datasetId: dataset.id,
+          name: `run-tie-c-${v4()}`,
+          projectId: localProjectId,
+          metadata: {},
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+      ],
+    });
+
+    const page1 = await makeZodVerifiedAPICall(
+      GetDatasetRunsV1Response,
+      "GET",
+      `/api/public/datasets/${encodeURIComponent(datasetName)}/runs?page=1&limit=2`,
+      undefined,
+      localAuth,
+    );
+    const page2 = await makeZodVerifiedAPICall(
+      GetDatasetRunsV1Response,
+      "GET",
+      `/api/public/datasets/${encodeURIComponent(datasetName)}/runs?page=2&limit=2`,
+      undefined,
+      localAuth,
+    );
+    const page1Repeat = await makeZodVerifiedAPICall(
+      GetDatasetRunsV1Response,
+      "GET",
+      `/api/public/datasets/${encodeURIComponent(datasetName)}/runs?page=1&limit=2`,
+      undefined,
+      localAuth,
+    );
+
+    expect(page1.status).toBe(200);
+    expect(page2.status).toBe(200);
+    expect(page1Repeat.status).toBe(200);
+
+    const page1Ids = page1.body.data.map((run) => run.id);
+    const page2Ids = page2.body.data.map((run) => run.id);
+    const page1RepeatIds = page1Repeat.body.data.map((run) => run.id);
+
+    expect(page1Ids).toEqual(page1RepeatIds);
+    page2Ids.forEach((id) => {
+      expect(page1Ids).not.toContain(id);
+    });
+
+    const mergedIds = [...page1Ids, ...page2Ids];
+    expect(mergedIds).toEqual(
+      expect.arrayContaining(["run-tie-a", "run-tie-b", "run-tie-c"]),
+    );
+  });
+
   it("dataset-run-items should fail when neither trace nor observation provided", async () => {
     const response = await makeAPICall(
       "POST",

--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -509,6 +509,136 @@ describe("MCP public API tools", () => {
     ).resolves.toEqual({ message: "Dataset item successfully deleted" });
   });
 
+  it("lists datasets and dataset runs deterministically when createdAt timestamps tie", async () => {
+    const { context, projectId } = await createMcpTestSetup();
+    const sharedCreatedAt = new Date("2026-01-03T00:00:00.000Z");
+
+    await prisma.dataset.createMany({
+      data: [
+        {
+          id: "mcp-dataset-tie-a",
+          name: `mcp-dataset-tie-a-${uuidv4()}`,
+          projectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+        {
+          id: "mcp-dataset-tie-b",
+          name: `mcp-dataset-tie-b-${uuidv4()}`,
+          projectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+        {
+          id: "mcp-dataset-tie-c",
+          name: `mcp-dataset-tie-c-${uuidv4()}`,
+          projectId,
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+      ],
+    });
+
+    const datasetsPage1 = (await handleListDatasets(
+      { page: 1, limit: 2 },
+      context,
+    )) as { data: Array<{ id: string }> };
+    const datasetsPage2 = (await handleListDatasets(
+      { page: 2, limit: 2 },
+      context,
+    )) as { data: Array<{ id: string }> };
+    const datasetsPage1Repeat = (await handleListDatasets(
+      { page: 1, limit: 2 },
+      context,
+    )) as { data: Array<{ id: string }> };
+
+    const datasetPage1Ids = datasetsPage1.data.map((item) => item.id);
+    const datasetPage2Ids = datasetsPage2.data.map((item) => item.id);
+    const datasetPage1RepeatIds = datasetsPage1Repeat.data.map(
+      (item) => item.id,
+    );
+
+    expect(datasetPage1Ids).toEqual(datasetPage1RepeatIds);
+    datasetPage2Ids.forEach((id) => {
+      expect(datasetPage1Ids).not.toContain(id);
+    });
+    expect([...datasetPage1Ids, ...datasetPage2Ids]).toEqual(
+      expect.arrayContaining([
+        "mcp-dataset-tie-a",
+        "mcp-dataset-tie-b",
+        "mcp-dataset-tie-c",
+      ]),
+    );
+
+    const datasetWithRunsName = `mcp-dataset-runs-tie-${uuidv4()}`;
+    const datasetWithRuns = await prisma.dataset.create({
+      data: {
+        id: `mcp-dataset-runs-id-${uuidv4()}`,
+        name: datasetWithRunsName,
+        projectId,
+        createdAt: sharedCreatedAt,
+        updatedAt: sharedCreatedAt,
+      },
+    });
+
+    await prisma.datasetRuns.createMany({
+      data: [
+        {
+          id: "mcp-run-tie-a",
+          datasetId: datasetWithRuns.id,
+          name: `mcp-run-tie-a-${uuidv4()}`,
+          projectId,
+          metadata: {},
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+        {
+          id: "mcp-run-tie-b",
+          datasetId: datasetWithRuns.id,
+          name: `mcp-run-tie-b-${uuidv4()}`,
+          projectId,
+          metadata: {},
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+        {
+          id: "mcp-run-tie-c",
+          datasetId: datasetWithRuns.id,
+          name: `mcp-run-tie-c-${uuidv4()}`,
+          projectId,
+          metadata: {},
+          createdAt: sharedCreatedAt,
+          updatedAt: sharedCreatedAt,
+        },
+      ],
+    });
+
+    const runsPage1 = (await handleListDatasetRuns(
+      { name: datasetWithRunsName, page: 1, limit: 2 },
+      context,
+    )) as { data: Array<{ id: string }> };
+    const runsPage2 = (await handleListDatasetRuns(
+      { name: datasetWithRunsName, page: 2, limit: 2 },
+      context,
+    )) as { data: Array<{ id: string }> };
+    const runsPage1Repeat = (await handleListDatasetRuns(
+      { name: datasetWithRunsName, page: 1, limit: 2 },
+      context,
+    )) as { data: Array<{ id: string }> };
+
+    const runPage1Ids = runsPage1.data.map((item) => item.id);
+    const runPage2Ids = runsPage2.data.map((item) => item.id);
+    const runPage1RepeatIds = runsPage1Repeat.data.map((item) => item.id);
+
+    expect(runPage1Ids).toEqual(runPage1RepeatIds);
+    runPage2Ids.forEach((id) => {
+      expect(runPage1Ids).not.toContain(id);
+    });
+    expect([...runPage1Ids, ...runPage2Ids]).toEqual(
+      expect.arrayContaining(["mcp-run-tie-a", "mcp-run-tie-b", "mcp-run-tie-c"]),
+    );
+  });
+
   it("covers health public API route and cross-project recent-event checks", async () => {
     const { context } = await createMcpTestSetup();
 

--- a/web/src/features/mcp/features/datasets/tools.ts
+++ b/web/src/features/mcp/features/datasets/tools.ts
@@ -162,7 +162,7 @@ export const [listDatasetsTool, handleListDatasets] = defineTool({
               id: true,
             },
             where: { projectId: context.projectId },
-            orderBy: { createdAt: "desc" },
+            orderBy: [{ createdAt: "desc" }, { id: "asc" }],
             take: input.limit,
             skip: (input.page - 1) * input.limit,
           }),
@@ -650,7 +650,7 @@ export const [listDatasetRunsTool, handleListDatasetRuns] = defineTool({
               where: { projectId: context.projectId },
               take: input.limit,
               skip: (input.page - 1) * input.limit,
-              orderBy: { createdAt: "desc" },
+              orderBy: [{ createdAt: "desc" }, { id: "asc" }],
             },
           },
         });

--- a/web/src/pages/api/public/datasets/[name]/runs/index.ts
+++ b/web/src/pages/api/public/datasets/[name]/runs/index.ts
@@ -24,9 +24,7 @@ export default withMiddlewares({
           datasetRuns: {
             take: query.limit,
             skip: (query.page - 1) * query.limit,
-            orderBy: {
-              createdAt: "desc",
-            },
+            orderBy: [{ createdAt: "desc" }, { id: "asc" }],
           },
         },
       });

--- a/web/src/pages/api/public/datasets/index.ts
+++ b/web/src/pages/api/public/datasets/index.ts
@@ -84,9 +84,7 @@ export default withMiddlewares({
         where: {
           projectId: auth.scope.projectId,
         },
-        orderBy: {
-          createdAt: "desc",
-        },
+        orderBy: [{ createdAt: "desc" }, { id: "asc" }],
         take: limit,
         skip: (page - 1) * limit,
       });

--- a/web/src/pages/api/public/v2/datasets/index.ts
+++ b/web/src/pages/api/public/v2/datasets/index.ts
@@ -66,9 +66,7 @@ export default withMiddlewares({
         where: {
           projectId: auth.scope.projectId,
         },
-        orderBy: {
-          createdAt: "desc",
-        },
+        orderBy: [{ createdAt: "desc" }, { id: "asc" }],
         take: query.limit,
         skip: (query.page - 1) * query.limit,
       });


### PR DESCRIPTION
Fix dataset and dataset run pagination so tied createdAt rows have a deterministic secondary order.

This updates all affected public dataset listing paths to sort by createdAt DESC and id ASC, including the v2 datasets endpoint.

The failure mode was offset pagination on createdAt alone. When multiple rows shared the same timestamp, the database could return tied rows in different orders across requests, which made repeated page fetches unstable and could cause overlap or skips between adjacent pages.

This change does not alter the pagination contract. It only makes the existing ordering total and deterministic.

Validation:
- targeted REST dataset pagination regression tests
- targeted REST dataset run pagination regression tests
- targeted v2 dataset pagination regression test
- targeted MCP dataset and dataset run pagination regression test

Closes #13816.
