### PR TITLE
fix(otel): support OpenInference llm cost totals

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2508,8 +2508,14 @@ export class OtelIngestionProcessor {
     );
     if (fromAttribute !== null) return fromAttribute;
 
-    if (attributes["gen_ai.usage.cost"]) {
-      return { total: attributes["gen_ai.usage.cost"] };
+    const openTelemetryCost = attributes["gen_ai.usage.cost"];
+    if (openTelemetryCost !== undefined) {
+      return { total: openTelemetryCost };
+    }
+
+    const openInferenceCost = attributes["llm.cost.total"];
+    if (openInferenceCost !== undefined) {
+      return { total: openInferenceCost };
     }
     return {};
   }

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -3045,6 +3045,18 @@ describe("OTel Resource Span Mapping", () => {
         },
       ],
       [
+        "should extract zero cost from llm.cost.total",
+        {
+          entity: "observation",
+          otelAttributeKey: "llm.cost.total",
+          otelAttributeValue: {
+            doubleValue: 0,
+          },
+          entityAttributeKey: "costDetails.total",
+          entityAttributeValue: 0,
+        },
+      ],
+      [
         "should not treat usage.cost as usage",
         {
           entity: "observation",

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -3021,6 +3021,30 @@ describe("OTel Resource Span Mapping", () => {
         },
       ],
       [
+        "should extract cost from llm.cost.total",
+        {
+          entity: "observation",
+          otelAttributeKey: "llm.cost.total",
+          otelAttributeValue: {
+            doubleValue: 0.000151,
+          },
+          entityAttributeKey: "costDetails.total",
+          entityAttributeValue: 0.000151,
+        },
+      ],
+      [
+        "should extract zero cost from gen_ai.usage.cost",
+        {
+          entity: "observation",
+          otelAttributeKey: "gen_ai.usage.cost",
+          otelAttributeValue: {
+            doubleValue: 0,
+          },
+          entityAttributeKey: "costDetails.total",
+          entityAttributeValue: 0,
+        },
+      ],
+      [
         "should not treat usage.cost as usage",
         {
           entity: "observation",


### PR DESCRIPTION
Failure mechanism
extractCostDetails() recognized langfuse.observation.cost_details and gen_ai.usage.cost, but ignored OpenInference spans that emit llm.cost.total.

That dropped a provided total cost and could force downstream recomputation from partial token fields instead.

Semantic change
- keep langfuse.observation.cost_details as the highest-precedence source
- keep gen_ai.usage.cost as a fallback source
- also accept llm.cost.total as a fallback input for costDetails.total
- use !== undefined so zero-valued costs are preserved instead of being dropped by a truthy check

Preserved invariant
- existing precedence stays unchanged
- spans that already send langfuse.observation.cost_details keep their current behavior
- non-cost usage parsing is unchanged

Validation
- added otel mapping coverage for gen_ai.usage.cost
- added otel mapping coverage for llm.cost.total
- added otel mapping coverage for zero-valued gen_ai.usage.cost

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends `extractCostDetails` in `OtelIngestionProcessor` to support OpenInference spans that emit `llm.cost.total`, and fixes a bug where zero-valued `gen_ai.usage.cost` was silently dropped by a truthy check.

- **`OtelIngestionProcessor.ts`**: Adds `llm.cost.total` as a third fallback cost source after `gen_ai.usage.cost`, and changes both guards from truthy checks to `!== undefined` so zero-valued costs are preserved.
- **`otelMapping.servertest.ts`**: Adds test coverage for `llm.cost.total` extraction and zero-valued `gen_ai.usage.cost`; a symmetric zero-value test for `llm.cost.total` is missing.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the logic change is small and correctly scoped to cost extraction with no impact on usage parsing.

The production code change is minimal and correct — precedence is preserved and the !== undefined guard properly fixes the zero-cost drop. The only gap is a missing test for zero-valued llm.cost.total, leaving the symmetric regression path untested.

The test file could use one more case: zero-valued llm.cost.total, mirroring the zero-valued gen_ai.usage.cost test that was added.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractCostDetails called] --> B{langfuse.observation.cost_details present?}
    B -- Yes --> C[Return parsed JSON object]
    B -- No --> D{gen_ai.usage.cost !== undefined?}
    D -- Yes --> E[Return total = gen_ai.usage.cost]
    D -- No --> F{llm.cost.total !== undefined? OpenInference NEW}
    F -- Yes --> G[Return total = llm.cost.total]
    F -- No --> H[Return empty object]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/api/otel/otelMapping.servertest.ts:3023-3034
A zero-cost test is added for `gen_ai.usage.cost` but not for `llm.cost.total`. The `!== undefined` fix is what makes zero values survive for both attributes, so both should have zero-value coverage to guard against regressions.

```suggestion
      [
        "should extract cost from llm.cost.total",
        {
          entity: "observation",
          otelAttributeKey: "llm.cost.total",
          otelAttributeValue: {
            doubleValue: 0.000151,
          },
          entityAttributeKey: "costDetails.total",
          entityAttributeValue: 0.000151,
        },
      ],
      [
        "should extract zero cost from llm.cost.total",
        {
          entity: "observation",
          otelAttributeKey: "llm.cost.total",
          otelAttributeValue: {
            doubleValue: 0,
          },
          entityAttributeKey: "costDetails.total",
          entityAttributeValue: 0,
        },
      ],
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): support llm cost totals"](https://github.com/langfuse/langfuse/commit/8e5ac2806994b8c3e3d6712d966adfd99e0143cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34076412)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->