### PR TITLE
feat(evals): allow manual batch runs on inactive evaluators

### DIFF
--- a/packages/shared/src/features/evals/evalConfigBlocking.ts
+++ b/packages/shared/src/features/evals/evalConfigBlocking.ts
@@ -3,6 +3,7 @@ import {
   JobConfigState,
   JobExecutionStatus,
 } from "@prisma/client";
+import { z } from "zod";
 
 export const PausedEvaluatorDisplayState = "PAUSED" as const;
 export type PausedEvaluatorDisplayState = typeof PausedEvaluatorDisplayState;
@@ -27,12 +28,27 @@ type BlockStateLike = {
   blockedAt?: Date | null;
 };
 
+export const JobConfigExecutionMode = z.enum(["LIVE", "MANUAL"]);
+export type JobConfigExecutionMode = z.infer<typeof JobConfigExecutionMode>;
+
 export function isJobConfigBlocked(config: Pick<BlockStateLike, "blockedAt">) {
   return config.blockedAt != null;
 }
 
 export function isJobConfigExecutable(config: BlockStateLike) {
   return config.status === JobConfigState.ACTIVE && !isJobConfigBlocked(config);
+}
+
+export function isJobConfigExecutableForExecutionMode(
+  config: BlockStateLike,
+  executionMode?: JobConfigExecutionMode,
+) {
+  if (executionMode === "MANUAL") {
+    // Manual batch runs bypass only the live-traffic toggle, not blocked configs.
+    return !isJobConfigBlocked(config);
+  }
+
+  return isJobConfigExecutable(config);
 }
 
 type EvaluatorBlockMetadata = {

--- a/packages/shared/src/server/queues.ts
+++ b/packages/shared/src/server/queues.ts
@@ -10,6 +10,7 @@ import { EventActionSchema } from "../domain";
 import { PromptDomainSchema } from "../domain/prompts";
 import { ObservationAddToDatasetConfigSchema } from "../features/batchAction/addToDatasetTypes";
 import { EvalTargetObjectSchema } from "../features/evals/types";
+import { JobConfigExecutionMode } from "../features/evals/evalConfigBlocking";
 
 export const IngestionEvent = z.object({
   data: z.object({
@@ -104,6 +105,7 @@ export const LLMAsJudgeExecutionEventSchema = z.object({
   projectId: z.string(),
   jobExecutionId: z.string(),
   observationS3Path: z.string(),
+  executionMode: JobConfigExecutionMode.optional(),
 });
 export const PostHogIntegrationProcessingEventSchema = z.object({
   projectId: z.string(),

--- a/worker/src/features/batchAction/processBatchedObservationEval.test.ts
+++ b/worker/src/features/batchAction/processBatchedObservationEval.test.ts
@@ -78,6 +78,7 @@ describe("processBatchedObservationEval", () => {
     expect(scheduleObservationEvals).toHaveBeenCalledWith(
       expect.objectContaining({
         configs: evaluators,
+        executionMode: "MANUAL",
       }),
     );
     expect(

--- a/worker/src/features/batchAction/processBatchedObservationEval.ts
+++ b/worker/src/features/batchAction/processBatchedObservationEval.ts
@@ -55,6 +55,7 @@ export async function processBatchedObservationEval(params: {
             observation,
             configs: evaluators,
             schedulerDeps,
+            executionMode: "MANUAL",
           });
         }),
       ),

--- a/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/observationEvalProcessor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
-import { JobExecutionStatus } from "@prisma/client";
+import { JobConfigState, JobExecutionStatus } from "@prisma/client";
 import {
   processObservationEval,
   type ObservationEvalProcessorDeps,
@@ -166,6 +166,77 @@ describe("processObservationEval", () => {
       });
       expect(deps.downloadObservationFromS3).not.toHaveBeenCalled();
       expect(executeLLMAsJudgeEvaluation).not.toHaveBeenCalled();
+    });
+
+    it("should cancel inactive evaluators when execution mode is omitted", async () => {
+      const job = createMockJobExecution({
+        id: jobExecutionId,
+        projectId,
+        status: JobExecutionStatus.PENDING,
+        jobConfigurationId: "config-123",
+      });
+      const config = createMockJobConfiguration({
+        id: "config-123",
+        projectId,
+        status: JobConfigState.INACTIVE,
+      });
+
+      (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
+      (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
+
+      const deps = createMockProcessorDeps();
+
+      await processObservationEval({ event: baseEvent, deps });
+
+      expect(prisma.jobExecution.update).toHaveBeenCalledWith({
+        where: {
+          id: job.id,
+          projectId,
+        },
+        data: {
+          status: JobExecutionStatus.CANCELLED,
+          endTime: expect.any(Date),
+        },
+      });
+      expect(deps.downloadObservationFromS3).not.toHaveBeenCalled();
+      expect(executeLLMAsJudgeEvaluation).not.toHaveBeenCalled();
+    });
+
+    it("should execute inactive evaluators for manual execution", async () => {
+      const job = createMockJobExecution({
+        id: jobExecutionId,
+        projectId,
+        status: JobExecutionStatus.PENDING,
+        jobConfigurationId: "config-123",
+      });
+      const config = createMockJobConfiguration({
+        id: "config-123",
+        projectId,
+        status: JobConfigState.INACTIVE,
+      });
+
+      (prisma.jobExecution.findFirst as Mock).mockResolvedValue(job);
+      (prisma.jobConfiguration.findFirst as Mock).mockResolvedValue(config);
+
+      const deps = createMockProcessorDeps();
+
+      await processObservationEval({
+        event: { ...baseEvent, executionMode: "MANUAL" },
+        deps,
+      });
+
+      expect(prisma.jobExecution.update).not.toHaveBeenCalled();
+      expect(deps.downloadObservationFromS3).toHaveBeenCalledWith(
+        observationS3Path,
+      );
+      expect(executeLLMAsJudgeEvaluation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId,
+          jobExecutionId,
+          job: expect.objectContaining({ id: jobExecutionId }),
+          config: expect.objectContaining({ id: "config-123" }),
+        }),
+      );
     });
   });
 

--- a/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
+++ b/worker/src/features/evaluation/observationEval/__tests__/scheduleObservationEvals.test.ts
@@ -147,6 +147,41 @@ describe("scheduleObservationEvals", () => {
       expect(schedulerDeps.upsertJobExecution).not.toHaveBeenCalled();
       expect(schedulerDeps.enqueueEvalJob).not.toHaveBeenCalled();
     });
+
+    it("should schedule inactive configs for manual execution while skipping blocked configs", async () => {
+      const schedulerDeps = createMockSchedulerDeps();
+      const observation = createMockObservation();
+      const inactiveConfig = createMockConfig({
+        id: "inactive-config",
+        status: JobConfigState.INACTIVE,
+      });
+
+      await scheduleObservationEvals({
+        observation,
+        configs: [
+          createMockConfig({
+            id: "blocked-config",
+            blockedAt: new Date(),
+          }),
+          inactiveConfig,
+        ],
+        schedulerDeps,
+        executionMode: "MANUAL",
+      });
+
+      expect(schedulerDeps.uploadObservationToS3).toHaveBeenCalledTimes(1);
+      expect(schedulerDeps.upsertJobExecution).toHaveBeenCalledTimes(1);
+      expect(schedulerDeps.upsertJobExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobConfigurationId: inactiveConfig.id,
+        }),
+      );
+      expect(schedulerDeps.enqueueEvalJob).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executionMode: "MANUAL",
+        }),
+      );
+    });
   });
 
   describe("S3 upload", () => {

--- a/worker/src/features/evaluation/observationEval/createSchedulerDeps.ts
+++ b/worker/src/features/evaluation/observationEval/createSchedulerDeps.ts
@@ -74,6 +74,9 @@ export function createObservationEvalSchedulerDeps(): ObservationEvalSchedulerDe
             projectId: params.projectId,
             jobExecutionId: params.jobExecutionId,
             observationS3Path: params.observationS3Path,
+            ...(params.executionMode
+              ? { executionMode: params.executionMode }
+              : {}),
           },
         },
         {

--- a/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
+++ b/worker/src/features/evaluation/observationEval/observationEvalProcessor.ts
@@ -7,7 +7,7 @@ import {
 import {
   observationForEvalSchema,
   observationVariableMappingList,
-  isJobConfigExecutable,
+  isJobConfigExecutableForExecutionMode,
   type ObservationVariableMapping,
 } from "@langfuse/shared";
 import { prisma, JobExecutionStatus } from "@langfuse/shared/src/db";
@@ -102,7 +102,9 @@ export async function processObservationEval({
     );
   }
 
-  if (!isJobConfigExecutable(evalJobConfig)) {
+  if (
+    !isJobConfigExecutableForExecutionMode(evalJobConfig, event.executionMode)
+  ) {
     logger.debug(
       `Job execution ${event.jobExecutionId} is not executable because the evaluator is blocked or inactive.`,
     );

--- a/worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts
+++ b/worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts
@@ -9,7 +9,8 @@ import {
   EvalTargetObject,
   JobExecutionStatus,
   type FilterState,
-  isJobConfigExecutable,
+  type JobConfigExecutionMode,
+  isJobConfigExecutableForExecutionMode,
   mapEventEvalFilterColumnIdToField,
 } from "@langfuse/shared";
 import { createW3CTraceId } from "../../utils";
@@ -18,6 +19,7 @@ interface ScheduleObservationEvalsParams {
   observation: ObservationForEval;
   configs: ObservationEvalConfig[];
   schedulerDeps: ObservationEvalSchedulerDeps;
+  executionMode?: JobConfigExecutionMode;
 }
 
 /**
@@ -36,7 +38,7 @@ interface ScheduleObservationEvalsParams {
 export async function scheduleObservationEvals(
   params: ScheduleObservationEvalsParams,
 ): Promise<void> {
-  const { observation, configs, schedulerDeps } = params;
+  const { observation, configs, schedulerDeps, executionMode } = params;
 
   // Early return if no configs
   if (configs.length === 0) {
@@ -46,7 +48,7 @@ export async function scheduleObservationEvals(
   // Filter configs that match this observation (filter + sampling).
   // This is done before S3 upload to avoid unnecessary uploads.
   const matchingConfigs = configs.filter((config) => {
-    if (!isJobConfigExecutable(config)) {
+    if (!isJobConfigExecutableForExecutionMode(config, executionMode)) {
       logger.debug("Skipping non-executable observation eval config", {
         configId: config.id,
       });
@@ -98,6 +100,7 @@ export async function scheduleObservationEvals(
         matchingConfig,
         observationS3Path,
         schedulerDeps,
+        executionMode,
       }).catch((error) => {
         logger.error("Failed to process observation eval config", {
           configId: matchingConfig.id,
@@ -115,13 +118,19 @@ interface ProcessConfigParams {
   matchingConfig: ObservationEvalConfig;
   observationS3Path: string;
   schedulerDeps: ObservationEvalSchedulerDeps;
+  executionMode?: JobConfigExecutionMode;
 }
 
 async function processMatchingConfig(
   params: ProcessConfigParams,
 ): Promise<void> {
-  const { observation, matchingConfig, observationS3Path, schedulerDeps } =
-    params;
+  const {
+    observation,
+    matchingConfig,
+    observationS3Path,
+    schedulerDeps,
+    executionMode,
+  } = params;
 
   const jobExecutionId = createW3CTraceId(
     `${matchingConfig.id}:${observation.span_id}`,
@@ -144,6 +153,7 @@ async function processMatchingConfig(
     projectId: observation.project_id,
     observationS3Path,
     delay: 0,
+    ...(executionMode ? { executionMode } : {}),
   });
 
   logger.debug("Scheduled observation eval job", {

--- a/worker/src/features/evaluation/observationEval/types.ts
+++ b/worker/src/features/evaluation/observationEval/types.ts
@@ -1,4 +1,5 @@
 import { JobConfiguration, JobExecutionStatus } from "@langfuse/shared/src/db";
+import { type JobConfigExecutionMode } from "@langfuse/shared";
 
 /**
  * Re-export ObservationForEval as the canonical observation type for eval operations.
@@ -61,5 +62,6 @@ export interface ObservationEvalSchedulerDeps {
     projectId: string;
     observationS3Path: string;
     delay: number;
+    executionMode?: JobConfigExecutionMode;
   }) => Promise<void>;
 }


### PR DESCRIPTION
## Summary

- Manual batch evaluation runs now bypass the LIVE/INACTIVE toggle so users can re-evaluate historic data against a paused evaluator. Blocked configs (auth/model errors) are still skipped.
- Introduces `JobConfigExecutionMode` (`LIVE` | `MANUAL`) and a new `isJobConfigExecutableForExecutionMode` helper. The mode is threaded from `processBatchedObservationEval` through `scheduleObservationEvals` and onto the `LLMAsJudgeExecution` queue payload, so the same gate is applied at schedule and processing time.
- Tests cover both directions: MANUAL bypasses inactive but still skips blocked, while the omitted-mode (live traffic) path keeps the original strict check.

## Linear

- [LFE-9333](https://linear.app/langfuse/issue/LFE-9333/fixbatch-evals-batch-evaluators-created-as-inactive)

## Review Focus

- `evalConfigBlocking.ts`: semantics of the new helper — MANUAL only bypasses status, not `blockedAt`.
- `LLMAsJudgeExecutionEventSchema` adds an optional `executionMode`; consumers default to strict behavior when absent (back-compat with in-flight jobs).
- Trace eval batched path is intentionally untouched; it uses a separate event schema.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `JobConfigExecutionMode` (`LIVE` | `MANUAL`) and an `isJobConfigExecutableForExecutionMode` helper so that manual batch eval runs can re-evaluate historic data against INACTIVE evaluators while still skipping evaluators whose `blockedAt` is set (auth/model errors). The mode is threaded from `processBatchedObservationEval` through `scheduleObservationEvals` and into the `LLMAsJudgeExecution` queue payload, where `observationEvalProcessor` re-checks it before executing — giving a safe double-gate.

- `evalConfigBlocking.ts` adds the enum and helper; MANUAL mode only bypasses the `status !== ACTIVE` check, not the `blockedAt` check.
- `LLMAsJudgeExecutionEventSchema` adds `executionMode` as optional, preserving backward compatibility with in-flight jobs that lack the field.
- `scheduleObservationEvals` and `observationEvalProcessor` are each updated to call the new helper, ensuring consistent enforcement at both schedule-time and process-time.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is self-contained and well-guarded: the new execution-mode check is applied consistently at both schedule time and process time, backward compatibility with in-flight jobs is preserved via the optional field, and blocked evaluators remain gated regardless of mode.

The core logic in `isJobConfigExecutableForExecutionMode` is correct and covered by tests for both directions. The two minor observations — a `"LIVE"` enum value that is never set by any caller, and sampling silently applying to manual batch runs — are worth flagging but do not affect current functionality.

`scheduleObservationEvals.ts` and `evalConfigBlocking.ts` are the most worth a second look: the former for the sampling-in-manual-mode question, the latter for the unused `"LIVE"` enum value.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant BA as BatchAction
    participant PBOE as processBatchedObservationEval
    participant SOE as scheduleObservationEvals
    participant S3 as S3 Storage
    participant Q as LLMAsJudgeExecution Queue
    participant OEP as observationEvalProcessor

    BA->>PBOE: trigger(projectId, evaluators, observationStream)
    loop for each observation batch
        PBOE->>SOE: "scheduleObservationEvals({..., executionMode: "MANUAL"})"
        SOE->>SOE: filter configs via isJobConfigExecutableForExecutionMode(config, "MANUAL")
        Note over SOE: INACTIVE → allowed<br/>blockedAt set → skipped
        SOE->>S3: uploadObservationToS3()
        SOE->>Q: "enqueueEvalJob({..., executionMode: "MANUAL"})"
    end

    Q->>OEP: process job event
    OEP->>OEP: isJobConfigExecutableForExecutionMode(evalJobConfig, event.executionMode)
    Note over OEP: Re-check at process time<br/>handles state changes between<br/>schedule and processing
    alt config is executable
        OEP->>S3: downloadObservationFromS3()
        OEP->>OEP: executeLLMAsJudgeEvaluation()
    else config not executable
        OEP->>OEP: cancel job execution
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/features/evals/evalConfigBlocking.ts:31-32
**`"LIVE"` enum value is never set by any code path**

`JobConfigExecutionMode` exposes a `"LIVE"` literal, but no call site ever passes `executionMode: "LIVE"` — the live/default behavior is represented by the absence of the field (`undefined`). Functionally this is fine because `isJobConfigExecutableForExecutionMode` treats every value other than `"MANUAL"` identically to `undefined`. However the enum implies callers would actively use `"LIVE"`, which can mislead future contributors into thinking it is distinct from omitting the field. Consider either removing `"LIVE"` from the enum (making the type `"MANUAL" | undefined`) or adding a comment clarifying that `"LIVE"` and `undefined` are equivalent here.

### Issue 2 of 2
worker/src/features/evaluation/observationEval/scheduleObservationEvals.ts:70-82
**Sampling still applied during MANUAL batch runs**

When `executionMode === "MANUAL"`, the per-config sampling check (`shouldSampleObservation`) is still evaluated. Users who trigger a manual batch to re-evaluate a specific set of observations may have some silently excluded by the sampling rate, producing an incomplete re-run with no indication of what was skipped. If sampling intentionally applies to manual runs (to allow partial re-evaluation at the evaluator's configured rate), a comment explaining that decision would prevent future changes from accidentally bypassing it or misunderstanding why some jobs are missing from the batch output.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): allow manual batch runs on ..."](https://github.com/langfuse/langfuse/commit/27814ee64e79ce4f8fb227c0eda903215d15de4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33736082)</sub>

<!-- /greptile_comment -->