### PR TITLE
fix: Fix typo in MembersTable component

### DIFF
--- a/web/src/features/rbac/components/MembersTable.tsx
+++ b/web/src/features/rbac/components/MembersTable.tsx
@@ -233,7 +233,7 @@ export function MembersTable({
                     side="right"
                   >
                     <p className="text-xs">
-                      The organization-level role can to be edited in the{" "}
+                      The organization-level role can be edited in the{" "}
                       <Link
                         href={`/organization/${orgId}/settings/members`}
                         className="underline"


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the MembersTable component.

No issue associated. Small typo fix only.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [ ] I haven't read the contributing guide
- [ ] My code doesn't follow the style guidelines of this project (`pnpm run format`)
- [ ] I haven't commented my code, particularly in hard-to-understand areas
- [ ] I haven't checked if my PR needs changes to the documentation
- [ ] I haven't checked if my changes generate no new warnings (`npm run lint`)
- [ ] I haven't added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a grammatical typo in the `MembersTable` component tooltip text, changing "can to be edited" to "can be edited".

- Removes the spurious word "to" from the tooltip text displayed when hovering over a member's organization-level role, correcting the sentence from "The organization-level role can to be edited in the…" to "The organization-level role can be edited in the…".
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Single-word typo fix in a UI tooltip string — no logic, state, or API changes.

The change removes one extraneous word from a static tooltip string. It has no impact on functionality, data flow, or component behaviour.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix typo in MembersTable component"](https://github.com/langfuse/langfuse/commit/8a913ca81fe7b96176f8ac4c18c280a1be2bb864) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33755083)</sub>

<!-- /greptile_comment -->