### PR TITLE
docs(agents): include paging monitors in regression sweep

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -126,6 +126,7 @@ Open: [code-review/SKILL.md](code-review/SKILL.md)
 
 Use for:
 - proactive Datadog sweeps across `prod-us`, `prod-eu`, `prod-hipaa`, and `prod-jp`
+- checking which paging monitors outside the SLO/burn-rate set alerted engineers and why
 - comparing recent production errors, logs, spans, and API latency to baselines
 - handing measured regressions to `linear-bug-triage` for Linear issues or comments
 

--- a/.agents/skills/detect-prod-regressions/SKILL.md
+++ b/.agents/skills/detect-prod-regressions/SKILL.md
@@ -2,12 +2,13 @@
 name: detect-prod-regressions
 description: |
   Proactively detect production regressions in Langfuse by comparing recent
-  Datadog errors, error logs, error spans, and API route latency signals against
-  baseline benchmarks or traces across prod-us, prod-eu, prod-hipaa, and
-  prod-jp. Use when asked to sweep production for new bugs, catch regressions
-  early, catch low-occurrence coding bugs or edge cases, compare recent changes
-  to Datadog measurements, or prepare measured production evidence for human
-  review before any optional Linear handoff.
+  Datadog paging alerts from monitors outside the SLO/burn-rate set, errors,
+  error logs, error spans, and API route latency signals against baseline
+  benchmarks or traces across prod-us, prod-eu, prod-hipaa, and prod-jp. Use
+  when asked to sweep production for new bugs, catch regressions early,
+  understand why engineers were paged, catch low-occurrence coding bugs or edge
+  cases, compare recent changes to Datadog measurements, or prepare measured
+  production evidence for human review before any optional Linear handoff.
 ---
 
 # Detect Prod Regressions
@@ -35,6 +36,10 @@ running a small count query rather than assuming where a tag lives.
 - Ground every bug claim in a measurable signal: counts, rates, p50/p95/p99
   duration, trace samples, flamegraphs, monitor thresholds, or benchmark
   comparisons.
+- Treat paging alerts from monitors outside the SLO/burn-rate set as triage
+  leads. Capture which monitors paged and why, then validate candidate
+  regressions with the underlying metric, log, span, trace, or event
+  measurements before calling them bugs.
 - If a requested measurement is missing or unavailable, write exactly
   "No measurements found" for that signal.
 - Treat a bug as new only when a recent window shows a new or materially worse
@@ -79,7 +84,33 @@ candidate regression becomes an incident-style root-cause analysis.
 
 For each environment, check:
 
-1. **Datadog errors**
+1. **Paging monitors outside the SLO/burn-rate set**
+   - Query Datadog monitor and event history for the recent window across both
+     Datadog sites as needed. Focus on monitors that notified paging routes,
+     escalation policies, PagerDuty/Opsgenie-style integrations, or on-call
+     alert channels.
+   - Exclude clearly SLO-backed monitors from the primary paging sweep, such as
+     monitors with SLO monitor types, `slo`/`burn rate` names, SLO tags, or SLO
+     queries. If a monitor is ambiguous, keep it and mark the SLO status as
+     uncertain instead of silently dropping it.
+   - Group repeated alert events by monitor ID, monitor name, environment,
+     service/team owner, group key, and trigger reason so renotifications or
+     flapping do not look like separate regressions.
+   - For each alerting monitor, capture the monitor URL, alert start/recovery
+     time, duration, notified paging target, current state, threshold, observed
+     value, group tags, no-data status when relevant, and the exact reason the
+     monitor entered alert.
+   - Explain the issue that paged engineers in operational terms: metric breach,
+     error cluster, queue backlog, saturation, no-data gap, host/task health,
+     failed job, or other monitor source. Then connect it to logs, spans,
+     traces, metrics, deployment markers, or dashboards that show whether the
+     signal is new or materially worse than baseline.
+   - Include monitor-driven candidates even when they are not top-volume error
+     or latency clusters. Conversely, mark noisy, flat, expected, SLO-only, or
+     non-regressing monitor pages as `none` with the measurements that justify
+     that decision.
+
+2. **Datadog errors**
    - Use Datadog Error Tracking to review error groups, new issues,
      regressions, affected services, and occurrence timelines. Also check the
      EU Datadog site equivalent when environment data is stored there.
@@ -90,18 +121,18 @@ For each environment, check:
      affected code path suggests a coding bug or edge case, even if occurrence
      counts are too small for top-N dashboards.
 
-2. **Datadog error logs**
+3. **Datadog error logs**
    - Aggregate `status:error` logs by service, route/resource, source,
      `error.message`, tenant/project identifiers when present, and environment.
    - Open representative logs only for clusters with measurable increase.
 
-3. **Datadog error spans**
+4. **Datadog error spans**
    - Aggregate error spans by `env`, `service`, `resource_name`, `http.route`,
      `error.type`, and `error.message`.
    - Fetch representative traces only after grouping identifies a candidate
      regression.
 
-4. **API route latencies**
+5. **API route latencies**
    - Focus on `service:web` HTTP spans and metrics such as
      `trace.http_request.duration` when available.
    - Compare p50, p95, and p99 by route/resource and environment.
@@ -122,6 +153,8 @@ include one row per candidate with:
 - Candidate / cluster name.
 - Environments.
 - Service and route/resource.
+- Monitor / page signal, including the paging monitor name, alert reason, and
+  notified route when applicable.
 - Recent window measurement.
 - Baseline measurement.
 - Delta / regression summary.
@@ -131,11 +164,11 @@ include one row per candidate with:
 Use a concrete markdown table shaped like this:
 
 ```markdown
-| Candidate | Envs | Service / Route | Recent Window | Baseline | Delta | Evidence | Proposed Linear Action |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| Public scores latency regression | prod-us | `web` `GET /api/public/v2/scores/index` | p95 `7.44s`, p99 `12.77s`, count `71,448` | p95 `4.34s`, p99 `6.60s`, count `26,024` | p95 `+72%`, p99 `+94%`, volume `+174%` | [metrics](https://app.datadoghq.com/) [spans](https://app.datadoghq.com/) [trace](https://app.datadoghq.com/) | comment existing |
-| ClickHouse socket hang up cluster | prod-us | `web-iso` `POST /` | errors `14,088` | errors `6,026` | `+134%` errors | [spans](https://app.datadoghq.com/) [trace](https://app.datadoghq.com/) | comment existing |
-| Ingestion DLQ monitor noise | prod-eu | `worker-cpu` `langfuse.queue.ingestion.dlq_length` | max `150` | max `150` | flat | [metrics](https://app.datadoghq.eu/) | none |
+| Candidate | Envs | Service / Route | Monitor / Page Signal | Recent Window | Baseline | Delta | Evidence | Proposed Linear Action |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Public scores latency regression | prod-us | `web` `GET /api/public/v2/scores/index` | Paging monitor `Public API p95 latency` alerted `pagerduty-web`; observed p95 crossed `5s` threshold | p95 `7.44s`, p99 `12.77s`, count `71,448` | p95 `4.34s`, p99 `6.60s`, count `26,024` | p95 `+72%`, p99 `+94%`, volume `+174%` | [monitor](https://app.datadoghq.com/) [metrics](https://app.datadoghq.com/) [spans](https://app.datadoghq.com/) [trace](https://app.datadoghq.com/) | comment existing |
+| ClickHouse socket hang up cluster | prod-us | `web-iso` `POST /` | Paging monitor `web-iso 5xx rate` alerted `pagerduty-web-iso`; grouped on `error.message:socket hang up` | errors `14,088` | errors `6,026` | `+134%` errors | [monitor](https://app.datadoghq.com/) [spans](https://app.datadoghq.com/) [trace](https://app.datadoghq.com/) | comment existing |
+| Ingestion DLQ monitor noise | prod-eu | `worker-cpu` `langfuse.queue.ingestion.dlq_length` | Paging monitor `Ingestion DLQ length` alerted `pagerduty-ingestion`; threshold breach but no increase versus baseline | max `150` | max `150` | flat | [monitor](https://app.datadoghq.eu/) [metrics](https://app.datadoghq.eu/) | none |
 ```
 
 If a requested signal is unavailable, write `No measurements found` in the
@@ -161,6 +194,8 @@ Hand off:
 Summarize:
 
 - The windows compared and all prod environments checked.
+- Which paging monitors outside the SLO/burn-rate set alerted engineers, why
+  they alerted, and which pages did or did not map to measured regressions.
 - The findings table shown to the human.
 - Whether the human approved sharing findings in Linear.
 - New Linear issues created, with links, only if approval was granted.

--- a/.agents/skills/detect-prod-regressions/agents/openai.yaml
+++ b/.agents/skills/detect-prod-regressions/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Detect Prod Regressions"
-  short_description: "Datadog regression sweep with Linear handoff"
-  default_prompt: "Use $detect-prod-regressions to compare recent production Datadog signals against baselines across all prod environments and hand measured bugs to $linear-bug-triage."
+  short_description: "Datadog monitor/page and regression sweep"
+  default_prompt: "Use $detect-prod-regressions to check which paging monitors outside the SLO/burn-rate set alerted engineers, explain why they alerted, compare production Datadog signals against baselines across all prod environments, and prepare measured findings for human review before any Linear handoff."


### PR DESCRIPTION
## Summary

- Update `$detect-prod-regressions` so production sweeps start from Datadog paging alerts from monitors outside the SLO/burn-rate set.
- Capture why engineers were paged, which monitor alerted, the paging target, observed values, thresholds, and recovery context.
- Add a monitor/page signal column to the findings table and refresh the skill README and OpenAI metadata.

## Impacted packages

- `.agents/skills/detect-prod-regressions`
- `.agents/skills/README.md`

## Verification

- `pnpm run agents:sync`
- `pnpm run agents:check`
- commit hook: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli`
- commit hook: `turbo run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the `detect-prod-regressions` skill to start every production sweep by querying Datadog for paging monitor alerts from monitors outside the SLO/burn-rate set, capturing why engineers were paged before proceeding to the existing error, log, span, and latency checks.

- **SKILL.md**: Adds a new step 1 covering paging monitor triage (with grouping, exclusion, and evidence capture rules), renumbers existing steps 2–5, adds a "Monitor / Page Signal" column to the findings table with updated example rows, and extends the Final Response summary to include paging context.
- **openai.yaml**: Updates `short_description` and `default_prompt` to reflect the monitor-first sweep order and align with the human-approval-before-Linear policy already in SKILL.md.
- **README.md**: Adds a bullet describing the paging monitor use case under the skill's routing guidance.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change to a skill configuration; no production code paths affected.

All three files are agent skill documentation and YAML metadata. The new paging-monitor step is correctly inserted as step 1, existing steps are renumbered consistently, the example table rows are internally coherent with the new column, and the updated default_prompt now aligns with the human-approval-before-Linear policy already stated in SKILL.md. No logic, data model, or runtime behavior is changed.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Start: detect-prod-regressions]) --> B

    subgraph sweep["Datadog Sweep — each prod environment"]
        B["1. Paging monitors\n(outside SLO/burn-rate set)"] --> C
        C["2. Datadog errors\n(Error Tracking)"] --> D
        D["3. Datadog error logs\n(status:error aggregations)"] --> E
        E["4. Datadog error spans\n(APM trace errors)"] --> F
        F["5. API route latencies\n(p50 / p95 / p99)"]
    end

    F --> G["Build findings table\n(incl. Monitor / Page Signal column)"]
    G --> H{Human reviewer\napproves sharing?}
    H -- Yes --> I["$linear-bug-triage handoff\n(comment existing / create new)"]
    H -- No --> J["Final Response:\nwindows, paging summary,\nfindings table only"]
    I --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): include paging monitors in..."](https://github.com/langfuse/langfuse/commit/8c17255d09990bbb58b48a614067f762d0a7f3c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33766996)</sub>

<!-- /greptile_comment -->