### PR TITLE
docs(docker): use shallow clone when self-host Langfuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Run Langfuse on your own infrastructure:
 
   ```bash
   # Get a copy of the latest Langfuse repository
-  git clone https://github.com/langfuse/langfuse.git
+  git clone --depth=1 https://github.com/langfuse/langfuse.git
   cd langfuse
 
   # Run the langfuse docker compose


### PR DESCRIPTION
## What does this PR do?

Updates the Docker Compose quick start instructions to use a shallow clone with `--depth=1`.

The self-hosted Docker Compose setup only needs the current working tree for a normal quick start run. A full clone also downloads repository history, which increases the initial checkout size for users who only want to start Langfuse locally with Docker Compose.

This keeps the existing setup flow unchanged while reducing the amount of Git data downloaded during the quick start.

Fixes # 

## Type of change

- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked if my PR needs changes to the documentation
- [x] This documentation-only change does not require tests

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the Docker Compose quick-start instructions in `README.md` to use a shallow clone (`--depth=1`), reducing the amount of Git history downloaded for users who only need the current working tree to run Langfuse locally.

- Adds `--depth=1` to the `git clone` command so only the latest snapshot is fetched, not the full commit history.
- No code, configuration, or behavior changes — documentation only.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single-character documentation tweak with no impact on runtime behavior.

The change only modifies one line in README.md, adding --depth=1 to a git clone example. Shallow clones are fully compatible with running Docker Compose from the checked-out directory, so the quick-start flow works identically for end users.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(docker): use shallow clone when sel..."](https://github.com/langfuse/langfuse/commit/191e198a326e54b11d7a4ae4db95b120600e5fd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33787774)</sub>

<!-- /greptile_comment -->