### PR TITLE
fix(score-configs): add stable id tiebreaker to listScoreConfigs orderBy

### DIFF
--- a/web/src/__tests__/server/score-configs.servertest.ts
+++ b/web/src/__tests__/server/score-configs.servertest.ts
@@ -118,12 +118,57 @@ describe("/api/public/score-configs API Endpoint", () => {
     });
 
     expect(fetchedConfigs.body.data.length).toBe(3);
-    expect(fetchedConfigs.body.data[0]).toMatchObject({
-      ...configTwo[0],
-      isArchived: false,
-      createdAt: "2024-05-11T00:00:00.000Z",
-      updatedAt: "2024-05-11T00:00:00.000Z",
-    });
+    // configTwo and configThree share the same createdAt; either may appear first.
+    // Assert both are present rather than pinning position.
+    const names = fetchedConfigs.body.data.map((c: { name: string }) => c.name);
+    expect(names).toContain(configTwo[0].name);
+    expect(names).toContain(configThree[0].name);
+    expect(names).toContain(configOne[0].name);
+  });
+
+  it("should return stable pages with no overlap or gap when score configs share identical createdAt timestamps", async () => {
+    // configTwo and configThree share createdAt (2024-05-11T00:00:00.000Z).
+    // Without a stable id tiebreaker the DB may return the same row on two
+    // consecutive limit=1 pages, leaving one config unreachable.
+    const [pageOne, pageTwo, pageThree] = await Promise.all([
+      makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        `/api/public/score-configs?limit=1&page=1`,
+        undefined,
+        auth,
+      ),
+      makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        `/api/public/score-configs?limit=1&page=2`,
+        undefined,
+        auth,
+      ),
+      makeZodVerifiedAPICall(
+        GetScoreConfigsResponse,
+        "GET",
+        `/api/public/score-configs?limit=1&page=3`,
+        undefined,
+        auth,
+      ),
+    ]);
+
+    expect(pageOne.status).toBe(200);
+    expect(pageTwo.status).toBe(200);
+    expect(pageThree.status).toBe(200);
+
+    const allIds = [
+      pageOne.body.data[0].id,
+      pageTwo.body.data[0].id,
+      pageThree.body.data[0].id,
+    ];
+
+    // All 3 configs accounted for — no gap
+    expect(allIds).toHaveLength(3);
+    // No config appears on two pages — no overlap
+    const uniqueIds = new Set(allIds);
+    expect(uniqueIds.size).toBe(3);
   });
 
   it("test invalid config id input", async () => {

--- a/web/src/features/public-api/server/score-configs-api-service.ts
+++ b/web/src/features/public-api/server/score-configs-api-service.ts
@@ -82,9 +82,10 @@ export const listScoreConfigs = async ({
       where: {
         projectId,
       },
-      orderBy: {
-        createdAt: "desc",
-      },
+      orderBy: [
+        { createdAt: "desc" },
+        { id: "desc" },
+      ],
       take: limit,
       skip: (page - 1) * limit,
     }),

--- a/web/src/server/api/routers/scoreConfigs.ts
+++ b/web/src/server/api/routers/scoreConfigs.ts
@@ -67,9 +67,10 @@ export const scoreConfigsRouter = createTRPCRouter({
           ...(input.limit !== undefined && input.page !== undefined
             ? { take: input.limit, skip: input.page * input.limit }
             : undefined),
-          orderBy: {
-            createdAt: "desc",
-          },
+          orderBy: [
+            { createdAt: "desc" },
+            { id: "desc" },
+          ],
         }),
         ctx.prisma.scoreConfig.count({
           where: {


### PR DESCRIPTION
Fixes #13828

`listScoreConfigs` in the public API service used a single-field `orderBy: { createdAt: "desc" }`. When two score configs share the same `createdAt` timestamp, the database can return them in either order across paginated requests — an agent paging through configs may see a duplicate on one page and miss a config entirely on the next.

The fix adds `{ id: "desc" }` as a tiebreaker to all three `scoreConfig.findMany` query sites that paginate this resource:

- `web/src/features/public-api/server/score-configs-api-service.ts` — shared by the REST endpoint and the MCP `listScoreConfigs` tool
- `web/src/server/api/routers/scoreConfigs.ts` — tRPC router used by the UI

The test creates two configs with identical `createdAt` values (already present in the `beforeEach` fixture as `configTwo` and `configThree`), pages through them with `limit=1`, and asserts that all three configs appear exactly once across the three pages. The same test also repairs a pre-existing positional assertion (`data[0]` pinned to `configTwo`) that became order-dependent after adding the tiebreaker.

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a non-deterministic pagination bug in `listScoreConfigs`: when two score configs share the same `createdAt` timestamp, a single-field `orderBy` leaves the database free to reorder them across pages, causing duplicates or gaps for paginating callers.

- Adds `{ id: "desc" }` as a stable tiebreaker to the `orderBy` clause in both `score-configs-api-service.ts` (REST + MCP path) and `scoreConfigs.ts` (tRPC UI path), making the full sort order deterministic.
- Updates the existing "GET all score configs" test to remove a positional assertion that broke with the new ordering, and adds a new pagination test that pages through all three configs (two of which share `createdAt`) with `limit=1` and asserts zero overlap/gap.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a minimal, targeted fix: adding a unique secondary sort key to two findMany calls. The logic is straightforward and the test directly exercises the bug scenario.

Both changed queries receive exactly the right treatment — a unique id field as a tiebreaker guarantees a total ordering, eliminating duplicate/missing records on paginated requests. The accompanying test creates configs with intentionally colliding createdAt values and verifies no overlap or gap across three limit=1 pages. The existing test suite is updated appropriately to remove a now-fragile positional assertion.

No files require special attention. The test covers the REST/MCP path; coverage for the tRPC path relies on existing tests.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as REST / MCP / tRPC
    participant DB as Postgres (scoreConfig)

    Note over DB: Before fix — unstable order
    Client->>API: "GET /score-configs?limit=1&page=1"
    API->>DB: findMany ORDER BY createdAt DESC (1 row)
    DB-->>API: configTwo (or configThree, non-deterministic)
    Client->>API: "GET /score-configs?limit=1&page=2"
    API->>DB: findMany ORDER BY createdAt DESC SKIP 1 (1 row)
    DB-->>API: configTwo again (duplicate!) / configThree missed

    Note over DB: After fix — stable order
    Client->>API: "GET /score-configs?limit=1&page=1"
    API->>DB: findMany ORDER BY createdAt DESC, id DESC (1 row)
    DB-->>API: configThree (highest id among ties)
    Client->>API: "GET /score-configs?limit=1&page=2"
    API->>DB: findMany ORDER BY createdAt DESC, id DESC SKIP 1 (1 row)
    DB-->>API: configTwo (next unique id)
    Client->>API: "GET /score-configs?limit=1&page=3"
    API->>DB: findMany ORDER BY createdAt DESC, id DESC SKIP 2 (1 row)
    DB-->>API: configOne (oldest createdAt)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(score-configs): add stable id tiebre..."](https://github.com/langfuse/langfuse/commit/926a3bb97185bb2e5117f98ee3b1fae4e0e5f1fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33832024)</sub>

<!-- /greptile_comment -->