### PR TITLE
feat(ui): add notification for lw5-d1

### DIFF
--- a/web/src/components/nav/sidebar-notifications.tsx
+++ b/web/src/components/nav/sidebar-notifications.tsx
@@ -41,6 +41,15 @@ const notifications: SidebarNotification[] = [
       />
     ),
   },
+  {
+    id: "lw5-1",
+    title: "Launch Week: Day 1",
+    description:
+      "Run experiments inside GitHub Actions to test every PR against a Langfuse dataset.",
+    link: "https://langfuse.com/launch-week-5",
+    linkTitle: "Learn more",
+    createdAt: "2026-05-25",
+  },
 ];
 
 const STORAGE_KEY = "dismissed-sidebar-notifications";


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a time-sensitive sidebar notification for Langfuse Launch Week Day 1, announcing the GitHub Actions + dataset experiment integration feature.

- Inserts a new `\"lw5-1\"` entry into the `notifications` array with a `createdAt` of 2026-05-25, so it auto-expires after the default two-week TTL.
- The notification links to `https://langfuse.com/launch-week-5` with a \"Learn more\" button rendered via the existing card/dismiss infrastructure.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a single notification entry appended to a static array, with no runtime logic changes.

The new notification entry is correct and will auto-expire via the existing TTL mechanism. The only concern is that placing the launch-week card after the permanent 'github-star' card means it may not be prominently visible to users who haven't dismissed the first notification, reducing the effective reach of the time-sensitive announcement.

web/src/components/nav/sidebar-notifications.tsx — specifically the ordering of entries in the notifications array.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SidebarNotifications renders] --> B[Load dismissedNotifications from localStorage]
    B --> C[Filter notifications array]
    C --> D{Is notification dismissed?}
    D -- Yes --> E[Skip]
    D -- No --> F{Is notification expired?\ncreatedAt + ttlMs < now}
    F -- Yes --> E
    F -- No --> G[Include in activeNotifications]
    G --> H[Render Card with title, description, link]
    H --> I{User clicks X}
    I --> J[Add id to dismissedNotifications in localStorage]
    J --> K[Notification hidden]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/nav/sidebar-notifications.tsx:29-46
The new launch-week notification is appended to the end of the array, so it renders *below* the persistent "Star Langfuse" card for any user who hasn't dismissed it yet. For a time-sensitive Day 1 announcement this means the promotional message is buried and may not be seen before it expires in two weeks.

```suggestion
const notifications: SidebarNotification[] = [
  {
    id: "lw5-1",
    title: "Launch Week: Day 1",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): add notification for lw5-d1"](https://github.com/langfuse/langfuse/commit/7d31749d514989f9e8d2a0049fb35f957e1286d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33833847)</sub>

<!-- /greptile_comment -->