### PR TITLE
fix(mcp): ensure MCP inputSchema has type: object at root

### DIFF
--- a/web/src/features/mcp/core/define-tool.ts
+++ b/web/src/features/mcp/core/define-tool.ts
@@ -138,6 +138,13 @@ export function defineTool<TInput>(
     );
   }
 
+  // MCP spec requires inputSchema to have "type": "object" at the root.
+  // Zod's intersection/and() schemas produce top-level allOf without type,
+  // so we add it when the schema is object-like but missing the type field.
+  if (!jsonSchema.type) {
+    jsonSchema.type = "object";
+  }
+
   // Build tool definition
   const toolDefinition: ToolDefinition = {
     name,


### PR DESCRIPTION
## What

Adds `type: "object"` to the root of MCP tool `inputSchema` when Zod's JSON Schema converter emits a top-level `allOf`/`oneOf` without a `type` field.

## Why

The MCP specification requires every tool's `inputSchema` to be a JSON Schema object with `type === "object"` at the root. Three tools (`createScore`, `createScoreConfig`, `updateScoreConfig`) use Zod intersection schemas (`.and(...)`) which produce top-level `allOf` without `type`. Strict MCP clients like Claude Code (Zod validation) reject the entire `tools/list` response, making all 22 Langfuse tools unavailable.

## How

In `defineTool()`, after the `isObjectLikeJsonSchema` validation check, adds a post-conversion step that sets `type: "object"` when the schema is object-like but missing the `type` field. This is compatible with `allOf`/`oneOf` keywords per JSON Schema spec.

Fixes #13833

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an MCP compatibility issue where three Langfuse tools (`createScore`, `createScoreConfig`, `updateScoreConfig`) used Zod intersection schemas (`.and(...)`) that produced a top-level `allOf` without a `type` field, causing strict MCP clients to reject the entire `tools/list` response.

- Adds a single guard in `defineTool()` that sets `type: \"object\"` when the generated JSON Schema is missing the `type` field, placed after the existing `isObjectLikeJsonSchema` validation check.
- The fix is targeted and correct for the `allOf` case, but `isObjectLikeJsonSchema` also passes `oneOf`/`anyOf` schemas without inspecting sub-schemas, so the new guard could silently add `type: \"object\"` to a mixed-type union in a future tool — a latent risk worth noting.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the three identified tools; the fix is minimal and correctly resolves the MCP spec violation.

The change is a one-liner that stamps `type: "object"` only when the field is absent, and it is always guarded by the pre-existing `isObjectLikeJsonSchema` check. The three affected tools all emit `allOf`, so the fix applies exactly as intended. The only noteworthy concern is that `isObjectLikeJsonSchema` accepts `oneOf`/`anyOf` without validating sub-schema types, meaning a future tool with a mixed-type union could silently receive an incorrect `type: "object"` — but no such tool exists today.

web/src/features/mcp/core/define-tool.ts — the `isObjectLikeJsonSchema` helper's handling of `oneOf`/`anyOf` is worth revisiting if discriminated-union tools are added in the future.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[defineTool called] --> B[z.toJSONSchema - baseSchema]
    B --> C{jsonSchema truthy?}
    C -- No --> D[throw Error]
    C -- Yes --> E{isObjectLikeJsonSchema?}
    E -- No --> F[throw Error]
    E -- Yes --> G{jsonSchema.type missing?}
    G -- Yes --> H[Set jsonSchema.type = 'object']
    G -- No --> I[Keep existing type]
    H --> J[Build ToolDefinition]
    I --> J
    J --> K[Wrap handler with validation]
    K --> L[Return - toolDefinition, wrappedHandler -]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/mcp/core/define-tool.ts:144-146
**Overly broad guard may mistype `oneOf`/`anyOf` schemas**

`isObjectLikeJsonSchema` returns `true` for any schema that contains `oneOf` or `anyOf`, without inspecting whether the sub-schemas are all objects. If Zod ever emits a union that mixes object and non-object sub-schemas (e.g., `{ oneOf: [{ type: "string" }, { type: "object", ... }] }`), the guard would pass and `type: "object"` would be injected. The resulting schema combines a root `type: "object"` constraint with a `oneOf` that includes a `type: "string"` branch — making that branch unmatchable and silently altering the tool's accepted inputs. The three tools targeted by this fix (`createScore`, `createScoreConfig`, `updateScoreConfig`) all use `allOf`, so they're safe today, but widening the guard to cover `oneOf`/`anyOf` without sub-schema validation creates a latent correctness risk for future tools.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: ensure MCP inputSchema always has t..."](https://github.com/langfuse/langfuse/commit/b8154bf9138c5c3862286ef097e86dd977676670) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33851267)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->