### PR TITLE
fix(mcp): stabilize list pagination ordering

### DIFF
--- a/web/src/features/mcp/features/comments/tools.ts
+++ b/web/src/features/mcp/features/comments/tools.ts
@@ -123,6 +123,7 @@ export const [listCommentsTool, handleListComments] = defineTool({
         const [comments, totalItems] = await Promise.all([
           prisma.comment.findMany({
             where,
+            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
             take: input.limit,
             skip: (input.page - 1) * input.limit,
           }),

--- a/web/src/features/mcp/features/datasets/tools.ts
+++ b/web/src/features/mcp/features/datasets/tools.ts
@@ -162,7 +162,7 @@ export const [listDatasetsTool, handleListDatasets] = defineTool({
               id: true,
             },
             where: { projectId: context.projectId },
-            orderBy: { createdAt: "desc" },
+            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
             take: input.limit,
             skip: (input.page - 1) * input.limit,
           }),
@@ -650,7 +650,7 @@ export const [listDatasetRunsTool, handleListDatasetRuns] = defineTool({
               where: { projectId: context.projectId },
               take: input.limit,
               skip: (input.page - 1) * input.limit,
-              orderBy: { createdAt: "desc" },
+              orderBy: [{ createdAt: "desc" }, { id: "desc" }],
             },
           },
         });

--- a/web/src/features/public-api/server/score-configs-api-service.ts
+++ b/web/src/features/public-api/server/score-configs-api-service.ts
@@ -82,9 +82,7 @@ export const listScoreConfigs = async ({
       where: {
         projectId,
       },
-      orderBy: {
-        createdAt: "desc",
-      },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: limit,
       skip: (page - 1) * limit,
     }),


### PR DESCRIPTION
## Summary
- Add deterministic `id` tie-breakers to MCP dataset, dataset run, and comment list ordering.
- Add the same stable ordering to public score config pagination used by MCP score config reads.
- Match the existing stable ordering pattern already used by annotation queue MCP tools.

This avoids unstable page boundaries when multiple rows share the same `createdAt` timestamp.

## Verification
- `git diff --check`
- `pnpm --filter web exec prettier --check src/features/mcp/features/datasets/tools.ts src/features/mcp/features/comments/tools.ts src/features/public-api/server/score-configs-api-service.ts`
- Commit hook completed repo lint successfully: `turbo run lint` (5/5 tasks successful).
- Attempted `pnpm --filter web test -- src/__tests__/server/mcp-tools-read.servertest.ts`; the local run expanded into the broader server suite and failed before useful assertions due missing local env/workspace setup (`DATABASE_URL`, `CLICKHOUSE_*`, `@langfuse/shared` resolution).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `id` as a deterministic tie-breaker to `orderBy` clauses in four paginated Prisma queries where rows with identical `createdAt` timestamps would otherwise produce unstable page boundaries. It matches the pattern already established in the annotation queue MCP tools.

- **`comments/tools.ts`**: `listComments` was previously missing an `orderBy` clause entirely; `[{ createdAt: "desc" }, { id: "desc" }]` is now added.
- **`datasets/tools.ts`**: Both `listDatasets` and `listDatasetRuns` are updated from the single-field `{ createdAt: "desc" }` to the stable two-field array form.
- **`score-configs-api-service.ts`**: Same fix applied to `listScoreConfigs`, which is shared by both the MCP `listScoreConfigs` tool and the public REST `GET /api/public/score-configs` endpoint — a positive side-effect.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all four queries now carry a unique tie-breaker, matching the existing annotation-queue pattern, and no functional behavior is changed beyond ordering determinism.

Each change is a single-line addition of `{ id: "desc" }` as a secondary sort key. The `id` field is unique in all four tables, so it fully stabilises page boundaries. The comments query gained a complete `orderBy` clause where none existed, removing the risk of random orderings on repeated requests. The `score-configs-api-service` change also fixes the public REST endpoint as a positive side-effect. No logic, filtering, or data shape is altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP / REST Client] --> B{Tool / Endpoint}
    B --> C[listComments\ntools.ts]
    B --> D[listDatasets\ntools.ts]
    B --> E[listDatasetRuns\ntools.ts]
    B --> F[listScoreConfigs\ntools.ts + REST endpoint]

    C --> C1["orderBy: [createdAt desc, id desc]\n(was: no orderBy)"]
    D --> D1["orderBy: [createdAt desc, id desc]\n(was: createdAt desc only)"]
    E --> E1["orderBy: [createdAt desc, id desc]\n(was: createdAt desc only)"]
    F --> F1["orderBy: [createdAt desc, id desc]\n(was: createdAt desc only)"]

    C1 --> G[Stable page boundaries]
    D1 --> G
    E1 --> G
    F1 --> G

    H[annotationQueues/tools.ts\nalready stable ✓] -.->|reference pattern| G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): stabilize list pagination orde..."](https://github.com/langfuse/langfuse/commit/d4789403ff40d6719e61d0f70236d0527efe29ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33866623)</sub>

<!-- /greptile_comment -->