### PR TITLE
chore(deps): bump qs to 6.15.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   '@types/react-dom': 19.2.3
   fast-xml-builder: 1.1.7
   glob: ^10.5.0
-  qs: 6.14.1
+  qs: 6.15.2
   path-to-regexp@0.1.12: 0.1.13
   ip-address@10.1.0: 10.2.0
   '@anthropic-ai/claude-agent-sdk>@anthropic-ai/sdk': 0.95.1
@@ -9217,8 +9217,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   query-selector-shadow-dom@1.0.1:
@@ -16435,7 +16435,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -17784,7 +17784,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -20251,7 +20251,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.14.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -21158,11 +21158,11 @@ snapshots:
   stripe@17.4.0:
     dependencies:
       '@types/node': 24.3.0
-      qs: 6.14.1
+      qs: 6.15.2
 
   stripe@18.5.0(@types/node@24.3.0):
     dependencies:
-      qs: 6.14.1
+      qs: 6.15.2
     optionalDependencies:
       '@types/node': 24.3.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ overrides:
   "@types/react-dom": 19.2.3
   fast-xml-builder: 1.1.7
   glob: ^10.5.0
-  qs: 6.14.1
+  qs: 6.15.2
   path-to-regexp@0.1.12: 0.1.13
   ip-address@10.1.0: 10.2.0
   "@anthropic-ai/claude-agent-sdk>@anthropic-ai/sdk": 0.95.1


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps the `qs` query-string parsing library from 6.14.1 to 6.15.2 across the monorepo using a pnpm workspace override, resolving two known vulnerabilities present in 6.14.1.

- **Security fix**: 6.14.1 carried CVE-2025-15284 (GHSA-6rw7-vpxm-498p), a high-severity DoS via `arrayLimit` bypass in bracket notation, fixed in 6.14.2; 6.15.2 additionally patches GHSA-q8mj-m7cp-5q26, bringing the package to zero known vulnerabilities per Snyk.
- **Lock file consistency**: All snapshot entries in `pnpm-lock.yaml` — covering `body-parser`, `express`, `stripe@17`, and `stripe@18` — are uniformly updated to 6.15.2 with the correct integrity hash.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a targeted dependency bump with no logic changes, and the new version eliminates all known vulnerabilities present in the previous pin.

The change touches only pnpm-workspace.yaml and pnpm-lock.yaml. The workspace override is updated consistently, and every snapshot entry in the lockfile — body-parser, express, stripe v17, and stripe v18 — correctly resolves to qs@6.15.2 with a matching integrity hash. No application code is modified, and the new version is confirmed clean by Snyk.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    WS["pnpm-workspace.yaml override: qs 6.14.1 to 6.15.2"]
    WS --> BP["body-parser: URL-encoded body parsing"]
    WS --> EX["express: query string parsing"]
    WS --> S1["stripe v17: API request serialization"]
    WS --> S2["stripe v18: API request serialization"]
    BP --> APP["Langfuse Application"]
    EX --> APP
    S1 --> APP
    S2 --> APP
    style WS fill:#4CAF50,color:#fff
    style APP fill:#2196F3,color:#fff
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump qs to 6.15.2"](https://github.com/langfuse/langfuse/commit/380d0b280a5c483069b80e32668519b872a1f4f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33878652)</sub>

<!-- /greptile_comment -->