### PR TITLE
chore(skills): update pnpm upgrade skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -173,6 +173,8 @@ Open: [debug-issue-with-datadog/SKILL.md](debug-issue-with-datadog/SKILL.md)
 Use for:
 - pnpm dependency bumps that need a specific target version
 - interactive upgrades where the package name or version may be missing
+- transitive lockfile bumps that may need temporary overrides and dedupe
+  verification before deciding whether the override should stay
 - checking whether `pnpm-workspace.yaml` `minimumReleaseAgeExclude` must change
 - comparing registry latest with the latest version installable under the
   current release-age gate

--- a/.agents/skills/pnpm-upgrade-package/AGENTS.md
+++ b/.agents/skills/pnpm-upgrade-package/AGENTS.md
@@ -44,15 +44,21 @@ pnpm workspace.
    - `pnpm -w up <package>@<version>` for root-only changes.
    - `pnpm --filter <workspace> up <package>@<version>` for one workspace.
    - `pnpm -r up <package>@<version>` only when every current reference should move.
+   - For an already-allowed transitive bump that pnpm refuses to move, use the
+     narrowest temporary `overrides` entry only to force resolution.
+   - After a temporary override moves the lockfile, remove that override and run
+     `pnpm install`, then `pnpm dedupe` when permitted. If the lockfile remains
+     at the target without the override, keep the lockfile-only result and do
+     not keep the override.
    - Do not hand-edit `pnpm-lock.yaml`.
 
 6. Validate.
    - Use the nearest package `AGENTS.md` plus the root verification matrix.
    - Finish with `pnpm why -r <package>`.
    - If companions moved too, run `pnpm why -r <companion-package>` for them as well.
-   - After fixing or upgrading a package, strongly suggest that the user run
-     `pnpm dedupe` as an optional cleanup step, but do not run it automatically
-     and do not require it.
+   - Run `pnpm dedupe` when validating temporary override removal or when the
+     user permits it; otherwise suggest it as optional cleanup. Review the diff
+     afterward because dedupe may move unrelated lockfile state.
 
 ## Quick Commands
 
@@ -72,3 +78,5 @@ pnpm workspace.
   `pnpm --filter web up <package>@<version>`
 - Bump everywhere that should move together:
   `pnpm -r up <package>@<version>`
+- Verify temporary override removal:
+  remove the override, then run `pnpm install` and `pnpm dedupe`

--- a/.agents/skills/pnpm-upgrade-package/SKILL.md
+++ b/.agents/skills/pnpm-upgrade-package/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: pnpm-upgrade-package
-description: Use when upgrading a dependency in this pnpm workspace, including requests to bump a package to a specific version, compare the registry latest version with the latest version installable under the current minimum-release-age window, or decide whether minimumReleaseAgeExclude in pnpm-workspace.yaml must change. Ask the user for the package name or target version when either is missing.
+description: >-
+  Upgrade pnpm workspace dependencies to target/latest versions:
+  direct/transitive bumps, release-age checks, temporary overrides,
+  minimumReleaseAgeExclude, lockfile/dedupe verification.
 ---
 
 # PNPM Upgrade Package
@@ -28,12 +31,17 @@ Use this skill for interactive dependency bumps in Langfuse.
 - If the current parent range does not cover the requested transitive version,
   upgrade that parent dependency instead of adding the target package directly
   unless the user explicitly wants that.
+- If pnpm will not move an already-allowed transitive version, a scoped
+  `overrides` entry may be used as a temporary resolution tool. After the
+  lockfile moves, remove the temporary override, run `pnpm install`, then run
+  `pnpm dedupe` when permitted. If the lockfile stays at the target without the
+  override, do not keep the override.
 - Never manually edit `pnpm-lock.yaml`; regenerate lockfile changes with
   `pnpm` commands only. If a lockfile-only refresh causes unrelated churn,
   adjust the pnpm command and rerun instead of patching the lockfile by hand.
-- After fixing or upgrading a package, strongly suggest that the user run
-  `pnpm dedupe` as an optional cleanup step, but do not run it automatically
-  and do not require it.
+- After fixing or upgrading a package, run `pnpm dedupe` when it is needed to
+  verify temporary resolver cleanup or when the user permits it; otherwise
+  suggest it as optional cleanup. Always inspect the diff after dedupe.
 - Resolve the registry latest version, but do not silently upgrade to latest
   unless the user asked for latest.
 - Compare the target version with the latest version installable under the


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the `pnpm-upgrade-package` agent skill to add explicit guidance for handling transitive dependency bumps that pnpm refuses to resolve on its own, using a temporary `overrides` entry as a resolution tool.

- Adds a \"temporary override\" workflow: use a scoped `overrides` entry to force resolution, verify the lockfile, then remove the override and run `pnpm install` + `pnpm dedupe` to confirm the target sticks without the override.
- Changes `pnpm dedupe` from \"always optional/never automatic\" to \"run automatically when validating temporary override removal or when the user permits it, and always inspect the diff afterward.\"
- Condenses the `SKILL.md` description into a shorter folded-scalar summary and propagates the new use-case bullets into `README.md`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only changes to agent skill files; no runtime code is affected.

All three changed files are Markdown skill definitions used by AI agents. The new override workflow is described consistently across README.md, AGENTS.md, and SKILL.md, and the updated dedupe guidance is internally coherent — it tightens the previous "never automatic" rule only for the specific case of validating override removal, and explicitly warns the agent to inspect the diff for unrelated lockfile churn. No production code, migrations, or configuration values are touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start: pnpm upgrade request] --> B{Direct or transitive bump?}
    B -- Direct --> C[pnpm up package@version]
    B -- Transitive --> D{pnpm resolves version?}
    D -- Yes --> E[Lockfile updated]
    D -- No --> F[Add scoped overrides entry]
    F --> G[pnpm install - lockfile moves to target]
    G --> H[Remove temporary override]
    H --> I[pnpm install]
    I --> J{Lockfile stays at target?}
    J -- Yes --> K[Keep lockfile-only result - No override needed]
    J -- No --> L[Investigate — override may be required]
    C --> E
    E --> M{User permits dedupe or override removal validation?}
    K --> M
    M -- Yes --> N[pnpm dedupe - Review diff for unrelated churn]
    M -- No --> O[Suggest dedupe as optional cleanup]
    N --> P[pnpm why -r package]
    O --> P
    P --> Q[Done]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(skills): update pnpm upgrade skill"](https://github.com/langfuse/langfuse/commit/cb075ed015fda65e504856c31175b033f27c97cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33881750)</sub>

<!-- /greptile_comment -->