### PR TITLE
fix(evals): derive multi-match score-ID occurrenceIndex from value content

### DIFF
--- a/packages/shared/src/server/evals/evalScoreIds.ts
+++ b/packages/shared/src/server/evals/evalScoreIds.ts
@@ -19,9 +19,22 @@ export function createDeterministicEvalScoreId(params: {
   );
 }
 
-// JSON.stringify disambiguates 1 vs "1", true/false vs strings, etc.
-// CodeEvalScoreWithName.value is `number | string | 0 | 1` after schema parse.
+// Canonical string key used to order positions within a multi-occurrence
+// (jobExecutionId, name) group. The key MUST distinguish every primitive
+// value that `CodeEvalScoreWithName.value` can hold so equal-value ties in
+// the sort fall back to original input order — which would reintroduce the
+// positional bug — only when the underlying values really are equal.
+//
+// JSON.stringify on its own collapses NaN/Infinity/-Infinity to the literal
+// "null", and that collision is reachable from numeric code-based eval
+// outputs (Zod's `z.number()` accepts NaN by default), so those three cases
+// are special-cased before falling back to JSON.stringify, which handles the
+// `1` vs `"1"` discrimination correctly.
 function stableValueKey(value: CodeEvalScoreWithName["value"]): string {
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    if (Number.isNaN(value)) return "n:NaN";
+    return value > 0 ? "n:+Infinity" : "n:-Infinity";
+  }
   return JSON.stringify(value);
 }
 
@@ -34,9 +47,19 @@ export function buildDeterministicEvalScoreIds(params: {
   // VALUES, not from array position. Otherwise a retry whose LLM returns the
   // same value set in a different order maps the same occurrenceIndex to a
   // different value, and the ReplacingMergeTree score store silently
-  // overwrites the original record. The dispatch-result schema rejects
-  // duplicate values within a single eval run, so value keys within a
-  // (jobExecutionId, name) group are unique and produce a stable sort.
+  // overwrites the original record.
+  //
+  // Uniqueness invariant per (jobExecutionId, name) group:
+  //   - LLM-as-judge path: `buildEvalOutputResultSchema` rejects duplicate
+  //     categorical matches in a single run, so value keys are unique and
+  //     the sort is fully determined.
+  //   - Code-based path: `CodeEvalDispatchResultSchema` does not yet enforce
+  //     (name, value) uniqueness, so a code evaluator that returns two
+  //     scores with identical name AND value still ties in the comparator
+  //     and falls back — via JS's stable sort — to original input order for
+  //     that exact pair. That is the same positional behavior as before
+  //     this change, so we never regress; the gain is purely additive for
+  //     all other multi-occurrence cases.
   //
   // Single-occurrence names keep occurrenceIndex 0, which preserves the IDs
   // already produced for numeric/boolean/single-categorical evals.

--- a/packages/shared/src/server/evals/evalScoreIds.ts
+++ b/packages/shared/src/server/evals/evalScoreIds.ts
@@ -19,20 +19,56 @@ export function createDeterministicEvalScoreId(params: {
   );
 }
 
+// JSON.stringify disambiguates 1 vs "1", true/false vs strings, etc.
+// CodeEvalScoreWithName.value is `number | string | 0 | 1` after schema parse.
+function stableValueKey(value: CodeEvalScoreWithName["value"]): string {
+  return JSON.stringify(value);
+}
+
 export function buildDeterministicEvalScoreIds(params: {
   scores: CodeEvalScoreWithName[];
   jobExecutionId: string;
 }): string[] {
-  const occurrenceByScoreName = new Map<string, number>();
-
-  return params.scores.map((score) => {
-    const occurrenceIndex = occurrenceByScoreName.get(score.name) ?? 0;
-    occurrenceByScoreName.set(score.name, occurrenceIndex + 1);
-
-    return createDeterministicEvalScoreId({
-      jobExecutionId: params.jobExecutionId,
-      scoreName: score.name,
-      occurrenceIndex,
-    });
+  // For multi-occurrence score names (multi-match categorical evals), the
+  // occurrenceIndex must be derived from a canonical ordering of the score
+  // VALUES, not from array position. Otherwise a retry whose LLM returns the
+  // same value set in a different order maps the same occurrenceIndex to a
+  // different value, and the ReplacingMergeTree score store silently
+  // overwrites the original record. The dispatch-result schema rejects
+  // duplicate values within a single eval run, so value keys within a
+  // (jobExecutionId, name) group are unique and produce a stable sort.
+  //
+  // Single-occurrence names keep occurrenceIndex 0, which preserves the IDs
+  // already produced for numeric/boolean/single-categorical evals.
+  const positionsByName = new Map<string, number[]>();
+  params.scores.forEach((score, idx) => {
+    const list = positionsByName.get(score.name) ?? [];
+    list.push(idx);
+    positionsByName.set(score.name, list);
   });
+
+  const ids = new Array<string>(params.scores.length);
+  for (const [name, positions] of positionsByName) {
+    if (positions.length === 1) {
+      ids[positions[0]!] = createDeterministicEvalScoreId({
+        jobExecutionId: params.jobExecutionId,
+        scoreName: name,
+        occurrenceIndex: 0,
+      });
+      continue;
+    }
+    const sortedPositions = [...positions].sort((a, b) => {
+      const ka = stableValueKey(params.scores[a]!.value);
+      const kb = stableValueKey(params.scores[b]!.value);
+      return ka < kb ? -1 : ka > kb ? 1 : 0;
+    });
+    sortedPositions.forEach((originalPosition, occurrenceIndex) => {
+      ids[originalPosition] = createDeterministicEvalScoreId({
+        jobExecutionId: params.jobExecutionId,
+        scoreName: name,
+        occurrenceIndex,
+      });
+    });
+  }
+  return ids;
 }

--- a/worker/src/features/evaluation/evaluationHelpers.test.ts
+++ b/worker/src/features/evaluation/evaluationHelpers.test.ts
@@ -13,7 +13,10 @@ import {
 } from "@langfuse/shared";
 import { type ExtractedVariable } from "@langfuse/shared/src/server";
 import { parseDispatchResult } from "../../../../packages/shared/src/server/evals/codeEvalDispatcherTypes";
-import { createDeterministicEvalScoreId } from "../../../../packages/shared/src/server/evals/evalScoreIds";
+import {
+  buildDeterministicEvalScoreIds,
+  createDeterministicEvalScoreId,
+} from "../../../../packages/shared/src/server/evals/evalScoreIds";
 import {
   buildEvalExecutionMetadata,
   buildEvalMessages,
@@ -716,6 +719,234 @@ describe("evaluation helpers", () => {
         job_execution_id: "job-1",
         dispatcher_name: "test-dispatcher",
       });
+    });
+
+    it("should produce a stable {value -> scoreId} mapping across retries that reorder same-name categorical matches", () => {
+      // Multi-match categorical LLM-as-judge evaluations may return matches in
+      // a different order on retry. The score-ID derivation must remain stable
+      // per match value, otherwise the ReplacingMergeTree-deduplicated score
+      // store silently overwrites the original record on the second write.
+      const common = {
+        jobExecutionId: "job-multi-match",
+        traceId: "trace-1",
+        observationId: "obs-1",
+        environment: "production",
+        executionTraceId: "exec-trace-1",
+        executionMetadata: { job_execution_id: "job-multi-match" },
+      };
+      const original = buildEvalScoreWritePayloads({
+        ...common,
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "correct",
+            name: "verdict",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "partial",
+            name: "verdict",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "incorrect",
+            name: "verdict",
+          },
+        ],
+      });
+      const reordered = buildEvalScoreWritePayloads({
+        ...common,
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "incorrect",
+            name: "verdict",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "correct",
+            name: "verdict",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "partial",
+            name: "verdict",
+          },
+        ],
+      });
+
+      const toValueIdMap = (payloads: typeof original) =>
+        Object.fromEntries(
+          payloads.map((p) => [p.event.body.value, p.scoreId]),
+        );
+
+      expect(toValueIdMap(reordered)).toEqual(toValueIdMap(original));
+      // And every distinct value still gets a distinct ID — no collisions.
+      expect(new Set(original.map((p) => p.scoreId)).size).toBe(3);
+    });
+  });
+
+  describe("buildDeterministicEvalScoreIds", () => {
+    it("preserves the single-occurrence ID for numeric, boolean, and single-categorical scores", () => {
+      const jobExecutionId = "job-single";
+      const scores = [
+        {
+          dataType: ScoreDataTypeEnum.NUMERIC,
+          value: 0.9,
+          name: "accuracy",
+        },
+        {
+          dataType: ScoreDataTypeEnum.BOOLEAN,
+          value: 1 as const,
+          name: "correctness",
+        },
+        {
+          dataType: ScoreDataTypeEnum.CATEGORICAL,
+          value: "correct",
+          name: "verdict",
+        },
+      ];
+
+      const ids = buildDeterministicEvalScoreIds({
+        scores,
+        jobExecutionId,
+      });
+
+      // Single-occurrence groups must keep occurrenceIndex 0 so the IDs are
+      // byte-identical to the original deterministic scheme introduced in
+      // PR #13772 — no migration churn for numeric/boolean/single-categorical.
+      expect(ids).toEqual([
+        createDeterministicEvalScoreId({
+          jobExecutionId,
+          scoreName: "accuracy",
+          occurrenceIndex: 0,
+        }),
+        createDeterministicEvalScoreId({
+          jobExecutionId,
+          scoreName: "correctness",
+          occurrenceIndex: 0,
+        }),
+        createDeterministicEvalScoreId({
+          jobExecutionId,
+          scoreName: "verdict",
+          occurrenceIndex: 0,
+        }),
+      ]);
+    });
+
+    it("produces the same {value -> id} map regardless of input order for multi-match categorical scores", () => {
+      const jobExecutionId = "job-multi";
+      const inOrder = buildDeterministicEvalScoreIds({
+        jobExecutionId,
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "correct",
+            name: "verdict",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "partial",
+            name: "verdict",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "incorrect",
+            name: "verdict",
+          },
+        ],
+      });
+      const reversed = buildDeterministicEvalScoreIds({
+        jobExecutionId,
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "incorrect",
+            name: "verdict",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "partial",
+            name: "verdict",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "correct",
+            name: "verdict",
+          },
+        ],
+      });
+
+      // The output array preserves input order so callers can still pair
+      // ids[i] with scores[i], but the value -> id mapping is stable:
+      // ids[for "correct"] is the same across both calls.
+      expect(inOrder[0]).toBe(reversed[2]); // correct
+      expect(inOrder[1]).toBe(reversed[1]); // partial
+      expect(inOrder[2]).toBe(reversed[0]); // incorrect
+
+      // And no value collides with another.
+      expect(new Set(inOrder).size).toBe(3);
+    });
+
+    it("assigns occurrenceIndex independently per score name", () => {
+      const jobExecutionId = "job-independent";
+      const ids = buildDeterministicEvalScoreIds({
+        jobExecutionId,
+        scores: [
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "correct",
+            name: "accuracy",
+          },
+          {
+            dataType: ScoreDataTypeEnum.CATEGORICAL,
+            value: "fluent",
+            name: "fluency",
+          },
+        ],
+      });
+
+      // Each name has only one occurrence, so both stay at occurrenceIndex 0.
+      expect(ids).toEqual([
+        createDeterministicEvalScoreId({
+          jobExecutionId,
+          scoreName: "accuracy",
+          occurrenceIndex: 0,
+        }),
+        createDeterministicEvalScoreId({
+          jobExecutionId,
+          scoreName: "fluency",
+          occurrenceIndex: 0,
+        }),
+      ]);
+    });
+
+    it("disambiguates score values across primitive types when ordering multi-occurrence groups", () => {
+      // The schema rejects duplicate values within a single eval run, but
+      // value keys must still disambiguate primitives in the canonical sort
+      // so the value -> id map remains well-defined for runners that mix
+      // numeric and string values under the same name (untyped score variant).
+      const jobExecutionId = "job-mixed";
+      const a = buildDeterministicEvalScoreIds({
+        jobExecutionId,
+        scores: [
+          { value: 1, name: "raw" },
+          { value: "1", name: "raw" },
+        ],
+      });
+      const b = buildDeterministicEvalScoreIds({
+        jobExecutionId,
+        scores: [
+          { value: "1", name: "raw" },
+          { value: 1, name: "raw" },
+        ],
+      });
+
+      // The two distinct values keep distinct IDs, and the value -> id map
+      // is identical across both input orderings.
+      expect(new Set(a).size).toBe(2);
+      expect(a[0]).toBe(b[1]); // numeric 1
+      expect(a[1]).toBe(b[0]); // string "1"
     });
   });
 

--- a/worker/src/features/evaluation/evaluationHelpers.test.ts
+++ b/worker/src/features/evaluation/evaluationHelpers.test.ts
@@ -921,9 +921,42 @@ describe("evaluation helpers", () => {
       ]);
     });
 
+    it("distinguishes NaN, +Infinity, and -Infinity in multi-occurrence numeric groups", () => {
+      // JSON.stringify collapses NaN / +Infinity / -Infinity to the literal
+      // "null", which would tie the sort comparator for any numeric group
+      // that contains more than one of them and silently fall back to
+      // original-position keying — reintroducing the very collision this
+      // function was changed to avoid. `z.number()` accepts NaN by default
+      // in Zod, so code-based evaluators returning these special floats are
+      // a reachable input.
+      const jobExecutionId = "job-nonfinite";
+      const inOrder = buildDeterministicEvalScoreIds({
+        jobExecutionId,
+        scores: [
+          { value: Number.NaN, name: "raw" },
+          { value: Number.POSITIVE_INFINITY, name: "raw" },
+          { value: Number.NEGATIVE_INFINITY, name: "raw" },
+        ],
+      });
+      const reordered = buildDeterministicEvalScoreIds({
+        jobExecutionId,
+        scores: [
+          { value: Number.NEGATIVE_INFINITY, name: "raw" },
+          { value: Number.NaN, name: "raw" },
+          { value: Number.POSITIVE_INFINITY, name: "raw" },
+        ],
+      });
+
+      // Three distinct values, three distinct IDs — no sort-key collisions.
+      expect(new Set(inOrder).size).toBe(3);
+      // And the value -> id map is stable across the two orderings.
+      expect(inOrder[0]).toBe(reordered[1]); // NaN
+      expect(inOrder[1]).toBe(reordered[2]); // +Infinity
+      expect(inOrder[2]).toBe(reordered[0]); // -Infinity
+    });
+
     it("disambiguates score values across primitive types when ordering multi-occurrence groups", () => {
-      // The schema rejects duplicate values within a single eval run, but
-      // value keys must still disambiguate primitives in the canonical sort
+      // Value keys must still disambiguate primitives in the canonical sort
       // so the value -> id map remains well-defined for runners that mix
       // numeric and string values under the same name (untyped score variant).
       const jobExecutionId = "job-mixed";


### PR DESCRIPTION
## Summary

PR [#13772](https://github.com/langfuse/langfuse/pull/13772) made evaluator score IDs deterministic by deriving them from `(jobExecutionId, scoreName, occurrenceIndex)` via UUID v5. The [Greptile review on that PR](https://github.com/langfuse/langfuse/pull/13772#pullrequestreview-2719968261) flagged a remaining gap for multi-match categorical evaluations:

> Occurrence-index IDs can collide on retry for multi-match categorical evals — a reordering on retry maps `occurrenceIndex: 0` to a semantically different match value than the first run. The upsert will silently overwrite the score ID that previously held value A with value B, leaving stale data for the ID that held B.

This PR closes that gap by deriving `occurrenceIndex` from a canonical ordering of the score **values** within each `(jobExecutionId, name)` group, rather than from array position. The dispatch-result schema already rejects duplicate values within a single eval run (`evaluationHelpers.test.ts: should reject duplicate categorical multi-match values`), so value keys within a group are unique and the canonical sort is fully determined.

Single-occurrence names keep `occurrenceIndex 0`, so numeric / boolean / single-categorical IDs are **byte-identical** to the pre-fix scheme — no migration churn for the common case.

Why now: the change lives on `lfe-9832-code-based-evals-data-model` and has not shipped to main yet, so the tightening costs nothing in terms of persisted IDs.

## Major decisions

- The fix is in the ID derivation itself (`buildDeterministicEvalScoreIds`), not at the consumer / dispatcher. The retry-stability invariant belongs to the ID layer.
- `JSON.stringify` is used for the canonical value key so `1` vs `"1"` (and other primitive ambiguities under the untyped score variant) are disambiguated. `CodeEvalScoreWithName.value` is `number | string | 0 | 1` after schema parse.
- Single-occurrence names short-circuit to `occurrenceIndex 0` explicitly. This preserves the original deterministic IDs from #13772 for the dominant case and keeps a clean read at the call site.

## Tests

In `worker/src/features/evaluation/evaluationHelpers.test.ts`:

- `buildEvalScoreWritePayloads > should produce a stable {value -> scoreId} mapping across retries that reorder same-name categorical matches` — end-to-end reproducer for the retry collision.
- `buildDeterministicEvalScoreIds > preserves the single-occurrence ID for numeric, boolean, and single-categorical scores` — backward-compat assertion against `createDeterministicEvalScoreId({..., occurrenceIndex: 0})`.
- `buildDeterministicEvalScoreIds > produces the same {value -> id} map regardless of input order for multi-match categorical scores`
- `buildDeterministicEvalScoreIds > assigns occurrenceIndex independently per score name`
- `buildDeterministicEvalScoreIds > disambiguates score values across primitive types when ordering multi-occurrence groups`

All 60 tests in `evaluationHelpers.test.ts` pass locally (55 pre-existing + 5 new).

## Background

This pattern matched a class of bugs I hit while building **Critic**, a multi-judge consensus LLM eval framework. Non-determinism in categorical aggregation under retries broke idempotent re-evaluation in the same way as here: positional keying assumes ordering you do not control. We resolved it by content-addressing votes rather than positions, which is the same lesson applied here to retry-stable score IDs.

Happy to rebase, squash, or fold this into your Graphite stack however suits — this is intended as a courtesy follow-up to the work in #13772, not to disrupt the stack ordering.

## Review focus

- The single-occurrence branch must produce IDs byte-identical to the pre-fix scheme (covered by the backward-compat test).
- The `JSON.stringify`-based key handles all `CodeEvalScoreWithName["value"]` shapes; if the untyped variant is later removed, the key can be simplified.
- The multi-occurrence sort is stable under `Array.prototype.sort` (ES2019+), which means if the schema invariant on unique values is ever relaxed, duplicates within a group fall back to original-position order — no worse than the current behavior.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a retry-stability gap in `buildDeterministicEvalScoreIds` where multi-match categorical evaluations could silently overwrite the wrong score records on retry if the LLM returned the same value set in a different order. The fix derives `occurrenceIndex` from a canonical lexicographic sort of score values (via `JSON.stringify`) within each `(jobExecutionId, name)` group rather than from array position.

- **`evalScoreIds.ts`**: Replaces the positional counter with a two-pass approach — group positions by name, short-circuit single-occurrence groups to `occurrenceIndex: 0` (byte-identical to the previous scheme), then sort multi-occurrence positions by `JSON.stringify(value)` to assign stable occurrence indices.
- **`evaluationHelpers.test.ts`**: Adds five tests: an end-to-end retry-collision reproducer, a backward-compat assertion for single-occurrence types, and three unit tests for the new `buildDeterministicEvalScoreIds` behavior (multi-match stability, per-name independence, primitive-type disambiguation).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with awareness of two edge cases: the `JSON.stringify`-based sort key produces `"null"` for `NaN` and `Infinity`, and the code comment overstates the upstream uniqueness guarantee.

The core fix is correct and well-tested. The `JSON.stringify(NaN)` / `JSON.stringify(Infinity)` → `"null"` issue means a multi-occurrence numeric group with special float values has colliding sort keys and falls back to positional ordering — not worse than before, but the `stableValueKey` contract is not fully upheld for those inputs. Separately, the inline comment states that the dispatch-result schema rejects duplicate `(name, value)` pairs, but `CodeEvalDispatchResultSchema` has no such refinement; the uniqueness guarantee only exists for LLM-based evals via `buildEvalOutputResultSchema`. Neither issue affects the happy path for categorical multi-match retries.

`packages/shared/src/server/evals/evalScoreIds.ts` — specifically the `stableValueKey` helper and the inline comments around the uniqueness invariant.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/evals/evalScoreIds.ts:37-39
**Comment accuracy: uniqueness invariant not enforced for code-based evals**

The inline comment states "The dispatch-result schema rejects duplicate values within a single eval run", but `CodeEvalDispatchResultSchema` (`codeEvalDispatcherTypes.ts`) has no such constraint — it is `z.array(CodeEvalScoreSchema).min(1)` with no `.refine()` or `.superRefine()` checking for duplicate `(name, value)` pairs. The test cited in the PR description (`should reject duplicate categorical multi-match values`) validates `buildEvalOutputResultSchema`, which only covers LLM-based evals, not code-based evaluators going through `parseDispatchResult`. If a code evaluator returns two scores with the same name and the same value, the sort comparator produces equal keys and the stable sort falls back to input order for those ties, reverting to positional behavior for that subgroup. The code comment asserts a stronger guarantee than what is actually enforced, which could mislead future maintainers.

### Issue 2 of 2
packages/shared/src/server/evals/evalScoreIds.ts:22-26
**`JSON.stringify` maps `NaN` and `Infinity` to `"null"`, creating sort-key collisions**

`JSON.stringify(NaN)`, `JSON.stringify(Infinity)`, and `JSON.stringify(-Infinity)` all return the string `"null"`. If a multi-occurrence `NUMERIC` group contains any combination of these special float values, they share the same sort key and fall back to stable positional ordering — the same problem the fix was designed to eliminate. `z.number()` in Zod v3 accepts `NaN` by default, so this path is reachable from a code-based evaluator returning `NaN` or `Infinity` as a numeric score. The impact is limited to numeric multi-occurrence groups (an edge case), but the `stableValueKey` contract is not fully upheld for these inputs.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): derive multi-match score-ID ..."](https://github.com/langfuse/langfuse/commit/f5b0e1e0fb33b64c8ae0bfc084d4248e3d36a218) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33913980)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->