### PR TITLE
fix(trace): truncate log view observation IO queries

### DIFF
--- a/web/src/components/trace/api/usePrefetchObservation.ts
+++ b/web/src/components/trace/api/usePrefetchObservation.ts
@@ -43,9 +43,11 @@ export function usePrefetchObservation({
           traceId,
           projectId,
           startTime,
+          verbosity: "truncated",
         },
         {
           staleTime: 5 * 60 * 1000, // 5 minutes
+          meta: { silentHttpCodes: [422] },
         },
       );
     }

--- a/web/src/components/trace/components/TraceLogView/useLogViewAllObservationsIO.ts
+++ b/web/src/components/trace/components/TraceLogView/useLogViewAllObservationsIO.ts
@@ -49,7 +49,13 @@ export function getObservationQueryKey(
   return [
     ["observations", "byId"],
     {
-      input: { observationId, traceId, projectId, startTime },
+      input: {
+        observationId,
+        traceId,
+        projectId,
+        startTime,
+        verbosity: "truncated",
+      },
       type: "query",
     },
   ];
@@ -200,6 +206,7 @@ export function useLogViewAllObservationsIO({
                 traceId,
                 projectId,
                 startTime: item.node.startTime,
+                verbosity: "truncated",
               });
 
               const baseData: ObservationIOData = {

--- a/web/src/components/trace/components/TraceLogView/useLogViewObservationIO.ts
+++ b/web/src/components/trace/components/TraceLogView/useLogViewObservationIO.ts
@@ -42,11 +42,13 @@ export function useLogViewObservationIO({
       traceId,
       projectId,
       startTime,
+      verbosity: "truncated",
     },
     {
       enabled: enabled && !isBetaEnabled,
       staleTime: Infinity,
       refetchOnWindowFocus: false,
+      meta: { silentHttpCodes: [422] },
     },
   );
 
@@ -110,6 +112,7 @@ export function useObservationIOLoadedCount({
             traceId,
             projectId,
             startTime: item.node.startTime,
+            verbosity: "truncated",
           },
           type: "query",
         },


### PR DESCRIPTION
## Summary

This PR reduces repeated `observations.byId` 422 failures in the trace log view for observations with large input/output payloads. The log view now requests truncated observation I/O, which uses the existing server-side `leftUTF8` path instead of pulling full ClickHouse payloads for inline rows and full JSON log mode.

## Key Changes

- Request `verbosity: "truncated"` for legacy trace log row expansion queries.
- Keep hover prefetch and React Query cache keys aligned with the truncated log-view query input.
- Suppress visible 422 toasts for trace log row expansion/prefetch while preserving row-level error state.
- Request truncated I/O in the full JSON trace log loader to avoid large full-payload fan-out queries.

## Implicit Impact

- Trace log inline I/O previews and JSON mode may show server-side-truncated I/O instead of full payloads for very large observations.
- Dedicated observation/detail views and other `observations.byId` callers still use the default full verbosity.
- This should reduce ClickHouse resource pressure and toast storms on large traces without changing the tRPC API shape.

## Verification

- `pnpm --filter web run lint`
- `pnpm --filter web run test-client -- src/components/trace/components/TraceLogView/log-view-flattening.clienttest.ts`
- `pnpm --filter web run typecheck` was attempted after `pnpm --filter @langfuse/shared run db:generate`; it is currently blocked by existing unrelated repo-wide type errors outside the touched files.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses 422 toast storms in the trace log view by switching `observations.byId` calls to `verbosity: \"truncated\"`, which routes through the server-side `leftUTF8` truncation path instead of pulling full ClickHouse payloads. Error suppression via `meta: { silentHttpCodes: [422] }` is added to the row-expansion and hover-prefetch paths.

- `useLogViewObservationIO` and `usePrefetchObservation` both pass `verbosity: \"truncated\"` and `meta: { silentHttpCodes: [422] }`, keeping cache keys aligned between the prefetch and the consuming query.
- `useLogViewAllObservationsIO` updates `getObservationQueryKey` and the `fetch` call in `loadAllData` to use `verbosity: \"truncated\"`, but omits `meta: { silentHttpCodes: [422] }` from the `fetch` options, so 422 toasts can still appear on the bulk-load path.
- `useObservationIOLoadedCount` duplicates the cache key shape inline rather than reusing `getObservationQueryKey`, creating a subtle maintenance hazard.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; it reduces ClickHouse load and silences 422 noise on the two most common paths.

The core goal — truncated I/O queries with silenced 422 toasts — works correctly for row expansion and hover prefetch. The bulk-load path (`loadAllData`) adopts the truncated verbosity but is missing the toast-suppression `meta`, so users clicking "download JSON" on large traces may still see 422 toasts. A duplicated inline cache key in `useObservationIOLoadedCount` could silently diverge in future if the key shape changes again.

web/src/components/trace/components/TraceLogView/useLogViewAllObservationsIO.ts — missing `meta: { silentHttpCodes: [422] }` on the bulk-fetch call; web/src/components/trace/components/TraceLogView/useLogViewObservationIO.ts — inline cache key duplication.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant PrefetchHook as usePrefetchObservation
    participant RowHook as useLogViewObservationIO
    participant BatchHook as useLogViewAllObservationsIO
    participant QCache as React Query Cache
    participant TRPC as observations.byId (tRPC)
    participant CH as ClickHouse (server)

    Note over PrefetchHook,TRPC: verbosity:"truncated" + silentHttpCodes:[422]
    User->>PrefetchHook: hover row
    PrefetchHook->>TRPC: prefetch(observationId, verbosity:"truncated")
    TRPC->>CH: query with leftUTF8 truncation
    CH-->>TRPC: truncated payload
    TRPC-->>QCache: cache under truncated key

    Note over RowHook,TRPC: verbosity:"truncated" + silentHttpCodes:[422]
    User->>RowHook: expand row
    RowHook->>QCache: check cache (truncated key)
    alt cache hit
        QCache-->>RowHook: cached data
    else cache miss
        RowHook->>TRPC: useQuery(verbosity:"truncated")
        TRPC->>CH: query with leftUTF8 truncation
        CH-->>RowHook: truncated payload
    end

    Note over BatchHook,TRPC: verbosity:"truncated" only (no silentHttpCodes)
    User->>BatchHook: loadAllData()
    loop per uncached observation
        BatchHook->>TRPC: fetch(verbosity:"truncated")
        TRPC->>CH: query with leftUTF8 truncation
        CH-->>BatchHook: data or 422
        Note right of BatchHook: 422 caught locally but toast still fires
    end
    BatchHook-->>User: combined ObservationIOData[]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/trace/components/TraceLogView/useLogViewAllObservationsIO.ts:204-210
The `fetch` call inside `loadAllData` doesn't pass `meta: { silentHttpCodes: [422] }`. When a 422 occurs during bulk loading, the `QueryCache.onError` handler in `api.ts` fires before the local `catch` block suppresses the error, so the user still sees a toast for each failed observation — inconsistent with the row-expansion and prefetch paths that do silence 422s.

```suggestion
              const result = await utils.observations.byId.fetch(
                {
                  observationId: item.node.id,
                  traceId,
                  projectId,
                  startTime: item.node.startTime,
                  verbosity: "truncated",
                },
                { meta: { silentHttpCodes: [422] } },
              );
```

### Issue 2 of 2
web/src/components/trace/components/TraceLogView/useLogViewObservationIO.ts:106-119
`useObservationIOLoadedCount` constructs the cache key inline instead of reusing `getObservationQueryKey` from the sibling file. The two definitions are currently in sync, but the next time `verbosity` or another field is added to the key, forgetting to update this inline copy will silently break the progress counter without any type-check warning.

```suggestion
      // Build the same query key that tRPC uses
      const queryKey = getObservationQueryKey(
        item.node.id,
        traceId,
        projectId,
        item.node.startTime,
      );
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trace): truncate log view observatio..."](https://github.com/langfuse/langfuse/commit/503b3b295756312c13c0ceb6713cefef815774cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33920217)</sub>

<!-- /greptile_comment -->