### PR TITLE
fix(blob-export): surface root cause and query_id in blob storage error logs

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -266,26 +266,27 @@ export async function* queryClickhouseStream<T>(
     }
   } catch (error) {
     if (error instanceof ClickHouseResourceError) {
-      if (queryId) {
-        const enriched = new Error(`${error.message} [query_id: ${queryId}]`, {
-          cause: error,
-        });
-        throw new ClickHouseResourceError(
-          error.errorType,
-          enriched,
-          error.tags,
-        );
-      }
-      throw error;
+      const enriched = enrichWithQueryId(error, queryId);
+      throw enriched === error
+        ? error
+        : new ClickHouseResourceError(error.errorType, enriched, error.tags);
     }
-    const base = error as Error;
-    const toWrap = queryId
-      ? new Error(`${base.message} [query_id: ${queryId}]`, { cause: base })
-      : base;
-    throw ClickHouseResourceError.wrapIfResourceError(toWrap, opts.tags);
+    throw ClickHouseResourceError.wrapIfResourceError(
+      enrichWithQueryId(error as Error, queryId),
+      opts.tags,
+    );
   } finally {
     span.end();
   }
+}
+
+function enrichWithQueryId(error: Error, queryId: string | undefined): Error {
+  if (!queryId) return error;
+  const enriched = new Error(`${error.message} [query_id: ${queryId}]`, {
+    cause: error,
+  });
+  enriched.stack = error.stack;
+  return enriched;
 }
 
 /**

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -240,6 +240,8 @@ export async function* queryClickhouseStream<T>(
     kind: SpanKind.CLIENT,
   });
 
+  let queryId: string | undefined;
+
   try {
     setSpanQueryAttributes(span, opts.query);
 
@@ -254,17 +256,33 @@ export async function* queryClickhouseStream<T>(
         );
       });
 
+    queryId = res.query_id;
+    span.setAttribute("ch.queryId", queryId);
+
     for await (const rows of res.stream<T>()) {
       for (const row of rows) {
         yield handleExceptionRow(row.json());
       }
     }
   } catch (error) {
-    if (error instanceof ClickHouseResourceError) throw error;
-    throw ClickHouseResourceError.wrapIfResourceError(
-      error as Error,
-      opts.tags,
-    );
+    if (error instanceof ClickHouseResourceError) {
+      if (queryId) {
+        const enriched = new Error(`${error.message} [query_id: ${queryId}]`, {
+          cause: error,
+        });
+        throw new ClickHouseResourceError(
+          error.errorType,
+          enriched,
+          error.tags,
+        );
+      }
+      throw error;
+    }
+    const base = error as Error;
+    const toWrap = queryId
+      ? new Error(`${base.message} [query_id: ${queryId}]`, { cause: base })
+      : base;
+    throw ClickHouseResourceError.wrapIfResourceError(toWrap, opts.tags);
   } finally {
     span.end();
   }

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -590,6 +590,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
 
     logger.error(
       `[BLOB INTEGRATION] Error processing blob storage integration for project ${projectId}: ${formatErrorChain(error)}`,
+      error instanceof Error ? { stack: error.stack } : {},
     );
     throw new Error(formatErrorChain(error), { cause: error });
   }

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -589,10 +589,9 @@ export const handleBlobStorageIntegrationProjectJob = async (
     notifyBlobStorageExportFailedInBackground(projectId);
 
     logger.error(
-      `[BLOB INTEGRATION] Error processing blob storage integration for project ${projectId}`,
-      error,
+      `[BLOB INTEGRATION] Error processing blob storage integration for project ${projectId}: ${formatErrorChain(error)}`,
     );
-    throw error; // Rethrow to trigger retries
+    throw new Error(formatErrorChain(error), { cause: error });
   }
 };
 
@@ -687,4 +686,15 @@ function extractStorageErrorMessage(error: unknown): string {
 
   // Fallback: ClickHouse errors or other non-wrapped errors
   return error.message.slice(0, 1000);
+}
+
+function formatErrorChain(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const parts: string[] = [];
+  let current: unknown = error;
+  while (current instanceof Error) {
+    parts.push(current.message);
+    current = current.cause;
+  }
+  return parts.join(" caused by ");
 }

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -588,11 +588,18 @@ export const handleBlobStorageIntegrationProjectJob = async (
 
     notifyBlobStorageExportFailedInBackground(projectId);
 
+    const chain = formatErrorChain(error);
     logger.error(
-      `[BLOB INTEGRATION] Error processing blob storage integration for project ${projectId}: ${formatErrorChain(error)}`,
+      `[BLOB INTEGRATION] Error processing blob storage integration for project ${projectId}: ${chain}`,
       error instanceof Error ? { stack: error.stack } : {},
     );
-    throw new Error(formatErrorChain(error), { cause: error });
+    const rethrown = new Error(chain, { cause: error });
+    // Copy the original stack so BullMQ and the queue processor see the real
+    // failure site rather than this rethrow line. rethrown.stack starts with
+    // the original error's message, which won't match rethrown.message (the
+    // full chain), but structured loggers record them as separate fields.
+    if (error instanceof Error) rethrown.stack = error.stack;
+    throw rethrown;
   }
 };
 


### PR DESCRIPTION
## Summary

Blob export job failures were reporting only `"Failed to upload file to S3 (buffered)"` in BullMQ and Datadog — masking the true root cause (e.g. ClickHouse OOM) and requiring manual trace correlation to diagnose.

### Why this was hard to triage
BullMQ logs `error.message` only; `error.cause` is never traversed automatically. The ClickHouse error (including query ID) was silently buried in the cause chain.

### Changes
- **`queryClickhouseStream`**: captures `res.query_id` after the query is sent and appends `[query_id: <id>]` to any error thrown during stream iteration. Introduces `enrichWithQueryId` helper that preserves the original stack and the `ClickHouseResourceError` type so existing `instanceof` checks in web/tRPC middleware are unaffected.
- **`handleBlobStorageIntegrationProjectJob`**: adds `formatErrorChain` that walks `.cause` and joins messages with `"caused by"`. Uses it in both the `logger.error` call and the rethrown error so the full root cause is visible in Datadog logs and the BullMQ job failure entry. Passes `{ stack }` (not the `Error`) to the logger to avoid Winston's message-duplication behaviour while still capturing the stack. Copies the original stack onto the rethrown error so the queue processor sees the real failure site.

### Impacted packages

- `@langfuse/shared` — `queryClickhouseStream` error enrichment
- `worker` — blob export job error logging and rethrow

## Test plan

- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter worker run lint`
- [ ] Integration: verify Datadog blob export failure log shows ClickHouse OOM message + query_id after next failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)