### PR TITLE
fix(api): Do not accept limit below 1 in pagination

### DIFF
--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -44,6 +44,7 @@ export const paginationZod = {
     (x) => (x === "" ? undefined : x),
     z.coerce.number().nonnegative().default(1),
   ),
+  // For internal use, we allow a limit of 0 until LFE-9976 is merged
   limit: z.preprocess(
     (x) => (x === "" ? undefined : x),
     z.coerce.number().nonnegative().lte(100).default(50),
@@ -57,7 +58,7 @@ export const publicApiPaginationZod = {
   ),
   limit: z.preprocess(
     (x) => (x === "" ? undefined : x),
-    z.coerce.number().lte(100).default(50),
+    z.coerce.number().gte(1).lte(100).default(50),
   ),
 };
 


### PR DESCRIPTION
Resolves #13846

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a minimum bound of `1` to the `limit` field in `publicApiPaginationZod`, preventing API callers from passing `limit=0` or a negative value. The single-character diff (`.gte(1)`) is well-targeted and directly resolves the reported issue.

- `publicApiPaginationZod.limit` now enforces `1 ≤ limit ≤ 100` (was `limit ≤ 100` only).
- The companion `paginationZod.limit` (used for internal/UI pagination) still uses `.nonnegative()`, which permits `0`; aligning it to `.gte(1)` would be consistent.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a single-line guard on the public API pagination limit with no side effects on existing valid requests.

The fix correctly blocks limit=0 and negative values from the public API. The only outstanding question is whether the internal paginationZod should receive the same treatment, but that is a separate concern and does not affect correctness of this change.

packages/shared/src/utils/zod.ts — specifically whether paginationZod.limit should also be updated to .gte(1) for consistency.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API Request with limit param] --> B{limit === ''}
    B -- yes --> C[coerce undefined → default 50]
    B -- no --> D[z.coerce.number]
    D --> E{gte 1?}
    E -- no --> F[Validation Error returned to caller]
    E -- yes --> G{lte 100?}
    G -- no --> F
    G -- yes --> H[Valid limit passed to query]
    C --> H
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/utils/zod.ts:47-51
The non-public `paginationZod.limit` uses `.nonnegative()`, which still allows `limit=0`. If a `limit` of `0` reaches a database query it can produce empty or unexpected result sets, and the behaviour is inconsistent with the fix applied to `publicApiPaginationZod`.

```suggestion
  limit: z.preprocess(
    (x) => (x === "" ? undefined : x),
    z.coerce.number().gte(1).lte(100).default(50),
  ),
};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): Do not accept limit below 1 in..."](https://github.com/langfuse/langfuse/commit/ab69ed53a5c30cc455b82959cb21910816cfac6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33931694)</sub>

<!-- /greptile_comment -->