### PR TITLE
fix(mcp,api): Ensure consistent ordering

### DIFF
--- a/web/src/features/mcp/features/datasets/tools/listDatasetRuns.ts
+++ b/web/src/features/mcp/features/datasets/tools/listDatasetRuns.ts
@@ -31,7 +31,7 @@ export const [listDatasetRunsTool, handleListDatasetRuns] = defineTool({
               where: { projectId: context.projectId },
               take: input.limit,
               skip: (input.page - 1) * input.limit,
-              orderBy: { createdAt: "desc" },
+              orderBy: [{ createdAt: "desc" }, { id: "asc" }],
             },
           },
         });

--- a/web/src/features/mcp/features/datasets/tools/listDatasets.ts
+++ b/web/src/features/mcp/features/datasets/tools/listDatasets.ts
@@ -36,7 +36,7 @@ export const [listDatasetsTool, handleListDatasets] = defineTool({
               id: true,
             },
             where: { projectId: context.projectId },
-            orderBy: { createdAt: "desc" },
+            orderBy: [{ createdAt: "desc" }, { id: "asc" }],
             take: input.limit,
             skip: (input.page - 1) * input.limit,
           }),

--- a/web/src/pages/api/public/datasets/[name]/runs/index.ts
+++ b/web/src/pages/api/public/datasets/[name]/runs/index.ts
@@ -24,9 +24,7 @@ export default withMiddlewares({
           datasetRuns: {
             take: query.limit,
             skip: (query.page - 1) * query.limit,
-            orderBy: {
-              createdAt: "desc",
-            },
+            orderBy: [{ createdAt: "desc" }, { id: "asc" }],
           },
         },
       });

--- a/web/src/pages/api/public/datasets/index.ts
+++ b/web/src/pages/api/public/datasets/index.ts
@@ -76,17 +76,13 @@ export default withMiddlewares({
             select: {
               name: true,
             },
-            orderBy: {
-              createdAt: "desc",
-            },
+            orderBy: [{ createdAt: "desc" }, { id: "asc" }],
           },
         },
         where: {
           projectId: auth.scope.projectId,
         },
-        orderBy: {
-          createdAt: "desc",
-        },
+        orderBy: [{ createdAt: "desc" }, { id: "asc" }],
         take: limit,
         skip: (page - 1) * limit,
       });

--- a/web/src/pages/api/public/v2/datasets/index.ts
+++ b/web/src/pages/api/public/v2/datasets/index.ts
@@ -66,9 +66,7 @@ export default withMiddlewares({
         where: {
           projectId: auth.scope.projectId,
         },
-        orderBy: {
-          createdAt: "desc",
-        },
+        orderBy: [{ createdAt: "desc" }, { id: "asc" }],
         take: query.limit,
         skip: (query.page - 1) * query.limit,
       });


### PR DESCRIPTION
Resolves #13816

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes non-deterministic pagination across all dataset-related endpoints (public API v1/v2 and MCP tools) by adding `{ id: "asc" }` as a tiebreaker to every `orderBy: { createdAt: "desc" }` clause. Without the secondary sort, records sharing the same `createdAt` timestamp could appear on multiple pages or be skipped entirely.

- All five files are updated consistently: `listDatasets`, `listDatasetRuns` (MCP), `/datasets` (v1 & v2), and `/datasets/[name]/runs` (public API).
- One nested `datasetRuns` sub-query in `datasets/index.ts` (v1) was missed — it still uses a single-field `orderBy` and would benefit from the same tiebreaker for consistency.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the ordering fix is correct and applied consistently across all five paginated queries.

The change is straightforward and correct everywhere it was applied. One nested `datasetRuns` sub-query inside the v1 datasets endpoint was not updated — it still orders only by `createdAt` without a tiebreaker — but this sub-query is not paginated so the impact is limited to non-deterministic run-name ordering within a single dataset response.

web/src/pages/api/public/datasets/index.ts — the nested datasetRuns relation inside the GET handler still uses a single-field orderBy
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Paginated List Request] --> B[Prisma Query]
    B --> C[orderBy: createdAt desc + id asc]
    C --> D{Records with same createdAt?}
    D -- Yes --> E[id ASC tiebreaker applied]
    D -- No --> F[createdAt order sufficient]
    E --> G[Stable, deterministic page]
    F --> G
    G --> H[Correct pagination across pages]

    subgraph Affected Endpoints
        I["GET /datasets (v1)"]
        J["GET /v2/datasets"]
        K["GET /datasets/:name/runs"]
        L["MCP listDatasets"]
        M["MCP listDatasetRuns"]
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/api/public/datasets/index.ts:75-82
The nested `datasetRuns` relation inside the outer `findMany` still uses a single-field `orderBy`, so it retains the same non-deterministic ordering issue that this PR is fixing everywhere else. While this sub-query isn't paginated (`take` is absent), the run names returned per dataset will shift order between requests when two runs share the same `createdAt`, making responses inconsistent.

```suggestion
          datasetRuns: {
            select: {
              name: true,
            },
            orderBy: [{ createdAt: "desc" }, { id: "asc" }],
          },
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp,public-api): Ensure consistent o..."](https://github.com/langfuse/langfuse/commit/a4547cf24bd6df78c72ac3632d1da6dffb527fbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33931778)</sub>

<!-- /greptile_comment -->