### PR TITLE
test(web): stabilize server test setup on Windows

### DIFF
--- a/web/src/__tests__/server/unit/test-infra-utils.servertest.ts
+++ b/web/src/__tests__/server/unit/test-infra-utils.servertest.ts
@@ -1,0 +1,39 @@
+import { hasGeneratedSchemaMatch } from "@/src/__tests__/vitest-test-db-setup";
+import { normalizeTestBaseUrl } from "@/src/__tests__/test-utils";
+
+describe("hasGeneratedSchemaMatch", () => {
+  it("returns true when a generated schema matches the current source schema", () => {
+    expect(
+      hasGeneratedSchemaMatch("model User {}", [
+        "model Session {}",
+        "model User {}",
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when only stale generated schemas are present", () => {
+    expect(
+      hasGeneratedSchemaMatch("model User { id String }", [
+        "model User { id String @id }",
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("normalizeTestBaseUrl", () => {
+  it("falls back to localhost when no override is configured", () => {
+    expect(normalizeTestBaseUrl()).toBe("http://localhost:3000");
+  });
+
+  it("removes trailing slashes from configured base URLs", () => {
+    expect(normalizeTestBaseUrl("http://localhost:3010/")).toBe(
+      "http://localhost:3010",
+    );
+  });
+
+  it("drops path suffixes from NEXTAUTH_URL-style values", () => {
+    expect(normalizeTestBaseUrl("https://example.com/auth")).toBe(
+      "https://example.com",
+    );
+  });
+});

--- a/web/src/__tests__/test-utils.ts
+++ b/web/src/__tests__/test-utils.ts
@@ -119,10 +119,18 @@ export type ErrorIngestion = {
   error: string;
 };
 
-const testBaseUrl =
-  process.env.LANGFUSE_TEST_BASE_URL ??
-  process.env.NEXTAUTH_URL ??
-  "http://localhost:3000";
+export const normalizeTestBaseUrl = (baseUrl?: string) => {
+  if (!baseUrl) {
+    return "http://localhost:3000";
+  }
+
+  const normalizedUrl = new URL(baseUrl);
+  return normalizedUrl.origin;
+};
+
+const testBaseUrl = normalizeTestBaseUrl(
+  process.env.LANGFUSE_TEST_BASE_URL ?? process.env.NEXTAUTH_URL,
+);
 
 export async function makeAPICall<T = IngestionAPIResponse>(
   method: "POST" | "GET" | "PUT" | "DELETE" | "PATCH",

--- a/web/src/__tests__/test-utils.ts
+++ b/web/src/__tests__/test-utils.ts
@@ -119,6 +119,11 @@ export type ErrorIngestion = {
   error: string;
 };
 
+const testBaseUrl =
+  process.env.LANGFUSE_TEST_BASE_URL ??
+  process.env.NEXTAUTH_URL ??
+  "http://localhost:3000";
+
 export async function makeAPICall<T = IngestionAPIResponse>(
   method: "POST" | "GET" | "PUT" | "DELETE" | "PATCH",
   url: string,
@@ -126,7 +131,7 @@ export async function makeAPICall<T = IngestionAPIResponse>(
   auth?: string,
   customHeaders?: Record<string, string>,
 ): Promise<{ body: T; status: number }> {
-  const finalUrl = `http://localhost:3000${url.startsWith("/") ? url : `/${url}`}`;
+  const finalUrl = `${testBaseUrl}${url.startsWith("/") ? url : `/${url}`}`;
   const authorization =
     auth || createBasicAuthHeader("pk-lf-1234567890", "sk-lf-1234567890");
   const options = {

--- a/web/src/__tests__/vitest-test-db-setup.ts
+++ b/web/src/__tests__/vitest-test-db-setup.ts
@@ -1,15 +1,54 @@
 const ensurePrismaClientGenerated = async (databaseUrl: string) => {
   const { execSync } = await import("child_process");
+  const fs = await import("fs");
   const path = await import("path");
   const sharedDir = path.resolve(__dirname, "../../../packages/shared");
+  const repoRoot = path.resolve(sharedDir, "../..");
+  const schemaPath = path.join(sharedDir, "prisma", "schema.prisma");
+  const pnpmPrismaSchemaPaths = fs.existsSync(
+    path.join(repoRoot, "node_modules", ".pnpm"),
+  )
+    ? fs
+        .readdirSync(path.join(repoRoot, "node_modules", ".pnpm"), {
+          withFileTypes: true,
+        })
+        .filter(
+          (entry) =>
+            entry.isDirectory() && entry.name.startsWith("@prisma+client@"),
+        )
+        .map((entry) =>
+          path.join(
+            repoRoot,
+            "node_modules",
+            ".pnpm",
+            entry.name,
+            "node_modules",
+            ".prisma",
+            "client",
+            "schema.prisma",
+          ),
+        )
+    : [];
+  const generatedSchemaPaths = [
+    path.join(repoRoot, "node_modules", ".prisma", "client", "schema.prisma"),
+    path.join(sharedDir, "node_modules", ".prisma", "client", "schema.prisma"),
+    ...pnpmPrismaSchemaPaths,
+  ];
 
-  try {
-    const prismaModule = await import("@prisma/client");
-    if (typeof prismaModule.PrismaClient === "function") {
-      return;
-    }
-  } catch {
-    // Fall through to prisma generate when the client is unavailable.
+  const sourceSchemaStat = fs.statSync(schemaPath);
+  const hasCurrentGeneratedClient = generatedSchemaPaths.some(
+    (generatedSchemaPath) => {
+      if (!fs.existsSync(generatedSchemaPath)) {
+        return false;
+      }
+
+      const generatedSchemaStat = fs.statSync(generatedSchemaPath);
+      return generatedSchemaStat.mtimeMs >= sourceSchemaStat.mtimeMs;
+    },
+  );
+
+  if (hasCurrentGeneratedClient) {
+    return;
   }
 
   execSync(
@@ -20,6 +59,16 @@ const ensurePrismaClientGenerated = async (databaseUrl: string) => {
       stdio: "inherit",
     },
   );
+
+  const generatedClientExists = generatedSchemaPaths.some(
+    (generatedSchemaPath) => fs.existsSync(generatedSchemaPath),
+  );
+
+  if (!generatedClientExists) {
+    throw new Error(
+      `Prisma client was not generated. Checked: ${generatedSchemaPaths.join(", ")}`,
+    );
+  }
 };
 
 const migrateTestDatabase = async (databaseUrl: string) => {

--- a/web/src/__tests__/vitest-test-db-setup.ts
+++ b/web/src/__tests__/vitest-test-db-setup.ts
@@ -1,3 +1,9 @@
+export const hasGeneratedSchemaMatch = (
+  sourceSchema: string,
+  generatedSchemas: ReadonlyArray<string>,
+) =>
+  generatedSchemas.some((generatedSchema) => generatedSchema === sourceSchema);
+
 const ensurePrismaClientGenerated = async (databaseUrl: string) => {
   const { execSync } = await import("child_process");
   const fs = await import("fs");
@@ -5,11 +11,10 @@ const ensurePrismaClientGenerated = async (databaseUrl: string) => {
   const sharedDir = path.resolve(__dirname, "../../../packages/shared");
   const repoRoot = path.resolve(sharedDir, "../..");
   const schemaPath = path.join(sharedDir, "prisma", "schema.prisma");
-  const pnpmPrismaSchemaPaths = fs.existsSync(
-    path.join(repoRoot, "node_modules", ".pnpm"),
-  )
+  const pnpmStorePath = path.join(repoRoot, "node_modules", ".pnpm");
+  const pnpmPrismaSchemaPaths = fs.existsSync(pnpmStorePath)
     ? fs
-        .readdirSync(path.join(repoRoot, "node_modules", ".pnpm"), {
+        .readdirSync(pnpmStorePath, {
           withFileTypes: true,
         })
         .filter(
@@ -18,9 +23,7 @@ const ensurePrismaClientGenerated = async (databaseUrl: string) => {
         )
         .map((entry) =>
           path.join(
-            repoRoot,
-            "node_modules",
-            ".pnpm",
+            pnpmStorePath,
             entry.name,
             "node_modules",
             ".prisma",
@@ -35,16 +38,20 @@ const ensurePrismaClientGenerated = async (databaseUrl: string) => {
     ...pnpmPrismaSchemaPaths,
   ];
 
-  const sourceSchemaStat = fs.statSync(schemaPath);
-  const hasCurrentGeneratedClient = generatedSchemaPaths.some(
-    (generatedSchemaPath) => {
-      if (!fs.existsSync(generatedSchemaPath)) {
-        return false;
-      }
+  if (!fs.existsSync(schemaPath)) {
+    throw new Error(`Prisma schema not found at: ${schemaPath}`);
+  }
 
-      const generatedSchemaStat = fs.statSync(generatedSchemaPath);
-      return generatedSchemaStat.mtimeMs >= sourceSchemaStat.mtimeMs;
-    },
+  const sourceSchema = fs.readFileSync(schemaPath, "utf8");
+  const generatedSchemas = generatedSchemaPaths.flatMap(
+    (generatedSchemaPath) =>
+      fs.existsSync(generatedSchemaPath)
+        ? [fs.readFileSync(generatedSchemaPath, "utf8")]
+        : [],
+  );
+  const hasCurrentGeneratedClient = hasGeneratedSchemaMatch(
+    sourceSchema,
+    generatedSchemas,
   );
 
   if (hasCurrentGeneratedClient) {
@@ -60,13 +67,15 @@ const ensurePrismaClientGenerated = async (databaseUrl: string) => {
     },
   );
 
-  const generatedClientExists = generatedSchemaPaths.some(
-    (generatedSchemaPath) => fs.existsSync(generatedSchemaPath),
+  const generatedClientMatchesSchema = generatedSchemaPaths.some(
+    (generatedSchemaPath) =>
+      fs.existsSync(generatedSchemaPath) &&
+      fs.readFileSync(generatedSchemaPath, "utf8") === sourceSchema,
   );
 
-  if (!generatedClientExists) {
+  if (!generatedClientMatchesSchema) {
     throw new Error(
-      `Prisma client was not generated. Checked: ${generatedSchemaPaths.join(", ")}`,
+      `Prisma client was not generated from the current schema. Checked: ${generatedSchemaPaths.join(", ")}`,
     );
   }
 };

--- a/web/src/__tests__/vitest-test-db-setup.ts
+++ b/web/src/__tests__/vitest-test-db-setup.ts
@@ -1,3 +1,27 @@
+const ensurePrismaClientGenerated = async (databaseUrl: string) => {
+  const { execSync } = await import("child_process");
+  const path = await import("path");
+  const sharedDir = path.resolve(__dirname, "../../../packages/shared");
+
+  try {
+    const prismaModule = await import("@prisma/client");
+    if (typeof prismaModule.PrismaClient === "function") {
+      return;
+    }
+  } catch {
+    // Fall through to prisma generate when the client is unavailable.
+  }
+
+  execSync(
+    "dotenv -e ../../.env.test -e ../../.env -- npx prisma generate --no-hints",
+    {
+      cwd: sharedDir,
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      stdio: "inherit",
+    },
+  );
+};
+
 const migrateTestDatabase = async (databaseUrl: string) => {
   const { execSync } = await import("child_process");
   const path = await import("path");
@@ -5,15 +29,6 @@ const migrateTestDatabase = async (databaseUrl: string) => {
 
   execSync(
     "dotenv -e ../../.env.test -e ../../.env -- npx prisma migrate deploy",
-    {
-      cwd: sharedDir,
-      env: { ...process.env, DATABASE_URL: databaseUrl },
-      stdio: "inherit",
-    },
-  );
-
-  execSync(
-    "dotenv -e ../../.env.test -e ../../.env -- npx prisma generate --no-hints",
     {
       cwd: sharedDir,
       env: { ...process.env, DATABASE_URL: databaseUrl },
@@ -31,6 +46,8 @@ const ensureTestDatabaseExists = async () => {
   ) {
     return;
   }
+
+  await ensurePrismaClientGenerated(databaseUrl);
 
   const { PrismaClient } = await import("@prisma/client");
   const prisma = new PrismaClient({


### PR DESCRIPTION
Failure mechanism
Server integration tests under web/src/__tests__/server call HTTP through web/src/__tests__/test-utils.ts. The helper previously hardcoded http://localhost:3000, which made the tests easy to route to an unrelated local Langfuse instance instead of the current worktree.

The Windows-specific failure mode in vitest global setup was separate: importing PrismaClient before prisma generate can lock the Prisma engine DLL, and the later generate step can fail.

Semantic change
- makeAPICall now reads LANGFUSE_TEST_BASE_URL first, then NEXTAUTH_URL, and only falls back to http://localhost:3000
- vitest test DB setup now checks generated Prisma client artifacts on disk before importing @prisma/client
- the generated-client check covers the pnpm install layout used in this repository, so redundant prisma generate is skipped without touching PrismaClient first

Preserved invariant
- production request handling is unchanged
- the default local fallback remains http://localhost:3000 when no test base URL is configured
- test DB bootstrap still runs prisma migrate deploy for langfuse_test

Validation
- reproduced the incorrect-host failure locally on Windows when port 3000 was occupied by another instance
- ran Vitest server global setup against the current worktree and confirmed test DB bootstrap completed without Prisma generation errors
- ran web/src/__tests__/server/billingCycleHelpers.servertest.ts under the server project after the setup change: 35 tests passed locally

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilises the Vitest server test setup on Windows by fixing two independent issues: hardcoded `http://localhost:3000` in `makeAPICall` (now reads `LANGFUSE_TEST_BASE_URL` → `NEXTAUTH_URL` → fallback), and a Prisma engine DLL lock on Windows caused by importing `PrismaClient` before `prisma generate` has finished (fixed by checking generated-client artifacts on disk first).

- `test-utils.ts`: `testBaseUrl` is now resolved from environment variables at module load, letting tests target the correct server regardless of what is listening on port 3000.
- `vitest-test-db-setup.ts`: A new `ensurePrismaClientGenerated` function scans known pnpm/flat `node_modules` paths and compares schema modification times; `prisma generate` is run only when no up-to-date generated client is found, and `PrismaClient` is imported only afterwards.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the stated Windows stabilisation goal; all changes are test-infrastructure only and do not touch production code paths.

Both changed files are test utilities with no production impact. The mtime-based staleness check in `ensurePrismaClientGenerated` is the most fragile piece: on CI or after certain git operations on Windows the comparison may silently skip a needed `prisma generate`, which would let a subsequent `PrismaClient` import succeed with a stale client and cause confusing test failures rather than a clear setup error. The `NEXTAUTH_URL` fallback in `testBaseUrl` may also misbehave if that variable carries a path suffix. Neither issue would cause harm outside test setup, but both could leave developers puzzled when tests fail in specific environments.

`vitest-test-db-setup.ts` — specifically the mtime comparison logic in `ensurePrismaClientGenerated` and the missing existence guard before `fs.statSync`.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[vitest global setup] --> B[ensureTestDatabaseExists]
    B --> C{DATABASE_URL contains langfuse_test AND NODE_ENV=test?}
    C -- No --> Z[Return early]
    C -- Yes --> D[ensurePrismaClientGenerated]
    D --> E{Any .pnpm directory?}
    E -- Yes --> F[Scan .pnpm for @prisma+client@ dirs]
    E -- No --> G[Use flat & shared client paths only]
    F --> H[Build generatedSchemaPaths list]
    G --> H
    H --> I[statSync source schema.prisma]
    I --> J{Any generated schema.prisma with mtime >= source mtime?}
    J -- Yes --> K[Skip generate, return]
    J -- No --> L[execSync: prisma generate]
    L --> M{Any generated schema.prisma exists now?}
    M -- No --> N[Throw Error]
    M -- Yes --> O[Return]
    K --> P[import PrismaClient]
    O --> P
    P --> Q{SELECT 1 succeeds?}
    Q -- Yes --> R[DB accessible, skip create]
    Q -- No --> S[Create DB via adminPrisma]
    R --> T[migrateTestDatabase]
    S --> T
    T --> U[execSync: prisma migrate deploy]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
web/src/__tests__/vitest-test-db-setup.ts:1-5
**Dynamic imports inside function bodies**

The new `ensurePrismaClientGenerated` function (and the pre-existing `migrateTestDatabase`) import `child_process`, `fs`, and `path` inside the function body via `await import(...)`. Per the team's coding standard, imports should be moved to the top of the module. These are all Node built-ins with no side effects, so top-level static imports would work here without any issue.

### Issue 2 of 4
web/src/__tests__/vitest-test-db-setup.ts:38
`fs.statSync(schemaPath)` is called without first verifying the file exists. If `packages/shared/prisma/schema.prisma` is missing (e.g. in a partial checkout or unusual worktree state), the thrown `ENOENT` error has no context about what was expected and will surface as a cryptic test-setup failure rather than a clear message about the missing schema.

```suggestion
  if (!fs.existsSync(schemaPath)) {
    throw new Error(`Prisma schema not found at: ${schemaPath}`);
  }
  const sourceSchemaStat = fs.statSync(schemaPath);
```

### Issue 3 of 4
web/src/__tests__/vitest-test-db-setup.ts:39-48
**mtime-based staleness check may silently skip a needed generate**

The check `generatedSchemaStat.mtimeMs >= sourceSchemaStat.mtimeMs` assumes the generated client's `schema.prisma` copy is always written after the source schema. On CI systems or after `git checkout`/`git reset` on Windows (where git sets file timestamps to the checkout time), the source `schema.prisma` can end up with an older mtime than a stale generated client from a prior run, causing the generate step to be skipped even when the schema has actually changed. A content-hash or git-tracked approach would be more reliable, though even a simple `git diff --name-only` check would avoid the mtime pitfall.

### Issue 4 of 4
web/src/__tests__/test-utils.ts:122-125
**`NEXTAUTH_URL` may carry a path component**

`NEXTAUTH_URL` is sometimes configured with a path suffix (e.g. `http://localhost:3000/` with a trailing slash, or in proxied deployments `https://example.com/auth`). Using it verbatim as a base URL would produce double-slashes or mis-routed paths like `http://localhost:3000//api/ingestion`. Consider stripping any trailing slash and/or path suffix before using it, or preferring only `LANGFUSE_TEST_BASE_URL` as the override.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(web): avoid early prisma client imp..."](https://github.com/langfuse/langfuse/commit/19253f075246505c21f0c70699a2e63c57fb2ece) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34076414)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->