### PR TITLE
docs(mcp): Update README.md

### DIFF
--- a/web/src/features/mcp/README.md
+++ b/web/src/features/mcp/README.md
@@ -1,6 +1,12 @@
 # Langfuse MCP Server
 
-Model Context Protocol (MCP) server for Langfuse, enabling AI assistants to interact with Langfuse prompts and read observation data programmatically.
+Model Context Protocol (MCP) server for Langfuse, enabling AI assistants to interact with Langfuse programmatically.
+
+A complete list of tools can be seen under [mcp.reference.langfuse.com](https://mcp.reference.langfuse.com).
+
+> ⚠️ **API stability**:
+> This MCP server is self-describing. Clients should dynamically inspect available tools and schemas rather than assuming a static interface.
+> Tool availability and schemas may evolve over time, including the addition, removal, or modification of tools and fields. Clients are expected to tolerate schema changes and refresh capabilities dynamically.
 
 ## Quick Start (Local Development)
 
@@ -37,105 +43,11 @@ Model Context Protocol (MCP) server for Langfuse, enabling AI assistants to inte
        --header "Authorization: Basic {your-base64-token}"
    ```
 
-4. **Verify prompt tools**
+4. **Verify prompt access**
    In Claude Code: `List all prompts in the project`
 
-5. **Verify observation tools**
+5. **Verify observation access**
    In Claude Code: `List recent Langfuse observations`
-
----
-
-## Available Tools
-
-The MCP server provides prompt-management tools, read-only observation tools, and read-only metrics tools.
-
-### Prompt Tools
-
-- **`getPrompt`** - Fetch a specific prompt by name with optional label or version (fully resolved with dependencies)
-- **`getPromptUnresolved`** - Fetch a specific prompt WITHOUT resolving dependencies (useful for prompt composition analysis)
-- **`listPrompts`** - List all prompts in the project with filtering (name/label/tag/updatedAt range) and pagination
-- **`createTextPrompt`** - Create a new text prompt version
-- **`createChatPrompt`** - Create a new chat prompt version (OpenAI-style messages)
-- **`updatePromptLabels`** - Add/move labels across prompt versions
-
-**Implementation:** See [`/web/src/features/mcp/features/prompts/tools/`](/web/src/features/mcp/features/prompts/tools/) for detailed schemas, parameters, and examples for each prompt tool.
-
-### Observation Tools
-
-Observation tools read from the events table v2 and are project-scoped to the authenticated API key.
-
-- **`listObservations`** - Find observations in the current project with filters, field projection, and cursor pagination
-- **`getObservation`** - Fetch one observation by observation ID
-- **`getObservationFieldSchema`** - List fields that can be requested from `listObservations` and `getObservation`
-- **`getObservationFilterSchema`** - List fields and operators that can be used in `listObservations` advanced filters
-- **`getObservationFilterValues`** - Discover available values for supported filter fields, such as names, types, levels, environments, model names, tags, users, or sessions
-
-**Implementation:** See [`/web/src/features/mcp/features/observations/tools/`](/web/src/features/mcp/features/observations/tools/) for detailed schemas and handlers.
-
-### Metrics Tools
-
-Metrics tools are project-scoped, read-only, and use the events table v2 backend.
-
-- **`queryMetrics`** - Query `/api/public/v2/metrics` semantics through MCP. The input is the v2 metrics query object directly, not the HTTP API's JSON-string `query` wrapper.
-- **`getMetricsSchema`** - Discover supported v2 metrics views, dimensions, measures, aggregation options, granularities, and config limits.
-
-`queryMetrics` supports the public v2 metrics views `observations`, `scores-numeric`, and `scores-categorical`. The internal `traces` v2 view is not exposed through MCP. Query validation matches the public v2 API, including high-cardinality safeguards and the default `row_limit` of `100`.
-
-**Implementation:** See [`/web/src/features/mcp/features/metrics/tools/`](/web/src/features/mcp/features/metrics/tools/) for schemas and handlers.
-
-### Prompt Resolution: `getPrompt` vs `getPromptUnresolved`
-
-Langfuse supports **prompt composition** where prompts can reference other prompts via dependency tags like `@@@langfusePrompt:name=xxx|label=yyy@@@`. The MCP server provides two tools for fetching prompts with different resolution behaviors:
-
-#### `getPrompt` (Fully Resolved)
-
-- **Use when**: You want the final, executable prompt ready to send to an LLM
-- **Behavior**: Recursively resolves all dependency tags by fetching and inserting referenced prompts
-- **Returns**: Final prompt content with all dependencies replaced
-- **Example**:
-  ```
-  Input:  "You are helpful. @@@langfusePrompt:name=base-rules|label=production@@@"
-  Output: "You are helpful. Always be kind and respectful."
-  ```
-
-#### `getPromptUnresolved` (Raw)
-
-- **Use when**: You want to analyze prompt composition, debug dependencies, or understand the prompt structure
-- **Behavior**: Returns raw prompt content with dependency tags intact
-- **Returns**: Original prompt content with `@@@langfusePrompt:...@@@` tags preserved
-- **Example**:
-  ```
-  Input:  "You are helpful. @@@langfusePrompt:name=base-rules|label=production@@@"
-  Output: "You are helpful. @@@langfusePrompt:name=base-rules|label=production@@@"
-  ```
-
-**Use Cases for `getPromptUnresolved`**:
-
-- Understanding how prompts compose together (prompt stacking)
-- Debugging dependency chains before execution
-- Analyzing prompt structure and references
-- Building tools that manage prompt composition
-
-### Observation Inspection
-
-Observation tools let MCP clients inspect traces at the observation level: generations, spans, events, agent steps, tool calls, model usage, cost, latency, payloads, and metadata.
-
-Typical workflow:
-
-1. **Discover fields**: call `getObservationFieldSchema`
-2. **Discover filters**: call `getObservationFilterSchema`
-3. **Find observations**: call `listObservations` with time, trace, type, level, environment, or advanced filters
-4. **Inspect one observation**: call `getObservation` with the returned observation ID
-
-Field projection controls response size:
-
-- Omit `fields` for compact defaults
-- Use `fields: ["*"]` for all available fields
-- Pass explicit fields such as `["id", "name", "type", "latency", "totalCost"]` for focused responses
-
-Payload and metadata fields can be large and may contain sensitive application data. MCP clients should request `input`, `output`, `metadata`, and `modelParameters` only when needed.
-
----
 
 ## Architecture
 
@@ -188,8 +100,8 @@ This design:
 
 Tools include hints for clients about their behavior:
 
-- **`readOnlyHint: true`**: Safe operations that don't modify data (getPrompt, getPromptUnresolved, listPrompts, all observation tools)
-- **`destructiveHint: true`**: Operations that create/modify data (createTextPrompt, createChatPrompt, updatePromptLabels)
+- **`readOnlyHint: true`**: Safe operations that don't modify data
+- **`destructiveHint: true`**: Operations that modify data in ways that are non-revertable. If an operation only creates entities, without updating existing, it can omit this.
 
 Clients like Claude Code can use these annotations to:
 
@@ -198,7 +110,7 @@ Clients like Claude Code can use these annotations to:
 
 ### Audit Logging
 
-All write operations (createTextPrompt, createChatPrompt, updatePromptLabels) automatically create audit log entries with before/after snapshots. Observation and metrics tools are read-only and do not create audit log entries.
+All write operations should audit-log entries with before/after snapshots.
 
 ---
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the MCP server README to remove the exhaustive inline \"Available Tools\" section and instead directs readers to the external reference site `mcp.reference.langfuse.com`. It also adds an API-stability callout warning clients to inspect available tools dynamically rather than assuming a static interface.

- The detailed tool catalogue (prompt, observation, and metrics tools with full parameter descriptions) is replaced by a single external link, keeping the README lean.
- Minor prose edits simplify section headers (\"Verify prompt tools\" → \"Verify prompt access\") and the Tool Annotations and Audit Logging descriptions.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change; no runtime code is modified and the update is safe to merge.

The change removes the inline tools catalogue and redirects readers to an external reference site, with a small API stability notice added. Two minor prose errors were found (a duplicate word and a missing verb in the Audit Logging line), but neither affects functionality.

web/src/features/mcp/README.md has two minor prose fixes worth applying before merging.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP Client sends request] --> B[Langfuse API receives request]
    B --> C{Validate BasicAuth}
    C -- Invalid --> D[Return 401 Unauthorized]
    C -- Valid --> E[Build ServerContext from API key]
    E --> F[Create fresh MCP server instance]
    F --> G[Execute requested tool]
    G --> H[Return tool response to client]
    H --> I[Discard server instance]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/mcp/README.md:104
Double "are" in the `destructiveHint` description — typo produces grammatically incorrect prose.

```suggestion
- **`destructiveHint: true`**: Operations that modify data in ways that are non-reversible. If an operation only creates entities, without updating existing, it can omit this.
```

### Issue 2 of 2
web/src/features/mcp/README.md:113
The sentence is missing a verb — "should audit-log entries" doesn't parse. It should read "should create audit-log entries" (or similar).

```suggestion
All write operations should create audit-log entries with before/after snapshots.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(mcp): Update README.md"](https://github.com/langfuse/langfuse/commit/d4e53ae5433dbcb83aa9ec85b2a445796e0c1c2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34140266)</sub>

<!-- /greptile_comment -->