### PR TITLE
feat: matches string filters that always uses TEXT index

### DIFF
--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -100,12 +100,12 @@ service:
                   "column": string,         // Required. Column to filter on (see available columns below)
                   "operator": string,       // Required. Operator based on type:
                                             // - datetime: ">", "<", ">=", "<="
-                                            // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                            // - string: "=", "contains", "does not contain", "starts with", "ends with", "matches"
                                             // - stringOptions: "any of", "none of"
                                             // - categoryOptions: "any of", "none of"
                                             // - arrayOptions: "any of", "none of", "all of"
                                             // - number: "=", ">", "<", ">=", "<="
-                                            // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                            // - stringObject: "=", "contains", "does not contain", "starts with", "ends with", "matches"
                                             // - numberObject: "=", ">", "<", ">=", "<="
                                             // - boolean: "=", "<>"
                                             // - null: "is null", "is not null"
@@ -157,7 +157,11 @@ service:
               - `promptVersion` (number) - Associated prompt version
 
               ### Structured Data
+              - `input` (string) - Observation input. Supports accelerated token search with the `matches` operator.
+              - `output` (string) - Observation output. Supports accelerated token search with the `matches` operator.
               - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
+
+              The `matches` operator is only supported for `input`, `output`, and stringObject `metadata` filters. It performs token-based full-text search using the events table text indexes. For input/output it is case-insensitive; for metadata values it is case-sensitive. Use `contains` for substring semantics.
 
               ## Filter Examples
               ```json
@@ -180,6 +184,12 @@ service:
                   "key": "environment",
                   "operator": "=",
                   "value": "production"
+                },
+                {
+                  "type": "string",
+                  "column": "output",
+                  "operator": "matches",
+                  "value": "needle"
                 }
               ]
               ```

--- a/fern/apis/server/definition/observations.yml
+++ b/fern/apis/server/definition/observations.yml
@@ -161,7 +161,7 @@ service:
               - `output` (string) - Observation output. Supports accelerated token search with the `matches` operator.
               - `metadata` (stringObject/numberObject/categoryOptions) - Metadata key-value pairs. Use `key` parameter to filter on specific metadata keys.
 
-              The `matches` operator is only supported for `input`, `output`, and stringObject `metadata` filters. It performs token-based full-text search using the events table text indexes. For input/output it is case-insensitive; for metadata values it is case-sensitive. Use `contains` for substring semantics.
+              The `matches` operator is only supported for `input`, `output`, and stringObject `metadata` filters. It performs token-based full-text search using the events table text indexes. Case sensitivity differs by target: `input` and `output` matches are case-insensitive, while metadata value matches are case-sensitive. Use `contains` for substring semantics. Any v2 `input` or `output` filter must be accompanied by at least one `=` or `matches` filter on `input` or `output`; standalone `contains`, `starts with`, `ends with`, and `does not contain` filters on these columns are rejected.
 
               ## Filter Examples
               ```json

--- a/packages/shared/src/interfaces/filters.ts
+++ b/packages/shared/src/interfaces/filters.ts
@@ -130,3 +130,37 @@ export const singleFilter = z.discriminatedUnion("type", [
   nullFilter,
   positionInTraceFilter,
 ]);
+
+const eventsTableStringOperator = z.union([
+  z.enum(filterOperators.string),
+  z.literal(FTS_MATCH_OPERATOR),
+]);
+
+const eventsTableStringObjectOperator = z.union([
+  z.enum(filterOperators.stringObject),
+  z.literal(FTS_MATCH_OPERATOR),
+]);
+
+export const eventsTableStringFilter = stringFilter.extend({
+  operator: eventsTableStringOperator,
+});
+
+export const eventsTableStringObjectFilter = stringObjectFilter.extend({
+  operator: eventsTableStringObjectOperator,
+});
+
+export const eventsTableSingleFilter = z.discriminatedUnion("type", [
+  timeFilter,
+  eventsTableStringFilter,
+  numberFilter,
+  stringOptionsFilter,
+  categoryOptionsFilter,
+  arrayOptionsFilter,
+  eventsTableStringObjectFilter,
+  numberObjectFilter,
+  booleanFilter,
+  nullFilter,
+  positionInTraceFilter,
+]);
+
+export const eventsTableFilterState = z.array(eventsTableSingleFilter);

--- a/packages/shared/src/interfaces/filters.ts
+++ b/packages/shared/src/interfaces/filters.ts
@@ -21,6 +21,9 @@ export const filterOperators = {
   positionInTrace: ["="],
 } as const;
 
+export const FTS_MATCH_OPERATOR = "matches" as const;
+export type FtsMatchOperator = typeof FTS_MATCH_OPERATOR;
+
 export const timeFilter = z.object({
   column: z.string(),
   operator: z.enum(filterOperators.datetime),

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -3,17 +3,11 @@ import {
   type FtsMatchOperator,
   filterOperators,
 } from "../../../interfaces/filters";
-import { InvalidRequestError } from "../../../errors";
 import { clickhouseCompliantRandomCharacters } from "../../repositories";
 import {
-  ftsMetadataArrayHas,
-  ftsMetadataArrayTokenConjunct,
-  ftsTextMatchesCondition,
-  ftsTextTokenConjunct,
-  hasFtsSearchToken,
-  isFtsMatchOperator,
+  assertValidFtsMatchFilter,
+  FTS_OPERATOR_DESCRIPTORS,
   isFtsEventsTable,
-  isFtsMetadataTarget,
   isFtsTextTarget,
 } from "./fts";
 
@@ -86,7 +80,11 @@ export class StringFilter implements Filter {
       case "=":
         query = `${fieldWithPrefix} = {${varName}: String}`;
         if (isFtsTextTarget(this.clickhouseTable, this.field, this.operator)) {
-          query = `(${query} AND ${ftsTextTokenConjunct(fieldWithPrefix, `{${varName}: String}`)})`;
+          query = FTS_OPERATOR_DESCRIPTORS["="].textCondition(
+            fieldWithPrefix,
+            `{${varName}: String}`,
+            query,
+          );
         }
         break;
       case "contains":
@@ -102,19 +100,18 @@ export class StringFilter implements Filter {
         query = `endsWith(${fieldWithPrefix}, {${varName}: String})`;
         break;
       case FTS_MATCH_OPERATOR:
-        if (!isFtsTextTarget(this.clickhouseTable, this.field, this.operator)) {
-          throw new InvalidRequestError(
-            "`matches` is only supported for input and output filters.",
-          );
-        }
-        if (!hasFtsSearchToken(this.value)) {
-          throw new InvalidRequestError(
-            "`matches` requires at least one search token.",
-          );
-        }
-        query = ftsTextMatchesCondition(
+        assertValidFtsMatchFilter({
+          filterType: "string",
+          clickhouseTable: this.clickhouseTable,
+          field: this.field,
+          value: this.value,
+        });
+        query = FTS_OPERATOR_DESCRIPTORS[FTS_MATCH_OPERATOR].textCondition(
           fieldWithPrefix,
           `{${varName}: String}`,
+          // `matches` shares the descriptor signature with exact filters but
+          // does not need a base exact predicate.
+          "",
         );
         break;
       default:
@@ -345,20 +342,6 @@ export class StringObjectFilter implements Filter {
     // Events tables use array columns (metadata_names/metadata_values);
     // observations/traces tables use a Map column (metadata).
     let query: string;
-    if (
-      isFtsMatchOperator(this.operator) &&
-      !isFtsMetadataTarget(this.clickhouseTable, this.field)
-    ) {
-      throw new InvalidRequestError(
-        "`matches` is only supported for metadata filters.",
-      );
-    }
-    if (isFtsMatchOperator(this.operator) && !hasFtsSearchToken(this.value)) {
-      throw new InvalidRequestError(
-        "`matches` requires at least one search token.",
-      );
-    }
-
     if (isFtsEventsTable(this.clickhouseTable)) {
       // ClickHouse's index analyzer cannot extract `has(names, k)` from
       // `values[indexOf(names, k)] OP v` (cross-array arrayElement form), so a
@@ -375,7 +358,12 @@ export class StringObjectFilter implements Filter {
 
       switch (this.operator) {
         case "=":
-          query = `${hasKey} AND ${ftsMetadataArrayHas(valuesColumn, valueParam)} AND (${valueAccessor} = ${valueParam})`;
+          query = FTS_OPERATOR_DESCRIPTORS["="].metadataArrayCondition({
+            hasKey,
+            valuesColumn,
+            valueAccessor,
+            valueParam,
+          });
           break;
         case "contains":
           query = `${hasKey} AND (position(${valueAccessor}, ${valueParam}) > 0)`;
@@ -390,7 +378,20 @@ export class StringObjectFilter implements Filter {
           query = `${hasKey} AND (endsWith(${valueAccessor}, ${valueParam}))`;
           break;
         case FTS_MATCH_OPERATOR:
-          query = `${hasKey} AND ${ftsMetadataArrayTokenConjunct(valuesColumn, valueParam)} AND ${ftsMetadataArrayTokenConjunct(valueAccessor, valueParam)}`;
+          assertValidFtsMatchFilter({
+            filterType: "stringObject",
+            clickhouseTable: this.clickhouseTable,
+            field: this.field,
+            value: this.value,
+          });
+          query = FTS_OPERATOR_DESCRIPTORS[
+            FTS_MATCH_OPERATOR
+          ].metadataArrayCondition({
+            hasKey,
+            valuesColumn,
+            valueAccessor,
+            valueParam,
+          });
           break;
         default:
           throw new Error(`Unsupported operator: ${this.operator}`);

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -1,15 +1,26 @@
-import { filterOperators } from "../../../interfaces/filters";
+import {
+  FTS_MATCH_OPERATOR,
+  type FtsMatchOperator,
+  filterOperators,
+} from "../../../interfaces/filters";
+import { InvalidRequestError } from "../../../errors";
 import { clickhouseCompliantRandomCharacters } from "../../repositories";
 import {
   ftsMetadataArrayHas,
+  ftsMetadataArrayTokenConjunct,
+  ftsTextMatchesCondition,
   ftsTextTokenConjunct,
+  hasFtsSearchToken,
+  isFtsMatchOperator,
   isFtsEventsTable,
+  isFtsMetadataTarget,
   isFtsTextTarget,
 } from "./fts";
 
 export type ClickhouseOperator =
   | (typeof filterOperators)[keyof typeof filterOperators][number]
-  | "!=";
+  | "!="
+  | FtsMatchOperator;
 export interface Filter {
   apply(): ClickhouseFilter;
   clickhouseTable: string;
@@ -26,14 +37,16 @@ export class StringFilter implements Filter {
   public clickhouseTable: string;
   public field: string;
   public value: string;
-  public operator: (typeof filterOperators)["string"][number];
+  public operator:
+    | (typeof filterOperators)["string"][number]
+    | FtsMatchOperator;
   public tablePrefix?: string;
   public emptyEqualsNull?: boolean;
 
   constructor(opts: {
     clickhouseTable: string;
     field: string;
-    operator: (typeof filterOperators)["string"][number];
+    operator: (typeof filterOperators)["string"][number] | FtsMatchOperator;
     value: string;
     tablePrefix?: string;
     emptyEqualsNull?: boolean;
@@ -72,6 +85,9 @@ export class StringFilter implements Filter {
     switch (this.operator) {
       case "=":
         query = `${fieldWithPrefix} = {${varName}: String}`;
+        if (isFtsTextTarget(this.clickhouseTable, this.field, this.operator)) {
+          query = `(${query} AND ${ftsTextTokenConjunct(fieldWithPrefix, `{${varName}: String}`)})`;
+        }
         break;
       case "contains":
         query = `position(${fieldWithPrefix}, {${varName}: String}) > 0`;
@@ -85,6 +101,22 @@ export class StringFilter implements Filter {
       case "ends with":
         query = `endsWith(${fieldWithPrefix}, {${varName}: String})`;
         break;
+      case FTS_MATCH_OPERATOR:
+        if (!isFtsTextTarget(this.clickhouseTable, this.field, this.operator)) {
+          throw new InvalidRequestError(
+            "`matches` is only supported for input and output filters.",
+          );
+        }
+        if (!hasFtsSearchToken(this.value)) {
+          throw new InvalidRequestError(
+            "`matches` requires at least one search token.",
+          );
+        }
+        query = ftsTextMatchesCondition(
+          fieldWithPrefix,
+          `{${varName}: String}`,
+        );
+        break;
       default:
         throw new Error(`Unsupported operator: ${this.operator}`);
     }
@@ -92,10 +124,6 @@ export class StringFilter implements Filter {
     // '' ≡ NULL: "does not contain" would match '' — guard against it
     if (this.emptyEqualsNull && this.operator === "does not contain") {
       query = `(${fieldWithPrefix} != '' AND ${query})`;
-    }
-
-    if (isFtsTextTarget(this.clickhouseTable, this.field, this.operator)) {
-      query = `(${query} AND ${ftsTextTokenConjunct(fieldWithPrefix, `{${varName}: String}`)})`;
     }
 
     return {
@@ -286,13 +314,17 @@ export class StringObjectFilter implements Filter {
   public field: string;
   public key: string;
   public value: string;
-  public operator: (typeof filterOperators)["stringObject"][number];
+  public operator:
+    | (typeof filterOperators)["stringObject"][number]
+    | FtsMatchOperator;
   public tablePrefix?: string;
 
   constructor(opts: {
     clickhouseTable: string;
     field: string;
-    operator: (typeof filterOperators)["stringObject"][number];
+    operator:
+      | (typeof filterOperators)["stringObject"][number]
+      | FtsMatchOperator;
     key: string;
     value: string;
     tablePrefix?: string;
@@ -313,6 +345,20 @@ export class StringObjectFilter implements Filter {
     // Events tables use array columns (metadata_names/metadata_values);
     // observations/traces tables use a Map column (metadata).
     let query: string;
+    if (
+      isFtsMatchOperator(this.operator) &&
+      !isFtsMetadataTarget(this.clickhouseTable, this.field)
+    ) {
+      throw new InvalidRequestError(
+        "`matches` is only supported for metadata filters.",
+      );
+    }
+    if (isFtsMatchOperator(this.operator) && !hasFtsSearchToken(this.value)) {
+      throw new InvalidRequestError(
+        "`matches` requires at least one search token.",
+      );
+    }
+
     if (isFtsEventsTable(this.clickhouseTable)) {
       // ClickHouse's index analyzer cannot extract `has(names, k)` from
       // `values[indexOf(names, k)] OP v` (cross-array arrayElement form), so a
@@ -342,6 +388,9 @@ export class StringObjectFilter implements Filter {
           break;
         case "ends with":
           query = `${hasKey} AND (endsWith(${valueAccessor}, ${valueParam}))`;
+          break;
+        case FTS_MATCH_OPERATOR:
+          query = `${hasKey} AND ${ftsMetadataArrayTokenConjunct(valuesColumn, valueParam)} AND ${ftsMetadataArrayTokenConjunct(valueAccessor, valueParam)}`;
           break;
         default:
           throw new Error(`Unsupported operator: ${this.operator}`);

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -1,6 +1,5 @@
-import z from "zod";
-import { singleFilter } from "../../../interfaces/filters";
-import { FilterCondition } from "../../../types";
+import { FTS_MATCH_OPERATOR } from "../../../interfaces/filters";
+import { type PublicApiV2FilterState } from "../../../types";
 import { InvalidRequestError } from "../../../errors";
 import { isValidTableName } from "../../clickhouse/schemaUtils";
 import { logger } from "../../logger";
@@ -23,6 +22,7 @@ import {
   StringObjectFilter,
   NullFilter,
 } from "./clickhouse-filter";
+import { hasFtsSearchToken, isFtsMetadataTarget, isFtsTextTarget } from "./fts";
 
 export class QueryBuilderError extends Error {
   constructor(message: string) {
@@ -35,7 +35,7 @@ export class QueryBuilderError extends Error {
 // The filter property in this column needs to be zod verified.
 // User input for values (e.g. project_id = <value>) are sent to Clickhouse as parameters to prevent SQL injection
 export const createFilterFromFilterState = (
-  filter: FilterCondition[],
+  filter: PublicApiV2FilterState,
   columnMapping: UiColumnMappings,
   columnDefinitions?: ColumnDefinition[],
 ) => {
@@ -58,6 +58,8 @@ export const createFilterFromFilterState = (
         }
       }
     }
+
+    validatePublicApiV2MatchesFilter(frontEndFilter, column);
 
     switch (frontEndFilter.type) {
       case "string":
@@ -155,8 +157,45 @@ export const createFilterFromFilterState = (
   });
 };
 
+const validatePublicApiV2MatchesFilter = (
+  filter: PublicApiV2FilterState[number],
+  column: UiColumnMappings[number],
+) => {
+  if (!("operator" in filter) || filter.operator !== FTS_MATCH_OPERATOR) {
+    return;
+  }
+
+  if (!("value" in filter) || !hasFtsSearchToken(String(filter.value))) {
+    throw new InvalidRequestError(
+      "`matches` requires at least one search token.",
+    );
+  }
+
+  if (filter.type === "string") {
+    if (
+      isFtsTextTarget(
+        column.clickhouseTableName,
+        column.clickhouseSelect,
+        FTS_MATCH_OPERATOR,
+      )
+    ) {
+      return;
+    }
+  } else if (filter.type === "stringObject") {
+    if (
+      isFtsMetadataTarget(column.clickhouseTableName, column.clickhouseSelect)
+    ) {
+      return;
+    }
+  }
+
+  throw new InvalidRequestError(
+    "`matches` is only supported for input, output, and metadata filters.",
+  );
+};
+
 const matchAndVerifyTracesUiColumn = (
-  filter: z.infer<typeof singleFilter>,
+  filter: PublicApiV2FilterState[number],
   uiTableDefinitions: UiColumnMappings,
 ) => {
   // tries to match the column name to the clickhouse table name

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -1,5 +1,5 @@
 import { FTS_MATCH_OPERATOR } from "../../../interfaces/filters";
-import { type PublicApiV2FilterState } from "../../../types";
+import { type EventsTableFilterState } from "../../../types";
 import { InvalidRequestError } from "../../../errors";
 import { isValidTableName } from "../../clickhouse/schemaUtils";
 import { logger } from "../../logger";
@@ -22,7 +22,7 @@ import {
   StringObjectFilter,
   NullFilter,
 } from "./clickhouse-filter";
-import { hasFtsSearchToken, isFtsMetadataTarget, isFtsTextTarget } from "./fts";
+import { assertValidFtsMatchFilter } from "./fts";
 
 export class QueryBuilderError extends Error {
   constructor(message: string) {
@@ -35,7 +35,7 @@ export class QueryBuilderError extends Error {
 // The filter property in this column needs to be zod verified.
 // User input for values (e.g. project_id = <value>) are sent to Clickhouse as parameters to prevent SQL injection
 export const createFilterFromFilterState = (
-  filter: PublicApiV2FilterState,
+  filter: EventsTableFilterState,
   columnMapping: UiColumnMappings,
   columnDefinitions?: ColumnDefinition[],
 ) => {
@@ -59,7 +59,7 @@ export const createFilterFromFilterState = (
       }
     }
 
-    validatePublicApiV2MatchesFilter(frontEndFilter, column);
+    validateEventsTableMatchesFilter(frontEndFilter, column);
 
     switch (frontEndFilter.type) {
       case "string":
@@ -157,45 +157,37 @@ export const createFilterFromFilterState = (
   });
 };
 
-const validatePublicApiV2MatchesFilter = (
-  filter: PublicApiV2FilterState[number],
+const validateEventsTableMatchesFilter = (
+  filter: EventsTableFilterState[number],
   column: UiColumnMappings[number],
 ) => {
   if (!("operator" in filter) || filter.operator !== FTS_MATCH_OPERATOR) {
     return;
   }
 
-  if (!("value" in filter) || !hasFtsSearchToken(String(filter.value))) {
-    throw new InvalidRequestError(
-      "`matches` requires at least one search token.",
-    );
-  }
-
   if (filter.type === "string") {
-    if (
-      isFtsTextTarget(
-        column.clickhouseTableName,
-        column.clickhouseSelect,
-        FTS_MATCH_OPERATOR,
-      )
-    ) {
-      return;
-    }
+    assertValidFtsMatchFilter({
+      filterType: "string",
+      clickhouseTable: column.clickhouseTableName,
+      field: column.clickhouseSelect,
+      value: filter.value,
+    });
+    return;
   } else if (filter.type === "stringObject") {
-    if (
-      isFtsMetadataTarget(column.clickhouseTableName, column.clickhouseSelect)
-    ) {
-      return;
-    }
+    assertValidFtsMatchFilter({
+      filterType: "stringObject",
+      clickhouseTable: column.clickhouseTableName,
+      field: column.clickhouseSelect,
+      value: filter.value,
+    });
+    return;
   }
 
-  throw new InvalidRequestError(
-    "`matches` is only supported for input, output, and metadata filters.",
-  );
+  throw new QueryBuilderError(`Invalid filter type`);
 };
 
 const matchAndVerifyTracesUiColumn = (
-  filter: PublicApiV2FilterState[number],
+  filter: EventsTableFilterState[number],
   uiTableDefinitions: UiColumnMappings,
 ) => {
   // tries to match the column name to the clickhouse table name

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -22,14 +22,7 @@ import {
   StringObjectFilter,
   NullFilter,
 } from "./clickhouse-filter";
-import {
-  assertValidFtsMatchFilter,
-  isFtsEventsTable,
-  isFtsTextField,
-} from "./fts";
-
-const EVENTS_IO_FILTER_TYPE_ERROR =
-  "Input/output filters only support filter type `string`.";
+import { assertValidFtsMatchFilter } from "./fts";
 
 export class QueryBuilderError extends Error {
   constructor(message: string) {
@@ -53,8 +46,6 @@ export const createFilterFromFilterState = (
   return applicableFilters.map((frontEndFilter) => {
     // checks if the column exists in the clickhouse schema
     const column = matchAndVerifyTracesUiColumn(frontEndFilter, columnMapping);
-
-    validateEventsTableIoFilterType(frontEndFilter, column);
 
     if (columnDefinitions && frontEndFilter.type !== "null") {
       const colDef = columnDefinitions.find((c) => c.id === column.uiTableId);
@@ -193,19 +184,6 @@ const validateEventsTableMatchesFilter = (
   }
 
   throw new QueryBuilderError(`Invalid filter type`);
-};
-
-const validateEventsTableIoFilterType = (
-  filter: EventsTableFilterState[number],
-  column: UiColumnMappings[number],
-) => {
-  if (
-    isFtsEventsTable(column.clickhouseTableName) &&
-    isFtsTextField(column.clickhouseSelect) &&
-    filter.type !== "string"
-  ) {
-    throw new InvalidRequestError(EVENTS_IO_FILTER_TYPE_ERROR);
-  }
 };
 
 const matchAndVerifyTracesUiColumn = (

--- a/packages/shared/src/server/queries/clickhouse-sql/factory.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/factory.ts
@@ -22,7 +22,14 @@ import {
   StringObjectFilter,
   NullFilter,
 } from "./clickhouse-filter";
-import { assertValidFtsMatchFilter } from "./fts";
+import {
+  assertValidFtsMatchFilter,
+  isFtsEventsTable,
+  isFtsTextField,
+} from "./fts";
+
+const EVENTS_IO_FILTER_TYPE_ERROR =
+  "Input/output filters only support filter type `string`.";
 
 export class QueryBuilderError extends Error {
   constructor(message: string) {
@@ -46,6 +53,8 @@ export const createFilterFromFilterState = (
   return applicableFilters.map((frontEndFilter) => {
     // checks if the column exists in the clickhouse schema
     const column = matchAndVerifyTracesUiColumn(frontEndFilter, columnMapping);
+
+    validateEventsTableIoFilterType(frontEndFilter, column);
 
     if (columnDefinitions && frontEndFilter.type !== "null") {
       const colDef = columnDefinitions.find((c) => c.id === column.uiTableId);
@@ -184,6 +193,19 @@ const validateEventsTableMatchesFilter = (
   }
 
   throw new QueryBuilderError(`Invalid filter type`);
+};
+
+const validateEventsTableIoFilterType = (
+  filter: EventsTableFilterState[number],
+  column: UiColumnMappings[number],
+) => {
+  if (
+    isFtsEventsTable(column.clickhouseTableName) &&
+    isFtsTextField(column.clickhouseSelect) &&
+    filter.type !== "string"
+  ) {
+    throw new InvalidRequestError(EVENTS_IO_FILTER_TYPE_ERROR);
+  }
 };
 
 const matchAndVerifyTracesUiColumn = (

--- a/packages/shared/src/server/queries/clickhouse-sql/fts.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/fts.ts
@@ -1,7 +1,14 @@
-import { filterOperators } from "../../../interfaces/filters";
+import {
+  FTS_MATCH_OPERATOR,
+  type FtsMatchOperator,
+  filterOperators,
+} from "../../../interfaces/filters";
 import { EVENTS_TABLE_NAMES } from "../../clickhouse/schema";
 
+export { FTS_MATCH_OPERATOR } from "../../../interfaces/filters";
+
 type StringOperator = (typeof filterOperators)["string"][number];
+export type FtsStringOperator = StringOperator | FtsMatchOperator;
 
 export const FTS_TEXT_NORMALIZER = "lower";
 
@@ -13,16 +20,17 @@ export const FTS_TEXT_FIELDS: ReadonlySet<string> = new Set([
   "input",
   "output",
 ]);
+export const FTS_METADATA_FIELD = "metadata";
 
 // StringFilter rewrites must preserve filter API semantics. Limit transparent
 // text-index rewrites to equality because substring filters are expected to
-// match inside larger tokens.
-export const FTS_TEXT_OPERATORS: ReadonlySet<StringOperator> =
-  new Set<StringOperator>(["="]);
+// match inside larger tokens. `matches` is an explicit token-search operator.
+export const FTS_TEXT_OPERATORS: ReadonlySet<FtsStringOperator> =
+  new Set<FtsStringOperator>(["=", FTS_MATCH_OPERATOR]);
 
 // Column mappings may carry a table prefix (e.g. "e.input"); strip to the bare
 // field name before set lookup.
-const bareField = (field: string): string => {
+export const bareFtsField = (field: string): string => {
   const dot = field.lastIndexOf(".");
   if (dot === -1) return field;
   const tail = field.slice(dot + 1);
@@ -34,14 +42,35 @@ export const isFtsEventsTable = (
 ): boolean =>
   clickhouseTable !== undefined && FTS_EVENTS_TABLES.has(clickhouseTable);
 
+export const isFtsMatchOperator = (
+  operator: string | undefined,
+): operator is FtsMatchOperator => operator === FTS_MATCH_OPERATOR;
+
+export const isFtsTextField = (field: string): boolean =>
+  FTS_TEXT_FIELDS.has(bareFtsField(field));
+
+export const isFtsMetadataField = (field: string): boolean =>
+  bareFtsField(field) === FTS_METADATA_FIELD;
+
 export const isFtsTextTarget = (
   clickhouseTable: string,
   field: string,
-  operator: StringOperator,
+  operator: FtsStringOperator,
 ): boolean =>
   isFtsEventsTable(clickhouseTable) &&
-  FTS_TEXT_FIELDS.has(bareField(field)) &&
+  isFtsTextField(field) &&
   FTS_TEXT_OPERATORS.has(operator);
+
+export const isFtsMetadataTarget = (
+  clickhouseTable: string,
+  field: string,
+): boolean => isFtsEventsTable(clickhouseTable) && isFtsMetadataField(field);
+
+export const isFtsAcceleratedIoOperator = (operator: string): boolean =>
+  FTS_TEXT_OPERATORS.has(operator as FtsStringOperator);
+
+export const hasFtsSearchToken = (value: string): boolean =>
+  /[\p{L}\p{N}]/u.test(value);
 
 const normalizeFtsTextExpr = (expr: string): string =>
   `${FTS_TEXT_NORMALIZER}(${expr})`;
@@ -52,7 +81,18 @@ export const ftsTextTokenConjunct = (
 ): string =>
   `(empty(tokens(${normalizeFtsTextExpr(valueParam)})) OR hasAllTokens(${normalizeFtsTextExpr(fieldExpr)}, ${normalizeFtsTextExpr(valueParam)}))`;
 
+export const ftsTextMatchesCondition = (
+  fieldExpr: string,
+  valueParam: string,
+): string =>
+  `hasAllTokens(${normalizeFtsTextExpr(fieldExpr)}, ${normalizeFtsTextExpr(valueParam)})`;
+
 export const ftsMetadataArrayHas = (
   arrayExpr: string,
   valueParam: string,
 ): string => `has(${arrayExpr}, ${valueParam})`;
+
+export const ftsMetadataArrayTokenConjunct = (
+  arrayExpr: string,
+  valueParam: string,
+): string => `hasAllTokens(${arrayExpr}, ${valueParam})`;

--- a/packages/shared/src/server/queries/clickhouse-sql/fts.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/fts.ts
@@ -3,12 +3,19 @@ import {
   type FtsMatchOperator,
   filterOperators,
 } from "../../../interfaces/filters";
+import { InvalidRequestError } from "../../../errors";
 import { EVENTS_TABLE_NAMES } from "../../clickhouse/schema";
 
 export { FTS_MATCH_OPERATOR } from "../../../interfaces/filters";
 
 type StringOperator = (typeof filterOperators)["string"][number];
 export type FtsStringOperator = StringOperator | FtsMatchOperator;
+export type FtsAcceleratedStringOperator = "=" | FtsMatchOperator;
+
+export const FTS_MATCH_TOKEN_ERROR =
+  "`matches` requires at least one search token.";
+export const FTS_MATCH_TARGET_ERROR =
+  "`matches` is only supported for input, output, and metadata filters.";
 
 export const FTS_TEXT_NORMALIZER = "lower";
 
@@ -21,12 +28,6 @@ export const FTS_TEXT_FIELDS: ReadonlySet<string> = new Set([
   "output",
 ]);
 export const FTS_METADATA_FIELD = "metadata";
-
-// StringFilter rewrites must preserve filter API semantics. Limit transparent
-// text-index rewrites to equality because substring filters are expected to
-// match inside larger tokens. `matches` is an explicit token-search operator.
-export const FTS_TEXT_OPERATORS: ReadonlySet<FtsStringOperator> =
-  new Set<FtsStringOperator>(["=", FTS_MATCH_OPERATOR]);
 
 // Column mappings may carry a table prefix (e.g. "e.input"); strip to the bare
 // field name before set lookup.
@@ -96,3 +97,77 @@ export const ftsMetadataArrayTokenConjunct = (
   arrayExpr: string,
   valueParam: string,
 ): string => `hasAllTokens(${arrayExpr}, ${valueParam})`;
+
+type FtsMetadataArrayConditionContext = {
+  hasKey: string;
+  valuesColumn: string;
+  valueAccessor: string;
+  valueParam: string;
+};
+
+type FtsOperatorDescriptor = {
+  textCondition: (
+    fieldExpr: string,
+    valueParam: string,
+    exactCondition: string,
+  ) => string;
+  metadataArrayCondition: (ctx: FtsMetadataArrayConditionContext) => string;
+};
+
+type FtsOperatorDescriptors = {
+  [operator in FtsAcceleratedStringOperator]: FtsOperatorDescriptor;
+};
+
+export const FTS_OPERATOR_DESCRIPTORS = {
+  "=": {
+    textCondition: (fieldExpr, valueParam, exactCondition) =>
+      `(${exactCondition} AND ${ftsTextTokenConjunct(fieldExpr, valueParam)})`,
+    metadataArrayCondition: ({
+      hasKey,
+      valuesColumn,
+      valueAccessor,
+      valueParam,
+    }) =>
+      `${hasKey} AND ${ftsMetadataArrayHas(valuesColumn, valueParam)} AND (${valueAccessor} = ${valueParam})`,
+  },
+  [FTS_MATCH_OPERATOR]: {
+    textCondition: (fieldExpr, valueParam, _exactCondition) =>
+      ftsTextMatchesCondition(fieldExpr, valueParam),
+    metadataArrayCondition: ({
+      hasKey,
+      valuesColumn,
+      valueAccessor,
+      valueParam,
+    }) =>
+      `${hasKey} AND ${ftsMetadataArrayTokenConjunct(valuesColumn, valueParam)} AND ${ftsMetadataArrayTokenConjunct(valueAccessor, valueParam)}`,
+  },
+} satisfies FtsOperatorDescriptors;
+
+// StringFilter rewrites must preserve filter API semantics. Limit transparent
+// text-index rewrites to equality because substring filters are expected to
+// match inside larger tokens. `matches` is an explicit token-search operator.
+export const FTS_TEXT_OPERATORS: ReadonlySet<FtsStringOperator> = new Set(
+  Object.keys(FTS_OPERATOR_DESCRIPTORS) as FtsAcceleratedStringOperator[],
+);
+
+export const assertValidFtsMatchFilter = (opts: {
+  filterType: "string" | "stringObject";
+  clickhouseTable: string;
+  field: string;
+  value: string;
+}) => {
+  if (!hasFtsSearchToken(opts.value)) {
+    throw new InvalidRequestError(FTS_MATCH_TOKEN_ERROR);
+  }
+
+  if (
+    (opts.filterType === "string" &&
+      isFtsTextTarget(opts.clickhouseTable, opts.field, FTS_MATCH_OPERATOR)) ||
+    (opts.filterType === "stringObject" &&
+      isFtsMetadataTarget(opts.clickhouseTable, opts.field))
+  ) {
+    return;
+  }
+
+  throw new InvalidRequestError(FTS_MATCH_TARGET_ERROR);
+};

--- a/packages/shared/src/server/queries/index.ts
+++ b/packages/shared/src/server/queries/index.ts
@@ -30,9 +30,18 @@ export {
 } from "./clickhouse-sql/search";
 export {
   FTS_EVENTS_TABLES,
+  FTS_MATCH_OPERATOR,
+  FTS_METADATA_FIELD,
   FTS_TEXT_FIELDS,
   FTS_TEXT_OPERATORS,
+  bareFtsField,
+  hasFtsSearchToken,
+  isFtsAcceleratedIoOperator,
   isFtsEventsTable,
+  isFtsMatchOperator,
+  isFtsMetadataField,
+  isFtsMetadataTarget,
+  isFtsTextField,
   isFtsTextTarget,
 } from "./clickhouse-sql/fts";
 export { postgresSearchCondition } from "./postgres-sql/search";

--- a/packages/shared/src/server/queries/public-api-filter-builder.ts
+++ b/packages/shared/src/server/queries/public-api-filter-builder.ts
@@ -10,7 +10,7 @@ import {
   type ClickhouseOperator,
 } from "./clickhouse-sql/clickhouse-filter";
 import { z } from "zod";
-import type { PublicApiV2FilterState } from "../../types";
+import type { EventsTableFilterState } from "../../types";
 import type {
   UiColumnMappings,
   ColumnDefinition,
@@ -368,7 +368,7 @@ export function convertApiProvidedFilterToClickhouseFilter(
 export function deriveFilters<T extends BaseQueryType>(
   simpleFilterProps: T,
   filterParamsMapping: ApiColumnMapping[],
-  advancedFilters: PublicApiV2FilterState | undefined,
+  advancedFilters: EventsTableFilterState | undefined,
   uiColumnDefinitions: UiColumnMappings,
   columnDefinitions?: ColumnDefinition[],
 ): FilterList {

--- a/packages/shared/src/server/queries/public-api-filter-builder.ts
+++ b/packages/shared/src/server/queries/public-api-filter-builder.ts
@@ -10,7 +10,7 @@ import {
   type ClickhouseOperator,
 } from "./clickhouse-sql/clickhouse-filter";
 import { z } from "zod";
-import type { FilterState } from "../../types";
+import type { PublicApiV2FilterState } from "../../types";
 import type {
   UiColumnMappings,
   ColumnDefinition,
@@ -368,7 +368,7 @@ export function convertApiProvidedFilterToClickhouseFilter(
 export function deriveFilters<T extends BaseQueryType>(
   simpleFilterProps: T,
   filterParamsMapping: ApiColumnMapping[],
-  advancedFilters: FilterState | undefined,
+  advancedFilters: PublicApiV2FilterState | undefined,
   uiColumnDefinitions: UiColumnMappings,
   columnDefinitions?: ColumnDefinition[],
 ): FilterList {

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -33,15 +33,16 @@ import {
   createPublicApiTracesColumnMapping,
   deriveFilters,
   isFtsAcceleratedIoOperator,
+  isFtsMetadataField,
   isFtsTextField,
   type ApiColumnMapping,
   ObservationPriceFields,
 } from "../queries";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import type {
+  EventsTableFilterState,
   FilterCondition,
   FilterState,
-  PublicApiV2FilterState,
 } from "../../types";
 import type { TracingSearchType } from "../../interfaces/search";
 import {
@@ -1067,7 +1068,7 @@ type PublicApiObservationsQuery = {
   toStartTime?: string;
   version?: string;
   environment?: string | string[];
-  advancedFilters?: PublicApiV2FilterState;
+  advancedFilters?: EventsTableFilterState;
   parseIoAsJson?: boolean;
   cursor?: {
     lastStartTimeTo: Date;
@@ -1084,13 +1085,13 @@ type PublicApiObservationsQuery = {
 };
 
 type BuildObservationsQueryComponentsOptions = {
-  requireIndexedIoFilter?: boolean;
+  allowUnindexedIoFilters?: boolean;
 };
 
 const isInputOutputFilter = (filter: Filter): boolean =>
   isFtsTextField(filter.field);
 
-const validatePublicApiV2InputOutputFilters = (filter: FilterList) => {
+const validateIndexedInputOutputFilters = (filter: FilterList) => {
   const hasIoFilter = filter.some(isInputOutputFilter);
   if (!hasIoFilter) {
     return;
@@ -1135,8 +1136,8 @@ function buildObservationsQueryComponents(
     eventsTableCols,
   );
 
-  if (options.requireIndexedIoFilter) {
-    validatePublicApiV2InputOutputFilters(observationsFilter);
+  if (!options.allowUnindexedIoFilters) {
+    validateIndexedInputOutputFilters(observationsFilter);
   }
 
   // Determine if we need to join traces (check both simple params and advanced filters)
@@ -1146,9 +1147,7 @@ function buildObservationsQueryComponents(
   const filtersNeedFullTable = observationsFilter.some(
     (f) =>
       f.clickhouseTable.startsWith("events") &&
-      (f.field === "e.input" ||
-        f.field === "e.output" ||
-        f.field === "metadata"),
+      (isFtsTextField(f.field) || isFtsMetadataField(f.field)),
   );
 
   // Extract time filter and apply filters
@@ -1191,6 +1190,7 @@ function buildObservationsQueryBase(
   const { queryBuilder, externalCTEs } = buildObservationsQueryComponents(
     opts,
     columnDefinitions,
+    { allowUnindexedIoFilters: true },
   );
   for (const cte of externalCTEs) {
     queryBuilder.withCTE(cte.name, cte.queryWithParams);
@@ -1388,7 +1388,6 @@ export const getObservationsV2FromEventsTableForPublicApi = async (
     buildObservationsQueryComponents(
       opts,
       eventsTableNativeUiColumnDefinitions,
-      { requireIndexedIoFilter: true },
     );
 
   baseBuilder.selectFieldSet("core");

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1367,6 +1367,7 @@ export const getObservationsV2FromEventsTableForPublicApi = async (
   opts: PublicApiObservationsQuery & {
     fields: ObservationFieldGroupPublicApi[];
   },
+  options: BuildObservationsQueryComponentsOptions = {},
 ): Promise<Array<EventsObservationPublic>> => {
   const { projectId, expandMetadataKeys } = opts;
 
@@ -1388,6 +1389,7 @@ export const getObservationsV2FromEventsTableForPublicApi = async (
     buildObservationsQueryComponents(
       opts,
       eventsTableNativeUiColumnDefinitions,
+      options,
     );
 
   baseBuilder.selectFieldSet("core");

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -6,7 +6,11 @@ import type {
   ObservationType,
 } from "../../domain";
 import { env } from "../../env";
-import { InternalServerError, LangfuseNotFoundError } from "../../errors";
+import {
+  InternalServerError,
+  InvalidRequestError,
+  LangfuseNotFoundError,
+} from "../../errors";
 import {
   convertDateToClickhouseDateTime,
   PreferredClickhouseService,
@@ -20,6 +24,7 @@ import {
 } from "./traces_converters";
 import {
   DateTimeFilter,
+  type Filter,
   FilterList,
   FullEventsObservations,
   orderByToClickhouseSql,
@@ -27,11 +32,17 @@ import {
   createPublicApiObservationsColumnMapping,
   createPublicApiTracesColumnMapping,
   deriveFilters,
+  isFtsAcceleratedIoOperator,
+  isFtsTextField,
   type ApiColumnMapping,
   ObservationPriceFields,
 } from "../queries";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
-import type { FilterCondition, FilterState } from "../../types";
+import type {
+  FilterCondition,
+  FilterState,
+  PublicApiV2FilterState,
+} from "../../types";
 import type { TracingSearchType } from "../../interfaces/search";
 import {
   eventsScoresAggregation,
@@ -1056,7 +1067,7 @@ type PublicApiObservationsQuery = {
   toStartTime?: string;
   version?: string;
   environment?: string | string[];
-  advancedFilters?: FilterState;
+  advancedFilters?: PublicApiV2FilterState;
   parseIoAsJson?: boolean;
   cursor?: {
     lastStartTimeTo: Date;
@@ -1072,6 +1083,29 @@ type PublicApiObservationsQuery = {
   expandMetadataKeys?: string[] | null;
 };
 
+type BuildObservationsQueryComponentsOptions = {
+  requireIndexedIoFilter?: boolean;
+};
+
+const isInputOutputFilter = (filter: Filter): boolean =>
+  isFtsTextField(filter.field);
+
+const validatePublicApiV2InputOutputFilters = (filter: FilterList) => {
+  const hasIoFilter = filter.some(isInputOutputFilter);
+  if (!hasIoFilter) {
+    return;
+  }
+
+  const hasRequiredIoFilter = filter.some(
+    (f) => isInputOutputFilter(f) && isFtsAcceleratedIoOperator(f.operator),
+  );
+  if (!hasRequiredIoFilter) {
+    throw new InvalidRequestError(
+      "Input/output filters require at least one `matches` or `=` operator.",
+    );
+  }
+};
+
 /**
  * Build observation query components: an EventsQueryBuilder (with JOINs and filters but
  * without CTEs) and any external CTEs that should be composed at the outer level.
@@ -1082,6 +1116,7 @@ type PublicApiObservationsQuery = {
 function buildObservationsQueryComponents(
   opts: PublicApiObservationsQuery,
   columnDefinitions: UiColumnMappings = eventsTableNativeUiColumnDefinitions,
+  options: BuildObservationsQueryComponentsOptions = {},
 ): {
   queryBuilder: EventsQueryBuilder;
   externalCTEs: Array<{
@@ -1099,6 +1134,10 @@ function buildObservationsQueryComponents(
     columnDefinitions,
     eventsTableCols,
   );
+
+  if (options.requireIndexedIoFilter) {
+    validatePublicApiV2InputOutputFilters(observationsFilter);
+  }
 
   // Determine if we need to join traces (check both simple params and advanced filters)
   const hasTraceFilter = observationsFilter.some(
@@ -1349,6 +1388,7 @@ export const getObservationsV2FromEventsTableForPublicApi = async (
     buildObservationsQueryComponents(
       opts,
       eventsTableNativeUiColumnDefinitions,
+      { requireIndexedIoFilter: true },
     );
 
   baseBuilder.selectFieldSet("core");

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -33,6 +33,7 @@ import {
   createPublicApiTracesColumnMapping,
   deriveFilters,
   isFtsAcceleratedIoOperator,
+  isFtsEventsTable,
   isFtsMetadataField,
   isFtsTextField,
   type ApiColumnMapping,
@@ -95,7 +96,10 @@ import {
   OrderByEntry,
 } from "../queries/clickhouse-sql/event-query-builder";
 import { type EventsObservationPublic } from "../queries/createGenerationsQuery";
-import { UiColumnMappings } from "../../tableDefinitions";
+import {
+  findUiColumnMapping,
+  type UiColumnMappings,
+} from "../../tableDefinitions";
 import { eventsTableCols } from "../../eventsTable";
 import { tracesTableCols } from "../../tableDefinitions/tracesTable";
 import { parseMetadataCHRecordToDomain } from "../utils/metadata_conversion";
@@ -1088,6 +1092,27 @@ type BuildObservationsQueryComponentsOptions = {
   allowUnindexedIoFilters?: boolean;
 };
 
+const EVENTS_IO_FILTER_TYPE_ERROR =
+  "Input/output filters only support filter type `string`.";
+
+const validateInputOutputFilterTypes = (
+  filterState: EventsTableFilterState | undefined,
+  columnDefinitions: UiColumnMappings,
+) => {
+  for (const filter of filterState ?? []) {
+    const column = findUiColumnMapping(columnDefinitions, filter.column);
+
+    if (
+      column &&
+      isFtsEventsTable(column.clickhouseTableName) &&
+      isFtsTextField(column.clickhouseSelect) &&
+      filter.type !== "string"
+    ) {
+      throw new InvalidRequestError(EVENTS_IO_FILTER_TYPE_ERROR);
+    }
+  }
+};
+
 const isInputOutputFilter = (filter: Filter): boolean =>
   isFtsTextField(filter.field);
 
@@ -1126,6 +1151,10 @@ function buildObservationsQueryComponents(
   }>;
 } {
   const { projectId, advancedFilters, ...filterParams } = opts;
+
+  if (!options.allowUnindexedIoFilters) {
+    validateInputOutputFilterTypes(advancedFilters, columnDefinitions);
+  }
 
   // Convert and merge simple and advanced filters
   const observationsFilter = deriveFilters(

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,6 +1,7 @@
 import { type z } from "zod";
 import {
-  FTS_MATCH_OPERATOR,
+  eventsTableFilterState,
+  eventsTableSingleFilter,
   singleFilter,
   timeFilter,
 } from "./interfaces/filters";
@@ -9,24 +10,10 @@ import {
 export type TimeFilter = z.infer<typeof timeFilter>;
 export type FilterCondition = z.infer<typeof singleFilter>;
 export type FilterState = FilterCondition[];
-export type PublicApiV2StringFilterCondition = Omit<
-  Extract<FilterCondition, { type: "string" }>,
-  "operator"
-> & {
-  operator: typeof FTS_MATCH_OPERATOR;
-};
-export type PublicApiV2StringObjectFilterCondition = Omit<
-  Extract<FilterCondition, { type: "stringObject" }>,
-  "operator"
-> & {
-  operator: typeof FTS_MATCH_OPERATOR;
-};
-export type PublicApiV2FilterCondition =
-  | PublicApiV2StringFilterCondition
-  | PublicApiV2StringObjectFilterCondition;
-export type PublicApiV2FilterState = Array<
-  FilterCondition | PublicApiV2FilterCondition
+export type EventsTableFilterCondition = z.infer<
+  typeof eventsTableSingleFilter
 >;
+export type EventsTableFilterState = z.infer<typeof eventsTableFilterState>;
 
 // to be used in the client during editing
 export type MakeOptional<T> = {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,10 +1,32 @@
 import { type z } from "zod";
-import { singleFilter, timeFilter } from "./interfaces/filters";
+import {
+  FTS_MATCH_OPERATOR,
+  singleFilter,
+  timeFilter,
+} from "./interfaces/filters";
 
 // to be sent to the server
 export type TimeFilter = z.infer<typeof timeFilter>;
 export type FilterCondition = z.infer<typeof singleFilter>;
 export type FilterState = FilterCondition[];
+export type PublicApiV2StringFilterCondition = Omit<
+  Extract<FilterCondition, { type: "string" }>,
+  "operator"
+> & {
+  operator: typeof FTS_MATCH_OPERATOR;
+};
+export type PublicApiV2StringObjectFilterCondition = Omit<
+  Extract<FilterCondition, { type: "stringObject" }>,
+  "operator"
+> & {
+  operator: typeof FTS_MATCH_OPERATOR;
+};
+export type PublicApiV2FilterCondition =
+  | PublicApiV2StringFilterCondition
+  | PublicApiV2StringObjectFilterCondition;
+export type PublicApiV2FilterState = Array<
+  FilterCondition | PublicApiV2FilterCondition
+>;
 
 // to be used in the client during editing
 export type MakeOptional<T> = {

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3303,12 +3303,12 @@ paths:
                 "column": string,         // Required. Column to filter on (see available columns below)
                 "operator": string,       // Required. Operator based on type:
                                           // - datetime: ">", "<", ">=", "<="
-                                          // - string: "=", "contains", "does not contain", "starts with", "ends with"
+                                          // - string: "=", "contains", "does not contain", "starts with", "ends with", "matches"
                                           // - stringOptions: "any of", "none of"
                                           // - categoryOptions: "any of", "none of"
                                           // - arrayOptions: "any of", "none of", "all of"
                                           // - number: "=", ">", "<", ">=", "<="
-                                          // - stringObject: "=", "contains", "does not contain", "starts with", "ends with"
+                                          // - stringObject: "=", "contains", "does not contain", "starts with", "ends with", "matches"
                                           // - numberObject: "=", ">", "<", ">=", "<="
                                           // - boolean: "=", "<>"
                                           // - null: "is null", "is not null"
@@ -3399,9 +3399,22 @@ paths:
 
             ### Structured Data
 
+            - `input` (string) - Observation input. Supports accelerated token
+            search with the `matches` operator.
+
+            - `output` (string) - Observation output. Supports accelerated token
+            search with the `matches` operator.
+
             - `metadata` (stringObject/numberObject/categoryOptions) - Metadata
             key-value pairs. Use `key` parameter to filter on specific metadata
             keys.
+
+
+            The `matches` operator is only supported for `input`, `output`, and
+            stringObject `metadata` filters. It performs token-based full-text
+            search using the events table text indexes. For input/output it is
+            case-insensitive; for metadata values it is case-sensitive. Use
+            `contains` for substring semantics.
 
 
             ## Filter Examples
@@ -3427,6 +3440,12 @@ paths:
                 "key": "environment",
                 "operator": "=",
                 "value": "production"
+              },
+              {
+                "type": "string",
+                "column": "output",
+                "operator": "matches",
+                "value": "needle"
               }
             ]
 

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -3412,9 +3412,13 @@ paths:
 
             The `matches` operator is only supported for `input`, `output`, and
             stringObject `metadata` filters. It performs token-based full-text
-            search using the events table text indexes. For input/output it is
-            case-insensitive; for metadata values it is case-sensitive. Use
-            `contains` for substring semantics.
+            search using the events table text indexes. Case sensitivity differs
+            by target: `input` and `output` matches are case-insensitive, while
+            metadata value matches are case-sensitive. Use `contains` for
+            substring semantics. Any v2 `input` or `output` filter must be
+            accompanied by at least one `=` or `matches` filter on `input` or
+            `output`; standalone `contains`, `starts with`, `ends with`, and
+            `does not contain` filters on these columns are rejected.
 
 
             ## Filter Examples

--- a/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
+++ b/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
@@ -336,41 +336,6 @@ describe("createFilterFromFilterState filter type validation", () => {
     expect(query).toContain("hasAllTokens(lower(e.input), lower(");
   });
 
-  it.each([
-    {
-      column: "input",
-      mapping: "eventInput",
-    },
-    {
-      column: "output",
-      mapping: "eventOutput",
-    },
-  ] as const)(
-    "rejects non-string filters on event $column",
-    ({ column, mapping }) => {
-      const filters = [
-        {
-          column,
-          type: "null",
-          operator: "is null",
-          value: "",
-        },
-      ] satisfies EventsTableFilterState;
-
-      expect(() =>
-        createFilterFromFilterState(
-          filters,
-          [mappings[mapping]],
-          columnDefinitions,
-        ),
-      ).toThrow(
-        new InvalidRequestError(
-          "Input/output filters only support filter type `string`.",
-        ),
-      );
-    },
-  );
-
   it("generates case-sensitive FTS SQL for event metadata matches", () => {
     const filters = [
       {

--- a/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
+++ b/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
@@ -336,6 +336,41 @@ describe("createFilterFromFilterState filter type validation", () => {
     expect(query).toContain("hasAllTokens(lower(e.input), lower(");
   });
 
+  it.each([
+    {
+      column: "input",
+      mapping: "eventInput",
+    },
+    {
+      column: "output",
+      mapping: "eventOutput",
+    },
+  ] as const)(
+    "rejects non-string filters on event $column",
+    ({ column, mapping }) => {
+      const filters = [
+        {
+          column,
+          type: "null",
+          operator: "is null",
+          value: "",
+        },
+      ] satisfies EventsTableFilterState;
+
+      expect(() =>
+        createFilterFromFilterState(
+          filters,
+          [mappings[mapping]],
+          columnDefinitions,
+        ),
+      ).toThrow(
+        new InvalidRequestError(
+          "Input/output filters only support filter type `string`.",
+        ),
+      );
+    },
+  );
+
   it("generates case-sensitive FTS SQL for event metadata matches", () => {
     const filters = [
       {

--- a/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
+++ b/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
@@ -3,6 +3,7 @@ import {
   InvalidRequestError,
   type UiColumnMapping,
   type ColumnDefinition,
+  type EventsTableFilterState,
 } from "@langfuse/shared";
 
 describe("createFilterFromFilterState filter type validation", () => {
@@ -291,15 +292,17 @@ describe("createFilterFromFilterState filter type validation", () => {
   });
 
   it("generates case-insensitive FTS SQL for event input/output matches", () => {
+    const filters = [
+      {
+        column: "output",
+        type: "string",
+        operator: "matches",
+        value: "needle",
+      },
+    ] satisfies EventsTableFilterState;
+
     const [result] = createFilterFromFilterState(
-      [
-        {
-          column: "output",
-          type: "string",
-          operator: "matches",
-          value: "needle",
-        } as any,
-      ],
+      filters,
       [mappings.eventOutput],
       columnDefinitions,
     );
@@ -334,16 +337,18 @@ describe("createFilterFromFilterState filter type validation", () => {
   });
 
   it("generates case-sensitive FTS SQL for event metadata matches", () => {
+    const filters = [
+      {
+        column: "metadata",
+        type: "stringObject",
+        operator: "matches",
+        key: "source",
+        value: "needle",
+      },
+    ] satisfies EventsTableFilterState;
+
     const [result] = createFilterFromFilterState(
-      [
-        {
-          column: "metadata",
-          type: "stringObject",
-          operator: "matches",
-          key: "source",
-          value: "needle",
-        } as any,
-      ],
+      filters,
       [mappings.eventMetadata],
       columnDefinitions,
     );
@@ -362,48 +367,55 @@ describe("createFilterFromFilterState filter type validation", () => {
   it.each([
     {
       description: "non-indexed event string column",
-      filter: {
-        column: "eventName",
-        type: "string",
-        operator: "matches",
-        value: "needle",
-      },
+      filters: [
+        {
+          column: "eventName",
+          type: "string",
+          operator: "matches",
+          value: "needle",
+        },
+      ] satisfies EventsTableFilterState,
       mapping: "eventName",
       colDefs: columnDefinitions,
+      expectedMessage:
+        "`matches` is only supported for input, output, and metadata filters.",
     },
     {
       description: "non-events table",
-      filter: {
-        column: "metadata",
-        type: "stringObject",
-        operator: "matches",
-        key: "source",
-        value: "needle",
-      },
+      filters: [
+        {
+          column: "metadata",
+          type: "stringObject",
+          operator: "matches",
+          key: "source",
+          value: "needle",
+        },
+      ] satisfies EventsTableFilterState,
       mapping: "metadata",
       colDefs: columnDefinitions,
+      expectedMessage:
+        "`matches` is only supported for input, output, and metadata filters.",
     },
     {
       description: "tokenless value",
-      filter: {
-        column: "output",
-        type: "string",
-        operator: "matches",
-        value: "!!!",
-      },
+      filters: [
+        {
+          column: "output",
+          type: "string",
+          operator: "matches",
+          value: "!!!",
+        },
+      ] satisfies EventsTableFilterState,
       mapping: "eventOutput",
       colDefs: columnDefinitions,
+      expectedMessage: "`matches` requires at least one search token.",
     },
   ] as const)(
     "rejects matches on $description",
-    ({ filter, mapping, colDefs }) => {
+    ({ filters, mapping, colDefs, expectedMessage }) => {
       expect(() =>
-        createFilterFromFilterState(
-          [filter as any],
-          [mappings[mapping]],
-          colDefs,
-        ),
-      ).toThrow(InvalidRequestError);
+        createFilterFromFilterState(filters, [mappings[mapping]], colDefs),
+      ).toThrow(new InvalidRequestError(expectedMessage));
     },
   );
 });

--- a/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
+++ b/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
@@ -47,6 +47,31 @@ describe("createFilterFromFilterState filter type validation", () => {
       clickhouseTableName: "scores",
       clickhouseSelect: "s.score_categories",
     },
+    eventInput: {
+      uiTableName: "Input",
+      uiTableId: "input",
+      clickhouseTableName: "events_proto",
+      clickhouseSelect: "e.input",
+    },
+    eventOutput: {
+      uiTableName: "Output",
+      uiTableId: "output",
+      clickhouseTableName: "events_proto",
+      clickhouseSelect: "e.output",
+    },
+    eventMetadata: {
+      uiTableName: "Metadata",
+      uiTableId: "metadata",
+      clickhouseTableName: "events_proto",
+      clickhouseSelect: "metadata",
+      queryPrefix: "e",
+    },
+    eventName: {
+      uiTableName: "Event Name",
+      uiTableId: "eventName",
+      clickhouseTableName: "events_proto",
+      clickhouseSelect: "e.name",
+    },
   };
 
   const columnDefinitions: ColumnDefinition[] = [
@@ -89,6 +114,24 @@ describe("createFilterFromFilterState filter type validation", () => {
       type: "categoryOptions",
       internal: "s.score_categories",
       options: [],
+    },
+    {
+      name: "Input",
+      id: "input",
+      type: "string",
+      internal: "e.input",
+    },
+    {
+      name: "Output",
+      id: "output",
+      type: "string",
+      internal: "e.output",
+    },
+    {
+      name: "Event Name",
+      id: "eventName",
+      type: "string",
+      internal: "e.name",
     },
   ];
 
@@ -246,4 +289,121 @@ describe("createFilterFromFilterState filter type validation", () => {
     );
     expect(result).toHaveLength(1);
   });
+
+  it("generates case-insensitive FTS SQL for event input/output matches", () => {
+    const [result] = createFilterFromFilterState(
+      [
+        {
+          column: "output",
+          type: "string",
+          operator: "matches",
+          value: "needle",
+        } as any,
+      ],
+      [mappings.eventOutput],
+      columnDefinitions,
+    );
+
+    const { query, params } = result.apply();
+    const paramName = Object.keys(params)[0];
+
+    expect(query).toBe(
+      `hasAllTokens(lower(e.output), lower({${paramName}: String}))`,
+    );
+    expect(params).toEqual({ [paramName]: "needle" });
+  });
+
+  it("keeps equality acceleration for event input/output filters", () => {
+    const [result] = createFilterFromFilterState(
+      [
+        {
+          column: "input",
+          type: "string",
+          operator: "=",
+          value: "needle",
+        },
+      ],
+      [mappings.eventInput],
+      columnDefinitions,
+    );
+
+    const { query } = result.apply();
+
+    expect(query).toContain("e.input =");
+    expect(query).toContain("hasAllTokens(lower(e.input), lower(");
+  });
+
+  it("generates case-sensitive FTS SQL for event metadata matches", () => {
+    const [result] = createFilterFromFilterState(
+      [
+        {
+          column: "metadata",
+          type: "stringObject",
+          operator: "matches",
+          key: "source",
+          value: "needle",
+        } as any,
+      ],
+      [mappings.eventMetadata],
+      columnDefinitions,
+    );
+
+    const { query, params } = result.apply();
+
+    expect(query).toContain("has(e.metadata_names,");
+    expect(query).toContain("hasAllTokens(e.metadata_values,");
+    expect(query).toContain(
+      "hasAllTokens(e.metadata_values[indexOf(e.metadata_names,",
+    );
+    expect(query).not.toContain("lower(");
+    expect(Object.values(params)).toEqual(["source", "needle"]);
+  });
+
+  it.each([
+    {
+      description: "non-indexed event string column",
+      filter: {
+        column: "eventName",
+        type: "string",
+        operator: "matches",
+        value: "needle",
+      },
+      mapping: "eventName",
+      colDefs: columnDefinitions,
+    },
+    {
+      description: "non-events table",
+      filter: {
+        column: "metadata",
+        type: "stringObject",
+        operator: "matches",
+        key: "source",
+        value: "needle",
+      },
+      mapping: "metadata",
+      colDefs: columnDefinitions,
+    },
+    {
+      description: "tokenless value",
+      filter: {
+        column: "output",
+        type: "string",
+        operator: "matches",
+        value: "!!!",
+      },
+      mapping: "eventOutput",
+      colDefs: columnDefinitions,
+    },
+  ] as const)(
+    "rejects matches on $description",
+    ({ filter, mapping, colDefs }) => {
+      expect(() =>
+        createFilterFromFilterState(
+          [filter as any],
+          [mappings[mapping]],
+          colDefs,
+        ),
+      ).toThrow(InvalidRequestError);
+    },
+  );
 });

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -61,24 +61,24 @@ describe("/api/public/v2/observations API Endpoint", () => {
     expect(response.status).toBe(400);
   });
 
-  it("allows legacy v1 contains filters on IO", async () => {
-    const filterParam = JSON.stringify([
-      {
-        type: "string",
-        column: "output",
-        operator: "contains",
-        value: "needle",
-      },
-    ]);
-
-    const response = await getRaw(
-      `/api/public/observations?useEventsTable=true&filter=${encodeURIComponent(filterParam)}`,
-    );
-
-    expect(response.status).toBe(200);
-  });
-
   maybe("GET /api/public/v2/observations", () => {
+    it("allows legacy v1 contains filters on IO", async () => {
+      const filterParam = JSON.stringify([
+        {
+          type: "string",
+          column: "output",
+          operator: "contains",
+          value: "needle",
+        },
+      ]);
+
+      const response = await getRaw(
+        `/api/public/observations?useEventsTable=true&filter=${encodeURIComponent(filterParam)}`,
+      );
+
+      expect(response.status).toBe(200);
+    });
+
     it("should fetch observations with only requested field groups", async () => {
       const traceId = randomUUID();
       const observationId = randomUUID();
@@ -862,6 +862,26 @@ describe("/api/public/v2/observations API Endpoint", () => {
         `/api/public/v2/observations?fields=basic&filter=${encodeURIComponent(metadataMatchesAndIoContainsFilter)}`,
       );
       expect(metadataMatchesAndIoContainsResponse.status).toBe(400);
+    });
+
+    it("rejects non-string public v2 IO filters", async () => {
+      const nullIoFilter = JSON.stringify([
+        {
+          type: "null",
+          column: "output",
+          operator: "is null",
+          value: "",
+        },
+      ]);
+
+      const response = await getRaw(
+        `/api/public/v2/observations?fields=basic&filter=${encodeURIComponent(nullIoFilter)}`,
+      );
+
+      expect(response.status).toBe(400);
+      expect(JSON.stringify(response.body)).toContain(
+        "Input/output filters only support filter type `string`.",
+      );
     });
 
     it.each([

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -864,25 +864,40 @@ describe("/api/public/v2/observations API Endpoint", () => {
       expect(metadataMatchesAndIoContainsResponse.status).toBe(400);
     });
 
-    it("rejects non-string public v2 IO filters", async () => {
-      const nullIoFilter = JSON.stringify([
-        {
+    it.each([
+      {
+        description: "null",
+        filter: {
           type: "null",
           column: "output",
           operator: "is null",
           value: "",
         },
-      ]);
+      },
+      {
+        description: "stringOptions",
+        filter: {
+          type: "stringOptions",
+          column: "output",
+          operator: "any of",
+          value: ["needle"],
+        },
+      },
+    ])(
+      "rejects non-string public v2 IO $description filters",
+      async ({ filter }) => {
+        const filterParam = JSON.stringify([filter]);
 
-      const response = await getRaw(
-        `/api/public/v2/observations?fields=basic&filter=${encodeURIComponent(nullIoFilter)}`,
-      );
+        const response = await getRaw(
+          `/api/public/v2/observations?fields=basic&filter=${encodeURIComponent(filterParam)}`,
+        );
 
-      expect(response.status).toBe(400);
-      expect(JSON.stringify(response.body)).toContain(
-        "Input/output filters only support filter type `string`.",
-      );
-    });
+        expect(response.status).toBe(400);
+        expect(JSON.stringify(response.body)).toContain(
+          "Input/output filters only support filter type `string`.",
+        );
+      },
+    );
 
     it.each([
       {

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -61,6 +61,23 @@ describe("/api/public/v2/observations API Endpoint", () => {
     expect(response.status).toBe(400);
   });
 
+  it("allows legacy v1 contains filters on IO", async () => {
+    const filterParam = JSON.stringify([
+      {
+        type: "string",
+        column: "output",
+        operator: "contains",
+        value: "needle",
+      },
+    ]);
+
+    const response = await getRaw(
+      `/api/public/observations?useEventsTable=true&filter=${encodeURIComponent(filterParam)}`,
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   maybe("GET /api/public/v2/observations", () => {
     it("should fetch observations with only requested field groups", async () => {
       const traceId = randomUUID();

--- a/web/src/__tests__/server/observations-api-v2.servertest.ts
+++ b/web/src/__tests__/server/observations-api-v2.servertest.ts
@@ -44,6 +44,23 @@ describe("/api/public/v2/observations API Endpoint", () => {
     // redis connection when everything else is skipped.
   });
 
+  it("rejects matches filters on v1 observations", async () => {
+    const filterParam = JSON.stringify([
+      {
+        type: "string",
+        column: "output",
+        operator: "matches",
+        value: "needle",
+      },
+    ]);
+
+    const response = await getRaw(
+      `/api/public/observations?useEventsTable=true&filter=${encodeURIComponent(filterParam)}`,
+    );
+
+    expect(response.status).toBe(400);
+  });
+
   maybe("GET /api/public/v2/observations", () => {
     it("should fetch observations with only requested field groups", async () => {
       const traceId = randomUUID();
@@ -574,6 +591,303 @@ describe("/api/public/v2/observations API Endpoint", () => {
       );
       expect(matchedObs).toBeDefined();
       expect(matchedObs?.name).toBe("nested-metadata-obs-1");
+    });
+
+    it("supports token-based matches filters for IO and metadata", async () => {
+      const traceId = randomUUID();
+      const timestamp = new Date();
+      const timeValue = timestamp.getTime() * 1000;
+      const tokenMatchId = randomUUID();
+      const punctuationMatchId = randomUUID();
+      const embeddedOnlyId = randomUUID();
+      const metadataCaseMatchId = randomUUID();
+      const metadataCaseMismatchId = randomUUID();
+      const metadataWrongKeyId = randomUUID();
+      const metadataMultiTokenMatchId = randomUUID();
+      const metadataSplitAcrossValuesId = randomUUID();
+      const metadataMultiTokenWrongKeyId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: tokenMatchId,
+          span_id: tokenMatchId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "io-token-match",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timeValue,
+          output: "Needle in mixed case",
+        }),
+        createEvent({
+          id: punctuationMatchId,
+          span_id: punctuationMatchId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "io-punctuation-match",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timeValue + 1000,
+          output: "needle@gmail.com",
+        }),
+        createEvent({
+          id: embeddedOnlyId,
+          span_id: embeddedOnlyId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "io-embedded-only",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timeValue + 2000,
+          output: "foobarneedle cadabra",
+        }),
+        createEvent({
+          id: metadataCaseMatchId,
+          span_id: metadataCaseMatchId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "metadata-case-match",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timeValue + 3000,
+          metadata: { source: "needle API" },
+          metadata_names: ["source"],
+          metadata_values: ["needle API"],
+        }),
+        createEvent({
+          id: metadataCaseMismatchId,
+          span_id: metadataCaseMismatchId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "metadata-case-mismatch",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timeValue + 4000,
+          metadata: { source: "Needle API" },
+          metadata_names: ["source"],
+          metadata_values: ["Needle API"],
+        }),
+        createEvent({
+          id: metadataWrongKeyId,
+          span_id: metadataWrongKeyId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "metadata-wrong-key",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timeValue + 5000,
+          metadata: { other: "needle API" },
+          metadata_names: ["other"],
+          metadata_values: ["needle API"],
+        }),
+        createEvent({
+          id: metadataMultiTokenMatchId,
+          span_id: metadataMultiTokenMatchId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "metadata-multi-token-match",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timeValue + 6000,
+          metadata: { source: "alpha beta" },
+          metadata_names: ["source"],
+          metadata_values: ["alpha beta"],
+        }),
+        createEvent({
+          id: metadataSplitAcrossValuesId,
+          span_id: metadataSplitAcrossValuesId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "metadata-split-across-values",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timeValue + 7000,
+          metadata: { source: "alpha", other: "beta" },
+          metadata_names: ["source", "other"],
+          metadata_values: ["alpha", "beta"],
+        }),
+        createEvent({
+          id: metadataMultiTokenWrongKeyId,
+          span_id: metadataMultiTokenWrongKeyId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: "metadata-multi-token-wrong-key",
+          type: "GENERATION",
+          level: "DEFAULT",
+          start_time: timeValue + 8000,
+          metadata: { source: "unrelated", other: "alpha beta" },
+          metadata_names: ["source", "other"],
+          metadata_values: ["unrelated", "alpha beta"],
+        }),
+      ]);
+
+      await waitForExpect(
+        async () => {
+          const result = await queryClickhouse<{ count: string }>({
+            query: `SELECT count() as count FROM events_core WHERE project_id = {projectId: String} AND trace_id = {traceId: String}`,
+            params: { projectId, traceId },
+          });
+          expect(Number(result[0]?.count)).toBeGreaterThanOrEqual(9);
+        },
+        5000,
+        10,
+      );
+
+      const ioFilterParam = JSON.stringify([
+        {
+          type: "string",
+          column: "output",
+          operator: "matches",
+          value: "needle",
+        },
+      ]);
+      const ioResponse = await getObservations(
+        `/api/public/v2/observations?traceId=${traceId}&fields=basic,io&filter=${encodeURIComponent(ioFilterParam)}`,
+      );
+      const ioIds = ioResponse.body.data.map((obs: any) => obs.id);
+
+      expect(ioResponse.status).toBe(200);
+      expect(ioIds).toEqual(
+        expect.arrayContaining([tokenMatchId, punctuationMatchId]),
+      );
+      expect(ioIds).not.toContain(embeddedOnlyId);
+
+      const metadataFilterParam = JSON.stringify([
+        {
+          type: "stringObject",
+          column: "metadata",
+          operator: "matches",
+          key: "source",
+          value: "needle",
+        },
+      ]);
+      const metadataResponse = await getObservations(
+        `/api/public/v2/observations?traceId=${traceId}&fields=basic,metadata&filter=${encodeURIComponent(metadataFilterParam)}`,
+      );
+      const metadataIds = metadataResponse.body.data.map((obs: any) => obs.id);
+
+      expect(metadataResponse.status).toBe(200);
+      expect(metadataIds).toContain(metadataCaseMatchId);
+      expect(metadataIds).not.toContain(metadataCaseMismatchId);
+      expect(metadataIds).not.toContain(metadataWrongKeyId);
+
+      const multiTokenMetadataFilterParam = JSON.stringify([
+        {
+          type: "stringObject",
+          column: "metadata",
+          operator: "matches",
+          key: "source",
+          value: "alpha beta",
+        },
+      ]);
+      const multiTokenMetadataResponse = await getObservations(
+        `/api/public/v2/observations?traceId=${traceId}&fields=basic,metadata&filter=${encodeURIComponent(multiTokenMetadataFilterParam)}`,
+      );
+      const multiTokenMetadataIds = multiTokenMetadataResponse.body.data.map(
+        (obs: any) => obs.id,
+      );
+
+      expect(multiTokenMetadataResponse.status).toBe(200);
+      expect(multiTokenMetadataIds).toContain(metadataMultiTokenMatchId);
+      expect(multiTokenMetadataIds).not.toContain(metadataSplitAcrossValuesId);
+      expect(multiTokenMetadataIds).not.toContain(metadataMultiTokenWrongKeyId);
+    });
+
+    it("rejects public v2 IO filters that are guaranteed to be slow", async () => {
+      const containsOnlyFilter = JSON.stringify([
+        {
+          type: "string",
+          column: "output",
+          operator: "contains",
+          value: "needle",
+        },
+      ]);
+      const containsOnlyResponse = await getRaw(
+        `/api/public/v2/observations?fields=basic&filter=${encodeURIComponent(containsOnlyFilter)}`,
+      );
+      expect(containsOnlyResponse.status).toBe(400);
+
+      const matchesAndContainsFilter = JSON.stringify([
+        {
+          type: "string",
+          column: "output",
+          operator: "matches",
+          value: "needle",
+        },
+        {
+          type: "string",
+          column: "output",
+          operator: "contains",
+          value: "needle",
+        },
+      ]);
+      const matchesAndContainsResponse = await getRaw(
+        `/api/public/v2/observations?fields=basic&filter=${encodeURIComponent(matchesAndContainsFilter)}`,
+      );
+      expect(matchesAndContainsResponse.status).toBe(200);
+
+      const metadataMatchesAndIoContainsFilter = JSON.stringify([
+        {
+          type: "stringObject",
+          column: "metadata",
+          operator: "matches",
+          key: "source",
+          value: "needle",
+        },
+        {
+          type: "string",
+          column: "output",
+          operator: "contains",
+          value: "needle",
+        },
+      ]);
+      const metadataMatchesAndIoContainsResponse = await getRaw(
+        `/api/public/v2/observations?fields=basic&filter=${encodeURIComponent(metadataMatchesAndIoContainsFilter)}`,
+      );
+      expect(metadataMatchesAndIoContainsResponse.status).toBe(400);
+    });
+
+    it.each([
+      {
+        description: "non-indexed event column",
+        filter: [
+          {
+            type: "string",
+            column: "name",
+            operator: "matches",
+            value: "needle",
+          },
+        ],
+      },
+      {
+        description: "empty value",
+        filter: [
+          {
+            type: "string",
+            column: "output",
+            operator: "matches",
+            value: "",
+          },
+        ],
+      },
+      {
+        description: "tokenless value",
+        filter: [
+          {
+            type: "stringObject",
+            column: "metadata",
+            operator: "matches",
+            key: "source",
+            value: "!!!",
+          },
+        ],
+      },
+    ])("rejects matches filters with $description", async ({ filter }) => {
+      const response = await getRaw(
+        `/api/public/v2/observations?fields=basic&filter=${encodeURIComponent(JSON.stringify(filter))}`,
+      );
+
+      expect(response.status).toBe(400);
     });
   });
 

--- a/web/src/features/mcp/features/observations/tools/listObservations.ts
+++ b/web/src/features/mcp/features/observations/tools/listObservations.ts
@@ -325,30 +325,35 @@ export const [listObservationsTool, handleListObservations] = defineTool({
           "mcp.field_groups": fieldGroups.join(","),
         });
 
-        const items = await getObservationsV2FromEventsTableForPublicApi({
-          projectId: context.projectId,
-          page: 0,
-          limit: input.limit,
-          traceId: input.traceId,
-          userId: input.userId,
-          level: input.level,
-          name: input.name,
-          type: input.type,
-          environment: input.environment,
-          parentObservationId: input.parentObservationId,
-          fromStartTime: input.fromStartTime,
-          toStartTime: input.toStartTime,
-          version: input.version,
-          advancedFilters: input.filter,
-          cursor: input.cursor
-            ? EncodedObservationsCursorV2.parse(input.cursor)
-            : undefined,
-          fields: fieldGroups,
-          expandMetadataKeys: getMetadataExpansionForProjection(
-            projectionFields,
-            input.expandMetadataKeys,
-          ),
-        });
+        const items = await getObservationsV2FromEventsTableForPublicApi(
+          {
+            projectId: context.projectId,
+            page: 0,
+            limit: input.limit,
+            traceId: input.traceId,
+            userId: input.userId,
+            level: input.level,
+            name: input.name,
+            type: input.type,
+            environment: input.environment,
+            parentObservationId: input.parentObservationId,
+            fromStartTime: input.fromStartTime,
+            toStartTime: input.toStartTime,
+            version: input.version,
+            advancedFilters: input.filter,
+            cursor: input.cursor
+              ? EncodedObservationsCursorV2.parse(input.cursor)
+              : undefined,
+            fields: fieldGroups,
+            expandMetadataKeys: getMetadataExpansionForProjection(
+              projectionFields,
+              input.expandMetadataKeys,
+            ),
+          },
+          // MCP keeps the legacy observation filter contract. Its separate
+          // selective-scope guard above limits expensive input/output filters.
+          { allowUnindexedIoFilters: true },
+        );
 
         const hasMore = items.length > input.limit;
         const dataToReturn = hasMore ? items.slice(0, input.limit) : items;

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -2,21 +2,10 @@ import {
   type Observation,
   type EventsObservation,
   ObservationLevel,
-  FTS_MATCH_OPERATOR,
-  arrayOptionsFilter,
-  booleanFilter,
-  categoryOptionsFilter,
-  filterOperators,
+  eventsTableSingleFilter,
   paginationMetaResponseZod,
   publicApiPaginationZod,
-  nullFilter,
-  numberFilter,
-  numberObjectFilter,
-  positionInTraceFilter,
   singleFilter,
-  stringObjectFilter,
-  stringOptionsFilter,
-  timeFilter,
   InvalidRequestError,
 } from "@langfuse/shared";
 import {
@@ -323,36 +312,6 @@ export const encodeCursor = (
   ).toString("base64");
 };
 
-const publicV2EventsStringOperator = z.union([
-  z.enum(filterOperators.string),
-  z.literal(FTS_MATCH_OPERATOR),
-]);
-
-const publicV2EventsStringFilter = z.object({
-  column: z.string(),
-  operator: publicV2EventsStringOperator,
-  value: z.string(),
-  type: z.literal("string"),
-});
-
-const publicV2EventsStringObjectFilter = stringObjectFilter.extend({
-  operator: publicV2EventsStringOperator,
-});
-
-const publicV2EventsSingleFilter = z.discriminatedUnion("type", [
-  timeFilter,
-  publicV2EventsStringFilter,
-  numberFilter,
-  stringOptionsFilter,
-  categoryOptionsFilter,
-  arrayOptionsFilter,
-  publicV2EventsStringObjectFilter,
-  numberObjectFilter,
-  booleanFilter,
-  nullFilter,
-  positionInTraceFilter,
-]);
-
 // GET /v2/observations
 export const GetObservationsV2Query = z.object({
   // Field groups parameter (optional - defaults to all groups)
@@ -421,7 +380,7 @@ export const GetObservationsV2Query = z.object({
         throw new InvalidRequestError("Invalid JSON in filter parameter");
       }
     })
-    .pipe(z.array(publicV2EventsSingleFilter).optional()),
+    .pipe(z.array(eventsTableSingleFilter).optional()),
 });
 
 /**

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -2,9 +2,21 @@ import {
   type Observation,
   type EventsObservation,
   ObservationLevel,
+  FTS_MATCH_OPERATOR,
+  arrayOptionsFilter,
+  booleanFilter,
+  categoryOptionsFilter,
+  filterOperators,
   paginationMetaResponseZod,
   publicApiPaginationZod,
+  nullFilter,
+  numberFilter,
+  numberObjectFilter,
+  positionInTraceFilter,
   singleFilter,
+  stringObjectFilter,
+  stringOptionsFilter,
+  timeFilter,
   InvalidRequestError,
 } from "@langfuse/shared";
 import {
@@ -311,6 +323,36 @@ export const encodeCursor = (
   ).toString("base64");
 };
 
+const publicV2EventsStringOperator = z.union([
+  z.enum(filterOperators.string),
+  z.literal(FTS_MATCH_OPERATOR),
+]);
+
+const publicV2EventsStringFilter = z.object({
+  column: z.string(),
+  operator: publicV2EventsStringOperator,
+  value: z.string(),
+  type: z.literal("string"),
+});
+
+const publicV2EventsStringObjectFilter = stringObjectFilter.extend({
+  operator: publicV2EventsStringOperator,
+});
+
+const publicV2EventsSingleFilter = z.discriminatedUnion("type", [
+  timeFilter,
+  publicV2EventsStringFilter,
+  numberFilter,
+  stringOptionsFilter,
+  categoryOptionsFilter,
+  arrayOptionsFilter,
+  publicV2EventsStringObjectFilter,
+  numberObjectFilter,
+  booleanFilter,
+  nullFilter,
+  positionInTraceFilter,
+]);
+
 // GET /v2/observations
 export const GetObservationsV2Query = z.object({
   // Field groups parameter (optional - defaults to all groups)
@@ -379,7 +421,7 @@ export const GetObservationsV2Query = z.object({
         throw new InvalidRequestError("Invalid JSON in filter parameter");
       }
     })
-    .pipe(z.array(singleFilter).optional()),
+    .pipe(z.array(publicV2EventsSingleFilter).optional()),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Adds `matches` as a public v2 observations operator for `events_*` input, output, and metadata filters.
- Centralizes FTS validation and SQL emission in shared ClickHouse helpers.
- Keeps v1 behavior unchanged while enforcing accelerated IO filters on the v2 events path.
- Updates Fern and generated OpenAPI so the contract matches the implementation.

## Testing
- Targeted server tests for observations v2, FTS rewrites, and filter validation passed.
- Shared typecheck, targeted ESLint, and diff whitespace checks passed.
- Added coverage for v1 rejection, IO acceleration rules, and metadata token-matching edge cases.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `matches` operator for `input`, `output`, and `metadata` string filters on the v2 observations API, routing them through ClickHouse text indexes (`hasAllTokens`). It centralises FTS SQL emission into `FTS_OPERATOR_DESCRIPTORS`, adds `assertValidFtsMatchFilter` to reject invalid targets/tokenless values, and enforces that any v2 IO filter request must include at least one indexed (`=` or `matches`) IO predicate.

- `eventsTableSingleFilter` / `eventsTableStringFilter` / `eventsTableStringObjectFilter` extend the existing filter schemas with the new `matches` operator, while keeping v1 using the unmodified `singleFilter`.
- `validateIndexedInputOutputFilters` is introduced on the v2 code path to reject requests that would trigger full-table IO scans without an accompanying indexed predicate.
- Generated OpenAPI/Fern definitions are updated to document the new operator and its semantics (case-insensitive for IO, case-sensitive for metadata).
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The v2 IO-filter gate incorrectly blocks null filters on input/output columns; v1 behavior is unaffected.

The `isInputOutputFilter` helper catches any filter on an input/output field including null filters, so a standalone `input is null` v2 request passes Zod but is rejected with a misleading error. No test covers this scenario.

packages/shared/src/server/repositories/events.ts — the `isInputOutputFilter` helper and `validateIndexedInputOutputFilters` function around lines 927–943.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ZodValidation as Zod (eventsTableSingleFilter)
    participant Factory as createFilterFromFilterState
    participant FtsValidator as assertValidFtsMatchFilter
    participant IoValidator as validateIndexedInputOutputFilters
    participant ClickHouse

    Client->>ZodValidation: "POST /v2/observations?filter=[{operator:matches,...}]"
    ZodValidation-->>Client: 400 if operator not in eventsTableSingleFilter
    ZodValidation->>Factory: validated EventsTableFilterState
    Factory->>FtsValidator: validateEventsTableMatchesFilter (token/target check)
    FtsValidator-->>Client: 400 InvalidRequestError if invalid target or tokenless value
    Factory-->>Factory: build StringFilter / StringObjectFilter
    Factory->>IoValidator: validateIndexedInputOutputFilters(FilterList)
    IoValidator-->>Client: "400 if IO filter present with no = or matches sibling"
    IoValidator->>ClickHouse: hasAllTokens(lower(field), lower(param)) SQL
    ClickHouse-->>Client: 200 matching observations
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/repositories/events.ts:927-943
**Null filters on IO columns incorrectly rejected in v2**

`isInputOutputFilter` returns `true` for any filter whose field resolves to `input` or `output`, including `NullFilter` (operator `"is null"` / `"is not null"`). Because `isFtsAcceleratedIoOperator("is null")` returns `false`, a request like `{ type: "null", column: "input", operator: "is null" }` will pass Zod validation against `eventsTableSingleFilter` (which includes `nullFilter` unchanged), be converted to a `NullFilter`, and then be rejected with `"Input/output filters require at least one \`matches\` or \`=\` operator."` — a misleading 400 that blocks a semantically valid query.

The fix is to narrow `isInputOutputFilter` to only string-operator filters, e.g.:

`const isInputOutputFilter = (filter: Filter): boolean => isFtsTextField(filter.field) && isFtsAcceleratedIoOperator(filter.operator);`

With this form the function returns `true` only for filters that are themselves accelerated IO filters, which can be used directly as the guard without a second `.some` pass.

### Issue 2 of 2
packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts:164-178
**`assertValidFtsMatchFilter` called twice for `matches` filters on the factory path**

`createFilterFromFilterState` in `factory.ts` already calls `validateEventsTableMatchesFilter` → `assertValidFtsMatchFilter` before constructing the `StringFilter`. When the caller then invokes `apply()`, `assertValidFtsMatchFilter` runs again with identical arguments. This is harmless on the happy path, but any future change to validation semantics must be kept in sync across both sites. Consider removing the call from `apply()` (relying on the factory-level guard) or removing it from the factory (relying on `apply()`).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: refactor and consolidate a bit"](https://github.com/langfuse/langfuse/commit/8c87a26d44c1532e8eb7c35fbfa0396206e49396) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34023525)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->