### PR TITLE
fix(ui-saved-views): do not restore view filters if queryparams are provided

### DIFF
--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -64,7 +64,7 @@ const hasQueryParam = (
 ) => {
   const value = query[key];
   if (Array.isArray(value)) return value.length > 0;
-  return value !== undefined;
+  return value !== undefined && value !== "";
 };
 
 const hasExplicitTableStateInUrl = (query: NextRouter["query"]) =>

--- a/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
+++ b/web/src/components/table/table-view-presets/hooks/useTableViewManager.ts
@@ -6,7 +6,7 @@ import {
   type TableViewPresetState,
   type ColumnDefinition,
 } from "@langfuse/shared";
-import { useRouter } from "next/router";
+import { type NextRouter, useRouter } from "next/router";
 import { useEffect, useCallback, useState, useRef } from "react";
 import { type VisibilityState } from "@tanstack/react-table";
 import { StringParam } from "use-query-params";
@@ -50,6 +50,25 @@ const isViewApplicableToTable = (
   currentTableName === viewTableName ||
   (currentTableName === TableViewPresetTableName.ObservationsEvents &&
     viewTableName === TableViewPresetTableName.Observations);
+
+const IMPLICIT_VIEW_BLOCKING_QUERY_PARAMS = [
+  "filter",
+  "search",
+  "searchType",
+  "orderBy",
+] as const;
+
+const hasQueryParam = (
+  query: NextRouter["query"],
+  key: (typeof IMPLICIT_VIEW_BLOCKING_QUERY_PARAMS)[number],
+) => {
+  const value = query[key];
+  if (Array.isArray(value)) return value.length > 0;
+  return value !== undefined;
+};
+
+const hasExplicitTableStateInUrl = (query: NextRouter["query"]) =>
+  IMPLICIT_VIEW_BLOCKING_QUERY_PARAMS.some((key) => hasQueryParam(query, key));
 
 /**
  * Hook to manage table view state with permalink support
@@ -161,6 +180,15 @@ export function useTableViewManager({
       return;
     }
 
+    // Query params such as `filter` are explicit table state. They must take
+    // precedence over implicit session/default view restoration, otherwise a
+    // direct filtered URL is immediately overwritten by the restored view.
+    if (hasExplicitTableStateInUrl(router.query)) {
+      setIsInitialized(true);
+      setIsLoading(false);
+      return;
+    }
+
     // Priority 1: Session storage (from a previous visit to this table)
     if (
       storedViewId &&
@@ -191,6 +219,7 @@ export function useTableViewManager({
     isInitialized,
     isRouterReady,
     selectedViewId,
+    router.query,
     storedViewId,
     isDefaultLoading,
     defaultViewId,

--- a/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
+++ b/web/src/features/filters/savedViewImplicitEnvironmentRegression.clienttest.tsx
@@ -11,6 +11,7 @@ import { useSidebarFilterState } from "./hooks/useSidebarFilterState";
 import { DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS } from "./constants/internal-environments";
 import type { FilterConfig } from "./lib/filter-config";
 import { useTableViewManager } from "../../components/table/table-view-presets/hooks/useTableViewManager";
+import { encodeFiltersGeneric } from "./lib/filter-query-encoding";
 
 const mockUseRouter = vi.fn();
 const mockCapture = vi.fn();
@@ -343,6 +344,77 @@ describe("Saved view restore with implicit environment defaults", () => {
     expect(screen.getByTestId("explicit-state").textContent).toContain(
       "checkout",
     );
+  });
+
+  it("does not apply a default saved view over explicit URL filters", async () => {
+    const explicitUrlFilters: FilterState = [
+      {
+        column: "name",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["search"],
+      },
+    ];
+    const encodedFilters = encodeFiltersGeneric(explicitUrlFilters);
+
+    queryParamStore.delete("viewId");
+    queryParamStore.set("filter", encodedFilters);
+    mockUseRouter.mockReturnValue({
+      isReady: true,
+      query: { filter: encodedFilters },
+    });
+    mockGetDefaultUseQuery.mockReturnValue({
+      data: { viewId: "view-1", scope: "project" },
+      isLoading: false,
+    });
+
+    render(<SavedViewHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading-state").textContent).toBe("ready");
+    });
+
+    expect(screen.getByTestId("explicit-state").textContent).toContain(
+      "search",
+    );
+    expect(screen.getByTestId("explicit-state").textContent).not.toContain(
+      "checkout",
+    );
+    expect(queryParamStore.has("viewId")).toBe(false);
+  });
+
+  it("does not restore a stored saved view over explicit URL filters", async () => {
+    const explicitUrlFilters: FilterState = [
+      {
+        column: "name",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["search"],
+      },
+    ];
+    const encodedFilters = encodeFiltersGeneric(explicitUrlFilters);
+
+    queryParamStore.delete("viewId");
+    queryParamStore.set("filter", encodedFilters);
+    mockUseRouter.mockReturnValue({
+      isReady: true,
+      query: { filter: encodedFilters },
+    });
+    sessionStorage.setItem("traces-project-1-viewId", JSON.stringify("view-1"));
+
+    render(<SavedViewHarness />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading-state").textContent).toBe("ready");
+    });
+
+    expect(screen.getByTestId("explicit-state").textContent).toContain(
+      "search",
+    );
+    expect(screen.getByTestId("explicit-state").textContent).not.toContain(
+      "checkout",
+    );
+    expect(queryParamStore.has("viewId")).toBe(false);
   });
 
   it("does not re-apply a saved view after explicit default selection during bootstrap", async () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where navigating directly to a filtered URL (e.g. `/traces?filter=...`) would have its explicit query-param state immediately overwritten by a restored saved view from session storage or a project/user default. The fix adds an early-return in the bootstrap `useEffect` that marks the view manager as initialized without restoring any view when `filter`, `search`, `searchType`, or `orderBy` are present in the URL.

- **`useTableViewManager.ts`**: Adds `IMPLICIT_VIEW_BLOCKING_QUERY_PARAMS`, two pure helper functions (`hasQueryParam`, `hasExplicitTableStateInUrl`), and a priority-0 guard in the resolve effect. `router.query` is added to the effect dependency array so the guard reacts correctly to any query change before initialization completes.
- **`savedViewImplicitEnvironmentRegression.clienttest.tsx`**: Two new test cases are added — one for a project-default view being blocked by URL filters, and one for a session-stored view — both verifying that the URL filter state survives bootstrap and the `viewId` param is never written.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a narrowly-scoped guard in the bootstrap effect, the happy paths are unchanged, and the two new tests directly exercise the fixed scenarios.

The logic is well-structured and the guard correctly sits after the viewId-in-URL check so explicit view permalinks are unaffected. The one minor concern is that hasQueryParam treats an empty-string value (?filter=) as present, which could unnecessarily skip view restoration if any of the watched params appear with no value — an unusual but possible URL shape.

web/src/components/table/table-view-presets/hooks/useTableViewManager.ts — specifically the hasQueryParam return path for non-array values.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/table/table-view-presets/hooks/useTableViewManager.ts:66-67
An empty-string query value (e.g. `?filter=`) passes the check because `value !== undefined` is `true` for `""`. The URL param exists but carries no meaningful state, so it would still block view restoration. Filtering out empty strings makes the intent more explicit and avoids this edge case.

```suggestion
  if (Array.isArray(value)) return value.length > 0;
  return value !== undefined && value !== "";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui-saved-views): do not restore view..."](https://github.com/langfuse/langfuse/commit/263cfbd2cd840c24612dac16ec3964be4b16f139) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34065428)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->