### PR TITLE
refactor(web): Disallow limit 0 in paginationZod

### DIFF
--- a/packages/shared/src/utils/zod.ts
+++ b/packages/shared/src/utils/zod.ts
@@ -44,10 +44,9 @@ export const paginationZod = {
     (x) => (x === "" ? undefined : x),
     z.coerce.number().nonnegative().default(1),
   ),
-  // For internal use, we allow a limit of 0 until LFE-9976 is merged
   limit: z.preprocess(
     (x) => (x === "" ? undefined : x),
-    z.coerce.number().nonnegative().lte(100).default(50),
+    z.coerce.number().gte(1).lte(100).default(50),
   ),
 };
 

--- a/web/src/__tests__/server/zod.servertest.ts
+++ b/web/src/__tests__/server/zod.servertest.ts
@@ -22,6 +22,7 @@ describe("Pagination Zod Schema", () => {
   it("should handle invalid input", () => {
     expect(() => paginationZod.page.parse("abc")).toThrow(ZodError);
     expect(() => paginationZod.limit.parse("abc")).toThrow(ZodError);
+    expect(() => paginationZod.limit.parse("0")).toThrow(ZodError);
   });
 });
 

--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -515,8 +515,6 @@ export default function ObservationsTable({
     filter: backendFilterState,
     searchQuery,
     searchType,
-    page: 0,
-    limit: 0,
     orderBy: null,
   };
 

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -383,8 +383,6 @@ export default function ScoresTable({
   const getCountPayload = {
     projectId,
     filter: backendFilterState,
-    page: 0,
-    limit: 1,
     orderBy: null,
   };
 

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -294,8 +294,6 @@ export default function SessionsTable({
     projectId,
     filter: backendFilterState,
     orderBy: null,
-    page: 0,
-    limit: 1,
   };
 
   const payloadGetAll = {

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -400,8 +400,6 @@ export default function TracesTable({
     filter: filterState,
     searchQuery: searchQuery,
     searchType: searchType,
-    page: 0,
-    limit: 0,
     orderBy: null,
   };
 

--- a/web/src/features/evals/hooks/useEvalTargetCount.ts
+++ b/web/src/features/evals/hooks/useEvalTargetCount.ts
@@ -33,8 +33,6 @@ export function useEvalTargetCount({
     searchQuery: null,
     searchType: ["id" as const],
     orderBy: null,
-    page: 0,
-    limit: 1,
   };
 
   const tracesCountQuery = api.traces.countAll.useQuery(tracesAllCountFilter, {

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -52,8 +52,6 @@ export function useEventsTableData({
       filter: filterState,
       searchQuery: searchQuery ?? null,
       searchType: searchType ?? ["id", "content"],
-      page: 1,
-      limit: 1,
       orderBy: null,
     }),
     [projectId, filterState, searchQuery, searchType],

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -115,7 +115,7 @@ export const eventsRouter = createTRPCRouter({
       );
     }),
   countAll: protectedProjectProcedure
-    .input(GetAllEventsInput)
+    .input(EventsTableOptions)
     .query(async ({ input, ctx }) => {
       const { filterState, hasNoMatches } = await applyCommentFilters({
         filterState: input.filter ?? [],

--- a/web/src/server/api/routers/generations/getAllQueries.ts
+++ b/web/src/server/api/routers/generations/getAllQueries.ts
@@ -37,7 +37,7 @@ export const getAllQueries = {
       return { generations };
     }),
   countAll: protectedProjectProcedure
-    .input(GetAllGenerationsInput)
+    .input(GenerationTableOptions)
     .query(async ({ input, ctx }) => {
       const { filterState, hasNoMatches } = await applyCommentFilters({
         filterState: input.filter ?? [],

--- a/web/src/server/api/routers/scores.ts
+++ b/web/src/server/api/routers/scores.ts
@@ -187,7 +187,7 @@ export const scoresRouter = createTRPCRouter({
       return toDomainWithStringifiedMetadata(score);
     }),
   countAll: protectedProjectProcedure
-    .input(ScoreAllOptions)
+    .input(ScoreFilterOptions)
     .query(async ({ input }) => {
       const normalizedOrderBy = normalizeOrderByForTable({
         orderBy: input.orderBy,
@@ -274,7 +274,7 @@ export const scoresRouter = createTRPCRouter({
    * v4: Count scores without traces JOIN.
    */
   countAllFromEvents: protectedProjectProcedure
-    .input(ScoreAllOptions)
+    .input(ScoreFilterOptions)
     .query(async ({ input }) => {
       const normalizedOrderBy = normalizeOrderByForTable({
         orderBy: input.orderBy,

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -54,10 +54,12 @@ import chunk from "lodash/chunk";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 import { toDomainArrayWithStringifiedMetadata } from "@/src/utils/clientSideDomainTypes";
 
-const SessionFilterOptions = z.object({
+const SessionCountOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure
   filter: z.array(singleFilter).nullable(),
   orderBy: orderBy,
+});
+const SessionFilterOptions = SessionCountOptions.extend({
   ...paginationZod,
 });
 
@@ -293,7 +295,7 @@ export const sessionRouter = createTRPCRouter({
       };
     }),
   countAll: protectedProjectProcedure
-    .input(SessionFilterOptions)
+    .input(SessionCountOptions)
     .query(async ({ input, ctx }) => {
       const { filterState, hasNoMatches } = await applyCommentFilters({
         filterState: input.filter ?? [],
@@ -327,7 +329,7 @@ export const sessionRouter = createTRPCRouter({
       };
     }),
   countAllFromEvents: protectedProjectProcedure
-    .input(SessionFilterOptions)
+    .input(SessionCountOptions)
     .query(async ({ input, ctx }) => {
       const { filterState, hasNoMatches } = await applyCommentFilters({
         filterState: input.filter ?? [],

--- a/web/src/server/api/routers/traces.ts
+++ b/web/src/server/api/routers/traces.ts
@@ -66,12 +66,14 @@ import {
 import { scoreFilters } from "@/src/features/scores/lib/scoreColumns";
 import partition from "lodash/partition";
 
-const TraceFilterOptions = z.object({
+const TraceCountOptions = z.object({
   projectId: z.string(), // Required for protectedProjectProcedure
   searchQuery: z.string().nullable(),
   searchType: z.array(TracingSearchType),
   filter: z.array(singleFilter).nullable(),
   orderBy: orderBy,
+});
+const TraceFilterOptions = TraceCountOptions.extend({
   ...paginationZod,
 });
 type TraceFilterOptions = z.infer<typeof TraceFilterOptions>;
@@ -151,7 +153,7 @@ export const traceRouter = createTRPCRouter({
       return { traces };
     }),
   countAll: protectedProjectProcedure
-    .input(TraceFilterOptions)
+    .input(TraceCountOptions)
     .query(async ({ input, ctx }) => {
       const { filterState, hasNoMatches } = await applyCommentFilters({
         filterState: input.filter ?? [],


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the legacy `limit: 0` workaround from `paginationZod` by changing the `limit` validator from `.nonnegative()` (which allowed 0) to `.gte(1)`, and cleans up all `countAll` tRPC endpoints so they no longer accept pagination fields in their input schema.

- **Schema change**: `paginationZod.limit` now requires `>= 1`, enforced with `.gte(1).lte(100)`. A matching test confirms `"0"` throws a `ZodError`.
- **`countAll` input schemas**: Each `countAll` procedure (traces, sessions, scores, events, generations) is switched to a slimmer "count-only" schema that omits `page`/`limit` — aligning with the fact that these handlers already hardcoded `page: 0, limit: 1` internally and never used the caller-supplied pagination values.
- **Frontend callers**: All sites that previously passed `page: 0, limit: 0/1` to count endpoints simply omit those fields now, consistent with the tightened server-side schemas.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes remove dead fields from count endpoint inputs and tighten an existing validation, with no risk of data loss or broken functionality.

All countAll handlers already hardcoded page: 0, limit: 1 internally and ignored caller-supplied pagination values. Removing those fields from the input schemas is a runtime no-op. The limit >= 1 constraint closes a deliberate workaround the old comment marked as temporary. Frontend callers are all updated consistently and a regression test covers the new validation boundary.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Frontend Component
    participant Router as tRPC Router (countAll)
    participant DB as ClickHouse / DB

    Note over UI,Router: Before this PR
    UI->>Router: "countAll({ projectId, filter, orderBy, page: 0, limit: 0 })"
    Note over Router: paginationZod allowed limit=0
    Router->>DB: query(page: 0, limit: 1) [hardcoded internally]
    DB-->>Router: count
    Router-->>UI: "{ totalCount }"

    Note over UI,Router: After this PR
    UI->>Router: "countAll({ projectId, filter, orderBy })"
    Note over Router: No pagination in input schema
    Router->>DB: query(page: 0, limit: 1) [still hardcoded]
    DB-->>Router: count
    Router-->>UI: "{ totalCount }"

    Note over UI,Router: paginationZod.limit now enforces gte(1) — limit=0 throws ZodError
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Disallow limit 0 in pagin..."](https://github.com/langfuse/langfuse/commit/0d7c24398f66818f4ed9398792f7cbac629f443c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34131466)</sub>

<!-- /greptile_comment -->