### PR TITLE
fix(evals): add info alert for updated evaluator in NewEvaluatorPage

### DIFF
--- a/web/src/components/ui/alert.tsx
+++ b/web/src/components/ui/alert.tsx
@@ -11,6 +11,7 @@ const alertVariants = cva(
         default: "bg-background text-foreground",
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+        info: "bg-light-blue border-dark-blue",
       },
     },
     defaultVariants: {

--- a/web/src/features/evals/pages/new-evaluator.tsx
+++ b/web/src/features/evals/pages/new-evaluator.tsx
@@ -2,7 +2,7 @@ import Page from "@/src/components/layouts/page";
 import { BreadcrumbSeparator } from "@/src/components/ui/breadcrumb";
 import { BreadcrumbPage } from "@/src/components/ui/breadcrumb";
 import { BreadcrumbItem } from "@/src/components/ui/breadcrumb";
-import { Check } from "lucide-react";
+import { Check, Info } from "lucide-react";
 import { cn } from "@/src/utils/tailwind";
 import { BreadcrumbList } from "@/src/components/ui/breadcrumb";
 import { Breadcrumb } from "@/src/components/ui/breadcrumb";
@@ -16,6 +16,8 @@ import { MaintainerTooltip } from "@/src/features/evals/components/maintainer-to
 import { DefaultEvalModelSetup } from "@/src/features/evals/components/default-eval-model-setup";
 import { useIsCodeEvalEnabled } from "@/src/features/evals/hooks/useIsCodeEvalEnabled";
 import { shouldShowEvalTemplate } from "@/src/features/evals/utils/code-eval-template-utils";
+import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
+import { Button } from "@/src/components/ui/button";
 
 // Multi-step setup process
 // 0. Set up default model (optional, only if no default model exists): /project/:projectId/evals/new
@@ -58,6 +60,41 @@ export default function NewEvaluatorPage() {
   const currentTemplate = evalTemplates.data?.templates
     .filter((template) => shouldShowEvalTemplate(template, isCodeEvalEnabled))
     .find((t) => t.id === evaluatorId);
+
+  const templatesForCurrentName = api.evals.allTemplatesForName.useQuery(
+    {
+      projectId,
+      name: currentTemplate?.name ?? "",
+      isUserManaged: Boolean(currentTemplate?.projectId),
+    },
+    {
+      enabled: !!projectId && !!currentTemplate?.name,
+      refetchOnMount: "always",
+    },
+  );
+
+  const latestTemplate = templatesForCurrentName.data?.templates[0];
+  const hasNewerTemplate =
+    !!currentTemplate &&
+    !!latestTemplate &&
+    latestTemplate.id !== currentTemplate.id &&
+    latestTemplate.version > currentTemplate.version;
+
+  const handleUseUpdatedEvaluator = () => {
+    if (!latestTemplate) return;
+
+    void router.replace(
+      {
+        pathname: router.pathname,
+        query: {
+          ...router.query,
+          evaluator: latestTemplate.id,
+        },
+      },
+      undefined,
+      { shallow: true },
+    );
+  };
 
   // Determine starting step:
   // - Step 2: Configure evaluator (when template already selected via evaluatorId)
@@ -160,11 +197,34 @@ export default function NewEvaluatorPage() {
       {
         // 2. Run Evaluator
         stepInt === 2 && evaluatorId && projectId && (
-          <RunEvaluatorForm
-            projectId={projectId}
-            evaluatorId={evaluatorId}
-            evalTemplates={evalTemplates.data?.templates ?? []}
-          />
+          <div className="flex flex-col gap-4">
+            {hasNewerTemplate && latestTemplate && currentTemplate ? (
+              <Alert variant="info">
+                <Info className="h-4 w-4" />
+                <AlertTitle>Selected Evaluator has been updated</AlertTitle>
+                <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <span>
+                    Click to use the latest version of your evaluator{" "}
+                    {latestTemplate.name}.
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="w-fit"
+                    onClick={handleUseUpdatedEvaluator}
+                  >
+                    Use updated evaluator
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            ) : null}
+            <RunEvaluatorForm
+              projectId={projectId}
+              evaluatorId={evaluatorId}
+              evalTemplates={evalTemplates.data?.templates ?? []}
+            />
+          </div>
         )
       }
     </Page>


### PR DESCRIPTION
Chose the alert path because it keeps evalTemplateId as a stable exact-version identifier everywhere, while making upgrades to the latest template an explicit user choice instead of hidden name-based behavior. Switching create path to rely on name not sensible at this stage. 

<img width="1266" height="497" alt="CleanShot 2026-05-27 at 14 08 21@2x" src="https://github.com/user-attachments/assets/74ef6eaf-351e-46ef-bc59-4567363d0705" />

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `info` alert variant to the shared `Alert` component and uses it in `NewEvaluatorPage` to notify users when a newer version of their selected evaluator template is available, offering a one-click upgrade to the latest version.

- A secondary `allTemplatesForName` tRPC query (sorted by version descending) is introduced to detect newer template versions; the `hasNewerTemplate` flag compares IDs and versions to guard against false positives.
- Clicking "Use updated evaluator" calls `router.replace` with `shallow: true`, updating only the `evaluator` query param and re-triggering all downstream hooks without a full page navigation.
- The new `info` alert variant in `alert.tsx` references `bg-light-blue` and `border-dark-blue` CSS custom properties that are properly defined for both light and dark modes in `globals.css`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge — the new query is additive and guarded by existing conditions, the routing update is shallow and non-destructive, and no data-mutation paths are affected.

The version-detection logic and navigation handler are correct. The only gaps are cosmetic: the `info` variant omits `text-foreground` (relying on inherited color) and the `Info` icon lacks the `text-dark-blue` class used by analogous icons elsewhere in the codebase.

`web/src/components/ui/alert.tsx` — the new `info` variant class string; `web/src/features/evals/pages/new-evaluator.tsx` — the `Info` icon color.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[NewEvaluatorPage mounts] --> B{evaluatorId in URL?}
    B -- No --> C[Step 1: Select Evaluator]
    B -- Yes --> D[Step 2: Run Evaluator]
    D --> E[Fetch allTemplates\nlimit=500]
    E --> F{currentTemplate\nfound by ID?}
    F -- No --> G[Show RunEvaluatorForm\nno alert]
    F -- Yes --> H[Fetch allTemplatesForName\nordered by version desc]
    H --> I{latestTemplate.version\n> currentTemplate.version?}
    I -- No --> G
    I -- Yes --> J[Show info Alert:\nSelected Evaluator has been updated]
    J --> K[User clicks\nUse updated evaluator]
    K --> L[router.replace with\nnew evaluatorId - shallow]
    L --> D
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/evals/pages/new-evaluator.tsx:203
**Icon color not set for `info` variant**

The `Info` icon has no explicit text color, so it inherits `text-foreground` from the alert base class. Elsewhere in this codebase (e.g., `eval-version-callout.tsx`) alert icons are colored to match their theme — `className="text-dark-yellow h-4 w-4"`. Without `text-dark-blue` here, the icon will render in the default foreground color against the blue background rather than following the established convention.

### Issue 2 of 2
web/src/components/ui/alert.tsx:14
**`info` variant is missing a text color class**

The `default` variant explicitly sets `text-foreground` to ensure readable text on its `bg-background`. The new `info` variant only sets `bg-light-blue border-dark-blue`, omitting any text color. In practice text inherits from the parent, but this is inconsistent with the established pattern and could cause faint or invisible text if a parent sets a non-standard text color.

```suggestion
        info: "bg-light-blue border-dark-blue text-foreground",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): add info alert for updated e..."](https://github.com/langfuse/langfuse/commit/e4fa00de28a567b138b611735881383c7fc5216d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34145732)</sub>

<!-- /greptile_comment -->