### PR TITLE
feat(evals): add dataType handling for boolean scores in JSON serialization

### DIFF
--- a/scripts/code-eval-runners/python/code_based_eval_handler.py
+++ b/scripts/code-eval-runners/python/code_based_eval_handler.py
@@ -128,6 +128,12 @@ def to_jsonable(value):
                 continue
             key = _DATACLASS_FIELD_NAME_OVERRIDES.get(f.name, f.name)
             result[key] = to_jsonable(raw)
+        if (
+            isinstance(value, Score)
+            and "dataType" not in result
+            and isinstance(value.value, bool)
+        ):
+            result["dataType"] = "BOOLEAN"
         return result
 
     if isinstance(value, list):

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
@@ -83,7 +83,7 @@ def evaluate(ctx):
     contains = ctx.observation.input in ctx.observation.output
     return {
         "scores": [
-            {"name": "output-contains-input-bool", "value": contains, "dataType": "BOOLEAN"},
+            Score(name="output-contains-input-bool", value=contains),
             {"name": "output-contains-input-int", "value": 1 if contains else 0, "dataType": "BOOLEAN"},
             {"name": "output-contains-input-str", "value": "true" if contains else "false", "dataType": "BOOLEAN"},
             {"name": ctx.observation.metadata["topic"], "value": ctx.experiment.item_metadata["item"], "dataType": "NUMERIC"},


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds automatic `dataType: "BOOLEAN"` inference for `Score` dataclass instances whose `value` field holds a Python `bool`, so users don't have to specify `data_type="BOOLEAN"` manually when returning native boolean values from their evaluators.

- **`code_based_eval_handler.py`**: After serializing all dataclass fields, a post-loop check injects `"dataType": "BOOLEAN"` into the result when the instance is a `Score`, no `dataType` key has been set yet (i.e., `data_type` was left `None`), and the raw `value` is a Python `bool`.
- **Integration test fixture**: The `PYTHON` runner source is updated to use `Score(name=..., value=contains)` (relying on inference) instead of an explicit dict with `"dataType": "BOOLEAN"`, exercising the new code path.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is narrowly scoped — it only affects Score dataclass serialization when data_type is unset and the value is a Python bool, leaving all other serialization paths untouched.

The boolean check correctly uses isinstance(value.value, bool), which in Python distinguishes True/False from integer 1/0 (since bool is a subclass of int but isinstance(1, bool) is False). The guard 'dataType' not in result ensures an explicit data_type field always wins. The integration test fixture exercises the inferred path end-to-end alongside the other data types.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["to_jsonable(value)"] --> B{is dataclass?}
    B -- No --> G{is list?}
    G -- Yes --> H["recurse over items"]
    G -- No --> I{is dict?}
    I -- Yes --> J["recurse over key/value pairs"]
    I -- No --> K["json.dumps fallback"]
    B -- Yes --> C["iterate fields, skip None,\napply name overrides,\nbuild result dict"]
    C --> D{isinstance Score AND\ndataType not in result AND\nvalue is bool?}
    D -- Yes --> E["result['dataType'] = 'BOOLEAN'"]
    D -- No --> F["return result"]
    E --> F
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): add dataType handling for b..."](https://github.com/langfuse/langfuse/commit/689d2c67f36300a9bc425964fc91a90cce9c189d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34147576)</sub>

<!-- /greptile_comment -->