### PR TITLE
feat(evals,playground,experiments): resolve media references

### DIFF
--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -7,6 +7,7 @@ import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import {
   AIMessage,
   BaseMessage,
+  ContentBlock,
   HumanMessage,
   SystemMessage,
   ToolMessage,
@@ -51,6 +52,13 @@ import {
 } from "./utils";
 import { logger } from "../logger";
 import { LLMCompletionError } from "./errors";
+import {
+  MEDIA_REFERENCE_PATTERN,
+  MediaReferenceStringSchema,
+  ParsedMediaReferenceType,
+} from "../../utils/IORepresentation";
+import { prisma } from "../../db";
+import { getS3MediaStorageClient } from "../s3";
 
 export type CompletionWithReasoning = { text: string; reasoning?: string };
 type AIMessageContent = AIMessage["content"];
@@ -89,16 +97,6 @@ const PROVIDERS_WITH_REQUIRED_USER_MESSAGE = [
   LLMAdapter.Anthropic,
   LLMAdapter.Bedrock,
 ];
-
-const transformSystemMessageToUserMessage = (
-  messages: ChatMessage[],
-): BaseMessage[] => {
-  const safeContent =
-    typeof messages[0].content === "string"
-      ? messages[0].content
-      : JSON.stringify(messages[0].content);
-  return [new HumanMessage(safeContent)];
-};
 
 const googleProviderOptionsSchema = z
   .object({
@@ -169,6 +167,7 @@ type LLMCompletionParams = {
   maxRetries?: number;
   traceSinkParams?: TraceSinkParams;
   shouldUseLangfuseAPIKey?: boolean;
+  projectId?: string;
 };
 
 type FetchLLMCompletionParams = LLMCompletionParams & {
@@ -252,8 +251,9 @@ export async function fetchLLMCompletion(
 
   finalCallbacks = finalCallbacks.length > 0 ? finalCallbacks : undefined;
 
-  // Helper function to safely stringify content
   const safeStringify = (content: any): string => {
+    if (typeof content === "string") return content;
+
     try {
       return JSON.stringify(content);
     } catch {
@@ -261,31 +261,95 @@ export async function fetchLLMCompletion(
     }
   };
 
-  let finalMessages: BaseMessage[];
-  // Some providers require at least 1 user message
-  if (
-    messages.length === 1 &&
-    PROVIDERS_WITH_REQUIRED_USER_MESSAGE.includes(modelParams.adapter)
-  ) {
-    // Ensure provider schema compliance
-    finalMessages = transformSystemMessageToUserMessage(messages);
-  } else {
-    finalMessages = messages.map((message, idx) => {
-      // For arbitrary content types, convert to string safely
-      const safeContent =
-        typeof message.content === "string"
-          ? message.content
-          : safeStringify(message.content);
+  const isHumanMessage = (message: ChatMessage, idx: number) => {
+    return (
+      message.role === ChatMessageRole.User ||
+      (PROVIDERS_WITH_REQUIRED_USER_MESSAGE.includes(modelParams.adapter) &&
+        messages.length === 1) ||
+      ((message.role === ChatMessageRole.System ||
+        message.role === ChatMessageRole.Developer) &&
+        idx > 0)
+    );
+  };
 
-      if (message.role === ChatMessageRole.User)
-        return new HumanMessage(safeContent);
+  const parsedMediaRefByToken = new Map<string, ParsedMediaReferenceType>();
+  let mediaUrlById: Map<string, string> | undefined;
+  if (params.projectId) {
+    for (const [idx, message] of messages.entries()) {
+      if (!isHumanMessage(message, idx)) continue;
+
+      const mediaRefTokenMatches = safeStringify(message.content).matchAll(
+        MEDIA_REFERENCE_PATTERN,
+      );
+
+      for (const [mediaRefToken] of mediaRefTokenMatches) {
+        if (parsedMediaRefByToken.has(mediaRefToken)) continue;
+
+        const parseRes = MediaReferenceStringSchema.safeParse(mediaRefToken);
+        if (parseRes.success)
+          parsedMediaRefByToken.set(mediaRefToken, parseRes.data);
+      }
+    }
+
+    const mediaIds = new Set(
+      [...parsedMediaRefByToken.values()].map(
+        (parsedMediaRef) => parsedMediaRef.id,
+      ),
+    );
+
+    const media =
+      mediaIds.size > 0
+        ? await prisma.media.findMany({
+            select: {
+              id: true,
+              bucketName: true,
+              bucketPath: true,
+            },
+            where: {
+              projectId: params.projectId,
+              id: { in: [...mediaIds] },
+              uploadHttpStatus: { in: [200, 201] },
+            },
+          })
+        : [];
+
+    if (media.length > 0) {
+      mediaUrlById = new Map(
+        await Promise.all(
+          media.map(async (media) => {
+            const storageService = getS3MediaStorageClient(media.bucketName);
+            return [
+              media.id,
+              await storageService.getSignedUrl(media.bucketPath, 60, false),
+            ] as const;
+          }),
+        ),
+      );
+    }
+  }
+
+  const finalMessages = messages
+    .map((message, idx): BaseMessage => {
+      // For arbitrary content types, convert to string safely
+      const safeContent = safeStringify(message.content);
+
+      if (isHumanMessage(message, idx))
+        return new HumanMessage(
+          mediaUrlById
+            ? createHumanMessageContentWithMedia({
+                safeContent,
+                parsedMediaRefByToken,
+                mediaUrlById,
+              })
+            : safeContent,
+        );
+
+      // for idx > 0, these messages are mapped to human messages above
       if (
         message.role === ChatMessageRole.System ||
         message.role === ChatMessageRole.Developer
       )
-        return idx === 0
-          ? new SystemMessage(safeContent)
-          : new HumanMessage(safeContent);
+        return new SystemMessage(safeContent);
 
       if (message.type === ChatMessageType.ToolResult) {
         return new ToolMessage({
@@ -301,12 +365,8 @@ export async function fetchLLMCompletion(
             ? (message.toolCalls as any)
             : undefined,
       });
-    });
-  }
-
-  finalMessages = finalMessages.filter(
-    (m) => m.content.length > 0 || "tool_calls" in m,
-  );
+    })
+    .filter((m) => m.content.length > 0 || "tool_calls" in m);
 
   // Common proxy configuration for all adapters
   const proxyUrl = env.HTTPS_PROXY;
@@ -699,6 +759,80 @@ export async function fetchLLMCompletion(
   } finally {
     await processTracedEvents();
   }
+}
+
+function createHumanMessageContentWithMedia(params: {
+  safeContent: string;
+  parsedMediaRefByToken: Map<string, ParsedMediaReferenceType>;
+  mediaUrlById: Map<string, string>;
+}): string | ContentBlock[] {
+  const { safeContent, parsedMediaRefByToken, mediaUrlById } = params;
+  const mediaRefTokenMatches = [
+    ...safeContent.matchAll(MEDIA_REFERENCE_PATTERN),
+  ];
+  if (mediaRefTokenMatches.length === 0) return safeContent;
+
+  const content: ContentBlock[] = [];
+  let lastIndex = 0;
+  let hasResolvedMedia = false;
+
+  const appendTextContentBlock = (text: string) => {
+    if (text.length === 0) return;
+
+    const previousBlock = content.at(-1);
+    if (
+      previousBlock?.type === "text" &&
+      typeof previousBlock.text === "string"
+    ) {
+      previousBlock.text += text;
+      return;
+    }
+
+    content.push({ type: "text", text });
+  };
+
+  for (const match of mediaRefTokenMatches) {
+    const mediaRefToken = match[0];
+    appendTextContentBlock(safeContent.slice(lastIndex, match.index));
+
+    const parsedMediaRef = parsedMediaRefByToken.get(mediaRefToken);
+    const signedUrl = parsedMediaRef
+      ? mediaUrlById.get(parsedMediaRef.id)
+      : undefined;
+
+    const mediaContentBlock =
+      parsedMediaRef && signedUrl
+        ? createMediaContentBlock(parsedMediaRef, signedUrl)
+        : undefined;
+
+    if (mediaContentBlock) {
+      content.push(mediaContentBlock);
+      hasResolvedMedia = true;
+    } else {
+      appendTextContentBlock(mediaRefToken);
+    }
+
+    lastIndex = match.index + mediaRefToken.length;
+  }
+
+  appendTextContentBlock(safeContent.slice(lastIndex));
+
+  return hasResolvedMedia ? content : safeContent;
+}
+
+function createMediaContentBlock(
+  parsedMediaRef: ParsedMediaReferenceType,
+  signedUrl: string,
+): ContentBlock | undefined {
+  const mimeType = parsedMediaRef.type;
+  if (mimeType.startsWith("image/"))
+    return { type: "image", mimeType, url: signedUrl };
+
+  if (mimeType.startsWith("audio/"))
+    return { type: "audio", mimeType, url: signedUrl };
+
+  if (mimeType.startsWith("video/"))
+    return { type: "video", mimeType, url: signedUrl };
 }
 
 function extractCompletionWithReasoning(

--- a/packages/shared/src/utils/IORepresentation/chatML/types.ts
+++ b/packages/shared/src/utils/IORepresentation/chatML/types.ts
@@ -36,6 +36,8 @@ export type ParsedMediaReferenceType = z.infer<
   typeof ParsedMediaReferenceSchema
 >;
 
+export const MEDIA_REFERENCE_PATTERN = /@@@langfuseMedia:[\s\S]*?@@@/g;
+
 /**
  * Schema that parses Langfuse media reference magic strings.
  * Format: @@@langfuseMedia:type=image/jpeg|id=<uuid>|source=base64@@@

--- a/web/src/components/ui/markdown-media.utils.ts
+++ b/web/src/components/ui/markdown-media.utils.ts
@@ -1,4 +1,5 @@
 import {
+  MEDIA_REFERENCE_PATTERN,
   MediaReferenceStringSchema,
   isOpenAIImageContentPart,
   type OpenAIContentSchema,
@@ -7,8 +8,6 @@ import {
 } from "@langfuse/shared";
 import { type MediaReturnType } from "@/src/features/media/validation";
 import { type z } from "zod";
-
-const MEDIA_REFERENCE_PATTERN = /@@@langfuseMedia:[\s\S]*?@@@/g;
 
 const getMediaReferenceId = (
   value: string | ParsedMediaReferenceType | null | undefined,

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -67,6 +67,7 @@ export default async function chatCompletionHandler(req: NextRequest) {
       }
 
       const fetchLLMCompletionParams = {
+        projectId: body.projectId,
         llmConnection: parsedKey.data,
         messages,
         modelParams,

--- a/worker/src/__tests__/experimentsService.test.ts
+++ b/worker/src/__tests__/experimentsService.test.ts
@@ -7,6 +7,7 @@ import { createExperimentJobClickhouse } from "../features/experiments/experimen
 import {
   createDatasetItem,
   createOrgProjectAndApiKey,
+  fetchLLMCompletion,
   logger,
 } from "@langfuse/shared/src/server";
 
@@ -27,6 +28,7 @@ vi.mock("@langfuse/shared/src/server", async () => {
 
 describe("create experiment jobs", () => {
   const mockLogger = vi.mocked(logger);
+  const mockFetchLLMCompletion = vi.mocked(fetchLLMCompletion);
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -113,6 +115,12 @@ describe("create experiment jobs", () => {
         projectId,
         datasetId,
         runId,
+      }),
+    );
+
+    expect(mockFetchLLMCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId,
       }),
     );
   });

--- a/worker/src/__tests__/fetchLLMCompletionMedia.test.ts
+++ b/worker/src/__tests__/fetchLLMCompletionMedia.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.fn();
+const pipeMock = vi.fn().mockReturnValue({
+  invoke: invokeMock,
+});
+const chatOpenAIConstructorMock = vi.fn().mockImplementation(function () {
+  return {
+    pipe: pipeMock,
+  };
+});
+const prismaMediaFindManyMock = vi.fn();
+const getSignedUrlMock = vi.fn();
+
+process.env.CLICKHOUSE_URL ??= "http://localhost:8123";
+process.env.CLICKHOUSE_USER ??= "default";
+process.env.CLICKHOUSE_PASSWORD ??= "password";
+process.env.LANGFUSE_S3_EVENT_UPLOAD_BUCKET ??= "test-bucket";
+process.env.ENCRYPTION_KEY ??=
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("fetchLLMCompletion media references", () => {
+  let originalCloudRegion: string | undefined;
+  let encrypt: typeof import("../../../packages/shared/src/encryption").encrypt;
+  let fetchLLMCompletion: typeof import("../../../packages/shared/src/server/llm/fetchLLMCompletion").fetchLLMCompletion;
+
+  beforeEach(async () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue("completion");
+    pipeMock.mockClear();
+    chatOpenAIConstructorMock.mockClear();
+    prismaMediaFindManyMock.mockReset();
+    getSignedUrlMock.mockReset();
+    vi.resetModules();
+    originalCloudRegion = process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    delete process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+
+    vi.doMock(
+      "../../../packages/shared/node_modules/@langchain/openai",
+      () => ({
+        ChatOpenAI: chatOpenAIConstructorMock,
+        AzureChatOpenAI: vi.fn(),
+      }),
+    );
+    vi.doMock("../../../packages/shared/src/db", () => ({
+      prisma: {
+        media: {
+          findMany: prismaMediaFindManyMock,
+        },
+      },
+    }));
+    vi.doMock("../../../packages/shared/src/server/s3", () => ({
+      getS3MediaStorageClient: vi.fn(() => ({
+        getSignedUrl: getSignedUrlMock,
+      })),
+    }));
+
+    ({ encrypt } = await import("../../../packages/shared/src/encryption"));
+    ({ fetchLLMCompletion } =
+      await import("../../../packages/shared/src/server/llm/fetchLLMCompletion"));
+  });
+
+  afterEach(() => {
+    if (originalCloudRegion === undefined) {
+      delete process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    } else {
+      process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+    }
+  });
+
+  it("replaces resolved media references in human messages with signed image content blocks", async () => {
+    const mediaId = "cc48838a-3da8-4ca4-a007-2cf8df930e69";
+    const resolvedToken = `@@@langfuseMedia:type=image/jpeg|id=${mediaId}|source=base64@@@`;
+    const unresolvedToken =
+      "@@@langfuseMedia:type=image/png|id=missing-media|source=base64@@@";
+
+    prismaMediaFindManyMock.mockResolvedValue([
+      {
+        id: mediaId,
+        bucketName: "media-bucket",
+        bucketPath: "project/media/image.jpg",
+      },
+    ]);
+
+    const signedUrl = "https://signed.example/image.jpg";
+    getSignedUrlMock.mockResolvedValue(signedUrl);
+
+    const projectId = "project-123";
+    await fetchLLMCompletion({
+      streaming: false,
+      messages: [
+        {
+          role: "user",
+          content: `Describe ${resolvedToken} and keep ${unresolvedToken}.`,
+          type: "public-api-created",
+        },
+      ],
+      modelParams: {
+        provider: "openai",
+        adapter: "openai",
+        model: "gpt-4o-mini",
+        temperature: 0,
+        max_tokens: 10,
+      },
+      llmConnection: {
+        secretKey: encrypt("test-api-key"),
+      },
+      projectId,
+    });
+
+    expect(prismaMediaFindManyMock).toHaveBeenCalledWith({
+      select: {
+        id: true,
+        bucketName: true,
+        bucketPath: true,
+      },
+      where: {
+        projectId,
+        id: { in: [mediaId, "missing-media"] },
+        uploadHttpStatus: { in: [200, 201] },
+      },
+    });
+
+    const [finalMessages] = invokeMock.mock.calls[0];
+    expect(finalMessages[0].content).toEqual([
+      { type: "text", text: "Describe " },
+      {
+        type: "image",
+        mimeType: "image/jpeg",
+        url: signedUrl,
+      },
+      { type: "text", text: ` and keep ${unresolvedToken}.` },
+    ]);
+  });
+
+  it("keeps resolved unsupported media references as text", async () => {
+    const mediaId = "cc48838a-3da8-4ca4-a007-2cf8df930e70";
+    const textToken = `@@@langfuseMedia:type=text/plain|id=${mediaId}|source=base64@@@`;
+
+    prismaMediaFindManyMock.mockResolvedValue([
+      {
+        id: mediaId,
+        bucketName: "media-bucket",
+        bucketPath: "project/media/document.txt",
+      },
+    ]);
+    getSignedUrlMock.mockResolvedValue("https://signed.example/document.txt");
+
+    await fetchLLMCompletion({
+      streaming: false,
+      messages: [
+        {
+          role: "user",
+          content: `Read ${textToken}.`,
+          type: "public-api-created",
+        },
+      ],
+      modelParams: {
+        provider: "openai",
+        adapter: "openai",
+        model: "gpt-4o-mini",
+        temperature: 0,
+        max_tokens: 10,
+      },
+      llmConnection: {
+        secretKey: encrypt("test-api-key"),
+      },
+      projectId: "project-id",
+    });
+
+    const [finalMessages] = invokeMock.mock.calls[0];
+    expect(finalMessages[0].content).toBe(`Read ${textToken}.`);
+  });
+});

--- a/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
+++ b/worker/src/features/evaluation/__tests__/evalExecutionDeps.test.ts
@@ -35,6 +35,7 @@ describe("createProductionEvalExecutionDeps", () => {
     const deps = createProductionEvalExecutionDeps();
 
     await deps.callLLM({
+      projectId: "project-123",
       messages: [
         {
           role: "user",
@@ -66,6 +67,7 @@ describe("createProductionEvalExecutionDeps", () => {
 
     expect(mockFetchLLMCompletion).toHaveBeenCalledWith(
       expect.objectContaining({
+        projectId: "project-123",
         traceSinkParams: expect.objectContaining({
           traceId: "trace-123",
           environment: "langfuse-llm-as-a-judge",

--- a/worker/src/features/evaluation/evalExecutionDeps.ts
+++ b/worker/src/features/evaluation/evalExecutionDeps.ts
@@ -44,6 +44,7 @@ export type ModelConfigResult =
  * Parameters for calling the LLM.
  */
 export interface LLMCallParams {
+  projectId: string;
   messages: ReturnType<typeof buildEvalMessages>;
   modelConfig: Extract<ModelConfigResult, { valid: true }>["config"];
   structuredOutputSchema: StructuredOutputSchema;
@@ -191,6 +192,7 @@ export function createProductionEvalExecutionDeps(): EvalExecutionDeps {
       >[0]["modelParams"]["adapter"];
 
       return fetchLLMCompletion({
+        projectId: params.projectId,
         streaming: false,
         llmConnection,
         messages: params.messages,

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -887,6 +887,7 @@ export async function executeLLMAsJudgeEvaluation({
 
           try {
             return await deps.callLLM({
+              projectId,
               messages,
               modelConfig: modelConfig.config,
               structuredOutputSchema:

--- a/worker/src/features/experiments/experimentServiceClickhouse.ts
+++ b/worker/src/features/experiments/experimentServiceClickhouse.ts
@@ -212,6 +212,7 @@ async function processLLMCall(
   };
 
   await fetchLLMCompletion({
+    projectId: config.projectId,
     streaming: false,
     llmConnection: config.validatedApiKey,
     maxRetries: 1,


### PR DESCRIPTION
## What does this PR do?

Resolve langfuse media reference tokens in `fetchLLMCompletion`. This adds multi-modality support for LLM-as-a-Judge evals (#13799) and experiments (#7823, #10821). In theory it also allows for multi-modality in the prompt playground (#6017), however this lacks proper UI.

I'm open to implementing alternative approaches for media support in LLM-as-a-Judge evals, however for now this seemed to be the easiest and highest leverage option. I understand if you don't want to resolve media references in `fetchLLMCompletion`, for now I deemed it reasonable as it's something we'd want to support across call sites.

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds multimodal support to `fetchLLMCompletion` by resolving Langfuse media reference tokens (`@@@langfuseMedia:...@@@`) into signed URLs and injecting them as LangChain `ContentBlock` objects (image/audio/video) before the LLM API call. The feature is enabled by passing an optional `projectId` to `fetchLLMCompletion`, which gates the entire resolution path.

- Media references are scanned only from human-role messages; resolved tokens are replaced with typed content blocks while unresolved ones fall back to plain text, so no existing behavior changes when `projectId` is absent.
- `projectId` is propagated to `fetchLLMCompletion` at all call sites: evals, experiments, and the playground, with the `MEDIA_REFERENCE_PATTERN` constant moved to the shared package.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change degrades gracefully when projectId is absent, but the 60-second signed URL TTL could cause media fetch failures in eval and experiment workloads.

Media reference resolution is gated correctly behind projectId and the project-scoped DB query prevents cross-project data access. The 60-second signed URL TTL stands out against every other usage in the codebase (3600 seconds), and in the exact workloads this feature targets — long-running evals and batch experiments — it is very likely to expire before the LLM provider downloads the image, silently discarding multimodal content or failing the call.

packages/shared/src/server/llm/fetchLLMCompletion.ts — the signed URL TTL and the variable shadowing in the media mapping loop need attention before merging.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller
    participant FLC as fetchLLMCompletion
    participant Prisma as Prisma
    participant S3 as S3 Storage
    participant LLM as LLM Provider
    Caller->>FLC: "fetchLLMCompletion({ projectId, messages })"
    activate FLC
    alt projectId present
        FLC->>FLC: scan human messages for tokens
        FLC->>Prisma: "media.findMany({ projectId, id in mediaIds })"
        Prisma-->>FLC: media records
        loop per media record
            FLC->>S3: getSignedUrl(bucketPath, TTL)
            S3-->>FLC: signedUrl
        end
    end
    FLC->>FLC: map messages to BaseMessage[]
    FLC->>LLM: chatModel.invoke(finalMessages)
    LLM-->>FLC: completion
    FLC-->>Caller: result
    deactivate FLC
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/llm/fetchLLMCompletion.ts:323
The signed URL TTL of 60 seconds is very short compared to every other call site in the codebase (which uses 3600 seconds). The URL is generated before the LLM API call is dispatched; if the provider is slow to process the request or download the image (common for large media in eval/batch workloads), the URL will have expired and the provider will receive a 403 — silently discarding the image or failing the call entirely.

```suggestion
              await storageService.getSignedUrl(media.bucketPath, 3600, false),
```

### Issue 2 of 2
packages/shared/src/server/llm/fetchLLMCompletion.ts:317-327
The callback parameter `media` shadows the outer `media` array variable. While this is harmless in this specific case (the outer variable isn't accessed inside the callback), it creates a readability hazard and can mask bugs if the outer binding is ever used inside the loop body.

```suggestion
      mediaUrlById = new Map(
        await Promise.all(
          media.map(async (mediaRecord) => {
            const storageService = getS3MediaStorageClient(mediaRecord.bucketName);
            return [
              mediaRecord.id,
              await storageService.getSignedUrl(mediaRecord.bucketPath, 3600, false),
            ] as const;
          }),
        ),
      );
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals,playground,experiments): reso..."](https://github.com/langfuse/langfuse/commit/ea816a4e4c710a7876e655e831c6cba17d508fab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34151991)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->