### PR TITLE
fix(evals): use correct events flag for code eval test runs

### DIFF
--- a/web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts
+++ b/web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts
@@ -28,9 +28,7 @@ vi.hoisted(() => {
 const orgIds: string[] = [];
 
 const maybe =
-  env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"
-    ? describe
-    : describe.skip;
+  env.LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS === "true" ? describe : describe.skip;
 
 async function prepare() {
   const { project, org } = await createOrgProjectAndApiKey();

--- a/web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts
+++ b/web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts
@@ -209,7 +209,7 @@ maybe("evals.testRunCodeEval", () => {
     expect(Number(scoreCount[0]?.count ?? 0)).toBe(0);
   });
 
-  it("runs against legacy observations when events table observations are disabled", async () => {
+  it("runs against legacy observations when events table evals are disabled", async () => {
     const { project, caller } = await prepare();
     const observationId = randomUUID();
     const traceId = randomUUID();
@@ -248,13 +248,13 @@ maybe("evals.testRunCodeEval", () => {
     ]);
 
     const mutableEnv = env as unknown as {
-      LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS: "true" | "false";
+      LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS: "true" | "false";
     };
-    const originalEventsTableObservationFlag =
-      mutableEnv.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS;
+    const originalEventsTableFlagsFlag =
+      mutableEnv.LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS;
 
     try {
-      mutableEnv.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS = "false";
+      mutableEnv.LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS = "false";
 
       const response = await caller.evals.testRunCodeEval({
         projectId: project.id,
@@ -298,8 +298,8 @@ maybe("evals.testRunCodeEval", () => {
         executionTraceFromTimestamp: expect.any(Date),
       });
     } finally {
-      mutableEnv.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS =
-        originalEventsTableObservationFlag;
+      mutableEnv.LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS =
+        originalEventsTableFlagsFlag;
     }
   });
 

--- a/web/src/features/evals/server/codeEvalTestRun.ts
+++ b/web/src/features/evals/server/codeEvalTestRun.ts
@@ -227,7 +227,7 @@ async function getObservationForEvalById(params: {
   shouldReadFromObservationsTable?: boolean;
 }): Promise<ObservationForEval> {
   if (
-    env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS !== "true" ||
+    env.LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS !== "true" ||
     params.shouldReadFromObservationsTable
   ) {
     return getObservationForEvalByIdFromLegacyObservations(params);


### PR DESCRIPTION
## Summary
- use the events-table feature flag for code eval test-run event reads instead of the observations migration flag

## Impacted packages
- web

## Verification
- pnpm --filter web test src/__tests__/server/code-eval-test-run-trpc.servertest.ts -t "experiment"
- git commit hooks: prettier check and turbo lint

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces the `LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS` flag with `LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS` in `getObservationForEvalById`, aligning code-eval test-run event reads with the flag already used by adjacent routers.

- The single-line production change in `codeEvalTestRun.ts` is correct and consistent with `runEvaluationRouter.ts` and `traces.ts`.
- The companion test file (`code-eval-test-run-trpc.servertest.ts`) was not updated: the suite-level skip guard and the "legacy path" test still toggle `LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS`, so the legacy-fallback branch can no longer be exercised and tests may be gated on the wrong flag.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The production code change is correct, but the test file still references the old flag in two critical places, leaving the legacy-fallback branch untested and the test suite potentially skipped under flag configurations where it should run.

The test that validates the legacy observations path now mutates a flag that the code no longer reads, so the fallback branch cannot be exercised. The suite-level guard was also not updated, meaning tests may silently skip in environments where the two flags diverge.

web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts needs its flag references updated from LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS to LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[testRunCodeEval tRPC call] --> B{shouldReadFromObservationsTable?}
    B -- yes --> C[Legacy observations table]
    B -- no --> D{LANGFUSE_ENABLE_EVENTS_TABLE_FLAGS equals true?}
    D -- false --> C
    D -- true --> E[Events table path]
    C --> F[Return ObservationForEval]
    E --> F
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): use events flag for code eva..."](https://github.com/langfuse/langfuse/commit/95adca2577b488f0ce8cc963f203d2e921fd04d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34177705)</sub>

<!-- /greptile_comment -->