### PR TITLE
chore: enable parallel replicas on events read-only CH pool

### DIFF
--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -15,6 +15,7 @@ export type PreferredClickhouseService =
 
 type ServiceClickhouseSettings = {
   enable_full_text_index?: 1;
+  enable_parallel_replicas?: 1;
 };
 
 /**
@@ -90,7 +91,7 @@ export class ClickHouseClientManager {
   ): ServiceClickhouseSettings {
     return preferredClickhouseService === "EventsReadOnly" &&
       this.isEventsTableReadPathEnabled()
-      ? { enable_full_text_index: 1 }
+      ? { enable_full_text_index: 1, enable_parallel_replicas: 1 }
       : {};
   }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables the `enable_parallel_replicas` ClickHouse setting on the `EventsReadOnly` connection pool, alongside the already-present `enable_full_text_index` setting. The new setting is applied at the client level, so it affects all queries routed through the `EventsReadOnly` service when the events read path is active.

- `enable_parallel_replicas: 1` is added to `ServiceClickhouseSettings` type and propagated into `getServiceClickhouseSettings`, so it flows into the client's `clickhouse_settings` for every query sent through the `EventsReadOnly` pool.
- The change only activates when at least one `LANGFUSE_ENABLE_EVENTS_TABLE_*` env var is `\"true\"`, consistent with the existing feature-flag guard.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line addition of a ClickHouse query setting, guarded by the existing events read-path feature flag.

The change is minimal and consistent with the existing enable_full_text_index pattern. It is only activated for the EventsReadOnly pool when the relevant feature-flag env vars are set, so no production path is altered without operator opt-in. The setting flows correctly into the client factory and the cache key is derived from the full settings object, so clients with and without this flag remain distinct. No async-insert or write paths are affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[clickhouseClient called] --> B{preferredClickhouseService?}
    B -- EventsReadOnly --> C{isEventsTableReadPathEnabled?}
    B -- ReadOnly / ReadWrite --> D["serviceClickhouseSettings = {}"]
    C -- false --> D
    C -- true --> E["serviceClickhouseSettings =\n{ enable_full_text_index: 1,\n  enable_parallel_replicas: 1 }"]
    D --> F[generateClientSettings]
    E --> F
    F --> G[generateClientSettingsKey JSON.stringify]
    G --> H{clientMap.has key?}
    H -- yes --> I[Return cached client]
    H -- no --> J[createClient with clickhouse_settings]
    J --> K[Store in clientMap]
    K --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: enable parallel replicas on event..."](https://github.com/langfuse/langfuse/commit/a4d73d99d71f7fc9589166f9a8631299244de555) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34184535)</sub>

<!-- /greptile_comment -->