### PR TITLE
fix(web): allow experiment code eval configs without sample trace

### DIFF
--- a/web/src/__tests__/server/evals-trpc.servertest.ts
+++ b/web/src/__tests__/server/evals-trpc.servertest.ts
@@ -1,5 +1,9 @@
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import {
+  EvalTemplateSourceCodeLanguage,
+  EvalTemplateType,
+} from "@prisma/client";
 import { prisma } from "@langfuse/shared/src/db";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import {
@@ -10,6 +14,31 @@ import {
   EvaluatorBlockReason,
 } from "@langfuse/shared";
 import type { Session } from "next-auth";
+import { beforeEach, vi } from "vitest";
+
+const { runCodeEvalTestForJobConfigMock } = vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_LANGFUSE_CODE_EVAL_ENABLED = "true";
+  process.env.LANGFUSE_ENABLE_EVENTS_TABLE_UI = "true";
+
+  return {
+    runCodeEvalTestForJobConfigMock: vi.fn(),
+  };
+});
+
+vi.mock("@/src/features/evals/server/codeEvalTestRun", () => ({
+  runCodeEvalTest: vi.fn(),
+  runCodeEvalTestForJobConfig: runCodeEvalTestForJobConfigMock,
+}));
+
+beforeEach(() => {
+  runCodeEvalTestForJobConfigMock.mockReset();
+  runCodeEvalTestForJobConfigMock.mockResolvedValue({
+    success: true,
+    result: { scores: [] },
+    executionTraceId: "test-execution-trace-id",
+    executionTraceFromTimestamp: new Date("2026-05-27T00:00:00.000Z"),
+  });
+});
 
 const __orgIds: string[] = [];
 
@@ -402,6 +431,95 @@ describe("evals trpc", () => {
   });
 
   describe("evals.createJob", () => {
+    it("saves experiment code evaluator configs without a matching observation", async () => {
+      const { project, caller } = await prepare();
+      runCodeEvalTestForJobConfigMock.mockResolvedValueOnce(null);
+
+      const evalTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: `code-experiment-template-${project.id}`,
+          version: 1,
+          type: EvalTemplateType.CODE,
+          prompt: null,
+          outputDefinition: undefined,
+          sourceCode:
+            'function evaluate() { return { scores: [{ name: "experiment-score", value: 1 }] }; }',
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        },
+      });
+
+      const response = await caller.evals.createJob({
+        projectId: project.id,
+        evalTemplateId: evalTemplate.id,
+        scoreName: "experiment-code-score",
+        target: EvalTargetObject.EXPERIMENT,
+        filter: [],
+        mapping: [],
+        sampling: 1,
+        delay: 0,
+        timeScope: ["NEW"],
+      });
+
+      const savedJob = await prisma.jobConfiguration.findUnique({
+        where: { id: response.id },
+      });
+
+      expect(savedJob?.targetObject).toBe(EvalTargetObject.EXPERIMENT);
+      expect(savedJob?.evalTemplateId).toBe(evalTemplate.id);
+      expect(runCodeEvalTestForJobConfigMock).toHaveBeenCalledOnce();
+    });
+
+    it("rejects experiment code evaluator configs when the matching test run fails", async () => {
+      const { project, caller } = await prepare();
+      runCodeEvalTestForJobConfigMock.mockResolvedValueOnce({
+        success: false,
+        error: {
+          code: "USER_CODE_ERROR",
+          message: "Evaluator failed during test run",
+        },
+        executionTraceId: "test-execution-trace-id",
+        executionTraceFromTimestamp: new Date("2026-05-27T00:00:00.000Z"),
+      });
+
+      const evalTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: `code-experiment-template-${project.id}`,
+          version: 1,
+          type: EvalTemplateType.CODE,
+          prompt: null,
+          outputDefinition: undefined,
+          sourceCode:
+            'function evaluate() { return { scores: [{ name: "experiment-score", value: 1 }] }; }',
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        },
+      });
+
+      await expect(
+        caller.evals.createJob({
+          projectId: project.id,
+          evalTemplateId: evalTemplate.id,
+          scoreName: "experiment-code-score",
+          target: EvalTargetObject.EXPERIMENT,
+          filter: [],
+          mapping: [],
+          sampling: 1,
+          delay: 0,
+          timeScope: ["NEW"],
+        }),
+      ).rejects.toThrow("Evaluator failed during test run");
+
+      await expect(
+        prisma.jobConfiguration.findFirst({
+          where: {
+            projectId: project.id,
+            scoreName: "experiment-code-score",
+          },
+        }),
+      ).resolves.toBeNull();
+    });
+
     it("rejects observation-only variable mappings for trace evaluators", async () => {
       const { project, caller } = await prepare();
 
@@ -491,6 +609,53 @@ describe("evals trpc", () => {
   });
 
   describe("evals.updateConfig", () => {
+    it("updates experiment code evaluator configs without a matching observation", async () => {
+      const { project, caller } = await prepare();
+      runCodeEvalTestForJobConfigMock.mockResolvedValueOnce(null);
+
+      const evalTemplate = await prisma.evalTemplate.create({
+        data: {
+          projectId: project.id,
+          name: `code-experiment-template-${project.id}`,
+          version: 1,
+          type: EvalTemplateType.CODE,
+          prompt: null,
+          outputDefinition: undefined,
+          sourceCode:
+            'function evaluate() { return { scores: [{ name: "experiment-score", value: 1 }] }; }',
+          sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        },
+      });
+
+      const evalJobConfig = await prisma.jobConfiguration.create({
+        data: {
+          projectId: project.id,
+          jobType: "EVAL",
+          evalTemplateId: evalTemplate.id,
+          scoreName: "experiment-code-score",
+          filter: [],
+          targetObject: EvalTargetObject.EXPERIMENT,
+          variableMapping: [],
+          sampling: 1,
+          delay: 0,
+          status: "ACTIVE",
+          timeScope: ["NEW"],
+        },
+      });
+
+      const response = await caller.evals.updateEvalJob({
+        projectId: project.id,
+        evalConfigId: evalJobConfig.id,
+        config: {
+          scoreName: "updated-experiment-code-score",
+        },
+      });
+
+      expect(response.id).toEqual(evalJobConfig.id);
+      expect(response.scoreName).toEqual("updated-experiment-code-score");
+      expect(runCodeEvalTestForJobConfigMock).toHaveBeenCalledOnce();
+    });
+
     it("should update an evaluator configuration", async () => {
       const { project, caller } = await prepare();
 

--- a/web/src/features/evals/server/codeEvalTestRun.ts
+++ b/web/src/features/evals/server/codeEvalTestRun.ts
@@ -86,12 +86,16 @@ export async function runCodeEvalTestForJobConfig(params: {
   mapping: ObservationVariableMapping[];
   scoreName: string;
   filter: FilterCondition[] | null;
-}): Promise<CodeEvalTestRunResult> {
+}): Promise<CodeEvalTestRunResult | null> {
   const observation = await getObservationForEvalByFilter({
     projectId: params.projectId,
     target: params.target,
     filter: params.filter,
   });
+
+  if (!observation) {
+    return null;
+  }
 
   return runCodeEvalTestForObservation({
     ...params,
@@ -190,7 +194,7 @@ async function getObservationForEvalByFilter(params: {
   projectId: string;
   target: EvalTargetObject;
   filter: FilterCondition[] | null;
-}): Promise<ObservationForEval> {
+}): Promise<ObservationForEval | null> {
   if (!isEventTarget(params.target) && !isExperimentTarget(params.target)) {
     throw new TRPCError({
       code: "BAD_REQUEST",
@@ -212,11 +216,7 @@ async function getObservationForEvalByFilter(params: {
     return observationForEvalSchema.parse(row);
   }
 
-  throw new TRPCError({
-    code: "PRECONDITION_FAILED",
-    message:
-      "No matching observation found to test this code evaluator. Adjust the filters and try again.",
-  });
+  return null;
 }
 
 async function getObservationForEvalById(params: {

--- a/web/src/features/evals/server/router.ts
+++ b/web/src/features/evals/server/router.ts
@@ -305,6 +305,18 @@ const assertCodeEvalJobConfigTestSucceeds = async ({
       filter,
     });
 
+    if (!result) {
+      if (target !== EvalTargetObject.EXPERIMENT) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            "No matching observation found to test this code evaluator. Adjust the filters and try again.",
+        });
+      }
+
+      return;
+    }
+
     if (!result.success) {
       throw new TRPCError({
         code: "PRECONDITION_FAILED",


### PR DESCRIPTION
## Summary

- Allow experiment-targeted code evaluator configs to be saved before any matching experiment run trace exists.
- Keep the pre-save code eval test call when a matching sample observation is available, so evaluator failures still block the save.
- Return `null` from the job-config test-run path when filters do not find a sample observation, and cover the create/update behavior in tRPC tests.

## Major Decisions

- Model missing sample data as a nullable test-run result in `runCodeEvalTestForJobConfig`. The router owns the target-specific policy: only experiment configs may continue when the test result is `null`.

## Review Focus

- Check that the nullable result is acceptable for all current callers of `runCodeEvalTestForJobConfig`.
- Check that event-targeted code evaluator configs still fail when no sample observation is available.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes how missing observations are handled in the code-eval pre-save test flow. Instead of throwing a `PRECONDITION_FAILED` error when no matching observation is found, `runCodeEvalTestForJobConfig` now returns `null`, and the policy decision (allow vs. block) is moved to the caller in `assertCodeEvalJobConfigTestSucceeds`.

- `getObservationForEvalByFilter` and `runCodeEvalTestForJobConfig` now return `null` instead of throwing when no observation matches the configured filters.
- `assertCodeEvalJobConfigTestSucceeds` handles the `null` result: non-experiment targets still receive the same `PRECONDITION_FAILED` error as before, while experiment-targeted configs are silently allowed to save.
- New tRPC-level tests cover the experiment create/update without a sample trace, and the experiment test-run-fails rejection path.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The change is narrow and well-contained: the only behavioral difference is that experiment-targeted code eval configs can now be saved when no sample observation exists, while every other target and the failed-test-run path retain their original blocking behavior.

The policy decision is cleanly separated into `assertCodeEvalJobConfigTestSucceeds`, and TypeScript propagates the `null` return type all the way from `getObservationForEvalByFilter` up to the router. The new tests cover both the null-bypass path and the fail-still-blocks path. No unintended target types can reach the null bypass due to the early guard. The only caveat is that any future caller of `runCodeEvalTestForJobConfig` that forgets to handle `null` would silently skip the pre-save test.

No files require special attention, but future callers of `runCodeEvalTestForJobConfig` must explicitly handle the `null` return to avoid silently bypassing the pre-save test.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): allow experiment code eval con..."](https://github.com/langfuse/langfuse/commit/9bab5c82c0eefa272c6be717a9cbdaa2d7aada62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34188180)</sub>

<!-- /greptile_comment -->