### PR TITLE
fix(evals): surface invalid code eval results

### DIFF
--- a/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
@@ -143,6 +143,7 @@ export const CodeEvalDispatcherErrorCodes = CodeEvalDispatcherErrorCode.enum;
 export class CodeEvalDispatcherError extends Error {
   public readonly code: CodeEvalDispatcherErrorCode;
   public readonly retryable: boolean;
+  public readonly returnedResult?: unknown;
 
   constructor(
     message: string,
@@ -150,12 +151,14 @@ export class CodeEvalDispatcherError extends Error {
       code: CodeEvalDispatcherErrorCode;
       retryable?: boolean;
       cause?: unknown;
+      returnedResult?: unknown;
     },
   ) {
     super(message, { cause: options.cause });
     this.name = "CodeEvalDispatcherError";
     this.code = options.code;
     this.retryable = options.retryable ?? false;
+    this.returnedResult = options.returnedResult;
   }
 }
 
@@ -205,7 +208,10 @@ export function parseDispatchResult(result: unknown): DispatchResult {
   if (!parsed.success) {
     throw new CodeEvalDispatcherError(
       `Invalid code eval result: ${parsed.error.message}`,
-      { code: CodeEvalDispatcherErrorCodes.INVALID_RESULT },
+      {
+        code: CodeEvalDispatcherErrorCodes.INVALID_RESULT,
+        returnedResult: result,
+      },
     );
   }
 

--- a/packages/shared/src/server/evals/codeEvalExecution.ts
+++ b/packages/shared/src/server/evals/codeEvalExecution.ts
@@ -72,6 +72,7 @@ export type CodeEvalUserVisibleError = {
   code: CodeEvalUserVisibleErrorCode;
   message: string;
   retryable: boolean;
+  returnedResult?: unknown;
 };
 
 export class CodeEvalExecutionError extends Error {
@@ -129,6 +130,7 @@ function buildCodeEvalPayload(params: {
 function getCodeEvalErrorDetails(error: unknown): {
   name: string;
   message: string;
+  returnedResult?: unknown;
   code: CodeEvalUserVisibleErrorCode;
   retryable: boolean;
 } {
@@ -136,6 +138,7 @@ function getCodeEvalErrorDetails(error: unknown): {
     return {
       name: error.name,
       message: error.message,
+      returnedResult: error.returnedResult,
       code: error.code,
       retryable: error.retryable,
     };
@@ -175,6 +178,9 @@ export function getCodeEvalUserVisibleError(
     code: details.code,
     message: message ?? details.message,
     retryable: details.retryable,
+    ...(details.returnedResult !== undefined
+      ? { returnedResult: details.returnedResult }
+      : {}),
   };
 }
 
@@ -240,6 +246,9 @@ export async function runCodeBasedEvaluationDispatch(params: {
       code: visibleError.code,
       message: visibleError.message,
       retryable: errorDetails.retryable,
+      ...(visibleError.returnedResult !== undefined
+        ? { returnedResult: visibleError.returnedResult }
+        : {}),
     };
     const errorCodeForTrace = errorDetails.code;
 

--- a/web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts
+++ b/web/src/__tests__/server/code-eval-test-run-trpc.servertest.ts
@@ -23,6 +23,7 @@ import { EvalTargetObject } from "@langfuse/shared";
 
 vi.hoisted(() => {
   process.env.NEXT_PUBLIC_LANGFUSE_CODE_EVAL_ENABLED = "true";
+  process.env.LANGFUSE_CODE_EVAL_DISPATCHER = "insecure-local";
 });
 
 const orgIds: string[] = [];
@@ -341,6 +342,53 @@ maybe("evals.testRunCodeEval", () => {
       error: {
         code: "USER_CODE_ERROR",
         message: "User code raised ValueError",
+      },
+      executionTraceId: expect.stringMatching(/^[0-9a-f]{32}$/),
+      executionTraceFromTimestamp: expect.any(Date),
+    });
+  });
+
+  it("returns invalid evaluator results for test-run debugging", async () => {
+    const { project, caller } = await prepare();
+    const observationId = randomUUID();
+    const traceId = randomUUID();
+    const startTime = new Date();
+    const template = await createCodeTemplate(
+      project.id,
+      `function evaluate() {
+        return { score: 1 };
+      }`,
+    );
+
+    await createEventsCh([
+      createEvent({
+        project_id: project.id,
+        trace_id: traceId,
+        span_id: observationId,
+        id: observationId,
+        start_time: startTime.getTime() * 1000,
+      }),
+    ]);
+
+    const response = await caller.evals.testRunCodeEval({
+      projectId: project.id,
+      evalTemplateId: template.id,
+      target: EvalTargetObject.EVENT,
+      scoreName: "unsaved-score",
+      observationId,
+      traceId,
+      startTime,
+      mapping: [],
+    });
+
+    expect(response).toEqual({
+      success: false,
+      error: {
+        code: "INVALID_RESULT",
+        message: expect.stringContaining(
+          "The evaluator returned an invalid result.",
+        ),
+        returnedResult: { score: 1 },
       },
       executionTraceId: expect.stringMatching(/^[0-9a-f]{32}$/),
       executionTraceFromTimestamp: expect.any(Date),

--- a/web/src/features/evals/server/codeEvalTestRun.ts
+++ b/web/src/features/evals/server/codeEvalTestRun.ts
@@ -9,7 +9,7 @@ import {
   processEventBatch,
   resolveConfiguredCodeEvalDispatcher,
   runCodeBasedEvaluationDispatch,
-  type CodeEvalUserVisibleErrorCode,
+  type CodeEvalUserVisibleError,
   type DispatchResult,
   type InternalTraceWriteInput,
 } from "@langfuse/shared/src/server";
@@ -33,6 +33,8 @@ import {
   isExperimentTarget,
 } from "@/src/features/evals/utils/typeHelpers";
 
+type CodeEvalTestRunError = Omit<CodeEvalUserVisibleError, "retryable">;
+
 export type CodeEvalTestRunResult =
   | {
       success: true;
@@ -42,10 +44,7 @@ export type CodeEvalTestRunResult =
     }
   | {
       success: false;
-      error: {
-        code: CodeEvalUserVisibleErrorCode;
-        message: string;
-      };
+      error: CodeEvalTestRunError;
       executionTraceId: string;
       executionTraceFromTimestamp: Date;
     };
@@ -177,13 +176,17 @@ async function runCodeEvalTestForObservation(params: {
 
   return {
     success: false,
-    error: {
-      code: dispatchOutcome.error.code,
-      message: dispatchOutcome.error.message,
-    },
+    error: toCodeEvalTestRunError(dispatchOutcome.error),
     executionTraceId: dispatchOutcome.executionTraceId,
     executionTraceFromTimestamp: dispatchOutcome.executionTraceFromTimestamp,
   };
+}
+
+function toCodeEvalTestRunError({
+  retryable: _retryable,
+  ...error
+}: CodeEvalUserVisibleError): CodeEvalTestRunError {
+  return error;
 }
 
 async function getObservationForEvalByFilter(params: {

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.test.ts
@@ -357,6 +357,36 @@ describe("AwsLambdaCodeEvalDispatcher", () => {
     } satisfies Partial<CodeEvalDispatcherError>);
   });
 
+  it("includes a small invalid Lambda result as structured error data", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Payload: Buffer.from(JSON.stringify({ score: 1 })),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "INVALID_RESULT",
+      retryable: false,
+      returnedResult: { score: 1 },
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
+  it("does not include a returned result for invalid JSON Lambda responses", async () => {
+    const send = vi.fn().mockResolvedValue({
+      Payload: Buffer.from("not-json"),
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "INVALID_RESULT",
+      retryable: false,
+      returnedResult: undefined,
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
+
   it("rejects Lambda responses that exceed the wire byte-size limit", async () => {
     // Build a response payload larger than the 256 KiB result cap. The
     // guard inspects `response.Payload.byteLength` before any JSON parsing,

--- a/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
+++ b/worker/src/features/evaluation/codeBased/executeCodeBasedEvaluation.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   CodeEvalDispatcherError,
   CodeEvalDispatcherErrorCodes,
+  parseDispatchResult,
 } from "../../../../../packages/shared/src/server/evals/codeEvalDispatcherTypes";
 import { CodeEvalExecutionError } from "../../../../../packages/shared/src/server/evals/codeEvalExecution";
 import { UnrecoverableError } from "../../../errors/UnrecoverableError";
@@ -480,6 +481,60 @@ describe("executeCodeBasedEvaluation", () => {
         ],
       }),
     );
+  });
+
+  it("preserves a small invalid returned result in the structured trace error", async () => {
+    mocks.dispatcher.dispatch.mockImplementation(() =>
+      parseDispatchResult({ score: 1 }),
+    );
+
+    const promise = executeCodeBasedEvaluation({
+      projectId: "project-1",
+      organizationId: "org-1",
+      job: {
+        id: "job-1",
+        jobConfigurationId: "config-1",
+        jobInputTraceId: "trace-1",
+        jobInputObservationId: "obs-1",
+        jobInputDatasetItemId: null,
+      } as any,
+      config: { id: "config-1", scoreName: "default-score" } as any,
+      template: {
+        id: "template-1",
+        name: "Code evaluator",
+        type: EvalTemplateType.CODE,
+        version: 1,
+        sourceCode: "function evaluate() {}",
+        sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+        prompt: null,
+        outputDefinition: null,
+      } as any,
+      extractedVariables: [{ var: "input", value: "prompt" }],
+      executionMetadata: { job_execution_id: "job-1" },
+    });
+
+    await expect(promise).rejects.toThrow(UnrecoverableError);
+    await expect(promise).rejects.toThrow(
+      "The evaluator returned an invalid result.",
+    );
+
+    const trace = mocks.writeInternalTrace.mock.calls[0]?.[0];
+    const output = JSON.parse(trace.eventInputs[0].output);
+
+    expect(mocks.writeInternalTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventInputs: [
+          expect.objectContaining({
+            statusMessage: expect.not.stringContaining("returnedResult"),
+            metadata: expect.objectContaining({
+              error_message: expect.not.stringContaining("returnedResult"),
+              error_code: "INVALID_RESULT",
+            }),
+          }),
+        ],
+      }),
+    );
+    expect(output.error.returnedResult).toEqual({ score: 1 });
   });
 
   it("writes an actionable user-visible timeout error", async () => {

--- a/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
@@ -251,4 +251,20 @@ describe("LocalCodeEvalDispatcher", () => {
       retryable: false,
     } satisfies Partial<CodeEvalDispatcherError>);
   });
+
+  it("includes a small invalid returned result as structured error data", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        runtime: { language: "TYPESCRIPT" },
+        code: { source: `function evaluate() { return { score: 1 }; }` },
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_RESULT",
+      retryable: false,
+      returnedResult: { score: 1 },
+    } satisfies Partial<CodeEvalDispatcherError>);
+  });
 });


### PR DESCRIPTION
## Summary

- Preserve small invalid code evaluator return values as structured `returnedResult` data so users can debug malformed evaluator outputs from test runs.
- Propagate the returned result through shared dispatcher errors, user-visible eval errors, and internal trace output while keeping status messages and metadata focused on the public error message.
- Derive the test-run error response from the shared code eval error type and strip `retryable` at the web boundary, so future error fields do not need to be copied manually.
- Add regression coverage across local dispatch, Lambda dispatch, worker execution traces, and the web test-run endpoint.

## Major Decisions

- Keep `returnedResult` as structured data instead of appending it to the error message. This makes the value easier to render in the UI and avoids bloating trace status messages or metadata fields.
- Keep `retryable` internal to execution handling for test runs. The web response only exposes the debugging fields users need for fixing evaluator code.

## Review Focus

- Confirm the returned evaluator payload is only exposed for user-visible invalid-result paths and does not leak into internal infrastructure errors.
- Check the trace output shape for invalid evaluator results, especially that metadata and status messages stay concise.
- Review the test-run API response shape because it now includes optional structured `returnedResult` data on failed test runs.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces the raw evaluator return value when a code eval produces an invalid shape, giving users actionable debugging context in the test-run API instead of a generic "validation failed" message. It also wires `returnedResult` through the internal trace `output` field while deliberately keeping it out of string fields (`statusMessage`, metadata), and strips `retryable` at the API boundary.

- **`CodeEvalDispatcherError`** gains `returnedResult?: unknown`, populated by `parseDispatchResult` when Zod rejects the evaluator output. Lambda path is safe: `assertDispatchResultWithinByteLimit` runs before parsing, bounding the captured value to ≤256 KiB. The local dispatcher skips that guard, so a VM result that fails schema validation but is non-JSON-serializable (e.g., `BigInt`, circular reference) would propagate to the tRPC response without a serialization guard.
- **`codeEvalTestRun.ts`** derives `CodeEvalTestRunError` from `Omit<CodeEvalUserVisibleError, \"retryable\">` and adds `toCodeEvalTestRunError` to cleanly drop `retryable` at the boundary while preserving `returnedResult`.
- **Test coverage** spans the local dispatcher, Lambda dispatcher (valid-JSON invalid-schema and non-JSON cases), the worker-level trace assertion, and a tRPC integration test for the end-to-end error response shape.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are scoped to the error-propagation path for invalid eval results, with no changes to the happy path or score persistence logic.

The chaining of returnedResult through the error → trace → API path is correct and well-tested. The one gap is that the local (development-only) dispatcher stores the raw VM result without a serializability guard, so a non-JSON-safe evaluator return (BigInt, circular ref) would cause tRPC serialization to throw rather than returning a structured error response. This only affects the insecure-local dev dispatcher, not production Lambda flows.

packages/shared/src/server/evals/codeEvalDispatcherTypes.ts — specifically the parseDispatchResult function where returnedResult is captured without a serializability check for the local dispatcher path.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Evaluator as User Evaluator Code
    participant Dispatcher as CodeEvalDispatcher(Local/Lambda)
    participant Parse as parseDispatchResult
    participant Exec as runCodeBasedEvaluationDispatch
    participant Trace as InternalTraceWriter
    participant API as codeEvalTestRun API

    Evaluator->>Dispatcher: "return { score: 1 }"
    Note over Dispatcher: Lambda only: assertDispatchResultWithinByteLimit()
    Dispatcher->>Parse: "parseDispatchResult({ score: 1 })"
    Parse-->>Dispatcher: "throw CodeEvalDispatcherError { code: INVALID_RESULT, returnedResult: { score: 1 } }"
    Dispatcher-->>Exec: throw (re-thrown)
    Exec->>Exec: getCodeEvalUserVisibleError(error) → visibleError includes returnedResult
    Exec->>Exec: "build traceError { code, message, retryable, returnedResult }"
    Exec->>Trace: "writeCodeEvalTrace(output: { error: traceError })"
    Note over Exec,Trace: returnedResult in JSON output only, not in statusMessage or metadata strings
    Exec-->>API: "{ success: false, error: { code, message, returnedResult } }"
    Note over API: toCodeEvalTestRunError strips retryable before returning to caller
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/evals/codeEvalDispatcherTypes.ts:205-219
**Unguarded non-serializable `returnedResult` on local dispatcher path**

`parseDispatchResult` stores `result` verbatim as `returnedResult`. For the Lambda dispatcher `assertDispatchResultWithinByteLimit` runs before this call, so by the time parsing is attempted the value is bounded JSON. The local dispatcher, however, calls `parseDispatchResult` directly with the raw VM result, applying no size or serializability guard. If a user's evaluator returns a non-JSON-serializable value — `BigInt`, a VM-realm `Date`, or a circular reference — `returnedResult` carries that value all the way to the tRPC test-run response, where plain `JSON.stringify` will throw and convert a validation failure into an unexpected 500. The trace write is safe (`writeCodeEvalTraceSafely` swallows errors), but the API response is not.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): surface invalid code eval re..."](https://github.com/langfuse/langfuse/commit/d1ae09ff329e67f674d4915f73cf2c66db4a3ed3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34188098)</sub>

<!-- /greptile_comment -->