### PR TITLE
feat(ui): swap visual order of detail page nav buttons

### DIFF
--- a/web/src/features/navigate-detail-pages/DetailPageNav.tsx
+++ b/web/src/features/navigate-detail-pages/DetailPageNav.tsx
@@ -85,34 +85,6 @@ export const DetailPageNav = (props: {
               variant="outline"
               type="button"
               className="p-2"
-              disabled={!previousPageEntry}
-              onClick={() => {
-                if (previousPageEntry) {
-                  capture("navigate_detail_pages:button_click_prev_or_next");
-                  navigateToEntry(previousPageEntry);
-                }
-              }}
-            >
-              <ChevronUp className="h-4 w-4" />
-              <span className="bg-primary/80 text-primary-foreground ml-1 h-4 w-4 rounded-sm text-xs shadow-xs">
-                K
-              </span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <span>Navigate up</span>
-            <InputCommandShortcut className="bg-muted ml-2 rounded-sm p-1 px-2">
-              k
-            </InputCommandShortcut>
-          </TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="outline"
-              type="button"
-              className="p-2"
               disabled={!nextPageEntry}
               onClick={() => {
                 if (nextPageEntry) {
@@ -131,6 +103,34 @@ export const DetailPageNav = (props: {
             <span>Navigate down</span>
             <InputCommandShortcut className="bg-muted ml-2 rounded-sm p-1 px-2">
               j
+            </InputCommandShortcut>
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              type="button"
+              className="p-2"
+              disabled={!previousPageEntry}
+              onClick={() => {
+                if (previousPageEntry) {
+                  capture("navigate_detail_pages:button_click_prev_or_next");
+                  navigateToEntry(previousPageEntry);
+                }
+              }}
+            >
+              <ChevronUp className="h-4 w-4" />
+              <span className="bg-primary/80 text-primary-foreground ml-1 h-4 w-4 rounded-sm text-xs shadow-xs">
+                K
+              </span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span>Navigate up</span>
+            <InputCommandShortcut className="bg-muted ml-2 rounded-sm p-1 px-2">
+              k
             </InputCommandShortcut>
           </TooltipContent>
         </Tooltip>


### PR DESCRIPTION
## What does this PR do?

Swaps the visual order of the two navigation buttons rendered by `DetailPageNav` (used across trace, session, prompt, dataset, dataset-item, run, user, and eval detail pages). They previously rendered as `↑K | ↓J`; this PR renders them as `↓J | ↑K`.

On a QWERTY keyboard `j` sits physically to the left of `k`, so the previous on-screen order placed each keycap where the *other* key is on the keyboard, making it easy to reach for the wrong shortcut. The new order matches the physical key layout. Keyboard bindings, chevron icons, and tooltip text are unchanged — only the rendered order of the two buttons.

Relates to discussion: https://github.com/orgs/langfuse/discussions/13543

### Before / After


Before:  [ ↑K ][ ↓J ]

<img width="1795" height="991" alt="Pasted_Image_5_27_26__10_40 AM" src="https://github.com/user-attachments/assets/cd5cbaf6-2905-4885-bf2c-d077859d3a37" />


After:   [ ↓J ][ ↑K ]

<img width="1785" height="981" alt="Pasted_Image_5_27_26__10_37 AM" src="https://github.com/user-attachments/assets/fe4aba7b-5525-4aac-bd93-8fcea828989f" />


## Type of change

- [x] Refactor (restructures existing code without changing behavior)

No functional change: navigation targets, keyboard shortcuts (`j` = down/next, `k` = up/previous), disabled-state logic, and accessibility labels are all identical. Only the DOM order of the two sibling buttons changes.

## Impacted packages

- `web` — `web/src/features/navigate-detail-pages/DetailPageNav.tsx` (single file)

## Testing

- `pnpm --filter web run lint` — pass
- Verified locally: `k`/`j` still navigate previous/next; the left button now shows `↓J` ("Navigate down") and the right shows `↑K` ("Navigate up").

No automated tests added: the change is a pure reordering of two sibling buttons with no logic change, and there is no existing test coverage for `DetailPageNav` button ordering.

## Mandatory Tasks

- [x] Self-reviewed the code.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR swaps the visual render order of the two navigation buttons in `DetailPageNav` so they display as `[ ↓J ][ ↑K ]` instead of `[ ↑K ][ ↓J ]`, matching the physical left-to-right position of `j` and `k` on a QWERTY keyboard.

- The first `<Tooltip>` block now renders the "down / next / J" button and the second renders the "up / previous / K" button; keyboard shortcuts, chevron icons, disabled-state guards, and tooltip text are all consistent with their respective navigation direction.
- The implementation swaps the internal content of both blocks rather than simply reordering the two sibling elements, which produces the same visual result but makes the diff harder to follow at a glance.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a pure visual reordering with no logic, routing, or shortcut behavior altered.

Every detail in the final file checks out: the first button correctly wires nextPageEntry to ChevronDown/J/Navigate down, and the second wires previousPageEntry to ChevronUp/K/Navigate up. The useEffect keyboard handler was not touched and remains correct (j → next, k → previous). Disabled-state guards match their respective entries.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): swap visual order of detail pa..."](https://github.com/langfuse/langfuse/commit/ff115649790f15726c2c819c302b0caf50827746) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34204227)</sub>

<!-- /greptile_comment -->