### PR TITLE
feat(ui): add notification for full text search launch

### DIFF
--- a/web/src/components/nav/sidebar-notifications.clienttest.tsx
+++ b/web/src/components/nav/sidebar-notifications.clienttest.tsx
@@ -3,7 +3,7 @@ import { SidebarNotifications } from "./sidebar-notifications";
 
 vi.mock("../useLocalStorage", () => ({
   __esModule: true,
-  default: () => [["lw5-1", "lw5-2"], vi.fn()],
+  default: () => [["lw5-1", "lw5-2", "lw5-3"], vi.fn()],
 }));
 
 describe("SidebarNotifications", () => {

--- a/web/src/components/nav/sidebar-notifications.tsx
+++ b/web/src/components/nav/sidebar-notifications.tsx
@@ -32,7 +32,7 @@ const notifications: SidebarNotification[] = [
     title: "Launch Week: Day 1",
     description:
       "Run experiments inside GitHub Actions to test every PR against a Langfuse dataset.",
-    link: "https://langfuse.com/launch-week-5",
+    link: "https://langfuse.com/changelog/2026-05-25-experiment-ci-cd-gates",
     linkTitle: "Learn more",
     createdAt: "2026-05-25",
   },
@@ -41,11 +41,18 @@ const notifications: SidebarNotification[] = [
     title: "Launch Week: Day 2",
     description:
       "Langfuse agent skill turns Langfuse into a headless platform to evaluate, query and instrument your application.",
-    link: "https://langfuse.com/launch-week-5",
+    link: "https://langfuse.com/changelog/2026-05-26-langfuse-agent-skill",
     linkTitle: "Learn more",
     createdAt: "2026-05-26",
   },
-
+  {
+    id: "lw5-3",
+    title: "Launch Week: Day 3",
+    description: "Fast full-text search on observation i/o via the UI and API",
+    link: "https://langfuse.com/changelog/2026-05-27-clickhouse-full-text-search-fast-mode",
+    linkTitle: "Learn more",
+    createdAt: "2026-05-27",
+  },
   {
     id: "github-star",
     title: "Star Langfuse",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates two existing Launch Week notifications to point to their specific changelog URLs (replacing the generic launch-week-5 landing page), and adds a new Day 3 notification announcing fast full-text search on observation I/O.

- Day 1 and Day 2 notification links are updated from `https://langfuse.com/launch-week-5` to their respective `/changelog/…` permalinks.
- A new `lw5-3` notification entry is added for the full-text search launch, with the correct `createdAt` date and a default two-week TTL.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are limited to static notification data with no logic alterations.

The change only adds one new static notification entry and updates two URLs; no component logic, state management, or data-fetching is touched. The new entry follows the same shape as existing ones and the TTL/expiry mechanism handles cleanup automatically.

No files require special attention.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/nav/sidebar-notifications.tsx:51
Minor casing nit: "i/o" should be capitalised as "I/O" to match standard technical writing conventions and the surrounding copy style.

```suggestion
    description: "Fast full-text search on observation I/O via the UI and API",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): add notification for full text..."](https://github.com/langfuse/langfuse/commit/ae9d4fbcbf77eefa1afa88d1bcb4515e151c445a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34211187)</sub>

<!-- /greptile_comment -->