### PR TITLE
fix(evals): update code evaluator docs link

### DIFF
--- a/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
+++ b/packages/shared/src/server/evals/codeEvalDispatcherTypes.ts
@@ -4,9 +4,8 @@ import { ScoreDataTypeEnum, TEXT_SCORE_MAX_LENGTH } from "../../domain/scores";
 export const CODE_EVAL_SOURCE_MAX_BYTES = 256 * 1024;
 export const CODE_EVAL_DISPATCH_PAYLOAD_MAX_BYTES = 5.5 * 1024 * 1024;
 export const CODE_EVAL_DISPATCH_RESULT_MAX_BYTES = 256 * 1024;
-// TODO: Replace with a dedicated code-based evaluator limits docs page.
 export const CODE_EVAL_DOCS_URL =
-  "https://langfuse.com/docs/evaluation/overview";
+  "https://langfuse.com/docs/evaluation/evaluation-methods/code-evaluators";
 
 export function withCodeEvalDocs(message: string): string {
   const trimmedMessage = message.trim();

--- a/scripts/code-eval-runners/node/code-based-eval-handler.mjs
+++ b/scripts/code-eval-runners/node/code-based-eval-handler.mjs
@@ -1,6 +1,7 @@
 import { stripTypeScriptTypes } from "node:module";
 
-const CODE_EVAL_DOCS_URL = "https://langfuse.com/docs/evaluation/overview";
+const CODE_EVAL_DOCS_URL =
+  "https://langfuse.com/docs/evaluation/evaluation-methods/code-evaluators";
 
 // `stripTypeScriptTypes` is loaded lazily - we call it hear to avoid doing the import in the call itself
 stripTypeScriptTypes("");

--- a/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
@@ -80,7 +80,7 @@ describe("LocalCodeEvalDispatcher", () => {
       retryable: false,
     } satisfies Partial<CodeEvalDispatcherError>);
     await expect(promise).rejects.toThrow(
-      "See https://langfuse.com/docs/evaluation/overview for details.",
+      "See https://langfuse.com/docs/evaluation/evaluation-methods/code-evaluators for details.",
     );
   });
 

--- a/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
+++ b/worker/src/queues/__tests__/codeEvalExecutionQueueProcessor.test.ts
@@ -241,7 +241,7 @@ describe("codeEvalExecutionQueueProcessor", () => {
 
   it("should preserve retryable code eval timeout messages on the final retry attempt", async () => {
     const timeoutMessage =
-      "Evaluator timed out. Code-based evaluators must complete within the configured runtime limit. Long executions can be caused by network calls, which are forbidden and may never complete. Remove network calls, optimize your evaluator code, and try again. See https://langfuse.com/docs/evaluation/overview for details.";
+      "Evaluator timed out. Code-based evaluators must complete within the configured runtime limit. Long executions can be caused by network calls, which are forbidden and may never complete. Remove network calls, optimize your evaluator code, and try again. See https://langfuse.com/docs/evaluation/evaluation-methods/code-evaluators for details.";
     const error = new CodeEvalExecutionError({
       code: CodeEvalDispatcherErrorCodes.TIMEOUT,
       message: timeoutMessage,


### PR DESCRIPTION
## What does this PR do?

Updates code evaluator error/help links to point at the dedicated code evaluators docs page instead of the general evaluation overview.
Keeps the shared dispatcher URL, bundled Node runner URL, and worker test assertions aligned.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the documentation URL used in code evaluator error messages from the general evaluation overview page to a dedicated code evaluators page, resolving a TODO comment left in the codebase.

- Updates `CODE_EVAL_DOCS_URL` in both the shared package (`codeEvalDispatcherTypes.ts`) and the standalone Node runner script (`code-based-eval-handler.mjs`) to point at the new dedicated URL.
- Updates two test files to assert against the new URL string in error messages.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to a string constant update with no behavioral impact.

All four changed locations are consistent: the shared constant, the standalone runner script, and both test assertions now point to the same dedicated URL. The old TODO comment is properly removed. No logic, control flow, or data handling is affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Code Evaluator Error Occurs] --> B{Error Source}
    B -->|Shared Package| C[codeEvalDispatcherTypes.ts\nCODE_EVAL_DOCS_URL]
    B -->|Node Runner Script| D[code-based-eval-handler.mjs\nCODE_EVAL_DOCS_URL]
    C --> E[withCodeEvalDocs\nappends URL to message]
    D --> F[withCodeEvalDocs\nappends URL to message]
    E --> G[Error message shown to user\nhttps://...code-evaluators]
    F --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): update code evaluator docs l..."](https://github.com/langfuse/langfuse/commit/a3bf15d22d5c7f7ab153c81ea57cdad6afd4046f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34213365)</sub>

<!-- /greptile_comment -->