### PR TITLE
fix(evals): align code evaluator editor and runtime globals

### DIFF
--- a/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/localCodeEvalDispatcher.ts
@@ -40,7 +40,20 @@ export class LocalCodeEvalDispatcher implements CodeEvalDispatcher {
       );
     }
 
-    const context = vm.createContext({ payload: input.payload });
+    const context = vm.createContext({
+      payload: input.payload,
+      console,
+      setTimeout,
+      clearTimeout,
+      setInterval,
+      clearInterval,
+      queueMicrotask,
+      structuredClone,
+      TextEncoder,
+      TextDecoder,
+      URL,
+      URLSearchParams,
+    });
     try {
       vm.runInContext(
         `${source}

--- a/web/src/features/evals/components/eval-template-type-selector.tsx
+++ b/web/src/features/evals/components/eval-template-type-selector.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { type UseFormReturn } from "react-hook-form";
 import { type z } from "zod";
 import {
@@ -17,7 +18,6 @@ import { type templateFormSchema } from "@/src/features/evals/utils/template-for
 import {
   type CodeEvalSourceCodeLanguage,
   getDefaultCodeEvalSource,
-  isDefaultCodeEvalSource,
 } from "@/src/features/evals/utils/code-eval-template-validation";
 
 type EvalTemplateFormInput = z.input<typeof templateFormSchema>;
@@ -27,6 +27,7 @@ type EvalTemplateFormReturn = UseFormReturn<
   unknown,
   EvalTemplateFormOutput
 >;
+type CodeEvalSourceDrafts = Partial<Record<CodeEvalSourceCodeLanguage, string>>;
 
 export type EvalTemplateTypeSelectorMode = "all" | "code-only" | "hidden";
 
@@ -43,6 +44,7 @@ export function EvalTemplateTypeSelector({
   hasExistingTemplate: boolean;
   onChange?: () => void;
 }) {
+  const sourceCodeDraftsRef = useRef<CodeEvalSourceDrafts>({});
   const evalTemplateType = form.watch("type");
   const sourceCodeLanguage =
     form.watch("sourceCodeLanguage") ??
@@ -61,23 +63,29 @@ export function EvalTemplateTypeSelector({
       | typeof EvalTemplateType.LLM_AS_JUDGE
       | CodeEvalSourceCodeLanguage,
   ) => {
+    const currentSourceCode = form.getValues("sourceCode") ?? "";
+    const currentSourceCodeLanguage =
+      form.getValues("sourceCodeLanguage") ??
+      EvalTemplateSourceCodeLanguage.TYPESCRIPT;
+
+    if (evalTemplateType === EvalTemplateType.CODE) {
+      sourceCodeDraftsRef.current[currentSourceCodeLanguage] =
+        currentSourceCode;
+    }
+
     if (nextValue === EvalTemplateType.LLM_AS_JUDGE) {
       form.setValue("type", EvalTemplateType.LLM_AS_JUDGE);
       onChange?.();
       return;
     }
 
-    const currentSourceCode = form.getValues("sourceCode") ?? "";
-    const shouldReplaceSourceCode =
-      currentSourceCode.trim().length === 0 ||
-      isDefaultCodeEvalSource(currentSourceCode);
-
     form.setValue("type", EvalTemplateType.CODE);
     form.setValue("sourceCodeLanguage", nextValue);
-
-    if (shouldReplaceSourceCode) {
-      form.setValue("sourceCode", getDefaultCodeEvalSource(nextValue));
-    }
+    form.setValue(
+      "sourceCode",
+      sourceCodeDraftsRef.current[nextValue] ??
+        getDefaultCodeEvalSource(nextValue),
+    );
 
     onChange?.();
   };

--- a/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
@@ -107,17 +107,51 @@ describe("code eval template validation", () => {
     expect(result.hasErrors).toBe(false);
   });
 
-  it("rejects async TypeScript evaluate functions", async () => {
+  it("accepts async TypeScript evaluate functions with timers", async () => {
     const result = await validateCodeEvalSourceWithLanguage({
       source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
 async function evaluate(ctx: EvaluationContext): Promise<EvaluationResult> {
+  await new Promise((resolve) => setTimeout(resolve, 2000));
   return { scores: [] };
 }
 `,
       sourceCodeLanguage: "TYPESCRIPT",
     });
 
-    expect(result.hasErrors).toBe(true);
+    expect(result.hasErrors).toBe(false);
+  });
+
+  it("accepts simple Node runtime globals and keeps process unavailable", async () => {
+    const result = await validateCodeEvalSourceWithLanguage({
+      source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  const encoded = new TextEncoder().encode(new URL("https://langfuse.com").hostname);
+  const copy = structuredClone({ length: encoded.length });
+  queueMicrotask(() => {});
+
+  return { scores: [{ name: "encoded", value: copy.length, dataType: "NUMERIC" }] };
+}
+`,
+      sourceCodeLanguage: "TYPESCRIPT",
+    });
+
+    expect(result.hasErrors).toBe(false);
+
+    const processResult = await validateCodeEvalSourceWithLanguage({
+      source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  return { scores: [{ name: "env", value: process.env.NODE_ENV ?? "", dataType: "TEXT" }] };
+}
+`,
+      sourceCodeLanguage: "TYPESCRIPT",
+    });
+
+    expect(processResult.hasErrors).toBe(true);
+    expect(
+      processResult.diagnostics.some((diagnostic) =>
+        diagnostic.message.includes("Cannot find name 'process'"),
+      ),
+    ).toBe(true);
   });
 
   it("rejects exported TypeScript evaluate functions", async () => {

--- a/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
@@ -112,7 +112,18 @@ describe("code eval template validation", () => {
       source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
 async function evaluate(ctx: EvaluationContext): Promise<EvaluationResult> {
   await new Promise((resolve) => setTimeout(resolve, 2000));
-  return { scores: [] };
+  const allValues = await Promise.all([Promise.resolve(1), Promise.resolve(2)]);
+  const settled = await Promise.allSettled([Promise.resolve("ok"), Promise.reject("no")]);
+  const raced = await Promise.race([Promise.resolve(3)]);
+  const anyValue = await Promise.any([Promise.reject("no"), Promise.resolve(4)]);
+
+  return {
+    scores: [{
+      name: "async helpers",
+      value: allValues[0] + allValues[1] + settled.length + raced + anyValue,
+      dataType: "NUMERIC",
+    }],
+  };
 }
 `,
       sourceCodeLanguage: "TYPESCRIPT",
@@ -126,10 +137,15 @@ async function evaluate(ctx: EvaluationContext): Promise<EvaluationResult> {
       source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
 function evaluate(ctx: EvaluationContext): EvaluationResult {
   const encoded = new TextEncoder().encode(new URL("https://langfuse.com").hostname);
+  const sliced = encoded.slice(0, 4).subarray(0, 2);
+  let byteTotal = 0;
+  sliced.forEach((value) => {
+    byteTotal = byteTotal + value;
+  });
   const copy = structuredClone({ length: encoded.length });
   queueMicrotask(() => {});
 
-  return { scores: [{ name: "encoded", value: copy.length, dataType: "NUMERIC" }] };
+  return { scores: [{ name: "encoded", value: copy.length + byteTotal, dataType: "NUMERIC" }] };
 }
 `,
       sourceCodeLanguage: "TYPESCRIPT",

--- a/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
@@ -110,17 +110,39 @@ describe("code eval template validation", () => {
   it("accepts async TypeScript evaluate functions with timers", async () => {
     const result = await validateCodeEvalSourceWithLanguage({
       source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
+type TimerHandle = unknown;
+type URLSearchParamsInit = string;
+
 async function evaluate(ctx: EvaluationContext): Promise<EvaluationResult> {
-  await new Promise((resolve) => setTimeout(resolve, 2000));
+  const timer: TimerHandle = setTimeout(() => {}, 1);
+  clearTimeout(timer);
+  const interval: TimerHandle = setInterval(() => {}, 1);
+  clearInterval(interval);
+  const paramsInit: URLSearchParamsInit = "source=eval";
+  const params = new URLSearchParams(paramsInit);
+  await new Promise((resolve) => setTimeout(resolve, params.has("source") ? 1 : 2));
   const allValues = await Promise.all([Promise.resolve(1), Promise.resolve(2)]);
   const settled = await Promise.allSettled([Promise.resolve("ok"), Promise.reject("no")]);
   const raced = await Promise.race([Promise.resolve(3)]);
   const anyValue = await Promise.any([Promise.reject("no"), Promise.resolve(4)]);
+  const slicedValues = allValues.slice(0, 2);
+  const firstLargeValue = slicedValues.find((value) => value > 1) ?? 0;
+  let iteratedTotal = 0;
+  slicedValues.forEach((value) => {
+    iteratedTotal = iteratedTotal + value;
+  });
+  const arrayScore =
+    slicedValues.reduce((total, value) => total + value, 0) +
+    (slicedValues.every((value) => value > 0) ? 1 : 0) +
+    (slicedValues.some((value) => value > 1) ? 1 : 0) +
+    (Array.isArray(slicedValues) ? 1 : 0) +
+    firstLargeValue +
+    iteratedTotal;
 
   return {
     scores: [{
       name: "async helpers",
-      value: allValues[0] + allValues[1] + settled.length + raced + anyValue,
+      value: arrayScore + settled.length + raced + anyValue,
       dataType: "NUMERIC",
     }],
   };
@@ -136,7 +158,25 @@ async function evaluate(ctx: EvaluationContext): Promise<EvaluationResult> {
     const result = await validateCodeEvalSourceWithLanguage({
       source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
 function evaluate(ctx: EvaluationContext): EvaluationResult {
-  const encoded = new TextEncoder().encode(new URL("https://langfuse.com").hostname);
+  const url = new URL("https://user:pass@langfuse.com:443/docs?source=eval#section");
+  const urlScore =
+    url.origin.length +
+    url.protocol.length +
+    url.host.length +
+    url.port.length +
+    url.username.length +
+    url.password.length +
+    url.hash.length;
+  const params = new URLSearchParams([["source", "eval"]]);
+  const paramsCopy = new URLSearchParams(params);
+  paramsCopy.append("next", "true");
+  paramsCopy.set("source", "code");
+  paramsCopy.delete("missing");
+  let paramsScore = paramsCopy.has("source") ? (paramsCopy.get("source") ?? "").length : 0;
+  paramsCopy.forEach((value, key) => {
+    paramsScore = paramsScore + value.length + key.length;
+  });
+  const encoded = new TextEncoder().encode(url.hostname);
   const sliced = encoded.slice(0, 4).subarray(0, 2);
   let byteTotal = 0;
   sliced.forEach((value) => {
@@ -145,7 +185,7 @@ function evaluate(ctx: EvaluationContext): EvaluationResult {
   const copy = structuredClone({ length: encoded.length });
   queueMicrotask(() => {});
 
-  return { scores: [{ name: "encoded", value: copy.length + byteTotal, dataType: "NUMERIC" }] };
+  return { scores: [{ name: "encoded", value: copy.length + byteTotal + paramsScore + urlScore, dataType: "NUMERIC" }] };
 }
 `,
       sourceCodeLanguage: "TYPESCRIPT",

--- a/web/src/features/evals/utils/code-eval-template-validation.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.ts
@@ -49,7 +49,6 @@ const __langfuseEvaluateCheck: __LangfuseExpectedEvaluate = evaluate;
 `;
 
 const CONTRACT_DECLARATIONS = `
-type TimerHandle = unknown;
 type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
 type PromiseSettledResult<T> =
   | { status: "fulfilled"; value: T }
@@ -58,10 +57,28 @@ type PromiseSettledResult<T> =
 interface Array<T> {
   length: number;
   [n: number]: T;
+  every(callbackfn: (value: T, index: number, array: T[]) => unknown): boolean;
   map<U>(callbackfn: (value: T, index: number, array: T[]) => U): U[];
   filter(callbackfn: (value: T, index: number, array: T[]) => unknown): T[];
+  find(callbackfn: (value: T, index: number, array: T[]) => unknown): T | undefined;
+  forEach(callbackfn: (value: T, index: number, array: T[]) => void): void;
   includes(searchElement: T, fromIndex?: number): boolean;
   join(separator?: string): string;
+  reduce<U>(
+    callbackfn: (
+      previousValue: U,
+      currentValue: T,
+      currentIndex: number,
+      array: T[],
+    ) => U,
+    initialValue: U,
+  ): U;
+  slice(start?: number, end?: number): T[];
+  some(callbackfn: (value: T, index: number, array: T[]) => unknown): boolean;
+}
+
+interface ArrayConstructor {
+  isArray(value: unknown): value is unknown[];
 }
 
 interface Boolean {}
@@ -106,6 +123,7 @@ interface PromiseConstructor {
 }
 
 interface String {
+  readonly length: number;
   includes(searchString: string, position?: number): boolean;
   trim(): string;
   toLowerCase(): string;
@@ -125,6 +143,7 @@ interface Uint8Array {
 type Record<K extends string, T> = { [P in K]: T };
 
 declare const Promise: PromiseConstructor;
+declare const Array: ArrayConstructor;
 declare const String: (value?: unknown) => string;
 declare const Number: (value?: unknown) => number;
 declare const Boolean: (value?: unknown) => boolean;
@@ -148,14 +167,14 @@ declare function setTimeout(
   callback: (...args: any[]) => void,
   delay?: number,
   ...args: any[]
-): TimerHandle;
-declare function clearTimeout(handle?: TimerHandle): void;
+): unknown;
+declare function clearTimeout(handle?: unknown): void;
 declare function setInterval(
   callback: (...args: any[]) => void,
   delay?: number,
   ...args: any[]
-): TimerHandle;
-declare function clearInterval(handle?: TimerHandle): void;
+): unknown;
+declare function clearInterval(handle?: unknown): void;
 declare function queueMicrotask(callback: () => void): void;
 declare function structuredClone<T>(value: T): T;
 declare class TextEncoder {
@@ -166,16 +185,27 @@ declare class TextDecoder {
 }
 declare class URL {
   constructor(url: string, base?: string | URL);
+  hash: string;
+  host: string;
   href: string;
   hostname: string;
+  origin: string;
   pathname: string;
+  password: string;
+  port: string;
+  protocol: string;
   search: string;
   searchParams: URLSearchParams;
+  username: string;
   toString(): string;
 }
 declare class URLSearchParams {
-  constructor(init?: string | Record<string, string>);
+  constructor(init?: string | Record<string, string> | string[][] | URLSearchParams);
   append(name: string, value: string): void;
+  delete(name: string): void;
+  forEach(
+    callbackfn: (value: string, key: string, parent: URLSearchParams) => void,
+  ): void;
   get(name: string): string | null;
   has(name: string): boolean;
   set(name: string, value: string): void;

--- a/web/src/features/evals/utils/code-eval-template-validation.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.ts
@@ -50,6 +50,10 @@ const __langfuseEvaluateCheck: __LangfuseExpectedEvaluate = evaluate;
 
 const CONTRACT_DECLARATIONS = `
 type TimerHandle = unknown;
+type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
+type PromiseSettledResult<T> =
+  | { status: "fulfilled"; value: T }
+  | { status: "rejected"; reason: any };
 
 interface Array<T> {
   length: number;
@@ -93,6 +97,10 @@ interface PromiseConstructor {
       reject: (reason?: any) => void,
     ) => void,
   ): Promise<T>;
+  all<T>(values: T[]): Promise<Awaited<T>[]>;
+  allSettled<T>(values: T[]): Promise<PromiseSettledResult<Awaited<T>>[]>;
+  any<T>(values: T[]): Promise<Awaited<T>>;
+  race<T>(values: T[]): Promise<Awaited<T>>;
   resolve<T>(value: T | PromiseLike<T>): Promise<T>;
   reject<T = never>(reason?: any): Promise<T>;
 }
@@ -107,6 +115,11 @@ interface String {
 interface Uint8Array {
   readonly length: number;
   [n: number]: number;
+  forEach(
+    callbackfn: (value: number, index: number, array: Uint8Array) => void,
+  ): void;
+  slice(start?: number, end?: number): Uint8Array;
+  subarray(begin?: number, end?: number): Uint8Array;
 }
 
 type Record<K extends string, T> = { [P in K]: T };

--- a/web/src/features/evals/utils/code-eval-template-validation.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.ts
@@ -44,11 +44,13 @@ type RuffWorkspace = {
 const SYNTHETIC_ASSERTION_PREFIX = `
 type __LangfuseExpectedEvaluate = (
   ctx: EvaluationContext,
-) => EvaluationResult;
+) => EvaluationResult | Promise<EvaluationResult>;
 const __langfuseEvaluateCheck: __LangfuseExpectedEvaluate = evaluate;
 `;
 
 const CONTRACT_DECLARATIONS = `
+type TimerHandle = unknown;
+
 interface Array<T> {
   length: number;
   [n: number]: T;
@@ -84,6 +86,17 @@ interface PromiseLike<T> {
   ): PromiseLike<TResult1 | TResult2>;
 }
 
+interface PromiseConstructor {
+  new <T>(
+    executor: (
+      resolve: (value: T | PromiseLike<T>) => void,
+      reject: (reason?: any) => void,
+    ) => void,
+  ): Promise<T>;
+  resolve<T>(value: T | PromiseLike<T>): Promise<T>;
+  reject<T = never>(reason?: any): Promise<T>;
+}
+
 interface String {
   includes(searchString: string, position?: number): boolean;
   trim(): string;
@@ -91,8 +104,14 @@ interface String {
   toString(): string;
 }
 
+interface Uint8Array {
+  readonly length: number;
+  [n: number]: number;
+}
+
 type Record<K extends string, T> = { [P in K]: T };
 
+declare const Promise: PromiseConstructor;
 declare const String: (value?: unknown) => string;
 declare const Number: (value?: unknown) => number;
 declare const Boolean: (value?: unknown) => boolean;
@@ -112,6 +131,43 @@ declare const console: {
   warn(...args: unknown[]): void;
   error(...args: unknown[]): void;
 };
+declare function setTimeout(
+  callback: (...args: any[]) => void,
+  delay?: number,
+  ...args: any[]
+): TimerHandle;
+declare function clearTimeout(handle?: TimerHandle): void;
+declare function setInterval(
+  callback: (...args: any[]) => void,
+  delay?: number,
+  ...args: any[]
+): TimerHandle;
+declare function clearInterval(handle?: TimerHandle): void;
+declare function queueMicrotask(callback: () => void): void;
+declare function structuredClone<T>(value: T): T;
+declare class TextEncoder {
+  encode(input?: string): Uint8Array;
+}
+declare class TextDecoder {
+  decode(input?: Uint8Array): string;
+}
+declare class URL {
+  constructor(url: string, base?: string | URL);
+  href: string;
+  hostname: string;
+  pathname: string;
+  search: string;
+  searchParams: URLSearchParams;
+  toString(): string;
+}
+declare class URLSearchParams {
+  constructor(init?: string | Record<string, string>);
+  append(name: string, value: string): void;
+  get(name: string): string | null;
+  has(name: string): boolean;
+  set(name: string, value: string): void;
+  toString(): string;
+}
 `;
 
 const IGNORED_DIAGNOSTIC_CODES = new Set([2318]);

--- a/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
+++ b/worker/src/features/evaluation/codeBased/localCodeEvalDispatcher.test.ts
@@ -55,6 +55,35 @@ describe("LocalCodeEvalDispatcher", () => {
     });
   });
 
+  it("exposes the supported Node-like evaluator globals", async () => {
+    const dispatcher = new LocalCodeEvalDispatcher();
+
+    const result = await dispatcher.dispatch({
+      ...baseInput,
+      runtime: { language: "TYPESCRIPT" },
+      code: {
+        source: `
+          async function evaluate() {
+            await new Promise((resolve) => setTimeout(resolve, 1));
+
+            const encoded = new TextEncoder().encode(
+              new URL("https://langfuse.com/docs").hostname,
+            );
+            const copy = structuredClone({ length: encoded.length });
+
+            return {
+              scores: [{ name: "encoded", value: copy.length, dataType: "NUMERIC" }],
+            };
+          }
+        `,
+      },
+    });
+
+    expect(result).toEqual({
+      scores: [{ name: "encoded", value: 12, dataType: "NUMERIC" }],
+    });
+  });
+
   it("rejects unsupported TypeScript syntax with a docs link", async () => {
     const dispatcher = new LocalCodeEvalDispatcher();
 


### PR DESCRIPTION
## Summary

- Keeps code evaluator source drafts separated per language so switching from edited TypeScript to Python loads Python starter code instead of carrying over JS/TS source.
- Allows async TypeScript evaluators in frontend validation and adds the matching supported runtime globals to the local TypeScript dispatcher.
- Covers the updated validation/runtime behavior with web and worker tests.

## Linear

- Not linked

## Major Decisions

- Store evaluator editor drafts locally by language in the selector instead of trying to infer whether existing source should be replaced. This avoids cross-language source leakage while preserving a user's draft when they switch back.
- Expose only the small runtime-global allowlist needed by supported code evaluator patterns instead of exposing broader Node globals like `process`.

## Review Focus

- Confirm the supported global allowlist is appropriate for local TypeScript evaluator execution.
- Check that async evaluator validation matches production/local runtime behavior.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related misalignments between the code evaluator's editor experience and its runtime behaviour. It introduces per-language draft storage in `EvalTemplateTypeSelector` so switching languages no longer carries over source from a different language, and it updates both the frontend TypeScript validator and the `LocalCodeEvalDispatcher` to support async evaluators with a consistent set of runtime globals.

- **Per-language draft storage** (`eval-template-type-selector.tsx`): a `useRef<Partial<Record<CodeEvalSourceCodeLanguage, string>>>` saves the current editor content under the active language key before each language switch, replacing the old `isDefaultCodeEvalSource` heuristic that could cause draft loss.
- **Async evaluator support** (`code-eval-template-validation.ts`): the `SYNTHETIC_ASSERTION_PREFIX` now accepts `Promise<EvaluationResult>` return types, and `CONTRACT_DECLARATIONS` is extended with `PromiseConstructor`, `Uint8Array`, timer functions, `structuredClone`, `TextEncoder`/`TextDecoder`, `URL`, and `URLSearchParams`.
- **Matching VM globals** (`localCodeEvalDispatcher.ts`): the same set of globals is injected into the `vm.createContext` call, and a `Promise.race`-based timeout already handles async evaluators that never settle.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core async-support and draft-storage changes are safe to merge; the main practical risk is that `Promise.all` and similar combinators will produce false editor errors while working at runtime, and `setInterval` handles created in user code are never cleaned up by the dispatcher.

The draft-storage refactor in the selector is straightforward and well-tested. The VM globals list is explicit and intentionally minimal (no `process`, no `fetch`), and the async timeout is handled by `Promise.race`. The gaps are in the type declaration layer: `PromiseConstructor` omits the four standard combinators that V8's native Promise exposes at runtime, so users who write `Promise.all(...)` will see editor errors on valid code. Neither issue breaks existing evaluators, but both perpetuate the validator/runtime gap the PR set out to close.

`web/src/features/evals/utils/code-eval-template-validation.ts` — the `PromiseConstructor` and `Uint8Array` interface declarations should be checked for completeness against what the VM sandbox actually exposes at runtime. `packages/shared/src/server/evals/localCodeEvalDispatcher.ts` — the `setInterval` exposure warrants a note or wrapping guard.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Editor as EvalTemplateTypeSelector
    participant Validator as validateCodeEvalSource (TS)
    participant Worker as LocalCodeEvalDispatcher
    participant VM as node:vm sandbox

    User->>Editor: Switch language (e.g. TS → Python)
    Editor->>Editor: Save current source to sourceCodeDraftsRef[TS]
    Editor->>Editor: Load sourceCodeDraftsRef[Python] ?? default Python source

    User->>Editor: Edit async TypeScript evaluator
    Editor->>Validator: validateCodeEvalSourceWithLanguage(source, TYPESCRIPT)
    Validator->>Validator: "Build validationSource = CONTRACT_DECLARATIONS + source + SYNTHETIC_ASSERTION_PREFIX"
    Note over Validator: SYNTHETIC_ASSERTION_PREFIX now accepts Promise<EvaluationResult>
    Validator-->>Editor: CodeEvalValidationResult (hasErrors, diagnostics)

    User->>Worker: Trigger evaluation
    Worker->>Worker: stripTypeScriptTypes(source)
    Worker->>VM: createContext with payload, console, setTimeout, setInterval, TextEncoder, URL, ...
    Worker->>VM: "runInContext(source + evaluate check, {timeout})"
    Worker->>VM: "runInContext(evaluate(payload), {timeout})"
    VM-->>Worker: evaluatorResult (Promise or value)
    Worker->>Worker: Promise.race([evaluatorResult, timeoutReject])
    Worker-->>User: DispatchResult (scores)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/features/evals/utils/code-eval-template-validation.ts:89-98
**Missing `Promise` combinators cause false validation errors**

`PromiseConstructor` only declares `new`, `resolve`, and `reject`. `Promise.all`, `Promise.allSettled`, `Promise.race`, and `Promise.any` are absent from the interface, so any evaluator that uses these patterns will get a TypeScript error in the editor (e.g. "Property 'all' does not exist on type 'PromiseConstructor'"). At runtime the VM sandbox's native V8 `Promise` exposes all four methods, so the code runs fine — this is exactly the kind of validation/runtime gap this PR is meant to close.

### Issue 2 of 3
web/src/features/evals/utils/code-eval-template-validation.ts:107-110
**Minimal `Uint8Array` declaration causes false errors on `TextEncoder` results**

The `Uint8Array` interface only exposes `length` and indexed access. `TextEncoder.encode()` returns `Uint8Array`, so any evaluator that calls `.forEach()`, `.slice()`, `.subarray()`, or other array-like methods on the encoded result will get a type error in the editor but will succeed at runtime. Consider adding at least `forEach` and `slice` to match common usage.

### Issue 3 of 3
packages/shared/src/server/evals/localCodeEvalDispatcher.ts:46-49
**`setInterval` callbacks created in user code are never cleaned up**

`setInterval` is passed directly as the host function, so any interval a user-supplied evaluator starts will keep firing in the worker's event loop after `dispatch` resolves or rejects. The `finally` block only clears the one `timeoutId` owned by the dispatcher; it has no reference to intervals started inside the VM. Over multiple evaluator runs this can accumulate and drain CPU. At minimum, documenting that users are responsible for calling `clearInterval` is prudent; a more robust fix would wrap `setInterval` to register handles and drain them after the race settles.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): align code evaluator editor ..."](https://github.com/langfuse/langfuse/commit/01ae2dadb34934d7a4ee96e1dbd8b89d054c7ebd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34223733)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->