### PR TITLE
fix(evals): overflow and scroll behaviour for setting up eval form

### DIFF
--- a/web/src/features/evals/components/run-evaluator-form.tsx
+++ b/web/src/features/evals/components/run-evaluator-form.tsx
@@ -14,7 +14,7 @@ export function RunEvaluatorForm({
   evalTemplates,
 }: RunEvaluatorFormProps) {
   return (
-    <Card className="grid max-h-[90vh] overflow-y-auto p-3">
+    <Card className="grid p-3">
       <EvaluatorForm
         projectId={projectId}
         evalTemplates={evalTemplates}

--- a/web/src/features/evals/pages/new-evaluator.tsx
+++ b/web/src/features/evals/pages/new-evaluator.tsx
@@ -110,6 +110,7 @@ export default function NewEvaluatorPage() {
   return (
     <Page
       withPadding
+      scrollable
       headerProps={{
         title: "Set up evaluator",
         breadcrumb: [


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes overflow and scroll behavior for the evaluator setup form by moving scroll responsibility from the inner card to the page level.

- **`run-evaluator-form.tsx`**: Removes `max-h-[90vh] overflow-y-auto` from the `Card` wrapper, eliminating the inner scroll container that was causing the layout issue.
- **`new-evaluator.tsx`**: Adds the `scrollable` prop to the `Page` component, which switches the page container from a fixed-height `overflow-hidden` layout to the `min-h-screen-with-banner` pattern used elsewhere in the codebase, allowing the page to grow and scroll naturally.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are limited to layout classes on two components and introduce no logic modifications.

The fix replaces a card-level scroll container with page-level scrolling via the existing `scrollable` prop, which follows the established `min-h-screen-with-banner` pattern used throughout the codebase. `RunEvaluatorForm` has a single call site, so removing the height cap carries no risk of breakage elsewhere.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[NewEvaluatorPage] --> B["Page scrollable=true"]
    B --> C["outer div: min-h-screen-with-banner flex flex-1"]
    C --> D["header: sticky top-0 z-50"]
    C --> E["main: min-h-screen-with-banner flex flex-1"]
    E --> F{stepInt}
    F -- "0" --> G[DefaultEvalModelSetup]
    F -- "1" --> H[SelectEvaluatorList]
    F -- "2" --> I[RunEvaluatorForm]
    I --> J["Card: grid p-3 (no max-height)"]
    J --> K[EvaluatorForm]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): overflow and scroll behaviou..."](https://github.com/langfuse/langfuse/commit/49c5b7fde689c5297e9fa06bc3de1930ffd09b19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34309148)</sub>

<!-- /greptile_comment -->