### PR TITLE
fix(comments): always show submit comment button

### DIFF
--- a/web/src/features/comments/CommentDrawerButton.tsx
+++ b/web/src/features/comments/CommentDrawerButton.tsx
@@ -180,7 +180,10 @@ export function CommentDrawerButton({
           )}
         </Button>
       </DrawerTrigger>
-      <DrawerContent overlayClassName="bg-primary/10">
+      <DrawerContent
+        overlayClassName="bg-primary/10"
+        className="h-screen-with-banner max-h-screen-with-banner overflow-hidden"
+      >
         <div
           className="mx-auto flex h-full w-full flex-col overflow-hidden focus:ring-0 focus:outline-hidden focus-visible:ring-0 focus-visible:outline-hidden md:max-h-full"
           tabIndex={-1}
@@ -197,7 +200,10 @@ export function CommentDrawerButton({
               <Header title="Comments"></Header>
             </DrawerTitle>
           </DrawerHeader>
-          <div data-vaul-no-drag className="min-h-0 flex-1 px-2 pt-2">
+          <div
+            data-vaul-no-drag
+            className="min-h-0 flex-1 overflow-hidden px-2 py-2"
+          >
             <CommentList
               projectId={projectId}
               objectId={objectId}

--- a/web/src/features/comments/CommentList.tsx
+++ b/web/src/features/comments/CommentList.tsx
@@ -490,7 +490,7 @@ export function CommentList({
     <div
       className={cn(
         cardView && "rounded-md border",
-        "flex h-full min-h-0 flex-col",
+        "flex h-full min-h-0 flex-col overflow-hidden",
         className,
       )}
     >
@@ -499,7 +499,7 @@ export function CommentList({
           Comments ({comments.data?.length ?? 0})
         </div>
       )}
-      <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {!cardView && (
           <div className="shrink-0 border-b">
             <div className="flex items-center justify-between gap-2 px-2 py-1.5">
@@ -697,13 +697,13 @@ export function CommentList({
         </div>
 
         {hasWriteAccess && (
-          <>
-            <div className="text-muted-foreground relative mt-2 mr-4 ml-2.5 flex flex-row items-center justify-between text-xs">
+          <div className="bg-background shrink-0 px-2 pt-2 pb-[calc(0.5rem+env(safe-area-inset-bottom,0px))]">
+            <div className="text-muted-foreground relative flex flex-row items-center justify-between text-xs">
               <span className="sr-only">New comment</span>
               <span></span>
               <span>Markdown and @-mentions support</span>
             </div>
-            <div className="border-border/60 relative mt-0.5 mr-3 mb-2 ml-2 min-h-[70px] shrink-0 rounded-lg border pt-1">
+            <div className="border-border/60 relative mt-0.5 min-h-[70px] rounded-lg border pt-1">
               {/* Visually hidden header for accessibility */}
 
               <Form {...form}>
@@ -803,7 +803,7 @@ export function CommentList({
                 </form>
               </Form>
             </div>
-          </>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the comment submit button being hidden when the comment list is long, by restructuring the CSS layout in `CommentList.tsx` and `CommentDrawerButton.tsx` to use a proper sticky-footer pattern.

- Wraps the comment input area in a `shrink-0` div (replacing a bare React Fragment), so it never gets pushed off-screen by a tall comment list; also adds `bg-background` to visually cover scrolled content underneath.
- Adds `overflow-hidden` at each flex container level in both files and constrains the drawer to `h-screen-with-banner` / `max-h-screen-with-banner`, ensuring the scrollable comment list and the fixed footer render within the available height.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are purely additive CSS class adjustments with no logic, data, or API surface affected.

Both files only touch Tailwind class strings and one Fragment-to-div refactor. The custom `h-screen-with-banner` utility is already defined and used across the project, `overflow-hidden` additions follow the established flexbox scroll pattern, and `shrink-0` with `bg-background` is a standard sticky-footer technique. No behavioural regressions are expected in either the drawer or card-view render paths.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DrawerContent\nh-screen-with-banner\noverflow-hidden] --> B[inner div\nflex flex-col\noverflow-hidden]
    B --> C[DrawerHeader\nshrink-0]
    B --> D[data-vaul-no-drag div\nmin-h-0 flex-1 overflow-hidden\npy-2]
    D --> E[CommentList\nflex flex-col overflow-hidden]
    E --> F[Search bar\nshrink-0 border-b]
    E --> G[Comments scroll area\nflex-1 overflow-y-auto]
    E --> H{hasWriteAccess?}
    H -- Yes --> I[Comment input wrapper\nshrink-0 bg-background\npb with safe-area-inset]
    I --> J[Markdown hint bar]
    I --> K[Textarea + Submit button]
    H -- No --> L[No input shown]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(comments): always show submit commen..."](https://github.com/langfuse/langfuse/commit/f3cc743471c4bbf26cf38a1d156b47a579504363) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34328011)</sub>

<!-- /greptile_comment -->