### PR TITLE
fix(dashboards): drop scoreName filter on traces and observations views

### DIFF
--- a/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.ts
@@ -64,14 +64,12 @@ const viewFilterDefinitions: Record<
 > = {
   traces: [
     defineField("name", sourceSpec("Trace Name", { uiTableId: "traceName" })),
-    defineField(
-      "observationName",
-      sourceSpec("Observation Name", { uiTableId: "observationName" }),
-    ),
+    // observationName intentionally omitted: traces:observations is 1:n and traceView has no
+    // observationName dimension.
     // scoreName intentionally omitted: traces:scores is 1:n, and traceView has
-    // no scoreName dimension. The legacy *Name->name fallback would silently
-    // rewrite this to traces.name (LFE-9773). Filter on the scores-numeric /
-    // scores-categorical views instead.
+    // no scoreName dimension.
+    // The legacy *Name->name fallback would silently rewrite this to traces.name.
+    // Filter on the scores-numeric / scores-categorical views instead.
     defineField("tags", sourceSpec("Tags", { uiTableId: "traceTags" })),
     defineField(
       "userId",

--- a/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.ts
@@ -68,10 +68,10 @@ const viewFilterDefinitions: Record<
       "observationName",
       sourceSpec("Observation Name", { uiTableId: "observationName" }),
     ),
-    defineField(
-      "scoreName",
-      sourceSpec("Score Name", { uiTableId: "scoreName" }),
-    ),
+    // scoreName intentionally omitted: traces:scores is 1:n, and traceView has
+    // no scoreName dimension. The legacy *Name->name fallback would silently
+    // rewrite this to traces.name (LFE-9773). Filter on the scores-numeric /
+    // scores-categorical views instead.
     defineField("tags", sourceSpec("Tags", { uiTableId: "traceTags" })),
     defineField(
       "userId",
@@ -100,10 +100,8 @@ const viewFilterDefinitions: Record<
       "name",
       sourceSpec("Observation Name", { uiTableId: "observationName" }),
     ),
-    defineField(
-      "scoreName",
-      sourceSpec("Score Name", { uiTableId: "scoreName" }),
-    ),
+    // scoreName intentionally omitted: observations:scores is 1:n, and
+    // observationsView has no scoreName dimension. See LFE-9773.
     defineField(
       "userId",
       sourceSpec("User", { uiTableId: "user" }),

--- a/web/src/features/widgets/components/widgetFilterColumns.ts
+++ b/web/src/features/widgets/components/widgetFilterColumns.ts
@@ -61,22 +61,11 @@ const getWidgetFilterColumnSpecs = ({
       },
       customSelect: true,
     },
-    {
-      column: {
-        name: "Observation Name",
-        id: "observationName",
-        type: "string",
-        internal: "internalValue",
-      },
-    },
-    {
-      column: {
-        name: "Score Name",
-        id: "scoreName",
-        type: "string",
-        internal: "internalValue",
-      },
-    },
+    // "Observation Name" and "Score Name" are intentionally NOT in the base
+    // list because they are not valid filter columns on the traces view
+    // (traces:observations and traces:scores are both 1:n -- see LFE-9773).
+    // They are added below per-view where the dashboardUiTableToViewMapping
+    // actually resolves them to a real dimension.
     {
       column: {
         name: "Tags",
@@ -130,6 +119,44 @@ const getWidgetFilterColumnSpecs = ({
         internal: "internalValue",
       },
     });
+  }
+
+  if (selectedView === "observations") {
+    // "Observation Name" on the observations view filters observations.name
+    // (mapped through dashboardUiTableToViewMapping). "Score Name" is omitted
+    // here because observations:scores is 1:n -- see LFE-9773.
+    filterColumns.push({
+      column: {
+        name: "Observation Name",
+        id: "observationName",
+        type: "string",
+        internal: "internalValue",
+      },
+    });
+  }
+
+  if (
+    selectedView === "scores-numeric" ||
+    selectedView === "scores-categorical"
+  ) {
+    filterColumns.push(
+      {
+        column: {
+          name: "Score Name",
+          id: "scoreName",
+          type: "string",
+          internal: "internalValue",
+        },
+      },
+      {
+        column: {
+          name: "Observation Name",
+          id: "observationName",
+          type: "string",
+          internal: "internalValue",
+        },
+      },
+    );
   }
 
   if (selectedView === "observations") {


### PR DESCRIPTION
The dashboard exposes a global "Score Name" filter that gets routed to every widget via dashboardUiTableToViewMapping. The traces and observations entries mapped it to a scoreName column, but neither traceView nor observationsView declares a scoreName dimension in the query data model. queryBuilder.resolveDimension then hit the generic *Name -> name fallback and silently rewrote the filter to traces.name or observations.name -- so picking a score label appeared to match trace names instead.

Removing the mappings lets the filter partition as unsupported on those views (still applied correctly on scores-numeric / scores-categorical), which avoids the silent miscarriage without changing the score-side UX.

Fixes LFE-9773.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes `scoreName` from the filter mappings for the `traces` and `observations` views in `dashboardUiTableToViewMapping.ts`. Previously, a global "Score Name" dashboard filter routed to these views caused a silent fallback in `queryBuilder.resolveDimension` that rewrote the filter to match `traces.name` or `observations.name` — producing wrong results without any error.

- **Root cause fixed**: `scoreName` had no corresponding dimension in `traceView`/`observationsView`, so the `*Name → name` fallback silently misapplied the filter. Removing the mapping means the filter is classified as "unsupported" (via `isKnownWidgetFilterColumn`, which still finds it in the scores views) and dropped cleanly rather than misapplied.
- **Behavioral impact on stored dashboards**: Trace/observation widgets that previously had a `scoreName` filter saved will now silently drop that filter instead of incorrectly filtering on the trace/observation name field. Users opening such a widget in the editor will see the filter listed as unsupported, which is the correct UX signal.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change removes two clearly wrong mappings and replaces them with well-commented omissions; existing saved filters that relied on the broken behavior will now be silently dropped rather than misapplied.

The change is minimal, targeted, and well-reasoned. The only behavioral delta is that stored trace/observation widgets with a scoreName filter stop silently matching against the wrong field and instead drop the filter. The isKnownWidgetFilterColumn path ensures the filter is classified as unsupported (not passed through as-is), which is the intended outcome.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Global dashboard filter\n(e.g. scoreName = 'accuracy')"] --> B{Target view?}
    B -->|"scores-numeric /\nscores-categorical"| C["Mapped to 'name' field\n(correct: scores have scoreName dimension)"]
    B -->|"traces / observations\n(BEFORE fix)"| D["No scoreName dimension\n→ *Name fallback\n→ silently rewritten to traces.name"]
    B -->|"traces / observations\n(AFTER fix)"| E["Not in view mappings\n→ isKnownWidgetFilterColumn = true\n→ classified as unsupportedFilters\n→ dropped cleanly"]
    C --> F["Query filtered on score name ✓"]
    D --> G["Query filtered on trace/observation name ✗"]
    E --> H["Filter not applied to query\n(unsupported, shown in editor) ✓"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboards): drop scoreName filter o..."](https://github.com/langfuse/langfuse/commit/ebf23f87393cfd2e831354d19f93f26d33cf6ebf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34345175)</sub>

<!-- /greptile_comment -->