### PR TITLE
docs: Update test running instructions

### DIFF
--- a/.agents/skills/backend-dev-guidelines/references/testing-guide.md
+++ b/.agents/skills/backend-dev-guidelines/references/testing-guide.md
@@ -510,8 +510,8 @@ Use the nearest package `AGENTS.md` as the source of truth for current test
 commands.
 
 Common targeted forms:
-- Web server tests: `pnpm --filter web run test -- <pattern>`
-- Web client tests: `pnpm --filter web run test-client -- <pattern>`
+- Web server tests: `pnpm --filter web run test <file-or-pattern>`
+- Web client tests: `pnpm --filter web run test-client <file-or-pattern>`
 - Worker tests: `pnpm --filter worker run test <file-or-pattern>`
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -324,8 +324,8 @@ We're using Vitest in the `web` package. There are two types of unit tests:
 To run a specific test by name within a file, run:
 
 ```sh
-cd web  # or with --filter=web
-pnpm test -- prompts.v2.servertest -t "should handle special characters in prompt names"
+cd web  # or use `pnpm --filter web test ...` from the repository root
+pnpm test prompts.v2.servertest -t "should handle special characters in prompt names"
 ```
 
 To run all tests:
@@ -345,7 +345,7 @@ pnpm run test:watch
 For the `worker` package, we're also using Vitest to run unit tests.
 
 ```sh
-pnpm run test --filter=worker -- FILE_YOU_WANT_TO_TEST.ts -t "test name"
+pnpm --filter worker run test FILE_YOU_WANT_TO_TEST.ts -t "test name"
 ```
 
 ## CI/CD

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -132,9 +132,9 @@ signoff of user-visible changes.
 - Lint: `pnpm --filter web run lint`
 - Lint fix: `pnpm --filter web run lint:fix`
 - Typecheck: `pnpm --filter web run typecheck`
-- Server tests: `pnpm --filter web run test -- <args>`
-- In-source tests: `pnpm --filter web run test:in-source -- <args>`
-- Client tests: `pnpm --filter web run test-client -- <args>`
+- Server tests: `pnpm --filter web run test <args>`
+- In-source tests: `pnpm --filter web run test:in-source <args>`
+- Client tests: `pnpm --filter web run test-client <args>`
 - E2E tests: `pnpm --filter web run test:e2e`
 - Agent browser install to the default user-level Playwright cache: `pnpm run playwright:install`
 - Build: `pnpm --filter web run build`

--- a/web/src/components/trace/components/_shared/tree-flattening.clienttest.ts
+++ b/web/src/components/trace/components/_shared/tree-flattening.clienttest.ts
@@ -4,7 +4,7 @@
  * Tests the flattenTree function which converts hierarchical tree structures
  * into flat lists for virtualized rendering.
  *
- * Run with: pnpm test-client --testPathPattern="tree-flattening"
+ * Run with: pnpm test-client "tree-flattening"
  */
 
 import { flattenTree } from "./tree-flattening";

--- a/web/src/components/trace/contexts/json-expansion-utils.clienttest.ts
+++ b/web/src/components/trace/contexts/json-expansion-utils.clienttest.ts
@@ -4,7 +4,7 @@
  * These functions handle translation between actual observation keys and
  * normalized keys for persistent storage across different traces.
  *
- * Run with: pnpm test-client --testPathPattern="json-expansion-utils"
+ * Run with: pnpm test-client "json-expansion-utils"
  */
 
 import {

--- a/web/src/components/trace/lib/tree-building.clienttest.ts
+++ b/web/src/components/trace/lib/tree-building.clienttest.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for tree-building utilities.
  *
- * Run with: pnpm test-client --testPathPattern="tree-building"
+ * Run with: pnpm test-client "tree-building"
  */
 
 import {

--- a/web/src/components/ui/AdvancedJsonViewer/README.md
+++ b/web/src/components/ui/AdvancedJsonViewer/README.md
@@ -259,7 +259,7 @@ AdvancedJsonViewer/
 Tests use `.clienttest.ts` extension and are colocated with utils:
 
 ```bash
-pnpm --filter=web run test-client --testPathPattern="AdvancedJsonViewer"
+pnpm --filter=web run test-client "AdvancedJsonViewer"
 ```
 
 Key test files:

--- a/web/src/features/score-analytics/README.md
+++ b/web/src/features/score-analytics/README.md
@@ -397,7 +397,7 @@ Test coverage:
 
 Run tests:
 ```bash
-pnpm --filter=web test -- --testPathPattern="score-comparison-analytics"
+pnpm --filter=web test "score-comparison-analytics"
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Most of the examples for running tests were not updated after [https://github.com/langfuse/langfuse/pull/13191](https://github.com/langfuse/langfuse/pull/13191). The CLI arguments differ between Vitest and Jest, so the examples were incorrect and did not match their intended behavior. Most notably, filtering tests to specific files in Vitest does not expect the `--` divider. When it was provided, Vitest would instead run the entire test suite.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects test-running command examples across documentation files after the project migrated from Jest to Vitest (PR #13191). Jest requires a `--` separator before positional arguments and `--testPathPattern`, while Vitest accepts the file/pattern directly as a positional argument.

- Removes the `--` argument separator from `pnpm test -- <pattern>` calls and replaces `--testPathPattern=` flags with bare positional patterns in all affected docs.
- Fixes an incorrect pnpm invocation in `CONTRIBUTING.md` (`pnpm run test --filter=worker --`) to the correct form (`pnpm --filter worker run test`).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change correcting command syntax; no production code is modified.

All eight changed files are documentation or test-file comments. The corrections align the example commands with Vitest's positional-argument syntax, replacing Jest-era `--` separators and `--testPathPattern` flags. No logic, configuration, or runtime behaviour is altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer runs test command] --> B{Which package?}
    B -->|web server tests| C["pnpm --filter web run test <pattern>"]
    B -->|web client tests| D["pnpm --filter web run test-client <pattern>"]
    B -->|worker tests| E["pnpm --filter worker run test <file> -t 'name'"]
    C --> F[Vitest matches pattern as file glob]
    D --> F
    E --> F
    F --> G[Tests execute]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: Update test running instructions"](https://github.com/langfuse/langfuse/commit/4a282bff15bc580237a2e51794aa14e55947ceba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34348328)</sub>

<!-- /greptile_comment -->