### PR TITLE
chore: Add .superset/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ web/test-results/*
 
 # Local overrides for AGENTS.md
 **/AGENTS.override.md
+
+# Superset config
+.superset/


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `.superset/` to `.gitignore` so local Apache Superset configuration directories are not tracked by git.

- Appends three lines to `.gitignore`: a blank separator, a comment `# Superset config`, and the pattern `.superset/`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only adds a single pattern to .gitignore with no code changes.

The change is limited to three lines in `.gitignore`, adding a comment and ignoring the `.superset/` directory. No source code, configuration, or build logic is touched.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Add .superset/ to .gitignore"](https://github.com/langfuse/langfuse/commit/5aeda0ca456f49e0d3d611dc0e9a9ca72dad3448) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34350709)</sub>

<!-- /greptile_comment -->