### PR TITLE
fix(evals): tighten eval log IO cell padding

### DIFF
--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -14,7 +14,10 @@ import {
   getRowHeightTailwindClass,
 } from "@/src/components/table/data-table-row-height-switch";
 import { TableTextLoadingCell } from "@/src/components/table/loading-cells";
-import { type LangfuseColumnDef } from "@/src/components/table/types";
+import {
+  type DataTableCellPadding,
+  type LangfuseColumnDef,
+} from "@/src/components/table/types";
 import { type ModelTableRow } from "@/src/components/table/use-cases/models";
 import {
   Table,
@@ -79,7 +82,7 @@ interface DataTableProps<TData, TValue> {
   getRowClassName?: (row: TData) => string;
   highlightAllRows?: boolean;
   topAlignCells?: boolean;
-  cellPadding?: "compact" | "comfortable";
+  cellPadding?: DataTableCellPadding;
 }
 
 export interface AsyncTableData<T> {
@@ -151,6 +154,17 @@ const getPinningClasses = <TData,>(column: Column<TData>): string => {
     isLastLeftPinnedColumn && "border-r border-border",
     isFirstRightPinnedColumn && "border-l border-border",
   );
+};
+
+const getCellPaddingClassName = (padding: DataTableCellPadding) => {
+  switch (padding) {
+    case "comfortable":
+      return "p-1";
+    case "none":
+      return "p-0 first:pl-0";
+    case "compact":
+      return "px-1";
+  }
 };
 
 export function DataTable<TData extends object, TValue>({
@@ -499,7 +513,7 @@ interface TableBodyComponentProps<TData> {
   getRowClassName?: (row: TData) => string;
   highlightAllRows?: boolean;
   topAlignCells?: boolean;
-  cellPadding?: "compact" | "comfortable";
+  cellPadding?: DataTableCellPadding;
   /** Used for React.memo comparison only */
   tableSnapshot?: {
     columnVisibility?: VisibilityState;
@@ -579,58 +593,62 @@ function TableBodyComponent<TData>({
       {data.isLoading || !data.data ? (
         Array.from({ length: skeletonRowCount }).map((_, rowIndex) => (
           <TableRow key={`loading-row-${rowIndex}`} aria-hidden="true">
-            {visibleColumns.map((column, columnIndex) => (
-              <TableCell
-                key={`${column.id}-loading-cell-${rowIndex}`}
-                className={cn(
-                  "overflow-hidden border-b text-xs first:pl-2",
-                  cellPadding === "comfortable" ? "p-1" : "px-1",
-                  (rowHeight ?? "s") === "s" && "whitespace-nowrap",
-                  getPinningClasses(column),
-                )}
-                style={{
-                  width: `calc(var(--col-${column.id}-size) * 1px)`,
-                  ...getCommonPinningStyles(column),
-                }}
-              >
-                <div
+            {visibleColumns.map((column, columnIndex) => {
+              const columnDef = column.columnDef as LangfuseColumnDef<TData>;
+
+              return (
+                <TableCell
+                  key={`${column.id}-loading-cell-${rowIndex}`}
                   className={cn(
-                    "flex",
-                    (rowHeight ?? "s") === "s" && !topAlignCells
-                      ? "items-center"
-                      : "items-start",
-                    (rowHeight ?? "s") !== "s" && "py-1",
-                    rowheighttw,
+                    "overflow-hidden border-b text-xs first:pl-2",
+                    getCellPaddingClassName(
+                      columnDef.cellPadding ?? cellPadding,
+                    ),
+                    (rowHeight ?? "s") === "s" && "whitespace-nowrap",
+                    getPinningClasses(column),
                   )}
+                  style={{
+                    width: `calc(var(--col-${column.id}-size) * 1px)`,
+                    ...getCommonPinningStyles(column),
+                  }}
                 >
-                  {(() => {
-                    const columnDef =
-                      column.columnDef as LangfuseColumnDef<TData>;
-                    const loadingCell = columnDef.loadingCell;
+                  <div
+                    className={cn(
+                      "flex",
+                      (rowHeight ?? "s") === "s" && !topAlignCells
+                        ? "items-center"
+                        : "items-start",
+                      (rowHeight ?? "s") !== "s" && "py-1",
+                      rowheighttw,
+                    )}
+                  >
+                    {(() => {
+                      const loadingCell = columnDef.loadingCell;
 
-                    if (typeof loadingCell === "function") {
-                      return loadingCell();
-                    }
+                      if (typeof loadingCell === "function") {
+                        return loadingCell();
+                      }
 
-                    if (loadingCell !== undefined) {
-                      return loadingCell;
-                    }
+                      if (loadingCell !== undefined) {
+                        return loadingCell;
+                      }
 
-                    return (
-                      <TableTextLoadingCell
-                        className={cn(
-                          "min-w-[3rem]",
-                          (rowIndex + columnIndex) % 4 === 0 && "w-3/4",
-                          (rowIndex + columnIndex) % 4 === 1 && "w-1/2",
-                          (rowIndex + columnIndex) % 4 === 2 && "w-2/3",
-                          (rowIndex + columnIndex) % 4 === 3 && "w-5/6",
-                        )}
-                      />
-                    );
-                  })()}
-                </div>
-              </TableCell>
-            ))}
+                      return (
+                        <TableTextLoadingCell
+                          className={cn(
+                            "min-w-[3rem]",
+                            (rowIndex + columnIndex) % 4 === 0 && "w-3/4",
+                            (rowIndex + columnIndex) % 4 === 1 && "w-1/2",
+                            (rowIndex + columnIndex) % 4 === 2 && "w-2/3",
+                            (rowIndex + columnIndex) % 4 === 3 && "w-5/6",
+                          )}
+                        />
+                      );
+                    })()}
+                  </div>
+                </TableCell>
+              );
+            })}
           </TableRow>
         ))
       ) : table.getRowModel().rows.length ? (
@@ -646,13 +664,17 @@ function TableBodyComponent<TData>({
               const cellValue = cell.getValue();
               const isStringCell = typeof cellValue === "string";
               const isSmallRowHeight = (rowHeight ?? "s") === "s";
+              const columnDef = cell.column
+                .columnDef as LangfuseColumnDef<TData>;
 
               return (
                 <TableCell
                   key={cell.id}
                   className={cn(
                     "overflow-hidden border-b text-xs first:pl-2",
-                    cellPadding === "comfortable" ? "p-1" : "px-1",
+                    getCellPaddingClassName(
+                      columnDef.cellPadding ?? cellPadding,
+                    ),
                     isSmallRowHeight && "whitespace-nowrap",
                     getPinningClasses(cell.column),
                   )}

--- a/web/src/components/table/types.ts
+++ b/web/src/components/table/types.ts
@@ -6,6 +6,8 @@ export type TableRowOptions = {
   options: { label: string; value: number; icon?: LucideIcon }[];
 };
 
+export type DataTableCellPadding = "compact" | "comfortable" | "none";
+
 declare module "@tanstack/react-table" {
   // extends tanstack ColumnDef to include additional properties
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -18,6 +20,7 @@ declare module "@tanstack/react-table" {
     isFixedPosition?: boolean; // if true, column cannot be reordered
     isPinnedLeft?: boolean; // if true, column will be pinned to left side
     loadingCell?: React.ReactNode | (() => React.ReactNode);
+    cellPadding?: DataTableCellPadding;
   }
 }
 

--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -13,17 +13,27 @@ import {
 } from "@/src/components/ui/hover-card";
 import { decodeUnicodeEscapesOnly } from "@/src/utils/unicode";
 
+type IOTableCellPadding = "default" | "compact";
+
+const ioTableCellPaddingClassNames: Record<IOTableCellPadding, string> = {
+  default: "px-2 py-1",
+  compact: "px-1 py-1",
+};
+
 const IOTableCellContent = ({
   data,
   singleLine,
   className,
+  padding,
 }: {
   data: unknown;
   singleLine: boolean;
   className?: string;
+  padding: IOTableCellPadding;
 }) => {
   const stringifiedJson =
     data !== null && data !== undefined ? stringifyJsonNode(data) : undefined;
+  const paddingClassName = ioTableCellPaddingClassNames[padding];
 
   // perf: truncate to IO_TABLE_CHAR_LIMIT characters as table becomes unresponsive attempting to render large JSONs with high levels of nesting
   const shouldTruncate =
@@ -32,7 +42,8 @@ const IOTableCellContent = ({
   return singleLine ? (
     <div
       className={cn(
-        "h-full w-full self-stretch truncate overflow-hidden overflow-y-auto px-2 py-1",
+        "h-full w-full self-stretch truncate overflow-hidden overflow-y-auto",
+        paddingClassName,
         className,
       )}
     >
@@ -49,7 +60,7 @@ const IOTableCellContent = ({
           true, // greedy mode for double-escaped Unicode (e.g., \\uXXXX)
         )}
         className={cn("h-full w-full self-stretch", className)}
-        codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
+        codeClassName={cn("min-h-0 h-full overflow-y-auto", paddingClassName)}
         collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
         borderless
       />
@@ -63,7 +74,7 @@ const IOTableCellContent = ({
         stringifiedJson ? decodeUnicodeEscapesOnly(stringifiedJson, true) : data
       }
       className={cn("h-full w-full self-stretch", className)}
-      codeClassName="py-1 px-2 min-h-0 h-full overflow-y-auto"
+      codeClassName={cn("min-h-0 h-full overflow-y-auto", paddingClassName)}
       collapseStringsAfterLength={null} // in table, show full strings as row height is fixed
       borderless
     />
@@ -74,12 +85,14 @@ export const IOTableCell = ({
   data,
   isLoading = false,
   className,
+  padding = "default",
   singleLine = false,
   enableExpandOnHover = false,
 }: {
   data: unknown;
   isLoading?: boolean;
   className?: string;
+  padding?: IOTableCellPadding;
   singleLine?: boolean;
   enableExpandOnHover?: boolean;
 }) => {
@@ -99,6 +112,7 @@ export const IOTableCell = ({
         data={data}
         singleLine={singleLine}
         className={className}
+        padding={padding}
       />
     );
   }
@@ -111,6 +125,7 @@ export const IOTableCell = ({
             data={data}
             singleLine={singleLine}
             className={className}
+            padding={padding}
           />
         </div>
       </HoverCardTrigger>

--- a/web/src/components/ui/IOTableCell.tsx
+++ b/web/src/components/ui/IOTableCell.tsx
@@ -96,12 +96,18 @@ export const IOTableCell = ({
   singleLine?: boolean;
   enableExpandOnHover?: boolean;
 }) => {
+  const paddingClassName = ioTableCellPaddingClassNames[padding];
+
   if (isLoading) {
     return (
       <JsonSkeleton
         borderless
         numRows={singleLine ? 1 : undefined}
-        className="h-full w-full overflow-hidden px-2 py-1"
+        className={cn(
+          "h-full w-full overflow-hidden",
+          paddingClassName,
+          className,
+        )}
       />
     );
   }

--- a/web/src/features/evals/components/eval-log.tsx
+++ b/web/src/features/evals/components/eval-log.tsx
@@ -126,6 +126,14 @@ export default function EvalLogTable({
       id: "scoreComment",
       enableHiding: true,
       cellPadding: "none",
+      loadingCell: () => (
+        <IOTableCell
+          isLoading
+          data={undefined}
+          padding="compact"
+          singleLine={rowHeight === "s"}
+        />
+      ),
       cell: (row) => {
         const value = row.getValue();
         return (
@@ -144,6 +152,14 @@ export default function EvalLogTable({
       header: "Error",
       enableHiding: true,
       cellPadding: "none",
+      loadingCell: () => (
+        <IOTableCell
+          isLoading
+          data={undefined}
+          padding="compact"
+          singleLine={rowHeight === "s"}
+        />
+      ),
       cell: (row) => {
         const value = row.getValue();
         return (

--- a/web/src/features/evals/components/eval-log.tsx
+++ b/web/src/features/evals/components/eval-log.tsx
@@ -125,11 +125,16 @@ export default function EvalLogTable({
       header: "Score Comment",
       id: "scoreComment",
       enableHiding: true,
+      cellPadding: "none",
       cell: (row) => {
         const value = row.getValue();
         return (
           value !== undefined && (
-            <IOTableCell data={value} singleLine={rowHeight === "s"} />
+            <IOTableCell
+              data={value}
+              padding="compact"
+              singleLine={rowHeight === "s"}
+            />
           )
         );
       },
@@ -138,11 +143,16 @@ export default function EvalLogTable({
       id: "error",
       header: "Error",
       enableHiding: true,
+      cellPadding: "none",
       cell: (row) => {
         const value = row.getValue();
         return (
           value !== undefined && (
-            <IOTableCell data={value} singleLine={rowHeight === "s"} />
+            <IOTableCell
+              data={value}
+              padding="compact"
+              singleLine={rowHeight === "s"}
+            />
           )
         );
       },


### PR DESCRIPTION
## Summary

- Add per-column table cell padding support so specific columns can opt out of the table-level cell padding.
- Add a compact padding mode to `IOTableCell` and use it for Eval Log score comment and error cells.
- Keep caller `className` separate from the padding API instead of relying on Tailwind class overrides.

## Review Focus

- Eval Log score comment and error column spacing across row heights.
- Shared `DataTable` loading and rendered row cell padding behavior.

## Checks

Before:
<img width="562" height="427" alt="CleanShot 2026-05-28 at 14 33 12" src="https://github.com/user-attachments/assets/0da0452e-8c6d-4f55-b8b6-85d46ef6c775" />

After:
<img width="648" height="444" alt="CleanShot 2026-05-28 at 14 33 30" src="https://github.com/user-attachments/assets/d9587c04-aa70-48be-9b75-c5675deb3dc9" />

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces per-column cell padding overrides in `DataTable` and a compact padding mode in `IOTableCell`, then uses both to tighten spacing in the Eval Log score-comment and error columns.

- `DataTableCellPadding` (`\"compact\" | \"comfortable\" | \"none\"`) is added to the TanStack column meta extension; `getCellPaddingClassName` maps it to Tailwind classes, and both the loading-skeleton loop and the rendered-row loop now resolve padding as `columnDef.cellPadding ?? cellPadding`.
- `IOTableCell` gains a `padding` prop (`\"default\"` | `\"compact\"`) backed by a lookup map; the eval-log score-comment and error columns pair `cellPadding: \"none\"` on the column with `padding=\"compact\"` on `IOTableCell` so the component fills the full cell and manages its own compact internal spacing.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; only the loading-skeleton path in IOTableCell has a visible padding mismatch.

The core padding logic is correct: tailwind-merge inside cn properly resolves the first:pl-0 vs first:pl-2 conflict, the column-level override propagates through both the skeleton and rendered-row paths, and the eval-log pairing of cellPadding:"none" + padding="compact" is internally consistent. The one gap is the isLoading branch in IOTableCell, which hardcodes px-2 py-1 regardless of the new padding prop, producing a small but noticeable column-width shift as data arrives.

web/src/components/ui/IOTableCell.tsx — the isLoading skeleton branch ignores the padding prop.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DataTable\ncellPadding prop\n(default: 'compact')"] --> B["TableBodyComponent"]
    B --> C{Column has\ncellPadding?}
    C -- "yes" --> D["columnDef.cellPadding\ne.g. 'none'"]
    C -- "no" --> E["table-level cellPadding\n'compact' | 'comfortable'"]
    D --> F["getCellPaddingClassName()"]
    E --> F
    F -- "'comfortable'" --> G["p-1"]
    F -- "'compact'" --> H["px-1"]
    F -- "'none'" --> I["p-0 first:pl-0"]
    G --> J["TableCell className\nvia cn() + tailwind-merge"]
    H --> J
    I --> J
    J --> K{Cell renders\nIOTableCell?}
    K -- "yes (eval-log)" --> L["IOTableCell\npadding='compact'\n→ px-1 py-1"]
    K -- "no" --> M["Direct content\nno extra padding layer"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/ui/IOTableCell.tsx:99-107
The `isLoading` branch hardcodes `px-2 py-1` and never consults the `padding` prop. When `padding="compact"` is passed (as the eval-log score/error columns do) and the data is still loading, the skeleton renders with `px-2` left padding while the loaded cell uses `px-1`, so the columns visually shift once loading completes.

```suggestion
  if (isLoading) {
    return (
      <JsonSkeleton
        borderless
        numRows={singleLine ? 1 : undefined}
        className={cn(
          "h-full w-full overflow-hidden py-1",
          ioTableCellPaddingClassNames[padding],
        )}
      />
    );
  }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): tighten eval log io cell pad..."](https://github.com/langfuse/langfuse/commit/95bfda1504c911535571b9c6790499fbeb6d2f7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34353307)</sub>

<!-- /greptile_comment -->