### PR TITLE
feat(auth): Show cloud region sign-in status in user switcher

### DIFF
--- a/web/src/components/layouts/app-layout/hooks/useCloudRegionsSignInState.ts
+++ b/web/src/components/layouts/app-layout/hooks/useCloudRegionsSignInState.ts
@@ -1,0 +1,91 @@
+import {
+  type RegionKey,
+  type getAvailableCloudRegionOptions,
+} from "@/src/features/organizations/cloudRegions";
+import { useEffect, useState } from "react";
+
+type RegionsState = Partial<
+  Record<
+    RegionKey,
+    | "idle"
+    | "unknowable"
+    | "loading"
+    | "signedIn"
+    | "signedOut"
+    | "aborted"
+    | "failed"
+  >
+>;
+
+// Checks the sign-in status for each available cloud region and returns an object with the results
+export const useCloudRegionsSignInState = (
+  regions: ReturnType<typeof getAvailableCloudRegionOptions>,
+  enabled = process.env.NODE_ENV === "production",
+) => {
+  const [signedInRegions, setSignedInRegions] = useState<RegionsState>(() =>
+    regions.reduce(
+      (acc, region) => ({
+        ...acc,
+        [region.name as RegionKey]: region.rootUrl ? "idle" : "unknowable",
+      }),
+      {} satisfies RegionsState,
+    ),
+  );
+
+  const setRegionStatus = (
+    regionName: RegionKey,
+    status: RegionsState[RegionKey],
+  ) =>
+    setSignedInRegions((prev) => ({
+      ...prev,
+      [regionName]: status,
+    }));
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const abortController = new AbortController();
+
+    regions.forEach((region) => {
+      if (!region.rootUrl) {
+        return;
+      }
+
+      setRegionStatus(region.name, "loading");
+
+      fetch(`${region.rootUrl}/api/auth/session`, {
+        credentials: "include",
+        mode: "cors",
+        signal: abortController.signal,
+      })
+        .then((response) => response.json())
+        .then((data) => {
+          setRegionStatus(
+            region.name,
+            isSignedInSession(data) ? "signedIn" : "signedOut",
+          );
+        })
+        .catch((error) => {
+          if (error.name === "AbortError") {
+            return setRegionStatus(region.name, "aborted");
+          }
+
+          setRegionStatus(region.name, "failed");
+        });
+    });
+
+    return () => {
+      abortController.abort();
+    };
+    // Use JSON.stingify to compare regions array deeply
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(regions), enabled]);
+
+  return signedInRegions;
+};
+
+export const isSignedInSession = (session: unknown) => {
+  return !!session && typeof session === "object" && "user" in session;
+};

--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -4,7 +4,7 @@
  * Used for all main application pages when user is authenticated
  */
 
-import type { PropsWithChildren } from "react";
+import { useMemo, type PropsWithChildren } from "react";
 import Head from "next/head";
 import { SidebarProvider, SidebarInset } from "@/src/components/ui/sidebar";
 import { AppSidebar } from "@/src/components/nav/app-sidebar";
@@ -22,6 +22,8 @@ import type { Session } from "next-auth";
 import type { NavigationItem } from "@/src/components/layouts/utilities/routes";
 import type { RouteGroup } from "@/src/components/layouts/routes";
 import dynamic from "next/dynamic";
+import { useCloudRegionsSignInState } from "@/src/components/layouts/app-layout/hooks/useCloudRegionsSignInState";
+import React from "react";
 
 const CommandMenu = dynamic(
   () =>
@@ -70,8 +72,8 @@ type GroupedNavigation = {
   flattened: NavigationItem[];
 };
 
-type AuthenticatedLayoutProps = PropsWithChildren<{
-  session: Session;
+type AuthenticatedLayoutInnerProps = PropsWithChildren<{
+  user: NonNullable<Session["user"]>;
   navigation: {
     mainNavigation: GroupedNavigation;
     secondaryNavigation: GroupedNavigation;
@@ -96,40 +98,28 @@ type AuthenticatedLayoutProps = PropsWithChildren<{
  * - Toast notifications
  * - Dynamic page metadata
  */
-export function AuthenticatedLayout({
+export function AuthenticatedLayoutInner({
   children,
-  session,
+  user,
   navigation,
   metadata,
   aiFeaturesEnabled,
   onSignOut,
-}: AuthenticatedLayoutProps) {
+}: AuthenticatedLayoutInnerProps) {
   const { isLangfuseCloud, region: currentRegion } = useLangfuseCloudRegion();
+
+  const availableRegions = useMemo(
+    () => getAvailableCloudRegionOptions(currentRegion),
+    [currentRegion],
+  );
+
+  const regionSignInState = useCloudRegionsSignInState(
+    availableRegions,
+    isLangfuseCloud && process.env.NODE_ENV === "production",
+  );
+
   const assistantEnabled =
     useIsFeatureEnabled("inAppAgent") && aiFeaturesEnabled;
-
-  // Safe assertion: AuthenticatedLayout is only rendered after auth checks pass
-  // in AppLayout, which guarantees session.user exists at this point
-  const user = session.user;
-  if (!user) {
-    // This should never happen due to guards in AppLayout, but TypeScript needs this
-    return null;
-  }
-
-  const regionMenuItems = getAvailableCloudRegionOptions(currentRegion).map(
-    (region) => ({
-      name: region.name,
-      content: `${region.flag} ${region.name}`,
-      onClick: () => {
-        if (!region.rootUrl) return;
-        window.open(
-          getCloudRegionAuthUrl(region.rootUrl, user.email),
-          "_blank",
-          "noopener,noreferrer",
-        );
-      },
-    }),
-  );
 
   // User navigation items for sidebar dropdown
   const userNavProps = {
@@ -145,11 +135,36 @@ export function AuthenticatedLayout({
         ? [
             {
               name: "Regions",
-              subItems: regionMenuItems,
+              subItems: availableRegions.map((region) => ({
+                name: region.name,
+                onClick: () => {
+                  if (!region.rootUrl) return;
+                  window.open(
+                    getCloudRegionAuthUrl(region.rootUrl, user.email),
+                    "_blank",
+                    "noopener,noreferrer",
+                  );
+                },
+                content: (
+                  <>
+                    {region.flag}
+                    {region.name}
+                    <>
+                      {(currentRegion === region.name ||
+                        regionSignInState[region.name] === "signedIn") && (
+                        <div className="ml-2 inline-flex items-center gap-1 rounded border border-green-100 bg-green-50 px-2 py-1 text-xs dark:border-green-900 dark:bg-green-900/20">
+                          <div className="size-2 rounded-full bg-green-300 dark:bg-green-700"></div>
+                          Signed in
+                        </div>
+                      )}
+                    </>
+                  </>
+                ),
+              })),
               content: (
                 <>
                   Regions
-                  <div className="ml-2 inline-flex rounded bg-black/5 p-1 text-xs dark:bg-white/10">
+                  <div className="ml-2 inline-flex rounded border px-2 py-1 text-xs">
                     Current: {currentRegion}
                   </div>
                 </>
@@ -199,5 +214,29 @@ export function AuthenticatedLayout({
         </SidebarProvider>
       </TopBannerProvider>
     </>
+  );
+}
+
+type AuthenticatedLayoutProps = Omit<AuthenticatedLayoutInnerProps, "user"> & {
+  session: Session;
+};
+
+export function AuthenticatedLayout({
+  children,
+  session,
+  ...props
+}: AuthenticatedLayoutProps) {
+  // Safe assertion: AuthenticatedLayout is only rendered after auth checks pass
+  // in AppLayout, which guarantees session.user exists at this point
+  const user = session.user;
+  if (!user) {
+    // This should never happen due to guards in AppLayout, but TypeScript needs this
+    return null;
+  }
+
+  return (
+    <AuthenticatedLayoutInner {...props} user={user}>
+      {children}
+    </AuthenticatedLayoutInner>
   );
 }

--- a/web/src/features/organizations/cloudRegions.ts
+++ b/web/src/features/organizations/cloudRegions.ts
@@ -43,6 +43,8 @@ const cloudRegions = [
   },
 ] as const;
 
+export type RegionKey = (typeof cloudRegions)[number]["name"];
+
 const availableRegionsByCurrentRegion = {
   STAGING: ["STAGING"],
   DEV: ["DEV"],


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a cross-region sign-in status indicator to the user switcher in the sidebar. A new hook (`useCloudRegionsSignInState`) probes each cloud region's NextAuth `/api/auth/session` endpoint with credentialed CORS fetches and surfaces a green "Signed in" badge next to any region where the browser already holds an active session.

- **New hook** (`useCloudRegionsSignInState`): fires parallel credentialed fetches per region, tracks per-region state (`idle` / `loading` / `signedIn` / `signedOut` / `failed` / `aborted`), and cleans up via `AbortController` on unmount.
- **`AuthenticatedLayout` refactor**: split into a thin session-guard wrapper (`AuthenticatedLayout`) and a full inner component (`AuthenticatedLayoutInner`) that accepts `user` directly; `availableRegions` is now memoized and fed into both the sign-in state hook and the region menu items.
- **`cloudRegions.ts`**: exports a new `RegionKey` union type derived from the const array.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the feature is additive and gated to production cloud only.

The core fetch logic is correct: abort cleanup is in place, all catch paths set a non-signed-in status, and the badge only renders on an explicit signedIn result. The remaining notes are hardening suggestions — the missing response.ok guard and the user-in-session null-value edge case — neither of which is reachable with current NextAuth responses, but worth addressing for robustness as the helper is exported.

web/src/components/layouts/app-layout/hooks/useCloudRegionsSignInState.ts — contains the fetch logic and the exported isSignedInSession helper.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as Browser (Current Region)
    participant H as useCloudRegionsSignInState
    participant EU as EU /api/auth/session
    participant US as US /api/auth/session
    participant JP as JP /api/auth/session

    B->>H: "mount (availableRegions, enabled=true)"
    H->>H: setState → loading for each region
    par Cross-origin credential checks
        H->>EU: fetch credentials:include, mode:cors
        H->>US: fetch credentials:include, mode:cors
        H->>JP: fetch credentials:include, mode:cors
    end
    EU-->>H: "{user:{...}} → signedIn"
    US-->>H: "{} → signedOut"
    JP-->>H: network error / abort → failed / aborted
    H-->>B: regionSignInState map
    B->>B: render Signed in badge for current region + signedIn regions
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
web/src/components/layouts/app-layout/hooks/useCloudRegionsSignInState.ts:58-63
HTTP errors are not checked before parsing the JSON body. If a Langfuse region endpoint returns a non-2xx response whose JSON body happens to contain a `user` field (e.g. a structured error envelope), `isSignedInSession` would incorrectly report the user as signed in. Guarding on `response.ok` first keeps the happy-path explicit and errors routed through the catch handler where they belong.

```suggestion
      fetch(`${region.rootUrl}/api/auth/session`, {
        credentials: "include",
        mode: "cors",
        signal: abortController.signal,
      })
        .then((response) => {
          if (!response.ok) {
            throw new Error(`Unexpected status: ${response.status}`);
          }
          return response.json();
        })
```

### Issue 2 of 4
web/src/components/layouts/app-layout/hooks/useCloudRegionsSignInState.ts:89-91
`"user" in session` returns `true` even when `session.user` is `null`. NextAuth should never return `{"user": null}`, but the exported `isSignedInSession` helper could be reused in other contexts where that assumption doesn't hold. Checking `!!session.user` (after narrowing) closes the gap.

```suggestion
export const isSignedInSession = (session: unknown) => {
  return (
    !!session &&
    typeof session === "object" &&
    "user" in session &&
    !!(session as { user: unknown }).user
  );
};
```

### Issue 3 of 4
web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx:25-26
Next.js uses the automatic JSX runtime (React 17+), so `React` does not need to be in scope for JSX. This import is unused and can be removed.

```suggestion
import { useCloudRegionsSignInState } from "@/src/components/layouts/app-layout/hooks/useCloudRegionsSignInState";
```

### Issue 4 of 4
web/src/components/layouts/app-layout/hooks/useCloudRegionsSignInState.ts:82
Typo in the eslint-disable comment: `JSON.stingify` should be `JSON.stringify`.

```suggestion
    // Use JSON.stringify to compare regions array deeply
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(auth): Show cloud region sign-in st..."](https://github.com/langfuse/langfuse/commit/ac26dada95f4f0bb0e4b6d0c2583f4656aadf05d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34366021)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->