### PR TITLE
 fix(tables): roll relative time-range presets forward instead of freezing

### DIFF
--- a/web/src/components/table/use-cases/observations.tsx
+++ b/web/src/components/table/use-cases/observations.tsx
@@ -48,10 +48,8 @@ import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-
 import { MemoizedIOTableCell } from "../../ui/IOTableCell";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTableStateContext";
-import {
-  toAbsoluteTimeRange,
-  type TableDateRange,
-} from "@/src/utils/date-range-utils";
+import { type TableDateRange } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { type ScoreAggregate } from "@langfuse/shared";
 import TagList from "@/src/features/tag/components/TagList";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
@@ -263,12 +261,7 @@ export default function ObservationsTable({
 
   const { timeRange, setTimeRange } = useTableDateRange(projectId);
 
-  // Convert timeRange to absolute date range for compatibility
-  // refreshTick forces recalculation on each refresh cycle
-  const tableDateRange = useMemo(() => {
-    return toAbsoluteTimeRange(timeRange) ?? undefined;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [timeRange, refreshTick]);
+  const tableDateRange = useAbsoluteTimeRange(timeRange, refreshTick);
 
   const dateRange = externalDateRange ?? tableDateRange;
 

--- a/web/src/components/table/use-cases/scores.tsx
+++ b/web/src/components/table/use-cases/scores.tsx
@@ -30,7 +30,7 @@ import { transformFiltersForBackend } from "@/src/features/filters/lib/filter-tr
 import { isNumericDataType } from "@/src/features/scores/lib/helpers";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
-import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { api } from "@/src/utils/api";
 
 import type { RouterOutput } from "@/src/utils/types";
@@ -147,10 +147,7 @@ export default function ScoresTable({
   const [rowHeight, setRowHeight] = useRowHeightLocalStorage("scores", "s");
   const { timeRange, setTimeRange } = useTableDateRange(projectId);
 
-  // Convert timeRange to absolute date range for compatibility
-  const dateRange = React.useMemo(() => {
-    return toAbsoluteTimeRange(timeRange) ?? undefined;
-  }, [timeRange]);
+  const dateRange = useAbsoluteTimeRange(timeRange);
 
   const dateRangeFilter: FilterState = dateRange
     ? [

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -45,7 +45,7 @@ import type Decimal from "decimal.js";
 import { useEffect, useState, useMemo, useRef, useCallback } from "react";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
-import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
 import TagList from "@/src/features/tag/components/TagList";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
@@ -103,10 +103,7 @@ export default function SessionsTable({
   const { setDetailPageList } = useDetailPageLists();
   const { timeRange, setTimeRange } = useTableDateRange(projectId);
 
-  // Convert timeRange to absolute date range for compatibility
-  const dateRange = useMemo(() => {
-    return toAbsoluteTimeRange(timeRange) ?? undefined;
-  }, [timeRange]);
+  const dateRange = useAbsoluteTimeRange(timeRange);
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
 
   const userIdFilter: FilterState = userId

--- a/web/src/components/table/use-cases/traces.tsx
+++ b/web/src/components/table/use-cases/traces.tsx
@@ -49,7 +49,7 @@ import {
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { MemoizedIOTableCell } from "../../ui/IOTableCell";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
-import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { type ScoreAggregate } from "@langfuse/shared";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
@@ -215,12 +215,10 @@ export default function TracesTable({
 
   const { timeRange, setTimeRange } = useTableDateRange(projectId);
 
-  // Convert timeRange to absolute date range for compatibility
-  // refreshTick forces recalculation on each refresh cycle
-  const tableDateRange = useMemo(() => {
-    return toAbsoluteTimeRange(timeRange) ?? undefined;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [timeRange, refreshTick]);
+  // Relative presets are rolling windows: useAbsoluteTimeRange re-evaluates
+  // "now" on focus/visibility and whenever refreshTick advances (auto-refresh
+  // / manual refresh), so the window doesn't freeze at selection time.
+  const tableDateRange = useAbsoluteTimeRange(timeRange, refreshTick);
 
   const dateRange = externalDateRange ?? tableDateRange;
 

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -41,10 +41,8 @@ import { numberFormatter, usdFormatter } from "@/src/utils/numbers";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
-import {
-  toAbsoluteTimeRange,
-  type TableDateRange,
-} from "@/src/utils/date-range-utils";
+import { type TableDateRange } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { type ScoreAggregate } from "@langfuse/shared";
 import TagList from "@/src/features/tag/components/TagList";
 import { usePeekTableState } from "@/src/components/table/peek/contexts/PeekTableStateContext";
@@ -327,13 +325,7 @@ export default function ObservationsEventsTable({
     ]);
   }, [utils]);
 
-  // Convert timeRange to absolute date range for compatibility
-  // Include refreshTick to force recalculation on refresh
-  const tableDateRange = useMemo(() => {
-    // refreshTick forces recalculation but isn't used in computation
-    void refreshTick;
-    return toAbsoluteTimeRange(timeRange) ?? undefined;
-  }, [timeRange, refreshTick]);
+  const tableDateRange = useAbsoluteTimeRange(timeRange, refreshTick);
 
   const dateRange = externalDateRange ?? tableDateRange;
 

--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -26,7 +26,7 @@ import { numberFormatter } from "@/src/utils/numbers";
 import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
-import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import useColumnOrder from "@/src/features/column-visibility/hooks/useColumnOrder";
 import { GitCompareArrows, LightbulbIcon } from "lucide-react";
 import { LocalIsoDate } from "@/src/components/LocalIsoDate";
@@ -96,10 +96,7 @@ export default function ExperimentsTable({
 
   const { timeRange, setTimeRange } = useTableDateRange(projectId);
 
-  // Convert timeRange to absolute date range for compatibility
-  const tableDateRange = useMemo(() => {
-    return toAbsoluteTimeRange(timeRange) ?? undefined;
-  }, [timeRange]);
+  const tableDateRange = useAbsoluteTimeRange(timeRange);
 
   const dateRangeFilter: FilterState = tableDateRange
     ? [

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -39,10 +39,8 @@ import startCase from "lodash/startCase";
 import { DatePickerWithRange } from "@/src/components/date-picker";
 import { InlineFilterBuilder } from "@/src/features/filters/components/filter-builder";
 import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
-import {
-  toAbsoluteTimeRange,
-  type DashboardDateRangeOptions,
-} from "@/src/utils/date-range-utils";
+import { type DashboardDateRangeOptions } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { normalizeSingleValueOptions } from "@/src/features/filters/lib/filter-transform";
 import { Chart } from "@/src/features/widgets/chart-library/Chart";
 import { type DataPoint } from "@/src/features/widgets/chart-library/chart-props";
@@ -414,10 +412,7 @@ export function WidgetForm({
     defaultRelativeAggregation: "last7Days",
   });
 
-  // Convert timeRange to absolute date range for compatibility
-  const dateRange = useMemo(() => {
-    return toAbsoluteTimeRange(timeRange) ?? undefined;
-  }, [timeRange]);
+  const dateRange = useAbsoluteTimeRange(timeRange);
 
   // Convert timeRange to legacy format for DatePickerWithRange compatibility
   const selectedOption = useMemo(() => {

--- a/web/src/hooks/use-environment-filter-options-cache.tsx
+++ b/web/src/hooks/use-environment-filter-options-cache.tsx
@@ -3,6 +3,7 @@ import {
   type TimeRange,
   toAbsoluteTimeRange,
 } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { api } from "@/src/utils/api";
 import { useMemo, useEffect } from "react";
 
@@ -69,10 +70,7 @@ export function useEnvironmentFilterOptionsCache({
   projectId: string;
   timeRange: TimeRange;
 }) {
-  const absoluteTimeRange = useMemo(
-    () => toAbsoluteTimeRange(timeRange) ?? undefined,
-    [timeRange],
-  );
+  const absoluteTimeRange = useAbsoluteTimeRange(timeRange);
   const cacheBucket = getCacheBucketFromTimeRange(timeRange);
   const ttlMs = getTtlMsFromTimeRange(timeRange);
 

--- a/web/src/hooks/useAbsoluteTimeRange.clienttest.ts
+++ b/web/src/hooks/useAbsoluteTimeRange.clienttest.ts
@@ -4,7 +4,9 @@ import { type TimeRange } from "@/src/utils/date-range-utils";
 
 describe("useAbsoluteTimeRange", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    // Only fake the clock, not setTimeout/scheduler — faking timers wholesale
+    // stalls React's scheduler and testing-library cleanup.
+    vi.useFakeTimers({ toFake: ["Date"] });
   });
 
   afterEach(() => {
@@ -32,6 +34,29 @@ describe("useAbsoluteTimeRange", () => {
       "2026-05-18T09:00:00.000Z",
     );
     expect(result.current?.to.toISOString()).toBe("2026-05-18T15:00:00.000Z");
+  });
+
+  it("rolls the window forward on visibilitychange when the tab becomes visible", () => {
+    vi.setSystemTime(new Date("2026-05-18T12:00:00.000Z"));
+    const timeRange: TimeRange = { range: "last6Hours" };
+
+    const { result } = renderHook(() => useAbsoluteTimeRange(timeRange));
+
+    expect(result.current?.to.toISOString()).toBe("2026-05-18T12:00:00.000Z");
+
+    act(() => {
+      vi.setSystemTime(new Date("2026-05-18T14:00:00.000Z"));
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "visible",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current?.from.toISOString()).toBe(
+      "2026-05-18T08:00:00.000Z",
+    );
+    expect(result.current?.to.toISOString()).toBe("2026-05-18T14:00:00.000Z");
   });
 
   it("keeps an absolute range stable across focus events", () => {

--- a/web/src/hooks/useAbsoluteTimeRange.clienttest.ts
+++ b/web/src/hooks/useAbsoluteTimeRange.clienttest.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from "@testing-library/react";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
+import { type TimeRange } from "@/src/utils/date-range-utils";
+
+describe("useAbsoluteTimeRange", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves a relative preset and rolls the window forward on focus", () => {
+    vi.setSystemTime(new Date("2026-05-18T12:00:00.000Z"));
+    const timeRange: TimeRange = { range: "last6Hours" };
+
+    const { result } = renderHook(() => useAbsoluteTimeRange(timeRange));
+
+    expect(result.current?.from.toISOString()).toBe(
+      "2026-05-18T06:00:00.000Z",
+    );
+    expect(result.current?.to.toISOString()).toBe("2026-05-18T12:00:00.000Z");
+
+    // Time passes while the tab is backgrounded, then the user returns to it.
+    act(() => {
+      vi.setSystemTime(new Date("2026-05-18T15:00:00.000Z"));
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(result.current?.from.toISOString()).toBe(
+      "2026-05-18T09:00:00.000Z",
+    );
+    expect(result.current?.to.toISOString()).toBe("2026-05-18T15:00:00.000Z");
+  });
+
+  it("keeps an absolute range stable across focus events", () => {
+    vi.setSystemTime(new Date("2026-05-18T12:00:00.000Z"));
+    const timeRange: TimeRange = {
+      from: new Date("2026-05-01T00:00:00.000Z"),
+      to: new Date("2026-05-02T00:00:00.000Z"),
+    };
+
+    const { result } = renderHook(() => useAbsoluteTimeRange(timeRange));
+    const first = result.current;
+
+    act(() => {
+      vi.setSystemTime(new Date("2026-05-18T15:00:00.000Z"));
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(result.current).toBe(first);
+    expect(result.current?.from.toISOString()).toBe(
+      "2026-05-01T00:00:00.000Z",
+    );
+    expect(result.current?.to.toISOString()).toBe("2026-05-02T00:00:00.000Z");
+  });
+
+  it("rolls the window forward when refreshSignal advances", () => {
+    vi.setSystemTime(new Date("2026-05-18T12:00:00.000Z"));
+    const timeRange: TimeRange = { range: "last1Hour" };
+
+    const { result, rerender } = renderHook(
+      ({ signal }) => useAbsoluteTimeRange(timeRange, signal),
+      { initialProps: { signal: 0 } },
+    );
+
+    expect(result.current?.to.toISOString()).toBe("2026-05-18T12:00:00.000Z");
+
+    act(() => {
+      vi.setSystemTime(new Date("2026-05-18T12:30:00.000Z"));
+    });
+    rerender({ signal: 1 });
+
+    expect(result.current?.to.toISOString()).toBe("2026-05-18T12:30:00.000Z");
+  });
+});

--- a/web/src/hooks/useAbsoluteTimeRange.ts
+++ b/web/src/hooks/useAbsoluteTimeRange.ts
@@ -32,7 +32,15 @@ export function useAbsoluteTimeRange(
   useEffect(() => {
     if (!isRelative || typeof window === "undefined") return;
 
-    const bump = () => setTick((t) => t + 1);
+    // `focus` and `visibilitychange` both fire when returning to a tab; coalesce
+    // them so a single return-to-view triggers exactly one re-evaluation.
+    let lastBump = 0;
+    const bump = () => {
+      const now = Date.now();
+      if (now - lastBump < 50) return;
+      lastBump = now;
+      setTick((t) => t + 1);
+    };
     const onVisibility = () => {
       if (document.visibilityState === "visible") bump();
     };

--- a/web/src/hooks/useAbsoluteTimeRange.ts
+++ b/web/src/hooks/useAbsoluteTimeRange.ts
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  type AbsoluteTimeRange,
+  type TimeRange,
+  toAbsoluteTimeRange,
+} from "@/src/utils/date-range-utils";
+
+/**
+ * Resolves a `TimeRange` (relative preset or absolute range) into concrete
+ * `from`/`to` timestamps, re-evaluating "now" for relative presets so the
+ * window rolls forward instead of freezing at the moment of selection.
+ *
+ * Absolute ranges (calendar selection) return a stable value.
+ * Relative presets re-evaluate when the tab regains focus or becomes visible
+ * again, i.e. when the user returns to the view. This intentionally does NOT
+ * poll on a timer: it leaves the per-table auto-refresh dropdown as the only
+ * mechanism that refetches data while the user stays on the page, so the
+ * "auto-refresh off" contract is preserved. Reopening the view, however,
+ * yields a fresh "Past N hours" window that matches the displayed label.
+ *
+ * `refreshSignal` lets callers that drive their own auto-refresh cadence
+ * (e.g. tables whose refresh interval increments a counter) force the window
+ * to roll forward in lockstep with their data refetches.
+ */
+export function useAbsoluteTimeRange(
+  timeRange: TimeRange,
+  refreshSignal?: number,
+): AbsoluteTimeRange | undefined {
+  const isRelative = !("from" in timeRange);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!isRelative || typeof window === "undefined") return;
+
+    const bump = () => setTick((t) => t + 1);
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") bump();
+    };
+
+    window.addEventListener("focus", bump);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      window.removeEventListener("focus", bump);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [isRelative]);
+
+  return useMemo(
+    () => toAbsoluteTimeRange(timeRange) ?? undefined,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [timeRange, tick, refreshSignal],
+  );
+}

--- a/web/src/hooks/useDashboardFilterOptions.ts
+++ b/web/src/hooks/useDashboardFilterOptions.ts
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
 import { api } from "@/src/utils/api";
 import { normalizeSingleValueOptions } from "@/src/features/filters/lib/filter-transform";
-import {
-  toAbsoluteTimeRange,
-  type TimeRange,
-} from "@/src/utils/date-range-utils";
+import { type TimeRange } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 
 type UseDashboardFilterOptionsParams = {
   projectId: string;
@@ -25,10 +23,7 @@ export function useDashboardFilterOptions({
     staleTime: Infinity,
   } as const;
 
-  const absoluteTimeRange = useMemo(
-    () => toAbsoluteTimeRange(timeRange) ?? undefined,
-    [timeRange],
-  );
+  const absoluteTimeRange = useAbsoluteTimeRange(timeRange);
 
   const traceTimestampFilter = useMemo(
     () =>

--- a/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
+++ b/web/src/pages/project/[projectId]/dashboards/[dashboardId]/index.tsx
@@ -22,10 +22,8 @@ import { useDebounce } from "@/src/hooks/useDebounce";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { DashboardGrid } from "@/src/features/widgets/components/DashboardGrid";
 import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
-import {
-  DASHBOARD_AGGREGATION_OPTIONS,
-  toAbsoluteTimeRange,
-} from "@/src/utils/date-range-utils";
+import { DASHBOARD_AGGREGATION_OPTIONS } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { useEntitlementLimit } from "@/src/features/entitlements/hooks";
 import { useEnvironmentFilterOptionsCache } from "@/src/hooks/use-environment-filter-options-cache";
 import {
@@ -83,10 +81,7 @@ export default function DashboardDetail() {
 
   // Date range state - use the hook for all date range logic
   const { timeRange, setTimeRange } = useDashboardDateRange();
-  const absoluteTimeRange = useMemo(
-    () => toAbsoluteTimeRange(timeRange) ?? undefined,
-    [timeRange],
-  );
+  const absoluteTimeRange = useAbsoluteTimeRange(timeRange);
 
   // Check if current filters differ from saved filters
   const hasUnsavedFilterChanges = useMemo(() => {

--- a/web/src/pages/project/[projectId]/index.tsx
+++ b/web/src/pages/project/[projectId]/index.tsx
@@ -17,9 +17,9 @@ import { useMemo } from "react";
 import {
   DASHBOARD_AGGREGATION_OPTIONS,
   findClosestDashboardInterval,
-  toAbsoluteTimeRange,
   type DashboardDateRangeAggregationOption,
 } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
 import { useDebounce } from "@/src/hooks/useDebounce";
 import { ScoreAnalytics } from "@/src/features/dashboard/components/score-analytics/ScoreAnalytics";
@@ -61,10 +61,7 @@ export default function Dashboard() {
   const { isBetaEnabled } = useV4Beta();
   const metricsVersion: ViewVersion = isBetaEnabled ? "v2" : "v1";
 
-  const absoluteTimeRange = useMemo(
-    () => toAbsoluteTimeRange(timeRange),
-    [timeRange],
-  );
+  const absoluteTimeRange = useAbsoluteTimeRange(timeRange) ?? null;
 
   const lookbackLimit = useEntitlementLimit("data-access-days");
 

--- a/web/src/pages/project/[projectId]/prompts/metrics.tsx
+++ b/web/src/pages/project/[projectId]/prompts/metrics.tsx
@@ -28,8 +28,7 @@ import {
 } from "@/src/features/scores/lib/scoreColumns";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
-import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
-import { useMemo } from "react";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 
 export type PromptVersionTableRow = {
   version: number;
@@ -110,10 +109,7 @@ export default function PromptVersionTable({
   const { timeRange, setTimeRange } = useTableDateRange(projectId, {
     defaultRelativeAggregation: "last30Days",
   });
-  const dateRange = useMemo(
-    () => ("range" in timeRange ? toAbsoluteTimeRange(timeRange) : timeRange),
-    [timeRange],
-  );
+  const dateRange = useAbsoluteTimeRange(timeRange) ?? null;
 
   const promptVersions = api.prompts.allVersions.useQuery(
     {

--- a/web/src/pages/project/[projectId]/scores/analytics.tsx
+++ b/web/src/pages/project/[projectId]/scores/analytics.tsx
@@ -8,10 +8,8 @@ import {
 import { useAnalyticsUrlState } from "@/src/features/score-analytics/lib/analytics-url-state";
 import { type ScoreOption } from "@/src/features/score-analytics/components/charts/ScoreCombobox";
 import { useDashboardDateRange } from "@/src/hooks/useDashboardDateRange";
-import {
-  toAbsoluteTimeRange,
-  getOptimalInterval,
-} from "@/src/utils/date-range-utils";
+import { getOptimalInterval } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { BarChart3 } from "lucide-react";
 import { api } from "@/src/utils/api";
 import {
@@ -140,11 +138,7 @@ export default function ScoresAnalyticsV2Page() {
     };
   }, [urlState.score2, scoreOptions]);
 
-  // Convert time range to absolute dates
-  const absoluteTimeRange = useMemo(
-    () => toAbsoluteTimeRange(timeRange),
-    [timeRange],
-  );
+  const absoluteTimeRange = useAbsoluteTimeRange(timeRange) ?? null;
 
   // Calculate optimal interval based on time range
   const interval = useMemo(() => {

--- a/web/src/pages/project/[projectId]/users/index.tsx
+++ b/web/src/pages/project/[projectId]/users/index.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import {
   NumberParam,
   StringParam,
@@ -24,7 +24,7 @@ import { type RouterOutput } from "@/src/utils/types";
 import { type FilterState, usersTableCols } from "@langfuse/shared";
 import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
-import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
+import { useAbsoluteTimeRange } from "@/src/hooks/useAbsoluteTimeRange";
 import { useDebounce } from "@/src/hooks/useDebounce";
 import Page from "@/src/components/layouts/page";
 import { UsersOnboarding } from "@/src/components/onboarding/UsersOnboarding";
@@ -136,10 +136,7 @@ const UsersTable = ({ isBetaEnabled }: { isBetaEnabled: boolean }) => {
 
   const { timeRange, setTimeRange } = useTableDateRange(projectId);
 
-  // Convert timeRange to absolute date range for compatibility
-  const dateRange = useMemo(() => {
-    return toAbsoluteTimeRange(timeRange) ?? undefined;
-  }, [timeRange]);
+  const dateRange = useAbsoluteTimeRange(timeRange);
 
   const dateRangeFilter: FilterState = dateRange
     ? [


### PR DESCRIPTION
Closes #13688

## Problem

  Relative time-range presets ("Past 6 hours", "Past 30 min", …) were resolved to absolute `from`/`to` timestamps once
  at mount via `useMemo(() => toAbsoluteTimeRange(timeRange), [timeRange])`. Because the symbolic `timeRange` (`6h`)
  never changes, the window froze at selection time. With auto-refresh off (the default and absent entirely on most
  tables) the filter kept querying the original click-time window, hiding recently ingested data when the user left the
  tab open or navigated back.

  ## Fix

  New `useAbsoluteTimeRange(timeRange, refreshSignal?)` hook:

  - **Absolute (calendar) ranges** → returned as-is, fully stable.
  - **Relative presets** → re-resolve `now` on `focus` / `visibilitychange`, i.e. when the user returns to the view. No
  timer polling, so the "auto-refresh off" contract is preserved sitting idle on a tab does not trigger background
  refetches.
  - Tables that own an auto-refresh loop (traces, observations, events) pass their `refreshTick` via `refreshSignal`, so
   the window rolls forward in lockstep with their existing refetches.

  This replaces the duplicated `useMemo(toAbsoluteTimeRange(...))` pattern across all call sites (traces, observations,
  events, sessions, scores, experiments, users, prompt metrics, score analytics, dashboards, widgets, dashboard filter
  caches).

  ## Tests

  Added `useAbsoluteTimeRange.clienttest.ts` covering: relative window rolls forward on focus, absolute range stays
  stable, and `refreshSignal` advancing rolls the window.

  ## Notes

  Addresses the discussion on the issue: the rolling behavior is scoped to "returning to the view" rather than periodic
  polling, to respect the auto-refresh = data-refresh model.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `useAbsoluteTimeRange`, a new hook that replaces a duplicated `useMemo(() => toAbsoluteTimeRange(timeRange), [timeRange])` pattern across 12+ call sites, fixing a bug where relative time-range presets froze at selection time instead of rolling forward when the user returned to the view.

- **New hook** re-evaluates \"now\" on `window.focus` and `document.visibilitychange` (→ visible) for relative presets, while returning stable object references for absolute (calendar) ranges. Tables with their own auto-refresh loop (traces, observations, events) pass `refreshTick` as `refreshSignal` to keep the window in lockstep with data refetches.
- **Tests** cover relative-rolling-on-focus, absolute-range-stability, and refreshSignal-advancement; the `visibilitychange` guard (`document.visibilityState === \"visible\"`) is the one path without a direct test case.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the fix is behaviorally correct across all call sites and the migration is consistent.

The hook logic is sound: absolute ranges return the same object reference (stable for downstream memo comparisons), relative presets correctly re-evaluate on focus/visibility, and auto-refresh tables retain their existing lockstep behaviour via refreshSignal. Both listeners fire on tab-switch, doubling the tick increment per interaction, but React 18 batching ensures only one useMemo recompute per gesture — no incorrect data is emitted. The only gap is the untested visibilitychange branch.

The hook implementation and its test file warrant a second look for the double-tick behaviour and the untested visibilitychange path.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant useAbsoluteTimeRange
    participant tRPC

    User->>Browser: Selects "Past 6 hours" preset
    Browser->>useAbsoluteTimeRange: "timeRange = {range: "last6Hours"}"
    useAbsoluteTimeRange->>useAbsoluteTimeRange: attach focus/visibilitychange listeners
    useAbsoluteTimeRange-->>tRPC: "from=T-6h, to=T"

    Note over User,tRPC: Time passes, user leaves tab

    User->>Browser: Returns to tab
    Browser->>useAbsoluteTimeRange: window focus fires → tick++
    Browser->>useAbsoluteTimeRange: visibilitychange visible fires → tick++
    useAbsoluteTimeRange->>useAbsoluteTimeRange: useMemo recomputes (batched, once)
    useAbsoluteTimeRange-->>tRPC: "from=T'-6h, to=T' (rolled forward)"

    Note over User,tRPC: For auto-refresh tables

    Browser->>useAbsoluteTimeRange: refreshSignal (refreshTick) increments
    useAbsoluteTimeRange->>useAbsoluteTimeRange: useMemo recomputes
    useAbsoluteTimeRange-->>tRPC: "from=T''-6h, to=T''"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/hooks/useAbsoluteTimeRange.clienttest.ts:13-40
**`visibilitychange` path has no test coverage**

The test suite exercises the `window.focus` code path but never dispatches a `visibilitychange` event. The two listeners are wired differently — `focus` calls `bump()` directly while `visibilitychange` guards on `document.visibilityState === "visible"` before calling `bump()`. If the guard logic ever regressed (e.g. bumped on `hidden` instead of `visible`), the existing tests would not catch it. Adding a case that sets `document.visibilityState` to `"visible"` and dispatches `document.dispatchEvent(new Event("visibilitychange"))` would fully cover this branch.

### Issue 2 of 2
web/src/hooks/useAbsoluteTimeRange.ts:37-45
**Double `tick` increment on tab-switch**

When the user returns to a backgrounded tab, both `window.focus` and `document.visibilitychange` (→ `"visible"`) fire in the same user gesture, so `setTick` is called twice — `tick` advances by 2 per tab-switch rather than by 1. React 18 batches both updates into a single re-render, so `toAbsoluteTimeRange` is only called once and the result is correct. However, the growing stride means the `tick` counter diverges from the actual number of "return to view" events, which can make debugging harder. A simple mitigation is to consolidate both listeners into a single debounced handler or to replace the counter with a `useRef`-based last-refresh timestamp.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tables): roll relative time-range pr..."](https://github.com/langfuse/langfuse/commit/7c10a58d0827706e4c9af0e375fe6241040af01a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34365151)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->