### PR TITLE
ci(sdk): use repo token for SDK spec workflow

### DIFF
--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -18,7 +18,6 @@ permissions:
 jobs:
   generate-sdk-api-specs:
     runs-on: ubuntu-latest
-    environment: "protected branches"
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What changed

Removed the `protected branches` environment from the SDK API spec generation workflow.

## Why

The workflow was resolving `GH_ACCESS_TOKEN` from the environment-scoped secret, which appears to authenticate as a token that cannot write to `langfuse/langfuse-python`. Dropping the environment lets the job use the repo/org `GH_ACCESS_TOKEN` for the cross-repo SDK branch push and PR creation flow.

## Verification

- `zizmor --min-severity low .github/workflows/sdk-api-spec.yml`
- commit hook: Prettier check and cached Turbo lint
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `environment: \"protected branches\"` declaration from the `generate-sdk-api-specs` job so that it resolves `GH_ACCESS_TOKEN` from the repo/org-level secret rather than from the named environment's secrets, fixing a cross-repo write failure to `langfuse/langfuse-python` and `langfuse/langfuse-js`.

- **Environment gate removed**: The `protected branches` environment was previously providing an extra approval layer before any job-level secrets could be accessed. Dropping it allows the workflow to use the org/repo `GH_ACCESS_TOKEN` directly, restoring the ability to push branches and open PRs in the SDK repos.
- **No other workflow logic changed**: Triggers (`push` to `main`, `workflow_dispatch`), permissions, action pins, and all shell steps are unchanged.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the one-line change restores cross-repo write access by moving secret resolution to the repo/org scope, and all other workflow logic is untouched.

The workflow now runs the cross-repo push without the extra manual-approval gate that the named environment provided. Since the workflow is gated on pushes to main (itself a protected branch) and workflow_dispatch access is limited to repository collaborators, the practical exposure is small and the tradeoff is intentional and well-described.

.github/workflows/sdk-api-spec.yml is the only changed file; the removal of the environment declaration is straightforward and low-risk.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(sdk): use repo token for sdk spec wor..."](https://github.com/langfuse/langfuse/commit/630cd9abb80828e882785ceaba9783061f17fa05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34367044)</sub>

<!-- /greptile_comment -->