### PR TITLE
fix(mcp): Rename relevant tools from create to upsert

### DIFF
--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -64,8 +64,6 @@ import {
   handleListComments,
 } from "@/src/features/mcp/features/comments/tools";
 import {
-  handleCreateDataset,
-  handleCreateDatasetItem,
   handleCreateDatasetRunItem,
   handleDeleteDatasetItem,
   handleDeleteDatasetRun,
@@ -76,6 +74,8 @@ import {
   handleListDatasetRunItems,
   handleListDatasetRuns,
   handleListDatasets,
+  handleUpsertDataset,
+  handleUpsertDatasetItem,
 } from "@/src/features/mcp/features/datasets/tools";
 import { handleGetHealth } from "@/src/features/mcp/features/health/tools";
 import {
@@ -188,7 +188,7 @@ describe("MCP public API tools", () => {
       mockServerContext({ isInAppAgentKey: true }),
     );
 
-    expect(inAppToolNames).not.toContain("createDataset");
+    expect(inAppToolNames).not.toContain("upsertDataset");
     expect(inAppToolNames).not.toContain("createModel");
 
     const writableToolNames = toolNames.filter(
@@ -213,8 +213,6 @@ describe("MCP public API tools", () => {
     expect(destructiveToolNames).toEqual(
       [
         "createChatPrompt",
-        "createDataset",
-        "createDatasetItem",
         "createScore",
         "createScoreConfig",
         "createTextPrompt",
@@ -227,6 +225,8 @@ describe("MCP public API tools", () => {
         "updateAnnotationQueueItem",
         "updatePromptLabels",
         "updateScoreConfig",
+        "upsertDataset",
+        "upsertDatasetItem",
       ].sort(),
     );
   });
@@ -470,7 +470,7 @@ describe("MCP public API tools", () => {
       }),
     ]);
 
-    const dataset = (await handleCreateDataset(
+    const dataset = (await handleUpsertDataset(
       {
         name: datasetName,
         description: "MCP dataset",
@@ -490,7 +490,7 @@ describe("MCP public API tools", () => {
       handleGetDataset({ datasetName }, context),
     ).resolves.toMatchObject({ id: dataset.id, name: datasetName });
 
-    const datasetItem = (await handleCreateDatasetItem(
+    const datasetItem = (await handleUpsertDatasetItem(
       {
         datasetName,
         input: { question: "ping" },
@@ -627,7 +627,7 @@ describe("MCP public API tools", () => {
     ).rejects.toThrow("Annotation queue not found");
 
     const datasetName = `mcp-dataset-isolation-${uuidv4()}`;
-    const dataset = (await handleCreateDataset(
+    const dataset = (await handleUpsertDataset(
       { name: datasetName },
       sourceContext,
     )) as { id: string };

--- a/web/src/features/mcp/features/datasets/index.ts
+++ b/web/src/features/mcp/features/datasets/index.ts
@@ -1,9 +1,9 @@
 import type { McpFeatureModule } from "../../server/registry";
-import { createDatasetTool, handleCreateDataset } from "./tools/createDataset";
+import { upsertDatasetTool, handleUpsertDataset } from "./tools/upsertDataset";
 import {
-  createDatasetItemTool,
-  handleCreateDatasetItem,
-} from "./tools/createDatasetItem";
+  upsertDatasetItemTool,
+  handleUpsertDatasetItem,
+} from "./tools/upsertDatasetItem";
 import {
   createDatasetRunItemTool,
   handleCreateDatasetRunItem,
@@ -41,7 +41,7 @@ export const datasetsFeature: McpFeatureModule = {
   description:
     "Manage datasets, named collections of dataset items for experiments and evaluations, plus runs and run items",
   tools: [
-    { definition: createDatasetTool, handler: handleCreateDataset },
+    { definition: upsertDatasetTool, handler: handleUpsertDataset },
     {
       definition: listDatasetsTool,
       handler: handleListDatasets,
@@ -52,7 +52,7 @@ export const datasetsFeature: McpFeatureModule = {
       handler: handleGetDataset,
       allowInAppAgentKey: true,
     },
-    { definition: createDatasetItemTool, handler: handleCreateDatasetItem },
+    { definition: upsertDatasetItemTool, handler: handleUpsertDatasetItem },
     {
       definition: listDatasetItemsTool,
       handler: handleListDatasetItems,

--- a/web/src/features/mcp/features/datasets/tools/index.ts
+++ b/web/src/features/mcp/features/datasets/tools/index.ts
@@ -1,5 +1,5 @@
-export * from "./createDataset";
-export * from "./createDatasetItem";
+export * from "./upsertDataset";
+export * from "./upsertDatasetItem";
 export * from "./createDatasetRunItem";
 export * from "./deleteDatasetItem";
 export * from "./deleteDatasetRun";

--- a/web/src/features/mcp/features/datasets/tools/upsertDataset.ts
+++ b/web/src/features/mcp/features/datasets/tools/upsertDataset.ts
@@ -8,15 +8,15 @@ import {
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
-export const [createDatasetTool, handleCreateDataset] = defineTool({
-  name: "createDataset",
+export const [upsertDatasetTool, handleUpsertDataset] = defineTool({
+  name: "upsertDataset",
   description:
-    "Create or update a dataset, a named collection of input and optional expected-output examples for experiments and evaluations.",
+    "Upsert a dataset, a named collection of input and optional expected-output examples for experiments and evaluations.",
   baseSchema: PostDatasetsV2Body,
   inputSchema: PostDatasetsV2Body,
   handler: async (input, context) =>
     runMcpTool({
-      spanName: "mcp.datasets.create",
+      spanName: "mcp.datasets.upsert",
       context,
       attributes: { "mcp.dataset_name": input.name },
       fn: async () => {

--- a/web/src/features/mcp/features/datasets/tools/upsertDatasetItem.ts
+++ b/web/src/features/mcp/features/datasets/tools/upsertDatasetItem.ts
@@ -6,15 +6,15 @@ import {
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
-export const [createDatasetItemTool, handleCreateDatasetItem] = defineTool({
-  name: "createDatasetItem",
+export const [upsertDatasetItemTool, handleUpsertDatasetItem] = defineTool({
+  name: "upsertDatasetItem",
   description:
-    "Create or upsert a dataset item, one example in a dataset with input and optional expected output.",
+    "Upsert a dataset item, one example in a dataset with input and optional expected output.",
   baseSchema: PostDatasetItemsV1Body,
   inputSchema: PostDatasetItemsV1Body,
   handler: async (input, context) =>
     runMcpTool({
-      spanName: "mcp.dataset_items.create",
+      spanName: "mcp.dataset_items.upsert",
       context,
       attributes: { "mcp.dataset_name": input.datasetName },
       fn: async () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR renames the MCP dataset tools from `createDataset`/`createDatasetItem` to `upsertDataset`/`upsertDatasetItem`, aligning the tool names with the upsert semantics that were already documented in their descriptions. The underlying implementation is unchanged.

- `createDataset.ts` → `upsertDataset.ts`: tool name, exported symbols, description, and span name all updated to "upsert"; audit log `action` field still says `"create"` for what may be an update operation.
- `createDatasetItem.ts` → `upsertDatasetItem.ts`: fully consistent rename with no residual "create" references.
- Both barrel `index.ts` files updated to re-export the new symbols.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the rename is mechanical and the underlying logic is untouched. The only rough edge is an audit log action that still reads 'create' when the tool may actually be updating an existing dataset.

All functional logic is carried over unchanged from the old files. The audit log action 'create' in upsertDataset.ts is the one inconsistency worth addressing — if a dataset is updated, the audit trail will misrepresent it as a creation — but it is a pre-existing issue made more visible by the rename, not a new regression.

web/src/features/mcp/features/datasets/tools/upsertDataset.ts — audit log action and stale import path reference are worth a quick look.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Registry as MCP Registry
    participant Tool as upsertDataset / upsertDatasetItem
    participant DB as Database
    participant Audit as Audit Log

    Client->>Registry: "call tool(upsertDataset | upsertDatasetItem)"
    Registry->>Tool: route to handler
    Tool->>DB: upsertDataset() / createDatasetItemForApi()
    DB-->>Tool: dataset / item record
    Tool->>Audit: "auditLog({ action: 'create' })"
    Note over Audit: action still says 'create' even for updates
    Tool-->>Client: parsed API response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/mcp/features/datasets/tools/upsertDataset.ts:34-36
The audit log still records `action: "create"` even when the tool performs an update on an existing dataset. Now that the tool is explicitly named `upsertDataset`, callers expecting audit history to differentiate creates from updates will see misleading entries whenever an existing dataset is modified via this tool.

```suggestion
        await auditLog({
          action: "upsert",
          resourceType: "dataset",
```

### Issue 2 of 2
web/src/features/mcp/features/datasets/tools/upsertDataset.ts:2
The import path still points at the old `createDataset` source file (`@/src/features/datasets/server/actions/createDataset`). While this works today, it may cause confusion for future maintainers who need to trace where `upsertDataset` lives. Consider renaming the underlying file or adding a comment clarifying the discrepancy.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Rename relevant tools from cre..."](https://github.com/langfuse/langfuse/commit/217f852f3839791dde1e18d262406499fa1dfada) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34378529)</sub>

<!-- /greptile_comment -->