### PR TITLE
fix(mcp): Throw if not exists in `deleteAnnotationQueueAssignment`

### DIFF
--- a/web/src/__tests__/server/annotation-queue-assignments-api.servertest.ts
+++ b/web/src/__tests__/server/annotation-queue-assignments-api.servertest.ts
@@ -317,6 +317,34 @@ describe("/api/public/annotation-queues/:queueId/assignments API", () => {
       expect(response.body.success).toBe(true);
     });
 
+    it("should be idempotent when assignment was already deleted", async () => {
+      const firstResponse = await makeZodVerifiedAPICall(
+        DeleteAnnotationQueueAssignmentResponse,
+        "DELETE",
+        `/api/public/annotation-queues/${queueId}/assignments`,
+        {
+          userId: testUserId,
+        },
+        auth,
+      );
+
+      expect(firstResponse.status).toBe(200);
+      expect(firstResponse.body.success).toBe(true);
+
+      const secondResponse = await makeZodVerifiedAPICall(
+        DeleteAnnotationQueueAssignmentResponse,
+        "DELETE",
+        `/api/public/annotation-queues/${queueId}/assignments`,
+        {
+          userId: testUserId,
+        },
+        auth,
+      );
+
+      expect(secondResponse.status).toBe(200);
+      expect(secondResponse.body.success).toBe(true);
+    });
+
     it("should return 404 for non-existent annotation queue", async () => {
       const nonExistentQueueId = uuidv4();
 

--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -370,6 +370,13 @@ describe("MCP public API tools", () => {
     ).resolves.toEqual({ success: true });
 
     await expect(
+      handleDeleteAnnotationQueueAssignment(
+        { queueId: queue.id, userId: user.id },
+        context,
+      ),
+    ).rejects.toThrow("Annotation queue assignment not found");
+
+    await expect(
       handleDeleteAnnotationQueueItem(
         { queueId: queue.id, itemId: queueItem.id },
         context,

--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -563,7 +563,7 @@ export const createAnnotationQueueAssignmentForApi = async ({
   };
 };
 
-export const deleteAnnotationQueueAssignmentForApi = async ({
+export const deleteAnnotationQueueAssignment = async ({
   projectId,
   queueId,
   input,
@@ -576,37 +576,17 @@ export const deleteAnnotationQueueAssignmentForApi = async ({
   // Verify the annotation queue exists and belongs to the project
   await getAnnotationQueueRecordOrThrow({ projectId, queueId });
 
-  let assignment;
-  try {
-    // Delete the assignment if it exists
-    assignment = await prisma.annotationQueueAssignment.delete({
-      where: {
-        projectId_queueId_userId: {
-          projectId,
-          queueId,
-          userId: input.userId,
-        },
+  // Delete the assignment if it exists. Missing assignments throw P2025 so
+  // callers can decide whether to treat that as success or not found.
+  const assignment = await prisma.annotationQueueAssignment.delete({
+    where: {
+      projectId_queueId_userId: {
+        projectId,
+        queueId,
+        userId: input.userId,
       },
-    });
-  } catch (error) {
-    // If the record doesn't exist, that's fine - we still return success.
-    // Only catch NotFound errors, re-throw other errors.
-    if (
-      error &&
-      typeof error === "object" &&
-      "code" in error &&
-      error.code !== "P2025"
-    ) {
-      throw error;
-    }
-
-    return {
-      deleted: false,
-      response: {
-        success: true,
-      },
-    };
-  }
+    },
+  });
 
   if (auditScope) {
     await auditLog({
@@ -621,9 +601,43 @@ export const deleteAnnotationQueueAssignmentForApi = async ({
   }
 
   return {
-    deleted: true,
     response: {
       success: true,
     },
   };
+};
+
+export const deleteAnnotationQueueAssignmentForApi = async ({
+  projectId,
+  queueId,
+  input,
+  auditScope,
+}: {
+  projectId: string;
+  queueId: string;
+  input: DeleteAnnotationQueueAssignmentInput;
+} & OptionalAuditScope) => {
+  try {
+    return await deleteAnnotationQueueAssignment({
+      projectId,
+      queueId,
+      input,
+      auditScope,
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      // Public API semantics are idempotent: deleting an already-absent
+      // assignment still succeeds.
+      return {
+        response: {
+          success: true,
+        },
+      };
+    }
+
+    throw error;
+  }
 };

--- a/web/src/features/mcp/features/annotationQueues/tools/deleteAnnotationQueueAssignment.ts
+++ b/web/src/features/mcp/features/annotationQueues/tools/deleteAnnotationQueueAssignment.ts
@@ -1,5 +1,6 @@
-import { deleteAnnotationQueueAssignmentForApi } from "@/src/features/annotation-queues/server/publicAnnotationQueueService";
+import { deleteAnnotationQueueAssignment } from "@/src/features/annotation-queues/server/publicAnnotationQueueService";
 import { DeleteAnnotationQueueAssignmentResponse } from "@/src/features/public-api/types/annotation-queues";
+import { LangfuseNotFoundError, Prisma } from "@langfuse/shared";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { DeleteAnnotationQueueAssignmentToolSchema } from "../schema";
@@ -18,14 +19,27 @@ export const [
       context,
       attributes: { "mcp.annotation_queue_id": input.queueId },
       fn: async () => {
-        const result = await deleteAnnotationQueueAssignmentForApi({
-          projectId: context.projectId,
-          queueId: input.queueId,
-          input: { userId: input.userId },
-          auditScope: context,
-        });
+        try {
+          const result = await deleteAnnotationQueueAssignment({
+            projectId: context.projectId,
+            queueId: input.queueId,
+            input: { userId: input.userId },
+            auditScope: context,
+          });
 
-        return DeleteAnnotationQueueAssignmentResponse.parse(result.response);
+          return DeleteAnnotationQueueAssignmentResponse.parse(result.response);
+        } catch (error) {
+          if (
+            error instanceof Prisma.PrismaClientKnownRequestError &&
+            error.code === "P2025"
+          ) {
+            throw new LangfuseNotFoundError(
+              "Annotation queue assignment not found",
+            );
+          }
+
+          throw error;
+        }
       },
     }),
   destructiveHint: true,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the MCP `deleteAnnotationQueueAssignment` tool throw a `LangfuseNotFoundError` when the targeted assignment does not exist, rather than silently returning success. The REST API retains its idempotent behaviour (returns 200 even on a second delete), while the MCP interface now enforces stricter "not found" semantics.

- **`deleteAnnotationQueueAssignment.ts`**: Adds a `!result.deleted` check after calling the service; throws `LangfuseNotFoundError` if the assignment was absent.
- **`annotation-queue-assignments-api.servertest.ts`**: New test documents that the REST API remains idempotent — a second DELETE on the same resource still returns 200.
- **`mcp-public-api-tools.servertest.ts`**: New assertion confirms the MCP handler rejects with `"Annotation queue assignment not found"` on a second invocation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; it introduces intentionally stricter MCP semantics while leaving the idempotent REST API path untouched, and tests cover both behaviours.

The `deleted: false` path in the underlying service can also be triggered by swallowed non-Prisma exceptions, meaning the new `LangfuseNotFoundError` could misrepresent the actual failure cause in those rare cases. This is unlikely in practice, but the error masking is a real gap worth addressing.

The catch block logic in `publicAnnotationQueueService.ts` (not modified here) deserves a follow-up look to ensure only true P2025 errors are silenced.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant MCP Tool
    participant Service
    participant DB

    Caller->>MCP Tool: deleteAnnotationQueueAssignment(queueId, userId)
    MCP Tool->>Service: deleteAnnotationQueueAssignmentForApi(...)
    Service->>DB: prisma.annotationQueueAssignment.delete(...)
    alt Assignment exists
        DB-->>Service: deleted record
        Service-->>MCP Tool: { deleted: true, response: { success: true } }
        MCP Tool-->>Caller: { success: true }
    else Assignment not found (P2025)
        DB-->>Service: PrismaClientKnownRequestError(P2025)
        Service-->>MCP Tool: { deleted: false, response: { success: true } }
        MCP Tool-->>Caller: throw LangfuseNotFoundError("Annotation queue assignment not found")
    end

    note over Caller,DB: REST API path: returns { success: true } regardless (idempotent)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/mcp/features/annotationQueues/tools/deleteAnnotationQueueAssignment.ts:29-33
**Error masking via swallowed non-Prisma exceptions**

The `deleteAnnotationQueueAssignmentForApi` service catches Prisma errors, but its guard (`"code" in error && error.code !== "P2025"`) silently swallows any exception that lacks a `.code` property (e.g., a network timeout or unexpected JS error). Before this PR those cases returned `{ deleted: false, response: { success: true } }` and the MCP handler silently returned success. Now that same swallowed error surfaces as `LangfuseNotFoundError("Annotation queue assignment not found")`, which misrepresents the failure. If the service ever returns `deleted: false` for a reason other than a genuine 404, callers receive a misleading error message and the real root cause is hidden.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Throw if not exists in deleteA..."](https://github.com/langfuse/langfuse/commit/2013c8fa034a29beb1deca363968eb8e8ee79d54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34382305)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->