### PR TITLE
fix(mcp): Missing audit logs

### DIFF
--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -41,6 +41,7 @@ import {
   createMcpTestSetup,
   createPromptInDb,
   mockServerContext,
+  verifyAuditLog,
   waitFor,
 } from "./mcp-helpers";
 import "@/src/features/mcp/server/bootstrap";
@@ -452,7 +453,7 @@ describe("MCP public API tools", () => {
   });
 
   it("covers dataset, dataset item, run item, and run public API routes", async () => {
-    const { context, projectId } = await createMcpTestSetup();
+    const { context, projectId, apiKeyId } = await createMcpTestSetup();
     const datasetName = `mcp-dataset-100% accuracy %20 ${uuidv4()}`;
     const traceId = uuidv4();
     const observationId = uuidv4();
@@ -530,6 +531,19 @@ describe("MCP public API tools", () => {
       context,
     )) as { id: string; datasetRunId: string; datasetItemId: string };
     expect(runItem.datasetItemId).toBe(datasetItem.id);
+    await expect(
+      verifyAuditLog({
+        projectId,
+        apiKeyId,
+        resourceType: "datasetRunItem",
+        resourceId: runItem.id,
+        action: "create",
+      }),
+    ).resolves.toMatchObject({
+      resourceType: "datasetRunItem",
+      resourceId: runItem.id,
+      action: "create",
+    });
 
     await createDatasetRunItemsCh([
       createDatasetRunItem({

--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -1563,7 +1563,7 @@ describe("MCP Read Tools", () => {
     });
 
     it("should create a score using v1 route semantics", async () => {
-      const { context } = await createMcpTestSetup();
+      const { context, projectId, apiKeyId } = await createMcpTestSetup();
       const scoreId = randomUUID();
 
       const result = await handleCreateScore(
@@ -1580,6 +1580,19 @@ describe("MCP Read Tools", () => {
       );
 
       expect(result).toEqual({ id: scoreId });
+      await expect(
+        verifyAuditLog({
+          projectId,
+          apiKeyId,
+          resourceType: "score",
+          resourceId: scoreId,
+          action: "create",
+        }),
+      ).resolves.toMatchObject({
+        resourceType: "score",
+        resourceId: scoreId,
+        action: "create",
+      });
     });
   });
 

--- a/web/src/features/audit-logs/auditLog.ts
+++ b/web/src/features/audit-logs/auditLog.ts
@@ -16,6 +16,7 @@ export type AuditableResource =
   | "datasetItem"
   | "dataset"
   | "datasetRun"
+  | "datasetRunItem"
   | "trace"
   | "project"
   | "observation"

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -10,6 +10,8 @@ import type {
   GetDatasetRunsV1Query,
   GetDatasetsV2Query,
   GetDatasetV2Query,
+  PostDatasetsV1Body,
+  PostDatasetsV2Body,
   PostDatasetItemsV1Body,
 } from "@/src/features/public-api/types/datasets";
 import {
@@ -24,6 +26,7 @@ import {
   Prisma,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
+import { upsertDataset } from "./actions/createDataset";
 import {
   addToDeleteDatasetQueue,
   createDatasetItemFilterState,
@@ -58,6 +61,14 @@ type GetDatasetV1Input = z.infer<typeof GetDatasetV1Query> & {
   projectId: string;
 };
 
+type CreateDatasetInput = {
+  input:
+    | z.infer<typeof PostDatasetsV1Body>
+    | z.infer<typeof PostDatasetsV2Body>;
+  projectId: string;
+  auditScope?: DatasetAuditScope;
+};
+
 type ListDatasetItemsInput = z.infer<typeof GetDatasetItemsV1Query> & {
   projectId: string;
 };
@@ -68,7 +79,8 @@ type GetDatasetItemInput = z.infer<typeof GetDatasetItemV1Query> & {
 
 type CreateDatasetItemInput = {
   input: z.infer<typeof PostDatasetItemsV1Body>;
-  auditScope: DatasetAuditScope;
+  projectId: string;
+  auditScope?: DatasetAuditScope;
 };
 
 type ListDatasetRunsInput = z.infer<typeof GetDatasetRunsV1Query> & {
@@ -144,6 +156,40 @@ const getDatasetRunRecordOrThrow = async ({
   }
 
   return datasetRuns[0];
+};
+
+export const createDatasetForApi = async ({
+  input,
+  projectId,
+  auditScope,
+}: CreateDatasetInput) => {
+  const dataset = await upsertDataset({
+    input: {
+      name: input.name,
+      description: input.description ?? undefined,
+      metadata: input.metadata ?? undefined,
+      inputSchema: input.inputSchema,
+      expectedOutputSchema: input.expectedOutputSchema,
+    },
+    projectId,
+  });
+
+  if (auditScope) {
+    await auditLog({
+      action:
+        dataset.createdAt.getTime() === dataset.updatedAt.getTime()
+          ? "create"
+          : "update",
+      resourceType: "dataset",
+      resourceId: dataset.id,
+      projectId,
+      orgId: auditScope.orgId,
+      apiKeyId: auditScope.apiKeyId,
+      after: dataset,
+    });
+  }
+
+  return transformDbDatasetToAPIDataset(dataset);
 };
 
 export const listDatasetsForApi = async ({
@@ -384,11 +430,19 @@ export const getDatasetItemForApi = async ({
 
 export const createDatasetItemForApi = async ({
   input,
+  projectId,
   auditScope,
 }: CreateDatasetItemInput) => {
   try {
+    const existingDatasetItem = input.id
+      ? await getDatasetItemById({
+          projectId,
+          datasetItemId: input.id,
+        })
+      : null;
+
     const datasetItem = await upsertDatasetItem({
-      projectId: auditScope.projectId,
+      projectId,
       datasetName: input.datasetName,
       datasetItemId: input.id ?? undefined,
       input: input.input ?? undefined,
@@ -401,15 +455,18 @@ export const createDatasetItemForApi = async ({
       validateOpts: { normalizeUndefinedToNull: !!input.id ? false : true },
     });
 
-    await auditLog({
-      action: "create",
-      resourceType: "datasetItem",
-      resourceId: datasetItem.id,
-      projectId: auditScope.projectId,
-      orgId: auditScope.orgId,
-      apiKeyId: auditScope.apiKeyId,
-      after: datasetItem,
-    });
+    if (auditScope) {
+      await auditLog({
+        action: existingDatasetItem ? "update" : "create",
+        resourceType: "datasetItem",
+        resourceId: datasetItem.id,
+        projectId,
+        orgId: auditScope.orgId,
+        apiKeyId: auditScope.apiKeyId,
+        before: existingDatasetItem ?? undefined,
+        after: datasetItem,
+      });
+    }
 
     return transformDbDatasetItemDomainToAPIDatasetItem({
       ...datasetItem,

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -210,6 +210,17 @@ export const createDatasetForApi = async ({
   projectId,
   auditScope,
 }: CreateDatasetInput) => {
+  const existingDataset = auditScope
+    ? await prisma.dataset.findUnique({
+        where: {
+          projectId_name: {
+            projectId,
+            name: input.name,
+          },
+        },
+      })
+    : null;
+
   const dataset = await upsertDataset({
     input: {
       name: input.name,
@@ -223,15 +234,13 @@ export const createDatasetForApi = async ({
 
   if (auditScope) {
     await auditLog({
-      action:
-        dataset.createdAt.getTime() === dataset.updatedAt.getTime()
-          ? "create"
-          : "update",
+      action: existingDataset ? "update" : "create",
       resourceType: "dataset",
       resourceId: dataset.id,
       projectId,
       orgId: auditScope.orgId,
       apiKeyId: auditScope.apiKeyId,
+      before: existingDataset ?? undefined,
       after: dataset,
     });
   }

--- a/web/src/features/mcp/features/datasets/tools/createDatasetRunItem.ts
+++ b/web/src/features/mcp/features/datasets/tools/createDatasetRunItem.ts
@@ -21,7 +21,11 @@ export const [createDatasetRunItemTool, handleCreateDatasetRunItem] =
         },
         fn: async () => {
           const auth = await getMcpPublicApiAuth(context);
-          return await createDatasetRunItemForApi({ body: input, auth });
+          return await createDatasetRunItemForApi({
+            body: input,
+            auth,
+            auditScope: context,
+          });
         },
       }),
   });

--- a/web/src/features/mcp/features/datasets/tools/upsertDataset.ts
+++ b/web/src/features/mcp/features/datasets/tools/upsertDataset.ts
@@ -1,9 +1,7 @@
-import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { upsertDataset } from "@/src/features/datasets/server/actions/createDataset";
+import { createDatasetForApi } from "@/src/features/datasets/server/publicDatasetService";
 import {
   PostDatasetsV2Body,
   PostDatasetsV2Response,
-  transformDbDatasetToAPIDataset,
 } from "@/src/features/public-api/types/datasets";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
@@ -20,30 +18,13 @@ export const [upsertDatasetTool, handleUpsertDataset] = defineTool({
       context,
       attributes: { "mcp.dataset_name": input.name },
       fn: async () => {
-        const dataset = await upsertDataset({
-          input: {
-            name: input.name,
-            description: input.description ?? undefined,
-            metadata: input.metadata ?? undefined,
-            inputSchema: input.inputSchema,
-            expectedOutputSchema: input.expectedOutputSchema,
-          },
+        const dataset = await createDatasetForApi({
+          input,
           projectId: context.projectId,
+          auditScope: context,
         });
 
-        await auditLog({
-          action: "create",
-          resourceType: "dataset",
-          resourceId: dataset.id,
-          projectId: context.projectId,
-          orgId: context.orgId,
-          apiKeyId: context.apiKeyId,
-          after: dataset,
-        });
-
-        return PostDatasetsV2Response.parse(
-          transformDbDatasetToAPIDataset(dataset),
-        );
+        return PostDatasetsV2Response.parse(dataset);
       },
     }),
   destructiveHint: true,

--- a/web/src/features/mcp/features/datasets/tools/upsertDatasetItem.ts
+++ b/web/src/features/mcp/features/datasets/tools/upsertDatasetItem.ts
@@ -20,6 +20,7 @@ export const [upsertDatasetItemTool, handleUpsertDatasetItem] = defineTool({
       fn: async () => {
         const result = await createDatasetItemForApi({
           input,
+          projectId: context.projectId,
           auditScope: context,
         });
 

--- a/web/src/features/mcp/features/scores/tools/createScore.ts
+++ b/web/src/features/mcp/features/scores/tools/createScore.ts
@@ -64,6 +64,7 @@ export const [createScoreTool, handleCreateScore] = defineTool({
               isIngestionSuspended: false,
             },
           },
+          auditScope: context,
         });
         span.setAttribute("mcp.score_id", scoreId);
 

--- a/web/src/features/public-api/server/dataset-run-items-api-service.ts
+++ b/web/src/features/public-api/server/dataset-run-items-api-service.ts
@@ -2,6 +2,7 @@ import { v4 } from "uuid";
 import type { NextApiResponse } from "next";
 import type { z } from "zod";
 
+import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { addDatasetRunItemsToEvalQueue } from "@/src/features/evals/server/addDatasetRunItemsToEvalQueue";
 import { createOrFetchDatasetRun } from "@/src/features/public-api/server/dataset-runs";
 import {
@@ -41,10 +42,12 @@ const resolveMetadata = (metadata: JSONValue): Record<string, unknown> => {
 export const createDatasetRunItemForApi = async ({
   body,
   auth,
+  auditScope,
   res,
 }: {
   body: z.infer<typeof PostDatasetRunItemsV1Body>;
   auth: AuthHeaderValidVerificationResultIngestion;
+  auditScope?: { orgId: string; apiKeyId: string };
   res?: NextApiResponse;
 }) => {
   /**************
@@ -153,17 +156,6 @@ export const createDatasetRunItemForApi = async ({
     throw new Error("Failed to create dataset run item");
   }
 
-  /***********************
-   * ASYNC RUN ITEM EVAL *
-   ***********************/
-  await addDatasetRunItemsToEvalQueue({
-    projectId,
-    datasetItemId: datasetItem.id,
-    datasetItemValidFrom: datasetItem.validFrom,
-    traceId: finalTraceId,
-    observationId: observationId ?? undefined,
-  });
-
   const datasetRunItem: APIDatasetRunItem = {
     id: event.body.id,
     datasetRunId: run.id,
@@ -174,6 +166,29 @@ export const createDatasetRunItemForApi = async ({
     createdAt,
     updatedAt: createdAt,
   };
+
+  if (auditScope) {
+    await auditLog({
+      action: "create",
+      resourceType: "datasetRunItem",
+      resourceId: datasetRunItem.id,
+      projectId,
+      orgId: auditScope.orgId,
+      apiKeyId: auditScope.apiKeyId,
+      after: datasetRunItem,
+    });
+  }
+
+  /***********************
+   * ASYNC RUN ITEM EVAL *
+   ***********************/
+  await addDatasetRunItemsToEvalQueue({
+    projectId,
+    datasetItemId: datasetItem.id,
+    datasetItemValidFrom: datasetItem.validFrom,
+    traceId: finalTraceId,
+    observationId: observationId ?? undefined,
+  });
 
   return PostDatasetRunItemsV1Response.parse(datasetRunItem);
 };

--- a/web/src/features/public-api/server/scores-api-service.ts
+++ b/web/src/features/public-api/server/scores-api-service.ts
@@ -29,12 +29,25 @@ export class ScoresApiService {
   async createScore({
     body,
     auth,
+    auditScope,
     scoreId = body.id ?? randomUUID(),
   }: {
     body: z.infer<typeof PostScoresBodyV1>;
     auth: AuthHeaderValidVerificationResultIngestion;
+    auditScope?: { projectId: string; orgId: string; apiKeyId: string };
     scoreId?: string;
   }) {
+    const existingScore = auditScope
+      ? await _handleGetScoreById({
+          projectId: auditScope.projectId,
+          scoreId,
+          scoreScope: this.apiVersion === "v1" ? "traces_only" : "all",
+          scoreDataTypes:
+            this.apiVersion === "v1" ? LISTABLE_SCORE_TYPES : undefined,
+          preferredClickhouseService: "ReadOnly",
+        })
+      : undefined;
+
     const result = await processEventBatch(
       [
         {
@@ -46,6 +59,25 @@ export class ScoresApiService {
       ],
       auth,
     );
+
+    if (
+      auditScope &&
+      result.errors.length === 0 &&
+      result.successes.length === 1
+    ) {
+      await auditLog({
+        action: existingScore ? "update" : "create",
+        resourceType: "score",
+        resourceId: scoreId,
+        projectId: auditScope.projectId,
+        orgId: auditScope.orgId,
+        apiKeyId: auditScope.apiKeyId,
+        before: existingScore
+          ? convertScoreToPublicApi(existingScore)
+          : undefined,
+        after: { ...body, id: scoreId },
+      });
+    }
 
     return { id: scoreId, result };
   }

--- a/web/src/pages/api/public/dataset-items/index.ts
+++ b/web/src/pages/api/public/dataset-items/index.ts
@@ -28,6 +28,7 @@ export default withMiddlewares({
     fn: async ({ body, auth }) =>
       await createDatasetItemForApi({
         input: body,
+        projectId: auth.scope.projectId,
         auditScope: auth.scope,
       }),
   }),

--- a/web/src/pages/api/public/datasets/index.ts
+++ b/web/src/pages/api/public/datasets/index.ts
@@ -5,11 +5,11 @@ import {
   GetDatasetsV1Response,
   PostDatasetsV1Body,
   PostDatasetsV1Response,
-  transformDbDatasetToAPIDataset,
 } from "@/src/features/public-api/types/datasets";
-import { upsertDataset } from "@/src/features/datasets/server/actions/createDataset";
-import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { listDatasetsByProjectForApi } from "@/src/features/datasets/server/publicDatasetService";
+import {
+  createDatasetForApi,
+  listDatasetsByProjectForApi,
+} from "@/src/features/datasets/server/publicDatasetService";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
@@ -18,32 +18,14 @@ export default withMiddlewares({
     responseSchema: PostDatasetsV1Response,
     rateLimitResource: "datasets",
     fn: async ({ body, auth }) => {
-      const { name, description, metadata, inputSchema, expectedOutputSchema } =
-        body;
-
-      const dataset = await upsertDataset({
-        input: {
-          name,
-          description: description ?? undefined,
-          metadata: metadata ?? undefined,
-          inputSchema,
-          expectedOutputSchema,
-        },
+      const dataset = await createDatasetForApi({
+        input: body,
         projectId: auth.scope.projectId,
-      });
-
-      await auditLog({
-        action: "create",
-        resourceType: "dataset",
-        resourceId: dataset.id,
-        projectId: auth.scope.projectId,
-        orgId: auth.scope.orgId,
-        apiKeyId: auth.scope.apiKeyId,
-        after: dataset,
+        auditScope: auth.scope,
       });
 
       return {
-        ...transformDbDatasetToAPIDataset(dataset),
+        ...dataset,
         items: [],
         runs: [],
       };

--- a/web/src/pages/api/public/v2/datasets/index.ts
+++ b/web/src/pages/api/public/v2/datasets/index.ts
@@ -4,12 +4,10 @@ import {
   GetDatasetsV2Response,
   PostDatasetsV2Body,
   PostDatasetsV2Response,
-  transformDbDatasetToAPIDataset,
 } from "@/src/features/public-api/types/datasets";
 import { withMiddlewares } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
-import { auditLog } from "@/src/features/audit-logs/auditLog";
-import { upsertDataset } from "@/src/features/datasets/server/actions/createDataset";
+import { createDatasetForApi } from "@/src/features/datasets/server/publicDatasetService";
 
 export default withMiddlewares({
   POST: createAuthedProjectAPIRoute({
@@ -18,31 +16,13 @@ export default withMiddlewares({
     responseSchema: PostDatasetsV2Response,
     rateLimitResource: "datasets",
     fn: async ({ body, auth }) => {
-      const { name, description, metadata, inputSchema, expectedOutputSchema } =
-        body;
-
-      const dataset = await upsertDataset({
-        input: {
-          name,
-          description: description ?? undefined,
-          metadata: metadata ?? undefined,
-          inputSchema,
-          expectedOutputSchema,
-        },
+      const dataset = await createDatasetForApi({
+        input: body,
         projectId: auth.scope.projectId,
+        auditScope: auth.scope,
       });
 
-      await auditLog({
-        action: "create",
-        resourceType: "dataset",
-        resourceId: dataset.id,
-        projectId: auth.scope.projectId,
-        orgId: auth.scope.orgId,
-        apiKeyId: auth.scope.apiKeyId,
-        after: dataset,
-      });
-
-      return transformDbDatasetToAPIDataset(dataset);
+      return dataset;
     },
   }),
   GET: createAuthedProjectAPIRoute({


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR correctly fills gaps in audit logging for MCP/public-API operations: dataset creation (v1 & v2), dataset run item creation, and score creation. It also consolidates three copies of duplicated upsert + audit-log logic into a single `createDatasetForApi` service function. Dataset item audit logging is also fixed to distinguish `"create"` from `"update"` actions.

- **`createDatasetForApi`** (new service function): consolidates `upsertDataset` + audit log across the v1 REST route, v2 REST route, and MCP tool; correctly sets the action to `"create"` or `"update"` based on a pre-check query.
- **`createDatasetRunItemForApi`**: audit log added after a successful `processEventBatch` call; `"datasetRunItem"` registered as a new `AuditableResource` type.
- **`ScoresApiService.createScore`**: audit log added inside the existing success-only guard (`errors.length === 0 && successes.length === 1`).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core logic adds missing audit log entries without touching business logic.

Both observations are in audit-log bookkeeping paths and do not affect the actual data written to the database. The TOCTOU race could produce incorrect action types in the audit log under concurrent load, and the non-null assertions suppress TypeScript warnings on optional-typed scope fields.

web/src/features/datasets/server/publicDatasetService.ts (create-vs-update pre-check pattern); web/src/features/public-api/server/dataset-run-items-api-service.ts and scores-api-service.ts (non-null assertions on optional scope fields)
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/datasets/server/publicDatasetService.ts:159-195
**TOCTOU race in create-vs-update audit log action**

`findUnique` to detect an existing dataset and `upsertDataset` are two separate database calls with no transaction wrapping them. A concurrent request that creates the dataset between these two calls will cause the audit log to record `"create"` for what was actually an `"update"` (or vice-versa). The audit record's `before` field would also be stale or wrong. The same pattern is replicated in `createDatasetItemForApi`. Since audit logs are the compliance record, incorrect action types are the main risk here.

### Issue 2 of 2
web/src/features/public-api/server/dataset-run-items-api-service.ts:178-188
**Non-null assertions on fields typed as optional in `ApiAccessScopeIngestion`**

`auth.scope` here is `ApiAccessScopeIngestion`, where `orgId` and `apiKeyId` are typed as `string | undefined` (via `MakeOptional<ApiAccessScopeMetadata>`). The `!` assertions silence TypeScript but do not provide a runtime guarantee. If either value is `undefined`, `auditLog` will silently receive `undefined` for a required `string` field. The same pattern is used in `scores-api-service.ts`. Consider adding an explicit guard (e.g. `if (!orgId || !apiKeyId) return;` or throwing) to make the failure mode visible.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Missing audit logs"](https://github.com/langfuse/langfuse/commit/c7e106cbf5a27212d844cc178e34523770e11c80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34387241)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->