### PR TITLE
fix(mcp): Use ids instead of names for dataset tools

### DIFF
--- a/packages/shared/src/server/repositories/dataset-items.ts
+++ b/packages/shared/src/server/repositories/dataset-items.ts
@@ -49,7 +49,9 @@ const emptyValidateOpts: { normalizeUndefinedToNull?: boolean } = {};
 async function getDatasets(props: {
   projectId: string;
   datasetIds: string[];
-}): Promise<Pick<Dataset, "id" | "inputSchema" | "expectedOutputSchema">[]> {
+}): Promise<
+  Pick<Dataset, "id" | "name" | "inputSchema" | "expectedOutputSchema">[]
+> {
   const datasets = await prisma.dataset.findMany({
     where: {
       id: { in: props.datasetIds },
@@ -57,6 +59,7 @@ async function getDatasets(props: {
     },
     select: {
       id: true,
+      name: true,
       inputSchema: true,
       expectedOutputSchema: true,
     },
@@ -73,7 +76,9 @@ async function getDatasets(props: {
 async function getDatasetById(props: {
   projectId: string;
   datasetId: string;
-}): Promise<Pick<Dataset, "id" | "inputSchema" | "expectedOutputSchema">> {
+}): Promise<
+  Pick<Dataset, "id" | "name" | "inputSchema" | "expectedOutputSchema">
+> {
   const result = await getDatasets({
     projectId: props.projectId,
     datasetIds: [props.datasetId],
@@ -84,7 +89,9 @@ async function getDatasetById(props: {
 async function getDatasetByName(props: {
   projectId: string;
   datasetName: string;
-}): Promise<Pick<Dataset, "id" | "inputSchema" | "expectedOutputSchema">> {
+}): Promise<
+  Pick<Dataset, "id" | "name" | "inputSchema" | "expectedOutputSchema">
+> {
   const dataset = await prisma.dataset.findFirst({
     where: {
       name: props.datasetName,
@@ -92,6 +99,7 @@ async function getDatasetByName(props: {
     },
     select: {
       id: true,
+      name: true,
       inputSchema: true,
       expectedOutputSchema: true,
     },
@@ -272,7 +280,7 @@ export async function upsertDatasetItem(
     normalizeOpts?: { sanitizeControlChars?: boolean };
     validateOpts: { normalizeUndefinedToNull?: boolean };
   } & IdOrName,
-): Promise<DatasetItemDomain> {
+): Promise<DatasetItemDomain & { datasetName: string }> {
   // 1. Get dataset
   const dataset =
     "datasetId" in props
@@ -430,7 +438,7 @@ export async function upsertDatasetItem(
     throw new InternalServerError("Failed to upsert dataset item");
   }
 
-  return toDomainType(item);
+  return { ...toDomainType(item), datasetName: dataset.name };
 }
 
 /**

--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -494,12 +494,12 @@ describe("MCP public API tools", () => {
     expect(datasets.data.map((item) => item.id)).toContain(dataset.id);
 
     await expect(
-      handleGetDataset({ datasetName }, context),
+      handleGetDataset({ datasetId: dataset.id }, context),
     ).resolves.toMatchObject({ id: dataset.id, name: datasetName });
 
     const datasetItem = (await handleUpsertDatasetItem(
       {
-        datasetName,
+        datasetId: dataset.id,
         input: { question: "ping" },
         expectedOutput: { answer: "pong" },
       },
@@ -508,7 +508,7 @@ describe("MCP public API tools", () => {
     expect(datasetItem.datasetName).toBe(datasetName);
 
     const datasetItems = (await handleListDatasetItems(
-      { datasetName, page: 1, limit: 10 },
+      { datasetId: dataset.id, page: 1, limit: 10 },
       context,
     )) as { data: Array<{ id: string }> };
     expect(datasetItems.data.map((item) => item.id)).toContain(datasetItem.id);
@@ -546,7 +546,12 @@ describe("MCP public API tools", () => {
 
     await waitFor(async () => {
       const runItems = (await handleListDatasetRunItems(
-        { datasetId: dataset.id, runName, page: 1, limit: 10 },
+        {
+          datasetId: dataset.id,
+          datasetRunId: runItem.datasetRunId,
+          page: 1,
+          limit: 10,
+        },
         context,
       )) as { data: Array<{ id: string }> };
 
@@ -554,7 +559,7 @@ describe("MCP public API tools", () => {
     });
 
     const datasetRuns = (await handleListDatasetRuns(
-      { name: datasetName, page: 1, limit: 10 },
+      { datasetId: dataset.id, page: 1, limit: 10 },
       context,
     )) as { data: Array<{ id: string; name: string }> };
     expect(datasetRuns.data).toEqual(
@@ -564,7 +569,10 @@ describe("MCP public API tools", () => {
     );
 
     await expect(
-      handleGetDatasetRun({ name: datasetName, runName }, context),
+      handleGetDatasetRun(
+        { datasetId: dataset.id, datasetRunId: runItem.datasetRunId },
+        context,
+      ),
     ).resolves.toMatchObject({
       id: runItem.datasetRunId,
       name: runName,
@@ -574,7 +582,10 @@ describe("MCP public API tools", () => {
     });
 
     await expect(
-      handleDeleteDatasetRun({ name: datasetName, runName }, context),
+      handleDeleteDatasetRun(
+        { datasetId: dataset.id, datasetRunId: runItem.datasetRunId },
+        context,
+      ),
     ).resolves.toEqual({ message: "Dataset run successfully deleted" });
 
     await expect(
@@ -640,11 +651,17 @@ describe("MCP public API tools", () => {
     )) as { id: string };
 
     await expect(
-      handleGetDataset({ datasetName }, targetContext),
+      handleGetDataset({ datasetId: dataset.id }, targetContext),
+    ).rejects.toThrow("Dataset not found");
+    await expect(
+      handleListDatasetItems(
+        { datasetId: dataset.id, page: 1, limit: 10 },
+        targetContext,
+      ),
     ).rejects.toThrow("Dataset not found");
     await expect(
       handleListDatasetRunItems(
-        { datasetId: dataset.id, runName: "missing", page: 1, limit: 10 },
+        { datasetId: dataset.id, datasetRunId: uuidv4(), page: 1, limit: 10 },
         targetContext,
       ),
     ).rejects.toThrow("Dataset run not found");

--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -21,6 +21,7 @@ vi.mock("@/src/features/media/server/getMediaStorageClient", () => ({
 
 import { nanoid } from "nanoid";
 import { createHash, randomUUID } from "crypto";
+import { z } from "zod";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   createEvent,
@@ -117,6 +118,13 @@ import {
   getMediaTool,
   handleGetMedia,
 } from "@/src/features/mcp/features/media/tools/getMedia";
+import {
+  GetDatasetItemsMcpInput,
+  GetDatasetMcpInput,
+  GetDatasetRunMcpInput,
+  GetDatasetRunsMcpInput,
+  GetDatasetsMcpInput,
+} from "@/src/features/mcp/features/datasets/schema";
 
 const maybeEventsTable =
   env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true"
@@ -209,6 +217,34 @@ const containsPropertyName = (value: unknown, expected: string): boolean => {
 };
 
 describe("MCP Read Tools", () => {
+  describe("dataset tool schemas", () => {
+    it("uses dataset IDs for existing dataset read addressing", () => {
+      for (const schema of [
+        GetDatasetMcpInput,
+        GetDatasetItemsMcpInput,
+        GetDatasetRunsMcpInput,
+        GetDatasetRunMcpInput,
+      ]) {
+        const jsonSchema = z.toJSONSchema(schema, { unrepresentable: "any" });
+        const properties = jsonSchema.properties as Record<string, unknown>;
+
+        expect(properties).toHaveProperty("datasetId");
+        expect(properties).not.toHaveProperty("datasetName");
+        expect(properties).not.toHaveProperty("name");
+      }
+    });
+
+    it("keeps dataset names only as a listDatasets discovery filter", () => {
+      const jsonSchema = z.toJSONSchema(GetDatasetsMcpInput, {
+        unrepresentable: "any",
+      });
+      const properties = jsonSchema.properties as Record<string, unknown>;
+
+      expect(properties).toHaveProperty("name");
+      expect(properties).not.toHaveProperty("datasetId");
+    });
+  });
+
   describe("getMedia tool", () => {
     it("should have readOnlyHint annotation", () => {
       verifyToolAnnotations(getMediaTool, { readOnlyHint: true });

--- a/web/src/__tests__/server/mcp-tools-write.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-write.servertest.ts
@@ -21,11 +21,16 @@ vi.mock("@langfuse/shared/src/server", async () => {
 
 import { prisma } from "@langfuse/shared/src/db";
 import { nanoid } from "nanoid";
+import { z } from "zod";
 import {
   createMcpTestSetup,
   createPromptInDb,
   verifyAuditLog,
 } from "./mcp-helpers";
+import {
+  DeleteDatasetRunMcpInput,
+  PostDatasetItemMcpInput,
+} from "@/src/features/mcp/features/datasets/schema";
 
 // Import MCP tool handlers directly
 import { handleCreateTextPrompt } from "@/src/features/mcp/features/prompts/tools/createTextPrompt";
@@ -33,6 +38,22 @@ import { handleCreateChatPrompt } from "@/src/features/mcp/features/prompts/tool
 import { handleUpdatePromptLabels } from "@/src/features/mcp/features/prompts/tools/updatePromptLabels";
 
 describe("MCP Write Tools", () => {
+  describe("dataset tool schemas", () => {
+    it("uses dataset IDs for existing dataset write addressing", () => {
+      for (const schema of [
+        PostDatasetItemMcpInput,
+        DeleteDatasetRunMcpInput,
+      ]) {
+        const jsonSchema = z.toJSONSchema(schema, { unrepresentable: "any" });
+        const properties = jsonSchema.properties as Record<string, unknown>;
+
+        expect(properties).toHaveProperty("datasetId");
+        expect(properties).not.toHaveProperty("datasetName");
+        expect(properties).not.toHaveProperty("name");
+      }
+    });
+  });
+
   describe("createTextPrompt tool", () => {
     it("should create a simple text prompt", async () => {
       const { context } = await createMcpTestSetup();

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -44,6 +44,7 @@ type DatasetAuditScope = {
 
 type ListDatasetsInput = z.infer<typeof GetDatasetsV2Query> & {
   projectId: string;
+  name?: string;
 };
 
 type ListDatasetsV1Input = z.infer<typeof GetDatasetsV1Query> & {
@@ -60,6 +61,7 @@ type GetDatasetV1Input = z.infer<typeof GetDatasetV1Query> & {
 
 type ListDatasetItemsInput = z.infer<typeof GetDatasetItemsV1Query> & {
   projectId: string;
+  datasetId?: string;
 };
 
 type GetDatasetItemInput = z.infer<typeof GetDatasetItemV1Query> & {
@@ -67,7 +69,11 @@ type GetDatasetItemInput = z.infer<typeof GetDatasetItemV1Query> & {
 };
 
 type CreateDatasetItemInput = {
-  input: z.infer<typeof PostDatasetItemsV1Body>;
+  input:
+    | z.infer<typeof PostDatasetItemsV1Body>
+    | (Omit<z.infer<typeof PostDatasetItemsV1Body>, "datasetName"> & {
+        datasetId: string;
+      });
   auditScope: DatasetAuditScope;
 };
 
@@ -75,12 +81,30 @@ type ListDatasetRunsInput = z.infer<typeof GetDatasetRunsV1Query> & {
   projectId: string;
 };
 
+type ListDatasetRunsByDatasetIdInput = {
+  projectId: string;
+  datasetId: string;
+  page: number;
+  limit: number;
+};
+
 type GetDatasetRunInput = z.infer<typeof GetDatasetRunV1Query> & {
   projectId: string;
 };
 
+type GetDatasetRunByIdInput = {
+  projectId: string;
+  datasetId: string;
+  datasetRunId: string;
+};
+
 type DeleteDatasetRunInput = DatasetAuditScope &
   z.infer<typeof GetDatasetRunV1Query>;
+
+type DeleteDatasetRunByIdInput = DatasetAuditScope & {
+  datasetId: string;
+  datasetRunId: string;
+};
 
 type DeleteDatasetItemInput = DatasetAuditScope &
   z.infer<typeof GetDatasetItemV1Query>;
@@ -96,6 +120,29 @@ const getDatasetByNameOrThrow = async ({
     where: {
       name: datasetName,
       projectId,
+    },
+  });
+
+  if (!dataset) {
+    throw new LangfuseNotFoundError("Dataset not found");
+  }
+
+  return dataset;
+};
+
+const getDatasetByIdOrThrow = async ({
+  projectId,
+  datasetId,
+}: {
+  projectId: string;
+  datasetId: string;
+}) => {
+  const dataset = await prisma.dataset.findUnique({
+    where: {
+      id_projectId: {
+        id: datasetId,
+        projectId,
+      },
     },
   });
 
@@ -146,11 +193,46 @@ const getDatasetRunRecordOrThrow = async ({
   return datasetRuns[0];
 };
 
+const getDatasetRunRecordByIdOrThrow = async ({
+  projectId,
+  datasetId,
+  datasetRunId,
+}: GetDatasetRunByIdInput) => {
+  const datasetRun = await prisma.datasetRuns.findUnique({
+    where: {
+      id_projectId: {
+        id: datasetRunId,
+        projectId,
+      },
+    },
+    include: {
+      dataset: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  if (!datasetRun || datasetRun.datasetId !== datasetId) {
+    throw new LangfuseNotFoundError("Dataset run not found");
+  }
+
+  return datasetRun;
+};
+
 export const listDatasetsForApi = async ({
   projectId,
+  name,
   page,
   limit,
 }: ListDatasetsInput) => {
+  const where: Prisma.DatasetWhereInput = {
+    projectId,
+    ...(name ? { name: { contains: name, mode: "insensitive" } } : {}),
+  };
+
   const [datasets, totalItems] = await Promise.all([
     prisma.dataset.findMany({
       select: {
@@ -164,12 +246,12 @@ export const listDatasetsForApi = async ({
         updatedAt: true,
         id: true,
       },
-      where: { projectId },
+      where,
       orderBy: [{ createdAt: "desc" }, { id: "asc" }],
       take: limit,
       skip: (page - 1) * limit,
     }),
-    prisma.dataset.count({ where: { projectId } }),
+    prisma.dataset.count({ where }),
   ]);
 
   return {
@@ -188,6 +270,17 @@ export const getDatasetForApi = async ({
   datasetName,
 }: GetDatasetInput) => {
   const dataset = await getDatasetByNameOrThrow({ projectId, datasetName });
+  return transformDbDatasetToAPIDataset(dataset);
+};
+
+export const getDatasetByIdForApi = async ({
+  projectId,
+  datasetId,
+}: {
+  projectId: string;
+  datasetId: string;
+}) => {
+  const dataset = await getDatasetByIdOrThrow({ projectId, datasetId });
   return transformDbDatasetToAPIDataset(dataset);
 };
 
@@ -299,6 +392,7 @@ export const getDatasetByNameForApi = async ({
 
 export const listDatasetItemsForApi = async ({
   projectId,
+  datasetId: inputDatasetId,
   datasetName,
   sourceTraceId,
   sourceObservationId,
@@ -306,9 +400,11 @@ export const listDatasetItemsForApi = async ({
   page,
   limit,
 }: ListDatasetItemsInput) => {
-  let datasetId: string | undefined;
+  let datasetId = inputDatasetId;
 
-  if (datasetName) {
+  if (datasetId) {
+    await getDatasetByIdOrThrow({ projectId, datasetId });
+  } else if (datasetName) {
     const dataset = await getDatasetByNameOrThrow({ projectId, datasetName });
     datasetId = dataset.id;
   }
@@ -386,10 +482,17 @@ export const createDatasetItemForApi = async ({
   input,
   auditScope,
 }: CreateDatasetItemInput) => {
+  const datasetIdentifierForLog =
+    "datasetId" in input ? input.datasetId : input.datasetName;
+
   try {
+    const datasetIdentifier =
+      "datasetId" in input
+        ? { datasetId: input.datasetId }
+        : { datasetName: input.datasetName };
     const datasetItem = await upsertDatasetItem({
       projectId: auditScope.projectId,
-      datasetName: input.datasetName,
+      ...datasetIdentifier,
       datasetItemId: input.id ?? undefined,
       input: input.input ?? undefined,
       expectedOutput: input.expectedOutput ?? undefined,
@@ -413,7 +516,7 @@ export const createDatasetItemForApi = async ({
 
     return transformDbDatasetItemDomainToAPIDatasetItem({
       ...datasetItem,
-      datasetName: input.datasetName,
+      datasetName: datasetItem.datasetName,
       status: datasetItem.status ?? "ACTIVE",
     });
   } catch (error) {
@@ -424,10 +527,10 @@ export const createDatasetItemForApi = async ({
         // When this constraint is violated, the database will upsert based on (id, projectId, datasetId).
         // If this record does not exist, the database will throw an error.
         logger.warn(
-          `Failed to upsert dataset item. Dataset item ${input.id} already exists for a different dataset than ${input.datasetName}`,
+          `Failed to upsert dataset item. Dataset item ${input.id} already exists for a different dataset than ${datasetIdentifierForLog}`,
         );
         throw new LangfuseNotFoundError(
-          `The dataset item with id ${input.id} already exists in a dataset other than ${input.datasetName}`,
+          `The dataset item with id ${input.id} already exists in a dataset other than ${datasetIdentifierForLog}`,
         );
       }
 
@@ -519,6 +622,45 @@ export const listDatasetRunsForApi = async ({
   };
 };
 
+export const listDatasetRunsByDatasetIdForApi = async ({
+  projectId,
+  datasetId,
+  page,
+  limit,
+}: ListDatasetRunsByDatasetIdInput) => {
+  const dataset = await getDatasetByIdOrThrow({ projectId, datasetId });
+
+  const [datasetRuns, totalItems] = await Promise.all([
+    prisma.datasetRuns.findMany({
+      where: {
+        datasetId,
+        projectId,
+      },
+      take: limit,
+      skip: (page - 1) * limit,
+      orderBy: [{ createdAt: "desc" }, { id: "asc" }],
+    }),
+    prisma.datasetRuns.count({
+      where: {
+        datasetId,
+        projectId,
+      },
+    }),
+  ]);
+
+  return {
+    data: datasetRuns
+      .map((run) => ({ ...run, datasetName: dataset.name }))
+      .map(transformDbDatasetRunToAPIDatasetRun),
+    meta: {
+      page,
+      limit,
+      totalItems,
+      totalPages: Math.ceil(totalItems / limit),
+    },
+  };
+};
+
 export const getDatasetRunForApi = async ({
   projectId,
   name,
@@ -528,6 +670,34 @@ export const getDatasetRunForApi = async ({
     projectId,
     datasetName: name,
     runName,
+  });
+
+  const datasetRunItems = (await generateDatasetRunItemsForPublicApi({
+    props: {
+      datasetId: run.datasetId,
+      runId: run.id,
+      projectId,
+    },
+  })) as APIDatasetRunItem[];
+
+  return {
+    ...transformDbDatasetRunToAPIDatasetRun({
+      ...run,
+      datasetName: dataset.name,
+    }),
+    datasetRunItems,
+  };
+};
+
+export const getDatasetRunByIdForApi = async ({
+  projectId,
+  datasetId,
+  datasetRunId,
+}: GetDatasetRunByIdInput) => {
+  const { dataset, ...run } = await getDatasetRunRecordByIdOrThrow({
+    projectId,
+    datasetId,
+    datasetRunId,
   });
 
   const datasetRunItems = (await generateDatasetRunItemsForPublicApi({
@@ -585,6 +755,51 @@ export const deleteDatasetRunForApi = async ({
   });
 
   // Trigger async delete of dataset run items
+  await addToDeleteDatasetQueue({
+    deletionType: "dataset-runs",
+    projectId,
+    datasetRunIds: [datasetRun.id],
+    datasetId: datasetRun.datasetId,
+  });
+
+  return {
+    message: "Dataset run successfully deleted" as const,
+  };
+};
+
+export const deleteDatasetRunByIdForApi = async ({
+  projectId,
+  orgId,
+  apiKeyId,
+  datasetId,
+  datasetRunId,
+}: DeleteDatasetRunByIdInput) => {
+  const { dataset: _dataset, ...datasetRun } =
+    await getDatasetRunRecordByIdOrThrow({
+      projectId,
+      datasetId,
+      datasetRunId,
+    });
+
+  await prisma.datasetRuns.delete({
+    where: {
+      id_projectId: {
+        projectId,
+        id: datasetRun.id,
+      },
+    },
+  });
+
+  await auditLog({
+    action: "delete",
+    resourceType: "datasetRun",
+    resourceId: datasetRun.id,
+    projectId,
+    orgId,
+    apiKeyId,
+    before: datasetRun,
+  });
+
   await addToDeleteDatasetQueue({
     deletionType: "dataset-runs",
     projectId,

--- a/web/src/features/mcp/features/datasets/schema.ts
+++ b/web/src/features/mcp/features/datasets/schema.ts
@@ -1,10 +1,17 @@
 import { z } from "zod";
-import type { JSONValue } from "@langfuse/shared";
+import {
+  publicApiPaginationZod,
+  versionZod,
+  type JSONValue,
+} from "@langfuse/shared";
 import {
   DeleteDatasetRunV1Query,
+  GetDatasetRunItemsV1Query,
   GetDatasetRunV1Query,
   GetDatasetRunsV1Query,
+  GetDatasetsV2Query,
   GetDatasetV2Query,
+  PostDatasetItemsV1Body,
 } from "@/src/features/public-api/types/datasets";
 
 export const resolveMetadata = (
@@ -19,20 +26,65 @@ export const resolveMetadata = (
   return { metadata };
 };
 
-export const GetDatasetMcpInput = GetDatasetV2Query.extend({
-  datasetName: z.string(),
+export const GetDatasetsMcpInput = GetDatasetsV2Query.extend({
+  name: z.string().optional(),
 });
 
-export const GetDatasetRunsMcpInput = GetDatasetRunsV1Query.extend({
-  name: z.string(),
+export const GetDatasetMcpInput = GetDatasetV2Query.omit({
+  datasetName: true,
+}).extend({
+  datasetId: z.string(),
 });
 
-export const GetDatasetRunMcpInput = GetDatasetRunV1Query.extend({
-  name: z.string(),
-  runName: z.string(),
+export const GetDatasetRunsMcpInput = GetDatasetRunsV1Query.omit({
+  name: true,
+}).extend({
+  datasetId: z.string(),
 });
 
-export const DeleteDatasetRunMcpInput = DeleteDatasetRunV1Query.extend({
-  name: z.string(),
-  runName: z.string(),
+export const GetDatasetRunMcpInput = GetDatasetRunV1Query.omit({
+  name: true,
+  runName: true,
+}).extend({
+  datasetId: z.string(),
+  datasetRunId: z.string(),
+});
+
+export const DeleteDatasetRunMcpInput = DeleteDatasetRunV1Query.omit({
+  name: true,
+  runName: true,
+}).extend({
+  datasetId: z.string(),
+  datasetRunId: z.string(),
+});
+
+export const GetDatasetRunItemsMcpInput = GetDatasetRunItemsV1Query.omit({
+  runName: true,
+}).extend({
+  datasetRunId: z.string(),
+});
+
+export const GetDatasetItemsMcpInput = z
+  .object({
+    datasetId: z.string().optional(),
+    sourceTraceId: z.string().nullish(),
+    sourceObservationId: z.string().nullish(),
+    version: versionZod.nullish(),
+    ...publicApiPaginationZod,
+  })
+  .refine(
+    (data) => {
+      if (data.version && !data.datasetId) return false;
+      return true;
+    },
+    {
+      message: "datasetId is required when version parameter is provided",
+      path: ["datasetId"],
+    },
+  );
+
+export const PostDatasetItemMcpInput = PostDatasetItemsV1Body.omit({
+  datasetName: true,
+}).extend({
+  datasetId: z.string(),
 });

--- a/web/src/features/mcp/features/datasets/tools/deleteDatasetRun.ts
+++ b/web/src/features/mcp/features/datasets/tools/deleteDatasetRun.ts
@@ -1,4 +1,4 @@
-import { deleteDatasetRunForApi } from "@/src/features/datasets/server/publicDatasetService";
+import { deleteDatasetRunByIdForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { DeleteDatasetRunV1Response } from "@/src/features/public-api/types/datasets";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
@@ -7,7 +7,7 @@ import { DeleteDatasetRunMcpInput } from "../schema";
 export const [deleteDatasetRunTool, handleDeleteDatasetRun] = defineTool({
   name: "deleteDatasetRun",
   description:
-    "Delete a dataset run, one experiment or evaluation execution over a dataset, and enqueue deletion of its run items.",
+    "Delete a dataset run by dataset ID and run ID, and enqueue deletion of its run items.",
   baseSchema: DeleteDatasetRunMcpInput,
   inputSchema: DeleteDatasetRunMcpInput,
   handler: async (input, context) =>
@@ -15,16 +15,16 @@ export const [deleteDatasetRunTool, handleDeleteDatasetRun] = defineTool({
       spanName: "mcp.dataset_runs.delete",
       context,
       attributes: {
-        "mcp.dataset_name": input.name,
-        "mcp.dataset_run_name": input.runName,
+        "mcp.dataset_id": input.datasetId,
+        "mcp.dataset_run_id": input.datasetRunId,
       },
       fn: async () => {
-        const result = await deleteDatasetRunForApi({
+        const result = await deleteDatasetRunByIdForApi({
           projectId: context.projectId,
           orgId: context.orgId,
           apiKeyId: context.apiKeyId,
-          name: input.name,
-          runName: input.runName,
+          datasetId: input.datasetId,
+          datasetRunId: input.datasetRunId,
         });
 
         return DeleteDatasetRunV1Response.parse(result);

--- a/web/src/features/mcp/features/datasets/tools/getDataset.ts
+++ b/web/src/features/mcp/features/datasets/tools/getDataset.ts
@@ -1,24 +1,24 @@
 import { GetDatasetV2Response } from "@/src/features/public-api/types/datasets";
-import { getDatasetForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
+import { getDatasetByIdForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { GetDatasetMcpInput } from "../schema";
 
 export const [getDatasetTool, handleGetDataset] = defineTool({
   name: "getDataset",
   description:
-    "Get a dataset, a named collection of input and optional expected-output examples for experiments and evaluations, by name.",
+    "Get a dataset, a named collection of input and optional expected-output examples for experiments and evaluations, by ID.",
   baseSchema: GetDatasetMcpInput,
   inputSchema: GetDatasetMcpInput,
   handler: async (input, context) =>
     runMcpTool({
       spanName: "mcp.datasets.get",
       context,
-      attributes: { "mcp.dataset_name": input.datasetName },
+      attributes: { "mcp.dataset_id": input.datasetId },
       fn: async () => {
-        const result = await getDatasetForApi({
+        const result = await getDatasetByIdForApi({
           projectId: context.projectId,
-          datasetName: input.datasetName,
+          datasetId: input.datasetId,
         });
 
         return GetDatasetV2Response.parse(result);

--- a/web/src/features/mcp/features/datasets/tools/getDatasetRun.ts
+++ b/web/src/features/mcp/features/datasets/tools/getDatasetRun.ts
@@ -1,5 +1,5 @@
 import { GetDatasetRunV1Response } from "@/src/features/public-api/types/datasets";
-import { getDatasetRunForApi } from "@/src/features/datasets/server/publicDatasetService";
+import { getDatasetRunByIdForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { GetDatasetRunMcpInput } from "../schema";
@@ -7,7 +7,7 @@ import { GetDatasetRunMcpInput } from "../schema";
 export const [getDatasetRunTool, handleGetDatasetRun] = defineTool({
   name: "getDatasetRun",
   description:
-    "Get a dataset run, one experiment or evaluation execution over a dataset, and its run items by dataset and run name.",
+    "Get a dataset run, one experiment or evaluation execution over a dataset, and its run items by dataset ID and run ID.",
   baseSchema: GetDatasetRunMcpInput,
   inputSchema: GetDatasetRunMcpInput,
   handler: async (input, context) =>
@@ -15,14 +15,14 @@ export const [getDatasetRunTool, handleGetDatasetRun] = defineTool({
       spanName: "mcp.dataset_runs.get",
       context,
       attributes: {
-        "mcp.dataset_name": input.name,
-        "mcp.dataset_run_name": input.runName,
+        "mcp.dataset_id": input.datasetId,
+        "mcp.dataset_run_id": input.datasetRunId,
       },
       fn: async () => {
-        const result = await getDatasetRunForApi({
+        const result = await getDatasetRunByIdForApi({
           projectId: context.projectId,
-          name: input.name,
-          runName: input.runName,
+          datasetId: input.datasetId,
+          datasetRunId: input.datasetRunId,
         });
 
         return GetDatasetRunV1Response.parse(result);

--- a/web/src/features/mcp/features/datasets/tools/listDatasetItems.ts
+++ b/web/src/features/mcp/features/datasets/tools/listDatasetItems.ts
@@ -1,23 +1,21 @@
-import {
-  GetDatasetItemsV1Query,
-  GetDatasetItemsV1Response,
-} from "@/src/features/public-api/types/datasets";
+import { GetDatasetItemsV1Response } from "@/src/features/public-api/types/datasets";
 import { listDatasetItemsForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
+import { GetDatasetItemsMcpInput } from "../schema";
 
 export const [listDatasetItemsTool, handleListDatasetItems] = defineTool({
   name: "listDatasetItems",
   description:
-    "List dataset items, individual examples with input and optional expected output, optionally filtered by dataset name, source trace, source observation, or version.",
-  baseSchema: GetDatasetItemsV1Query,
-  inputSchema: GetDatasetItemsV1Query,
+    "List dataset items, individual examples with input and optional expected output, optionally filtered by dataset ID, source trace, source observation, or version.",
+  baseSchema: GetDatasetItemsMcpInput,
+  inputSchema: GetDatasetItemsMcpInput,
   handler: async (input, context) =>
     runMcpTool({
       spanName: "mcp.dataset_items.list",
       context,
       attributes: {
-        "mcp.dataset_name": input.datasetName ?? undefined,
+        "mcp.dataset_id": input.datasetId,
         "mcp.pagination_page": input.page,
         "mcp.pagination_limit": input.limit,
       },

--- a/web/src/features/mcp/features/datasets/tools/listDatasetRunItems.ts
+++ b/web/src/features/mcp/features/datasets/tools/listDatasetRunItems.ts
@@ -1,30 +1,28 @@
-import { listDatasetRunItemsForApi } from "@/src/features/public-api/server/dataset-run-items-api-service";
-import {
-  GetDatasetRunItemsV1Query,
-  GetDatasetRunItemsV1Response,
-} from "@/src/features/public-api/types/datasets";
+import { listDatasetRunItemsByRunIdForApi } from "@/src/features/public-api/server/dataset-run-items-api-service";
+import { GetDatasetRunItemsV1Response } from "@/src/features/public-api/types/datasets";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { paginationMeta } from "../../publicApi";
+import { GetDatasetRunItemsMcpInput } from "../schema";
 
 export const [listDatasetRunItemsTool, handleListDatasetRunItems] = defineTool({
   name: "listDatasetRunItems",
   description:
-    "List dataset run items, each linking one dataset item to a trace or observation within a dataset run, by dataset ID and run name.",
-  baseSchema: GetDatasetRunItemsV1Query,
-  inputSchema: GetDatasetRunItemsV1Query,
+    "List dataset run items, each linking one dataset item to a trace or observation within a dataset run, by dataset ID and run ID.",
+  baseSchema: GetDatasetRunItemsMcpInput,
+  inputSchema: GetDatasetRunItemsMcpInput,
   handler: async (input, context) =>
     runMcpTool({
       spanName: "mcp.dataset_run_items.list",
       context,
       attributes: {
         "mcp.dataset_id": input.datasetId,
-        "mcp.dataset_run_name": input.runName,
+        "mcp.dataset_run_id": input.datasetRunId,
       },
       fn: async () => {
-        const result = await listDatasetRunItemsForApi({
+        const result = await listDatasetRunItemsByRunIdForApi({
           datasetId: input.datasetId,
-          runName: input.runName,
+          datasetRunId: input.datasetRunId,
           projectId: context.projectId,
           limit: input.limit,
           page: input.page,

--- a/web/src/features/mcp/features/datasets/tools/listDatasetRuns.ts
+++ b/web/src/features/mcp/features/datasets/tools/listDatasetRuns.ts
@@ -1,5 +1,5 @@
 import { GetDatasetRunsV1Response } from "@/src/features/public-api/types/datasets";
-import { listDatasetRunsForApi } from "@/src/features/datasets/server/publicDatasetService";
+import { listDatasetRunsByDatasetIdForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { GetDatasetRunsMcpInput } from "../schema";
@@ -7,18 +7,18 @@ import { GetDatasetRunsMcpInput } from "../schema";
 export const [listDatasetRunsTool, handleListDatasetRuns] = defineTool({
   name: "listDatasetRuns",
   description:
-    "List dataset runs, each experiment or evaluation execution over a dataset, by dataset name.",
+    "List dataset runs, each experiment or evaluation execution over a dataset, by dataset ID.",
   baseSchema: GetDatasetRunsMcpInput,
   inputSchema: GetDatasetRunsMcpInput,
   handler: async (input, context) =>
     runMcpTool({
       spanName: "mcp.dataset_runs.list",
       context,
-      attributes: { "mcp.dataset_name": input.name },
+      attributes: { "mcp.dataset_id": input.datasetId },
       fn: async () => {
-        const result = await listDatasetRunsForApi({
+        const result = await listDatasetRunsByDatasetIdForApi({
           projectId: context.projectId,
-          name: input.name,
+          datasetId: input.datasetId,
           page: input.page,
           limit: input.limit,
         });

--- a/web/src/features/mcp/features/datasets/tools/listDatasets.ts
+++ b/web/src/features/mcp/features/datasets/tools/listDatasets.ts
@@ -1,17 +1,15 @@
-import {
-  GetDatasetsV2Query,
-  GetDatasetsV2Response,
-} from "@/src/features/public-api/types/datasets";
-import { listDatasetsForApi } from "@/src/features/datasets/server/publicDatasetService";
+import { GetDatasetsV2Response } from "@/src/features/public-api/types/datasets";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
+import { listDatasetsForApi } from "@/src/features/datasets/server/publicDatasetService";
+import { GetDatasetsMcpInput } from "../schema";
 
 export const [listDatasetsTool, handleListDatasets] = defineTool({
   name: "listDatasets",
   description:
-    "List datasets, named collections of input and optional expected-output examples for experiments and evaluations.",
-  baseSchema: GetDatasetsV2Query,
-  inputSchema: GetDatasetsV2Query,
+    "List datasets, named collections of input and optional expected-output examples for experiments and evaluations. Optionally filter by dataset name to find a dataset ID.",
+  baseSchema: GetDatasetsMcpInput,
+  inputSchema: GetDatasetsMcpInput,
   handler: async (input, context) =>
     runMcpTool({
       spanName: "mcp.datasets.list",
@@ -19,10 +17,12 @@ export const [listDatasetsTool, handleListDatasets] = defineTool({
       attributes: {
         "mcp.pagination_page": input.page,
         "mcp.pagination_limit": input.limit,
+        "mcp.dataset_name": input.name,
       },
       fn: async () => {
         const result = await listDatasetsForApi({
           projectId: context.projectId,
+          name: input.name,
           page: input.page,
           limit: input.limit,
         });

--- a/web/src/features/mcp/features/datasets/tools/upsertDatasetItem.ts
+++ b/web/src/features/mcp/features/datasets/tools/upsertDatasetItem.ts
@@ -1,22 +1,19 @@
 import { createDatasetItemForApi } from "@/src/features/datasets/server/publicDatasetService";
-import {
-  PostDatasetItemsV1Body,
-  PostDatasetItemsV1Response,
-} from "@/src/features/public-api/types/datasets";
+import { PostDatasetItemsV1Response } from "@/src/features/public-api/types/datasets";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
+import { PostDatasetItemMcpInput } from "../schema";
 
 export const [upsertDatasetItemTool, handleUpsertDatasetItem] = defineTool({
   name: "upsertDatasetItem",
-  description:
-    "Upsert a dataset item, one example in a dataset with input and optional expected output.",
-  baseSchema: PostDatasetItemsV1Body,
-  inputSchema: PostDatasetItemsV1Body,
+  description: "Upsert a dataset item (one example in a dataset) by dataset ID",
+  baseSchema: PostDatasetItemMcpInput,
+  inputSchema: PostDatasetItemMcpInput,
   handler: async (input, context) =>
     runMcpTool({
       spanName: "mcp.dataset_items.upsert",
       context,
-      attributes: { "mcp.dataset_name": input.datasetName },
+      attributes: { "mcp.dataset_id": input.datasetId },
       fn: async () => {
         const result = await createDatasetItemForApi({
           input,

--- a/web/src/features/public-api/server/dataset-run-items-api-service.ts
+++ b/web/src/features/public-api/server/dataset-run-items-api-service.ts
@@ -247,3 +247,72 @@ export const listDatasetRunItemsForApi = async ({
     },
   };
 };
+
+export const listDatasetRunItemsByRunIdForApi = async ({
+  datasetId,
+  datasetRunId,
+  projectId,
+  limit,
+  page,
+}: {
+  datasetId: string;
+  datasetRunId: string;
+  projectId: string;
+  limit: number;
+  page: number;
+}) => {
+  /**************
+   * VALIDATION *
+   **************/
+  const datasetRun = await prisma.datasetRuns.findUnique({
+    where: {
+      id_projectId: {
+        id: datasetRunId,
+        projectId,
+      },
+    },
+    select: { id: true, datasetId: true },
+  });
+
+  if (!datasetRun || datasetRun.datasetId !== datasetId) {
+    throw new LangfuseNotFoundError(
+      "Dataset run not found for the given project and dataset id",
+    );
+  }
+
+  /************
+   * RESPONSE *
+   ************/
+  const [items, count] = await Promise.all([
+    generateDatasetRunItemsForPublicApi({
+      props: {
+        datasetId,
+        runId: datasetRun.id,
+        projectId,
+        limit,
+        page,
+      },
+    }),
+    getDatasetRunItemsCountForPublicApi({
+      props: {
+        datasetId,
+        runId: datasetRun.id,
+        projectId,
+        limit,
+        page,
+      },
+    }),
+  ]);
+
+  const totalItems = count || 0;
+
+  return {
+    data: items,
+    meta: {
+      page,
+      limit,
+      totalItems,
+      totalPages: Math.ceil(totalItems / limit),
+    },
+  };
+};


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates all MCP dataset tools from name-based addressing to ID-based addressing, making the MCP interface consistent with how the rest of the system identifies resources. A new `name` filter on `listDatasets` enables LLM agents to discover dataset IDs by name before calling any of the other tools.

- New ID-based schemas (`GetDatasetMcpInput`, `GetDatasetRunsMcpInput`, `GetDatasetRunMcpInput`, etc.) replace the name-based counterparts, with corresponding new service functions (`getDatasetByIdForApi`, `listDatasetRunsByDatasetIdForApi`, `getDatasetRunByIdForApi`, `deleteDatasetRunByIdForApi`, `listDatasetRunItemsByRunIdForApi`) added alongside the existing ones.
- For `listDatasetItems` and `upsertDatasetItem`, the tool layer bridges the gap by resolving `datasetId` → `datasetName` before calling the unchanged underlying service, which then resolves the name back to an ID — resulting in two extra DB round-trips per call; a future improvement would extend those service functions to accept `datasetId` directly.
- All new ID lookups correctly scope queries using the `id_projectId` compound unique key to prevent cross-project data access.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all new DB lookups use the id_projectId compound key to enforce project scoping, and the behavioral changes are isolated to the MCP interface.

The changes are well-contained: name-based MCP inputs are replaced by ID-based ones, new service functions correctly validate dataset and run ownership, and the existing public REST API is unchanged. The only imperfection is the ID → name → ID bridging in listDatasetItems and upsertDatasetItem, which wastes DB round-trips but does not cause incorrect behavior.

listDatasetItems.ts and upsertDatasetItem.ts for the double DB lookup pattern.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Tool as MCP Tool Layer
    participant Svc as publicDatasetService
    participant RunSvc as dataset-run-items-api-service
    participant DB as Database

    Note over Client,DB: listDatasets (discovery by name)
    Client->>Tool: "listDatasets({ name?, page, limit })"
    Tool->>Svc: "listDatasetsForApi({ name?, projectId, page, limit })"
    Svc->>DB: dataset.findMany WHERE projectId AND name ILIKE %name%
    DB-->>Tool: datasets[]

    Note over Client,DB: getDataset by ID
    Client->>Tool: "getDataset({ datasetId })"
    Tool->>Svc: "getDatasetByIdForApi({ datasetId, projectId })"
    Svc->>DB: dataset.findUnique WHERE id+projectId
    DB-->>Tool: dataset

    Note over Client,DB: listDatasetItems by datasetId
    Client->>Tool: "listDatasetItems({ datasetId, page, limit })"
    Tool->>Svc: "getDatasetNameByIdForApi({ datasetId, projectId })"
    Svc->>DB: dataset.findUnique WHERE id+projectId
    DB-->>Svc: name
    Tool->>Svc: "listDatasetItemsForApi({ datasetName, ... })"
    Svc->>DB: dataset.findUnique WHERE name+projectId
    DB-->>Tool: items[]

    Note over Client,DB: listDatasetRunItems by datasetRunId
    Client->>Tool: "listDatasetRunItems({ datasetId, datasetRunId, page, limit })"
    Tool->>RunSvc: listDatasetRunItemsByRunIdForApi(...)
    RunSvc->>DB: datasetRuns.findUnique WHERE id+projectId, verify datasetId
    RunSvc->>DB: generateDatasetRunItems + count
    DB-->>Tool: items[]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/mcp/features/datasets/tools/listDatasetItems.ts:26-37
**Redundant ID → name → ID round-trip**

The MCP layer resolves `datasetId` to a `datasetName` via `getDatasetNameByIdForApi`, then passes `datasetName` to `listDatasetItemsForApi` which internally calls `getDatasetByNameOrThrow` to convert the name back into an ID. This results in two unnecessary database lookups where zero are needed. The same pattern exists in `upsertDatasetItem.ts`. A leaner fix would be to extend `listDatasetItemsForApi` (and `upsertDatasetItem`/`createDatasetItemForApi`) to accept an optional `datasetId` directly and skip the name resolution path entirely.

### Issue 2 of 2
web/src/__tests__/server/mcp-tools-read.servertest.ts:120-146
**`GetDatasetRunItemsMcpInput` not covered by schema guard tests**

The schema validation loop checks `GetDatasetMcpInput`, `GetDatasetItemsMcpInput`, `GetDatasetRunsMcpInput`, and `GetDatasetRunMcpInput`, but `GetDatasetRunItemsMcpInput` is not included. Since that schema was also refactored (replacing `runName` with `datasetRunId`), adding it to this guard test would prevent a future regression that re-introduces a name-based field.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(mcp): Use ids instead of names for d..."](https://github.com/langfuse/langfuse/commit/26e3058251cf85aa60afde0fad0c143416dddb37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34388411)</sub>

<!-- /greptile_comment -->