### PR TITLE
fix(api): honor useEventsTable env fallback

### DIFF
--- a/packages/shared/src/features/query/types.test.ts
+++ b/packages/shared/src/features/query/types.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+import { useEventsTableSchema } from "./types";
+
+describe("useEventsTableSchema", () => {
+  it("preserves undefined when query param is omitted", () => {
+    const schema = z.object({ useEventsTable: useEventsTableSchema });
+    const parsed = schema.parse({});
+    expect(parsed.useEventsTable).toBeUndefined();
+  });
+
+  it("parses boolean-like values", () => {
+    expect(useEventsTableSchema.parse("true")).toBe(true);
+    expect(useEventsTableSchema.parse("false")).toBe(false);
+    expect(useEventsTableSchema.parse(true)).toBe(true);
+    expect(useEventsTableSchema.parse(false)).toBe(false);
+  });
+});

--- a/packages/shared/src/features/query/types.ts
+++ b/packages/shared/src/features/query/types.ts
@@ -212,4 +212,6 @@ export const query = z
 export const useEventsTableSchema = z
   .union([z.literal("true"), z.literal("false"), z.boolean()])
   .optional()
-  .transform((val) => val === "true" || val === true);
+  .transform((val) =>
+    val === undefined ? undefined : val === "true" || val === true,
+  );

--- a/web/src/features/public-api/types/useEventsTableQueryParsing.test.ts
+++ b/web/src/features/public-api/types/useEventsTableQueryParsing.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+
+import { GetObservationsV1Query } from "./observations";
+import { GetTracesV1Query } from "./traces";
+
+describe("useEventsTable query parsing", () => {
+  it("keeps useEventsTable undefined when query param is omitted", () => {
+    const now = new Date().toISOString();
+
+    const traces = GetTracesV1Query.parse({
+      fromTimestamp: now,
+      toTimestamp: now,
+    });
+    expect(traces.useEventsTable).toBeUndefined();
+
+    const observations = GetObservationsV1Query.parse({
+      fromStartTime: now,
+      toStartTime: now,
+    });
+    expect(observations.useEventsTable).toBeUndefined();
+  });
+
+  it("parses explicit useEventsTable overrides", () => {
+    const now = new Date().toISOString();
+
+    const traces = GetTracesV1Query.parse({
+      fromTimestamp: now,
+      toTimestamp: now,
+      useEventsTable: "false",
+    });
+    expect(traces.useEventsTable).toBe(false);
+
+    const observations = GetObservationsV1Query.parse({
+      fromStartTime: now,
+      toStartTime: now,
+      useEventsTable: "true",
+    });
+    expect(observations.useEventsTable).toBe(true);
+  });
+});

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -9,6 +9,7 @@ import {
   withMiddlewares,
 } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+import { env } from "@/src/env.mjs";
 import { LangfuseNotFoundError } from "@langfuse/shared";
 import {
   enrichObservationWithModelData,
@@ -25,14 +26,18 @@ export default withMiddlewares(
       responseSchema: GetObservationV1Response,
       rejectInEventsOnlyMode: true,
       fn: async ({ query, auth }) => {
-        const clickhouseObservation = query.useEventsTable
+        // Use events table if query parameter is explicitly set, otherwise use environment variable
+        const useEventsTable =
+          query.useEventsTable ??
+          env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+
+        const clickhouseObservation = useEventsTable
           ? await getObservationByIdFromEventsTable({
               id: query.observationId,
               projectId: auth.scope.projectId,
               fetchWithInputOutput: true,
             })
-          : // eslint-disable-next-line @typescript-eslint/no-deprecated
-            await getObservationById({
+          : await getObservationById({
               id: query.observationId,
               projectId: auth.scope.projectId,
               fetchWithInputOutput: true,

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -19,6 +19,7 @@ import {
   generateObservationsForPublicApi,
   getObservationsCountForPublicApi,
 } from "@/src/features/public-api/server/observations";
+import { env } from "@/src/env.mjs";
 
 export default withMiddlewares(
   {
@@ -46,7 +47,12 @@ export default withMiddlewares(
           advancedFilters: query.filter,
         };
 
-        if (query.useEventsTable) {
+        // Use events table if query parameter is explicitly set, otherwise use environment variable
+        const useEventsTable =
+          query.useEventsTable ??
+          env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+
+        if (useEventsTable) {
           const [items, count] = await Promise.all([
             getObservationsFromEventsTableForPublicApi(filterProps),
             getObservationsCountFromEventsTableForPublicApi(filterProps),

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -127,7 +127,12 @@ export default withMiddlewares(
           toTimestamp: query.toTimestamp ?? undefined,
         };
 
-        if (query.useEventsTable) {
+        // Use events table if query parameter is explicitly set, otherwise use environment variable
+        const useEventsTable =
+          query.useEventsTable ??
+          env.LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true";
+
+        if (useEventsTable) {
           const [items, count] = await Promise.all([
             getTracesFromEventsTableForPublicApi({
               ...filterProps,


### PR DESCRIPTION
Fixes #13814.

The shared `useEventsTableSchema` now preserves the omitted state (`undefined`) instead of coercing it to `false`. Public traces/observations routes use nullish coalescing to fall back to `LANGFUSE_ENABLE_EVENTS_TABLE_OBSERVATIONS === "true"` when the query param is not provided.

This also fixes the observations routes which previously fell back to the raw env string, which is truthy even when set to `"false"`.

Tests:
- `node node_modules\.pnpm\vitest@4.1.4_@opentelemetry_30e46a091a16bf4f41d45bc501604489\node_modules\vitest\vitest.mjs run packages/shared/src/features/query/types.test.ts`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter web exec vitest run --project in-source src/features/public-api/types/useEventsTableQueryParsing.test.ts`
