### PR TITLE
fix(auth): hide password fields on sign-up when credentials auth is disabled

### DIFF
--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -93,9 +93,10 @@ function StandardSignupFlow({
   const [formError, setFormError] = useState<string | null>(null);
 
   // Two-step login flow: ask for email first, detect SSO, then either redirect to SSO or reveal password field.
-  // Skip this flow when no SSO is configured - show password field immediately
+  // Skip this flow when no SSO is configured and credentials are enabled - show password field immediately.
+  // Never show password step when credentials auth is disabled (AUTH_DISABLE_USERNAME_PASSWORD=true).
   const [showPasswordStep, setShowPasswordStep] = useState<boolean>(
-    !authProviders.sso,
+    !authProviders.sso && authProviders.credentials,
   );
   const [continueLoading, setContinueLoading] = useState<boolean>(false);
   const [lastUsedAuthMethod, setLastUsedAuthMethod] =
@@ -166,21 +167,25 @@ function StandardSignupFlow({
         return; // stop further execution – page redirect expected
       }
 
-      // No SSO – fall back to password step
-      setShowPasswordStep(true);
+      if (authProviders.credentials) {
+        // No SSO – fall back to password step
+        setShowPasswordStep(true);
 
-      // Auto-focus password input when password step becomes visible
-      setTimeout(() => {
-        // Find and focus the name input (since it's the first new field) or password?
-        // Plan says "name + password fields". Usually Name is first in Sign Up.
-        // Let's focus Name.
-        const nameInput = document.querySelector(
-          'input[name="name"]',
-        ) as HTMLInputElement;
-        if (nameInput) {
-          nameInput.focus();
-        }
-      }, 100);
+        // Auto-focus name input when password step becomes visible
+        setTimeout(() => {
+          const nameInput = document.querySelector(
+            'input[name="name"]',
+          ) as HTMLInputElement;
+          if (nameInput) {
+            nameInput.focus();
+          }
+        }, 100);
+      } else {
+        // Credentials auth is disabled – cannot fall back to password step
+        setFormError(
+          "No sign-in method available for this email. Please use one of the available SSO options.",
+        );
+      }
     } catch (error) {
       console.error(error);
       setFormError("Unable to check SSO configuration. Please try again.");


### PR DESCRIPTION
## Problem

When `AUTH_DISABLE_USERNAME_PASSWORD=true` is set (e.g. SSO-only deployments with invitation-required signup), the invitation acceptance page at `/auth/sign-up` still shows username/password setup fields in two scenarios:

1. **No SSO configured** — `showPasswordStep` initialised to `!authProviders.sso`, which is `true` when no SSO provider is configured, ignoring the disabled-credentials flag and immediately showing the password form.

2. **SSO configured, email domain has no enterprise SSO match** — `handleContinue()` unconditionally called `setShowPasswordStep(true)` as the fallback, revealing password fields even though credentials auth is globally disabled.

The main `/auth/sign-in` page correctly hides the credential form when `credentials: false`, but the sign-up/invitation flow did not share this guard.

Fixes #13893.

## Solution

- Guard the initial `showPasswordStep` value: only set to `true` when **both** no SSO is configured AND credentials auth is enabled (`!authProviders.sso && authProviders.credentials`).
- Guard the fallback in `handleContinue`: when credentials are disabled and no enterprise SSO matches the email domain, show an informative error instead of revealing the password step.

## Testing

- With `AUTH_DISABLE_USERNAME_PASSWORD=true` and Google SSO configured, click an invitation link → `/auth/sign-up?email=...` — the form no longer shows password fields; instead, clicking Continue for a non-SSO-domain email shows an error directing the user to use SSO.
- Existing behaviour unchanged when `AUTH_DISABLE_USERNAME_PASSWORD` is unset or `false`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the invitation/sign-up page so it correctly hides password fields when credentials auth is disabled, bringing its behaviour in line with the sign-in page.

- The initial `showPasswordStep` state now requires both no SSO configured and credentials enabled (`!authProviders.sso && authProviders.credentials`), preventing immediate exposure of the password form in SSO-only deployments.
- The `handleContinue` fallback is guarded so that when no enterprise SSO matches the email domain, the password step is only revealed when credentials are enabled; otherwise an informative error is shown.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change only restricts what UI is shown to the user and does not touch any server-side auth enforcement.

The two guards are minimal and well-scoped: one in initial state, one in the continue-handler fallback. The VerifiedSignupFlow (OTP path) is untouched. The one edge case worth noting is that the error message in the new else branch says 'use one of the available SSO options' even when no SSO providers are actually configured, which could confuse users in that misconfiguration scenario.

web/src/pages/auth/sign-up.tsx — specifically the error message in the new else branch around line 185.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits /auth/sign-up] --> B{emailVerificationRequired?}
    B -- yes --> C[VerifiedSignupFlow OTP path, unaffected]
    B -- no --> D[StandardSignupFlow]
    D --> E{authProviders.sso AND authProviders.credentials}
    E -- "!sso && credentials" --> F[showPasswordStep = true Show name+password form immediately]
    E -- "sso present OR !credentials" --> G[showPasswordStep = false Show email-only form with Continue button]
    G --> H[User types email & clicks Continue]
    H --> I[POST /api/auth/check-sso for domain]
    I -- res.ok: enterprise SSO found --> J[signIn with SSO provider Redirect to IdP]
    I -- no SSO match --> K{authProviders.credentials?}
    K -- true --> L[setShowPasswordStep true Reveal name+password fields]
    K -- false --> M[setFormError: No sign-in method available]
    style M fill:#fca5a5
    style F fill:#86efac
    style L fill:#86efac
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/auth/sign-up.tsx:185-187
When credentials are disabled and the user's email domain has no enterprise SSO match, the error message instructs them to "use one of the available SSO options." If the deployment has no SSO providers configured at all alongside the credentials-disabled flag, the `SSOButtons` component renders nothing and the message is actively misleading. A simple guard on `authProviders.sso` makes the fallback message accurate in both cases.

```suggestion
        setFormError(
          authProviders.sso
            ? "No sign-in method available for this email. Please use one of the available SSO options."
            : "Password-based sign-up is disabled. Please contact your administrator.",
        );
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): hide password fields on sign-..."](https://github.com/langfuse/langfuse/commit/c7ae06d2cc31f08ae66164f20d30c62b999aff53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34456083)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->