### PR TITLE
fix(mcp): compat for allOf/anyOf in scoreConfig tools

### DIFF
--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -89,6 +89,20 @@ import { handleGetScoreConfig } from "@/src/features/mcp/features/scores/tools/g
 import { handleListScoreConfigs } from "@/src/features/mcp/features/scores/tools/listScoreConfigs";
 import { handleUpdateScoreConfig } from "@/src/features/mcp/features/scores/tools/updateScoreConfig";
 
+const TOP_LEVEL_SCHEMA_COMPOSITION_KEYWORDS = [
+  "oneOf",
+  "anyOf",
+  "allOf",
+] as const;
+
+const getTopLevelSchemaCompositionKeywords = (
+  schema: Record<string, unknown>,
+) =>
+  TOP_LEVEL_SCHEMA_COMPOSITION_KEYWORDS.filter((keyword) => keyword in schema);
+
+const referencesDefinitions = (schema: Record<string, unknown>) =>
+  JSON.stringify(schema).includes("#/definitions/");
+
 const createScoreConfig = async (projectId: string) =>
   prisma.scoreConfig.create({
     data: {
@@ -154,6 +168,36 @@ describe("MCP public API tools", () => {
         "createScoreConfig",
       ]),
     );
+  });
+
+  it("exposes model-compatible root input schemas", async () => {
+    const tools = await toolRegistry.getToolDefinitions(mockServerContext());
+
+    const incompatibleTools = tools.flatMap((tool) => {
+      const schema = tool.inputSchema;
+      const compositionKeywords = getTopLevelSchemaCompositionKeywords(schema);
+      const missingDefinitions =
+        referencesDefinitions(schema) && !("definitions" in schema);
+
+      if (
+        schema.type === "object" &&
+        compositionKeywords.length === 0 &&
+        !missingDefinitions
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          name: tool.name,
+          type: schema.type,
+          compositionKeywords,
+          missingDefinitions,
+        },
+      ];
+    });
+
+    expect(incompatibleTools).toEqual([]);
   });
 
   it("exposes read-only tools for in-app agent keys", async () => {

--- a/web/src/features/mcp/core/define-tool.ts
+++ b/web/src/features/mcp/core/define-tool.ts
@@ -7,6 +7,11 @@
 
 import { z } from "zod";
 import { wrapErrorHandling } from "./error-formatting";
+import {
+  isObjectLikeJsonSchema,
+  normalizeMcpInputSchema,
+  type JsonSchemaObject,
+} from "./input-schema-compat";
 import type { ServerContext } from "../types";
 
 /**
@@ -58,30 +63,6 @@ export interface ToolDefinition {
     destructiveHint?: boolean;
     expensiveHint?: boolean;
   };
-}
-
-type JsonSchemaObject = Record<string, unknown>;
-
-function isObjectLikeJsonSchema(schema: JsonSchemaObject): boolean {
-  if (schema.type === "object") return true;
-
-  const subSchemas = (() => {
-    if ("oneOf" in schema && Array.isArray(schema.oneOf)) return schema.oneOf;
-    if ("anyOf" in schema && Array.isArray(schema.anyOf)) return schema.anyOf;
-    if ("allOf" in schema && Array.isArray(schema.allOf)) return schema.allOf;
-    return [];
-  })();
-
-  if (subSchemas.length > 0) {
-    return subSchemas.every(
-      (subSchema) =>
-        typeof subSchema === "object" &&
-        subSchema !== null &&
-        isObjectLikeJsonSchema(subSchema),
-    );
-  }
-
-  return false;
 }
 
 /**
@@ -141,15 +122,13 @@ export function defineTool<TInput>(
     );
   }
 
-  // The MCP TypeScript SDK validates Tool.inputSchema.type as `z.literal("object")`,
-  // so clients reject any tool whose root schema lacks `type: "object"`. Zod's
-  // JSON Schema converter omits the root `type` for intersection/union schemas
-  // (emitting allOf/oneOf/anyOf instead), so we inject it here. JSON Schema
-  // draft-7 allows `type` alongside these keywords — all constraints must hold.
-  const normalizedJsonSchema: JsonSchemaObject =
-    (jsonSchema as JsonSchemaObject).type === "object"
-      ? (jsonSchema as JsonSchemaObject)
-      : { ...(jsonSchema as JsonSchemaObject), type: "object" };
+  // The MCP TypeScript SDK requires root `type: "object"`, while model tool
+  // validators can reject root `oneOf`/`anyOf`/`allOf`. Zod emits those for
+  // object intersections and unions, so keep nested detail but normalize the
+  // root into a plain object schema for client compatibility.
+  const normalizedJsonSchema = normalizeMcpInputSchema(
+    jsonSchema as JsonSchemaObject,
+  );
 
   // Build tool definition
   const toolDefinition: ToolDefinition = {

--- a/web/src/features/mcp/core/define-tool.ts
+++ b/web/src/features/mcp/core/define-tool.ts
@@ -8,7 +8,6 @@
 import { z } from "zod";
 import { wrapErrorHandling } from "./error-formatting";
 import {
-  isObjectLikeJsonSchema,
   normalizeMcpInputSchema,
   type JsonSchemaObject,
 } from "./input-schema-compat";
@@ -114,14 +113,6 @@ export function defineTool<TInput>(
     );
   }
 
-  // Validate that we got a usable schema. Intersections of object schemas are
-  // emitted as top-level allOf by Zod's JSON Schema converter.
-  if (!isObjectLikeJsonSchema(jsonSchema)) {
-    throw new Error(
-      `Failed to convert Zod schema to JSON Schema for tool: ${name}. Expected object or union schema, got: ${JSON.stringify(jsonSchema).slice(0, 100)}`,
-    );
-  }
-
   // The MCP TypeScript SDK requires root `type: "object"`, while model tool
   // validators can reject root `oneOf`/`anyOf`/`allOf`. Zod emits those for
   // object intersections and unions, so keep nested detail but normalize the
@@ -129,6 +120,12 @@ export function defineTool<TInput>(
   const normalizedJsonSchema = normalizeMcpInputSchema(
     jsonSchema as JsonSchemaObject,
   );
+
+  if (!normalizedJsonSchema) {
+    throw new Error(
+      `Failed to convert Zod schema to JSON Schema for tool: ${name}. Expected object or union schema, got: ${JSON.stringify(jsonSchema).slice(0, 100)}`,
+    );
+  }
 
   // Build tool definition
   const toolDefinition: ToolDefinition = {

--- a/web/src/features/mcp/core/input-schema-compat.ts
+++ b/web/src/features/mcp/core/input-schema-compat.ts
@@ -6,6 +6,7 @@ type ObjectShape = {
 };
 
 const ROOT_COMPOSITION_KEYWORDS = ["oneOf", "anyOf", "allOf"] as const;
+const MAX_SCHEMA_NORMALIZATION_DEPTH = 10;
 const DROPPED_ROOT_KEYS = new Set([
   "type",
   "properties",
@@ -37,9 +38,10 @@ const withoutDefaults = (
 function mergeShapes(
   schemas: unknown[],
   mode: "intersection" | "union",
+  depth: number,
 ): ObjectShape | undefined {
   const shapes = schemas.map((schema) =>
-    isRecord(schema) ? collectObjectShape(schema) : undefined,
+    isRecord(schema) ? collectObjectShape(schema, depth - 1) : undefined,
   );
 
   if (!shapes.every(Boolean)) {
@@ -62,12 +64,17 @@ function mergeShapes(
   };
 }
 
-function collectObjectShape(schema: JsonSchemaObject): ObjectShape | undefined {
+function collectObjectShape(
+  schema: JsonSchemaObject,
+  depth = MAX_SCHEMA_NORMALIZATION_DEPTH,
+): ObjectShape | undefined {
+  if (depth <= 0) return undefined;
+
   const allOf = asArray(schema.allOf);
-  if (allOf) return mergeShapes(allOf, "intersection");
+  if (allOf) return mergeShapes(allOf, "intersection", depth);
 
   const oneOfOrAnyOf = asArray(schema.oneOf) ?? asArray(schema.anyOf);
-  if (oneOfOrAnyOf) return mergeShapes(oneOfOrAnyOf, "union");
+  if (oneOfOrAnyOf) return mergeShapes(oneOfOrAnyOf, "union", depth);
 
   if (schema.type !== "object") {
     return undefined;

--- a/web/src/features/mcp/core/input-schema-compat.ts
+++ b/web/src/features/mcp/core/input-schema-compat.ts
@@ -81,12 +81,9 @@ function collectObjectShape(
   };
 }
 
-export const isObjectLikeJsonSchema = (schema: JsonSchemaObject): boolean =>
-  collectObjectShape(schema) !== undefined;
-
 export function normalizeMcpInputSchema(
   schema: JsonSchemaObject,
-): JsonSchemaObject {
+): JsonSchemaObject | undefined {
   if (
     schema.type === "object" &&
     !ROOT_COMPOSITION_KEYWORDS.some((keyword) => keyword in schema)
@@ -95,6 +92,8 @@ export function normalizeMcpInputSchema(
   }
 
   const shape = collectObjectShape(schema);
+  if (!shape) return undefined;
+
   const {
     type: _type,
     properties: _properties,
@@ -109,7 +108,7 @@ export function normalizeMcpInputSchema(
   return {
     ...metadata,
     type: "object",
-    properties: shape?.properties ?? {},
-    ...(shape?.required.length ? { required: shape.required } : {}),
+    properties: shape.properties,
+    ...(shape.required.length ? { required: shape.required } : {}),
   };
 }

--- a/web/src/features/mcp/core/input-schema-compat.ts
+++ b/web/src/features/mcp/core/input-schema-compat.ts
@@ -7,13 +7,6 @@ type ObjectShape = {
 
 const ROOT_COMPOSITION_KEYWORDS = ["oneOf", "anyOf", "allOf"] as const;
 const MAX_SCHEMA_NORMALIZATION_DEPTH = 10;
-const DROPPED_ROOT_KEYS = new Set([
-  "type",
-  "properties",
-  "required",
-  "additionalProperties",
-  ...ROOT_COMPOSITION_KEYWORDS,
-]);
 
 const isRecord = (value: unknown): value is JsonSchemaObject =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -88,12 +81,6 @@ function collectObjectShape(
   };
 }
 
-function copyRootMetadata(schema: JsonSchemaObject): JsonSchemaObject {
-  return Object.fromEntries(
-    Object.entries(schema).filter(([key]) => !DROPPED_ROOT_KEYS.has(key)),
-  );
-}
-
 export const isObjectLikeJsonSchema = (schema: JsonSchemaObject): boolean =>
   collectObjectShape(schema) !== undefined;
 
@@ -108,9 +95,19 @@ export function normalizeMcpInputSchema(
   }
 
   const shape = collectObjectShape(schema);
+  const {
+    type: _type,
+    properties: _properties,
+    required: _required,
+    additionalProperties: _additionalProperties,
+    oneOf: _oneOf,
+    anyOf: _anyOf,
+    allOf: _allOf,
+    ...metadata
+  } = schema;
 
   return {
-    ...copyRootMetadata(schema),
+    ...metadata,
     type: "object",
     properties: shape?.properties ?? {},
     ...(shape?.required.length ? { required: shape.required } : {}),

--- a/web/src/features/mcp/core/input-schema-compat.ts
+++ b/web/src/features/mcp/core/input-schema-compat.ts
@@ -1,0 +1,111 @@
+export type JsonSchemaObject = Record<string, unknown>;
+
+type ObjectShape = {
+  properties: Record<string, unknown>;
+  required: string[];
+};
+
+const ROOT_COMPOSITION_KEYWORDS = ["oneOf", "anyOf", "allOf"] as const;
+const DROPPED_ROOT_KEYS = new Set([
+  "type",
+  "properties",
+  "required",
+  "additionalProperties",
+  ...ROOT_COMPOSITION_KEYWORDS,
+]);
+
+const isRecord = (value: unknown): value is JsonSchemaObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const asArray = (value: unknown): unknown[] | undefined =>
+  Array.isArray(value) ? value : undefined;
+
+const withoutDefaults = (
+  required: unknown,
+  properties: Record<string, unknown>,
+) =>
+  Array.isArray(required)
+    ? required.filter(
+        (property): property is string =>
+          typeof property === "string" &&
+          !(
+            isRecord(properties[property]) && "default" in properties[property]
+          ),
+      )
+    : [];
+
+function mergeShapes(
+  schemas: unknown[],
+  mode: "intersection" | "union",
+): ObjectShape | undefined {
+  const shapes = schemas.map((schema) =>
+    isRecord(schema) ? collectObjectShape(schema) : undefined,
+  );
+
+  if (!shapes.every(Boolean)) {
+    return undefined;
+  }
+
+  const validShapes = shapes as ObjectShape[];
+
+  return {
+    properties: Object.assign(
+      {},
+      ...validShapes.map((shape) => shape.properties),
+    ),
+    required:
+      mode === "intersection"
+        ? [...new Set(validShapes.flatMap((shape) => shape.required))]
+        : (validShapes[0]?.required.filter((property) =>
+            validShapes.every((shape) => shape.required.includes(property)),
+          ) ?? []),
+  };
+}
+
+function collectObjectShape(schema: JsonSchemaObject): ObjectShape | undefined {
+  const allOf = asArray(schema.allOf);
+  if (allOf) return mergeShapes(allOf, "intersection");
+
+  const oneOfOrAnyOf = asArray(schema.oneOf) ?? asArray(schema.anyOf);
+  if (oneOfOrAnyOf) return mergeShapes(oneOfOrAnyOf, "union");
+
+  if (schema.type !== "object") {
+    return undefined;
+  }
+
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+
+  return {
+    properties,
+    required: withoutDefaults(schema.required, properties),
+  };
+}
+
+function copyRootMetadata(schema: JsonSchemaObject): JsonSchemaObject {
+  return Object.fromEntries(
+    Object.entries(schema).filter(([key]) => !DROPPED_ROOT_KEYS.has(key)),
+  );
+}
+
+export const isObjectLikeJsonSchema = (schema: JsonSchemaObject): boolean =>
+  collectObjectShape(schema) !== undefined;
+
+export function normalizeMcpInputSchema(
+  schema: JsonSchemaObject,
+): JsonSchemaObject {
+  if (
+    schema.type === "object" &&
+    !ROOT_COMPOSITION_KEYWORDS.some((keyword) => keyword in schema)
+  ) {
+    return schema;
+  }
+
+  const shape = collectObjectShape(schema);
+
+  return {
+    ...copyRootMetadata(schema),
+    type: "object",
+    properties: shape?.properties ?? {},
+    ...(shape?.required.length ? { required: shape.required } : {}),
+  };
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces a simple `type: \"object\"` injection with a proper schema normalization pass that flattens root-level `allOf`/`anyOf`/`oneOf` (produced by Zod's `.and()` intersections on score-config tools) into a plain object schema that MCP model validators accept.

- `input-schema-compat.ts` is introduced to recursively collect and merge `properties`/`required` from composition-keyword schemas, preserving `definitions` and other metadata through `copyRootMetadata`.
- A regression test is added to `mcp-public-api-tools.servertest.ts` that asserts no registered tool exposes root-level composition keywords or unresolved `$ref` pointers after normalization.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the normalization logic correctly handles Zod's allOf/anyOf output, definitions are preserved, and a targeted regression test guards against regressions.

The core path (Zod `.and()` → `allOf` → normalized flat object schema) is sound and well-tested. Three edge cases are worth watching: the union `required` intersection collapses to empty if any `anyOf` variant has no required fields; `additionalProperties: false` is dropped from normalized schemas; and `anyOf` is silently ignored when `oneOf` is also present. None are reachable with the current score-config Zod schemas.

web/src/features/mcp/core/input-schema-compat.ts — the mergeShapes union path and DROPPED_ROOT_KEYS set are the areas most likely to need revisiting if new tools introduce anyOf/oneOf or rely on additionalProperties constraints.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Zod schema with .and / intersection] -->|z.toJSONSchema| B{Root schema shape?}
    B -->|type:object, no composition keywords| C[Return as-is fast path]
    B -->|allOf at root| D[collectObjectShape allOf
mergeShapes intersection]
    B -->|anyOf or oneOf at root| E[collectObjectShape anyOf/oneOf
mergeShapes union]
    D --> F[Union all required fields
Merge all properties]
    E --> G[Intersect required fields
Merge all properties]
    F --> H[copyRootMetadata
preserves definitions etc]
    G --> H
    H --> I[Output: type:object
properties, required, metadata]
    I --> J[MCP ToolDefinition
inputSchema]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/features/mcp/core/input-schema-compat.ts:56-62
**Union `required` intersection depends on first shape ordering**

The `union` branch seeds the intersection with `validShapes[0]?.required` and then cross-filters against every other shape. Mathematically this is correct — any field in the true intersection must appear in every shape, including shape 0 — but the result silently drops all required fields if `validShapes[0]` is an empty shape (e.g. a bare `z.object({})` variant in `anyOf`). If any Zod `anyOf` variant has no required fields, the entire normalized schema will have `required: []`, making every field optional. Worth guarding against or documenting as a known trade-off.

### Issue 2 of 3
web/src/features/mcp/core/input-schema-compat.ts:9-15
**`additionalProperties` is silently stripped from composition-keyword schemas**

`DROPPED_ROOT_KEYS` discards `additionalProperties` when the schema contains `allOf`/`anyOf`/`oneOf` at root. For the subset of Zod schemas that emit `additionalProperties: false` alongside a composition keyword, the normalized output omits that constraint. Zod's runtime validation still rejects extra fields, but LLM clients reading the schema have no signal to avoid sending them, which will produce tool-call errors at runtime. If the normalized schema should remain strict, re-apply `additionalProperties: false` unconditionally in `normalizeMcpInputSchema`.

### Issue 3 of 3
web/src/features/mcp/core/input-schema-compat.ts:65-70
**`oneOf` and `anyOf` are mutually exclusive; only the first present wins**

`const oneOfOrAnyOf = asArray(schema.oneOf) ?? asArray(schema.anyOf)` means that if a schema has both `oneOf` and `anyOf` at the root, `anyOf` is silently ignored. While Zod's current JSON Schema output is unlikely to emit both at the same level, the function makes no assumption explicit. A comment here clarifying the priority would prevent surprises if the Zod serializer behaviour ever changes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["more simp"](https://github.com/langfuse/langfuse/commit/7d68ce02c0c974025e25da9bd5d1a54de85d4480) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34476250)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->