### PR TITLE
fix(redis): add sentinelRetryStrategy to prevent permanent connection loss after failover

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -168,6 +168,8 @@ const createRedisSentinelInstance = (
     password: env.REDIS_AUTH || undefined,
     sentinelUsername: env.REDIS_SENTINEL_USERNAME || undefined,
     sentinelPassword: env.REDIS_SENTINEL_PASSWORD || undefined,
+    // Retry sentinel discovery indefinitely so the worker self-heals after failover without a pod restart.
+    sentinelRetryStrategy: (retries: number) => Math.min(retries * 200, 10_000),
     ...defaultRedisOptions,
     ...additionalOptions,
     ...tlsOptions,


### PR DESCRIPTION
## Problem

When a Redis data node restarts during failover, the `langfuse-worker` pod enters a permanently broken state and stops processing all queues. The only recovery is a manual pod restart.

Closes #13880

## Root Cause

`createRedisSentinelInstance` never configures `sentinelRetryStrategy`. ioredis uses its default strategy, which gives up retrying sentinel discovery after a bounded number of attempts and leaves the `Redis` instance permanently broken.

The existing `retryStrategy` and `reconnectOnError` in `redisQueueRetryOptions` handle data-node reconnects, but `sentinelRetryStrategy` is a separate ioredis callback used specifically when all sentinel addresses are exhausted during a reconnect round. Without it, the connection never recovers.

## Solution

Add `sentinelRetryStrategy` to `createRedisSentinelInstance`, placed before `...additionalOptions` so callers can still override it:

```ts
sentinelRetryStrategy: (retries: number) => Math.min(retries * 200, 10_000),
```

This backs off up to 10 s between retry rounds but never stops retrying, allowing the worker to self-heal once sentinel failover completes (typically a few seconds).

## Testing

- Requires a Redis Sentinel setup to verify end-to-end
- Unit: `sentinelRetryStrategy` is a well-typed ioredis option; the type signature `((retryAttempts: number) => number | void | null)` matches
- Manual verification described in the original issue: restart a Redis data node and observe the worker recovers without a pod restart

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `sentinelRetryStrategy` to `createRedisSentinelInstance` so ioredis retries sentinel discovery indefinitely (backing off up to 10 s) instead of permanently abandoning the connection after a bounded number of attempts during failover.

- **Root cause fixed**: without `sentinelRetryStrategy`, ioredis exhausted its default retry limit during a Redis data-node restart and left the worker in a broken state requiring a manual pod restart.
- **Placement**: the option is defined before `...additionalOptions`, so callers can still supply their own strategy; `defaultRedisOptions` does not define `sentinelRetryStrategy` so there is no accidental override from that spread.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a single targeted option addition that restores self-healing behaviour after Redis Sentinel failover without touching any existing logic paths.

The fix correctly addresses the permanent connection loss by adding `sentinelRetryStrategy`. The only notable detail is that `retries * 200` evaluates to `0 ms` on the very first retry round, causing an immediate re-attempt before the backoff ramp begins; this is benign but worth tightening for consistency with the rest of the retry configuration.

packages/shared/src/server/redis/redis.ts — specifically the `sentinelRetryStrategy` formula at line 172.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Worker as langfuse-worker
    participant ioredis as ioredis Redis client
    participant Sentinel as Redis Sentinel
    participant DataNode as Redis Data Node

    Note over Worker,DataNode: Normal operation
    Worker->>ioredis: enqueue/process jobs
    ioredis->>DataNode: commands

    Note over Sentinel,DataNode: Failover begins — data node restarts
    DataNode--xioredis: connection lost
    ioredis->>Sentinel: ask for new master address
    Sentinel--xioredis: all sentinels unreachable (briefly)

    alt Before fix (no sentinelRetryStrategy)
        ioredis->>ioredis: exhaust bounded retries
        ioredis-->>Worker: permanent broken state
        Note over Worker: Manual pod restart required
    else After fix (sentinelRetryStrategy added)
        loop "retries * 200ms, capped at 10s"
            ioredis->>Sentinel: retry sentinel discovery
        end
        Sentinel->>ioredis: new master address
        ioredis->>DataNode: reconnect to new master
        Worker->>ioredis: resume processing queues
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/redis/redis.ts:172
When `retries` is `0` (first complete failure round through all sentinels), this returns `0 ms`, meaning ioredis immediately retries without any back-off at all. While a single burst is unlikely to matter in practice, it diverges from the existing `retryStrategy` in `redisQueueRetryOptions` which enforces a 1 s minimum. Using `(retries + 1) * 200` ensures a floor of 200 ms on the very first retry, making the ramp consistent.

```suggestion
    sentinelRetryStrategy: (retries: number) => Math.min((retries + 1) * 200, 10_000),
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(redis): add sentinelRetryStrategy to..."](https://github.com/langfuse/langfuse/commit/1acd26d7e77e8a33b255f77759a93abac4a504cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34499547)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->