### PR TITLE
fix(evals): allow re-evaluation after cancelled or failed job executions

### DIFF
--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -5,6 +5,7 @@ import {
   variableMappingList,
   EvalTargetObject,
 } from "@langfuse/shared";
+import { JobExecutionStatus } from "@prisma/client";
 import { encrypt } from "@langfuse/shared/encryption";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -1358,6 +1359,250 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
       expect(jobs[0].status.toString()).toBe("CANCELLED");
       expect(jobs[0].startTime).not.toBeNull();
       expect(jobs[0].endTime).not.toBeNull();
+    }, 10_000);
+
+    // @ana A001, A002, A003
+    test("creates a new eval job after a cancelled job when trace re-matches", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const traceId = randomUUID();
+
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        user_id: "a",
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      await prisma.llmApiKeys.create({
+        data: {
+          id: randomUUID(),
+          projectId,
+          secretKey: encrypt(String(OPENAI_API_KEY)),
+          provider: "openai",
+          adapter: LLMAdapter.OpenAI,
+          customModels: [],
+          displaySecretKey: "123456",
+        },
+      });
+
+      const templateId = randomUUID();
+      await prisma.evalTemplate.create({
+        data: {
+          id: templateId,
+          projectId,
+          name: "test-template",
+          version: 1,
+          prompt: "Please evaluate toxicity {{input}} {{output}}",
+          model: "gpt-3.5-turbo",
+          provider: "openai",
+          modelParams: {},
+          outputDefinition: {
+            reasoning: "Please explain your reasoning",
+            score: "Please provide a score between 0 and 1",
+          },
+        },
+      });
+
+      await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId,
+          filter: [
+            {
+              type: "string",
+              value: "a",
+              column: "User ID",
+              operator: "contains",
+            },
+          ],
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: EvalTargetObject.TRACE,
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+          evalTemplateId: templateId,
+        },
+      });
+
+      const payload = {
+        projectId,
+        traceId: traceId,
+      };
+
+      // First call: creates a PENDING job
+      await createEvalJobs({
+        sourceEventType: "trace-upsert",
+        event: payload,
+        jobTimestamp,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Deselect the trace by changing user_id
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        user_id: "b",
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      // Second call: cancels the existing job
+      await createEvalJobs({
+        sourceEventType: "trace-upsert",
+        event: payload,
+        jobTimestamp,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Re-select the trace by restoring user_id
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        user_id: "a",
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      // Third call: should create a new job since the old one is CANCELLED
+      await createEvalJobs({
+        sourceEventType: "trace-upsert",
+        event: payload,
+        jobTimestamp,
+      });
+
+      const jobs = await prisma.jobExecution.findMany({
+        where: { projectId },
+      });
+
+      expect(jobs.length).toBe(2);
+
+      const cancelledJob = jobs.find(
+        (j) => j.status.toString() === "CANCELLED",
+      );
+      const pendingJob = jobs.find((j) => j.status.toString() === "PENDING");
+
+      expect(cancelledJob).toBeDefined();
+      expect(cancelledJob!.status.toString()).toBe("CANCELLED");
+      expect(pendingJob).toBeDefined();
+      expect(pendingJob!.status.toString()).toBe("PENDING");
+    }, 10_000);
+
+    // @ana A004, A005, A006
+    test("creates a new eval job after an errored job when trace event arrives", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const traceId = randomUUID();
+
+      await upsertTrace({
+        id: traceId,
+        project_id: projectId,
+        user_id: "a",
+        timestamp: convertDateToClickhouseDateTime(new Date()),
+        created_at: convertDateToClickhouseDateTime(new Date()),
+        updated_at: convertDateToClickhouseDateTime(new Date()),
+      });
+
+      await prisma.llmApiKeys.create({
+        data: {
+          id: randomUUID(),
+          projectId,
+          secretKey: encrypt(String(OPENAI_API_KEY)),
+          provider: "openai",
+          adapter: LLMAdapter.OpenAI,
+          customModels: [],
+          displaySecretKey: "123456",
+        },
+      });
+
+      const templateId = randomUUID();
+      await prisma.evalTemplate.create({
+        data: {
+          id: templateId,
+          projectId,
+          name: "test-template",
+          version: 1,
+          prompt: "Please evaluate toxicity {{input}} {{output}}",
+          model: "gpt-3.5-turbo",
+          provider: "openai",
+          modelParams: {},
+          outputDefinition: {
+            reasoning: "Please explain your reasoning",
+            score: "Please provide a score between 0 and 1",
+          },
+        },
+      });
+
+      await prisma.jobConfiguration.create({
+        data: {
+          id: randomUUID(),
+          projectId,
+          filter: [
+            {
+              type: "string",
+              value: "a",
+              column: "User ID",
+              operator: "contains",
+            },
+          ],
+          jobType: "EVAL",
+          delay: 0,
+          sampling: new Decimal("1"),
+          targetObject: EvalTargetObject.TRACE,
+          scoreName: "score",
+          variableMapping: JSON.parse("[]"),
+          evalTemplateId: templateId,
+        },
+      });
+
+      const payload = {
+        projectId,
+        traceId: traceId,
+      };
+
+      // First call: creates a PENDING job
+      await createEvalJobs({
+        sourceEventType: "trace-upsert",
+        event: payload,
+        jobTimestamp,
+      });
+
+      // Manually set the job to ERROR status
+      await prisma.jobExecution.updateMany({
+        where: { projectId },
+        data: {
+          status: JobExecutionStatus.ERROR,
+          endTime: new Date(),
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Second call: should create a new job since the old one is ERROR
+      await createEvalJobs({
+        sourceEventType: "trace-upsert",
+        event: payload,
+        jobTimestamp,
+      });
+
+      const jobs = await prisma.jobExecution.findMany({
+        where: { projectId },
+      });
+
+      expect(jobs.length).toBe(2);
+
+      const errorJob = jobs.find((j) => j.status.toString() === "ERROR");
+      const pendingJob = jobs.find((j) => j.status.toString() === "PENDING");
+
+      expect(errorJob).toBeDefined();
+      expect(errorJob!.status.toString()).toBe("ERROR");
+      expect(pendingJob).toBeDefined();
+      expect(pendingJob!.status.toString()).toBe("PENDING");
     }, 10_000);
 
     test("does not create eval job for existing traces if time scope is EXISTING but handler enforces NEW only", async () => {

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -350,6 +350,9 @@ export const createEvalJobs = async ({
             projectId: event.projectId,
             jobInputTraceId: event.traceId,
             jobConfigurationId: { in: configIds },
+            status: {
+              notIn: [JobExecutionStatus.CANCELLED, JobExecutionStatus.ERROR],
+            },
           },
         })
       : [];


### PR DESCRIPTION
## Summary

Fix the trace-level eval dedup query so that `CANCELLED` and `ERROR` job executions no longer permanently block re-evaluation.

## The Problem

`createEvalJobs()` in `evalService.ts` deduplicates by querying all existing `jobExecution` records for a trace+config pair — but the query has no status filter. This means terminal states (`CANCELLED`, `ERROR`) block new job creation forever.

**Scenario A — cancelled re-match:**
1. Trace matches evaluator → job created (`PENDING`)
2. Trace updated, no longer matches → job set to `CANCELLED`
3. Trace updated again, matches again → dedup finds the `CANCELLED` job → **silently skips** → evaluation never runs

**Scenario B — error recovery:**
1. Trace matches evaluator → job created → enqueued
2. LLM provider rate limit or outage → eval fails → status set to `ERROR`
3. Provider recovers → trace gets any update → dedup finds `ERROR` job → **silently skips** → evaluation never retries

After BullMQ exhausts retries and sets `ERROR`, there is no recovery path short of manually deleting records from Postgres.

The observation-level eval path (`scheduleObservationEvals.ts`) handles this differently — it uses `upsert` with deterministic IDs, always resetting to `PENDING`. The trace-level path doesn't have this safety valve.

## The Fix

Add `status: { notIn: [CANCELLED, ERROR] }` to the dedup query's `WHERE` clause (line 349):

- `PENDING` / `DELAYED` still block → correct (job is in progress)
- `COMPLETED` still blocks → correct (already successfully evaluated)
- `CANCELLED` does **not** block → fixed (evaluation was aborted, should retry)
- `ERROR` does **not** block → fixed (evaluation failed, new attempt warranted)

Uses `notIn` rather than `in` so that any future `JobExecutionStatus` enum values block by default (fail-closed).

## Testing

Two new integration tests extending the existing cancel test scaffold:

- **CANCELLED re-match:** trace matches → deselect → cancel → re-select → asserts 2 jobs (1 CANCELLED + 1 new PENDING)
- **ERROR re-evaluation:** trace matches → manually set to ERROR → retrigger → asserts 2 jobs (1 ERROR + 1 new PENDING)

Both follow the existing test patterns in `evalService.test.ts` (real Postgres, real ClickHouse, same helper usage).

Lint clean. No modifications to existing tests or logic.

---

Found while analyzing the codebase with [Anatomia](https://anatomia.dev). [Full analysis →](https://github.com/rpatricksmith/langfuse/tree/feature/fix-eval-dedup-status-filter/.ana/plans/active/fix-eval-dedup-status-filter)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a deduplication gap in the trace-level eval job creation path where `CANCELLED` and `ERROR` job executions permanently blocked re-evaluation. A single `status: { notIn: [CANCELLED, ERROR] }` predicate is added to the batch dedup query, plus two integration tests that verify the corrected behavior.

- **`evalService.ts`**: Adds a `notIn` status filter to the `allExistingJobs` batch query so only active (`PENDING`, `DELAYED`) and terminal-success (`COMPLETED`) records block new job creation; failed/aborted records no longer prevent retry.
- **`evalService.test.ts`**: Two new tests extend the cancel scaffold — one for CANCELLED re-match and one for ERROR re-evaluation — both asserting that a second PENDING job is created alongside the existing terminal-state record.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge. The one-line query fix correctly unblocks re-evaluation for terminal-failure jobs without touching any other execution path.

The production code change is a single, well-scoped predicate addition that does exactly what the PR description says. The cancellation path, sampling logic, and COMPLETED dedup are all untouched and continue to work correctly. New integration tests cover both the CANCELLED and ERROR scenarios. The only notes are minor: leftover @ana annotation comments in the test file, and a side-effect that re-triggered traces will be subject to sampling again (which is the correct semantic for a fresh evaluation attempt but may surprise operators who expect a guaranteed retry).

No files require special attention; the diff is small and focused.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Trace Event
    participant C as createEvalJobs()
    participant DB as Postgres (jobExecution)
    participant Q as EvalExecutionQueue

    Note over T,Q: Scenario A — Cancelled re-match (fixed)
    T->>C: trace-upsert (matches filter)
    C->>DB: findMany (status notIn [CANCELLED,ERROR])
    DB-->>C: [] (no active jobs)
    C->>DB: create PENDING job
    C->>Q: enqueue job

    T->>C: trace-upsert (no longer matches)
    C->>DB: findMany (status notIn [CANCELLED,ERROR])
    DB-->>C: [PENDING job]
    C->>DB: updateMany → CANCELLED

    T->>C: trace-upsert (matches again)
    C->>DB: findMany (status notIn [CANCELLED,ERROR])
    DB-->>C: [] (CANCELLED excluded)
    C->>DB: create new PENDING job
    C->>Q: enqueue new job

    Note over T,Q: Scenario B — Error recovery (fixed)
    T->>C: trace-upsert (matches filter)
    C->>DB: findMany (status notIn [CANCELLED,ERROR])
    DB-->>C: [] (no active jobs)
    C->>DB: create PENDING job
    C->>Q: enqueue job

    Note over DB: BullMQ exhausts retries → ERROR
    T->>C: trace-upsert (any update)
    C->>DB: findMany (status notIn [CANCELLED,ERROR])
    DB-->>C: [] (ERROR excluded)
    C->>DB: create new PENDING job
    C->>Q: enqueue new job
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/__tests__/evalService.test.ts:1364
**Leftover external-tool annotations**

The `// @ana A001, A002, A003` and `// @ana A004, A005, A006` comments are references to an external analysis tool (Anatomia) used to author this PR. They carry no meaning in the test suite itself and will confuse future readers. Consider removing them before merging.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): allow re-evaluation after ca..."](https://github.com/langfuse/langfuse/commit/41d0f29531795074d3fded7fba6d4e6c0c387d32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34530431)</sub>

<!-- /greptile_comment -->