### PR TITLE
fix(mcp): Update score tool descriptions

### DIFF
--- a/web/src/features/mcp/features/scores/tools/createScore.ts
+++ b/web/src/features/mcp/features/scores/tools/createScore.ts
@@ -64,8 +64,10 @@ const CreateScoreBaseSchema = z.object({
 
 export const [createScoreTool, handleCreateScore] = defineTool({
   name: "createScore",
-  description:
-    "Create one score in the current Langfuse project using the v1 /api/public/scores route semantics. This is the v1 fallback because score creation has no v2 public route.",
+  description: [
+    "Create one score in the current Langfuse project.",
+    "Score reads are eventually consistent: after creation, getScore and listScores may not return the new score immediately. Wait briefly and retry reads when confirming creation.",
+  ].join("\n"),
   baseSchema: CreateScoreBaseSchema,
   inputSchema: PostScoresBodyV1,
   destructiveHint: true,

--- a/web/src/features/mcp/features/scores/tools/getScore.ts
+++ b/web/src/features/mcp/features/scores/tools/getScore.ts
@@ -11,8 +11,10 @@ import { ScoresApiService } from "@/src/features/public-api/server/scores-api-se
 
 export const [getScoreTool, handleGetScore] = defineTool({
   name: "getScore",
-  description:
-    "Fetch one score by ID from the current Langfuse project using the v2 /api/public/v2/scores/{scoreId} semantics. Returns the public score object directly.",
+  description: [
+    "Fetch one score by ID from the current Langfuse project.",
+    "Score reads are eventually consistent: a score created with createScore may not be returned by getScore immediately. If a newly created score is not found, wait briefly and retry.",
+  ].join("\n"),
   baseSchema: GetScoreQueryV2,
   inputSchema: GetScoreQueryV2,
   handler: async (input, context) => {

--- a/web/src/features/mcp/features/scores/tools/listScores.ts
+++ b/web/src/features/mcp/features/scores/tools/listScores.ts
@@ -91,6 +91,7 @@ export const [listScoresTool, handleListScores] = defineTool({
     "Find scores in Langfuse.",
     "Use this to review quality, evaluation, or feedback scores for traces, observations, sessions, and dataset runs.",
     "Filter by score details, time range, environment, source, trace information, or dataset run context to narrow the results.",
+    "Score reads are eventually consistent: a score created with createScore may not appear in listScores immediately. If a newly created score is missing, wait briefly and retry.",
   ].join("\n"),
   baseSchema: ListScoresBaseSchema,
   inputSchema: ListScoresInputSchema,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the MCP score tool descriptions to remove internal API route references and add eventual-consistency guidance for AI agents consuming these tools.

- `createScore`, `getScore`, and `listScores` descriptions drop mentions of `/api/public/scores` and `/api/public/v2/scores/{scoreId}` — implementation details that are not useful to tool callers.
- All three tools gain a consistent note that score reads are eventually consistent after creation and that callers should wait briefly and retry if a newly created score is not immediately visible.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Only tool description strings are changed — no logic, schema, or handler code is touched, making this safe to merge.

All three changed files modify only the description array passed to defineTool. The eventual-consistency guidance is accurate and consistent across all three tools, and the removal of internal route paths from tool descriptions is a clear improvement. No handler, schema, or runtime behavior is affected.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent as MCP Agent
    participant createScore as createScore Tool
    participant getScore as getScore Tool
    participant listScores as listScores Tool
    participant DB as Langfuse DB (eventually consistent)

    Agent->>createScore: create score
    createScore->>DB: write score (async propagation)
    createScore-->>Agent: "{ id: scoreId }"

    Note over Agent,DB: Score reads are eventually consistent — new scores may not be visible immediately after creation

    Agent->>getScore: getScore(scoreId)
    getScore->>DB: read score
    alt Score not yet propagated
        DB-->>getScore: not found
        getScore-->>Agent: LangfuseNotFoundError
        Agent->>Agent: wait briefly, retry
    else Score available
        DB-->>getScore: score data
        getScore-->>Agent: GetScoreResponseV2
    end

    Agent->>listScores: listScores(filters)
    listScores->>DB: query scores
    DB-->>listScores: result set
    listScores-->>Agent: "{ data, meta }"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Update score tool descriptions"](https://github.com/langfuse/langfuse/commit/d9f5eefbcd1b70d54d155cc9738ca8073271e46b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34572179)</sub>

<!-- /greptile_comment -->