### PR TITLE
fix(mcp): Improve description for 'latest' label

### DIFF
--- a/web/src/features/mcp/features/prompts/tools/updatePromptLabels.ts
+++ b/web/src/features/mcp/features/prompts/tools/updatePromptLabels.ts
@@ -32,7 +32,7 @@ const UpdatePromptLabelsBaseSchema = z.object({
   newLabels: z
     .array(z.string())
     .describe(
-      "Array of new labels to assign to the prompt version (can be empty to remove all labels)",
+      "Array of new labels to assign to the prompt version (can be empty to remove all labels). The 'latest' label is auto-managed and cannot be supplied.",
     ),
 });
 

--- a/web/src/features/mcp/features/prompts/validation.ts
+++ b/web/src/features/mcp/features/prompts/validation.ts
@@ -83,4 +83,6 @@ export const ParamNewLabels = z
   .refine((labels) => !labels.includes(LATEST_PROMPT_LABEL), {
     message: "Label 'latest' is always assigned to the latest prompt version",
   })
-  .describe("Array of new labels to assign to the prompt version");
+  .describe(
+    "Array of new labels to assign to the prompt version. The 'latest' label is auto-managed and cannot be supplied.",
+  );


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the description strings for the `newLabels` parameter in the MCP prompts feature, explicitly communicating to MCP clients that the `latest` label is auto-managed and cannot be supplied by the caller.

- Updates the `newLabels` field description in `UpdatePromptLabelsBaseSchema` (used for JSON Schema / MCP client display) to mention the `latest` label restriction alongside the existing "can be empty" note.
- Updates the `ParamNewLabels` Zod schema description in `validation.ts` to match, aligning the human-readable description with the existing `.refine()` guard that already rejects inputs containing `latest`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are limited to description strings and do not affect validation logic or runtime behavior.

Both changed files only update `.describe()` call strings to surface the already-enforced `latest` label restriction to MCP clients. The underlying `.refine()` guard in `ParamNewLabels` is untouched, so runtime behavior is identical before and after this change.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Tool as updatePromptLabels Tool
    participant Base as UpdatePromptLabelsBaseSchema<br/>(JSON Schema / display)
    participant Input as UpdatePromptLabelsInputSchema<br/>(runtime validation)
    participant API as updatePromptLabelsForApi

    Client->>Tool: updatePromptLabels(name, version, newLabels)
    Note over Base: newLabels description now includes:<br/>"The 'latest' label is auto-managed<br/>and cannot be supplied."
    Tool->>Input: validate(input)
    Note over Input: ParamNewLabels.refine() rejects<br/>newLabels containing "latest"
    alt newLabels includes "latest"
        Input-->>Tool: Validation error
        Tool-->>Client: Error: "'latest' is always assigned automatically"
    else valid labels
        Input-->>Tool: Validated input
        Tool->>API: updatePromptLabelsForApi(...)
        API-->>Tool: updatedPrompt
        Tool-->>Client: "{ id, name, version, labels, message }"
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Improve description for &#39;lates..."](https://github.com/langfuse/langfuse/commit/215a6dac2f936ffae00bddbcd1c66900dad93f74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34572190)</sub>

<!-- /greptile_comment -->