### PR TITLE
fix(mcp): Be more liberal in accepting dataset input and output schema

### DIFF
--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -77,6 +77,7 @@ import {
   handleListDatasets,
   handleUpsertDataset,
   handleUpsertDatasetItem,
+  upsertDatasetTool,
 } from "@/src/features/mcp/features/datasets/tools";
 import { handleGetHealth } from "@/src/features/mcp/features/health/tools";
 import {
@@ -478,15 +479,57 @@ describe("MCP public API tools", () => {
       }),
     ]);
 
-    const dataset = (await handleUpsertDataset(
+    const datasetInputSchema = {
+      type: "object",
+      properties: { question: { type: "string" } },
+      required: ["question"],
+      additionalProperties: false,
+    };
+    const datasetExpectedOutputSchema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"],
+      additionalProperties: false,
+    };
+    const upsertDataset = await toolRegistry.getEnabledTool(
+      upsertDatasetTool.name,
+      context,
+    );
+    expect(upsertDataset).toBeDefined();
+
+    const dataset = (await upsertDataset?.handler(
       {
         name: datasetName,
         description: "MCP dataset",
         metadata: { source: "mcp" },
+        inputSchema: datasetInputSchema,
+        expectedOutputSchema: datasetExpectedOutputSchema,
       },
       context,
-    )) as { id: string; name: string };
+    )) as {
+      id: string;
+      name: string;
+      inputSchema: unknown;
+      expectedOutputSchema: unknown;
+    };
     expect(dataset.name).toBe(datasetName);
+    expect(dataset.inputSchema).toEqual(datasetInputSchema);
+    expect(dataset.expectedOutputSchema).toEqual(datasetExpectedOutputSchema);
+
+    await expect(
+      upsertDataset?.handler(
+        {
+          name: datasetName,
+          inputSchema: JSON.stringify(datasetInputSchema),
+          expectedOutputSchema: JSON.stringify(datasetExpectedOutputSchema),
+        },
+        context,
+      ),
+    ).resolves.toMatchObject({
+      id: dataset.id,
+      inputSchema: datasetInputSchema,
+      expectedOutputSchema: datasetExpectedOutputSchema,
+    });
 
     const datasets = (await handleListDatasets(
       { page: 1, limit: 10 },

--- a/web/src/features/mcp/features/datasets/tools/upsertDataset.ts
+++ b/web/src/features/mcp/features/datasets/tools/upsertDataset.ts
@@ -4,6 +4,7 @@ import {
   PostDatasetsV2Body,
   PostDatasetsV2Response,
 } from "@/src/features/public-api/types/datasets";
+import { DatasetJSONSchema } from "@langfuse/shared/src/server";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
@@ -15,12 +16,36 @@ const UpsertDatasetBaseSchema = z.object({
   expectedOutputSchema: z.any().optional(),
 });
 
+const StringifiedDatasetJSONSchema = z
+  .string()
+  .transform((schema, ctx) => {
+    try {
+      return JSON.parse(schema) as unknown;
+    } catch {
+      ctx.addIssue({
+        code: "custom",
+        message: "Must be a valid JSON string containing a JSON Schema",
+      });
+      return z.NEVER;
+    }
+  })
+  .pipe(DatasetJSONSchema);
+
+const DatasetJSONSchemaInput = z
+  .union([DatasetJSONSchema, StringifiedDatasetJSONSchema])
+  .nullish();
+
+const UpsertDatasetInputSchema = PostDatasetsV2Body.extend({
+  inputSchema: DatasetJSONSchemaInput,
+  expectedOutputSchema: DatasetJSONSchemaInput,
+});
+
 export const [upsertDatasetTool, handleUpsertDataset] = defineTool({
   name: "upsertDataset",
   description:
     "Upsert a dataset, a named collection of input and optional expected-output examples for experiments and evaluations.",
   baseSchema: UpsertDatasetBaseSchema,
-  inputSchema: PostDatasetsV2Body,
+  inputSchema: UpsertDatasetInputSchema,
   handler: async (input, context) =>
     runMcpTool({
       spanName: "mcp.datasets.upsert",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the MCP `upsertDataset` tool more permissive by accepting `inputSchema` and `expectedOutputSchema` as either a raw JSON object or a JSON-serialized string (e.g., what an LLM might emit). A `z.preprocess` step is added to attempt `JSON.parse` before delegating to the existing `DatasetJSONSchema` validator.

- `parseJsonSchemaString` is introduced to parse string values before Zod validation; it silently returns the original string when `JSON.parse` throws, allowing the downstream `z.record` check to reject it.
- `UpsertDatasetInputSchema` extends `PostDatasetsV2Body`, overriding only the two schema fields with the new preprocessor-aware definition.
- Tests now cover both the object form and the JSON-string form of schema inputs via the full tool-registry path.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core logic correctly gates invalid inputs via Zod and the preprocessing path is well-tested.

The change is narrow and the preprocessing approach is sound. The only notable issue is that a malformed JSON string silently returns itself from `parseJsonSchemaString`, causing a misleading Zod error message downstream instead of a descriptive one — this is a developer-experience concern rather than a data-safety problem.

`web/src/features/mcp/features/datasets/tools/upsertDataset.ts` — specifically the `catch` branch in `parseJsonSchemaString`.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant LLM as LLM / MCP Client
    participant Tool as upsertDatasetTool (handler)
    participant Pre as parseJsonSchemaString
    participant Zod as UpsertDatasetInputSchema (Zod)
    participant API as createDatasetForApi

    LLM->>Tool: call with inputSchema (object OR JSON string)
    Tool->>Zod: inputSchema.parse(rawInput)
    Zod->>Pre: z.preprocess — inputSchema field
    alt inputSchema is a string
        Pre->>Pre: JSON.parse(schema)
        alt parse succeeds
            Pre-->>Zod: parsed object
        else parse fails
            Pre-->>Zod: original string (returns schema unchanged)
            Zod-->>Tool: ZodError "Expected object, received string"
        end
    else inputSchema is already an object
        Pre-->>Zod: pass through
    end
    Zod->>Zod: DatasetJSONSchema.nullish() validates parsed value
    Zod-->>Tool: validated input
    Tool->>API: createDatasetForApi(input, projectId)
    API-->>Tool: dataset record
    Tool-->>LLM: PostDatasetsV2Response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/mcp/features/datasets/tools/upsertDataset.ts:22-26
When `JSON.parse` throws (invalid JSON string), the function returns the original string unchanged. The downstream `DatasetJSONSchema` validator — a `z.record(z.string(), ...)` — will then fail with `"Expected object, received string"`, which gives no indication that the value was interpreted as a JSON string or that it was malformed JSON. Returning `undefined` (or re-throwing as a `ZodError`) would surface a clearer message tied to the actual schema expectation.

```suggestion
  try {
    return JSON.parse(schema) as unknown;
  } catch {
    // Return undefined so DatasetJSONSchema.nullish() emits a clear
    // "invalid JSON Schema" error rather than "Expected object, received string".
    return undefined;
  }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Be more liberal in accepting d..."](https://github.com/langfuse/langfuse/commit/a60d5585518033e933e08ce23f7e3019109a2c55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34572531)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->