### PR TITLE
fix(mcp): Normalize fields in queryMetrics tool

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -1036,6 +1036,143 @@ describe("MCP Read Tools", () => {
       expect(Number(rows[0].count_count)).toBe(3);
     });
 
+    it("should accept raw metric names in orderBy", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const traceId = randomUUID();
+      const highCountName = `mcp-metrics-order-high-${nanoid()}`;
+      const lowCountName = `mcp-metrics-order-low-${nanoid()}`;
+
+      await createEventsCh([
+        ...Array.from({ length: 3 }, (_, index) =>
+          createObservationEvent({
+            projectId,
+            traceId,
+            name: highCountName,
+            startTime: new Date(`2026-01-01T00:00:0${index}.000Z`),
+          }),
+        ),
+        createObservationEvent({
+          projectId,
+          traceId,
+          name: lowCountName,
+          startTime: new Date("2026-01-01T00:01:00.000Z"),
+        }),
+      ]);
+
+      const rows = getMetricRows(
+        await handleQueryMetrics(
+          {
+            view: "observations",
+            dimensions: [{ field: "name" }],
+            metrics: [{ measure: "count", aggregation: "count" }],
+            filters: [
+              {
+                type: "string",
+                column: "traceId",
+                operator: "=",
+                value: traceId,
+              },
+            ],
+            orderBy: [{ field: "count", direction: "desc" }],
+            ...metricsWindow,
+          },
+          context,
+        ),
+      );
+
+      expect(rows).toHaveLength(2);
+      expect(rows[0].name).toBe(highCountName);
+      expect(Number(rows[0].count_count)).toBe(3);
+      expect(rows[1].name).toBe(lowCountName);
+      expect(Number(rows[1].count_count)).toBe(1);
+    });
+
+    it("should prefer dimension fields over matching raw metric names in orderBy", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const traceId = randomUUID();
+      const scoreName = `mcp-metrics-score-value-order-${nanoid()}`;
+      const observationId = randomUUID();
+
+      await createEventsCh([
+        createEvent({
+          id: observationId,
+          span_id: observationId,
+          trace_id: traceId,
+          project_id: projectId,
+          name: `mcp-score-observation-${nanoid()}`,
+          start_time: Date.parse("2026-01-01T00:00:00.000Z") * 1000,
+        }),
+      ]);
+      await createScoresCh([
+        ...Array.from({ length: 3 }, () =>
+          createTraceScore({
+            id: randomUUID(),
+            project_id: projectId,
+            trace_id: traceId,
+            observation_id: observationId,
+            name: scoreName,
+            value: 1,
+            data_type: "NUMERIC",
+            timestamp: Date.parse("2026-01-01T00:00:00.000Z"),
+          }),
+        ),
+        createTraceScore({
+          id: randomUUID(),
+          project_id: projectId,
+          trace_id: traceId,
+          observation_id: observationId,
+          name: scoreName,
+          value: 2,
+          data_type: "NUMERIC",
+          timestamp: Date.parse("2026-01-01T00:00:00.000Z"),
+        }),
+      ]);
+
+      const rows = getMetricRows(
+        await handleQueryMetrics(
+          {
+            view: "scores-numeric",
+            dimensions: [{ field: "value" }],
+            metrics: [{ measure: "value", aggregation: "count" }],
+            filters: [
+              {
+                type: "string",
+                column: "name",
+                operator: "=",
+                value: scoreName,
+              },
+            ],
+            orderBy: [{ field: "value", direction: "desc" }],
+            ...metricsWindow,
+          },
+          context,
+        ),
+      );
+
+      expect(rows).toHaveLength(2);
+      expect(Number(rows[0].value)).toBe(2);
+      expect(Number(rows[0].count_value)).toBe(1);
+      expect(Number(rows[1].value)).toBe(1);
+      expect(Number(rows[1].count_value)).toBe(3);
+    });
+
+    it("should reject internal sql field names in orderBy", async () => {
+      const { context } = await createMcpTestSetup();
+
+      await expect(
+        handleQueryMetrics(
+          {
+            view: "observations",
+            dimensions: [{ field: "name" }],
+            metrics: [{ measure: "count", aggregation: "count" }],
+            orderBy: [{ field: "observations.name", direction: "asc" }],
+            ...metricsWindow,
+          },
+          context,
+        ),
+      ).rejects.toThrow(/Use returned metric aliases.*getMetricsSchema/i);
+    });
+
     it("should apply default row_limit of 100 when omitted", async () => {
       const { context, projectId } = await createMcpTestSetup();
       const traceId = randomUUID();

--- a/web/src/features/mcp/features/metrics/tools/queryMetrics.ts
+++ b/web/src/features/mcp/features/metrics/tools/queryMetrics.ts
@@ -14,6 +14,49 @@ import { z } from "zod";
 
 const DEFAULT_ROW_LIMIT = 100;
 
+const normalizeMetricOrderByFields = (
+  input: z.infer<typeof MetricsQueryObjectV2>,
+) => {
+  if (!input.orderBy) {
+    return input;
+  }
+
+  const metricAliases = input.metrics.map(
+    (metric) => `${metric.aggregation}_${metric.measure}`,
+  );
+  const allowedOrderByFields = new Set([
+    ...input.dimensions.map((dimension) => dimension.field),
+    ...metricAliases,
+    ...(input.timeDimension ? ["time_dimension"] : []),
+  ]);
+
+  return {
+    ...input,
+    orderBy: input.orderBy.map((orderBy) => {
+      const matchingMetrics = input.dimensions.some(
+        (dimension) => dimension.field === orderBy.field,
+      )
+        ? []
+        : input.metrics.filter((metric) => metric.measure === orderBy.field);
+      const normalizedField =
+        matchingMetrics.length === 1
+          ? `${matchingMetrics[0].aggregation}_${matchingMetrics[0].measure}`
+          : orderBy.field;
+
+      if (!allowedOrderByFields.has(normalizedField)) {
+        throw new InvalidRequestError(
+          `Invalid orderBy field: ${orderBy.field}. Use returned metric aliases like 'sum_totalCost' or fields returned by getMetricsSchema.`,
+        );
+      }
+
+      return {
+        ...orderBy,
+        field: normalizedField,
+      };
+    }),
+  };
+};
+
 const MetricsFilterBaseSchema = z.object({
   column: z.string(),
   operator: z.string(),
@@ -64,13 +107,14 @@ export const [queryMetricsTool, handleQueryMetrics] = defineTool({
         "mcp.metrics_view": input.view,
       },
       fn: async () => {
-        const validation = validateQuery(input, "v2");
+        const normalizedInput = normalizeMetricOrderByFields(input);
+        const validation = validateQuery(normalizedInput, "v2");
 
         if (!validation.valid) {
           throw new InvalidRequestError(validation.reason);
         }
 
-        const { config, ...query } = input;
+        const { config, ...query } = normalizedInput;
         const queryParams = {
           ...query,
           chartConfig: {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `normalizeMetricOrderByFields` helper that allows callers (typically LLM agents) to use raw measure names like `"count"` in `orderBy` instead of requiring the full internal alias `"count_count"`. It also validates that `orderBy` fields are limited to declared dimensions, metric aliases, or `time_dimension`.

- **Normalization logic**: when exactly one metric matches the raw measure name, the field is rewritten to `${aggregation}_${measure}`; ambiguous or already-aliased fields pass through to the allowlist check unchanged.
- **Validation**: any field not in the computed allowlist throws an `InvalidRequestError` with a helpful message pointing at `getMetricsSchema`.
- **Tests**: two new server tests cover the happy path (raw measure → alias mapping) and the rejection of internal SQL-qualified field names.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is additive, narrowly scoped to orderBy normalization, and both the normalization and allowlist validation run before the query executes.

The normalization logic handles the zero-match and single-match cases correctly, and the allowlist check guards against invalid fields. The multi-match (ambiguous) path intentionally errors out with a clear message. A few edge cases — ordering by an already-aliased field, ordering by dimension-only, and the ambiguous-metrics failure path — are not exercised by the new tests, leaving a small gap in validated behaviour.

Both changed files are straightforward. The test file lacks coverage for the already-normalized alias pass-through and multi-metric ambiguity cases, but neither represents a production risk with the current implementation.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleQueryMetrics called with input] --> B{input.orderBy present?}
    B -- No --> E[validateQuery normalizedInput]
    B -- Yes --> C[Build allowedOrderByFields\ndimensions + metricAliases + time_dimension]
    C --> D[For each orderBy entry\nfind matching metrics by measure]
    D --> F{matchingMetrics\n.length === 1?}
    F -- Yes --> G[normalizedField =\naggregation_measure]
    F -- No\nzero or ambiguous --> H[normalizedField =\norderBy.field unchanged]
    G --> I{normalizedField in\nallowedOrderByFields?}
    H --> I
    I -- No --> J[throw InvalidRequestError]
    I -- Yes --> K[Return updated orderBy entry]
    K --> E
    E --> L{validation.valid?}
    L -- No --> M[throw InvalidRequestError\nvalidation.reason]
    L -- Yes --> N[executeQuery with normalizedInput]
    N --> O[Return result data]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Normalize fields in queryMetri..."](https://github.com/langfuse/langfuse/commit/764d5b8f65ad0abf176f8e7ba9b75bf59ac2209c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34577060)</sub>

<!-- /greptile_comment -->