### PR TITLE
fix(mcp): Prompt retrieval defaults to production

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -2051,27 +2051,70 @@ describe("MCP Read Tools", () => {
       ).resolves.toBeDefined();
     });
 
-    it("should fetch prompt by name only (defaults to production label)", async () => {
+    it("should fetch prompt by name only (defaults to latest label)", async () => {
       const { context, projectId } = await createMcpTestSetup();
       const promptName = `test-prompt-${nanoid()}`;
 
-      // Create a prompt with production label
       await createPromptInDb({
         name: promptName,
-        prompt: "You are a helpful assistant.",
+        prompt: "Production prompt",
         projectId,
         labels: ["production"],
         version: 1,
       });
 
+      await createPromptInDb({
+        name: promptName,
+        prompt: "Latest prompt",
+        projectId,
+        labels: ["latest"],
+        version: 2,
+      });
+
       const result = (await handleGetPrompt({ name: promptName }, context)) as {
         name: string;
         version: number;
+        prompt: string;
         labels: string[];
       };
 
       expect(result.name).toBe(promptName);
+      expect(result.version).toBe(2);
+      expect(result.prompt).toBe("Latest prompt");
+      expect(result.labels).toContain("latest");
+    });
+
+    it("should fetch production prompt when production label is explicit", async () => {
+      const { context, projectId } = await createMcpTestSetup();
+      const promptName = `test-prompt-${nanoid()}`;
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "Production prompt",
+        projectId,
+        labels: ["production"],
+        version: 1,
+      });
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: "Latest prompt",
+        projectId,
+        labels: ["latest"],
+        version: 2,
+      });
+
+      const result = (await handleGetPrompt(
+        { name: promptName, label: "production" },
+        context,
+      )) as {
+        version: number;
+        prompt: string;
+        labels: string[];
+      };
+
       expect(result.version).toBe(1);
+      expect(result.prompt).toBe("Production prompt");
       expect(result.labels).toContain("production");
     });
 
@@ -2205,14 +2248,14 @@ describe("MCP Read Tools", () => {
         name: promptName,
         prompt: "Project 1 content",
         projectId: projectId1,
-        labels: ["production"],
+        labels: ["production", "latest"],
       });
 
       await createPromptInDb({
         name: promptName,
         prompt: "Project 2 content",
         projectId: projectId2,
-        labels: ["production"],
+        labels: ["production", "latest"],
       });
 
       // Each context should only see its own project's prompt
@@ -2237,7 +2280,7 @@ describe("MCP Read Tools", () => {
         name: promptName,
         prompt: "Special chars test",
         projectId,
-        labels: ["production"],
+        labels: ["production", "latest"],
       });
 
       const result = (await handleGetPrompt({ name: promptName }, context)) as {
@@ -2254,7 +2297,7 @@ describe("MCP Read Tools", () => {
         name: promptName,
         prompt: "Test",
         projectId,
-        labels: ["production"],
+        labels: ["production", "latest"],
         config: { model: "gpt-4", temperature: 0.7 },
       });
 
@@ -2273,7 +2316,7 @@ describe("MCP Read Tools", () => {
         name: promptName,
         prompt: "Test",
         projectId,
-        labels: ["production"],
+        labels: ["production", "latest"],
         tags: ["experimental", "v2"],
       });
 
@@ -2678,20 +2721,27 @@ describe("MCP Read Tools", () => {
       ).resolves.toBeDefined();
     });
 
-    it("should fetch prompt without resolving dependencies (by name only)", async () => {
+    it("should fetch latest prompt without resolving dependencies by default", async () => {
       const { context, projectId } = await createMcpTestSetup();
       const promptName = `test-prompt-unresolved-${nanoid()}`;
 
-      // Create a prompt with dependency tags (unresolved)
       const rawPromptContent =
         "You are a helpful assistant. @@@langfusePrompt:name=base-instructions|label=production@@@";
 
       await createPromptInDb({
         name: promptName,
-        prompt: rawPromptContent,
+        prompt: "Production prompt",
         projectId,
         labels: ["production"],
         version: 1,
+      });
+
+      await createPromptInDb({
+        name: promptName,
+        prompt: rawPromptContent,
+        projectId,
+        labels: ["latest"],
+        version: 2,
       });
 
       const result = (await handleGetPromptUnresolved(
@@ -2705,8 +2755,8 @@ describe("MCP Read Tools", () => {
       };
 
       expect(result.name).toBe(promptName);
-      expect(result.version).toBe(1);
-      expect(result.labels).toContain("production");
+      expect(result.version).toBe(2);
+      expect(result.labels).toContain("latest");
       // Verify dependency tags are NOT resolved
       expect(result.prompt).toBe(rawPromptContent);
       expect(result.prompt).toContain(
@@ -2822,7 +2872,7 @@ describe("MCP Read Tools", () => {
         name: promptName,
         prompt: chatMessages,
         projectId,
-        labels: ["production"],
+        labels: ["production", "latest"],
         version: 1,
         type: "chat",
       });

--- a/web/src/features/mcp/features/prompts/tools/getPrompt.ts
+++ b/web/src/features/mcp/features/prompts/tools/getPrompt.ts
@@ -15,7 +15,7 @@ export const [getPromptTool, handleGetPrompt] = createPromptReadTool({
     "Retrieval options:",
     "- label: Get prompt with specific label (e.g., 'production', 'staging')",
     "- version: Get specific version number (e.g., 1, 2, 3)",
-    "- neither: Returns 'production' version by default",
+    "- neither: Returns 'latest' version by default",
     "",
     "Note: label and version are mutually exclusive. Returns full prompt content with resolved dependencies.",
   ].join("\n"),

--- a/web/src/features/mcp/features/prompts/tools/getPromptUnresolved.ts
+++ b/web/src/features/mcp/features/prompts/tools/getPromptUnresolved.ts
@@ -22,7 +22,7 @@ export const [getPromptUnresolvedTool, handleGetPromptUnresolved] =
       "Retrieval options:",
       "- label: Get prompt with specific label (e.g., 'production', 'staging')",
       "- version: Get specific version number (e.g., 1, 2, 3)",
-      "- neither: Returns 'production' version by default",
+      "- neither: Returns 'latest' version by default",
       "",
       "Note: label and version are mutually exclusive. To get resolved prompts, use the 'getPrompt' tool instead.",
     ].join("\n"),

--- a/web/src/features/mcp/features/prompts/tools/promptReadToolFactory.ts
+++ b/web/src/features/mcp/features/prompts/tools/promptReadToolFactory.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { type Prompt } from "@langfuse/shared";
+import { LATEST_PROMPT_LABEL, type Prompt } from "@langfuse/shared";
 
 import { getPromptForApi } from "@/src/features/prompts/server/prompt-api-service";
 
@@ -67,22 +67,26 @@ export const createPromptReadTool = (options: CreatePromptReadToolOptions) => {
     baseSchema: PromptReadBaseSchema,
     inputSchema: PromptReadInputSchema,
     handler: async (input, context) => {
+      const effectiveLabel = input.version
+        ? input.label
+        : (input.label ?? LATEST_PROMPT_LABEL);
+
       return await runMcpTool({
         spanName,
         context,
         attributes: {
           "mcp.prompt_name": input.name,
           "mcp.unresolved": resolve ? undefined : true,
-          "mcp.prompt_label": input.label,
+          "mcp.prompt_label": effectiveLabel,
           "mcp.prompt_version": input.version ?? undefined,
         },
         fn: async () => {
-          const { name, label, version } = input;
+          const { name, version } = input;
 
           const prompt = await getPromptForApi({
             promptName: name,
             projectId: context.projectId,
-            label,
+            label: effectiveLabel,
             version,
             resolve,
           });
@@ -91,7 +95,7 @@ export const createPromptReadTool = (options: CreatePromptReadToolOptions) => {
             throw new UserInputError(
               buildPromptNotFoundMessage({
                 name,
-                label,
+                label: effectiveLabel,
                 version,
               }),
             );

--- a/web/src/features/mcp/features/prompts/validation.ts
+++ b/web/src/features/mcp/features/prompts/validation.ts
@@ -27,7 +27,7 @@ export const ParamPromptName = z
 
 /**
  * Prompt label parameter (optional)
- * Defaults to "production" if not specified
+ * Defaults to "latest" if not specified
  */
 export const ParamPromptLabel = z
   .string()
@@ -36,7 +36,7 @@ export const ParamPromptLabel = z
   .regex(PROMPT_LABEL_REGEX, PROMPT_LABEL_REGEX_ERROR)
   .optional()
   .describe(
-    'Label to retrieve (e.g., "production", "staging"). Defaults to "production".',
+    'Label to retrieve (e.g., "production", "staging"). Defaults to "latest".',
   );
 
 /**


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the MCP prompt-retrieval tools (`getPrompt` and `getPromptUnresolved`) so that when no `label` or `version` is specified, they default to the `"latest"` label instead of silently falling through to `"production"` inside `getPromptByName`.

- `promptReadToolFactory.ts` computes an `effectiveLabel` before calling `getPromptForApi`: if `version` is set, no label is forwarded (version lookup remains unchanged); if neither is set, `LATEST_PROMPT_LABEL` (`"latest"`) is injected, bypassing the `PRODUCTION_LABEL` fallback that was previously applied inside `getPromptByName`.
- Tool description strings in `getPrompt.ts` and `getPromptUnresolved.ts` are updated to match the new default.
- Tests are extended with a second prompt version carrying the `"latest"` label to verify the new default, and a new test case confirms that explicitly passing `label: "production"` still returns the production prompt.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrow, well-tested, and only affects MCP callers; all other consumers of getPromptByName are unaffected.

The fix is small and surgical: one computed variable replaces an implicit downstream fallback, both lookup paths (version-only and label-only) continue to behave correctly, and the new tests cover the default-to-latest case as well as the explicit-production case. No schema changes, no shared-service changes, no side effects on non-MCP callers.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as MCP Client
    participant T as promptReadToolFactory
    participant S as getPromptForApi
    participant B as getPromptByName

    C->>T: "getPrompt({ name })"
    Note over T: effectiveLabel = LATEST_PROMPT_LABEL
    T->>S: "{ name, label: "latest", version: undefined }"
    S->>B: "{ promptName, label: "latest" }"
    Note over B: if(label) branch taken
    B-->>T: Prompt with "latest" label
    T-->>C: formatted prompt response

    C->>T: "getPrompt({ name, label: "production" })"
    Note over T: effectiveLabel = "production"
    T->>S: "{ name, label: "production", version: undefined }"
    S->>B: "{ promptName, label: "production" }"
    B-->>T: Prompt with "production" label
    T-->>C: formatted prompt response

    C->>T: "getPrompt({ name, version: 3 })"
    Note over T: effectiveLabel = undefined (version takes over)
    T->>S: "{ name, label: undefined, version: 3 }"
    S->>B: "{ promptName, version: 3 }"
    Note over B: if(version) branch taken
    B-->>T: Prompt at version 3
    T-->>C: formatted prompt response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Prompt retrieval defaults to p..."](https://github.com/langfuse/langfuse/commit/898b4423b3ca2c5afc0a2a300f50055452c3081f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34577924)</sub>

<!-- /greptile_comment -->