### PR TITLE
fix(mcp): Update descriptions for createScore

### DIFF
--- a/web/src/features/mcp/features/scores/tools/createScore.ts
+++ b/web/src/features/mcp/features/scores/tools/createScore.ts
@@ -36,31 +36,38 @@ const throwCreateScoreBatchError = (error: CreateScoreBatchError): never => {
   throw new ApiServerError("Failed to create score");
 };
 
-const CreateScoreBaseSchema = z.object({
-  id: z.string().optional(),
-  name: z.string().min(1),
-  traceId: z.string().optional(),
-  sessionId: z.string().optional(),
-  datasetRunId: z.string().optional(),
-  observationId: z.string().optional(),
-  comment: z.string().optional(),
-  metadata: z.any().optional(),
-  environment: z.string().optional(),
-  queueId: z.string().optional(),
-  source: PublicApiCreateScoreSourceDomain.optional(),
-  value: z
-    .any()
-    .describe(
-      "Score value. Use number for NUMERIC and BOOLEAN scores; use string for CATEGORICAL, TEXT, and CORRECTION scores.",
-    ),
-  dataType: z
-    .enum(["NUMERIC", "CATEGORICAL", "BOOLEAN", "CORRECTION", "TEXT"])
-    .optional()
-    .describe(
-      "Score data type. When omitted, legacy scoring accepts string or number values.",
-    ),
-  configId: z.string().optional(),
-});
+const CreateScoreBaseSchema = z
+  .object({
+    id: z.string().optional(),
+    name: z.string().min(1),
+    traceId: z.string().optional().describe("Target trace ID."),
+    sessionId: z.string().optional().describe("Target session ID."),
+    datasetRunId: z.string().optional().describe("Target dataset run ID."),
+    observationId: z
+      .string()
+      .optional()
+      .describe("Optional observation ID for trace-scoped scores."),
+    comment: z.string().optional(),
+    metadata: z.any().optional(),
+    environment: z.string().optional(),
+    queueId: z.string().optional(),
+    source: PublicApiCreateScoreSourceDomain.optional(),
+    value: z
+      .any()
+      .describe(
+        'Score value. Must be a JSON number for NUMERIC and BOOLEAN scores; numeric strings like "0.92" are invalid. Use a string for CATEGORICAL, TEXT, and CORRECTION scores.',
+      ),
+    dataType: z
+      .enum(["NUMERIC", "CATEGORICAL", "BOOLEAN", "CORRECTION", "TEXT"])
+      .optional()
+      .describe(
+        "Score data type. When omitted, legacy scoring accepts string or number values.",
+      ),
+    configId: z.string().optional(),
+  })
+  .describe(
+    "Create score request. Provide exactly one of traceId, sessionId, or datasetRunId. observationId may only be provided together with traceId.",
+  );
 
 export const [createScoreTool, handleCreateScore] = defineTool({
   name: "createScore",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the MCP tool descriptions for `createScore`, making the schema hints more precise for LLM clients consuming the tool.

- Adds individual `.describe()` annotations to `traceId`, `sessionId`, `datasetRunId`, and `observationId` fields, and a top-level schema description clarifying the "exactly one of traceId/sessionId/datasetRunId" constraint and the `observationId`+`traceId` pairing rule.
- Tightens the `value` field description to explicitly state that numeric strings like `"0.92"` are invalid for NUMERIC/BOOLEAN scores, where a JSON number is required.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

All changes are description-only — no execution logic, validation rules, or data flow is altered.

The diff touches only Zod .describe() calls and schema reformatting. No runtime behaviour changes; the actual input validation still goes through PostScoresBodyV1.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LLM calls createScore MCP tool] --> B{Validate input\nagainst CreateScoreBaseSchema\ndescriptions}
    B --> C{Validate against\nPostScoresBodyV1}
    C -->|Valid| D[ScoresApiService.createScore]
    C -->|Invalid| E[Throw InvalidRequestError]
    D --> F{result.errors.length > 0?}
    F -->|Yes| G[throwCreateScoreBatchError\n400 / 401 / 404 / 500]
    F -->|No| H{result.successes.length === 1?}
    H -->|No| I[Throw ApiServerError]
    H -->|Yes| J[Return PostScoresResponseV1\nwith score ID]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): Update descriptions for create..."](https://github.com/langfuse/langfuse/commit/4aae6ff3af794390476e168632f4a5460a5667e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34581788)</sub>

<!-- /greptile_comment -->