### PR TITLE
feat(mcp): Add optional id to upsertDataset

### DIFF
--- a/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
+++ b/web/src/__tests__/server/mcp-public-api-tools.servertest.ts
@@ -531,6 +531,43 @@ describe("MCP public API tools", () => {
       expectedOutputSchema: datasetExpectedOutputSchema,
     });
 
+    const renamedDatasetName = `mcp-dataset-renamed-${uuidv4()}`;
+    const renamedDataset = (await handleUpsertDataset(
+      {
+        id: dataset.id,
+        name: renamedDatasetName,
+        description: "Renamed MCP dataset",
+      },
+      context,
+    )) as { id: string; name: string; description: string };
+    expect(renamedDataset).toMatchObject({
+      id: dataset.id,
+      name: renamedDatasetName,
+      description: "Renamed MCP dataset",
+    });
+
+    await expect(
+      handleUpsertDataset(
+        {
+          id: "",
+          name: `mcp-dataset-empty-id-${uuidv4()}`,
+        },
+        context,
+      ),
+    ).rejects.toThrow("Validation failed");
+
+    const conflictingDatasetName = `mcp-dataset-conflict-${uuidv4()}`;
+    await handleUpsertDataset({ name: conflictingDatasetName }, context);
+    await expect(
+      handleUpsertDataset(
+        {
+          id: dataset.id,
+          name: conflictingDatasetName,
+        },
+        context,
+      ),
+    ).rejects.toThrow("Dataset name already in use");
+
     const datasets = (await handleListDatasets(
       { page: 1, limit: 10 },
       context,
@@ -539,7 +576,7 @@ describe("MCP public API tools", () => {
 
     await expect(
       handleGetDataset({ datasetId: dataset.id }, context),
-    ).resolves.toMatchObject({ id: dataset.id, name: datasetName });
+    ).resolves.toMatchObject({ id: dataset.id, name: renamedDatasetName });
 
     const datasetItem = (await handleUpsertDatasetItem(
       {
@@ -549,7 +586,7 @@ describe("MCP public API tools", () => {
       },
       context,
     )) as { id: string; datasetName: string };
-    expect(datasetItem.datasetName).toBe(datasetName);
+    expect(datasetItem.datasetName).toBe(renamedDatasetName);
 
     const datasetItems = (await handleListDatasetItems(
       { datasetId: dataset.id, page: 1, limit: 10 },
@@ -559,7 +596,10 @@ describe("MCP public API tools", () => {
 
     await expect(
       handleGetDatasetItem({ datasetItemId: datasetItem.id }, context),
-    ).resolves.toMatchObject({ id: datasetItem.id, datasetName });
+    ).resolves.toMatchObject({
+      id: datasetItem.id,
+      datasetName: renamedDatasetName,
+    });
 
     const runName = `mcp-run-50% accuracy %20 ${uuidv4()}`;
     const runItem = (await handleCreateDatasetRunItem(

--- a/web/src/features/datasets/server/actions/createDataset.ts
+++ b/web/src/features/datasets/server/actions/createDataset.ts
@@ -1,6 +1,7 @@
 import {
   DatasetNameSchema,
   InvalidRequestError,
+  LangfuseConflictError,
   Prisma,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
@@ -12,6 +13,7 @@ type DatasetJson =
   | typeof Prisma.DbNull;
 
 type UpsertDatasetInput = {
+  id?: string;
   name: string;
   description?: string;
   metadata?: DatasetJson;
@@ -38,6 +40,10 @@ export const upsertDataset = async ({
   input: UpsertDatasetInput;
   projectId: string;
 }) => {
+  if (input.id === "") {
+    throw new InvalidRequestError("Dataset id must not be empty");
+  }
+
   const validation = DatasetNameSchema.safeParse(input.name);
   if (!validation.success) {
     throw new InvalidRequestError(
@@ -45,20 +51,44 @@ export const upsertDataset = async ({
     );
   }
 
-  // Check if dataset exists (for UPDATE path)
   const existingDataset = await prisma.dataset.findUnique({
-    where: {
-      projectId_name: {
-        projectId,
-        name: input.name,
-      },
-    },
+    where: input.id
+      ? {
+          id_projectId: {
+            id: input.id,
+            projectId,
+          },
+        }
+      : {
+          projectId_name: {
+            projectId,
+            name: input.name,
+          },
+        },
     select: {
       id: true,
       inputSchema: true,
       expectedOutputSchema: true,
     },
   });
+
+  if (input.id && !existingDataset) {
+    const existingDatasetWithName = await prisma.dataset.findUnique({
+      where: {
+        projectId_name: {
+          projectId,
+          name: input.name,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    if (existingDatasetWithName) {
+      throw new LangfuseConflictError("Dataset name already in use");
+    }
+  }
 
   // If updating and schemas are being set, validate all existing items
   if (existingDataset) {
@@ -96,48 +126,67 @@ export const upsertDataset = async ({
     }
   }
 
-  return await prisma.dataset.upsert({
-    where: {
-      projectId_name: {
-        projectId,
-        name: input.name,
+  const data = {
+    name: input.name,
+    description: input.description ?? undefined,
+    metadata: input.metadata ?? undefined,
+    inputSchema:
+      input.inputSchema === undefined
+        ? undefined
+        : input.inputSchema === null
+          ? Prisma.DbNull
+          : input.inputSchema,
+    expectedOutputSchema:
+      input.expectedOutputSchema === undefined
+        ? undefined
+        : input.expectedOutputSchema === null
+          ? Prisma.DbNull
+          : input.expectedOutputSchema,
+  };
+
+  try {
+    if (input.id) {
+      return await prisma.dataset.upsert({
+        where: {
+          id_projectId: {
+            id: input.id,
+            projectId,
+          },
+        },
+        create: {
+          id: input.id,
+          ...data,
+          projectId,
+        },
+        update: data,
+      });
+    }
+
+    const { name: _name, ...updateData } = data;
+
+    return await prisma.dataset.upsert({
+      where: {
+        projectId_name: {
+          projectId,
+          name: input.name,
+        },
       },
-    },
-    create: {
-      name: input.name,
-      description: input.description ?? undefined,
-      metadata: input.metadata ?? undefined,
-      inputSchema:
-        input.inputSchema === undefined
-          ? undefined
-          : input.inputSchema === null
-            ? Prisma.DbNull
-            : input.inputSchema,
-      expectedOutputSchema:
-        input.expectedOutputSchema === undefined
-          ? undefined
-          : input.expectedOutputSchema === null
-            ? Prisma.DbNull
-            : input.expectedOutputSchema,
-      projectId,
-    },
-    update: {
-      description: input.description ?? undefined,
-      metadata: input.metadata ?? undefined,
-      inputSchema:
-        input.inputSchema === undefined
-          ? undefined
-          : input.inputSchema === null
-            ? Prisma.DbNull
-            : input.inputSchema,
-      expectedOutputSchema:
-        input.expectedOutputSchema === undefined
-          ? undefined
-          : input.expectedOutputSchema === null
-            ? Prisma.DbNull
-            : input.expectedOutputSchema,
-    },
-  });
+      create: {
+        ...data,
+        projectId,
+      },
+      update: updateData,
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw new LangfuseConflictError("Dataset name already in use");
+    }
+
+    throw error;
+  }
 };
 
 export const updateDataset = async ({

--- a/web/src/features/datasets/server/publicDatasetService.ts
+++ b/web/src/features/datasets/server/publicDatasetService.ts
@@ -78,9 +78,12 @@ type GetDatasetV1Input = z.infer<typeof GetDatasetV1Query> & {
 };
 
 type CreateDatasetInput = {
-  input:
+  input: (
     | z.infer<typeof PostDatasetsV1Body>
-    | z.infer<typeof PostDatasetsV2Body>;
+    | z.infer<typeof PostDatasetsV2Body>
+  ) & {
+    id?: string;
+  };
   projectId: string;
   auditScope?: DatasetAuditScope;
 };
@@ -244,18 +247,26 @@ export const createDatasetForApi = async ({
 }: CreateDatasetInput) => {
   const existingDataset = auditScope
     ? await prisma.dataset.findUnique({
-        where: {
-          projectId_name: {
-            projectId,
-            name: input.name,
-          },
-        },
+        where: input.id
+          ? {
+              id_projectId: {
+                id: input.id,
+                projectId,
+              },
+            }
+          : {
+              projectId_name: {
+                projectId,
+                name: input.name,
+              },
+            },
       })
     : null;
 
   const dataset = await upsertDataset({
     input: {
       name: input.name,
+      id: input.id,
       description: input.description ?? undefined,
       metadata: input.metadata ?? undefined,
       inputSchema: input.inputSchema,

--- a/web/src/features/mcp/features/datasets/tools/upsertDataset.ts
+++ b/web/src/features/mcp/features/datasets/tools/upsertDataset.ts
@@ -8,7 +8,10 @@ import { DatasetJSONSchema } from "@langfuse/shared/src/server";
 import { defineTool } from "../../../core/define-tool";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
+const idField = z.string().min(1).optional();
+
 const UpsertDatasetBaseSchema = z.object({
+  id: idField,
   name: z.string(),
   description: z.string().optional(),
   metadata: z.any().optional(),
@@ -38,6 +41,7 @@ const DatasetJSONSchemaInput = z
 const UpsertDatasetInputSchema = PostDatasetsV2Body.extend({
   inputSchema: DatasetJSONSchemaInput,
   expectedOutputSchema: DatasetJSONSchemaInput,
+  id: idField,
 });
 
 export const [upsertDatasetTool, handleUpsertDataset] = defineTool({


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional `id` field to the MCP `upsertDataset` tool, allowing callers to create or rename a dataset by its ID rather than solely by name.

- **`createDataset.ts`**: Reworks the `upsertDataset` action to branch on whether `id` is supplied — using the `id_projectId` index when present, falling back to `projectId_name`. A pre-flight name-conflict check guards the CREATE path, and a `P2002` catch converts constraint violations into a user-friendly `LangfuseConflictError`.
- **`publicDatasetService.ts`**: Widens `CreateDatasetInput` to accept the optional `id` and updates the audit-log `existingDataset` lookup to use the correct index when `id` is given.
- **`upsertDataset.ts` (MCP tool)**: Introduces a shared `idField = z.string().min(1).optional()` reused in both `UpsertDatasetBaseSchema` and `UpsertDatasetInputSchema`, and extends the test suite with rename, empty-id, and name-conflict scenarios.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the ID-based upsert path is well-guarded with a pre-flight name conflict check and a P2002 catch-all, and the test suite covers the rename, empty-id, and conflict scenarios introduced by this change.

The logic branches cleanly between ID-based and name-based lookups. Race conditions between the pre-flight check and the actual upsert are covered by the P2002 handler. The test additions verify rename, empty-ID rejection, and name-conflict behaviour. No unguarded code paths were found.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MCP upsertDataset call] --> B{id provided?}
    B -- Yes --> C[findUnique by id_projectId]
    B -- No --> D[findUnique by projectId_name]

    C -- Found --> E[Schema validation if needed]
    C -- Not found --> F[findUnique by projectId_name]
    F -- Name taken --> G[throw LangfuseConflictError]
    F -- Name free --> E

    D -- Found or not --> E

    E --> H{id provided?}
    H -- Yes --> I[upsert WHERE id_projectId\nCREATE with id, UPDATE with name+fields]
    H -- No --> J[upsert WHERE projectId_name\nCREATE with fields, UPDATE without name]

    I --> K{P2002?}
    J --> K
    K -- Yes --> L[throw LangfuseConflictError]
    K -- No --> M[return dataset]
    M --> N[auditLog create/update]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(mcp): Add optional id to upsertData..."](https://github.com/langfuse/langfuse/commit/15ea93f25d96e15a37958574f0025133a5bb1545) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34583224)</sub>

<!-- /greptile_comment -->