### PR TITLE
fix(redis): replace socketTimeout with commandTimeout to stop idle-reconnect log spam

### DIFF
--- a/packages/shared/src/server/redis/redis.ts
+++ b/packages/shared/src/server/redis/redis.ts
@@ -8,7 +8,7 @@ const defaultRedisOptions: Partial<RedisOptions> = {
   maxRetriesPerRequest: null,
   enableAutoPipelining: env.REDIS_ENABLE_AUTO_PIPELINING === "true",
   keepAlive: 10000, // 10s — prevents middleboxes from killing idle connections
-  socketTimeout: 30000, // 30s — forces reconnect if no data received, prevents hung moveToCompleted() from blocking concurrency slots forever
+  commandTimeout: 30000, // 30s — aborts pending commands that never receive a response (e.g. hung moveToCompleted()), without firing on intentionally idle queue connections
 };
 
 const REDIS_SCAN_COUNT = 1000;


### PR DESCRIPTION
## Problem

`socketTimeout: 30000` in `defaultRedisOptions` fires whenever no data is received on the socket for 30 seconds — including on intentionally idle BullMQ queue connections. This generates periodic `ERROR` log lines on every queue (`secondary-ingestion-queue`, `notification-queue`, `create-eval-queue`, `batch-export-queue`, etc.) roughly every 30s, even when the worker and Redis are both completely healthy:

```
2026-05-29T20:08:28Z error  Queue job secondary-ingestion-queue errored: Error: Socket timeout. Expecting data, but didn't receive any in 30000ms.
    at Timeout._onTimeout (ioredis/built/Redis.js:467:33)
```

The noise makes it hard to distinguish real errors from the constant reconnect churn.

## Root cause

ioredis `socketTimeout` closes the socket if **no data at all** is received for N ms. On idle queue connections (no jobs arriving), Redis never sends data — so the timeout fires every 30s and triggers a reconnect + BullMQ error log.

## Fix

Replace `socketTimeout` with `commandTimeout`.

`commandTimeout` only fires when a **pending command** has not received a response in N ms — which is the actual failure mode being guarded against (a hung `moveToCompleted()` blocking a BullMQ concurrency slot forever). It does not fire on idle connections where no command is outstanding.

This preserves the original intent (prevent hung commands from starving workers) without the false-positive idle-reconnect errors.

## Testing

- Worker queues stay silent when idle instead of logging ERROR every 30s
- A genuinely hung Redis command (simulated by blocking the socket mid-command) still times out after 30s and retries via BullMQ at-least-once semantics

## References

- ioredis docs: [`socketTimeout`](https://ioredis.js.org/classes/Redis.html) vs [`commandTimeout`](https://ioredis.js.org/classes/Redis.html)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces `socketTimeout: 30000` with `commandTimeout: 30000` in `defaultRedisOptions` to stop periodic false-positive error logs on idle BullMQ queue connections. The root cause is that `socketTimeout` fires whenever no socket data arrives for 30 s — which is normal for queues with no jobs — triggering a reconnect and an error log on every BullMQ queue roughly every 30 s.

- `commandTimeout` only aborts a command that has been *pending* (sent but not answered) for 30 s, so idle connections with no outstanding commands are unaffected, eliminating the log spam while preserving protection against genuinely hung commands like a stalled `moveToCompleted()`.
- The `keepAlive: 10000` TCP option already handles zombie connection detection for connections with no pending commands, so removing `socketTimeout` does not leave idle connections unguarded.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the one-line change correctly addresses the idle-reconnect noise without weakening hung-command protection, and the existing TCP keepalive covers zombie connections with no pending commands.

The change is minimal and well-reasoned. The only nuance worth watching is that `commandTimeout` still applies to BullMQ's blocking poll commands (BLMOVE/BRPOP); BullMQ issues these with short server-side timeouts (~5 s), so in practice the 30 s `commandTimeout` never fires for idle queue polling. This is a pre-existing interaction that the PR does not worsen, but it is worth keeping in mind if BullMQ queue configuration ever changes.

No files require special attention beyond `packages/shared/src/server/redis/redis.ts`, which contains the single changed line.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as BullMQ Worker
    participant IO as ioredis
    participant R as Redis

    Note over W,R: Idle queue (no jobs) — BEFORE fix (socketTimeout)
    W->>IO: BLMOVE wait→active BLOCK 5000
    IO->>R: BLMOVE wait→active BLOCK 5000
    R-->>IO: nil (after 5s, queue empty)
    IO-->>W: nil
    Note over IO: Socket silent for 30s total
    IO->>IO: socketTimeout fires ❌ "Socket timeout" error
    IO->>R: reconnect

    Note over W,R: Idle queue (no jobs) — AFTER fix (commandTimeout)
    W->>IO: BLMOVE wait→active BLOCK 5000
    IO->>R: BLMOVE wait→active BLOCK 5000
    R-->>IO: nil (after 5s, queue empty)
    IO-->>W: nil (command completed — commandTimeout timer never fires ✅)

    Note over W,R: Hung command — AFTER fix (commandTimeout)
    W->>IO: moveToCompleted Lua script
    IO->>R: EVALSHA ...
    Note over R: Redis hangs / no response
    IO->>IO: commandTimeout fires after 30s ✅
    IO-->>W: Error: Command timed out
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/redis/redis.ts:11
**`commandTimeout` applies to BullMQ blocking commands too**

`commandTimeout` fires for *all* pending ioredis commands, including the blocking `BLMOVE`/`BRPOP` calls that BullMQ's Worker connections keep outstanding while waiting for jobs. In practice BullMQ issues these with short server-side timeouts (typically ≤5 s), so each poll completes before the 30 s deadline — but if any blocking command is ever issued with a server-side timeout ≥ 30 s (e.g., `BLMOVE ... 0` for indefinite blocking), `commandTimeout` would fire on it just as `socketTimeout` did. The dedicated `blockingTimeout` option exists precisely to handle blocking commands separately from non-blocking ones, so pairing `commandTimeout` with `blockingTimeout` would give fully independent knobs for each category if that becomes necessary.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(redis): replace socketTimeout with c..."](https://github.com/langfuse/langfuse/commit/9d7933d53e8c677339d754bb32fe7ddbbe7bc95e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34648620)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->