### PR TITLE
 fix(auth): hide credentials signup form when credentials auth is disabled

### DIFF
--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -225,8 +225,8 @@ export function SSOButtons({
       });
   };
 
-  // Only show separator if credentials are enabled (for sign-in) or if action is sign-up (which always has the form)
-  const showSeparator = authProviders.credentials || action !== "sign in";
+  // Only show separator if credentials are enabled
+  const showSeparator = authProviders.credentials;
 
   return (
     // any authprovider from props is enabled

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -231,7 +231,7 @@ export function SSOButtons({
   return (
     // any authprovider from props is enabled
     Object.entries(authProviders).some(
-      ([name, enabled]) => enabled && name !== "credentials",
+      ([name, enabled]) => enabled && name !== "credentials" && name !== "sso",
     ) ? (
       <div>
         {showSeparator ? (
@@ -591,6 +591,12 @@ export default function SignIn({
   );
   const hasMultipleAuthMethods = availableProviders.length > 1;
 
+  // True when at least one static OAuth provider (Google, GitHub, etc.) is configured.
+  // Used to show the "all auth disabled" fallback message when neither credentials nor SSO are enabled.
+  const hasSsoProviders = Object.entries(authProviders).some(
+    ([name, enabled]) => enabled && name !== "credentials" && name !== "sso",
+  );
+
   // Read query params for targetPath and email pre-population
   const queryTargetPath = router.query.targetPath as string | undefined;
   const emailParam = router.query.email as string | undefined;
@@ -695,6 +701,14 @@ export default function SignIn({
         return; // stop further execution – page redirect expected
       }
 
+      // No SSO found
+      if (!authProviders.credentials) {
+        setCredentialsFormError(
+          "Password sign-in is disabled, and no SSO provider is configured for this domain."
+        );
+        return;
+      }
+
       // No SSO – fall back to password step
       setShowPasswordStep(true);
 
@@ -749,14 +763,14 @@ export default function SignIn({
 
         <div className="bg-background mt-14 px-6 py-10 shadow-sm sm:mx-auto sm:w-full sm:max-w-[480px] sm:rounded-lg sm:px-10">
           <div className="space-y-6">
-            {/* Email / (optional) password form – only when credentials auth is enabled */}
-            {authProviders.credentials && (
+            {/* Email / (optional) password form – when credentials auth is enabled OR dynamic SSO is configured */}
+            {authProviders.credentials || authProviders.sso ? (
               <div>
                 <Form {...credentialsForm}>
                   <form
                     className="space-y-6"
                     onSubmit={
-                      showPasswordStep
+                      showPasswordStep && authProviders.credentials
                         ? credentialsForm.handleSubmit(onCredentialsSubmit)
                         : (e) => {
                             e.preventDefault();
@@ -784,8 +798,8 @@ export default function SignIn({
                       )}
                     />
 
-                    {/* Password only shown once we know SSO is not configured */}
-                    {showPasswordStep && (
+                    {/* Password only shown once we know SSO is not configured AND credentials are enabled */}
+                    {showPasswordStep && authProviders.credentials && (
                       <FormField
                         control={credentialsForm.control}
                         name="password"
@@ -816,34 +830,41 @@ export default function SignIn({
                       type="submit"
                       className="w-full"
                       loading={
-                        showPasswordStep
+                        showPasswordStep && authProviders.credentials
                           ? credentialsForm.formState.isSubmitting
                           : continueLoading
                       }
                       disabled={
                         credentialsForm.watch("email") === "" ||
                         (showPasswordStep &&
+                          authProviders.credentials &&
                           credentialsForm.watch("password") === "")
                       }
                       data-testid="submit-email-password-sign-in-form"
                     >
-                      {showPasswordStep ? "Sign in" : "Continue"}
+                      {showPasswordStep && authProviders.credentials ? "Sign in" : "Continue"}
                     </Button>
                   </form>
                 </Form>
-                <div
-                  className={cn(
-                    "text-muted-foreground mt-1 text-center text-xs",
-                    hasMultipleAuthMethods &&
-                      lastUsedAuthMethod === "credentials"
-                      ? "block"
-                      : "hidden",
-                  )}
-                >
-                  Last used
-                </div>
+                {authProviders.credentials && (
+                  <div
+                    className={cn(
+                      "text-muted-foreground mt-1 text-center text-xs",
+                      hasMultipleAuthMethods &&
+                        lastUsedAuthMethod === "credentials"
+                        ? "block"
+                        : "hidden",
+                    )}
+                  >
+                    Last used
+                  </div>
+                )}
               </div>
-            )}
+            ) : !hasSsoProviders ? (
+              <div className="text-muted-foreground text-center text-sm">
+                Sign-in is disabled because no authentication methods are enabled. Please contact your administrator.
+              </div>
+            ) : null}
             {credentialsFormError ? (
               <div className="text-destructive text-center text-sm font-medium">
                 {credentialsFormError}

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -85,6 +85,10 @@ function StandardSignupFlow({
   const queryTargetPath = router.query.targetPath as string | undefined;
   const emailParam = router.query.email as string | undefined;
 
+  const hasSsoProviders = Object.entries(authProviders).some(
+    ([name, enabled]) => enabled && name !== "credentials" && name !== "sso",
+  );
+
   // Validate targetPath to prevent open redirect attacks
   const targetPath = queryTargetPath
     ? getSafeRedirectPath(queryTargetPath)
@@ -302,7 +306,7 @@ function StandardSignupFlow({
             ) : null}
           </form>
         </Form>
-      ) : (
+      ) : hasSsoProviders ? (
         emailParam && (
           <div className="text-muted-foreground mb-6 text-center text-sm">
             You have been invited as{" "}
@@ -310,6 +314,48 @@ function StandardSignupFlow({
             Please sign up with an SSO provider to accept the invitation.
           </div>
         )
+      ) : authProviders.sso ? (
+        <div className="text-muted-foreground mb-6 text-center text-sm">
+          {emailParam ? (
+            <>
+              You have been invited as{" "}
+              <span className="text-primary font-semibold">{emailParam}</span>.
+              Please{" "}
+              <Link
+                href={`/auth/sign-in${router.asPath.includes("?") ? router.asPath.substring(router.asPath.indexOf("?")) : ""}`}
+                className="text-primary-accent hover:text-hover-primary-accent font-semibold"
+              >
+                sign in
+              </Link>{" "}
+              to accept the invitation using your organization's SSO.
+            </>
+          ) : (
+            <>
+              Sign-up is disabled, but you can{" "}
+              <Link
+                href={`/auth/sign-in${router.asPath.includes("?") ? router.asPath.substring(router.asPath.indexOf("?")) : ""}`}
+                className="text-primary-accent hover:text-hover-primary-accent font-semibold"
+              >
+                sign in
+              </Link>{" "}
+              using your organization's SSO.
+            </>
+          )}
+        </div>
+      ) : (
+        <div className="text-muted-foreground mb-6 text-center text-sm">
+          {emailParam ? (
+            <>
+              You have been invited as{" "}
+              <span className="text-primary font-semibold">{emailParam}</span>,
+              but sign-up is disabled because password authentication is
+              disabled and no SSO providers are configured. Please contact your
+              administrator.
+            </>
+          ) : (
+            "Sign-up is disabled because no authentication methods are enabled. Please contact your administrator."
+          )}
+        </div>
       )}
       <SSOButtons
         authProviders={authProviders}
@@ -328,6 +374,10 @@ function VerifiedSignupFlow({
   const router = useRouter();
   const capture = usePostHogClientCapture();
   const emailParam = router.query.email as string | undefined;
+
+  const hasSsoProviders = Object.entries(authProviders).some(
+    ([name, enabled]) => enabled && name !== "credentials" && name !== "sso",
+  );
 
   const [formError, setFormError] = useState<string | null>(null);
   const [phase, setPhase] = useState<SignupPhase>("form");
@@ -537,7 +587,7 @@ function VerifiedSignupFlow({
             ) : null}
           </form>
         </Form>
-      ) : (
+      ) : hasSsoProviders ? (
         emailParam && (
           <div className="text-muted-foreground mb-6 text-center text-sm">
             You have been invited as{" "}
@@ -545,6 +595,48 @@ function VerifiedSignupFlow({
             Please sign up with an SSO provider to accept the invitation.
           </div>
         )
+      ) : authProviders.sso ? (
+        <div className="text-muted-foreground mb-6 text-center text-sm">
+          {emailParam ? (
+            <>
+              You have been invited as{" "}
+              <span className="text-primary font-semibold">{emailParam}</span>.
+              Please{" "}
+              <Link
+                href={`/auth/sign-in${router.asPath.includes("?") ? router.asPath.substring(router.asPath.indexOf("?")) : ""}`}
+                className="text-primary-accent hover:text-hover-primary-accent font-semibold"
+              >
+                sign in
+              </Link>{" "}
+              to accept the invitation using your organization's SSO.
+            </>
+          ) : (
+            <>
+              Sign-up is disabled, but you can{" "}
+              <Link
+                href={`/auth/sign-in${router.asPath.includes("?") ? router.asPath.substring(router.asPath.indexOf("?")) : ""}`}
+                className="text-primary-accent hover:text-hover-primary-accent font-semibold"
+              >
+                sign in
+              </Link>{" "}
+              using your organization's SSO.
+            </>
+          )}
+        </div>
+      ) : (
+        <div className="text-muted-foreground mb-6 text-center text-sm">
+          {emailParam ? (
+            <>
+              You have been invited as{" "}
+              <span className="text-primary font-semibold">{emailParam}</span>,
+              but sign-up is disabled because password authentication is
+              disabled and no SSO providers are configured. Please contact your
+              administrator.
+            </>
+          ) : (
+            "Sign-up is disabled because no authentication methods are enabled. Please contact your administrator."
+          )}
+        </div>
       )}
       <SSOButtons
         authProviders={authProviders}

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -223,84 +223,94 @@ function StandardSignupFlow({
 
   return (
     <SignupPageShell>
-      <Form {...form}>
-        <form
-          className="space-y-6"
-          onSubmit={
-            showPasswordStep
-              ? form.handleSubmit(onSubmit)
-              : (e) => {
-                  e.preventDefault();
-                  void handleContinue();
-                }
-          }
-        >
-          {showPasswordStep && (
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Name</FormLabel>
-                  <FormControl>
-                    <Input placeholder="Jane Doe" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          )}
-          <FormField
-            control={form.control}
-            name="email"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Email</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="jsdoe@example.com"
-                    allowPasswordManager
-                    autoComplete="email"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          {showPasswordStep && (
-            <FormField
-              control={form.control}
-              name="password"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Password</FormLabel>
-                  <FormControl>
-                    <PasswordInput {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          )}
-          <Button
-            type="submit"
-            className="w-full"
-            loading={
-              showPasswordStep ? form.formState.isSubmitting : continueLoading
+      {authProviders.credentials ? (
+        <Form {...form}>
+          <form
+            className="space-y-6"
+            onSubmit={
+              showPasswordStep
+                ? form.handleSubmit(onSubmit)
+                : (e) => {
+                    e.preventDefault();
+                    void handleContinue();
+                  }
             }
-            disabled={showPasswordStep ? false : form.watch("email") === ""}
-            data-testid="submit-email-password-sign-up-form"
           >
-            {showPasswordStep ? "Sign up" : "Continue"}
-          </Button>
-          {formError ? (
-            <div className="text-destructive text-center text-sm font-medium">
-              {formError}
-            </div>
-          ) : null}
-        </form>
-      </Form>
+            {showPasswordStep && (
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Jane Doe" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="jsdoe@example.com"
+                      allowPasswordManager
+                      autoComplete="email"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {showPasswordStep && (
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <FormControl>
+                      <PasswordInput {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+            <Button
+              type="submit"
+              className="w-full"
+              loading={
+                showPasswordStep ? form.formState.isSubmitting : continueLoading
+              }
+              disabled={showPasswordStep ? false : form.watch("email") === ""}
+              data-testid="submit-email-password-sign-up-form"
+            >
+              {showPasswordStep ? "Sign up" : "Continue"}
+            </Button>
+            {formError ? (
+              <div className="text-destructive text-center text-sm font-medium">
+                {formError}
+              </div>
+            ) : null}
+          </form>
+        </Form>
+      ) : (
+        emailParam && (
+          <div className="text-muted-foreground mb-6 text-center text-sm">
+            You have been invited as{" "}
+            <span className="text-primary font-semibold">{emailParam}</span>.
+            Please sign up with an SSO provider to accept the invitation.
+          </div>
+        )
+      )}
       <SSOButtons
         authProviders={authProviders}
         action="sign up"
@@ -475,57 +485,67 @@ function VerifiedSignupFlow({
   // Form phase
   return (
     <SignupPageShell>
-      <Form {...form}>
-        <form
-          className="space-y-6"
-          onSubmit={form.handleSubmit(onVerifiedSubmit)}
-        >
-          <FormField
-            control={form.control}
-            name="name"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Name</FormLabel>
-                <FormControl>
-                  <Input placeholder="Jane Doe" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="email"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Email</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="jsdoe@example.com"
-                    allowPasswordManager
-                    autoComplete="email"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <Button
-            type="submit"
-            className="w-full"
-            loading={form.formState.isSubmitting}
-            data-testid="submit-email-password-sign-up-form"
+      {authProviders.credentials ? (
+        <Form {...form}>
+          <form
+            className="space-y-6"
+            onSubmit={form.handleSubmit(onVerifiedSubmit)}
           >
-            Continue
-          </Button>
-          {formError ? (
-            <div className="text-destructive text-center text-sm font-medium">
-              {formError}
-            </div>
-          ) : null}
-        </form>
-      </Form>
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Jane Doe" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="jsdoe@example.com"
+                      allowPasswordManager
+                      autoComplete="email"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button
+              type="submit"
+              className="w-full"
+              loading={form.formState.isSubmitting}
+              data-testid="submit-email-password-sign-up-form"
+            >
+              Continue
+            </Button>
+            {formError ? (
+              <div className="text-destructive text-center text-sm font-medium">
+                {formError}
+              </div>
+            ) : null}
+          </form>
+        </Form>
+      ) : (
+        emailParam && (
+          <div className="text-muted-foreground mb-6 text-center text-sm">
+            You have been invited as{" "}
+            <span className="text-primary font-semibold">{emailParam}</span>.
+            Please sign up with an SSO provider to accept the invitation.
+          </div>
+        )
+      )}
       <SSOButtons
         authProviders={authProviders}
         action="sign up"


### PR DESCRIPTION
# PR: Respect `AUTH_DISABLE_USERNAME_PASSWORD` on signup/invitation page

**PR Title:** `fix(auth): hide credentials signup form when credentials auth is disabled`

---

## What does this PR do?

This PR fixes a bug where the username/password credentials signup fields (name, email, password) were still rendered on the signup page (which is also used for invitation acceptances) even when password-based authentication was globally disabled via the `AUTH_DISABLE_USERNAME_PASSWORD=true` environment variable.

### Changes:
- **`web/src/pages/auth/sign-up.tsx`**: Wrapped the credentials forms in both `StandardSignupFlow` and `VerifiedSignupFlow` with a conditional check on `authProviders.credentials` to hide the fields when password signup is disabled.
- **`web/src/pages/auth/sign-up.tsx`**: Added a helpful message for invited users (when the `email` query parameter is present) instructing them to accept the invitation by signing up via one of the configured SSO providers.
- **`web/src/pages/auth/sign-in.tsx`**: Adjusted `SSOButtons`'s `showSeparator` property to equal `authProviders.credentials` (instead of `authProviders.credentials || action !== "sign in"`) so that the `"or sign up with"` text separator is correctly hidden when credentials signup is disabled, avoiding an orphaned separator in the UI.

Fixes #13893

### Visual Proof (Screenshots):

#### 1. Credentials Disabled (`AUTH_DISABLE_USERNAME_PASSWORD=true` & Google SSO enabled)

| Signup / Invitation Acceptance Page | Sign-In Page |
| --- | --- |
| <img width="1280" height="800" alt="signup_fix" src="https://github.com/user-attachments/assets/b14824ba-e768-4775-9fc1-3724575a5a05" /> | <img width="1280" height="800" alt="signin_fix" src="https://github.com/user-attachments/assets/81bad0a6-4428-4c7f-9e35-e29118206888" /> |

#### 2. Credentials Enabled (`AUTH_DISABLE_USERNAME_PASSWORD=false` & Google SSO enabled) - Regression Verification

| Signup Page | Sign-In Page |
| --- | --- |
| <img width="1280" height="800" alt="signup_regression" src="https://github.com/user-attachments/assets/4392fdd2-b33e-4e6e-8802-df9703ef83a4" /> | <img width="1280" height="800" alt="signin_regression" src="https://github.com/user-attachments/assets/ac996101-a4d1-4360-a8b5-d75aa30b9123" /> |

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the username/password credential signup form was rendered on the invitation/sign-up page even when `AUTH_DISABLE_USERNAME_PASSWORD=true`. It also corrects an orphaned "or sign up with" separator on that page when credentials are disabled.

- In both `StandardSignupFlow` and `VerifiedSignupFlow`, the credential form is now wrapped in `authProviders.credentials`, and an invitation guidance message is shown instead when credentials are disabled and `?email=` is present.
- `SSOButtons.showSeparator` is simplified from `authProviders.credentials || action !== "sign in"` to just `authProviders.credentials`, removing the separator that previously appeared above SSO buttons on the sign-up page when the credential form was not rendered.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the core bug fix; the credential form is correctly hidden and the orphaned separator is resolved. One edge case — both credentials and all SSO providers disabled — would leave an invited user with a misleading message and no buttons, but this requires a broken configuration unlikely in practice.

Both changed flows apply the same conditional pattern consistently, the showSeparator simplification in SSOButtons is logically sound, and React's JSX escaping keeps the emailParam display safe. The only gap is that the invitation guidance message appears regardless of whether any SSO provider is configured.

The invitation fallback block in web/src/pages/auth/sign-up.tsx (shared between StandardSignupFlow and VerifiedSignupFlow) should verify that at least one non-credential provider is available before instructing users to sign up with an SSO provider.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sign-up page loads] --> B{emailVerificationRequired?}
    B -- Yes --> C[VerifiedSignupFlow]
    B -- No --> D[StandardSignupFlow]
    C --> E{authProviders.credentials?}
    D --> E
    E -- Yes --> F[Render credential form]
    E -- No --> G{emailParam in URL?}
    G -- Yes --> H[Show invitation message]
    G -- No --> I[Render nothing above SSO buttons]
    F --> J[SSOButtons showSeparator=true]
    H --> K{Any SSO provider configured?}
    I --> K
    K -- Yes --> L[SSOButtons renders providers]
    K -- No --> M[SSOButtons returns null - user stuck]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/auth/sign-up.tsx:306-312
**Invitation message shown when no SSO providers exist**

When `authProviders.credentials` is `false`, `emailParam` is present, but no SSO providers are configured, the page renders "Please sign up with an SSO provider to accept the invitation" — yet `SSOButtons` returns `null` because no non-credential providers are enabled. The invited user sees a dead-end with no actionable next step. The same pattern is repeated identically in `VerifiedSignupFlow`. Adding a guard on whether any SSO provider is actually available would prevent the misleading state.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): hide credentials signup form ..."](https://github.com/langfuse/langfuse/commit/b547f6bbc31af6035339e7be68c9fffc26d0914e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34669161)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->