### PR TITLE
fix(worker): remove stale Large Context pricing tier from claude-sonnet-4-6

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -3318,33 +3318,6 @@
           "input_cached_tokens": 3e-7,
           "input_cache_read": 3e-7
         }
-      },
-      {
-        "id": "7830bfc2-c464-4ffe-b9a2-6e741f6c5486",
-        "name": "Large Context",
-        "isDefault": false,
-        "priority": 1,
-        "conditions": [
-          {
-            "usageDetailPattern": "input",
-            "operator": "gt",
-            "value": 200000,
-            "caseSensitive": false
-          }
-        ],
-        "prices": {
-          "input": 6e-6,
-          "input_tokens": 6e-6,
-          "output": 22.5e-6,
-          "output_tokens": 22.5e-6,
-          "cache_creation_input_tokens": 7.5e-6,
-          "input_cache_creation": 7.5e-6,
-          "input_cache_creation_5m": 7.5e-6,
-          "input_cache_creation_1h": 12e-6,
-          "cache_read_input_tokens": 6e-7,
-          "input_cached_tokens": 6e-7,
-          "input_cache_read": 6e-7
-        }
       }
     ]
   },


### PR DESCRIPTION
## Summary

Remove the obsolete \\Large Context\\ pricing tier from the \\claude-sonnet-4-6\\ model definition in \\worker/src/constants/default-model-prices.json\\.

Anthropic [confirmed](https://platform.claude.com/docs/en/about-claude/pricing#long-context-pricing) that Claude Opus 4.6 and Sonnet 4.6 include the full 1M token context window at standard pricing — a 900k-token request is billed at the same per-token rate as a 9k-token request. The long-context premium no longer applies.

## Problem

The stale \\Large Context\\ tier doubled all rates when any \\input\\-matching usage detail exceeded 200K tokens. Because the condition uses a substring match on \\input\\, it triggered on \\cache_read_input_tokens\\ — common with prompt caching — causing **~2x inflated cost calculations**.

Example from the issue reporter:
- Tokens: input=16, cache_read=226,784, cache_creation=48,454, output=2,621
- Langfuse calculated: **\.558544** (Large Context tier, 2x rates)
- Correct cost: **\.289** (standard rates)

## Changes

- Removed the \\Large Context\\ pricing tier object from \\claude-sonnet-4-6\\ (27 lines deleted)
- \\claude-opus-4-6\\ already had only a Standard tier (no change needed)

## Notes on claude-sonnet-4-5

The \\claude-sonnet-4-5-20250929\\ definition also has a Large Context tier. Anthropic's long-context pricing docs only mention Opus 4.6+ and Sonnet 4.6 as models with the premium removed, so I've left the 4.5 tier untouched. If the team has info that 4.5 also lost the premium, happy to include that in this PR.

## Validation

- [x] JSON parses correctly after edit
- [x] Existing \\pricing-tier-matcher.test.ts\\ tests unaffected (they test against \\claude-sonnet-4-5-20250929\\, not 4-6)

## Impacted packages

- \\worker\\

Fixes #12996

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the stale "Large Context" pricing tier from the `claude-sonnet-4-6` model definition in `default-model-prices.json`, fixing a ~2x cost inflation that users experienced when prompt caching was active. The root cause was the tier's unanchored `usageDetailPattern: "input"` acting as a substring regex, so `cache_read_input_tokens` (which contains "input") was included in the condition's sum and could push the total above 200 K tokens even when actual input was tiny.

- **Tier deletion handled automatically**: `upsertDefaultModelPrices.ts` compares JSON tier IDs against the database on startup (step 3 of `upsertModelWithTiers`) and deletes any tier present in the DB but absent from the JSON, so no manual migration is needed.
- **`claude-sonnet-4-5` intentionally untouched**: the PR explicitly preserves the Large Context tier for that model per Anthropic's current pricing documentation, where the 200 K premium still applies.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, single-file JSON edit that removes an incorrect pricing tier, and the existing upsert logic will propagate the deletion to the database automatically on the next deployment.

The removal is accurate and well-scoped: only the stale Large Context tier for claude-sonnet-4-6 is deleted, the Standard tier is untouched, JSON structure remains valid, and the startup upsert script handles DB cleanup via tier-ID diffing. The only observation is that updatedAt was not advanced, which is a hygiene point with no functional impact here.

No files require special attention. The single changed file (worker/src/constants/default-model-prices.json) is straightforward.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming usage details\ne.g. input=16\ncache_read=226k] --> B{Evaluate pricing tiers\nfor claude-sonnet-4-6}
    
    subgraph BEFORE["BEFORE this PR (2 tiers)"]
        B --> C["Sum all keys matching\npattern 'input' (unanchored)"]
        C --> D["input=16\n+ cache_read_input_tokens=226k\n= 226,016 tokens"]
        D --> E{226k > 200k?}
        E -->|YES| F["Large Context tier\n2x rates applied\nCost: ~$0.56"]
        E -->|NO| G["Standard tier\nNormal rates"]
    end

    subgraph AFTER["AFTER this PR (1 tier only)"]
        B --> H["Only 'Standard' tier exists\nNo conditions to check"]
        H --> I["Standard tier always used\nNormal rates applied\nCost: ~$0.29"]
    end

    style BEFORE fill:#ffe6e6,stroke:#cc0000
    style AFTER fill:#e6ffe6,stroke:#006600
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/constants/default-model-prices.json:3297-3298
The model's `updatedAt` was not advanced after removing the Large Context tier. The `upsertDefaultModelPrices` script detects tier-count changes independently of `updatedAt` (via the `isModelUpToDate` tier-ID set comparison), so the stale DB tier will still be cleaned up correctly. That said, bumping `updatedAt` to today's date is the conventional signal that a model definition changed and makes the upgrade path more legible for anyone reading the JSON alongside the git history.

```suggestion
    "createdAt": "2026-02-18T00:00:00.000Z",
    "updatedAt": "2026-05-30T00:00:00.000Z",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): remove stale Large Context ..."](https://github.com/langfuse/langfuse/commit/a52f3dcc7e9f028558a1341b9dff3dc2d4ff128f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34749276)</sub>

<!-- /greptile_comment -->