### PR TITLE
feat: show time-to-first-token tooltip on trace timeline split marker

### DIFF
--- a/web/src/components/trace/components/TraceTimeline/TimelineBar.tsx
+++ b/web/src/components/trace/components/TraceTimeline/TimelineBar.tsx
@@ -12,6 +12,11 @@ import { formatIntervalSeconds } from "@/src/utils/dates";
 import { usdFormatter } from "@/src/utils/numbers";
 import { heatMapTextColor } from "@/src/components/trace/lib/helpers";
 import { isPresent } from "@langfuse/shared";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 
 export function TimelineBar({
   node,
@@ -29,7 +34,7 @@ export function TimelineBar({
   commentCount,
   scores,
 }: TimelineBarProps) {
-  const { startOffset, itemWidth, firstTokenTimeOffset, latency } = metrics;
+  const { startOffset, itemWidth, firstTokenTimeOffset, timeToFirstToken, latency } = metrics;
   const duration = latency ? latency * 1000 : undefined;
   const hasChildren = node.children.length > 0;
 
@@ -53,14 +58,23 @@ export function TimelineBar({
           )}
           style={{ marginLeft: `${startOffset}px` }}
         >
-          {/* First token time bar (waiting period) */}
-          <div
-            className={cn(
-              "bg-muted flex h-8 items-center justify-start rounded-l-sm border-r border-gray-400 opacity-60",
-              itemWidth ? "" : "border border-dashed",
+          {/* First token time bar (waiting period) with TTFT tooltip on the split marker */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={cn(
+                  "bg-muted flex h-8 items-center justify-start rounded-l-sm border-r-2 border-blue-400 opacity-60",
+                  itemWidth ? "" : "border border-dashed",
+                )}
+                style={{ width: `${firstTokenWidth}px` }}
+              />
+            </TooltipTrigger>
+            {timeToFirstToken != null && (
+              <TooltipContent side="top">
+                Time to first token: {formatIntervalSeconds(timeToFirstToken)}
+              </TooltipContent>
             )}
-            style={{ width: `${firstTokenWidth}px` }}
-          />
+          </Tooltip>
 
           {/* Completion time bar */}
           <div

--- a/web/src/components/trace/components/TraceTimeline/timeline-flattening.ts
+++ b/web/src/components/trace/components/TraceTimeline/timeline-flattening.ts
@@ -82,21 +82,30 @@ export function flattenTreeWithTimelineMetrics(
 
     // Handle first token time for streaming LLMs (completionStartTime)
     // This is stored on observations that have streaming responses
-    const firstTokenTimeOffset =
+    const hasCompletionStart =
       "completionStartTime" in currentNode &&
-      currentNode.completionStartTime instanceof Date
-        ? calculateTimelineOffset(
-            currentNode.completionStartTime,
-            traceStartTime,
-            totalScaleSpan,
-            scaleWidth,
-          )
-        : undefined;
+      currentNode.completionStartTime instanceof Date;
+
+    const firstTokenTimeOffset = hasCompletionStart
+      ? calculateTimelineOffset(
+          (currentNode as { completionStartTime: Date }).completionStartTime,
+          traceStartTime,
+          totalScaleSpan,
+          scaleWidth,
+        )
+      : undefined;
+
+    const timeToFirstToken = hasCompletionStart
+      ? ((currentNode as { completionStartTime: Date }).completionStartTime.getTime() -
+          currentNode.startTime.getTime()) /
+        1000
+      : undefined;
 
     const metrics: TimelineMetrics = {
       startOffset,
       itemWidth,
       firstTokenTimeOffset,
+      timeToFirstToken,
       latency,
     };
 

--- a/web/src/components/trace/components/TraceTimeline/types.ts
+++ b/web/src/components/trace/components/TraceTimeline/types.ts
@@ -18,6 +18,8 @@ export interface TimelineMetrics {
   itemWidth: number;
   /** Offset for first token time marker (for streaming LLMs, in pixels) */
   firstTokenTimeOffset?: number;
+  /** Time to first token in seconds (for streaming LLMs) */
+  timeToFirstToken?: number;
   /** Duration in seconds */
   latency?: number;
 }


### PR DESCRIPTION
## Summary

Resolves #3517.

TTFT was already computed and shown in the observation detail panel, but the Trace Timeline view had no way to read the exact value without clicking through. This PR surfaces it directly on the timeline.

## Changes

### `types.ts`
Added `timeToFirstToken?: number` (in seconds) to `TimelineMetrics` alongside the existing `firstTokenTimeOffset` (pixels).

### `timeline-flattening.ts`
Computed `timeToFirstToken = (completionStartTime - startTime) / 1000` for observations that have a `completionStartTime`. Refactored the repeated `"completionStartTime" in currentNode` check into a single `hasCompletionStart` variable.

### `TimelineBar.tsx`
Wrapped the waiting-period div (left side of the split bar) in a Radix `Tooltip` that shows **"Time to first token: Xs"** on hover. Changed the split border from `border-gray-400` to `border-blue-400 border-r-2` to make the marker more visually distinct.

## Before / After

**Before:** The split bar showed two muted segments with a subtle gray border and "First token" text—TTFT duration not visible.

**After:** Hovering the split marker shows a tooltip with the exact TTFT duration; the marker is highlighted in blue.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces the time-to-first-token (TTFT) value directly on the trace timeline by adding a Radix `Tooltip` to the waiting-period segment of streaming LLM spans, so users no longer need to click through to the observation detail panel to read the exact duration.

- **`types.ts` / `timeline-flattening.ts`**: `timeToFirstToken` (seconds) is computed alongside the existing `firstTokenTimeOffset` (pixels) from the same `hasCompletionStart` guard, keeping the two values in sync. The refactoring is clean and the type cast is safe given the runtime check.
- **`TimelineBar.tsx`**: The waiting-period div is wrapped in a `Tooltip` (provider is globally registered in `_app.tsx`). The new `border-blue-400` split-marker color is a raw palette value rather than a semantic theme token, unlike the rest of the component's styling.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the only concern is a hardcoded Tailwind palette color that won't adapt if the design token system is ever customised.

The tooltip logic is correct, the global TooltipProvider is confirmed in _app.tsx, and the TTFT computation mirrors the pre-existing observation detail panel calculation. The single style note — border-blue-400 bypassing the semantic theming tokens — is a cosmetic risk rather than a functional one.

A second look at TimelineBar.tsx is worthwhile to confirm the border-blue-400 colour is intentional given the project's Tailwind theming setup.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TF as timeline-flattening.ts
    participant TM as TimelineMetrics (types.ts)
    participant TB as TimelineBar.tsx
    participant TT as Radix Tooltip

    TF->>TF: Check hasCompletionStart
    TF->>TF: Compute firstTokenTimeOffset (px)
    TF->>TF: Compute timeToFirstToken (s)
    TF->>TM: "Store {firstTokenTimeOffset, timeToFirstToken}"
    TM->>TB: Pass metrics as props
    TB->>TB: if (firstTokenTimeOffset) → split-bar branch
    TB->>TT: Render Tooltip wrapping waiting-period div
    TT-->>TB: User hovers split marker
    TB->>TT: Show TooltipContent: Time to first token Xs
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/trace/components/TraceTimeline/TimelineBar.tsx:66
The split-bar marker now uses `border-blue-400`, a raw Tailwind palette color that is not sensitive to the active theme. The rest of the component relies on semantic tokens (`bg-muted`, `border-border`, `text-primary`). If the color scheme is customised or dark-mode contrast is tuned via CSS variables, this border will stay fixed at the hardcoded blue shade. Consider using a semantic accent token — e.g. `border-primary` — to keep the marker consistent with the theming system.

```suggestion
                  "bg-muted flex h-8 items-center justify-start rounded-l-sm border-r-2 border-primary opacity-60",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add TTFT tooltip marker on trace t..."](https://github.com/langfuse/langfuse/commit/527b0f9805d75ff224288273bc689f190796fef3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34777458)</sub>

<!-- /greptile_comment -->