### PR TITLE
refactor(web): Align peek view detail components

### DIFF
--- a/web/src/components/table/peek/peek-evaluator-config-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-config-detail.tsx
@@ -23,8 +23,9 @@ import { LegacyEvalCallout } from "@/src/features/evals/components/legacy-eval-c
 import { EvaluatorPausedCallout } from "@/src/features/evals/components/evaluator-paused-callout";
 import { isLegacyEvalTarget } from "@/src/features/evals/utils/typeHelpers";
 import { useLazyEvaluatorExecutionCounts } from "@/src/features/evals/hooks/useLazyEvaluatorExecutionCounts";
+import { TablePeekView } from "@/src/components/table/peek";
 
-export const PeekViewEvaluatorConfigDetail = ({
+const PeekViewEvaluatorConfigDetail = ({
   projectId,
 }: {
   projectId: string;
@@ -158,5 +159,22 @@ export const PeekViewEvaluatorConfigDetail = ({
         />
       </div>
     </div>
+  );
+};
+
+export const TablePeekViewEvaluatorConfigDetail = (
+  props: Omit<
+    React.ComponentProps<typeof TablePeekView>,
+    "children" | "title"
+  > & {
+    projectId: string;
+  },
+) => {
+  const { projectId } = props;
+
+  return (
+    <TablePeekView {...props}>
+      <PeekViewEvaluatorConfigDetail projectId={projectId} />
+    </TablePeekView>
   );
 };

--- a/web/src/components/table/peek/peek-evaluator-template-detail.tsx
+++ b/web/src/components/table/peek/peek-evaluator-template-detail.tsx
@@ -4,8 +4,9 @@ import { usePeekEvalTemplateData } from "@/src/components/table/peek/hooks/usePe
 import { EvalTemplateForm } from "@/src/features/evals/components/template-form";
 import { MaintainerTooltip } from "@/src/features/evals/components/maintainer-tooltip";
 import { getMaintainer } from "@/src/features/evals/utils/typeHelpers";
+import { TablePeekView } from "@/src/components/table/peek";
 
-export const PeekViewEvaluatorTemplateDetail = ({
+const PeekViewEvaluatorTemplateDetail = ({
   projectId,
 }: {
   projectId: string;
@@ -42,5 +43,22 @@ export const PeekViewEvaluatorTemplateDetail = ({
         />
       </div>
     </div>
+  );
+};
+
+export const TablePeekViewEvaluatorTemplateDetail = (
+  props: Omit<
+    React.ComponentProps<typeof TablePeekView>,
+    "children" | "title"
+  > & {
+    projectId: string;
+  },
+) => {
+  const { projectId } = props;
+
+  return (
+    <TablePeekView {...props}>
+      <PeekViewEvaluatorTemplateDetail projectId={projectId} />
+    </TablePeekView>
   );
 };

--- a/web/src/components/table/peek/peek-experiment-item-detail.tsx
+++ b/web/src/components/table/peek/peek-experiment-item-detail.tsx
@@ -2,12 +2,9 @@ import { useRouter } from "next/router";
 import { usePeekData } from "@/src/components/table/peek/hooks/usePeekData";
 import { Trace } from "@/src/components/trace/Trace";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import { TablePeekView } from "@/src/components/table/peek";
 
-export const PeekViewExperimentItemDetail = ({
-  projectId,
-}: {
-  projectId: string;
-}) => {
+const PeekViewExperimentItemDetail = ({ projectId }: { projectId: string }) => {
   const router = useRouter();
   const peekId = router.query.peek as string | undefined;
   const timestampParam = router.query.timestamp as string | undefined;
@@ -40,5 +37,27 @@ export const PeekViewExperimentItemDetail = ({
       observations={trace.data.observations}
       context="peek"
     />
+  );
+};
+
+export const TablePeekViewExperimentItemDetail = (
+  props: Omit<
+    React.ComponentProps<typeof TablePeekView>,
+    "children" | "title"
+  > & {
+    projectId: string;
+  },
+) => {
+  const { projectId } = props;
+  const router = useRouter();
+  const peekId = router.query.peek as string | undefined;
+
+  return (
+    <TablePeekView
+      {...props}
+      title={peekId ? `Experiment Item: ${peekId}` : undefined}
+    >
+      <PeekViewExperimentItemDetail projectId={projectId} />
+    </TablePeekView>
   );
 };

--- a/web/src/components/table/peek/peek-observation-detail.tsx
+++ b/web/src/components/table/peek/peek-observation-detail.tsx
@@ -4,7 +4,7 @@ import { Trace } from "@/src/components/trace/Trace";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { useRouter } from "next/router";
 
-export const PeekViewObservationDetail = ({
+const PeekViewObservationDetail = ({
   peekId,
   trace,
 }: {

--- a/web/src/components/table/peek/peek-trace-detail.tsx
+++ b/web/src/components/table/peek/peek-trace-detail.tsx
@@ -4,7 +4,7 @@ import { Trace } from "@/src/components/trace/Trace";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import { TablePeekView } from "@/src/components/table/peek";
 
-export const PeekViewTraceDetail = ({
+const PeekViewTraceDetail = ({
   trace,
 }: {
   trace: ReturnType<typeof usePeekData>;

--- a/web/src/features/evals/components/eval-templates-table.tsx
+++ b/web/src/features/evals/components/eval-templates-table.tsx
@@ -11,9 +11,8 @@ import { useQueryParam, StringParam, withDefault } from "use-query-params";
 import { useEffect, useMemo, useState } from "react";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
 import TableIdOrName from "@/src/components/table/table-id";
-import { PeekViewEvaluatorTemplateDetail } from "@/src/components/table/peek/peek-evaluator-template-detail";
+import { TablePeekViewEvaluatorTemplateDetail } from "@/src/components/table/peek/peek-evaluator-template-detail";
 import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
-import { TablePeekView } from "@/src/components/table/peek";
 import { useDetailPageLists } from "@/src/features/navigate-detail-pages/context";
 import { Button } from "@/src/components/ui/button";
 import { useRouter } from "next/router";
@@ -487,9 +486,10 @@ export default function EvalsTemplateTable({
           />
         </div>
       </div>
-      <TablePeekView {...peekConfig}>
-        <PeekViewEvaluatorTemplateDetail projectId={projectId} />
-      </TablePeekView>
+      <TablePeekViewEvaluatorTemplateDetail
+        {...peekConfig}
+        projectId={projectId}
+      />
       <Dialog
         open={!!editTemplateId && template.isSuccess}
         onOpenChange={(open) => {

--- a/web/src/features/evals/components/evaluator-table.tsx
+++ b/web/src/features/evals/components/evaluator-table.tsx
@@ -26,8 +26,7 @@ import { useOrderByState } from "@/src/features/orderBy/hooks/useOrderByState";
 import TableIdOrName from "@/src/components/table/table-id";
 import { MoreVertical, ExternalLinkIcon, Edit, Info } from "lucide-react";
 import { usePeekNavigation } from "@/src/components/table/peek/hooks/usePeekNavigation";
-import { PeekViewEvaluatorConfigDetail } from "@/src/components/table/peek/peek-evaluator-config-detail";
-import { TablePeekView } from "@/src/components/table/peek";
+import { TablePeekViewEvaluatorConfigDetail } from "@/src/components/table/peek/peek-evaluator-config-detail";
 import { evalConfigTargetValues } from "@/src/server/api/definitions/evalConfigsTable";
 import {
   DropdownMenu,
@@ -528,9 +527,10 @@ export default function EvaluatorTable({ projectId }: { projectId: string }) {
             />
           </div>
         </ResizableFilterLayout>
-        <TablePeekView {...peekConfig}>
-          <PeekViewEvaluatorConfigDetail projectId={projectId} />
-        </TablePeekView>
+        <TablePeekViewEvaluatorConfigDetail
+          {...peekConfig}
+          projectId={projectId}
+        />
       </div>
       <Dialog
         open={!!editConfigId && existingEvaluator.isSuccess}

--- a/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentItemsTable.tsx
@@ -50,10 +50,7 @@ import {
   getExperimentColorStyles,
 } from "./types";
 import { MemoizedIOTableCell } from "@/src/components/ui/IOTableCell";
-import {
-  type DataTablePeekViewProps,
-  TablePeekView,
-} from "@/src/components/table/peek";
+import { type DataTablePeekViewProps } from "@/src/components/table/peek";
 import { cn } from "@/src/utils/tailwind";
 import { useScoreColumns } from "@/src/features/scores/hooks/useScoreColumns";
 import { scoreFilters } from "@/src/features/scores/lib/scoreColumns";
@@ -62,8 +59,7 @@ import { ExperimentCompareTable } from "./ExperimentCompareTable";
 import { useExperimentNames } from "@/src/features/experiments/hooks/useExperimentNames";
 import { DiffLabel } from "@/src/features/datasets/components/DiffLabel";
 import { computeScoreDiffs } from "@/src/features/datasets/lib/computeScoreDiffs";
-import { useRouter } from "next/router";
-import { PeekViewExperimentItemDetail } from "@/src/components/table/peek/peek-experiment-item-detail";
+import { TablePeekViewExperimentItemDetail } from "@/src/components/table/peek/peek-experiment-item-detail";
 
 const renderExperimentSpecificHeader = (label: string) => (
   <span className="text-muted-foreground">{label}</span>
@@ -227,7 +223,6 @@ export default function ExperimentItemsTable({
   projectId,
   hideControls = false,
 }: ExperimentItemsTableProps) {
-  const router = useRouter();
   const { setDetailPageList } = useDetailPageLists();
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
   const [showRunEvaluationDialog, setShowRunEvaluationDialog] = useState(false);
@@ -912,9 +907,6 @@ export default function ExperimentItemsTable({
     };
   }, [peekNavigationProps, canUsePeek]);
 
-  const peekId =
-    typeof router.query.peek === "string" ? router.query.peek : undefined;
-
   const rows: ExperimentItemsTableRow[] = useMemo(() => {
     if (items.status === "success" && items.rows) {
       // Add 'id' field for DataTable row identification (peek view requires it)
@@ -1159,12 +1151,10 @@ export default function ExperimentItemsTable({
 
         {/* Peek view panel */}
         {peekConfig && (
-          <TablePeekView
+          <TablePeekViewExperimentItemDetail
             {...peekConfig}
-            title={peekId ? `Experiment Item: ${peekId}` : undefined}
-          >
-            <PeekViewExperimentItemDetail projectId={projectId} />
-          </TablePeekView>
+            projectId={projectId}
+          />
         )}
 
         {/* Run Evaluation Dialog */}


### PR DESCRIPTION
[https://github.com/langfuse/langfuse/pull/13283](https://github.com/langfuse/langfuse/pull/13283/changes#diff-dcb0f29a49d84b953986cbbb3bdecc9cb3b151d6268dffd530ef330fd33df2aa) added new `TablePeekViewObservationDetail` and `TablePeekViewTraceDetail` components that inline TablePeekView while all other peek views still are wrapped by `TablePeekView`. This PR aligns this.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the peek-view detail components to follow a consistent wrapper pattern, aligning `PeekViewEvaluatorConfigDetail`, `PeekViewEvaluatorTemplateDetail`, and `PeekViewExperimentItemDetail` with the already-refactored `TablePeekViewTraceDetail` and `TablePeekViewObservationDetail`.

- Introduces public `TablePeekView*` wrapper components (e.g., `TablePeekViewEvaluatorConfigDetail`, `TablePeekViewExperimentItemDetail`) that encapsulate `TablePeekView`, while making the underlying detail components private (non-exported).
- Updates all call sites (`eval-templates-table.tsx`, `evaluator-table.tsx`, `ExperimentItemsTable.tsx`) to use the new wrappers, removing the now-redundant inline `TablePeekView` usage and the related `router.query.peek` derivation from `ExperimentItemsTable`.
- Removes the `useRouter` import from `ExperimentItemsTable.tsx` since the `peekId` for the title is now computed inside `TablePeekViewExperimentItemDetail`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely structural refactoring with no behavioral changes at the call sites.

All five changed peek-detail components now consistently encapsulate TablePeekView inside a public wrapper, matching the pattern already used by the observation and trace variants. The only notable point is the duplicate useRouter() call in TablePeekViewExperimentItemDetail / PeekViewExperimentItemDetail, but that is a minor style matter with no runtime impact. Title logic, props forwarding, and the removal of the inline router/peekId variables in ExperimentItemsTable are all correct.

No files require special attention; peek-experiment-item-detail.tsx has a minor redundancy worth cleaning up but nothing blocking.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Call Site\ne.g. EvaluatorTable] -->|passes peekConfig + projectId| B[TablePeekViewEvaluatorConfigDetail\nPublic wrapper]
    B -->|spreads props, no title| C[TablePeekView\nSheets container]
    C -->|title falls back to router.query.peek| D[SheetHeader / title]
    C --> E[PeekViewEvaluatorConfigDetail\nPrivate inner component]

    F[ExperimentItemsTable] -->|passes peekConfig + projectId| G[TablePeekViewExperimentItemDetail\nPublic wrapper]
    G -->|reads router.query.peek for title| H[TablePeekView\ntitle = Experiment Item: peekId]
    H --> I[PeekViewExperimentItemDetail\nPrivate inner component\nalso reads useRouter]

    J[Already-refactored\ne.g. TracesTable] --> K[TablePeekViewTraceDetail]
    K -->|computes title from trace data| L[TablePeekView]
    L --> M[PeekViewTraceDetail]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/table/peek/peek-experiment-item-detail.tsx:7-10
`useRouter` is called twice: once in the wrapper (`TablePeekViewExperimentItemDetail`) to derive the title, and again inside `PeekViewExperimentItemDetail` for the same `peekId` as well as `timestampParam` and `traceId`. The wrapper's `peekId` can be passed down as a prop to the inner component, eliminating the duplicate hook call and mirroring how `TablePeekViewObservationDetail` handles this (which also receives `peekId` explicitly).

```suggestion
const PeekViewExperimentItemDetail = ({
  projectId,
  peekId,
}: {
  projectId: string;
  peekId: string | undefined;
}) => {
  const router = useRouter();
  const timestampParam = router.query.timestamp as string | undefined;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: Align peek view detail compone..."](https://github.com/langfuse/langfuse/commit/e4f7333939247c658e5a555d62f9317516b94aba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34877002)</sub>

<!-- /greptile_comment -->