### PR TITLE
docs(agents): warn against is_deleted filter on ClickHouse reads

### DIFF
--- a/.agents/skills/backend-dev-guidelines/references/database-patterns.md
+++ b/.agents/skills/backend-dev-guidelines/references/database-patterns.md
@@ -358,6 +358,28 @@ const query = `
 `;
 ```
 
+**`is_deleted` on ReplacingMergeTree tables is a dormant artifact — do not filter on it.**
+
+The `traces`, `observations`, and `scores` tables are declared
+as `ReplacingMergeTree(event_ts, is_deleted)`, which gives the
+engine an `is_deleted` deletion column. However, **no
+production code writes `is_deleted = 1`**. A full repo search
+for `is_deleted: 1` returns zero hits. All actual deletes use
+ClickHouse's lightweight `DELETE FROM` mutation (e.g.
+`deleteObservationsByTraceIds`,
+`deleteObservationsByProjectId`,
+`deleteObservationsOlderThanDays`), which marks rows via the
+engine-managed `_row_exists` column. `_row_exists` is handled
+transparently by the read path; it does **not** require any
+special query handling.
+
+What this means for query authors:
+
+- **Do not add `WHERE is_deleted = 0` filters** to reads. The
+  column is always `0` in practice, so the filter is dead
+  weight that obscures intent. Reviewers should reject this
+  unless soft-delete writes have actually been introduced.
+
 **3. Use time-based filtering for performance:**
 
 ```typescript

--- a/.agents/skills/backend-dev-guidelines/references/database-patterns.md
+++ b/.agents/skills/backend-dev-guidelines/references/database-patterns.md
@@ -358,27 +358,33 @@ const query = `
 `;
 ```
 
-**`is_deleted` on ReplacingMergeTree tables is a dormant artifact — do not filter on it.**
+**`is_deleted` on `traces`, `observations`, and `scores` is dormant — avoid new filters.**
 
-The `traces`, `observations`, and `scores` tables are declared
-as `ReplacingMergeTree(event_ts, is_deleted)`, which gives the
-engine an `is_deleted` deletion column. However, **no
-production code writes `is_deleted = 1`**. A full repo search
-for `is_deleted: 1` returns zero hits. All actual deletes use
+These three tables are declared as
+`ReplacingMergeTree(event_ts, is_deleted)`, but no production
+code writes `is_deleted = 1` for them — all deletes use
 ClickHouse's lightweight `DELETE FROM` mutation (e.g.
 `deleteObservationsByTraceIds`,
 `deleteObservationsByProjectId`,
 `deleteObservationsOlderThanDays`), which marks rows via the
 engine-managed `_row_exists` column. `_row_exists` is handled
-transparently by the read path; it does **not** require any
-special query handling.
+transparently by the read path; no special query handling is
+needed.
 
 What this means for query authors:
 
-- **Do not add `WHERE is_deleted = 0` filters** to reads. The
-  column is always `0` in practice, so the filter is dead
-  weight that obscures intent. Reviewers should reject this
-  unless soft-delete writes have actually been introduced.
+- **`WHERE is_deleted = 0` filters on these three tables are
+  dead weight in practice.** A few legacy reads still carry
+  them (e.g. `web/src/features/score-analytics/server/`); new
+  code should not add them unless soft-delete writes have
+  actually been introduced.
+
+**Separate case: `blob_storage_file_log`.** This table is also
+a `ReplacingMergeTree` but **does** use soft-delete
+intentionally — `ingestionFileDeletion.ts` writes
+`is_deleted: "1"`, `batch-project-blob-cleaner` reads with
+`countIf(is_deleted = 1)`. The guidance above does not apply
+to it.
 
 **3. Use time-based filtering for performance:**
 


### PR DESCRIPTION
## Summary
- Adds backend agent guidance noting that the `is_deleted` column on the `traces`/`observations`/`scores` ReplacingMergeTree tables is a dormant artifact.
- A full repo search for `is_deleted: 1` returns zero hits; all actual deletes use `DELETE FROM` (ClickHouse lightweight delete via `_row_exists`), not soft-delete.
- Tells query authors not to add defensive `WHERE is_deleted = 0` filters or `SELECT * EXCEPT (is_deleted) FROM (...)` wrappers — reviewers should reject them on sight unless soft-delete writes have actually been introduced.

## Impacted packages
- `.agents/skills/backend-dev-guidelines/`

## Verification
- Docs-only change. No code paths affected, no tests required.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a documentation warning to the backend dev agent skills reference discouraging developers from adding `WHERE is_deleted = 0` guards to ClickHouse reads on the `traces`, `observations`, and `scores` tables, explaining that the column is always `0` in practice and that actual hard-deletes use lightweight `DELETE FROM` mutations.

- Adds a new section explaining that `is_deleted` is a dormant `ReplacingMergeTree` artifact for the three main telemetry tables and should not be filtered on in new queries.
- The schema facts and deletion-path description are accurate based on the migration files and `IngestionService`, but the "zero hits" claim in the prose is slightly overstated — `is_deleted: "1"` is actively written to the separate `blob_storage_file_log` table, and `buildEstimateQuery.ts`/`buildScoreComparisonQuery.ts` already filter `scores` with `AND is_deleted = 0`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change to an agent skills reference file; no runtime code is affected.

The schema facts and deletion-path description are correct, but the "zero hits" statement overstates the case — `is_deleted: 1` is actively used on `blob_storage_file_log`, and production score-analytics queries already carry the exact `AND is_deleted = 0` filter the doc tells reviewers to reject.

.agents/skills/backend-dev-guidelines/references/database-patterns.md — the "zero hits" claim and missing acknowledgement of pre-existing score-analytics filters need tightening.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.agents/skills/backend-dev-guidelines/references/database-patterns.md:364-371
**"Zero hits" claim is inaccurate and may confuse AI agents reading this doc**

The assertion that "a full repo search for `is_deleted: 1` returns zero hits" is not true repo-wide. `packages/shared/src/server/data-deletion/ingestionFileDeletion.ts` writes `is_deleted: "1"` to the `blob_storage_file_log` table (a separate `ReplacingMergeTree` that intentionally uses soft-delete), and `worker/src/features/batch-project-blob-cleaner/index.ts` queries `countIf(is_deleted = 1)` against that same table. Additionally, `web/src/features/score-analytics/server/buildEstimateQuery.ts` and `buildScoreComparisonQuery.ts` already filter `scores` with `AND is_deleted = 0` in production — the exact pattern the guidance says to reject. Scoping the claim to "for traces, observations, and scores no write of `is_deleted = 1` exists" and acknowledging the pre-existing `scores` filters would keep this accurate.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): warn against is\_deleted fi..."](https://github.com/langfuse/langfuse/commit/06ff08f5d7c6ca4498ea8407abd58c95448e903c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34874464)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->