### PR TITLE
chore: adding a few more tests after #13644

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/search.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/search.ts
@@ -10,7 +10,7 @@ const regexIndefiniteCharacters = "%";
  * UTF-16 surrogate pair). ASCII is left untouched.
  *
  * Trace / observation `input` and `output` ingested through that path is persisted in ClickHouse
- * verbatim in this escaped form (e.g. `你好` is stored as the literal `你好`), so a
+ * verbatim in this escaped form (e.g. `你好` is stored as the literal `\u4f60\u597d`), so a
  * substring search for the raw, human-readable text would never match it. By also searching for
  * this escaped form we recover full-text search for non-English content. See issue #11538.
  */

--- a/web/src/__tests__/server/clickhouseSearchCondition.servertest.ts
+++ b/web/src/__tests__/server/clickhouseSearchCondition.servertest.ts
@@ -2,8 +2,12 @@ import { env } from "@/src/env.mjs";
 import { type TracingSearchType } from "@langfuse/shared";
 import {
   clickhouseSearchCondition,
+  createEvent,
+  createEventsCh,
+  getObservationsWithModelDataFromEventsTable,
   queryClickhouse,
 } from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
 
 const maybeEventsTable =
   env.LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS === "true"
@@ -25,6 +29,8 @@ const searchFixture = `
     ('output-match-cyrillic', 'plain name', 'unrelated input', 'contains привет token'),
     ('input-match-cjk', 'plain name', 'contains 東京 token', 'unrelated output'),
     ('output-match-cjk', 'plain name', 'unrelated input', 'contains 東京 token'),
+    ('input-match-escaped-cjk', 'plain name', 'contains \\\\u6771\\\\u4eac token', 'unrelated output'),
+    ('output-match-escaped-cjk', 'plain name', 'unrelated input', 'contains \\\\u6771\\\\u4eac token'),
     ('miss', 'plain name', 'unrelated input', 'unrelated output')
   ) AS e
 `;
@@ -123,10 +129,15 @@ describe("clickhouseSearchCondition", () => {
       {
         query: "東京",
         searchType: ["content"],
-        expectedIds: ["input-match-cjk", "output-match-cjk"],
+        expectedIds: [
+          "input-match-cjk",
+          "input-match-escaped-cjk",
+          "output-match-cjk",
+          "output-match-escaped-cjk",
+        ],
       },
     ])(
-      "preserves baseline substring search semantics for $query $searchType search",
+      "matches expected substring rows for $query $searchType search",
       async ({ query, searchType, expectedIds }) => {
         await expect(
           matchingIds({
@@ -150,6 +161,116 @@ describe("clickhouseSearchCondition", () => {
 
       expect(baseIds).toEqual(["id-match"]);
       expect(ftsIds).toEqual(baseIds);
+    });
+
+    it("matches JSON-escaped Unicode content on events tables with the FTS prefilter", async () => {
+      const search = clickhouseSearchCondition({
+        query: "東京",
+        searchType: ["content"],
+        tablePrefix: "e",
+        searchColumns: ["id", "name"],
+        useEventsTablePath: true,
+      });
+
+      expect(search.params).toMatchObject({
+        searchString: "%東京%",
+        searchStringEscaped: "%\\u6771\\u4eac%",
+      });
+      expect(search.query).toContain("{searchStringEscaped: String}");
+      expect(search.query).toContain(
+        "hasAllTokens(lower(e.input), lower({searchStringEscaped: String}))",
+      );
+      expect(search.query).toContain(
+        "hasAllTokens(lower(e.output), lower({searchStringEscaped: String}))",
+      );
+
+      await expect(
+        matchingIds({
+          query: "東京",
+          searchType: ["content"],
+          useEventsTablePath: true,
+        }),
+      ).resolves.toEqual([
+        "input-match-cjk",
+        "input-match-escaped-cjk",
+        "output-match-cjk",
+        "output-match-escaped-cjk",
+      ]);
+    });
+
+    it("round-trips raw and JSON-escaped Unicode through events_full search", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const rawSpanId = randomUUID();
+      const escapedSpanId = randomUUID();
+      const rawInput = `{"message":"東京"}`;
+      const escapedInput = `{"message":"\\u6771\\u4eac"}`;
+
+      await createEventsCh([
+        createEvent({
+          id: rawSpanId,
+          span_id: rawSpanId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "GENERATION",
+          name: "raw-unicode-search-roundtrip",
+          input: rawInput,
+          output: "ascii output",
+        }),
+        createEvent({
+          id: escapedSpanId,
+          span_id: escapedSpanId,
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "GENERATION",
+          name: "escaped-unicode-search-roundtrip",
+          input: escapedInput,
+          output: "ascii output",
+        }),
+      ]);
+
+      const stored = await queryClickhouse<{ span_id: string; input: string }>({
+        query: `
+          SELECT span_id, input
+          FROM events_full
+          WHERE project_id = {projectId: String}
+            AND span_id IN ({rawSpanId: String}, {escapedSpanId: String})
+          ORDER BY span_id ASC
+        `,
+        params: {
+          projectId: uniqueProjectId,
+          rawSpanId,
+          escapedSpanId,
+        },
+        preferredClickhouseService: "EventsReadOnly",
+        tags: {
+          feature: "clickhouse-search-condition-test",
+          type: "events",
+          kind: "test",
+        },
+      });
+
+      expect(stored).toHaveLength(2);
+      expect(rawInput).not.toBe(escapedInput);
+
+      const storedInputBySpanId = new Map(
+        stored.map((row) => [row.span_id, row.input]),
+      );
+      expect(storedInputBySpanId.get(rawSpanId)).toBe(rawInput);
+      expect(storedInputBySpanId.get(escapedSpanId)).toBe(escapedInput);
+
+      const observations = await getObservationsWithModelDataFromEventsTable({
+        projectId: uniqueProjectId,
+        filter: [],
+        searchQuery: "東京",
+        searchType: ["content"],
+        limit: 100,
+        offset: 0,
+      });
+
+      expect(observations.map((observation) => observation.id).sort()).toEqual(
+        [rawSpanId, escapedSpanId].sort(),
+      );
     });
   });
 

--- a/web/src/__tests__/server/multilingual-fulltext-search.servertest.ts
+++ b/web/src/__tests__/server/multilingual-fulltext-search.servertest.ts
@@ -7,9 +7,9 @@
  * Langfuse Python SDK v3 uses, and what the bug reporter used), its `input` / `output`
  * payload is stored in ClickHouse **verbatim as the JSON string the SDK produced**. Python's
  * `json.dumps(...)` defaults to `ensure_ascii=True`, so a value like `你好` is persisted on
- * disk as the literal 12-byte ASCII string `你好`. The UI's display layer parses that
+ * disk as the literal 12-byte ASCII string `\u4f60\u597d`. The UI's display layer parses that
  * JSON back, so the user *sees* `你好` — but full-text search (`clickhouseSearchCondition`)
- * runs a literal `input ILIKE '%你好%'`, which can never match the stored bytes `你好`.
+ * runs a literal `input ILIKE '%你好%'`, which can never match the stored bytes `\u4f60\u597d`.
  * ASCII text (`Hello`) is not escaped, so it matches.
  *
  * These tests reproduce that: they store trace/observation I/O in the exact escaped form the
@@ -336,7 +336,7 @@ describe("multilingual full-text search (issue #11538)", () => {
         name: `ml-emoji-${randomUUID()}`,
         input: { status: "Deployment 🚀 succeeded" },
       });
-      // 🚀 (U+1F680) is persisted as the literal sequence 🚀; a correct fix encodes the
+      // 🚀 (U+1F680) is persisted as the literal sequence \ud83d\ude80; a correct fix encodes the
       // query the same way.
       expect(await searchTraceIds("🚀", ["id", "content"])).toContain(trace.id);
     });
@@ -344,7 +344,7 @@ describe("multilingual full-text search (issue #11538)", () => {
     it("finds a trace by a supplementary-plane CJK ideograph (CJK Ext. B)", async () => {
       const trace = await insertEscapedTrace({
         name: `ml-cjk-ext-b-${randomUUID()}`,
-        // 𠀀 = U+20000, 𠀁 = U+20001 — both stored as surrogate pairs (𠀀, 𠀁).
+        // 𠀀 = U+20000, 𠀁 = U+20001 — both stored as surrogate pairs (\ud840\udc00, \ud840\udc01).
         input: { rareChars: "古文字 𠀀𠀁 测试" },
       });
       expect(await searchTraceIds("𠀀𠀁", ["id", "content"])).toContain(


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends test coverage for the Unicode JSON-escape fix introduced in #13644, which added dual-form (raw + `\uXXXX`-escaped) ILIKE matching to `clickhouseSearchCondition` so that CJK and other non-ASCII content serialised by Python's `ensure_ascii=True` is findable via full-text search.

- Adds fixture rows and expected-ID assertions for the escaped CJK form (`\u6771\u4eac` = 東京) alongside the existing raw-character fixtures, verifying both ILIKE paths work together.
- Adds a new integration test that inserts raw and escaped Unicode events directly into `events_full` and confirms `getObservationsWithModelDataFromEventsTable` returns both observations for a raw CJK search query.
- Corrects code comments in `search.ts` and `multilingual-fulltext-search.servertest.ts` to display the actual on-disk byte representation (`\u4f60\u597d`) instead of the decoded character (`你好`).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are tests and documentation comments with no production logic modified.

The only production file touched is a single-line comment correction in search.ts. All new code is test-only: new fixture rows, additional assertions in existing parameterised tests, and a new round-trip integration test that writes to ClickHouse with a unique project ID for isolation. The escaping arithmetic is correctly layered, ordering in ORDER-BY-dependent assertions is consistent with the fixture IDs, and the maybeEventsTable gate ensures the integration tests only run when the events-table APIs are enabled.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as Test (servertest)
    participant Helper as matchingIds / createEventsCh
    participant CSC as clickhouseSearchCondition
    participant CH as ClickHouse (events_full)

    Test->>CSC: "query="東京", searchType=["content"]"
    CSC-->>Test: "params { searchString: "%東京%", searchStringEscaped: "%\u6771\u4eac%" }"
    Test->>Helper: matchingIds(query, useEventsTablePath?)
    Helper->>CSC: build WHERE clause
    CSC-->>Helper: input ILIKE %東京% OR input ILIKE %\u6771\u4eac%
    Helper->>CH: SELECT id FROM (VALUES fixture) WHERE clause
    CH-->>Helper: [input-match-cjk, input-match-escaped-cjk, output-match-cjk, output-match-escaped-cjk]
    Helper-->>Test: sorted IDs

    Note over Test,CH: Round-trip integration test
    Test->>Helper: createEventsCh([rawEvent, escapedEvent])
    Helper->>CH: INSERT INTO events_full
    Test->>CH: "SELECT span_id, input WHERE project_id=uniqueProjectId"
    CH-->>Test: 2 rows (raw + escaped)
    Test->>CH: "getObservationsWithModelDataFromEventsTable(searchQuery="東京")"
    CH-->>Test: both observations found
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: adding a few more tests after #13..."](https://github.com/langfuse/langfuse/commit/fa20b82a153f50c1aa6b6b6b6bd769a9f3f5b9b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34878210)</sub>

<!-- /greptile_comment -->