### PR TITLE
fix(agents): require exhaustive datadog alert sweep

### DIFF
--- a/.agents/skills/weekly-production-review/SKILL.md
+++ b/.agents/skills/weekly-production-review/SKILL.md
@@ -48,7 +48,11 @@ output.
    follow-ups; use the status page as the customer-facing source of truth.
 3. Gather Datadog alert/page signals for the window. Use incident.io alerts or
    escalations when they represent pages; use Datadog monitor/event data when
-   available. Group repeated firings of the same monitor instead of counting
+   available. First build the exhaustive alert universe by paginating through
+   Datadog events until no more results remain for the window; do not rely on a
+   truncated first page, sampled titles, or a few spot checks. Cover all prod
+   envs in scope even when one site is noisy or one env looks quiet. After the
+   full pass, group repeated firings of the same monitor instead of counting
    every notification as a separate event.
 4. Gather Linear bugs from the `bug` label first. Include all `bug`-labeled
    tickets created, updated, completed, or still-open with production evidence
@@ -167,6 +171,16 @@ the primary narrative. Use these verdicts:
 Group repeated pages by monitor name or ID, environment, service/team, and
 trigger reason. Exclude or clearly mark SLO/burn-rate monitors, test monitors,
 and maintenance-window noise when the review is about actionable breakage.
+The table must still account for every production Datadog alert cluster found
+in the full event pass, including clusters later classified as `expected/test`,
+`monitor noise`, or `unknown/no measurements`.
+
+Before finalizing the review, perform a completeness check:
+
+1. Compare the final Datadog table against the full paginated event sweep.
+2. Confirm every production monitor title seen during the window appears in the
+   table or is explicitly excluded as non-prod.
+3. If a known title is missing, add it before writing the narrative summary.
 
 `Linked Event` should be the canonical incident.io reference, Linear issue key,
 or explicit disposition. Do not leave a real page as `none` unless the next


### PR DESCRIPTION
## Summary
- require weekly production reviews to paginate through the full Datadog event set before clustering alerts
- add a completeness check so every production monitor title seen in the week is represented or explicitly excluded
- close the gap that let the May 31 `Experiment Backfill Missing Logs` alert get missed in the review

## Impacted packages
- `.agents/skills/weekly-production-review`

## Verification
- `.agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/weekly-production-review`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens the `weekly-production-review` agent skill to close a gap where a production Datadog alert (`Experiment Backfill Missing Logs`, May 31) was missed because the review stopped at the first page of results.

- **Pagination requirement added (Workflow step 3):** The agent must now exhaust all paginated Datadog event pages for the window before grouping or classifying alerts, and must cover all prod environments even when one is quiet or noisy.
- **Completeness check added (Datadog section):** Before finalising the narrative, the agent must compare its Datadog table against the full paginated sweep, confirm every production monitor title is represented or explicitly excluded as non-prod, and add any missing title to the table.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — this is a documentation-only change to an agent skill instruction file with no executable code path.

The pagination requirement and completeness-check loop are clearly specified and directly address the reported gap. The only rough edge is that the completeness check's "explicitly excluded as non-prod" exit condition is narrower than the existing table guidance, which also allows excluding SLO/burn-rate and maintenance-window-noise monitors from production environments.

.agents/skills/weekly-production-review/SKILL.md — the completeness check exclusion wording could be broadened to stay consistent with the earlier table-guidance exclusion rules.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start: Confirm review window & timezone] --> B[Gather status page & incident.io incidents]
    B --> C[Query Datadog events – page 1]
    C --> D{More pages?}
    D -- Yes --> E[Fetch next page]
    E --> D
    D -- No --> F[Full alert universe assembled]
    F --> G[Group repeated firings by monitor name/ID/env]
    G --> H[Gather Linear bugs labeled 'bug']
    H --> I[Classify each bug and alert]
    I --> J[Build Datadog Alert/Page Signals table]
    J --> K{Completeness check}
    K --> L[Compare table vs. full paginated sweep]
    L --> M{Every prod monitor title present or explicitly excluded?}
    M -- No --> N[Add missing title to table]
    N --> M
    M -- Yes --> O[Write narrative summary]
    O --> P[Assemble Event-Centric View, Incident Table, Linear Bug Table, Executive Summary]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.agents/skills/weekly-production-review/SKILL.md:183
**Completeness-check exclusion criteria is narrower than the existing exclusion rules**

The completeness check says a monitor can be omitted only when it is "explicitly excluded as non-prod", but the table guidance a few lines above still allows excluding SLO/burn-rate monitors, test monitors, and maintenance-window noise — all of which may fire from production environments and are therefore not "non-prod." An agent following the completeness check literally would either (a) add a noisy prod SLO monitor back into the table after it was intentionally excluded, or (b) mislabel the exclusion reason as "non-prod" when the real reason is "monitor noise/burn-rate." Aligning the exclusion criteria (e.g. "non-prod or excluded per table guidance") would remove the ambiguity.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agents): require exhaustive datadog ..."](https://github.com/langfuse/langfuse/commit/ce09b2ded8752cafeda4c794498b888a547a38ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34878934)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->