### PR TITLE
refactor(code-evaluators): TS and python code formatting to auto-collapse comments

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -283,7 +283,7 @@ importers:
         version: 11.2.7
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nodemailer:
         specifier: ^7.0.11
         version: 7.0.11
@@ -674,7 +674,7 @@ importers:
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-query-params:
         specifier: ^5.1.0
         version: 5.1.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(use-query-params@2.2.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -778,6 +778,9 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.5
+        version: 6.2.5
       '@jedmao/location':
         specifier: ^3.0.0
         version: 3.0.0
@@ -1596,6 +1599,9 @@ packages:
 
   '@codemirror/commands@6.10.3':
     resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
 
   '@codemirror/lang-json@6.0.2':
     resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
@@ -2444,6 +2450,9 @@ packages:
 
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
 
   '@lezer/json@1.0.3':
     resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
@@ -11845,6 +11854,16 @@ snapshots:
       '@codemirror/view': 6.42.0
       '@lezer/common': 1.5.1
 
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.17.0(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.42.0)(@lezer/common@1.5.1)
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.6
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.42.0
+      '@lezer/common': 1.5.1
+      '@lezer/javascript': 1.5.4
+
   '@codemirror/lang-json@6.0.2':
     dependencies:
       '@codemirror/language': 6.12.3
@@ -12646,6 +12665,12 @@ snapshots:
     dependencies:
       '@lezer/common': 1.5.1
 
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+
   '@lezer/json@1.0.3':
     dependencies:
       '@lezer/common': 1.5.1
@@ -12742,7 +12767,7 @@ snapshots:
   '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@prisma/client': 6.19.3(prisma@6.19.3(magicast@0.5.2)(typescript@5.9.2))(typescript@5.9.2)
-      next-auth: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-auth: 4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   '@next/env@16.0.0': {}
 
@@ -17435,7 +17460,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -19512,7 +19537,7 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
-  next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next-auth@4.24.13(patch_hash=7b301d2607ee3cd8bba4f6978ba8cdd7a616b59d6e414191da3b38950ce08e66)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(nodemailer@7.0.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@babel/runtime': 7.29.2
       '@panva/hkdf': 1.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       '@baselime/trpc-opentelemetry-middleware':
         specifier: ^0.1.2
         version: 0.1.2(@opentelemetry/api@1.9.0)(@trpc/server@11.13.4(typescript@5.9.2))
+      '@codemirror/lang-javascript':
+        specifier: ^6.2.5
+        version: 6.2.5
       '@codemirror/lang-json':
         specifier: ^6.0.2
         version: 6.0.2
@@ -778,9 +781,6 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
-      '@codemirror/lang-javascript':
-        specifier: ^6.2.5
-        version: 6.2.5
       '@jedmao/location':
         specifier: ^3.0.0
         version: 3.0.0

--- a/web/package.json
+++ b/web/package.json
@@ -170,6 +170,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@codemirror/lang-javascript": "^6.2.5",
     "@jedmao/location": "^3.0.0",
     "@playwright/test": "^1.57.0",
     "@repo/eslint-config": "workspace:*",

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,7 @@
     "@appsignal/opentelemetry-instrumentation-bullmq": "^0.8.0",
     "@astral-sh/ruff-wasm-web": "0.15.13",
     "@baselime/trpc-opentelemetry-middleware": "^0.1.2",
+    "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/language": "^6.12.3",
@@ -170,7 +171,6 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@codemirror/lang-javascript": "^6.2.5",
     "@jedmao/location": "^3.0.0",
     "@playwright/test": "^1.57.0",
     "@repo/eslint-config": "workspace:*",

--- a/web/src/components/editor/shared-theme.ts
+++ b/web/src/components/editor/shared-theme.ts
@@ -27,7 +27,7 @@ export const bothThemeStyles: CreateThemeOptions["styles"] = [
       t.labelName,
       t.definition(t.name),
     ],
-    color: "hsl(var(--primary-accent))",
+    color: "hsl(var(--foreground))",
   },
   { tag: t.strong, fontWeight: "bold" },
   { tag: t.emphasis, fontStyle: "italic" },

--- a/web/src/components/editor/shared-theme.ts
+++ b/web/src/components/editor/shared-theme.ts
@@ -27,7 +27,7 @@ export const bothThemeStyles: CreateThemeOptions["styles"] = [
       t.labelName,
       t.definition(t.name),
     ],
-    color: "hsl(var(--foreground))",
+    color: "hsl(var(--primary-accent))",
   },
   { tag: t.strong, fontWeight: "bold" },
   { tag: t.emphasis, fontStyle: "italic" },

--- a/web/src/features/evals/components/code-eval-template-form-body.tsx
+++ b/web/src/features/evals/components/code-eval-template-form-body.tsx
@@ -5,8 +5,9 @@ import CodeMirror, {
 } from "@uiw/react-codemirror";
 import { EditorState, Prec } from "@codemirror/state";
 import { linter, type Diagnostic } from "@codemirror/lint";
-import { StreamLanguage, type StringStream } from "@codemirror/language";
+import { javascript } from "@codemirror/lang-javascript";
 import { python } from "@codemirror/lang-python";
+import { foldEffect, foldable } from "@codemirror/language";
 import { EvalTemplateSourceCodeLanguage } from "@langfuse/shared";
 import { useTheme } from "next-themes";
 import {
@@ -28,6 +29,7 @@ import {
 } from "@/src/features/evals/utils/code-eval-template-hover-docs";
 import {
   formatPythonCodeEvalSourceWithRuff,
+  PYTHON_CODE_EVAL_CONTRACT,
   TYPESCRIPT_CODE_EVAL_CONTRACT,
   type CodeEvalSourceCodeLanguage,
   type CodeEvalValidationResult,
@@ -55,79 +57,6 @@ type ContractRanges = {
 const PYTHON_EVALUATE_SIGNATURE_PATTERN =
   /(?:^|\n)def evaluate\s*\(\s*ctx\s*:\s*EvaluationContext\s*\)\s*->\s*EvaluationResult\s*:/;
 const FORMAT_SHORTCUT_ARIA = "Alt+Shift+F";
-const TYPESCRIPT_KEYWORDS = new Set([
-  "async",
-  "await",
-  "const",
-  "let",
-  "return",
-  "export",
-  "function",
-  "type",
-  "interface",
-  "if",
-  "else",
-  "true",
-  "false",
-  "undefined",
-  "null",
-]);
-const TYPESCRIPT_BUILTIN_TYPES = new Set([
-  "any",
-  "boolean",
-  "number",
-  "Promise",
-  "Record",
-  "string",
-  "unknown",
-]);
-
-const typescriptCodeEvalLanguage = StreamLanguage.define({
-  name: "typescript-code-eval",
-  token: (stream: StringStream) => {
-    if (stream.match("//")) {
-      stream.skipToEnd();
-      return "comment";
-    }
-
-    if (stream.match("/*")) {
-      while (!stream.eol()) {
-        if (stream.match("*/")) break;
-        stream.next();
-      }
-      return "comment";
-    }
-
-    if (stream.match(/["'`]/, false)) {
-      const quote = stream.next();
-      let escaped = false;
-      while (!stream.eol()) {
-        const next = stream.next();
-        if (next === quote && !escaped) break;
-        escaped = next === "\\" && !escaped;
-      }
-      return "string";
-    }
-
-    const identifier = stream.match(/[A-Za-z_][A-Za-z0-9_]*/, false);
-    if (identifier && identifier !== true) {
-      const word = identifier[0];
-      stream.match(word);
-      if (TYPESCRIPT_KEYWORDS.has(word)) return "keyword";
-      if (TYPESCRIPT_BUILTIN_TYPES.has(word) || /^[A-Z]/.test(word)) {
-        return "typeName";
-      }
-      return null;
-    }
-
-    if (stream.match(/\b\d+(?:\.\d+)?\b/)) {
-      return "number";
-    }
-
-    stream.next();
-    return null;
-  },
-});
 
 function createCodeEvalHoverExtension(hoverDocs: CodeEvalHoverDocs) {
   return hoverTooltip((view, pos) => {
@@ -283,6 +212,45 @@ function scrollCodeMirrorToBottom(view: EditorView) {
   });
 }
 
+function foldContractTypes(
+  view: EditorView,
+  sourceCodeLanguage: CodeEvalSourceCodeLanguage,
+) {
+  if (typeof window === "undefined") return;
+
+  const contractLength =
+    sourceCodeLanguage === "PYTHON"
+      ? PYTHON_CODE_EVAL_CONTRACT.length
+      : TYPESCRIPT_CODE_EVAL_CONTRACT.length;
+
+  const doFold = () => {
+    if (!view.dom.isConnected) return;
+
+    const effects: ReturnType<typeof foldEffect.of>[] = [];
+    const state = view.state;
+
+    // Find all foldable ranges within the contract section
+    let pos = 0;
+    while (pos < contractLength && pos < state.doc.length) {
+      const line = state.doc.lineAt(pos);
+      const range = foldable(state, line.from, line.to);
+      if (range && range.from < contractLength) {
+        effects.push(foldEffect.of({ from: range.from, to: range.to }));
+      }
+      pos = line.to + 1;
+    }
+
+    if (effects.length > 0) {
+      view.dispatch({ effects });
+    }
+  };
+
+  // Delay to ensure the language parser has time to analyze the document.
+  // Python parsing may need more time than TypeScript.
+  const delay = sourceCodeLanguage === "PYTHON" ? 100 : 50;
+  setTimeout(doFold, delay);
+}
+
 export function CodeEvalTemplateFormBody({
   sourceCode,
   sourceCodeLanguage,
@@ -301,17 +269,31 @@ export function CodeEvalTemplateFormBody({
       : "TypeScript";
   const shouldShowFormatButton = editable;
 
-  const handleCreateEditor = useCallback((view: EditorView) => {
-    codeMirrorViewRef.current = view;
-    scrollCodeMirrorToBottom(view);
-  }, []);
+  const handleCreateEditor = useCallback(
+    (view: EditorView) => {
+      codeMirrorViewRef.current = view;
+      foldContractTypes(view, sourceCodeLanguage);
+      scrollCodeMirrorToBottom(view);
+    },
+    [sourceCodeLanguage],
+  );
 
   useEffect(() => {
     const view = codeMirrorViewRef.current;
     if (!view) return;
 
+    // Don't re-fold on every sourceCode change, only on language change
     scrollCodeMirrorToBottom(view);
-  }, [sourceCode, sourceCodeLanguage]);
+  }, [sourceCode]);
+
+  useEffect(() => {
+    const view = codeMirrorViewRef.current;
+    if (!view) return;
+
+    // Re-fold when language changes
+    foldContractTypes(view, sourceCodeLanguage);
+    scrollCodeMirrorToBottom(view);
+  }, [sourceCodeLanguage]);
 
   const diagnostics = useMemo(
     () => validationResult?.diagnostics ?? [],
@@ -384,7 +366,7 @@ export function CodeEvalTemplateFormBody({
     () =>
       sourceCodeLanguage === EvalTemplateSourceCodeLanguage.PYTHON
         ? python()
-        : typescriptCodeEvalLanguage,
+        : javascript({ typescript: true }),
     [sourceCodeLanguage],
   );
   const codeEvalHoverExtension = useMemo(

--- a/web/src/features/evals/hooks/useCodeEvalSourceValidation.ts
+++ b/web/src/features/evals/hooks/useCodeEvalSourceValidation.ts
@@ -106,7 +106,7 @@ export function useCodeEvalSourceValidation({
         .finally(() => {
           if (isActive) setIsPending(false);
         });
-    }, 250);
+    }, 300);
 
     return () => {
       isActive = false;
@@ -115,8 +115,7 @@ export function useCodeEvalSourceValidation({
   }, [enabled, reset, sourceCode, sourceCodeLanguage]);
 
   return {
-    isValid:
-      Boolean(validationResult) && !isPending && !validationResult?.hasErrors,
+    isValid: Boolean(validationResult) && !validationResult?.hasErrors,
     isPending,
     validationResult,
     validate,

--- a/web/src/features/evals/utils/code-eval-template-starter-examples.ts
+++ b/web/src/features/evals/utils/code-eval-template-starter-examples.ts
@@ -1,125 +1,38 @@
-export const TYPESCRIPT_CODE_EVAL_CONTRACT = `/**
- * The data Langfuse passes to a code evaluator.
- */
-type EvaluationContext = {
-  /**
-   * The observation selected by the evaluator target.
-   */
+export const TYPESCRIPT_CODE_EVAL_CONTRACT = `type EvaluationContext = {
   observation: {
-    /**
-     * The input recorded on the observation.
-     */
     input: any;
-    /**
-     * The output recorded on the observation.
-     */
     output: any;
-    /**
-     * The metadata recorded on the observation.
-     */
     metadata: any;
   };
-  /**
-   * Experiment item data. Present when the evaluator runs on an experiment.
-   */
   experiment:
     | {
-        /**
-         * The expected output from the experiment item.
-         */
         itemExpectedOutput: any;
-        /**
-         * The metadata from the experiment item.
-         */
         itemMetadata: any;
       }
     | undefined;
 };
 
-/**
- * A Langfuse score returned by a code evaluator.
- */
 type ScoreBase = {
-  /**
-   * The score name.
-   */
   name: string;
-  /**
-   * The reasoning or explanation stored with the score.
-   */
   comment?: string;
-  /**
-   * The score config id to attach to the score.
-   */
   configId?: string | null;
-  /**
-   * Extra metadata stored with the score.
-   */
   metadata?: Record<string, unknown>;
 };
 
-type NumericScore = ScoreBase & {
-  /**
-   * The Langfuse score data type.
-   */
-  dataType: "NUMERIC";
-  /**
-   * The score value.
-   */
-  value: number;
-};
-
-type BooleanScore = ScoreBase & {
-  /**
-   * The Langfuse score data type.
-   */
-  dataType: "BOOLEAN";
-  /**
-   * The score value.
-   */
-  value: boolean;
-};
-
-type CategoricalScore = ScoreBase & {
-  /**
-   * The Langfuse score data type.
-   */
-  dataType: "CATEGORICAL";
-  /**
-   * The score value.
-   */
-  value: string;
-};
-
-type TextScore = ScoreBase & {
-  /**
-   * The Langfuse score data type.
-   */
-  dataType: "TEXT";
-  /**
-   * The score value.
-   */
-  value: string;
-};
+type NumericScore = ScoreBase & { dataType: "NUMERIC"; value: number };
+type BooleanScore = ScoreBase & { dataType: "BOOLEAN"; value: boolean };
+type CategoricalScore = ScoreBase & { dataType: "CATEGORICAL"; value: string };
+type TextScore = ScoreBase & { dataType: "TEXT"; value: string };
 
 type Score = NumericScore | BooleanScore | CategoricalScore | TextScore;
 
-/**
- * The value returned by evaluate.
- */
 type EvaluationResult = {
-  /**
-   * One or more Langfuse scores to create for the target observation.
-   */
   scores: Score[];
 };
 `;
 
 export const DEFAULT_TYPESCRIPT_CODE_EVAL_SOURCE = `${TYPESCRIPT_CODE_EVAL_CONTRACT}
 
-/**
- * Evaluates one observation and returns one or more Langfuse scores.
- */
 function evaluate(ctx: EvaluationContext): EvaluationResult {
   const input = ctx.observation.input;
   const matchesOutput =


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the code-evaluator editor to auto-collapse the contract type preamble (TypeScript and Python) on load, replacing the hand-rolled `StreamLanguage` tokenizer with the full `@codemirror/lang-javascript` TypeScript extension and adding a `foldContractTypes` helper.

- The verbose JSDoc comments are stripped from `TYPESCRIPT_CODE_EVAL_CONTRACT` since the preamble is now hidden by default via CodeMirror fold effects; the `PYTHON_CODE_EVAL_CONTRACT` is similarly expected to collapse on mount.
- `useCodeEvalSourceValidation` drops `!isPending` from `isValid` so the previously-valid state is retained while revalidation runs, and the debounce is bumped from 250 ms to 300 ms.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after moving `@codemirror/lang-javascript` to `dependencies`; all other changes are UI-only with no data-path risk.

`@codemirror/lang-javascript` is the only runtime dependency of the new TypeScript language extension but it was placed in `devDependencies`. In production environments that install only production dependencies the build would fail. The `foldContractTypes` timing heuristics are cosmetic — if the fold misses, the preamble stays expanded rather than crashing. Everything else (comment stripping, `isValid` change, theme tweak) is low-risk.

`web/package.json` — the misclassified dependency needs to move to `dependencies` before this is production-safe.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CodeEvalForm as CodeEvalTemplateFormBody
    participant CM as CodeMirror Editor
    participant FoldFn as foldContractTypes
    participant Parser as CM Language Parser

    User->>CodeEvalForm: Open editor (mount)
    CodeEvalForm->>CM: Render with languageExtension + extensions
    CM-->>CodeEvalForm: onCreateEditor(view)
    CodeEvalForm->>FoldFn: foldContractTypes(view, language)
    FoldFn->>FoldFn: setTimeout(doFold, 50ms / 100ms)
    Parser-->>CM: Syntax tree ready (async)
    FoldFn->>CM: dispatch foldEffect for each foldable range in contract
    CM-->>User: Contract preamble collapsed

    User->>CodeEvalForm: Switch language
    CodeEvalForm->>CM: Update languageExtension (new language)
    CodeEvalForm->>FoldFn: useEffect → foldContractTypes(view, newLang)
    FoldFn->>FoldFn: setTimeout(doFold, 50ms / 100ms)
    FoldFn->>CM: dispatch foldEffect for new contract ranges
    CM-->>User: New contract preamble collapsed
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/package.json:173
`@codemirror/lang-javascript` is added to `devDependencies`, but every other `@codemirror/*` runtime package (`lang-json`, `lang-python`, `language`, `lint`, `search`, `state`) lives in `dependencies`. In production Docker builds or CI pipelines that install only production dependencies, this package will be missing, causing a build failure when webpack tries to bundle `code-eval-template-form-body.tsx`.

### Issue 2 of 2
web/src/features/evals/components/code-eval-template-form-body.tsx:248-251
**Fragile parser-timing heuristics in `foldContractTypes`**

The 50 ms / 100 ms `setTimeout` delays assume the language parser will always finish before the timer fires. On a slower device, a large document, or a busy main thread, the parser may not have produced syntax nodes by then, so `foldable` returns `null` for every line and no folds are applied — the contract section stays fully expanded with no error or retry. Consider using CodeMirror's `syntaxTree` or `ensureSyntaxTree` utilities to wait for an actual parsed tree before dispatching fold effects, which avoids any dependency on wall-clock timing.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): increase debounce time in us..."](https://github.com/langfuse/langfuse/commit/dadef43fc437aa5803079788a8ffd9bd9cdef18c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34892582)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->