### PR TITLE
chore(deps): bump axios to 1.16.0

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -176,8 +176,8 @@ Open: [debug-issue-with-datadog/SKILL.md](debug-issue-with-datadog/SKILL.md)
 Use for:
 - pnpm dependency bumps that need a specific target version
 - interactive upgrades where the package name or version may be missing
-- transitive lockfile bumps that may need temporary overrides and dedupe
-  verification before deciding whether the override should stay
+- transitive lockfile bumps that may need temporary overrides, then a
+  remove/install/dedupe check before deciding whether the override should stay
 - checking whether `pnpm-workspace.yaml` `minimumReleaseAgeExclude` must change
 - comparing registry latest with the latest version installable under the
   current release-age gate

--- a/.agents/skills/pnpm-upgrade-package/SKILL.md
+++ b/.agents/skills/pnpm-upgrade-package/SKILL.md
@@ -32,16 +32,18 @@ Use this skill for interactive dependency bumps in Langfuse.
   upgrade that parent dependency instead of adding the target package directly
   unless the user explicitly wants that.
 - If pnpm will not move an already-allowed transitive version, a scoped
-  `overrides` entry may be used as a temporary resolution tool. After the
-  lockfile moves, remove the temporary override, run `pnpm install`, then run
-  `pnpm dedupe` when permitted. If the lockfile stays at the target without the
-  override, do not keep the override.
+  `overrides` entry in `pnpm-workspace.yaml` may be used as a temporary
+  resolution tool. Before finishing, prove whether the override is still
+  required: remove it, run `pnpm install`, then run `pnpm dedupe`. Inspect the
+  diff after each generated change. If the target version remains without the
+  override, do not keep the override; keep or restore it only when pnpm reverts
+  or drifts from the requested version without it.
 - Never manually edit `pnpm-lock.yaml`; regenerate lockfile changes with
   `pnpm` commands only. If a lockfile-only refresh causes unrelated churn,
   adjust the pnpm command and rerun instead of patching the lockfile by hand.
-- After fixing or upgrading a package, run `pnpm dedupe` when it is needed to
-  verify temporary resolver cleanup or when the user permits it; otherwise
-  suggest it as optional cleanup. Always inspect the diff after dedupe.
+- After fixing or upgrading a package, run `pnpm dedupe`. Always inspect the
+  diff after dedupe and revert that generated attempt if it introduces
+  unrelated churn.
 - Resolve the registry latest version, but do not silently upgrade to latest
   unless the user asked for latest.
 - Compare the target version with the latest version installable under the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5892,8 +5892,8 @@ packages:
     resolution: {integrity: sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==}
     engines: {node: '>=4'}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -14691,7 +14691,7 @@ snapshots:
       '@slack/types': 2.20.1
       '@types/node': 24.3.0
       '@types/retry': 0.12.0
-      axios: 1.15.2
+      axios: 1.16.0
       eventemitter3: 5.0.4
       form-data: 4.0.5
       is-electron: 2.2.2
@@ -16354,7 +16354,7 @@ snapshots:
 
   axe-core@4.11.2: {}
 
-  axios@1.15.2:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps `axios` from `1.15.2` to `1.16.0` in the lockfile and refines the `pnpm-upgrade-package` skill documentation to clarify the transitive-override removal workflow.

- **`pnpm-lock.yaml`**: Only the `axios` entry and its resolution integrity hash are updated; the package's own dependency set (`follow-redirects`, `form-data`, `proxy-from-env`) is unchanged, and only the `@slack/web-api` snapshot references are touched.
- **Skill docs** (`.agents/skills/README.md` and `SKILL.md`): Prose improvements to the override workflow — explicitly requiring removal + install + dedupe to prove whether an override is still needed before deciding to keep it.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a focused dependency bump with no logic changes — safe to merge.

The lockfile change is minimal: only the axios resolution hash and the single @slack/web-api snapshot reference are updated; axios's own dependency tree (follow-redirects, form-data, proxy-from-env) is unchanged. The skill documentation edits are prose-only improvements. No application code is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Identify transitive dep to upgrade] --> B[Add scoped override in pnpm-workspace.yaml]
    B --> C[pnpm install]
    C --> D[Inspect lockfile diff]
    D --> E[Remove the temporary override]
    E --> F[pnpm install again]
    F --> G[pnpm dedupe]
    G --> H{Target version retained?}
    H -- Yes --> I[Keep override removed ✓]
    H -- No / reverts --> J[Restore override and keep it]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into nimar/bump-axio..."](https://github.com/langfuse/langfuse/commit/65f1cb6a5765ca5729617493b7b4ca8ea7bd3b6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34898398)</sub>

<!-- /greptile_comment -->