### PR TITLE
fix(web): remove manual base path prefix from Change Password link

### DIFF
--- a/web/src/pages/account/settings/index.tsx
+++ b/web/src/pages/account/settings/index.tsx
@@ -288,7 +288,7 @@ const getAccountSettingsPages = (userEmail: string): AccountSettingsPage[] => [
             </p>
             <Button asChild variant="secondary">
               <Link
-                href={`${env.NEXT_PUBLIC_BASE_PATH ?? ""}/auth/reset-password`}
+                href="/auth/reset-password"
               >
                 Change Password
               </Link>


### PR DESCRIPTION
Fixes #13736

The Change Password button in Account Settings was manually prepending `NEXT_PUBLIC_BASE_PATH` to the `/auth/reset-password` href. Next.js `Link` already prepends `basePath` automatically, so the path was duplicated when a custom base path was configured (e.g. `/langfuse/langfuse/auth/reset-password` instead of `/langfuse/auth/reset-password`).

The fix matches how the same link is already handled on the sign-in page — just use the plain path and let Next.js handle the prefix.

**Impacted package:** `web`
**Verification:** `pnpm --filter web run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the manual `NEXT_PUBLIC_BASE_PATH` prefix from the Change Password `Link` in account settings, since Next.js's `Link` component automatically prepends `basePath` — so the prefix was being doubled when a custom base path was configured.

- The one-line fix in `web/src/pages/account/settings/index.tsx` makes the href consistent with the same link on the sign-in page (`/auth/reset-password`).
- `ResetPasswordButton.tsx` still manually prepends the base path for `callbackUrl` strings passed directly to `signIn()` and `window.location.href`, which is correct in those cases since they bypass Next.js routing.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line change correcting a URL double-prefix bug with no side-effects.

The change removes a manual base-path prefix that was being applied redundantly on top of Next.js's own automatic basePath handling. It matches the pattern already used on the sign-in page and does not touch any server-side logic, auth flows, or shared utilities.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks 'Change Password'] --> B["Link href='/auth/reset-password'"]
    B --> C["Next.js Link auto-prepends basePath"]
    C --> D["Final URL: /langfuse/auth/reset-password ✅"]

    E["OLD: Link href=basePath + '/auth/reset-password'"] --> F["Next.js Link auto-prepends basePath"]
    F --> G["Final URL: /langfuse/langfuse/auth/reset-password ❌ (doubled)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove manual base path prefix from..."](https://github.com/langfuse/langfuse/commit/d2c52593a0955eb7f14c45ea8d438680a7e1aeff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34900283)</sub>

<!-- /greptile_comment -->