### PR TITLE
docs: update readme banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
-<img width="4856" height="1000" alt="github-banner" src="https://github.com/user-attachments/assets/6f435ef3-1194-4e26-87af-aa13826bbb5f" />
+<img width="2400" height="600" alt="hero-b" src="https://github.com/user-attachments/assets/5ccecfb8-2990-4d03-8014-88ec7cd75e9a" />
 
 <div align="center">
    <div>
       <h3>
-        <a href="https://langfuse.com/blog/2025-06-04-open-sourcing-langfuse-product">
-            <strong>Langfuse Is Doubling Down On Open Source</strong>
-         </a> <br> <br>
          <a href="https://cloud.langfuse.com">
             <strong>Langfuse Cloud</strong>
          </a> · 
@@ -60,8 +57,6 @@
    <img alt="Issues closed" src="https://img.shields.io/github/issues-search?query=repo%3Alangfuse%2Flangfuse%20is%3Aclosed&label=issues%20closed&labelColor=%20%237d89b0&color=%20%235d6b98"></a>
    <a href="https://github.com/langfuse/langfuse/discussions/" target="_blank">
    <img alt="Discussion posts" src="https://img.shields.io/github/discussions/langfuse/langfuse?labelColor=%20%239b8afb&color=%20%237a5af8"></a>
-   <a href="https://deepwiki.com/langfuse/langfuse" target="_blank">
-   <img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"></a>
 </p>
 
 <p align="center">
@@ -71,20 +66,12 @@
   <a href="./README.kr.md"><img alt="README in Korean" src="https://img.shields.io/badge/한국어-d9d9d9"></a>
 </p>
 
-<p align="center">
-   <a href="https://github.com/ClickHouse/ClickHouse"><strong>Proudly made with ClickHouse open source database</strong></a>
-</p>
-
-
-
 Langfuse is an **open source LLM engineering** platform. It helps teams collaboratively
-**develop, monitor, evaluate,** and **debug** AI applications. Langfuse can be **self-hosted in minutes** and is **battle-tested**.
-
-[![Langfuse Overview Video](https://github.com/user-attachments/assets/925d71db-6331-445e-8f3e-727ee95d1c9f)](https://langfuse.com/watch-demo)
+**develop, monitor, evaluate,** and **debug** AI applications. Langfuse can be **self-hosted in minutes** and is **battle-tested**. Proudly made with [ClickHouse open source database](https://github.com/ClickHouse/ClickHouse).
 
 ## ✨ Core Features
 
-<img width="4856" height="1944" alt="Langfuse Overview" src="https://github.com/user-attachments/assets/5dac68ef-d546-49fb-b06f-cfafc19282e3" />
+<img width="2400" height="1040" alt="features" src="https://github.com/user-attachments/assets/0fad3dee-f3ad-423c-9f0d-7ccd0f26cc2d" />
 
 - [LLM Application Observability](https://langfuse.com/docs/tracing): Instrument your app and start ingesting traces to Langfuse, thereby tracking LLM calls and other relevant logic in your app such as retrieval, embedding, or agent actions. Inspect and debug complex logs and user sessions. Try the interactive [demo](https://langfuse.com/docs/demo) to see this in action.
 
@@ -100,7 +87,7 @@ Langfuse is an **open source LLM engineering** platform. It helps teams collabor
 
 ## 📦 Deploy Langfuse
 
-<img width="4856" height="1322" alt="Langfuse Deployment Options" src="https://github.com/user-attachments/assets/98f020c7-7a20-4264-a201-65c41a52a5d5" />
+<img width="2400" height="880" alt="deploy" src="https://github.com/user-attachments/assets/cf72e7f8-db7f-4e11-a2a1-ecfbe46f262c" />
 
 ### Langfuse Cloud
 
@@ -108,7 +95,7 @@ Managed deployment by the Langfuse team, generous free-tier, no credit card requ
 
 <div align="center">
     <a href="https://cloud.langfuse.com" target="_blank">
-        <img alt="Static Badge" src="https://img.shields.io/badge/»%20Sign%20up%20for%20Langfuse%20Cloud-8A2BE2?&color=orange">
+        <img alt="Static Badge" src="https://img.shields.io/badge/»%20Sign%20up%20for%20Langfuse%20Cloud-8A2BE2?&color=black">
     </a>
 </div>
 
@@ -135,7 +122,7 @@ See [self-hosting documentation](https://langfuse.com/self-hosting) to learn mor
 
 ## 🔌 Integrations
 
-<img width="4856" height="1322" alt="github-integrations" src="https://github.com/user-attachments/assets/e41ea0fb-742d-41ce-bf94-1d4fb95750cd" />
+<img width="2400" height="980" alt="integrations" src="https://github.com/user-attachments/assets/b85c9a45-68f0-4f76-b545-0e8632abef9f" />
 
 ### Main Integrations:
 
@@ -224,17 +211,9 @@ main()
 
 See your language model calls and other application logic in Langfuse.
 
-<img width="1787" height="674" alt="Example trace in Langfuse" src="https://github.com/user-attachments/assets/f796eb78-dfb5-4570-b236-bdb4b67d4d55" />
+<img width="1600" height="833" alt="example-trace-for-github" src="https://github.com/user-attachments/assets/8f6995b7-285f-441a-b52f-1331d13ceb45" />
 
-_[Public example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/2cec01e3-3dc2-472f-afcf-3b968cf0c1f4?timestamp=2025-02-10T14%3A27%3A30.275Z&observation=cb5ff844-07ef-41e6-b8e2-6c64344bc13b)_
-
-> [!TIP]
->
-> [Learn more](https://langfuse.com/docs/tracing) about tracing in Langfuse or play with the [interactive demo](https://langfuse.com/docs/demo).
-
-## ⭐️ Star Us
-
-![star-langfuse-on-github](https://github.com/user-attachments/assets/79a1d816-d229-4526-aecc-097d4a19f1ad)
+_[Public example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/db22d0a442216b485abd83cc9df6d9ee)_
 
 ## 💭 Support
 


### PR DESCRIPTION
Updated images and links in the README file, removed outdated references, and improved clarity of the Langfuse description.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refreshes the `README.md` with updated banner/feature images at smaller resolutions (2400-wide vs the previous 4856-wide), removes stale or time-sensitive content, and tightens the overall copy.

- **Images replaced**: Hero, features, deploy, integrations, and example-trace images all swapped for new GitHub-hosted assets with corrected dimensions.
- **Content removed**: The "Langfuse Is Doubling Down On Open Source" blog-post link, the DeepWiki badge, the demo video embed, the standalone ClickHouse paragraph (moved inline), the TIP callout, and the entire "⭐️ Star Us" section.
- **Minor tweaks**: The "Sign up" badge color changed from orange to black, and the public trace URL was simplified by removing query-string parameters.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Purely a README update — no application code, configuration, or schema is touched.

All changes are cosmetic: image swaps, link removals, and minor copy edits. Nothing here affects runtime behaviour.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] --> B[Hero Banner]
    A --> C[Navigation Links]
    A --> D[Badges / Shields]
    A --> E[Description]
    A --> F[Core Features]
    A --> G[Deploy Langfuse]
    A --> H[Integrations]
    A --> I[Code Example]
    A --> J[Example Trace]
    A --> K[Support]

    B -->|Updated| B1["New image 2400x600 (was 4856x1000)"]
    C -->|Removed| C1["'Doubling Down On OSS' blog link"]
    D -->|Removed| D1["DeepWiki badge"]
    E -->|Inlined| E1["ClickHouse credit now inline (was standalone paragraph)"]
    E -->|Removed| E2["Demo video embed"]
    F -->|Updated| F1["New image 2400x1040 (was 4856x1944)"]
    G -->|Updated| G1["New image 2400x880 (was 4856x1322), badge color: orange to black"]
    H -->|Updated| H1["New image 2400x980 (was 4856x1322)"]
    J -->|Updated| J1["New image 1600x833, simplified trace URL, removed TIP callout"]
    J -->|Removed| J2["Star Us section"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update readme banners"](https://github.com/langfuse/langfuse/commit/3fe80db1dfcb69eeb67dccc29600cbec31e91389) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34916038)</sub>

<!-- /greptile_comment -->