### PR TITLE
ci: Add workflow to label PRs with merge conflicts

### DIFF
--- a/.github/workflows/label-prs-with-conflicts.yml
+++ b/.github/workflows/label-prs-with-conflicts.yml
@@ -1,0 +1,80 @@
+name: Label PRs with conflicts
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches: [main]
+
+permissions:
+  pull-requests: read
+  issues: write
+
+jobs:
+  label-prs-with-conflicts:
+    runs-on: ubuntu-latest
+    # Only run pull_request events for same-repo PRs to avoid permission issues with forks.
+    # Fork PRs are intentionally not labeled by this workflow.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Check mergeability and update label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          LABEL_NAME: has-conflicts
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          update_label_if_needed() {
+            local pr_number="$1"
+            local remove_stale_label="${2:-false}"
+
+            mergeable=$(gh api "repos/${REPO}/pulls/${pr_number}" --jq '.mergeable')
+            for delay in 3 6 12 24; do
+              if [ "${mergeable}" != "null" ]; then
+                break
+              fi
+
+              sleep "${delay}"
+              mergeable=$(gh api "repos/${REPO}/pulls/${pr_number}" --jq '.mergeable')
+            done
+
+            echo "PR #${pr_number}: mergeable=${mergeable}"
+
+            if [ "${mergeable}" = "null" ]; then
+              echo "::warning::PR #${pr_number}: mergeability was not computed after retries"
+              return 1
+            fi
+
+            if [ "${mergeable}" = "false" ]; then
+              gh api \
+                --method POST \
+                "repos/${REPO}/issues/${pr_number}/labels" \
+                -f "labels[]=${LABEL_NAME}"
+            elif [ "${mergeable}" = "true" ] && [ "${remove_stale_label}" = "true" ]; then
+              gh api \
+                --method DELETE \
+                "repos/${REPO}/issues/${pr_number}/labels/${LABEL_NAME}" \
+                --silent || true
+            fi
+          }
+
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            update_label_if_needed "${PR_NUMBER}" true
+          else
+            sleep 10
+            cutoff_date=$(date -u -d "14 days ago" +%F)
+            # On main pushes, only scan same-repo PRs that are not already labeled.
+            # Stale has-conflicts labels are intentionally removed only on PR updates.
+            gh api --paginate "search/issues?q=repo:${REPO}+is:pr+is:open+-label:${LABEL_NAME}+updated:>=${cutoff_date}&per_page=100" --jq '.items[].number' \
+              | while read -r pr; do
+                  head_repo=$(gh api "repos/${REPO}/pulls/${pr}" --jq '.head.repo.full_name') || continue
+                  if [ "${head_repo}" != "${REPO}" ]; then
+                    continue
+                  fi
+                  update_label_if_needed "${pr}" || true
+                done
+          fi


### PR DESCRIPTION
This PR adds a GitHub action that labels PRs with a `has-conflicts` label should they need manual conflict resolution. If the conflicts are resolved, the label should be automatically removed. For now, the action is filtered out on PRs from forks. This should hopefully make it easier to filter for PRs that need attention in the PR list + also notify people if their PRs need manual attention.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a GitHub Actions workflow that automatically attaches a `has-conflicts` label to open PRs whenever a merge conflict is detected, and removes it once the conflict is resolved. Fork PRs are excluded via an `if` guard on the job, and a bulk re-scan of all unlabeled PRs is triggered on every push to `main`.

- **PR-event path**: On `opened`, `reopened`, or `synchronize` for same-repo PRs, the workflow polls the GitHub API (up to 4 retries, 45 s total) for the `mergeable` field and adds or removes the label accordingly.
- **Push-to-main path**: After a 10 s startup sleep, the workflow uses the GitHub search API to enumerate all open PRs without the label, skips fork PRs, and calls `update_label_if_needed` (without stale-label removal) for each — intentionally leaving label cleanup to the PR-update path.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the workflow is read-only on PRs except for label mutations and is carefully guarded against fork permission issues.

The workflow is a self-contained CI helper with no effect on production code or data. The logic correctly handles fork filtering, mergeability polling with retries, and idempotent label add/remove. The only finding is a missing ready_for_review event type, which causes a minor gap in coverage for draft PRs going live.

No files require special attention; the single changed workflow file is straightforward.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow triggered] --> B{Event type?}
    B -->|pull_request event| C{Same-repo PR?}
    B -->|push to main| D[sleep 10s]
    C -->|No - fork PR| E[Skip / job if-filtered]
    C -->|Yes| F[update_label_if_needed PR_NUMBER, remove_stale=true]
    D --> G[Search open PRs without has-conflicts label]
    G --> H[For each PR number]
    H --> I{Fork PR?}
    I -->|Yes| J[Skip PR]
    I -->|No| K[update_label_if_needed pr, remove_stale=false]
    K --> H
    F --> L[Poll mergeable field]
    K --> L
    L --> M{mergeable?}
    M -->|null - retry up to 4x| L
    M -->|still null after retries| N[emit warning, return 1]
    M -->|false - has conflicts| O[POST label has-conflicts]
    M -->|true + remove_stale=true| P[DELETE label has-conflicts - silent or true]
    M -->|true + remove_stale=false| Q[No-op]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/label-prs-with-conflicts.yml:5
When a PR transitions from **draft → ready for review**, neither `opened` nor `synchronize` fires, so the workflow never runs for that event. A PR that accumulated conflicts while it was a draft won't be labeled until the next push to `main` triggers the bulk scan. Adding `ready_for_review` closes this gap and ensures the label is applied (or confirmed absent) immediately when the PR becomes visible in the review queue.

```suggestion
    types: [opened, reopened, synchronize, ready_for_review]
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: Add workflow to label PRs with merge..."](https://github.com/langfuse/langfuse/commit/0b3ebd8ee7d3b9985bf6baf579e01c289c87d87d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35090836)</sub>

<!-- /greptile_comment -->