### PR TITLE
docs(agents): warn against is_deleted filter on ClickHouse reads

### DIFF
--- a/.agents/skills/backend-dev-guidelines/references/database-patterns.md
+++ b/.agents/skills/backend-dev-guidelines/references/database-patterns.md
@@ -359,9 +359,9 @@ const query = `
 `;
 ```
 
-**`is_deleted` on `traces`, `observations`, and `scores` is dormant — avoid new filters.**
+**`is_deleted` on `traces`, `observations`, `scores`, and `dataset_run_items_rmt` is dormant — avoid new filters.**
 
-These three tables are declared as
+These four tables are declared as
 `ReplacingMergeTree(event_ts, is_deleted)`, but no production
 code writes `is_deleted = 1` for them — all deletes use
 ClickHouse's lightweight `DELETE FROM` mutation (e.g.
@@ -374,7 +374,7 @@ needed.
 
 What this means for query authors:
 
-- **`WHERE is_deleted = 0` filters on these three tables are
+- **`WHERE is_deleted = 0` filters on these four tables are
   dead weight in practice.** A few legacy reads still carry
   them (e.g. `web/src/features/score-analytics/server/`); new
   code should not add them unless soft-delete writes have


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a documentation section to the backend developer guidelines warning that `is_deleted` is dormant on the `traces`, `observations`, and `scores` ClickHouse tables, and that new query code should not add `WHERE is_deleted = 0` filters for those tables.

- The new section explains the split between `ReplacingMergeTree(event_ts, is_deleted)` schema declarations and the actual delete mechanism (lightweight `DELETE FROM` / `_row_exists`), helping future developers avoid adding dead filters.
- A carve-out is clearly documented for `blob_storage_file_log`, which intentionally does use soft-delete writes and reads.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no runtime impact; safe to merge.

The change is confined to a developer guidelines markdown file. The content is internally consistent, technically specific (naming exact delete functions, files, and the _row_exists mechanism), and the carve-out for blob_storage_file_log is accurate. No production code paths are touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Delete request] --> B{Which table?}
    B --> |traces / observations / scores| C[Lightweight DELETE FROM mutation]
    B --> |blob_storage_file_log| D[Soft-delete: write is_deleted=1]
    C --> E[ClickHouse marks rows via _row_exists]
    D --> F[Queries filter with countIf / is_deleted=1]
    E --> G[_row_exists handled transparently by read path]
    G --> H[WHERE is_deleted=0 is dead weight — avoid]
    F --> I[is_deleted filter required on reads]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): scope is\_deleted guidance ..."](https://github.com/langfuse/langfuse/commit/c91e1fcc7602c302fed552ffaf1593f0952a1065) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35091074)</sub>

<!-- /greptile_comment -->