### PR TITLE
fix(security): enforce auditLogs:read and audit-logs entitlement for audit_logs batch exports

### DIFF
--- a/web/src/__tests__/server/batchExport-trpc.servertest.ts
+++ b/web/src/__tests__/server/batchExport-trpc.servertest.ts
@@ -1,0 +1,161 @@
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { prisma } from "@langfuse/shared/src/db";
+import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import type { Session } from "next-auth";
+import {
+  BatchExportFileFormat,
+  BatchTableNames,
+  type Plan,
+} from "@langfuse/shared";
+import type { Role } from "@langfuse/shared/src/db";
+
+const __orgIds: string[] = [];
+
+function makeSession(
+  orgId: string,
+  orgName: string,
+  projectId: string,
+  projectName: string,
+  opts: {
+    plan?: Plan;
+    projectRole?: Role;
+  } = {},
+): Session {
+  const { plan = "cloud:hobby", projectRole = "MEMBER" } = opts;
+  return {
+    expires: "1",
+    user: {
+      id: "user-test",
+      canCreateOrganizations: true,
+      name: "Test User",
+      organizations: [
+        {
+          id: orgId,
+          name: orgName,
+          role: "MEMBER",
+          plan,
+          cloudConfig: undefined,
+          metadata: {},
+          aiFeaturesEnabled: false,
+          projects: [
+            {
+              id: projectId,
+              role: projectRole,
+              retentionDays: null,
+              deletedAt: null,
+              hasTraces: false,
+              name: projectName,
+              metadata: {},
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: false,
+        inAppAgent: false,
+        v4BetaToggleVisible: false,
+        observationEvals: false,
+        experimentsV4Enabled: false,
+        monitors: false,
+      },
+      admin: false,
+    },
+    environment: {
+      enableExperimentalFeatures: false,
+      selfHostedInstancePlan: plan,
+    },
+  };
+}
+
+const exportInput = (projectId: string) => ({
+  projectId,
+  name: "audit log export attempt",
+  query: {
+    tableName: BatchTableNames.AuditLogs,
+    filter: null,
+    orderBy: null,
+  },
+  format: BatchExportFileFormat.CSV,
+});
+
+describe("batchExport tRPC – audit_logs table authorization", () => {
+  afterAll(async () => {
+    await prisma.organization.deleteMany({
+      where: { id: { in: __orgIds } },
+    });
+  });
+
+  it("blocks a MEMBER (no auditLogs:read) from exporting audit_logs even on cloud:team plan", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    const caller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          plan: "cloud:team",
+          projectRole: "MEMBER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    await expect(
+      caller.batchExport.create(exportInput(project.id)),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("blocks an OWNER on cloud:hobby (no audit-logs entitlement) from exporting audit_logs", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    const caller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          plan: "cloud:hobby",
+          projectRole: "OWNER",
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    await expect(
+      caller.batchExport.create(exportInput(project.id)),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it.each<[Plan, Role]>([
+    ["cloud:team", "OWNER"],
+    ["cloud:team", "ADMIN"],
+    ["self-hosted:enterprise", "OWNER"],
+  ])(
+    "allows plan=%s role=%s (both entitlement and auditLogs:read) to export audit_logs",
+    async (plan, projectRole) => {
+      const { project, org } = await createOrgProjectAndApiKey();
+      __orgIds.push(org.id);
+
+      const caller = appRouter.createCaller({
+        ...createInnerTRPCContext({
+          session: makeSession(org.id, org.name, project.id, project.name, {
+            plan,
+            projectRole,
+          }),
+          headers: {},
+        }),
+        prisma,
+      });
+
+      await caller.batchExport.create(exportInput(project.id));
+
+      const job = await prisma.batchExport.findFirst({
+        where: { projectId: project.id, name: "audit log export attempt" },
+      });
+      expect(job).not.toBeNull();
+      expect(job?.query).toMatchObject({ tableName: "audit_logs" });
+    },
+  );
+});

--- a/web/src/features/batch-exports/server/batchExport.ts
+++ b/web/src/features/batch-exports/server/batchExport.ts
@@ -34,11 +34,6 @@ export const batchExportRouter = createTRPCRouter({
 
         const { projectId, query, format, name } = input;
 
-        // Audit log exports require additional permissions beyond batch export access.
-        // This check is intentionally at job-creation time only; the worker processes
-        // stored jobs without re-authorizing, so a job queued before this guard was
-        // deployed would still execute. That window is accepted as it requires an
-        // already-privileged actor and is bounded by the 30-day auto-fail cutoff.
         if (query.tableName === BatchExportTableName.AuditLogs) {
           throwIfNoEntitlement({
             entitlement: "audit-logs",

--- a/web/src/features/batch-exports/server/batchExport.ts
+++ b/web/src/features/batch-exports/server/batchExport.ts
@@ -1,4 +1,5 @@
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import {
   createTRPCRouter,
@@ -6,6 +7,7 @@ import {
 } from "@/src/server/api/trpc";
 import {
   BatchExportStatus,
+  BatchExportTableName,
   CreateBatchExportSchema,
   paginationZod,
 } from "@langfuse/shared";
@@ -31,6 +33,25 @@ export const batchExportRouter = createTRPCRouter({
         });
 
         const { projectId, query, format, name } = input;
+
+        // Audit log exports require additional permissions beyond batch export access.
+        // This check is intentionally at job-creation time only; the worker processes
+        // stored jobs without re-authorizing, so a job queued before this guard was
+        // deployed would still execute. That window is accepted as it requires an
+        // already-privileged actor and is bounded by the 30-day auto-fail cutoff.
+        if (query.tableName === BatchExportTableName.AuditLogs) {
+          throwIfNoEntitlement({
+            entitlement: "audit-logs",
+            sessionUser: ctx.session.user,
+            projectId,
+          });
+          throwIfNoProjectAccess({
+            session: ctx.session,
+            projectId,
+            scope: "auditLogs:read",
+          });
+        }
+
         assertLegacyTracingIoSearchCanCreateBatchJob({
           searchQuery: query.searchQuery,
           searchType: query.searchType,


### PR DESCRIPTION
## Summary

Fixes [LFE-10025](https://linear.app/langfuse/issue/LFE-10025) — intra-project privilege escalation via batch export table tampering.

A project member with `batchExports:create` could send a batch export request with `query.tableName = "audit_logs"`. The `batchExport.create` handler only checked `batchExports:create` before storing the job and enqueuing the worker — which then streamed the full project audit log to blob storage, bypassing the `auditLogs:read` RBAC scope and `audit-logs` entitlement checks that protect the normal audit log route.

- Add table-level authorization in `batchExport.create`: when `tableName === BatchExportTableName.AuditLogs`, require both `throwIfNoEntitlement("audit-logs")` and `throwIfNoProjectAccess("auditLogs:read")`, matching `auditLogs.allByProject` exactly.

### Impacted packages

- \`web\` — tRPC handler + regression tests

## Test plan

- [x] \`pnpm --filter web run lint\` — clean
- [x] \`pnpm --filter web exec tsc --noEmit --skipLibCheck\` — no errors in changed files
- [x] \`pnpm --filter web run test src/__tests__/server/batchExport-trpc.servertest.ts\` — 5/5 passed
  - blocks MEMBER (has entitlement, lacks `auditLogs:read`) → FORBIDDEN
  - blocks OWNER on `cloud:hobby` (lacks entitlement) → FORBIDDEN
  - allows OWNER on `cloud:team` → job created in DB ✓
  - allows ADMIN on `cloud:team` → job created in DB ✓
  - allows OWNER on `self-hosted:enterprise` → job created in DB ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a privilege escalation vulnerability where a project member with `batchExports:create` could bypass `auditLogs:read` RBAC and `audit-logs` entitlement checks by submitting a batch export request with `tableName = "audit_logs"`. The fix adds table-level authorization in the `batchExport.create` handler and includes regression tests.

- Adds a conditional check in `batchExport.create`: when `query.tableName === BatchExportTableName.AuditLogs`, both `throwIfNoEntitlement("audit-logs")` and `throwIfNoProjectAccess("auditLogs:read")` are enforced, mirroring the guards on `auditLogs.allByProject`.
- Adds 5 server-level regression tests covering MEMBER (blocked), OWNER on `cloud:hobby` (blocked), and OWNER/ADMIN on `cloud:team` plus OWNER on `self-hosted:enterprise` (all allowed).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The fix correctly closes the privilege escalation path by adding both the entitlement and RBAC checks before the job is persisted and enqueued; the worker itself has no authorization layer, which is expected given the async-job pattern.

The authorization logic is sound and the regression tests cover the key allowed/blocked combinations. The only rough edge is that expected FORBIDDEN throws from the new guards travel through the catch block and get logged at error level, which could generate alert noise but does not affect correctness or security.

The catch block in `web/src/features/batch-exports/server/batchExport.ts` (lines 91–99) logs auth errors alongside system errors at the same severity; worth a second look when addressing log hygiene.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/batch-exports/server/batchExport.ts:91-99
**FORBIDDEN errors logged at error level**

The `catch` block logs every thrown error — including expected `FORBIDDEN` responses from `throwIfNoEntitlement` and `throwIfNoProjectAccess` — at `logger.error` level before re-throwing. With the new auth guards for `audit_logs`, any unauthorized export attempt will emit an error-level log entry, which may trigger alerts and obscure genuine system failures. Consider skipping the error log (or logging at `warn`/`info`) when the caught exception is a `TRPCError` with an auth-related code such as `FORBIDDEN` or `UNAUTHORIZED`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove comment from audit log bat..."](https://github.com/langfuse/langfuse/commit/26da78cd8a84eac825eb2eb61a1c86550f31e42d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34946670)</sub>

<!-- /greptile_comment -->