### PR TITLE
fix(agent): Remove explicit `LANGFUSE_AWS_BEDROCK_REGION` precondition

### DIFF
--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -50,15 +50,6 @@ export default async function handler(request: Request) {
       );
     }
 
-    if (!env.LANGFUSE_AWS_BEDROCK_REGION) {
-      throw new BaseError(
-        "PreconditionFailedError",
-        412,
-        "Assistant is not configured",
-        true,
-      );
-    }
-
     const bodyResult = await readBoundedJsonBody(
       request,
       MAX_IN_APP_AGENT_INPUT_BYTES,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes an explicit precondition that required `LANGFUSE_AWS_BEDROCK_REGION` to be set before allowing the in-app agent handler to proceed. The region is now optional, allowing the AWS SDK to fall back to its built-in region discovery (e.g., `AWS_REGION`, `AWS_DEFAULT_REGION`, EC2/ECS metadata).

- The `awsBedrock.region` field in `CreateAgUiStreamOptions` was already typed as `region?: string`, and `agent.ts` already conditionally omits `AWS_DEFAULT_REGION`/`AWS_REGION` from the env when the value is undefined — so the downstream code was already prepared for this scenario.
- The cloud-only guard on `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` (line 44) remains in place, so self-hosted deployments are still blocked.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change removes an overly strict guard, and the downstream agent code already handles an undefined region gracefully.

The `awsBedrock.region` field was already typed optional (`region?: string`) in `CreateAgUiStreamOptions`, and `agent.ts` already guards the `AWS_DEFAULT_REGION`/`AWS_REGION` env assignment with a truthy check. Removing the 412 precondition simply allows deployments that rely on ambient AWS region configuration (IAM roles, ECS task metadata, etc.) to work without an explicit env var. No logic is changed downstream, and the cloud-only guard remains untouched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request] --> B{Authenticated?}
    B -- No --> C[401 Unauthorized]
    B -- Yes --> D{NEXT_PUBLIC_LANGFUSE_CLOUD_REGION set?}
    D -- No --> E[412 Not available in self-hosted]
    D -- Yes --> F[Parse & validate body]
    F --> G[Verify session / project membership]
    G --> H{Feature flag enabled?}
    H -- No --> I[403 Forbidden]
    H -- Yes --> J{AI features enabled for org?}
    J -- No --> K[403 Forbidden]
    J -- Yes --> L[createAgUiStream]
    L --> M{LANGFUSE_AWS_BEDROCK_REGION set?}
    M -- Yes --> N[Set AWS_REGION + AWS_DEFAULT_REGION env vars]
    M -- No --> O[AWS SDK auto-detects region]
    N --> P[Stream SSE response]
    O --> P
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Remove explicit \`LANGFUSE\_AW..."](https://github.com/langfuse/langfuse/commit/4881f1b13a12ff5d8f380e8158c4bba3a643994d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35100633)</sub>

<!-- /greptile_comment -->