### PR TITLE
fix(ui): better trace detail header spacings

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -84,6 +84,9 @@ signoff of user-visible changes.
   must be installed, ask the user before doing so.
 - Tailwind is the default styling layer; use the shared palette and globals in
   `src/styles/globals.css`.
+- In flex layouts, prefer `gap-*` over margin-based `space-x-*`/`space-y-*`.
+- Treat `!` Tailwind classes as a smell. Step back and fix the owning layout,
+  variant, or primitive before overriding with higher specificity.
 - When changing shared UI/table patterns, update sibling variants consistently,
   including default-visible and hidden columns or states.
 - For component style variants, prefer `cva` with `VariantProps` and merge

--- a/web/src/components/ItemBadge.tsx
+++ b/web/src/components/ItemBadge.tsx
@@ -116,6 +116,7 @@ export function ItemBadge({
 
   // Modify this line to ensure the icon is properly sized
   const iconClass = cn(
+    "shrink-0",
     iconVariants({ type }),
     isSmall ? "h-3 w-3" : "h-4 w-4",
     className,

--- a/web/src/components/table/peek.tsx
+++ b/web/src/components/table/peek.tsx
@@ -113,7 +113,7 @@ function TablePeekViewComponent(props: TablePeekViewProps) {
         className="flex max-h-full min-h-0 min-w-[60vw] flex-col gap-0 overflow-hidden p-0"
       >
         <SheetHeader className="bg-header flex min-h-11 flex-row flex-nowrap items-center justify-between px-2 py-1">
-          <SheetTitle className="mt-0! ml-2 flex min-w-0 flex-row items-center gap-2">
+          <SheetTitle className="flex min-w-0 flex-row items-center gap-2">
             <ItemBadge type={peekView.itemType} showLabel />
             <span
               className="truncate text-sm font-medium focus:outline-hidden"

--- a/web/src/components/trace/components/ObservationDetailView/ObservationDetailViewHeader.tsx
+++ b/web/src/components/trace/components/ObservationDetailView/ObservationDetailViewHeader.tsx
@@ -102,11 +102,9 @@ export const ObservationDetailViewHeader = memo(
       <div className="@container shrink-0 space-y-2 border-b p-2">
         {/* Title row with actions */}
         <div className="grid w-full grid-cols-1 items-start gap-2 @2xl:grid-cols-[auto_auto] @2xl:justify-between">
-          <div className="flex w-full flex-row items-start gap-1">
-            <div className="mt-1.5">
-              <ItemBadge type={observation.type as ObservationType} isSmall />
-            </div>
-            <span className="mb-0 ml-1 line-clamp-2 min-w-0 font-medium break-all md:break-normal md:wrap-break-word">
+          <div className="flex w-full flex-row items-center gap-1">
+            <ItemBadge type={observation.type as ObservationType} isSmall />
+            <span className="mb-0 line-clamp-2 min-w-0 font-medium break-all md:break-normal md:wrap-break-word">
               {observation.name || observation.id}
             </span>
             <DetailHeaderActionsMenu

--- a/web/src/components/trace/components/SpanContent.tsx
+++ b/web/src/components/trace/components/SpanContent.tsx
@@ -104,7 +104,7 @@ export function SpanContent({
       onMouseEnter={onHover}
       title={node.name}
       className={cn(
-        "peer relative flex min-w-0 flex-1 items-start rounded-md py-0.5 pr-2 pl-1 text-left",
+        "peer relative flex min-w-0 flex-1 items-center rounded-md py-0.5 pr-2 pl-1 text-left",
         className,
       )}
     >

--- a/web/src/components/trace/components/TraceDetailView/TraceDetailViewHeader.tsx
+++ b/web/src/components/trace/components/TraceDetailView/TraceDetailViewHeader.tsx
@@ -88,11 +88,9 @@ export const TraceDetailViewHeader = memo(function TraceDetailViewHeader({
     <div className="@container shrink-0 space-y-2 border-b p-2">
       {/* Title row with actions */}
       <div className="grid w-full grid-cols-1 items-start gap-2 @2xl:grid-cols-[auto_auto] @2xl:justify-between">
-        <div className="flex w-full flex-row items-start gap-1">
-          <div className="mt-1.5">
-            <ItemBadge type="TRACE" isSmall />
-          </div>
-          <span className="mb-0 ml-1 line-clamp-2 min-w-0 font-medium break-all md:break-normal md:wrap-break-word">
+        <div className="flex w-full flex-row items-center gap-1">
+          <ItemBadge type="TRACE" isSmall />
+          <span className="line-clamp-2 min-w-0 font-medium break-all md:break-normal md:wrap-break-word">
             {trace.name || trace.id}
           </span>
           <CopyIdsPopover idItems={[{ id: trace.id, name: "Trace ID" }]} />

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -80,10 +80,7 @@ const SheetHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
-      className,
-    )}
+    className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
     {...props}
   />
 );


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tidies up spacing in the trace detail header and the table peek view by replacing manual margin hacks (`mt-1.5` wrappers, `mb-0 ml-1` overrides, `space-y-2`) with idiomatic flex `gap`/`items-center` alignment. Two new AGENTS.md guidelines codify the approach: prefer `gap-*` over `space-*` in flex layouts, and treat Tailwind `!` overrides as a sign that the owning layout needs fixing.

- `sheet.tsx` switches `SheetHeader` from `space-y-2` to `gap-2`, which eliminates the need for the `mt-0!` child overrides that were patching over it.
- `TraceDetailViewHeader.tsx` and `SpanContent.tsx` drop manual badge/span offset workarounds in favour of `items-center` on the flex parent.
- Two `mt-0!` overrides on the siblings div in `peek.tsx` (lines 127 and 141) weren't cleaned up even though the root cause is now gone.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Pure Tailwind/layout-only changes with no data or logic touched; safe to merge.

All changes are limited to CSS class strings — no component logic, data flow, or API surface is modified. The space-y-2 to gap-2 swap in sheet.tsx is semantically correct for a flex-column container, and the remaining findings are minor cleanup suggestions.

No files require special attention, though peek.tsx still carries two mt-0! overrides that the fix to SheetHeader made unnecessary.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["SheetHeader\n(sheet.tsx)"] -->|"was: space-y-2"| B["mt-0! overrides needed\n(peek.tsx lines 116, 127, 141)"]
    A -->|"now: gap-2"| C["mt-0! on SheetTitle removed ✓"]
    A -.->|"still present"| D["mt-0! on sibling divs\n(peek.tsx lines 127, 141)"]
    E["TraceDetailViewHeader.tsx"] -->|"was: items-start + mt-1.5 wrapper"| F["Manual badge offset"]
    E -->|"now: items-center"| G["Badge and title naturally aligned ✓"]
    H["SpanContent.tsx"] -->|"was: items-start"| I["Content top-aligned"]
    H -->|"now: items-center"| J["Content vertically centered ✓"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/table/peek.tsx:127-141
**Leftover `!` overrides now unnecessary**

The `mt-0!` on lines 127 and 141 were compensating for the `space-y-2` margin that `SheetHeader` was adding to its children. Now that `SheetHeader` uses `gap-2` instead, those child elements no longer receive unwanted `margin-top`, so the `!` overrides can be removed — consistent with the new AGENTS.md guideline that treats them as a layout smell.

These are the two remaining sites: `"mt-0! flex shrink-0 flex-row items-center gap-2"` (line 127) and `"mt-0! mr-8 flex h-full flex-row items-center gap-1 border-l"` (line 141).

### Issue 2 of 2
web/src/components/ui/sheet.tsx:95
`SheetFooter` still uses `sm:space-x-2` in the same file this PR touches. Per the new AGENTS.md guideline, `gap-*` is preferred over `space-x-*` in flex layouts.

```suggestion
      "flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-x-2",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): better trace detail header spac..."](https://github.com/langfuse/langfuse/commit/8e58771c5997878807898d54d9bd748836140819) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35106417)</sub>

<!-- /greptile_comment -->