### PR TITLE
fix(worker): add OpenAI priority service tier pricing

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2288,6 +2288,16 @@ export class OtelIngestionProcessor {
               openaiMetadata["rejectedPredictionTokens"];
             usageDetails["output_reasoning_tokens"] ??=
               openaiMetadata["reasoningTokens"];
+
+            // Extract service tier for priority pricing matching.
+            // The serviceTier field is a string (e.g., "priority", "default").
+            // Encode as numeric flag: 1 for priority, absent otherwise.
+            const serviceTier = (openaiMetadata as Record<string, unknown>)[
+              "serviceTier"
+            ];
+            if (serviceTier === "priority") {
+              usageDetails["service_tier"] = 1;
+            }
           }
 
           // "ai.response.providerMetadata": {"anthropic":{"usage":{"input_tokens":7,"cache_creation_input_tokens":2089,"cache_read_input_tokens":16399,"cache_creation":{"ephemeral_5m_input_tokens":2089,"ephemeral_1h_input_tokens":0},"output_tokens":445,"service_tier":"standard"},"cacheCreationInputTokens":2089,"stopSequence":null,"container":null,"contextManagement":null}}

--- a/web/src/components/ui/time-period-select.tsx
+++ b/web/src/components/ui/time-period-select.tsx
@@ -42,12 +42,7 @@ export const TimePeriodSelect = React.forwardRef<
     if (date) {
       const hours = display12HourValue(date.getHours());
       setDate(
-        setDateByType(
-          new Date(date),
-          hours.toString(),
-          "12hours",
-          period === "AM" ? "PM" : "AM",
-        ),
+        setDateByType(new Date(date), hours.toString(), "12hours", value),
       );
     }
   };
@@ -55,7 +50,7 @@ export const TimePeriodSelect = React.forwardRef<
   return (
     <div className="flex h-7 items-center">
       <Select
-        defaultValue={period}
+        value={period}
         onValueChange={(value: Period) => handleValueChange(value)}
       >
         <SelectTrigger

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -2,7 +2,7 @@
   {
     "id": "b9854a5c92dc496b997d99d20",
     "modelName": "gpt-4o",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o)$",
     "createdAt": "2024-05-13T23:15:07.670Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -19,10 +19,30 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000025,
-          "input_cached_tokens": 0.00000125,
-          "input_cache_read": 0.00000125,
-          "output": 0.00001
+          "input": 2.5e-06,
+          "input_cached_tokens": 1.25e-06,
+          "input_cache_read": 1.25e-06,
+          "output": 1e-05
+        }
+      },
+      {
+        "id": "b9854a5c92dc496b997d99d20_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 4.25e-06,
+          "input_cached_tokens": 2.125e-06,
+          "input_cache_read": 2.125e-06,
+          "output": 1.7e-05
         }
       }
     ]
@@ -30,7 +50,7 @@
   {
     "id": "b9854a5c92dc496b997d99d21",
     "modelName": "gpt-4o-2024-05-13",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-05-13)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-05-13)$",
     "createdAt": "2024-05-13T23:15:07.670Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -47,8 +67,26 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000005,
-          "output": 0.000015
+          "input": 5e-06,
+          "output": 1.5e-05
+        }
+      },
+      {
+        "id": "b9854a5c92dc496b997d99d21_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 8.75e-06,
+          "output": 2.625e-05
         }
       }
     ]
@@ -56,7 +94,7 @@
   {
     "id": "clrkvq6iq000008ju6c16gynt",
     "modelName": "gpt-4-1106-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-1106-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-1106-preview)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -73,8 +111,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -82,7 +120,7 @@
   {
     "id": "clrkvx5gp000108juaogs54ea",
     "modelName": "gpt-4-turbo-vision",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4(-\\d{4})?-vision-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4(-\\d{4})?-vision-preview)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -99,8 +137,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -108,7 +146,7 @@
   {
     "id": "clrkvyzgw000308jue4hse4j9",
     "modelName": "gpt-4-32k",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-32k)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -125,7 +163,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00006,
+          "input": 6e-05,
           "output": 0.00012
         }
       }
@@ -134,7 +172,7 @@
   {
     "id": "clrkwk4cb000108l5hwwh3zdi",
     "modelName": "gpt-4-32k-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-32k-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -151,7 +189,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00006,
+          "input": 6e-05,
           "output": 0.00012
         }
       }
@@ -160,7 +198,7 @@
   {
     "id": "clrkwk4cb000208l59yvb9yq8",
     "modelName": "gpt-3.5-turbo-1106",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-1106)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-1106)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -177,8 +215,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000001,
-          "output": 0.000002
+          "input": 1e-06,
+          "output": 2e-06
         }
       }
     ]
@@ -186,7 +224,7 @@
   {
     "id": "clrkwk4cc000808l51xmk4uic",
     "modelName": "gpt-3.5-turbo-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -203,8 +241,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000015,
-          "output": 0.000002
+          "input": 1.5e-06,
+          "output": 2e-06
         }
       }
     ]
@@ -212,7 +250,7 @@
   {
     "id": "clrkwk4cc000908l537kl0rx3",
     "modelName": "gpt-4-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-0613)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -229,8 +267,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00003,
-          "output": 0.00006
+          "input": 3e-05,
+          "output": 6e-05
         }
       }
     ]
@@ -238,7 +276,7 @@
   {
     "id": "clrkwk4cc000a08l562uc3s9g",
     "modelName": "gpt-3.5-turbo-instruct",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-instruct)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-instruct)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -255,8 +293,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000015,
-          "output": 0.000002
+          "input": 1.5e-06,
+          "output": 2e-06
         }
       }
     ]
@@ -279,7 +317,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 0.000004
+          "total": 4e-06
         }
       }
     ]
@@ -302,7 +340,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 5e-7
+          "total": 5e-07
         }
       }
     ]
@@ -325,7 +363,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 0.00002
+          "total": 2e-05
         }
       }
     ]
@@ -348,7 +386,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 0.00002
+          "total": 2e-05
         }
       }
     ]
@@ -371,7 +409,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 0.00002
+          "total": 2e-05
         }
       }
     ]
@@ -394,7 +432,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 0.00002
+          "total": 2e-05
         }
       }
     ]
@@ -417,7 +455,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-7
+          "total": 1e-07
         }
       }
     ]
@@ -440,7 +478,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-7
+          "total": 1e-07
         }
       }
     ]
@@ -448,7 +486,7 @@
   {
     "id": "clrntjt89000a08jw0gcdbd5a",
     "modelName": "gpt-3.5-turbo-16k-0613",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-16k-0613)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-16k-0613)$",
     "createdAt": "2024-02-03T17:29:57.350Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -465,8 +503,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "output": 0.000004
+          "input": 3e-06,
+          "output": 4e-06
         }
       }
     ]
@@ -474,7 +512,7 @@
   {
     "id": "clrntkjgy000a08jx4e062mr0",
     "modelName": "gpt-3.5-turbo-0301",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0301)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0301)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -491,8 +529,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000002,
-          "output": 0.000002
+          "input": 2e-06,
+          "output": 2e-06
         }
       }
     ]
@@ -500,7 +538,7 @@
   {
     "id": "clrntkjgy000d08jx0p4y9h4l",
     "modelName": "gpt-4-32k-0314",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-32k-0314)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-32k-0314)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -517,7 +555,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00006,
+          "input": 6e-05,
           "output": 0.00012
         }
       }
@@ -526,7 +564,7 @@
   {
     "id": "clrntkjgy000e08jx4x6uawoo",
     "modelName": "gpt-4-0314",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-0314)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-0314)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -543,8 +581,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00003,
-          "output": 0.00006
+          "input": 3e-05,
+          "output": 6e-05
         }
       }
     ]
@@ -552,7 +590,7 @@
   {
     "id": "clrntkjgy000f08jx79v9g1xj",
     "modelName": "gpt-4",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4)$",
     "createdAt": "2024-01-24T10:19:21.693Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -569,8 +607,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00003,
-          "output": 0.00006
+          "input": 3e-05,
+          "output": 6e-05
         }
       }
     ]
@@ -578,7 +616,7 @@
   {
     "id": "clrnwb41q000308jsfrac9uh6",
     "modelName": "claude-instant-1.2",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-instant-1.2)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-instant-1.2)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -590,8 +628,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000163,
-          "output": 0.00000551
+          "input": 1.63e-06,
+          "output": 5.51e-06
         }
       }
     ]
@@ -599,7 +637,7 @@
   {
     "id": "clrnwb836000408jsallr6u11",
     "modelName": "claude-2.0",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-2.0)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-2.0)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -611,8 +649,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000008,
-          "output": 0.000024
+          "input": 8e-06,
+          "output": 2.4e-05
         }
       }
     ]
@@ -620,7 +658,7 @@
   {
     "id": "clrnwbd1m000508js4hxu6o7n",
     "modelName": "claude-2.1",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-2.1)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-2.1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -632,8 +670,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000008,
-          "output": 0.000024
+          "input": 8e-06,
+          "output": 2.4e-05
         }
       }
     ]
@@ -641,7 +679,7 @@
   {
     "id": "clrnwbg2b000608jse2pp4q2d",
     "modelName": "claude-1.3",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-1.3)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-1.3)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -653,8 +691,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000008,
-          "output": 0.000024
+          "input": 8e-06,
+          "output": 2.4e-05
         }
       }
     ]
@@ -662,7 +700,7 @@
   {
     "id": "clrnwbi9d000708jseiy44k26",
     "modelName": "claude-1.2",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-1.2)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-1.2)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -674,8 +712,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000008,
-          "output": 0.000024
+          "input": 8e-06,
+          "output": 2.4e-05
         }
       }
     ]
@@ -683,7 +721,7 @@
   {
     "id": "clrnwblo0000808jsc1385hdp",
     "modelName": "claude-1.1",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-1.1)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-1.1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -695,8 +733,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000008,
-          "output": 0.000024
+          "input": 8e-06,
+          "output": 2.4e-05
         }
       }
     ]
@@ -704,7 +742,7 @@
   {
     "id": "clrnwbota000908jsgg9mb1ml",
     "modelName": "claude-instant-1",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-instant-1)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-instant-1)$",
     "createdAt": "2024-01-30T15:44:13.447Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -716,8 +754,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000163,
-          "output": 0.00000551
+          "input": 1.63e-06,
+          "output": 5.51e-06
         }
       }
     ]
@@ -740,8 +778,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 4e-7,
-          "output": 0.0000016
+          "input": 4e-07,
+          "output": 1.6e-06
         }
       }
     ]
@@ -764,8 +802,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000006,
-          "output": 0.000012
+          "input": 6e-06,
+          "output": 1.2e-05
         }
       }
     ]
@@ -788,7 +826,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 2e-8
+          "total": 2e-08
         }
       }
     ]
@@ -811,7 +849,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1.3e-7
+          "total": 1.3e-07
         }
       }
     ]
@@ -819,7 +857,7 @@
   {
     "id": "clruwnahl00030al7ab9rark7",
     "modelName": "gpt-3.5-turbo-0125",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-0125)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-0125)$",
     "createdAt": "2024-01-26T17:35:21.129Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -836,8 +874,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-7,
-          "output": 0.0000015
+          "input": 5e-07,
+          "output": 1.5e-06
         }
       }
     ]
@@ -845,7 +883,7 @@
   {
     "id": "clruwnahl00040al78f1lb0at",
     "modelName": "gpt-3.5-turbo",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo)$",
     "createdAt": "2024-02-13T12:00:37.424Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -862,8 +900,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-7,
-          "output": 0.0000015
+          "input": 5e-07,
+          "output": 1.5e-06
         }
       }
     ]
@@ -871,7 +909,7 @@
   {
     "id": "clruwnahl00050al796ck3p44",
     "modelName": "gpt-4-0125-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-0125-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-0125-preview)$",
     "createdAt": "2024-01-26T17:35:21.129Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -888,8 +926,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -914,8 +952,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "output": 0.000006
+          "input": 3e-06,
+          "output": 6e-06
         }
       }
     ]
@@ -940,8 +978,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000012,
-          "output": 0.000016
+          "input": 1.2e-05,
+          "output": 1.6e-05
         }
       }
     ]
@@ -964,8 +1002,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000012,
-          "output": 0.000012
+          "input": 1.2e-05,
+          "output": 1.2e-05
         }
       }
     ]
@@ -988,8 +1026,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000016,
-          "output": 0.0000016
+          "input": 1.6e-06,
+          "output": 1.6e-06
         }
       }
     ]
@@ -1008,8 +1046,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1028,8 +1066,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1048,8 +1086,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1068,8 +1106,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1088,8 +1126,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1108,8 +1146,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000025,
-          "output": 0.0000075
+          "input": 2.5e-06,
+          "output": 7.5e-06
         }
       }
     ]
@@ -1128,8 +1166,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1148,7 +1186,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-7
+          "total": 1e-07
         }
       }
     ]
@@ -1167,7 +1205,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "total": 1e-7
+          "total": 1e-07
         }
       }
     ]
@@ -1186,8 +1224,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1206,8 +1244,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1226,8 +1264,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1235,7 +1273,7 @@
   {
     "id": "clsk9lntu000008jwfc51bbqv",
     "modelName": "gpt-3.5-turbo-16k",
-    "matchPattern": "(?i)^(openai\/)?(gpt-)(35|3.5)(-turbo-16k)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-)(35|3.5)(-turbo-16k)$",
     "createdAt": "2024-02-13T12:00:37.424Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1252,8 +1290,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-7,
-          "output": 0.0000015
+          "input": 5e-07,
+          "output": 1.5e-06
         }
       }
     ]
@@ -1261,7 +1299,7 @@
   {
     "id": "clsnq07bn000008l4e46v1ll8",
     "modelName": "gpt-4-turbo-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo-preview)$",
     "createdAt": "2024-02-15T21:21:50.947Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1278,8 +1316,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -1287,7 +1325,7 @@
   {
     "id": "cltgy0iuw000008le3vod1hhy",
     "modelName": "claude-3-opus-20240229",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-opus-20240229|anthropic\\.claude-3-opus-20240229-v1:0|claude-3-opus@20240229)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-opus-20240229|anthropic\\.claude-3-opus-20240229-v1:0|claude-3-opus@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1299,8 +1337,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "output": 0.000075
+          "input": 1.5e-05,
+          "output": 7.5e-05
         }
       }
     ]
@@ -1308,7 +1346,7 @@
   {
     "id": "cltgy0pp6000108le56se7bl3",
     "modelName": "claude-3-sonnet-20240229",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-sonnet-20240229|anthropic\\.claude-3-sonnet-20240229-v1:0|claude-3-sonnet@20240229)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-sonnet-20240229|anthropic\\.claude-3-sonnet-20240229-v1:0|claude-3-sonnet@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1320,17 +1358,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "input_cache_creation_5m": 0.00000375,
-          "input_cache_creation_1h": 0.000006,
-          "cache_read_input_tokens": 3e-7,
-          "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "input_cache_creation_5m": 3.75e-06,
+          "input_cache_creation_1h": 6e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cached_tokens": 3e-07,
+          "input_cache_read": 3e-07
         }
       }
     ]
@@ -1338,7 +1376,7 @@
   {
     "id": "cltr0w45b000008k1407o9qv1",
     "modelName": "claude-3-haiku-20240307",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-haiku-20240307|anthropic\\.claude-3-haiku-20240307-v1:0|claude-3-haiku@20240307)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-haiku-20240307|anthropic\\.claude-3-haiku-20240307-v1:0|claude-3-haiku@20240307)$",
     "createdAt": "2024-03-14T09:41:18.736Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1350,8 +1388,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 0.00000125
+          "input": 2.5e-07,
+          "output": 1.25e-06
         }
       }
     ]
@@ -1359,7 +1397,7 @@
   {
     "id": "cluv2sjeo000008ih0fv23hi0",
     "modelName": "gemini-1.0-pro-latest",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-1.0-pro-latest)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-1.0-pro-latest)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -1370,8 +1408,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "output": 5e-7
+          "input": 2.5e-07,
+          "output": 5e-07
         }
       }
     ]
@@ -1379,7 +1417,7 @@
   {
     "id": "cluv2subq000108ih2mlrga6a",
     "modelName": "gemini-1.0-pro",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-1.0-pro)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-1.0-pro)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -1390,8 +1428,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-7,
-          "output": 3.75e-7
+          "input": 1.25e-07,
+          "output": 3.75e-07
         }
       }
     ]
@@ -1399,7 +1437,7 @@
   {
     "id": "cluv2sx04000208ihbek75lsz",
     "modelName": "gemini-1.0-pro-001",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-1.0-pro-001)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-1.0-pro-001)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -1410,8 +1448,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-7,
-          "output": 3.75e-7
+          "input": 1.25e-07,
+          "output": 3.75e-07
         }
       }
     ]
@@ -1419,7 +1457,7 @@
   {
     "id": "cluv2szw0000308ihch3n79x7",
     "modelName": "gemini-pro",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-pro)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-pro)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -1430,8 +1468,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-7,
-          "output": 3.75e-7
+          "input": 1.25e-07,
+          "output": 3.75e-07
         }
       }
     ]
@@ -1439,7 +1477,7 @@
   {
     "id": "cluv2t2x0000408ihfytl45l1",
     "modelName": "gemini-1.5-pro-latest",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-1.5-pro-latest)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-1.5-pro-latest)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2024-04-11T10:27:46.517Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -1450,8 +1488,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000025,
-          "output": 0.0000075
+          "input": 2.5e-06,
+          "output": 7.5e-06
         }
       }
     ]
@@ -1459,7 +1497,7 @@
   {
     "id": "cluv2t5k3000508ih5kve9zag",
     "modelName": "gpt-4-turbo-2024-04-09",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo-2024-04-09)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo-2024-04-09)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1476,8 +1514,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -1485,7 +1523,7 @@
   {
     "id": "cluvpl4ls000008l6h2gx3i07",
     "modelName": "gpt-4-turbo",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-turbo)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-turbo)$",
     "createdAt": "2024-04-11T21:13:44.989Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1502,8 +1540,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -1511,7 +1549,7 @@
   {
     "id": "clv2o2x0p000008jsf9afceau",
     "modelName": " gpt-4-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4-preview)$",
     "createdAt": "2024-04-23T10:37:17.092Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1528,8 +1566,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00001,
-          "output": 0.00003
+          "input": 1e-05,
+          "output": 3e-05
         }
       }
     ]
@@ -1537,7 +1575,7 @@
   {
     "id": "clxt0n0m60000pumz1j5b7zsf",
     "modelName": "claude-3-5-sonnet-20240620",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
     "createdAt": "2024-06-25T11:47:24.475Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1549,17 +1587,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "input_cache_creation_5m": 0.00000375,
-          "input_cache_creation_1h": 0.000006,
-          "cache_read_input_tokens": 3e-7,
-          "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "input_cache_creation_5m": 3.75e-06,
+          "input_cache_creation_1h": 6e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cached_tokens": 3e-07,
+          "input_cache_read": 3e-07
         }
       }
     ]
@@ -1567,7 +1605,7 @@
   {
     "id": "clyrjp56f0000t0mzapoocd7u",
     "modelName": "gpt-4o-mini",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-mini)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-mini)$",
     "createdAt": "2024-07-18T17:56:09.591Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1584,10 +1622,30 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-7,
-          "output": 6e-7,
-          "input_cached_tokens": 7.5e-8,
-          "input_cache_read": 7.5e-8
+          "input": 1.5e-07,
+          "output": 6e-07,
+          "input_cached_tokens": 7.5e-08,
+          "input_cache_read": 7.5e-08
+        }
+      },
+      {
+        "id": "clyrjp56f0000t0mzapoocd7u_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 2.5e-07,
+          "output": 1e-06,
+          "input_cached_tokens": 1.25e-07,
+          "input_cache_read": 1.25e-07
         }
       }
     ]
@@ -1595,7 +1653,7 @@
   {
     "id": "clyrjpbe20000t0mzcbwc42rg",
     "modelName": "gpt-4o-mini-2024-07-18",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-mini-2024-07-18)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-mini-2024-07-18)$",
     "createdAt": "2024-07-18T17:56:09.591Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1612,10 +1670,30 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-7,
-          "input_cached_tokens": 7.5e-8,
-          "input_cache_read": 7.5e-8,
-          "output": 6e-7
+          "input": 1.5e-07,
+          "input_cached_tokens": 7.5e-08,
+          "input_cache_read": 7.5e-08,
+          "output": 6e-07
+        }
+      },
+      {
+        "id": "clyrjpbe20000t0mzcbwc42rg_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 2.5e-07,
+          "input_cached_tokens": 1.25e-07,
+          "input_cache_read": 1.25e-07,
+          "output": 1e-06
         }
       }
     ]
@@ -1623,7 +1701,7 @@
   {
     "id": "clzjr85f70000ymmzg7hqffra",
     "modelName": "gpt-4o-2024-08-06",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-08-06)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-08-06)$",
     "createdAt": "2024-08-07T11:54:31.298Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1640,10 +1718,30 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000025,
-          "input_cached_tokens": 0.00000125,
-          "input_cache_read": 0.00000125,
-          "output": 0.00001
+          "input": 2.5e-06,
+          "input_cached_tokens": 1.25e-06,
+          "input_cache_read": 1.25e-06,
+          "output": 1e-05
+        }
+      },
+      {
+        "id": "clzjr85f70000ymmzg7hqffra_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 4.25e-06,
+          "input_cached_tokens": 2.125e-06,
+          "input_cache_read": 2.125e-06,
+          "output": 1.7e-05
         }
       }
     ]
@@ -1651,7 +1749,7 @@
   {
     "id": "cm10ivcdp0000gix7lelmbw80",
     "modelName": "o1-preview",
-    "matchPattern": "(?i)^(openai\/)?(o1-preview)$",
+    "matchPattern": "(?i)^(openai/)?(o1-preview)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1662,12 +1760,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_cached_tokens": 0.0000075,
-          "input_cache_read": 0.0000075,
-          "output": 0.00006,
-          "output_reasoning_tokens": 0.00006,
-          "output_reasoning": 0.00006
+          "input": 1.5e-05,
+          "input_cached_tokens": 7.5e-06,
+          "input_cache_read": 7.5e-06,
+          "output": 6e-05,
+          "output_reasoning_tokens": 6e-05,
+          "output_reasoning": 6e-05
         }
       }
     ]
@@ -1675,7 +1773,7 @@
   {
     "id": "cm10ivo130000n8x7qopcjjcg",
     "modelName": "o1-preview-2024-09-12",
-    "matchPattern": "(?i)^(openai\/)?(o1-preview-2024-09-12)$",
+    "matchPattern": "(?i)^(openai/)?(o1-preview-2024-09-12)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1686,12 +1784,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_cached_tokens": 0.0000075,
-          "input_cache_read": 0.0000075,
-          "output": 0.00006,
-          "output_reasoning_tokens": 0.00006,
-          "output_reasoning": 0.00006
+          "input": 1.5e-05,
+          "input_cached_tokens": 7.5e-06,
+          "input_cache_read": 7.5e-06,
+          "output": 6e-05,
+          "output_reasoning_tokens": 6e-05,
+          "output_reasoning": 6e-05
         }
       }
     ]
@@ -1699,7 +1797,7 @@
   {
     "id": "cm10ivwo40000r1x7gg3syjq0",
     "modelName": "o1-mini",
-    "matchPattern": "(?i)^(openai\/)?(o1-mini)$",
+    "matchPattern": "(?i)^(openai/)?(o1-mini)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1710,12 +1808,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 5.5e-7,
-          "input_cache_read": 5.5e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 5.5e-07,
+          "input_cache_read": 5.5e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
         }
       }
     ]
@@ -1723,7 +1821,7 @@
   {
     "id": "cm10iw6p20000wgx7it1hlb22",
     "modelName": "o1-mini-2024-09-12",
-    "matchPattern": "(?i)^(openai\/)?(o1-mini-2024-09-12)$",
+    "matchPattern": "(?i)^(openai/)?(o1-mini-2024-09-12)$",
     "createdAt": "2024-09-13T10:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1734,12 +1832,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 5.5e-7,
-          "input_cache_read": 5.5e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 5.5e-07,
+          "input_cache_read": 5.5e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
         }
       }
     ]
@@ -1747,7 +1845,7 @@
   {
     "id": "cm2krz1uf000208jjg5653iud",
     "modelName": "claude-3.5-sonnet-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20241022-v2:0|claude-3-5-sonnet-V2@20241022)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1759,17 +1857,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "input_cache_creation_5m": 0.00000375,
-          "input_cache_creation_1h": 0.000006,
-          "cache_read_input_tokens": 3e-7,
-          "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "input_cache_creation_5m": 3.75e-06,
+          "input_cache_creation_1h": 6e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cached_tokens": 3e-07,
+          "input_cache_read": 3e-07
         }
       }
     ]
@@ -1777,7 +1875,7 @@
   {
     "id": "cm2ks2vzn000308jjh4ze1w7q",
     "modelName": "claude-3.5-sonnet-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-sonnet-latest)$",
     "createdAt": "2024-10-22T18:48:01.676Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1789,17 +1887,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "input_cache_creation_5m": 0.00000375,
-          "input_cache_creation_1h": 0.000006,
-          "cache_read_input_tokens": 3e-7,
-          "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "input_cache_creation_5m": 3.75e-06,
+          "input_cache_creation_1h": 6e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cached_tokens": 3e-07,
+          "input_cache_read": 3e-07
         }
       }
     ]
@@ -1807,7 +1905,7 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "modelName": "claude-3-5-haiku-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1819,17 +1917,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-7,
-          "input_tokens": 8e-7,
-          "output": 0.000004,
-          "output_tokens": 0.000004,
-          "cache_creation_input_tokens": 0.000001,
-          "input_cache_creation": 0.000001,
-          "input_cache_creation_5m": 0.000001,
-          "input_cache_creation_1h": 0.0000016,
-          "cache_read_input_tokens": 8e-8,
-          "input_cached_tokens": 8e-8,
-          "input_cache_read": 8e-8
+          "input": 8e-07,
+          "input_tokens": 8e-07,
+          "output": 4e-06,
+          "output_tokens": 4e-06,
+          "cache_creation_input_tokens": 1e-06,
+          "input_cache_creation": 1e-06,
+          "input_cache_creation_5m": 1e-06,
+          "input_cache_creation_1h": 1.6e-06,
+          "cache_read_input_tokens": 8e-08,
+          "input_cached_tokens": 8e-08,
+          "input_cache_read": 8e-08
         }
       }
     ]
@@ -1837,7 +1935,7 @@
   {
     "id": "cm34aqb9h000307ml6nypd618",
     "modelName": "claude-3.5-haiku-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-5-haiku-latest)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1849,17 +1947,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 8e-7,
-          "input_tokens": 8e-7,
-          "output": 0.000004,
-          "output_tokens": 0.000004,
-          "cache_creation_input_tokens": 0.000001,
-          "input_cache_creation": 0.000001,
-          "input_cache_creation_5m": 0.000001,
-          "input_cache_creation_1h": 0.0000016,
-          "cache_read_input_tokens": 8e-8,
-          "input_cached_tokens": 8e-8,
-          "input_cache_read": 8e-8
+          "input": 8e-07,
+          "input_tokens": 8e-07,
+          "output": 4e-06,
+          "output_tokens": 4e-06,
+          "cache_creation_input_tokens": 1e-06,
+          "input_cache_creation": 1e-06,
+          "input_cache_creation_5m": 1e-06,
+          "input_cache_creation_1h": 1.6e-06,
+          "cache_read_input_tokens": 8e-08,
+          "input_cached_tokens": 8e-08,
+          "input_cache_read": 8e-08
         }
       }
     ]
@@ -1884,8 +1982,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000005,
-          "output": 0.000015
+          "input": 5e-06,
+          "output": 1.5e-05
         }
       }
     ]
@@ -1893,7 +1991,7 @@
   {
     "id": "cm48akqgo000008ldbia24qg0",
     "modelName": "gpt-4o-2024-11-20",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-2024-11-20)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-2024-11-20)$",
     "createdAt": "2024-12-03T10:06:12.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -1910,10 +2008,30 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000025,
-          "input_cached_tokens": 0.00000125,
-          "input_cache_read": 0.00000125,
-          "output": 0.00001
+          "input": 2.5e-06,
+          "input_cached_tokens": 1.25e-06,
+          "input_cache_read": 1.25e-06,
+          "output": 1e-05
+        }
+      },
+      {
+        "id": "cm48akqgo000008ldbia24qg0_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 4.25e-06,
+          "input_cached_tokens": 2.125e-06,
+          "input_cache_read": 2.125e-06,
+          "output": 1.7e-05
         }
       }
     ]
@@ -1921,7 +2039,7 @@
   {
     "id": "cm48b2ksh000008l0hn3u0hl3",
     "modelName": "gpt-4o-audio-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-audio-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-audio-preview)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1932,8 +2050,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 0.0000025,
-          "output_text_tokens": 0.00001,
+          "input_text_tokens": 2.5e-06,
+          "output_text_tokens": 1e-05,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
           "output_audio_tokens": 0.0002,
@@ -1945,7 +2063,7 @@
   {
     "id": "cm48bbm0k000008l69nsdakwf",
     "modelName": "gpt-4o-audio-preview-2024-10-01",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-audio-preview-2024-10-01)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-audio-preview-2024-10-01)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1956,8 +2074,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 0.0000025,
-          "output_text_tokens": 0.00001,
+          "input_text_tokens": 2.5e-06,
+          "output_text_tokens": 1e-05,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
           "output_audio_tokens": 0.0002,
@@ -1969,7 +2087,7 @@
   {
     "id": "cm48c2qh4000008mhgy4mg2qc",
     "modelName": "gpt-4o-realtime-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-realtime-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-realtime-preview)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -1980,12 +2098,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 0.000005,
-          "input_cached_text_tokens": 0.0000025,
-          "output_text_tokens": 0.00002,
+          "input_text_tokens": 5e-06,
+          "input_cached_text_tokens": 2.5e-06,
+          "output_text_tokens": 2e-05,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
-          "input_cached_audio_tokens": 0.00002,
+          "input_cached_audio_tokens": 2e-05,
           "output_audio_tokens": 0.0002,
           "output_audio": 0.0002
         }
@@ -1995,7 +2113,7 @@
   {
     "id": "cm48cjxtc000008jrcsso3avv",
     "modelName": "gpt-4o-realtime-preview-2024-10-01",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4o-realtime-preview-2024-10-01)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4o-realtime-preview-2024-10-01)$",
     "createdAt": "2024-12-03T10:19:56.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2006,12 +2124,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text_tokens": 0.000005,
-          "input_cached_text_tokens": 0.0000025,
-          "output_text_tokens": 0.00002,
+          "input_text_tokens": 5e-06,
+          "input_cached_text_tokens": 2.5e-06,
+          "output_text_tokens": 2e-05,
           "input_audio_tokens": 0.0001,
           "input_audio": 0.0001,
-          "input_cached_audio_tokens": 0.00002,
+          "input_cached_audio_tokens": 2e-05,
           "output_audio_tokens": 0.0002,
           "output_audio": 0.0002
         }
@@ -2021,7 +2139,7 @@
   {
     "id": "cm48cjxtc000108jrcsso3avv",
     "modelName": "o1",
-    "matchPattern": "(?i)^(openai\/)?(o1)$",
+    "matchPattern": "(?i)^(openai/)?(o1)$",
     "createdAt": "2025-01-17T00:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2032,12 +2150,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_cached_tokens": 0.0000075,
-          "input_cache_read": 0.0000075,
-          "output": 0.00006,
-          "output_reasoning_tokens": 0.00006,
-          "output_reasoning": 0.00006
+          "input": 1.5e-05,
+          "input_cached_tokens": 7.5e-06,
+          "input_cache_read": 7.5e-06,
+          "output": 6e-05,
+          "output_reasoning_tokens": 6e-05,
+          "output_reasoning": 6e-05
         }
       }
     ]
@@ -2045,7 +2163,7 @@
   {
     "id": "cm48cjxtc000208jrcsso3avv",
     "modelName": "o1-2024-12-17",
-    "matchPattern": "(?i)^(openai\/)?(o1-2024-12-17)$",
+    "matchPattern": "(?i)^(openai/)?(o1-2024-12-17)$",
     "createdAt": "2025-01-17T00:01:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2056,12 +2174,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_cached_tokens": 0.0000075,
-          "input_cache_read": 0.0000075,
-          "output": 0.00006,
-          "output_reasoning_tokens": 0.00006,
-          "output_reasoning": 0.00006
+          "input": 1.5e-05,
+          "input_cached_tokens": 7.5e-06,
+          "input_cache_read": 7.5e-06,
+          "output": 6e-05,
+          "output_reasoning_tokens": 6e-05,
+          "output_reasoning": 6e-05
         }
       }
     ]
@@ -2069,7 +2187,7 @@
   {
     "id": "cm6l8j7vs0000tymz9vk7ew8t",
     "modelName": "o3-mini",
-    "matchPattern": "(?i)^(openai\/)?(o3-mini)$",
+    "matchPattern": "(?i)^(openai/)?(o3-mini)$",
     "createdAt": "2025-01-31T20:41:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2080,12 +2198,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 5.5e-7,
-          "input_cache_read": 5.5e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 5.5e-07,
+          "input_cache_read": 5.5e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
         }
       }
     ]
@@ -2093,7 +2211,7 @@
   {
     "id": "cm6l8jan90000tymz52sh0ql8",
     "modelName": "o3-mini-2025-01-31",
-    "matchPattern": "(?i)^(openai\/)?(o3-mini-2025-01-31)$",
+    "matchPattern": "(?i)^(openai/)?(o3-mini-2025-01-31)$",
     "createdAt": "2025-01-31T20:41:35.373Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2104,12 +2222,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 5.5e-7,
-          "input_cache_read": 5.5e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 5.5e-07,
+          "input_cache_read": 5.5e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
         }
       }
     ]
@@ -2117,7 +2235,7 @@
   {
     "id": "cm6l8jdef0000tymz52sh0ql0",
     "modelName": "gemini-2.0-flash-001",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.0-flash-001)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.0-flash-001)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-02-06T11:11:35.241Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -2128,8 +2246,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-7,
-          "output": 4e-7
+          "input": 1e-07,
+          "output": 4e-07
         }
       }
     ]
@@ -2137,7 +2255,7 @@
   {
     "id": "cm6l8jfgh0000tymz52sh0ql1",
     "modelName": "gemini-2.0-flash-lite-preview-02-05",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.0-flash-lite-preview-02-05)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.0-flash-lite-preview-02-05)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-02-06T11:11:35.241Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -2148,8 +2266,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 7.5e-8,
-          "output": 3e-7
+          "input": 7.5e-08,
+          "output": 3e-07
         }
       }
     ]
@@ -2157,7 +2275,7 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "modelName": "claude-3.7-sonnet-20250219",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2169,17 +2287,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "input_cache_creation_5m": 0.00000375,
-          "input_cache_creation_1h": 0.000006,
-          "cache_read_input_tokens": 3e-7,
-          "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "input_cache_creation_5m": 3.75e-06,
+          "input_cache_creation_1h": 6e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cached_tokens": 3e-07,
+          "input_cache_read": 3e-07
         }
       }
     ]
@@ -2187,7 +2305,7 @@
   {
     "id": "cm7ka7zob000208jsfs9h5ajj",
     "modelName": "claude-3.7-sonnet-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-7-sonnet-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-3-7-sonnet-latest)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2199,17 +2317,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "input_cache_creation_5m": 0.00000375,
-          "input_cache_creation_1h": 0.000006,
-          "cache_read_input_tokens": 3e-7,
-          "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "input_cache_creation_5m": 3.75e-06,
+          "input_cache_creation_1h": 6e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cached_tokens": 3e-07,
+          "input_cache_read": 3e-07
         }
       }
     ]
@@ -2217,7 +2335,7 @@
   {
     "id": "cm7nusjvk0000tvmz71o85jwg",
     "modelName": "gpt-4.5-preview",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.5-preview)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.5-preview)$",
     "createdAt": "2025-02-27T21:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2228,10 +2346,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000075,
-          "input_cached_tokens": 0.0000375,
-          "input_cached_text_tokens": 0.0000375,
-          "input_cache_read": 0.0000375,
+          "input": 7.5e-05,
+          "input_cached_tokens": 3.75e-05,
+          "input_cached_text_tokens": 3.75e-05,
+          "input_cache_read": 3.75e-05,
           "output": 0.00015
         }
       }
@@ -2240,7 +2358,7 @@
   {
     "id": "cm7nusn640000tvmzf10z2x65",
     "modelName": "gpt-4.5-preview-2025-02-27",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.5-preview-2025-02-27)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.5-preview-2025-02-27)$",
     "createdAt": "2025-02-27T21:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2251,10 +2369,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000075,
-          "input_cached_tokens": 0.0000375,
-          "input_cached_text_tokens": 0.0000375,
-          "input_cache_read": 0.0000375,
+          "input": 7.5e-05,
+          "input_cached_tokens": 3.75e-05,
+          "input_cached_text_tokens": 3.75e-05,
+          "input_cache_read": 3.75e-05,
           "output": 0.00015
         }
       }
@@ -2263,7 +2381,7 @@
   {
     "id": "cm7nusn643377tvmzh27m33kl",
     "modelName": "gpt-4.1",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2280,11 +2398,32 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000002,
-          "input_cached_tokens": 5e-7,
-          "input_cached_text_tokens": 5e-7,
-          "input_cache_read": 5e-7,
-          "output": 0.000008
+          "input": 2e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cached_text_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 8e-06
+        }
+      },
+      {
+        "id": "cm7nusn643377tvmzh27m33kl_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 3.5e-06,
+          "input_cached_tokens": 8.75e-07,
+          "input_cached_text_tokens": 8.75e-07,
+          "input_cache_read": 8.75e-07,
+          "output": 1.4e-05
         }
       }
     ]
@@ -2292,7 +2431,7 @@
   {
     "id": "cm7qahw732891bpmzy45r3x70",
     "modelName": "gpt-4.1-2025-04-14",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-2025-04-14)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2309,11 +2448,32 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000002,
-          "input_cached_tokens": 5e-7,
-          "input_cached_text_tokens": 5e-7,
-          "input_cache_read": 5e-7,
-          "output": 0.000008
+          "input": 2e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cached_text_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 8e-06
+        }
+      },
+      {
+        "id": "cm7qahw732891bpmzy45r3x70_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 3.5e-06,
+          "input_cached_tokens": 8.75e-07,
+          "input_cached_text_tokens": 8.75e-07,
+          "input_cache_read": 8.75e-07,
+          "output": 1.4e-05
         }
       }
     ]
@@ -2321,7 +2481,7 @@
   {
     "id": "cm7sglt825463kxnza72p6v81",
     "modelName": "gpt-4.1-mini-2025-04-14",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-mini-2025-04-14)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-mini-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2338,11 +2498,32 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 4e-7,
-          "input_cached_tokens": 1e-7,
-          "input_cached_text_tokens": 1e-7,
-          "input_cache_read": 1e-7,
-          "output": 0.0000016
+          "input": 4e-07,
+          "input_cached_tokens": 1e-07,
+          "input_cached_text_tokens": 1e-07,
+          "input_cache_read": 1e-07,
+          "output": 1.6e-06
+        }
+      },
+      {
+        "id": "cm7sglt825463kxnza72p6v81_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 7e-07,
+          "input_cached_tokens": 1.75e-07,
+          "input_cached_text_tokens": 1.75e-07,
+          "input_cache_read": 1.75e-07,
+          "output": 2.8e-06
         }
       }
     ]
@@ -2350,7 +2531,7 @@
   {
     "id": "cm7vxpz967124dhjtb95w8f92",
     "modelName": "gpt-4.1-nano-2025-04-14",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-nano-2025-04-14)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-nano-2025-04-14)$",
     "createdAt": "2025-04-15T10:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2367,11 +2548,32 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-7,
-          "input_cached_tokens": 2.5e-8,
-          "input_cached_text_tokens": 2.5e-8,
-          "input_cache_read": 2.5e-8,
-          "output": 4e-7
+          "input": 1e-07,
+          "input_cached_tokens": 2.5e-08,
+          "input_cached_text_tokens": 2.5e-08,
+          "input_cache_read": 2.5e-08,
+          "output": 4e-07
+        }
+      },
+      {
+        "id": "cm7vxpz967124dhjtb95w8f92_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 2.0000000000000002e-07,
+          "input_cached_tokens": 5.0000000000000004e-08,
+          "input_cached_text_tokens": 5.0000000000000004e-08,
+          "input_cache_read": 5.0000000000000004e-08,
+          "output": 8.000000000000001e-07
         }
       }
     ]
@@ -2379,7 +2581,7 @@
   {
     "id": "cm7wmny967124dhjtb95w8f81",
     "modelName": "o3",
-    "matchPattern": "(?i)^(openai\/)?(o3)$",
+    "matchPattern": "(?i)^(openai/)?(o3)$",
     "createdAt": "2025-04-16T23:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2390,12 +2592,34 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000002,
-          "input_cached_tokens": 5e-7,
-          "input_cache_read": 5e-7,
-          "output": 0.000008,
-          "output_reasoning_tokens": 0.000008,
-          "output_reasoning": 0.000008
+          "input": 2e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 8e-06,
+          "output_reasoning_tokens": 8e-06,
+          "output_reasoning": 8e-06
+        }
+      },
+      {
+        "id": "cm7wmny967124dhjtb95w8f81_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 3.5e-06,
+          "input_cached_tokens": 8.75e-07,
+          "input_cache_read": 8.75e-07,
+          "output": 1.4e-05,
+          "output_reasoning_tokens": 1.4e-05,
+          "output_reasoning": 1.4e-05
         }
       }
     ]
@@ -2403,7 +2627,7 @@
   {
     "id": "cm7wopq3327124dhjtb95w8f81",
     "modelName": "o3-2025-04-16",
-    "matchPattern": "(?i)^(openai\/)?(o3-2025-04-16)$",
+    "matchPattern": "(?i)^(openai/)?(o3-2025-04-16)$",
     "createdAt": "2025-04-16T23:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2414,12 +2638,34 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000002,
-          "input_cached_tokens": 5e-7,
-          "input_cache_read": 5e-7,
-          "output": 0.000008,
-          "output_reasoning_tokens": 0.000008,
-          "output_reasoning": 0.000008
+          "input": 2e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 8e-06,
+          "output_reasoning_tokens": 8e-06,
+          "output_reasoning": 8e-06
+        }
+      },
+      {
+        "id": "cm7wopq3327124dhjtb95w8f81_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 3.5e-06,
+          "input_cached_tokens": 8.75e-07,
+          "input_cache_read": 8.75e-07,
+          "output": 1.4e-05,
+          "output_reasoning_tokens": 1.4e-05,
+          "output_reasoning": 1.4e-05
         }
       }
     ]
@@ -2438,12 +2684,34 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 2.75e-7,
-          "input_cache_read": 2.75e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 2.75e-07,
+          "input_cache_read": 2.75e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
+        }
+      },
+      {
+        "id": "cm7wqrs1327124dhjtb95w8f81_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 2e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 8e-06,
+          "output_reasoning_tokens": 8e-06,
+          "output_reasoning": 8e-06
         }
       }
     ]
@@ -2462,12 +2730,34 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.0000011,
-          "input_cached_tokens": 2.75e-7,
-          "input_cache_read": 2.75e-7,
-          "output": 0.0000044,
-          "output_reasoning_tokens": 0.0000044,
-          "output_reasoning": 0.0000044
+          "input": 1.1e-06,
+          "input_cached_tokens": 2.75e-07,
+          "input_cache_read": 2.75e-07,
+          "output": 4.4e-06,
+          "output_reasoning_tokens": 4.4e-06,
+          "output_reasoning": 4.4e-06
+        }
+      },
+      {
+        "id": "cm7zqrs1327124dhjtb95w8f82_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 2e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 8e-06,
+          "output_reasoning_tokens": 8e-06,
+          "output_reasoning": 8e-06
         }
       }
     ]
@@ -2475,7 +2765,7 @@
   {
     "id": "cm7zsrs1327124dhjtb95w8f74",
     "modelName": "gemini-2.0-flash",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.0-flash)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.0-flash)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -2486,8 +2776,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-7,
-          "output": 4e-7
+          "input": 1e-07,
+          "output": 4e-07
         }
       }
     ]
@@ -2495,7 +2785,7 @@
   {
     "id": "cm7ztrs1327124dhjtb95w8f19",
     "modelName": "gemini-2.0-flash-lite-preview",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.0-flash-lite-preview)(@[a-zA-Z0-9]+)?$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.0-flash-lite-preview)(@[a-zA-Z0-9]+)?$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2026-03-06T00:00:00.000Z",
     "pricingTiers": [
@@ -2506,8 +2796,8 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 7.5e-8,
-          "output": 3e-7
+          "input": 7.5e-08,
+          "output": 3e-07
         }
       }
     ]
@@ -2515,7 +2805,7 @@
   {
     "id": "cm7zxrs1327124dhjtb95w8f45",
     "modelName": "gpt-4.1-nano",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-nano)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-nano)$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2532,11 +2822,32 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-7,
-          "input_cached_tokens": 2.5e-8,
-          "input_cached_text_tokens": 2.5e-8,
-          "input_cache_read": 2.5e-8,
-          "output": 4e-7
+          "input": 1e-07,
+          "input_cached_tokens": 2.5e-08,
+          "input_cached_text_tokens": 2.5e-08,
+          "input_cache_read": 2.5e-08,
+          "output": 4e-07
+        }
+      },
+      {
+        "id": "cm7zxrs1327124dhjtb95w8f45_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 2.0000000000000002e-07,
+          "input_cached_tokens": 5.0000000000000004e-08,
+          "input_cached_text_tokens": 5.0000000000000004e-08,
+          "input_cache_read": 5.0000000000000004e-08,
+          "output": 8.000000000000001e-07
         }
       }
     ]
@@ -2544,7 +2855,7 @@
   {
     "id": "cm7zzrs1327124dhjtb95w8p96",
     "modelName": "gpt-4.1-mini",
-    "matchPattern": "(?i)^(openai\/)?(gpt-4.1-mini)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-4.1-mini)$",
     "createdAt": "2025-04-22T10:11:35.241Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2561,11 +2872,32 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 4e-7,
-          "input_cached_tokens": 1e-7,
-          "input_cached_text_tokens": 1e-7,
-          "input_cache_read": 1e-7,
-          "output": 0.0000016
+          "input": 4e-07,
+          "input_cached_tokens": 1e-07,
+          "input_cached_text_tokens": 1e-07,
+          "input_cache_read": 1e-07,
+          "output": 1.6e-06
+        }
+      },
+      {
+        "id": "cm7zzrs1327124dhjtb95w8p96_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 7e-07,
+          "input_cached_tokens": 1.75e-07,
+          "input_cached_text_tokens": 1.75e-07,
+          "input_cache_read": 1.75e-07,
+          "output": 2.8e-06
         }
       }
     ]
@@ -2573,7 +2905,7 @@
   {
     "id": "c5qmrqolku82tra3vgdixmys",
     "modelName": "claude-sonnet-4-5-20250929",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
     "createdAt": "2025-09-29T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2585,17 +2917,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "input_cache_creation_5m": 0.00000375,
-          "input_cache_creation_1h": 0.000006,
-          "cache_read_input_tokens": 3e-7,
-          "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "input_cache_creation_5m": 3.75e-06,
+          "input_cache_creation_1h": 6e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cached_tokens": 3e-07,
+          "input_cache_read": 3e-07
         }
       },
       {
@@ -2612,17 +2944,17 @@
           }
         ],
         "prices": {
-          "input": 0.000006,
-          "input_tokens": 0.000006,
-          "output": 0.0000225,
-          "output_tokens": 0.0000225,
-          "cache_creation_input_tokens": 0.0000075,
-          "input_cache_creation": 0.0000075,
-          "input_cache_creation_5m": 0.0000075,
-          "input_cache_creation_1h": 0.000012,
-          "cache_read_input_tokens": 6e-7,
-          "input_cached_tokens": 6e-7,
-          "input_cache_read": 6e-7
+          "input": 6e-06,
+          "input_tokens": 6e-06,
+          "output": 2.25e-05,
+          "output_tokens": 2.25e-05,
+          "cache_creation_input_tokens": 7.5e-06,
+          "input_cache_creation": 7.5e-06,
+          "input_cache_creation_5m": 7.5e-06,
+          "input_cache_creation_1h": 1.2e-05,
+          "cache_read_input_tokens": 6e-07,
+          "input_cached_tokens": 6e-07,
+          "input_cache_read": 6e-07
         }
       }
     ]
@@ -2630,7 +2962,7 @@
   {
     "id": "cmazmkzlm00000djp1e1qe4k4",
     "modelName": "claude-sonnet-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2642,17 +2974,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "input_cache_creation_5m": 0.00000375,
-          "input_cache_creation_1h": 0.000006,
-          "cache_read_input_tokens": 3e-7,
-          "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "input_cache_creation_5m": 3.75e-06,
+          "input_cache_creation_1h": 6e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cached_tokens": 3e-07,
+          "input_cache_read": 3e-07
         }
       }
     ]
@@ -2660,7 +2992,7 @@
   {
     "id": "cmazmlbnv00010djpazed91va",
     "modelName": "claude-sonnet-4-latest",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-latest)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-sonnet-4-latest)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2672,17 +3004,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000003,
-          "input_tokens": 0.000003,
-          "output": 0.000015,
-          "output_tokens": 0.000015,
-          "cache_creation_input_tokens": 0.00000375,
-          "input_cache_creation": 0.00000375,
-          "input_cache_creation_5m": 0.00000375,
-          "input_cache_creation_1h": 0.000006,
-          "cache_read_input_tokens": 3e-7,
-          "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "input_cache_creation_5m": 3.75e-06,
+          "input_cache_creation_1h": 6e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cached_tokens": 3e-07,
+          "input_cache_read": 3e-07
         }
       }
     ]
@@ -2690,7 +3022,7 @@
   {
     "id": "cmazmlm2p00020djpa9s64jw5",
     "modelName": "claude-opus-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2702,17 +3034,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_tokens": 0.000015,
-          "output": 0.000075,
-          "output_tokens": 0.000075,
-          "cache_creation_input_tokens": 0.00001875,
-          "input_cache_creation": 0.00001875,
-          "input_cache_creation_5m": 0.00001875,
-          "input_cache_creation_1h": 0.00003,
-          "cache_read_input_tokens": 0.0000015,
-          "input_cached_tokens": 0.0000015,
-          "input_cache_read": 0.0000015
+          "input": 1.5e-05,
+          "input_tokens": 1.5e-05,
+          "output": 7.5e-05,
+          "output_tokens": 7.5e-05,
+          "cache_creation_input_tokens": 1.875e-05,
+          "input_cache_creation": 1.875e-05,
+          "input_cache_creation_5m": 1.875e-05,
+          "input_cache_creation_1h": 3e-05,
+          "cache_read_input_tokens": 1.5e-06,
+          "input_cached_tokens": 1.5e-06,
+          "input_cache_read": 1.5e-06
         }
       }
     ]
@@ -2720,7 +3052,7 @@
   {
     "id": "cmz9x72kq55721pqrs83y4n2bx",
     "modelName": "o3-pro",
-    "matchPattern": "(?i)^(openai\/)?(o3-pro)$",
+    "matchPattern": "(?i)^(openai/)?(o3-pro)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2731,10 +3063,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00002,
-          "output": 0.00008,
-          "output_reasoning_tokens": 0.00008,
-          "output_reasoning": 0.00008
+          "input": 2e-05,
+          "output": 8e-05,
+          "output_reasoning_tokens": 8e-05,
+          "output_reasoning": 8e-05
         }
       }
     ]
@@ -2742,7 +3074,7 @@
   {
     "id": "cmz9x72kq55721pqrs83y4n2by",
     "modelName": "o3-pro-2025-06-10",
-    "matchPattern": "(?i)^(openai\/)?(o3-pro-2025-06-10)$",
+    "matchPattern": "(?i)^(openai/)?(o3-pro-2025-06-10)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2753,10 +3085,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00002,
-          "output": 0.00008,
-          "output_reasoning_tokens": 0.00008,
-          "output_reasoning": 0.00008
+          "input": 2e-05,
+          "output": 8e-05,
+          "output_reasoning_tokens": 8e-05,
+          "output_reasoning": 8e-05
         }
       }
     ]
@@ -2764,7 +3096,7 @@
   {
     "id": "cmbrold5b000107lbftb9fdoo",
     "modelName": "o1-pro",
-    "matchPattern": "(?i)^(openai\/)?(o1-pro)$",
+    "matchPattern": "(?i)^(openai/)?(o1-pro)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2786,7 +3118,7 @@
   {
     "id": "cmbrolpax000207lb3xkedysz",
     "modelName": "o1-pro-2025-03-19",
-    "matchPattern": "(?i)^(openai\/)?(o1-pro-2025-03-19)$",
+    "matchPattern": "(?i)^(openai/)?(o1-pro-2025-03-19)$",
     "createdAt": "2025-06-10T22:26:54.132Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "pricingTiers": [
@@ -2808,7 +3140,7 @@
   {
     "id": "cmcnjkfwn000107l43bf5e8ax",
     "modelName": "gemini-2.5-flash",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.5-flash)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.5-flash)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -2819,22 +3151,22 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-7,
-          "input_text": 3e-7,
-          "input_modality_1": 3e-7,
-          "prompt_token_count": 3e-7,
-          "promptTokenCount": 3e-7,
-          "input_cached_tokens": 3e-8,
-          "cached_content_token_count": 3e-8,
-          "output": 0.0000025,
-          "output_text": 0.0000025,
-          "output_modality_1": 0.0000025,
-          "candidates_token_count": 0.0000025,
-          "candidatesTokenCount": 0.0000025,
-          "thoughtsTokenCount": 0.0000025,
-          "thoughts_token_count": 0.0000025,
-          "output_reasoning": 0.0000025,
-          "input_audio_tokens": 0.000001
+          "input": 3e-07,
+          "input_text": 3e-07,
+          "input_modality_1": 3e-07,
+          "prompt_token_count": 3e-07,
+          "promptTokenCount": 3e-07,
+          "input_cached_tokens": 3e-08,
+          "cached_content_token_count": 3e-08,
+          "output": 2.5e-06,
+          "output_text": 2.5e-06,
+          "output_modality_1": 2.5e-06,
+          "candidates_token_count": 2.5e-06,
+          "candidatesTokenCount": 2.5e-06,
+          "thoughtsTokenCount": 2.5e-06,
+          "thoughts_token_count": 2.5e-06,
+          "output_reasoning": 2.5e-06,
+          "input_audio_tokens": 1e-06
         }
       }
     ]
@@ -2842,7 +3174,7 @@
   {
     "id": "cmcnjkrfa000207l4fpnh5mnv",
     "modelName": "gemini-2.5-flash-lite",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.5-flash-lite)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.5-flash-lite)$",
     "createdAt": "2025-07-03T13:44:06.964Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -2853,22 +3185,22 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1e-7,
-          "input_text": 1e-7,
-          "input_modality_1": 1e-7,
-          "prompt_token_count": 1e-7,
-          "promptTokenCount": 1e-7,
-          "input_cached_tokens": 2.5e-8,
-          "cached_content_token_count": 2.5e-8,
-          "output": 4e-7,
-          "output_text": 4e-7,
-          "output_modality_1": 4e-7,
-          "candidates_token_count": 4e-7,
-          "candidatesTokenCount": 4e-7,
-          "thoughtsTokenCount": 4e-7,
-          "thoughts_token_count": 4e-7,
-          "output_reasoning": 4e-7,
-          "input_audio_tokens": 5e-7
+          "input": 1e-07,
+          "input_text": 1e-07,
+          "input_modality_1": 1e-07,
+          "prompt_token_count": 1e-07,
+          "promptTokenCount": 1e-07,
+          "input_cached_tokens": 2.5e-08,
+          "cached_content_token_count": 2.5e-08,
+          "output": 4e-07,
+          "output_text": 4e-07,
+          "output_modality_1": 4e-07,
+          "candidates_token_count": 4e-07,
+          "candidatesTokenCount": 4e-07,
+          "thoughtsTokenCount": 4e-07,
+          "thoughts_token_count": 4e-07,
+          "output_reasoning": 4e-07,
+          "input_audio_tokens": 5e-07
         }
       }
     ]
@@ -2876,7 +3208,7 @@
   {
     "id": "cmdysde5w0000rkmzbc1g5au3",
     "modelName": "claude-opus-4-1-20250805",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
     "createdAt": "2025-08-05T15:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2888,17 +3220,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
-          "input_tokens": 0.000015,
-          "output": 0.000075,
-          "output_tokens": 0.000075,
-          "cache_creation_input_tokens": 0.00001875,
-          "input_cache_creation": 0.00001875,
-          "input_cache_creation_5m": 0.00001875,
-          "input_cache_creation_1h": 0.00003,
-          "cache_read_input_tokens": 0.0000015,
-          "input_cached_tokens": 0.0000015,
-          "input_cache_read": 0.0000015
+          "input": 1.5e-05,
+          "input_tokens": 1.5e-05,
+          "output": 7.5e-05,
+          "output_tokens": 7.5e-05,
+          "cache_creation_input_tokens": 1.875e-05,
+          "input_cache_creation": 1.875e-05,
+          "input_cache_creation_5m": 1.875e-05,
+          "input_cache_creation_1h": 3e-05,
+          "cache_read_input_tokens": 1.5e-06,
+          "input_cached_tokens": 1.5e-06,
+          "input_cache_read": 1.5e-06
         }
       }
     ]
@@ -2906,7 +3238,7 @@
   {
     "id": "38c3822a-09a3-457b-b200-2c6f17f7cf2f",
     "modelName": "gpt-5",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2923,12 +3255,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000125,
-          "input_cached_tokens": 1.25e-7,
-          "output": 0.00001,
-          "input_cache_read": 1.25e-7,
-          "output_reasoning_tokens": 0.00001,
-          "output_reasoning": 0.00001
+          "input": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "output": 1e-05,
+          "input_cache_read": 1.25e-07,
+          "output_reasoning_tokens": 1e-05,
+          "output_reasoning": 1e-05
         }
       }
     ]
@@ -2936,7 +3268,7 @@
   {
     "id": "12543803-2d5f-4189-addc-821ad71c8b55",
     "modelName": "gpt-5-2025-08-07",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-2025-08-07)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2953,12 +3285,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000125,
-          "input_cached_tokens": 1.25e-7,
-          "output": 0.00001,
-          "input_cache_read": 1.25e-7,
-          "output_reasoning_tokens": 0.00001,
-          "output_reasoning": 0.00001
+          "input": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "output": 1e-05,
+          "input_cache_read": 1.25e-07,
+          "output_reasoning_tokens": 1e-05,
+          "output_reasoning": 1e-05
         }
       }
     ]
@@ -2966,7 +3298,7 @@
   {
     "id": "3d6a975a-a42d-4ea2-a3ec-4ae567d5a364",
     "modelName": "gpt-5-mini",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-mini)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-mini)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -2983,12 +3315,34 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "input_cached_tokens": 2.5e-8,
-          "output": 0.000002,
-          "input_cache_read": 2.5e-8,
-          "output_reasoning_tokens": 0.000002,
-          "output_reasoning": 0.000002
+          "input": 2.5e-07,
+          "input_cached_tokens": 2.5e-08,
+          "output": 2e-06,
+          "input_cache_read": 2.5e-08,
+          "output_reasoning_tokens": 2e-06,
+          "output_reasoning": 2e-06
+        }
+      },
+      {
+        "id": "3d6a975a-a42d-4ea2-a3ec-4ae567d5a364_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 4.5000000000000003e-07,
+          "input_cached_tokens": 4.5e-08,
+          "output": 3.6000000000000003e-06,
+          "input_cache_read": 4.5e-08,
+          "output_reasoning_tokens": 3.6000000000000003e-06,
+          "output_reasoning": 3.6000000000000003e-06
         }
       }
     ]
@@ -2996,7 +3350,7 @@
   {
     "id": "03b83894-7172-4e1e-8e8b-37d792484efd",
     "modelName": "gpt-5-mini-2025-08-07",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-mini-2025-08-07)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-mini-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3013,12 +3367,34 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-7,
-          "input_cached_tokens": 2.5e-8,
-          "output": 0.000002,
-          "input_cache_read": 2.5e-8,
-          "output_reasoning_tokens": 0.000002,
-          "output_reasoning": 0.000002
+          "input": 2.5e-07,
+          "input_cached_tokens": 2.5e-08,
+          "output": 2e-06,
+          "input_cache_read": 2.5e-08,
+          "output_reasoning_tokens": 2e-06,
+          "output_reasoning": 2e-06
+        }
+      },
+      {
+        "id": "03b83894-7172-4e1e-8e8b-37d792484efd_tier_priority",
+        "name": "Priority",
+        "isDefault": false,
+        "priority": 1,
+        "conditions": [
+          {
+            "usageDetailPattern": "service_tier",
+            "operator": "gte",
+            "value": 1,
+            "caseSensitive": false
+          }
+        ],
+        "prices": {
+          "input": 4.5000000000000003e-07,
+          "input_cached_tokens": 4.5e-08,
+          "output": 3.6000000000000003e-06,
+          "input_cache_read": 4.5e-08,
+          "output_reasoning_tokens": 3.6000000000000003e-06,
+          "output_reasoning": 3.6000000000000003e-06
         }
       }
     ]
@@ -3026,7 +3402,7 @@
   {
     "id": "f0b40234-b694-4c40-9494-7b0efd860fb9",
     "modelName": "gpt-5-nano",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-nano)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-nano)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3043,12 +3419,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-8,
-          "input_cached_tokens": 5e-9,
-          "output": 4e-7,
-          "input_cache_read": 5e-9,
-          "output_reasoning_tokens": 4e-7,
-          "output_reasoning": 4e-7
+          "input": 5e-08,
+          "input_cached_tokens": 5e-09,
+          "output": 4e-07,
+          "input_cache_read": 5e-09,
+          "output_reasoning_tokens": 4e-07,
+          "output_reasoning": 4e-07
         }
       }
     ]
@@ -3056,7 +3432,7 @@
   {
     "id": "4489fde4-a594-4011-948b-526989300cd3",
     "modelName": "gpt-5-nano-2025-08-07",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-nano-2025-08-07)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-nano-2025-08-07)$",
     "createdAt": "2025-08-11T08:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3073,12 +3449,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-8,
-          "input_cached_tokens": 5e-9,
-          "output": 4e-7,
-          "input_cache_read": 5e-9,
-          "output_reasoning_tokens": 4e-7,
-          "output_reasoning": 4e-7
+          "input": 5e-08,
+          "input_cached_tokens": 5e-09,
+          "output": 4e-07,
+          "input_cache_read": 5e-09,
+          "output_reasoning_tokens": 4e-07,
+          "output_reasoning": 4e-07
         }
       }
     ]
@@ -3086,7 +3462,7 @@
   {
     "id": "8ba72ee3-ebe8-4110-a614-bf81094447e5",
     "modelName": "gpt-5-chat-latest",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-chat-latest)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-chat-latest)$",
     "createdAt": "2025-08-07T16:00:00.000Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3103,12 +3479,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000125,
-          "input_cached_tokens": 1.25e-7,
-          "output": 0.00001,
-          "input_cache_read": 1.25e-7,
-          "output_reasoning_tokens": 0.00001,
-          "output_reasoning": 0.00001
+          "input": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "output": 1e-05,
+          "input_cache_read": 1.25e-07,
+          "output_reasoning_tokens": 1e-05,
+          "output_reasoning": 1e-05
         }
       }
     ]
@@ -3116,7 +3492,7 @@
   {
     "id": "cmgg9zco3000004l258um9xk8",
     "modelName": "gpt-5-pro",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-pro)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-pro)$",
     "createdAt": "2025-10-07T08:03:54.727Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3133,7 +3509,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
+          "input": 1.5e-05,
           "output": 0.00012,
           "output_reasoning_tokens": 0.00012,
           "output_reasoning": 0.00012
@@ -3144,7 +3520,7 @@
   {
     "id": "cmgga0vh9000104l22qe4fes4",
     "modelName": "gpt-5-pro-2025-10-06",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5-pro-2025-10-06)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5-pro-2025-10-06)$",
     "createdAt": "2025-10-07T08:03:54.727Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3161,7 +3537,7 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000015,
+          "input": 1.5e-05,
           "output": 0.00012,
           "output_reasoning_tokens": 0.00012,
           "output_reasoning": 0.00012
@@ -3172,7 +3548,7 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
     "updatedAt": "2026-04-20T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3184,17 +3560,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.000001,
-          "input_tokens": 0.000001,
-          "output": 0.000005,
-          "output_tokens": 0.000005,
-          "cache_creation_input_tokens": 0.00000125,
-          "input_cache_creation": 0.00000125,
-          "input_cache_creation_5m": 0.00000125,
-          "input_cache_creation_1h": 0.000002,
-          "cache_read_input_tokens": 1e-7,
-          "input_cached_tokens": 1e-7,
-          "input_cache_read": 1e-7
+          "input": 1e-06,
+          "input_tokens": 1e-06,
+          "output": 5e-06,
+          "output_tokens": 5e-06,
+          "cache_creation_input_tokens": 1.25e-06,
+          "input_cache_creation": 1.25e-06,
+          "input_cache_creation_5m": 1.25e-06,
+          "input_cache_creation_1h": 2e-06,
+          "cache_read_input_tokens": 1e-07,
+          "input_cached_tokens": 1e-07,
+          "input_cache_read": 1e-07
         }
       }
     ]
@@ -3202,7 +3578,7 @@
   {
     "id": "cmhymgpym000d04ih34rndvhr",
     "modelName": "gpt-5.1",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.1)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.1)$",
     "createdAt": "2025-11-14T08:57:23.481Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3219,12 +3595,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000125,
-          "input_cached_tokens": 1.25e-7,
-          "output": 0.00001,
-          "input_cache_read": 1.25e-7,
-          "output_reasoning_tokens": 0.00001,
-          "output_reasoning": 0.00001
+          "input": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "output": 1e-05,
+          "input_cache_read": 1.25e-07,
+          "output_reasoning_tokens": 1e-05,
+          "output_reasoning": 1e-05
         }
       }
     ]
@@ -3232,7 +3608,7 @@
   {
     "id": "cmhymgxiw000e04ihh9pw12ef",
     "modelName": "gpt-5.1-2025-11-13",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.1-2025-11-13)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.1-2025-11-13)$",
     "createdAt": "2025-11-14T08:57:23.481Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3249,12 +3625,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.00000125,
-          "input_cached_tokens": 1.25e-7,
-          "output": 0.00001,
-          "input_cache_read": 1.25e-7,
-          "output_reasoning_tokens": 0.00001,
-          "output_reasoning": 0.00001
+          "input": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "output": 1e-05,
+          "input_cache_read": 1.25e-07,
+          "output_reasoning_tokens": 1e-05,
+          "output_reasoning": 1e-05
         }
       }
     ]
@@ -3262,7 +3638,7 @@
   {
     "id": "cmieupdva000004l541kwae70",
     "modelName": "claude-opus-4-5-20251101",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-5(-20251101)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-5(-20251101)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
     "createdAt": "2025-11-24T20:53:27.571Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3275,17 +3651,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_tokens": 5e-6,
-          "output": 25e-6,
-          "output_tokens": 25e-6,
-          "cache_creation_input_tokens": 6.25e-6,
-          "input_cache_creation": 6.25e-6,
-          "input_cache_creation_5m": 6.25e-6,
-          "input_cache_creation_1h": 10e-6,
-          "cache_read_input_tokens": 0.5e-6,
-          "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input": 5e-06,
+          "input_tokens": 5e-06,
+          "output": 2.5e-05,
+          "output_tokens": 2.5e-05,
+          "cache_creation_input_tokens": 6.25e-06,
+          "input_cache_creation": 6.25e-06,
+          "input_cache_creation_5m": 6.25e-06,
+          "input_cache_creation_1h": 1e-05,
+          "cache_read_input_tokens": 5e-07,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07
         }
       }
     ]
@@ -3306,17 +3682,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 3e-6,
-          "input_tokens": 3e-6,
-          "output": 15e-6,
-          "output_tokens": 15e-6,
-          "cache_creation_input_tokens": 3.75e-6,
-          "input_cache_creation": 3.75e-6,
-          "input_cache_creation_5m": 3.75e-6,
-          "input_cache_creation_1h": 6e-6,
-          "cache_read_input_tokens": 3e-7,
-          "input_cached_tokens": 3e-7,
-          "input_cache_read": 3e-7
+          "input": 3e-06,
+          "input_tokens": 3e-06,
+          "output": 1.5e-05,
+          "output_tokens": 1.5e-05,
+          "cache_creation_input_tokens": 3.75e-06,
+          "input_cache_creation": 3.75e-06,
+          "input_cache_creation_5m": 3.75e-06,
+          "input_cache_creation_1h": 6e-06,
+          "cache_read_input_tokens": 3e-07,
+          "input_cached_tokens": 3e-07,
+          "input_cache_read": 3e-07
         }
       },
       {
@@ -3333,17 +3709,17 @@
           }
         ],
         "prices": {
-          "input": 6e-6,
-          "input_tokens": 6e-6,
-          "output": 22.5e-6,
-          "output_tokens": 22.5e-6,
-          "cache_creation_input_tokens": 7.5e-6,
-          "input_cache_creation": 7.5e-6,
-          "input_cache_creation_5m": 7.5e-6,
-          "input_cache_creation_1h": 12e-6,
-          "cache_read_input_tokens": 6e-7,
-          "input_cached_tokens": 6e-7,
-          "input_cache_read": 6e-7
+          "input": 6e-06,
+          "input_tokens": 6e-06,
+          "output": 2.25e-05,
+          "output_tokens": 2.25e-05,
+          "cache_creation_input_tokens": 7.5e-06,
+          "input_cache_creation": 7.5e-06,
+          "input_cache_creation_5m": 7.5e-06,
+          "input_cache_creation_1h": 1.2e-05,
+          "cache_read_input_tokens": 6e-07,
+          "input_cached_tokens": 6e-07,
+          "input_cache_read": 6e-07
         }
       }
     ]
@@ -3351,7 +3727,7 @@
   {
     "id": "13458bc0-1c20-44c2-8753-172f54b67647",
     "modelName": "claude-opus-4-6",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
     "createdAt": "2026-02-09T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3364,17 +3740,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_tokens": 5e-6,
-          "output": 25e-6,
-          "output_tokens": 25e-6,
-          "cache_creation_input_tokens": 6.25e-6,
-          "input_cache_creation": 6.25e-6,
-          "input_cache_creation_5m": 6.25e-6,
-          "input_cache_creation_1h": 10e-6,
-          "cache_read_input_tokens": 0.5e-6,
-          "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input": 5e-06,
+          "input_tokens": 5e-06,
+          "output": 2.5e-05,
+          "output_tokens": 2.5e-05,
+          "cache_creation_input_tokens": 6.25e-06,
+          "input_cache_creation": 6.25e-06,
+          "input_cache_creation_5m": 6.25e-06,
+          "input_cache_creation_1h": 1e-05,
+          "cache_read_input_tokens": 5e-07,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07
         }
       }
     ]
@@ -3382,7 +3758,7 @@
   {
     "id": "d506b291-cc9c-4833-9014-0f387a8e1cc8",
     "modelName": "claude-opus-4-7",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7-v1(:0)?|claude-opus-4-7)$",
+    "matchPattern": "(?i)^(anthropic/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7-v1(:0)?|claude-opus-4-7)$",
     "createdAt": "2026-04-16T00:00:00.000Z",
     "updatedAt": "2026-04-16T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3395,17 +3771,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_tokens": 5e-6,
-          "output": 25e-6,
-          "output_tokens": 25e-6,
-          "cache_creation_input_tokens": 6.25e-6,
-          "input_cache_creation": 6.25e-6,
-          "input_cache_creation_5m": 6.25e-6,
-          "input_cache_creation_1h": 10e-6,
-          "cache_read_input_tokens": 0.5e-6,
-          "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input": 5e-06,
+          "input_tokens": 5e-06,
+          "output": 2.5e-05,
+          "output_tokens": 2.5e-05,
+          "cache_creation_input_tokens": 6.25e-06,
+          "input_cache_creation": 6.25e-06,
+          "input_cache_creation_5m": 6.25e-06,
+          "input_cache_creation_1h": 1e-05,
+          "cache_read_input_tokens": 5e-07,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07
         }
       }
     ]
@@ -3413,7 +3789,7 @@
   {
     "id": "80753fd5-342b-4ed3-bbb1-57d3d57b7e03",
     "modelName": "claude-opus-4-8",
-    "matchPattern": "(?i)^((anthropic\/)?claude-opus-4-8|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-8(-v1(:0)?)?)$",
+    "matchPattern": "(?i)^((anthropic/)?claude-opus-4-8|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-8(-v1(:0)?)?)$",
     "createdAt": "2026-05-28T00:00:00.000Z",
     "updatedAt": "2026-05-28T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3426,17 +3802,17 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_tokens": 5e-6,
-          "output": 25e-6,
-          "output_tokens": 25e-6,
-          "cache_creation_input_tokens": 6.25e-6,
-          "input_cache_creation": 6.25e-6,
-          "input_cache_creation_5m": 6.25e-6,
-          "input_cache_creation_1h": 10e-6,
-          "cache_read_input_tokens": 0.5e-6,
-          "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6
+          "input": 5e-06,
+          "input_tokens": 5e-06,
+          "output": 2.5e-05,
+          "output_tokens": 2.5e-05,
+          "cache_creation_input_tokens": 6.25e-06,
+          "input_cache_creation": 6.25e-06,
+          "input_cache_creation_5m": 6.25e-06,
+          "input_cache_creation_1h": 1e-05,
+          "cache_read_input_tokens": 5e-07,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07
         }
       }
     ]
@@ -3444,7 +3820,7 @@
   {
     "id": "cmig1hb7i000104l72qrzgc6h",
     "modelName": "gemini-2.5-pro",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-2.5-pro)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-2.5-pro)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -3455,21 +3831,21 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.25e-6,
-          "input_text": 1.25e-6,
-          "input_modality_1": 1.25e-6,
-          "prompt_token_count": 1.25e-6,
-          "promptTokenCount": 1.25e-6,
-          "input_cached_tokens": 0.125e-6,
-          "cached_content_token_count": 0.125e-6,
-          "output": 10e-6,
-          "output_text": 10e-6,
-          "output_modality_1": 10e-6,
-          "candidates_token_count": 10e-6,
-          "candidatesTokenCount": 10e-6,
-          "thoughtsTokenCount": 10e-6,
-          "thoughts_token_count": 10e-6,
-          "output_reasoning": 10e-6
+          "input": 1.25e-06,
+          "input_text": 1.25e-06,
+          "input_modality_1": 1.25e-06,
+          "prompt_token_count": 1.25e-06,
+          "promptTokenCount": 1.25e-06,
+          "input_cached_tokens": 1.25e-07,
+          "cached_content_token_count": 1.25e-07,
+          "output": 1e-05,
+          "output_text": 1e-05,
+          "output_modality_1": 1e-05,
+          "candidates_token_count": 1e-05,
+          "candidatesTokenCount": 1e-05,
+          "thoughtsTokenCount": 1e-05,
+          "thoughts_token_count": 1e-05,
+          "output_reasoning": 1e-05
         }
       },
       {
@@ -3486,21 +3862,21 @@
           }
         ],
         "prices": {
-          "input": 2.5e-6,
-          "input_text": 2.5e-6,
-          "input_modality_1": 2.5e-6,
-          "prompt_token_count": 2.5e-6,
-          "promptTokenCount": 2.5e-6,
-          "input_cached_tokens": 0.25e-6,
-          "cached_content_token_count": 0.25e-6,
-          "output": 15e-6,
-          "output_text": 15e-6,
-          "output_modality_1": 15e-6,
-          "candidates_token_count": 15e-6,
-          "candidatesTokenCount": 15e-6,
-          "thoughtsTokenCount": 15e-6,
-          "thoughts_token_count": 15e-6,
-          "output_reasoning": 15e-6
+          "input": 2.5e-06,
+          "input_text": 2.5e-06,
+          "input_modality_1": 2.5e-06,
+          "prompt_token_count": 2.5e-06,
+          "promptTokenCount": 2.5e-06,
+          "input_cached_tokens": 2.5e-07,
+          "cached_content_token_count": 2.5e-07,
+          "output": 1.5e-05,
+          "output_text": 1.5e-05,
+          "output_modality_1": 1.5e-05,
+          "candidates_token_count": 1.5e-05,
+          "candidatesTokenCount": 1.5e-05,
+          "thoughtsTokenCount": 1.5e-05,
+          "thoughts_token_count": 1.5e-05,
+          "output_reasoning": 1.5e-05
         }
       }
     ]
@@ -3508,7 +3884,7 @@
   {
     "id": "cmig1wmep000404l7fh6q5uog",
     "modelName": "gemini-3-pro-preview",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3-pro-preview)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3-pro-preview)$",
     "createdAt": "2025-11-26T13:27:53.545Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -3519,21 +3895,21 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-6,
-          "input_text": 2e-6,
-          "input_modality_1": 2e-6,
-          "prompt_token_count": 2e-6,
-          "promptTokenCount": 2e-6,
-          "input_cached_tokens": 0.2e-6,
-          "cached_content_token_count": 0.2e-6,
-          "output": 12e-6,
-          "output_text": 12e-6,
-          "output_modality_1": 12e-6,
-          "candidates_token_count": 12e-6,
-          "candidatesTokenCount": 12e-6,
-          "thoughtsTokenCount": 12e-6,
-          "thoughts_token_count": 12e-6,
-          "output_reasoning": 12e-6
+          "input": 2e-06,
+          "input_text": 2e-06,
+          "input_modality_1": 2e-06,
+          "prompt_token_count": 2e-06,
+          "promptTokenCount": 2e-06,
+          "input_cached_tokens": 2e-07,
+          "cached_content_token_count": 2e-07,
+          "output": 1.2e-05,
+          "output_text": 1.2e-05,
+          "output_modality_1": 1.2e-05,
+          "candidates_token_count": 1.2e-05,
+          "candidatesTokenCount": 1.2e-05,
+          "thoughtsTokenCount": 1.2e-05,
+          "thoughts_token_count": 1.2e-05,
+          "output_reasoning": 1.2e-05
         }
       },
       {
@@ -3550,21 +3926,21 @@
           }
         ],
         "prices": {
-          "input": 4e-6,
-          "input_text": 4e-6,
-          "input_modality_1": 4e-6,
-          "prompt_token_count": 4e-6,
-          "promptTokenCount": 4e-6,
-          "input_cached_tokens": 0.4e-6,
-          "cached_content_token_count": 0.4e-6,
-          "output": 18e-6,
-          "output_text": 18e-6,
-          "output_modality_1": 18e-6,
-          "candidates_token_count": 18e-6,
-          "candidatesTokenCount": 18e-6,
-          "thoughtsTokenCount": 18e-6,
-          "thoughts_token_count": 18e-6,
-          "output_reasoning": 18e-6
+          "input": 4e-06,
+          "input_text": 4e-06,
+          "input_modality_1": 4e-06,
+          "prompt_token_count": 4e-06,
+          "promptTokenCount": 4e-06,
+          "input_cached_tokens": 4e-07,
+          "cached_content_token_count": 4e-07,
+          "output": 1.8e-05,
+          "output_text": 1.8e-05,
+          "output_modality_1": 1.8e-05,
+          "candidates_token_count": 1.8e-05,
+          "candidatesTokenCount": 1.8e-05,
+          "thoughtsTokenCount": 1.8e-05,
+          "thoughts_token_count": 1.8e-05,
+          "output_reasoning": 1.8e-05
         }
       }
     ]
@@ -3572,7 +3948,7 @@
   {
     "id": "55106bba-a5dd-441b-bc0d-5652582b349d",
     "modelName": "gemini-3.1-pro-preview",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-pro-preview(-customtools)?)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3.1-pro-preview(-customtools)?)$",
     "createdAt": "2026-02-19T00:00:00.000Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -3583,21 +3959,21 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2e-6,
-          "input_modality_1": 2e-6,
-          "input_text": 2e-6,
-          "prompt_token_count": 2e-6,
-          "promptTokenCount": 2e-6,
-          "input_cached_tokens": 0.2e-6,
-          "cached_content_token_count": 0.2e-6,
-          "output": 12e-6,
-          "output_text": 12e-6,
-          "output_modality_1": 12e-6,
-          "candidates_token_count": 12e-6,
-          "candidatesTokenCount": 12e-6,
-          "thoughtsTokenCount": 12e-6,
-          "thoughts_token_count": 12e-6,
-          "output_reasoning": 12e-6
+          "input": 2e-06,
+          "input_modality_1": 2e-06,
+          "input_text": 2e-06,
+          "prompt_token_count": 2e-06,
+          "promptTokenCount": 2e-06,
+          "input_cached_tokens": 2e-07,
+          "cached_content_token_count": 2e-07,
+          "output": 1.2e-05,
+          "output_text": 1.2e-05,
+          "output_modality_1": 1.2e-05,
+          "candidates_token_count": 1.2e-05,
+          "candidatesTokenCount": 1.2e-05,
+          "thoughtsTokenCount": 1.2e-05,
+          "thoughts_token_count": 1.2e-05,
+          "output_reasoning": 1.2e-05
         }
       },
       {
@@ -3614,21 +3990,21 @@
           }
         ],
         "prices": {
-          "input": 4e-6,
-          "input_modality_1": 4e-6,
-          "input_text": 4e-6,
-          "prompt_token_count": 4e-6,
-          "promptTokenCount": 4e-6,
-          "input_cached_tokens": 0.4e-6,
-          "cached_content_token_count": 0.4e-6,
-          "output": 18e-6,
-          "output_text": 18e-6,
-          "output_modality_1": 18e-6,
-          "candidates_token_count": 18e-6,
-          "candidatesTokenCount": 18e-6,
-          "thoughtsTokenCount": 18e-6,
-          "thoughts_token_count": 18e-6,
-          "output_reasoning": 18e-6
+          "input": 4e-06,
+          "input_modality_1": 4e-06,
+          "input_text": 4e-06,
+          "prompt_token_count": 4e-06,
+          "promptTokenCount": 4e-06,
+          "input_cached_tokens": 4e-07,
+          "cached_content_token_count": 4e-07,
+          "output": 1.8e-05,
+          "output_text": 1.8e-05,
+          "output_modality_1": 1.8e-05,
+          "candidates_token_count": 1.8e-05,
+          "candidatesTokenCount": 1.8e-05,
+          "thoughtsTokenCount": 1.8e-05,
+          "thoughts_token_count": 1.8e-05,
+          "output_reasoning": 1.8e-05
         }
       }
     ]
@@ -3636,7 +4012,7 @@
   {
     "id": "cmj2n4f2a000304kz49g4c43u",
     "modelName": "gpt-5.2",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3653,12 +4029,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.75e-6,
-          "input_cached_tokens": 0.175e-6,
-          "input_cache_read": 0.175e-6,
-          "output": 14e-6,
-          "output_reasoning_tokens": 14e-6,
-          "output_reasoning": 14e-6
+          "input": 1.75e-06,
+          "input_cached_tokens": 1.75e-07,
+          "input_cache_read": 1.75e-07,
+          "output": 1.4e-05,
+          "output_reasoning_tokens": 1.4e-05,
+          "output_reasoning": 1.4e-05
         }
       }
     ]
@@ -3666,7 +4042,7 @@
   {
     "id": "cmj2muxg6000104kzd2tc8953",
     "modelName": "gpt-5.2-2025-12-11",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-2025-12-11)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2-2025-12-11)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3683,12 +4059,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.75e-6,
-          "input_cached_tokens": 0.175e-6,
-          "input_cache_read": 0.175e-6,
-          "output": 14e-6,
-          "output_reasoning_tokens": 14e-6,
-          "output_reasoning": 14e-6
+          "input": 1.75e-06,
+          "input_cached_tokens": 1.75e-07,
+          "input_cache_read": 1.75e-07,
+          "output": 1.4e-05,
+          "output_reasoning_tokens": 1.4e-05,
+          "output_reasoning": 1.4e-05
         }
       }
     ]
@@ -3696,7 +4072,7 @@
   {
     "id": "cmj2n6pkq000404kz2s0b6if7",
     "modelName": "gpt-5.2-pro",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-pro)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2-pro)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3713,10 +4089,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 21e-6,
-          "output": 168e-6,
-          "output_reasoning_tokens": 168e-6,
-          "output_reasoning": 168e-6
+          "input": 2.1e-05,
+          "output": 0.000168,
+          "output_reasoning_tokens": 0.000168,
+          "output_reasoning": 0.000168
         }
       }
     ]
@@ -3724,7 +4100,7 @@
   {
     "id": "cmj2n70oe000504kz21b76mes",
     "modelName": "gpt-5.2-pro-2025-12-11",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.2-pro-2025-12-11)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.2-pro-2025-12-11)$",
     "createdAt": "2025-12-12T09:00:06.513Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerConfig": {
@@ -3741,10 +4117,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 21e-6,
-          "output": 168e-6,
-          "output_reasoning_tokens": 168e-6,
-          "output_reasoning": 168e-6
+          "input": 2.1e-05,
+          "output": 0.000168,
+          "output_reasoning_tokens": 0.000168,
+          "output_reasoning": 0.000168
         }
       }
     ]
@@ -3752,7 +4128,7 @@
   {
     "id": "bee3c111-fe6f-4641-8775-73ea33b29fca",
     "modelName": "gpt-5.4",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.4)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.4)$",
     "createdAt": "2026-03-05T00:00:00.000Z",
     "updatedAt": "2026-03-05T00:00:00.000Z",
     "tokenizerConfig": {
@@ -3769,12 +4145,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-6,
-          "input_cached_tokens": 0.25e-6,
-          "input_cache_read": 0.25e-6,
-          "output": 15e-6,
-          "output_reasoning_tokens": 15e-6,
-          "output_reasoning": 15e-6
+          "input": 2.5e-06,
+          "input_cached_tokens": 2.5e-07,
+          "input_cache_read": 2.5e-07,
+          "output": 1.5e-05,
+          "output_reasoning_tokens": 1.5e-05,
+          "output_reasoning": 1.5e-05
         }
       }
     ]
@@ -3782,7 +4158,7 @@
   {
     "id": "68d32054-8748-4d25-9f64-d78d483601bd",
     "modelName": "gpt-5.4-pro",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.4-pro)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.4-pro)$",
     "createdAt": "2026-03-05T00:00:00.000Z",
     "updatedAt": "2026-03-05T00:00:00.000Z",
     "tokenizerConfig": {
@@ -3799,10 +4175,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 30e-6,
-          "output": 180e-6,
-          "output_reasoning_tokens": 180e-6,
-          "output_reasoning": 180e-6
+          "input": 3e-05,
+          "output": 0.00018,
+          "output_reasoning_tokens": 0.00018,
+          "output_reasoning": 0.00018
         }
       }
     ]
@@ -3810,7 +4186,7 @@
   {
     "id": "22dfc7e1-1fe1-4286-b1af-928635e7ecb9",
     "modelName": "gpt-5.4-2026-03-05",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.4-2026-03-05)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.4-2026-03-05)$",
     "createdAt": "2026-03-05T00:00:00.000Z",
     "updatedAt": "2026-03-05T00:00:00.000Z",
     "tokenizerConfig": {
@@ -3827,12 +4203,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 2.5e-6,
-          "input_cached_tokens": 0.25e-6,
-          "input_cache_read": 0.25e-6,
-          "output": 15e-6,
-          "output_reasoning_tokens": 15e-6,
-          "output_reasoning": 15e-6
+          "input": 2.5e-06,
+          "input_cached_tokens": 2.5e-07,
+          "input_cache_read": 2.5e-07,
+          "output": 1.5e-05,
+          "output_reasoning_tokens": 1.5e-05,
+          "output_reasoning": 1.5e-05
         }
       }
     ]
@@ -3840,7 +4216,7 @@
   {
     "id": "d8873413-05ab-4374-8223-e8c9005c4a0e",
     "modelName": "gpt-5.4-pro-2026-03-05",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.4-pro-2026-03-05)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.4-pro-2026-03-05)$",
     "createdAt": "2026-03-05T00:00:00.000Z",
     "updatedAt": "2026-03-05T00:00:00.000Z",
     "tokenizerConfig": {
@@ -3857,10 +4233,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 30e-6,
-          "output": 180e-6,
-          "output_reasoning_tokens": 180e-6,
-          "output_reasoning": 180e-6
+          "input": 3e-05,
+          "output": 0.00018,
+          "output_reasoning_tokens": 0.00018,
+          "output_reasoning": 0.00018
         }
       }
     ]
@@ -3885,10 +4261,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.75e-6,
-          "input_cached_tokens": 0.075e-6,
-          "input_cache_read": 0.075e-6,
-          "output": 4.5e-6
+          "input": 7.5e-07,
+          "input_cached_tokens": 7.5e-08,
+          "input_cache_read": 7.5e-08,
+          "output": 4.5e-06
         }
       }
     ]
@@ -3913,10 +4289,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.75e-6,
-          "input_cached_tokens": 0.075e-6,
-          "input_cache_read": 0.075e-6,
-          "output": 4.5e-6
+          "input": 7.5e-07,
+          "input_cached_tokens": 7.5e-08,
+          "input_cache_read": 7.5e-08,
+          "output": 4.5e-06
         }
       }
     ]
@@ -3941,10 +4317,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.2e-6,
-          "input_cached_tokens": 0.02e-6,
-          "input_cache_read": 0.02e-6,
-          "output": 1.25e-6
+          "input": 2e-07,
+          "input_cached_tokens": 2e-08,
+          "input_cache_read": 2e-08,
+          "output": 1.25e-06
         }
       }
     ]
@@ -3969,10 +4345,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.2e-6,
-          "input_cached_tokens": 0.02e-6,
-          "input_cache_read": 0.02e-6,
-          "output": 1.25e-6
+          "input": 2e-07,
+          "input_cached_tokens": 2e-08,
+          "input_cache_read": 2e-08,
+          "output": 1.25e-06
         }
       }
     ]
@@ -3980,7 +4356,7 @@
   {
     "id": "0a8ec527-44e0-4ee3-8005-a1865d712ec6",
     "modelName": "gpt-5.5-2026-04-23",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.5(-2026-04-23)?)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.5(-2026-04-23)?)$",
     "createdAt": "2026-04-25T00:00:00.000Z",
     "updatedAt": "2026-04-25T00:00:00.000Z",
     "tokenizerConfig": {
@@ -3997,12 +4373,12 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 5e-6,
-          "input_cached_tokens": 0.5e-6,
-          "input_cache_read": 0.5e-6,
-          "output": 30e-6,
-          "output_reasoning_tokens": 30e-6,
-          "output_reasoning": 30e-6
+          "input": 5e-06,
+          "input_cached_tokens": 5e-07,
+          "input_cache_read": 5e-07,
+          "output": 3e-05,
+          "output_reasoning_tokens": 3e-05,
+          "output_reasoning": 3e-05
         }
       }
     ]
@@ -4010,7 +4386,7 @@
   {
     "id": "913d4e67-7472-49d1-97de-0a707ca3e31e",
     "modelName": "gpt-5.5-pro-2026-04-23",
-    "matchPattern": "(?i)^(openai\/)?(gpt-5.5-pro(-2026-04-23)?)$",
+    "matchPattern": "(?i)^(openai/)?(gpt-5.5-pro(-2026-04-23)?)$",
     "createdAt": "2026-04-25T00:00:00.000Z",
     "updatedAt": "2026-04-25T00:00:00.000Z",
     "tokenizerConfig": {
@@ -4027,10 +4403,10 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 30e-6,
-          "output": 180e-6,
-          "output_reasoning_tokens": 180e-6,
-          "output_reasoning": 180e-6
+          "input": 3e-05,
+          "output": 0.00018,
+          "output_reasoning_tokens": 0.00018,
+          "output_reasoning": 0.00018
         }
       }
     ]
@@ -4038,7 +4414,7 @@
   {
     "id": "6ed696e7-5f3a-4113-a233-019155fb3ff0",
     "modelName": "gemini-3.5-flash",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.5-flash)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3.5-flash)$",
     "createdAt": "2026-05-20T00:00:00.000Z",
     "updatedAt": "2026-05-20T00:00:00.000Z",
     "pricingTiers": [
@@ -4049,21 +4425,21 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 1.5e-6,
-          "input_modality_1": 1.5e-6,
-          "input_text": 1.5e-6,
-          "prompt_token_count": 1.5e-6,
-          "promptTokenCount": 1.5e-6,
-          "input_cached_tokens": 0.15e-6,
-          "cached_content_token_count": 0.15e-6,
-          "output": 9e-6,
-          "output_text": 9e-6,
-          "output_modality_1": 9e-6,
-          "candidates_token_count": 9e-6,
-          "candidatesTokenCount": 9e-6,
-          "thoughtsTokenCount": 9e-6,
-          "thoughts_token_count": 9e-6,
-          "output_reasoning": 9e-6
+          "input": 1.5e-06,
+          "input_modality_1": 1.5e-06,
+          "input_text": 1.5e-06,
+          "prompt_token_count": 1.5e-06,
+          "promptTokenCount": 1.5e-06,
+          "input_cached_tokens": 1.5e-07,
+          "cached_content_token_count": 1.5e-07,
+          "output": 9e-06,
+          "output_text": 9e-06,
+          "output_modality_1": 9e-06,
+          "candidates_token_count": 9e-06,
+          "candidatesTokenCount": 9e-06,
+          "thoughtsTokenCount": 9e-06,
+          "thoughts_token_count": 9e-06,
+          "output_reasoning": 9e-06
         }
       }
     ]
@@ -4071,7 +4447,7 @@
   {
     "id": "cmjfoeykl000004l8ffzra8c7",
     "modelName": "gemini-3-flash-preview",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3-flash-preview)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3-flash-preview)$",
     "createdAt": "2025-12-21T12:01:42.282Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -4082,21 +4458,21 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.5e-6,
-          "input_text": 0.5e-6,
-          "input_modality_1": 0.5e-6,
-          "prompt_token_count": 0.5e-6,
-          "promptTokenCount": 0.5e-6,
-          "input_cached_tokens": 0.05e-6,
-          "cached_content_token_count": 0.05e-6,
-          "output": 3e-6,
-          "output_text": 3e-6,
-          "output_modality_1": 3e-6,
-          "candidates_token_count": 3e-6,
-          "candidatesTokenCount": 3e-6,
-          "thoughtsTokenCount": 3e-6,
-          "thoughts_token_count": 3e-6,
-          "output_reasoning": 3e-6
+          "input": 5e-07,
+          "input_text": 5e-07,
+          "input_modality_1": 5e-07,
+          "prompt_token_count": 5e-07,
+          "promptTokenCount": 5e-07,
+          "input_cached_tokens": 5e-08,
+          "cached_content_token_count": 5e-08,
+          "output": 3e-06,
+          "output_text": 3e-06,
+          "output_modality_1": 3e-06,
+          "candidates_token_count": 3e-06,
+          "candidatesTokenCount": 3e-06,
+          "thoughtsTokenCount": 3e-06,
+          "thoughts_token_count": 3e-06,
+          "output_reasoning": 3e-06
         }
       }
     ]
@@ -4104,7 +4480,7 @@
   {
     "id": "79f4d62c-22fb-4ec3-82e1-6e56cdd5e23c",
     "modelName": "gemini-3.1-flash-lite",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-flash-lite)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3.1-flash-lite)$",
     "createdAt": "2026-05-20T00:00:00.000Z",
     "updatedAt": "2026-05-20T00:00:00.000Z",
     "pricingTiers": [
@@ -4115,22 +4491,22 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.25e-6,
-          "input_modality_1": 0.25e-6,
-          "input_text": 0.25e-6,
-          "prompt_token_count": 0.25e-6,
-          "promptTokenCount": 0.25e-6,
-          "input_cached_tokens": 0.025e-6,
-          "cached_content_token_count": 0.025e-6,
-          "output": 1.5e-6,
-          "output_text": 1.5e-6,
-          "output_modality_1": 1.5e-6,
-          "candidates_token_count": 1.5e-6,
-          "candidatesTokenCount": 1.5e-6,
-          "thoughtsTokenCount": 1.5e-6,
-          "thoughts_token_count": 1.5e-6,
-          "output_reasoning": 1.5e-6,
-          "input_audio_tokens": 0.5e-6
+          "input": 2.5e-07,
+          "input_modality_1": 2.5e-07,
+          "input_text": 2.5e-07,
+          "prompt_token_count": 2.5e-07,
+          "promptTokenCount": 2.5e-07,
+          "input_cached_tokens": 2.5e-08,
+          "cached_content_token_count": 2.5e-08,
+          "output": 1.5e-06,
+          "output_text": 1.5e-06,
+          "output_modality_1": 1.5e-06,
+          "candidates_token_count": 1.5e-06,
+          "candidatesTokenCount": 1.5e-06,
+          "thoughtsTokenCount": 1.5e-06,
+          "thoughts_token_count": 1.5e-06,
+          "output_reasoning": 1.5e-06,
+          "input_audio_tokens": 5e-07
         }
       }
     ]
@@ -4138,7 +4514,7 @@
   {
     "id": "0707bef8-10c8-46e2-a871-0436f05f0b92",
     "modelName": "gemini-3.1-flash-lite-preview",
-    "matchPattern": "(?i)^(google(ai)?\/)?(gemini-3.1-flash-lite-preview)$",
+    "matchPattern": "(?i)^(google(ai)?/)?(gemini-3.1-flash-lite-preview)$",
     "createdAt": "2026-03-03T00:00:00.000Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "pricingTiers": [
@@ -4149,22 +4525,22 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input": 0.25e-6,
-          "input_modality_1": 0.25e-6,
-          "input_text": 0.25e-6,
-          "prompt_token_count": 0.25e-6,
-          "promptTokenCount": 0.25e-6,
-          "input_cached_tokens": 0.025e-6,
-          "cached_content_token_count": 0.025e-6,
-          "output": 1.5e-6,
-          "output_text": 1.5e-6,
-          "output_modality_1": 1.5e-6,
-          "candidates_token_count": 1.5e-6,
-          "candidatesTokenCount": 1.5e-6,
-          "thoughtsTokenCount": 1.5e-6,
-          "thoughts_token_count": 1.5e-6,
-          "output_reasoning": 1.5e-6,
-          "input_audio_tokens": 0.5e-6
+          "input": 2.5e-07,
+          "input_modality_1": 2.5e-07,
+          "input_text": 2.5e-07,
+          "prompt_token_count": 2.5e-07,
+          "promptTokenCount": 2.5e-07,
+          "input_cached_tokens": 2.5e-08,
+          "cached_content_token_count": 2.5e-08,
+          "output": 1.5e-06,
+          "output_text": 1.5e-06,
+          "output_modality_1": 1.5e-06,
+          "candidates_token_count": 1.5e-06,
+          "candidatesTokenCount": 1.5e-06,
+          "thoughtsTokenCount": 1.5e-06,
+          "thoughts_token_count": 1.5e-06,
+          "output_reasoning": 1.5e-06,
+          "input_audio_tokens": 5e-07
         }
       }
     ]
@@ -4172,7 +4548,7 @@
   {
     "id": "029e6695-ff24-47f0-b37b-7285fb2e5785",
     "modelName": "gemini-live-2.5-flash-native-audio",
-    "matchPattern": "(?i)^(google\/)?(gemini-live-2.5-flash-native-audio)$",
+    "matchPattern": "(?i)^(google/)?(gemini-live-2.5-flash-native-audio)$",
     "createdAt": "2026-03-16T00:00:00.000Z",
     "updatedAt": "2026-03-19T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -4185,11 +4561,11 @@
         "priority": 0,
         "conditions": [],
         "prices": {
-          "input_text": 0.5e-6,
-          "input_audio": 3e-6,
-          "input_image": 3e-6,
-          "output_text": 2e-6,
-          "output_audio": 12e-6
+          "input_text": 5e-07,
+          "input_audio": 3e-06,
+          "input_image": 3e-06,
+          "output_text": 2e-06,
+          "output_audio": 1.2e-05
         }
       }
     ]


### PR DESCRIPTION
## fix(worker): add OpenAI priority service tier pricing

**Fixes #13780**

### What

OpenAI's `service_tier: "priority"` (which costs ~1.7–1.8× standard rates) was never captured from API provider metadata, so priority-processed requests were billed at standard rates.

### Why

The Vercel AI SDK passes `serviceTier` in OpenAI provider metadata (`ai.response.providerMetadata.openai.serviceTier`), but `OtelIngestionProcessor` never extracted it. Without `service_tier` in usage details, the tier matcher had no signal to match against — all requests fell through to the default/standard pricing tier regardless of actual processing tier.

### Changes

**`packages/shared/src/server/otel/OtelIngestionProcessor.ts`** (+10 lines)
- Extract `serviceTier` from OpenAI provider metadata
- Encode as numeric flag: `usageDetails["service_tier"] = 1` when `serviceTier === "priority"`
- Absent/undefined otherwise, so existing requests are unaffected

**`worker/src/constants/default-model-prices.json`**
- Added a "Priority" pricing tier (priority: 1, `isDefault: false`) to **18 OpenAI model entries**
- Condition: `{ usageDetailPattern: "service_tier", operator: "gte", value: 1 }` — matches the existing numeric matcher without any schema changes
- Prices sourced from [OpenAI's official priority processing page](https://openai.com/api-priority-processing/)

#### Models Updated

| Model | Variants | Priority Input (/1M) | Priority Cached (/1M) | Priority Output (/1M) |
|-------|----------|---------------------|----------------------|----------------------|
| **gpt-4o** | `gpt-4o`, `-2024-05-13`, `-2024-08-06`, `-2024-11-20` | $4.25 ($8.75 for 05-13) | $2.125 | $17.00 ($26.25 for 05-13) |
| **gpt-4o-mini** | `gpt-4o-mini`, `-2024-07-18` | $0.25 | $0.125 | $1.00 |
| **gpt-4.1** | `gpt-4.1`, `-2025-04-14` | $3.50 | $0.875 | $14.00 |
| **gpt-4.1-mini** | `gpt-4.1-mini`, `-2025-04-14` | $0.70 | $0.175 | $2.80 |
| **gpt-4.1-nano** | `gpt-4.1-nano`, `-2025-04-14` | $0.20 | $0.05 | $0.80 |
| **o3** | `o3`, `-2025-04-16` | $3.50 | $0.875 | $14.00 |
| **o4-mini** | `o4-mini`, `-2025-04-16` | $2.00 | $0.50 | $8.00 |
| **gpt-5-mini** | `gpt-5-mini`, `-2025-08-07` | $0.45 | $0.045 | $3.60 |

### Backward Compatibility

- **No schema changes**: uses existing `PricingTierCondition` with `operator: "gte"`
- **No matcher changes**: `usageDetails` stays `Record<string, number>`
- **No impact on existing requests**: when `serviceTier` is absent or not `"priority"`, `usageDetails["service_tier"]` is never set, so standard tier matching is unaffected
- Models not on OpenAI's priority page (o3-mini, o1, gpt-4-turbo, embeddings, fine-tuned) intentionally skipped

### Verification

- `pnpm --filter worker run lint` passes
- `pnpm --filter @langfuse/shared run lint` passes
- `pnpm --filter @langfuse/shared run typecheck` - no new errors
- Pricing math spot-checked against OpenAI's published rates

### Impacted Packages

- `packages/shared` — OtelIngestionProcessor
- `worker` — default-model-prices.json

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds support for OpenAI's `service_tier: "priority"` pricing by extracting `serviceTier` from the Vercel AI SDK's OpenAI provider metadata in `OtelIngestionProcessor` and encoding it as a numeric flag in `usageDetails`, then adding corresponding Priority pricing tiers to 18 OpenAI model entries in `default-model-prices.json`. It also fixes an unrelated AM/PM toggle bug in `time-period-select.tsx`.

- **OtelIngestionProcessor**: Reads `serviceTier` from the OpenAI provider metadata block and sets `usageDetails["service_tier"] = 1` when the value is `"priority"`, leaving existing requests unaffected.
- **default-model-prices.json**: Adds a Priority pricing tier (with `usageDetailPattern: "service_tier", operator: "gte", value: 1`) to `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `o3`, `o4-mini`, and `gpt-5-mini` (and their dated variants); pricing numbers sourced from OpenAI's published priority processing rates.
- **time-period-select.tsx**: Fixes a bug where the AM/PM picker was passing the inverted period to `setDateByType` and switches the control from uncontrolled to controlled.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The pricing logic change is purely additive — existing requests are unaffected — and the OtelIngestionProcessor change is a small, well-scoped extraction. The main concerns are cosmetic floating-point noise in four gpt-4.1-nano and gpt-5-mini priority tier entries and an unrelated time-picker fix bundled into the PR.

The OtelIngestionProcessor change is correct and backward-compatible. The JSON pricing data is accurate for all models except four entries where floating-point arithmetic produced trailing-digit noise instead of clean scientific notation literals. These do not cause meaningful billing errors but indicate the values were not manually verified before commit. The time-period-select.tsx change is a valid fix but unrelated to the PR scope.

The gpt-4.1-nano and gpt-5-mini priority tier entries (both base and dated variants) in default-model-prices.json contain floating-point noise and should be corrected to clean literals.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SDK as Vercel AI SDK
    participant OTel as OtelIngestionProcessor
    participant UD as usageDetails
    participant PM as PricingMatcher
    participant JSON as default-model-prices.json

    SDK->>OTel: "providerMetadata (openai.serviceTier="priority")"
    OTel->>OTel: parse providerMetadata JSON
    OTel->>UD: "service_tier = 1"
    OTel->>PM: resolve pricing tier
    PM->>JSON: "find matching tier where usageDetailPattern="service_tier" gte 1"
    JSON-->>PM: Priority tier (e.g. gpt-4o: $4.25/1M input)
    PM-->>OTel: apply Priority pricing
    Note over UD,PM: Absent serviceTier → service_tier key never set → Standard tier matched
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
worker/src/constants/default-model-prices.json:2559-2576
Floating-point precision artifacts in the `gpt-4.1-nano-2025-04-14` priority tier. These appear to have been generated by multiplying standard prices by a ratio in floating-point (`1e-07 * 2`, etc.) rather than writing the intended exact literals. The same issue is repeated for the `gpt-4.1-nano` base model entry.

```suggestion
          "input": 2e-07,
          "input_cached_tokens": 5e-08,
          "input_cached_text_tokens": 5e-08,
          "input_cache_read": 5e-08,
          "output": 8e-07
```

### Issue 2 of 3
worker/src/constants/default-model-prices.json:3340-3351
Same floating-point precision artifact in both `gpt-5-mini` and `gpt-5-mini-2025-08-07` priority tiers. `4.5e-07` and `3.6e-06` are the correct exact representations; the extra trailing digits are IEEE 754 noise from computing `2.5e-07 * 1.8` and `2e-06 * 1.8` at runtime instead of writing the literals directly. This also affects `output_reasoning_tokens` and `output_reasoning`.

### Issue 3 of 3
web/src/components/ui/time-period-select.tsx:42-46
**Unrelated change bundled into a pricing PR**

This file fixes an AM/PM toggle bug (the old code passed the inverted period to `setDateByType`, and changed from uncontrolled `defaultValue` to controlled `value`), which is a valid fix but has no connection to the stated PR goal of adding OpenAI priority service tier pricing. Consider splitting it into a separate PR to keep the scope clear and avoid unintended review blind spots.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): add OpenAI priority service..."](https://github.com/langfuse/langfuse/commit/78756c58affb87bff43cf8e6005ccd921c7987e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35113716)</sub>

<!-- /greptile_comment -->