### PR TITLE
fix(shared): unwrap primitive JsonPath results and parse stringified JSON

### DIFF
--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -53,7 +53,25 @@ function parseMultiEncodedJson(value: unknown): unknown {
 }
 
 function parseJsonDefault(selectedColumn: unknown, jsonSelector: string) {
-  // JSONPath can only query objects/arrays — return primitives as-is
+  // JSONPath can only query objects/arrays. If selectedColumn is a string,
+  // it may be stringified JSON (e.g. a JSON array or object serialized by
+  // the SDK). Try to parse it so JSONPath can query the structure instead
+  // of treating the string as a raw value.
+  if (typeof selectedColumn === "string") {
+    try {
+      const parsed = JSON.parse(selectedColumn);
+      // Only use the parsed result if it's a queryable structure (object or
+      // array). Primitive JSON values (numbers, booleans, bare strings)
+      // should fall through and be returned as-is.
+      if (typeof parsed === "object" && parsed !== null) {
+        selectedColumn = parsed;
+      }
+    } catch {
+      // Not valid JSON — return the raw string as-is
+      return selectedColumn;
+    }
+  }
+
   if (typeof selectedColumn !== "object" || selectedColumn === null) {
     return selectedColumn;
   }
@@ -70,6 +88,21 @@ function parseJsonDefault(selectedColumn: unknown, jsonSelector: string) {
 
   // For single-match queries (e.g. $.name), return the unwrapped value.
   // For multi-match queries (e.g. $[1:], $[*].name), return the full array.
+  // Also unwrap single-element arrays containing primitives (strings,
+  // numbers, booleans) — JSONPath always wraps results in an array, so a
+  // query like $.field that resolves to a string returns ["string"].
+  if (result.length === 1) {
+    const first = result[0];
+    if (
+      typeof first === "string" ||
+      typeof first === "number" ||
+      typeof first === "boolean" ||
+      first === null
+    ) {
+      return first;
+    }
+  }
+
   return result.length === 1 ? result[0] : result;
 }
 

--- a/worker/src/__tests__/jsonpath-string-extraction.test.ts
+++ b/worker/src/__tests__/jsonpath-string-extraction.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { extractValueFromObject } from "../../../packages/shared/src/features/evals/utilities";
+
+describe("extractValueFromObject - JsonPath on stringified JSON", () => {
+  const stringifiedOutput = JSON.stringify({
+    actual_output: "**Whitelist User Count (Incremental L1)**...",
+    context: "[milvus-kb.search_sql_recipes]...",
+  });
+
+  it("should extract plain string from stringified JSON via JsonPath", () => {
+    const { value, error } = extractValueFromObject(
+      { output: stringifiedOutput },
+      "output",
+      "$.actual_output",
+    );
+
+    expect(error).toBeNull();
+    expect(value).toBe("**Whitelist User Count (Incremental L1)**...");
+  });
+
+  it("should NOT wrap extracted primitive in array brackets", () => {
+    const { value } = extractValueFromObject(
+      { output: stringifiedOutput },
+      "output",
+      "$.actual_output",
+    );
+
+    expect(typeof value).toBe("string");
+    expect(value).not.toMatch(/^\[/);
+  });
+
+  it("should extract string containing brackets from JsonPath", () => {
+    const { value, error } = extractValueFromObject(
+      { output: stringifiedOutput },
+      "output",
+      "$.context",
+    );
+
+    expect(error).toBeNull();
+    expect(value).toBe("[milvus-kb.search_sql_recipes]...");
+  });
+
+  it("should extract first element from stringified array", () => {
+    const stringifiedArray = JSON.stringify(["item1", "item2", "item3"]);
+
+    const { value, error } = extractValueFromObject(
+      { output: stringifiedArray },
+      "output",
+      "$[0]",
+    );
+
+    expect(error).toBeNull();
+    expect(value).toBe("item1");
+  });
+
+  it("should return full array via wildcard selector", () => {
+    const stringifiedArray = JSON.stringify(["item1", "item2", "item3"]);
+
+    const { value, error } = extractValueFromObject(
+      { output: stringifiedArray },
+      "output",
+      "$[*]",
+    );
+
+    expect(error).toBeNull();
+    expect(value).toEqual(["item1", "item2", "item3"]);
+  });
+
+  it("should work with already-parsed objects (observation eval path)", () => {
+    const parsed = JSON.parse(stringifiedOutput);
+
+    const { value, error } = extractValueFromObject(
+      { output: parsed },
+      "output",
+      "$.actual_output",
+    );
+
+    expect(error).toBeNull();
+    expect(value).toBe("**Whitelist User Count (Incremental L1)**...");
+  });
+
+  it("should return raw string when no jsonSelector provided", () => {
+    const { value, error } = extractValueFromObject(
+      { output: "hello world" },
+      "output",
+    );
+
+    expect(error).toBeNull();
+    expect(value).toBe("hello world");
+  });
+});


### PR DESCRIPTION
## Description

When an LLM-as-a-judge evaluator variable is mapped to a flat string field inside trace output via JsonPath (e.g., `$.actual_output`), the template engine was wrapping the injected string in JSON array brackets (`["..."]`).

Fixes #13990

### Root Cause

`parseJsonDefault` in `packages/shared/src/features/evals/utilities.ts` had two gaps:

1. When the input was a string (not parsed by `parseMultiEncodedJson`), it was returned raw without applying the jsonSelector. A stringified JSON array like `["text"]` was returned as-is instead of being queried.
2. jsonpath-plus wraps all results in an array by default. A query like `$.field` that resolves to a string returns `["string"]`. The existing unwrapping at `result.length === 1` only handled objects, not primitives.

### Changes

- Parse stringified JSON in `parseJsonDefault` before querying so JSONPath can search the structure instead of treating the string as a raw value.
- Unwrap single-element arrays containing primitives (strings, numbers, booleans) in addition to objects.

### Impacted packages

- `@langfuse/shared` — `packages/shared/src/features/evals/utilities.ts`

### Verification

- All existing tests pass
- Added 7 new tests covering: stringified JSON extraction, array bracket unwrapping, stringified array indexing, wildcard selectors, already-parsed objects, and no-selector passthrough
- `pnpm --filter @langfuse/shared run lint` passes
- `pnpm --filter worker run lint` passes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR attempts to fix a reported issue where LLM-as-a-judge evaluator variable extraction via JSONPath was wrapping primitive string results in array brackets. Two changes are made to `parseJsonDefault` in `packages/shared/src/features/evals/utilities.ts`: a string-parsing block that tries `JSON.parse` before querying, and a primitive-type guard before the existing unwrap return. Seven new unit tests are added in the `worker` package.

- The new primitive-unwrapping block (`if (result.length === 1)` with type checks) is logically dead: the existing `return result.length === 1 ? result[0] : result` already returns `result[0]` unconditionally for single-element results, making the new guard's return value identical in every reachable case.
- The string-parsing block in `parseJsonDefault` is unreachable through the normal call path, because `extractValueFromObject` already invokes `parseMultiEncodedJson` on string inputs before dispatching to `parseJsonDefault`.
- The new tests are placed in the `worker` package via a relative cross-package import rather than in the existing `extractValueFromObject.test.ts` co-located with the function under test.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change adds code to `parseJsonDefault` but the two new blocks are unreachable through the existing call chain, meaning the original production behavior is unchanged — the reported wrapping issue from #13990 is not demonstrably addressed by this diff.

Both added code blocks in `parseJsonDefault` are inert: the string-parsing block is never reached because `extractValueFromObject` already converts strings via `parseMultiEncodedJson` before calling `parseJsonDefault`, and the primitive-type guard is logically equivalent to the existing ternary that immediately follows it. All seven new tests pass against the pre-PR code for the same reason. If the array-wrapping regression was real in production, this change does not fix it, and the root cause remains undiagnosed.

packages/shared/src/features/evals/utilities.ts deserves the most attention — specifically whether the actual production bug path goes through `parseDatabaseRowValue` in `evalService.ts` or through `extractObservationVariables.ts`, both of which call `extractValueFromObject` with data that may differ from the unit-test inputs.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/src/features/evals/utilities.ts:94-106
**Primitive-unwrapping block is dead code**

The new `if (result.length === 1)` guard returns `first` when it is a primitive — but the very next line (`return result.length === 1 ? result[0] : result`) already returns `result[0]` unconditionally whenever `result.length === 1`, regardless of whether the element is a primitive or an object. Every branch of the new block produces an outcome that the existing ternary would also produce, so this block is never reachable in a way that changes the return value.

Because the new block is never effective, the "Fix 2" claim in the PR description is not borne out by the code, and the seven new tests in `jsonpath-string-extraction.test.ts` all pass against the pre-PR code as well (traced: `parseMultiEncodedJson` in `extractValueFromObject` already converts a JSON string to an object before `parseJsonDefault` is invoked, so the existing ternary has always handled this path correctly). If the `["..."]` wrapping was a real regression in production, the root cause may lie elsewhere and is still present.

### Issue 2 of 3
packages/shared/src/features/evals/utilities.ts:60-73
**String-parsing block is unreachable through the normal call path**

Every caller of `parseJsonDefault` goes through `extractValueFromObject`, which already calls `parseMultiEncodedJson` on string inputs before dispatching to `parseJsonDefault`. If `parseMultiEncodedJson` succeeds in parsing the string to an object/array, `parseJsonDefault` receives an object — the new `typeof selectedColumn === "string"` branch is never entered. If `parseMultiEncodedJson` fails (invalid JSON), `JSON.parse` in the new branch will also throw, resulting in the same early-return as the original `typeof selectedColumn !== "object"` guard.

Since `parseJsonDefault` is unexported, there is currently no reachable code path where this block changes behavior. It is safe to remove or to retain as defense-in-depth, but in the latter case the comment should note why the redundancy is intentional rather than implying it fixes a gap that `extractValueFromObject`'s pre-processing already closed.

### Issue 3 of 3
worker/src/__tests__/jsonpath-string-extraction.test.ts:1-5
**Test file for a `packages/shared` function lives in the `worker` package**

`extractValueFromObject` is defined in `@langfuse/shared`. The existing unit tests for it sit in `worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts`, where the import uses the package alias. These new tests use a relative cross-package path (`../../../packages/shared/src/features/evals/utilities`), which bypasses the package boundary, won't benefit from any package-level build check, and may break if the file moves. New tests for this function should be added to the existing test file in the same package.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): unwrap primitive JsonPath r..."](https://github.com/langfuse/langfuse/commit/c77aae2056fa44f91f298becc8d013bc73cdb977) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35121658)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->