### PR TITLE
refactor: Fix void operator linting issues

### DIFF
--- a/web/src/features/in-app-agent/server/agent.ts
+++ b/web/src/features/in-app-agent/server/agent.ts
@@ -113,7 +113,7 @@ export function createAgUiStream(params: {
 
     finished = true;
     try {
-      void Promise.resolve(params.options.onFinish?.()).catch((error) => {
+      Promise.resolve(params.options.onFinish?.()).catch((error) => {
         console.error("Error in agent stream cleanup:", error);
       });
     } catch (error) {
@@ -201,7 +201,7 @@ export function createAgUiStream(params: {
       closed = true;
       removeAbortHandler();
       subscription?.unsubscribe();
-      void adapter.interrupt().catch(() => undefined);
+      adapter.interrupt().catch(() => undefined);
       finish();
     },
   });


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This refactor removes the `void` operator from two fire-and-forget promise chains in `agent.ts` to satisfy updated linting rules. Both affected call sites already have `.catch()` attached, so error handling is unchanged.

- In `finish()`, `void Promise.resolve(params.options.onFinish?.()).catch(...)` is simplified to the same expression without `void`, which is already how the `abort()` helper handles the same pattern at line 138.
- In `cancel()`, `void adapter.interrupt().catch(() => undefined)` is similarly simplified, making it consistent with the existing `abort()` call.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the two removed `void` operators had no effect on runtime behavior since `.catch()` was already chained on both promises.

Both changes are purely cosmetic linting fixes. The `void` operator only discards a return value; removing it does not alter the promise lifecycle, error handling, or cleanup order. The `abort()` helper in the same file already used the same pattern without `void`, so these two changes bring consistency to the file.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stream cancel / abort triggered] --> B{closed?}
    B -- yes --> C[Return early]
    B -- no --> D[Set closed = true]
    D --> E[removeAbortHandler]
    E --> F[subscription.unsubscribe]
    F --> G["adapter.interrupt().catch(() => undefined)"]
    G --> H[finish]
    H --> I{finished?}
    I -- yes --> J[Return early]
    I -- no --> K[Set finished = true]
    K --> L["Promise.resolve(onFinish?.()).catch(console.error)"]
    L --> M[Done]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: Fix void operator linting issu..."](https://github.com/langfuse/langfuse/commit/58e7a8c91521bd51945ecc7ac777c443c98b116d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35122509)</sub>

<!-- /greptile_comment -->