### PR TITLE
feat(llm): support OpenAI Responses API connections

### DIFF
--- a/fern/apis/server/definition/llm-connections.yml
+++ b/fern/apis/server/definition/llm-connections.yml
@@ -62,7 +62,7 @@ types:
         docs: Keys of extra headers sent with requests (values excluded for security)
       config:
         type: optional<map<string, unknown>>
-        docs: Adapter-specific configuration. Required for Bedrock (`{"region":"us-east-1"}`), optional for VertexAI (`{"location":"us-central1"}`), not used by other adapters.
+        docs: Adapter-specific configuration. Required for Bedrock (`{"region":"us-east-1"}`), optional for OpenAI (`{"useResponsesApi":true}`), optional for VertexAI (`{"location":"us-central1"}`), not used by other adapters.
       createdAt: datetime
       updatedAt: datetime
 
@@ -100,6 +100,7 @@ types:
         docs: >
           Adapter-specific configuration. Validation rules:
           - **Bedrock**: Required. Must be `{"region": "<aws-region>"}` (e.g., `{"region":"us-east-1"}`)
+          - **OpenAI**: Optional. If provided, must be `{"useResponsesApi": <boolean>}` to control whether Langfuse routes calls through OpenAI's Responses API.
           - **VertexAI**: Optional. If provided, must be `{"location": "<gcp-location>"}` (e.g., `{"location":"us-central1"}`)
           - **Other adapters**: Not supported. Omit this field or set to null.
 

--- a/packages/shared/src/interfaces/customLLMProviderConfigSchemas.ts
+++ b/packages/shared/src/interfaces/customLLMProviderConfigSchemas.ts
@@ -11,6 +11,23 @@ export const VERTEXAI_USE_DEFAULT_CREDENTIALS =
 export const BedrockConfigSchema = z.object({ region: z.string() });
 export type BedrockConfig = z.infer<typeof BedrockConfigSchema>;
 
+export const LLMConnectionConfigValueSchema = z.union([
+  z.string(),
+  z.boolean(),
+]);
+export const LLMConnectionConfigSchema = z.record(
+  z.string(),
+  LLMConnectionConfigValueSchema,
+);
+export type LLMConnectionConfig = z.infer<typeof LLMConnectionConfigSchema>;
+
+export const OpenAIConfigSchema = z
+  .object({
+    useResponsesApi: z.boolean().default(false),
+  })
+  .strict();
+export type OpenAIConfig = z.infer<typeof OpenAIConfigSchema>;
+
 export const BedrockAccessKeysSchema = z
   .object({
     accessKeyId: z.string().min(1),

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -24,6 +24,8 @@ import GCPServiceAccountKeySchema, {
   BedrockAccessKeysSchema,
   BedrockConfigSchema,
   BedrockCredentialSchema,
+  LLMConnectionConfig,
+  OpenAIConfigSchema,
   VertexAIConfigSchema,
   BEDROCK_USE_DEFAULT_CREDENTIALS,
   VERTEXAI_USE_DEFAULT_CREDENTIALS,
@@ -185,7 +187,7 @@ type LLMCompletionParams = {
     secretKey: string;
     extraHeaders?: string | null;
     baseURL?: string | null;
-    config?: Record<string, string> | null;
+    config?: LLMConnectionConfig | null;
   };
   structuredOutputSchema?: ZodType | LLMJSONSchema;
   callbacks?: BaseCallbackHandler[];
@@ -346,6 +348,7 @@ export async function fetchLLMCompletion(
     });
 
   let chatModel: ChatOpenAI | ChatAnthropic | ChatBedrockConverse | ChatGoogle;
+  let usesOpenAIResponsesApi = false;
   if (modelParams.adapter === LLMAdapter.Anthropic) {
     const shouldNormalizeAnthropicSamplingParams =
       modelParams.model?.includes("claude-opus-4-8") ||
@@ -404,6 +407,8 @@ export async function fetchLLMCompletion(
       url: baseURL,
       modelName: modelParams.model,
     });
+    const openAIConfig = OpenAIConfigSchema.parse(config ?? {});
+    usesOpenAIResponsesApi = openAIConfig.useResponsesApi;
 
     chatModel = new ChatOpenAI({
       apiKey,
@@ -422,6 +427,7 @@ export async function fetchLLMCompletion(
         defaultHeaders: extraHeaders,
         fetch: secureLlmFetch("OpenAI LLM base URL"),
       },
+      useResponsesApi: openAIConfig.useResponsesApi,
       modelKwargs: modelParams.providerOptions,
       timeout: timeoutMs,
     });
@@ -566,6 +572,8 @@ export async function fetchLLMCompletion(
     : runConfig;
 
   const supportsReasoning = adapterSupportsReasoning(modelParams.adapter);
+  const shouldNormalizeStreamingContentBlocks =
+    supportsReasoning || usesOpenAIResponsesApi;
 
   try {
     // Important: await all generations in the try block as otherwise `processTracedEvents` will run too early in finally block
@@ -632,7 +640,9 @@ export async function fetchLLMCompletion(
         abortController: runtimeTimeoutController,
         operation: () =>
           chatModel
-            .pipe(createBytesOutputParser(supportsReasoning))
+            .pipe(
+              createBytesOutputParser(shouldNormalizeStreamingContentBlocks),
+            )
             .stream(finalMessages, runConfigWithTimeout),
       });
 
@@ -735,18 +745,19 @@ function extractCompletionWithReasoning(
 }
 
 function createBytesOutputParser(
-  filterReasoningBlocks: boolean,
+  normalizeContentBlocks: boolean,
 ): BytesOutputParser {
-  return filterReasoningBlocks
-    ? new ReasoningStrippingBytesOutputParser()
+  return normalizeContentBlocks
+    ? new ContentBlockBytesOutputParser()
     : new BytesOutputParser();
 }
 
-class ReasoningStrippingBytesOutputParser extends BytesOutputParser {
+class ContentBlockBytesOutputParser extends BytesOutputParser {
   // Override `_baseMessageToString` (not `_baseMessageContentToString`) so we
   // have the whole AIMessage(Chunk) and can read `contentBlocks`, which the
-  // langchain provider translator normalizes into standard blocks. Streaming
-  // yields AIMessageChunk instances, so we check both predicates explicitly.
+  // langchain provider translator normalizes into standard blocks. This strips
+  // reasoning blocks and also avoids serializing OpenAI Responses API lifecycle
+  // chunks such as empty `final_answer` phase markers.
   protected _baseMessageToString(message: BaseMessage): string {
     if (AIMessage.isInstance(message) || AIMessageChunk.isInstance(message)) {
       return splitAIMessage(message).text;

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -515,7 +515,7 @@ export const LLMApiKeySchema = z
     customModels: z.array(z.string()),
     withDefaultModels: z.boolean(),
     config: z
-      .union([BedrockConfigSchema, OpenAIConfigSchema, VertexAIConfigSchema])
+      .union([BedrockConfigSchema, VertexAIConfigSchema, OpenAIConfigSchema])
       .nullish(),
   })
   // strict mode to prevent extra keys. Thorws error otherwise

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -2,6 +2,7 @@ import { LlmApiKeys } from "@prisma/client";
 import z from "zod";
 import {
   BedrockConfigSchema,
+  OpenAIConfigSchema,
   VertexAIConfigSchema,
 } from "../../interfaces/customLLMProviderConfigSchemas";
 import { JSONObjectSchema } from "../../utils/zod";
@@ -513,7 +514,9 @@ export const LLMApiKeySchema = z
     baseURL: z.string().nullable(),
     customModels: z.array(z.string()),
     withDefaultModels: z.boolean(),
-    config: z.union([BedrockConfigSchema, VertexAIConfigSchema]).nullish(), // Bedrock and VertexAI have additional config
+    config: z
+      .union([BedrockConfigSchema, OpenAIConfigSchema, VertexAIConfigSchema])
+      .nullish(),
   })
   // strict mode to prevent extra keys. Thorws error otherwise
   // https://github.com/colinhacks/zod?tab=readme-ov-file#strict

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -10480,7 +10480,8 @@ components:
           nullable: true
           description: >-
             Adapter-specific configuration. Required for Bedrock
-            (`{"region":"us-east-1"}`), optional for VertexAI
+            (`{"region":"us-east-1"}`), optional for OpenAI
+            (`{"useResponsesApi":true}`), optional for VertexAI
             (`{"location":"us-central1"}`), not used by other adapters.
         createdAt:
           type: string
@@ -10554,10 +10555,12 @@ components:
           description: >-
             Adapter-specific configuration. Validation rules: - **Bedrock**:
             Required. Must be `{"region": "<aws-region>"}` (e.g.,
-            `{"region":"us-east-1"}`) - **VertexAI**: Optional. If provided,
-            must be `{"location": "<gcp-location>"}` (e.g.,
-            `{"location":"us-central1"}`) - **Other adapters**: Not supported.
-            Omit this field or set to null.
+            `{"region":"us-east-1"}`) - **OpenAI**: Optional. If provided, must
+            be `{"useResponsesApi": <boolean>}` to control whether Langfuse
+            routes calls through OpenAI's Responses API. - **VertexAI**:
+            Optional. If provided, must be `{"location": "<gcp-location>"}`
+            (e.g., `{"location":"us-central1"}`) - **Other adapters**: Not
+            supported. Omit this field or set to null.
       required:
         - provider
         - adapter

--- a/web/src/__tests__/server/llm-api-key.servertest.ts
+++ b/web/src/__tests__/server/llm-api-key.servertest.ts
@@ -302,6 +302,29 @@ describe("llmApiKey.all RPC", () => {
     expect(llmApiKeys[0].config).toEqual({ useResponsesApi: false });
   });
 
+  it("should preserve empty VertexAI config without applying OpenAI defaults", async () => {
+    await prisma.llmApiKeys.create({
+      data: {
+        projectId,
+        provider: "vertex-empty-config",
+        adapter: LLMAdapter.VertexAI,
+        secretKey: encrypt("test-secret"),
+        displaySecretKey: "...cret",
+        customModels: ["gemini-2.5-flash"],
+        withDefaultModels: false,
+        extraHeaderKeys: [],
+        config: {},
+      },
+    });
+
+    const { data: llmApiKeys } = await caller.llmApiKey.all({
+      projectId,
+    });
+
+    expect(llmApiKeys).toHaveLength(1);
+    expect(llmApiKeys[0].config).toEqual({});
+  });
+
   it("should derive the Bedrock auth method in llmApiKey.all without returning secrets", async () => {
     await prisma.llmApiKeys.createMany({
       data: [

--- a/web/src/__tests__/server/llm-api-key.servertest.ts
+++ b/web/src/__tests__/server/llm-api-key.servertest.ts
@@ -242,6 +242,66 @@ describe("llmApiKey.all RPC", () => {
     expect(secretKey).toBeUndefined();
   });
 
+  it("should create and get an OpenAI llm api key with Responses API config", async () => {
+    await caller.llmApiKey.create({
+      projectId,
+      secretKey: "test-secret",
+      provider: "openai-responses",
+      adapter: LLMAdapter.OpenAI,
+      baseURL: "https://example.com/v1",
+      customModels: ["openai.gpt-5.4"],
+      withDefaultModels: false,
+      config: { useResponsesApi: true },
+    });
+
+    const { data: llmApiKeys } = await caller.llmApiKey.all({
+      projectId,
+    });
+
+    expect(llmApiKeys).toHaveLength(1);
+    expect(llmApiKeys[0].config).toEqual({ useResponsesApi: true });
+    expect(llmApiKeys[0].customModels).toEqual(["openai.gpt-5.4"]);
+    expect(llmApiKeys[0].secretKey).toBeUndefined();
+  });
+
+  it("should update an OpenAI llm api key to disable Responses API config", async () => {
+    await caller.llmApiKey.create({
+      projectId,
+      secretKey: "test-secret",
+      provider: "openai-responses",
+      adapter: LLMAdapter.OpenAI,
+      baseURL: "https://example.com/v1",
+      customModels: ["openai.gpt-5.4"],
+      withDefaultModels: false,
+      config: { useResponsesApi: true },
+    });
+
+    const existingKey = await prisma.llmApiKeys.findFirstOrThrow({
+      where: {
+        projectId,
+        provider: "openai-responses",
+      },
+    });
+
+    await caller.llmApiKey.update({
+      id: existingKey.id,
+      projectId,
+      provider: "openai-responses",
+      adapter: LLMAdapter.OpenAI,
+      baseURL: "https://example.com/v1",
+      customModels: ["openai.gpt-5.4"],
+      withDefaultModels: false,
+      config: { useResponsesApi: false },
+    });
+
+    const { data: llmApiKeys } = await caller.llmApiKey.all({
+      projectId,
+    });
+
+    expect(llmApiKeys).toHaveLength(1);
+    expect(llmApiKeys[0].config).toEqual({ useResponsesApi: false });
+  });
+
   it("should derive the Bedrock auth method in llmApiKey.all without returning secrets", async () => {
     await prisma.llmApiKeys.createMany({
       data: [

--- a/web/src/__tests__/server/llm-connections-api.servertest.ts
+++ b/web/src/__tests__/server/llm-connections-api.servertest.ts
@@ -1095,13 +1095,36 @@ describe("/api/public/llm-connections API Endpoints", () => {
         expect(response.body.config).toBeNull();
       });
 
-      it("should reject OpenAI connection with config", async () => {
+      it("should create OpenAI connection with Responses API config", async () => {
+        const createData = {
+          provider: generateUniqueProvider("openai-responses-api"),
+          adapter: LLMAdapter.OpenAI,
+          secretKey: "sk-test123",
+          config: {
+            useResponsesApi: true,
+          },
+        };
+
+        const response = await makeZodVerifiedAPICall(
+          PutLlmConnectionV1Response,
+          "PUT",
+          "/api/public/llm-connections",
+          createData,
+          auth,
+          201,
+        );
+
+        expect(response.status).toBe(201);
+        expect(response.body.config).toEqual({ useResponsesApi: true });
+      });
+
+      it("should reject OpenAI connection with unsupported config", async () => {
         const createData = {
           provider: generateUniqueProvider("openai-with-config"),
           adapter: LLMAdapter.OpenAI,
           secretKey: "sk-test123",
           config: {
-            region: "us-east-1", // OpenAI doesn't support config
+            region: "us-east-1",
           },
         };
 
@@ -1114,7 +1137,7 @@ describe("/api/public/llm-connections API Endpoints", () => {
 
         expect(response.status).toBe(400);
         expect(JSON.stringify(response.body)).toContain(
-          "Config is not supported for openai adapter",
+          "Invalid OpenAI config",
         );
       });
 

--- a/web/src/features/llm-api-key/server/router.ts
+++ b/web/src/features/llm-api-key/server/router.ts
@@ -20,11 +20,13 @@ import {
   GCPServiceAccountKeySchema,
   BedrockConfigSchema,
   BedrockCredentialSchema,
+  OpenAIConfigSchema,
   VertexAIConfigSchema,
   BEDROCK_USE_DEFAULT_CREDENTIALS,
   VERTEXAI_USE_DEFAULT_CREDENTIALS,
   EvaluatorBlockReason,
   getEvaluatorBlockMetadata,
+  type LLMConnectionConfig,
 } from "@langfuse/shared";
 import { findDefaultModelEvalTemplateIds } from "@/src/features/evals/server/defaultModelEvalTemplateRepository";
 import { encrypt, decrypt } from "@langfuse/shared/encryption";
@@ -128,11 +130,13 @@ async function testLLMConnection(
     ];
 
     // Parse config properly for type safety
-    let parsedConfig: Record<string, string> | null = null;
+    let parsedConfig: LLMConnectionConfig | null = null;
     if (params.config && params.adapter === LLMAdapter.Bedrock) {
       const bedrockConfig = BedrockConfigSchema.parse(params.config);
 
       parsedConfig = { region: bedrockConfig.region };
+    } else if (params.config && params.adapter === LLMAdapter.OpenAI) {
+      parsedConfig = OpenAIConfigSchema.parse(params.config);
     } else if (params.config && params.adapter === LLMAdapter.VertexAI) {
       const vertexAIConfig = VertexAIConfigSchema.parse(params.config);
       parsedConfig = vertexAIConfig.location

--- a/web/src/features/llm-api-key/types.ts
+++ b/web/src/features/llm-api-key/types.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   LLMAdapter,
   BedrockConfigSchema,
+  OpenAIConfigSchema,
   VertexAIConfigSchema,
   LLMApiKeySchema,
 } from "@langfuse/shared";
@@ -16,7 +17,9 @@ export const LlmApiKeySchema = z.object({
   baseURL: z.url().optional(),
   withDefaultModels: z.boolean().optional(),
   customModels: z.array(z.string().min(1)).optional(),
-  config: z.union([VertexAIConfigSchema, BedrockConfigSchema]).optional(),
+  config: z
+    .union([VertexAIConfigSchema, BedrockConfigSchema, OpenAIConfigSchema])
+    .optional(),
   extraHeaders: z.record(z.string(), z.string()).optional(),
 });
 

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -5,6 +5,7 @@ import {
   type BedrockApiKey,
   type BedrockAccessKeys,
   type BedrockConfig,
+  type OpenAIConfig,
   type VertexAIConfig,
   LLMAdapter,
   BEDROCK_USE_DEFAULT_CREDENTIALS,
@@ -106,6 +107,7 @@ const createFormSchema = (params: {
       authMethod: BedrockAuthMethodSchema,
       awsRegion: z.string().optional(),
       vertexAILocation: z.string().optional(),
+      openAIUseResponsesApi: z.boolean(),
       extraHeaders: z.array(
         z.object({
           key: z.string().min(1),
@@ -325,6 +327,11 @@ export function CreateLLMApiKeyForm({
               existingKey.adapter === LLMAdapter.VertexAI && existingKey.config
                 ? ((existingKey.config as VertexAIConfig).location ?? "")
                 : "",
+            openAIUseResponsesApi:
+              existingKey.adapter === LLMAdapter.OpenAI &&
+              existingKey.config !== null
+                ? Boolean((existingKey.config as OpenAIConfig).useResponsesApi)
+                : false,
             awsRegion:
               existingKey.adapter === LLMAdapter.Bedrock && existingKey.config
                 ? ((existingKey.config as BedrockConfig).region ?? "")
@@ -346,6 +353,7 @@ export function CreateLLMApiKeyForm({
             customModels: [],
             extraHeaders: [],
             vertexAILocation: "global",
+            openAIUseResponsesApi: false,
             awsRegion: "",
             awsAccessKeyId: "",
             awsSecretAccessKey: "",
@@ -525,7 +533,7 @@ export function CreateLLMApiKeyForm({
     }
 
     let secretKey = values.secretKey;
-    let config: BedrockConfig | VertexAIConfig | undefined;
+    let config: BedrockConfig | OpenAIConfig | VertexAIConfig | undefined;
 
     if (currentAdapter === LLMAdapter.Bedrock) {
       const shouldPreserveExistingBedrockCredentials =
@@ -573,14 +581,18 @@ export function CreateLLMApiKeyForm({
       // In create mode, secretKey is already set from values.secretKey
 
       // Build config with location only (projectId removed for security - ADC auto-detects)
-      config = {};
+      const vertexAIConfig: VertexAIConfig = {};
       if (values.vertexAILocation?.trim()) {
-        config.location = values.vertexAILocation.trim();
+        vertexAIConfig.location = values.vertexAILocation.trim();
       }
       // If config is empty, set to undefined
-      if (Object.keys(config).length === 0) {
-        config = undefined;
-      }
+      config =
+        Object.keys(vertexAIConfig).length > 0 ? vertexAIConfig : undefined;
+    } else if (currentAdapter === LLMAdapter.OpenAI) {
+      config =
+        values.openAIUseResponsesApi || mode === "update"
+          ? { useResponsesApi: values.openAIUseResponsesApi }
+          : undefined;
     }
 
     const extraHeaders =
@@ -1219,6 +1231,36 @@ export function CreateLLMApiKeyForm({
                       <FormControl>
                         <Input {...field} placeholder="global" />
                       </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+
+              {/* OpenAI Responses API */}
+              {currentAdapter === LLMAdapter.OpenAI && (
+                <FormField
+                  control={form.control}
+                  name="openAIUseResponsesApi"
+                  render={({ field }) => (
+                    <FormItem>
+                      <span className="row flex">
+                        <span className="flex-1">
+                          <FormLabel>Use Responses API</FormLabel>
+                          <FormDescription>
+                            Route OpenAI requests through the Responses API
+                            instead of Chat Completions.
+                          </FormDescription>
+                        </span>
+
+                        <FormControl>
+                          <Switch
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl>
+                      </span>
+
                       <FormMessage />
                     </FormItem>
                   )}

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -329,7 +329,7 @@ export function CreateLLMApiKeyForm({
                 : "",
             openAIUseResponsesApi:
               existingKey.adapter === LLMAdapter.OpenAI &&
-              existingKey.config !== null
+              existingKey.config != null
                 ? Boolean((existingKey.config as OpenAIConfig).useResponsesApi)
                 : false,
             awsRegion:

--- a/web/src/features/public-api/types/llm-connections.ts
+++ b/web/src/features/public-api/types/llm-connections.ts
@@ -6,6 +6,8 @@ import {
   BedrockConfigSchema,
   BedrockCredentialSchema,
   BEDROCK_USE_DEFAULT_CREDENTIALS,
+  LLMConnectionConfigSchema,
+  OpenAIConfigSchema,
   VertexAIConfigSchema,
 } from "@langfuse/shared";
 
@@ -20,7 +22,7 @@ export const LlmConnectionResponse = z
     customModels: z.array(z.string()),
     withDefaultModels: z.boolean(),
     extraHeaderKeys: z.array(z.string()),
-    config: z.record(z.string(), z.unknown()).nullable(),
+    config: LLMConnectionConfigSchema.nullable(),
     createdAt: z.coerce.date(),
     updatedAt: z.coerce.date(),
   })
@@ -55,7 +57,7 @@ const PutLlmConnectionV1BodyBase = z.object({
   customModels: z.array(z.string().min(1)).optional(),
   withDefaultModels: z.boolean().optional().default(true),
   extraHeaders: z.record(z.string(), z.string()).optional(),
-  config: z.record(z.string(), z.string()).optional(),
+  config: LLMConnectionConfigSchema.optional(),
 });
 
 // PUT /api/public/llm-connections request body (upsert) with adapter-specific validation
@@ -100,6 +102,18 @@ export const PutLlmConnectionV1Body = PutLlmConnectionV1BodyBase.superRefine(
             message:
               "Invalid Bedrock credentials. Expected a JSON object with either {accessKeyId, secretAccessKey} or {apiKey}.",
             path: ["secretKey"],
+          });
+        }
+      }
+    } else if (adapter === LLMAdapter.OpenAI) {
+      // OpenAI config is optional, but if provided only supports explicit Responses API routing
+      if (config) {
+        const result = OpenAIConfigSchema.safeParse(config);
+        if (!result.success) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Invalid OpenAI config: ${result.error.issues.map((e) => e.message).join(", ")}. Expected: { useResponsesApi: boolean }`,
+            path: ["config"],
           });
         }
       }

--- a/worker/src/__tests__/secureLlmFetch.test.ts
+++ b/worker/src/__tests__/secureLlmFetch.test.ts
@@ -37,6 +37,51 @@ const OPENAI_RESPONSE_BODY = JSON.stringify({
   ],
 });
 
+const OPENAI_RESPONSES_BODY = JSON.stringify({
+  id: "resp_test",
+  object: "response",
+  created_at: 1,
+  status: "completed",
+  error: null,
+  incomplete_details: null,
+  instructions: null,
+  max_output_tokens: null,
+  model: "gpt-4o-mini",
+  output: [
+    {
+      id: "msg_test",
+      type: "message",
+      status: "completed",
+      role: "assistant",
+      content: [
+        {
+          type: "output_text",
+          text: "4",
+          annotations: [],
+        },
+      ],
+    },
+  ],
+  parallel_tool_calls: true,
+  previous_response_id: null,
+  reasoning: null,
+  store: true,
+  temperature: 0,
+  text: { format: { type: "text" } },
+  tool_choice: "auto",
+  tools: [],
+  top_p: 1,
+  truncation: "disabled",
+  usage: {
+    input_tokens: 10,
+    output_tokens: 1,
+    total_tokens: 11,
+  },
+  user: null,
+  metadata: {},
+});
+const OPENAI_RESPONSES_RESPONSE = JSON.parse(OPENAI_RESPONSES_BODY);
+
 describe("secure LLM fetch", () => {
   const originalWhitelistedHosts = env.LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST;
   // env is the zod-validated object: read from process.env at module load and
@@ -107,6 +152,138 @@ describe("secure LLM fetch", () => {
         expect(JSON.parse(request.body)).toMatchObject({
           model: "gpt-4o-mini",
         });
+      },
+    );
+
+    test(
+      "OpenAI Responses API config routes through the responses endpoint",
+      { timeout: 30_000 },
+      async () => {
+        const server = await spinUp((_req, _body, res) => {
+          res.setHeader("content-type", "application/json");
+          res.end(OPENAI_RESPONSES_BODY);
+        });
+
+        const completion = await fetchLLMCompletion({
+          streaming: false,
+          messages: [
+            {
+              role: "user",
+              content: "What is 2+2? Answer only with the number.",
+              type: ChatMessageType.PublicAPICreated,
+            },
+          ],
+          modelParams: {
+            provider: "openai",
+            adapter: LLMAdapter.OpenAI,
+            model: "gpt-4o-mini",
+            temperature: 0,
+            max_tokens: 10,
+          },
+          llmConnection: {
+            secretKey: encrypt("openai-api-key"),
+            baseURL: `${server.url}/v1`,
+            config: {
+              useResponsesApi: true,
+            },
+          },
+        });
+
+        expect(completion).toBe("4");
+        expect(server.requests).toHaveLength(1);
+        const [request] = server.requests;
+        expect(request.method).toBe("POST");
+        expect(request.url).toBe("/v1/responses");
+        expect(request.headers.authorization).toBe("Bearer openai-api-key");
+        expect(JSON.parse(request.body)).toMatchObject({
+          model: "gpt-4o-mini",
+        });
+      },
+    );
+
+    test(
+      "OpenAI Responses API streaming returns text instead of content block arrays",
+      { timeout: 30_000 },
+      async () => {
+        const server = await spinUp((_req, _body, res) => {
+          res.writeHead(200, {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            connection: "keep-alive",
+          });
+
+          const writeEvent = (event: Record<string, unknown>) => {
+            res.write(`data: ${JSON.stringify(event)}\n\n`);
+          };
+
+          writeEvent({
+            type: "response.created",
+            response: {
+              id: "resp_test",
+              model: "gpt-4o-mini",
+            },
+          });
+          writeEvent({
+            type: "response.output_item.added",
+            output_index: 0,
+            item: {
+              id: "msg_test",
+              type: "message",
+              status: "in_progress",
+              role: "assistant",
+              content: [],
+              phase: "final_answer",
+            },
+          });
+          writeEvent({
+            type: "response.output_text.delta",
+            item_id: "msg_test",
+            output_index: 0,
+            content_index: 0,
+            delta: "pong",
+          });
+          writeEvent({
+            type: "response.completed",
+            response: OPENAI_RESPONSES_RESPONSE,
+          });
+          res.write("data: [DONE]\n\n");
+          res.end();
+        });
+
+        const stream = await fetchLLMCompletion({
+          streaming: true,
+          messages: [
+            {
+              role: "user",
+              content: "What is 2+2? Answer only with the number.",
+              type: ChatMessageType.PublicAPICreated,
+            },
+          ],
+          modelParams: {
+            provider: "openai",
+            adapter: LLMAdapter.OpenAI,
+            model: "gpt-4o-mini",
+            temperature: 0,
+            max_tokens: 10,
+          },
+          llmConnection: {
+            secretKey: encrypt("openai-api-key"),
+            baseURL: `${server.url}/v1`,
+            config: {
+              useResponsesApi: true,
+            },
+          },
+        });
+
+        const decoder = new TextDecoder();
+        let text = "";
+        for await (const chunk of stream) {
+          text += decoder.decode(chunk);
+        }
+
+        expect(text).toBe("pong");
+        expect(server.requests).toHaveLength(1);
+        expect(server.requests[0].url).toBe("/v1/responses");
       },
     );
   });


### PR DESCRIPTION
## Summary

- Adds optional OpenAI LLM connection config for \`useResponsesApi\`, enabling OpenAI-compatible endpoints such as Bedrock-hosted OpenAI models to route through LangChain’s Responses API.
- Persists and validates OpenAI adapter config across the UI, tRPC LLM connection flow, public LLM connections API, and shared LLM API key schemas.
- Updates streaming parsing for OpenAI Responses API output so Langfuse emits text chunks instead of serialized content block arrays.
- Documents the new OpenAI config option in the Fern LLM connections API definition.

## Linear

- [LFE-10099](https://linear.app/langfuse/issue/LFE-10099/openai-in-bedrock-compatibility)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `useResponsesApi` support to OpenAI LLM connections, routing requests through LangChain's Responses API when enabled. It propagates the config through the public API, tRPC router, shared schemas, and the `fetchLLMCompletion` streaming path.

- Adds `OpenAIConfigSchema` with a strict `{ useResponsesApi: boolean }` shape and threads it through all validation layers (PUT body, tRPC router, `LLMApiKeySchema`).
- Renames `ReasoningStrippingBytesOutputParser` → `ContentBlockBytesOutputParser` and activates it for Responses API streaming to return plain text instead of serialized content-block arrays.
- Adds a UI toggle in the LLM connection form and comprehensive server integration tests covering create, update, and streaming scenarios.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for new OpenAI Responses API functionality, but the union ordering change in LLMApiKeySchema may silently break VertexAI playground completions for connections whose config was stored as an empty object `{}`.

The `OpenAIConfigSchema` (with its `.default(false)`) was inserted before `VertexAIConfigSchema` in the shared `LLMApiKeySchema` union. Any VertexAI connection that stored `{}` as its config will now be mis-parsed as `{ useResponsesApi: false }`, and the subsequent strict `VertexAIConfigSchema.parse` in `fetchLLMCompletion` will throw — silently breaking those connections in the playground and any other path that calls `LLMApiKeySchema.safeParse` on DB records.

packages/shared/src/server/llm/types.ts — the config union ordering needs VertexAIConfigSchema before OpenAIConfigSchema.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as CreateLLMApiKeyForm
    participant API as PUT /api/public/llm-connections
    participant Router as tRPC llmApiKey router
    participant DB as Database
    participant FetchLLM as fetchLLMCompletion
    participant LangChain as ChatOpenAI (LangChain)
    participant OpenAIAPI as OpenAI Responses API / Chat API

    UI->>API: "PUT { adapter: OpenAI, config: { useResponsesApi: true } }"
    API->>API: PutLlmConnectionV1Body.superRefine → OpenAIConfigSchema.safeParse
    API->>DB: "store config { useResponsesApi: true }"

    note over Router: tRPC flow (same validation path)
    Router->>Router: OpenAIConfigSchema.parse(params.config)
    Router->>FetchLLM: "llmConnection.config = { useResponsesApi: true }"

    FetchLLM->>FetchLLM: "OpenAIConfigSchema.parse(config ?? {})"
    FetchLLM->>FetchLLM: "usesOpenAIResponsesApi = true"
    FetchLLM->>LangChain: "new ChatOpenAI({ useResponsesApi: true })"

    alt "useResponsesApi = true"
        LangChain->>OpenAIAPI: POST /v1/responses
        OpenAIAPI-->>LangChain: SSE stream (response.output_text.delta)
        LangChain-->>FetchLLM: AIMessageChunk stream
        FetchLLM->>FetchLLM: ContentBlockBytesOutputParser → plain text chunks
    else "useResponsesApi = false (default)"
        LangChain->>OpenAIAPI: POST /v1/chat/completions
        OpenAIAPI-->>LangChain: SSE stream (content delta)
        LangChain-->>FetchLLM: AIMessageChunk stream
        FetchLLM->>FetchLLM: BytesOutputParser → plain text chunks
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/llm/types.ts:517-519
**Union ordering causes VertexAI config `{}` to be misidentified as OpenAI config**

`OpenAIConfigSchema` has `.default(false)` on `useResponsesApi`, so it matches any empty object (`{}`). Because `OpenAIConfigSchema` is listed before `VertexAIConfigSchema` in this union, any VertexAI connection whose config was stored as `{}` (which is valid per `VertexAIConfigSchema`) will now be parsed into `{ useResponsesApi: false }`. The `chatCompletionHandler` calls `LLMApiKeySchema.safeParse()` on the DB record and then passes `config` to `fetchLLMCompletion`, where `VertexAIConfigSchema.parse({ useResponsesApi: false })` throws because the schema is `.strict()`.

The fix is to move `VertexAIConfigSchema` before `OpenAIConfigSchema` — exactly what was done in the form schema at `web/src/features/llm-api-key/types.ts` where the union is correctly ordered `[VertexAIConfigSchema, BedrockConfigSchema, OpenAIConfigSchema]`.

### Issue 2 of 2
web/src/features/public-api/components/CreateLLMApiKeyForm.tsx:330-334
**Null check does not guard against `undefined`**

`existingKey.config !== null` passes when `config` is `undefined` (the `LLMApiKeySchema` union uses `.nullish()`, so the type includes `undefined`). If `config` is `undefined`, accessing `.useResponsesApi` on it at runtime throws a TypeError. Using a loose inequality (`!= null`) covers both `null` and `undefined`, matching the existing pattern used for `vertexAILocation`.

```suggestion
            openAIUseResponsesApi:
              existingKey.adapter === LLMAdapter.OpenAI &&
              existingKey.config != null
                ? Boolean((existingKey.config as OpenAIConfig).useResponsesApi)
                : false,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(llm): support OpenAI Responses API ..."](https://github.com/langfuse/langfuse/commit/f4b7f16233b5a6fe13d3f0693a2df0d4849f43bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35136684)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->