### PR TITLE
feat(scores): add all filter params to v3 scores API (Phase 4)

### DIFF
--- a/fern/apis/server/_drafts/scores-v3.yml
+++ b/fern/apis/server/_drafts/scores-v3.yml
@@ -47,7 +47,7 @@ service:
             docs: Comma-separated list of score sources to filter by (e.g. API, ANNOTATION, EVAL).
           dataType:
             type: optional<string>
-            docs: Comma-separated list of data types to filter by (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, CORRECTION). Must be a single value when used with value, valueMin, or valueMax.
+            docs: Comma-separated list of data types to filter by (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, CORRECTION). Must be a single value when used with value, valueMin, or valueMax; otherwise the request returns HTTP 400.
           environment:
             type: optional<string>
             docs: Comma-separated list of environments to filter by.
@@ -64,16 +64,17 @@ service:
             type: optional<string>
             docs: >
               Comma-separated list of exact values to filter by. Requires a
-              single dataType from NUMERIC, BOOLEAN, or CATEGORICAL. For
-              BOOLEAN, each value must be "true" or "false". For NUMERIC, values
-              are matched against the Float64 column. For CATEGORICAL, values
-              are matched against string_value.
+              single dataType from NUMERIC, BOOLEAN, or CATEGORICAL; any other
+              dataType, multiple dataTypes, or omitting dataType returns HTTP
+              400. For BOOLEAN, each value must be "true" or "false"; for
+              NUMERIC, each value must be a finite number. Otherwise the
+              request returns HTTP 400.
           valueMin:
             type: optional<double>
-            docs: Inclusive lower bound on the numeric value. Requires dataType=NUMERIC as a single value.
+            docs: Inclusive lower bound on the numeric value. Requires dataType=NUMERIC as a single value; otherwise the request returns HTTP 400.
           valueMax:
             type: optional<double>
-            docs: Inclusive upper bound on the numeric value. Requires dataType=NUMERIC as a single value.
+            docs: Inclusive upper bound on the numeric value. Requires dataType=NUMERIC as a single value; otherwise the request returns HTTP 400.
           traceId:
             type: optional<string>
             docs: Comma-separated list of trace IDs to filter by. Mutually exclusive with sessionId, observationId, experimentId.

--- a/fern/apis/server/_drafts/scores-v3.yml
+++ b/fern/apis/server/_drafts/scores-v3.yml
@@ -47,7 +47,7 @@ service:
             docs: Comma-separated list of score sources to filter by (e.g. API, ANNOTATION, EVAL).
           dataType:
             type: optional<string>
-            docs: Comma-separated list of data types to filter by (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, CORRECTION). Must be a single value when used with value, valueMin, or valueMax; otherwise the request returns HTTP 400.
+            docs: Comma-separated list of data types to filter by (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, CORRECTION). Must be a single value when used with value, valueMin, or valueMax; otherwise the request returns HTTP 400. Must be NUMERIC when used with valueMin or valueMax.
           environment:
             type: optional<string>
             docs: Comma-separated list of environments to filter by.

--- a/fern/apis/server/_drafts/scores-v3.yml
+++ b/fern/apis/server/_drafts/scores-v3.yml
@@ -77,13 +77,16 @@ service:
             docs: Inclusive upper bound on the numeric value. Requires dataType=NUMERIC as a single value; otherwise the request returns HTTP 400.
           traceId:
             type: optional<string>
-            docs: Comma-separated list of trace IDs to filter by. Mutually exclusive with sessionId, observationId, experimentId.
+            docs: Comma-separated list of trace IDs to filter by. Mutually exclusive with sessionId, experimentId. May be combined with observationId to scope the observation lookup to a specific trace.
           sessionId:
             type: optional<string>
             docs: Comma-separated list of session IDs to filter by. Mutually exclusive with traceId, observationId, experimentId.
           observationId:
             type: optional<string>
-            docs: Comma-separated list of observation IDs to filter by. Mutually exclusive with traceId, sessionId, experimentId.
+            docs: >
+              Comma-separated list of observation IDs to filter by. Requires traceId to be specified,
+              because observation IDs are scoped to a trace. Mutually exclusive with sessionId, experimentId.
+              Returns HTTP 400 when used without traceId.
           experimentId:
             type: optional<string>
             docs: Comma-separated list of dataset run IDs (experiment IDs) to filter by. Mutually exclusive with traceId, sessionId, observationId.

--- a/fern/apis/server/_drafts/scores-v3.yml
+++ b/fern/apis/server/_drafts/scores-v3.yml
@@ -88,7 +88,7 @@ service:
             docs: Comma-separated list of dataset run IDs (experiment IDs) to filter by. Mutually exclusive with traceId, sessionId, observationId.
           fromTimestamp:
             type: optional<datetime>
-            docs: Inclusive lower bound on the score timestamp. Optional in Phase 4; will be required in Phase 5 unless an entity-bounded filter is present.
+            docs: Inclusive lower bound on the score timestamp.
           toTimestamp:
             type: optional<datetime>
             docs: Exclusive upper bound on the score timestamp.

--- a/fern/apis/server/_drafts/scores-v3.yml
+++ b/fern/apis/server/_drafts/scores-v3.yml
@@ -36,6 +36,62 @@ service:
             docs: >
               Comma-separated field groups to include. Allowed: core, details,
               subject, annotation. Defaults to "core". Unknown names return HTTP 400.
+          id:
+            type: optional<string>
+            docs: Comma-separated list of score IDs to filter by (OR within, AND across filters).
+          name:
+            type: optional<string>
+            docs: Comma-separated list of score names to filter by.
+          source:
+            type: optional<string>
+            docs: Comma-separated list of score sources to filter by (e.g. API, ANNOTATION, EVAL).
+          dataType:
+            type: optional<string>
+            docs: Comma-separated list of data types to filter by (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, CORRECTION). Must be a single value when used with value, valueMin, or valueMax.
+          environment:
+            type: optional<string>
+            docs: Comma-separated list of environments to filter by.
+          configId:
+            type: optional<string>
+            docs: Comma-separated list of score config IDs to filter by.
+          queueId:
+            type: optional<string>
+            docs: Comma-separated list of annotation queue IDs to filter by.
+          authorUserId:
+            type: optional<string>
+            docs: Comma-separated list of author user IDs to filter by.
+          value:
+            type: optional<string>
+            docs: >
+              Comma-separated list of exact values to filter by. Requires a
+              single dataType from NUMERIC, BOOLEAN, or CATEGORICAL. For
+              BOOLEAN, each value must be "true" or "false". For NUMERIC, values
+              are matched against the Float64 column. For CATEGORICAL, values
+              are matched against string_value.
+          valueMin:
+            type: optional<double>
+            docs: Inclusive lower bound on the numeric value. Requires dataType=NUMERIC as a single value.
+          valueMax:
+            type: optional<double>
+            docs: Inclusive upper bound on the numeric value. Requires dataType=NUMERIC as a single value.
+          traceId:
+            type: optional<string>
+            docs: Comma-separated list of trace IDs to filter by. Mutually exclusive with sessionId, observationId, experimentId.
+          sessionId:
+            type: optional<string>
+            docs: Comma-separated list of session IDs to filter by. Mutually exclusive with traceId, observationId, experimentId.
+          observationId:
+            type: optional<string>
+            docs: Comma-separated list of observation IDs to filter by. Mutually exclusive with traceId, sessionId, experimentId.
+          experimentId:
+            type: optional<string>
+            docs: Comma-separated list of dataset run IDs (experiment IDs) to filter by. Mutually exclusive with traceId, sessionId, observationId.
+          fromTimestamp:
+            type: optional<datetime>
+            docs: Inclusive lower bound on the score timestamp. Optional in Phase 4; will be required in Phase 5 unless an entity-bounded filter is present.
+          toTimestamp:
+            type: optional<datetime>
+            docs: Exclusive upper bound on the score timestamp.
       response: GetScoresV3Response
 
 types:

--- a/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+  ScoreDataTypeArray,
+  ScoreSourceArray,
+} from "../../../../../domain/scores";
 import { APIScoreSchemaV3 } from "./schemas";
 
 export const SCORE_FIELD_GROUPS_V3 = [
@@ -17,8 +21,39 @@ const fieldsParam = z
 
 const csvStringParam = z
   .string()
-  .transform((val) => val.split(",").map((v) => v.trim()))
+  .transform((val) =>
+    val
+      .split(",")
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0),
+  )
   .optional();
+
+const csvEnumParam = <T extends readonly string[]>(
+  allowedValues: T,
+  label: string,
+) =>
+  z
+    .string()
+    .transform((val) =>
+      val
+        .split(",")
+        .map((v) => v.trim())
+        .filter((v) => v.length > 0),
+    )
+    .pipe(
+      z.array(z.string()).superRefine((values, ctx) => {
+        for (const v of values) {
+          if (!allowedValues.includes(v as T[number])) {
+            ctx.addIssue({
+              code: "custom",
+              message: `Invalid ${label} value: "${v}". Allowed: ${allowedValues.join(", ")}`,
+            });
+          }
+        }
+      }),
+    )
+    .optional();
 
 // GET /v3/scores — all filter params optional; superRefine validation lives in the handler.
 export const GetScoresQueryV3 = z.object({
@@ -27,8 +62,8 @@ export const GetScoresQueryV3 = z.object({
   // Identifier filters (multi-value, comma-separated)
   id: csvStringParam,
   name: csvStringParam,
-  source: csvStringParam,
-  dataType: csvStringParam,
+  source: csvEnumParam(ScoreSourceArray, "source"),
+  dataType: csvEnumParam(ScoreDataTypeArray, "dataType"),
   environment: csvStringParam,
   configId: csvStringParam,
   queueId: csvStringParam,

--- a/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
@@ -20,7 +20,7 @@ const csvStringParam = z
   .transform((val) => val.split(",").map((v) => v.trim()))
   .optional();
 
-// GET /v3/scores
+// GET /v3/scores — all filter params optional; superRefine validation lives in the handler.
 export const GetScoresQueryV3 = z.object({
   limit: z.coerce.number().int().positive().max(100).default(50),
   fields: fieldsParam,

--- a/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
@@ -15,10 +15,39 @@ const fieldsParam = z
   .transform((val) => (val ? val.split(",").map((g) => g.trim()) : ["core"]))
   .pipe(z.array(z.enum(SCORE_FIELD_GROUPS_V3)));
 
+const csvStringParam = z
+  .string()
+  .transform((val) => val.split(",").map((v) => v.trim()))
+  .optional();
+
 // GET /v3/scores
 export const GetScoresQueryV3 = z.object({
   limit: z.coerce.number().int().positive().max(100).default(50),
   fields: fieldsParam,
+  // Identifier filters (multi-value, comma-separated)
+  id: csvStringParam,
+  name: csvStringParam,
+  source: csvStringParam,
+  dataType: csvStringParam,
+  environment: csvStringParam,
+  configId: csvStringParam,
+  queueId: csvStringParam,
+  authorUserId: csvStringParam,
+  // Value filters
+  value: csvStringParam,
+  valueMin: z.coerce.number().optional(),
+  valueMax: z.coerce.number().optional(),
+  // Entity-bounded filters
+  traceId: csvStringParam,
+  sessionId: csvStringParam,
+  observationId: csvStringParam,
+  experimentId: csvStringParam,
+  // Timestamp filters
+  fromTimestamp: z.coerce.date().optional(),
+  toTimestamp: z.coerce.date().optional(),
+  // Deferred params (always → 400 — require trace JOIN not present in v3)
+  userId: z.string().optional(),
+  traceTags: z.string().optional(),
 });
 
 export const GetScoresResponseV3 = z.object({

--- a/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
@@ -70,8 +70,17 @@ export const GetScoresQueryV3 = z.object({
   authorUserId: csvStringParam,
   // Value filters
   value: csvStringParam,
-  valueMin: z.coerce.number().optional(),
-  valueMax: z.coerce.number().optional(),
+  // Treat empty string as absent so `?valueMin=` doesn't silently coerce to 0
+  // and narrow results to `value >= 0`. Zod 4 rejects ±Infinity / NaN out of
+  // the box, so `.finite()` is not needed.
+  valueMin: z.preprocess(
+    (v) => (v === "" ? undefined : v),
+    z.coerce.number().optional(),
+  ),
+  valueMax: z.preprocess(
+    (v) => (v === "" ? undefined : v),
+    z.coerce.number().optional(),
+  ),
   // Entity-bounded filters
   traceId: csvStringParam,
   sessionId: csvStringParam,

--- a/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
@@ -86,9 +86,16 @@ export const GetScoresQueryV3 = z.object({
   sessionId: csvStringParam,
   observationId: csvStringParam,
   experimentId: csvStringParam,
-  // Timestamp filters
-  fromTimestamp: z.coerce.date().optional(),
-  toTimestamp: z.coerce.date().optional(),
+  // Timestamp filters — preprocess empty string to undefined so ?fromTimestamp=
+  // from a templating system is treated as absent, consistent with valueMin/valueMax.
+  fromTimestamp: z.preprocess(
+    (v) => (v === "" ? undefined : v),
+    z.coerce.date().optional(),
+  ),
+  toTimestamp: z.preprocess(
+    (v) => (v === "" ? undefined : v),
+    z.coerce.date().optional(),
+  ),
   // Deferred params (always → 400 — require trace JOIN not present in v3).
   // Treat the empty string as absent so a stray `?userId=` from a templating
   // system doesn't trigger the "use v2" 400 spuriously.

--- a/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
@@ -80,9 +80,17 @@ export const GetScoresQueryV3 = z.object({
   // Timestamp filters
   fromTimestamp: z.coerce.date().optional(),
   toTimestamp: z.coerce.date().optional(),
-  // Deferred params (always → 400 — require trace JOIN not present in v3)
-  userId: z.string().optional(),
-  traceTags: z.string().optional(),
+  // Deferred params (always → 400 — require trace JOIN not present in v3).
+  // Treat the empty string as absent so a stray `?userId=` from a templating
+  // system doesn't trigger the "use v2" 400 spuriously.
+  userId: z
+    .string()
+    .optional()
+    .transform((v) => (v === "" ? undefined : v)),
+  traceTags: z
+    .string()
+    .optional()
+    .transform((v) => (v === "" ? undefined : v)),
 });
 
 export const GetScoresResponseV3 = z.object({

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -1316,6 +1316,184 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(200);
     });
 
+    it("source=INVALID → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?source=BOGUS",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("dataType=INVALID → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?dataType=NUMRIC",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("value=notanumber&dataType=NUMERIC → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?value=notanumber&dataType=NUMERIC",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("value=Infinity&dataType=NUMERIC → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?value=Infinity&dataType=NUMERIC",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("value= (empty) with dataType=NUMERIC → 200 (not treated as present)", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?value=&dataType=NUMERIC",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("environment filter returns only scores with matching environment", async () => {
+      const scoreId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          environment: "staging",
+        }),
+        createTraceScore({ project_id: projectId, environment: "production" }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?id=${scoreId}&environment=staging`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.every((s) => s.environment === "staging")).toBe(
+        true,
+      );
+      expect(res.body.data.some((s) => s.id === scoreId)).toBe(true);
+    });
+
+    it("configId filter returns only scores with matching configId", async () => {
+      const scoreId = v4();
+      const configId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          config_id: configId,
+        }),
+        createTraceScore({ project_id: projectId }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?configId=${configId}&fields=core,details`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.some((s) => s.id === scoreId)).toBe(true);
+    });
+
+    it("queueId filter returns only scores with matching queueId", async () => {
+      const scoreId = v4();
+      const queueId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          queue_id: queueId,
+        }),
+        createTraceScore({ project_id: projectId }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?queueId=${queueId}&fields=core,annotation`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.some((s) => s.id === scoreId)).toBe(true);
+    });
+
+    it("authorUserId filter returns only scores with matching authorUserId", async () => {
+      const scoreId = v4();
+      const userId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          author_user_id: userId,
+        }),
+        createTraceScore({ project_id: projectId }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?authorUserId=${userId}&fields=core,annotation`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.some((s) => s.id === scoreId)).toBe(true);
+    });
+
+    it("toTimestamp excludes scores after the cutoff", async () => {
+      const oldId = v4();
+      const newId = v4();
+      const cutoff = new Date("2025-01-01T00:00:00Z");
+      await createScoresCh([
+        createTraceScore({
+          id: oldId,
+          project_id: projectId,
+          timestamp: new Date("2024-06-01T00:00:00Z").getTime(),
+        }),
+        createTraceScore({
+          id: newId,
+          project_id: projectId,
+          timestamp: new Date("2025-06-01T00:00:00Z").getTime(),
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?fromTimestamp=2020-01-01&toTimestamp=${cutoff.toISOString()}`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.some((s) => s.id === oldId)).toBe(true);
+      expect(res.body.data.some((s) => s.id === newId)).toBe(false);
+    });
+
     it("regression: limit and fields still work alongside filters", async () => {
       const scoreId = v4();
       await createScoresCh([

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -6,6 +6,10 @@ import {
   createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
 import {
+  valueFilterColumn,
+  transformBooleanValueForFilter,
+} from "@/src/features/public-api/server/scores-api-v3";
+import {
   makeAPICall,
   makeZodVerifiedAPICall,
 } from "@/src/__tests__/test-utils";
@@ -794,6 +798,565 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(score).toHaveProperty("annotation");
       expect(score!.subject!.kind).toBe("trace");
       expect(score!.subject!.id).toBe(traceId);
+    });
+  });
+
+  describe("valueFilterColumn unit", () => {
+    it("NUMERIC → value", () => {
+      expect(valueFilterColumn("NUMERIC")).toBe("value");
+    });
+    it("BOOLEAN → value", () => {
+      expect(valueFilterColumn("BOOLEAN")).toBe("value");
+    });
+    it("CATEGORICAL → string_value", () => {
+      expect(valueFilterColumn("CATEGORICAL")).toBe("string_value");
+    });
+    it("TEXT → null", () => {
+      expect(valueFilterColumn("TEXT")).toBeNull();
+    });
+    it("CORRECTION → null", () => {
+      expect(valueFilterColumn("CORRECTION")).toBeNull();
+    });
+  });
+
+  describe("transformBooleanValueForFilter unit", () => {
+    it('"true" → 1', () => {
+      expect(transformBooleanValueForFilter("true")).toBe(1);
+    });
+    it('"false" → 0', () => {
+      expect(transformBooleanValueForFilter("false")).toBe(0);
+    });
+  });
+
+  maybe("GET /api/public/v3/scores — filter params (Phase 4)", () => {
+    let auth: string;
+    let projectId: string;
+
+    beforeAll(async () => {
+      const project = await createOrgProjectAndApiKey();
+      auth = project.auth;
+      projectId = project.projectId;
+    });
+
+    // --- Validation (400) tests ---
+
+    it("userId → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?userId=u1",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("traceTags → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?traceTags=tag1",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("value= without dataType → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?value=0.5",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("value= with multi-value dataType → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?value=0.5&dataType=NUMERIC,BOOLEAN",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("value= with dataType=TEXT → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?value=foo&dataType=TEXT",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("value=1 with dataType=BOOLEAN → 400 (must be true/false)", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?value=1&dataType=BOOLEAN",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("valueMin= with dataType=CATEGORICAL → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?valueMin=0.2&dataType=CATEGORICAL",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("valueMin= without dataType → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?valueMin=0.2",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("two parent-entity params → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        `/api/public/v3/scores?traceId=${v4()}&sessionId=${v4()}`,
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    // --- Filter correctness tests ---
+
+    it("id filter (single) returns only matching score", async () => {
+      const scoreId = v4();
+      const otherId = v4();
+      await createScoresCh([
+        createTraceScore({ id: scoreId, project_id: projectId }),
+        createTraceScore({ id: otherId, project_id: projectId }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?id=${scoreId}`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((s) => s.id)).toEqual([scoreId]);
+    });
+
+    it("id filter (comma-separated) returns both matching scores", async () => {
+      const id1 = v4();
+      const id2 = v4();
+      const id3 = v4();
+      await createScoresCh([
+        createTraceScore({ id: id1, project_id: projectId }),
+        createTraceScore({ id: id2, project_id: projectId }),
+        createTraceScore({ id: id3, project_id: projectId }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?id=${id1},${id2}`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(id1);
+      expect(ids).toContain(id2);
+      expect(ids).not.toContain(id3);
+    });
+
+    it("name filter returns only scores with matching name", async () => {
+      const scoreName = `phase4-name-${v4()}`;
+      const scoreId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          name: scoreName,
+        }),
+        createTraceScore({ project_id: projectId, name: "other-name" }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?name=${encodeURIComponent(scoreName)}`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.every((s) => s.name === scoreName)).toBe(true);
+      expect(res.body.data.some((s) => s.id === scoreId)).toBe(true);
+    });
+
+    it("source filter returns only scores with matching source", async () => {
+      const scoreId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          source: "ANNOTATION",
+        }),
+        createTraceScore({ project_id: projectId, source: "API" }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?source=ANNOTATION",
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.every((s) => s.source === "ANNOTATION")).toBe(true);
+    });
+
+    it("dataType filter returns only scores of that type", async () => {
+      const numericId = v4();
+      const boolId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: numericId,
+          project_id: projectId,
+          data_type: "NUMERIC",
+          value: 0.5,
+        }),
+        createTraceScore({
+          id: boolId,
+          project_id: projectId,
+          data_type: "BOOLEAN",
+          value: 1,
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?dataType=NUMERIC",
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.every((s) => s.dataType === "NUMERIC")).toBe(true);
+    });
+
+    it("traceId filter returns only scores for that trace", async () => {
+      const traceId = v4();
+      const scoreId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          trace_id: traceId,
+        }),
+        createTraceScore({ project_id: projectId, trace_id: v4() }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?traceId=${traceId}`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((s) => s.id)).toEqual([scoreId]);
+    });
+
+    it("observationId filter returns only observation-level scores", async () => {
+      const observationId = v4();
+      const scoreId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          observation_id: observationId,
+        }),
+        createTraceScore({ project_id: projectId }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?observationId=${observationId}`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((s) => s.id)).toEqual([scoreId]);
+    });
+
+    it("sessionId filter returns only session scores", async () => {
+      const sessionId = v4();
+      const scoreId = v4();
+      await createScoresCh([
+        createSessionScore({
+          id: scoreId,
+          project_id: projectId,
+          session_id: sessionId,
+        }),
+        createTraceScore({ project_id: projectId }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?sessionId=${sessionId}`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((s) => s.id)).toEqual([scoreId]);
+    });
+
+    it("experimentId filter returns only dataset run scores", async () => {
+      const datasetRunId = v4();
+      const scoreId = v4();
+      await createScoresCh([
+        createDatasetRunScore({
+          id: scoreId,
+          project_id: projectId,
+          dataset_run_id: datasetRunId,
+        }),
+        createTraceScore({ project_id: projectId }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?experimentId=${datasetRunId}`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((s) => s.id)).toEqual([scoreId]);
+    });
+
+    it("value=0.85 dataType=NUMERIC matches numeric column", async () => {
+      const scoreId = v4();
+      const otherId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          data_type: "NUMERIC",
+          value: 0.85,
+        }),
+        createTraceScore({
+          id: otherId,
+          project_id: projectId,
+          data_type: "NUMERIC",
+          value: 0.5,
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?value=0.85&dataType=NUMERIC",
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((s) => s.id)).toContain(scoreId);
+      expect(res.body.data.map((s) => s.id)).not.toContain(otherId);
+    });
+
+    it("value=good,bad dataType=CATEGORICAL matches string_value", async () => {
+      const goodId = v4();
+      const badId = v4();
+      const otherId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: goodId,
+          project_id: projectId,
+          data_type: "CATEGORICAL",
+          value: 0,
+          string_value: "good",
+        }),
+        createTraceScore({
+          id: badId,
+          project_id: projectId,
+          data_type: "CATEGORICAL",
+          value: 0,
+          string_value: "bad",
+        }),
+        createTraceScore({
+          id: otherId,
+          project_id: projectId,
+          data_type: "CATEGORICAL",
+          value: 0,
+          string_value: "neutral",
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?value=good,bad&dataType=CATEGORICAL",
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(goodId);
+      expect(ids).toContain(badId);
+      expect(ids).not.toContain(otherId);
+    });
+
+    it("value=true dataType=BOOLEAN matches numeric column = 1", async () => {
+      const trueId = v4();
+      const falseId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: trueId,
+          project_id: projectId,
+          data_type: "BOOLEAN",
+          value: 1,
+          string_value: "true",
+        }),
+        createTraceScore({
+          id: falseId,
+          project_id: projectId,
+          data_type: "BOOLEAN",
+          value: 0,
+          string_value: "false",
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?value=true&dataType=BOOLEAN",
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(trueId);
+      expect(ids).not.toContain(falseId);
+    });
+
+    it("value=true,false dataType=BOOLEAN → 200, returns all boolean scores", async () => {
+      const trueId = v4();
+      const falseId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: trueId,
+          project_id: projectId,
+          data_type: "BOOLEAN",
+          value: 1,
+          string_value: "true",
+        }),
+        createTraceScore({
+          id: falseId,
+          project_id: projectId,
+          data_type: "BOOLEAN",
+          value: 0,
+          string_value: "false",
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?value=true,false&dataType=BOOLEAN",
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(trueId);
+      expect(ids).toContain(falseId);
+    });
+
+    it("valueMin/valueMax filter matches only scores in range", async () => {
+      const inRangeId = v4();
+      const outOfRangeId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: inRangeId,
+          project_id: projectId,
+          data_type: "NUMERIC",
+          value: 0.7,
+        }),
+        createTraceScore({
+          id: outOfRangeId,
+          project_id: projectId,
+          data_type: "NUMERIC",
+          value: 0.2,
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?valueMin=0.5&valueMax=1.0&dataType=NUMERIC",
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(inRangeId);
+      expect(ids).not.toContain(outOfRangeId);
+    });
+
+    it("fromTimestamp omitted with no entity filter → 200 (allowed in Phase 4)", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("Phase 1–3 regression: limit and fields still work", async () => {
+      const scoreId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          comment: "regression-check",
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?limit=10&fields=core,details",
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.meta.limit).toBe(10);
+      const score = res.body.data.find((s) => s.id === scoreId);
+      expect(score?.details?.comment).toBe("regression-check");
     });
   });
 });

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -5,10 +5,7 @@ import {
   createScoresCh,
   createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
-import {
-  valueFilterColumn,
-  transformBooleanValueForFilter,
-} from "@/src/features/public-api/server/scores-api-v3";
+import { transformBooleanValueForFilter } from "@/src/features/public-api/server/scores-api-v3";
 import {
   makeAPICall,
   makeZodVerifiedAPICall,
@@ -798,24 +795,6 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(score).toHaveProperty("annotation");
       expect(score!.subject!.kind).toBe("trace");
       expect(score!.subject!.id).toBe(traceId);
-    });
-  });
-
-  describe("valueFilterColumn unit", () => {
-    it("NUMERIC → value", () => {
-      expect(valueFilterColumn("NUMERIC")).toBe("value");
-    });
-    it("BOOLEAN → value", () => {
-      expect(valueFilterColumn("BOOLEAN")).toBe("value");
-    });
-    it("CATEGORICAL → string_value", () => {
-      expect(valueFilterColumn("CATEGORICAL")).toBe("string_value");
-    });
-    it("TEXT → null", () => {
-      expect(valueFilterColumn("TEXT")).toBeNull();
-    });
-    it("CORRECTION → null", () => {
-      expect(valueFilterColumn("CORRECTION")).toBeNull();
     });
   });
 

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -978,7 +978,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
     });
 
     it("name filter returns only scores with matching name", async () => {
-      const scoreName = `phase4-name-${v4()}`;
+      const scoreName = `filter-test-name-${v4()}`;
       const scoreId = v4();
       await createScoresCh([
         createTraceScore({

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -1717,6 +1717,16 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(ids).not.toContain(onlyDataTypeId);
     });
 
+    it("empty fromTimestamp/toTimestamp query params are treated as absent → 200", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?fromTimestamp=&toTimestamp=",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(200);
+    });
+
     it("empty userId/traceTags query params do not trigger the use-v2 400", async () => {
       // ?userId= (empty) and ?traceTags= should be treated as absent rather
       // than tripping the trace-JOIN-not-supported error.

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -1543,6 +1543,82 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.body.data.some((s) => s.id === newId)).toBe(false);
     });
 
+    it("combines multiple filters with AND semantics", async () => {
+      // Three scores: each matches one filter dimension, only one matches all
+      // three. The AND-stacking in buildDynamicFilters' .join(" AND ") must
+      // return exactly the all-three-match row.
+      const matchId = v4();
+      const onlyNameId = v4();
+      const onlySourceId = v4();
+      const onlyDataTypeId = v4();
+      const sharedTs = new Date("2025-04-01T00:00:00Z").getTime();
+      await createScoresCh([
+        createTraceScore({
+          id: matchId,
+          project_id: projectId,
+          name: "combo-name",
+          source: "ANNOTATION",
+          data_type: "CATEGORICAL",
+          string_value: "x",
+          value: 0,
+          timestamp: sharedTs,
+        }),
+        createTraceScore({
+          id: onlyNameId,
+          project_id: projectId,
+          name: "combo-name",
+          source: "API",
+          data_type: "NUMERIC",
+          timestamp: sharedTs,
+        }),
+        createTraceScore({
+          id: onlySourceId,
+          project_id: projectId,
+          name: "other-name",
+          source: "ANNOTATION",
+          data_type: "NUMERIC",
+          timestamp: sharedTs,
+        }),
+        createTraceScore({
+          id: onlyDataTypeId,
+          project_id: projectId,
+          name: "other-name",
+          source: "API",
+          data_type: "CATEGORICAL",
+          string_value: "x",
+          value: 0,
+          timestamp: sharedTs,
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?name=combo-name&source=ANNOTATION&dataType=CATEGORICAL",
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(matchId);
+      expect(ids).not.toContain(onlyNameId);
+      expect(ids).not.toContain(onlySourceId);
+      expect(ids).not.toContain(onlyDataTypeId);
+    });
+
+    it("empty userId/traceTags query params do not trigger the use-v2 400", async () => {
+      // ?userId= (empty) and ?traceTags= should be treated as absent rather
+      // than tripping the trace-JOIN-not-supported error.
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?userId=&traceTags=",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(200);
+    });
+
     it("regression: limit and fields still work alongside filters", async () => {
       const scoreId = v4();
       await createScoresCh([

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -564,6 +564,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(score!.details).toBeDefined();
       expect(score!.details!.comment).toBe("test comment");
       expect(score!.details!.configId).toBe("cfg-abc");
+      expect(score!.details!.metadata).toEqual({ key: "val" });
       expect(score).not.toHaveProperty("subject");
       expect(score).not.toHaveProperty("annotation");
     });

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -899,10 +899,20 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(400);
     });
 
-    it("two parent-entity params → 400", async () => {
+    it("two exclusive parent-entity params → 400", async () => {
       const res = await makeAPICall(
         "GET",
         `/api/public/v3/scores?traceId=${v4()}&sessionId=${v4()}`,
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("observationId without traceId → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        `/api/public/v3/scores?observationId=${v4()}`,
         undefined,
         auth,
       );
@@ -1060,13 +1070,15 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.body.data.map((s) => s.id)).toEqual([scoreId]);
     });
 
-    it("observationId filter returns only observation-level scores", async () => {
+    it("observationId + traceId filter returns only the matching observation-level score", async () => {
+      const traceId = v4();
       const observationId = v4();
       const scoreId = v4();
       await createScoresCh([
         createTraceScore({
           id: scoreId,
           project_id: projectId,
+          trace_id: traceId,
           observation_id: observationId,
         }),
         createTraceScore({ project_id: projectId }),
@@ -1075,7 +1087,39 @@ describe("/api/public/v3/scores API Endpoint", () => {
       const res = await makeZodVerifiedAPICall(
         GetScoresResponseV3,
         "GET",
-        `/api/public/v3/scores?observationId=${observationId}`,
+        `/api/public/v3/scores?traceId=${traceId}&observationId=${observationId}`,
+        undefined,
+        auth,
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.map((s) => s.id)).toEqual([scoreId]);
+    });
+
+    it("traceId + observationId scopes to the correct trace (cross-trace isolation)", async () => {
+      const traceId = v4();
+      const observationId = v4();
+      const scoreId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: scoreId,
+          project_id: projectId,
+          trace_id: traceId,
+          observation_id: observationId,
+        }),
+        // same observationId but on a different trace — must not appear
+        createTraceScore({
+          project_id: projectId,
+          trace_id: v4(),
+          observation_id: observationId,
+        }),
+        createTraceScore({ project_id: projectId }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        `/api/public/v3/scores?traceId=${traceId}&observationId=${observationId}`,
         undefined,
         auth,
       );

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -1430,6 +1430,72 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(200);
     });
 
+    it("valueMin= (empty) with dataType=NUMERIC → 200, does not narrow to value>=0", async () => {
+      // Regression: z.coerce.number() coerces "" to 0, which would emit
+      // `s.value >= 0` and silently drop negative-valued scores.
+      const project = await createOrgProjectAndApiKey();
+      const negativeId = v4();
+      const positiveId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: negativeId,
+          project_id: project.projectId,
+          data_type: "NUMERIC",
+          value: -1.5,
+        }),
+        createTraceScore({
+          id: positiveId,
+          project_id: project.projectId,
+          data_type: "NUMERIC",
+          value: 0.5,
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?valueMin=&dataType=NUMERIC",
+        undefined,
+        project.auth,
+      );
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(negativeId);
+      expect(ids).toContain(positiveId);
+    });
+
+    it("valueMax= (empty) with dataType=NUMERIC → 200, does not narrow to value<=0", async () => {
+      const project = await createOrgProjectAndApiKey();
+      const negativeId = v4();
+      const positiveId = v4();
+      await createScoresCh([
+        createTraceScore({
+          id: negativeId,
+          project_id: project.projectId,
+          data_type: "NUMERIC",
+          value: -1.5,
+        }),
+        createTraceScore({
+          id: positiveId,
+          project_id: project.projectId,
+          data_type: "NUMERIC",
+          value: 0.5,
+        }),
+      ]);
+
+      const res = await makeZodVerifiedAPICall(
+        GetScoresResponseV3,
+        "GET",
+        "/api/public/v3/scores?valueMax=&dataType=NUMERIC",
+        undefined,
+        project.auth,
+      );
+      expect(res.status).toBe(200);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(negativeId);
+      expect(ids).toContain(positiveId);
+    });
+
     it("environment filter returns only scores with matching environment", async () => {
       const scoreId = v4();
       const controlId = v4();

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -1356,6 +1356,26 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(400);
     });
 
+    it("valueMin=Infinity&dataType=NUMERIC → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?valueMin=Infinity&dataType=NUMERIC",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("valueMax=-Infinity&dataType=NUMERIC → 400", async () => {
+      const res = await makeAPICall(
+        "GET",
+        "/api/public/v3/scores?valueMax=-Infinity&dataType=NUMERIC",
+        undefined,
+        auth,
+      );
+      expect(res.status).toBe(400);
+    });
+
     it("value= (empty) with dataType=NUMERIC → 200 (not treated as present)", async () => {
       const res = await makeAPICall(
         "GET",
@@ -1368,32 +1388,41 @@ describe("/api/public/v3/scores API Endpoint", () => {
 
     it("environment filter returns only scores with matching environment", async () => {
       const scoreId = v4();
+      const controlId = v4();
       await createScoresCh([
         createTraceScore({
           id: scoreId,
           project_id: projectId,
           environment: "staging",
         }),
-        createTraceScore({ project_id: projectId, environment: "production" }),
+        createTraceScore({
+          id: controlId,
+          project_id: projectId,
+          environment: "production",
+        }),
       ]);
 
       const res = await makeZodVerifiedAPICall(
         GetScoresResponseV3,
         "GET",
-        `/api/public/v3/scores?id=${scoreId}&environment=staging`,
+        `/api/public/v3/scores?environment=staging`,
         undefined,
         auth,
       );
 
       expect(res.status).toBe(200);
-      expect(res.body.data.every((s) => s.environment === "staging")).toBe(
-        true,
-      );
-      expect(res.body.data.some((s) => s.id === scoreId)).toBe(true);
+      expect(
+        res.body.data.length > 0 &&
+          res.body.data.every((s) => s.environment === "staging"),
+      ).toBe(true);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(scoreId);
+      expect(ids).not.toContain(controlId);
     });
 
     it("configId filter returns only scores with matching configId", async () => {
       const scoreId = v4();
+      const controlId = v4();
       const configId = v4();
       await createScoresCh([
         createTraceScore({
@@ -1401,7 +1430,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
           project_id: projectId,
           config_id: configId,
         }),
-        createTraceScore({ project_id: projectId }),
+        createTraceScore({ id: controlId, project_id: projectId }),
       ]);
 
       const res = await makeZodVerifiedAPICall(
@@ -1413,11 +1442,18 @@ describe("/api/public/v3/scores API Endpoint", () => {
       );
 
       expect(res.status).toBe(200);
-      expect(res.body.data.some((s) => s.id === scoreId)).toBe(true);
+      expect(
+        res.body.data.length > 0 &&
+          res.body.data.every((s) => s.details?.configId === configId),
+      ).toBe(true);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(scoreId);
+      expect(ids).not.toContain(controlId);
     });
 
     it("queueId filter returns only scores with matching queueId", async () => {
       const scoreId = v4();
+      const controlId = v4();
       const queueId = v4();
       await createScoresCh([
         createTraceScore({
@@ -1425,7 +1461,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
           project_id: projectId,
           queue_id: queueId,
         }),
-        createTraceScore({ project_id: projectId }),
+        createTraceScore({ id: controlId, project_id: projectId }),
       ]);
 
       const res = await makeZodVerifiedAPICall(
@@ -1437,11 +1473,18 @@ describe("/api/public/v3/scores API Endpoint", () => {
       );
 
       expect(res.status).toBe(200);
-      expect(res.body.data.some((s) => s.id === scoreId)).toBe(true);
+      expect(
+        res.body.data.length > 0 &&
+          res.body.data.every((s) => s.annotation?.queueId === queueId),
+      ).toBe(true);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(scoreId);
+      expect(ids).not.toContain(controlId);
     });
 
     it("authorUserId filter returns only scores with matching authorUserId", async () => {
       const scoreId = v4();
+      const controlId = v4();
       const userId = v4();
       await createScoresCh([
         createTraceScore({
@@ -1449,7 +1492,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
           project_id: projectId,
           author_user_id: userId,
         }),
-        createTraceScore({ project_id: projectId }),
+        createTraceScore({ id: controlId, project_id: projectId }),
       ]);
 
       const res = await makeZodVerifiedAPICall(
@@ -1461,7 +1504,13 @@ describe("/api/public/v3/scores API Endpoint", () => {
       );
 
       expect(res.status).toBe(200);
-      expect(res.body.data.some((s) => s.id === scoreId)).toBe(true);
+      expect(
+        res.body.data.length > 0 &&
+          res.body.data.every((s) => s.annotation?.authorUserId === userId),
+      ).toBe(true);
+      const ids = res.body.data.map((s) => s.id);
+      expect(ids).toContain(scoreId);
+      expect(ids).not.toContain(controlId);
     });
 
     it("toTimestamp excludes scores after the cutoff", async () => {

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -828,7 +828,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
     });
   });
 
-  maybe("GET /api/public/v3/scores — filter params (Phase 4)", () => {
+  maybe("GET /api/public/v3/scores — filter params", () => {
     let auth: string;
     let projectId: string;
 
@@ -1325,7 +1325,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(ids).not.toContain(outOfRangeId);
     });
 
-    it("fromTimestamp omitted with no entity filter → 200 (allowed in Phase 4)", async () => {
+    it("fromTimestamp omitted with no entity filter → 200", async () => {
       const res = await makeAPICall(
         "GET",
         "/api/public/v3/scores",
@@ -1335,7 +1335,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(200);
     });
 
-    it("Phase 1–3 regression: limit and fields still work", async () => {
+    it("regression: limit and fields still work alongside filters", async () => {
       const scoreId = v4();
       await createScoresCh([
         createTraceScore({

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -1002,6 +1002,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.data.every((s) => s.source === "ANNOTATION")).toBe(true);
+      expect(res.body.data.some((s) => s.id === scoreId)).toBe(true);
     });
 
     it("dataType filter returns only scores of that type", async () => {
@@ -1032,6 +1033,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.data.every((s) => s.dataType === "NUMERIC")).toBe(true);
+      expect(res.body.data.some((s) => s.id === numericId)).toBe(true);
     });
 
     it("traceId filter returns only scores for that trace", async () => {

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -807,7 +807,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
     });
   });
 
-  maybe("GET /api/public/v3/scores — filter params", () => {
+  describe("GET /api/public/v3/scores — filter params", () => {
     let auth: string;
     let projectId: string;
 

--- a/web/src/features/public-api/server/scores-api-v3.ts
+++ b/web/src/features/public-api/server/scores-api-v3.ts
@@ -1,10 +1,15 @@
 import {
   convertClickhouseScoreToDomain,
   convertDateToClickhouseDateTime,
+  DateTimeFilter,
+  FilterList,
   logger,
   measureAndReturn,
+  NumberFilter,
   parseClickhouseUTCDateTimeFormat,
   queryClickhouse,
+  clickhouseCompliantRandomCharacters,
+  StringOptionsFilter,
   type ScoreRecordReadType,
 } from "@langfuse/shared/src/server";
 import type {
@@ -171,7 +176,242 @@ export const buildSelectColumns = (fields: ScoreFieldGroupV3[]): string => {
   return selected.join(",\n    ");
 };
 
-const buildV3ListQuery = (withCursor: boolean, fields: ScoreFieldGroupV3[]) => `
+export function valueFilterColumn(
+  dataType: string,
+): "value" | "string_value" | null {
+  if (dataType === "NUMERIC" || dataType === "BOOLEAN") return "value";
+  if (dataType === "CATEGORICAL") return "string_value";
+  return null;
+}
+
+export function transformBooleanValueForFilter(v: string): number {
+  return v === "true" ? 1 : 0;
+}
+
+type ListFilterParams = {
+  id?: string[];
+  name?: string[];
+  source?: string[];
+  dataType?: string[];
+  environment?: string[];
+  configId?: string[];
+  queueId?: string[];
+  authorUserId?: string[];
+  value?: string[];
+  valueMin?: number;
+  valueMax?: number;
+  traceId?: string[];
+  sessionId?: string[];
+  observationId?: string[];
+  experimentId?: string[];
+  fromTimestamp?: Date;
+  toTimestamp?: Date;
+};
+
+function buildDynamicFilters(params: ListFilterParams): {
+  query: string;
+  params: Record<string, unknown>;
+} {
+  const filterList = new FilterList();
+
+  if (params.id?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "id",
+        operator: "any of",
+        values: params.id,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.name?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "name",
+        operator: "any of",
+        values: params.name,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.source?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "source",
+        operator: "any of",
+        values: params.source,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.dataType?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "data_type",
+        operator: "any of",
+        values: params.dataType,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.environment?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "environment",
+        operator: "any of",
+        values: params.environment,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.configId?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "config_id",
+        operator: "any of",
+        values: params.configId,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.queueId?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "queue_id",
+        operator: "any of",
+        values: params.queueId,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.authorUserId?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "author_user_id",
+        operator: "any of",
+        values: params.authorUserId,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.traceId?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "trace_id",
+        operator: "any of",
+        values: params.traceId,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.sessionId?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "session_id",
+        operator: "any of",
+        values: params.sessionId,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.observationId?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "observation_id",
+        operator: "any of",
+        values: params.observationId,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.experimentId?.length)
+    filterList.push(
+      new StringOptionsFilter({
+        clickhouseTable: "scores",
+        field: "dataset_run_id",
+        operator: "any of",
+        values: params.experimentId,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.fromTimestamp !== undefined)
+    filterList.push(
+      new DateTimeFilter({
+        clickhouseTable: "scores",
+        field: "timestamp",
+        operator: ">=",
+        value: params.fromTimestamp,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.toTimestamp !== undefined)
+    filterList.push(
+      new DateTimeFilter({
+        clickhouseTable: "scores",
+        field: "timestamp",
+        operator: "<",
+        value: params.toTimestamp,
+        tablePrefix: "s",
+      }),
+    );
+  if (params.valueMin !== undefined)
+    filterList.push(
+      new NumberFilter({
+        clickhouseTable: "scores",
+        field: "value",
+        operator: ">=",
+        value: params.valueMin,
+        tablePrefix: "s",
+        clickhouseTypeOverwrite: "Float64",
+      }),
+    );
+  if (params.valueMax !== undefined)
+    filterList.push(
+      new NumberFilter({
+        clickhouseTable: "scores",
+        field: "value",
+        operator: "<=",
+        value: params.valueMax,
+        tablePrefix: "s",
+        clickhouseTypeOverwrite: "Float64",
+      }),
+    );
+
+  const compiled = filterList.apply();
+
+  // value= routes to different columns depending on dataType
+  const extraClauses: string[] = [];
+  const extraParams: Record<string, unknown> = {};
+
+  if (params.value?.length && params.dataType?.length === 1) {
+    const dt = params.dataType[0];
+    const uid = clickhouseCompliantRandomCharacters();
+    const varName = `valueFilter${uid}`;
+
+    if (dt === "NUMERIC") {
+      extraClauses.push(`s.value IN ({${varName}: Array(Float64)})`);
+      extraParams[varName] = params.value.map(Number);
+    } else if (dt === "BOOLEAN") {
+      extraClauses.push(`s.value IN ({${varName}: Array(Float64)})`);
+      extraParams[varName] = params.value.map(transformBooleanValueForFilter);
+    } else if (dt === "CATEGORICAL") {
+      extraClauses.push(`s.string_value IN ({${varName}: Array(String)})`);
+      extraParams[varName] = params.value;
+    }
+  }
+
+  const allClauses = [compiled.query, ...extraClauses]
+    .filter(Boolean)
+    .join(" AND ");
+
+  return { query: allClauses, params: { ...compiled.params, ...extraParams } };
+}
+
+const buildV3ListQuery = (
+  withCursor: boolean,
+  fields: ScoreFieldGroupV3[],
+  filterClause: string,
+) => `
   SELECT
     ${buildSelectColumns(fields)}
   FROM scores s
@@ -181,17 +421,24 @@ const buildV3ListQuery = (withCursor: boolean, fields: ScoreFieldGroupV3[]) => `
       ? "AND (s.timestamp, s.id) < ({lastTimestamp: DateTime64(3)}, {lastId: String})"
       : ""
   }
+  ${filterClause ? `AND ${filterClause}` : ""}
   ORDER BY s.timestamp DESC, s.id DESC, s.event_ts DESC
   LIMIT 1 BY s.id, s.project_id
   LIMIT {limit: Int32}
 `;
 
-export async function listScoresV3ForPublicApi(params: {
-  projectId: string;
-  limit: number;
-  cursor?: ScoresCursorV3Type;
-  fields: ScoreFieldGroupV3[];
-}): Promise<{ data: APIScoreV3[]; cursor?: string }> {
+export async function listScoresV3ForPublicApi(
+  params: {
+    projectId: string;
+    limit: number;
+    cursor?: ScoresCursorV3Type;
+    fields: ScoreFieldGroupV3[];
+  } & ListFilterParams,
+): Promise<{ data: APIScoreV3[]; cursor?: string }> {
+  const { query: filterClause, params: filterParams } =
+    buildDynamicFilters(params);
+
+
   return measureAndReturn({
     operationName: "listScoresV3ForPublicApi",
     projectId: params.projectId,
@@ -205,6 +452,7 @@ export async function listScoresV3ForPublicApi(params: {
           ),
           lastId: params.cursor.lastId,
         }),
+        ...filterParams,
       },
       tags: {
         feature: "scoring",
@@ -215,7 +463,11 @@ export async function listScoresV3ForPublicApi(params: {
     },
     fn: async (input) => {
       const records = await queryClickhouse<ScoreRecordReadType>({
-        query: buildV3ListQuery(Boolean(params.cursor), params.fields),
+        query: buildV3ListQuery(
+          Boolean(params.cursor),
+          params.fields,
+          filterClause,
+        ),
         params: input.params,
         tags: input.tags,
         preferredClickhouseService: "ReadOnly",

--- a/web/src/features/public-api/server/scores-api-v3.ts
+++ b/web/src/features/public-api/server/scores-api-v3.ts
@@ -176,13 +176,6 @@ export const buildSelectColumns = (fields: ScoreFieldGroupV3[]): string => {
   return selected.join(",\n    ");
 };
 
-export function valueFilterColumn(
-  dataType: string,
-): "value" | "string_value" | null {
-  if (dataType === "NUMERIC" || dataType === "BOOLEAN") return "value";
-  if (dataType === "CATEGORICAL") return "string_value";
-  return null;
-}
 
 export function transformBooleanValueForFilter(v: string): number {
   return v === "true" ? 1 : 0;

--- a/web/src/features/public-api/server/scores-api-v3.ts
+++ b/web/src/features/public-api/server/scores-api-v3.ts
@@ -177,7 +177,14 @@ export const buildSelectColumns = (fields: ScoreFieldGroupV3[]): string => {
 };
 
 export function transformBooleanValueForFilter(v: "true" | "false"): number {
-  return v === "true" ? 1 : 0;
+  // Belt-and-braces: the route-handler superRefine narrows v to "true"|"false"
+  // before this is called, but a regression in that validator would otherwise
+  // silently return 0 for any non-"true" input. Throw loud instead.
+  if (v === "true") return 1;
+  if (v === "false") return 0;
+  throw new InternalServerError(
+    `transformBooleanValueForFilter received unexpected value: ${v}`,
+  );
 }
 
 type ListFilterParams = {
@@ -206,126 +213,43 @@ function buildDynamicFilters(params: ListFilterParams): {
 } {
   const filterList = new FilterList();
 
-  if (params.id?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "id",
-        operator: "any of",
-        values: params.id,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.name?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "name",
-        operator: "any of",
-        values: params.name,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.source?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "source",
-        operator: "any of",
-        values: params.source,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.dataType?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "data_type",
-        operator: "any of",
-        values: params.dataType,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.environment?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "environment",
-        operator: "any of",
-        values: params.environment,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.configId?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "config_id",
-        operator: "any of",
-        values: params.configId,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.queueId?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "queue_id",
-        operator: "any of",
-        values: params.queueId,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.authorUserId?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "author_user_id",
-        operator: "any of",
-        values: params.authorUserId,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.traceId?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "trace_id",
-        operator: "any of",
-        values: params.traceId,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.sessionId?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "session_id",
-        operator: "any of",
-        values: params.sessionId,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.observationId?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "observation_id",
-        operator: "any of",
-        values: params.observationId,
-        tablePrefix: "s",
-      }),
-    );
-  if (params.experimentId?.length)
-    filterList.push(
-      new StringOptionsFilter({
-        clickhouseTable: "scores",
-        field: "dataset_run_id",
-        operator: "any of",
-        values: params.experimentId,
-        tablePrefix: "s",
-      }),
-    );
+  // Each entry maps a ListFilterParams key to its ClickHouse column. Adding a
+  // new identifier filter is a single row here — same operator/table shape.
+  const STRING_OPTIONS_FILTERS: ReadonlyArray<{
+    key: Exclude<
+      keyof ListFilterParams,
+      "valueMin" | "valueMax" | "fromTimestamp" | "toTimestamp" | "value"
+    >;
+    field: string;
+  }> = [
+    { key: "id", field: "id" },
+    { key: "name", field: "name" },
+    { key: "source", field: "source" },
+    { key: "dataType", field: "data_type" },
+    { key: "environment", field: "environment" },
+    { key: "configId", field: "config_id" },
+    { key: "queueId", field: "queue_id" },
+    { key: "authorUserId", field: "author_user_id" },
+    { key: "traceId", field: "trace_id" },
+    { key: "sessionId", field: "session_id" },
+    { key: "observationId", field: "observation_id" },
+    { key: "experimentId", field: "dataset_run_id" },
+  ];
+
+  for (const { key, field } of STRING_OPTIONS_FILTERS) {
+    const values = params[key];
+    if (values?.length) {
+      filterList.push(
+        new StringOptionsFilter({
+          clickhouseTable: "scores",
+          field,
+          operator: "any of",
+          values,
+          tablePrefix: "s",
+        }),
+      );
+    }
+  }
   if (params.fromTimestamp !== undefined)
     filterList.push(
       new DateTimeFilter({
@@ -382,7 +306,18 @@ function buildDynamicFilters(params: ListFilterParams): {
 
     if (dt === "NUMERIC") {
       extraClauses.push(`s.value IN ({${varName}: Array(Float64)})`);
-      extraParams[varName] = params.value.map(Number);
+      // Belt-and-braces: the route-handler superRefine asserts each value is
+      // a finite number before this is called. Re-validate so a regression
+      // can't land NaN/Infinity directly in a CH IN-clause parameter.
+      extraParams[varName] = params.value.map((v) => {
+        const n = Number(v);
+        if (!Number.isFinite(n)) {
+          throw new InternalServerError(
+            `NUMERIC value filter received non-finite value: ${v}`,
+          );
+        }
+        return n;
+      });
     } else if (dt === "BOOLEAN") {
       extraClauses.push(`s.value IN ({${varName}: Array(Float64)})`);
       extraParams[varName] = params.value.map((v) =>

--- a/web/src/features/public-api/server/scores-api-v3.ts
+++ b/web/src/features/public-api/server/scores-api-v3.ts
@@ -316,32 +316,53 @@ function buildDynamicFilters(params: ListFilterParams): {
   const extraParams: Record<string, unknown> = {};
 
   if (params.value?.length && params.dataType?.length === 1) {
-    const dt = params.dataType[0];
+    // Cast: handler superRefine validates dt is a ScoreDataTypeType member.
+    const dt = params.dataType[0] as ScoreDataTypeType;
     const uid = clickhouseCompliantRandomCharacters();
     const varName = `valueFilter${uid}`;
 
-    if (dt === "NUMERIC") {
-      extraClauses.push(`s.value IN ({${varName}: Array(Float64)})`);
-      // Belt-and-braces: the route-handler superRefine asserts each value is
-      // a finite number before this is called. Re-validate so a regression
-      // can't land NaN/Infinity directly in a CH IN-clause parameter.
-      extraParams[varName] = params.value.map((v) => {
-        const n = Number(v);
-        if (!Number.isFinite(n)) {
-          throw new InternalServerError(
-            `NUMERIC value filter received non-finite value: ${v}`,
-          );
-        }
-        return n;
-      });
-    } else if (dt === "BOOLEAN") {
-      extraClauses.push(`s.value IN ({${varName}: Array(Float64)})`);
-      extraParams[varName] = params.value.map((v) =>
-        transformBooleanValueForFilter(v as "true" | "false"),
-      );
-    } else if (dt === "CATEGORICAL") {
-      extraClauses.push(`s.string_value IN ({${varName}: Array(String)})`);
-      extraParams[varName] = params.value;
+    switch (dt) {
+      case ScoreDataTypeEnum.NUMERIC: {
+        extraClauses.push(`s.value IN ({${varName}: Array(Float64)})`);
+        // Belt-and-braces: the route-handler superRefine asserts each value is
+        // a finite number before this is called. Re-validate so a regression
+        // can't land NaN/Infinity directly in a CH IN-clause parameter.
+        extraParams[varName] = params.value.map((v) => {
+          const n = Number(v);
+          if (!Number.isFinite(n)) {
+            throw new InternalServerError(
+              `NUMERIC value filter received non-finite value: ${v}`,
+            );
+          }
+          return n;
+        });
+        break;
+      }
+      case ScoreDataTypeEnum.BOOLEAN: {
+        extraClauses.push(`s.value IN ({${varName}: Array(Float64)})`);
+        extraParams[varName] = params.value.map((v) =>
+          transformBooleanValueForFilter(v as "true" | "false"),
+        );
+        break;
+      }
+      case ScoreDataTypeEnum.CATEGORICAL: {
+        extraClauses.push(`s.string_value IN ({${varName}: Array(String)})`);
+        extraParams[varName] = params.value;
+        break;
+      }
+      case ScoreDataTypeEnum.TEXT:
+      case ScoreDataTypeEnum.CORRECTION:
+        // Handler superRefine rejects value= with TEXT/CORRECTION; reaching
+        // this branch means the validator regressed.
+        throw new InternalServerError(
+          `value filter with dataType=${dt} should have been rejected by handler validation`,
+        );
+      default: {
+        const _exhaustiveCheck: never = dt;
+        throw new InternalServerError(
+          `value filter received unknown dataType: ${_exhaustiveCheck as string}`,
+        );
+      }
     }
   }
 

--- a/web/src/features/public-api/server/scores-api-v3.ts
+++ b/web/src/features/public-api/server/scores-api-v3.ts
@@ -176,8 +176,7 @@ export const buildSelectColumns = (fields: ScoreFieldGroupV3[]): string => {
   return selected.join(",\n    ");
 };
 
-
-export function transformBooleanValueForFilter(v: string): number {
+export function transformBooleanValueForFilter(v: "true" | "false"): number {
   return v === "true" ? 1 : 0;
 }
 
@@ -386,7 +385,9 @@ function buildDynamicFilters(params: ListFilterParams): {
       extraParams[varName] = params.value.map(Number);
     } else if (dt === "BOOLEAN") {
       extraClauses.push(`s.value IN ({${varName}: Array(Float64)})`);
-      extraParams[varName] = params.value.map(transformBooleanValueForFilter);
+      extraParams[varName] = params.value.map((v) =>
+        transformBooleanValueForFilter(v as "true" | "false"),
+      );
     } else if (dt === "CATEGORICAL") {
       extraClauses.push(`s.string_value IN ({${varName}: Array(String)})`);
       extraParams[varName] = params.value;
@@ -430,7 +431,6 @@ export async function listScoresV3ForPublicApi(
 ): Promise<{ data: APIScoreV3[]; cursor?: string }> {
   const { query: filterClause, params: filterParams } =
     buildDynamicFilters(params);
-
 
   return measureAndReturn({
     operationName: "listScoresV3ForPublicApi",

--- a/web/src/features/public-api/server/scores-api-v3.ts
+++ b/web/src/features/public-api/server/scores-api-v3.ts
@@ -213,13 +213,29 @@ function buildDynamicFilters(params: ListFilterParams): {
 } {
   const filterList = new FilterList();
 
+  // Positive union of the string-array filter keys. TypeScript errors if a
+  // key is listed here that does not exist in ListFilterParams, catching drift
+  // without a manual deny-list that has to grow alongside non-string filters.
+  type StringOptionFilterKey = Extract<
+    keyof ListFilterParams,
+    | "id"
+    | "name"
+    | "source"
+    | "dataType"
+    | "environment"
+    | "configId"
+    | "queueId"
+    | "authorUserId"
+    | "traceId"
+    | "sessionId"
+    | "observationId"
+    | "experimentId"
+  >;
+
   // Each entry maps a ListFilterParams key to its ClickHouse column. Adding a
   // new identifier filter is a single row here — same operator/table shape.
   const STRING_OPTIONS_FILTERS: ReadonlyArray<{
-    key: Exclude<
-      keyof ListFilterParams,
-      "valueMin" | "valueMax" | "fromTimestamp" | "toTimestamp" | "value"
-    >;
+    key: StringOptionFilterKey;
     field: string;
   }> = [
     { key: "id", field: "id" },

--- a/web/src/pages/api/public/v3/scores/index.ts
+++ b/web/src/pages/api/public/v3/scores/index.ts
@@ -74,17 +74,29 @@ const GetScoresV3Query = GetScoresQueryV3.extend({
       });
     }
   }
-  const entityFilters = [
-    data.traceId,
-    data.sessionId,
-    data.observationId,
-    data.experimentId,
-  ].filter((arr) => arr && arr.length > 0);
-  if (entityFilters.length > 1) {
+  const hasTraceId = (data.traceId?.length ?? 0) > 0;
+  const hasObservationId = (data.observationId?.length ?? 0) > 0;
+
+  if (hasObservationId && !hasTraceId) {
     ctx.addIssue({
       code: "custom",
       message:
-        "At most one of traceId, sessionId, observationId, experimentId may be specified",
+        "observationId filter requires traceId — observation IDs are scoped to a trace",
+    });
+  }
+
+  // traceId, sessionId, experimentId remain mutually exclusive with each other.
+  // observationId is allowed alongside traceId (enforced above).
+  const exclusiveEntityFilters = [
+    data.traceId,
+    data.sessionId,
+    data.experimentId,
+  ].filter((arr) => arr && arr.length > 0);
+  if (exclusiveEntityFilters.length > 1) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "At most one of traceId, sessionId, experimentId may be specified",
     });
   }
 });

--- a/web/src/pages/api/public/v3/scores/index.ts
+++ b/web/src/pages/api/public/v3/scores/index.ts
@@ -26,7 +26,7 @@ const GetScoresV3Query = GetScoresQueryV3.extend({
         "traceTags filter requires a trace JOIN and is not supported in v3 — use v2 or omit this filter",
     });
   }
-  if (data.value !== undefined) {
+  if (data.value !== undefined && data.value.length > 0) {
     if (!data.dataType || data.dataType.length !== 1) {
       ctx.addIssue({
         code: "custom",
@@ -42,10 +42,10 @@ const GetScoresV3Query = GetScoresQueryV3.extend({
         });
       } else if (dt === "NUMERIC") {
         for (const v of data.value) {
-          if (isNaN(Number(v))) {
+          if (!isFinite(Number(v))) {
             ctx.addIssue({
               code: "custom",
-              message: `value filter with dataType=NUMERIC requires each value to be a number (got "${v}")`,
+              message: `value filter with dataType=NUMERIC requires each value to be a finite number (got "${v}")`,
             });
           }
         }

--- a/web/src/pages/api/public/v3/scores/index.ts
+++ b/web/src/pages/api/public/v3/scores/index.ts
@@ -11,6 +11,73 @@ import { env } from "@/src/env.mjs";
 
 const GetScoresV3Query = GetScoresQueryV3.extend({
   cursor: EncodedScoresCursorV3.optional(),
+}).superRefine((data, ctx) => {
+  if (data.userId !== undefined) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "userId filter requires a trace JOIN and is not supported in v3 — use v2 or omit this filter",
+    });
+  }
+  if (data.traceTags !== undefined) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "traceTags filter requires a trace JOIN and is not supported in v3 — use v2 or omit this filter",
+    });
+  }
+  if (data.value !== undefined) {
+    if (!data.dataType || data.dataType.length !== 1) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "value filter requires a single dataType from: NUMERIC, BOOLEAN, CATEGORICAL",
+      });
+    } else {
+      const dt = data.dataType[0];
+      if (!["NUMERIC", "BOOLEAN", "CATEGORICAL"].includes(dt)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `value filter requires dataType to be NUMERIC, BOOLEAN, or CATEGORICAL (got "${dt}")`,
+        });
+      } else if (dt === "BOOLEAN") {
+        for (const v of data.value) {
+          if (v !== "true" && v !== "false") {
+            ctx.addIssue({
+              code: "custom",
+              message: `value filter with dataType=BOOLEAN requires each value to be "true" or "false" (got "${v}")`,
+            });
+          }
+        }
+      }
+    }
+  }
+  if (data.valueMin !== undefined || data.valueMax !== undefined) {
+    if (
+      !data.dataType ||
+      data.dataType.length !== 1 ||
+      data.dataType[0] !== "NUMERIC"
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "valueMin and valueMax require dataType=NUMERIC as a single value",
+      });
+    }
+  }
+  const entityFilters = [
+    data.traceId,
+    data.sessionId,
+    data.observationId,
+    data.experimentId,
+  ].filter(Boolean);
+  if (entityFilters.length > 1) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "At most one of traceId, sessionId, observationId, experimentId may be specified",
+    });
+  }
 });
 
 export default withMiddlewares({
@@ -30,6 +97,23 @@ export default withMiddlewares({
         limit: query.limit,
         cursor: query.cursor,
         fields: query.fields,
+        id: query.id,
+        name: query.name,
+        source: query.source,
+        dataType: query.dataType,
+        environment: query.environment,
+        configId: query.configId,
+        queueId: query.queueId,
+        authorUserId: query.authorUserId,
+        value: query.value,
+        valueMin: query.valueMin,
+        valueMax: query.valueMax,
+        traceId: query.traceId,
+        sessionId: query.sessionId,
+        observationId: query.observationId,
+        experimentId: query.experimentId,
+        fromTimestamp: query.fromTimestamp,
+        toTimestamp: query.toTimestamp,
       });
 
       return {

--- a/web/src/pages/api/public/v3/scores/index.ts
+++ b/web/src/pages/api/public/v3/scores/index.ts
@@ -40,6 +40,15 @@ const GetScoresV3Query = GetScoresQueryV3.extend({
           code: "custom",
           message: `value filter requires dataType to be NUMERIC, BOOLEAN, or CATEGORICAL (got "${dt}")`,
         });
+      } else if (dt === "NUMERIC") {
+        for (const v of data.value) {
+          if (isNaN(Number(v))) {
+            ctx.addIssue({
+              code: "custom",
+              message: `value filter with dataType=NUMERIC requires each value to be a number (got "${v}")`,
+            });
+          }
+        }
       } else if (dt === "BOOLEAN") {
         for (const v of data.value) {
           if (v !== "true" && v !== "false") {

--- a/web/src/pages/api/public/v3/scores/index.ts
+++ b/web/src/pages/api/public/v3/scores/index.ts
@@ -79,7 +79,7 @@ const GetScoresV3Query = GetScoresQueryV3.extend({
     data.sessionId,
     data.observationId,
     data.experimentId,
-  ].filter(Boolean);
+  ].filter((arr) => arr && arr.length > 0);
   if (entityFilters.length > 1) {
     ctx.addIssue({
       code: "custom",

--- a/web/src/pages/api/public/v3/scores/index.ts
+++ b/web/src/pages/api/public/v3/scores/index.ts
@@ -108,8 +108,10 @@ export default withMiddlewares({
     responseSchema: GetScoresResponseV3,
     fn: async ({ query, auth }) => {
       if (env.LANGFUSE_ENABLE_SCORES_V3_API !== "true") {
-        // Generic message to avoid disclosing the feature-flag existence to
-        // unauthenticated probes. Cloud has the flag on; self-hosted gets 404.
+        // Returns 404 to authenticated callers when disabled. Note: auth and
+        // Zod parsing already ran, so an unauthenticated caller sees 401 here
+        // (signalling the endpoint exists). Cloud has the flag on by default;
+        // self-hosted instances see 404 until the API graduates from preview.
         throw new LangfuseNotFoundError("Not Found");
       }
 


### PR DESCRIPTION
## Summary

Phase 4 of [LFE-9539](https://linear.app/langfuse/issue/LFE-9539) — adds all filter query parameters to \`GET /api/public/v3/scores\`. All filters are optional.

Stacked on #14001 (Phase 3).

**New query params:**

| Param | Type | Notes |
|---|---|---|
| \`id\` | comma-separated | OR within, AND across filters |
| \`name\` | comma-separated | |
| \`source\` | comma-separated enum | \`API\`, \`EVAL\`, \`ANNOTATION\` — invalid values → 400 |
| \`dataType\` | comma-separated enum | \`NUMERIC\`, \`BOOLEAN\`, \`CATEGORICAL\`, \`TEXT\`, \`CORRECTION\` — invalid values → 400 |
| \`environment\` | comma-separated | |
| \`configId\` / \`queueId\` / \`authorUserId\` | comma-separated | |
| \`traceId\` / \`sessionId\` / \`observationId\` / \`experimentId\` | comma-separated | mutually exclusive |
| \`value\` | comma-separated | requires single \`dataType\` from NUMERIC / BOOLEAN / CATEGORICAL |
| \`valueMin\` / \`valueMax\` | number | requires \`dataType=NUMERIC\` |
| \`fromTimestamp\` / \`toTimestamp\` | datetime | optional |
| \`userId\` / \`traceTags\` | — | always → 400 (require trace JOIN, not supported in v3) |

### Validation details

- \`source\` and \`dataType\` validated against their enum allowlists at parse time
- Bare params (e.g. \`?id=\`) produce empty arrays — not treated as present
- \`?value=\` (empty/comma-only) → treated as absent, not a 400
- \`?traceId=&sessionId=<uuid>\` → empty \`traceId\` ignored, no false mutual-exclusion 400
- \`value=abc&dataType=NUMERIC\` → 400 (non-numeric, using \`!isFinite\` to also catch Infinity)
- \`value=true&dataType=BOOLEAN\` valid; \`value=1&dataType=BOOLEAN\` → 400
- \`transformBooleanValueForFilter\` parameter narrowed to \`"true" | "false"\`

### Impacted packages

- \`@langfuse/shared\` — \`GetScoresV3\` extended with all filter params; \`csvStringParam\` (blank-segment filtered); \`csvEnumParam\` for validated enum params
- \`web\` — \`buildDynamicFilters\` wires params to \`FilterList\`; \`GetScoresV3Query\` superRefine in handler; \`transformBooleanValueForFilter\` helper; tests

## Test plan

- [x] \`pnpm --filter web run lint\` — clean
- [x] \`pnpm --filter @langfuse/shared run typecheck\` — clean
- [x] 12 unit tests pass (polymorphicValue, transformBooleanValueForFilter)
- [ ] Integration tests — require live ClickHouse + \`LANGFUSE_ENABLE_SCORES_V3_API=true\`
  - 400 validation: userId, traceTags, entity mutual exclusion, source=INVALID, dataType=INVALID, value type/format checks, empty value= → 200
  - filter correctness: id, name, source, dataType, environment, configId, queueId, authorUserId, traceId, sessionId, observationId, experimentId, value NUMERIC/CATEGORICAL/BOOLEAN, valueMin/valueMax, toTimestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)