### PR TITLE
feat(web): add MCP & CLI settings page and agent tools banner

### DIFF
--- a/web/src/features/developer-tools/components/AgentToolsBanner.tsx
+++ b/web/src/features/developer-tools/components/AgentToolsBanner.tsx
@@ -1,0 +1,40 @@
+import { Callout } from "@/src/components/ui/callout";
+import { Button } from "@/src/components/ui/button";
+import Link from "next/link";
+import { Bot } from "lucide-react";
+
+const DOCS_HREF =
+  "https://langfuse.com/docs/api-and-data-platform/features/agent-skill";
+
+/**
+ * Informational, dismissible banner that highlights Langfuse's support for AI
+ * coding agents via the Agent Skill, MCP server, and CLI. Rendered on the
+ * organization overview page.
+ */
+export function AgentToolsBanner() {
+  return (
+    <Callout
+      id="agent-tools-banner:v1"
+      variant="info"
+      align="middle"
+      actions={() => (
+        <Button asChild size="sm" variant="secondary">
+          <Link href={DOCS_HREF} target="_blank">
+            Learn more
+          </Link>
+        </Button>
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <Bot className="h-4 w-4 shrink-0" />
+        <span>
+          <span className="font-semibold">
+            Langfuse works great with your AI coding agents.
+          </span>{" "}
+          Connect Claude Code, Codex, and other agents to your data with the
+          Langfuse Agent Skill, MCP server, and CLI.
+        </span>
+      </div>
+    </Callout>
+  );
+}

--- a/web/src/features/developer-tools/components/DeveloperToolsSettings.tsx
+++ b/web/src/features/developer-tools/components/DeveloperToolsSettings.tsx
@@ -1,0 +1,95 @@
+import Header from "@/src/components/layouts/header";
+import { Button } from "@/src/components/ui/button";
+import { Card } from "@/src/components/ui/card";
+import { CodeBlock } from "@/src/components/ui/Codeblock";
+import Link from "next/link";
+import { Bot, SquareTerminal, Sparkles } from "lucide-react";
+
+const DocsButton = ({ href }: { href: string }) => (
+  <Button asChild variant="ghost">
+    <Link href={href} target="_blank">
+      Documentation ↗
+    </Link>
+  </Button>
+);
+
+export function DeveloperToolsSettings() {
+  return (
+    <div>
+      <Header title="MCP & CLI" />
+      <p className="text-muted-foreground mb-6 text-sm">
+        Bring Langfuse into your terminal and AI coding agents. These tools let
+        you and your agents read and write Langfuse data—traces, prompts,
+        datasets, scores, and more—without leaving your development environment.
+      </p>
+      <div className="space-y-6">
+        <Card className="p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Sparkles className="text-foreground h-5 w-5" />
+            <span className="font-semibold">Agent Skill</span>
+          </div>
+          <p className="text-primary mb-4 text-sm">
+            The Langfuse Agent Skill is an open-source skill following
+            Anthropic&apos;s Agent Skills standard. It equips AI coding agents
+            (Claude Code, Cursor, Windsurf) with native Langfuse capabilities
+            and conditions them to follow best practices, so agents produce
+            better results when it is installed.
+          </p>
+          <CodeBlock
+            language="shell"
+            value={`npx skills add langfuse/skills --skill "langfuse"`}
+          />
+          <div className="mt-4 flex items-center gap-2">
+            <DocsButton href="https://langfuse.com/docs/api-and-data-platform/features/agent-skill" />
+          </div>
+        </Card>
+
+        <Card className="p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Bot className="text-foreground h-5 w-5" />
+            <span className="font-semibold">MCP Server</span>
+          </div>
+          <p className="text-primary mb-4 text-sm">
+            The Langfuse MCP server lets AI assistants and agents interact with
+            your Langfuse data programmatically via the Model Context Protocol.
+            It supports both read and write operations, and you can restrict it
+            to read-only access with an allowlist. Authenticate with a
+            project-scoped API key pair.
+          </p>
+          <CodeBlock
+            language="shell"
+            value={`claude mcp add --transport http langfuse \\
+  https://cloud.langfuse.com/api/public/mcp \\
+  --header "Authorization: Basic {your-base64-token}"`}
+          />
+          <div className="mt-4 flex items-center gap-2">
+            <DocsButton href="https://langfuse.com/docs/api-and-data-platform/features/mcp-server" />
+          </div>
+        </Card>
+
+        <Card className="p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <SquareTerminal className="text-foreground h-5 w-5" />
+            <span className="font-semibold">CLI</span>
+          </div>
+          <p className="text-primary mb-4 text-sm">
+            The Langfuse CLI provides terminal access to the full Langfuse API.
+            It wraps every API endpoint, so you can manage traces, prompts,
+            datasets, scores, and sessions directly from your shell or scripts.
+            It uses the same API key pair as the Langfuse SDKs.
+          </p>
+          <CodeBlock
+            language="shell"
+            value={`export LANGFUSE_PUBLIC_KEY="pk-lf-..."
+export LANGFUSE_SECRET_KEY="sk-lf-..."
+
+npx langfuse-cli api <resource> <action>`}
+          />
+          <div className="mt-4 flex items-center gap-2">
+            <DocsButton href="https://langfuse.com/docs/api-and-data-platform/features/cli" />
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/organizations/components/ProjectOverview.tsx
+++ b/web/src/features/organizations/components/ProjectOverview.tsx
@@ -33,6 +33,7 @@ import { isCloudPlan, planLabels } from "@langfuse/shared";
 import ContainerPage from "@/src/components/layouts/container-page";
 import { type User } from "next-auth";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { AgentToolsBanner } from "@/src/features/developer-tools/components/AgentToolsBanner";
 
 const OrganizationProjectTiles = ({
   org,
@@ -309,6 +310,9 @@ export const OrganizationProjectOverview = () => {
         ),
       }}
     >
+      <div className="mb-4">
+        <AgentToolsBanner />
+      </div>
       {showOnboarding && <Onboarding />}
       {organizations
         .sort((a, b) => {

--- a/web/src/pages/project/[projectId]/settings/index.tsx
+++ b/web/src/pages/project/[projectId]/settings/index.tsx
@@ -31,6 +31,7 @@ import { SiSlack } from "react-icons/si";
 import { ScoreConfigSettings } from "@/src/features/score-configs/components/ScoreConfigSettings";
 import { env } from "@/src/env.mjs";
 import { NotificationSettings } from "@/src/features/notifications/components/NotificationSettings";
+import { DeveloperToolsSettings } from "@/src/features/developer-tools/components/DeveloperToolsSettings";
 
 type ProjectSettingsPage = {
   title: string;
@@ -135,6 +136,21 @@ export const getProjectSettingsPages = ({
         <ApiKeyList entityId={project.id} scope="project" />
       </div>
     ),
+  },
+  {
+    title: "MCP & CLI",
+    slug: "developer-tools",
+    cmdKKeywords: [
+      "mcp",
+      "cli",
+      "skill",
+      "agent",
+      "model context protocol",
+      "command line",
+      "claude code",
+      "cursor",
+    ],
+    content: <DeveloperToolsSettings />,
   },
   {
     title: "LLM Connections",


### PR DESCRIPTION
## What does this PR do?

Introduces users to the Langfuse Agent Skill, MCP server, and CLI from inside the app:

1. **New "MCP & CLI" project settings page** (`Project Settings → MCP & CLI`). Content-only (no functionality) — a short intro plus three cards (Agent Skill, MCP Server, CLI), each with a copyable install/usage snippet and a link to the relevant docs page. Agent Skill is listed first.
2. **Dismissible banner on the organization overview page** highlighting that Langfuse works well with AI coding agents (Claude Code, Codex, etc.) via the Agent Skill, MCP server, and CLI. It reuses the existing `Callout` primitive (localStorage-backed dismissal with TTL) and links to the docs.

Motivation: raise awareness of the recently shipped Langfuse CLI, MCP server, and Agent Skill so users can connect their coding agents to their Langfuse data.

Fixes # (no linked issue)

### Implementation notes for reviewers
- New component dir: `web/src/features/developer-tools/components/` (`DeveloperToolsSettings.tsx`, `AgentToolsBanner.tsx`).
- Settings tab wired into `getProjectSettingsPages()` in `web/src/pages/project/[projectId]/settings/index.tsx` (slug `developer-tools`, placed after **API Keys**).
- Banner injected at the top of the org overview content in `web/src/features/organizations/components/ProjectOverview.tsx`.
- No backend, schema, API, or entitlement changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Lint passes (`pnpm run lint`) — full suite ran green via the pre-commit hook.
- [x] Verified both surfaces in a local browser (settings page + org banner) with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "MCP & CLI" project settings page and a dismissible informational banner on the organization overview, raising awareness of the Langfuse Agent Skill, MCP server, and CLI. It is content-only with no backend, schema, or API changes.

- **`DeveloperToolsSettings.tsx`**: Three cards (Agent Skill, MCP Server, CLI) with copy-able snippets and doc links. The MCP snippet hardcodes `https://cloud.langfuse.com`, which is only correct for EU-region Cloud users — US, JP, HIPAA, and self-hosted users would copy the wrong endpoint. All three card descriptions also use `text-primary` instead of `text-muted-foreground`, making them visually inconsistent with the rest of the page.
- **`AgentToolsBanner.tsx`** + **`ProjectOverview.tsx`**: Correctly reuses the existing `Callout` primitive with a versioned id for localStorage-backed dismissal. Clean, no issues.
- **`settings/index.tsx`**: Wires the page into the settings nav after API Keys with a comprehensive `cmdKKeywords` list.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for EU cloud users; US, JP, HIPAA, and self-hosted users will see a wrong MCP endpoint URL in the settings page snippet.

The MCP code snippet in the settings page shows a hardcoded EU hostname that is incorrect for three other production cloud regions and all self-hosted deployments. Users on those deployments who copy the snippet will get a non-functional MCP configuration until they notice and manually substitute the right base URL.

web/src/features/developer-tools/components/DeveloperToolsSettings.tsx — the MCP snippet URL and card description text colors both need attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits Org Overview] --> B{localStorage: banner dismissed?}
    B -- No / Expired --> C[Render AgentToolsBanner]
    B -- Yes & not expired --> D[Banner hidden]
    C --> E{User clicks Dismiss}
    E --> F[Write dismissedAt to localStorage TTL = 30 days]
    F --> D
    C --> G[User clicks Learn more]
    G --> H[Opens docs in new tab]

    I[User visits Project Settings] --> J[Settings nav renders MCP & CLI tab]
    J --> K[DeveloperToolsSettings]
    K --> L[Agent Skill card]
    K --> M[MCP Server card - hardcoded cloud.langfuse.com]
    K --> N[CLI card]
    M --> O((Warning: URL hardcoded to EU region))
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
web/src/features/developer-tools/components/DeveloperToolsSettings.tsx:59-64
**Hardcoded EU cloud URL in MCP snippet**

The MCP snippet hardcodes `https://cloud.langfuse.com/api/public/mcp`, which is only correct for the EU cloud region. Users on US (`us.cloud.langfuse.com`), JP (`jp.cloud.langfuse.com`), or HIPAA (`hipaa.cloud.langfuse.com`) regions will copy a wrong endpoint and get connection failures. Self-hosted deployments are also broken. The component should derive the base URL from `window.location.origin` (or the Next.js router) at render time so the snippet is always correct for the current deployment.

### Issue 2 of 4
web/src/features/developer-tools/components/DeveloperToolsSettings.tsx:31-37
**`text-primary` on card description text causes high-contrast body copy**

The card description paragraphs use `text-primary`, which renders as the bold foreground color (typically black/white), while the page-level description correctly uses `text-muted-foreground` for subdued secondary text. Using `text-muted-foreground` here is consistent with the rest of the settings page.

```suggestion
          <p className="text-muted-foreground mb-4 text-sm">
            The Langfuse Agent Skill is an open-source skill following
            Anthropic&apos;s Agent Skills standard. It equips AI coding agents
            (Claude Code, Cursor, Windsurf) with native Langfuse capabilities
            and conditions them to follow best practices, so agents produce
            better results when it is installed.
          </p>
```

### Issue 3 of 4
web/src/features/developer-tools/components/DeveloperToolsSettings.tsx:52-58
Same `text-primary` inconsistency on the MCP card description — should be `text-muted-foreground` to match the other cards once fixed.

```suggestion
          <p className="text-muted-foreground mb-4 text-sm">
            The Langfuse MCP server lets AI assistants and agents interact with
            your Langfuse data programmatically via the Model Context Protocol.
            It supports both read and write operations, and you can restrict it
            to read-only access with an allowlist. Authenticate with a
            project-scoped API key pair.
          </p>
```

### Issue 4 of 4
web/src/features/developer-tools/components/DeveloperToolsSettings.tsx:75-80
Same `text-primary` inconsistency on the CLI card description.

```suggestion
          <p className="text-muted-foreground mb-4 text-sm">
            The Langfuse CLI provides terminal access to the full Langfuse API.
            It wraps every API endpoint, so you can manage traces, prompts,
            datasets, scores, and sessions directly from your shell or scripts.
            It uses the same API key pair as the Langfuse SDKs.
          </p>
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): add MCP &amp; CLI settings page a..."](https://github.com/langfuse/langfuse/commit/778637d7c1c4a963bbbbb23750a784e8a220905b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35164559)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->