### PR TITLE
ci: limit SDK workflow write token exposure

### DIFF
--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -197,6 +197,13 @@ jobs:
             fi
           done
 
+          # Resolve the reviewer before pushing so a transient GitHub API failure cannot orphan a branch.
+          ORIGINAL_AUTHOR="$("$GH_BIN" api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
+          REVIEWER_ARGS=()
+          if [ -n "$ORIGINAL_AUTHOR" ]; then
+            REVIEWER_ARGS=(--reviewer "$ORIGINAL_AUTHOR")
+          fi
+
           # Push new branch and create PR from a fresh repo that never ran SDK install scripts.
           GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \
             -C "$PUSH_REPO" \
@@ -205,12 +212,6 @@ jobs:
             -c core.hooksPath=/dev/null \
             push "https://x-access-token:${GH_TOKEN}@github.com/langfuse/langfuse-python.git" "$BRANCH_NAME"
 
-          # Create PR with original author as reviewer
-          ORIGINAL_AUTHOR="$("$GH_BIN" api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
-          REVIEWER_ARGS=()
-          if [ -n "$ORIGINAL_AUTHOR" ]; then
-            REVIEWER_ARGS=(--reviewer "$ORIGINAL_AUTHOR")
-          fi
           "$GH_BIN" pr create \
             --repo langfuse/langfuse-python \
             --head "$BRANCH_NAME" \
@@ -252,6 +253,13 @@ jobs:
             fi
           done
 
+          # Resolve the reviewer before pushing so a transient GitHub API failure cannot orphan a branch.
+          ORIGINAL_AUTHOR="$("$GH_BIN" api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
+          REVIEWER_ARGS=()
+          if [ -n "$ORIGINAL_AUTHOR" ]; then
+            REVIEWER_ARGS=(--reviewer "$ORIGINAL_AUTHOR")
+          fi
+
           # Push new branch and create PR from a fresh repo that never ran SDK install scripts.
           GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \
             -C "$PUSH_REPO" \
@@ -260,12 +268,6 @@ jobs:
             -c core.hooksPath=/dev/null \
             push "https://x-access-token:${GH_TOKEN}@github.com/langfuse/langfuse-js.git" "$BRANCH_NAME"
 
-          # Create PR with original author as reviewer
-          ORIGINAL_AUTHOR="$("$GH_BIN" api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
-          REVIEWER_ARGS=()
-          if [ -n "$ORIGINAL_AUTHOR" ]; then
-            REVIEWER_ARGS=(--reviewer "$ORIGINAL_AUTHOR")
-          fi
           "$GH_BIN" pr create \
             --repo langfuse/langfuse-js \
             --head "$BRANCH_NAME" \

--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -102,12 +102,19 @@ jobs:
           gh pr list --author langfuse-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
 
           # Push new branch and create PR
-          gh auth setup-git
-          git -c core.hooksPath=/dev/null push origin "$BRANCH_NAME"
+          git \
+            -c credential.helper= \
+            -c credential.https://github.com.helper= \
+            -c core.hooksPath=/dev/null \
+            push "https://x-access-token:${GH_TOKEN}@github.com/langfuse/langfuse-python.git" "$BRANCH_NAME"
 
           # Create PR with original author as reviewer
-          ORIGINAL_AUTHOR="$(gh api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login')"
-          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body "" --reviewer "$ORIGINAL_AUTHOR"
+          ORIGINAL_AUTHOR="$(gh api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
+          REVIEWER_ARGS=()
+          if [ -n "$ORIGINAL_AUTHOR" ]; then
+            REVIEWER_ARGS=(--reviewer "$ORIGINAL_AUTHOR")
+          fi
+          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body "" "${REVIEWER_ARGS[@]}"
 
       - name: Prepare TypeScript SDK update
         id: prepare-typescript-sdk
@@ -169,12 +176,19 @@ jobs:
           gh pr list --author langfuse-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
 
           # Push new branch and create PR
-          gh auth setup-git
-          git -c core.hooksPath=/dev/null push origin "$BRANCH_NAME"
+          git \
+            -c credential.helper= \
+            -c credential.https://github.com.helper= \
+            -c core.hooksPath=/dev/null \
+            push "https://x-access-token:${GH_TOKEN}@github.com/langfuse/langfuse-js.git" "$BRANCH_NAME"
 
           # Create PR with original author as reviewer
-          ORIGINAL_AUTHOR="$(gh api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login')"
-          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body "" --reviewer "$ORIGINAL_AUTHOR"
+          ORIGINAL_AUTHOR="$(gh api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
+          REVIEWER_ARGS=()
+          if [ -n "$ORIGINAL_AUTHOR" ]; then
+            REVIEWER_ARGS=(--reviewer "$ORIGINAL_AUTHOR")
+          fi
+          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body "" "${REVIEWER_ARGS[@]}"
 
   notify-slack-on-failure:
     needs: generate-sdk-api-specs

--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -18,6 +18,11 @@ permissions:
 jobs:
   generate-sdk-api-specs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      python_has_changes: ${{ steps.prepare-python-sdk.outputs.has_changes }}
+      python_branch_name: ${{ steps.prepare-python-sdk.outputs.branch_name }}
+      typescript_has_changes: ${{ steps.prepare-typescript-sdk.outputs.has_changes }}
+      typescript_branch_name: ${{ steps.prepare-typescript-sdk.outputs.branch_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -86,35 +91,19 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           git add .
           git commit -m "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}"
+          git bundle create "$RUNNER_TEMP/langfuse-python-api-spec-bot.bundle" "$BRANCH_NAME"
 
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
           echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Push Python SDK update
+      - name: Upload Python SDK update
         if: steps.prepare-python-sdk.outputs.has_changes == 'true'
-        env:
-          BRANCH_NAME: ${{ steps.prepare-python-sdk.outputs.branch_name }}
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: |
-          cd ../langfuse-python
-
-          # Close existing api-spec-bot PRs
-          gh pr list --author langfuse-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
-
-          # Push new branch and create PR
-          git \
-            -c credential.helper= \
-            -c credential.https://github.com.helper= \
-            -c core.hooksPath=/dev/null \
-            push "https://x-access-token:${GH_TOKEN}@github.com/langfuse/langfuse-python.git" "$BRANCH_NAME"
-
-          # Create PR with original author as reviewer
-          ORIGINAL_AUTHOR="$(gh api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
-          REVIEWER_ARGS=()
-          if [ -n "$ORIGINAL_AUTHOR" ]; then
-            REVIEWER_ARGS=(--reviewer "$ORIGINAL_AUTHOR")
-          fi
-          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body "" "${REVIEWER_ARGS[@]}"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: langfuse-python-sdk-update
+          path: ${{ runner.temp }}/langfuse-python-api-spec-bot.bundle
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Prepare TypeScript SDK update
         id: prepare-typescript-sdk
@@ -160,38 +149,135 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           git add .
           git commit -m "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --no-verify
+          git bundle create "$RUNNER_TEMP/langfuse-js-api-spec-bot.bundle" "$BRANCH_NAME"
 
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
           echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Push TypeScript SDK update
+      - name: Upload TypeScript SDK update
         if: steps.prepare-typescript-sdk.outputs.has_changes == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: langfuse-js-sdk-update
+          path: ${{ runner.temp }}/langfuse-js-api-spec-bot.bundle
+          if-no-files-found: error
+          retention-days: 1
+
+  push-python-sdk:
+    needs: generate-sdk-api-specs
+    if: needs.generate-sdk-api-specs.outputs.python_has_changes == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Download Python SDK update
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: langfuse-python-sdk-update
+          path: ${{ runner.temp }}/langfuse-python-sdk-update
+
+      - name: Push Python SDK update
         env:
-          BRANCH_NAME: ${{ steps.prepare-typescript-sdk.outputs.branch_name }}
+          BRANCH_NAME: ${{ needs.generate-sdk-api-specs.outputs.python_branch_name }}
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
-          cd ../langfuse-js
+          set -euo pipefail
+
+          GIT_BIN="$(command -v git)"
+          GH_BIN="$(command -v gh)"
+          BUNDLE_PATH="$RUNNER_TEMP/langfuse-python-sdk-update/langfuse-python-api-spec-bot.bundle"
+          PUSH_REPO="$RUNNER_TEMP/push-langfuse-python"
+
+          mkdir -p "$PUSH_REPO"
+          "$GIT_BIN" -C "$PUSH_REPO" init -q
+          "$GIT_BIN" -C "$PUSH_REPO" fetch --no-tags "$BUNDLE_PATH" "$BRANCH_NAME:refs/heads/$BRANCH_NAME"
 
           # Close existing api-spec-bot PRs
-          gh pr list --author langfuse-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
+          "$GH_BIN" pr list --repo langfuse/langfuse-python --author langfuse-bot --state open --json number --jq '.[].number' | while read -r pr_number; do
+            if [ -n "$pr_number" ]; then
+              "$GH_BIN" pr close --repo langfuse/langfuse-python "$pr_number"
+            fi
+          done
 
-          # Push new branch and create PR
-          git \
+          # Push new branch and create PR from a fresh repo that never ran SDK install scripts.
+          GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \
+            -C "$PUSH_REPO" \
+            -c credential.helper= \
+            -c credential.https://github.com.helper= \
+            -c core.hooksPath=/dev/null \
+            push "https://x-access-token:${GH_TOKEN}@github.com/langfuse/langfuse-python.git" "$BRANCH_NAME"
+
+          # Create PR with original author as reviewer
+          ORIGINAL_AUTHOR="$("$GH_BIN" api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
+          REVIEWER_ARGS=()
+          if [ -n "$ORIGINAL_AUTHOR" ]; then
+            REVIEWER_ARGS=(--reviewer "$ORIGINAL_AUTHOR")
+          fi
+          "$GH_BIN" pr create \
+            --repo langfuse/langfuse-python \
+            --head "$BRANCH_NAME" \
+            --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" \
+            --body "" \
+            "${REVIEWER_ARGS[@]}"
+
+  push-typescript-sdk:
+    needs: generate-sdk-api-specs
+    if: needs.generate-sdk-api-specs.outputs.typescript_has_changes == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Download TypeScript SDK update
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: langfuse-js-sdk-update
+          path: ${{ runner.temp }}/langfuse-js-sdk-update
+
+      - name: Push TypeScript SDK update
+        env:
+          BRANCH_NAME: ${{ needs.generate-sdk-api-specs.outputs.typescript_branch_name }}
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          GIT_BIN="$(command -v git)"
+          GH_BIN="$(command -v gh)"
+          BUNDLE_PATH="$RUNNER_TEMP/langfuse-js-sdk-update/langfuse-js-api-spec-bot.bundle"
+          PUSH_REPO="$RUNNER_TEMP/push-langfuse-js"
+
+          mkdir -p "$PUSH_REPO"
+          "$GIT_BIN" -C "$PUSH_REPO" init -q
+          "$GIT_BIN" -C "$PUSH_REPO" fetch --no-tags "$BUNDLE_PATH" "$BRANCH_NAME:refs/heads/$BRANCH_NAME"
+
+          # Close existing api-spec-bot PRs
+          "$GH_BIN" pr list --repo langfuse/langfuse-js --author langfuse-bot --state open --json number --jq '.[].number' | while read -r pr_number; do
+            if [ -n "$pr_number" ]; then
+              "$GH_BIN" pr close --repo langfuse/langfuse-js "$pr_number"
+            fi
+          done
+
+          # Push new branch and create PR from a fresh repo that never ran SDK install scripts.
+          GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \
+            -C "$PUSH_REPO" \
             -c credential.helper= \
             -c credential.https://github.com.helper= \
             -c core.hooksPath=/dev/null \
             push "https://x-access-token:${GH_TOKEN}@github.com/langfuse/langfuse-js.git" "$BRANCH_NAME"
 
           # Create PR with original author as reviewer
-          ORIGINAL_AUTHOR="$(gh api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
+          ORIGINAL_AUTHOR="$("$GH_BIN" api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login // empty')"
           REVIEWER_ARGS=()
           if [ -n "$ORIGINAL_AUTHOR" ]; then
             REVIEWER_ARGS=(--reviewer "$ORIGINAL_AUTHOR")
           fi
-          gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body "" "${REVIEWER_ARGS[@]}"
+          "$GH_BIN" pr create \
+            --repo langfuse/langfuse-js \
+            --head "$BRANCH_NAME" \
+            --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" \
+            --body "" \
+            "${REVIEWER_ARGS[@]}"
 
   notify-slack-on-failure:
-    needs: generate-sdk-api-specs
+    needs:
+      - generate-sdk-api-specs
+      - push-python-sdk
+      - push-typescript-sdk
     if: failure()
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:

--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           version: 11.1.3
 
-      # Keep this secret-bearing job cache-cold to avoid exposing Fern and
-      # GitHub write credentials to potentially poisoned shared package-manager state.
+      # Keep this secret-bearing job cache-cold to avoid exposing Fern
+      # credentials to potentially poisoned shared package-manager state.
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -50,9 +50,8 @@ jobs:
         with:
           version: "0.11.2"
 
-      - name: Update Python SDK
-        env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Prepare Python SDK update
+        id: prepare-python-sdk
         run: |
           # Clone langfuse-python repository
           git clone https://github.com/langfuse/langfuse-python.git ../langfuse-python
@@ -60,8 +59,6 @@ jobs:
 
           git config user.name "langfuse-bot"
           git config user.email "langfuse-bot@langfuse.com"
-          echo "$GH_ACCESS_TOKEN" | gh auth login --with-token
-          gh auth setup-git
 
           # Delete existing API contents
           rm -rf langfuse/api/*
@@ -80,30 +77,40 @@ jobs:
           # Check for changes and show diff for debugging
           if git diff --quiet; then
             echo "No changes detected in Python SDK"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Close existing api-spec-bot PRs
-          gh pr list --author langfuse-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
-
-          # Get the GitHub username of the original commit author
-          cd ../langfuse
-          ORIGINAL_AUTHOR=$(gh api repos/langfuse/langfuse/commits/${GITHUB_SHA} --jq '.author.login')
-          cd ../langfuse-python
-
-          # Create new branch and push changes
+          # Create new branch and commit changes
           BRANCH_NAME="api-spec-bot-${GITHUB_SHA::7}"
           git checkout -b "$BRANCH_NAME"
           git add .
           git commit -m "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}"
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Push Python SDK update
+        if: steps.prepare-python-sdk.outputs.has_changes == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.prepare-python-sdk.outputs.branch_name }}
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          cd ../langfuse-python
+
+          # Close existing api-spec-bot PRs
+          gh pr list --author langfuse-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
+
+          # Push new branch and create PR
+          gh auth setup-git
           git push origin "$BRANCH_NAME"
 
           # Create PR with original author as reviewer
+          ORIGINAL_AUTHOR="$(gh api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login')"
           gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body "" --reviewer "$ORIGINAL_AUTHOR"
 
-      - name: Update TypeScript SDK
-        env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Prepare TypeScript SDK update
+        id: prepare-typescript-sdk
         run: |
           # Clone langfuse-js repository
           git clone https://github.com/langfuse/langfuse-js.git ../langfuse-js
@@ -112,8 +119,6 @@ jobs:
           # Configure git
           git config user.name "langfuse-bot"
           git config user.email "langfuse-bot@langfuse.com"
-          echo "$GH_ACCESS_TOKEN" | gh auth login --with-token
-          gh auth setup-git
 
           # Delete existing API contents
           rm -rf packages/core/src/api/*
@@ -139,25 +144,36 @@ jobs:
           # Check for changes and show diff for debugging
           if git diff --quiet; then
             echo "No changes detected in TypeScript SDK"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Close existing api-spec-bot PRs
-          gh pr list --author langfuse-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
-
-          # Get the GitHub username of the original commit author
-          cd ../langfuse
-          ORIGINAL_AUTHOR=$(gh api repos/langfuse/langfuse/commits/${GITHUB_SHA} --jq '.author.login')
-          cd ../langfuse-js
-
-          # Create new branch and push changes
+          # Create new branch and commit changes
           BRANCH_NAME="api-spec-bot-${GITHUB_SHA::7}"
           git checkout -b "$BRANCH_NAME"
           git add .
           git commit -m "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --no-verify
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Push TypeScript SDK update
+        if: steps.prepare-typescript-sdk.outputs.has_changes == 'true'
+        env:
+          BRANCH_NAME: ${{ steps.prepare-typescript-sdk.outputs.branch_name }}
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          cd ../langfuse-js
+
+          # Close existing api-spec-bot PRs
+          gh pr list --author langfuse-bot --state open --json number --jq '.[].number' | xargs -I {} gh pr close {}
+
+          # Push new branch and create PR
+          gh auth setup-git
           git push origin "$BRANCH_NAME"
 
           # Create PR with original author as reviewer
+          ORIGINAL_AUTHOR="$(gh api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login')"
           gh pr create --title "feat(api): update API spec from langfuse/langfuse ${GITHUB_SHA::7}" --body "" --reviewer "$ORIGINAL_AUTHOR"
 
   notify-slack-on-failure:

--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -103,7 +103,7 @@ jobs:
 
           # Push new branch and create PR
           gh auth setup-git
-          git push origin "$BRANCH_NAME"
+          git -c core.hooksPath=/dev/null push origin "$BRANCH_NAME"
 
           # Create PR with original author as reviewer
           ORIGINAL_AUTHOR="$(gh api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login')"
@@ -170,7 +170,7 @@ jobs:
 
           # Push new branch and create PR
           gh auth setup-git
-          git push origin "$BRANCH_NAME"
+          git -c core.hooksPath=/dev/null push origin "$BRANCH_NAME"
 
           # Create PR with original author as reviewer
           ORIGINAL_AUTHOR="$(gh api "repos/langfuse/langfuse/commits/${GITHUB_SHA}" --jq '.author.login')"

--- a/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
+++ b/worker/src/features/evaluation/codeBased/awsLambdaCodeEvalDispatcher.integration.test.ts
@@ -8,6 +8,7 @@ import {
 
 const endpoint = process.env.LANGFUSE_CODE_EVAL_AWS_LAMBDA_ENDPOINT;
 const describeWithFloci = endpoint ? describe : describe.skip;
+const FLOCI_TEST_TIMEOUT_MS = 30_000;
 
 process.env.AWS_ACCESS_KEY_ID ??= "test";
 process.env.AWS_SECRET_ACCESS_KEY ??= "test";
@@ -108,21 +109,26 @@ describeWithFloci("AwsLambdaCodeEvalDispatcher Floci integration", () => {
         }),
       ).resolves.toEqual({ scores: expectedScores });
     },
+    FLOCI_TEST_TIMEOUT_MS,
   );
 
-  it("preserves runner error classifications", async () => {
-    await expect(
-      dispatcher.dispatch({
-        ...baseInput,
-        runtime: { language: "TYPESCRIPT" },
-        code: {
-          source: `function evaluate() { throw new Error("boom") }`,
-        },
-      }),
-    ).rejects.toMatchObject({
-      code: "USER_CODE_ERROR",
-      message: "boom",
-      retryable: false,
-    } satisfies Partial<CodeEvalDispatcherError>);
-  });
+  it(
+    "preserves runner error classifications",
+    async () => {
+      await expect(
+        dispatcher.dispatch({
+          ...baseInput,
+          runtime: { language: "TYPESCRIPT" },
+          code: {
+            source: `function evaluate() { throw new Error("boom") }`,
+          },
+        }),
+      ).rejects.toMatchObject({
+        code: "USER_CODE_ERROR",
+        message: "boom",
+        retryable: false,
+      } satisfies Partial<CodeEvalDispatcherError>);
+    },
+    FLOCI_TEST_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary

- Splits SDK API spec updates into token-free preparation steps and token-backed push/PR steps.
- Keeps clone, generated file copy, dependency install, formatting, diffing, branch creation, and commit creation out of the GitHub write-token environment.
- Resolves the original author only when creating the SDK PRs, where GitHub API access is already needed.

## Linear

- [LFE-10091](https://linear.app/langfuse/issue/LFE-10091/vulnerability-langfuse-sdk-workflow-exposes-write-token-to-mutable)

## Major Decisions

- Kept the existing single workflow and SDK update behavior, but narrowed the secret-bearing surface by moving write-token usage into dedicated push steps.

## Review Focus

- Confirm the split preserves the existing Python and TypeScript SDK update flow.
- Check that `GH_ACCESS_TOKEN` is only available where closing bot PRs, pushing branches, and creating PRs require it.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR narrows the write-token exposure surface in the SDK API spec workflow by splitting each SDK update into a token-free "prepare" step (clone, copy files, format, diff, commit) and a token-bearing "push" step (close stale PRs, push branch, create PR). `GH_TOKEN` is now injected only into the two push steps, and the previous `gh auth login --with-token` pattern is replaced by the idiomatic `GH_TOKEN` env-var approach with `gh auth setup-git` called correctly before `git push`.

- Both prepare steps run entirely without credentials; branch creation and local commits happen before any token is loaded into the environment.
- `ORIGINAL_AUTHOR` resolution via `gh api` is moved into the push steps (where GitHub API access is already required), eliminating the redundant `cd ../langfuse` / `cd ../langfuse-python` directory dance from the original code.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The workflow change is safe to merge; it correctly scopes the write token and preserves the existing SDK update logic end-to-end.

The token-scoping refactor is correct and the authentication flow works as intended. The only rough edge is the pre-existing pattern where a null author login from the GitHub API causes gh pr create --reviewer null to fail after the branch has already been pushed, leaving an orphaned branch. This is not a regression introduced by the PR, but moving the lookup into the push step is a good opportunity to add a guard.

.github/workflows/sdk-api-spec.yml — both push steps share the same ORIGINAL_AUTHOR / --reviewer pattern worth hardening.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant WF as Workflow Runner
    participant PR as langfuse-python/js repo
    participant GH as GitHub API
    participant GHT as GH_TOKEN (secret)

    Note over WF: Prepare Python SDK update (no token)
    WF->>PR: git clone
    WF->>WF: Copy generated files, format, diff
    WF-->>WF: Output: has_changes, branch_name

    Note over WF,GHT: Push Python SDK update (token scoped here only)
    WF->>GHT: GH_TOKEN loaded into env
    WF->>PR: "gh pr list | xargs gh pr close"
    WF->>WF: gh auth setup-git
    WF->>PR: git push origin BRANCH_NAME
    WF->>GH: gh api repos/.../commits/SHA (get author)
    WF->>PR: gh pr create --reviewer ORIGINAL_AUTHOR

    Note over WF: Prepare TypeScript SDK update (no token)
    WF->>PR: git clone (langfuse-js)
    WF->>WF: Copy generated files, format, diff
    WF-->>WF: Output: has_changes, branch_name

    Note over WF,GHT: Push TypeScript SDK update (token scoped here only)
    WF->>GHT: GH_TOKEN loaded into env
    WF->>PR: "gh pr list | xargs gh pr close"
    WF->>WF: gh auth setup-git
    WF->>PR: git push origin BRANCH_NAME
    WF->>GH: gh api repos/.../commits/SHA (get author)
    WF->>PR: gh pr create --reviewer ORIGINAL_AUTHOR
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/sdk-api-spec.yml:109-110
**Orphaned branch when author lookup returns `null`**

If the commit has no associated GitHub user (e.g. a deleted account or a bot commit), `gh api .../commits/${GITHUB_SHA} --jq '.author.login'` returns the literal string `null`. The subsequent `gh pr create --reviewer "null"` will fail, leaving the already-pushed branch in the remote without a corresponding PR. This is pre-existing behaviour — the old code had the same race — but since the lookup was moved here alongside the push it is worth adding an explicit guard or a `|| true` fallback on the reviewer flag.

### Issue 2 of 2
.github/workflows/sdk-api-spec.yml:176-177
**Same orphaned-branch risk in the TypeScript push step**

Identical pattern: if `ORIGINAL_AUTHOR` resolves to `null`, `gh pr create --reviewer "null"` will fail after `git push` has already completed, leaving an unparented branch in `langfuse-js`. Applies the same logic as the Python push step above.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: limit SDK workflow write token expos..."](https://github.com/langfuse/langfuse/commit/8874f059221066e8df5dfc7da2e530035af3816c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35165780)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->