### PR TITLE
fix(datasets): gate remote experiment config reads

### DIFF
--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -449,6 +449,17 @@ export const datasetRouter = createTRPCRouter({
             projectId: input.projectId,
           },
         },
+        select: {
+          id: true,
+          projectId: true,
+          name: true,
+          description: true,
+          metadata: true,
+          inputSchema: true,
+          expectedOutputSchema: true,
+          createdAt: true,
+          updatedAt: true,
+        },
       });
     }),
   runById: protectedProjectProcedure
@@ -1704,6 +1715,12 @@ export const datasetRouter = createTRPCRouter({
   getRemoteExperiment: protectedProjectProcedure
     .input(z.object({ projectId: z.string(), datasetId: z.string() }))
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:CUD",
+      });
+
       const dataset = await ctx.prisma.dataset.findUnique({
         where: {
           id_projectId: { id: input.datasetId, projectId: input.projectId },


### PR DESCRIPTION
## What changed

- Require `datasets:CUD` server-side before returning remote experiment config from `datasets.getRemoteExperiment`.
- Restrict `datasets.byId` to the regular dataset fields so project readers cannot receive remote experiment URL/payload fields through the generic dataset read endpoint.

## Why

LFE-10055 identified that the UI hid remote experiment management behind a write-access check, but the tRPC resolver only required project membership. A project viewer could call the resolver directly and read the stored remote experiment URL/payload. `datasets.byId` also returned the full Prisma `Dataset`, including the same config columns.

## Impacted packages

- `web`

## Verification

- Pre-commit hook passed: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli`
- Pre-commit hook passed: `turbo run lint`
- Targeted tests not run per request.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR patches two authorization holes that allowed project-viewer members to read sensitive remote experiment configuration (webhook URL and payload). Both `datasets.byId` and `datasets.getRemoteExperiment` were accessible to anyone with project membership, even though the UI restricted the feature to users with write access.

- **`datasets.getRemoteExperiment`**: adds an explicit `throwIfNoProjectAccess` call requiring `datasets:CUD` before the Prisma query executes, preventing read-only members from retrieving the stored webhook URL and default payload.
- **`datasets.byId`**: narrows the Prisma `select` to only the non-sensitive dataset columns (`id`, `name`, `description`, `metadata`, `inputSchema`, `expectedOutputSchema`, `createdAt`, `updatedAt`), stripping `remoteExperimentUrl`, `remoteExperimentPayload`, and `remoteExperimentEnabled` from the generic read path.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both changes are minimal, targeted authorization fixes with no new logic paths introduced.

The diff is small and surgical. Both hunks close a read-access gap by either adding an access-control check or restricting a Prisma select; neither change adds new behavior. The rest of the remote-experiment surface was already correctly guarded, so the fixes bring getRemoteExperiment and byId into line with the existing pattern. TypeScript's narrowed Prisma return type acts as a compile-time regression guard for any callers of byId that might have previously consumed the removed fields.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant tRPC as tRPC Router
    participant Auth as throwIfNoProjectAccess
    participant DB as Prisma / DB

    Note over Client,DB: datasets.byId
    Client->>tRPC: "byId({ projectId, datasetId })"
    tRPC->>DB: findUnique (select: safe fields only)
    DB-->>tRPC: "{ id, name, description, metadata, ... }"
    tRPC-->>Client: No remoteExperimentUrl/Payload/Enabled

    Note over Client,DB: datasets.getRemoteExperiment
    Client->>tRPC: "getRemoteExperiment({ projectId, datasetId })"
    tRPC->>Auth: "scope = datasets:CUD"
    alt User has datasets:CUD
        Auth-->>tRPC: allowed
        tRPC->>DB: findUnique (select: remoteExperiment fields)
        DB-->>tRPC: "{ remoteExperimentUrl, remoteExperimentPayload, remoteExperimentEnabled }"
        tRPC-->>Client: "{ url, payload, enabled }"
    else Viewer / no CUD scope
        Auth-->>tRPC: throws UNAUTHORIZED
        tRPC-->>Client: UNAUTHORIZED error
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(datasets): gate remote experiment co..."](https://github.com/langfuse/langfuse/commit/dcc9fff6d3ea047dfda524dd007bd8f1a0a40099) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35322030)</sub>

<!-- /greptile_comment -->