### PR TITLE
chore(deps): bump pnpm to 11.4.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ FROM mcr.microsoft.com/devcontainers/universal:2
 COPY --from=migrate-builder /out/migrate /usr/local/bin/migrate
 
 # Activate the repo's pinned pnpm via Corepack
-RUN corepack enable && corepack prepare pnpm@11.1.3 --activate
+RUN corepack enable && corepack prepare pnpm@11.4.0 --activate
 
 # Install Clickhouse
 RUN curl https://clickhouse.com/ | sh && \

--- a/.github/workflows/ci.yml.template
+++ b/.github/workflows/ci.yml.template
@@ -30,7 +30,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
         with:
-          version: 11.1.3
+          version: 11.4.0
 
       - name: Setup Node 24
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -99,7 +99,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.3
+          version: 11.4.0
       - name: Use Node.js ${{ env.NODE_VERSION }} without cache
         if: env.CI_CACHE_ALLOWED != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -145,7 +145,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.3
+          version: 11.4.0
       - name: Use Node.js ${{ env.NODE_VERSION }} without cache
         if: env.CI_CACHE_ALLOWED != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -202,7 +202,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.3
+          version: 11.4.0
       - name: Use Node.js ${{ env.NODE_VERSION }} without cache
         if: env.CI_CACHE_ALLOWED != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -234,7 +234,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.3
+          version: 11.4.0
       - name: Use Node.js ${{ env.NODE_VERSION }} without cache
         if: env.CI_CACHE_ALLOWED != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -351,7 +351,7 @@ jobs:
           which migrate
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.3
+          version: 11.4.0
       - name: Login to Docker Hub
         if: github.repository == 'langfuse/langfuse' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -474,7 +474,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.3
+          version: 11.4.0
       - name: Login to Docker Hub
         if: github.repository == 'langfuse/langfuse' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -560,7 +560,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.3
+          version: 11.4.0
       - name: Login to Docker Hub
         if: github.repository == 'langfuse/langfuse' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -637,7 +637,7 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.3
+          version: 11.4.0
       - name: Use Node.js ${{ env.NODE_VERSION }} without cache
         if: env.CI_CACHE_ALLOWED != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -738,7 +738,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN_READ }}
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.3
+          version: 11.4.0
       - name: Use Node.js ${{ env.NODE_VERSION }} without cache
         if: env.CI_CACHE_ALLOWED != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/sdk-api-spec.yml
+++ b/.github/workflows/sdk-api-spec.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 11.1.3
+          version: 11.4.0
 
       # Keep this secret-bearing job cache-cold to avoid exposing Fern and
       # GitHub write credentials to potentially poisoned shared package-manager state.
@@ -132,7 +132,7 @@ jobs:
 
           # Install dependencies and format
           corepack enable
-          corepack prepare pnpm@11.1.3 --activate
+          corepack prepare pnpm@11.4.0 --activate
           pnpm install
           pnpm format
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ We built a monorepo using [pnpm](https://pnpm.io/motivation) and [turbo](https:/
 Requirements
 
 - Node.js 24 as specified in the [.nvmrc](.nvmrc)
-- Pnpm v.11.1.3
+- Pnpm v.11.4.0
 - Docker to run the database locally
 - Clickhouse client
 

--- a/package.json
+++ b/package.json
@@ -97,5 +97,5 @@
       }
     }
   },
-  "packageManager": "pnpm@11.1.3"
+  "packageManager": "pnpm@11.4.0"
 }

--- a/scripts/codex/maintenance.sh
+++ b/scripts/codex/maintenance.sh
@@ -8,7 +8,7 @@ if ! command -v corepack >/dev/null 2>&1; then
 fi
 
 corepack enable
-corepack prepare pnpm@11.1.3 --activate
+corepack prepare pnpm@11.4.0 --activate
 
 pnpm install --frozen-lockfile
 

--- a/scripts/codex/maintenance_cloud.sh
+++ b/scripts/codex/maintenance_cloud.sh
@@ -8,7 +8,7 @@ if ! command -v corepack >/dev/null 2>&1; then
 fi
 
 corepack enable
-corepack prepare pnpm@11.1.3 --activate
+corepack prepare pnpm@11.4.0 --activate
 
 # shellcheck source=/dev/null
 source "$(dirname "${BASH_SOURCE[0]}")/cloud_services.sh"

--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -19,7 +19,7 @@ if ! command -v corepack >/dev/null 2>&1; then
 fi
 
 corepack enable
-corepack prepare pnpm@11.1.3 --activate
+corepack prepare pnpm@11.4.0 --activate
 
 ensure_env_file .env .env.dev.example
 ensure_env_file .env.test .env.test.example

--- a/scripts/codex/setup_cloud.sh
+++ b/scripts/codex/setup_cloud.sh
@@ -19,7 +19,7 @@ if ! command -v corepack >/dev/null 2>&1; then
 fi
 
 corepack enable
-corepack prepare pnpm@11.1.3 --activate
+corepack prepare pnpm@11.4.0 --activate
 
 ensure_env_file .env .env.dev.example
 ensure_env_file .env.test .env.test.example

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install turbo@2.9.14 --global
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
-RUN corepack prepare pnpm@11.1.3 --activate
+RUN corepack prepare pnpm@11.4.0 --activate
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS runtime-base
 # Remove build-only package managers. npm stays here because the runner stage

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install turbo@2.9.14 --global
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
-RUN corepack prepare pnpm@11.1.3 --activate
+RUN corepack prepare pnpm@11.4.0 --activate
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine AS runtime-base
 # package managers and build-only CLIs only increase exposure to CVEs -> remove them


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Bumps pnpm from `11.1.3` to `11.4.0` consistently across all environments and tooling in the monorepo.

- All `corepack prepare pnpm@...` calls in Dockerfiles, shell scripts, and CI workflows are updated in lockstep with the `packageManager` field in `package.json` and the `CONTRIBUTING.md` requirement.
- The change is purely mechanical with no logic alterations; every reference to the old version string has been replaced.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — every reference to the old pnpm version string is updated consistently and no logic is touched.

The change touches only version strings across Dockerfiles, shell scripts, CI workflow YAML, package.json, and documentation. All 12 files are updated in lockstep from 11.1.3 to 11.4.0; there are no partial updates, no logic changes, and no overlooked files.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer / CI] -->|corepack prepare| B[pnpm 11.4.0]
    B --> C[pnpm install frozen-lockfile]
    C --> D[Build and Test]

    subgraph Environments
        E[.devcontainer Dockerfile]
        F[web Dockerfile]
        G[worker Dockerfile]
        H[scripts/codex shell scripts]
        I[GitHub Actions workflows]
    end

    B -.->|activated in| E
    B -.->|activated in| F
    B -.->|activated in| G
    B -.->|activated in| H
    B -.->|version 11.4.0| I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump pnpm to 11.4.0"](https://github.com/langfuse/langfuse/commit/d11510fced586f59c17670221fa6c68b2a6ff090) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35241056)</sub>

<!-- /greptile_comment -->