### PR TITLE
fix(evals): skip trace ordering for eval creation

### DIFF
--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -514,6 +514,7 @@ export const getTraceById = async ({
   preferredClickhouseService,
   excludeInputOutput = false,
   excludeMetadata = false,
+  orderByEventTs = true,
 }: {
   traceId: string;
   projectId: string;
@@ -526,6 +527,8 @@ export const getTraceById = async ({
   excludeInputOutput?: boolean;
   /** When true, sets metadata column to empty in the query to reduce database load */
   excludeMetadata?: boolean;
+  /** When true, returns the latest physical trace version by event timestamp. */
+  orderByEventTs?: boolean;
 }) => {
   const records = await measureAndReturn({
     operationName: "getTraceById",
@@ -587,7 +590,7 @@ export const getTraceById = async ({
         AND project_id = {projectId: String}
         ${timestamp ? `AND toDate(timestamp) = toDate({timestamp: DateTime64(3)})` : ""}
         ${fromTimestamp ? `AND timestamp >= {fromTimestamp: DateTime64(3)}` : ""}
-        ORDER BY event_ts DESC
+        ${orderByEventTs ? "ORDER BY event_ts DESC" : ""}
         LIMIT 1
       `;
 

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -42,11 +42,12 @@ vi.mock("@langfuse/shared/src/server", async () => {
     fetchLLMCompletion: vi
       .fn()
       .mockImplementation(actual.fetchLLMCompletion as any),
+    getTraceById: vi.fn().mockImplementation(actual.getTraceById as any),
   };
 });
 
 // Import the mocked function
-import { fetchLLMCompletion } from "@langfuse/shared/src/server";
+import { fetchLLMCompletion, getTraceById } from "@langfuse/shared/src/server";
 import { UnrecoverableError } from "../errors/UnrecoverableError";
 
 let OPENAI_API_KEY = process.env.OPENAI_API_KEY;
@@ -791,6 +792,83 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
       // If this does not throw, we're good.
       expect(true).toBe(true);
     });
+
+    test("fetches cached trace without event timestamp ordering when creating eval jobs", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      const traceId = randomUUID();
+      const now = new Date();
+
+      await prisma.jobConfiguration.createMany({
+        data: [
+          {
+            id: randomUUID(),
+            projectId,
+            filter: JSON.parse("[]"),
+            jobType: "EVAL",
+            delay: 0,
+            sampling: new Decimal("1"),
+            targetObject: EvalTargetObject.TRACE,
+            scoreName: "score-a",
+            variableMapping: JSON.parse("[]"),
+          },
+          {
+            id: randomUUID(),
+            projectId,
+            filter: JSON.parse("[]"),
+            jobType: "EVAL",
+            delay: 0,
+            sampling: new Decimal("1"),
+            targetObject: EvalTargetObject.TRACE,
+            scoreName: "score-b",
+            variableMapping: JSON.parse("[]"),
+          },
+        ],
+      });
+
+      const mockGetTraceById = vi.mocked(getTraceById);
+      mockGetTraceById.mockClear();
+      mockGetTraceById.mockResolvedValueOnce({
+        id: traceId,
+        projectId,
+        timestamp: now,
+        name: null,
+        environment: "default",
+        tags: [],
+        bookmarked: false,
+        public: false,
+        release: null,
+        version: null,
+        input: null,
+        output: null,
+        metadata: {},
+        createdAt: now,
+        updatedAt: now,
+        sessionId: null,
+        userId: null,
+      });
+
+      await createEvalJobs({
+        sourceEventType: "trace-upsert",
+        event: {
+          projectId,
+          traceId,
+          timestamp: now,
+        },
+        jobTimestamp,
+      });
+
+      expect(mockGetTraceById).toHaveBeenCalledTimes(1);
+      expect(mockGetTraceById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          traceId,
+          projectId,
+          clickhouseFeatureTag: "eval-create",
+          excludeInputOutput: true,
+          excludeMetadata: false,
+          orderByEventTs: false,
+        }),
+      );
+    }, 10_000);
 
     test("creates new eval job for a dataset on upsert of the trace", async () => {
       const { projectId } = await createOrgProjectAndApiKey();

--- a/worker/src/__tests__/evalService.test.ts
+++ b/worker/src/__tests__/evalService.test.ts
@@ -42,12 +42,11 @@ vi.mock("@langfuse/shared/src/server", async () => {
     fetchLLMCompletion: vi
       .fn()
       .mockImplementation(actual.fetchLLMCompletion as any),
-    getTraceById: vi.fn().mockImplementation(actual.getTraceById as any),
   };
 });
 
 // Import the mocked function
-import { fetchLLMCompletion, getTraceById } from "@langfuse/shared/src/server";
+import { fetchLLMCompletion } from "@langfuse/shared/src/server";
 import { UnrecoverableError } from "../errors/UnrecoverableError";
 
 let OPENAI_API_KEY = process.env.OPENAI_API_KEY;
@@ -792,83 +791,6 @@ Respond with JSON: {"score": <number>, "reasoning": "<explanation>"}`;
       // If this does not throw, we're good.
       expect(true).toBe(true);
     });
-
-    test("fetches cached trace without event timestamp ordering when creating eval jobs", async () => {
-      const { projectId } = await createOrgProjectAndApiKey();
-      const traceId = randomUUID();
-      const now = new Date();
-
-      await prisma.jobConfiguration.createMany({
-        data: [
-          {
-            id: randomUUID(),
-            projectId,
-            filter: JSON.parse("[]"),
-            jobType: "EVAL",
-            delay: 0,
-            sampling: new Decimal("1"),
-            targetObject: EvalTargetObject.TRACE,
-            scoreName: "score-a",
-            variableMapping: JSON.parse("[]"),
-          },
-          {
-            id: randomUUID(),
-            projectId,
-            filter: JSON.parse("[]"),
-            jobType: "EVAL",
-            delay: 0,
-            sampling: new Decimal("1"),
-            targetObject: EvalTargetObject.TRACE,
-            scoreName: "score-b",
-            variableMapping: JSON.parse("[]"),
-          },
-        ],
-      });
-
-      const mockGetTraceById = vi.mocked(getTraceById);
-      mockGetTraceById.mockClear();
-      mockGetTraceById.mockResolvedValueOnce({
-        id: traceId,
-        projectId,
-        timestamp: now,
-        name: null,
-        environment: "default",
-        tags: [],
-        bookmarked: false,
-        public: false,
-        release: null,
-        version: null,
-        input: null,
-        output: null,
-        metadata: {},
-        createdAt: now,
-        updatedAt: now,
-        sessionId: null,
-        userId: null,
-      });
-
-      await createEvalJobs({
-        sourceEventType: "trace-upsert",
-        event: {
-          projectId,
-          traceId,
-          timestamp: now,
-        },
-        jobTimestamp,
-      });
-
-      expect(mockGetTraceById).toHaveBeenCalledTimes(1);
-      expect(mockGetTraceById).toHaveBeenCalledWith(
-        expect.objectContaining({
-          traceId,
-          projectId,
-          clickhouseFeatureTag: "eval-create",
-          excludeInputOutput: true,
-          excludeMetadata: false,
-          orderByEventTs: false,
-        }),
-      );
-    }, 10_000);
 
     test("creates new eval job for a dataset on upsert of the trace", async () => {
       const { projectId } = await createOrgProjectAndApiKey();

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -271,6 +271,7 @@ export const createEvalJobs = async ({
         clickhouseFeatureTag: "eval-create",
         excludeInputOutput: true,
         excludeMetadata: false, // Metadata needed for in-memory filter evaluation
+        orderByEventTs: false,
       });
 
       recordIncrement("langfuse.evaluation-execution.trace_cache_fetch", 1, {


### PR DESCRIPTION
## Summary

- Add an `orderByEventTs` option to `getTraceById`, defaulting to the existing latest-version behavior.
- Use `orderByEventTs: false` for the eval creation cached trace fetch so this path avoids `ORDER BY event_ts DESC`.

Linear: https://linear.app/langfuse/issue/LFE-10108/remove-trace-ordering-from-eval-creation-fetches

## Impacted packages

- `packages/shared`
- `worker`

## Verification

- `pnpm --filter @langfuse/shared run db:generate`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter @langfuse/shared run lint`
- `pnpm --filter @langfuse/shared run typecheck`
- `pnpm --filter worker run lint`
- `pnpm --filter worker run typecheck`

Note: no regression test is included per follow-up request.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Introduces an `orderByEventTs` option to `getTraceById` (default `true`) and uses `orderByEventTs: false` in the eval-creation cached-trace fetch path to eliminate the `ORDER BY event_ts DESC` clause as a performance optimisation.

- `packages/shared`: Adds the `orderByEventTs` parameter to `getTraceById`, conditionally omitting the `ORDER BY event_ts DESC` clause when the flag is `false`.
- `worker/evalService.ts`: Passes `orderByEventTs: false` to the pre-fetch that caches a trace when multiple eval configs are processed together.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change deliberately removes deterministic ordering on the cached-trace fetch path; callers using that result for in-memory filter evaluation may act on a stale trace version, silently skipping or creating eval jobs incorrectly.

Removing `ORDER BY event_ts DESC` makes `LIMIT 1` non-deterministic in ClickHouse whenever multiple physical versions of a trace coexist (pre-merge). The cached trace is then used directly for in-memory filter evaluation against mutable fields such as `metadata`, `tags`, `name`, `version`, and `release`. A stale row here can produce the wrong filter outcome with no error surfaced — eval jobs are silently missed or spuriously created.

Both changed files warrant close attention: `traces.ts` for the query-level non-determinism, and `evalService.ts` for how the non-deterministic result drives filter decisions without any fallback for stale data.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as Worker (createEvalJobs)
    participant CH as ClickHouse
    participant P as Postgres (Prisma)

    W->>W: "configs.length > 1?"
    alt Multiple configs
        W->>CH: getTraceById(orderByEventTs: false) LIMIT 1 no ORDER BY
        CH-->>W: cachedTrace (any physical row)
    end

    loop For each config
        W->>W: requiresDatabaseLookup(traceFilter)?
        alt In-memory filter possible
            W->>W: InMemoryFilterService.evaluateFilter(cachedTrace, filter)
            W->>W: "traceExists = result"
        else DB lookup required
            W->>CH: checkTraceExistsAndGetTimestamp(...)
            CH-->>W: exists + timestamp
        end

        alt traceExists
            W->>P: Create JobExecution
        end
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/repositories/traces.ts:593-594
**Non-deterministic row returned when `orderByEventTs: false`**

Without `ORDER BY event_ts DESC`, ClickHouse's `LIMIT 1` returns whichever physical row appears first in storage order. In a ReplacingMergeTree, before a part merge completes, multiple physical versions of the same trace row coexist. The row returned could be any of those versions — not necessarily the latest. In `evalService.ts` this result is passed straight into `InMemoryFilterService.evaluateFilter` for in-memory filter checks against mutable fields like `metadata`, `tags`, `name`, `version`, `release`, and `environment`. A stale version can cause filter mismatches, silently skipping an eval job that should have been created (or vice-versa).

### Issue 2 of 2
packages/shared/src/server/repositories/traces.ts:530-531
The JSDoc describes only the `true` case. The `false` case — that `LIMIT 1` returns a non-deterministic physical row (any version, not necessarily the latest) — is worth documenting so callers understand the consistency trade-off they are accepting.

```suggestion
  /**
   * When true, returns the latest physical trace version by ordering on event_ts DESC.
   * When false, ORDER BY is omitted and LIMIT 1 returns an indeterminate physical row;
   * use only when consistency of mutable fields is not required (e.g. pure performance
   * optimisation paths where filter false-negatives are acceptable).
   */
  orderByEventTs?: boolean;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(evals): remove trace ordering asser..."](https://github.com/langfuse/langfuse/commit/cd3b2054a588733e8c32b54b7660f20447ee54fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35246894)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->