### PR TITLE
feat(public-api): tag legacy ClickHouse queries with API paths

### DIFF
--- a/packages/shared/src/features/query/server/queryExecutor.ts
+++ b/packages/shared/src/features/query/server/queryExecutor.ts
@@ -23,6 +23,7 @@ export async function prepareExecuteQuery(opts: {
   query: QueryType;
   version?: ViewVersion;
   enableSingleLevelOptimization?: boolean;
+  clickhouseTags?: Record<string, string>;
 }): Promise<PreparedQuery> {
   const {
     projectId,
@@ -54,6 +55,7 @@ export async function prepareExecuteQuery(opts: {
     : undefined;
 
   const tags = {
+    ...(opts.clickhouseTags ?? {}),
     feature: "custom-queries",
     type: query.view,
     kind: "analytic",
@@ -98,12 +100,14 @@ export async function executeQuery(
   query: QueryType,
   version: ViewVersion = "v1",
   enableSingleLevelOptimization: boolean = false,
+  clickhouseTags?: Record<string, string>,
 ): Promise<Array<Record<string, unknown>>> {
   const prepared = await prepareExecuteQuery({
     projectId,
     query,
     version,
     enableSingleLevelOptimization,
+    clickhouseTags,
   });
 
   const chOpts = toClickhouseQueryOpts(prepared);

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -681,6 +681,7 @@ export const getObservationByIdFromEventsTable = async ({
   traceId,
   renderingProps = DEFAULT_RENDERING_PROPS,
   preferredClickhouseService,
+  clickhouseTags,
 }: {
   id: string;
   projectId: string;
@@ -690,6 +691,7 @@ export const getObservationByIdFromEventsTable = async ({
   traceId?: string;
   renderingProps?: RenderingProps;
   preferredClickhouseService?: PreferredClickhouseService;
+  clickhouseTags?: Record<string, string>;
 }) => {
   const records = await getObservationByIdFromEventsTableInternal({
     id,
@@ -700,6 +702,7 @@ export const getObservationByIdFromEventsTable = async ({
     traceId,
     renderingProps,
     preferredClickhouseService: preferredClickhouseService ?? "EventsReadOnly",
+    clickhouseTags,
   });
   const mapped = records.map((record) => {
     // Remove raw tags field as this is re-mapped to traceTags
@@ -890,6 +893,7 @@ async function getObservationByIdFromEventsTableInternal({
   traceId,
   renderingProps = DEFAULT_RENDERING_PROPS,
   preferredClickhouseService,
+  clickhouseTags,
 }: {
   id: string;
   projectId: string;
@@ -899,6 +903,7 @@ async function getObservationByIdFromEventsTableInternal({
   traceId?: string;
   renderingProps?: RenderingProps;
   preferredClickhouseService?: PreferredClickhouseService;
+  clickhouseTags?: Record<string, string>;
 }) {
   const queryBuilder = new EventsQueryBuilder({ projectId })
     .selectFieldSet("byIdBase", "byIdModel", "byIdPrompt", "byIdTimestamps")
@@ -930,6 +935,7 @@ async function getObservationByIdFromEventsTableInternal({
     query,
     params,
     tags: {
+      ...(clickhouseTags ?? {}),
       feature: "tracing",
       type: "events",
       kind: "byId",
@@ -1090,6 +1096,7 @@ type PublicApiObservationsQuery = {
    * - string[]: expand specified keys (or all keys if empty array)
    */
   expandMetadataKeys?: string[] | null;
+  clickhouseTags?: Record<string, string>;
 };
 
 type BuildObservationsQueryComponentsOptions = {
@@ -1154,7 +1161,12 @@ function buildObservationsQueryComponents(
     queryWithParams: { query: string; params: Record<string, any> };
   }>;
 } {
-  const { projectId, advancedFilters, ...filterParams } = opts;
+  const {
+    projectId,
+    advancedFilters,
+    clickhouseTags: _clickhouseTags,
+    ...filterParams
+  } = opts;
 
   if (!options.allowUnindexedIoFilters) {
     validateInputOutputFilterTypes(advancedFilters, columnDefinitions);
@@ -1284,6 +1296,7 @@ async function getObservationsRowsFromBuilder<T>(
   projectId: string,
   queryBuilder: QueryWithParams,
   operationName: string = "getObservationsFromEventsTableForPublicApi_rows",
+  clickhouseTags?: Record<string, string>,
 ): Promise<Array<T>> {
   const { query, params } = queryBuilder.buildWithParams();
 
@@ -1293,6 +1306,7 @@ async function getObservationsRowsFromBuilder<T>(
     input: {
       params,
       tags: {
+        ...(clickhouseTags ?? {}),
         feature: "tracing",
         type: "events",
         kind: "publicApiRows",
@@ -1332,6 +1346,7 @@ async function getObservationsCountFromEventsTableForPublicApiInternal(
     input: {
       params,
       tags: {
+        ...(opts.clickhouseTags ?? {}),
         feature: "tracing",
         type: "events",
         kind: "publicApiCount",
@@ -1374,6 +1389,8 @@ export const getObservationsFromEventsTableForPublicApi = async (
     await getObservationsRowsFromBuilder<ObservationsTableQueryResultWitouhtTraceFields>(
       projectId,
       queryBuilder,
+      undefined,
+      opts.clickhouseTags,
     );
 
   const observations = await enrichObservationsWithModelData(
@@ -1457,6 +1474,8 @@ export const getObservationsV2FromEventsTableForPublicApi = async (
     await getObservationsRowsFromBuilder<ObservationsTableQueryResultWitouhtTraceFields>(
       projectId,
       builder,
+      undefined,
+      opts.clickhouseTags,
     );
 
   return await enrichObservationsWithModelData(
@@ -1494,6 +1513,7 @@ type PublicApiTracesQuery = {
   fields?: string[];
   advancedFilters?: FilterState;
   orderBy?: { column: string; order: "ASC" | "DESC" } | null;
+  clickhouseTags?: Record<string, string>;
 };
 
 /**
@@ -1511,6 +1531,7 @@ async function getTracesFromEventsTableForPublicApiInternal<T>(
     advancedFilters,
     fields,
     orderBy,
+    clickhouseTags,
     ...filterParams
   } = opts;
 
@@ -1649,6 +1670,7 @@ async function getTracesFromEventsTableForPublicApiInternal<T>(
     input: {
       params,
       tags: {
+        ...(clickhouseTags ?? {}),
         feature: "tracing",
         type: "traces",
         kind: opts.select === "count" ? "publicApiCount" : "publicApiRows",

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -131,6 +131,7 @@ export type GetObservationsForTraceOpts<IncludeIO extends boolean> = {
   timestamp?: Date;
   includeIO?: IncludeIO;
   preferredClickhouseService?: PreferredClickhouseService;
+  clickhouseTags?: Record<string, string>;
 };
 
 export const getObservationsForTrace = async <IncludeIO extends boolean>(
@@ -142,6 +143,7 @@ export const getObservationsForTrace = async <IncludeIO extends boolean>(
     timestamp,
     includeIO = false,
     preferredClickhouseService,
+    clickhouseTags,
   } = opts;
 
   // OTel projects use immutable spans - no need for deduplication
@@ -196,6 +198,7 @@ export const getObservationsForTrace = async <IncludeIO extends boolean>(
         : {}),
     },
     tags: {
+      ...(clickhouseTags ?? {}),
       feature: "tracing",
       type: "observation",
       kind: "list",
@@ -337,6 +340,7 @@ export const getObservationById = async ({
   traceId,
   renderingProps = DEFAULT_RENDERING_PROPS,
   preferredClickhouseService,
+  clickhouseTags,
 }: {
   id: string;
   projectId: string;
@@ -346,6 +350,7 @@ export const getObservationById = async ({
   traceId?: string;
   renderingProps?: RenderingProps;
   preferredClickhouseService?: PreferredClickhouseService;
+  clickhouseTags?: Record<string, string>;
 }) => {
   const records = await getObservationByIdInternal({
     id,
@@ -356,6 +361,7 @@ export const getObservationById = async ({
     traceId,
     renderingProps,
     preferredClickhouseService,
+    clickhouseTags,
   });
   const mapped = records.map((record) =>
     convertObservation(record, renderingProps),
@@ -446,6 +452,7 @@ const getObservationByIdInternal = async ({
   traceId,
   renderingProps = DEFAULT_RENDERING_PROPS,
   preferredClickhouseService,
+  clickhouseTags,
 }: {
   id: string;
   projectId: string;
@@ -455,6 +462,7 @@ const getObservationByIdInternal = async ({
   traceId?: string;
   renderingProps?: RenderingProps;
   preferredClickhouseService?: PreferredClickhouseService;
+  clickhouseTags?: Record<string, string>;
 }) => {
   const query = `
   SELECT
@@ -511,6 +519,7 @@ const getObservationByIdInternal = async ({
       ...(traceId ? { traceId } : {}),
     },
     tags: {
+      ...(clickhouseTags ?? {}),
       feature: "tracing",
       type: "observation",
       kind: "byId",

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -179,6 +179,7 @@ export type GetScoresForTracesProps<
   excludeMetadata?: ExcludeMetadata;
   includeHasMetadata?: IncludeHasMetadata;
   preferredClickhouseService?: PreferredClickhouseService;
+  clickhouseTags?: Record<string, string>;
 };
 
 type GetScoresForSessionsProps<
@@ -515,6 +516,7 @@ const getScoresForTracesInternal = async <
     excludeMetadata = false,
     includeHasMetadata = false,
     preferredClickhouseService,
+    clickhouseTags,
   } = props;
 
   const select = formatMetadataSelect(excludeMetadata, includeHasMetadata);
@@ -560,6 +562,7 @@ const getScoresForTracesInternal = async <
         : {}),
     },
     tags: {
+      ...(clickhouseTags ?? {}),
       feature: "tracing",
       type: "score",
       kind: "list",

--- a/packages/shared/src/server/repositories/traces.ts
+++ b/packages/shared/src/server/repositories/traces.ts
@@ -514,6 +514,7 @@ export const getTraceById = async ({
   preferredClickhouseService,
   excludeInputOutput = false,
   excludeMetadata = false,
+  clickhouseTags,
 }: {
   traceId: string;
   projectId: string;
@@ -526,6 +527,7 @@ export const getTraceById = async ({
   excludeInputOutput?: boolean;
   /** When true, sets metadata column to empty in the query to reduce database load */
   excludeMetadata?: boolean;
+  clickhouseTags?: Record<string, string>;
 }) => {
   const records = await measureAndReturn({
     operationName: "getTraceById",
@@ -542,6 +544,7 @@ export const getTraceById = async ({
           : {}),
       },
       tags: {
+        ...(clickhouseTags ?? {}),
         feature: clickhouseFeatureTag,
         type: "trace",
         kind: "byId",

--- a/web/src/features/public-api/server/observations.ts
+++ b/web/src/features/public-api/server/observations.ts
@@ -24,6 +24,7 @@ type QueryType = {
   toStartTime?: string;
   version?: string;
   advancedFilters?: FilterState;
+  clickhouseTags?: Record<string, string>;
 };
 
 export const generateObservationsForPublicApi = async (props: QueryType) => {
@@ -102,6 +103,7 @@ export const generateObservationsForPublicApi = async (props: QueryType) => {
           : {}),
       },
       tags: {
+        ...(props.clickhouseTags ?? {}),
         feature: "tracing",
         type: "observation",
         projectId: props.projectId,
@@ -140,6 +142,7 @@ export const getObservationsCountForPublicApi = async (props: QueryType) => {
     input: {
       params: { ...filter.params, projectId: props.projectId },
       tags: {
+        ...(props.clickhouseTags ?? {}),
         feature: "tracing",
         type: "observation",
         projectId: props.projectId,
@@ -165,7 +168,11 @@ const filterParams = createPublicApiObservationsColumnMapping(
 );
 
 const generateFilter = (query: QueryType) => {
-  const { advancedFilters, ...simpleFilterProps } = query;
+  const {
+    advancedFilters,
+    clickhouseTags: _clickhouseTags,
+    ...simpleFilterProps
+  } = query;
   const chFilter = deriveFilters(
     simpleFilterProps,
     filterParams,

--- a/web/src/features/public-api/server/traces.ts
+++ b/web/src/features/public-api/server/traces.ts
@@ -43,6 +43,7 @@ export type TraceQueryType = {
   toTimestamp?: string;
   fields?: TraceFieldGroup[];
   useEventsTable?: boolean | null;
+  clickhouseTags?: Record<string, string>;
 };
 
 async function buildTracesBaseQuery(
@@ -76,8 +77,10 @@ async function buildTracesBaseQuery(
   const propagateObservationsTimeBounds =
     env.LANGFUSE_API_CLICKHOUSE_PROPAGATE_OBSERVATIONS_TIME_BOUNDS === "true";
 
+  const { clickhouseTags: _clickhouseTags, ...filterProps } = props;
+
   let filter = deriveFilters(
-    props,
+    filterProps,
     filterParams,
     advancedFilters,
     tracesTableUiColumnDefinitions,
@@ -431,6 +434,7 @@ export const generateTracesForPublicApi = async ({
     input: {
       params,
       tags: {
+        ...(props.clickhouseTags ?? {}),
         feature: "tracing",
         type: "trace",
         kind: "public-api",
@@ -472,8 +476,9 @@ export const getTracesCountForPublicApi = async ({
   props: TraceQueryType;
   advancedFilters?: FilterState;
 }) => {
+  const { clickhouseTags: _clickhouseTags, ...filterProps } = props;
   let filter = deriveFilters(
-    props,
+    filterProps,
     filterParams,
     advancedFilters,
     tracesTableUiColumnDefinitions,
@@ -517,6 +522,7 @@ export const getTracesCountForPublicApi = async ({
     input: {
       params,
       tags: {
+        ...(props.clickhouseTags ?? {}),
         feature: "tracing",
         type: "trace",
         kind: "count",

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -28,7 +28,13 @@ export default withMiddlewares(
           });
 
           // Execute the query using QueryBuilder
-          const result = await executeQuery(auth.scope.projectId, queryParams);
+          const result = await executeQuery(
+            auth.scope.projectId,
+            queryParams,
+            "v1",
+            false,
+            { api_path: "GET /api/public/metrics" },
+          );
 
           // Format and return the result
           return {

--- a/web/src/pages/api/public/observations/[observationId].ts
+++ b/web/src/pages/api/public/observations/[observationId].ts
@@ -36,12 +36,18 @@ export default withMiddlewares(
               id: query.observationId,
               projectId: auth.scope.projectId,
               fetchWithInputOutput: true,
+              clickhouseTags: {
+                api_path: "GET /api/public/observations/{id}",
+              },
             })
           : await getObservationById({
               id: query.observationId,
               projectId: auth.scope.projectId,
               fetchWithInputOutput: true,
               preferredClickhouseService: "ReadOnly",
+              clickhouseTags: {
+                api_path: "GET /api/public/observations/{id}",
+              },
             });
 
         if (!clickhouseObservation) {

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -44,6 +44,7 @@ export default withMiddlewares(
           toStartTime: query.toStartTime ?? undefined,
           version: query.version ?? undefined,
           advancedFilters: query.filter,
+          clickhouseTags: { api_path: "GET /api/public/observations" },
         };
 
         // Use events table if query parameter is explicitly set, otherwise use environment variable

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -54,6 +54,9 @@ export default withMiddlewares(
         const includeObservations = requestedFields.includes("observations");
         const includeScores = requestedFields.includes("scores");
         const includeMetrics = requestedFields.includes("metrics");
+        const clickhouseTags = {
+          api_path: "GET /api/public/traces/{id}",
+        };
 
         const trace = await getTraceById({
           traceId,
@@ -62,6 +65,7 @@ export default withMiddlewares(
           preferredClickhouseService: "ReadOnly",
           excludeInputOutput: !includeIO,
           excludeMetadata: !includeIO,
+          clickhouseTags,
         });
 
         if (!trace) {
@@ -78,6 +82,7 @@ export default withMiddlewares(
                 timestamp: trace?.timestamp,
                 includeIO: includeObservations,
                 preferredClickhouseService: "ReadOnly",
+                clickhouseTags,
               })
             : Promise.resolve([]),
           includeScores
@@ -86,6 +91,7 @@ export default withMiddlewares(
                 traceIds: [traceId],
                 timestamp: trace?.timestamp,
                 preferredClickhouseService: "ReadOnly",
+                clickhouseTags,
               })
             : Promise.resolve([]),
         ]);

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -121,6 +121,7 @@ export default withMiddlewares(
           release: query.release ?? undefined,
           fromTimestamp: effectiveFromTimestamp,
           toTimestamp: query.toTimestamp ?? undefined,
+          clickhouseTags: { api_path: "GET /api/public/traces" },
         };
 
         // Use events table if query parameter is explicitly set, otherwise use environment variable


### PR DESCRIPTION
## Summary

- Add `api_path` ClickHouse log-comment tags for the legacy public metrics, observations, and traces GET endpoints.
- Thread optional ClickHouse tags through the public API query helpers and related repository calls used by those endpoints.

## Impacted packages

- `web`
- `@langfuse/shared`

## Verification

- `pnpm exec prettier --write ...` on touched files
- `pnpm --filter @repo/eslint-plugin run build`
- `pnpm --filter @langfuse/shared run lint`
- `pnpm --filter web run lint`
- `pnpm --filter worker run lint`
- `pnpm install`
- `pnpm run db:generate`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter @langfuse/shared run typecheck`
- `pnpm --filter worker run typecheck`
- `git diff --check`
- Commit hook: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli` and `turbo run lint`

Known caveat: `pnpm --filter web run typecheck` still fails with broad pre-existing web type errors unrelated to this patch, including existing implicit `any`/unknown errors and generated Prisma enum mismatches.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR threads an optional `clickhouseTags` parameter through the shared repository layer and the public-API server helpers so that legacy `GET` endpoints for metrics, observations, and traces can attach `api_path` log-comment tags to every ClickHouse query they issue.

- Each changed repository function (`getTraceById`, `getObservationById`, `getObservationsForTrace`, `getScoresForTraces`, etc.) accepts `clickhouseTags?: Record<string, string>` and spreads caller-supplied tags before the hardcoded `feature`/`type`/`kind` fields, preserving the existing tag hierarchy while allowing new keys like `api_path` to flow through.
- The `clickhouseTags` field is carefully stripped from filter-parameter spreads (`clickhouseTags: _clickhouseTags`) in every location where the props object is forwarded into query-builder or `deriveFilters` calls, preventing runtime filter errors.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is purely additive — it attaches observability metadata to ClickHouse queries and has no effect on query results, response payloads, or authentication. All affected code paths are covered.

The tag propagation is complete and consistent across all six endpoints and both code paths (events-table and legacy-table). The only rough edge is in metrics/index.ts where default parameter values are now hard-coded positionally to accommodate the new argument, which is a minor maintenance concern rather than a functional issue.

web/src/pages/api/public/metrics/index.ts — the explicit positional defaults warrant a second look if executeQuery's defaults ever change.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Public API Route
    participant Helper as Server Helper (traces.ts / observations.ts)
    participant Repo as Repository (traces/observations/scores)
    participant CH as ClickHouse

    Client->>API: GET /api/public/traces (or observations, metrics)
    API->>API: "build filterProps with clickhouseTags={api_path:...}"
    API->>Helper: "generateTracesForPublicApi({...filterProps})"
    Helper->>Helper: strip clickhouseTags from deriveFilters input
    Helper->>Repo: "queryClickhouse({ tags: {...clickhouseTags, feature, type, kind} })"
    Repo->>CH: SQL query with log comment tags (api_path, feature, type, kind, projectId)
    CH-->>Repo: result rows
    Repo-->>Helper: typed records
    Helper-->>API: formatted response
    API-->>Client: JSON response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/api/public/metrics/index.ts:29-35
**Implicit defaults now hard-coded at call site**

To reach the new fifth positional argument, `"v1"` and `false` are now explicitly passed where they previously resolved from their default values. If either default in `executeQuery` changes later, this call site will silently diverge. Consider adding an inline comment (e.g. `// defaults`) or, as a longer-term improvement, accepting `clickhouseTags` via the existing opts-object pattern used by `prepareExecuteQuery` so callers never need to supply positional placeholders.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): tag legacy ClickHouse ..."](https://github.com/langfuse/langfuse/commit/395ee2d1c574a2ffcd59d48f8f27421e0fb58387) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35806133)</sub>

<!-- /greptile_comment -->