### PR TITLE
fix(agent): Pass redis to `deleteApiKeyFromDb`

### DIFF
--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -27,7 +27,7 @@ import {
   createAndAddApiKeysToDb,
   deleteApiKeyFromDb,
 } from "@langfuse/shared/src/server/auth/apiKeys";
-import { logger } from "@langfuse/shared/src/server";
+import { logger, redis } from "@langfuse/shared/src/server";
 
 const IN_APP_AGENT_API_KEY_NOTE = "In-app agent MCP session";
 const MAX_IN_APP_AGENT_INPUT_BYTES = 1024 * 1024;
@@ -255,6 +255,7 @@ async function cleanupInAppAgentMcpApiKey(params: {
     id: params.apiKeyId,
     entityId: params.projectId,
     scope: "PROJECT",
+    redis,
   });
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a missing `redis` argument in `cleanupInAppAgentMcpApiKey` so that the Redis cache is properly invalidated when a temporary in-app agent MCP API key is deleted.

- Previously, `deleteApiKeyFromDb` was called without a `redis` instance, meaning deleted keys could remain in the Redis auth cache until TTL expiry, leaving a window where the deleted key would still authenticate requests.
- The fix imports `redis` from `@langfuse/shared/src/server` and passes it through to `deleteApiKeyFromDb`, which already accepts an optional `redis` parameter and handles `null` gracefully.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted one-line fix that passes the Redis client to an existing optional parameter; no new logic is introduced.

The deletion of temporary in-app agent API keys previously skipped Redis cache invalidation, leaving deleted keys valid in cache until TTL expiry. This fix closes that gap by supplying the already-imported redis instance. The deleteApiKeyFromDb function already handles a null redis gracefully, so environments without Redis are unaffected.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent as In-App Agent Handler
    participant DB as Prisma (DB)
    participant Redis as Redis Cache

    Agent->>DB: createAndAddApiKeysToDb(projectId)
    DB-->>Agent: "mcpApiKey {id, publicKey, secretKey}"

    Agent->>Agent: createAgUiStream(mcpApiKey)
    Note over Agent: stream finishes or error occurs

    Agent->>+DB: "deleteApiKeyFromDb({prisma, id, entityId, scope, redis})"
    DB->>DB: findFirstOrThrow(apiKeyId)
    DB->>Redis: invalidateCachedApiKeys([apiKey]) NEW: redis now passed
    Redis-->>DB: cache entry evicted
    DB->>DB: apiKey.delete(id)
    DB-->>-Agent: true
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Pass redis to deleteApiKeyFr..."](https://github.com/langfuse/langfuse/commit/9ed2286b9f8f286f1265cad8a2d54c4b21fa9c7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35337355)</sub>

<!-- /greptile_comment -->