### PR TITLE
chore: Add dark/light mode toggle to Storybook

### DIFF
--- a/web/.storybook/preview.ts
+++ b/web/.storybook/preview.ts
@@ -1,9 +1,48 @@
 import { definePreview } from "@storybook/nextjs-vite";
 import addonA11y from "@storybook/addon-a11y";
+import { createElement } from "react";
+import { ThemeProvider } from "../src/features/theming/ThemeProvider";
 import "../src/styles/globals.css";
 
 export default definePreview({
   addons: [addonA11y()],
+  globalTypes: {
+    theme: {
+      description: "Global theme for components",
+      toolbar: {
+        title: "Theme",
+        icon: "sun",
+        items: [
+          { value: "light", title: "Light" },
+          { value: "dark", title: "Dark" },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: "light",
+  },
+  decorators: [
+    (Story, context) => {
+      const theme = context.globals.theme === "dark" ? "dark" : "light";
+
+      return createElement(
+        ThemeProvider,
+        {
+          attribute: "class",
+          disableTransitionOnChange: true,
+          enableSystem: false,
+          forcedTheme: theme,
+        },
+        createElement(
+          "div",
+          { className: "min-h-screen bg-background text-foreground" },
+          createElement(Story),
+        ),
+      );
+    },
+  ],
   parameters: {
     a11y: {
       test: "todo",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a dark/light mode toggle to the Storybook toolbar, wrapping every story in the app's `ThemeProvider` with a `forcedTheme` driven by the selected global. The initial theme defaults to `"light"`.

- A new `globalTypes.theme` toolbar entry exposes a sun-icon toggle with `"light"` and `"dark"` options, while `initialGlobals` pins the default to `"light"`.
- A decorator wraps each story in `ThemeProvider` (a thin `next-themes` shim) and a full-height `div` carrying `bg-background`/`text-foreground`, so Tailwind CSS variables respond correctly to the active theme class.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it only touches Storybook configuration and has no impact on production code paths.

The change is entirely confined to web/.storybook/preview.ts. The decorator correctly derives the forced theme with a safe 'light' fallback, createElement is used appropriately in a .ts file without JSX, all imports are at the module top level, and the ThemeProvider wrapper is a thin pass-through to next-themes already used in the app.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Storybook toolbar\n(Theme toggle: light / dark)"] -->|"context.globals.theme"| B["Decorator function"]
    B -->|"forcedTheme = 'light' | 'dark'"| C["ThemeProvider\n(next-themes)"]
    C -->|"sets class on document"| D["div.min-h-screen.bg-background.text-foreground"]
    D --> E["Story component"]
    E -->|"reads CSS variables\n(--background, --foreground, …)"| F["Rendered story\nwith correct theme"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Add dark/light mode toggle to Sto..."](https://github.com/langfuse/langfuse/commit/58a93849a1c930000a45187fda0436ff0d5072cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35360883)</sub>

<!-- /greptile_comment -->