### PR TITLE
chore(shared): trace code eval dispatches

### DIFF
--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts
@@ -1,0 +1,203 @@
+import { SpanKind } from "@opentelemetry/api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AwsLambdaCodeEvalDispatcher } from "./awsLambdaCodeEvalDispatcher";
+import type { DispatchInput } from "./codeEvalDispatcherTypes";
+
+const mocks = vi.hoisted(() => {
+  const span = {
+    setAttribute: vi.fn(),
+    setAttributes: vi.fn(),
+  };
+
+  return {
+    span,
+    instrumentAsync: vi.fn(async (_ctx, callback) => callback(span)),
+    traceException: vi.fn(),
+  };
+});
+
+vi.mock("../instrumentation", () => ({
+  instrumentAsync: mocks.instrumentAsync,
+  traceException: mocks.traceException,
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}));
+
+const baseInput: DispatchInput = {
+  scope: {
+    organizationId: "org-1",
+    projectId: "project-1",
+    evaluatorId: "evaluator-1",
+  },
+  runtime: { language: "TYPESCRIPT" },
+  execution: { jobExecutionId: "job-1" },
+  code: { source: "function evaluate() {}" },
+  payload: {
+    observation: {
+      input: null,
+      output: null,
+      metadata: null,
+    },
+  },
+};
+
+function expectSpanAttributes(attributes: Record<string, unknown>): void {
+  expect(mocks.span.setAttributes).toHaveBeenCalledWith(
+    expect.objectContaining(attributes),
+  );
+}
+
+describe("AwsLambdaCodeEvalDispatcher observability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches inside a dedicated trace with code evaluator context", async () => {
+    const send = vi.fn().mockResolvedValue({
+      StatusCode: 200,
+      ExecutedVersion: "$LATEST",
+      Payload: Buffer.from(
+        JSON.stringify({
+          scores: [{ name: "score", value: 1, dataType: "NUMERIC" }],
+        }),
+      ),
+      $metadata: {
+        requestId: "request-1",
+        httpStatusCode: 200,
+        attempts: 2,
+        totalRetryDelay: 15,
+      },
+    });
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send } as any,
+    });
+
+    await dispatcher.dispatch(baseInput);
+
+    expect(mocks.instrumentAsync).toHaveBeenCalledWith(
+      {
+        name: "code-eval.dispatch.aws-lambda",
+        spanKind: SpanKind.CLIENT,
+        traceScope: "code-eval-dispatcher",
+        startNewTrace: true,
+      },
+      expect.any(Function),
+    );
+    expectSpanAttributes({
+      "langfuse.code_eval.dispatcher": "aws-lambda",
+      "langfuse.code_eval.runtime.language": "TYPESCRIPT",
+      "langfuse.code_eval.lambda.function_name":
+        "code-based-eval-executor-node",
+      "langfuse.organization.id": "org-1",
+      "langfuse.project.id": "project-1",
+      "langfuse.evaluator.id": "evaluator-1",
+      "langfuse.eval.job_execution_id": "job-1",
+    });
+    expect(mocks.span.setAttribute).toHaveBeenCalledWith(
+      "langfuse.code_eval.result.score_count",
+      1,
+    );
+    expectSpanAttributes({
+      "langfuse.code_eval.lambda.status_code": 200,
+      "langfuse.code_eval.lambda.executed_version": "$LATEST",
+      "aws.request_id": "request-1",
+      "aws.http_status_code": 200,
+      "aws.sdk.attempts": 2,
+      "aws.sdk.total_retry_delay_ms": 15,
+    });
+  });
+
+  it("records the original AWS SDK error before throwing the derived dispatcher error", async () => {
+    const error = Object.assign(new Error("Rate exceeded"), {
+      code: "TooManyRequests",
+      $metadata: {
+        requestId: "request-2",
+        httpStatusCode: 429,
+        attempts: 3,
+        totalRetryDelay: 25,
+      },
+    });
+    error.name = "TooManyRequestsException";
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send: vi.fn().mockRejectedValue(error) } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "LAMBDA_CONCURRENCY_LIMIT",
+      retryable: true,
+    });
+
+    expect(mocks.traceException).toHaveBeenCalledWith(
+      error,
+      mocks.span,
+      "code_eval.aws_lambda.original_error",
+    );
+    expectSpanAttributes({
+      "langfuse.code_eval.error.code": "LAMBDA_CONCURRENCY_LIMIT",
+      "langfuse.code_eval.error.retryable": true,
+    });
+    expectSpanAttributes({
+      "langfuse.code_eval.aws_error.name": "TooManyRequestsException",
+      "langfuse.code_eval.aws_error.code": "TooManyRequests",
+      "aws.request_id": "request-2",
+      "aws.http_status_code": 429,
+      "aws.sdk.attempts": 3,
+      "aws.sdk.total_retry_delay_ms": 25,
+    });
+  });
+
+  it("records the original Lambda FunctionError before throwing the derived user-facing error", async () => {
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: {
+        send: vi.fn().mockResolvedValue({
+          StatusCode: 200,
+          FunctionError: "Handled",
+          Payload: Buffer.from(
+            JSON.stringify({
+              errorMessage: "x is not defined",
+              errorType: "ReferenceError",
+              stackTrace: ["at evaluate (index.js:1:1)"],
+            }),
+          ),
+          $metadata: {
+            requestId: "request-3",
+            httpStatusCode: 200,
+            attempts: 1,
+            totalRetryDelay: 0,
+          },
+        }),
+      } as any,
+    });
+
+    await expect(dispatcher.dispatch(baseInput)).rejects.toMatchObject({
+      code: "USER_CODE_ERROR",
+      message: "ReferenceError: x is not defined",
+      retryable: false,
+    });
+
+    const tracedError = mocks.traceException.mock.calls[0][0];
+    expect(tracedError).toMatchObject({
+      name: "ReferenceError",
+      message: "x is not defined",
+      stack: "at evaluate (index.js:1:1)",
+    });
+    expect(mocks.traceException).toHaveBeenCalledWith(
+      tracedError,
+      mocks.span,
+      "code_eval.aws_lambda.function_error",
+    );
+    expectSpanAttributes({
+      "langfuse.code_eval.error.code": "USER_CODE_ERROR",
+      "langfuse.code_eval.error.retryable": false,
+    });
+    expectSpanAttributes({
+      "langfuse.code_eval.lambda.status_code": 200,
+      "langfuse.code_eval.lambda.function_error": "Handled",
+      "aws.request_id": "request-3",
+    });
+  });
+});

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.test.ts
@@ -88,19 +88,16 @@ describe("AwsLambdaCodeEvalDispatcher observability", () => {
       expect.any(Function),
     );
     expectSpanAttributes({
-      "langfuse.code_eval.dispatcher": "aws-lambda",
-      "langfuse.code_eval.runtime.language": "TYPESCRIPT",
+      "eval.dispatcher.name": "aws-lambda",
+      "eval.job_execution.id": "job-1",
+      "eval.runner.language": "TYPESCRIPT",
+      "eval.template.id": "evaluator-1",
       "langfuse.code_eval.lambda.function_name":
         "code-based-eval-executor-node",
-      "langfuse.organization.id": "org-1",
+      "langfuse.org.id": "org-1",
       "langfuse.project.id": "project-1",
-      "langfuse.evaluator.id": "evaluator-1",
-      "langfuse.eval.job_execution_id": "job-1",
     });
-    expect(mocks.span.setAttribute).toHaveBeenCalledWith(
-      "langfuse.code_eval.result.score_count",
-      1,
-    );
+    expect(mocks.span.setAttribute).toHaveBeenCalledWith("eval.score.count", 1);
     expectSpanAttributes({
       "langfuse.code_eval.lambda.status_code": 200,
       "langfuse.code_eval.lambda.executed_version": "$LATEST",
@@ -147,6 +144,35 @@ describe("AwsLambdaCodeEvalDispatcher observability", () => {
       "aws.http_status_code": 429,
       "aws.sdk.attempts": 3,
       "aws.sdk.total_retry_delay_ms": 25,
+    });
+  });
+
+  it("records dispatch context and error code for preflight limit failures", async () => {
+    const dispatcher = new AwsLambdaCodeEvalDispatcher({
+      lambdaClient: { send: vi.fn() } as any,
+    });
+
+    await expect(
+      dispatcher.dispatch({
+        ...baseInput,
+        code: { source: "a".repeat(256 * 1024 + 1) },
+      }),
+    ).rejects.toMatchObject({
+      code: "SOURCE_TOO_LARGE",
+      retryable: false,
+    });
+
+    expectSpanAttributes({
+      "eval.dispatcher.name": "aws-lambda",
+      "eval.job_execution.id": "job-1",
+      "eval.runner.language": "TYPESCRIPT",
+      "eval.template.id": "evaluator-1",
+      "langfuse.org.id": "org-1",
+      "langfuse.project.id": "project-1",
+    });
+    expectSpanAttributes({
+      "langfuse.code_eval.error.code": "SOURCE_TOO_LARGE",
+      "langfuse.code_eval.error.retryable": false,
     });
   });
 

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -3,7 +3,9 @@ import {
   LambdaClient,
   type InvokeCommandInput,
 } from "@aws-sdk/client-lambda";
+import { SpanKind, type AttributeValue, type Span } from "@opentelemetry/api";
 import { z } from "zod";
+import { instrumentAsync, traceException } from "../instrumentation";
 import { logger } from "../logger";
 import {
   assertDispatchInputWithinLimits,
@@ -162,8 +164,37 @@ export class AwsLambdaCodeEvalDispatcher implements CodeEvalDispatcher {
   }
 
   async dispatch(input: DispatchInput): Promise<DispatchResult> {
+    return instrumentAsync(
+      {
+        name: "code-eval.dispatch.aws-lambda",
+        spanKind: SpanKind.CLIENT,
+        traceScope: "code-eval-dispatcher",
+        startNewTrace: true,
+      },
+      async (span) => this.dispatchWithTracing(input, span),
+    );
+  }
+
+  private async dispatchWithTracing(
+    input: DispatchInput,
+    span: Span,
+  ): Promise<DispatchResult> {
     const serializedPayload = assertDispatchInputWithinLimits(input);
     const functionName = this.functionNameByLanguage[input.runtime.language];
+
+    span.setAttributes({
+      "langfuse.code_eval.dispatcher": this.name,
+      "langfuse.code_eval.runtime.language": input.runtime.language,
+      "langfuse.code_eval.lambda.function_name": functionName,
+      "langfuse.code_eval.payload.bytes": Buffer.byteLength(
+        serializedPayload,
+        "utf8",
+      ),
+      "langfuse.organization.id": input.scope.organizationId,
+      "langfuse.project.id": input.scope.projectId,
+      "langfuse.evaluator.id": input.scope.evaluatorId,
+      "langfuse.eval.job_execution_id": input.execution.jobExecutionId,
+    });
 
     try {
       const commandInput: InvokeCommandInput = {
@@ -176,17 +207,30 @@ export class AwsLambdaCodeEvalDispatcher implements CodeEvalDispatcher {
       const response = await this.lambdaClient.send(
         new InvokeCommand(commandInput),
       );
+      setSpanAttributes(span, {
+        ...getAwsMetadataSpanAttributes(response.$metadata),
+        "langfuse.code_eval.lambda.status_code": response.StatusCode,
+        "langfuse.code_eval.lambda.executed_version": response.ExecutedVersion,
+        "langfuse.code_eval.lambda.function_error": response.FunctionError,
+      });
 
       // Lambda function errors come back as HTTP 200 with `FunctionError`
       // set; the SDK does NOT throw for these. SDK service exceptions
       // (throttling, auth, etc.) hit the outer catch instead.
       // https://docs.aws.amazon.com/lambda/latest/dg/invocation-errors.html
       if (response.FunctionError) {
-        throw classifyLambdaFunctionError({
+        const dispatcherError = classifyLambdaFunctionError({
           functionName,
           functionError: response.FunctionError,
           payload: response.Payload,
         });
+        traceLambdaFunctionError({
+          span,
+          functionName,
+          functionError: response.FunctionError,
+          payload: response.Payload,
+        });
+        throw dispatcherError;
       }
 
       if (!response.Payload) {
@@ -199,21 +243,42 @@ export class AwsLambdaCodeEvalDispatcher implements CodeEvalDispatcher {
         );
       }
 
-      return parseLambdaResponsePayload({
+      span.setAttribute(
+        "langfuse.code_eval.lambda.response_payload.bytes",
+        response.Payload.byteLength,
+      );
+
+      const result = parseLambdaResponsePayload({
         functionName,
         payload: response.Payload,
       });
+      span.setAttribute(
+        "langfuse.code_eval.result.score_count",
+        result.scores.length,
+      );
+      return result;
     } catch (error) {
       if (error instanceof CodeEvalDispatcherError) {
+        setDispatcherErrorSpanAttributes(span, error);
         logDispatcherError({ functionName, error });
         throw error;
       }
 
+      traceException(error, span, "code_eval.aws_lambda.original_error");
+      const errorRecord = isRecord(error) ? error : null;
+      setSpanAttributes(span, {
+        ...getAwsMetadataSpanAttributes(errorRecord?.$metadata),
+        "langfuse.code_eval.aws_error.name":
+          error instanceof Error ? error.name : undefined,
+        "langfuse.code_eval.aws_error.code":
+          typeof errorRecord?.code === "string" ? errorRecord.code : undefined,
+      });
       const awsError = classifyAwsLambdaError(error);
       const dispatcherError = new CodeEvalDispatcherError(
         `Failed to invoke code eval Lambda ${functionName}: ${error instanceof Error ? error.message : String(error)}`,
         { ...awsError, cause: error },
       );
+      setDispatcherErrorSpanAttributes(span, dispatcherError);
       logDispatcherError({ functionName, error: dispatcherError });
       throw dispatcherError;
     }
@@ -235,6 +300,78 @@ function logDispatcherError(params: {
       retryable: params.error.retryable,
     },
   );
+}
+
+function setDispatcherErrorSpanAttributes(
+  span: Span,
+  error: CodeEvalDispatcherError,
+): void {
+  span.setAttributes({
+    "langfuse.code_eval.error.code": error.code,
+    "langfuse.code_eval.error.retryable": error.retryable,
+  });
+}
+
+function getAwsMetadataSpanAttributes(
+  metadata: unknown,
+): Record<string, AttributeValue | undefined> {
+  if (!isRecord(metadata)) return {};
+
+  return {
+    "aws.request_id":
+      typeof metadata.requestId === "string" ? metadata.requestId : undefined,
+    "aws.http_status_code":
+      typeof metadata.httpStatusCode === "number"
+        ? metadata.httpStatusCode
+        : undefined,
+    "aws.sdk.attempts":
+      typeof metadata.attempts === "number" ? metadata.attempts : undefined,
+    "aws.sdk.total_retry_delay_ms":
+      typeof metadata.totalRetryDelay === "number"
+        ? metadata.totalRetryDelay
+        : undefined,
+  };
+}
+
+function setSpanAttributes(
+  span: Span,
+  attributes: Record<string, AttributeValue | undefined>,
+): void {
+  const definedAttributes = Object.fromEntries(
+    Object.entries(attributes).filter(([, value]) => value !== undefined),
+  ) as Record<string, AttributeValue>;
+
+  if (Object.keys(definedAttributes).length > 0) {
+    span.setAttributes(definedAttributes);
+  }
+}
+
+function traceLambdaFunctionError(params: {
+  span: Span;
+  functionName: string;
+  functionError: string;
+  payload: Uint8Array | undefined;
+}): void {
+  const errorPayload = parseLambdaErrorPayload(params.payload);
+  const record = isRecord(errorPayload) ? errorPayload : null;
+
+  const error = new Error(
+    typeof record?.errorMessage === "string"
+      ? record.errorMessage
+      : `Code eval Lambda ${params.functionName} returned FunctionError=${params.functionError}`,
+  );
+  error.name =
+    typeof record?.errorType === "string"
+      ? record.errorType
+      : "LambdaFunctionError";
+
+  if (Array.isArray(record?.stackTrace)) {
+    error.stack = record.stackTrace
+      .filter((line) => typeof line === "string")
+      .join("\n");
+  }
+
+  traceException(error, params.span, "code_eval.aws_lambda.function_error");
 }
 
 function classifyLambdaFunctionError(params: {

--- a/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
+++ b/packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts
@@ -179,24 +179,25 @@ export class AwsLambdaCodeEvalDispatcher implements CodeEvalDispatcher {
     input: DispatchInput,
     span: Span,
   ): Promise<DispatchResult> {
-    const serializedPayload = assertDispatchInputWithinLimits(input);
     const functionName = this.functionNameByLanguage[input.runtime.language];
 
     span.setAttributes({
-      "langfuse.code_eval.dispatcher": this.name,
-      "langfuse.code_eval.runtime.language": input.runtime.language,
+      "eval.dispatcher.name": this.name,
+      "eval.job_execution.id": input.execution.jobExecutionId,
+      "eval.runner.language": input.runtime.language,
+      "eval.template.id": input.scope.evaluatorId,
       "langfuse.code_eval.lambda.function_name": functionName,
-      "langfuse.code_eval.payload.bytes": Buffer.byteLength(
-        serializedPayload,
-        "utf8",
-      ),
-      "langfuse.organization.id": input.scope.organizationId,
+      "langfuse.org.id": input.scope.organizationId,
       "langfuse.project.id": input.scope.projectId,
-      "langfuse.evaluator.id": input.scope.evaluatorId,
-      "langfuse.eval.job_execution_id": input.execution.jobExecutionId,
     });
 
     try {
+      const serializedPayload = assertDispatchInputWithinLimits(input);
+      span.setAttribute(
+        "langfuse.code_eval.payload.bytes",
+        Buffer.byteLength(serializedPayload, "utf8"),
+      );
+
       const commandInput: InvokeCommandInput = {
         FunctionName: functionName,
         InvocationType: "RequestResponse",
@@ -252,10 +253,7 @@ export class AwsLambdaCodeEvalDispatcher implements CodeEvalDispatcher {
         functionName,
         payload: response.Payload,
       });
-      span.setAttribute(
-        "langfuse.code_eval.result.score_count",
-        result.scores.length,
-      );
+      span.setAttribute("eval.score.count", result.scores.length);
       return result;
     } catch (error) {
       if (error instanceof CodeEvalDispatcherError) {


### PR DESCRIPTION
## Summary

- Add a dedicated root OpenTelemetry trace around AWS Lambda code evaluator dispatches so each dispatch can be inspected independently.
- Record original AWS SDK exceptions and Lambda `FunctionError` payloads separately from the derived `CodeEvalDispatcherError`, while adding queryable AWS request/status/retry metadata.
- Add focused unit coverage for the dispatch tracing contract.

## Linear

- None

## Major Decisions

- Keep evaluator source, input/output payloads, returned scores, and Lambda log output out of traces; record only byte sizes, score count, AWS metadata, and error classification fields.
- Let `instrumentAsync` continue tracing the derived dispatcher error, and explicitly trace only the original AWS/Lambda failure sources.

## Review Focus

- Attribute names and whether they match the Datadog query shape reviewers expect.
- Error-event behavior for Lambda `FunctionError` responses versus thrown AWS SDK errors.
- Test mocking around shared instrumentation and logger imports.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wraps each AWS Lambda code-evaluator dispatch in a dedicated root OpenTelemetry trace, adds rich span attributes (AWS request metadata, runtime/org/project context, score counts), and explicitly records the original AWS SDK exception or Lambda `FunctionError` as a separate `traceException` event before the derived `CodeEvalDispatcherError` is emitted. Focused unit tests cover the success, SDK-error, and FunctionError paths against the new tracing contract.

- `awsLambdaCodeEvalDispatcher.ts`: refactored `dispatch` → `dispatchWithTracing` under `instrumentAsync({startNewTrace: true})`; added `setSpanAttributes`/`getAwsMetadataSpanAttributes`/`traceLambdaFunctionError` helpers; `setDispatcherErrorSpanAttributes` uses raw `setAttributes` rather than the undefined-filtering helper, leaving the `retryable` attribute absent for error classifications that omit it (e.g. `AccessDeniedException`).
- `awsLambdaCodeEvalDispatcher.test.ts`: new file with three `vi.hoisted`-mocked test cases verifying span attribute shape and `traceException` call contracts for each dispatch outcome.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the tracing wrapper is additive and the dispatch logic itself is unchanged.

The core dispatch behavior is unmodified; the new code only adds span instrumentation. The one concrete gap is that setDispatcherErrorSpanAttributes bypasses the undefined-filtering helper, causing the retryable span attribute to be silently absent for several AWS error classifications, which could make certain Datadog filters return incomplete results. Everything else — attribute naming, error ordering, test coverage — looks correct.

packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts — specifically the setDispatcherErrorSpanAttributes function and its interaction with optional retryable values.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Caller
    participant D as AwsLambdaCodeEvalDispatcher
    participant IA as instrumentAsync
    participant S as OTel Span
    participant L as AWS Lambda

    C->>D: dispatch(input)
    D->>IA: "instrumentAsync({name, spanKind, startNewTrace})"
    IA->>S: startActiveSpan (new root trace)
    IA->>D: dispatchWithTracing(input, span)
    D->>S: setAttributes (org/project/evaluator/runtime/payload.bytes)
    D->>L: InvokeCommand(payload)

    alt Success
        L-->>D: "{StatusCode:200, Payload, $metadata}"
        D->>S: setAttributes (status_code, executed_version, aws metadata)
        D->>S: setAttribute (response_payload.bytes)
        D->>S: setAttribute (result.score_count)
        D-->>C: DispatchResult
        IA->>S: span.end()
    else Lambda FunctionError
        L-->>D: "{StatusCode:200, FunctionError, Payload, $metadata}"
        D->>S: setAttributes (status_code, function_error, aws metadata)
        D->>D: classifyLambdaFunctionError → dispatcherError
        D->>D: traceLambdaFunctionError
        D->>S: traceException(syntheticError, code_eval.aws_lambda.function_error)
        D->>D: throw dispatcherError (CodeEvalDispatcherError)
        D->>S: setDispatcherErrorSpanAttributes (error.code, error.retryable)
        D-->>C: throws CodeEvalDispatcherError
        IA->>S: traceException(dispatcherError)
        IA->>S: span.end()
    else AWS SDK Exception
        L-->>D: throws AwsError
        D->>S: traceException(awsError, code_eval.aws_lambda.original_error)
        D->>S: setAttributes (aws_error.name, aws_error.code, aws metadata)
        D->>D: classifyAwsLambdaError → awsError
        D->>D: new CodeEvalDispatcherError(dispatcherError)
        D->>S: setDispatcherErrorSpanAttributes (error.code, error.retryable)
        D-->>C: throws CodeEvalDispatcherError
        IA->>S: traceException(dispatcherError)
        IA->>S: span.end()
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts:305-313
`setDispatcherErrorSpanAttributes` calls `span.setAttributes` directly with `error.retryable`, which is typed as `boolean | undefined` and is `undefined` for several AWS error classifications (e.g. `AccessDeniedException`, `InvalidParameterValueException`, `ResourceNotFoundException`). Unlike the `setSpanAttributes` helper, no undefined-filtering step is applied here. The OTel SDK silently drops the undefined value, so spans for these error types will have no `langfuse.code_eval.error.retryable` attribute, making Datadog queries like `@langfuse.code_eval.error.retryable:false` miss a non-trivial subset of failures.

```suggestion
function setDispatcherErrorSpanAttributes(
  span: Span,
  error: CodeEvalDispatcherError,
): void {
  setSpanAttributes(span, {
    "langfuse.code_eval.error.code": error.code,
    "langfuse.code_eval.error.retryable": error.retryable,
  });
}
```

### Issue 2 of 2
packages/shared/src/server/evals/awsLambdaCodeEvalDispatcher.ts:349-375
**Double payload parse on every FunctionError**

`traceLambdaFunctionError` calls `parseLambdaErrorPayload` independently after `classifyLambdaFunctionError` already parsed the same `payload`. For a user-code error path both functions do a `JSON.parse` on the same `Uint8Array`. While not a correctness issue, extracting the parsed payload once and passing it to both helpers would keep the logic cleaner and avoids redundant work under load.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(shared): trace code eval dispatches"](https://github.com/langfuse/langfuse/commit/fe4345c6e2d7ae31fb9107240d5ebbe1470dd271) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35370171)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->