### PR TITLE
fix(web): avoid native title overlap on help tooltips

### DIFF
--- a/web/src/components/ModelParameters/index.tsx
+++ b/web/src/components/ModelParameters/index.tsx
@@ -529,10 +529,7 @@ const ProviderOptionsInput = ({
   const [error, setError] = useState<string | null>(null);
 
   return (
-    <div
-      className="space-y-3"
-      title="Additional options to pass to the invocation. Please check your provider's API reference for supported values."
-    >
+    <div className="space-y-3">
       <div className="flex flex-row">
         <div className="flex-1 flex-row space-x-1">
           <span

--- a/web/src/components/layouts/page-header.tsx
+++ b/web/src/components/layouts/page-header.tsx
@@ -132,16 +132,6 @@ const PageHeader = ({
                               data-testid="page-header-title"
                             >
                               {title}
-                              {help && (
-                                <span className="whitespace-nowrap">
-                                  &nbsp;
-                                  <DocPopup
-                                    description={help.description}
-                                    href={help.href}
-                                    className={help.className}
-                                  />
-                                </span>
-                              )}
                             </span>
                           </TooltipTrigger>
                           <TooltipContent side="bottom" className="max-w-xs">
@@ -156,16 +146,16 @@ const PageHeader = ({
                         data-testid="page-header-title"
                       >
                         {title}
-                        {help && (
-                          <span className="whitespace-nowrap">
-                            &nbsp;
-                            <DocPopup
-                              description={help.description}
-                              href={help.href}
-                              className={help.className}
-                            />
-                          </span>
-                        )}
+                      </span>
+                    )}
+                    {help && (
+                      <span className="whitespace-nowrap">
+                        &nbsp;
+                        <DocPopup
+                          description={help.description}
+                          href={help.href}
+                          className={help.className}
+                        />
                       </span>
                     )}
                   </h2>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a tooltip overlap issue where the `DocPopup` help icon was nested inside elements with native `title` attributes or inside `TooltipTrigger` wrappers, causing two tooltips to appear simultaneously when hovering over the help icon.

- In `page-header.tsx`, the `DocPopup` is moved outside the title `<span>` and outside the `TooltipTrigger` in both the `titleTooltip` and plain title branches, so the help popup no longer inherits the parent's tooltip context.
- In `ModelParameters/index.tsx`, the redundant `title` attribute on the outer `<div>` is removed since the same text is already surfaced through the `Tooltip`/`TooltipContent` component on the `InfoIcon`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both changes are minimal, targeted UI fixes with no logic or data-handling side effects.

Both files touch only presentation layer concerns. The restructuring in page-header.tsx correctly moves the DocPopup outside tooltip/title containers in all render paths, and the ModelParameters change is a straightforward attribute removal. No new state, no new data flows, and no edge cases are introduced.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PageHeader renders title] --> B{titleTooltip provided?}
    B -- Yes --> C[TooltipProvider/Tooltip wraps title span only]
    C --> D[help DocPopup rendered OUTSIDE TooltipTrigger]
    B -- No --> E[span with native title attr for long-title clipping]
    E --> F[help DocPopup rendered OUTSIDE the span]
    D --> G[No tooltip overlap]
    F --> G

    H[ProviderOptionsInput renders Additional options] --> I[div with no title attr]
    I --> J[InfoIcon with Tooltip/TooltipContent]
    J --> K[Single tooltip — no native overlap]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): avoid native title overlap on ..."](https://github.com/langfuse/langfuse/commit/b9e02e58e0deda50b853fdeb583399835b35b144) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35407526)</sub>

<!-- /greptile_comment -->