### PR TITLE
chore: Setup storybook branch deployments

### DIFF
--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -1,0 +1,146 @@
+name: Storybook Preview
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions: {}
+
+concurrency:
+  group: storybook-preview-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'storybook' }}
+
+jobs:
+  deploy:
+    name: Deploy Storybook preview
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.pull_request.labels.*.name, 'storybook') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action != 'labeled' || github.event.label.name == 'storybook'))
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Resolve pull request number
+        id: resolve-pr-number
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          pr_number=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/pulls" -f "head=${GITHUB_REPOSITORY%%/*}:${GITHUB_REF_NAME}" -f state=open --jq '.[0].number')
+
+          if [ -z "${pr_number}" ] || [ "${pr_number}" = "null" ]; then
+            echo "No open pull request found for branch ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pull request
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.4.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Load default env
+        run: cp .env.dev.example .env
+
+      - name: Build Storybook
+        run: pnpm --filter web run build-storybook
+
+      - name: Deploy preview to Vercel
+        id: publish
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || steps.resolve-pr-number.outputs.pr_number }}
+          VERCEL_ORG_ID: ${{ secrets.STORYBOOK_VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.STORYBOOK_VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.STORYBOOK_VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          pnpm install -g vercel@54.7.0
+
+          set +e
+          deploy_output=$(vercel deploy web/storybook-static --yes --scope langfuse 2>&1)
+          deploy_status=$?
+          set -e
+
+          if [ "${deploy_status}" -ne 0 ]; then
+            printf '%s\n' "${deploy_output}"
+            echo "Vercel deploy failed."
+            exit "${deploy_status}"
+          fi
+
+          preview_url=$(printf '%s\n' "${deploy_output}" | grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | tail -n 1 || true)
+
+          if [ -z "${preview_url}" ]; then
+            printf '%s\n' "${deploy_output}"
+            echo "Failed to determine Vercel preview URL."
+            exit 1
+          fi
+
+          preview_alias="pr-${PR_NUMBER}-storybook.langfuse.vercel.app"
+          vercel alias set "${preview_url}" "${preview_alias}" --scope langfuse
+          preview_url="https://${preview_alias}"
+
+          echo "url=${preview_url}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview link
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PREVIEW_URL: ${{ steps.publish.outputs.url }}
+          PR_NUMBER: ${{ github.event.pull_request.number || steps.resolve-pr-number.outputs.pr_number }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        with:
+          script: |
+            const marker = "<!-- storybook-preview -->";
+            const body = `${marker}\nStorybook preview: ${process.env.PREVIEW_URL}\n\nUpdated at: ${new Date().toISOString()}\nCommit: ${process.env.COMMIT_SHA}`;
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previousComment = comments.find(
+              (comment) =>
+                comment.user?.login === "github-actions[bot]" &&
+                comment.body?.includes(marker),
+            );
+
+            if (previousComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previousComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new GitHub Actions workflow that builds and deploys a Storybook static site to a Vercel preview URL whenever a PR is labeled `storybook`, then posts or updates a comment with the preview link.

- **Deployment flow**: checks out the PR, installs deps, builds Storybook via `pnpm --filter web run build-storybook`, deploys to Vercel, creates a stable alias (`pr-{N}-storybook.langfuse.vercel.app`), and upserts a marker comment on the PR.
- **Security posture**: top-level permissions are locked down to `{}` with job-scoped `issues: write` / `pull-requests: write`; fork PRs are excluded via a same-repo guard; credentials are stored in secrets. The main gap is the unpinned `vercel@latest` CLI resolved at runtime.
- **Dead trigger**: the `workflow_dispatch` entry never runs the job because the `if` condition requires PR event data that isn't present on manual dispatches.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The workflow should not be merged until the Vercel CLI version is pinned — the current @latest resolution gives an unpinned runtime binary access to an org-scoped Vercel token on every run.

The overall structure is sound: action SHAs are pinned, top-level permissions are empty, fork PRs are excluded, and credentials come from secrets. However, both pnpm dlx vercel@latest calls resolve the Vercel CLI at runtime, and that CLI is handed the STORYBOOK_VERCEL_TOKEN which grants org-level access to the langfuse Vercel account. A supply-chain compromise of the vercel npm package would immediately affect this workflow.

.github/workflows/storybook-preview.yml — specifically the two pnpm dlx vercel@latest invocations in the Deploy preview to Vercel step.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Supply chain risk via unpinned `vercel@latest`** (`.github/workflows/storybook-preview.yml`, lines 60 & 70): The Vercel CLI is fetched at runtime using `@latest`, meaning a newly published (potentially compromised) version would be used automatically. This workflow holds `STORYBOOK_VERCEL_TOKEN` scoped to the langfuse Vercel org — a compromised CLI binary could exfiltrate this token or deploy malicious content without any code-review gate.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub
    participant Runner as CI Runner
    participant PNPM as pnpm dlx (vercel@latest)
    participant Vercel as Vercel API
    participant PR as Pull Request

    GH->>Runner: PR event (labeled/sync/opened/reopened)
    Runner->>Runner: Check: has 'storybook' label AND same-repo PR?
    Runner->>Runner: Checkout + Install deps
    Runner->>Runner: Build Storybook (pnpm build-storybook)
    Runner->>PNPM: "pnpm dlx vercel@latest deploy storybook-static"
    PNPM->>Vercel: Deploy static files (VERCEL_TOKEN)
    Vercel-->>PNPM: Preview URL
    PNPM-->>Runner: deploy_output (grep for URL)
    Runner->>PNPM: "pnpm dlx vercel@latest alias set preview_url to pr-N-storybook.langfuse.vercel.app"
    PNPM->>Vercel: Create alias (VERCEL_TOKEN)
    Vercel-->>Runner: Alias confirmed
    Runner->>PR: Find existing storybook-preview comment
    alt Comment exists
        Runner->>PR: Update comment with new URL
    else No existing comment
        Runner->>PR: Create new comment with preview URL
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/storybook-preview.yml:60-70
Using `vercel@latest` resolves the Vercel CLI version at runtime rather than pinning it. If a malicious version is ever published to the npm registry, this workflow would automatically pick it up — and since `STORYBOOK_VERCEL_TOKEN` grants org-level access to the langfuse Vercel account, a compromised CLI could exfiltrate that token or deploy arbitrary content. The same applies to the `alias set` call on line 70. Pin to a specific version (e.g., `vercel@44.x.x`) to make the resolved package deterministic.

```suggestion
          deploy_output=$(pnpm dlx vercel@44 deploy web/storybook-static --yes --scope langfuse --token "${VERCEL_TOKEN}" 2>&1)
          preview_url=$(printf '%s\n' "${deploy_output}" | grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | tail -n 1)

          if [ -z "${preview_url}" ]; then
            printf '%s\n' "${deploy_output}"
            echo "Failed to determine Vercel preview URL."
            exit 1
          fi

          preview_alias="pr-${PR_NUMBER}-storybook.langfuse.vercel.app"
          pnpm dlx vercel@44 alias set "${preview_url}" "${preview_alias}" --scope langfuse --token "${VERCEL_TOKEN}"
```

### Issue 2 of 2
.github/workflows/storybook-preview.yml:3-6
**`workflow_dispatch` trigger is effectively a no-op**

The `deploy` job's `if` condition requires `github.event.pull_request.labels.*.name` to contain `'storybook'` and `github.event.pull_request.head.repo.full_name` to match the repository. On a manually-dispatched run there is no `pull_request` event payload, so both expressions evaluate to empty/false and the job is always skipped. If manual re-triggering of a specific PR's preview is desired, a `workflow_dispatch` input for the PR number would be needed; otherwise the `workflow_dispatch` trigger can be removed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Setup storybook branch deployment..."](https://github.com/langfuse/langfuse/commit/06c0105322977090ac06b71a2cd7c3b2b56a44bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35577240)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->