### PR TITLE
feat(blob-storage): decouple export source visibility from V4 beta toggle

### DIFF
--- a/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
@@ -36,3 +36,11 @@ export function isLegacyBlobExportAllowed(
   if (!isCloud) return true;
   return projectCreatedAt < LEGACY_BLOB_EXPORT_CUTOFF;
 }
+
+/**
+ * Whether this deployment has the enriched events export path.
+ * Today equivalent to `isLangfuseCloud`; flip when self-hosted is provisioned with the migration.
+ */
+export function isEnrichedBlobExportAvailable(isCloud: boolean): boolean {
+  return isCloud;
+}

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -56,10 +56,10 @@ import {
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
   isLegacyBlobExportAllowed,
+  isEnrichedBlobExportAvailable,
 } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
-import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { Info, ExternalLink } from "lucide-react";
 
 export default function BlobStorageIntegrationSettings() {
@@ -234,7 +234,6 @@ const BlobStorageIntegrationSettingsForm = ({
 }) => {
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
-  const { isBetaEnabled } = useV4Beta();
   const { project } = useQueryProject();
   const [integrationType, setIntegrationType] =
     useState<BlobStorageIntegrationType>(BlobStorageIntegrationType.S3);
@@ -248,7 +247,8 @@ const BlobStorageIntegrationSettingsForm = ({
   const isPostCutoffCloud =
     project?.createdAt != null &&
     !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
-  const showExportSourceField = isBetaEnabled && !isPostCutoffCloud;
+  const eventsExportAvailable = isEnrichedBlobExportAvailable(isLangfuseCloud);
+  const showExportSourceField = eventsExportAvailable && !isPostCutoffCloud;
 
   const blobStorageForm = useForm({
     resolver: zodResolver(blobStorageIntegrationFormSchema),
@@ -273,7 +273,7 @@ const BlobStorageIntegrationSettingsForm = ({
       exportSource: isPostCutoffCloud
         ? AnalyticsIntegrationExportSource.EVENTS
         : state?.exportSource ||
-          (isBetaEnabled
+          (eventsExportAvailable
             ? AnalyticsIntegrationExportSource.EVENTS
             : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
       exportFieldGroups:
@@ -308,7 +308,7 @@ const BlobStorageIntegrationSettingsForm = ({
       exportSource: isPostCutoffCloud
         ? AnalyticsIntegrationExportSource.EVENTS
         : state?.exportSource ||
-          (isBetaEnabled
+          (eventsExportAvailable
             ? AnalyticsIntegrationExportSource.EVENTS
             : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
       exportFieldGroups:
@@ -744,7 +744,7 @@ const BlobStorageIntegrationSettingsForm = ({
           />
         )}
 
-        {isBetaEnabled &&
+        {eventsExportAvailable &&
           (watchedExportSource === AnalyticsIntegrationExportSource.EVENTS ||
             watchedExportSource ===
               AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS) && (


### PR DESCRIPTION
## Summary

- Replaces the per-user `isBetaEnabled` gate on the export source picker and export field groups section with `eventsExportAvailable` (`isEnrichedBlobExportAvailable(isLangfuseCloud)`)
- All Cloud users on pre-cutoff projects now see consistent form behaviour regardless of their personal V4 beta flag
- Adds `isEnrichedBlobExportAvailable(isCloud: boolean): boolean` to `blob-export-gate.ts` as the shared deployment-level predicate (today returns `isCloud`; self-hosted flip is one line when provisioned)
- `useV4Beta` / `isBetaEnabled` removed from the blob storage form entirely

## Impacted packages

- `packages/shared` — new exported helper `isEnrichedBlobExportAvailable`
- `web` — `blobstorage.tsx` form gate change

## Verification

- `pnpm --filter @langfuse/shared run lint` ✓
- `pnpm --filter web run lint` ✓
- `pnpm --filter web run typecheck` ✓

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR decouples the blob storage export source picker and export field groups visibility from the per-user `isBetaEnabled` / `useV4Beta` flag, replacing it with a new deployment-level predicate `isEnrichedBlobExportAvailable(isCloud)` that currently returns `isCloud`. All pre-cutoff Cloud projects now uniformly see the export source picker and enriched-export field groups regardless of each user's personal V4 beta setting.

- **New predicate** `isEnrichedBlobExportAvailable` added to `blob-export-gate.ts` and exported from `@langfuse/shared`; the function is intentionally minimal today (returns `isCloud`) with a comment marking the self-hosted flip point.
- **Form gate change** in `blobstorage.tsx`: `isBetaEnabled && !isPostCutoffCloud` → `eventsExportAvailable && !isPostCutoffCloud`; also updates the default `exportSource` and the export field groups section guard accordingly, and drops the `useV4Beta` import entirely.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change removes a per-user session flag and replaces it with a static, env-var-derived cloud check, narrowing the surface area and eliminating inconsistent UI states between users on the same project.

Both changed files are small and self-contained. The new predicate is a single-line function with a clear, well-commented upgrade path. All three usage sites in the form are consistently updated, and the export from @langfuse/shared is already wired through the existing export * chain.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(blob-storage): decouple export sour..."](https://github.com/langfuse/langfuse/commit/f777b26d10afeae30c29e60a72b4f2cd938b3cdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35575014)</sub>

<!-- /greptile_comment -->