### PR TITLE
chore(seeder): default ai features on in seeder

### DIFF
--- a/packages/shared/scripts/seeder/seed-postgres.ts
+++ b/packages/shared/scripts/seeder/seed-postgres.ts
@@ -92,6 +92,7 @@ async function main() {
     create: {
       id: seedOrgId,
       name: "Seed Org",
+      aiFeaturesEnabled: true,
       cloudConfig: {
         plan: "Team",
       },


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables AI features by default for the seed organization in the Postgres seeder, making it easier to demo and develop against AI-powered functionality without manual configuration.

- `aiFeaturesEnabled: true` is added to the `create` block of the primary seed org (`seed-org-id`), but the corresponding `update` block and the second demo org (`demo-org-id`) are not updated, so re-seeding an existing database or running the `examples`/`load` environment seed will not consistently enable AI features everywhere.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a one-line addition to a dev/demo seeder with no impact on production code or data migrations. Safe to merge.

The change only affects the seeder's `create` path. Re-running the seeder on an existing database, or seeding the second demo org, will not enable AI features as the `update` block and second org upsert are untouched. For a dev-only script this is low-risk, but it means the intent of enabling AI features by default isn't fully achieved in all seeding scenarios.

packages/shared/scripts/seeder/seed-postgres.ts — the `update` block and the second demo organization upsert both need `aiFeaturesEnabled: true`.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Run Seeder] --> B{Seed Org exists?}
    B -- No --> C[CREATE: id, name, aiFeaturesEnabled=true, cloudConfig]
    B -- Yes --> D[UPDATE: name, cloudConfig\n⚠️ aiFeaturesEnabled NOT updated]
    C --> E[Seed Org: aiFeaturesEnabled=true ✅]
    D --> F[Seed Org: aiFeaturesEnabled unchanged ⚠️]
    A --> G{Demo Org exists?}
    G -- No --> H[CREATE: id, name\n⚠️ aiFeaturesEnabled NOT set]
    G -- Yes --> I[UPDATE: name\n⚠️ aiFeaturesEnabled NOT set]
    H --> J[Demo Org: aiFeaturesEnabled=false ⚠️]
    I --> K[Demo Org: aiFeaturesEnabled=false ⚠️]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/scripts/seeder/seed-postgres.ts:86-91
`aiFeaturesEnabled: true` is only in the `create` block, not the `update` block. When the seeder is re-run against an existing database, the upsert will hit the `update` path and leave `aiFeaturesEnabled` unchanged (potentially `false` or `null` from an older seed). Add it to the `update` block as well so re-seeding consistently enables AI features.

```suggestion
    update: {
      name: "Seed Org",
      aiFeaturesEnabled: true,
      cloudConfig: {
        plan: "Team",
      },
    },
```

### Issue 2 of 2
packages/shared/scripts/seeder/seed-postgres.ts:219-222
The second demo organization ("Langfuse Demo" / `demo-org-id`) does not have `aiFeaturesEnabled: true` set in either its `create` or `update` block. If the intent of this PR is to enable AI features across all seeded organizations, this org will be left without them enabled.

```suggestion
      create: {
        id: seedOrgIdOrg2,
        name: "Langfuse Demo",
        aiFeaturesEnabled: true,
      },
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(seeder): default ai features on in..."](https://github.com/langfuse/langfuse/commit/9534cb51c9fea4f0988c8b7bc70c744df8fa179e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35580556)</sub>

<!-- /greptile_comment -->