### PR TITLE
docs(agents): add frontend feature architecture skill

### DIFF
--- a/.agents/skills/frontend-large-feature-architecture/SKILL.md
+++ b/.agents/skills/frontend-large-feature-architecture/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: frontend-large-feature-architecture
+description: |
+  Use when refactoring large Langfuse frontend features, virtualized lists,
+  large tables, controller components, local feature state, Zustand stores,
+  row selection, high-frequency UI state, or rendering-performance issues.
+---
+
+# Frontend Large Feature Architecture
+
+Use this skill when a frontend surface has become a controller component: data
+fetching, view state, table/list state, actions, and expensive rendering all
+owned by one React component.
+
+## Big Feature Rules
+
+When a feature grows, split rendering from logic. Most components should be
+view-only. Data preparation should be pure. Complex user actions should live in
+external async functions or local-store actions. Effects are integration
+boundaries, not the normal way to derive state.
+
+For the full rules, read
+[`references/big-feature-rules.md`](references/big-feature-rules.md).
+
+## Required Model
+
+- The page/view owns lifecycle and creates feature-scoped dependencies.
+- Server/query state stays in tRPC/React Query.
+- Route state stays in the router.
+- High-frequency feature UI state belongs in a view-scoped store created per
+  mounted feature instance.
+- Create local store instances with a lazy `useState` initializer by default,
+  e.g. `const [store] = useState(() => createFeatureStore(...))`. Do not use
+  `useMemo` for store instance lifetime.
+- Do not turn local-state-heavy pages into global-store features. Use local
+  stores by default; global state is only for truly cross-feature, cross-route
+  product state.
+- React context may provide a stable store/controller instance. Do not put
+  frequently changing state directly in context provider values.
+- Rendered rows/cells/items should be view-only. Put effects, subscriptions,
+  and data loading in narrow containers around them.
+- Shared `src/components/*` exports should stay context-free or receive explicit
+  props. Put view-scoped Zustand consumers in `src/features/*` containers.
+- Large feature folders should have a concise `README.md` owner map that lists
+  entry points, subfolders, external consumers, state boundaries, performance
+  boundaries, and relevant agent docs.
+
+## Local Store Default
+
+Prefer a local vanilla Zustand store for large or high-frequency feature state.
+The store must be created by the page/view and destroyed on unmount. Do not
+create global stores for feature instance state.
+
+Use selectors that return primitives or stable references. If a component needs
+multiple values, use shallow selector helpers or split subscriptions so one
+changing field does not rerender unrelated UI.
+
+This is a performance and stability pattern: narrow subscriptions prevent one
+state change from rerunning controllers, recreating props/config, refiring
+effects, resetting virtualized row state, or retriggering measurement loops.
+
+Complex user workflows should live in `actions/*.ts` files or store actions.
+The component wires hooks and passes dependencies; the action owns the workflow.
+
+## When To Read References
+
+- For the core big-feature rules and migration reality, read
+  [`references/big-feature-rules.md`](references/big-feature-rules.md).
+- For virtualized lists, translated DOM, row measurement, and scroll rerenders,
+  read [`references/virtualized-lists.md`](references/virtualized-lists.md).
+- For local feature stores and controller breakup, read
+  [`references/local-feature-state.md`](references/local-feature-state.md).
+- For feature `README.md` owner maps, read
+  [`references/feature-readmes.md`](references/feature-readmes.md).
+- For a step-by-step migration from a controller component to a managed feature
+  pattern, read
+  [`references/controller-migration.md`](references/controller-migration.md).

--- a/.agents/skills/frontend-large-feature-architecture/SKILL.md
+++ b/.agents/skills/frontend-large-feature-architecture/SKILL.md
@@ -43,7 +43,10 @@ For the full rules, read
   props. Put view-scoped Zustand consumers in `src/features/*` containers.
 - Large feature folders should have a concise `README.md` owner map that lists
   entry points, subfolders, external consumers, state boundaries, performance
-  boundaries, and relevant agent docs.
+  boundaries, migration state, and relevant agent docs.
+- Migrate real features through small reliable PRs. Each PR should improve one
+  state boundary, action workflow, data-preparation seam, or render boundary and
+  document the next slice.
 
 ## Local Store Default
 
@@ -75,3 +78,5 @@ The component wires hooks and passes dependencies; the action owns the workflow.
 - For a step-by-step migration from a controller component to a managed feature
   pattern, read
   [`references/controller-migration.md`](references/controller-migration.md).
+  This is the default reference for traces/observations tables, sessions,
+  experiments, prompts, evals, datasets, and other controller-heavy surfaces.

--- a/.agents/skills/frontend-large-feature-architecture/SKILL.md
+++ b/.agents/skills/frontend-large-feature-architecture/SKILL.md
@@ -1,16 +1,21 @@
 ---
 name: frontend-large-feature-architecture
 description: |
-  Use when refactoring large Langfuse frontend features, virtualized lists,
-  large tables, controller components, local feature state, Zustand stores,
-  row selection, high-frequency UI state, or rendering-performance issues.
+  Use when building, changing, or refactoring large Langfuse frontend features,
+  virtualized lists, large tables, controller components, local feature state,
+  Zustand stores, row selection, high-frequency UI state, or
+  rendering-performance issues.
 ---
 
 # Frontend Large Feature Architecture
 
-Use this skill when a frontend surface has become a controller component: data
-fetching, view state, table/list state, actions, and expensive rendering all
-owned by one React component.
+Use this skill when building, changing, or refactoring a large frontend
+surface.
+
+In this skill, "controller" means a component or hook that owns feature logic:
+data fetching, view state, table/list state, effects, actions, and expensive
+rendering. The problem is not the name; it is one place owning too many
+changing responsibilities.
 
 ## Big Feature Rules
 
@@ -25,42 +30,29 @@ For the full rules, read
 ## Required Model
 
 - The page/view owns lifecycle and creates feature-scoped dependencies.
-- Server/query state stays in tRPC/React Query.
-- Route state stays in the router.
-- High-frequency feature UI state belongs in a view-scoped store created per
-  mounted feature instance.
-- Create local store instances with a lazy `useState` initializer by default,
-  e.g. `const [store] = useState(() => createFeatureStore(...))`. Do not use
-  `useMemo` for store instance lifetime.
-- Do not turn local-state-heavy pages into global-store features. Use local
-  stores by default; global state is only for truly cross-feature, cross-route
-  product state.
-- React context may provide a stable store/controller instance. Do not put
-  frequently changing state directly in context provider values.
-- Rendered rows/cells/items should be view-only. Put effects, subscriptions,
-  and data loading in narrow containers around them.
-- Shared `src/components/*` exports should stay context-free or receive explicit
-  props. Put view-scoped Zustand consumers in `src/features/*` containers.
-- Large feature folders should have a concise `README.md` owner map that lists
-  entry points, subfolders, external consumers, state boundaries, performance
-  boundaries, migration state, and relevant agent docs.
-- Migrate real features through small reliable PRs. Each PR should improve one
-  state boundary, action workflow, data-preparation seam, or render boundary and
-  document the next slice.
+- Server/query state stays in tRPC/React Query; route state stays in the
+  router/filter hooks.
+- High-frequency feature UI state belongs in a per-mount local vanilla Zustand
+  store. Create it with lazy `useState`, not `useMemo`.
+- Global stores are only for truly cross-feature, cross-route product state.
+- React context may provide a stable store or action owner. Do not put
+  frequently changing state directly in provider values.
+- Rendered rows/cells/items should be view-only or narrow containers. Put
+  effects, subscriptions, data loading, and workflows outside expensive views.
+- Shared `src/components/*` exports should stay context-free or receive
+  explicit props. Put view-scoped Zustand consumers in `src/features/*`.
+- Large feature folders should have a concise `README.md` owner map.
+- Migrate real features through small PRs that improve one state boundary,
+  action workflow, data-preparation seam, or render boundary.
 
 ## Local Store Default
 
 Prefer a local vanilla Zustand store for large or high-frequency feature state.
-The store must be created by the page/view and destroyed on unmount. Do not
-create global stores for feature instance state.
+The store is created by the page/view and destroyed on unmount.
 
 Use selectors that return primitives or stable references. If a component needs
 multiple values, use shallow selector helpers or split subscriptions so one
 changing field does not rerender unrelated UI.
-
-This is a performance and stability pattern: narrow subscriptions prevent one
-state change from rerunning controllers, recreating props/config, refiring
-effects, resetting virtualized row state, or retriggering measurement loops.
 
 Complex user workflows should live in `actions/*.ts` files or store actions.
 The component wires hooks and passes dependencies; the action owns the workflow.
@@ -71,7 +63,7 @@ The component wires hooks and passes dependencies; the action owns the workflow.
   [`references/big-feature-rules.md`](references/big-feature-rules.md).
 - For virtualized lists, translated DOM, row measurement, and scroll rerenders,
   read [`references/virtualized-lists.md`](references/virtualized-lists.md).
-- For local feature stores and controller breakup, read
+- For local feature stores and splitting large components, read
   [`references/local-feature-state.md`](references/local-feature-state.md).
 - For feature `README.md` owner maps, read
   [`references/feature-readmes.md`](references/feature-readmes.md).

--- a/.agents/skills/frontend-large-feature-architecture/agents/openai.yaml
+++ b/.agents/skills/frontend-large-feature-architecture/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Frontend Feature Architecture"
-  short_description: "Refactor large React features safely"
-  default_prompt: "Use $frontend-large-feature-architecture to refactor this large frontend surface into local state, stable subscriptions, and view-only render boundaries."
+  short_description: "Build, change, or refactor React features"
+  default_prompt: "Use $frontend-large-feature-architecture to build, change, or refactor this large frontend surface with clear state ownership, stable subscriptions, and view-only render boundaries."
 
 policy:
   allow_implicit_invocation: true

--- a/.agents/skills/frontend-large-feature-architecture/agents/openai.yaml
+++ b/.agents/skills/frontend-large-feature-architecture/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Frontend Feature Architecture"
+  short_description: "Refactor large React features safely"
+  default_prompt: "Use $frontend-large-feature-architecture to refactor this large frontend surface into local state, stable subscriptions, and view-only render boundaries."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/frontend-large-feature-architecture/references/big-feature-rules.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/big-feature-rules.md
@@ -1,14 +1,31 @@
 # Big Feature Rules
 
-Use these rules when a feature keeps growing and the instinct is to add another
-state variable, prop, callback, or effect to the same controller component.
+Use these rules when a feature keeps growing and the instinct is to add one
+more state variable, prop, callback, or effect to the same component.
+
+Here, "controller" means a component or hook that owns feature logic: state,
+effects, data loading, subscriptions, actions, and derived data. Some
+controller code is necessary. The failure mode is one controller owning too many
+changing responsibilities and waking too much UI.
+
+## Ownership Baseline
+
+- The page/view owns lifecycle and creates feature-scoped dependencies.
+- Server/query state stays in tRPC/React Query.
+- Route state stays in router/filter hooks.
+- High-frequency local UI state belongs in a per-mount feature store.
+- Global stores are only for product state shared across routes or features.
+- Pure data preparation turns fetched data into UI data before rendering.
+- Complex workflows live in `actions/*.ts` or store actions.
+- Effects are integration boundaries, not ordinary state derivation.
+- Expensive rows/cells/items should be view-only behind narrow containers.
 
 ## Hard Rules
 
 1. Growth usually means React rendering and feature logic need to be separated.
    A bigger component is not an architecture.
-2. Most components should be stupid. They render what they are given, or they
-   read a small selected value from a context-available feature store.
+2. Most components should be view-only. They render what they are given, or
+   they read a small selected value from a context-available feature store.
 3. Complicated data preparation belongs in separate pure functions. Backend
    data should flow one way: fetched data -> compiled UI data -> render.
 4. User actions that trigger complex logic should live outside render
@@ -16,34 +33,20 @@ state variable, prop, callback, or effect to the same controller component.
    lot of context, pass the feature store instance and let the action read what
    it needs.
 5. A feature with both local store state and React Query data needs an explicit
-   bridge. The store can trigger refetching. If store decisions depend on query
-   data, put the interaction in a custom hook or store/controller action so the
-   relationship is visible.
+   bridge in a custom hook or named action.
 6. Prefer view-scoped local feature stores over global stores for page-instance
    state. Filters, selected rows, expanded rows, lazy load state, drawers, and
    local actions usually belong to one mounted page instance.
 7. Create local store instances with a lazy `useState` initializer, not
    `useMemo`. The store is a per-mount instance, not a render-time derived
    value.
-8. If effects are unavoidable, consolidate them into one initialization effect
-   that calls `store.init(...)`. Prefer no dependencies. The store should own
-   the initialization state machine.
-9. The local feature store should be a simple, navigable state machine. It
-   should expose state, derived facts, and actions with names that explain the
-   feature workflow.
-10. Effects should not be normal state mutators. If an effect changes state on
-    every render or data change, the feature is not preparing data correctly.
-11. Every time you want to add `useEffect` or `useLayoutEffect`, stop and try to
-    replace it with pure data preparation, a store action, or an explicit event
-    handler.
-12. Do not copy existing large Langfuse feature components as examples. Treat
-    them as legacy unless they follow this skill.
-13. Prefer small reliable migration PRs over a large rewrite. Each PR should
-    improve one state boundary, action workflow, data-preparation seam, or
-    render boundary.
-14. Every migration PR should leave a clearer map for the next one: update the
-    feature README or migration note with what is now improved, what remains
-    spread, and the next atomic slice.
+8. Effects should not be normal state mutators. Before adding an effect, try
+   pure data preparation, a store action, or an explicit event handler.
+9. Do not copy existing large Langfuse feature components as examples. Treat
+   them as legacy unless they follow this skill.
+10. Prefer small reliable PRs over a large rewrite. Each PR should improve one
+    state boundary, action workflow, data-preparation seam, or render boundary,
+    then update the feature README or migration note with the next slice.
 
 ## Migration Reality
 
@@ -58,42 +61,24 @@ For the step-by-step path, read `controller-migration.md`.
 ## Small PR Policy
 
 A good big-feature PR is intentionally incomplete. It should change one
-semantic interaction and keep behavior stable. Examples:
-
-- extract row selection and batch actions without touching filters
-- extract filter-target state without changing table columns
-- move a download/export workflow into `actions/*.ts` without adding a store
-- move expensive row data preparation into a pure helper without changing UI
-- add a local store provider and one subscribed state slice, leaving other state
-  in place
+semantic interaction and keep behavior stable: one selection boundary, one
+action workflow, one pure data-preparation helper, or one render boundary.
 
 Do not bundle file reorganization, state extraction, visual changes, and
-behavior fixes in the same PR unless the user explicitly asks for that risk.
+behavior fixes in the same PR unless the user explicitly asks for that scope.
 When a reorganization is needed, prefer a rename-only PR first or a later
 follow-up PR.
 
-## Effect Policy
+## Effects And Actions
 
-Effects are allowed for integration boundaries: subscriptions, observers,
-imperative third-party APIs, one-time initialization, and cleanup. They are not
-the default place to derive UI state.
+Effects are for subscriptions, observers, imperative third-party APIs,
+one-time initialization, and cleanup. Keep them in containers or feature hooks,
+not view components. If an effect writes state repeatedly, make the store action
+idempotent.
 
-When an effect is necessary:
-
-- Keep it in a container or feature hook, not a view component.
-- Prefer one init effect that calls a named store action.
-- Keep the effect body tiny.
-- Make repeated state writes idempotent inside the store.
-- Document why render-time data preparation is insufficient.
-
-## Action Policy
-
-Complex actions should be callable without rendering a component. Put
-surface-specific workflows in `actions/*.ts` or in named store actions. The
-component should wire hooks and pass dependencies; the action should own the
-workflow.
-
-Prefer:
+Complex actions should be callable without rendering a component. Put workflows
+in `actions/*.ts` or named store actions. Components wire hooks and pass
+dependencies; actions own the workflow.
 
 ```ts
 await applyBulkAction({
@@ -101,24 +86,6 @@ await applyBulkAction({
   queryClient,
   projectId,
 });
-```
-
-or:
-
-```ts
-await exportFeatureData({
-  capture,
-  fetchDetails,
-  projectId,
-  refetchSummary,
-  selectedIds,
-});
-```
-
-or:
-
-```ts
-await store.getState().actions.applyBulkAction({ queryClient });
 ```
 
 Actions must not call React hooks. Pass hook results, query helpers, the local

--- a/.agents/skills/frontend-large-feature-architecture/references/big-feature-rules.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/big-feature-rules.md
@@ -1,0 +1,106 @@
+# Big Feature Rules
+
+Use these rules when a feature keeps growing and the instinct is to add another
+state variable, prop, callback, or effect to the same controller component.
+
+## Hard Rules
+
+1. Growth usually means React rendering and feature logic need to be separated.
+   A bigger component is not an architecture.
+2. Most components should be stupid. They render what they are given, or they
+   read a small selected value from a context-available feature store.
+3. Complicated data preparation belongs in separate pure functions. Backend
+   data should flow one way: fetched data -> compiled UI data -> render.
+4. User actions that trigger complex logic should live outside render
+   components as named async functions or store actions. If the action needs a
+   lot of context, pass the feature store instance and let the action read what
+   it needs.
+5. A feature with both local store state and React Query data needs an explicit
+   bridge. The store can trigger refetching. If store decisions depend on query
+   data, put the interaction in a custom hook or store/controller action so the
+   relationship is visible.
+6. Prefer view-scoped local feature stores over global stores for page-instance
+   state. Filters, selected rows, expanded rows, lazy load state, drawers, and
+   local actions usually belong to one mounted page instance.
+7. Create local store instances with a lazy `useState` initializer, not
+   `useMemo`. The store is a per-mount instance, not a render-time derived
+   value.
+8. If effects are unavoidable, consolidate them into one initialization effect
+   that calls `store.init(...)`. Prefer no dependencies. The store should own
+   the initialization state machine.
+9. The local feature store should be a simple, navigable state machine. It
+   should expose state, derived facts, and actions with names that explain the
+   feature workflow.
+10. Effects should not be normal state mutators. If an effect changes state on
+    every render or data change, the feature is not preparing data correctly.
+11. Every time you want to add `useEffect` or `useLayoutEffect`, stop and try to
+    replace it with pure data preparation, a store action, or an explicit event
+    handler.
+12. Do not copy existing large Langfuse feature components as examples. Treat
+    them as legacy unless they follow this skill.
+
+## Migration Reality
+
+Most large frontend features are not yet in the ideal shape. Do not copy an
+existing large component just because it works today. Treat controller-heavy
+surfaces as migration candidates and move them one state boundary at a time.
+
+For the step-by-step path, read `references/controller-migration.md`.
+
+## Effect Policy
+
+Effects are allowed for integration boundaries: subscriptions, observers,
+imperative third-party APIs, one-time initialization, and cleanup. They are not
+the default place to derive UI state.
+
+When an effect is necessary:
+
+- Keep it in a container or feature hook, not a view component.
+- Prefer one init effect that calls a named store action.
+- Keep the effect body tiny.
+- Make repeated state writes idempotent inside the store.
+- Document why render-time data preparation is insufficient.
+
+## Action Policy
+
+Complex actions should be callable without rendering a component. Put
+surface-specific workflows in `actions/*.ts` or in named store actions. The
+component should wire hooks and pass dependencies; the action should own the
+workflow.
+
+Prefer:
+
+```ts
+await applyBulkAction({
+  store,
+  queryClient,
+  projectId,
+});
+```
+
+or:
+
+```ts
+await exportFeatureData({
+  capture,
+  fetchDetails,
+  projectId,
+  refetchSummary,
+  selectedIds,
+});
+```
+
+or:
+
+```ts
+await store.getState().actions.applyBulkAction({ queryClient });
+```
+
+Actions must not call React hooks. Pass hook results, query helpers, the local
+store instance, or narrow callback dependencies into the action. If an action
+needs substantial data preparation, export a pure helper next to it so the
+transformation can be tested independently.
+
+Do not pass twenty props through the tree so a button can do feature-level work,
+and do not leave complex workflows inline in a page controller because that
+controller happened to have all dependencies in scope.

--- a/.agents/skills/frontend-large-feature-architecture/references/big-feature-rules.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/big-feature-rules.md
@@ -38,14 +38,39 @@ state variable, prop, callback, or effect to the same controller component.
     handler.
 12. Do not copy existing large Langfuse feature components as examples. Treat
     them as legacy unless they follow this skill.
+13. Prefer small reliable migration PRs over a large rewrite. Each PR should
+    improve one state boundary, action workflow, data-preparation seam, or
+    render boundary.
+14. Every migration PR should leave a clearer map for the next one: update the
+    feature README or migration note with what is now improved, what remains
+    spread, and the next atomic slice.
 
 ## Migration Reality
 
-Most large frontend features are not yet in the ideal shape. Do not copy an
-existing large component just because it works today. Treat controller-heavy
-surfaces as migration candidates and move them one state boundary at a time.
+Most large frontend features are not yet in the ideal shape. Traces,
+observations, experiments, prompts, evals, datasets, and session views all have
+some controller-heavy surfaces. Do not copy an existing large component just
+because it works today. Treat it as a migration candidate and move it one
+state/action/data-preparation boundary at a time.
 
-For the step-by-step path, read `references/controller-migration.md`.
+For the step-by-step path, read `controller-migration.md`.
+
+## Small PR Policy
+
+A good big-feature PR is intentionally incomplete. It should change one
+semantic interaction and keep behavior stable. Examples:
+
+- extract row selection and batch actions without touching filters
+- extract filter-target state without changing table columns
+- move a download/export workflow into `actions/*.ts` without adding a store
+- move expensive row data preparation into a pure helper without changing UI
+- add a local store provider and one subscribed state slice, leaving other state
+  in place
+
+Do not bundle file reorganization, state extraction, visual changes, and
+behavior fixes in the same PR unless the user explicitly asks for that risk.
+When a reorganization is needed, prefer a rename-only PR first or a later
+follow-up PR.
 
 ## Effect Policy
 

--- a/.agents/skills/frontend-large-feature-architecture/references/controller-migration.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/controller-migration.md
@@ -1,19 +1,11 @@
 # Controller Migration Guide
 
-Use this when a frontend surface has grown into one component that owns data
-fetching, route glue, filters, table/list state, selection, drawers, actions,
-and expensive rendering.
+Use this when a frontend surface has grown into one component or hook that owns
+data fetching, route glue, filters, table/list state, selection, drawers,
+actions, and expensive rendering.
 
-The future target is not "everything in a store." The target is clear
-ownership:
-
-- the page/view owns lifecycle and creates feature-scoped dependencies
-- server state remains in tRPC/React Query
-- route state remains in router/filter hooks
-- high-frequency local UI state lives in a per-mount feature store
-- pure data preparation lives in named helper functions
-- complex workflows live in `actions/*.ts` or store actions
-- rendered components are mostly view-only
+The target is clear ownership, not "everything in a store." Start from the
+ownership baseline in `big-feature-rules.md`.
 
 Most existing features are not there yet. Migrate in narrow slices and keep
 behavior stable.
@@ -40,9 +32,9 @@ feature moves forward.
 
 1. **Map the controller.** List every state group, query, derived value, effect,
    callback, action, and expensive child render owned by the component.
-2. **Classify state.** Separate server/query state, route state, persisted
-   browser state, high-frequency local UI state, derived view data, imperative
-   integration state, and one-off modal/form state.
+2. **Classify state.** Separate server/query, route, persisted browser,
+   high-frequency local UI, derived view data, imperative integration, and
+   one-off modal/form state.
 3. **Instrument one symptom.** Pick a concrete interaction such as row
    selection, scroll, filter change, drawer open, form step change, or
    saved-view change. Measure what rerenders, remounts, refetches, or
@@ -52,9 +44,8 @@ feature moves forward.
    column/view state, wizard step state, or pure data preparation. Do not
    migrate everything at once.
 5. **Choose the lightest tool.** A pure helper or action extraction may be the
-   right first PR. Add a local store only when state is high-frequency,
-   cross-component within the mounted feature, or currently reruns unrelated
-   expensive rendering.
+   right first PR. Add a local store only when selective subscriptions or
+   per-mount persistence are needed.
 6. **Create a local store instance when needed.** Use lazy `useState` in the
    page/view:
 
@@ -67,8 +58,8 @@ feature moves forward.
 7. **Move mutations into named actions.** Put state-changing logic in store
    actions or external action functions. Keep components responsible for user
    events, not workflows.
-8. **Split containers from views.** Containers may subscribe to store slices,
-   call hooks, or fetch data. Views should render props or tiny selected values.
+8. **Split containers from views.** Containers may subscribe, call hooks, or
+   fetch data. Views should render props or tiny selected values.
 9. **Move data preparation out of render.** Put expensive or complicated
    transformations in pure functions. Backend data should flow into compiled UI
    data, then into rendering.
@@ -86,41 +77,32 @@ feature moves forward.
 
 ## Feature-Specific First Slices
 
-Use the feature's current shape to pick the first slice. These are common
-Langfuse patterns seen in large surfaces:
+Use the feature's current shape to pick the first slice:
 
 - **Traces and observations tables**: start with row selection, select-all,
-  batch actions, or expensive cell data wrappers. Keep filters, saved views,
-  pagination, and peek routing unchanged in the first PR.
+  batch actions, or expensive cell wrappers.
 - **Session detail and session events**: isolate virtualization, lazy-row load
-  state, and dynamic measurement from rendered row content. Keep shared session
-  components context-free when other features import them.
+  state, and dynamic measurement from rendered row content.
 - **Experiment result tables**: start with selected-row state, filter-target
   mapping, run/evaluation batch actions, or pure helpers for comparison column
-  construction. Do not mix this with layout/view-mode redesigns.
+  construction.
 - **Experiment creation wizards**: separate submitted form data from display
   state such as active step, selected prompt labels, schema display names, and
-  evaluator selection. Extract default-name/default-run derivation before
-  moving state.
+  evaluator selection.
 - **Prompt management**: split prompt detail route/query state, label/version
-  selection, prompt history data preparation, and mutation workflows. Actions
-  such as duplicate, delete, set labels, and create prompt should be callable
-  outside render components.
+  selection, prompt history data preparation, and mutation workflows.
 - **Eval template and evaluator forms**: extract form defaults, model/provider
   preparation, validation helpers, and submit workflows before adding a store.
-  Most of this state is form-local; use a store only when multiple mounted
-  subtrees need selective subscriptions.
 - **Datasets and dataset runs**: isolate active-cell/compare-field state,
-  table selection, run comparison preparation, and upload/import workflows. Do
-  not let table row UI own run-level actions.
+  table selection, run comparison preparation, and upload/import workflows.
 
 If a feature already has hooks for part of this work, treat them as partial
 migration, not proof that the whole surface is healthy.
 
-## What Good Looks Like
+## Acceptance Criteria
 
 - A local state change wakes only components that selected that state.
-- Page controllers no longer rebuild columns, filters, row wrappers, and action
+- Page components no longer rebuild columns, filters, row wrappers, and action
   callbacks for unrelated row-level changes.
 - Expensive rows/cells are view-only behind narrow containers.
 - Effects are integration boundaries or one-time initialization, not ordinary
@@ -129,13 +111,12 @@ migration, not proof that the whole surface is healthy.
 - The feature README tells the next developer what has improved, what remains
   spread, and what the next small PR should target.
 
-## What To Avoid
+Avoid:
 
 - Replacing a giant component with a giant global store.
 - Moving all state at once without measured acceptance criteria.
 - Treating memoization as the architecture.
 - Putting provider-coupled store hooks into shared `src/components/*` exports.
-- Creating a feature folder structure without documenting ownership boundaries.
 - Leaving a workflow inline in the page because the page had every dependency in
   scope.
 - Using the README as a victory statement while hiding remaining controller

--- a/.agents/skills/frontend-large-feature-architecture/references/controller-migration.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/controller-migration.md
@@ -18,16 +18,45 @@ ownership:
 Most existing features are not there yet. Migrate in narrow slices and keep
 behavior stable.
 
+## Realistic Migration Strategy
+
+Do not start by designing the perfect final feature. Start by making the next
+change safer than the previous one.
+
+For each migration PR, write down:
+
+- the current controller problem being targeted
+- the single state/action/data-preparation/render boundary being improved
+- what behavior must remain unchanged
+- what instrumentation or tests prove the slice worked
+- what still remains spread across the feature
+- the next recommended atomic slice
+
+This is how large features become managed features without review-hostile
+rewrites. The feature README is the living owner map; update it in place as the
+feature moves forward.
+
 ## Step-by-Step Path
 
 1. **Map the controller.** List every state group, query, derived value, effect,
    callback, action, and expensive child render owned by the component.
-2. **Instrument one symptom.** Pick a concrete interaction such as row
-   selection, scroll, filter change, drawer open, or saved-view change. Measure
-   what rerenders, remounts, refetches, or recalculates.
-3. **Choose one state boundary.** Start with high-frequency local UI state that
-   currently reruns unrelated logic. Do not migrate everything at once.
-4. **Create a local store instance.** Use lazy `useState` in the page/view:
+2. **Classify state.** Separate server/query state, route state, persisted
+   browser state, high-frequency local UI state, derived view data, imperative
+   integration state, and one-off modal/form state.
+3. **Instrument one symptom.** Pick a concrete interaction such as row
+   selection, scroll, filter change, drawer open, form step change, or
+   saved-view change. Measure what rerenders, remounts, refetches, or
+   recalculates.
+4. **Choose one boundary.** Start with the smallest high-value boundary:
+   selection, lazy-row state, batch action workflow, filter-target mapping,
+   column/view state, wizard step state, or pure data preparation. Do not
+   migrate everything at once.
+5. **Choose the lightest tool.** A pure helper or action extraction may be the
+   right first PR. Add a local store only when state is high-frequency,
+   cross-component within the mounted feature, or currently reruns unrelated
+   expensive rendering.
+6. **Create a local store instance when needed.** Use lazy `useState` in the
+   page/view:
 
    ```ts
    const [store] = useState(() => createFeatureStore(initialState));
@@ -35,25 +64,58 @@ behavior stable.
 
    Provide only this stable store instance through context.
 
-5. **Move mutations into named actions.** Put state-changing logic in store
+7. **Move mutations into named actions.** Put state-changing logic in store
    actions or external action functions. Keep components responsible for user
    events, not workflows.
-6. **Split containers from views.** Containers may subscribe to store slices,
+8. **Split containers from views.** Containers may subscribe to store slices,
    call hooks, or fetch data. Views should render props or tiny selected values.
-7. **Move data preparation out of render.** Put expensive or complicated
+9. **Move data preparation out of render.** Put expensive or complicated
    transformations in pure functions. Backend data should flow into compiled UI
    data, then into rendering.
-8. **Bridge query state explicitly.** If local store decisions depend on React
-   Query data, use a named feature hook or action to express that relationship.
-9. **Isolate imperative integration.** Virtualizers, observers, keyboard
-   listeners, third-party DOM mutation handling, and timers belong in narrow
-   integration hooks.
-10. **Update the feature README.** Record the current owner map, desired
-    boundaries, known spread state, and next extraction target.
-11. **Remove debug instrumentation.** Temporary logs are useful during
+10. **Bridge query state explicitly.** If local store decisions depend on React
+    Query data, use a named feature hook or action to express that relationship.
+11. **Isolate imperative integration.** Virtualizers, observers, keyboard
+    listeners, third-party DOM mutation handling, and timers belong in narrow
+    integration hooks.
+12. **Update the feature README.** Record what this PR improved, desired
+    boundaries, known spread state, and the next extraction target.
+13. **Remove debug instrumentation.** Temporary logs are useful during
     migration, but should not survive the slice.
-12. **Repeat.** Each slice should make one semantic interaction narrower and
+14. **Repeat.** Each slice should make one semantic interaction narrower and
     easier to reason about.
+
+## Feature-Specific First Slices
+
+Use the feature's current shape to pick the first slice. These are common
+Langfuse patterns seen in large surfaces:
+
+- **Traces and observations tables**: start with row selection, select-all,
+  batch actions, or expensive cell data wrappers. Keep filters, saved views,
+  pagination, and peek routing unchanged in the first PR.
+- **Session detail and session events**: isolate virtualization, lazy-row load
+  state, and dynamic measurement from rendered row content. Keep shared session
+  components context-free when other features import them.
+- **Experiment result tables**: start with selected-row state, filter-target
+  mapping, run/evaluation batch actions, or pure helpers for comparison column
+  construction. Do not mix this with layout/view-mode redesigns.
+- **Experiment creation wizards**: separate submitted form data from display
+  state such as active step, selected prompt labels, schema display names, and
+  evaluator selection. Extract default-name/default-run derivation before
+  moving state.
+- **Prompt management**: split prompt detail route/query state, label/version
+  selection, prompt history data preparation, and mutation workflows. Actions
+  such as duplicate, delete, set labels, and create prompt should be callable
+  outside render components.
+- **Eval template and evaluator forms**: extract form defaults, model/provider
+  preparation, validation helpers, and submit workflows before adding a store.
+  Most of this state is form-local; use a store only when multiple mounted
+  subtrees need selective subscriptions.
+- **Datasets and dataset runs**: isolate active-cell/compare-field state,
+  table selection, run comparison preparation, and upload/import workflows. Do
+  not let table row UI own run-level actions.
+
+If a feature already has hooks for part of this work, treat them as partial
+migration, not proof that the whole surface is healthy.
 
 ## What Good Looks Like
 
@@ -64,7 +126,8 @@ behavior stable.
 - Effects are integration boundaries or one-time initialization, not ordinary
   data derivation.
 - Complex workflows can be called without rendering the page.
-- The feature README tells the next developer where state belongs.
+- The feature README tells the next developer what has improved, what remains
+  spread, and what the next small PR should target.
 
 ## What To Avoid
 
@@ -75,3 +138,5 @@ behavior stable.
 - Creating a feature folder structure without documenting ownership boundaries.
 - Leaving a workflow inline in the page because the page had every dependency in
   scope.
+- Using the README as a victory statement while hiding remaining controller
+  state. Be explicit about remaining debt.

--- a/.agents/skills/frontend-large-feature-architecture/references/controller-migration.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/controller-migration.md
@@ -1,0 +1,77 @@
+# Controller Migration Guide
+
+Use this when a frontend surface has grown into one component that owns data
+fetching, route glue, filters, table/list state, selection, drawers, actions,
+and expensive rendering.
+
+The future target is not "everything in a store." The target is clear
+ownership:
+
+- the page/view owns lifecycle and creates feature-scoped dependencies
+- server state remains in tRPC/React Query
+- route state remains in router/filter hooks
+- high-frequency local UI state lives in a per-mount feature store
+- pure data preparation lives in named helper functions
+- complex workflows live in `actions/*.ts` or store actions
+- rendered components are mostly view-only
+
+Most existing features are not there yet. Migrate in narrow slices and keep
+behavior stable.
+
+## Step-by-Step Path
+
+1. **Map the controller.** List every state group, query, derived value, effect,
+   callback, action, and expensive child render owned by the component.
+2. **Instrument one symptom.** Pick a concrete interaction such as row
+   selection, scroll, filter change, drawer open, or saved-view change. Measure
+   what rerenders, remounts, refetches, or recalculates.
+3. **Choose one state boundary.** Start with high-frequency local UI state that
+   currently reruns unrelated logic. Do not migrate everything at once.
+4. **Create a local store instance.** Use lazy `useState` in the page/view:
+
+   ```ts
+   const [store] = useState(() => createFeatureStore(initialState));
+   ```
+
+   Provide only this stable store instance through context.
+
+5. **Move mutations into named actions.** Put state-changing logic in store
+   actions or external action functions. Keep components responsible for user
+   events, not workflows.
+6. **Split containers from views.** Containers may subscribe to store slices,
+   call hooks, or fetch data. Views should render props or tiny selected values.
+7. **Move data preparation out of render.** Put expensive or complicated
+   transformations in pure functions. Backend data should flow into compiled UI
+   data, then into rendering.
+8. **Bridge query state explicitly.** If local store decisions depend on React
+   Query data, use a named feature hook or action to express that relationship.
+9. **Isolate imperative integration.** Virtualizers, observers, keyboard
+   listeners, third-party DOM mutation handling, and timers belong in narrow
+   integration hooks.
+10. **Update the feature README.** Record the current owner map, desired
+    boundaries, known spread state, and next extraction target.
+11. **Remove debug instrumentation.** Temporary logs are useful during
+    migration, but should not survive the slice.
+12. **Repeat.** Each slice should make one semantic interaction narrower and
+    easier to reason about.
+
+## What Good Looks Like
+
+- A local state change wakes only components that selected that state.
+- Page controllers no longer rebuild columns, filters, row wrappers, and action
+  callbacks for unrelated row-level changes.
+- Expensive rows/cells are view-only behind narrow containers.
+- Effects are integration boundaries or one-time initialization, not ordinary
+  data derivation.
+- Complex workflows can be called without rendering the page.
+- The feature README tells the next developer where state belongs.
+
+## What To Avoid
+
+- Replacing a giant component with a giant global store.
+- Moving all state at once without measured acceptance criteria.
+- Treating memoization as the architecture.
+- Putting provider-coupled store hooks into shared `src/components/*` exports.
+- Creating a feature folder structure without documenting ownership boundaries.
+- Leaving a workflow inline in the page because the page had every dependency in
+  scope.

--- a/.agents/skills/frontend-large-feature-architecture/references/feature-readmes.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/feature-readmes.md
@@ -5,9 +5,8 @@ owner map for humans and agents. Prefer `README.md` over `FEATURE.md` to match
 the existing `web/src/features/*` convention. Use `FEATURE.md` only if a folder
 already has a user-facing or generated README.
 
-The README is not a changelog. It should describe durable boundaries: entry
-points, subfolders, state ownership, performance-sensitive interactions, and
-where to find deeper migration notes.
+The README is not a changelog. It should describe durable boundaries and point
+to deeper migration notes.
 
 ## Required Sections
 
@@ -32,21 +31,9 @@ where to find deeper migration notes.
 
 ## State Ownership Rules
 
-- Server data remains in tRPC/React Query unless a pure prepared view model is
-  needed for rendering.
-- URL state remains in router/filter hooks, but feature-specific interpretation
-  belongs in a controller hook, pure helper, or local store action.
-- Local feature stores are created by the mounted page/view and destroyed on
-  unmount. This is the default for Langfuse pages because they are often
-  local-state heavy.
-- Global stores are only for product state shared across routes or features.
-  Do not globalize state to hide prop drilling or controller complexity.
-- DOM integration state, such as virtualizer measurement, observers, and
-  third-party mutation handling, belongs in narrow integration hooks.
-- View components should render props or subscribe to a small store slice. They
-  should not derive controller state or own feature workflows.
-- Complex feature workflows should live in `actions/*.ts` or store actions, not
-  inline in page controllers or view components.
+Use the ownership baseline in `big-feature-rules.md`. The README only needs to
+name where each state category lives in this feature and where known spread
+state remains.
 
 ## Performance And Stability Map
 
@@ -60,7 +47,7 @@ must stay narrow. Typical examples:
 - browser translation or other third-party DOM mutation
 - resize and dynamic row measurement
 
-For each interaction, state which boundary should update. The page controller
+For each interaction, state which boundary should update. The page component
 should not rerun expensive data preparation, recreate column/config objects, or
 rerender unchanged expensive cells for unrelated state changes.
 
@@ -99,4 +86,4 @@ Feature README updates should match the PR size:
   boundary being improved.
 
 The README should help the next contributor avoid falling back into the same
-controller component, not argue that the migration is complete.
+large component, not argue that the migration is complete.

--- a/.agents/skills/frontend-large-feature-architecture/references/feature-readmes.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/feature-readmes.md
@@ -1,0 +1,69 @@
+# Feature READMEs
+
+Large frontend feature folders should have a short `README.md` that acts as an
+owner map for humans and agents. Prefer `README.md` over `FEATURE.md` to match
+the existing `web/src/features/*` convention. Use `FEATURE.md` only if a folder
+already has a user-facing or generated README.
+
+The README is not a changelog. It should describe durable boundaries: entry
+points, subfolders, state ownership, performance-sensitive interactions, and
+where to find deeper migration notes.
+
+## Required Sections
+
+- **Surface**: what product surface the folder owns.
+- **Entry Points**: route files or parent components that mount the feature,
+  and the page/view lifecycle owner files they call.
+- **Structure**: what each subfolder owns. Use root `components/` only for
+  components reused across surfaces inside the feature. Use surface folders such
+  as `detail/` for page controllers, local stores, `actions/`, integration
+  hooks, and surface-private containers.
+- **External Consumers**: other features that import these components. This
+  keeps shared exports context-free and prevents accidental provider coupling.
+- **State Ownership**: where server/query state, route state, local feature
+  state, global product state, DOM integration state, and view-only props live.
+- **Performance And Stability Boundaries**: which interactions are
+  high-frequency or externally unstable, and which components are allowed to
+  rerender or measure because of them.
+- **Development Context**: agent skills, migration notes, or issue docs to read
+  before extending the feature.
+
+## State Ownership Rules
+
+- Server data remains in tRPC/React Query unless a pure prepared view model is
+  needed for rendering.
+- URL state remains in router/filter hooks, but feature-specific interpretation
+  belongs in a controller hook, pure helper, or local store action.
+- Local feature stores are created by the mounted page/view and destroyed on
+  unmount. This is the default for Langfuse pages because they are often
+  local-state heavy.
+- Global stores are only for product state shared across routes or features.
+  Do not globalize state to hide prop drilling or controller complexity.
+- DOM integration state, such as virtualizer measurement, observers, and
+  third-party mutation handling, belongs in narrow integration hooks.
+- View components should render props or subscribe to a small store slice. They
+  should not derive controller state or own feature workflows.
+- Complex feature workflows should live in `actions/*.ts` or store actions, not
+  inline in page controllers or view components.
+
+## Performance And Stability Map
+
+Every large feature README should name the high-frequency interactions that
+must stay narrow. Typical examples:
+
+- scroll and virtualization updates
+- row selection, hover, expansion, and lazy-loading
+- filter, saved-view, and column-state changes
+- drawers, peek navigation, and keyboard navigation
+- browser translation or other third-party DOM mutation
+- resize and dynamic row measurement
+
+For each interaction, state which boundary should update. The page controller
+should not rerun expensive data preparation, recreate column/config objects, or
+rerender unchanged expensive cells for unrelated state changes.
+
+## Current-State Honesty
+
+If a feature is mid-migration, say so. The README should make the desired
+boundaries clear while naming known spread state as debt. Do not present a
+partially migrated feature as the final pattern.

--- a/.agents/skills/frontend-large-feature-architecture/references/feature-readmes.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/feature-readmes.md
@@ -25,6 +25,8 @@ where to find deeper migration notes.
 - **Performance And Stability Boundaries**: which interactions are
   high-frequency or externally unstable, and which components are allowed to
   rerender or measure because of them.
+- **Migration State**: what has already been improved, what state/actions are
+  still spread, and the next one or two atomic slices.
 - **Development Context**: agent skills, migration notes, or issue docs to read
   before extending the feature.
 
@@ -67,3 +69,34 @@ rerender unchanged expensive cells for unrelated state changes.
 If a feature is mid-migration, say so. The README should make the desired
 boundaries clear while naming known spread state as debt. Do not present a
 partially migrated feature as the final pattern.
+
+Use an update-in-place style rather than a changelog. For example:
+
+- **Improved in current shape**: local store owns row selection; export action
+  moved to `actions/exportFeatureData.ts`; row view no longer subscribes to
+  filter state.
+- **Still spread**: saved-view state remains in the page controller; filter
+  option preparation is still inline; mutation workflows still close over page
+  hooks.
+- **Next slice**: extract filter-option preparation into pure helpers; move
+  batch action workflow into an action file; split route/query glue from view
+  components.
+
+This makes small PRs reviewable while keeping the feature migration plan
+visible. Do not wait for a perfect reorganization before documenting the
+current state.
+
+## PR-Scale Guidance
+
+Feature README updates should match the PR size:
+
+- For a small state/action extraction, add or update only the relevant
+  migration-state bullets.
+- For a new feature folder structure, include the owner map and external
+  consumers before moving logic into the folder.
+- For a rename-only PR, document intended structure but avoid changing behavior.
+- For behavior PRs, avoid unrelated file moves unless they are required for the
+  boundary being improved.
+
+The README should help the next contributor avoid falling back into the same
+controller component, not argue that the migration is complete.

--- a/.agents/skills/frontend-large-feature-architecture/references/local-feature-state.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/local-feature-state.md
@@ -48,8 +48,7 @@ Do not use the README as a changelog. If the feature has known architectural
 debt, record only durable state-boundary facts and link to the relevant agent
 reference note.
 
-For a concrete owner-map template, read
-`references/feature-readmes.md`.
+For a concrete owner-map template, read `feature-readmes.md`.
 
 ## Why Local, Not Global
 
@@ -65,6 +64,12 @@ cross-route state leaks, and makes ownership visible.
 Global state is reserved for product state that is genuinely shared across
 features or routes. Do not promote state globally to avoid prop drilling or to
 make a controller component smaller.
+
+Do not add a store just to make a PR look architectural. If the immediate
+problem is an inline export workflow, duplicated filter option shaping, or a
+large column builder, first extract an action or pure helper. Use the store when
+state needs selective subscriptions or must survive row remounts within one
+mounted feature instance.
 
 ## Creating The Store
 
@@ -174,13 +179,17 @@ instance when updating.
 ## Migration Steps
 
 1. Instrument first: identify which semantic state change causes broad renders.
-2. Extract that one state group into a local store.
-3. Replace broad props with selector subscriptions at the smallest UI boundary.
-4. Move related mutations into named actions.
-5. Stabilize callbacks and data wrappers.
-6. Move expensive data preparation into pure functions.
-7. Move complex user actions into store actions or external functions under
+2. Choose the smallest useful boundary: store state, action workflow, pure data
+   preparation, or imperative integration hook.
+3. Extract that one state group into a local store only when selective
+   subscriptions are needed.
+4. Replace broad props with selector subscriptions at the smallest UI boundary.
+5. Move related mutations into named actions.
+6. Stabilize callbacks and data wrappers.
+7. Move expensive data preparation into pure functions.
+8. Move complex user actions into store actions or external functions under
    `actions/*.ts`.
-8. Update the feature README and migration notes with remaining spread state.
-9. Remove debug instrumentation.
-10. Repeat for the next state group.
+9. Update the feature README with what improved, what remains spread, and the
+   next atomic slice.
+10. Remove debug instrumentation.
+11. Repeat for the next state group.

--- a/.agents/skills/frontend-large-feature-architecture/references/local-feature-state.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/local-feature-state.md
@@ -1,54 +1,34 @@
 # Local Feature State
 
-Large frontend features should not let one controller component own everything.
-That shape guarantees broad rerenders: one checkbox or row-hover state change
-reruns the component that also builds filters, columns, data wrappers, expensive
-cells, actions, drawers, and routing glue.
+Large frontend features should not let one component or hook own everything.
+That shape makes one checkbox, hover, or row-selection change rerun the code
+that also builds filters, columns, data wrappers, expensive cells, drawers,
+actions, and routing glue.
 
-This is not just inefficient. It is unstable. Broad rerenders recreate
-identities, refire effects, reset row-local state, retrigger query containers,
-and can feed virtualization or DOM-measurement loops. The goal is to make each
-state change wake only the UI and actions that semantically depend on it.
+The goal is to make each state change wake only the UI and actions that
+semantically depend on it.
 
 ## Default Pattern
 
-1. Keep the page/view as the lifecycle owner.
-2. Create one local vanilla Zustand store per mounted feature instance with a
-   lazy `useState` initializer.
-3. Provide only the stable store instance through context.
-4. Keep server/query state in tRPC/React Query.
-5. Keep URL state in the router/filter hooks.
-6. Move state-changing logic into named store actions.
-7. Split UI into small subscribers that select only the state they need.
-8. Keep expensive cells/rows view-only behind narrow containers.
-9. Put complex data preparation in pure functions before render.
-10. Put complex user actions in external async functions or store actions.
-11. Bridge local store state and React Query data explicitly in a feature hook
-    when they need to influence each other.
-12. Add or update the feature root `README.md` for large features so entry
-    points, folder boundaries, state ownership, and relevant agent docs are
-    discoverable before the next change.
+Start from the ownership baseline in `big-feature-rules.md`, then add a local
+vanilla Zustand store only when state is high-frequency, shared across multiple
+subtrees in the mounted feature, or must survive row/item remounts.
+
+Use this shape:
+
+1. The page/view creates one store instance with lazy `useState`.
+2. Context provides only the stable store instance.
+3. Components subscribe to the smallest useful slice.
+4. Mutations live in named store actions.
+5. Complex user workflows live in `actions/*.ts` or store actions.
+6. Expensive cells/rows stay view-only behind narrow containers.
+7. Large feature roots have a short `README.md` owner map.
 
 ## Feature README
 
-Use `README.md` in the feature root, matching the existing
-`web/src/features/*` convention. Keep it short. It should answer:
-
-- What surface does this feature own?
-- Which files are page/view lifecycle owners?
-- Which subfolders contain shared components, surface-private components, pure
-  helpers, stores, or integration hooks?
-- Where does server state, route state, local feature state, and imperative DOM
-  integration state belong?
-- Which high-frequency interactions are performance or stability boundaries?
-- Which agent docs or migration notes should be read before extending the
-  feature?
-
-Do not use the README as a changelog. If the feature has known architectural
-debt, record only durable state-boundary facts and link to the relevant agent
-reference note.
-
-For a concrete owner-map template, read `feature-readmes.md`.
+For a concrete owner-map template, read `feature-readmes.md`. Do not use the
+README as a changelog; record durable ownership facts and the next migration
+slice.
 
 ## Why Local, Not Global
 
@@ -63,7 +43,7 @@ cross-route state leaks, and makes ownership visible.
 
 Global state is reserved for product state that is genuinely shared across
 features or routes. Do not promote state globally to avoid prop drilling or to
-make a controller component smaller.
+make a large component smaller.
 
 Do not add a store just to make a PR look architectural. If the immediate
 problem is an inline export workflow, duplicated filter option shaping, or a
@@ -99,21 +79,10 @@ Complex workflows should be independent functions. Put surface-specific actions
 in `actions/*.ts`, or make them named store actions when they are tightly coupled
 to local feature state.
 
-The component is responsible for hooks and lifecycle wiring:
-
-- call tRPC/React Query hooks
-- read route params
-- create or access the local store
-- get analytics capture functions
-- pass the narrow dependencies to the action
-
-The action owns the workflow:
-
-- fetch/refetch data through callbacks it receives
-- read state from a passed store if needed
-- call pure data-preparation helpers
-- perform browser side effects such as file downloads
-- emit analytics through a passed capture function
+The component wires hooks, route params, stores, analytics, and query helpers.
+The action owns the workflow: refetching through callbacks, reading the passed
+store if needed, calling pure helpers, performing browser side effects, and
+emitting analytics.
 
 Actions must not call React hooks. If a workflow needs a lot of context, pass
 the local store instance or a small dependency object rather than threading long
@@ -131,9 +100,8 @@ await exportFeatureData({
 });
 ```
 
-For substantial data shaping, export a pure helper next to the action, e.g.
-`buildFeatureExportData(...)`. That keeps the action testable without rendering
-the page.
+For substantial data shaping, export a pure helper next to the action so the
+transformation can be tested without rendering the page.
 
 ## Store Shape
 
@@ -155,7 +123,7 @@ instance when updating.
 
 ## Anti-Patterns
 
-- A table/list controller owns selection, filters, columns, routing, peek state,
+- A table/list component owns selection, filters, columns, routing, peek state,
   batch actions, local dialogs, and expensive rendered cells.
 - Context provider `value` changes on row selection, hover, scroll, active row,
   expanded row, or other high-frequency state.
@@ -167,13 +135,12 @@ instance when updating.
 - Memoization is the only fix. `memo` helps, but it does not fix a bad state
   boundary.
 - A callback depends on an inline config object and changes identity on every
-  controller render.
+  render.
 - Components subscribe to large objects when they only need a boolean.
-- `useEffect` derives ordinary UI state from fetched data. Prepare data
-  directly from query results instead.
+- `useEffect` derives ordinary UI state from fetched data.
 - A component passes a long chain of feature context through props just so a
   button can perform an action.
-- A page controller keeps a complex async workflow inline because all the hooks
+- A page component keeps a complex async workflow inline because all the hooks
   happen to be in scope there.
 
 ## Migration Steps

--- a/.agents/skills/frontend-large-feature-architecture/references/local-feature-state.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/local-feature-state.md
@@ -1,0 +1,186 @@
+# Local Feature State
+
+Large frontend features should not let one controller component own everything.
+That shape guarantees broad rerenders: one checkbox or row-hover state change
+reruns the component that also builds filters, columns, data wrappers, expensive
+cells, actions, drawers, and routing glue.
+
+This is not just inefficient. It is unstable. Broad rerenders recreate
+identities, refire effects, reset row-local state, retrigger query containers,
+and can feed virtualization or DOM-measurement loops. The goal is to make each
+state change wake only the UI and actions that semantically depend on it.
+
+## Default Pattern
+
+1. Keep the page/view as the lifecycle owner.
+2. Create one local vanilla Zustand store per mounted feature instance with a
+   lazy `useState` initializer.
+3. Provide only the stable store instance through context.
+4. Keep server/query state in tRPC/React Query.
+5. Keep URL state in the router/filter hooks.
+6. Move state-changing logic into named store actions.
+7. Split UI into small subscribers that select only the state they need.
+8. Keep expensive cells/rows view-only behind narrow containers.
+9. Put complex data preparation in pure functions before render.
+10. Put complex user actions in external async functions or store actions.
+11. Bridge local store state and React Query data explicitly in a feature hook
+    when they need to influence each other.
+12. Add or update the feature root `README.md` for large features so entry
+    points, folder boundaries, state ownership, and relevant agent docs are
+    discoverable before the next change.
+
+## Feature README
+
+Use `README.md` in the feature root, matching the existing
+`web/src/features/*` convention. Keep it short. It should answer:
+
+- What surface does this feature own?
+- Which files are page/view lifecycle owners?
+- Which subfolders contain shared components, surface-private components, pure
+  helpers, stores, or integration hooks?
+- Where does server state, route state, local feature state, and imperative DOM
+  integration state belong?
+- Which high-frequency interactions are performance or stability boundaries?
+- Which agent docs or migration notes should be read before extending the
+  feature?
+
+Do not use the README as a changelog. If the feature has known architectural
+debt, record only durable state-boundary facts and link to the relevant agent
+reference note.
+
+For a concrete owner-map template, read
+`references/feature-readmes.md`.
+
+## Why Local, Not Global
+
+Langfuse pages are often local-state heavy: filters, saved views, selected rows,
+expanded rows, drawers, peek navigation, lazy row load state, and view-local
+actions. Those states usually belong to one mounted page instance, not the whole
+application.
+
+Use local feature stores for this state. Create the store in the page/view and
+destroy it on unmount. This keeps multiple mounted instances independent, avoids
+cross-route state leaks, and makes ownership visible.
+
+Global state is reserved for product state that is genuinely shared across
+features or routes. Do not promote state globally to avoid prop drilling or to
+make a controller component smaller.
+
+## Creating The Store
+
+Prefer lazy `useState` for local store instances:
+
+```ts
+const [store] = useState(() =>
+  createFeatureStore({
+    initialProjectId: projectId,
+  }),
+);
+```
+
+This expresses the real lifecycle: one store instance for the committed mounted
+view. The unused setter is acceptable. `useMemo` is the wrong default because it
+is a render-time cache for derived values, not an ownership boundary for an
+external store instance. A local store is stateful infrastructure, so treat its
+identity as state.
+
+`useRef` can also hold a stable instance, but prefer `useState` unless a ref is
+needed for imperative setup. Keep store creation pure; sync changing route/query
+inputs into named store actions such as `resetForFeature(...)` or `init(...)`.
+
+## Independent Actions
+
+Complex workflows should be independent functions. Put surface-specific actions
+in `actions/*.ts`, or make them named store actions when they are tightly coupled
+to local feature state.
+
+The component is responsible for hooks and lifecycle wiring:
+
+- call tRPC/React Query hooks
+- read route params
+- create or access the local store
+- get analytics capture functions
+- pass the narrow dependencies to the action
+
+The action owns the workflow:
+
+- fetch/refetch data through callbacks it receives
+- read state from a passed store if needed
+- call pure data-preparation helpers
+- perform browser side effects such as file downloads
+- emit analytics through a passed capture function
+
+Actions must not call React hooks. If a workflow needs a lot of context, pass
+the local store instance or a small dependency object rather than threading long
+prop chains through view components.
+
+Example:
+
+```ts
+await exportFeatureData({
+  capture,
+  fetchDetails,
+  projectId,
+  refetchSummary,
+  selectedIds,
+});
+```
+
+For substantial data shaping, export a pure helper next to the action, e.g.
+`buildFeatureExportData(...)`. That keeps the action testable without rendering
+the page.
+
+## Store Shape
+
+Use immutable plain objects for keyed state that must be selector-friendly:
+
+```ts
+type FeatureStoreState = {
+  selectedIds: Record<string, true>;
+  activeId: string | null;
+  actions: {
+    toggleSelected: (id: string, selected: boolean) => void;
+    setActiveId: (id: string | null) => void;
+  };
+};
+```
+
+Avoid mutating `Set` or `Map` in place. If you use them, replace the whole
+instance when updating.
+
+## Anti-Patterns
+
+- A table/list controller owns selection, filters, columns, routing, peek state,
+  batch actions, local dialogs, and expensive rendered cells.
+- Context provider `value` changes on row selection, hover, scroll, active row,
+  expanded row, or other high-frequency state.
+- Local feature state is promoted to a global store even though it only belongs
+  to one mounted page instance.
+- `useMemo` is used to own a local external store instance.
+- A shared `src/components/*` component calls a feature-scoped store hook. That
+  silently breaks other callers that do not mount the feature provider.
+- Memoization is the only fix. `memo` helps, but it does not fix a bad state
+  boundary.
+- A callback depends on an inline config object and changes identity on every
+  controller render.
+- Components subscribe to large objects when they only need a boolean.
+- `useEffect` derives ordinary UI state from fetched data. Prepare data
+  directly from query results instead.
+- A component passes a long chain of feature context through props just so a
+  button can perform an action.
+- A page controller keeps a complex async workflow inline because all the hooks
+  happen to be in scope there.
+
+## Migration Steps
+
+1. Instrument first: identify which semantic state change causes broad renders.
+2. Extract that one state group into a local store.
+3. Replace broad props with selector subscriptions at the smallest UI boundary.
+4. Move related mutations into named actions.
+5. Stabilize callbacks and data wrappers.
+6. Move expensive data preparation into pure functions.
+7. Move complex user actions into store actions or external functions under
+   `actions/*.ts`.
+8. Update the feature README and migration notes with remaining spread state.
+9. Remove debug instrumentation.
+10. Repeat for the next state group.

--- a/.agents/skills/frontend-large-feature-architecture/references/virtualized-lists.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/virtualized-lists.md
@@ -1,0 +1,91 @@
+# Virtualized Lists
+
+Virtualized lists are render-boundary infrastructure. They should calculate
+which item shells are visible and position those shells. They should not become
+row controllers.
+
+## Current Langfuse Surfaces
+
+TanStack virtualized surfaces currently include:
+
+- `web/src/components/trace/components/_shared/VirtualizedTree.tsx`
+- `web/src/components/trace/components/_shared/VirtualizedList.tsx`
+- `web/src/components/trace/components/_shared/JSONTableView/JSONTableView.tsx`
+- `web/src/components/trace/components/TraceTimeline/index.tsx`
+- `web/src/components/ui/AdvancedJsonViewer/VirtualizedMultiSectionViewer.tsx`
+- `web/src/features/slack/components/ChannelSelector.tsx`
+
+Review these with the same state-boundary rules before adding measurement,
+row-local effects, or controller state.
+
+## Smartness Trap
+
+The broken shape is:
+
+- virtualizer rerenders on scroll
+- parent recreates callbacks, config, row wrappers, or data objects
+- row components receive changed props even though the semantic row did not
+  change
+- row-local effects/load state reset or refire
+- dynamic measurement observes DOM changed by an external mutator such as Google
+  Translate
+- measurement updates virtualizer state, which rerenders the same rows again
+
+That is not a small memoization bug. It is leaked state ownership.
+
+The fix is to make scroll and measurement state update the smallest possible
+integration boundary. If scrolling changes a virtual item offset, unchanged row
+content should not receive new semantic props, refire effects, or recreate
+expensive derived data.
+
+## Google Translate DOM Behavior
+
+Google Translate mutates rendered DOM after React has committed it. It can wrap
+text nodes, replace text, and change element dimensions outside React's data
+flow. React and TanStack Virtual do not know whether the changed DOM represents
+stable translated content or a transient mutation.
+
+Do not opt product UI out of translation with `translate="no"` unless product
+explicitly chooses that. Langfuse must work under browser translation.
+
+## Measurement Rules
+
+- Always put the correct `data-index` on the row element TanStack treats as the
+  item.
+- Do not combine live `measureElement` with externally mutated translated DOM
+  in text-heavy rows.
+- Prefer fixed estimates plus overscan for simple rows.
+- For dynamic text-heavy rows, use controlled measurement:
+- `ResizeObserver` reads the row shell.
+- Debounce commits.
+- Do not commit while actively scrolling.
+- Round heights to avoid sub-pixel churn.
+- Call `virtualizer.resizeItem(index, height)`.
+- If a row alternates between two heights repeatedly, clamp to a minimum height
+  that still allows later legitimate growth.
+
+## Row Rules
+
+- The virtualizer owns positioning only.
+- Row load state lives outside the row instance if remounts are expected.
+- Expensive row content should be a memoized view component.
+- Row containers may subscribe to local store slices and queries.
+- View components should receive stable props and perform no effects.
+- Feature-scoped row containers belong under `src/features/*`; shared
+  `src/components/*` row exports should be context-free.
+- Scrolling may rerender the virtualizer. It should not rerender unchanged
+  expensive row content.
+- Do not use a global store to preserve row state across virtualization. Use a
+  view-scoped store owned by the mounted list/page instance.
+
+## Migration Steps
+
+1. Add temporary logs to identify whether scroll causes remounts, prop changes,
+   measurement loops, or query refetches.
+2. Remove logs before shipping.
+3. Move row-local state that must survive virtualization into a local store.
+4. Stabilize callbacks and config objects passed to rows.
+5. Replace live `measureElement` with fixed estimates or controlled measurement.
+6. Move row data preparation into pure functions or feature-local containers.
+7. Verify with browser translation enabled, horizontal resize, and small
+   vertical scroll deltas.

--- a/.agents/skills/frontend-large-feature-architecture/references/virtualized-lists.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/virtualized-lists.md
@@ -1,22 +1,12 @@
 # Virtualized Lists
 
 Virtualized lists are render-boundary infrastructure. They should calculate
-which item shells are visible and position those shells. They should not become
-row controllers.
+which item shells are visible and position those shells. They should not make
+each row own feature state, effects, subscriptions, data loading, and workflows.
 
-## Current Langfuse Surfaces
-
-TanStack virtualized surfaces currently include:
-
-- `web/src/components/trace/components/_shared/VirtualizedTree.tsx`
-- `web/src/components/trace/components/_shared/VirtualizedList.tsx`
-- `web/src/components/trace/components/_shared/JSONTableView/JSONTableView.tsx`
-- `web/src/components/trace/components/TraceTimeline/index.tsx`
-- `web/src/components/ui/AdvancedJsonViewer/VirtualizedMultiSectionViewer.tsx`
-- `web/src/features/slack/components/ChannelSelector.tsx`
-
-Review these with the same state-boundary rules before adding measurement,
-row-local effects, or controller state.
+Langfuse uses `@tanstack/react-virtual` for virtualization. Find current
+callsites before changing a virtualized surface, then apply the same
+state-boundary rules as any large feature.
 
 ## Smartness Trap
 
@@ -67,9 +57,9 @@ explicitly chooses that. Langfuse must work under browser translation.
 ## Row Rules
 
 - The virtualizer owns positioning only.
-- Row load state lives outside the row instance if remounts are expected.
+- State that must survive remounts lives outside the row instance.
 - Expensive row content should be a memoized view component.
-- Row containers may subscribe to local store slices and queries.
+- Narrow row containers may subscribe to local store slices and queries.
 - View components should receive stable props and perform no effects.
 - Feature-scoped row containers belong under `src/features/*`; shared
   `src/components/*` row exports should be context-free.
@@ -86,6 +76,6 @@ explicitly chooses that. Langfuse must work under browser translation.
 3. Move row-local state that must survive virtualization into a local store.
 4. Stabilize callbacks and config objects passed to rows.
 5. Replace live `measureElement` with fixed estimates or controlled measurement.
-6. Move row data preparation into pure functions or feature-local containers.
+6. Move row logic into pure helpers or feature-local containers.
 7. Verify with browser translation enabled, horizontal resize, and small
    vertical scroll deltas.

--- a/.agents/skills/frontend-large-feature-architecture/references/virtualized-lists.md
+++ b/.agents/skills/frontend-large-feature-architecture/references/virtualized-lists.md
@@ -56,13 +56,13 @@ explicitly chooses that. Langfuse must work under browser translation.
   in text-heavy rows.
 - Prefer fixed estimates plus overscan for simple rows.
 - For dynamic text-heavy rows, use controlled measurement:
-- `ResizeObserver` reads the row shell.
-- Debounce commits.
-- Do not commit while actively scrolling.
-- Round heights to avoid sub-pixel churn.
-- Call `virtualizer.resizeItem(index, height)`.
-- If a row alternates between two heights repeatedly, clamp to a minimum height
-  that still allows later legitimate growth.
+  - `ResizeObserver` reads the row shell.
+  - Debounce commits.
+  - Do not commit while actively scrolling.
+  - Round heights to avoid sub-pixel churn.
+  - Call `virtualizer.resizeItem(index, height)`.
+  - If a row alternates between two heights repeatedly, clamp to a minimum
+    height that still allows later legitimate growth.
 
 ## Row Rules
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -62,6 +62,8 @@ Use root [AGENTS.md](../AGENTS.md) for monorepo-level rules.
 
 - Shared browser-review workflow for user-visible frontend changes:
   [`../.agents/skills/frontend-browser-review/SKILL.md`](../.agents/skills/frontend-browser-review/SKILL.md)
+- Large frontend feature, virtualized-list, and local state architecture:
+  [`../.agents/skills/frontend-large-feature-architecture/SKILL.md`](../.agents/skills/frontend-large-feature-architecture/SKILL.md)
 - React composition and component API design:
   [`web/.agents/skills/vercel-composition-patterns/SKILL.md`](.agents/skills/vercel-composition-patterns/SKILL.md)
 - React/Next.js performance and rendering best practices:
@@ -69,8 +71,9 @@ Use root [AGENTS.md](../AGENTS.md) for monorepo-level rules.
 
 Read these package-local skills before substantial frontend refactors when the
 task involves component composition, reusable component APIs, rendering
-performance, bundle size, React/Next.js performance patterns, or browser-based
-signoff of user-visible changes.
+performance, virtualized lists, local feature stores, bundle size,
+React/Next.js performance patterns, or browser-based signoff of user-visible
+changes.
 
 ## Web Conventions
 
@@ -162,7 +165,7 @@ signoff of user-visible changes.
 
 ### Error handling (tRPC + REST)
 
-1. Throw `BaseError` subclasses (eg `LangfuseNotFoundError`) from handlers and services. 
+1. Throw `BaseError` subclasses (eg `LangfuseNotFoundError`) from handlers and services.
 2. Let `BaseError`s bubble up to the tRPC and REST middlewares (eg. don't `try/catch` and rethrow in to `TRPCError` the handler)
 3. Extend the `BaseError` or its subclasses in [`packages/shared/src/errors/`](../packages/shared/src/errors/) as needed.
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new agent skill (`frontend-large-feature-architecture`) that documents patterns for refactoring large Langfuse frontend features, and registers it in `web/AGENTS.md`. No executable code is changed.

- **New skill** (`SKILL.md` + five reference files) covers local Zustand store patterns, controller migration steps, virtualized-list state boundaries, feature README templates, and hard architecture rules for splitting render from logic.
- **`web/AGENTS.md`** adds the skill link under the frontend skills section and expands the paragraph that describes when to reach for package-local skills to include virtualized lists and local feature stores.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only PR with no executable code changes; safe to merge after the minor markdown formatting fix.

All changes are Markdown reference documents and a YAML agent config. The only concrete issue is a broken list hierarchy in the virtualized-lists reference that could mislead an agent reading the document — the controlled-measurement sub-steps appear as sibling bullets rather than children. No runtime behaviour is affected.

`references/virtualized-lists.md` has the list-indentation issue in the Measurement Rules section.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Page / View\nLifecycle Owner] -->|lazy useState| B[Local Zustand Store\nper mounted instance]
    A -->|tRPC / React Query| C[Server State]
    A -->|router / filter hooks| D[Route State]
    B -->|stable store ref via context| E[Container Components\nsrc/features/*]
    E -->|selector subscription| F[View Components\nrender-only]
    E -->|calls| G[Actions\nactions/*.ts or store actions]
    G -->|reads/writes| B
    G -->|refetch callbacks| C
    C -->|pure data prep| H[Compiled UI Data]
    H --> F
    B -->|bridge hook| C
    style F fill:#d4edda
    style G fill:#cce5ff
    style B fill:#fff3cd
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.agents/skills/frontend-large-feature-architecture/references/virtualized-lists.md:621-627
**Broken sub-list indentation in Measurement Rules**

The steps describing the controlled-measurement approach (`ResizeObserver reads the row shell`, `Debounce commits`, etc.) are at the same indentation level as the parent bullet "For dynamic text-heavy rows, use controlled measurement:". In rendered Markdown they appear as independent sibling rules rather than children of that branch. An agent following this reference may misread them as independent top-level requirements rather than steps within the dynamic-measurement path. Each of those five lines should be indented with two spaces to nest them under the parent bullet.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): add frontend feature archi..."](https://github.com/langfuse/langfuse/commit/3a5511b79fd8dc9ba670626ad15a49124c980468) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35668769)</sub>

<!-- /greptile_comment -->