### PR TITLE
feat(batch-export): read sessions from events table for v4 users

### DIFF
--- a/packages/shared/src/features/batchExport/types.ts
+++ b/packages/shared/src/features/batchExport/types.ts
@@ -54,6 +54,11 @@ export const BatchExportQuerySchema = z.object({
   orderBy,
   limit: z.number().optional(),
   page: z.number().optional(),
+  // Snapshotted at dispatch time from the user's v4 beta flag. When true, the
+  // sessions export reads from the ClickHouse events table instead of the
+  // legacy traces path. Persisted in the job's query column so the worker reads
+  // the snapshot, never the live user record.
+  useEventsTable: z.boolean().optional(),
 });
 
 export type BatchExportQueryType = z.infer<typeof BatchExportQuerySchema>;

--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -175,7 +175,7 @@ export const getSessionsWithMetricsFromEvents = async (props: {
       limit: props.limit,
       page: props.page,
       clickhouseConfigs: props.clickhouseConfigs,
-      tags: { kind: "metrics" },
+      tags: { kind: "analytic_events" },
     },
   );
 

--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -9,6 +9,7 @@ import {
   FilterList,
   StringOptionsFilter,
   orderByToClickhouseSql,
+  type SessionEventsMetricsRow,
 } from "../queries";
 import { createFilterFromFilterState } from "../queries/clickhouse-sql/factory";
 import {
@@ -150,6 +151,38 @@ export const getSessionsTableFromEvents = async (props: {
   return rows.map((row) => ({
     ...row,
     trace_count: Number(row.trace_count),
+  }));
+};
+
+// Single-query equivalent of getSessionsTableFromEvents + getSessionMetricsFromEvents,
+// mirroring the legacy getSessionsWithMetrics. Used by batch export so the metrics
+// aggregation inherits the same filter (incl. the createdAt cutoff) and clickhouseConfigs
+// (extended HTTP timeouts) as the row query, in a single round-trip.
+export const getSessionsWithMetricsFromEvents = async (props: {
+  projectId: string;
+  filter: FilterState;
+  orderBy?: OrderByState;
+  limit?: number;
+  page?: number;
+  clickhouseConfigs?: ClickHouseClientConfigOptions | undefined;
+}) => {
+  const rows = await getSessionsTableFromEventsGeneric<SessionEventsMetricsRow>(
+    {
+      select: "metrics",
+      projectId: props.projectId,
+      filter: props.filter,
+      orderBy: props.orderBy,
+      limit: props.limit,
+      page: props.page,
+      clickhouseConfigs: props.clickhouseConfigs,
+      tags: { kind: "metrics" },
+    },
+  );
+
+  return rows.map((row) => ({
+    ...row,
+    trace_count: Number(row.trace_count),
+    total_observations: Number(row.total_observations),
   }));
 };
 

--- a/web/src/__tests__/server/batchExport-trpc.servertest.ts
+++ b/web/src/__tests__/server/batchExport-trpc.servertest.ts
@@ -20,15 +20,21 @@ function makeSession(
   opts: {
     plan?: Plan;
     projectRole?: Role;
+    v4BetaEnabled?: boolean;
   } = {},
 ): Session {
-  const { plan = "cloud:hobby", projectRole = "MEMBER" } = opts;
+  const {
+    plan = "cloud:hobby",
+    projectRole = "MEMBER",
+    v4BetaEnabled = false,
+  } = opts;
   return {
     expires: "1",
     user: {
       id: "user-test",
       canCreateOrganizations: true,
       name: "Test User",
+      v4BetaEnabled,
       organizations: [
         {
           id: orgId,
@@ -158,4 +164,79 @@ describe("batchExport tRPC – audit_logs table authorization", () => {
       expect(job?.query).toMatchObject({ tableName: "audit_logs" });
     },
   );
+});
+
+describe("batchExport tRPC – useEventsTable snapshot", () => {
+  afterAll(async () => {
+    await prisma.organization.deleteMany({
+      where: { id: { in: __orgIds } },
+    });
+  });
+
+  const sessionsExportInput = (projectId: string, name: string) => ({
+    projectId,
+    name,
+    query: {
+      tableName: BatchTableNames.Sessions,
+      filter: null,
+      orderBy: null,
+    },
+    format: BatchExportFileFormat.CSV,
+  });
+
+  it("snapshots useEventsTable=true into the persisted query when v4 beta is enabled", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    const caller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          projectRole: "OWNER",
+          v4BetaEnabled: true,
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    await caller.batchExport.create(
+      sessionsExportInput(project.id, "sessions export v4 on"),
+    );
+
+    const job = await prisma.batchExport.findFirst({
+      where: { projectId: project.id, name: "sessions export v4 on" },
+    });
+    expect(job?.query).toMatchObject({
+      tableName: "sessions",
+      useEventsTable: true,
+    });
+  });
+
+  it("snapshots useEventsTable=false when v4 beta is disabled", async () => {
+    const { project, org } = await createOrgProjectAndApiKey();
+    __orgIds.push(org.id);
+
+    const caller = appRouter.createCaller({
+      ...createInnerTRPCContext({
+        session: makeSession(org.id, org.name, project.id, project.name, {
+          projectRole: "OWNER",
+          v4BetaEnabled: false,
+        }),
+        headers: {},
+      }),
+      prisma,
+    });
+
+    await caller.batchExport.create(
+      sessionsExportInput(project.id, "sessions export v4 off"),
+    );
+
+    const job = await prisma.batchExport.findFirst({
+      where: { projectId: project.id, name: "sessions export v4 off" },
+    });
+    expect(job?.query).toMatchObject({
+      tableName: "sessions",
+      useEventsTable: false,
+    });
+  });
 });

--- a/web/src/__tests__/server/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/server/sessions-ui-table.servertest.ts
@@ -592,7 +592,11 @@ describe("trpc.sessions", () => {
   });
 });
 
-describe("parity: getSessionsWithMetrics vs getSessionsWithMetricsFromEvents", () => {
+// The events tables only exist where the v4 preview is enabled (CI creates
+// them via ch:dev-tables in the default deploy mode only).
+const maybeEventsTable = isEventsPath ? describe : describe.skip;
+
+maybeEventsTable("parity: sessions metrics from events vs legacy", () => {
   it("returns equivalent metric fields for the same session data", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
     const sessionId = v4();
@@ -605,12 +609,12 @@ describe("parity: getSessionsWithMetrics vs getSessionsWithMetricsFromEvents", (
       createTrace({
         session_id: sessionId,
         project_id: projectId,
-        user_id: "userA",
+        user_id: "user1",
       }),
       createTrace({
         session_id: sessionId,
         project_id: projectId,
-        user_id: "userB",
+        user_id: "user2",
       }),
     ];
 

--- a/web/src/__tests__/server/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/server/sessions-ui-table.servertest.ts
@@ -8,6 +8,7 @@ import {
   createSessionScore,
   createTracesCh,
   getSessionsWithMetrics,
+  getSessionsWithMetricsFromEvents,
   getSessionMetricsFromEvents,
   getSessionsTable,
   getSessionsTableFromEvents,
@@ -588,5 +589,124 @@ describe("trpc.sessions", () => {
 
     expect(tableRows).toHaveLength(1);
     expect(tableRows[0].session_id).toEqual(session_id_with_score);
+  });
+});
+
+describe("parity: getSessionsWithMetrics vs getSessionsWithMetricsFromEvents", () => {
+  it("returns equivalent metric fields for the same session data", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const sessionId = v4();
+
+    await prisma.traceSession.create({
+      data: { id: sessionId, projectId },
+    });
+
+    const traces = [
+      createTrace({
+        session_id: sessionId,
+        project_id: projectId,
+        user_id: "userA",
+      }),
+      createTrace({
+        session_id: sessionId,
+        project_id: projectId,
+        user_id: "userB",
+      }),
+    ];
+
+    const observations = traces.flatMap((trace) => [
+      createObservation({ trace_id: trace.id, project_id: projectId }),
+      createObservation({ trace_id: trace.id, project_id: projectId }),
+    ]);
+
+    // Seed legacy path (sessions materialized view) and events table in parallel
+    await createTracesCh(traces);
+    await createObservationsCh(observations);
+    await createEventsCh(buildMatchingEvents(traces, observations));
+
+    const filter: FilterState = [];
+
+    const [legacy, fromEvents] = await Promise.all([
+      getSessionsWithMetrics({ projectId, filter }),
+      getSessionsWithMetricsFromEvents({ projectId, filter }),
+    ]);
+
+    expect(legacy).toHaveLength(1);
+    expect(fromEvents).toHaveLength(1);
+
+    const l = legacy[0];
+    const e = fromEvents[0];
+
+    expect(e.session_id).toBe(l.session_id);
+    expect(e.trace_count).toBe(l.trace_count);
+    expect([...e.trace_ids].sort()).toEqual([...l.trace_ids].sort());
+    expect([...e.user_ids].sort()).toEqual([...l.user_ids].sort());
+    expect(e.total_observations).toBe(l.total_observations);
+
+    // Export-critical cost/usage fields (getDatabaseReadStream maps these directly)
+    expect(Number(e.session_input_cost)).toBeCloseTo(
+      Number(l.session_input_cost),
+      4,
+    );
+    expect(Number(e.session_output_cost)).toBeCloseTo(
+      Number(l.session_output_cost),
+      4,
+    );
+    expect(Number(e.session_total_cost)).toBeCloseTo(
+      Number(l.session_total_cost),
+      4,
+    );
+    expect(Number(e.session_input_usage)).toBeCloseTo(
+      Number(l.session_input_usage),
+      0,
+    );
+    expect(Number(e.session_output_usage)).toBeCloseTo(
+      Number(l.session_output_usage),
+      0,
+    );
+    expect(Number(e.session_total_usage)).toBeCloseTo(
+      Number(l.session_total_usage),
+      0,
+    );
+  });
+
+  it("honours the same filter so only the targeted session is returned", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const targetId = v4();
+    const otherId = v4();
+
+    await prisma.traceSession.createMany({
+      data: [
+        { id: targetId, projectId },
+        { id: otherId, projectId },
+      ],
+    });
+
+    const traces = [
+      createTrace({ session_id: targetId, project_id: projectId }),
+      createTrace({ session_id: otherId, project_id: projectId }),
+    ];
+
+    await createTracesCh(traces);
+    await createEventsCh(buildMatchingEvents(traces, []));
+
+    const filter: FilterState = [
+      {
+        column: "id",
+        type: "stringOptions",
+        operator: "any of",
+        value: [targetId],
+      },
+    ];
+
+    const [legacy, fromEvents] = await Promise.all([
+      getSessionsWithMetrics({ projectId, filter }),
+      getSessionsWithMetricsFromEvents({ projectId, filter }),
+    ]);
+
+    expect(legacy).toHaveLength(1);
+    expect(fromEvents).toHaveLength(1);
+    expect(legacy[0].session_id).toBe(targetId);
+    expect(fromEvents[0].session_id).toBe(targetId);
   });
 });

--- a/web/src/features/batch-exports/server/batchExport.ts
+++ b/web/src/features/batch-exports/server/batchExport.ts
@@ -32,7 +32,15 @@ export const batchExportRouter = createTRPCRouter({
           scope: "batchExports:create",
         });
 
-        const { projectId, query, format, name } = input;
+        const { projectId, format, name } = input;
+
+        // Snapshot the user's v4 beta flag into the persisted query so the
+        // worker reads events-aware data sources from the dispatch-time
+        // snapshot, never the live user record. Overrides any client-sent value.
+        const query = {
+          ...input.query,
+          useEventsTable: ctx.session.user.v4BetaEnabled ?? false,
+        };
 
         if (query.tableName === BatchExportTableName.AuditLogs) {
           throwIfNoEntitlement({

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -2358,6 +2358,93 @@ describe("batch export test suite", () => {
   // ==================== EVENTS TABLE EXPORT TESTS ====================
 
   maybeDescribe("events table export tests", () => {
+    it("should export sessions from the events table when useEventsTable is true", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+
+      const sessionId = randomUUID();
+      const sessionId2 = randomUUID();
+
+      await prisma.traceSession.createMany({
+        data: [
+          { id: sessionId, projectId },
+          { id: sessionId2, projectId },
+        ],
+      });
+
+      const now = Date.now() * 1000; // Events use microseconds
+
+      // session 1: one trace; session 2: two traces
+      const events = [
+        createEvent({
+          project_id: projectId,
+          trace_id: randomUUID(),
+          session_id: sessionId,
+          type: "GENERATION",
+          start_time: now,
+          end_time: now + 1000000,
+        }),
+        createEvent({
+          project_id: projectId,
+          trace_id: randomUUID(),
+          session_id: sessionId2,
+          type: "GENERATION",
+          start_time: now,
+          end_time: now + 1000000,
+        }),
+        createEvent({
+          project_id: projectId,
+          trace_id: randomUUID(),
+          session_id: sessionId2,
+          type: "GENERATION",
+          start_time: now,
+          end_time: now + 1000000,
+        }),
+      ];
+
+      await createEventsCh(events);
+
+      const stream = await getDatabaseReadStreamPaginated({
+        projectId,
+        tableName: BatchExportTableName.Sessions,
+        cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+        filter: [],
+        orderBy: { column: "createdAt", order: "DESC" },
+        useEventsTable: true,
+      });
+
+      const rows: any[] = [];
+      for await (const chunk of stream) {
+        rows.push(chunk);
+      }
+
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: sessionId, countTraces: 1 }),
+          expect.objectContaining({ id: sessionId2, countTraces: 2 }),
+        ]),
+      );
+      // Metrics come from getSessionMetricsFromEvents; a present row implies the
+      // metrics join resolved (sessions without metrics are dropped).
+      expect(rows.every((r) => r.totalCost !== undefined)).toBe(true);
+    });
+
+    it("routes events exports through getEventsStream, not the paginated reader", async () => {
+      // Path A contract: the events-table export is served by getEventsStream
+      // (wired in handleBatchExportJob). The paginated reader intentionally has
+      // no "events" case, so a regression that drops the getEventsStream route
+      // would surface as this throw rather than silently exporting nothing.
+      await expect(
+        getDatabaseReadStreamPaginated({
+          projectId: randomUUID(),
+          tableName: BatchExportTableName.Events,
+          cutoffCreatedAt: new Date(),
+          filter: [],
+          orderBy: { column: "startTime", order: "DESC" },
+        }),
+      ).rejects.toThrow("Unhandled table case: events");
+    });
+
     it("should export events from events table", async () => {
       const { projectId } = await createOrgProjectAndApiKey();
 

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -2424,9 +2424,10 @@ describe("batch export test suite", () => {
           expect.objectContaining({ id: sessionId2, countTraces: 2 }),
         ]),
       );
-      // Metrics come from getSessionMetricsFromEvents; a present row implies the
-      // metrics join resolved (sessions without metrics are dropped).
-      expect(rows.every((r) => r.totalCost !== undefined)).toBe(true);
+      // Concrete metric check: usage aggregates from the events table, so a
+      // regression that silently zeroed metrics would surface here.
+      const session2Row = rows.find((r) => r.id === sessionId2);
+      expect(session2Row?.totalTokens).toBeGreaterThan(0n);
     });
 
     it("routes events exports through getEventsStream, not the paginated reader", async () => {

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -15,6 +15,8 @@ import {
   getScoresUiTable,
   getPublicSessionsFilter,
   getSessionsWithMetrics,
+  getSessionsTableFromEvents,
+  getSessionMetricsFromEvents,
   getDistinctScoreNames,
   getObservationsTableWithModelData,
   getScoresForObservations,
@@ -104,6 +106,7 @@ export const getDatabaseReadStreamPaginated = async ({
   cutoffCreatedAt,
   searchQuery,
   searchType,
+  useEventsTable,
   rowLimit = env.BATCH_EXPORT_ROW_LIMIT,
 }: {
   projectId: string;
@@ -209,14 +212,41 @@ export const getDatabaseReadStreamPaginated = async ({
             projectId,
             finalFilter ?? [],
           );
-          const sessions = await getSessionsWithMetrics({
-            projectId: projectId,
-            filter: sessionsFilter,
-            orderBy: orderBy,
-            limit: pageSize,
-            page: Math.floor(offset / pageSize),
-            clickhouseConfigs,
-          });
+          // v4-enabled users (snapshotted as useEventsTable at dispatch) read
+          // sessions from the ClickHouse events table. The list reader applies
+          // filter/order/pagination; metrics (duration, cost, usage) come from a
+          // second call keyed by the page's session ids, mirroring the Sessions
+          // UI flow. Both readers expose the same field names, so the row
+          // mapping below is shared with the legacy traces path.
+          const sessions = useEventsTable
+            ? await (async () => {
+                const list = await getSessionsTableFromEvents({
+                  projectId,
+                  filter: sessionsFilter,
+                  orderBy,
+                  limit: pageSize,
+                  page: Math.floor(offset / pageSize),
+                });
+                const metricsById = new Map(
+                  (
+                    await getSessionMetricsFromEvents({
+                      projectId,
+                      sessionIds: list.map((s) => s.session_id),
+                    })
+                  ).map((m) => [m.session_id, m]),
+                );
+                return list
+                  .map((s) => metricsById.get(s.session_id))
+                  .filter((m): m is NonNullable<typeof m> => Boolean(m));
+              })()
+            : await getSessionsWithMetrics({
+                projectId: projectId,
+                filter: sessionsFilter,
+                orderBy: orderBy,
+                limit: pageSize,
+                page: Math.floor(offset / pageSize),
+                clickhouseConfigs,
+              });
 
           const prismaSessionInfo = await prisma.traceSession.findMany({
             where: {

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -15,8 +15,7 @@ import {
   getScoresUiTable,
   getPublicSessionsFilter,
   getSessionsWithMetrics,
-  getSessionsTableFromEvents,
-  getSessionMetricsFromEvents,
+  getSessionsWithMetricsFromEvents,
   getDistinctScoreNames,
   getObservationsTableWithModelData,
   getScoresForObservations,
@@ -213,32 +212,18 @@ export const getDatabaseReadStreamPaginated = async ({
             finalFilter ?? [],
           );
           // v4-enabled users (snapshotted as useEventsTable at dispatch) read
-          // sessions from the ClickHouse events table. The list reader applies
-          // filter/order/pagination; metrics (duration, cost, usage) come from a
-          // second call keyed by the page's session ids, mirroring the Sessions
-          // UI flow. Both readers expose the same field names, so the row
-          // mapping below is shared with the legacy traces path.
+          // sessions from the ClickHouse events table. Both readers apply the
+          // same filter (incl. the createdAt cutoff) and clickhouseConfigs, and
+          // expose the same field names, so the row mapping below is shared.
           const sessions = useEventsTable
-            ? await (async () => {
-                const list = await getSessionsTableFromEvents({
-                  projectId,
-                  filter: sessionsFilter,
-                  orderBy,
-                  limit: pageSize,
-                  page: Math.floor(offset / pageSize),
-                });
-                const metricsById = new Map(
-                  (
-                    await getSessionMetricsFromEvents({
-                      projectId,
-                      sessionIds: list.map((s) => s.session_id),
-                    })
-                  ).map((m) => [m.session_id, m]),
-                );
-                return list
-                  .map((s) => metricsById.get(s.session_id))
-                  .filter((m): m is NonNullable<typeof m> => Boolean(m));
-              })()
+            ? await getSessionsWithMetricsFromEvents({
+                projectId: projectId,
+                filter: sessionsFilter,
+                orderBy: orderBy,
+                limit: pageSize,
+                page: Math.floor(offset / pageSize),
+                clickhouseConfigs,
+              })
             : await getSessionsWithMetrics({
                 projectId: projectId,
                 filter: sessionsFilter,


### PR DESCRIPTION
## Summary

- Branch the **sessions** batch export on a new `useEventsTable` flag so v4 beta users export session data from the ClickHouse events table instead of the legacy traces path, keeping exports consistent with what those users see in the UI.
- The flag is snapshotted from the user's v4 beta flag at dispatch and persisted in the job query (`BatchExportQuerySchema`), so the worker reads the dispatch-time snapshot rather than the live user record — no flag-flip race between dispatch and pickup.
- The events path mirrors the Sessions UI flow: list rows via `getSessionsTableFromEvents` (filter/order/pagination), then metrics (duration, cost, usage) via `getSessionMetricsFromEvents`, merged by session id. Both readers expose the same field names, so the row mapping is shared with the legacy path.
- Legacy `getSessionsWithMetrics` path is unchanged when the flag is false/absent (self-hosted stays on legacy, since the beta flag is Cloud-only).
- The events-table **observations** export already routes through `getEventsStream`; added a regression test that locks that route in.

## Impacted packages

- `packages/shared` — `useEventsTable?: boolean` added to `BatchExportQuerySchema`.
- `web` — `batchExport.create` dispatcher snapshots `v4BetaEnabled` into the persisted query.
- `worker` — `getDatabaseReadStream` sessions case branches to the events-table readers when the flag is set.

## Verification

- `pnpm --filter @langfuse/shared --filter worker --filter web run typecheck` — green
- `pnpm --filter @langfuse/shared --filter worker --filter web run lint` — green
- Added worker integration tests (sessions-from-events + events-export route guard) and web dispatch-snapshot tests; these need live infra and run in CI.
- Browser review of the live export flows pending.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `useEventsTable` flag to the batch-export sessions path so that v4-beta users read session data from the ClickHouse events table instead of the legacy traces path. The flag is snapshotted from the user's session at dispatch time, persisted in the job's query column, and passed through to the worker's paginated stream reader.

- `BatchExportQuerySchema` gains an optional `useEventsTable` boolean; the tRPC mutation stamps the live `v4BetaEnabled` value onto the query object before persisting it, preventing the worker from ever reading the stale/live user record.
- The paginated reader's `sessions` case now forks on `useEventsTable`: the events-table path calls `getSessionsTableFromEvents` for the paginated list and `getSessionMetricsFromEvents` for metrics, then joins them by `session_id`; the legacy path is unchanged.
- New server-test cases verify that the flag is correctly snapshotted for both enabled and disabled users; a new worker test verifies that the events-table stream returns the expected sessions with correct `countTraces`.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change is safe for non-sessions exports and for users without the v4 beta flag; the sessions export via the events table is functionally new, and the two-query join does not forward the export cutoff timestamp to the metrics call.

The core dispatch-time snapshot mechanism is solid and well-tested. The concern is in the worker's new sessions branch: getSessionMetricsFromEvents is called without the cutoffCreatedAt upper bound that the list query carries through sessionsFilter. This means trace_count, duration, totalCost, and related fields in the export can reflect events ingested after the job was enqueued, while the legacy path forwards the cutoff all the way into its metrics calculation.

worker/src/features/database-read-stream/getDatabaseReadStream.ts — specifically the useEventsTable branch in the sessions case, where the metrics query is missing the cutoff filter.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant tRPC as batchExportRouter (web)
    participant DB as Prisma / Postgres
    participant Queue as BatchExportQueue
    participant Worker as handleBatchExportJob
    participant CH_List as ClickHouse (getSessionsTableFromEvents)
    participant CH_Metrics as ClickHouse (getSessionMetricsFromEvents)

    Client->>tRPC: create sessions export
    tRPC->>tRPC: stamp useEventsTable from v4BetaEnabled
    tRPC->>DB: persist batchExport with snapshotted query
    tRPC->>Queue: enqueue BatchExportJob
    Queue->>Worker: dequeue job
    Worker->>DB: fetch job reads persisted useEventsTable
    alt useEventsTable true
        Worker->>CH_List: getSessionsTableFromEvents with sessionsFilter and page
        CH_List-->>Worker: list of session_id and trace_ids
        Worker->>CH_Metrics: getSessionMetricsFromEvents with sessionIds only
        CH_Metrics-->>Worker: metrics with cost and duration
        Worker->>Worker: join by session_id and drop unmatched
    else useEventsTable false or undefined
        Worker->>CH_List: getSessionsWithMetrics with sessionsFilter
        CH_List-->>Worker: sessions with metrics
    end
    Worker->>DB: traceSession findMany for bookmarked and public
    Worker-->>Client: export rows
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/database-read-stream/getDatabaseReadStream.ts:232-236
**Metrics query does not inherit the export cutoff upper bound**

`getSessionMetricsFromEvents` is called with only `projectId` and `sessionIds` – the `cutoffCreatedAt` upper bound applied to the list query (via `createdAtCutoffFilter` in `sessionsFilter`) is not forwarded. As a result, the aggregated metrics for a session (trace count, duration, total cost, etc.) can reflect events ingested *after* the export was queued, diverging from the snapshot semantics that the cutoff is supposed to enforce. The legacy path passes `sessionsFilter` (which carries the cutoff) all the way into `getSessionsWithMetrics`, so the two paths behave differently.

### Issue 2 of 2
worker/src/features/database-read-stream/getDatabaseReadStream.ts:238-241
**Silent session drop without observability**

Sessions that appear in the paginated list but lack a corresponding entry in `metricsById` are silently filtered out. The test comment even documents this ("sessions without metrics are dropped"), but there is no `logger.warn` or counter emitted when this happens. In production, if a ClickHouse timing gap or aggregation edge case causes the metrics call to miss a session, the export will simply produce fewer rows than the list query returned, with no trace in logs or metrics to surface the discrepancy. Adding at least a debug-level log for the dropped count would make the behavior observable.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(batch-export): read sessions from e..."](https://github.com/langfuse/langfuse/commit/87f30be6fb5ff06353dcac81ef224e3fe31bfd5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35685445)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->