### PR TITLE
fix: correct typo in project members hover message

### DIFF
--- a/web/src/features/rbac/components/MembersTable.tsx
+++ b/web/src/features/rbac/components/MembersTable.tsx
@@ -233,7 +233,7 @@ export function MembersTable({
                     side="right"
                   >
                     <p className="text-xs">
-                      The organization-level role can to be edited in the{" "}
+                      The organization-level role can be edited in the{" "}
                       <Link
                         href={`/organization/${orgId}/settings/members`}
                         className="underline"


### PR DESCRIPTION
## Problem

The hover tooltip for the "Organization Role" column in Project settings → Project members contains a grammatical error:

> The organization-level role **can to be** edited in the organization settings.

## Fix

Removed the extra "to" to make the sentence grammatically correct:

> The organization-level role **can be** edited in the organization settings.

**File:** `web/src/features/rbac/components/MembersTable.tsx`

Fixes #13826

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a grammatical error in the hover tooltip for the "Organization Role" column in the Project Members table, changing "can to be edited" to "can be edited".

- Removes the extra word "to" from the tooltip string in `web/src/features/rbac/components/MembersTable.tsx`, making the sentence grammatically correct.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-word removal from a UI tooltip string with no functional impact.

The change touches exactly one string literal in a tooltip and corrects a grammatical error introduced earlier. There is no logic, state, or API surface affected.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: correct hover message in project me..."](https://github.com/langfuse/langfuse/commit/e6b9c66dc86b25c64e7ec62baedf1a42cbf8bf58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35690667)</sub>

<!-- /greptile_comment -->