### PR TITLE
fix: add deterministic ordering to public comments API

### DIFF
--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -130,7 +130,7 @@ export const listCommentsForApi = async ({
   const [comments, totalItems] = await Promise.all([
     prisma.comment.findMany({
       where,
-      orderBy: { createdAt: "desc" },
+      orderBy: [{ createdAt: "desc" }, { id: "asc" }],
       take: limit,
       skip: (page - 1) * limit,
     }),

--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -130,6 +130,7 @@ export const listCommentsForApi = async ({
   const [comments, totalItems] = await Promise.all([
     prisma.comment.findMany({
       where,
+      orderBy: { createdAt: "desc" },
       take: limit,
       skip: (page - 1) * limit,
     }),


### PR DESCRIPTION
## Problem

The `GET /api/public/comments` endpoint and `listComments` MCP tool return comments in non-deterministic order. Combined with pagination (`take`/`skip`), this can cause duplicate or missing comments across pages.

## Fix

Added `orderBy: { createdAt: "desc" }` to the `prisma.comment.findMany()` call in `listCommentsForApi`, ensuring consistent newest-first ordering.

**File:** `web/src/features/comments/server/publicCommentService.ts`

Fixes #13812

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes non-deterministic ordering in the `GET /api/public/comments` endpoint by adding `orderBy: { createdAt: "desc" }` to the `prisma.comment.findMany()` call in `listCommentsForApi`, which previously returned rows in an arbitrary database-engine order that could cause duplicates or gaps across paginated pages.

- **Single-line change** in `publicCommentService.ts`: adds `orderBy: { createdAt: "desc" }` to `findMany`, ensuring newest-first ordering and consistent pagination across all pages.
- The fix correctly resolves the pagination consistency bug described in #13812; a secondary sort key on `id` would harden it further against the edge case of two comments sharing an identical `createdAt` timestamp.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a one-line addition that adds deterministic ordering to a paginated list query, directly fixing the reported duplicate/missing-comment bug.

The fix is correct and well-scoped. The only residual concern is that two comments with the exact same `createdAt` value are still ordered arbitrarily relative to each other; adding `id` as a tiebreaker would make the ordering fully stable, but this edge case is unlikely to matter in practice.

No files require special attention beyond the suggestion to add a secondary sort key in `publicCommentService.ts`.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as GET /api/public/comments
    participant Service as listCommentsForApi
    participant DB as Prisma (comment)

    Client->>API: "GET /api/public/comments?page=2&limit=10"
    API->>Service: "listCommentsForApi({ page, limit, ... })"
    Service->>DB: "comment.findMany({ where, orderBy: { createdAt: desc }, take, skip })"
    Service->>DB: "comment.count({ where })"
    DB-->>Service: comments[] (newest-first)
    DB-->>Service: totalItems
    Service-->>API: "{ data, meta: { page, limit, totalItems, totalPages } }"
    API-->>Client: 200 OK (consistent, paginated results)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/comments/server/publicCommentService.ts:133
Missing secondary sort key for deterministic tie-breaking. If two comments share the same `createdAt` timestamp (possible under any write burst), their relative order within a page is still undefined. Adding `id` as a secondary sort key guarantees a stable total order across all pages.

```suggestion
      orderBy: [{ createdAt: "desc" }, { id: "asc" }],
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add deterministic ordering to comme..."](https://github.com/langfuse/langfuse/commit/e4a6eeaec843d8e0202ed4d9c5d7be258ca8da25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35690693)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->