### PR TITLE
feat(blob-storage): block legacy export source for new Cloud exporters

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -67,6 +67,9 @@ NEXT_PUBLIC_LANGFUSE_CLOUD_REGION="DEV"
 # post-cutoff, or a future date (e.g. 2099-01-01T00:00:00.000Z) to grandfather
 # all projects. Must be a valid ISO 8601 datetime string. Leave unset in prod.
 # NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF=
+# Same, for the integration-level cutoff applied to the blob storage
+# integration row's creation date instead of the project's.
+# NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF=
 
 # Langfuse experimental features
 LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES="false"

--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -131,9 +131,11 @@ types:
       exportSource:
         type: optional<BlobStorageExportSource>
         docs: |
-          Data to export. When omitted on update, the existing value is preserved. When omitted on create: pre-cutoff Cloud projects and self-hosted deployments fall back to `LEGACY_TRACES_OBSERVATIONS`; post-cutoff Cloud projects (created on or after 2026-05-20) auto-default to `OBSERVATIONS_V2`. Required when `exportFieldGroups` is provided.
+          Data to export. When omitted on update, the existing value is preserved. When omitted on create: integrations on Langfuse Cloud default to `OBSERVATIONS_V2`; self-hosted deployments fall back to `LEGACY_TRACES_OBSERVATIONS`. Required when `exportFieldGroups` is provided.
 
-          **Cloud-only deprecation gate (effective 2026-05-20):** For projects created on or after 2026-05-20 on Langfuse Cloud, `LEGACY_TRACES_OBSERVATIONS` and `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP 400. Omitting `exportSource` on these projects silently defaults to `OBSERVATIONS_V2` rather than the schema column default. Use `OBSERVATIONS_V2` for all new integrations. Projects created before 2026-05-20 and self-hosted deployments are unaffected.
+          **Cloud-only project deprecation gate (effective 2026-05-20):** For projects created on or after 2026-05-20 on Langfuse Cloud, `LEGACY_TRACES_OBSERVATIONS` and `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP 400. Use `OBSERVATIONS_V2` for all new integrations. Self-hosted deployments are unaffected.
+
+          **Cloud-only integration deprecation gate (effective 2026-06-22):** On Langfuse Cloud, legacy export sources are only accepted for blob storage integrations created before 2026-06-22, regardless of project age. Requests that would create a new integration with `LEGACY_TRACES_OBSERVATIONS` or `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP 400. Use `OBSERVATIONS_V2` instead. Self-hosted deployments are unaffected.
 
       exportFieldGroups:
         type: optional<list<BlobStorageExportFieldGroup>>

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -7,6 +7,8 @@ const EnvSchema = z.object({
   // export cutoff for local testing (e.g. "2020-01-01T00:00:00.000Z" makes
   // every project post-cutoff; "2099-01-01T00:00:00.000Z" grandfathers all).
   NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF: z.iso.datetime().optional(),
+  // Same, for the integration-level cutoff (BlobStorageIntegration.createdAt).
+  NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF: z.iso.datetime().optional(),
   NODE_ENV: z
     .enum(["development", "test", "production"])
     .default("development"),

--- a/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
@@ -4,6 +4,11 @@
 import { AnalyticsIntegrationExportSource } from "@prisma/client";
 
 // Cloud projects created on or after this instant cannot use legacy export sources.
+// Cloud-only by design: enforced via the `!isCloud` short-circuit in
+// `isLegacyBlobExportAllowed`, decoupled from `isEnrichedBlobExportAvailable` so a
+// future self-hosted flip of the latter does not silently activate this cutoff. The
+// self-hosted policy decision is tracked in LFE-10148. Its sibling, the
+// integration-level `LEGACY_BLOB_EXPORTER_CUTOFF`, is joined at the same decision point.
 // NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF overrides the default for local dev testing.
 const _override = process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF
   ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF)
@@ -12,6 +17,21 @@ export const LEGACY_BLOB_EXPORT_CUTOFF =
   _override && !isNaN(_override.getTime())
     ? _override
     : new Date("2026-05-20T00:00:00.000Z");
+
+// Cloud blob storage integrations created on or after this instant cannot use legacy
+// export sources. Symmetric with `LEGACY_BLOB_EXPORT_CUTOFF` (project-level) but applied
+// to `BlobStorageIntegration.createdAt` instead of `Project.createdAt`. Cloud-only by
+// design: enforced via the `!isCloud` short-circuit in `isLegacyBlobExporter`, decoupled
+// from `isEnrichedBlobExportAvailable` so a future self-hosted flip of the latter does not
+// silently activate this cutoff. The self-hosted policy decision is tracked in LFE-10148.
+// NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF overrides the default for local dev testing.
+const _exporterOverride = process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF
+  ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF)
+  : null;
+export const LEGACY_BLOB_EXPORTER_CUTOFF =
+  _exporterOverride && !isNaN(_exporterOverride.getTime())
+    ? _exporterOverride
+    : new Date("2026-06-12T00:00:00.000Z");
 
 // Internal enum values that are considered "legacy". satisfies ensures each
 // element remains a valid AnalyticsIntegrationExportSource — catches renames or
@@ -28,6 +48,9 @@ export const LEGACY_BLOB_EXPORT_SOURCES = [
  *
  * Shared by the server guard (throws when false + legacy source) and the UI
  * (hides legacy dropdown options when false) so the predicate lives once.
+ *
+ * Cloud-only via the `!isCloud` short-circuit; joined at the same decision point
+ * as `isLegacyBlobExporter` (integration-level). See LFE-10148.
  */
 export function isLegacyBlobExportAllowed(
   projectCreatedAt: Date,
@@ -35,6 +58,28 @@ export function isLegacyBlobExportAllowed(
 ): boolean {
   if (!isCloud) return true;
   return projectCreatedAt < LEGACY_BLOB_EXPORT_CUTOFF;
+}
+
+/**
+ * Whether a blob storage integration row counts as legacy — i.e. may still use
+ * legacy export sources. Applied to `BlobStorageIntegration.createdAt`.
+ *
+ * - `!isCloud` → `true`: self-hosted is exempt (cutoff does not apply; see LFE-10148).
+ * - `null` createdAt → `false`: no existing row means a brand-new integration,
+ *   which follows new-customer rules.
+ * - otherwise legacy iff the row was created strictly before the cutoff.
+ *
+ * Cloud-only via the `!isCloud` short-circuit, decoupled from
+ * `isEnrichedBlobExportAvailable` so a future self-hosted flip of the latter
+ * does not silently activate this cutoff.
+ */
+export function isLegacyBlobExporter(
+  integrationCreatedAt: Date | null,
+  isCloud: boolean,
+): boolean {
+  if (!isCloud) return true;
+  if (integrationCreatedAt == null) return false;
+  return integrationCreatedAt < LEGACY_BLOB_EXPORTER_CUTOFF;
 }
 
 /**

--- a/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
@@ -31,7 +31,7 @@ const _exporterOverride = process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF
 export const LEGACY_BLOB_EXPORTER_CUTOFF =
   _exporterOverride && !isNaN(_exporterOverride.getTime())
     ? _exporterOverride
-    : new Date("2026-06-12T00:00:00.000Z");
+    : new Date("2026-06-22T00:00:00.000Z");
 
 // Internal enum values that are considered "legacy". satisfies ensures each
 // element remains a valid AnalyticsIntegrationExportSource — catches renames or

--- a/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
@@ -4,11 +4,10 @@
 import { AnalyticsIntegrationExportSource } from "@prisma/client";
 
 // Cloud projects created on or after this instant cannot use legacy export sources.
-// Cloud-only by design: enforced via the `!isCloud` short-circuit in
-// `isLegacyBlobExportAllowed`, decoupled from `isEnrichedBlobExportAvailable` so a
-// future self-hosted flip of the latter does not silently activate this cutoff. The
-// self-hosted policy decision is tracked in LFE-10148. Its sibling, the
-// integration-level `LEGACY_BLOB_EXPORTER_CUTOFF`, is joined at the same decision point.
+// Both cutoffs in this file are Cloud-only by design (the `!isCloud` short-circuits
+// below): self-hosted instances can enable the enriched export via the V4 preview
+// opt-in, but that must not activate these cutoffs — deprecating legacy sources
+// on self-hosted is a separate, still-open decision.
 // NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF overrides the default for local dev testing.
 const _override = process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF
   ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF)
@@ -20,10 +19,8 @@ export const LEGACY_BLOB_EXPORT_CUTOFF =
 
 // Cloud blob storage integrations created on or after this instant cannot use legacy
 // export sources. Symmetric with `LEGACY_BLOB_EXPORT_CUTOFF` (project-level) but applied
-// to `BlobStorageIntegration.createdAt` instead of `Project.createdAt`. Cloud-only by
-// design: enforced via the `!isCloud` short-circuit in `isLegacyBlobExporter`, decoupled
-// from `isEnrichedBlobExportAvailable` so a future self-hosted flip of the latter does not
-// silently activate this cutoff. The self-hosted policy decision is tracked in LFE-10148.
+// to `BlobStorageIntegration.createdAt` instead of `Project.createdAt`. Cloud-only —
+// see the note above.
 // NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF overrides the default for local dev testing.
 const _exporterOverride = process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF
   ? new Date(process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF)
@@ -48,9 +45,6 @@ export const LEGACY_BLOB_EXPORT_SOURCES = [
  *
  * Shared by the server guard (throws when false + legacy source) and the UI
  * (hides legacy dropdown options when false) so the predicate lives once.
- *
- * Cloud-only via the `!isCloud` short-circuit; joined at the same decision point
- * as `isLegacyBlobExporter` (integration-level). See LFE-10148.
  */
 export function isLegacyBlobExportAllowed(
   projectCreatedAt: Date,
@@ -64,14 +58,10 @@ export function isLegacyBlobExportAllowed(
  * Whether a blob storage integration row counts as legacy — i.e. may still use
  * legacy export sources. Applied to `BlobStorageIntegration.createdAt`.
  *
- * - `!isCloud` → `true`: self-hosted is exempt (cutoff does not apply; see LFE-10148).
+ * - `!isCloud` → `true`: self-hosted is exempt (cutoff does not apply).
  * - `null` createdAt → `false`: no existing row means a brand-new integration,
  *   which follows new-customer rules.
  * - otherwise legacy iff the row was created strictly before the cutoff.
- *
- * Cloud-only via the `!isCloud` short-circuit, decoupled from
- * `isEnrichedBlobExportAvailable` so a future self-hosted flip of the latter
- * does not silently activate this cutoff.
  */
 export function isLegacyBlobExporter(
   integrationCreatedAt: Date | null,

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,10 @@
   "$schema": "https://turbo.build/schema.json",
   "noUpdateNotifier": true,
   "globalDependencies": [".env"],
-  "globalEnv": ["NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF"],
+  "globalEnv": [
+    "NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF",
+    "NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF"
+  ],
   "envMode": "loose",
   "tasks": {
     "build": {

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7847,21 +7847,28 @@ components:
           nullable: true
           description: >-
             Data to export. When omitted on update, the existing value is
-            preserved. When omitted on create: pre-cutoff Cloud projects and
-            self-hosted deployments fall back to `LEGACY_TRACES_OBSERVATIONS`;
-            post-cutoff Cloud projects (created on or after 2026-05-20)
-            auto-default to `OBSERVATIONS_V2`. Required when `exportFieldGroups`
-            is provided.
+            preserved. When omitted on create: integrations on Langfuse Cloud
+            default to `OBSERVATIONS_V2`; self-hosted deployments fall back to
+            `LEGACY_TRACES_OBSERVATIONS`. Required when `exportFieldGroups` is
+            provided.
 
 
-            **Cloud-only deprecation gate (effective 2026-05-20):** For projects
-            created on or after 2026-05-20 on Langfuse Cloud,
+            **Cloud-only project deprecation gate (effective 2026-05-20):** For
+            projects created on or after 2026-05-20 on Langfuse Cloud,
             `LEGACY_TRACES_OBSERVATIONS` and
             `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP
-            400. Omitting `exportSource` on these projects silently defaults to
-            `OBSERVATIONS_V2` rather than the schema column default. Use
-            `OBSERVATIONS_V2` for all new integrations. Projects created before
-            2026-05-20 and self-hosted deployments are unaffected.
+            400. Use `OBSERVATIONS_V2` for all new integrations. Self-hosted
+            deployments are unaffected.
+
+
+            **Cloud-only integration deprecation gate (effective 2026-06-22):**
+            On Langfuse Cloud, legacy export sources are only accepted for blob
+            storage integrations created before 2026-06-22, regardless of
+            project age. Requests that would create a new integration with
+            `LEGACY_TRACES_OBSERVATIONS` or
+            `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` are rejected with HTTP
+            400. Use `OBSERVATIONS_V2` instead. Self-hosted deployments are
+            unaffected.
         exportFieldGroups:
           type: array
           items:

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -301,9 +301,8 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("should update an existing blob storage integration", async () => {
-      // Create initial integration. Backdated before the integration-level
-      // cutoff: the row keeps the legacy exportSource column default, which the
-      // in-transaction backstop only tolerates on grandfathered rows.
+      // Backdated: the row keeps the legacy exportSource column default,
+      // which only grandfathered (pre-integration-cutoff) rows may carry.
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -603,9 +602,8 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("should preserve exportFieldGroups in DB when updating via REST", async () => {
-      // Seed a row with a custom subset. Backdated: the row keeps the legacy
-      // exportSource column default, which the in-transaction backstop only
-      // tolerates on grandfathered (pre-integration-cutoff) rows.
+      // Seed a custom subset. Backdated: the row keeps the legacy exportSource
+      // column default, which only grandfathered rows may carry.
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -672,11 +670,9 @@ describe("Blob Storage Integrations API", () => {
       });
     });
 
-    // Seed a grandfathered (pre-integration-cutoff) legacy row so a subsequent
-    // legacy-source PUT passes the integration-level cutoff gate — brand-new
-    // Cloud rows can no longer be created with a legacy source, so these tests
-    // exercise the UPDATE path. exportFieldGroups stays at the column default
-    // (all groups) unless overridden.
+    // Pre-integration-cutoff legacy row: lets a legacy-source PUT pass the
+    // integration-level gate (new Cloud rows can no longer be legacy, so these
+    // tests exercise the UPDATE path).
     const seedGrandfatheredLegacyRow = (
       data: { exportFieldGroups?: string[] } = {},
     ) =>
@@ -1529,8 +1525,8 @@ describe("Blob Storage Integrations API", () => {
           where: { id: testProject1Id },
           data: { createdAt: PRE_CUTOFF },
         });
-        // Grandfathered (pre-integration-cutoff) row: the integration-level
-        // gate only allows a legacy source on an existing pre-cutoff row.
+        // Grandfathered row: legacy sources are only allowed on existing
+        // pre-integration-cutoff rows.
         await prisma.blobStorageIntegration.create({
           data: {
             projectId: testProject1Id,
@@ -1716,13 +1712,11 @@ describe("Blob Storage Integrations API", () => {
   });
 
   describe("integration-level legacy exporter cutoff gate", () => {
-    // Cloud mode comes from the server process env — see the note in the
-    // project-level gate suite above. The project is pinned pre-cutoff
-    // throughout, so the project-level gate never rejects: every 400 in this
-    // suite is the integration-level cutoff. The self-hosted bypass (legacy
-    // allowed without an existing row) cannot be exercised over HTTP for the
-    // same frozen-env reason; the tRPC suite covers it in-process through the
-    // same shared gate.
+    // Cloud mode comes from the server process env (see note in the
+    // project-level gate suite). The project is pinned pre-cutoff, so every
+    // 400 here is the integration-level cutoff. The self-hosted bypass cannot
+    // be tested over HTTP (frozen server env); the tRPC suite covers it
+    // through the same shared gate.
     const basePayload = {
       ...validBlobStorageConfig,
       projectId: "", // set per test
@@ -1859,9 +1853,8 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("no existing row + omitted exportSource → 200 and persists EVENTS", async () => {
-      // A brand-new Cloud row must never be born with the legacy Prisma column
-      // default, even on a pre-cutoff project: the handler forces EVENTS on
-      // CREATE when exportSource is omitted.
+      // New Cloud rows must never get the legacy column default, even on a
+      // pre-cutoff project.
       const result = await makeAPICall(
         "PUT",
         "/api/public/integrations/blob-storage",

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -12,12 +12,19 @@ import {
 import {
   OBSERVATION_FIELD_GROUPS_FULL,
   LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_BLOB_EXPORTER_CUTOFF,
 } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
 const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
+const INTEGRATION_PRE_CUTOFF = new Date(
+  LEGACY_BLOB_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
+);
+const INTEGRATION_POST_CUTOFF = new Date(
+  LEGACY_BLOB_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+);
 
 // Schemas based on Fern schema definition
 const BlobStorageIntegrationResponseSchema = z.object({
@@ -294,7 +301,9 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("should update an existing blob storage integration", async () => {
-      // Create initial integration
+      // Create initial integration. Backdated before the integration-level
+      // cutoff: the row keeps the legacy exportSource column default, which the
+      // in-transaction backstop only tolerates on grandfathered rows.
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -309,6 +318,7 @@ describe("Blob Storage Integrations API", () => {
           forcePathStyle: true,
           fileType: "JSON",
           exportMode: "FROM_TODAY",
+          createdAt: INTEGRATION_PRE_CUTOFF,
         },
       });
 
@@ -593,7 +603,9 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("should preserve exportFieldGroups in DB when updating via REST", async () => {
-      // Seed a row with a custom subset
+      // Seed a row with a custom subset. Backdated: the row keeps the legacy
+      // exportSource column default, which the in-transaction backstop only
+      // tolerates on grandfathered (pre-integration-cutoff) rows.
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -609,6 +621,7 @@ describe("Blob Storage Integrations API", () => {
           fileType: "JSONL",
           exportMode: "FULL_HISTORY",
           exportFieldGroups: ["core", "io"],
+          createdAt: INTEGRATION_PRE_CUTOFF,
         },
       });
 
@@ -658,6 +671,34 @@ describe("Blob Storage Integrations API", () => {
         },
       });
     });
+
+    // Seed a grandfathered (pre-integration-cutoff) legacy row so a subsequent
+    // legacy-source PUT passes the integration-level cutoff gate — brand-new
+    // Cloud rows can no longer be created with a legacy source, so these tests
+    // exercise the UPDATE path. exportFieldGroups stays at the column default
+    // (all groups) unless overridden.
+    const seedGrandfatheredLegacyRow = (
+      data: { exportFieldGroups?: string[] } = {},
+    ) =>
+      prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject1Id,
+          type: "S3",
+          bucketName: "seed-bucket",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportSource: "TRACES_OBSERVATIONS",
+          createdAt: INTEGRATION_PRE_CUTOFF,
+          ...data,
+        },
+      });
 
     // ---- OBSERVATIONS_V2 / LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS path ----
 
@@ -792,6 +833,7 @@ describe("Blob Storage Integrations API", () => {
     // ---- LEGACY_TRACES_OBSERVATIONS path ----
 
     it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups omitted -> 200; GET returns all 11 groups", async () => {
+      await seedGrandfatheredLegacyRow();
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -826,6 +868,7 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=null -> 200; GET returns all 11 groups", async () => {
+      await seedGrandfatheredLegacyRow();
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -879,6 +922,7 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=[core,io] -> 200 and GET returns same value", async () => {
+      await seedGrandfatheredLegacyRow();
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -944,25 +988,8 @@ describe("Blob Storage Integrations API", () => {
     });
 
     it("PUT LEGACY_TRACES_OBSERVATIONS preserves existing export_field_groups column in DB", async () => {
-      // Seed with a custom subset
-      await prisma.blobStorageIntegration.create({
-        data: {
-          projectId: testProject1Id,
-          type: "S3",
-          bucketName: "initial-bucket",
-          region: "us-east-1",
-          accessKeyId: "key",
-          secretAccessKey: "secret",
-          prefix: "",
-          exportFrequency: "daily",
-          enabled: true,
-          forcePathStyle: false,
-          fileType: "JSONL",
-          exportMode: "FULL_HISTORY",
-          exportSource: "TRACES_OBSERVATIONS",
-          exportFieldGroups: ["core", "io"],
-        },
-      });
+      // Seed a grandfathered row with a custom subset
+      await seedGrandfatheredLegacyRow({ exportFieldGroups: ["core", "io"] });
 
       await makeZodVerifiedAPICall(
         BlobStorageIntegrationResponseSchema,
@@ -988,6 +1015,7 @@ describe("Blob Storage Integrations API", () => {
     // ---- Response shape ----
 
     it("PUT response includes exportSource and exportFieldGroups for LEGACY_TRACES_OBSERVATIONS", async () => {
+      await seedGrandfatheredLegacyRow();
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -1501,6 +1529,26 @@ describe("Blob Storage Integrations API", () => {
           where: { id: testProject1Id },
           data: { createdAt: PRE_CUTOFF },
         });
+        // Grandfathered (pre-integration-cutoff) row: the integration-level
+        // gate only allows a legacy source on an existing pre-cutoff row.
+        await prisma.blobStorageIntegration.create({
+          data: {
+            projectId: testProject1Id,
+            type: "S3",
+            bucketName: "seed-bucket",
+            region: "us-east-1",
+            accessKeyId: "key",
+            secretAccessKey: "secret",
+            prefix: "",
+            exportFrequency: "daily",
+            enabled: true,
+            forcePathStyle: false,
+            fileType: "JSONL",
+            exportMode: "FULL_HISTORY",
+            exportSource: "TRACES_OBSERVATIONS",
+            createdAt: INTEGRATION_PRE_CUTOFF,
+          },
+        });
         const result = await makeAPICall(
           "PUT",
           "/api/public/integrations/blob-storage",
@@ -1664,6 +1712,169 @@ describe("Blob Storage Integrations API", () => {
           where: { projectId: testProject1Id },
         });
       }
+    });
+  });
+
+  describe("integration-level legacy exporter cutoff gate", () => {
+    // Cloud mode comes from the server process env — see the note in the
+    // project-level gate suite above. The project is pinned pre-cutoff
+    // throughout, so the project-level gate never rejects: every 400 in this
+    // suite is the integration-level cutoff. The self-hosted bypass (legacy
+    // allowed without an existing row) cannot be exercised over HTTP for the
+    // same frozen-env reason; the tRPC suite covers it in-process through the
+    // same shared gate.
+    const basePayload = {
+      ...validBlobStorageConfig,
+      projectId: "", // set per test
+    };
+
+    const seedIntegration = (createdAt: Date) =>
+      prisma.blobStorageIntegration.create({
+        data: {
+          projectId: testProject1Id,
+          type: "S3",
+          bucketName: "existing-bucket",
+          region: "us-east-1",
+          accessKeyId: "key",
+          secretAccessKey: "secret",
+          prefix: "",
+          exportFrequency: "daily",
+          enabled: true,
+          forcePathStyle: false,
+          fileType: "JSONL",
+          exportMode: "FULL_HISTORY",
+          exportSource: "TRACES_OBSERVATIONS",
+          createdAt,
+        },
+      });
+
+    beforeAll(async () => {
+      await prisma.project.update({
+        where: { id: testProject1Id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+    });
+
+    afterAll(async () => {
+      await prisma.project.update({
+        where: { id: testProject1Id },
+        data: { createdAt: new Date() },
+      });
+    });
+
+    afterEach(async () => {
+      await prisma.blobStorageIntegration.deleteMany({
+        where: { projectId: testProject1Id },
+      });
+    });
+
+    it("no existing row + legacy source → 400 mentioning the integration cutoff", async () => {
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        {
+          ...basePayload,
+          projectId: testProject1Id,
+          exportSource: "LEGACY_TRACES_OBSERVATIONS",
+        },
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(400);
+      expect(result.body.message).toContain(
+        "blob storage integrations created on or after",
+      );
+      expect(result.body.message).toContain(
+        LEGACY_BLOB_EXPORTER_CUTOFF.toISOString(),
+      );
+      expect(result.body.message).toContain("OBSERVATIONS_V2");
+    });
+
+    it("pre-cutoff existing row + legacy source → 200 (grandfathered)", async () => {
+      await seedIntegration(INTEGRATION_PRE_CUTOFF);
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        {
+          ...basePayload,
+          projectId: testProject1Id,
+          exportSource: "LEGACY_TRACES_OBSERVATIONS",
+        },
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(200);
+      expect(result.body.exportSource).toBe("LEGACY_TRACES_OBSERVATIONS");
+    });
+
+    it("existing row created exactly at the cutoff + legacy source → 400", async () => {
+      // Boundary: only rows created strictly before the cutoff are
+      // grandfathered.
+      await seedIntegration(LEGACY_BLOB_EXPORTER_CUTOFF);
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        {
+          ...basePayload,
+          projectId: testProject1Id,
+          exportSource: "LEGACY_TRACES_OBSERVATIONS",
+        },
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(400);
+      expect(result.body.message).toContain(
+        "blob storage integrations created on or after",
+      );
+    });
+
+    it("post-cutoff existing row + legacy source → 400", async () => {
+      await seedIntegration(INTEGRATION_POST_CUTOFF);
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        {
+          ...basePayload,
+          projectId: testProject1Id,
+          exportSource: "LEGACY_TRACES_OBSERVATIONS",
+        },
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(400);
+      expect(result.body.message).toContain(
+        "blob storage integrations created on or after",
+      );
+    });
+
+    it("no existing row + OBSERVATIONS_V2 → 200", async () => {
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        {
+          ...basePayload,
+          projectId: testProject1Id,
+          exportSource: "OBSERVATIONS_V2",
+        },
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(200);
+      expect(result.body.exportSource).toBe("OBSERVATIONS_V2");
+    });
+
+    it("no existing row + omitted exportSource → 200 and persists EVENTS", async () => {
+      // A brand-new Cloud row must never be born with the legacy Prisma column
+      // default, even on a pre-cutoff project: the handler forces EVENTS on
+      // CREATE when exportSource is omitted.
+      const result = await makeAPICall(
+        "PUT",
+        "/api/public/integrations/blob-storage",
+        { ...basePayload, projectId: testProject1Id },
+        createBasicAuthHeader(testApiKey, testApiSecretKey),
+      );
+      expect(result.status).toBe(200);
+      expect(result.body.exportSource).toBe("OBSERVATIONS_V2");
+
+      const saved = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      });
+      expect(saved?.exportSource).toBe("EVENTS");
     });
   });
 });

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -507,6 +507,14 @@ describe("Blob Storage Integration tRPC Router", () => {
         where: { id: project.id },
         data: { createdAt: PRE_CUTOFF },
       });
+      // Pre-cutoff integration row (legacy exporter) so the integration-cutoff
+      // gate allows the legacy source; this test only exercises field-group
+      // handling, not the cutoff.
+      await createIntegration({ projectId: project.id });
+      await prisma.blobStorageIntegration.update({
+        where: { projectId: project.id },
+        data: { createdAt: INTEGRATION_PRE_CUTOFF },
+      });
 
       await caller.blobStorageIntegration.update({
         projectId: project.id,
@@ -775,7 +783,7 @@ describe("Blob Storage Integration tRPC Router", () => {
             projectId: project.id,
             ...baseConfig,
             exportSource: "TRACES_OBSERVATIONS" as const,
-            exportFieldGroups: [],
+            exportFieldGroups: ["core"],
           }),
         ).rejects.toMatchObject({ code: "BAD_REQUEST" });
       } finally {
@@ -803,7 +811,7 @@ describe("Blob Storage Integration tRPC Router", () => {
             projectId: project.id,
             ...baseConfig,
             exportSource: "TRACES_OBSERVATIONS" as const,
-            exportFieldGroups: [],
+            exportFieldGroups: ["core"],
           }),
         ).resolves.not.toThrow();
       } finally {
@@ -852,7 +860,7 @@ describe("Blob Storage Integration tRPC Router", () => {
             projectId: project.id,
             ...baseConfig,
             exportSource: "TRACES_OBSERVATIONS" as const,
-            exportFieldGroups: [],
+            exportFieldGroups: ["core"],
           }),
         ).rejects.toMatchObject({ code: "BAD_REQUEST" });
       } finally {

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -14,6 +14,7 @@ import {
 import {
   OBSERVATION_FIELD_GROUPS_FULL,
   LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_BLOB_EXPORTER_CUTOFF,
 } from "@langfuse/shared";
 import { env } from "@/src/env.mjs";
 import { env as sharedEnv } from "@langfuse/shared/src/env";
@@ -21,6 +22,13 @@ import { env as sharedEnv } from "@langfuse/shared/src/env";
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const PRE_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY);
 const POST_CUTOFF = new Date(LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY);
+// Integration-level cutoff applied to BlobStorageIntegration.createdAt.
+const INTEGRATION_PRE_CUTOFF = new Date(
+  LEGACY_BLOB_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
+);
+const INTEGRATION_POST_CUTOFF = new Date(
+  LEGACY_BLOB_EXPORTER_CUTOFF.getTime() + MS_PER_DAY,
+);
 
 vi.mock("@langfuse/shared/src/server", async () => {
   const actual = await vi.importActual("@langfuse/shared/src/server");
@@ -726,6 +734,114 @@ describe("Blob Storage Integration tRPC Router", () => {
           exportSource: "EVENTS" as const,
         }),
       ).resolves.not.toThrow();
+    });
+  });
+
+  describe("legacy blob exporter (integration createdAt) cutoff gate", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    // All cases use a pre-cutoff project so the project-level delegate gate
+    // allows and the integration-level cutoff is isolated.
+
+    it("(a) Cloud + pre-cutoff project + no row + legacy → BAD_REQUEST", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        const { caller, project } = await prepare();
+        await prisma.project.update({
+          where: { id: project.id },
+          data: { createdAt: PRE_CUTOFF },
+        });
+        await expect(
+          caller.blobStorageIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+            exportSource: "TRACES_OBSERVATIONS" as const,
+            exportFieldGroups: [],
+          }),
+        ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      }
+    });
+
+    it("(b) Cloud + pre-cutoff project + row (createdAt < CUTOFF) + legacy → succeeds", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        const { caller, project } = await prepare();
+        await prisma.project.update({
+          where: { id: project.id },
+          data: { createdAt: PRE_CUTOFF },
+        });
+        await createIntegration({ projectId: project.id });
+        // Backdate the row to before the integration cutoff (legacy exporter).
+        await prisma.blobStorageIntegration.update({
+          where: { projectId: project.id },
+          data: { createdAt: INTEGRATION_PRE_CUTOFF },
+        });
+        await expect(
+          caller.blobStorageIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+            exportSource: "TRACES_OBSERVATIONS" as const,
+            exportFieldGroups: [],
+          }),
+        ).resolves.not.toThrow();
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      }
+    });
+
+    it("(c) Cloud + pre-cutoff project + no row + EVENTS → succeeds", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        const { caller, project } = await prepare();
+        await prisma.project.update({
+          where: { id: project.id },
+          data: { createdAt: PRE_CUTOFF },
+        });
+        await expect(
+          caller.blobStorageIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+            exportSource: "EVENTS" as const,
+          }),
+        ).resolves.not.toThrow();
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      }
+    });
+
+    it("(d) Cloud + pre-cutoff project + row (createdAt >= CUTOFF, reset-recreated) + legacy → BAD_REQUEST", async () => {
+      const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      try {
+        const { caller, project } = await prepare();
+        await prisma.project.update({
+          where: { id: project.id },
+          data: { createdAt: PRE_CUTOFF },
+        });
+        await createIntegration({ projectId: project.id });
+        // Post-date the row to on/after the integration cutoff (not legacy).
+        await prisma.blobStorageIntegration.update({
+          where: { projectId: project.id },
+          data: { createdAt: INTEGRATION_POST_CUTOFF },
+        });
+        await expect(
+          caller.blobStorageIntegration.update({
+            projectId: project.id,
+            ...baseConfig,
+            exportSource: "TRACES_OBSERVATIONS" as const,
+            exportFieldGroups: [],
+          }),
+        ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      } finally {
+        (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      }
     });
   });
 });

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -482,6 +482,14 @@ describe("Blob Storage Integration tRPC Router", () => {
         where: { id: project.id },
         data: { createdAt: PRE_CUTOFF },
       });
+      // Pre-cutoff integration row (legacy exporter) so the integration-cutoff
+      // gate allows the legacy source; this test only exercises field-group
+      // handling, not the cutoff.
+      await createIntegration({ projectId: project.id });
+      await prisma.blobStorageIntegration.update({
+        where: { projectId: project.id },
+        data: { createdAt: INTEGRATION_PRE_CUTOFF },
+      });
 
       await expect(
         caller.blobStorageIntegration.update({
@@ -544,7 +552,7 @@ describe("Blob Storage Integration tRPC Router", () => {
       vi.restoreAllMocks();
     });
 
-    it("Cloud + pre-cutoff project + legacy source → allow", async () => {
+    it("Cloud + pre-cutoff project + pre-cutoff legacy row + legacy source → allow", async () => {
       const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
       (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
       try {
@@ -552,6 +560,14 @@ describe("Blob Storage Integration tRPC Router", () => {
         await prisma.project.update({
           where: { id: project.id },
           data: { createdAt: PRE_CUTOFF },
+        });
+        // The project-level gate allows pre-cutoff projects, but the
+        // integration-cutoff gate also applies: a legacy source is only allowed
+        // when an existing pre-cutoff row classifies the exporter as legacy.
+        await createIntegration({ projectId: project.id });
+        await prisma.blobStorageIntegration.update({
+          where: { projectId: project.id },
+          data: { createdAt: INTEGRATION_PRE_CUTOFF },
         });
         await expect(
           caller.blobStorageIntegration.update({

--- a/web/src/__tests__/server/unit/assertLegacyBlobExportSourceAllowedForUpsert.servertest.ts
+++ b/web/src/__tests__/server/unit/assertLegacyBlobExportSourceAllowedForUpsert.servertest.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { assertLegacyBlobExportSourceAllowedForUpsert } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert";
+import {
+  LEGACY_BLOB_EXPORT_CUTOFF,
+  LEGACY_BLOB_EXPORTER_CUTOFF,
+} from "@langfuse/shared";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Project-level cutoff (post-cutoff Cloud projects are forced to EVENTS).
+const PROJECT_PRE_CUTOFF = new Date(
+  LEGACY_BLOB_EXPORT_CUTOFF.getTime() - MS_PER_DAY,
+);
+const PROJECT_POST_CUTOFF = new Date(
+  LEGACY_BLOB_EXPORT_CUTOFF.getTime() + MS_PER_DAY,
+);
+
+// Integration-level cutoff (rows created on/after this cannot keep legacy sources).
+const INTEGRATION_PRE_CUTOFF = new Date(
+  LEGACY_BLOB_EXPORTER_CUTOFF.getTime() - MS_PER_DAY,
+);
+const INTEGRATION_AT_CUTOFF = LEGACY_BLOB_EXPORTER_CUTOFF;
+
+describe("assertLegacyBlobExportSourceAllowedForUpsert", () => {
+  it("1. Cloud + pre-cutoff project + no row + legacy → throws", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowedForUpsert({
+        project: { createdAt: PROJECT_PRE_CUTOFF },
+        existingIntegration: null,
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: true,
+      }),
+    ).toThrow();
+  });
+
+  it("2. Cloud + pre-cutoff project + row (createdAt < CUTOFF) + legacy → allows", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowedForUpsert({
+        project: { createdAt: PROJECT_PRE_CUTOFF },
+        existingIntegration: { createdAt: INTEGRATION_PRE_CUTOFF },
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("3. Cloud + post-cutoff project + no row + legacy → throws (delegate)", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowedForUpsert({
+        project: { createdAt: PROJECT_POST_CUTOFF },
+        existingIntegration: null,
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: true,
+      }),
+    ).toThrow();
+  });
+
+  it("4. Cloud + post-cutoff project + row (createdAt < CUTOFF) + legacy → throws (delegate wins)", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowedForUpsert({
+        project: { createdAt: PROJECT_POST_CUTOFF },
+        existingIntegration: { createdAt: INTEGRATION_PRE_CUTOFF },
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: true,
+      }),
+    ).toThrow();
+  });
+
+  it("5. Cloud + any + EVENTS → allows", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowedForUpsert({
+        project: { createdAt: PROJECT_POST_CUTOFF },
+        existingIntegration: null,
+        nextInternalExportSource: "EVENTS",
+        isCloud: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("6. self-hosted + post-cutoff project + no row + legacy → allows (short-circuit)", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowedForUpsert({
+        project: { createdAt: PROJECT_POST_CUTOFF },
+        existingIntegration: null,
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("7. Cloud + pre-cutoff project + no row + TRACES_OBSERVATIONS_EVENTS → throws", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowedForUpsert({
+        project: { createdAt: PROJECT_PRE_CUTOFF },
+        existingIntegration: null,
+        nextInternalExportSource: "TRACES_OBSERVATIONS_EVENTS",
+        isCloud: true,
+      }),
+    ).toThrow();
+  });
+
+  it("8. Cloud + pre-cutoff project + row (createdAt >= CUTOFF, reset-recreated) + legacy → throws", () => {
+    expect(() =>
+      assertLegacyBlobExportSourceAllowedForUpsert({
+        project: { createdAt: PROJECT_PRE_CUTOFF },
+        existingIntegration: { createdAt: INTEGRATION_AT_CUTOFF },
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: true,
+      }),
+    ).toThrow();
+  });
+});

--- a/web/src/__tests__/server/unit/assertLegacyBlobExportSourceAllowedForUpsert.servertest.ts
+++ b/web/src/__tests__/server/unit/assertLegacyBlobExportSourceAllowedForUpsert.servertest.ts
@@ -22,7 +22,7 @@ const INTEGRATION_PRE_CUTOFF = new Date(
 const INTEGRATION_AT_CUTOFF = LEGACY_BLOB_EXPORTER_CUTOFF;
 
 describe("assertLegacyBlobExportSourceAllowedForUpsert", () => {
-  it("1. Cloud + pre-cutoff project + no row + legacy → throws", () => {
+  it("Cloud + pre-cutoff project + no row + legacy → throws", () => {
     expect(() =>
       assertLegacyBlobExportSourceAllowedForUpsert({
         project: { createdAt: PROJECT_PRE_CUTOFF },
@@ -33,7 +33,7 @@ describe("assertLegacyBlobExportSourceAllowedForUpsert", () => {
     ).toThrow();
   });
 
-  it("2. Cloud + pre-cutoff project + row (createdAt < CUTOFF) + legacy → allows", () => {
+  it("Cloud + pre-cutoff project + row (createdAt < CUTOFF) + legacy → allows", () => {
     expect(() =>
       assertLegacyBlobExportSourceAllowedForUpsert({
         project: { createdAt: PROJECT_PRE_CUTOFF },
@@ -44,7 +44,7 @@ describe("assertLegacyBlobExportSourceAllowedForUpsert", () => {
     ).not.toThrow();
   });
 
-  it("3. Cloud + post-cutoff project + no row + legacy → throws (delegate)", () => {
+  it("Cloud + post-cutoff project + no row + legacy → throws (delegate)", () => {
     expect(() =>
       assertLegacyBlobExportSourceAllowedForUpsert({
         project: { createdAt: PROJECT_POST_CUTOFF },
@@ -55,7 +55,7 @@ describe("assertLegacyBlobExportSourceAllowedForUpsert", () => {
     ).toThrow();
   });
 
-  it("4. Cloud + post-cutoff project + row (createdAt < CUTOFF) + legacy → throws (delegate wins)", () => {
+  it("Cloud + post-cutoff project + row (createdAt < CUTOFF) + legacy → throws (delegate wins)", () => {
     expect(() =>
       assertLegacyBlobExportSourceAllowedForUpsert({
         project: { createdAt: PROJECT_POST_CUTOFF },
@@ -66,7 +66,7 @@ describe("assertLegacyBlobExportSourceAllowedForUpsert", () => {
     ).toThrow();
   });
 
-  it("5. Cloud + any + EVENTS → allows", () => {
+  it("Cloud + any + EVENTS → allows", () => {
     expect(() =>
       assertLegacyBlobExportSourceAllowedForUpsert({
         project: { createdAt: PROJECT_POST_CUTOFF },
@@ -77,7 +77,7 @@ describe("assertLegacyBlobExportSourceAllowedForUpsert", () => {
     ).not.toThrow();
   });
 
-  it("6. self-hosted + post-cutoff project + no row + legacy → allows (short-circuit)", () => {
+  it("self-hosted + post-cutoff project + no row + legacy → allows (short-circuit)", () => {
     expect(() =>
       assertLegacyBlobExportSourceAllowedForUpsert({
         project: { createdAt: PROJECT_POST_CUTOFF },
@@ -88,7 +88,7 @@ describe("assertLegacyBlobExportSourceAllowedForUpsert", () => {
     ).not.toThrow();
   });
 
-  it("7. Cloud + pre-cutoff project + no row + TRACES_OBSERVATIONS_EVENTS → throws", () => {
+  it("Cloud + pre-cutoff project + no row + TRACES_OBSERVATIONS_EVENTS → throws", () => {
     expect(() =>
       assertLegacyBlobExportSourceAllowedForUpsert({
         project: { createdAt: PROJECT_PRE_CUTOFF },
@@ -99,7 +99,7 @@ describe("assertLegacyBlobExportSourceAllowedForUpsert", () => {
     ).toThrow();
   });
 
-  it("8. Cloud + pre-cutoff project + row (createdAt >= CUTOFF, reset-recreated) + legacy → throws", () => {
+  it("Cloud + pre-cutoff project + row (createdAt >= CUTOFF, reset-recreated) + legacy → throws", () => {
     expect(() =>
       assertLegacyBlobExportSourceAllowedForUpsert({
         project: { createdAt: PROJECT_PRE_CUTOFF },

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -466,6 +466,7 @@ export const env = createEnv({
       .enum(["US", "EU", "STAGING", "DEV", "HIPAA", "JP"])
       .optional(),
     NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF: z.iso.datetime().optional(),
+    NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF: z.iso.datetime().optional(),
     NEXT_PUBLIC_DEMO_PROJECT_ID: z.string().optional(),
     NEXT_PUBLIC_DEMO_ORG_ID: z.string().optional(),
     NEXT_PUBLIC_SIGN_UP_DISABLED: z.enum(["true", "false"]).default("false"),
@@ -499,6 +500,8 @@ export const env = createEnv({
       process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION,
     NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF:
       process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORT_CUTOFF,
+    NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF:
+      process.env.NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF,
     NEXT_PUBLIC_SIGN_UP_DISABLED: process.env.NEXT_PUBLIC_SIGN_UP_DISABLED,
     LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES:
       process.env.LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES,

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -130,6 +130,10 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         return await upsertBlobStorageIntegration({
           prisma: ctx.prisma,
           projectId,
+          // In-transaction backstop closing the TOCTOU window: if a concurrent
+          // DELETE flips this upsert to the CREATE branch, refuse a legacy
+          // source so a new (post-cutoff) Cloud row can never be born legacy.
+          refuseLegacyOnCreate: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
           data: {
             type: rest.type,
             bucketName: rest.bucketName,

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -12,7 +12,7 @@ import {
   validateExportFieldGroups,
 } from "@/src/features/blobstorage-integration/validation";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
-import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
+import { assertLegacyBlobExportSourceAllowedForUpsert } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert";
 import { assertEnrichedBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertEnrichedBlobExportSourceAllowed";
 import { TRPCError } from "@trpc/server";
 import { env } from "@/src/env.mjs";
@@ -94,12 +94,19 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
 
         if (input.exportSource) {
           const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
-          const project = await ctx.prisma.project.findUniqueOrThrow({
-            where: { id: input.projectId },
-            select: { createdAt: true },
-          });
-          assertLegacyBlobExportSourceAllowed({
+          const [project, existingIntegration] = await Promise.all([
+            ctx.prisma.project.findUniqueOrThrow({
+              where: { id: input.projectId },
+              select: { createdAt: true },
+            }),
+            ctx.prisma.blobStorageIntegration.findUnique({
+              where: { projectId: input.projectId },
+              select: { createdAt: true },
+            }),
+          ]);
+          assertLegacyBlobExportSourceAllowedForUpsert({
             project,
+            existingIntegration,
             nextInternalExportSource: input.exportSource,
             isCloud,
           });

--- a/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert.ts
+++ b/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert.ts
@@ -8,10 +8,11 @@ import { type AnalyticsIntegrationExportSource } from "@langfuse/shared/src/db";
 import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
 
 /**
- * Write-time gate for blob storage upserts. Composes the project-level
- * post-cutoff gate (`assertLegacyBlobExportSourceAllowed`, still used by REST)
- * with the integration-level cutoff: a row may only keep using a legacy export
- * source if its own `createdAt` predates `LEGACY_BLOB_EXPORTER_CUTOFF`.
+ * Write-time gate for blob storage upserts, shared by the tRPC and REST paths.
+ * Composes the project-level post-cutoff gate
+ * (`assertLegacyBlobExportSourceAllowed`) with the integration-level cutoff: a
+ * row may only keep using a legacy export source if its own `createdAt`
+ * predates `LEGACY_BLOB_EXPORTER_CUTOFF`.
  *
  * `existingIntegration` is `null` for a brand-new integration, which is treated
  * as non-legacy (new-customer rules) by `isLegacyBlobExporter`.
@@ -49,9 +50,9 @@ export function assertLegacyBlobExportSourceAllowedForUpsert({
     return;
 
   // Distinct message from the project-level gate so the two rejection paths can
-  // be counted separately in logs. Not customer-facing: the UI prevents this
-  // state from arising in the form flow. The date is read from the constant so
-  // a NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF override stays accurate.
+  // be counted separately in logs. Customer-facing via the public REST PUT
+  // (the UI prevents this state in the form flow). The date is read from the
+  // constant so a cutoff override stays accurate.
   throw new InvalidRequestError(
     `Legacy export sources are not available for blob storage integrations created on or after ${LEGACY_BLOB_EXPORTER_CUTOFF.toISOString()} on Cloud. Use 'OBSERVATIONS_V2' instead.`,
   );

--- a/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert.ts
+++ b/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert.ts
@@ -16,9 +16,8 @@ import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-
  * `existingIntegration` is `null` for a brand-new integration, which is treated
  * as non-legacy (new-customer rules) by `isLegacyBlobExporter`.
  *
- * The cutoff is keyed on `isCloud` directly (via the helper's short-circuit),
- * not `isEnrichedBlobExportAvailable(isCloud)`, so a future self-hosted flip of
- * the latter does not silently fire this gate for self-hosted (LFE-10148).
+ * Keyed on `isCloud` directly, not on enriched-export availability: self-hosted
+ * stays exempt even with the V4 preview enabled (see blob-export-gate.ts).
  */
 export function assertLegacyBlobExportSourceAllowedForUpsert({
   project,

--- a/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert.ts
+++ b/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert.ts
@@ -1,0 +1,57 @@
+import {
+  InvalidRequestError,
+  isLegacyBlobExporter,
+  LEGACY_BLOB_EXPORT_SOURCES,
+} from "@langfuse/shared";
+import { type AnalyticsIntegrationExportSource } from "@langfuse/shared/src/db";
+import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
+
+/**
+ * Write-time gate for blob storage upserts. Composes the project-level
+ * post-cutoff gate (`assertLegacyBlobExportSourceAllowed`, still used by REST)
+ * with the integration-level cutoff: a row may only keep using a legacy export
+ * source if its own `createdAt` predates `LEGACY_BLOB_EXPORTER_CUTOFF`.
+ *
+ * `existingIntegration` is `null` for a brand-new integration, which is treated
+ * as non-legacy (new-customer rules) by `isLegacyBlobExporter`.
+ *
+ * The cutoff is keyed on `isCloud` directly (via the helper's short-circuit),
+ * not `isEnrichedBlobExportAvailable(isCloud)`, so a future self-hosted flip of
+ * the latter does not silently fire this gate for self-hosted (LFE-10148).
+ */
+export function assertLegacyBlobExportSourceAllowedForUpsert({
+  project,
+  existingIntegration,
+  nextInternalExportSource,
+  isCloud,
+}: {
+  project: { createdAt: Date };
+  existingIntegration: { createdAt: Date } | null;
+  nextInternalExportSource: AnalyticsIntegrationExportSource;
+  isCloud: boolean;
+}): void {
+  // Project-level post-cutoff gate first (shared with REST). Throws on a
+  // post-cutoff Cloud project + legacy source regardless of the row's age.
+  assertLegacyBlobExportSourceAllowed({
+    project,
+    nextInternalExportSource,
+    isCloud,
+  });
+
+  if (
+    !(LEGACY_BLOB_EXPORT_SOURCES as ReadonlyArray<string>).includes(
+      nextInternalExportSource,
+    )
+  )
+    return; // OBSERVATIONS_V2 (internal: EVENTS) is always allowed.
+
+  if (isLegacyBlobExporter(existingIntegration?.createdAt ?? null, isCloud))
+    return;
+
+  // Distinct message from the project-level gate so the two rejection paths can
+  // be counted separately in logs. Not customer-facing: the UI prevents this
+  // state from arising in the form flow.
+  throw new InvalidRequestError(
+    "Legacy export sources are not available for blob storage integrations created on or after 2026-06-12 on Cloud. Use 'OBSERVATIONS_V2' instead.",
+  );
+}

--- a/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert.ts
+++ b/web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert.ts
@@ -2,6 +2,7 @@ import {
   InvalidRequestError,
   isLegacyBlobExporter,
   LEGACY_BLOB_EXPORT_SOURCES,
+  LEGACY_BLOB_EXPORTER_CUTOFF,
 } from "@langfuse/shared";
 import { type AnalyticsIntegrationExportSource } from "@langfuse/shared/src/db";
 import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
@@ -50,8 +51,9 @@ export function assertLegacyBlobExportSourceAllowedForUpsert({
 
   // Distinct message from the project-level gate so the two rejection paths can
   // be counted separately in logs. Not customer-facing: the UI prevents this
-  // state from arising in the form flow.
+  // state from arising in the form flow. The date is read from the constant so
+  // a NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF override stays accurate.
   throw new InvalidRequestError(
-    "Legacy export sources are not available for blob storage integrations created on or after 2026-06-12 on Cloud. Use 'OBSERVATIONS_V2' instead.",
+    `Legacy export sources are not available for blob storage integrations created on or after ${LEGACY_BLOB_EXPORTER_CUTOFF.toISOString()} on Cloud. Use 'OBSERVATIONS_V2' instead.`,
   );
 }

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -4,6 +4,8 @@ import {
   BlobStorageIntegrationType,
   InvalidRequestError,
   AnalyticsIntegrationExportSource,
+  LEGACY_BLOB_EXPORT_SOURCES,
+  LEGACY_BLOB_EXPORTER_CUTOFF,
   type BlobStorageIntegrationFileType,
   type ObservationFieldGroupFull,
 } from "@langfuse/shared";
@@ -58,6 +60,12 @@ export async function upsertBlobStorageIntegration(params: {
   // Evaluated inside the transaction so the row-state check and the INSERT are
   // atomic — no TOCTOU window.
   forceEventsOnCreate?: boolean;
+  // When true and no existing row is found inside the transaction, the CREATE
+  // branch refuses a legacy export source (throws). Evaluated in-transaction so
+  // a concurrent DELETE between the router's pre-flight read and this upsert
+  // cannot slip a new post-cutoff row in with a legacy source. Symmetric with
+  // forceEventsOnCreate; set by the tRPC path (Cloud), never by REST.
+  refuseLegacyOnCreate?: boolean;
 }) {
   const { prisma, projectId, data } = params;
 
@@ -140,6 +148,25 @@ export async function upsertBlobStorageIntegration(params: {
       (params.forceEventsOnCreate
         ? AnalyticsIntegrationExportSource.EVENTS
         : undefined);
+
+    // In-transaction backstop for the integration-cutoff gate: a CREATE here
+    // means no row exists at INSERT time, so the row is brand-new (post-cutoff)
+    // and must not carry a legacy source. `createExportSource === undefined`
+    // would let Postgres apply the legacy column default, so treat it as legacy.
+    if (!existing && params.refuseLegacyOnCreate) {
+      const effectiveCreateSource =
+        createExportSource ??
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
+      if (
+        (LEGACY_BLOB_EXPORT_SOURCES as ReadonlyArray<string>).includes(
+          effectiveCreateSource,
+        )
+      ) {
+        throw new InvalidRequestError(
+          `Legacy export sources are not available for blob storage integrations created on or after ${LEGACY_BLOB_EXPORTER_CUTOFF.toISOString()} on Cloud. Use 'OBSERVATIONS_V2' instead.`,
+        );
+      }
+    }
 
     return tx.blobStorageIntegration.upsert({
       where: { projectId },

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -6,6 +6,7 @@ import {
   AnalyticsIntegrationExportSource,
   LEGACY_BLOB_EXPORT_SOURCES,
   LEGACY_BLOB_EXPORTER_CUTOFF,
+  isLegacyBlobExporter,
   type BlobStorageIntegrationFileType,
   type ObservationFieldGroupFull,
 } from "@langfuse/shared";
@@ -149,26 +150,7 @@ export async function upsertBlobStorageIntegration(params: {
         ? AnalyticsIntegrationExportSource.EVENTS
         : undefined);
 
-    // In-transaction backstop for the integration-cutoff gate: a CREATE here
-    // means no row exists at INSERT time, so the row is brand-new (post-cutoff)
-    // and must not carry a legacy source. `createExportSource === undefined`
-    // would let Postgres apply the legacy column default, so treat it as legacy.
-    if (!existing && params.refuseLegacyOnCreate) {
-      const effectiveCreateSource =
-        createExportSource ??
-        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
-      if (
-        (LEGACY_BLOB_EXPORT_SOURCES as ReadonlyArray<string>).includes(
-          effectiveCreateSource,
-        )
-      ) {
-        throw new InvalidRequestError(
-          `Legacy export sources are not available for blob storage integrations created on or after ${LEGACY_BLOB_EXPORTER_CUTOFF.toISOString()} on Cloud. Use 'OBSERVATIONS_V2' instead.`,
-        );
-      }
-    }
-
-    return tx.blobStorageIntegration.upsert({
+    const result = await tx.blobStorageIntegration.upsert({
       where: { projectId },
       create: {
         ...writeData,
@@ -187,5 +169,27 @@ export async function upsertBlobStorageIntegration(params: {
         ...(modeChanged ? { lastSyncAt: null, nextSyncAt: null } : {}),
       },
     });
+
+    // Race-free integration-cutoff backstop. The pre-flight `existing` snapshot
+    // (and the router's pre-flight gate) are racy under READ COMMITTED: a
+    // concurrent DELETE can flip this upsert to a CREATE after those reads.
+    // Validate the *persisted* row instead — its `createdAt` reflects the actual
+    // CREATE/UPDATE outcome (CREATE → now(); UPDATE → preserved). If the row
+    // that now exists is a brand-new post-cutoff Cloud exporter carrying a legacy
+    // source, throw to roll back. UPDATEs of pre-cutoff rows (User B) keep their
+    // original createdAt and are unaffected.
+    if (
+      params.refuseLegacyOnCreate &&
+      !isLegacyBlobExporter(result.createdAt, !isSelfHosted) &&
+      (LEGACY_BLOB_EXPORT_SOURCES as ReadonlyArray<string>).includes(
+        result.exportSource,
+      )
+    ) {
+      throw new InvalidRequestError(
+        `Legacy export sources are not available for blob storage integrations created on or after ${LEGACY_BLOB_EXPORTER_CUTOFF.toISOString()} on Cloud. Use 'OBSERVATIONS_V2' instead.`,
+      );
+    }
+
+    return result;
   });
 }

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -176,7 +176,7 @@ export async function upsertBlobStorageIntegration(params: {
     // Validate the *persisted* row instead — its `createdAt` reflects the actual
     // CREATE/UPDATE outcome (CREATE → now(); UPDATE → preserved). If the row
     // that now exists is a brand-new post-cutoff Cloud exporter carrying a legacy
-    // source, throw to roll back. UPDATEs of pre-cutoff rows (User B) keep their
+    // source, throw to roll back. UPDATEs of pre-cutoff rows keep their
     // original createdAt and are unaffected.
     if (
       params.refuseLegacyOnCreate &&

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -65,7 +65,7 @@ export async function upsertBlobStorageIntegration(params: {
   // branch refuses a legacy export source (throws). Evaluated in-transaction so
   // a concurrent DELETE between the router's pre-flight read and this upsert
   // cannot slip a new post-cutoff row in with a legacy source. Symmetric with
-  // forceEventsOnCreate; set by the tRPC path (Cloud), never by REST.
+  // forceEventsOnCreate; set by both the tRPC and REST paths on Cloud.
   refuseLegacyOnCreate?: boolean;
 }) {
   const { prisma, projectId, data } = params;

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -15,11 +15,10 @@ import {
   LangfuseNotFoundError,
   UnauthorizedError,
   ForbiddenError,
-  isLegacyBlobExportAllowed,
   isEnrichedBlobExportAvailable,
 } from "@langfuse/shared";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
-import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
+import { assertLegacyBlobExportSourceAllowedForUpsert } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert";
 import { assertEnrichedBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertEnrichedBlobExportSourceAllowed";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { env } from "@/src/env.mjs";
@@ -168,27 +167,33 @@ async function handleUpsertBlobStorageIntegration(
       ? toInternalExportSource(validatedData.exportSource)
       : undefined;
 
+  // One read serving both write-time gates (the conditions are disjoint, so at
+  // most one query runs):
+  // - exportSource provided → the legacy upsert gate needs the row's createdAt
+  //   to decide whether the integration is grandfathered for legacy sources.
+  // - exportSource omitted (partial PUT) → the persisted value stays in effect,
+  //   so the enriched gate must consider the existing row too — otherwise a
+  //   stale enriched source left behind by a V4-preview flag rollback keeps
+  //   driving the worker against unpopulated tables. Read only when that gate
+  //   could actually reject (enriched export unavailable).
+  const existingIntegration =
+    internalExportSource !== undefined ||
+    !isEnrichedBlobExportAvailable(isCloud, isV4PreviewEnabled)
+      ? await prisma.blobStorageIntegration.findUnique({
+          where: { projectId: validatedData.projectId },
+          select: { createdAt: true, exportSource: true },
+        })
+      : null;
+
   if (internalExportSource) {
-    assertLegacyBlobExportSourceAllowed({
+    assertLegacyBlobExportSourceAllowedForUpsert({
       project,
+      existingIntegration,
       nextInternalExportSource: internalExportSource,
       isCloud,
     });
   }
 
-  // Partial PUTs that omit exportSource preserve the persisted value, so the
-  // enriched gate must consider the existing row too — otherwise a stale
-  // enriched source left behind by a V4-preview flag rollback keeps driving
-  // the worker against unpopulated tables. The extra read only happens when
-  // the gate could actually reject (enriched export unavailable).
-  const existingIntegration =
-    internalExportSource === undefined &&
-    !isEnrichedBlobExportAvailable(isCloud, isV4PreviewEnabled)
-      ? await prisma.blobStorageIntegration.findUnique({
-          where: { projectId: validatedData.projectId },
-          select: { exportSource: true },
-        })
-      : null;
   assertEnrichedBlobExportSourceAllowed({
     nextInternalExportSource: internalExportSource,
     existingExportSource: existingIntegration?.exportSource,
@@ -207,12 +212,17 @@ async function handleUpsertBlobStorageIntegration(
   const integration = await upsertBlobStorageIntegration({
     prisma,
     projectId: validatedData.projectId,
-    // When exportSource is absent and the project is post-cutoff Cloud, have
-    // the service substitute EVENTS on CREATE inside its own transaction —
-    // eliminating the TOCTOU window that a pre-flight findUnique would create.
-    forceEventsOnCreate:
-      validatedData.exportSource == null &&
-      !isLegacyBlobExportAllowed(project.createdAt, isCloud),
+    // When exportSource is absent, have the service substitute EVENTS on
+    // CREATE inside its own transaction (eliminating the TOCTOU window that a
+    // pre-flight findUnique would create) for every Cloud project: a brand-new
+    // Cloud row counts as a post-cutoff integration, so letting the legacy
+    // Prisma column default through would trip refuseLegacyOnCreate and fail a
+    // partial PUT that never mentioned exportSource.
+    forceEventsOnCreate: validatedData.exportSource == null && isCloud,
+    // In-transaction backstop closing the TOCTOU window: if a concurrent
+    // DELETE flips this upsert to the CREATE branch, refuse a legacy source so
+    // a new (post-cutoff) Cloud row can never be born legacy.
+    refuseLegacyOnCreate: isCloud,
     data: {
       type: validatedData.type,
       bucketName: validatedData.bucketName,

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -167,15 +167,10 @@ async function handleUpsertBlobStorageIntegration(
       ? toInternalExportSource(validatedData.exportSource)
       : undefined;
 
-  // One read serving both write-time gates (the conditions are disjoint, so at
-  // most one query runs):
-  // - exportSource provided → the legacy upsert gate needs the row's createdAt
-  //   to decide whether the integration is grandfathered for legacy sources.
-  // - exportSource omitted (partial PUT) → the persisted value stays in effect,
-  //   so the enriched gate must consider the existing row too — otherwise a
-  //   stale enriched source left behind by a V4-preview flag rollback keeps
-  //   driving the worker against unpopulated tables. Read only when that gate
-  //   could actually reject (enriched export unavailable).
+  // Single conditional read serving both write-time gates: the legacy upsert
+  // gate needs the row's createdAt when exportSource is provided; the enriched
+  // gate needs the persisted exportSource when it is omitted (partial PUT) and
+  // enriched export is unavailable, so a stale enriched value is rejected.
   const existingIntegration =
     internalExportSource !== undefined ||
     !isEnrichedBlobExportAvailable(isCloud, isV4PreviewEnabled)
@@ -212,16 +207,13 @@ async function handleUpsertBlobStorageIntegration(
   const integration = await upsertBlobStorageIntegration({
     prisma,
     projectId: validatedData.projectId,
-    // When exportSource is absent, have the service substitute EVENTS on
-    // CREATE inside its own transaction (eliminating the TOCTOU window that a
-    // pre-flight findUnique would create) for every Cloud project: a brand-new
-    // Cloud row counts as a post-cutoff integration, so letting the legacy
-    // Prisma column default through would trip refuseLegacyOnCreate and fail a
-    // partial PUT that never mentioned exportSource.
+    // New Cloud rows default to EVENTS when exportSource is omitted: a
+    // brand-new row is post-cutoff, so the legacy column default would trip
+    // refuseLegacyOnCreate and fail a partial PUT that never mentioned
+    // exportSource. Substituted in-transaction to avoid a TOCTOU window.
     forceEventsOnCreate: validatedData.exportSource == null && isCloud,
-    // In-transaction backstop closing the TOCTOU window: if a concurrent
-    // DELETE flips this upsert to the CREATE branch, refuse a legacy source so
-    // a new (post-cutoff) Cloud row can never be born legacy.
+    // In-transaction backstop: a concurrent DELETE can flip this upsert to
+    // CREATE; never let a new Cloud row be born with a legacy source.
     refuseLegacyOnCreate: isCloud,
     data: {
       type: validatedData.type,

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -267,7 +267,11 @@ const BlobStorageIntegrationSettingsForm = ({
   );
   const forceEventsExport =
     isPostCutoffCloud || (eventsExportAvailable && !isLegacyExporter);
-  const showExportSourceField = !forceEventsExport;
+  // The picker only exists where the enriched events export is available
+  // (Cloud today). On self-hosted it stays hidden, defaulting to
+  // TRACES_OBSERVATIONS, until LFE-10148. `!forceEventsExport` alone would drop
+  // that gate and expose EVENTS on self-hosted, which is not provisioned there.
+  const showExportSourceField = eventsExportAvailable && !forceEventsExport;
 
   const blobStorageForm = useForm({
     resolver: zodResolver(blobStorageIntegrationFormSchema),

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -256,11 +256,10 @@ const BlobStorageIntegrationSettingsForm = ({
     project?.createdAt != null &&
     !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
   const eventsExportAvailable = isEnrichedExportAvailable;
-  // Integration-level cutoff: an existing row created before
+  // Integration-level cutoff (Cloud only): an existing row created before
   // LEGACY_BLOB_EXPORTER_CUTOFF stays legacy (picker visible); a new row (no
   // state yet) or a post-cutoff row is not legacy (picker hidden, pinned to
-  // EVENTS). Stable across User A's return journey because the row's createdAt
-  // is immutable.
+  // EVENTS). Stable across revisits because the row's createdAt is immutable.
   const isLegacyExporter = isLegacyBlobExporter(
     state?.createdAt ? new Date(state.createdAt) : null,
     isLangfuseCloud,
@@ -268,9 +267,9 @@ const BlobStorageIntegrationSettingsForm = ({
   const forceEventsExport =
     isPostCutoffCloud || (eventsExportAvailable && !isLegacyExporter);
   // The picker only exists where the enriched events export is available
-  // (Cloud today). On self-hosted it stays hidden, defaulting to
-  // TRACES_OBSERVATIONS, until LFE-10148. `!forceEventsExport` alone would drop
-  // that gate and expose EVENTS on self-hosted, which is not provisioned there.
+  // (Cloud, or self-hosted with the V4 preview opt-in — server-computed flag).
+  // Where it isn't, the picker stays hidden and the form defaults to
+  // TRACES_OBSERVATIONS, since EVENTS is not provisioned there.
   const showExportSourceField = eventsExportAvailable && !forceEventsExport;
 
   const blobStorageForm = useForm({

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -56,6 +56,7 @@ import {
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
   isLegacyBlobExportAllowed,
+  isLegacyBlobExporter,
 } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
@@ -255,7 +256,18 @@ const BlobStorageIntegrationSettingsForm = ({
     project?.createdAt != null &&
     !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
   const eventsExportAvailable = isEnrichedExportAvailable;
-  const showExportSourceField = eventsExportAvailable && !isPostCutoffCloud;
+  // Integration-level cutoff: an existing row created before
+  // LEGACY_BLOB_EXPORTER_CUTOFF stays legacy (picker visible); a new row (no
+  // state yet) or a post-cutoff row is not legacy (picker hidden, pinned to
+  // EVENTS). Stable across User A's return journey because the row's createdAt
+  // is immutable.
+  const isLegacyExporter = isLegacyBlobExporter(
+    state?.createdAt ? new Date(state.createdAt) : null,
+    isLangfuseCloud,
+  );
+  const forceEventsExport =
+    isPostCutoffCloud || (eventsExportAvailable && !isLegacyExporter);
+  const showExportSourceField = !forceEventsExport;
 
   const blobStorageForm = useForm({
     resolver: zodResolver(blobStorageIntegrationFormSchema),
@@ -277,7 +289,7 @@ const BlobStorageIntegrationSettingsForm = ({
       fileType: state?.fileType || BlobStorageIntegrationFileType.JSONL,
       exportMode: state?.exportMode || BlobStorageExportMode.FULL_HISTORY,
       exportStartDate: state?.exportStartDate || null,
-      exportSource: isPostCutoffCloud
+      exportSource: forceEventsExport
         ? AnalyticsIntegrationExportSource.EVENTS
         : (() => {
             const persisted = state?.exportSource;
@@ -321,7 +333,7 @@ const BlobStorageIntegrationSettingsForm = ({
       fileType: state?.fileType || BlobStorageIntegrationFileType.JSONL,
       exportMode: state?.exportMode || BlobStorageExportMode.FULL_HISTORY,
       exportStartDate: state?.exportStartDate || null,
-      exportSource: isPostCutoffCloud
+      exportSource: forceEventsExport
         ? AnalyticsIntegrationExportSource.EVENTS
         : (() => {
             const persisted = state?.exportSource;


### PR DESCRIPTION
## Summary

Blocks new Cloud blob storage exporters from selecting the legacy `TRACES_OBSERVATIONS` export sources. Implements [LFE-10065](https://linear.app/langfuse/issue/LFE-10065).

- Adds `LEGACY_BLOB_EXPORTER_CUTOFF` (2026-06-12) applied to `BlobStorageIntegration.createdAt`, plus `isLegacyBlobExporter(createdAt, isCloud)`. A `NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF` env override (symmetric with the existing project-level cutoff) allows local-dev simulation of post-cutoff behavior.
- New server helper `assertLegacyBlobExportSourceAllowedForUpsert` **wraps** the existing project-level `assertLegacyBlobExportSourceAllowed` and adds the integration-`createdAt` cutoff on top. REST keeps calling the original helper unchanged.
- tRPC `update` now reads project + integration `createdAt` in parallel (`Promise.all`) and gates via the new helper.
- Settings form derives `forceEventsExport` from `isLegacyBlobExporter(state?.createdAt)`; the export-source picker is hidden and pinned to `EVENTS` for new/post-cutoff rows, and stays visible for pre-cutoff (grandfathered) rows.

No schema change, no migration, no backfill — the legacy classification is derived from the row's immutable `createdAt`. Both cutoffs short-circuit on `!isCloud`, deliberately decoupled from `isEnrichedBlobExportAvailable` so the future self-hosted flip ([LFE-10148](https://linear.app/langfuse/issue/LFE-10148)) does not silently activate either gate.

## Impacted packages

- `@langfuse/shared` — new cutoff constant + predicate in `blob-export-gate.ts`; `turbo.json` `globalEnv` entry for the new env var.
- `web` — new upsert gate helper, tRPC router wiring, settings form gate, unit + integration tests.

REST contract and self-hosted behavior are unchanged.

## Verification

- [x] `pnpm --filter @langfuse/shared run lint`
- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter web run typecheck`
- [x] `pnpm --filter web run test src/__tests__/server/unit/assertLegacyBlobExportSourceAllowedForUpsert.servertest.ts` — 8/8
- [ ] `src/__tests__/server/blob-storage-integration-trpc.servertest.ts` — runs in CI (no servertest env locally)
- [ ] Browser review of User A (picker hidden before/after first save, via the cutoff override) and User B (picker visible throughout) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an integration-level cutoff gate (`LEGACY_BLOB_EXPORTER_CUTOFF`, 2026-06-12) that blocks Cloud blob storage integrations created on or after that date from using legacy export sources (`TRACES_OBSERVATIONS`, `TRACES_OBSERVATIONS_EVENTS`), complementing the existing project-level cutoff (2026-05-20).

- Adds `isLegacyBlobExporter` predicate and `LEGACY_BLOB_EXPORTER_CUTOFF` constant to `@langfuse/shared`, both properly short-circuited for self-hosted deployments.
- Introduces `assertLegacyBlobExportSourceAllowedForUpsert` which composes the project-level and new integration-level gates; wires it into the tRPC router with a parallel `Promise.all` fetch of project and integration rows.
- Updates the settings UI to derive `forceEventsExport` from both the project-level and integration-level legacy checks, hiding the export source picker for non-legacy integrations.
- The public REST `PUT /api/public/integrations/blob-storage` endpoint retains only the project-level gate and does not apply the new integration-level check, leaving a bypass path for pre-cutoff Cloud projects after the cutoff date.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for the tRPC/UI path, but the REST API endpoint does not enforce the new integration-level gate, creating a functional bypass for the feature this PR is intended to ship.

The tRPC router and UI correctly enforce both the project-level and integration-level cutoffs, and the unit/integration test coverage is solid. However, `PUT /api/public/integrations/blob-storage` only applies `assertLegacyBlobExportSourceAllowed` (project-level), so after 2026-06-12 a caller with a pre-cutoff Cloud project can explicitly pass a legacy `exportSource` and create a new legacy integration that the tRPC path would have rejected. The bypass is reachable with a valid org API key.

web/src/pages/api/public/integrations/blob-storage/index.ts — the PUT handler needs the same integration-level gate applied as in the tRPC router.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Update blob storage integration] --> B{exportSource provided?}
    B -- No --> Z[Upsert with forceEventsOnCreate if post-cutoff Cloud]
    B -- Yes --> C{Path?}

    C -- tRPC router --> D[Fetch project + existingIntegration in parallel]
    D --> E[assertLegacyBlobExportSourceAllowedForUpsert]
    E --> F{Legacy source?}
    F -- No EVENTS --> G[Allow]
    F -- Yes --> H{isLegacyBlobExportAllowed project-level?}
    H -- No post-cutoff project --> I[Throw: project-level block]
    H -- Yes pre-cutoff project --> J{isLegacyBlobExporter integration-level?}
    J -- Yes row before 2026-06-12 --> K[Allow]
    J -- No new or post-cutoff row --> L[Throw: integration-level block]

    C -- REST API PUT --> M[Fetch project only]
    M --> N[assertLegacyBlobExportSourceAllowed project-level only]
    N --> O{isLegacyBlobExportAllowed project-level?}
    O -- No --> P[Throw: project-level block]
    O -- Yes pre-cutoff project --> Q[Allow — integration-level gate NOT applied]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert.ts:54-56
The error message hardcodes `"2026-06-12"` but the actual enforcement date is controlled by `LEGACY_BLOB_EXPORTER_CUTOFF`, which can be overridden via `NEXT_PUBLIC_LANGFUSE_BLOB_EXPORTER_CUTOFF`. In dev/test environments where the override is set to a different value the message will be misleading.

```suggestion
  throw new InvalidRequestError(
    `Legacy export sources are not available for blob storage integrations created on or after ${LEGACY_BLOB_EXPORTER_CUTOFF.toISOString()} on Cloud. Use 'OBSERVATIONS_V2' instead.`,
  );
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(blob-storage): block legacy export ..."](https://github.com/langfuse/langfuse/commit/2f75ce2b965a1e647f940f8bebeea7119950986e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35693133)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->