### PR TITLE
chore(dx): ignore playwright mcp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ migrate
 /coverage
 **/coverage/
 /certs/
+.playwright-mcp/*
 
 # database
 /prisma/db.sqlite


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `.playwright-mcp/*` to `.gitignore` to prevent Playwright MCP-generated files from being accidentally committed.

- Adds a single `.gitignore` entry for the `.playwright-mcp/` directory contents, keeping local Playwright MCP artifacts out of version control.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds a single .gitignore entry with no impact on existing tracked files or build processes.

The change is a one-line addition to .gitignore that excludes Playwright MCP tool output from version control. It does not affect any source files, build steps, or CI workflows.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer runs Playwright MCP] --> B[.playwright-mcp/ directory created]
    B --> C{git status}
    C -->|Before this PR| D[.playwright-mcp/* shows as untracked]
    C -->|After this PR| E[.playwright-mcp/* ignored by .gitignore]
    E --> F[Clean git status]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(dx): ignore playwright mcp files"](https://github.com/langfuse/langfuse/commit/09c5ac3ba5b2959f2c83c3f029701c688c9b7668) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35788407)</sub>

<!-- /greptile_comment -->