### PR TITLE
fix(otel): handle OTLP/JSON string-encoded numeric attribute values

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1287,6 +1287,15 @@ export class OtelIngestionProcessor {
       return value.stringValue;
     }
     if (value.doubleValue !== undefined) {
+      // OTLP/JSON encodes regular doubles as JSON numbers, but the special
+      // values "NaN", "Infinity" and "-Infinity" are encoded as strings.
+      // Coerce numeric strings; keep non-finite values as their string form so
+      // we never emit NaN/Infinity into metadata (which is not valid JSON and
+      // fails ingestion validation).
+      if (typeof value.doubleValue === "string") {
+        const parsed = Number(value.doubleValue);
+        return Number.isFinite(parsed) ? parsed : value.doubleValue;
+      }
       return value.doubleValue;
     }
     if (value.boolValue !== undefined) {
@@ -1297,23 +1306,50 @@ export class OtelIngestionProcessor {
         this.convertValueToPlainJavascript(v),
       );
     }
-    if (value.intValue && value.intValue.high === 0) {
-      return value.intValue.low;
-    }
-    if (value.intValue && typeof value.intValue === "number") {
-      return value.intValue;
-    }
-    if (
-      value.intValue &&
-      value.intValue.high === -1 &&
-      value.intValue.low === -1
-    ) {
-      return -1;
-    }
-    if (value.intValue && value.intValue.high !== 0) {
-      return value.intValue.high * Math.pow(2, 32) + value.intValue.low;
+    if (value.intValue !== undefined) {
+      const parsedInt = this.convertOtelIntValue(value.intValue);
+      if (parsedInt !== undefined) {
+        return parsedInt;
+      }
     }
     return JSON.stringify(value);
+  }
+
+  /**
+   * Converts an OTLP int64 attribute value into a plain number.
+   *
+   * The same logical value reaches us in different shapes depending on the
+   * transport:
+   *  - protobuf (`application/x-protobuf`) is decoded into a Long-like object
+   *    `{ low, high, unsigned }`.
+   *  - OTLP/JSON (`application/json`) encodes int64 fields as decimal strings
+   *    (e.g. `"7"`) per the spec, since JSON numbers cannot safely represent
+   *    the full int64 range.
+   *  - some encoders send a plain JavaScript number.
+   *
+   * Returns `undefined` for values we cannot parse so the caller can fall back
+   * to a safe representation instead of emitting `NaN`.
+   */
+  private convertOtelIntValue(intValue: any): number | undefined {
+    if (typeof intValue === "number") {
+      return intValue;
+    }
+    if (typeof intValue === "string") {
+      const parsed = Number(intValue);
+      return Number.isNaN(parsed) ? undefined : parsed;
+    }
+    if (intValue && typeof intValue === "object") {
+      if (intValue.high === 0) {
+        return intValue.low;
+      }
+      if (intValue.high === -1 && intValue.low === -1) {
+        return -1;
+      }
+      if (typeof intValue.high === "number") {
+        return intValue.high * Math.pow(2, 32) + intValue.low;
+      }
+    }
+    return undefined;
   }
 
   private convertKeyPathToNestedObject(

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -3670,6 +3670,39 @@ describe("OTel Resource Span Mapping", () => {
           entityAttributeValue: '{"temperature": 75, "condition": "sunny"}',
         },
       ],
+      [
+        // OTLP/JSON encodes int64 attribute values as decimal strings (e.g. "100")
+        // rather than the Long object produced by the protobuf decoder. See
+        // https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
+        "should convert OTLP/JSON string-encoded intValue (max_tokens)",
+        {
+          entity: "observation",
+          otelAttributeKey: "gen_ai.request.max_tokens",
+          otelAttributeValue: { intValue: "100" },
+          entityAttributeKey: "modelParameters.max_tokens",
+          entityAttributeValue: 100,
+        },
+      ],
+      [
+        "should convert OTLP/JSON string-encoded intValue (usage input)",
+        {
+          entity: "observation",
+          otelAttributeKey: "gen_ai.usage.input_tokens",
+          otelAttributeValue: { intValue: "100" },
+          entityAttributeKey: "usageDetails.input",
+          entityAttributeValue: 100,
+        },
+      ],
+      [
+        "should convert OTLP/JSON string-encoded doubleValue (cost)",
+        {
+          entity: "observation",
+          otelAttributeKey: "gen_ai.usage.cost",
+          otelAttributeValue: { doubleValue: "0.000151" },
+          entityAttributeKey: "costDetails.total",
+          entityAttributeValue: 0.000151,
+        },
+      ],
     ])(
       "Attributes: %s",
       async (
@@ -3728,6 +3761,46 @@ describe("OTel Resource Span Mapping", () => {
         ).toEqual(spec.entityAttributeValue);
       },
     );
+
+    // Regression: OTLP/JSON exporters (e.g. the OpenTelemetry PHP SDK) send
+    // int64 resource attributes as decimal strings (intValue: "7") rather than
+    // the Long object produced by the protobuf decoder. Previously these were
+    // converted to NaN, which failed ingestion validation on body.metadata.
+    it("should convert OTLP/JSON string-encoded int resource attributes without producing NaN", async () => {
+      // Setup - resource attributes as emitted by an OTLP/JSON exporter
+      const resourceSpan = {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "langfuse-demo" } },
+            { key: "process.pid", value: { intValue: "7" } },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: { name: "demo-tracer" },
+            spans: [defaultSpanProps],
+          },
+        ],
+      };
+
+      // When
+      const langfuseEvents = await convertOtelSpanToIngestionEvent(
+        resourceSpan,
+        new Set(),
+      );
+
+      // Then - the int is parsed to a number, not NaN
+      const resourceAttributes =
+        langfuseEvents[1].body.metadata.resourceAttributes;
+      expect(resourceAttributes["process.pid"]).toBe(7);
+      expect(resourceAttributes["service.name"]).toBe("langfuse-demo");
+
+      // And - the events pass ingestion validation (previously rejected with an
+      // invalid_union error on body.metadata because of the NaN value)
+      const schema = createIngestionEventSchema();
+      const parsedEvents = langfuseEvents.map((event) => schema.parse(event));
+      expect(parsedEvents).toHaveLength(2);
+    });
 
     it.each([
       [


### PR DESCRIPTION
OTLP/JSON encodes int64 fields (e.g. attribute intValues) as decimal strings per the spec, since JSON numbers cannot represent the full int64 range. The attribute converter only handled the Long object produced by the protobuf decoder and a plain number, so a JSON-encoded intValue like "7" fell through to `high * 2^32 + low` with `high` undefined and produced NaN. That NaN propagated into resourceAttributes / metadata and was rejected by ingestion validation (invalid_union on body.metadata), so spans from OTLP/JSON exporters such as the OpenTelemetry PHP SDK were dropped.

Centralize int parsing in convertOtelIntValue, which handles the Long object, plain number, and decimal-string representations and returns undefined (falling back to JSON.stringify) instead of NaN for unparseable values. Also coerce string-encoded doubleValues, keeping non-finite specials ("NaN"/"Infinity") as JSON-valid strings.

Adds otelMapping coverage for string-encoded int/double attributes and a regression test for the reported process.pid resource attribute.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where OTLP/JSON-encoded int64 attribute values (e.g. `{ intValue: "7" }`) were producing `NaN` because the old code assumed a protobuf Long object and computed `undefined * 2^32 + undefined`. The `NaN` then propagated into `resourceAttributes`/`metadata` and failed ingestion schema validation, silently dropping spans from OTLP/JSON exporters such as the OpenTelemetry PHP SDK.

- Centralizes int64 decoding in a new `convertOtelIntValue` helper that handles plain numbers, OTLP/JSON decimal strings, and protobuf Long objects, returning `undefined` (rather than `NaN`) for unrecognized shapes so the caller can safely fall back to `JSON.stringify`.
- Adds symmetric string-coercion for `doubleValue`, preserving non-finite specials (`"NaN"`, `"Infinity"`) as strings to avoid emitting non-JSON-serializable values into metadata.
- Covers both changes with parameterized unit tests and a dedicated regression test verifying that `process.pid: "7"` round-trips to the number `7` and passes ingestion schema validation.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly eliminates the NaN propagation path that was dropping OTLP/JSON spans, and the regression test validates the full ingestion round-trip.

The core logic is sound and well-tested. The one small gap is that `convertOtelIntValue` guards with `!Number.isNaN` rather than `Number.isFinite`, meaning a string like `"Infinity"` would leak a JavaScript `Infinity` into metadata — which `JSON.stringify` silently coerces to `null`. This is a speculative edge case (the OTLP/JSON spec only calls for decimal integer strings), but aligning with the `Number.isFinite` guard already used for `doubleValue` would close it cleanly.

The `convertOtelIntValue` helper in `OtelIngestionProcessor.ts` is the only area worth a second look, specifically the string-parsing guard.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OTLP attribute value] --> B{value type?}
    B -->|stringValue| C[return string]
    B -->|doubleValue| D{typeof === 'string'?}
    D -->|yes| E[Number parse]
    E --> F{isFinite?}
    F -->|yes| G[return number]
    F -->|no - NaN/Infinity| H[return original string]
    D -->|no - already a number| G
    B -->|boolValue| I[return boolean]
    B -->|arrayValue| J[map recursively]
    B -->|intValue| K[convertOtelIntValue]
    K --> L{typeof intValue?}
    L -->|number| G
    L -->|string| M[Number parse]
    M --> N{isNaN?}
    N -->|false| G
    N -->|true| O[return undefined]
    L -->|object - Long| P{high === 0?}
    P -->|yes| Q[return low]
    P -->|no| R{high === -1 AND low === -1?}
    R -->|yes| S[return -1]
    R -->|no| T{typeof high === number?}
    T -->|yes| U[return high * 2^32 + low]
    T -->|no| O
    O --> V[fall back to JSON.stringify value]
    K -->|undefined returned| V
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/otel/OtelIngestionProcessor.ts:1337-1340
`Number.isNaN` guard instead of `Number.isFinite` lets edge-case strings such as `"Infinity"` or `"1e308"` slip through as JavaScript `Infinity` or an overflowed float. `JSON.stringify` silently coerces `Infinity` to `null`, so a resource attribute like `{ intValue: "Infinity" }` would be silently dropped rather than preserved as a string. The `doubleValue` branch already uses `Number.isFinite` for exactly this reason — the same guard should be applied here.

```suggestion
    if (typeof intValue === "string") {
      const parsed = Number(intValue);
      return Number.isFinite(parsed) ? parsed : undefined;
    }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): handle OTLP/JSON string-encod..."](https://github.com/langfuse/langfuse/commit/0bf8f319445d4036ddd20851322f7c9c89a72471) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35795001)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->