### PR TITLE
fix(agent): page and seed correctly

### DIFF
--- a/packages/shared/scripts/seeder/utils/in-app-agent-seed.ts
+++ b/packages/shared/scripts/seeder/utils/in-app-agent-seed.ts
@@ -140,6 +140,15 @@ export async function seedInAppAgentDemoConversation({
     event: Prisma.InputJsonValue;
     createdAt: Date;
   }> = [];
+  const eventCountByRunId = new Map<string, number>();
+  const getEventCreatedAt = (runId: string) => {
+    const eventCount = eventCountByRunId.get(runId) ?? 0;
+    eventCountByRunId.set(runId, eventCount + 1);
+
+    const runCreatedAt =
+      runId === secondRunId ? secondRunCreatedAt : firstRunCreatedAt;
+    return new Date(runCreatedAt.getTime() + eventCount * 1000);
+  };
   const addEvent = (
     runId: string,
     type: string,
@@ -153,7 +162,7 @@ export async function seedInAppAgentDemoConversation({
       sequenceNumber,
       type,
       event: event as Prisma.InputJsonValue,
-      createdAt: new Date(firstRunFinishedAt.getTime() + sequenceNumber * 1000),
+      createdAt: getEventCreatedAt(runId),
     });
   };
 

--- a/web/src/features/in-app-agent/components/InAppAgentDrawer.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentDrawer.tsx
@@ -133,6 +133,7 @@ export function InAppAgentDrawer(props: InAppAgentDrawerProps) {
               }
 
               if (value === LOAD_MORE_CONVERSATIONS_VALUE) {
+                onLoadMoreConversations();
                 return;
               }
 
@@ -162,10 +163,6 @@ export function InAppAgentDrawer(props: InAppAgentDrawerProps) {
                     value={LOAD_MORE_CONVERSATIONS_VALUE}
                     className="h-8"
                     disabled={isLoadingMoreConversations}
-                    onSelect={(event) => {
-                      event.preventDefault();
-                      onLoadMoreConversations();
-                    }}
                   >
                     {isLoadingMoreConversations ? "Loading..." : "Load more"}
                   </SelectItem>

--- a/web/src/features/in-app-agent/server/handler.ts
+++ b/web/src/features/in-app-agent/server/handler.ts
@@ -261,8 +261,7 @@ export default async function handler(request: Request) {
 
                 return replacePersistedRunEvents();
               },
-              onComplete: () =>
-                replacePersistedRunEvents().then(() => finishCurrentRun()),
+              onComplete: finishCurrentRun,
               onAbort: () =>
                 finishCurrentRun({
                   errorCode: "cancelled",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two UI/data bugs in the in-app agent feature: the "Load more conversations" trigger was silently swallowed because it relied on a Radix `SelectItem.onSelect` with `preventDefault`, and seeded demo events used a hardcoded `firstRunFinishedAt` timestamp as their base instead of each run's own start time.

- **`InAppAgentDrawer.tsx`**: Moves the `onLoadMoreConversations()` call from `SelectItem.onSelect` (with `preventDefault`) into the parent `Select.onValueChange` guard, ensuring the callback actually fires when the user clicks the item.
- **`handler.ts`**: Simplifies `onComplete` from `replacePersistedRunEvents().then(() => finishCurrentRun())` to just `finishCurrentRun`, relying on the `eventQueue` chain in `agent.ts` to guarantee that the `RUN_FINISHED` event (which triggers `replacePersistedRunEvents` via `shouldFlushPersistedEvent`) is fully processed before `onComplete` fires.
- **`in-app-agent-seed.ts`**: Introduces a per-run event counter so each seeded run's `createdAt` timestamps are anchored to that run's start time rather than the global `firstRunFinishedAt`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. All three changes are targeted bug fixes with no new logic paths that could corrupt state.

The handler.ts simplification removes the explicit replacePersistedRunEvents() call from onComplete, relying instead on the event queue in agent.ts to guarantee the RUN_FINISHED flush completes before finishCurrentRun fires. This is correct given the current agent.ts architecture, but introduces an implicit dependency on the AG-UI protocol always emitting RUN_FINISHED before the observable completes. The other two changes are straightforward and low risk.

handler.ts — the onComplete simplification is correct today but would silently drop un-flushed events if the adapter ever completes without emitting RUN_FINISHED.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant H as handler.ts
    participant A as agent.ts (eventQueue)
    participant DB as Database

    C->>H: POST /run
    H->>DB: replaceRunEvents (RUN_STARTED)
    H->>A: createAgUiStream()

    loop Agent events
        A->>H: onEvent(event)
        H->>H: persistedEvents.push(event)
        alt shouldFlushPersistedEvent(event)
            H->>DB: replaceRunEvents(all events)
        end
        A->>C: SSE data: event
    end

    Note over A,H: RUN_FINISHED triggers flush via shouldFlushPersistedEvent
    A->>H: onEvent(RUN_FINISHED)
    H->>DB: replaceRunEvents(all events incl. RUN_FINISHED)

    Note over A,H: onComplete fires AFTER eventQueue drains
    A->>H: onComplete → finishCurrentRun()
    H->>DB: finishRun (mark run complete)
    A->>C: stream closed
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): page and seed correctly"](https://github.com/langfuse/langfuse/commit/74ffc3704201b1925913a763a8ad3284c671cccc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35800425)</sub>

<!-- /greptile_comment -->