### PR TITLE
fix(agent): use bedrock model reilably

### DIFF
--- a/web/src/features/in-app-agent/server/agent.ts
+++ b/web/src/features/in-app-agent/server/agent.ts
@@ -83,7 +83,7 @@ export function createAgUiStream(params: {
     },
     includePartialMessages: true,
     // TODO: Persist and configure an exact provider model id once we stop using SDK aliases.
-    model: "haiku",
+    model: "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
   });
 
   const adapterInput = params.options.resumeSessionId


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the generic SDK model alias `"haiku"` with the explicit Bedrock model ID `"eu.anthropic.claude-haiku-4-5-20251001-v1:0"` in the in-app agent adapter to make Bedrock model selection more deterministic.

- The hardcoded `eu.` prefix designates an AWS Bedrock geographic cross-region inference profile that is only callable from EU source regions (`eu-central-1`, `eu-west-1`, etc.). Deployments using US or AP regions will receive a runtime error from Bedrock on every agent invocation.
- The existing TODO comment about persisting and configuring an exact provider model ID is still in place, suggesting this may be a partial or interim change.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change will break all agent invocations for deployments outside EU AWS regions due to the hardcoded geographic inference profile ID.

The single-line change swaps a generic alias for an EU-region-specific Bedrock model ID. Because awsBedrock.region is configurable per deployment, any instance running in a US or AP region will immediately fail at inference time on every agent call. The fix is narrow in scope but the impact is broad for non-EU deployments.

web/src/features/in-app-agent/server/agent.ts — the hardcoded model ID needs to be either made region-agnostic or derived dynamically from the configured AWS region.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant AgentEndpoint as Agent Endpoint
    participant ClaudeAgentAdapter as ClaudeAgentAdapter
    participant AWSBedrock as AWS Bedrock (eu.* profile)

    Client->>AgentEndpoint: POST /run-agent (with awsBedrock region)
    AgentEndpoint->>ClaudeAgentAdapter: "new ClaudeAgentAdapter({ model: eu.anthropic.claude-haiku-4-5-20251001-v1:0 })"
    ClaudeAgentAdapter->>AWSBedrock: InvokeModel (eu.anthropic.claude-haiku-4-5-20251001-v1:0)
    alt "AWS_DEFAULT_REGION is eu-*"
        AWSBedrock-->>ClaudeAgentAdapter: Stream response
        ClaudeAgentAdapter-->>AgentEndpoint: SSE events
        AgentEndpoint-->>Client: SSE stream
    else "AWS_DEFAULT_REGION is us-* or ap-*"
        AWSBedrock-->>ClaudeAgentAdapter: ResourceNotFoundException
        ClaudeAgentAdapter-->>AgentEndpoint: RUN_ERROR event
        AgentEndpoint-->>Client: Error response
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/in-app-agent/server/agent.ts:86
**EU-only Bedrock model ID breaks non-EU deployments**

The `eu.` prefix in `eu.anthropic.claude-haiku-4-5-20251001-v1:0` is an AWS Bedrock geographic cross-region inference profile identifier that can only be called from EU source regions (e.g. `eu-central-1`, `eu-west-1`). Any deployment configured with a US (`us-east-1`, `us-west-2`) or AP region will receive a `ResourceNotFoundException` or `ValidationException` at inference time because geographic CRIS profiles are region-scoped. The `awsBedrock.region` option is configurable per deployment, so this is a live breakage for non-EU users right now.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): use bedrock model reilably"](https://github.com/langfuse/langfuse/commit/292906b9a29a435e795580d6e4970d8699774378) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35818132)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->