### PR TITLE
fix: suppress network connectivity error toasts

### DIFF
--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -56,10 +56,102 @@ export const getPathnameWithoutBasePath = () => {
 let buildId: string | null = null;
 
 const CLIENT_STALE_CACHE_CODES = [404, 400];
+const REPORTED_FAILED_FETCH_MESSAGE = /^failed to fetch(?: \([^)]+\))?$/i;
 
 // Cache to store hashes of recently shown errors (client-side only)
 const recentErrorCache = new Set<string>();
 const ERROR_DEBOUNCE_MS = 20000;
+
+const hasResponseMeta = (error: TRPCClientError<any>): boolean =>
+  Boolean((error.meta as { response?: unknown } | undefined)?.response);
+
+const getCause = (error: unknown): unknown =>
+  error instanceof Error ? error.cause : undefined;
+
+const hasReportedFailedFetchMessage = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false;
+
+  return REPORTED_FAILED_FETCH_MESSAGE.test(error.message);
+};
+
+const isNetworkConnectivityError = (error: unknown): boolean => {
+  if (!(error instanceof TRPCClientError)) return false;
+
+  // tRPC server errors and infrastructure responses have response metadata.
+  if (error.data || hasResponseMeta(error)) return false;
+
+  const cause = getCause(error);
+
+  return (
+    (cause instanceof TypeError && hasReportedFailedFetchMessage(cause)) ||
+    hasReportedFailedFetchMessage(error)
+  );
+};
+
+/* eslint-disable @repo/no-in-source-vitest */
+const vitest = import.meta.vitest;
+
+if (vitest && typeof vitest === "object") {
+  const { describe, expect, it } = vitest;
+
+  describe("isNetworkConnectivityError", () => {
+    it("detects the reported failed fetch error without a response", () => {
+      const error = TRPCClientError.from(new TypeError("Failed to fetch"));
+
+      expect(isNetworkConnectivityError(error)).toBe(true);
+    });
+
+    it("detects the reported failed fetch error with a hostname suffix", () => {
+      const error = TRPCClientError.from(
+        new TypeError("Failed to fetch (cloud.langfuse.com)"),
+      );
+
+      expect(isNetworkConnectivityError(error)).toBe(true);
+    });
+
+    it("does not treat other network failures as connectivity errors", () => {
+      const error = TRPCClientError.from(new TypeError("Load failed"));
+
+      expect(isNetworkConnectivityError(error)).toBe(false);
+    });
+
+    it("does not treat tRPC server errors as connectivity errors", () => {
+      const error = TRPCClientError.from({
+        error: {
+          code: -32603,
+          message: "Internal server error",
+          data: {
+            code: "INTERNAL_SERVER_ERROR",
+            httpStatus: 500,
+            path: "events.all",
+          },
+        },
+      });
+
+      expect(isNetworkConnectivityError(error)).toBe(false);
+    });
+
+    it("does not treat response parsing errors as connectivity errors", () => {
+      const error = TRPCClientError.from(
+        new SyntaxError("Unexpected token <"),
+        {
+          meta: {
+            response: new Response("<html></html>", { status: 502 }),
+          },
+        },
+      );
+
+      expect(isNetworkConnectivityError(error)).toBe(false);
+    });
+
+    it("does not treat non-tRPC errors as connectivity errors", () => {
+      expect(isNetworkConnectivityError(new TypeError("Failed to fetch"))).toBe(
+        false,
+      );
+    });
+  });
+}
+/* eslint-enable @repo/no-in-source-vitest */
 
 /**
  * Creates a unique hash for an error to track it for debouncing; implementation hashes based on the tRPC path and http status
@@ -163,6 +255,10 @@ const shouldSilenceError = (
   meta: Record<string, unknown>,
   error: Error,
 ): boolean => {
+  if (isNetworkConnectivityError(error)) {
+    return true;
+  }
+
   if (Array.isArray(meta?.silentHttpCodes)) {
     return (
       error instanceof TRPCClientError &&


### PR DESCRIPTION
## Summary

Suppress the reported browser fetch failure from the global tRPC query error toast path.

This keeps the small `isNetworkConnectivityError` classifier private in `web/src/utils/api.ts` and only matches the reported `Failed to fetch` shape, including the hostname suffix shown in the toast, for tRPC errors without server response metadata. The check lives in the existing `shouldSilenceError` query-cache path, so mutation errors from user-triggered writes still show the existing error feedback.

Normal tRPC server errors, response parsing errors, non-tRPC errors, and other browser network messages such as Safari's `Load failed` stay on the existing path.

The in-source Vitest block is guarded so Turbopack/Next production builds do not execute it during page-data collection.

## Impacted Packages

- `web`

## Verification

- `pnpm --filter web run lint`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/langfuse NEXTAUTH_URL=http://localhost:3000 SALT=testsalt CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_USER=default CLICKHOUSE_PASSWORD=password pnpm --filter web exec vitest run --project in-source src/utils/api.ts`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/langfuse NEXTAUTH_SECRET=local-nextauth-secret NEXTAUTH_URL=http://localhost:3000 SALT=0123456789abcdef0123456789abcdef CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_USER=default CLICKHOUSE_PASSWORD=password LANGFUSE_S3_EVENT_UPLOAD_BUCKET=local-event-upload-bucket NEXT_IGNORE_BUILD_ERRORS=true pnpm --filter web run build`
- `git diff --check`
- Commit hook: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli`
- Commit hook: `turbo run lint`
