### PR TITLE
fix: make delete mask cleaner wait for submitted mutations to appear

### DIFF
--- a/worker/src/features/deleted-mask-cleaner/helpers.ts
+++ b/worker/src/features/deleted-mask-cleaner/helpers.ts
@@ -86,6 +86,19 @@ function quoteClickhouseIdentifier(value: string, label: string): string {
   return `\`${value.replace(/\\/g, "\\\\").replace(/`/g, "\\`")}\``;
 }
 
+function buildMutationSource(
+  useClusterAllReplicas: boolean,
+  clusterName: string,
+): string {
+  if (useClusterAllReplicas) {
+    assertClickHouseName(clusterName, "cluster");
+  }
+
+  return useClusterAllReplicas
+    ? `clusterAllReplicas(${quoteClickhouseString(clusterName)}, 'system.mutations')`
+    : "system.mutations";
+}
+
 export function isAbortError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
@@ -171,20 +184,12 @@ export function buildMutationCountQuery(
   useClusterAllReplicas: boolean,
   clusterName: string,
 ): string {
-  if (useClusterAllReplicas) {
-    assertClickHouseName(clusterName, "cluster");
-  }
-
-  const mutationSource = useClusterAllReplicas
-    ? `clusterAllReplicas(${quoteClickhouseString(clusterName)}, 'system.mutations')`
-    : "system.mutations";
-
   return `
     SELECT
       database,
       table,
       count() AS mutation_count
-    FROM ${mutationSource}
+    FROM ${buildMutationSource(useClusterAllReplicas, clusterName)}
     WHERE database = {database: String}
       AND table IN ({tables: Array(String)})
       AND is_done = 0

--- a/worker/src/features/deleted-mask-cleaner/index.ts
+++ b/worker/src/features/deleted-mask-cleaner/index.ts
@@ -26,6 +26,12 @@ export const DELETED_MASK_CLEANER_LOCK_KEY =
   "langfuse:clickhouse-deleted-mask-cleaner";
 
 const METRIC_PREFIX = "langfuse.clickhouse_deleted_mask_cleaner";
+const MUTATION_VISIBILITY_WAIT_TIMEOUT_MS = 30_000;
+const MUTATION_VISIBILITY_POLL_INTERVAL_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
  * DeletedMaskCleaner physically applies ClickHouse lightweight delete masks for
@@ -143,12 +149,7 @@ export class DeletedMaskCleaner extends PeriodicExclusiveRunner {
 
     return queryClickhouse<MutationCountRow>({
       query: buildMutationCountQuery(
-        shouldUseDeletedMaskCleanerClusterMode({
-          clusterEnabled: env.CLICKHOUSE_CLUSTER_ENABLED === "true",
-          cleanerClusterModeEnabled:
-            env.LANGFUSE_CLICKHOUSE_DELETED_MASK_CLEANER_CLUSTER_MODE_ENABLED ===
-            "true",
-        }),
+        this.useCleanerClusterMode(),
         env.CLICKHOUSE_CLUSTER_NAME,
       ),
       params: {
@@ -162,15 +163,19 @@ export class DeletedMaskCleaner extends PeriodicExclusiveRunner {
     });
   }
 
+  private useCleanerClusterMode(): boolean {
+    return shouldUseDeletedMaskCleanerClusterMode({
+      clusterEnabled: env.CLICKHOUSE_CLUSTER_ENABLED === "true",
+      cleanerClusterModeEnabled:
+        env.LANGFUSE_CLICKHOUSE_DELETED_MASK_CLEANER_CLUSTER_MODE_ENABLED ===
+        "true",
+    });
+  }
+
   private async applyDeletedMask(candidate: WorkCandidateRow): Promise<void> {
     const query = buildApplyDeletedMaskQuery(candidate, {
       database: env.CLICKHOUSE_DB,
-      clusterEnabled: shouldUseDeletedMaskCleanerClusterMode({
-        clusterEnabled: env.CLICKHOUSE_CLUSTER_ENABLED === "true",
-        cleanerClusterModeEnabled:
-          env.LANGFUSE_CLICKHOUSE_DELETED_MASK_CLEANER_CLUSTER_MODE_ENABLED ===
-          "true",
-      }),
+      clusterEnabled: this.useCleanerClusterMode(),
       clusterName: env.CLICKHOUSE_CLUSTER_NAME,
     });
 
@@ -226,5 +231,33 @@ export class DeletedMaskCleaner extends PeriodicExclusiveRunner {
     } finally {
       clearTimeout(timeoutId);
     }
+
+    await this.waitForSubmittedMutationVisibility(candidate.table);
+  }
+
+  private async waitForSubmittedMutationVisibility(
+    table: string,
+  ): Promise<void> {
+    const deadline = Date.now() + MUTATION_VISIBILITY_WAIT_TIMEOUT_MS;
+
+    // This is a best-effort lock hold after async DDL submission. Tiny mutations
+    // may complete before system.mutations ever exposes them as unfinished, which
+    // is fine because the lock was still held through the duplicate-submit window.
+    while (Date.now() < deadline) {
+      if ((await this.getActiveMutationCount(table)) > 0) {
+        return;
+      }
+
+      await sleep(MUTATION_VISIBILITY_POLL_INTERVAL_MS);
+    }
+  }
+
+  private async getActiveMutationCount(table: string): Promise<number> {
+    const mutationCounts = normalizeMutationCounts(
+      [table],
+      await this.getMutationCountRows([table]),
+    );
+
+    return mutationCounts.get(table) ?? 0;
   }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a post-submission polling loop to `DeletedMaskCleaner` that waits up to 30 seconds for a submitted `APPLY DELETED MASK` mutation to appear in `system.mutations`, preventing a race where the next tick starts before ClickHouse registers the new mutation. It also refactors `buildMutationSource` into a reusable helper and deduplicates `shouldUseDeletedMaskCleanerClusterMode` calls into a `useCleanerClusterMode()` method.

- **Visibility wait (`waitForSubmittedMutationVisibility`)**: Polls `system.mutations` with `is_done = 0` every 500 ms until mutation count exceeds zero, then returns; logs a warning if the 30-second deadline expires.
- **Abort-path coupling**: The visibility wait is called unconditionally after the `commandClickhouse` try/catch, meaning it also fires when the submit was aborted — which can cascade additional ClickHouse query failures if connectivity is the root cause.
- **Fast-completion gap**: The `is_done = 0` filter means a mutation that completes before the first poll is invisible to the wait, causing a full 30-second stall and misleading timeout warning on every such partition.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core logic improves mutation-ordering correctness, but the unconditional visibility wait after a command abort can amplify connectivity failures into a cascade of additional query errors.

The abort path calls waitForSubmittedMutationVisibility even when no mutation was submitted; if ClickHouse is unreachable, every getActiveMutationCount poll inside the loop will also fail, changing a controlled submission-timed-out log entry into an unexpected error thrown from applyDeletedMask.

worker/src/features/deleted-mask-cleaner/index.ts — specifically the applyDeletedMask abort path and the waitForSubmittedMutationVisibility polling condition.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant E as execute()
    participant A as applyDeletedMask()
    participant W as waitForSubmittedMutationVisibility()
    participant CH as ClickHouse

    E->>A: call with candidate
    A->>CH: "commandClickhouse APPLY DELETED MASK mutations_sync=0"
    alt Command acknowledged
        CH-->>A: OK
        A->>A: recordIncrement commands_submitted
    else Abort timeout fires
        A->>A: log Stopped waiting for submission
        A->>A: recordIncrement command_submit_aborted
    end
    A->>A: clearTimeout
    A->>W: waitForSubmittedMutationVisibility unconditional
    loop Poll every 500ms until deadline 30s
        W->>CH: "getActiveMutationCount WHERE is_done=0"
        CH-->>W: count
        alt "count > 0"
            W-->>A: return mutation visible
        else "count = 0"
            W->>W: sleep 500ms
        end
    end
    W->>W: log WARN mutation did not become visible
    W-->>A: return
    A-->>E: return
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/deleted-mask-cleaner/index.ts:213-235
**Visibility wait runs unconditionally after an abort**

`waitForSubmittedMutationVisibility` is called after the `try/catch/finally` block regardless of whether the mutation was actually submitted. When the abort path fires — meaning ClickHouse is slow or unreachable — each `getActiveMutationCount` call inside the polling loop will also hit a slow or unreachable ClickHouse, and those query errors will propagate out of `applyDeletedMask` as an unexpected throw (the error handler in `execute` will log it as a general tick failure rather than an expected abort). A simple boolean flag tracking whether the command was delivered can gate the call.

### Issue 2 of 2
worker/src/features/deleted-mask-cleaner/index.ts:238-265
**Fast-completing mutations cause a false-positive timeout warning**

The polling query filters `is_done = 0`. If a mutation on a small partition is submitted and completes within the first 500 ms poll interval, every subsequent poll returns 0 — indistinguishable from "mutation never appeared" — so the wait runs the full 30 seconds and logs `"Submitted mutation did not become visible before timeout"` even though the mutation completed successfully. The next tick would proceed correctly, but the 30-second stall and misleading warning would fire on every fast partition. Extending the query to also count recently-completed mutations (e.g. `is_done = 0 OR create_time >= now() - INTERVAL 60 SECOND`) would cover this case.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make delete mask cleaner wait for s..."](https://github.com/langfuse/langfuse/commit/4b9205b7b37f2df2aca552697fbdc63d1ee31772) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35832981)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->