### PR TITLE
fix: hide password fields on signup page when AUTH_DISABLE_USERNAME_PASSWORD is true

### DIFF
--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -94,8 +94,9 @@ function StandardSignupFlow({
 
   // Two-step login flow: ask for email first, detect SSO, then either redirect to SSO or reveal password field.
   // Skip this flow when no SSO is configured - show password field immediately
+  // Also skip when credentials auth is disabled (AUTH_DISABLE_USERNAME_PASSWORD)
   const [showPasswordStep, setShowPasswordStep] = useState<boolean>(
-    !authProviders.sso,
+    !authProviders.sso && authProviders.credentials,
   );
   const [continueLoading, setContinueLoading] = useState<boolean>(false);
   const [lastUsedAuthMethod, setLastUsedAuthMethod] =
@@ -166,21 +167,27 @@ function StandardSignupFlow({
         return; // stop further execution – page redirect expected
       }
 
-      // No SSO – fall back to password step
-      setShowPasswordStep(true);
+      // No SSO – fall back to password step if credentials are enabled
+      if (authProviders.credentials) {
+        setShowPasswordStep(true);
 
-      // Auto-focus password input when password step becomes visible
-      setTimeout(() => {
-        // Find and focus the name input (since it's the first new field) or password?
-        // Plan says "name + password fields". Usually Name is first in Sign Up.
-        // Let's focus Name.
-        const nameInput = document.querySelector(
-          'input[name="name"]',
-        ) as HTMLInputElement;
-        if (nameInput) {
-          nameInput.focus();
-        }
-      }, 100);
+        // Auto-focus password input when password step becomes visible
+        setTimeout(() => {
+          // Find and focus the name input (since it's the first new field) or password?
+          // Plan says "name + password fields". Usually Name is first in Sign Up.
+          // Let's focus Name.
+          const nameInput = document.querySelector(
+            'input[name="name"]',
+          ) as HTMLInputElement;
+          if (nameInput) {
+            nameInput.focus();
+          }
+        }, 100);
+      } else {
+        setFormError(
+          "Password-based signup is disabled. Please use SSO to sign up.",
+        );
+      }
     } catch (error) {
       console.error(error);
       setFormError("Unable to check SSO configuration. Please try again.");


### PR DESCRIPTION
## What does this PR do?

Fixes #13893

When `AUTH_DISABLE_USERNAME_PASSWORD=true`, the signup page (`/auth/sign-up`) still displayed name and password fields, even though password-based authentication was disabled. The sign-in page correctly respects this env var, but the sign-up page did not.

## Changes

1. **`StandardSignupFlow` initial state**: `showPasswordStep` now checks `authProviders.credentials` in addition to `!authProviders.sso`
2. **`handleContinue`**: When SSO domain lookup finds no provider, now checks `authProviders.credentials` before revealing password fields. If credentials are disabled, shows an error message directing users to SSO.

## How to test

1. Set `AUTH_DISABLE_USERNAME_PASSWORD=true` in `.env`
2. Navigate to `/auth/sign-up`
3. **Before fix**: Name, email, and password fields are shown
4. **After fix**: Only email field is shown; after entering email with no SSO match, error message "Password-based signup is disabled. Please use SSO to sign up." is displayed

## Related

- The sign-in page (`/auth/sign-in`) already handles this correctly at line 753: `{authProviders.credentials && (...)}`
- Server-side validation in `signupApiHandler.ts` and `auth.ts` also blocks password auth when the env var is set

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the signup page (`/auth/sign-up`) displayed name and password fields even when `AUTH_DISABLE_USERNAME_PASSWORD=true`, making it inconsistent with the sign-in page that already respects this flag correctly.

- `showPasswordStep` initial state now gates on `authProviders.credentials` in addition to the absence of SSO, so the password step is never shown up-front when credentials auth is disabled.
- `handleContinue` (the post-SSO-check fallback) now also checks `authProviders.credentials` before revealing the password fields; when credentials are disabled, it surfaces a clear error message directing the user to SSO instead.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the client-side UI of the signup form, and server-side handlers already block credential-based signup when the env var is set.

Both changed guards mirror the existing pattern used on the sign-in page. The authProviders.credentials boolean is reliably populated server-side from the env var, and neither modified expression can accidentally surface password fields when credentials are disabled. No logic paths were removed; the new else branch simply replaces a silent no-op with a user-visible error message.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: hide password fields on signup page..."](https://github.com/langfuse/langfuse/commit/4e95003f15dec5213ff9158ae942af244ffd67d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35851238)</sub>

<!-- /greptile_comment -->