### PR TITLE
fix: show error toast when evaluator deactivation/update fails

### DIFF
--- a/web/src/components/ui/time-period-select.tsx
+++ b/web/src/components/ui/time-period-select.tsx
@@ -46,7 +46,7 @@ export const TimePeriodSelect = React.forwardRef<
           new Date(date),
           hours.toString(),
           "12hours",
-          period === "AM" ? "PM" : "AM",
+          value,
         ),
       );
     }

--- a/web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
+++ b/web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
@@ -136,7 +136,7 @@ export const CreateNewAnnotationQueueItem = ({
           )}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent>
+      <DropdownMenuContent className="max-h-[300px] overflow-y-auto">
         <DropdownMenuLabel>In queue(s)</DropdownMenuLabel>
         {queues.data?.queues.length ? (
           queues.data?.queues.map((queue) => (

--- a/web/src/features/datasets/components/DatasetItemDetailPage.tsx
+++ b/web/src/features/datasets/components/DatasetItemDetailPage.tsx
@@ -191,7 +191,7 @@ export const DatasetItemDetailPage = ({
             {item.data?.sourceTraceId && (
               <Button variant="ghost" size="icon-xs" asChild>
                 <Link
-                  href={`/project/${projectId}/traces/${item.data.sourceTraceId}`}
+                  href={`/project/${projectId}/traces/${item.data.sourceTraceId}${item.data.sourceObservationId ? `?observation=${item.data.sourceObservationId}` : ""}`}
                   title={`View source ${item.data.sourceObservationId ? "observation" : "trace"}`}
                 >
                   <ListTree className="h-4 w-4" />

--- a/web/src/features/evals/components/deactivate-config.tsx
+++ b/web/src/features/evals/components/deactivate-config.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/src/components/ui/popover";
 import { Button } from "@/src/components/ui/button";
 import { Switch } from "@/src/components/ui/switch";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 
 export function DeactivateEvalConfig({
   projectId,
@@ -27,6 +28,9 @@ export function DeactivateEvalConfig({
   const mutEvaluator = api.evals.updateEvalJob.useMutation({
     onSuccess: () => {
       utils.evals.invalidate();
+    },
+    onError: (error) => {
+      showErrorToast("Failed to update evaluator", error.message);
     },
   });
 

--- a/web/src/features/experiments/hooks/useExperimentResultsState.ts
+++ b/web/src/features/experiments/hooks/useExperimentResultsState.ts
@@ -4,6 +4,7 @@ import {
   ArrayParam,
   StringParam,
 } from "use-query-params";
+import useLocalStorage from "@/src/components/useLocalStorage";
 
 const MAX_COMPARISONS = 4;
 
@@ -11,7 +12,7 @@ export function useExperimentResultsState() {
   const [state, setState] = useQueryParams({
     baseline: withDefault(StringParam, undefined),
     c: withDefault(ArrayParam, []),
-    layout: withDefault(StringParam, "grid"),
+    layout: StringParam,
     itemVisibility: withDefault(StringParam, "baseline-only"),
   });
 
@@ -76,10 +77,15 @@ export function useExperimentResultsState() {
     setComparisonIds(comparisonIds.filter((existingId) => existingId !== id));
   };
 
-  // Layout management
-  const layout = (state.layout as "grid" | "list") ?? "list";
+  // Layout management - persist to localStorage so preference survives navigation
+  const [savedLayout, setSavedLayout] = useLocalStorage<"grid" | "list">(
+    "experimentResultsLayout",
+    "grid",
+  );
+  const layout = (state.layout as "grid" | "list") ?? savedLayout ?? "grid";
   const setLayout = (newLayout: "grid" | "list") => {
     setState({ layout: newLayout });
+    setSavedLayout(newLayout);
   };
 
   // Item visibility management

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -94,8 +94,9 @@ function StandardSignupFlow({
 
   // Two-step login flow: ask for email first, detect SSO, then either redirect to SSO or reveal password field.
   // Skip this flow when no SSO is configured - show password field immediately
+  // Also skip when credentials auth is disabled (AUTH_DISABLE_USERNAME_PASSWORD)
   const [showPasswordStep, setShowPasswordStep] = useState<boolean>(
-    !authProviders.sso,
+    !authProviders.sso && authProviders.credentials,
   );
   const [continueLoading, setContinueLoading] = useState<boolean>(false);
   const [lastUsedAuthMethod, setLastUsedAuthMethod] =
@@ -166,21 +167,27 @@ function StandardSignupFlow({
         return; // stop further execution – page redirect expected
       }
 
-      // No SSO – fall back to password step
-      setShowPasswordStep(true);
+      // No SSO – fall back to password step if credentials are enabled
+      if (authProviders.credentials) {
+        setShowPasswordStep(true);
 
-      // Auto-focus password input when password step becomes visible
-      setTimeout(() => {
-        // Find and focus the name input (since it's the first new field) or password?
-        // Plan says "name + password fields". Usually Name is first in Sign Up.
-        // Let's focus Name.
-        const nameInput = document.querySelector(
-          'input[name="name"]',
-        ) as HTMLInputElement;
-        if (nameInput) {
-          nameInput.focus();
-        }
-      }, 100);
+        // Auto-focus password input when password step becomes visible
+        setTimeout(() => {
+          // Find and focus the name input (since it's the first new field) or password?
+          // Plan says "name + password fields". Usually Name is first in Sign Up.
+          // Let's focus Name.
+          const nameInput = document.querySelector(
+            'input[name="name"]',
+          ) as HTMLInputElement;
+          if (nameInput) {
+            nameInput.focus();
+          }
+        }, 100);
+      } else {
+        setFormError(
+          "Password-based signup is disabled. Please use SSO to sign up.",
+        );
+      }
     } catch (error) {
       console.error(error);
       setFormError("Unable to check SSO configuration. Please try again.");


### PR DESCRIPTION
Fixes #13315

The DeactivateEvalConfig component mutation had no onError handler. When server rejected update (e.g., timeScope includes EXISTING), failure was silent — no toast, just button flash.

Added showErrorToast matching pattern in evaluator-paused-callout.tsx and inner-evaluator-form.tsx.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes silent failures when an evaluator deactivation/update is rejected by the server, and bundles several unrelated bug fixes and UX improvements collected since the last merge.

- **`deactivate-config.tsx`**: Adds an `onError` handler with `showErrorToast` so the user gets feedback when the server rejects the toggle. However, the `onClick` handler still calls `mutateAsync` without `await` or `.catch()`, producing an unhandled promise rejection on failure; the surrounding patterns (`evaluator-paused-callout.tsx`) use `mutate` for this fire-and-forget case.
- **`time-period-select.tsx`**: Corrects an AM/PM inversion bug — was passing the opposite period to `setDateByType` instead of the newly selected value.
- **`sign-up.tsx`**: Guards the password step behind `authProviders.credentials` so users on instances with `AUTH_DISABLE_USERNAME_PASSWORD` see a clear error instead of an unusable form.
- **`useExperimentResultsState.ts`**: Persists layout preference to localStorage so it survives page navigation, with URL param taking precedence.
- **`DatasetItemDetailPage.tsx`** / **`CreateNewAnnotationQueueItem.tsx`**: Minor UX fixes (observation deep-link, scrollable dropdown).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; the onError toast works correctly at runtime, but a dangling unhandled promise rejection is left behind whenever the mutation fails.

The core error-handling path fires correctly — the toast appears and the cache is not invalidated on failure. The only defect is that mutateAsync is called without await or .catch(), so every server rejection also produces an unhandled promise rejection in the browser. This is a real, observable side effect (console errors, potential error-boundary activation), not a hypothetical one.

web/src/features/evals/components/deactivate-config.tsx — the onClick handler should use mutate instead of mutateAsync to match the fire-and-forget pattern used in evaluator-paused-callout.tsx.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant DeactivateEvalConfig
    participant TanStackQuery
    participant Server

    User->>DeactivateEvalConfig: Click toggle (Activate/Deactivate)
    DeactivateEvalConfig->>TanStackQuery: mutateAsync(updateEvalJob)
    TanStackQuery->>Server: POST updateEvalJob
    alt Success
        Server-->>TanStackQuery: 200 OK
        TanStackQuery-->>DeactivateEvalConfig: onSuccess - invalidate cache
    else Error
        Server-->>TanStackQuery: 4xx/5xx
        TanStackQuery-->>DeactivateEvalConfig: onError - showErrorToast
        Note over TanStackQuery,DeactivateEvalConfig: mutateAsync also throws unhandled rejection
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/evals/components/deactivate-config.tsx:45-51
`mutateAsync` without `await` or `.catch()` leaves its rejection unhandled. When the server rejects the request the `onError` handler still fires (so the toast appears), but the dangling rejected promise also triggers an unhandled-rejection warning and can activate a React error boundary. The companion file `evaluator-paused-callout.tsx` correctly uses `mutate` for this fire-and-forget pattern.

```suggestion
    mutEvaluator.mutate({
      projectId,
      evalConfigId: evalConfig?.id ?? "",
      config: {
        status: isActive ? EvaluatorStatus.INACTIVE : EvaluatorStatus.ACTIVE,
      },
    });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: show error toast when evaluator dea..."](https://github.com/langfuse/langfuse/commit/a6aef2e6ff9d4c9108a8a9aba32ea99c0d9bfd50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35865932)</sub>

<!-- /greptile_comment -->