### PR TITLE
Feat/ttft diamond marker

### DIFF
--- a/web/src/components/trace/components/TraceTimeline/TimelineBar.clienttest.tsx
+++ b/web/src/components/trace/components/TraceTimeline/TimelineBar.clienttest.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { TooltipProvider } from "@/src/components/ui/tooltip";
+import { TimelineBar } from "./TimelineBar";
+import type { TimelineBarProps } from "./types";
+
+const baseProps: TimelineBarProps = {
+  node: {
+    id: "obs-1",
+    type: "GENERATION",
+    name: "test-generation",
+    startTime: new Date("2024-01-01T00:00:00Z"),
+    endTime: new Date("2024-01-01T00:00:10Z"),
+    children: [],
+    startTimeSinceTrace: 0,
+    startTimeSinceParentStart: null,
+    depth: 0,
+    childrenDepth: 0,
+  },
+  metrics: {
+    startOffset: 0,
+    itemWidth: 200,
+    firstTokenTimeOffset: undefined,
+    timeToFirstToken: undefined,
+    latency: 10,
+  },
+  isSelected: false,
+  onSelect: () => {},
+  showDuration: false,
+  showCostTokens: false,
+  showScores: false,
+  showComments: false,
+  colorCodeMetrics: false,
+};
+
+const renderWithTooltip = (props: TimelineBarProps) =>
+  render(
+    <TooltipProvider>
+      <TimelineBar {...props} />
+    </TooltipProvider>,
+  );
+
+describe("TimelineBar", () => {
+  describe("diamond marker (TTFT)", () => {
+    it("does not render diamond when timeToFirstToken is absent", () => {
+      renderWithTooltip(baseProps);
+      expect(document.querySelector("[class*='rotate-45']")).toBeNull();
+    });
+
+    it("does not render diamond when firstTokenTimeOffset set but timeToFirstToken is absent", () => {
+      renderWithTooltip({
+        ...baseProps,
+        metrics: {
+          ...baseProps.metrics,
+          firstTokenTimeOffset: 80,
+          timeToFirstToken: undefined,
+        },
+      });
+      expect(document.querySelector("[class*='rotate-45']")).toBeNull();
+    });
+
+    it("renders diamond marker when both firstTokenTimeOffset and timeToFirstToken are present", () => {
+      renderWithTooltip({
+        ...baseProps,
+        metrics: {
+          ...baseProps.metrics,
+          firstTokenTimeOffset: 80,
+          timeToFirstToken: 2,
+        },
+      });
+      expect(
+        document.querySelector("[class*='rotate-45']"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows tooltip with formatted TTFT on mouseenter", async () => {
+      renderWithTooltip({
+        ...baseProps,
+        metrics: {
+          ...baseProps.metrics,
+          firstTokenTimeOffset: 80,
+          timeToFirstToken: 2,
+        },
+      });
+
+      const diamond = document.querySelector(
+        "[class*='rotate-45']",
+      ) as HTMLElement;
+      fireEvent.mouseEnter(diamond);
+      fireEvent.focus(diamond);
+
+      await waitFor(() => {
+        // Radix renders a hidden <span role="tooltip"> for accessibility
+        const tooltip = screen.getByRole("tooltip");
+        expect(tooltip).toHaveTextContent(/Time to first token: 2\.00s/);
+      });
+    });
+
+    it("shows correct TTFT for sub-second values in tooltip", async () => {
+      renderWithTooltip({
+        ...baseProps,
+        metrics: {
+          ...baseProps.metrics,
+          firstTokenTimeOffset: 40,
+          timeToFirstToken: 0.5,
+        },
+      });
+
+      const diamond = document.querySelector(
+        "[class*='rotate-45']",
+      ) as HTMLElement;
+      fireEvent.mouseEnter(diamond);
+      fireEvent.focus(diamond);
+
+      await waitFor(() => {
+        const tooltip = screen.getByRole("tooltip");
+        expect(tooltip).toHaveTextContent(/Time to first token: 0\.50s/);
+      });
+    });
+
+    it("renders 'First token' label in split bar", () => {
+      renderWithTooltip({
+        ...baseProps,
+        metrics: {
+          ...baseProps.metrics,
+          firstTokenTimeOffset: 80,
+          timeToFirstToken: 2,
+        },
+      });
+      expect(screen.getByText("First token")).toBeInTheDocument();
+    });
+  });
+
+  describe("regular bar (no TTFT)", () => {
+    it("renders node name", () => {
+      renderWithTooltip(baseProps);
+      expect(screen.getByText("test-generation")).toBeInTheDocument();
+    });
+
+    it("does not render 'First token' label", () => {
+      renderWithTooltip(baseProps);
+      expect(screen.queryByText("First token")).not.toBeInTheDocument();
+    });
+
+    it("calls onSelect when clicked", () => {
+      const onSelect = vi.fn();
+      renderWithTooltip({ ...baseProps, onSelect });
+      fireEvent.click(screen.getByText("test-generation"));
+      expect(onSelect).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/web/src/components/trace/components/TraceTimeline/TimelineBar.clienttest.tsx
+++ b/web/src/components/trace/components/TraceTimeline/TimelineBar.clienttest.tsx
@@ -120,6 +120,34 @@ describe("TimelineBar", () => {
       });
     });
 
+    it("does not render diamond when timeToFirstToken is negative (clock drift)", () => {
+      renderWithTooltip({
+        ...baseProps,
+        metrics: {
+          ...baseProps.metrics,
+          firstTokenTimeOffset: 80,
+          timeToFirstToken: -1.23,
+        },
+      });
+      expect(document.querySelector("[class*='rotate-45']")).toBeNull();
+      // falls back to a normal bar
+      expect(screen.getByText("test-generation")).toBeInTheDocument();
+      expect(screen.queryByText("First token")).not.toBeInTheDocument();
+    });
+
+    it("does not render diamond when timeToFirstToken is zero", () => {
+      renderWithTooltip({
+        ...baseProps,
+        metrics: {
+          ...baseProps.metrics,
+          firstTokenTimeOffset: 80,
+          timeToFirstToken: 0,
+        },
+      });
+      expect(document.querySelector("[class*='rotate-45']")).toBeNull();
+      expect(screen.queryByText("First token")).not.toBeInTheDocument();
+    });
+
     it("renders 'First token' label in split bar", () => {
       renderWithTooltip({
         ...baseProps,

--- a/web/src/components/trace/components/TraceTimeline/TimelineBar.tsx
+++ b/web/src/components/trace/components/TraceTimeline/TimelineBar.tsx
@@ -12,6 +12,11 @@ import { formatIntervalSeconds } from "@/src/utils/dates";
 import { usdFormatter } from "@/src/utils/numbers";
 import { heatMapTextColor } from "@/src/components/trace/lib/helpers";
 import { isPresent } from "@langfuse/shared";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 
 export function TimelineBar({
   node,
@@ -29,7 +34,13 @@ export function TimelineBar({
   commentCount,
   scores,
 }: TimelineBarProps) {
-  const { startOffset, itemWidth, firstTokenTimeOffset, latency } = metrics;
+  const {
+    startOffset,
+    itemWidth,
+    firstTokenTimeOffset,
+    timeToFirstToken,
+    latency,
+  } = metrics;
   const duration = latency ? latency * 1000 : undefined;
   const hasChildren = node.children.length > 0;
 
@@ -46,7 +57,7 @@ export function TimelineBar({
       >
         <div
           className={cn(
-            "border-border flex rounded-sm border",
+            "border-border relative flex rounded-sm border",
             isSelected
               ? "ring-primary-accent ring-3"
               : "group-hover:ring-tertiary group-hover:ring-3",
@@ -62,6 +73,21 @@ export function TimelineBar({
             style={{ width: `${firstTokenWidth}px` }}
           />
 
+          {/* Diamond marker at the first-token split point with TTFT tooltip */}
+          {isPresent(timeToFirstToken) && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div
+                  className="bg-primary-accent hover:bg-hover-primary-accent absolute top-1/2 z-10 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rotate-45 cursor-default"
+                  style={{ left: `${firstTokenWidth}px` }}
+                />
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                Time to first token: {formatIntervalSeconds(timeToFirstToken)}
+              </TooltipContent>
+            </Tooltip>
+          )}
+
           {/* Completion time bar */}
           <div
             className={cn(
@@ -71,7 +97,7 @@ export function TimelineBar({
             style={{ width: `${completionWidth}px` }}
           >
             <div className="text-muted-foreground -ml-8 flex flex-row items-center justify-start gap-2 text-xs">
-              <span className="text-xxs text-primary">First token</span>
+              <span className="text-primary text-xs">First token</span>
               <ItemBadge type={node.type} isSmall />
               <span className="text-primary text-sm font-medium whitespace-nowrap">
                 {node.name}

--- a/web/src/components/trace/components/TraceTimeline/TimelineBar.tsx
+++ b/web/src/components/trace/components/TraceTimeline/TimelineBar.tsx
@@ -44,8 +44,15 @@ export function TimelineBar({
   const duration = latency ? latency * 1000 : undefined;
   const hasChildren = node.children.length > 0;
 
-  // Render split bar for streaming LLMs (first token time)
-  if (firstTokenTimeOffset) {
+  // Render split bar for streaming LLMs (first token time).
+  // Require a strictly positive time-to-first-token so clock-drift cases where
+  // completionStartTime <= startTime fall back to a normal bar instead of
+  // showing a negative TTFT or a diamond positioned outside the bar.
+  if (
+    firstTokenTimeOffset &&
+    isPresent(timeToFirstToken) &&
+    timeToFirstToken > 0
+  ) {
     const firstTokenWidth = firstTokenTimeOffset - startOffset;
     const completionWidth = itemWidth - firstTokenWidth;
 
@@ -74,19 +81,17 @@ export function TimelineBar({
           />
 
           {/* Diamond marker at the first-token split point with TTFT tooltip */}
-          {isPresent(timeToFirstToken) && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div
-                  className="bg-primary-accent hover:bg-hover-primary-accent absolute top-1/2 z-10 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rotate-45 cursor-default"
-                  style={{ left: `${firstTokenWidth}px` }}
-                />
-              </TooltipTrigger>
-              <TooltipContent side="top">
-                Time to first token: {formatIntervalSeconds(timeToFirstToken)}
-              </TooltipContent>
-            </Tooltip>
-          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className="bg-primary-accent hover:bg-hover-primary-accent absolute top-1/2 z-10 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rotate-45 cursor-default"
+                style={{ left: `${firstTokenWidth}px` }}
+              />
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              Time to first token: {formatIntervalSeconds(timeToFirstToken)}
+            </TooltipContent>
+          </Tooltip>
 
           {/* Completion time bar */}
           <div

--- a/web/src/components/trace/components/TraceTimeline/timeline-flattening.clienttest.ts
+++ b/web/src/components/trace/components/TraceTimeline/timeline-flattening.clienttest.ts
@@ -1,0 +1,200 @@
+import { flattenTreeWithTimelineMetrics } from "./timeline-flattening";
+import { SCALE_WIDTH } from "./timeline-calculations";
+import type { TreeNode } from "../../lib/types";
+
+const baseNode = (overrides: Partial<TreeNode> & { id: string }): TreeNode => ({
+  id: overrides.id,
+  type: "SPAN",
+  name: overrides.id,
+  startTime: new Date("2024-01-01T00:00:00Z"),
+  endTime: new Date("2024-01-01T00:00:10Z"),
+  startTimeSinceTrace: 0,
+  startTimeSinceParentStart: null,
+  depth: 0,
+  childrenDepth: 0,
+  children: [],
+  ...overrides,
+});
+
+const traceStart = new Date("2024-01-01T00:00:00Z");
+const totalDuration = 10; // 10 seconds
+
+describe("flattenTreeWithTimelineMetrics", () => {
+  describe("timeToFirstToken computation", () => {
+    it("is undefined when node has no completionStartTime", () => {
+      const node = baseNode({ id: "n1" });
+      const result = flattenTreeWithTimelineMetrics(
+        [node],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result[0]?.metrics.timeToFirstToken).toBeUndefined();
+      expect(result[0]?.metrics.firstTokenTimeOffset).toBeUndefined();
+    });
+
+    it("is undefined when completionStartTime is null", () => {
+      const node = {
+        ...baseNode({ id: "n1" }),
+        completionStartTime: null,
+      };
+      const result = flattenTreeWithTimelineMetrics(
+        [node as unknown as TreeNode],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result[0]?.metrics.timeToFirstToken).toBeUndefined();
+    });
+
+    it("computes TTFT in seconds from completionStartTime", () => {
+      const node = {
+        ...baseNode({ id: "n1" }),
+        completionStartTime: new Date("2024-01-01T00:00:02Z"), // 2s after start
+      };
+      const result = flattenTreeWithTimelineMetrics(
+        [node as unknown as TreeNode],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result[0]?.metrics.timeToFirstToken).toBe(2);
+    });
+
+    it("computes TTFT correctly for sub-second precision", () => {
+      const node = {
+        ...baseNode({ id: "n1" }),
+        completionStartTime: new Date("2024-01-01T00:00:00.500Z"), // 500ms
+      };
+      const result = flattenTreeWithTimelineMetrics(
+        [node as unknown as TreeNode],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result[0]?.metrics.timeToFirstToken).toBe(0.5);
+    });
+
+    it("computes TTFT relative to the node's own startTime, not trace start", () => {
+      // Node starts at 3s into trace, first token at 5s — TTFT should be 2s
+      const nodeStart = new Date("2024-01-01T00:00:03Z");
+      const node = {
+        ...baseNode({ id: "n1", startTime: nodeStart }),
+        completionStartTime: new Date("2024-01-01T00:00:05Z"),
+      };
+      const result = flattenTreeWithTimelineMetrics(
+        [node as unknown as TreeNode],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result[0]?.metrics.timeToFirstToken).toBe(2);
+    });
+  });
+
+  describe("firstTokenTimeOffset computation", () => {
+    it("matches expected pixel offset for completionStartTime at trace midpoint", () => {
+      const node = {
+        ...baseNode({ id: "n1" }),
+        completionStartTime: new Date("2024-01-01T00:00:05Z"), // 5s = 50%
+      };
+      const result = flattenTreeWithTimelineMetrics(
+        [node as unknown as TreeNode],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result[0]?.metrics.firstTokenTimeOffset).toBe(SCALE_WIDTH / 2);
+    });
+
+    it("firstTokenTimeOffset and timeToFirstToken are consistent", () => {
+      // firstTokenOffset - startOffset should correspond to timeToFirstToken
+      const nodeStart = new Date("2024-01-01T00:00:02Z");
+      const completionStart = new Date("2024-01-01T00:00:04Z");
+      const node = {
+        ...baseNode({ id: "n1", startTime: nodeStart }),
+        completionStartTime: completionStart,
+      };
+      const result = flattenTreeWithTimelineMetrics(
+        [node as unknown as TreeNode],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      const metrics = result[0]?.metrics;
+      expect(metrics).toBeDefined();
+
+      const firstTokenWidth =
+        metrics!.firstTokenTimeOffset! - metrics!.startOffset;
+      // firstTokenWidth in pixels / SCALE_WIDTH * totalDuration = timeToFirstToken
+      const derivedTTFT = (firstTokenWidth / SCALE_WIDTH) * totalDuration;
+      expect(derivedTTFT).toBeCloseTo(metrics!.timeToFirstToken!, 10);
+    });
+  });
+
+  describe("existing behaviour is not broken", () => {
+    it("returns empty array for empty roots", () => {
+      const result = flattenTreeWithTimelineMetrics(
+        [],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+      expect(result).toEqual([]);
+    });
+
+    it("computes startOffset and itemWidth correctly for a plain node", () => {
+      const node = baseNode({
+        id: "n1",
+        startTime: new Date("2024-01-01T00:00:00Z"),
+        endTime: new Date("2024-01-01T00:00:10Z"),
+      });
+      const result = flattenTreeWithTimelineMetrics(
+        [node],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result[0]?.metrics.startOffset).toBe(0);
+      expect(result[0]?.metrics.itemWidth).toBe(SCALE_WIDTH);
+    });
+
+    it("hides children of collapsed nodes", () => {
+      const child = baseNode({ id: "child" });
+      const parent = baseNode({ id: "parent", children: [child] });
+      const result = flattenTreeWithTimelineMetrics(
+        [parent],
+        new Set(["parent"]),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.node.id).toBe("parent");
+    });
+
+    it("preserves latency from node endTime - startTime", () => {
+      const node = baseNode({
+        id: "n1",
+        startTime: new Date("2024-01-01T00:00:00Z"),
+        endTime: new Date("2024-01-01T00:00:04Z"),
+      });
+      const result = flattenTreeWithTimelineMetrics(
+        [node],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result[0]?.metrics.latency).toBeCloseTo(4, 5);
+    });
+  });
+});

--- a/web/src/components/trace/components/TraceTimeline/timeline-flattening.clienttest.ts
+++ b/web/src/components/trace/components/TraceTimeline/timeline-flattening.clienttest.ts
@@ -49,6 +49,39 @@ describe("flattenTreeWithTimelineMetrics", () => {
       expect(result[0]?.metrics.timeToFirstToken).toBeUndefined();
     });
 
+    it("is undefined when completionStartTime precedes startTime (clock drift)", () => {
+      const node = {
+        ...baseNode({ id: "n1", startTime: new Date("2024-01-01T00:00:02Z") }),
+        completionStartTime: new Date("2024-01-01T00:00:01Z"), // before start
+      };
+      const result = flattenTreeWithTimelineMetrics(
+        [node as unknown as TreeNode],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result[0]?.metrics.timeToFirstToken).toBeUndefined();
+      expect(result[0]?.metrics.firstTokenTimeOffset).toBeUndefined();
+    });
+
+    it("is undefined when completionStartTime equals startTime", () => {
+      const nodeStart = new Date("2024-01-01T00:00:02Z");
+      const node = {
+        ...baseNode({ id: "n1", startTime: nodeStart }),
+        completionStartTime: nodeStart,
+      };
+      const result = flattenTreeWithTimelineMetrics(
+        [node as unknown as TreeNode],
+        new Set(),
+        traceStart,
+        totalDuration,
+      );
+
+      expect(result[0]?.metrics.timeToFirstToken).toBeUndefined();
+      expect(result[0]?.metrics.firstTokenTimeOffset).toBeUndefined();
+    });
+
     it("computes TTFT in seconds from completionStartTime", () => {
       const node = {
         ...baseNode({ id: "n1" }),

--- a/web/src/components/trace/components/TraceTimeline/timeline-flattening.ts
+++ b/web/src/components/trace/components/TraceTimeline/timeline-flattening.ts
@@ -82,21 +82,30 @@ export function flattenTreeWithTimelineMetrics(
 
     // Handle first token time for streaming LLMs (completionStartTime)
     // This is stored on observations that have streaming responses
-    const firstTokenTimeOffset =
+    const completionStartTime =
       "completionStartTime" in currentNode &&
       currentNode.completionStartTime instanceof Date
-        ? calculateTimelineOffset(
-            currentNode.completionStartTime,
-            traceStartTime,
-            totalScaleSpan,
-            scaleWidth,
-          )
+        ? currentNode.completionStartTime
         : undefined;
+
+    const firstTokenTimeOffset = completionStartTime
+      ? calculateTimelineOffset(
+          completionStartTime,
+          traceStartTime,
+          totalScaleSpan,
+          scaleWidth,
+        )
+      : undefined;
+
+    const timeToFirstToken = completionStartTime
+      ? (completionStartTime.getTime() - currentNode.startTime.getTime()) / 1000
+      : undefined;
 
     const metrics: TimelineMetrics = {
       startOffset,
       itemWidth,
       firstTokenTimeOffset,
+      timeToFirstToken,
       latency,
     };
 

--- a/web/src/components/trace/components/TraceTimeline/timeline-flattening.ts
+++ b/web/src/components/trace/components/TraceTimeline/timeline-flattening.ts
@@ -80,11 +80,16 @@ export function flattenTreeWithTimelineMetrics(
       scaleWidth,
     );
 
-    // Handle first token time for streaming LLMs (completionStartTime)
-    // This is stored on observations that have streaming responses
+    // Handle first token time for streaming LLMs (completionStartTime).
+    // This is stored on observations that have streaming responses. Only treat
+    // it as a first-token split when it lands strictly after the node start;
+    // clock drift can make completionStartTime <= startTime, which would
+    // otherwise yield a negative time-to-first-token.
     const completionStartTime =
       "completionStartTime" in currentNode &&
-      currentNode.completionStartTime instanceof Date
+      currentNode.completionStartTime instanceof Date &&
+      currentNode.completionStartTime.getTime() >
+        currentNode.startTime.getTime()
         ? currentNode.completionStartTime
         : undefined;
 

--- a/web/src/components/trace/components/TraceTimeline/types.ts
+++ b/web/src/components/trace/components/TraceTimeline/types.ts
@@ -18,6 +18,8 @@ export interface TimelineMetrics {
   itemWidth: number;
   /** Offset for first token time marker (for streaming LLMs, in pixels) */
   firstTokenTimeOffset?: number;
+  /** Time to first token in seconds (for streaming LLMs) */
+  timeToFirstToken?: number;
   /** Duration in seconds */
   latency?: number;
 }

--- a/web/src/components/trace/lib/tree-building.clienttest.ts
+++ b/web/src/components/trace/lib/tree-building.clienttest.ts
@@ -266,6 +266,40 @@ describe("buildTraceUiData", () => {
     });
   });
 
+  describe("completionStartTime propagation (TTFT diamond marker)", () => {
+    it("carries completionStartTime from the observation onto the tree node", () => {
+      const trace = createMockTrace({ id: "trace-ttft" });
+      const completionStartTime = new Date("2024-01-01T00:00:00.300Z");
+      const observations: ObservationReturnType[] = [
+        createMockObservation({
+          id: "gen-streaming",
+          type: "GENERATION",
+          startTime: new Date("2024-01-01T00:00:00.000Z"),
+          endTime: new Date("2024-01-01T00:00:01.000Z"),
+          completionStartTime,
+        }),
+      ];
+
+      const result = buildTraceUiData(trace, observations);
+      const node = result.roots[0].children[0];
+
+      expect(node.id).toBe("gen-streaming");
+      expect(node.completionStartTime).toEqual(completionStartTime);
+    });
+
+    it("leaves completionStartTime null for non-streaming observations", () => {
+      const trace = createMockTrace({ id: "trace-no-ttft" });
+      const observations: ObservationReturnType[] = [
+        createMockObservation({ id: "span-1", completionStartTime: null }),
+      ];
+
+      const result = buildTraceUiData(trace, observations);
+      const node = result.roots[0].children[0];
+
+      expect(node.completionStartTime).toBeNull();
+    });
+  });
+
   describe("Events-based traces (multiple roots)", () => {
     it("returns single observation as root when rootObservationType is set", () => {
       const trace = createMockTrace({

--- a/web/src/components/trace/lib/tree-building.ts
+++ b/web/src/components/trace/lib/tree-building.ts
@@ -272,6 +272,7 @@ function buildTreeNodesBottomUp(
       name: obs.name ?? "",
       startTime: obs.startTime,
       endTime: obs.endTime,
+      completionStartTime: obs.completionStartTime,
       level: obs.level,
       children: childTreeNodes,
       inputUsage: obs.inputUsage,

--- a/web/src/components/trace/lib/types.ts
+++ b/web/src/components/trace/lib/types.ts
@@ -18,6 +18,8 @@ export type TreeNode = {
   name: string;
   startTime: Date;
   endTime?: Date | null;
+  /** First-token time for streaming generations; drives the timeline TTFT diamond marker */
+  completionStartTime?: Date | null;
   level?: string;
   children: TreeNode[];
   // Token usage


### PR DESCRIPTION
## What does this PR do?

## PR Title

feat(web): add TTFT diamond marker to trace timeline

## PR Description

Adds a diamond marker on trace-timeline generation bars at the first-token split
point, with a tooltip showing time-to-first-token (TTFT). This surfaces streaming
latency directly on the Gantt-style timeline, so users can see how long a streaming
LLM call took to produce its first token without leaving the timeline view.

**Changes**
- Compute `timeToFirstToken` / `firstTokenTimeOffset` during timeline flattening
- Render a diamond marker + "First token" split bar with a TTFT tooltip in `TimelineBar`
- Propagate `completionStartTime` from the observation onto the timeline `TreeNode`
  so the marker renders against real trace data

**Impacted packages:** `web` only · No new dependencies.

<!-- drag ttft-diamond-tooltip.png below this line to attach the screenshot -->
<img width="1200" height="1279" alt="ttft-diamond-tooltip" src="https://github.com/user-attachments/assets/d50a5599-5d87-4dae-9d65-11a6884f90a6" />


Fixes #3517

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] My changes generate no new warnings (`pnpm run lint`, `--max-warnings 0`)
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally (full web client suite: 1229 passed)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces TTFT (time-to-first-token) on the Gantt-style trace timeline by placing a diamond marker at the `completionStartTime` split point, with a tooltip showing the TTFT value in seconds.

- Propagates `completionStartTime` from the observation through `tree-building.ts` onto `TreeNode`, then pre-computes `timeToFirstToken` and `firstTokenTimeOffset` during timeline flattening for O(1) access at render time.
- Renders a `rotate-45` diamond inside a Radix `Tooltip` at the first-token split point within the existing split-bar path in `TimelineBar`; the `TooltipProvider` is already present at the app root so no new provider is needed.
- Adds comprehensive client-side unit tests for the new TTFT fields and diamond rendering, including sub-second precision and regression coverage for pre-existing flattening behavior.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change is mostly safe, but the TTFT computation has no guard against completionStartTime arriving before node.startTime, which would display a negative time-to-first-token and position the diamond outside the bar boundary.

The core propagation and rendering logic is sound for well-formed data. However, timeToFirstToken is computed as a raw arithmetic difference with no validation, so any observation where completionStartTime < startTime (e.g., due to clock drift in user-instrumented SDKs) produces a negative TTFT shown directly in the UI. The diamond also gets positioned at a negative left value within the bar container, pushing it out of bounds visually.

timeline-flattening.ts — the timeToFirstToken calculation should guard against a negative result before setting the field, and the matching render guard in TimelineBar.tsx should be tightened to timeToFirstToken > 0.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant OBS as Observation (API)
    participant TB as tree-building.ts
    participant TN as TreeNode
    participant TF as timeline-flattening.ts
    participant TM as TimelineMetrics
    participant Bar as TimelineBar

    OBS->>TB: completionStartTime
    TB->>TN: completionStartTime propagated
    TN->>TF: flattenTreeWithTimelineMetrics()
    TF->>TF: Compute firstTokenTimeOffset (px from trace start)
    TF->>TF: Compute timeToFirstToken (s from node start)
    TF->>TM: "{ firstTokenTimeOffset, timeToFirstToken }"
    TM->>Bar: metrics prop
    Bar->>Bar: if(firstTokenTimeOffset) → split-bar path
    Bar->>Bar: isPresent(timeToFirstToken) → diamond + Tooltip
    Bar-->>User: Diamond marker + 'Time to first token: Xs' tooltip
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/trace/components/TraceTimeline/timeline-flattening.ts:100-102
**Negative `timeToFirstToken` renders invalid tooltip**

`timeToFirstToken` is computed as `(completionStartTime - startTime) / 1000`. If a user-supplied `completionStartTime` precedes `startTime` due to clock skew or bad ingestion data, this produces a negative value. The diamond marker still renders (since `isPresent` accepts any non-null value), and the tooltip reads "Time to first token: -1.23s". The same arithmetic makes `firstTokenWidth = firstTokenTimeOffset - startOffset < 0` in `TimelineBar`, which positions the diamond to the left of the bar container's edge. Adding a guard like `timeToFirstToken > 0` before setting the field, and mirroring it in the render condition, would prevent the glitched display.

### Issue 2 of 2
web/src/components/trace/components/TraceTimeline/TimelineBar.tsx:76-77
The diamond is gated by `isPresent(timeToFirstToken)` while the entire split-bar branch is entered via `if (firstTokenTimeOffset)`. These two are derived from the same `completionStartTime`, so they should agree — but using `isPresent` (which accepts `0`) on `timeToFirstToken` while using a falsy check on `firstTokenTimeOffset` (which rejects `0`) creates a subtle asymmetry. A TTFT of 0 would render the diamond showing "Time to first token: 0.00s", which looks confusing. Using the same guard (`timeToFirstToken && timeToFirstToken > 0`) for both makes the conditions consistent and prevents the zero-TTFT edge case from displaying.

```suggestion
          {/* Diamond marker at the first-token split point with TTFT tooltip */}
          {timeToFirstToken && timeToFirstToken > 0 && (
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/ttft-diamo..."](https://github.com/langfuse/langfuse/commit/4f189c32b33b805f5dd8625f920b81ecd2465479) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36055650)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->