### PR TITLE
fix(security): enforce data-retention entitlement server-side in setRetention

### DIFF
--- a/web/src/__tests__/server/projectsRouter-setRetention.servertest.ts
+++ b/web/src/__tests__/server/projectsRouter-setRetention.servertest.ts
@@ -1,0 +1,133 @@
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { prisma } from "@langfuse/shared/src/db";
+import { type Plan, Role } from "@langfuse/shared";
+import type { Session } from "next-auth";
+import { v4 as uuidv4 } from "uuid";
+
+async function createOrgAndProject() {
+  const orgId = uuidv4();
+  const userId = uuidv4();
+  const projectId = uuidv4();
+
+  await prisma.organization.create({
+    data: { id: orgId, name: `Retention Org ${orgId.slice(0, 8)}` },
+  });
+  await prisma.project.create({
+    data: {
+      id: projectId,
+      name: `Retention Project ${projectId.slice(0, 8)}`,
+      orgId,
+    },
+  });
+  const user = await prisma.user.create({
+    data: {
+      id: userId,
+      email: `retention-${userId.slice(0, 8)}@test.com`,
+      name: "Test User",
+    },
+  });
+  await prisma.organizationMembership.create({
+    data: { userId: user.id, orgId, role: Role.OWNER },
+  });
+
+  return { orgId, projectId, user };
+}
+
+function makeCaller({
+  userId,
+  orgId,
+  projectId,
+  plan,
+  role = Role.OWNER,
+}: {
+  userId: string;
+  orgId: string;
+  projectId: string;
+  plan: Plan;
+  role?: Role;
+}) {
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: userId,
+      canCreateOrganizations: true,
+      name: "Test User",
+      email: "retention@test.com",
+      organizations: [
+        {
+          id: orgId,
+          name: "Test Organization",
+          role,
+          plan,
+          cloudConfig: undefined,
+          metadata: {},
+          aiFeaturesEnabled: false,
+          aiTelemetryEnabled: true,
+          projects: [
+            {
+              id: projectId,
+              role,
+              retentionDays: 0,
+              deletedAt: null,
+              name: "Test Project",
+              metadata: {},
+            },
+          ],
+        },
+      ],
+      featureFlags: {
+        excludeClickhouseRead: false,
+        templateFlag: true,
+        v4BetaToggleVisible: false,
+        observationEvals: false,
+        experimentsV4Enabled: false,
+      },
+      admin: false,
+    },
+    environment: {} as any,
+  };
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+  return appRouter.createCaller({ ...ctx, prisma });
+}
+
+describe("projectsRouter.setRetention entitlement enforcement", () => {
+  it("rejects when the project's plan lacks the data-retention entitlement", async () => {
+    const { orgId, projectId, user } = await createOrgAndProject();
+    const caller = makeCaller({
+      userId: user.id,
+      orgId,
+      projectId,
+      plan: "cloud:hobby", // no data-retention entitlement
+    });
+
+    await expect(
+      caller.projects.setRetention({ projectId, retention: 3 }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    // The destructive retention setting must not have been persisted.
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+    });
+    expect(project?.retentionDays).toBeNull();
+  });
+
+  it("allows setting retention when the plan has the data-retention entitlement", async () => {
+    const { orgId, projectId, user } = await createOrgAndProject();
+    const caller = makeCaller({
+      userId: user.id,
+      orgId,
+      projectId,
+      plan: "cloud:pro", // has data-retention entitlement
+    });
+
+    await expect(
+      caller.projects.setRetention({ projectId, retention: 5 }),
+    ).resolves.toBe(true);
+
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+    });
+    expect(project?.retentionDays).toBe(5);
+  });
+});

--- a/web/src/features/projects/server/projectsRouter.ts
+++ b/web/src/features/projects/server/projectsRouter.ts
@@ -5,6 +5,7 @@ import {
 } from "@/src/server/api/trpc";
 import * as z from "zod";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
+import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 import { TRPCError } from "@trpc/server";
 import { projectNameSchema } from "@/src/features/auth/lib/projectNameSchema";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
@@ -135,6 +136,11 @@ export const projectsRouter = createTRPCRouter({
         session: ctx.session,
         projectId: input.projectId,
         scope: "project:update",
+      });
+      throwIfNoEntitlement({
+        entitlement: "data-retention",
+        sessionUser: ctx.session.user,
+        projectId: input.projectId,
       });
 
       const project = await ctx.prisma.project.update({

--- a/web/src/features/projects/server/projectsRouter.ts
+++ b/web/src/features/projects/server/projectsRouter.ts
@@ -137,11 +137,13 @@ export const projectsRouter = createTRPCRouter({
         projectId: input.projectId,
         scope: "project:update",
       });
-      throwIfNoEntitlement({
-        entitlement: "data-retention",
-        sessionUser: ctx.session.user,
-        projectId: input.projectId,
-      });
+      if (input.retention !== null && input.retention > 0) {
+        throwIfNoEntitlement({
+          entitlement: "data-retention",
+          sessionUser: ctx.session.user,
+          projectId: input.projectId,
+        });
+      }
 
       const project = await ctx.prisma.project.update({
         where: {


### PR DESCRIPTION
The data-retention entitlement was only enforced in the UI (ConfigureRetention.tsx disables the input client-side). The backing projects.setRetention tRPC mutation validated project membership and the project:update RBAC scope but not the plan entitlement, so a project OWNER/ADMIN on a plan without data-retention could call the mutation directly and set a destructive retentionDays, triggering the worker deletion scheduler despite the feature not being available for the plan.

Add a server-side throwIfNoEntitlement check scoped to the project, after the existing RBAC check, matching the pattern used in other routers. Keep the UI check as presentation only. Add a server-side regression test covering both the non-entitled (FORBIDDEN, not persisted) and entitled (succeeds) plans.

Fixes LFE-10054

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a server-side security gap where the `data-retention` entitlement was only enforced client-side in `ConfigureRetention.tsx`; a privileged user could call the `projects.setRetention` tRPC mutation directly and activate destructive data deletion on any plan. A `throwIfNoEntitlement` guard is added after the existing RBAC check and a new server-integration test covers the forbidden and allowed plan scenarios.

- **`projectsRouter.ts`**: Adds `throwIfNoEntitlement({ entitlement: "data-retention", … })` immediately after `throwIfNoProjectAccess` in the `setRetention` mutation, matching the pattern used in other routers.
- **`projectsRouter-setRetention.servertest.ts`**: New integration test that seeds a real org/project/user in the DB, constructs a typed session with the relevant plan, and asserts FORBIDDEN for `cloud:hobby` and success for `cloud:pro`.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core entitlement guard is correctly placed and uses the established pattern, but it unconditionally blocks `retention: null`, the only path for downgraded users to stop data deletion — leaving them with no recovery route until an admin intervenes.

The unconditional entitlement check catches the primary threat (setting a positive retention value without a qualifying plan), but it also blocks the `null` / clear-retention call. A user who set a 30-day retention window on the pro plan and later downgrades to hobby has the deletion worker actively purging their data with no self-service way to cancel it. That is a present logic defect on the changed code path, not a hypothetical. The test suite also has no coverage for the null case, so the behaviour (intentional or not) is unverified.

The `setRetention` mutation in `projectsRouter.ts` needs a condition to allow `retention: null` through regardless of entitlement. The new test file should add a case exercising the null path.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant tRPC as tRPC setRetention
    participant RBAC as throwIfNoProjectAccess
    participant Ent as throwIfNoEntitlement
    participant DB as Prisma / Postgres
    participant Audit as auditLog

    Client->>tRPC: "setRetention({ projectId, retention })"
    tRPC->>RBAC: check project:update scope
    alt RBAC fails
        RBAC-->>Client: FORBIDDEN (RBAC)
    end
    RBAC-->>tRPC: ok
    tRPC->>Ent: check data-retention entitlement (via session plan)
    alt No entitlement
        Ent-->>Client: FORBIDDEN (entitlement)
    end
    Ent-->>tRPC: ok
    tRPC->>DB: "project.update({ retentionDays: retention })"
    DB-->>tRPC: updated project
    tRPC->>Audit: log project update
    tRPC-->>Client: true
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/projects/server/projectsRouter.ts:140-144
**Entitlement check blocks safe `null` (clear-retention) calls**

The schema accepts `retention: null` to remove the data-retention schedule, which is a safe/recovery operation — it stops the deletion worker from running. Placing `throwIfNoEntitlement` unconditionally before the DB update means a user who set retention while on `cloud:pro` and later downgrades to `cloud:hobby` can never clear that value. Until an admin intervenes, the deletion worker will keep running for their data with no UI or API path to stop it. The entitlement guard should only fire when `input.retention` is a positive number; a `null` value should be permitted on any plan.

### Issue 2 of 2
web/src/__tests__/server/projectsRouter-setRetention.servertest.ts:94-133
**No test coverage for `retention: null` on non-entitled plans**

The test suite verifies setting a positive value is blocked and allowed, but never exercises `retention: null` (the clear/disable path). If the entitlement guard is intentionally narrowed to allow `null` on any plan (see the logic comment above), a regression test proving that path works would prevent the fix from being reverted unintentionally. If the guard is intended to block `null` as well, a test asserting that behavior would make the intent explicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): enforce data-retention en..."](https://github.com/langfuse/langfuse/commit/4723b4d962f6d96eb3712b9a838af632d7c93e27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36074005)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->