### PR TITLE
fix(web): Margins on project overview

### DIFF
--- a/web/src/components/ui/callout.tsx
+++ b/web/src/components/ui/callout.tsx
@@ -20,6 +20,7 @@ export interface CalloutProps {
   children: React.ReactNode;
   onDismiss?: () => void;
   actions?: () => React.ReactNode;
+  className?: string;
 }
 
 export function Callout({
@@ -30,6 +31,7 @@ export function Callout({
   children,
   onDismiss,
   actions,
+  className,
 }: CalloutProps) {
   const [dismissedCallouts, setDismissedCallouts] = useLocalStorage<Callout[]>(
     id + "-" + DEFAULT_STORAGE_KEY,
@@ -87,7 +89,9 @@ export function Callout({
       : "";
 
   return (
-    <Alert className={`${variantClass} ${alignmentOverrides}`}>
+    <Alert
+      className={`${variantClass} ${alignmentOverrides} ${className ?? ""}`}
+    >
       <AlertDescription
         className={`flex ${alignmentClass} ml-1 justify-between`}
       >

--- a/web/src/features/developer-tools/components/AgentToolsBanner.tsx
+++ b/web/src/features/developer-tools/components/AgentToolsBanner.tsx
@@ -14,6 +14,7 @@ const DOCS_HREF =
 export function AgentToolsBanner() {
   return (
     <Callout
+      className="mb-4"
       id="agent-tools-banner:v1"
       variant="info"
       align="middle"

--- a/web/src/features/organizations/components/ProjectOverview.tsx
+++ b/web/src/features/organizations/components/ProjectOverview.tsx
@@ -223,7 +223,7 @@ const SingleOrganizationProjectOverviewTile = ({
   }
 
   return (
-    <div key={orgId} className="mb-10">
+    <div key={orgId}>
       <Header
         title={org.name}
         className="truncate"
@@ -310,30 +310,31 @@ export const OrganizationProjectOverview = () => {
         ),
       }}
     >
-      <div className="mb-4">
-        <AgentToolsBanner />
-      </div>
+      <AgentToolsBanner />
       {showOnboarding && <Onboarding />}
       {organizations
-        .sort((a, b) => {
-          // sort demo org to the bottom
-          const isDemoA = env.NEXT_PUBLIC_DEMO_ORG_ID === a.id;
-          const isDemoB = env.NEXT_PUBLIC_DEMO_ORG_ID === b.id;
+        .map((org) => {
+          const isDemo = env.NEXT_PUBLIC_DEMO_ORG_ID === org.id;
+          return [org, isDemo] as const;
+        })
+        .sort(([, isDemoA], [, isDemoB]) => {
           if (isDemoA) return 1;
           if (isDemoB) return -1;
           return 0;
         })
-        .map((org) => (
-          <Fragment key={org.id}>
-            {!queryOrgId && org.id === env.NEXT_PUBLIC_DEMO_ORG_ID && (
-              <Separator className="my-4" />
-            )}
-            <SingleOrganizationProjectOverviewTile
-              orgId={org.id}
-              search={search ?? undefined}
-            />
-          </Fragment>
-        ))}
+        .map(([org, isDemo], index) => {
+          return (
+            <Fragment key={org.id}>
+              {!queryOrgId && isDemo && <Separator className="my-8" />}
+              <div key={org.id} className={index > 0 && !isDemo ? "mt-8" : ""}>
+                <SingleOrganizationProjectOverviewTile
+                  orgId={org.id}
+                  search={search ?? undefined}
+                />
+              </div>
+            </Fragment>
+          );
+        })}
     </ContainerPage>
   );
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the spacing and layout on the project overview page, moving `mb-4` from a wrapper div into `AgentToolsBanner` and reworking the organization list to use a pre-computed `isDemo` flag for sorting and conditional spacing.

- `AgentToolsBanner.tsx`: adds `mb-4` to the inner content div inside the `Callout`, but this puts the margin inside the `Alert` rather than below it, removing the visual gap between the banner and the next section.
- `ProjectOverview.tsx`: org list now computes `isDemo` before sorting (cleaner), uses `mt-8` for spacing between non-demo orgs and a `Separator` before the demo org, but includes an accidental `console.log` that leaks org data on every render.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Two issues block a clean merge: a debug console.log that exposes org data in the browser console on every render, and a misplaced mb-4 that adds extra padding inside the callout instead of spacing below it.

The console.log statement on line 326 leaks org objects to the browser console for every user visiting the overview page. The mb-4 moved to the inner div of AgentToolsBanner fails to reproduce the original below-banner spacing, leaving the banner and the next section flush with each other.

Both changed files need attention: ProjectOverview.tsx for the console.log, and AgentToolsBanner.tsx for the mb-4 placement.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/features/organizations/components/ProjectOverview.tsx:325-327
Debug `console.log` left in production code. This fires on every render of the overview page, logging full org objects and the `isDemo` flag to the browser console for every user.

```suggestion
        .map(([org, isDemo], index) => {
          return (
```

### Issue 2 of 3
web/src/features/developer-tools/components/AgentToolsBanner.tsx:28
`mb-4` is applied to the inner content `div` *inside* the `Callout`/`Alert`, not on the outermost element. The `Alert` will get extra height with blank space at the bottom, but there will be no margin between the banner and whatever follows it (the onboarding card or the organizations list). The spacing below the callout that the old wrapper `<div className="mb-4">` provided is now gone. The `mb-4` should instead be on the `Callout` itself.

```suggestion
      <div className="flex items-center gap-2">
```

### Issue 3 of 3
web/src/features/organizations/components/ProjectOverview.tsx:313-314
Since the `Callout` component does not accept a `className` prop, the below-banner spacing needs to be restored in the parent. Adding a wrapping div with `mb-4` here (matching the original pattern) keeps the gap between the banner and the organizations/onboarding section.

```suggestion
      <div className="mb-4">
        <AgentToolsBanner />
      </div>
      {showOnboarding && <Onboarding />}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): Margins on project overview"](https://github.com/langfuse/langfuse/commit/5e8a43de3f64d41fbae9bea01694c960fc86730d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36161101)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->