### PR TITLE
feat(traces): Add trace delete button to events table

### DIFF
--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -580,7 +580,7 @@ export default function ObservationsEventsTable({
             type: BatchActionType.Delete,
             label: "Delete Traces",
             description:
-              "This permanently deletes the traces related to the selected observations and cannot be undone. All observations in those traces will be deleted, not only the selected observations. Trace deletion happens asynchronously and may take up to 24 hours.",
+              "This permanently deletes all observations within this trace(s), as well as the trace(s), even if you only have single observations selected. This action cannot be undone. Trace deletion happens asynchronously and may take up to 24 hours.",
             disabled: selectAll || selectedTraceIds.length === 0,
             disabledReason: selectAll
               ? "Delete traces is only available for observations selected on the current page."

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -99,6 +99,8 @@ import useSessionStorage from "@/src/components/useSessionStorage";
 import { api } from "@/src/utils/api";
 import { RunEvaluationDialog } from "@/src/features/batch-actions/components/RunEvaluationDialog/index";
 import { AddObservationsToDatasetDialog } from "@/src/features/batch-actions/components/AddObservationsToDatasetDialog/index";
+import { useHasEntitlement } from "@/src/features/entitlements/hooks";
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 
 export type EventsTableRow = {
   // Identity fields
@@ -516,6 +518,8 @@ export default function ObservationsEventsTable({
       defaultHidden: true,
     });
 
+  const hasTraceDeletionEntitlement = useHasEntitlement("trace-deletion");
+
   const { selectActionColumn } = TableSelectionManager<EventsTableRow>({
     projectId,
     tableName: "observations",
@@ -523,7 +527,72 @@ export default function ObservationsEventsTable({
     setSelectAll,
   });
 
+  const traceDeleteMutation = api.traces.deleteMany.useMutation({
+    onSuccess: () => {
+      showSuccessToast({
+        title: "Traces deleted",
+        description:
+          "Selected traces will be deleted. Traces are removed asynchronously and may continue to be visible for up to 15 minutes.",
+      });
+    },
+    onSettled: () => {
+      utils.events.all.invalidate();
+      utils.events.countAll.invalidate();
+      utils.traces.all.invalidate();
+    },
+  });
+
+  const selectedTraceIds = useMemo(() => {
+    const visibleObservationsById = new Map(
+      (observations.rows ?? []).map((observation) => [
+        observation.id,
+        observation,
+      ]),
+    );
+    return [
+      ...new Set(
+        Object.keys(selectedRows)
+          .map(
+            (observationId) =>
+              visibleObservationsById.get(observationId)?.traceId,
+          )
+          .filter((traceId): traceId is string => Boolean(traceId)),
+      ),
+    ];
+  }, [observations.rows, selectedRows]);
+
+  const handleDeleteTraces = async ({ projectId }: { projectId: string }) => {
+    if (selectedTraceIds.length === 0) return;
+
+    await traceDeleteMutation.mutateAsync({
+      projectId,
+      traceIds: selectedTraceIds,
+      isBatchAction: false,
+    });
+    setSelectedRows({});
+  };
+
   const tableActions: TableAction[] = [
+    ...(hasTraceDeletionEntitlement
+      ? [
+          {
+            id: ActionId.TraceDelete,
+            type: BatchActionType.Delete,
+            label: "Delete Traces",
+            description:
+              "This permanently deletes the traces related to the selected observations and cannot be undone. All observations in those traces will be deleted, not only the selected observations. Trace deletion happens asynchronously and may take up to 24 hours.",
+            disabled: selectAll || selectedTraceIds.length === 0,
+            disabledReason: selectAll
+              ? "Delete traces is only available for observations selected on the current page."
+              : "Selected observations are missing trace IDs.",
+            accessCheck: {
+              scope: "traces:delete",
+              entitlement: "trace-deletion",
+            },
+            execute: handleDeleteTraces,
+          } as TableAction,
+        ]
+      : []),
     {
       id: ActionId.ObservationAddToAnnotationQueue,
       type: BatchActionType.Create,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Delete Traces" batch action to the events (observations) table, mirroring the same capability that already exists in the traces table. It gates the action behind the `trace-deletion` entitlement and disables it when `selectAll` is active since deletion is limited to traces visible on the current page.

- Adds a `useMemo`-derived `selectedTraceIds` that maps selected observation rows to their parent trace IDs using the current page's data, deduplicating via `Set`.
- Introduces a `traceDeleteMutation` and `handleDeleteTraces` handler modelled closely on the existing `traces.tsx` pattern, with `onSettled` cache invalidation for both events and traces queries.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is additive and closely mirrors the existing delete-traces pattern from the traces table, with no impact on unrelated features.

The implementation faithfully replicates the established pattern from traces.tsx: same mutation shape, same success toast, same onSettled invalidation, and the same entitlement gate. The one small gap is a misleading disabled-reason message shown when no observations are selected at all.

web/src/features/events/components/EventsTable.tsx — specifically the disabledReason ternary around line 585.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant EventsTable
    participant TableActionMenu
    participant traceDeleteMutation
    participant Server

    User->>EventsTable: Selects observation rows
    EventsTable->>EventsTable: useMemo derives selectedTraceIds from observations.rows + selectedRows
    User->>TableActionMenu: Clicks "Delete Traces"
    TableActionMenu->>EventsTable: "execute({ projectId })"
    EventsTable->>EventsTable: "if selectedTraceIds.length === 0, return early"
    EventsTable->>traceDeleteMutation: "mutateAsync({ projectId, traceIds, isBatchAction: false })"
    traceDeleteMutation->>Server: api.traces.deleteMany
    Server-->>traceDeleteMutation: success/error
    traceDeleteMutation->>EventsTable: onSuccess → showSuccessToast
    traceDeleteMutation->>EventsTable: onSettled → invalidate events + traces queries
    EventsTable->>EventsTable: "setSelectedRows({})"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/events/components/EventsTable.tsx:584-587
The `disabledReason` for the non-`selectAll` branch is shown whenever `selectedTraceIds.length === 0`, which includes the common case where no rows are selected at all — not just the edge case where selected observations genuinely lack trace IDs. A user with no rows selected would see "Selected observations are missing trace IDs" which is misleading.

```suggestion
            disabled: selectAll || selectedTraceIds.length === 0,
            disabledReason: selectAll
              ? "Delete traces is only available for observations selected on the current page."
              : Object.keys(selectedRows).length === 0
                ? "No observations selected."
                : "Selected observations are missing trace IDs.",
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(traces): Add trace delete button to..."](https://github.com/langfuse/langfuse/commit/f0a5b343d1134d01df184b51cbfe240a142f0d62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36163789)</sub>

<!-- /greptile_comment -->