### PR TITLE
docs(agents): document versioned API type location convention

### DIFF
--- a/.agents/skills/backend-dev-guidelines/references/routing-and-controllers.md
+++ b/.agents/skills/backend-dev-guidelines/references/routing-and-controllers.md
@@ -362,6 +362,30 @@ export default withMiddlewares({
 - Input/output validated with Zod schemas
 - Delegate to services for business logic
 
+### Versioned API Type Location
+
+When a feature has versioned public API types, place them in `packages/shared/`
+under the feature's `interfaces/api/` folder, one subdirectory per version:
+
+```
+packages/shared/src/features/<domain>/interfaces/api/
+├── v1/
+│   ├── schemas.ts     # Zod schemas for request/response shapes
+│   ├── endpoints.ts   # Composed request/response types
+│   └── validation.ts  # Cross-field validation helpers
+├── v2/
+│   └── ...
+└── vN/
+    └── ...
+```
+
+The scores feature (`packages/shared/src/features/scores/interfaces/api/`) is
+the canonical example. The `GetScoresQueryV1` / `GetScoresResponseV1` symbols
+imported from `@langfuse/shared` in the example below originate there.
+
+Do not create a flat file (e.g. `<domain>-api-v2.ts`) and do not place
+versioned types in `web/src/features/public-api/types/`.
+
 ### Fern API Definitions
 
 When modifying public API types in `web/src/features/public-api/types/`, update

--- a/.agents/skills/backend-dev-guidelines/references/routing-and-controllers.md
+++ b/.agents/skills/backend-dev-guidelines/references/routing-and-controllers.md
@@ -365,7 +365,13 @@ export default withMiddlewares({
 ### Versioned API Type Location
 
 When a feature has versioned public API types, place them in `packages/shared/`
-under the feature's `interfaces/api/` folder, one subdirectory per version:
+under the feature's `interfaces/api/` folder, one subdirectory per version.
+The scores feature (`packages/shared/src/features/scores/interfaces/api/`) is
+the canonical example — the `GetScoresQueryV1` / `GetScoresResponseV1` symbols
+imported from `@langfuse/shared` originate there.
+
+Do not create a flat file (e.g. `<domain>-api-v2.ts`) and do not place
+versioned types in `web/src/features/public-api/types/`.
 
 ```
 packages/shared/src/features/<domain>/interfaces/api/
@@ -378,13 +384,6 @@ packages/shared/src/features/<domain>/interfaces/api/
 └── vN/
     └── ...
 ```
-
-The scores feature (`packages/shared/src/features/scores/interfaces/api/`) is
-the canonical example. The `GetScoresQueryV1` / `GetScoresResponseV1` symbols
-imported from `@langfuse/shared` in the example below originate there.
-
-Do not create a flat file (e.g. `<domain>-api-v2.ts`) and do not place
-versioned types in `web/src/features/public-api/types/`.
 
 ### Fern API Definitions
 

--- a/.agents/skills/backend-dev-guidelines/references/routing-and-controllers.md
+++ b/.agents/skills/backend-dev-guidelines/references/routing-and-controllers.md
@@ -387,8 +387,9 @@ packages/shared/src/features/<domain>/interfaces/api/
 
 ### Fern API Definitions
 
-When modifying public API types in `web/src/features/public-api/types/`, update
-the matching Fern API definitions in `fern/apis/server/definition/`.
+When modifying public API types in `web/src/features/public-api/types/` or under
+`packages/shared/src/features/<domain>/interfaces/api/`, update the matching
+Fern API definitions in `fern/apis/server/definition/`.
 
 **Zod to Fern Type Mapping:**
 


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "Versioned API Type Location" subsection to the backend dev guidelines, documenting the convention for placing versioned public API types under `packages/shared/src/features/<domain>/interfaces/api/v{N}/`. The described directory structure and canonical example (the `scores` feature) accurately match the current repository layout.

- Adds directory-tree illustration and three recommended files per version (`schemas.ts`, `endpoints.ts`, `validation.ts`), matching what already exists for `scores` v1–v3.
- Documents two anti-patterns to avoid: flat versioned files and placing types in `web/src/features/public-api/types/`.
- One minor cross-reference error: the text says "example below" but the cited code block appears above the new section.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change that accurately describes an existing pattern already used across the scores feature. Safe to merge.

The added section correctly reflects the actual directory structure in the repo (verified against packages/shared/src/features/scores/interfaces/api/). The only issue is a minor directional error in a cross-reference ('below' vs 'above') that does not affect the correctness of the convention being documented.

The single changed file .agents/skills/backend-dev-guidelines/references/routing-and-controllers.md contains a misdirected cross-reference on line 384 worth a quick fix before merge.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New versioned API feature] --> B{Where to place types?}
    B -->|Correct| C["packages/shared/src/features/domain/interfaces/api/vN/"]
    C --> D["schemas.ts — Zod request/response shapes"]
    C --> E["endpoints.ts — Composed types"]
    C --> F["validation.ts — Cross-field helpers"]
    B -->|Anti-pattern 1| G["❌ Flat file: domain-api-v2.ts"]
    B -->|Anti-pattern 2| H["❌ web/src/features/public-api/types/"]
    C --> I["Export via @langfuse/shared"]
    I --> J["Consumed by web/src/pages/api/public/..."]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.agents/skills/backend-dev-guidelines/references/routing-and-controllers.md:383-385
**Stale cross-reference direction**

The text says "in the example below", but the code block that uses `GetScoresQueryV1` / `GetScoresResponseV1` (imported from `@langfuse/shared`) lives in the **REST API Pattern** section immediately *above* this new section, not below it. Readers following the pointer downward will find nothing.

Change "example below" → "example above".

```suggestion
The scores feature (`packages/shared/src/features/scores/interfaces/api/`) is
the canonical example. The `GetScoresQueryV1` / `GetScoresResponseV1` symbols
imported from `@langfuse/shared` in the example above originate there.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): document versioned API typ..."](https://github.com/langfuse/langfuse/commit/f0ff59bd10074b5d86f5c84106a1972c53f99d87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36165686)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->