### PR TITLE
feat(agent): Show tool calls in the UI

### DIFF
--- a/web/src/features/in-app-agent/components/ControlledInAppAgentDrawer.tsx
+++ b/web/src/features/in-app-agent/components/ControlledInAppAgentDrawer.tsx
@@ -6,8 +6,12 @@ import {
   InAppAgentDrawer,
   type InAppAgentDrawerMessage,
 } from "./InAppAgentDrawer";
+import type { InAppAgentToolCallContent } from "./InAppAgentMessage";
 import { useInAppAiAgent } from "./InAppAiAgentProvider";
-import { AgUiMessageSchema } from "@/src/features/in-app-agent/schema";
+import {
+  AgUiMessageSchema,
+  type AgUiMessage,
+} from "@/src/features/in-app-agent/schema";
 
 type ControlledInAppAgentDrawerProps =
   | {
@@ -41,87 +45,160 @@ export function ControlledInAppAgentDrawer(
 
   const drawerMessages = useMemo(() => {
     const parsedMessages = z.array(AgUiMessageSchema).parse(messages);
+    const toolResults = getToolResultsByToolCallId(parsedMessages);
 
-    const mappedMessages = parsedMessages.flatMap(
-      (message, index): InAppAgentDrawerMessage[] => {
-        if (
-          message.role === "system" ||
-          message.role === "developer" ||
-          message.role === "tool" ||
-          message.role === "activity"
-        ) {
-          return [];
+    const mappedMessages: InAppAgentDrawerMessage[] = [];
+    let pendingTools: InAppAgentToolCallContent[] = [];
+    let pendingToolGroupId: string | null = null;
+    const flushPendingTools = () => {
+      if (pendingTools.length === 0) {
+        return;
+      }
+
+      mappedMessages.push({
+        id: pendingToolGroupId ?? "tools-pending",
+        role: "assistant",
+        content: { type: "toolGroup", tools: pendingTools },
+      });
+      pendingTools = [];
+      pendingToolGroupId = null;
+    };
+
+    parsedMessages.forEach((message, index) => {
+      if (
+        message.role === "system" ||
+        message.role === "developer" ||
+        message.role === "tool" ||
+        message.role === "activity"
+      ) {
+        return;
+      }
+
+      const role = message.role === "user" ? "user" : "assistant";
+      const isLoading = message.role === "reasoning";
+
+      if (isLoading) {
+        flushPendingTools();
+
+        const hasLaterAssistantMessage = parsedMessages.some(
+          (message, messageIndex) =>
+            messageIndex > index && message.role === "assistant",
+        );
+
+        if (!isRunning || hasLaterAssistantMessage) {
+          return;
         }
 
-        const role = message.role === "user" ? "user" : "assistant";
-        const isLoading = message.role === "reasoning";
+        mappedMessages.push({
+          id: message.id,
+          role,
+          content: { type: "loading" },
+        });
+        return;
+      }
 
-        if (isLoading) {
-          const hasLaterAssistantMessage = parsedMessages.some(
-            (message, messageIndex) =>
-              messageIndex > index && message.role === "assistant",
-          );
-
-          if (!isRunning || hasLaterAssistantMessage) {
-            return [];
-          }
-
-          return [
-            {
-              id: message.id,
-              role,
-              content: [{ type: "loading" }],
-            },
-          ];
-        }
-
-        const text =
-          typeof message.content === "string"
+      const text =
+        typeof message.content === "string"
+          ? message.content
+          : Array.isArray(message.content)
             ? message.content
-            : Array.isArray(message.content)
-              ? message.content
-                  .flatMap((part) => (part.type === "text" ? [part.text] : []))
-                  .join("")
-              : "";
+                .flatMap((part) => (part.type === "text" ? [part.text] : []))
+                .join("")
+            : "";
 
-        if (role === "assistant" && !text.trim()) {
-          return [];
-        }
+      const toolContent =
+        message.role === "assistant"
+          ? (message.toolCalls?.map((toolCall): InAppAgentToolCallContent => {
+              const result = toolResults.get(toolCall.id);
 
-        return [
-          {
-            id: message.id,
-            role,
-            content: [
-              {
-                type: "text",
-                text,
-              },
-            ],
+              return {
+                type: "tool",
+                name: toolCall.function.name,
+                args: toolCall.function.arguments,
+                ...(result?.content !== undefined
+                  ? { result: result.content }
+                  : {}),
+                ...(result?.error !== undefined ? { error: result.error } : {}),
+              };
+            }) ?? [])
+          : [];
+
+      if (role === "assistant" && toolContent.length > 0 && !text.trim()) {
+        pendingToolGroupId ??= `tools-${message.id}`;
+        pendingTools.push(...toolContent);
+        return;
+      }
+
+      flushPendingTools();
+
+      if (role === "assistant" && !text.trim() && toolContent.length === 0) {
+        return;
+      }
+
+      if (text.trim() || role === "user") {
+        mappedMessages.push({
+          id: message.id,
+          role,
+          content: {
+            type: "text",
+            text,
           },
-        ];
-      },
-    );
+        });
+      }
 
-    const lastMessage = mappedMessages.at(-1);
-    const hasAssistantAnswer = mappedMessages.some(
-      (message) =>
-        message.role === "assistant" &&
-        message.content.some((content) => content.type === "text"),
+      if (toolContent.length > 0) {
+        mappedMessages.push({
+          id: `${message.id}-tools`,
+          role,
+          content: { type: "toolGroup", tools: toolContent },
+        });
+      }
+    });
+
+    flushPendingTools();
+
+    const latestUserMessageIndex = mappedMessages.findLastIndex(
+      (message) => message.role === "user",
     );
+    const latestAssistantMessageIndex = mappedMessages.findLastIndex(
+      (message, index) =>
+        index > latestUserMessageIndex && message.role === "assistant",
+    );
+    const latestAssistantMessage = mappedMessages[latestAssistantMessageIndex];
 
     // Insert an optimistic loading message
-    if (isRunning && !error && lastMessage?.role === "user") {
+    if (
+      isRunning &&
+      !error &&
+      latestUserMessageIndex >= 0 &&
+      latestAssistantMessage?.content.type !== "text" &&
+      latestAssistantMessage?.content.type !== "loading"
+    ) {
+      if (latestAssistantMessage?.content.type === "toolGroup") {
+        // Set the tool group message to loading state
+        return mappedMessages.map((message, index) =>
+          index === latestAssistantMessageIndex
+            ? {
+                ...message,
+                content: { ...latestAssistantMessage.content, isLoading: true },
+              }
+            : message,
+        );
+      }
+
+      const hasAssistantAnswer = mappedMessages.some(
+        (message) =>
+          message.role === "assistant" && message.content.type === "text",
+      );
+
       return [
         ...mappedMessages,
         {
           id: hasAssistantAnswer ? "loading" : "connecting",
           role: "assistant",
-          content: [
-            hasAssistantAnswer
-              ? { type: "loading" }
-              : { type: "loading", label: "Connecting..." },
-          ],
+          content: hasAssistantAnswer
+            ? { type: "loading" }
+            : { type: "loading", label: "Connecting..." },
         } satisfies InAppAgentDrawerMessage,
       ];
     }
@@ -150,4 +227,16 @@ export function ControlledInAppAgentDrawer(
       {...closeButtonProps}
     />
   );
+}
+
+function getToolResultsByToolCallId(messages: readonly AgUiMessage[]) {
+  const results = new Map<string, Extract<AgUiMessage, { role: "tool" }>>();
+
+  for (const message of messages) {
+    if (message.role === "tool") {
+      results.set(message.toolCallId, message);
+    }
+  }
+
+  return results;
 }

--- a/web/src/features/in-app-agent/components/InAppAgentDrawer.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentDrawer.stories.tsx
@@ -56,42 +56,62 @@ export const Conversation = meta.story({
       {
         id: "user-1",
         role: "user",
-        content: [
-          {
-            type: "text",
-            text: "Which traces had the highest latency today?",
-          },
-        ],
+        content: {
+          type: "text",
+          text: "Which traces had the highest latency today?",
+        },
       },
       {
-        id: "assistant-1",
+        id: "assistant-tool-1",
         role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "Start by filtering traces by timestamp, then sort by latency. Open the slowest traces to inspect long-running observations.",
-          },
-        ],
+        content: {
+          type: "toolGroup",
+          tools: [
+            {
+              type: "tool",
+              name: "langfuse_queryMetrics",
+              args: JSON.stringify({
+                view: "observations",
+                dimensions: [],
+                metrics: [{ measure: "count", aggregation: "count" }],
+                filters: [],
+                fromTimestamp: "2025-06-30T00:00:00Z",
+                toTimestamp: "2025-07-06T23:59:59Z",
+              }),
+              result: JSON.stringify({ data: [{ count_count: 0 }] }),
+            },
+            {
+              type: "tool",
+              name: "langfuse_getTraces",
+              args: JSON.stringify({ limit: 10 }),
+              result: JSON.stringify({ data: [] }),
+            },
+          ],
+        },
+      },
+      {
+        id: "assistant-text-1",
+        role: "assistant",
+        content: {
+          type: "text",
+          text: "Start by filtering traces by timestamp, then sort by latency. Open the slowest traces to inspect long-running observations.",
+        },
       },
       {
         id: "user-2",
         role: "user",
-        content: [
-          {
-            type: "text",
-            text: "Can I compare that with scores?",
-          },
-        ],
+        content: {
+          type: "text",
+          text: "Can I compare that with scores?",
+        },
       },
       {
         id: "assistant-2",
         role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "Yes. Add score filters or group the traces by score name to see whether latency correlates with lower quality.",
-          },
-        ],
+        content: {
+          type: "text",
+          text: "Yes. Add score filters or group the traces by score name to see whether latency correlates with lower quality.",
+        },
       },
     ],
   },
@@ -103,21 +123,99 @@ export const LoadingResponse = meta.story({
       {
         id: "user-1",
         role: "user",
-        content: [
-          {
-            type: "text",
-            text: "Summarize recent ingestion errors.",
-          },
-        ],
+        content: {
+          type: "text",
+          text: "Summarize recent ingestion errors.",
+        },
       },
       {
         id: "assistant-1",
         role: "assistant",
-        content: [
-          {
-            type: "loading",
-          },
-        ],
+        content: {
+          type: "loading",
+        },
+      },
+    ],
+  },
+});
+
+export const LoadingAfterToolCall = meta.story({
+  args: {
+    isInputDisabled: true,
+    messages: [
+      {
+        id: "user-1",
+        role: "user",
+        content: {
+          type: "text",
+          text: "How many OpenAI tokens were used last week?",
+        },
+      },
+      {
+        id: "assistant-tool-1",
+        role: "assistant",
+        content: {
+          type: "toolGroup",
+          tools: [
+            {
+              type: "tool",
+              name: "langfuse_queryMetrics",
+              args: JSON.stringify({
+                view: "observations",
+                metrics: [{ measure: "totalTokens", aggregation: "sum" }],
+                filters: [
+                  {
+                    column: "providedModelName",
+                    operator: "contains",
+                    value: "gpt",
+                    type: "string",
+                  },
+                ],
+              }),
+              result: JSON.stringify({
+                data: [{ sum_totalTokens: 6848204 }],
+              }),
+            },
+          ],
+        },
+      },
+      {
+        id: "assistant-text-1",
+        role: "assistant",
+        content: {
+          type: "text",
+          text: "Let me check what model names are available to better identify OpenAI models.",
+        },
+      },
+      {
+        id: "assistant-tool-2",
+        role: "assistant",
+        content: {
+          type: "toolGroup",
+          isLoading: true,
+          tools: [
+            {
+              type: "tool",
+              name: "langfuse_getObservationFilterValues",
+              args: JSON.stringify({
+                column: "providedModelName",
+                limit: 50,
+                fromStartTime: "2026-06-01T00:00:00Z",
+                toStartTime: "2026-06-08T00:00:00Z",
+              }),
+              result: JSON.stringify({
+                type: "VALUES",
+                column: "providedModelName",
+                values: [
+                  {
+                    value: "gpt-4",
+                    count: 41700,
+                  },
+                ],
+              }),
+            },
+          ],
+        },
       },
     ],
   },
@@ -130,22 +228,18 @@ export const Connecting = meta.story({
       {
         id: "user-1",
         role: "user",
-        content: [
-          {
-            type: "text",
-            text: "Summarize recent ingestion errors.",
-          },
-        ],
+        content: {
+          type: "text",
+          text: "Summarize recent ingestion errors.",
+        },
       },
       {
         id: "connecting",
         role: "assistant",
-        content: [
-          {
-            type: "loading",
-            label: "Connecting...",
-          },
-        ],
+        content: {
+          type: "loading",
+          label: "Connecting...",
+        },
       },
     ],
   },
@@ -158,12 +252,10 @@ export const Error = meta.story({
       {
         id: "user-1",
         role: "user",
-        content: [
-          {
-            type: "text",
-            text: "Help me inspect this trace.",
-          },
-        ],
+        content: {
+          type: "text",
+          text: "Help me inspect this trace.",
+        },
       },
     ],
   },

--- a/web/src/features/in-app-agent/components/InAppAgentDrawer.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentDrawer.tsx
@@ -25,7 +25,7 @@ const LOAD_MORE_CONVERSATIONS_VALUE = "__load_more__";
 export type InAppAgentDrawerMessage = {
   id: string;
   role: InAppAgentMessageRole;
-  content: InAppAgentMessageContent[];
+  content: InAppAgentMessageContent;
 };
 
 export type InAppAgentDrawerConversation = {
@@ -215,26 +215,26 @@ export function InAppAgentDrawer(props: InAppAgentDrawerProps) {
               </div>
             ) : null}
 
-            <ol className="flex w-full flex-col gap-4">
-              {messages.map((message) => (
-                <li
-                  key={message.id}
-                  className={cn(
-                    "w-fit max-w-[92%]",
-                    message.role === "user" && "ml-auto",
-                  )}
-                >
-                  <div className="flex w-full">
-                    {message.content.map((content, index) => (
-                      <InAppAgentMessage
-                        key={`${message.id}-${index}`}
-                        role={message.role}
-                        content={content}
-                      />
-                    ))}
-                  </div>
-                </li>
-              ))}
+            <ol className="flex w-full flex-col gap-3">
+              {messages.map((message) => {
+                const hasToolContent = message.content.type === "toolGroup";
+
+                return (
+                  <li
+                    key={message.id}
+                    className={cn(
+                      "max-w-[92%]",
+                      hasToolContent ? "w-full" : "w-fit",
+                      message.role === "user" && "ml-auto",
+                    )}
+                  >
+                    <InAppAgentMessage
+                      role={message.role}
+                      content={message.content}
+                    />
+                  </li>
+                );
+              })}
             </ol>
 
             {error ? (

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.stories.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.stories.tsx
@@ -73,6 +73,87 @@ export const UserText = meta.story({
   },
 });
 
+export const ToolCallGroup = meta.story({
+  args: {
+    role: "assistant",
+    content: {
+      type: "toolGroup",
+      tools: [
+        {
+          type: "tool",
+          name: "langfuse_queryMetrics",
+          args: JSON.stringify({ view: "observations" }),
+          result: JSON.stringify({ data: [{ count_count: 0 }] }),
+        },
+        {
+          type: "tool",
+          name: "langfuse_getTraces",
+          args: JSON.stringify({ limit: 10 }),
+          result: JSON.stringify({ data: [] }),
+        },
+      ],
+    },
+  },
+});
+
+export const SingleToolCallGroup = meta.story({
+  args: {
+    role: "assistant",
+    content: {
+      type: "toolGroup",
+      tools: [
+        {
+          type: "tool",
+          name: "langfuse_queryMetrics",
+          args: JSON.stringify(
+            {
+              view: "observations",
+              dimensions: [],
+              metrics: [{ measure: "count", aggregation: "count" }],
+              filters: [],
+              fromTimestamp: "2025-06-30T00:00:00Z",
+              toTimestamp: "2025-07-06T23:59:59Z",
+            },
+            null,
+            2,
+          ),
+          result: JSON.stringify({
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ data: [{ count_count: 0 }] }, null, 2),
+              },
+            ],
+          }),
+        },
+      ],
+    },
+  },
+});
+
+export const LoadingToolCallGroup = meta.story({
+  args: {
+    role: "assistant",
+    content: {
+      type: "toolGroup",
+      isLoading: true,
+      tools: [
+        {
+          type: "tool",
+          name: "langfuse_queryMetrics",
+          args: JSON.stringify({ view: "observations" }),
+          result: JSON.stringify({ data: [{ count_count: 0 }] }),
+        },
+        {
+          type: "tool",
+          name: "langfuse_getTraces",
+          args: JSON.stringify({ limit: 10 }),
+        },
+      ],
+    },
+  },
+});
+
 export const Loading = meta.story({
   args: {
     role: "assistant",

--- a/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -1,14 +1,28 @@
 "use client";
 
-import { Loader2 } from "lucide-react";
+import { Loader2, Wrench } from "lucide-react";
 import { Streamdown } from "streamdown";
 import { cn } from "@/src/utils/tailwind";
+import { useMemo } from "react";
 
 export type InAppAgentMessageRole = "assistant" | "user";
 
 export type InAppAgentMessageContent =
   | { type: "loading"; label?: string }
-  | { type: "text"; text: string };
+  | { type: "text"; text: string }
+  | {
+      type: "toolGroup";
+      tools: InAppAgentToolCallContent[];
+      isLoading?: boolean;
+    };
+
+export type InAppAgentToolCallContent = {
+  type: "tool";
+  name: string;
+  args: string;
+  result?: string;
+  error?: string;
+};
 
 export type InAppAgentMessageProps = {
   role: InAppAgentMessageRole;
@@ -17,6 +31,14 @@ export type InAppAgentMessageProps = {
 
 export function InAppAgentMessage({ role, content }: InAppAgentMessageProps) {
   const isUser = role === "user";
+
+  if (content.type === "toolGroup") {
+    return (
+      <div className="bg-card text-card-foreground border-border rounded-2xl border py-2 text-sm shadow-xs">
+        <ToolCallGroup tools={content.tools} isLoading={content.isLoading} />
+      </div>
+    );
+  }
 
   return (
     <div
@@ -32,6 +54,109 @@ export function InAppAgentMessage({ role, content }: InAppAgentMessageProps) {
       ) : (
         <MessageText role={role} text={content.text} />
       )}
+    </div>
+  );
+}
+
+function ToolCallGroup({
+  tools,
+  isLoading = false,
+}: {
+  tools: InAppAgentToolCallContent[];
+  isLoading?: boolean;
+}) {
+  const label = `${isLoading ? "Calling" : "Called"} ${tools.length} ${tools.length === 1 ? "tool" : "tools"}`;
+
+  return (
+    <details className="group/tool-group min-w-0">
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-3.5 text-xs leading-none font-medium [&::-webkit-details-marker]:hidden">
+        {isLoading ? (
+          <Loader2 className="text-muted-foreground h-3.5 w-3.5 shrink-0 animate-spin" />
+        ) : (
+          <Wrench className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+        )}
+        <span className="min-w-0 flex-1 truncate">{label}</span>
+        <span className="text-muted-foreground text-xs group-open/tool-group:hidden">
+          Show
+        </span>
+        <span className="text-muted-foreground hidden text-xs group-open/tool-group:inline">
+          Hide
+        </span>
+      </summary>
+      <div className="border-border mt-2 space-y-2 border-t px-3.5 pt-2">
+        {tools.map((tool, index) => (
+          <div key={`${tool.name}-${index}`} className="rounded-lg">
+            <ToolCallDetails tool={tool} />
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+function ToolCallDetails({ tool }: { tool: InAppAgentToolCallContent }) {
+  const resultLabel = tool.error ? "Error" : "Result";
+
+  return (
+    <details className="group/tool min-w-0">
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-xs leading-none font-medium [&::-webkit-details-marker]:hidden">
+        <Wrench className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+        <span className="min-w-0 flex-1 truncate">Used {tool.name}</span>
+        <span className="text-muted-foreground text-xs group-open/tool:hidden">
+          Show
+        </span>
+        <span className="text-muted-foreground hidden text-xs group-open/tool:inline">
+          Hide
+        </span>
+      </summary>
+      <div className="mt-2 space-y-2">
+        <ToolPayload label="Arguments" value={tool.args} />
+        {tool.result !== undefined || tool.error !== undefined ? (
+          <ToolPayload
+            label={resultLabel}
+            value={tool.error ?? tool.result ?? ""}
+            isError={Boolean(tool.error)}
+          />
+        ) : null}
+      </div>
+    </details>
+  );
+}
+
+function ToolPayload({
+  label,
+  value,
+  isError = false,
+}: {
+  label: string;
+  value: string;
+  isError?: boolean;
+}) {
+  const toolPayload = useMemo(() => {
+    const trimmedValue = value.trim();
+
+    if (!trimmedValue) {
+      return "{}";
+    }
+
+    try {
+      return JSON.stringify(JSON.parse(trimmedValue), null, 2);
+    } catch {
+      return value;
+    }
+  }, [value]);
+
+  return (
+    <div className="space-y-1">
+      <p className="text-muted-foreground text-xs font-medium">{label}</p>
+      <pre
+        className={cn(
+          "bg-muted text-muted-foreground max-h-64 overflow-auto rounded-md p-2 text-xs whitespace-pre-wrap",
+          isError && "text-destructive",
+        )}
+      >
+        {toolPayload}
+      </pre>
     </div>
   );
 }

--- a/web/src/features/in-app-agent/server/agent.ts
+++ b/web/src/features/in-app-agent/server/agent.ts
@@ -14,12 +14,31 @@ import { createInAppAgentInstrumentation } from "@/src/features/in-app-agent/ser
 import { logger } from "@langfuse/shared/src/server";
 
 const ASSISTANT_TITLE = "Langfuse Assistant";
-const ASSISTANT_SYSTEM_PROMPT = [
-  "You are the persistent in-app assistant for Langfuse.",
-  "Be concise, factual, and useful.",
-  "If you are not confident in the answer, say that directly instead of guessing.",
-  "Use markdown when it improves clarity.",
-].join(" ");
+const getAssistantSystemPrompt = () => `
+<identity>
+  You are an assistant called Langfuse Assistant.
+  Your role is to assist users with tasks in the Langfuse Cloud product.
+</identity>
+
+<behavioral_rules>
+If you are not confident in the answer, say that directly instead of guessing.
+Focus on answering the user's questions. Do not comment on your own behavior:
+- Do not comment on tools you are using or will use.
+- Do not comment on the process you are following.
+Always provide a complete answer to the user's question in your response, do not rely on users seeing tool input or output.
+If a tool call fails but you intend on re-trying it, do not mention the failure and just retry the tool call.
+If you cannot provide an answer to the user, spare the user the details of failed tool calls and instead summarize the issue.
+</behavioral_rules>
+
+<style_rules>
+Be concise, factual, and useful.
+Use markdown in your responses when appropriate, especially for tables and lists.
+</style_rules>
+
+<world_knowledge>
+The current time is ${new Date().toDateString()}.
+</world_knowledge>
+`;
 const MAX_AGENT_STEPS = 10;
 
 type CreateAgUiStreamOptions = {
@@ -473,7 +492,7 @@ async function createMastraAdapter(params: {
     const agent = new Agent({
       id: "langfuse-in-app-assistant",
       name: ASSISTANT_TITLE,
-      instructions: ASSISTANT_SYSTEM_PROMPT,
+      instructions: getAssistantSystemPrompt(),
       model: bedrock(
         params.options.awsBedrock.modelId as Parameters<typeof bedrock>[0],
       ),


### PR DESCRIPTION
Resolves LFE-10172

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds tool-call visibility to the in-app agent chat UI. When the assistant makes MCP tool calls, a collapsible card is now shown in the conversation with the tool name, arguments, and result (or error). It also reworks the `InAppAgentDrawerMessage` content from an array to a discriminated union, refactors the message-mapping logic to group consecutive tool-only assistant messages, and updates the system prompt.

- **Tool-call display** (`InAppAgentMessage.tsx`, `ControlledInAppAgentDrawer.tsx`): a new `toolGroup` content type renders collapsible `<details>` elements for each tool; consecutive tool-only assistant messages are batched together and the latest group shows a spinner while the agent is still running.
- **System prompt expansion** (`agent.ts`): prompt rewritten with XML-tagged sections for identity, behavioral rules, style, and world knowledge; the current date is injected via a template literal baked at module-load time — this date will become stale on long-running servers (see inline comment).
- **Content model simplification** (`InAppAgentDrawer.tsx`): `content` changed from `InAppAgentMessageContent[]` to a single `InAppAgentMessageContent`, removing the array wrapper throughout the render tree.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one fix: the date in the system prompt should be computed per-request rather than at module load.

The UI logic for grouping and displaying tool calls is well-structured and the pending-tools flush mechanism handles edge cases correctly. The one real defect is in `agent.ts`: the system prompt constant captures `new Date().toDateString()` once when the module loads, so after midnight on a long-running server every conversation will include a wrong date — affecting temporal reasoning for every user until the process restarts.

web/src/features/in-app-agent/server/agent.ts — the static date injection in the system prompt constant.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parsedMessages] --> B{message.role?}
    B -->|system/developer/tool/activity| C[skip]
    B -->|reasoning| D{isRunning & no later assistant?}
    D -->|yes| E[push loading bubble]
    D -->|no| C
    B -->|assistant/user| F{assistant with tools only, no text?}
    F -->|yes| G[accumulate pendingTools]
    F -->|no| H[flushPendingTools]
    H --> I{has text?}
    I -->|yes or user role| J[push text message]
    I -->|no & no tools| C
    H --> K{has toolContent?}
    K -->|yes| L[push toolGroup message]
    G --> M[end of loop: flushPendingTools]
    M --> N{isRunning & !error & latestUserMsg exists?}
    N -->|latestAssistant is toolGroup| O[mark toolGroup isLoading=true]
    N -->|no assistant after user yet| P[append loading/connecting bubble]
    N -->|no| Q[return mappedMessages]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/in-app-agent/server/agent.ts:14-39
The date is captured once at module load and stays frozen for the process lifetime. Convert `ASSISTANT_SYSTEM_PROMPT` to a function so the date is evaluated fresh on every agent run.

```suggestion
const ASSISTANT_TITLE = "Langfuse Assistant";
const getAssistantSystemPrompt = () => `
<identity>
  You are an assistant called Langfuse Assistant.
  Your role is to assist users with tasks in the Langfuse Cloud product.
</identity>

<behavioral_rules>
If you are not confident in the answer, say that directly instead of guessing.
Focus on answering the user's questions. Do not comment on your own behavior:
- Do not comment on tools you are using or will use.
- Do not comment on the process you are following.
Always provide a complete answer to the user's question in your response, do not rely on users seeing tool input or output.
If a tool call fails but you intend on re-trying it, do not mention the failure and just retry the tool call.
If you cannot provide an answer to the user, spare the user the details of failed tool calls and instead summarize the issue.
</behavioral_rules>

<style_rules>
Be concise, factual, and useful.
Use markdown in your responses when appropriate, especially for tables and lists.
</style_rules>

<world_knowledge>
The current time is ${new Date().toDateString()}.
</world_knowledge>
`;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agent): Show tool calls in the UI"](https://github.com/langfuse/langfuse/commit/362113b179d91e16fb5153fe4da821a64b9b27dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36177057)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->