### PR TITLE
feat(scores): flatten v3 response shape to match proposal

### DIFF
--- a/fern/apis/server/_drafts/scores-v3.yml
+++ b/fern/apis/server/_drafts/scores-v3.yml
@@ -127,7 +127,7 @@ types:
         docs: The dataset run ID (experiment ID).
 
   ScoreSubjectV3:
-    docs: Returned when fields includes "subject".
+    docs: A reference to the entity this score is attached to. Discriminated by "kind" — one of trace, observation, session, or experiment.
     discriminant: kind
     union:
       trace:
@@ -157,22 +157,22 @@ types:
       updatedAt: datetime
       comment:
         type: optional<nullable<string>>
-        docs: Optional comment attached to the score.
+        docs: Optional comment attached to the score. Present when "details" is included in the fields parameter.
       configId:
         type: optional<nullable<string>>
-        docs: The score config ID, if this score was created from a config.
+        docs: The score config ID, if this score was created from a config. Present when "details" is included in the fields parameter.
       metadata:
         type: optional<map<string, unknown>>
-        docs: Arbitrary metadata attached to the score.
+        docs: Arbitrary metadata attached to the score. Present when "details" is included in the fields parameter.
       authorUserId:
         type: optional<nullable<string>>
-        docs: The user who created this score, if available.
+        docs: The user who created this score, if available. Present when "annotation" is included in the fields parameter.
       queueId:
         type: optional<nullable<string>>
-        docs: The annotation queue this score belongs to, if any.
+        docs: The annotation queue this score belongs to, if any. Present when "annotation" is included in the fields parameter.
       subject:
         type: optional<ScoreSubjectV3>
-        docs: Present when "subject" is included in the fields parameter.
+        docs: The entity this score is attached to (trace, observation, session, or experiment). Present when "subject" is included in the fields parameter.
 
   NumericScoreV3:
     extends: BaseScoreV3

--- a/fern/apis/server/_drafts/scores-v3.yml
+++ b/fern/apis/server/_drafts/scores-v3.yml
@@ -99,19 +99,6 @@ service:
       response: GetScoresV3Response
 
 types:
-  ScoreDetailsV3:
-    docs: Returned when fields includes "details".
-    properties:
-      comment:
-        type: nullable<string>
-        docs: Optional comment attached to the score.
-      configId:
-        type: nullable<string>
-        docs: The score config ID, if this score was created from a config.
-      metadata:
-        type: map<string, unknown>
-        docs: Arbitrary metadata attached to the score.
-
   ScoreSubjectTraceV3:
     properties:
       id:
@@ -156,16 +143,6 @@ types:
         type: ScoreSubjectExperimentV3
         docs: Subject is a dataset run (experiment) score.
 
-  ScoreAnnotationV3:
-    docs: Returned when fields includes "annotation".
-    properties:
-      authorUserId:
-        type: nullable<string>
-        docs: The user who created this score, if available.
-      queueId:
-        type: nullable<string>
-        docs: The annotation queue this score belongs to, if any.
-
   BaseScoreV3:
     properties:
       id: string
@@ -178,15 +155,24 @@ types:
         docs: The environment from which this score originated.
       createdAt: datetime
       updatedAt: datetime
-      details:
-        type: optional<ScoreDetailsV3>
-        docs: Present when "details" is included in the fields parameter.
+      comment:
+        type: optional<nullable<string>>
+        docs: Optional comment attached to the score.
+      configId:
+        type: optional<nullable<string>>
+        docs: The score config ID, if this score was created from a config.
+      metadata:
+        type: optional<map<string, unknown>>
+        docs: Arbitrary metadata attached to the score.
+      authorUserId:
+        type: optional<nullable<string>>
+        docs: The user who created this score, if available.
+      queueId:
+        type: optional<nullable<string>>
+        docs: The annotation queue this score belongs to, if any.
       subject:
         type: optional<ScoreSubjectV3>
         docs: Present when "subject" is included in the fields parameter.
-      annotation:
-        type: optional<ScoreAnnotationV3>
-        docs: Present when "annotation" is included in the fields parameter.
 
   NumericScoreV3:
     extends: BaseScoreV3

--- a/packages/shared/src/features/scores/interfaces/api/v3/schemas.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v3/schemas.ts
@@ -1,13 +1,6 @@
 import { z } from "zod";
 import { ScoreSourceDomain } from "../../../../../domain/scores";
 
-// Optional group schemas
-export const ScoreDetailsV3 = z.object({
-  comment: z.string().nullable(),
-  configId: z.string().nullable(),
-  metadata: z.record(z.string(), z.unknown()),
-});
-
 // Discriminated on `kind` so the type system enforces that `traceId` is
 // only ever present on the observation arm — matches the Fern union and
 // the deriveSubject runtime contract.
@@ -31,11 +24,6 @@ export const ScoreSubjectV3 = z.discriminatedUnion("kind", [
   }),
 ]);
 
-export const ScoreAnnotationV3 = z.object({
-  authorUserId: z.string().nullable(),
-  queueId: z.string().nullable(),
-});
-
 /**
  * Foundation schema for scores API v3.
  *
@@ -55,9 +43,12 @@ const ScoreFoundationSchemaV3 = z.object({
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
   // optional groups
-  details: ScoreDetailsV3.optional(),
+  comment: z.string().nullable().optional(),
+  configId: z.string().nullable().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  authorUserId: z.string().nullable().optional(),
+  queueId: z.string().nullable().optional(),
   subject: ScoreSubjectV3.optional(),
-  annotation: ScoreAnnotationV3.optional(),
 });
 
 export const APIScoreSchemaV3 = z.discriminatedUnion("dataType", [

--- a/web/src/__tests__/server/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v3.servertest.ts
@@ -458,8 +458,8 @@ describe("/api/public/v3/scores API Endpoint", () => {
         for (const s of res.body.data) {
           expect(seenIds.has(s.id)).toBe(false);
           seenIds.add(s.id);
-          expect(s.details).toBeDefined();
-          expect(s.details!.comment).toMatch(/^c\d$/);
+          expect(s.comment).toBeDefined();
+          expect(s.comment!).toMatch(/^c\d$/);
         }
         cursor = res.body.meta.cursor;
       } while (cursor);
@@ -534,9 +534,12 @@ describe("/api/public/v3/scores API Endpoint", () => {
 
       const score = res.body.data.find((s) => s.id === scoreId);
       expect(score).toBeDefined();
-      expect(score).not.toHaveProperty("details");
+      expect(score!.comment).toBeUndefined();
+      expect(score!.configId).toBeUndefined();
+      expect(score!.metadata).toBeUndefined();
       expect(score).not.toHaveProperty("subject");
-      expect(score).not.toHaveProperty("annotation");
+      expect(score!.authorUserId).toBeUndefined();
+      expect(score!.queueId).toBeUndefined();
     });
 
     it("fields=core,details → details present", async () => {
@@ -561,12 +564,12 @@ describe("/api/public/v3/scores API Endpoint", () => {
 
       const score = res.body.data.find((s) => s.id === scoreId);
       expect(score).toBeDefined();
-      expect(score!.details).toBeDefined();
-      expect(score!.details!.comment).toBe("test comment");
-      expect(score!.details!.configId).toBe("cfg-abc");
-      expect(score!.details!.metadata).toEqual({ key: "val" });
+      expect(score!.comment).toBe("test comment");
+      expect(score!.configId).toBe("cfg-abc");
+      expect(score!.metadata).toEqual({ key: "val" });
       expect(score).not.toHaveProperty("subject");
-      expect(score).not.toHaveProperty("annotation");
+      expect(score!.authorUserId).toBeUndefined();
+      expect(score!.queueId).toBeUndefined();
     });
 
     it("fields=core,annotation → annotation present", async () => {
@@ -590,10 +593,11 @@ describe("/api/public/v3/scores API Endpoint", () => {
 
       const score = res.body.data.find((s) => s.id === scoreId);
       expect(score).toBeDefined();
-      expect(score!.annotation).toBeDefined();
-      expect(score!.annotation!.authorUserId).toBe("user-xyz");
-      expect(score!.annotation!.queueId).toBe("queue-abc");
-      expect(score).not.toHaveProperty("details");
+      expect(score!.authorUserId).toBe("user-xyz");
+      expect(score!.queueId).toBe("queue-abc");
+      expect(score!.comment).toBeUndefined();
+      expect(score!.configId).toBeUndefined();
+      expect(score!.metadata).toBeUndefined();
       expect(score).not.toHaveProperty("subject");
     });
 
@@ -616,9 +620,8 @@ describe("/api/public/v3/scores API Endpoint", () => {
 
       const score = res.body.data.find((s) => s.id === scoreId);
       expect(score).toBeDefined();
-      expect(score!.annotation).toBeDefined();
-      expect(score!.annotation!.authorUserId).toBeNull();
-      expect(score!.annotation!.queueId).toBeNull();
+      expect(score!.authorUserId).toBeNull();
+      expect(score!.queueId).toBeNull();
     });
 
     it("fields=core,subject → trace score has kind=trace", async () => {
@@ -763,9 +766,12 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(200);
       const score = res.body.data.find((s) => s.id === scoreId);
       expect(score).toBeDefined();
-      expect(score).not.toHaveProperty("details");
+      expect(score!.comment).toBeUndefined();
+      expect(score!.configId).toBeUndefined();
+      expect(score!.metadata).toBeUndefined();
       expect(score).not.toHaveProperty("subject");
-      expect(score).not.toHaveProperty("annotation");
+      expect(score!.authorUserId).toBeUndefined();
+      expect(score!.queueId).toBeUndefined();
     });
 
     it("fields=core,details,subject,annotation → all groups present simultaneously", async () => {
@@ -791,9 +797,12 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(200);
       const score = res.body.data.find((s) => s.id === scoreId);
       expect(score).toBeDefined();
-      expect(score).toHaveProperty("details");
+      expect(score).toHaveProperty("comment");
+      expect(score).toHaveProperty("configId");
+      expect(score).toHaveProperty("metadata");
       expect(score).toHaveProperty("subject");
-      expect(score).toHaveProperty("annotation");
+      expect(score).toHaveProperty("authorUserId");
+      expect(score).toHaveProperty("queueId");
       expect(score!.subject!.kind).toBe("trace");
       expect(score!.subject!.id).toBe(traceId);
     });
@@ -1555,7 +1564,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(200);
       expect(
         res.body.data.length > 0 &&
-          res.body.data.every((s) => s.details?.configId === configId),
+          res.body.data.every((s) => s.configId === configId),
       ).toBe(true);
       const ids = res.body.data.map((s) => s.id);
       expect(ids).toContain(scoreId);
@@ -1586,7 +1595,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(200);
       expect(
         res.body.data.length > 0 &&
-          res.body.data.every((s) => s.annotation?.queueId === queueId),
+          res.body.data.every((s) => s.queueId === queueId),
       ).toBe(true);
       const ids = res.body.data.map((s) => s.id);
       expect(ids).toContain(scoreId);
@@ -1617,7 +1626,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(200);
       expect(
         res.body.data.length > 0 &&
-          res.body.data.every((s) => s.annotation?.authorUserId === userId),
+          res.body.data.every((s) => s.authorUserId === userId),
       ).toBe(true);
       const ids = res.body.data.map((s) => s.id);
       expect(ids).toContain(scoreId);
@@ -1761,7 +1770,7 @@ describe("/api/public/v3/scores API Endpoint", () => {
       expect(res.status).toBe(200);
       expect(res.body.meta.limit).toBe(10);
       const score = res.body.data.find((s) => s.id === scoreId);
-      expect(score?.details?.comment).toBe("regression-check");
+      expect(score?.comment).toBe("regression-check");
     });
   });
 });

--- a/web/src/features/public-api/server/scores-api-v3.ts
+++ b/web/src/features/public-api/server/scores-api-v3.ts
@@ -113,22 +113,18 @@ function domainToV3(
     updatedAt: score.updatedAt,
     ...(fields.includes("details")
       ? {
-          details: {
-            comment: score.comment,
-            configId: score.configId,
-            metadata: score.metadata,
-          },
+          comment: score.comment,
+          configId: score.configId,
+          metadata: score.metadata,
+        }
+      : {}),
+    ...(fields.includes("annotation")
+      ? {
+          authorUserId: score.authorUserId,
+          queueId: score.queueId,
         }
       : {}),
     ...(fields.includes("subject") ? { subject: deriveSubject(score) } : {}),
-    ...(fields.includes("annotation")
-      ? {
-          annotation: {
-            authorUserId: score.authorUserId,
-            queueId: score.queueId,
-          },
-        }
-      : {}),
   } as APIScoreV3;
 }
 


### PR DESCRIPTION
## What does this PR do?

Flatten the v3 scores response shape so opt-in field groups appear as top-level fields instead of being wrapped in `details` / `annotation` objects. This matches the canonical JSON in the v3 API design proposal.

Hoisted to top-level: `comment`, `configId`, `metadata`, `authorUserId`, `queueId`. `subject` stays nested because it's a discriminated union on `kind` with an optional `traceId` only on the observation arm — flattening would lose the type relationship and collide with the top-level `id` field.

`fields=` syntax and group-gating semantics are unchanged. Only the response wrapping changes.

The v3 endpoint is flag-gated and off by default, so no production callers are affected.

## Type of change

- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR flattens the v3 scores API response shape by hoisting the previously-nested `details` and `annotation` wrapper objects to top-level fields (`comment`, `configId`, `metadata`, `authorUserId`, `queueId`). The change is consistent across the Fern YAML spec, the Zod schemas, the `domainToV3` mapping function, and the server tests.

- `ScoreDetailsV3` and `ScoreAnnotationV3` sub-schemas are removed; their fields become individually `optional` (and `nullable` where appropriate) on `BaseScoreV3` / `ScoreFoundationSchemaV3`.
- Field-group gating semantics are unchanged — `details` controls `comment`/`configId`/`metadata` and `annotation` controls `authorUserId`/`queueId`; only the response wrapping is removed.
- The endpoint remains flag-gated and off by default, so no production callers are affected by this breaking shape change.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the v3 endpoint is flag-gated and off by default, so the breaking shape change has no production impact. All field-group gating logic is preserved; only the JSON wrapper objects are removed.

The refactoring is internally consistent across YAML, Zod schemas, the domain mapper, and tests. The only gap is that the five newly-promoted fields in the Fern YAML no longer document which `fields=` group gates them, while `subject` still does — a small but real usability gap for SDK consumers reading the spec.

fern/apis/server/_drafts/scores-v3.yml — the flat field docs should note which `fields=` group activates each property, matching the existing `subject` documentation pattern.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as API Consumer
    participant H as Route Handler
    participant D as domainToV3()
    participant CH as ClickHouse

    C->>H: "GET /v3/scores?fields=core,details,annotation,subject"
    H->>CH: SELECT core cols + DETAILS_COLS + ANNOTATION_COLS + SUBJECT_COLS
    CH-->>H: ScoreRecordReadType rows
    H->>D: convertClickhouseScoreToDomain(row), fields
    Note over D: fields includes "details"<br/>→ spread comment, configId, metadata
    Note over D: fields includes "annotation"<br/>→ spread authorUserId, queueId
    Note over D: fields includes "subject"<br/>→ spread subject (discriminated union)
    D-->>H: APIScoreV3 (flat shape)
    H->>H: filterAndValidateV3GetScoreList(items)
    H-->>C: "{ data: [{ id, comment, configId, metadata, authorUserId, queueId, subject, ... }] }"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
fern/apis/server/_drafts/scores-v3.yml:158-172
The five newly-flattened fields have no docs string indicating which `fields=` group activates them, while `subject` still documents this clearly. Without this hint, consumers of the generated SDK or OpenAPI spec can't tell that `comment`/`configId`/`metadata` require `fields=details` and `authorUserId`/`queueId` require `fields=annotation`.

```suggestion
      comment:
        type: optional<nullable<string>>
        docs: Optional comment attached to the score. Present when "details" is included in the fields parameter.
      configId:
        type: optional<nullable<string>>
        docs: The score config ID, if this score was created from a config. Present when "details" is included in the fields parameter.
      metadata:
        type: optional<map<string, unknown>>
        docs: Arbitrary metadata attached to the score. Present when "details" is included in the fields parameter.
      authorUserId:
        type: optional<nullable<string>>
        docs: The user who created this score, if available. Present when "annotation" is included in the fields parameter.
      queueId:
        type: optional<nullable<string>>
        docs: The annotation queue this score belongs to, if any. Present when "annotation" is included in the fields parameter.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(scores): flatten v3 response shape ..."](https://github.com/langfuse/langfuse/commit/9125aff627020282d532ff4dd0a81108efc2218d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36194891)</sub>

<!-- /greptile_comment -->