### PR TITLE
feat(scores): accept lowercase source and dataType on v3 list endpoint

### DIFF
--- a/fern/apis/server/_drafts/scores-v3.yml
+++ b/fern/apis/server/_drafts/scores-v3.yml
@@ -44,10 +44,10 @@ service:
             docs: Comma-separated list of score names to filter by.
           source:
             type: optional<string>
-            docs: Comma-separated list of score sources to filter by (e.g. API, ANNOTATION, EVAL).
+            docs: Comma-separated list of score sources to filter by (e.g. API, ANNOTATION, EVAL). Case-insensitive — `api` and `API` are equivalent.
           dataType:
             type: optional<string>
-            docs: Comma-separated list of data types to filter by (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, CORRECTION). Must be a single value when used with value, valueMin, or valueMax; otherwise the request returns HTTP 400. Must be NUMERIC when used with valueMin or valueMax.
+            docs: Comma-separated list of data types to filter by (NUMERIC, BOOLEAN, CATEGORICAL, TEXT, CORRECTION). Case-insensitive — `numeric` and `NUMERIC` are equivalent. Must be a single value when used with value, valueMin, or valueMax; otherwise the request returns HTTP 400. Must be NUMERIC when used with valueMin or valueMax.
           environment:
             type: optional<string>
             docs: Comma-separated list of environments to filter by.

--- a/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
@@ -29,6 +29,8 @@ const csvStringParam = z
   )
   .optional();
 
+// Accepts case-insensitive input for uppercase enum allowedValues (e.g. "api"
+// or "API" both parse to "API"). Downstream code only sees the canonical form.
 const csvEnumParam = <T extends readonly string[]>(
   allowedValues: T,
   label: string,
@@ -39,7 +41,8 @@ const csvEnumParam = <T extends readonly string[]>(
       val
         .split(",")
         .map((v) => v.trim())
-        .filter((v) => v.length > 0),
+        .filter((v) => v.length > 0)
+        .map((v) => v.toUpperCase()),
     )
     .pipe(
       z.array(z.string()).superRefine((values, ctx) => {

--- a/web/src/__tests__/server/unit/scores-api-v3.servertest.ts
+++ b/web/src/__tests__/server/unit/scores-api-v3.servertest.ts
@@ -1,4 +1,35 @@
 import { buildSelectColumns } from "@/src/features/public-api/server/scores-api-v3";
+import { GetScoresQueryV3 } from "@langfuse/shared";
+
+describe("GetScoresQueryV3 enum case-insensitivity", () => {
+  it("accepts lowercase source values and normalizes to uppercase", () => {
+    const parsed = GetScoresQueryV3.parse({ source: "api,annotation" });
+    expect(parsed.source).toEqual(["API", "ANNOTATION"]);
+  });
+
+  it("accepts lowercase dataType values and normalizes to uppercase", () => {
+    const parsed = GetScoresQueryV3.parse({ dataType: "numeric,boolean" });
+    expect(parsed.dataType).toEqual(["NUMERIC", "BOOLEAN"]);
+  });
+
+  it("accepts mixed-case input", () => {
+    const parsed = GetScoresQueryV3.parse({
+      source: "Api,EVAL",
+      dataType: "Numeric,categorical",
+    });
+    expect(parsed.source).toEqual(["API", "EVAL"]);
+    expect(parsed.dataType).toEqual(["NUMERIC", "CATEGORICAL"]);
+  });
+
+  it("still rejects values that are not a valid enum after upper-casing", () => {
+    expect(() => GetScoresQueryV3.parse({ source: "nope" })).toThrow(
+      /Invalid source value/,
+    );
+    expect(() => GetScoresQueryV3.parse({ dataType: "string" })).toThrow(
+      /Invalid dataType value/,
+    );
+  });
+});
 
 describe("buildSelectColumns", () => {
   it("core always selects the polymorphic value columns", () => {


### PR DESCRIPTION
## What does this PR do?

Lets `GET /v3/scores` accept lowercase (and mixed-case) values for the `source` and `dataType` query parameters. Previously `?source=api,annotation` failed with HTTP 400; now it parses identically to `?source=API,ANNOTATION`. Implemented by upper-casing inside `csvEnumParam` before the enum check, so downstream code keeps seeing the canonical uppercase form unchanged — `superRefine` and `listScoresV3ForPublicApi` don't need to know about the normalization.

Scope is limited to v3 scores — `csvEnumParam` is local to `packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts`. Other public APIs use `z.enum(...)` directly and are unaffected. Adds 4 unit tests covering lowercase, mixed-case, and still-invalid input. The `_drafts/scores-v3.yml` Fern source documents the new case-insensitivity on `source` and `dataType`.

The BOOLEAN `value` filter (`"true"`/`"false"`) is deliberately left case-sensitive — those are JSON-literal-shaped values, not enum names.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the `source` and `dataType` query parameters on the v3 scores list endpoint case-insensitive by adding a `.toUpperCase()` normalisation step inside `csvEnumParam` before the allow-list validation runs. API documentation in the Fern YAML is updated accordingly, and a new unit-test suite covers lowercase, mixed-case, and invalid-after-normalisation inputs.

- `csvEnumParam` in `endpoints.ts` now upper-cases each CSV token so callers can pass `api`, `Api`, or `API` and all map to the canonical `"API"` form before downstream code sees the value.
- Tests in `scores-api-v3.servertest.ts` verify the normalisation for both `source` and `dataType` as well as the rejection path for values that are not valid even after upper-casing.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow, well-tested normalisation addition with no effect on the downstream query path.

The only change to runtime behaviour is the added `.toUpperCase()` call inside `csvEnumParam`. Both callers use all-uppercase enum arrays, so existing valid inputs are unaffected and previously-invalid lowercase inputs now pass through correctly. The four new unit tests cover the happy path, mixed-case, and the rejection path, giving good confidence that the normalisation works as intended. The generic function carries an implicit all-uppercase contract that isn't enforced by its type signature, but this is a documentation concern rather than a present defect.

No files require special attention. The test file and YAML docs are straightforward; `endpoints.ts` has one minor implicit contract worth noting in a comment.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["GET /v3/scores?source=api&dataType=numeric"] --> B["csvEnumParam transform"]
    B --> C["split by comma"]
    C --> D["trim whitespace"]
    D --> E["filter empty strings"]
    E --> F["v.toUpperCase() — NEW"]
    F --> G["superRefine: allowedValues.includes(v)"]
    G -->|"valid"| H["downstream query sees canonical form\ne.g. 'API', 'NUMERIC'"]
    G -->|"invalid"| I["z.ZodError: Invalid source/dataType value"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts:32-37
The `csvEnumParam` helper silently assumes that every value in `allowedValues` is already uppercase. The `.toUpperCase()` transform normalises input, but the `allowedValues.includes(v)` check then compares against the original array. If a future caller passes a mixed-case or lowercase enum (e.g. `["api", "eval"]`), the normalised input `"API"` would never match and every value would be rejected. Adding a runtime guard makes the contract explicit and prevents a hard-to-debug silent failure for any future callers.

```suggestion
// Accepts case-insensitive input for uppercase enum allowedValues (e.g. "api"
// or "API" both parse to "API"). Downstream code only sees the canonical form.
// NOTE: allowedValues must be all-uppercase; the transform normalises input to
// uppercase before the include-check, so mixed-case allowed values would never
// match.
const csvEnumParam = <T extends readonly string[]>(
  allowedValues: T,
  label: string,
) =>
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(scores): accept lowercase source an..."](https://github.com/langfuse/langfuse/commit/adaa226d2519a0393f345cce57f6a47aee3ac425) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36205251)</sub>

<!-- /greptile_comment -->