### PR TITLE
feat(scores): reject unknown query params on v3 list endpoint

### DIFF
--- a/fern/apis/server/_drafts/scores-v3.yml
+++ b/fern/apis/server/_drafts/scores-v3.yml
@@ -18,6 +18,9 @@ service:
         Use the `fields` parameter to include optional field groups beyond the
         default `core`. Unknown group names return HTTP 400.
 
+        Unknown query parameters (e.g. `field` instead of `fields`) return HTTP
+        400 rather than being silently ignored.
+
         Currently in preview for Langfuse Cloud v4 users; not yet available on
         self-hosted Langfuse.
       method: GET

--- a/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
+++ b/packages/shared/src/features/scores/interfaces/api/v3/endpoints.ts
@@ -55,59 +55,62 @@ const csvEnumParam = <T extends readonly string[]>(
     )
     .optional();
 
-// GET /v3/scores — all filter params optional; superRefine validation lives in the handler.
-export const GetScoresQueryV3 = z.object({
-  limit: z.coerce.number().int().positive().max(100).default(50),
-  fields: fieldsParam,
-  // Identifier filters (multi-value, comma-separated)
-  id: csvStringParam,
-  name: csvStringParam,
-  source: csvEnumParam(ScoreSourceArray, "source"),
-  dataType: csvEnumParam(ScoreDataTypeArray, "dataType"),
-  environment: csvStringParam,
-  configId: csvStringParam,
-  queueId: csvStringParam,
-  authorUserId: csvStringParam,
-  // Value filters
-  value: csvStringParam,
-  // Treat empty string as absent so `?valueMin=` doesn't silently coerce to 0
-  // and narrow results to `value >= 0`. Zod 4 rejects ±Infinity / NaN out of
-  // the box, so `.finite()` is not needed.
-  valueMin: z.preprocess(
-    (v) => (v === "" ? undefined : v),
-    z.coerce.number().optional(),
-  ),
-  valueMax: z.preprocess(
-    (v) => (v === "" ? undefined : v),
-    z.coerce.number().optional(),
-  ),
-  // Entity-bounded filters
-  traceId: csvStringParam,
-  sessionId: csvStringParam,
-  observationId: csvStringParam,
-  experimentId: csvStringParam,
-  // Timestamp filters — preprocess empty string to undefined so ?fromTimestamp=
-  // from a templating system is treated as absent, consistent with valueMin/valueMax.
-  fromTimestamp: z.preprocess(
-    (v) => (v === "" ? undefined : v),
-    z.coerce.date().optional(),
-  ),
-  toTimestamp: z.preprocess(
-    (v) => (v === "" ? undefined : v),
-    z.coerce.date().optional(),
-  ),
-  // Deferred params (always → 400 — require trace JOIN not present in v3).
-  // Treat the empty string as absent so a stray `?userId=` from a templating
-  // system doesn't trigger the "use v2" 400 spuriously.
-  userId: z
-    .string()
-    .optional()
-    .transform((v) => (v === "" ? undefined : v)),
-  traceTags: z
-    .string()
-    .optional()
-    .transform((v) => (v === "" ? undefined : v)),
-});
+// GET /v3/scores — all filter params optional; unknown query params return 400 via .strict();
+// cross-field superRefine validation lives in the handler.
+export const GetScoresQueryV3 = z
+  .object({
+    limit: z.coerce.number().int().positive().max(100).default(50),
+    fields: fieldsParam,
+    // Identifier filters (multi-value, comma-separated)
+    id: csvStringParam,
+    name: csvStringParam,
+    source: csvEnumParam(ScoreSourceArray, "source"),
+    dataType: csvEnumParam(ScoreDataTypeArray, "dataType"),
+    environment: csvStringParam,
+    configId: csvStringParam,
+    queueId: csvStringParam,
+    authorUserId: csvStringParam,
+    // Value filters
+    value: csvStringParam,
+    // Treat empty string as absent so `?valueMin=` doesn't silently coerce to 0
+    // and narrow results to `value >= 0`. Zod 4 rejects ±Infinity / NaN out of
+    // the box, so `.finite()` is not needed.
+    valueMin: z.preprocess(
+      (v) => (v === "" ? undefined : v),
+      z.coerce.number().optional(),
+    ),
+    valueMax: z.preprocess(
+      (v) => (v === "" ? undefined : v),
+      z.coerce.number().optional(),
+    ),
+    // Entity-bounded filters
+    traceId: csvStringParam,
+    sessionId: csvStringParam,
+    observationId: csvStringParam,
+    experimentId: csvStringParam,
+    // Timestamp filters — preprocess empty string to undefined so ?fromTimestamp=
+    // from a templating system is treated as absent, consistent with valueMin/valueMax.
+    fromTimestamp: z.preprocess(
+      (v) => (v === "" ? undefined : v),
+      z.coerce.date().optional(),
+    ),
+    toTimestamp: z.preprocess(
+      (v) => (v === "" ? undefined : v),
+      z.coerce.date().optional(),
+    ),
+    // Deferred params (always → 400 — require trace JOIN not present in v3).
+    // Treat the empty string as absent so a stray `?userId=` from a templating
+    // system doesn't trigger the "use v2" 400 spuriously.
+    userId: z
+      .string()
+      .optional()
+      .transform((v) => (v === "" ? undefined : v)),
+    traceTags: z
+      .string()
+      .optional()
+      .transform((v) => (v === "" ? undefined : v)),
+  })
+  .strict();
 
 export const GetScoresResponseV3 = z.object({
   data: z.array(APIScoreSchemaV3),


### PR DESCRIPTION
## What does this PR do?

Makes `GET /v3/scores` reject unknown query parameters (e.g. `field` instead of `fields`) with HTTP 400 rather than silently dropping them. Adds `.strict()` to the `GetScoresQueryV3` Zod schema; the existing `createAuthedProjectAPIRoute` error middleware already maps Zod errors to 400.

Scope is limited to v3 scores — v1, v2, and every other public endpoint defines its own Zod schema and is unaffected. The `_drafts/scores-v3.yml` Fern source is updated to document the behavior; the file is not yet wired into the published spec (the v3 API is still in preview).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `.strict()` to the `GetScoresQueryV3` Zod schema, causing the v3 scores list endpoint to return HTTP 400 for any unrecognized query parameters instead of silently ignoring them. The accompanying YAML draft is updated to document this behavior.

- **`GetScoresQueryV3` in `endpoints.ts`**: Wraps the existing `z.object({…})` with `.strict()`, rejecting unknown keys at the Zod-parse stage.
- **`scores-v3.yml`**: Adds documentation that unknown query parameters (e.g., `field` instead of `fields`) result in HTTP 400.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line addition to an in-preview endpoint that had no prior strict-key enforcement.

The only change is appending `.strict()` to the base Zod object. Zod's `.extend()` call in the handler preserves the `unknownKeys: "strict"` setting from `_def`, so `cursor` (added via `.extend()`) is still a valid key while every other unrecognized param is correctly rejected. The `userId` and `traceTags` deferred-error params remain in the known shape and continue to be caught downstream by `superRefine`, which is unchanged. The endpoint is still behind a preview flag, so there is no risk of breaking production callers.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as GET /v3/scores
    participant Schema as GetScoresV3Query<br/>(extend + superRefine)
    participant Base as GetScoresQueryV3<br/>(.strict())

    Client->>Handler: "GET /v3/scores?unknownParam=x"
    Handler->>Schema: parse(query)
    Schema->>Base: parse(query)
    Base-->>Schema: ZodError (unrecognized_keys)
    Schema-->>Handler: parse failure
    Handler-->>Client: HTTP 400

    Client->>Handler: "GET /v3/scores?cursor=abc&limit=10"
    Handler->>Schema: parse(query)
    Schema->>Base: parse(query)
    Base-->>Schema: OK (cursor added via .extend)
    Schema-->>Handler: validated data
    Handler-->>Client: HTTP 200 + data
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(scores): reject unknown query param..."](https://github.com/langfuse/langfuse/commit/8af2891323a200057e56213cb6bb20d0c329f12c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36205302)</sub>

<!-- /greptile_comment -->