### PR TITLE
feat(scores): gate v3 list endpoint behind v4 preview opt-in

### DIFF
--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -73,6 +73,12 @@ export type AuthedProjectAPIRouteConfig<
    * return stale or empty data.
    */
   rejectInEventsOnlyMode?: boolean;
+  /**
+   * When true, this route returns 404 if LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN
+   * is not "true". Set this on routes that depend on v4 data structures or
+   * query patterns only available when the v4 preview is enabled.
+   */
+  requiresV4?: boolean;
   fn: (params: {
     query: z.infer<TQuery>;
     body: z.infer<TBody>;
@@ -308,6 +314,17 @@ export const createAuthedProjectAPIRoute = <
       res.status(404).json({
         message:
           "This endpoint is not available on deployments running in Langfuse v4 events_only mode. Learn more about Langfuse v4 at: https://langfuse.com/docs/v4",
+      });
+      return;
+    }
+
+    if (
+      routeConfig.requiresV4 &&
+      env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN !== "true"
+    ) {
+      res.status(404).json({
+        message:
+          "This endpoint requires Langfuse v4. Learn more at: https://langfuse.com/docs/v4",
       });
       return;
     }

--- a/web/src/pages/api/public/v3/scores/index.ts
+++ b/web/src/pages/api/public/v3/scores/index.ts
@@ -106,6 +106,7 @@ export default withMiddlewares({
     name: "Get Scores V3",
     querySchema: GetScoresV3Query,
     responseSchema: GetScoresResponseV3,
+    requiresV4: true,
     fn: async ({ query, auth }) => {
       if (env.LANGFUSE_ENABLE_SCORES_V3_API !== "true") {
         // Returns 404 to authenticated callers when disabled. Note: auth and


### PR DESCRIPTION
## What does this PR do?

Gates the `GET /api/public/v3/scores` endpoint behind `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`. Requests to this endpoint on deployments where v4 is not enabled receive a `404` with a descriptive error message.

**Implementation:**
- Added a `requiresV4?: boolean` option to `createAuthedProjectAPIRoute` (parallel to the existing `rejectInEventsOnlyMode` option). When set, the middleware short-circuits with `404` before authentication if `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN !== "true"`.
- Set `requiresV4: true` on the scores v3 `GET` handler.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infrastructure change
- [ ] Documentation (no code changes)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have checked that my changes do not introduce linting errors (`pnpm run lint`)
- [ ] I have added tests for new functionality

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gates `GET /api/public/v3/scores` behind the `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN` environment variable by adding a `requiresV4` option to `createAuthedProjectAPIRoute` that short-circuits with a 404 before authentication, mirroring the existing `rejectInEventsOnlyMode` pattern.

- Added `requiresV4?: boolean` to `AuthedProjectAPIRouteConfig` with a corresponding pre-auth guard in the middleware that returns 404 when the env var is not `"true"`.
- Set `requiresV4: true` on the scores v3 GET handler, which now has two sequential feature-flag gates: the new pre-auth `requiresV4` check and the existing post-auth `LANGFUSE_ENABLE_SCORES_V3_API` check.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is additive and follows an established middleware pattern already in use.

The implementation is straightforward and consistent with the existing rejectInEventsOnlyMode guard. The only nuance worth noting is that two independent feature flags now gate the same endpoint at different layers — requiresV4 (pre-auth) and LANGFUSE_ENABLE_SCORES_V3_API (post-auth) — which could surprise operators who enable the v4 preview but leave the inner flag unset, seeing 401 responses for unauthenticated callers instead of 404.

web/src/pages/api/public/v3/scores/index.ts warrants a second look for the interaction between the two feature flags.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Middleware as createAuthedProjectAPIRoute
    participant Auth as verifyAuth
    participant Handler as scores/index.ts fn

    Client->>Middleware: GET /api/public/v3/scores

    alt "rejectInEventsOnlyMode && WRITE_MODE === events_only"
        Middleware-->>Client: 404 (events_only mode)
    else "requiresV4 && ALLOW_PREVIEW_OPT_IN !== true"
        Middleware-->>Client: 404 (v4 not enabled)
    else v4 enabled
        Middleware->>Auth: verifyAuth(req)
        alt Auth fails
            Auth-->>Middleware: "throw {status, message}"
            Middleware-->>Client: 401/403
        else Auth succeeds
            Auth-->>Middleware: auth scope
            Middleware->>Middleware: Rate limit check
            alt Rate limited
                Middleware-->>Client: 429
            else Within limits
                Middleware->>Handler: "fn({ query, auth })"
                alt "LANGFUSE_ENABLE_SCORES_V3_API !== true"
                    Handler-->>Middleware: throw LangfuseNotFoundError
                    Middleware-->>Client: 404
                else API enabled
                    Handler->>Handler: listScoresV3ForPublicApi(...)
                    Handler-->>Middleware: "{ data, meta }"
                    Middleware-->>Client: "200 { data, meta }"
                end
            end
        end
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/api/public/v3/scores/index.ts:111-117
**Dual-gate interaction may confuse deployment operators**

With `requiresV4: true` in place, a v4-enabled deployment that still has `LANGFUSE_ENABLE_SCORES_V3_API` unset (or `!== "true"`) will let unauthenticated requests reach auth and return 401, signalling "this endpoint exists but you're not authenticated" — while the same deployment returns 404 to authenticated callers. The existing inline comment acknowledges this, but it was written when there was no pre-auth gate; now the two flags independently control visibility at different layers. Consider either (a) documenting that both flags must be set together when opt-in is active, or (b) checking whether `requiresV4` should implicitly treat `LANGFUSE_ENABLE_SCORES_V3_API` as enabled to avoid surprising operators who turn on the v4 preview but forget the inner flag.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/scores-v3-..."](https://github.com/langfuse/langfuse/commit/ae7191a4e8173073b1131f2bbac85dedad13733d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36233710)</sub>

<!-- /greptile_comment -->