### PR TITLE
feat(evals): allowlist more TypeScript evaluator helpers

### DIFF
--- a/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
@@ -312,9 +312,9 @@ function evaluate(ctx: EvaluationContext): EvaluationResult {
   params.append("tool", decodedName);
   params.append("tool", "validate");
   params.sort();
-  const paramNames = params.keys();
-  const paramValues = params.values();
-  const paramEntries = params.entries();
+  const paramNames = Array.from(params.keys());
+  const paramValues = Array.from(params.values());
+  const paramEntries = Array.from(params.entries());
   const sealedArgs = Object.seal(weatherArgs);
   const frozenArgs = Object.freeze(sealedArgs);
   const hasLocation =
@@ -473,9 +473,9 @@ function evaluate(ctx: EvaluationContext): EvaluationResult {
     Object.hasOwn(toolCall ?? {}, "arguments"),
   );
 
-  const ids = JSON.stringify(actual)
-    .matchAll(/"id":\\s*"([^"]+)"/g)
-    .map((match) => match[1]);
+  const ids = Array.from(
+    JSON.stringify(actual).matchAll(/"id":\\s*"([^"]+)"/g),
+  ).map((match) => match[1]);
   const idScore = ids
     .map((id: string) => id.at(0)?.codePointAt(0) ?? 0)
     .fill(0, ids.length)
@@ -525,6 +525,41 @@ function evaluate(ctx: EvaluationContext): EvaluationResult {
     expect(
       result.diagnostics.some((diagnostic) =>
         diagnostic.message.includes("Property 'random' does not exist"),
+      ),
+    ).toBe(true);
+  });
+
+  it("requires Array.from before using array helpers on iterators", async () => {
+    const result = await validateCodeEvalSourceWithLanguage({
+      source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  const params = new URLSearchParams("tool=validate");
+  const hasTool = params.keys().includes("tool");
+  const ids = JSON.stringify(ctx.observation.output ?? {})
+    .matchAll(/"id":\\s*"([^"]+)"/g)
+    .map((match) => match[1]);
+
+  return {
+    scores: [{
+      name: "iterator helpers",
+      value: hasTool && ids.length > 0,
+      dataType: "BOOLEAN",
+    }],
+  };
+}
+`,
+      sourceCodeLanguage: "TYPESCRIPT",
+    });
+
+    expect(result.hasErrors).toBe(true);
+    expect(
+      result.diagnostics.some((diagnostic) =>
+        diagnostic.message.includes("Property 'includes' does not exist"),
+      ),
+    ).toBe(true);
+    expect(
+      result.diagnostics.some((diagnostic) =>
+        diagnostic.message.includes("Property 'map' does not exist"),
       ),
     ).toBe(true);
   });

--- a/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.clienttest.ts
@@ -210,6 +210,325 @@ function evaluate(ctx: EvaluationContext): EvaluationResult {
     ).toBe(true);
   });
 
+  it("accepts basic TypeScript string and regular expression helpers", async () => {
+    const result = await validateCodeEvalSourceWithLanguage({
+      source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  const rawValue = String(ctx.observation.output ?? "");
+  const normalized = rawValue.trim().toLowerCase();
+  const idMatch = normalized.match(/id:(\\d+)/);
+  const id = idMatch?.[1]?.substring(0, 8) ?? "missing";
+  const hasTicket = new RegExp("ticket-[0-9]+", "i").test(normalized);
+  const tokens = normalized.replace(/\\s+/g, " ").split(" ");
+  tokens.push("fallback");
+  tokens.sort();
+  const copiedTokens = tokens.toSorted().toReversed().toSpliced(0, 1, "copy");
+  const replacedTokens = copiedTokens.with(0, "first");
+  const shiftedTokens = replacedTokens.slice();
+  shiftedTokens.copyWithin(0, 1);
+  const removedTokens = shiftedTokens.splice(0, 1);
+  const firstToken = tokens.at(0) ?? "";
+  const scoreToken = tokens.find((token) => token.includes("score")) ?? "";
+  const scoreTokenIndex = tokens.findIndex((token) => token.includes("score"));
+  const tokenPosition = tokens.indexOf(scoreToken);
+  const reversedTokens = tokens.slice().reverse();
+  const containsExact = normalized.includes("exact");
+  const startsWithPass = normalized.startsWith("pass");
+  const endsWithDone = normalized.endsWith("done");
+  const indexScore = normalized.indexOf("score");
+  const sliced = normalized.slice(0, 10);
+  const tokenLengths = Object.fromEntries(
+    tokens.map((token) => [token, token.length]),
+  );
+  const objectScore =
+    Object.keys(tokenLengths).length +
+    Object.values(tokenLengths).reduce((total, value) => total + value, 0) +
+    Object.entries(tokenLengths).length +
+    (Object.hasOwn(tokenLengths, firstToken) ? 1 : 0);
+
+  return {
+    scores: [{
+      name: "string helpers",
+      value: [
+        id,
+        firstToken,
+        sliced,
+        scoreToken,
+        String(
+          scoreTokenIndex +
+            tokenPosition +
+            reversedTokens.length +
+            objectScore +
+            removedTokens.length +
+            shiftedTokens.length,
+        ),
+      ].join(":"),
+      dataType: "TEXT",
+      comment: containsExact || startsWithPass || endsWithDone || hasTicket || indexScore >= 0
+        ? "matched"
+        : "not matched",
+    }],
+  };
+}
+`,
+      sourceCodeLanguage: "TYPESCRIPT",
+    });
+
+    expect(result.hasErrors).toBe(false);
+  });
+
+  it("accepts helpers for JSON and tool call argument checks", async () => {
+    const result = await validateCodeEvalSourceWithLanguage({
+      source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  const rawToolCalls = JSON.stringify(
+    ctx.observation.output?.toolCalls ?? [],
+    undefined,
+    2,
+  );
+  const toolCalls = JSON.parse(rawToolCalls);
+  const toolNames = Array.from(
+    new Set(
+      toolCalls.map((toolCall: any) =>
+        String(toolCall.name ?? "").trim().toLocaleLowerCase(),
+      ),
+    ),
+  );
+  const argsByName = new Map<string, any>(
+    toolCalls.map((toolCall: any) => [
+      String(toolCall.name ?? "").toLowerCase(),
+      toolCall.arguments ?? {},
+    ]),
+  );
+  const weatherArgs = Object.assign(
+    { units: "celsius" },
+    argsByName.get("get_weather") ?? {},
+  );
+  const encodedName = encodeURIComponent("get weather");
+  const decodedName = decodeURIComponent(encodedName).replace(" ", "_");
+  const encodedUrl = encodeURI("https://langfuse.com/docs?topic=tool calls");
+  const decodedUrl = decodeURI(encodedUrl);
+  const params = new URL(decodedUrl).searchParams;
+  params.append("tool", decodedName);
+  params.append("tool", "validate");
+  params.sort();
+  const paramNames = params.keys();
+  const paramValues = params.values();
+  const paramEntries = params.entries();
+  const sealedArgs = Object.seal(weatherArgs);
+  const frozenArgs = Object.freeze(sealedArgs);
+  const hasLocation =
+    Object.hasOwn(frozenArgs, "location") &&
+    frozenArgs.hasOwnProperty("location") &&
+    frozenArgs.propertyIsEnumerable("units") &&
+    String(weatherArgs.location ?? "").padStart(1).localeCompare("") > 0;
+  const uniqueToolCount = toolNames.length;
+  const hasSearchTool = toolNames.includes("search");
+  const hasWeatherTool =
+    argsByName.has("get_weather") &&
+    Object.getOwnPropertyNames(frozenArgs).includes("units") &&
+    frozenArgs.toString().includes("Object") &&
+    Object.is(frozenArgs.valueOf(), frozenArgs) &&
+    params.getAll("tool").includes("validate") &&
+    paramNames.includes("tool") &&
+    paramValues.includes(decodedName) &&
+    paramEntries.some((entry) => entry.join("=").includes("tool="));
+
+  try {
+    JSON.parse("{");
+  } catch (error) {
+    const message = error instanceof Error ? error.message.padEnd(1) : "parse failed";
+    console.warn(message);
+  }
+
+  return {
+    scores: [{
+      name: "tool call arguments",
+      value: hasLocation && hasWeatherTool && !hasSearchTool,
+      dataType: "BOOLEAN",
+      metadata: {
+        uniqueToolCount,
+        toolNames,
+        normalizedUnits: String(weatherArgs.units ?? "").toUpperCase(),
+        urlTopic: params.get("topic"),
+      },
+    }],
+  };
+}
+`,
+      sourceCodeLanguage: "TYPESCRIPT",
+    });
+
+    expect(result.hasErrors).toBe(false);
+  });
+
+  it("accepts helpers for numeric scoring and normalized comparisons", async () => {
+    const result = await validateCodeEvalSourceWithLanguage({
+      source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  const values = [["1.5", "2"], ["3.25"]]
+    .flat()
+    .flatMap((value) => [Number.parseFloat(value), parseFloat(value)]);
+  const finiteValues = values.filter((value) => Number.isFinite(value) && isFinite(value));
+  const total = finiteValues.reduce((sum, value) => sum + value, 0);
+  const average = total / Math.max(1, finiteValues.length);
+  const rounded =
+    Math.floor(average) +
+    Math.ceil(average) +
+    Math.round(average) +
+    Math.trunc(average) +
+    Math.sqrt(Math.pow(average, 2));
+  const expectedCount = Number.parseInt("6", 10) + parseInt("0", 10);
+  const normalizedActual = String(ctx.observation.output ?? "").normalize("NFKC");
+  const normalizedExpected = String(ctx.experiment?.itemExpectedOutput ?? "").normalize("NFKC");
+  const sameOutput = normalizedActual.localeCompare(normalizedExpected) === 0;
+  const parsedDate = Date.parse("2026-01-01T00:00:00.000Z");
+  const date = new Date(parsedDate);
+  const utcDate = new Date(Date.UTC(2026, 0, 2, 3, 4, 5, 6));
+  const adjustedDate = new Date("2026-01-01T00:00:00.000Z");
+  adjustedDate.setUTCDate(adjustedDate.getUTCDate() + 1);
+  adjustedDate.setUTCHours(3, 4, 5, 6);
+  const elapsedMs = utcDate.getTime() - date.valueOf();
+  const sameDay =
+    adjustedDate.getUTCFullYear() === utcDate.getUTCFullYear() &&
+    adjustedDate.getUTCMonth() === utcDate.getUTCMonth() &&
+    adjustedDate.getUTCDate() === utcDate.getUTCDate();
+  const dateComment = [
+    utcDate.toISOString(),
+    utcDate.toUTCString(),
+    utcDate.toDateString(),
+    utcDate.toTimeString(),
+    utcDate.toJSON(),
+    String(Date.now()).slice(0, 1),
+  ].join("|");
+  const numericComment = Number.isInteger(expectedCount)
+    ? rounded.toFixed(2) + dateComment
+    : rounded.toPrecision(2);
+
+  return {
+    scores: [{
+      name: "normalized numeric comparison",
+      value: sameOutput && finiteValues.length === expectedCount && !Number.isNaN(parsedDate) && !isNaN(date.getTime()) && sameDay && elapsedMs > 0,
+      dataType: "BOOLEAN",
+      comment: numericComment,
+    }],
+  };
+}
+`,
+      sourceCodeLanguage: "TYPESCRIPT",
+    });
+
+    expect(result.hasErrors).toBe(false);
+  });
+
+  it("accepts helpers for deep JSON diffs and nested payload inspection", async () => {
+    const result = await validateCodeEvalSourceWithLanguage({
+      source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  const seen = new WeakSet<object>();
+  const visits = new WeakMap<object, number>();
+  const deepEqual = (a: any, b: any): boolean => {
+    if (Object.is(a, b)) return true;
+    if (typeof a !== "object" || a === null) return false;
+    if (typeof b !== "object" || b === null) return false;
+    if (seen.has(a)) return true;
+    seen.add(a);
+    visits.set(a, (visits.get(a) ?? 0) + 1);
+    if (Array.isArray(a) || Array.isArray(b)) {
+      if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+        return false;
+      }
+      return a.every((value: any, index: number) => deepEqual(value, b[index]));
+    }
+    const aKeys = Object.keys(a).sort();
+    const bKeys = Object.keys(b).sort();
+    return (
+      aKeys.length === bKeys.length &&
+      aKeys.every(
+        (key: string, index: number) =>
+          key === bKeys[index] && deepEqual(a[key], b[key]),
+      )
+    );
+  };
+
+  const actual = JSON.parse(
+    JSON.stringify(ctx.observation.output ?? { toolCalls: [] }),
+    (_key: string, value: any) =>
+      typeof value === "string" ? value.trim() : value,
+  );
+  const expected = JSON.parse(
+    JSON.stringify(ctx.experiment?.itemExpectedOutput ?? { toolCalls: [] }),
+  );
+
+  const toolCalls: any[] = Array.isArray(actual.toolCalls)
+    ? actual.toolCalls
+    : [];
+  const nestedArgs = toolCalls
+    .flatMap((toolCall: any) => Object.values(toolCall.arguments ?? {}))
+    .flat();
+  const lastToolCall = toolCalls.findLast((toolCall: any) =>
+    Object.hasOwn(toolCall ?? {}, "arguments"),
+  );
+  const lastToolIndex = toolCalls.findLastIndex((toolCall: any) =>
+    Object.hasOwn(toolCall ?? {}, "arguments"),
+  );
+
+  const ids = JSON.stringify(actual)
+    .matchAll(/"id":\\s*"([^"]+)"/g)
+    .map((match) => match[1]);
+  const idScore = ids
+    .map((id: string) => id.at(0)?.codePointAt(0) ?? 0)
+    .fill(0, ids.length)
+    .reduceRight((sum: number, value: number) => sum + Math.sign(value), 0);
+
+  const marker = String.fromCharCode(67) + String.fromCodePoint(72);
+  const withinSafeRange =
+    nestedArgs.length <= Number.MAX_SAFE_INTEGER &&
+    nestedArgs.length >= Number.MIN_SAFE_INTEGER &&
+    Number.isSafeInteger(lastToolIndex) &&
+    Math.abs(idScore) < Number.MAX_VALUE + Number.EPSILON;
+
+  return {
+    scores: [{
+      name: "deep payload diff",
+      value:
+        deepEqual(actual, expected) && withinSafeRange && Boolean(lastToolCall),
+      dataType: "BOOLEAN",
+      comment: marker + ":" + String(nestedArgs.length + idScore),
+    }],
+  };
+}
+`,
+      sourceCodeLanguage: "TYPESCRIPT",
+    });
+
+    expect(result.hasErrors).toBe(false);
+  });
+
+  it("keeps non-deterministic Math.random unavailable", async () => {
+    const result = await validateCodeEvalSourceWithLanguage({
+      source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  return {
+    scores: [{
+      name: "random",
+      value: Math.random(),
+      dataType: "NUMERIC",
+    }],
+  };
+}
+`,
+      sourceCodeLanguage: "TYPESCRIPT",
+    });
+
+    expect(result.hasErrors).toBe(true);
+    expect(
+      result.diagnostics.some((diagnostic) =>
+        diagnostic.message.includes("Property 'random' does not exist"),
+      ),
+    ).toBe(true);
+  });
+
   it("rejects exported TypeScript evaluate functions", async () => {
     const result = await validateCodeEvalSourceWithLanguage({
       source: `${TYPESCRIPT_CODE_EVAL_CONTRACT}

--- a/web/src/features/evals/utils/code-eval-template-validation.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.ts
@@ -57,13 +57,28 @@ type PromiseSettledResult<T> =
 interface Array<T> {
   length: number;
   [n: number]: T;
+  at(index: number): T | undefined;
+  concat(...items: T[][]): T[];
+  concat(...items: (T | T[])[]): T[];
+  copyWithin(target: number, start: number, end?: number): this;
   every(callbackfn: (value: T, index: number, array: T[]) => unknown): boolean;
+  fill(value: T, start?: number, end?: number): this;
   map<U>(callbackfn: (value: T, index: number, array: T[]) => U): U[];
+  flat(depth?: number): any[];
+  flatMap<U>(
+    callbackfn: (value: T, index: number, array: T[]) => U | U[],
+  ): U[];
   filter(callbackfn: (value: T, index: number, array: T[]) => unknown): T[];
   find(callbackfn: (value: T, index: number, array: T[]) => unknown): T | undefined;
+  findIndex(callbackfn: (value: T, index: number, array: T[]) => unknown): number;
+  findLast(callbackfn: (value: T, index: number, array: T[]) => unknown): T | undefined;
+  findLastIndex(callbackfn: (value: T, index: number, array: T[]) => unknown): number;
   forEach(callbackfn: (value: T, index: number, array: T[]) => void): void;
   includes(searchElement: T, fromIndex?: number): boolean;
+  indexOf(searchElement: T, fromIndex?: number): number;
   join(separator?: string): string;
+  pop(): T | undefined;
+  push(...items: T[]): number;
   reduce<U>(
     callbackfn: (
       previousValue: U,
@@ -73,17 +88,206 @@ interface Array<T> {
     ) => U,
     initialValue: U,
   ): U;
+  reduce(
+    callbackfn: (
+      previousValue: T,
+      currentValue: T,
+      currentIndex: number,
+      array: T[],
+    ) => T,
+  ): T;
+  reduceRight<U>(
+    callbackfn: (
+      previousValue: U,
+      currentValue: T,
+      currentIndex: number,
+      array: T[],
+    ) => U,
+    initialValue: U,
+  ): U;
+  reverse(): T[];
+  shift(): T | undefined;
   slice(start?: number, end?: number): T[];
   some(callbackfn: (value: T, index: number, array: T[]) => unknown): boolean;
+  sort(compareFn?: (a: T, b: T) => number): this;
+  splice(start: number, deleteCount?: number): T[];
+  splice(start: number, deleteCount: number, ...items: T[]): T[];
+  toReversed(): T[];
+  toSorted(compareFn?: (a: T, b: T) => number): T[];
+  toSpliced(start: number, deleteCount?: number): T[];
+  toSpliced(start: number, deleteCount: number, ...items: T[]): T[];
+  unshift(...items: T[]): number;
+  with(index: number, value: T): T[];
 }
 
 interface ArrayConstructor {
+  from<T>(arrayLike: ArrayLike<T>): T[];
+  from<T, U>(
+    arrayLike: ArrayLike<T>,
+    mapfn: (value: T, index: number) => U,
+  ): U[];
+  from<T>(values: IterableLike<T>): T[];
+  from<T, U>(
+    values: IterableLike<T>,
+    mapfn: (value: T, index: number) => U,
+  ): U[];
   isArray(value: unknown): value is unknown[];
+  of<T>(...items: T[]): T[];
 }
 
 interface Boolean {}
 
-interface Number {}
+interface Date {
+  getDate(): number;
+  getDay(): number;
+  getFullYear(): number;
+  getHours(): number;
+  getMilliseconds(): number;
+  getMinutes(): number;
+  getMonth(): number;
+  getSeconds(): number;
+  getTime(): number;
+  getUTCDate(): number;
+  getUTCDay(): number;
+  getUTCFullYear(): number;
+  getUTCHours(): number;
+  getUTCMilliseconds(): number;
+  getUTCMinutes(): number;
+  getUTCMonth(): number;
+  getUTCSeconds(): number;
+  setDate(date: number): number;
+  setFullYear(year: number, month?: number, date?: number): number;
+  setHours(hours: number, min?: number, sec?: number, ms?: number): number;
+  setMilliseconds(ms: number): number;
+  setMinutes(min: number, sec?: number, ms?: number): number;
+  setMonth(month: number, date?: number): number;
+  setSeconds(sec: number, ms?: number): number;
+  setTime(time: number): number;
+  setUTCDate(date: number): number;
+  setUTCFullYear(year: number, month?: number, date?: number): number;
+  setUTCHours(hours: number, min?: number, sec?: number, ms?: number): number;
+  setUTCMilliseconds(ms: number): number;
+  setUTCMinutes(min: number, sec?: number, ms?: number): number;
+  setUTCMonth(month: number, date?: number): number;
+  setUTCSeconds(sec: number, ms?: number): number;
+  toDateString(): string;
+  toISOString(): string;
+  toJSON(): string;
+  toString(): string;
+  toTimeString(): string;
+  toUTCString(): string;
+  valueOf(): number;
+}
+
+interface DateConstructor {
+  new (): Date;
+  new (value: number | string): Date;
+  new (
+    year: number,
+    monthIndex: number,
+    date?: number,
+    hours?: number,
+    minutes?: number,
+    seconds?: number,
+    ms?: number,
+  ): Date;
+  (): string;
+  now(): number;
+  parse(dateString: string): number;
+  UTC(
+    year: number,
+    monthIndex: number,
+    date?: number,
+    hours?: number,
+    minutes?: number,
+    seconds?: number,
+    ms?: number,
+  ): number;
+}
+
+interface Error {
+  name: string;
+  message: string;
+  stack?: string;
+}
+
+interface ErrorConstructor {
+  new (message?: string): Error;
+  (message?: string): Error;
+}
+
+interface ArrayLike<T> {
+  readonly length: number;
+  readonly [n: number]: T;
+}
+
+interface IterableLike<T> {
+  values(): T[];
+}
+
+interface Map<K, V> {
+  readonly size: number;
+  clear(): void;
+  delete(key: K): boolean;
+  entries(): [K, V][];
+  forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void): void;
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  keys(): K[];
+  set(key: K, value: V): this;
+  values(): V[];
+}
+
+interface MapConstructor {
+  new <K, V>(entries?: [K, V][]): Map<K, V>;
+}
+
+interface Number {
+  toFixed(fractionDigits?: number): string;
+  toPrecision(precision?: number): string;
+  toString(radix?: number): string;
+  valueOf(): number;
+}
+
+interface NumberConstructor {
+  (value?: unknown): number;
+  readonly EPSILON: number;
+  readonly MAX_SAFE_INTEGER: number;
+  readonly MAX_VALUE: number;
+  readonly MIN_SAFE_INTEGER: number;
+  readonly MIN_VALUE: number;
+  readonly NaN: number;
+  readonly NEGATIVE_INFINITY: number;
+  readonly POSITIVE_INFINITY: number;
+  isFinite(value: unknown): boolean;
+  isInteger(value: unknown): boolean;
+  isNaN(value: unknown): boolean;
+  isSafeInteger(value: unknown): boolean;
+  parseFloat(string: string): number;
+  parseInt(string: string, radix?: number): number;
+}
+
+interface Object {
+  hasOwnProperty(key: string): boolean;
+  propertyIsEnumerable(key: string): boolean;
+  toString(): string;
+  valueOf(): object;
+}
+
+interface ObjectConstructor {
+  assign<T extends object, U>(target: T, source: U): T & U;
+  freeze<T extends object>(value: T): T;
+  getOwnPropertyNames(value: object): string[];
+  is(value1: unknown, value2: unknown): boolean;
+  keys(value: object): string[];
+  seal<T extends object>(value: T): T;
+  values<T>(value: Record<string, T>): T[];
+  values(value: object): unknown[];
+  entries<T>(value: Record<string, T>): [string, T][];
+  entries(value: object): [string, unknown][];
+  fromEntries<T>(entries: [string, T][]): Record<string, T>;
+  hasOwn(value: object, key: string): boolean;
+}
 
 interface Promise<T> {
   then<TResult1 = T, TResult2 = never>(
@@ -122,12 +326,126 @@ interface PromiseConstructor {
   reject<T = never>(reason?: any): Promise<T>;
 }
 
+interface RegExp {
+  readonly flags: string;
+  readonly global: boolean;
+  readonly ignoreCase: boolean;
+  lastIndex: number;
+  readonly multiline: boolean;
+  readonly source: string;
+  readonly sticky: boolean;
+  readonly unicode: boolean;
+  exec(string: string): RegExpExecArray | null;
+  test(string: string): boolean;
+  toString(): string;
+}
+
+interface RegExpConstructor {
+  new (pattern: string | RegExp, flags?: string): RegExp;
+  (pattern: string | RegExp, flags?: string): RegExp;
+}
+
+interface RegExpMatchArray extends Array<string> {
+  index?: number;
+  input?: string;
+  groups?: Record<string, string>;
+}
+
+interface RegExpExecArray extends Array<string> {
+  index: number;
+  input: string;
+  groups?: Record<string, string>;
+}
+
+interface Set<T> {
+  readonly size: number;
+  add(value: T): this;
+  clear(): void;
+  delete(value: T): boolean;
+  entries(): [T, T][];
+  forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void): void;
+  has(value: T): boolean;
+  keys(): T[];
+  values(): T[];
+}
+
+interface SetConstructor {
+  new <T>(values?: T[]): Set<T>;
+}
+
 interface String {
   readonly length: number;
+  at(index: number): string | undefined;
+  charAt(pos: number): string;
+  charCodeAt(index: number): number;
+  codePointAt(pos: number): number | undefined;
+  concat(...strings: string[]): string;
+  endsWith(searchString: string, endPosition?: number): boolean;
   includes(searchString: string, position?: number): boolean;
+  indexOf(searchString: string, position?: number): number;
+  lastIndexOf(searchString: string, position?: number): number;
+  localeCompare(that: string): number;
+  match(regexp: RegExp): RegExpMatchArray | null;
+  matchAll(regexp: RegExp): RegExpMatchArray[];
+  normalize(form?: string): string;
+  padEnd(maxLength: number, fillString?: string): string;
+  padStart(maxLength: number, fillString?: string): string;
+  repeat(count: number): string;
+  replace(
+    searchValue: string | RegExp,
+    replaceValue: string,
+  ): string;
+  replace(
+    searchValue: string | RegExp,
+    replacer: (
+      substring: string,
+      ...args: any[]
+    ) => string,
+  ): string;
+  replaceAll(
+    searchValue: string | RegExp,
+    replaceValue: string,
+  ): string;
+  search(regexp: RegExp): number;
+  slice(start?: number, end?: number): string;
+  split(separator: string | RegExp, limit?: number): string[];
+  startsWith(searchString: string, position?: number): boolean;
+  substring(start: number, end?: number): string;
   trim(): string;
+  trimEnd(): string;
+  trimStart(): string;
+  toLocaleLowerCase(): string;
+  toLocaleUpperCase(): string;
   toLowerCase(): string;
   toString(): string;
+  toUpperCase(): string;
+}
+
+interface StringConstructor {
+  (value?: unknown): string;
+  fromCharCode(...codes: number[]): string;
+  fromCodePoint(...codePoints: number[]): string;
+}
+
+interface WeakMap<K extends object, V> {
+  delete(key: K): boolean;
+  get(key: K): V | undefined;
+  has(key: K): boolean;
+  set(key: K, value: V): this;
+}
+
+interface WeakMapConstructor {
+  new <K extends object, V>(entries?: [K, V][]): WeakMap<K, V>;
+}
+
+interface WeakSet<T extends object> {
+  add(value: T): this;
+  delete(value: T): boolean;
+  has(value: T): boolean;
+}
+
+interface WeakSetConstructor {
+  new <T extends object>(values?: T[]): WeakSet<T>;
 }
 
 interface Uint8Array {
@@ -144,20 +462,33 @@ type Record<K extends string, T> = { [P in K]: T };
 
 declare const Promise: PromiseConstructor;
 declare const Array: ArrayConstructor;
-declare const String: (value?: unknown) => string;
-declare const Number: (value?: unknown) => number;
+declare const Error: ErrorConstructor;
+declare const Map: MapConstructor;
+declare const Object: ObjectConstructor;
+declare const RegExp: RegExpConstructor;
+declare const Set: SetConstructor;
+declare const String: StringConstructor;
+declare const Number: NumberConstructor;
 declare const Boolean: (value?: unknown) => boolean;
+declare const WeakMap: WeakMapConstructor;
+declare const WeakSet: WeakSetConstructor;
 declare const JSON: {
-  parse(text: string): unknown;
-  stringify(value: unknown): string;
+  parse(text: string, reviver?: (key: string, value: any) => any): any;
+  stringify(value: unknown, replacer?: unknown, space?: string | number): string;
 };
 declare const Math: {
   abs(value: number): number;
+  ceil(value: number): number;
+  floor(value: number): number;
   max(...values: number[]): number;
   min(...values: number[]): number;
+  pow(x: number, y: number): number;
   round(value: number): number;
+  sign(value: number): number;
+  sqrt(value: number): number;
+  trunc(value: number): number;
 };
-declare const Date: any;
+declare const Date: DateConstructor;
 declare const console: {
   log(...args: unknown[]): void;
   warn(...args: unknown[]): void;
@@ -176,6 +507,14 @@ declare function setInterval(
 ): unknown;
 declare function clearInterval(handle?: unknown): void;
 declare function queueMicrotask(callback: () => void): void;
+declare function isFinite(value: unknown): boolean;
+declare function isNaN(value: unknown): boolean;
+declare function parseFloat(string: string): number;
+declare function parseInt(string: string, radix?: number): number;
+declare function decodeURI(encodedURI: string): string;
+declare function decodeURIComponent(encodedURIComponent: string): string;
+declare function encodeURI(uri: string): string;
+declare function encodeURIComponent(uriComponent: string): string;
 declare function structuredClone<T>(value: T): T;
 declare class TextEncoder {
   encode(input?: string): Uint8Array;
@@ -207,9 +546,14 @@ declare class URLSearchParams {
     callbackfn: (value: string, key: string, parent: URLSearchParams) => void,
   ): void;
   get(name: string): string | null;
+  getAll(name: string): string[];
   has(name: string): boolean;
+  keys(): string[];
   set(name: string, value: string): void;
+  sort(): void;
   toString(): string;
+  values(): string[];
+  entries(): string[][];
 }
 `;
 

--- a/web/src/features/evals/utils/code-eval-template-validation.ts
+++ b/web/src/features/evals/utils/code-eval-template-validation.ts
@@ -131,6 +131,13 @@ interface ArrayConstructor {
     values: IterableLike<T>,
     mapfn: (value: T, index: number) => U,
   ): U[];
+  from<T>(values: IteratorLike<T>): T[];
+  from<T, U>(
+    values: IteratorLike<T>,
+    mapfn: (value: T, index: number) => U,
+  ): U[];
+  from<K, V>(values: Map<K, V>): [K, V][];
+  from<T>(values: Set<T>): T[];
   isArray(value: unknown): value is unknown[];
   of<T>(...items: T[]): T[];
 }
@@ -225,17 +232,26 @@ interface IterableLike<T> {
   values(): T[];
 }
 
+interface IteratorResult<T> {
+  done?: boolean;
+  value: T;
+}
+
+interface IteratorLike<T> {
+  next(): IteratorResult<T>;
+}
+
 interface Map<K, V> {
   readonly size: number;
   clear(): void;
   delete(key: K): boolean;
-  entries(): [K, V][];
+  entries(): IteratorLike<[K, V]>;
   forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void): void;
   get(key: K): V | undefined;
   has(key: K): boolean;
-  keys(): K[];
+  keys(): IteratorLike<K>;
   set(key: K, value: V): this;
-  values(): V[];
+  values(): IteratorLike<V>;
 }
 
 interface MapConstructor {
@@ -362,11 +378,11 @@ interface Set<T> {
   add(value: T): this;
   clear(): void;
   delete(value: T): boolean;
-  entries(): [T, T][];
+  entries(): IteratorLike<[T, T]>;
   forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void): void;
   has(value: T): boolean;
-  keys(): T[];
-  values(): T[];
+  keys(): IteratorLike<T>;
+  values(): IteratorLike<T>;
 }
 
 interface SetConstructor {
@@ -386,7 +402,7 @@ interface String {
   lastIndexOf(searchString: string, position?: number): number;
   localeCompare(that: string): number;
   match(regexp: RegExp): RegExpMatchArray | null;
-  matchAll(regexp: RegExp): RegExpMatchArray[];
+  matchAll(regexp: RegExp): IteratorLike<RegExpMatchArray>;
   normalize(form?: string): string;
   padEnd(maxLength: number, fillString?: string): string;
   padStart(maxLength: number, fillString?: string): string;
@@ -548,12 +564,12 @@ declare class URLSearchParams {
   get(name: string): string | null;
   getAll(name: string): string[];
   has(name: string): boolean;
-  keys(): string[];
+  keys(): IteratorLike<string>;
   set(name: string, value: string): void;
   sort(): void;
   toString(): string;
-  values(): string[];
-  entries(): string[][];
+  values(): IteratorLike<string>;
+  entries(): IteratorLike<[string, string]>;
 }
 `;
 


### PR DESCRIPTION
## Summary

- Expands TypeScript code evaluator validation declarations for common evaluator logic: string/regex handling, JSON parsing, object/array helpers, dates, numbers, maps/sets, URI helpers, and URL query params.
- Keeps the evaluator validation allowlist explicit instead of importing the full TypeScript standard lib, preserving the current restricted-global model.
- Removes `Math.random` from the allowed surface and adds regression coverage that it remains unavailable.

## Linear

- [LFE-10180](https://linear.app/langfuse/issue/LFE-10180/allowlist-more-ts-functions)

## Major Decisions

- Kept declarations manually allowlisted rather than enabling `lib.d.ts`, so TypeScript validation only exposes safe JS helpers and still rejects Node/browser globals like `process`.

## Review Focus

- Whether the newly allowed globals match the intended code evaluator runtime surface.
- Whether any helper should remain unavailable for determinism or sandbox clarity.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands the TypeScript evaluator sandbox's declared type allowlist to include common string/regex, JSON, numeric, date, Map/Set, WeakMap/WeakSet, URI, and `URLSearchParams` helpers, while explicitly removing `Math.random` for determinism and replacing the old `declare const Date: any` with a fully typed `DateConstructor`.

- Adds ~200 lines of hand-maintained interface and constructor declarations (Array, String, Map, Set, RegExp, Date, Number, Object, WeakMap/WeakSet, URLSearchParams, Error) to `CONTRACT_DECLARATIONS`, replacing several `any`-typed stubs and expanding the `Math` object.
- Removes `Math.random` from the allowed surface and adds a dedicated regression test asserting it remains rejected by the validator.
- Adds five new test cases covering string helpers, JSON/tool-call inspection, numeric/date scoring, deep payload diffing, and the `Math.random` exclusion.
</details>

<details><summary><h3>Confidence Score: 2/5</h3></summary>

Merging as-is would silently allow evaluator code to pass the validator while throwing TypeError at actual execution time for several common patterns.

Two independent categories of iterator-vs-array type mismatch were introduced: String.matchAll() is declared as returning an array when every standard JS runtime returns an iterator, and Map/Set/URLSearchParams key/value/entry methods share the same problem. The test file itself demonstrates the broken patterns, confirming the validator accepts them but they would fail at runtime.

The iterator-method return types in code-eval-template-validation.ts need attention: specifically String.matchAll, Map/Set keys/values/entries, and URLSearchParams keys/values/entries.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/features/evals/utils/code-eval-template-validation.ts:389
**`matchAll` declared as array but returns iterator at runtime**

`String.prototype.matchAll()` returns a `RegExpStringIterator`, not a plain array, in every standard JS runtime (V8, SpiderMonkey, QuickJS). Typing it as `RegExpMatchArray[]` lets evaluator code pass validation while silently breaking at runtime: any call that chains `.map()`, `.filter()`, `.includes()`, or `.reduce()` directly on the `matchAll()` result will throw `TypeError: ...matchAll(...).map is not a function`. The test in `code-eval-template-validation.clienttest.ts` demonstrates exactly this pattern (`.matchAll(...).map(match => match[1])`), meaning any evaluator written in the same style will fail at execution time even though it passes the validator.

### Issue 2 of 3
web/src/features/evals/utils/code-eval-template-validation.ts:228-243
**`Map`/`Set`/`URLSearchParams` iterator methods declared as plain arrays**

`Map.keys()`, `Map.values()`, `Map.entries()`, `Set.keys()`, `Set.values()`, and `URLSearchParams.keys()`/`values()`/`entries()` all return iterators in every standard JS runtime, not plain arrays. Declaring their return types as `K[]`, `V[]`, `[K,V][]`, etc. makes evaluator code that calls array-specific methods on the results type-check cleanly but throw at runtime. The test concretely exercises this: `paramNames.includes(...)`, `paramValues.includes(...)`, and `paramEntries.some(...)` all operate on iterator-typed return values, which would throw `TypeError` when executed against a real JS engine.

### Issue 3 of 3
web/src/features/evals/utils/code-eval-template-validation.ts:195
**`Date.now()` introduces non-determinism analogous to the removed `Math.random`**

The PR's stated motivation for removing `Math.random` is to keep evaluators deterministic. `Date.now()` is equally non-deterministic. Consider whether it belongs in the same excluded-for-determinism bucket as `Math.random`, or whether a comment explaining the intentional trade-off would clarify intent for future reviewers.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): allowlist more TypeScript e..."](https://github.com/langfuse/langfuse/commit/960184471a19522f294e896e107dd65c703e8422) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36247230)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->