### PR TITLE
feat(blob-exporter): gate isEnrichedBlobExportAvailable on V4 env vars for self-hosted

### DIFF
--- a/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
@@ -39,8 +39,13 @@ export function isLegacyBlobExportAllowed(
 
 /**
  * Whether this deployment has the enriched events export path.
- * Today equivalent to `isLangfuseCloud`; flip when self-hosted is provisioned with the migration.
+ * True for Cloud, or for self-hosted instances that have opted into the V4 preview
+ * via LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN (server-side only — pass the flag
+ * from a server-computed context rather than reading it client-side).
  */
-export function isEnrichedBlobExportAvailable(isCloud: boolean): boolean {
-  return isCloud;
+export function isEnrichedBlobExportAvailable(
+  isCloud: boolean,
+  isV4PreviewEnabled?: boolean,
+): boolean {
+  return isCloud || isV4PreviewEnabled === true;
 }

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -661,4 +661,71 @@ describe("Blob Storage Integration tRPC Router", () => {
       expect(result.isEnrichedExportAvailable).toBe(true);
     });
   });
+
+  describe("update: enriched export source guard", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalV4Preview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
+        originalV4Preview;
+    });
+
+    it("rejects EVENTS on self-hosted without V4 preview opt-in", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("rejects TRACES_OBSERVATIONS_EVENTS on self-hosted without V4 preview opt-in", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "TRACES_OBSERVATIONS_EVENTS" as const,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    it("allows EVENTS on self-hosted with V4 preview opt-in", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it("allows EVENTS on Cloud regardless of V4 flag", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...baseConfig,
+          exportSource: "EVENTS" as const,
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
 });

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -502,7 +502,7 @@ describe("Blob Storage Integration tRPC Router", () => {
       const result = await caller.blobStorageIntegration.get({
         projectId: project.id,
       });
-      expect(result?.exportFieldGroups).toStrictEqual(["core", "io"]);
+      expect(result?.config?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
     it("overwrites stored subset when a new subset is submitted", async () => {

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -420,7 +420,7 @@ describe("Blob Storage Integration tRPC Router", () => {
       const result = await caller.blobStorageIntegration.get({
         projectId: project.id,
       });
-      expect(result?.exportFieldGroups).toStrictEqual(["core", "io"]);
+      expect(result?.config?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
     it("defaults to all groups when exportFieldGroups is omitted", async () => {
@@ -523,7 +523,7 @@ describe("Blob Storage Integration tRPC Router", () => {
       const result = await caller.blobStorageIntegration.get({
         projectId: project.id,
       });
-      expect(result?.exportFieldGroups).toStrictEqual([
+      expect(result?.config?.exportFieldGroups).toStrictEqual([
         "core",
         "io",
         "metrics",
@@ -618,6 +618,47 @@ describe("Blob Storage Integration tRPC Router", () => {
       } finally {
         (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
       }
+    });
+  });
+
+  describe("get: isEnrichedExportAvailable flag", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalV4Preview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
+        originalV4Preview;
+    });
+
+    it("returns true for Cloud deployments regardless of V4 flag", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      const result = await caller.blobStorageIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.isEnrichedExportAvailable).toBe(true);
+    });
+
+    it("returns false for self-hosted without V4 preview opt-in", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      const result = await caller.blobStorageIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.isEnrichedExportAvailable).toBe(false);
+    });
+
+    it("returns true for self-hosted with V4 preview opt-in enabled", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const { caller, project } = await prepare();
+      const result = await caller.blobStorageIntegration.get({
+        projectId: project.id,
+      });
+      expect(result.isEnrichedExportAvailable).toBe(true);
     });
   });
 });

--- a/web/src/__tests__/server/unit/assertEnrichedBlobExportSourceAllowed.servertest.ts
+++ b/web/src/__tests__/server/unit/assertEnrichedBlobExportSourceAllowed.servertest.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { assertEnrichedBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertEnrichedBlobExportSourceAllowed";
+
+describe("assertEnrichedBlobExportSourceAllowed", () => {
+  it("Cloud + explicit EVENTS → allow", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: "EVENTS",
+        isCloud: true,
+        isV4PreviewEnabled: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("self-hosted + V4 preview + explicit EVENTS → allow", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: "EVENTS",
+        isCloud: false,
+        isV4PreviewEnabled: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("self-hosted without V4 preview + explicit EVENTS → reject", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: "EVENTS",
+        isCloud: false,
+        isV4PreviewEnabled: false,
+      }),
+    ).toThrow("Enriched blob export is not available on this deployment");
+  });
+
+  it("self-hosted without V4 preview + explicit TRACES_OBSERVATIONS_EVENTS → reject", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: "TRACES_OBSERVATIONS_EVENTS",
+        isCloud: false,
+        isV4PreviewEnabled: false,
+      }),
+    ).toThrow("Enriched blob export is not available on this deployment");
+  });
+
+  it("self-hosted without V4 preview + explicit TRACES_OBSERVATIONS → allow", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        isCloud: false,
+        isV4PreviewEnabled: false,
+      }),
+    ).not.toThrow();
+  });
+
+  // Partial updates: the request omits exportSource, so the persisted value
+  // stays in effect and must satisfy the gate too (V4-preview rollback case).
+  it("self-hosted without V4 preview + omitted source + existing EVENTS → reject", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: undefined,
+        existingExportSource: "EVENTS",
+        isCloud: false,
+        isV4PreviewEnabled: false,
+      }),
+    ).toThrow("Enriched blob export is not available on this deployment");
+  });
+
+  it("self-hosted without V4 preview + omitted source + existing TRACES_OBSERVATIONS_EVENTS → reject", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: undefined,
+        existingExportSource: "TRACES_OBSERVATIONS_EVENTS",
+        isCloud: false,
+        isV4PreviewEnabled: false,
+      }),
+    ).toThrow("Enriched blob export is not available on this deployment");
+  });
+
+  it("self-hosted without V4 preview + omitted source + existing TRACES_OBSERVATIONS → allow", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: undefined,
+        existingExportSource: "TRACES_OBSERVATIONS",
+        isCloud: false,
+        isV4PreviewEnabled: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("self-hosted without V4 preview + omitted source + no existing row → allow", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: undefined,
+        existingExportSource: null,
+        isCloud: false,
+        isV4PreviewEnabled: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("Cloud + omitted source + existing EVENTS → allow", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: undefined,
+        existingExportSource: "EVENTS",
+        isCloud: true,
+        isV4PreviewEnabled: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("explicit legacy source overrides an existing enriched value → allow", () => {
+    expect(() =>
+      assertEnrichedBlobExportSourceAllowed({
+        nextInternalExportSource: "TRACES_OBSERVATIONS",
+        existingExportSource: "EVENTS",
+        isCloud: false,
+        isV4PreviewEnabled: false,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -26,6 +26,7 @@ import {
 import { randomUUID } from "crypto";
 import { decrypt } from "@langfuse/shared/encryption";
 import {
+  AnalyticsIntegrationExportSource,
   BlobStorageIntegrationType,
   InvalidRequestError,
   isEnrichedBlobExportAvailable,
@@ -92,6 +93,7 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         });
 
         if (input.exportSource) {
+          const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
           const project = await ctx.prisma.project.findUniqueOrThrow({
             where: { id: input.projectId },
             select: { createdAt: true },
@@ -99,8 +101,26 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           assertLegacyBlobExportSourceAllowed({
             project,
             nextInternalExportSource: input.exportSource,
-            isCloud: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+            isCloud,
           });
+          const enrichedSources = [
+            AnalyticsIntegrationExportSource.EVENTS,
+            AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+          ];
+          if (enrichedSources.includes(input.exportSource)) {
+            if (
+              !isEnrichedBlobExportAvailable(
+                isCloud,
+                env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true",
+              )
+            ) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message:
+                  "Enriched blob export is not available on this deployment",
+              });
+            }
+          }
         }
 
         await auditLog({

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -28,6 +28,7 @@ import { decrypt } from "@langfuse/shared/encryption";
 import {
   BlobStorageIntegrationType,
   InvalidRequestError,
+  isEnrichedBlobExportAvailable,
 } from "@langfuse/shared";
 
 const getAuditLogErrorType = (error: unknown) =>
@@ -50,6 +51,12 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         scope: "integrations:CRUD",
       });
       try {
+        const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
+        const isEnrichedExportAvailable = isEnrichedBlobExportAvailable(
+          isCloud,
+          env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true",
+        );
+
         const config = await ctx.prisma.blobStorageIntegration.findFirst({
           where: {
             projectId: input.projectId,
@@ -59,11 +66,7 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           },
         });
 
-        if (!config) {
-          return null;
-        }
-
-        return config;
+        return { config: config ?? null, isEnrichedExportAvailable };
       } catch (e) {
         logger.error(`Failed to get blob storage integration`, e);
         throw new TRPCError({

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -13,6 +13,7 @@ import {
 } from "@/src/features/blobstorage-integration/validation";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
+import { assertEnrichedBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertEnrichedBlobExportSourceAllowed";
 import { TRPCError } from "@trpc/server";
 import { env } from "@/src/env.mjs";
 import {
@@ -26,7 +27,6 @@ import {
 import { randomUUID } from "crypto";
 import { decrypt } from "@langfuse/shared/encryption";
 import {
-  AnalyticsIntegrationExportSource,
   BlobStorageIntegrationType,
   InvalidRequestError,
   isEnrichedBlobExportAvailable,
@@ -103,24 +103,12 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
             nextInternalExportSource: input.exportSource,
             isCloud,
           });
-          if (
-            input.exportSource === AnalyticsIntegrationExportSource.EVENTS ||
-            input.exportSource ===
-              AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS
-          ) {
-            if (
-              !isEnrichedBlobExportAvailable(
-                isCloud,
-                env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true",
-              )
-            ) {
-              throw new TRPCError({
-                code: "BAD_REQUEST",
-                message:
-                  "Enriched blob export is not available on this deployment",
-              });
-            }
-          }
+          assertEnrichedBlobExportSourceAllowed({
+            nextInternalExportSource: input.exportSource,
+            isCloud,
+            isV4PreviewEnabled:
+              env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true",
+          });
         }
 
         await auditLog({

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -103,11 +103,11 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
             nextInternalExportSource: input.exportSource,
             isCloud,
           });
-          const enrichedSources = [
-            AnalyticsIntegrationExportSource.EVENTS,
-            AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
-          ];
-          if (enrichedSources.includes(input.exportSource)) {
+          if (
+            input.exportSource === AnalyticsIntegrationExportSource.EVENTS ||
+            input.exportSource ===
+              AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS
+          ) {
             if (
               !isEnrichedBlobExportAvailable(
                 isCloud,

--- a/web/src/features/blobstorage-integration/server/assertEnrichedBlobExportSourceAllowed.ts
+++ b/web/src/features/blobstorage-integration/server/assertEnrichedBlobExportSourceAllowed.ts
@@ -1,0 +1,41 @@
+import {
+  AnalyticsIntegrationExportSource,
+  InvalidRequestError,
+  isEnrichedBlobExportAvailable,
+} from "@langfuse/shared";
+
+/**
+ * Rejects enriched export sources (EVENTS, TRACES_OBSERVATIONS_EVENTS) on
+ * deployments where the enriched export path is unavailable (self-hosted
+ * without the V4 preview opt-in).
+ *
+ * For partial updates that omit exportSource, the persisted value stays in
+ * effect — pass it as existingExportSource so a stale enriched value left
+ * behind by a V4-preview flag rollback is rejected instead of silently
+ * driving the worker against unpopulated tables.
+ */
+export function assertEnrichedBlobExportSourceAllowed({
+  nextInternalExportSource,
+  existingExportSource,
+  isCloud,
+  isV4PreviewEnabled,
+}: {
+  nextInternalExportSource: AnalyticsIntegrationExportSource | undefined;
+  existingExportSource?: AnalyticsIntegrationExportSource | null;
+  isCloud: boolean;
+  isV4PreviewEnabled: boolean;
+}): void {
+  const effectiveSource = nextInternalExportSource ?? existingExportSource;
+  if (
+    effectiveSource !== AnalyticsIntegrationExportSource.EVENTS &&
+    effectiveSource !==
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS
+  )
+    return;
+
+  if (isEnrichedBlobExportAvailable(isCloud, isV4PreviewEnabled)) return;
+
+  throw new InvalidRequestError(
+    "Enriched blob export is not available on this deployment",
+  );
+}

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -15,7 +15,9 @@ import {
   LangfuseNotFoundError,
   UnauthorizedError,
   ForbiddenError,
+  InvalidRequestError,
   isLegacyBlobExportAllowed,
+  isEnrichedBlobExportAvailable,
 } from "@langfuse/shared";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
@@ -160,13 +162,28 @@ async function handleUpsertBlobStorageIntegration(
   const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
   if (validatedData.exportSource) {
+    const internalSource = toInternalExportSource(validatedData.exportSource);
     assertLegacyBlobExportSourceAllowed({
       project,
-      nextInternalExportSource: toInternalExportSource(
-        validatedData.exportSource,
-      ),
+      nextInternalExportSource: internalSource,
       isCloud,
     });
+    if (
+      internalSource === AnalyticsIntegrationExportSource.EVENTS ||
+      internalSource ===
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS
+    ) {
+      if (
+        !isEnrichedBlobExportAvailable(
+          isCloud,
+          env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true",
+        )
+      ) {
+        throw new InvalidRequestError(
+          "Enriched blob export is not available on this deployment",
+        );
+      }
+    }
   }
 
   await auditLog({

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -15,12 +15,12 @@ import {
   LangfuseNotFoundError,
   UnauthorizedError,
   ForbiddenError,
-  InvalidRequestError,
   isLegacyBlobExportAllowed,
   isEnrichedBlobExportAvailable,
 } from "@langfuse/shared";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { assertLegacyBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowed";
+import { assertEnrichedBlobExportSourceAllowed } from "@/src/features/blobstorage-integration/server/assertEnrichedBlobExportSourceAllowed";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { env } from "@/src/env.mjs";
 
@@ -161,30 +161,40 @@ async function handleUpsertBlobStorageIntegration(
 
   const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
 
-  if (validatedData.exportSource) {
-    const internalSource = toInternalExportSource(validatedData.exportSource);
+  const isV4PreviewEnabled =
+    env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
+  const internalExportSource =
+    validatedData.exportSource != null
+      ? toInternalExportSource(validatedData.exportSource)
+      : undefined;
+
+  if (internalExportSource) {
     assertLegacyBlobExportSourceAllowed({
       project,
-      nextInternalExportSource: internalSource,
+      nextInternalExportSource: internalExportSource,
       isCloud,
     });
-    if (
-      internalSource === AnalyticsIntegrationExportSource.EVENTS ||
-      internalSource ===
-        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS
-    ) {
-      if (
-        !isEnrichedBlobExportAvailable(
-          isCloud,
-          env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true",
-        )
-      ) {
-        throw new InvalidRequestError(
-          "Enriched blob export is not available on this deployment",
-        );
-      }
-    }
   }
+
+  // Partial PUTs that omit exportSource preserve the persisted value, so the
+  // enriched gate must consider the existing row too — otherwise a stale
+  // enriched source left behind by a V4-preview flag rollback keeps driving
+  // the worker against unpopulated tables. The extra read only happens when
+  // the gate could actually reject (enriched export unavailable).
+  const existingIntegration =
+    internalExportSource === undefined &&
+    !isEnrichedBlobExportAvailable(isCloud, isV4PreviewEnabled)
+      ? await prisma.blobStorageIntegration.findUnique({
+          where: { projectId: validatedData.projectId },
+          select: { exportSource: true },
+        })
+      : null;
+  assertEnrichedBlobExportSourceAllowed({
+    nextInternalExportSource: internalExportSource,
+    existingExportSource: existingIntegration?.exportSource,
+    isCloud,
+    isV4PreviewEnabled,
+  });
 
   await auditLog({
     action: "update",
@@ -218,10 +228,7 @@ async function handleUpsertBlobStorageIntegration(
       exportMode: validatedData.exportMode,
       exportStartDate: validatedData.exportStartDate ?? null,
       compressed: validatedData.compressed,
-      exportSource:
-        validatedData.exportSource != null
-          ? toInternalExportSource(validatedData.exportSource)
-          : undefined,
+      exportSource: internalExportSource,
       exportFieldGroups: validatedData.exportFieldGroups ?? undefined,
     },
   });

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -279,10 +279,18 @@ const BlobStorageIntegrationSettingsForm = ({
       exportStartDate: state?.exportStartDate || null,
       exportSource: isPostCutoffCloud
         ? AnalyticsIntegrationExportSource.EVENTS
-        : state?.exportSource ||
-          (eventsExportAvailable
-            ? AnalyticsIntegrationExportSource.EVENTS
-            : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+        : (() => {
+            const persisted = state?.exportSource;
+            const isEnriched =
+              persisted === AnalyticsIntegrationExportSource.EVENTS ||
+              persisted ===
+                AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS;
+            if (persisted && (!isEnriched || eventsExportAvailable))
+              return persisted;
+            return eventsExportAvailable
+              ? AnalyticsIntegrationExportSource.EVENTS
+              : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
+          })(),
       // Empty array in the DB means "export everything" (the worker falls back
       // to all groups), so surface it as the full selection in the form.
       exportFieldGroups: state?.exportFieldGroups?.length
@@ -315,10 +323,18 @@ const BlobStorageIntegrationSettingsForm = ({
       exportStartDate: state?.exportStartDate || null,
       exportSource: isPostCutoffCloud
         ? AnalyticsIntegrationExportSource.EVENTS
-        : state?.exportSource ||
-          (eventsExportAvailable
-            ? AnalyticsIntegrationExportSource.EVENTS
-            : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
+        : (() => {
+            const persisted = state?.exportSource;
+            const isEnriched =
+              persisted === AnalyticsIntegrationExportSource.EVENTS ||
+              persisted ===
+                AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS;
+            if (persisted && (!isEnriched || eventsExportAvailable))
+              return persisted;
+            return eventsExportAvailable
+              ? AnalyticsIntegrationExportSource.EVENTS
+              : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
+          })(),
       // Empty array in the DB means "export everything" (the worker falls back
       // to all groups), so surface it as the full selection in the form.
       exportFieldGroups: state?.exportFieldGroups?.length

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -56,7 +56,6 @@ import {
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
   isLegacyBlobExportAllowed,
-  isEnrichedBlobExportAvailable,
 } from "@langfuse/shared";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
@@ -81,16 +80,16 @@ export default function BlobStorageIntegrationSettings() {
   );
 
   const syncStatus =
-    state.isLoading || !hasAccess || !state.data
+    state.isLoading || !hasAccess || !state.data?.config
       ? undefined
       : deriveSyncStatus({
-          enabled: state.data.enabled,
-          lastError: state.data.lastError,
-          lastSyncAt: state.data.lastSyncAt
-            ? new Date(state.data.lastSyncAt)
+          enabled: state.data.config.enabled,
+          lastError: state.data.config.lastError,
+          lastSyncAt: state.data.config.lastSyncAt
+            ? new Date(state.data.config.lastSyncAt)
             : null,
-          nextSyncAt: state.data.nextSyncAt
-            ? new Date(state.data.nextSyncAt)
+          nextSyncAt: state.data.config.nextSyncAt
+            ? new Date(state.data.config.nextSyncAt)
             : null,
         });
 
@@ -140,19 +139,19 @@ export default function BlobStorageIntegrationSettings() {
           reach out to your project admin or owner.
         </p>
       )}
-      {state.data && (
+      {state.data?.config && (
         <>
           <Header title="Status" />
-          {state.data.lastError && (
+          {state.data.config.lastError && (
             <Alert variant="destructive" className="mb-4">
               <AlertTitle>Last export failed</AlertTitle>
               <AlertDescription>
-                {state.data.lastError}
-                {state.data.lastErrorAt && (
+                {state.data.config.lastError}
+                {state.data.config.lastErrorAt && (
                   <>
                     <br />
                     <span className="text-xs opacity-70">
-                      {new Date(state.data.lastErrorAt).toLocaleString()}
+                      {new Date(state.data.config.lastErrorAt).toLocaleString()}
                     </span>
                   </>
                 )}
@@ -163,42 +162,45 @@ export default function BlobStorageIntegrationSettings() {
             <div className="grid grid-cols-[auto,1fr] gap-x-4 gap-y-1 text-sm">
               <span className="text-muted-foreground">Data exported up to</span>
               <span>
-                {state.data.lastSyncAt
-                  ? new Date(state.data.lastSyncAt).toLocaleString()
+                {state.data.config.lastSyncAt
+                  ? new Date(state.data.config.lastSyncAt).toLocaleString()
                   : "Never (pending)"}
               </span>
-              {state.data.nextSyncAt && (
+              {state.data.config.nextSyncAt && (
                 <>
                   <span className="text-muted-foreground">
                     Next export scheduled
                   </span>
                   <span>
-                    {new Date(state.data.nextSyncAt).toLocaleString()}
+                    {new Date(state.data.config.nextSyncAt).toLocaleString()}
                   </span>
                 </>
               )}
               <span className="text-muted-foreground">Export mode</span>
               <span>
-                {state.data.exportMode === BlobStorageExportMode.FULL_HISTORY
+                {state.data.config.exportMode ===
+                BlobStorageExportMode.FULL_HISTORY
                   ? "Full history"
-                  : state.data.exportMode === BlobStorageExportMode.FROM_TODAY
+                  : state.data.config.exportMode ===
+                      BlobStorageExportMode.FROM_TODAY
                     ? "From setup date"
-                    : state.data.exportMode ===
+                    : state.data.config.exportMode ===
                         BlobStorageExportMode.FROM_CUSTOM_DATE
                       ? "From custom date"
                       : "Unknown"}
               </span>
-              {(state.data.exportMode ===
+              {(state.data.config.exportMode ===
                 BlobStorageExportMode.FROM_CUSTOM_DATE ||
-                state.data.exportMode === BlobStorageExportMode.FROM_TODAY) &&
-                state.data.exportStartDate && (
+                state.data.config.exportMode ===
+                  BlobStorageExportMode.FROM_TODAY) &&
+                state.data.config.exportStartDate && (
                   <>
                     <span className="text-muted-foreground">
                       Export start date
                     </span>
                     <span>
                       {new Date(
-                        state.data.exportStartDate,
+                        state.data.config.exportStartDate,
                       ).toLocaleDateString()}
                     </span>
                   </>
@@ -212,9 +214,12 @@ export default function BlobStorageIntegrationSettings() {
           <Header title="Configuration" className="mt-8" />
           <Card className="p-3">
             <BlobStorageIntegrationSettingsForm
-              state={state.data || undefined}
+              state={state.data?.config || undefined}
               projectId={projectId}
               isLoading={state.isLoading}
+              isEnrichedExportAvailable={
+                state.data?.isEnrichedExportAvailable ?? false
+              }
             />
           </Card>
         </>
@@ -227,10 +232,12 @@ const BlobStorageIntegrationSettingsForm = ({
   state,
   projectId,
   isLoading,
+  isEnrichedExportAvailable,
 }: {
   state?: Partial<BlobStorageIntegration>;
   projectId: string;
   isLoading: boolean;
+  isEnrichedExportAvailable: boolean;
 }) => {
   const capture = usePostHogClientCapture();
   const { isLangfuseCloud } = useLangfuseCloudRegion();
@@ -247,7 +254,7 @@ const BlobStorageIntegrationSettingsForm = ({
   const isPostCutoffCloud =
     project?.createdAt != null &&
     !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
-  const eventsExportAvailable = isEnrichedBlobExportAvailable(isLangfuseCloud);
+  const eventsExportAvailable = isEnrichedExportAvailable;
   const showExportSourceField = eventsExportAvailable && !isPostCutoffCloud;
 
   const blobStorageForm = useForm({

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -327,7 +327,7 @@ const BlobStorageIntegrationSettingsForm = ({
       compressed: state?.compressed ?? true,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state]);
+  }, [state, isEnrichedExportAvailable, isPostCutoffCloud]);
 
   const watchedExportMode = blobStorageForm.watch("exportMode");
   const watchedExportSource = blobStorageForm.watch("exportSource");


### PR DESCRIPTION
## What does this PR do?

Self-hosted instances with `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN=true` have `events_full` populated via the V4 migration path and should be able to use the enriched blob export source. Previously `isEnrichedBlobExportAvailable` returned `isCloud` only, so self-hosted operators with the preview flag enabled were incorrectly locked out of the EVENTS export source in the UI.

**Changes:**
- Extends `isEnrichedBlobExportAvailable` in `packages/shared` to accept an optional `isV4PreviewEnabled` boolean, returning `isCloud || isV4PreviewEnabled`
- Moves the availability check server-side: the `blobStorageIntegration.get` tRPC procedure now computes `isEnrichedExportAvailable` from `env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` and `env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`, returning it alongside the persisted config
- Updates the blobstorage settings UI to read `eventsExportAvailable` from the tRPC response instead of calling the client-side predicate (which could never read the server-only env var)
- Adds 3 server tests covering Cloud, self-hosted-off, and self-hosted-on cases for the new flag

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have self-reviewed the code
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] My changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing relevant tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gates the enriched blob export source (`EVENTS`) for self-hosted instances that have enabled `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`, fixing a case where those operators were incorrectly locked out of the export source selector.

- Extends `isEnrichedBlobExportAvailable` to accept an optional `isV4PreviewEnabled` flag and moves the availability check server-side in the `blobStorageIntegration.get` tRPC procedure, which now returns `{ config, isEnrichedExportAvailable }` instead of just the config record.
- Updates the blobstorage settings UI to read `eventsExportAvailable` from the tRPC response (covering the server-only env var) rather than the client-side predicate.
- Adds three server-side tests covering the Cloud, self-hosted-off, and self-hosted-on scenarios for the new flag.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The main change is safe for existing users, but there is a form initialization bug that affects the exact user group this PR targets.

The `useEffect` in `BlobStorageIntegrationSettingsForm` only re-runs when the `state` prop (the persisted config) changes. For users who have not yet created a blob-storage config — the primary audience for this feature addition — `state` stays `undefined` both before and after the tRPC query resolves. `isEnrichedExportAvailable` changes from `false` to `true` once the query returns, but the effect never fires to reset the form. The Export Source dropdown appears for these users with `TRACES_OBSERVATIONS` as the selected value instead of the intended `EVENTS` default. Before this PR, `eventsExportAvailable` was derived from the immediately-available `NEXT_PUBLIC_LANGFUSE_CLOUD_REGION` client env var, so this stale-closure path was never reached.

The `useEffect` dependency array in `web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx` needs `eventsExportAvailable` (or `isEnrichedExportAvailable`) added to prevent the stale-closure scenario for users without an existing config.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx:327-328
The `useEffect` that resets the form tracks only `state` (the persisted config) in its dependency array, but now also closes over `eventsExportAvailable`, which is derived from the `isEnrichedExportAvailable` prop. When a user has no existing blob-storage config, `state` is `undefined` before and after the tRPC query resolves, so the effect never re-runs. Meanwhile `isEnrichedExportAvailable` changes from `false` to `true` once the query returns, causing `eventsExportAvailable` to become `true` and `showExportSourceField` to flip to `true` — but the form is never reset, so the Export Source dropdown appears with the wrong default of `TRACES_OBSERVATIONS` instead of `EVENTS`. This is a regression specifically for the new target users (self-hosted V4-preview instances and pre-cutoff Cloud users) who have not yet configured blob storage.

```suggestion
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [state, eventsExportAvailable]);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(blob-exporter): gate isEnrichedBlob..."](https://github.com/langfuse/langfuse/commit/22f780ca8fe94d27e3426834b266c352d3dcf487) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36249692)</sub>

<!-- /greptile_comment -->