### PR TITLE
chore: remove foreign keys from project-media

### DIFF
--- a/packages/shared/prisma/migrations/20260608191624_remove_foreign_keys_media/migration.sql
+++ b/packages/shared/prisma/migrations/20260608191624_remove_foreign_keys_media/migration.sql
@@ -3,6 +3,3 @@ ALTER TABLE "observation_media" DROP CONSTRAINT "observation_media_project_id_fk
 
 -- DropForeignKey
 ALTER TABLE "trace_media" DROP CONSTRAINT "trace_media_project_id_fkey";
-
--- AddForeignKey
-ALTER TABLE "observation_media" ADD CONSTRAINT "observation_media_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/shared/prisma/migrations/20260608191624_remove_foreign_keys_media/migration.sql
+++ b/packages/shared/prisma/migrations/20260608191624_remove_foreign_keys_media/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "observation_media" DROP CONSTRAINT "observation_media_project_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "trace_media" DROP CONSTRAINT "trace_media_project_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "observation_media" ADD CONSTRAINT "observation_media_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/shared/prisma/migrations/20260608191624_remove_foreign_keys_media/migration.sql
+++ b/packages/shared/prisma/migrations/20260608191624_remove_foreign_keys_media/migration.sql
@@ -1,5 +1,5 @@
 -- DropForeignKey
-ALTER TABLE "observation_media" DROP CONSTRAINT "observation_media_project_id_fkey";
+ALTER TABLE "observation_media" DROP CONSTRAINT IF EXISTS "observation_media_project_id_fkey";
 
 -- DropForeignKey
-ALTER TABLE "trace_media" DROP CONSTRAINT "trace_media_project_id_fkey";
+ALTER TABLE "trace_media" DROP CONSTRAINT IF EXISTS "trace_media_project_id_fkey";

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -148,9 +148,7 @@ model Project {
   commentReactions          CommentReaction[]
   annotationQueue           AnnotationQueue[]
   annotationQueueItem       AnnotationQueueItem[]
-  TraceMedia                TraceMedia[]
   Media                     Media[]
-  ObservationMedia          ObservationMedia[]
   LegacyTrace               LegacyPrismaTrace[]
   LegacyObservation         LegacyPrismaObservation[]
   LegacyScore               LegacyPrismaScore[]
@@ -176,6 +174,7 @@ model Project {
   InAppAgentConversation    InAppAgentConversation[]
   InAppAgentEvent           InAppAgentEvent[]
   InAppAgentRun             InAppAgentRun[]
+  observationMedias         ObservationMedia[]
 
   @@index([orgId])
   @@map("projects")
@@ -1354,7 +1353,6 @@ model Media {
 model TraceMedia {
   id        String   @id @default(cuid())
   projectId String   @map("project_id")
-  project   Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
   mediaId   String   @map("media_id")
@@ -1370,7 +1368,6 @@ model TraceMedia {
 model ObservationMedia {
   id            String   @id @default(cuid())
   projectId     String   @map("project_id")
-  project       Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @default(now()) @updatedAt @map("updated_at")
   mediaId       String   @map("media_id")
@@ -1378,6 +1375,7 @@ model ObservationMedia {
   traceId       String   @map("trace_id")
   observationId String   @map("observation_id")
   field         String   @map("field")
+  project       Project  @relation(fields: [projectId], references: [id])
 
   @@unique([projectId, traceId, observationId, mediaId, field])
   @@index([projectId, mediaId])

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -174,7 +174,6 @@ model Project {
   InAppAgentConversation    InAppAgentConversation[]
   InAppAgentEvent           InAppAgentEvent[]
   InAppAgentRun             InAppAgentRun[]
-  observationMedias         ObservationMedia[]
 
   @@index([orgId])
   @@map("projects")
@@ -1375,7 +1374,6 @@ model ObservationMedia {
   traceId       String   @map("trace_id")
   observationId String   @map("observation_id")
   field         String   @map("field")
-  project       Project  @relation(fields: [projectId], references: [id])
 
   @@unique([projectId, traceId, observationId, mediaId, field])
   @@index([projectId, mediaId])


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This migration removes the direct `project_id` FK from both `trace_media` and `observation_media`, then re-adds only the `observation_media` FK — but with `ON DELETE RESTRICT` instead of the original `ON DELETE CASCADE`. The Prisma schema is updated consistently, renaming the reverse-relation field on `Project` from `ObservationMedia` to `observationMedias`.

- `trace_media.project_id` now has no FK constraint; referential integrity relies entirely on the `media → trace_media` CASCADE chain and application-level cleanup.
- `observation_media.project_id` is changed from CASCADE to RESTRICT, meaning a project delete will fail at the DB level if any `observation_media` rows still reference that project; the existing project-deletion worker depends on prior cleanup steps (guarded by `LANGFUSE_S3_MEDIA_UPLOAD_BUCKET`) to drain those rows first.
- Any Prisma client code that referenced `project.ObservationMedia` or `project.TraceMedia` must be updated to `project.observationMedias` and removed respectively — these are compile-time errors in TypeScript.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The project-deletion worker has a latent path where the observation_media RESTRICT FK could block a project delete if cleanup did not run first; safe to merge only after confirming the cascade ordering or adding an explicit pre-delete of observation_media rows.

Changing observation_media.project_id from CASCADE to RESTRICT means the project-deletion flow now depends on either explicit pre-cleanup (gated on S3 config) or the correct PostgreSQL trigger-firing order of the media→observation_media cascade preceding the RESTRICT check. The comment in projectDelete.ts still claims cascades handle cleanup, which is no longer accurate for observation_media. An environment without S3 configured — or any future code path that deletes a project without going through the worker — could hit a FK violation and loop indefinitely.

worker/src/queues/projectDelete.ts — the pre-cleanup block is conditional on S3 being configured, and the project delete at line 94 now relies on cascade ordering rather than a direct CASCADE action from project to observation_media.
</details>

<details><summary><h3>Entity Relationship Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
erDiagram
    projects {
        string id PK
    }
    media {
        string id PK
        string project_id FK
    }
    trace_media {
        string id PK
        string project_id "no FK after PR"
        string media_id FK
    }
    observation_media {
        string id PK
        string project_id FK
        string media_id FK
    }

    projects ||--o{ media : "CASCADE unchanged"
    media ||--o{ trace_media : "CASCADE unchanged"
    media ||--o{ observation_media : "CASCADE unchanged"
    projects ||--o{ observation_media : "RESTRICT was CASCADE"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/prisma/migrations/20260608191624_remove_foreign_keys_media/migration.sql:4-5
**`trace_media.project_id` now has no FK constraint**

The FK on `trace_media.project_id` is dropped but not re-added (unlike `observation_media`, which gets a new RESTRICT FK). The only remaining cascade that cleans up `trace_media` rows is via `trace_media.media_id → media.id ON DELETE CASCADE`. Any code path that deletes `media` rows directly (e.g. the retention cleanup job) will cascade-delete matching `trace_media`, but if a `media` row is deleted out-of-band or if a `trace_media` row is ever inserted with a non-existent `project_id`, there is no database-level guard. Worth confirming the absence of the FK is deliberate for `trace_media` specifically (in contrast to `observation_media` which keeps a RESTRICT FK).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: cleanup"](https://github.com/langfuse/langfuse/commit/001c836d0125bd8a434382384e28ae1bea08d89c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36287648)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->