### PR TITLE
feat(media): dedup link requests via redis

### DIFF
--- a/web/src/__tests__/server/media.servertest.ts
+++ b/web/src/__tests__/server/media.servertest.ts
@@ -241,7 +241,7 @@ describe("Media Upload API", () => {
 
   describeIfNotAzureBlobStorage("End-to-end tests", () => {
     it("should upload and retrieve a PNG media asset for trace input", async () => {
-      const traceId = "test";
+      const traceId = "media-e2e-png-trace-input";
       const field = "input";
 
       const result = await runMediaUploadEndToEndTest({
@@ -293,8 +293,8 @@ describe("Media Upload API", () => {
     }, 10_000);
 
     it("should upload and retrieve a PDF media asset for observation output", async () => {
-      const traceId = "test";
-      const observationId = "test";
+      const traceId = "media-e2e-pdf-observation-output";
+      const observationId = "media-e2e-pdf-observation";
       const field = "output";
 
       const result = await runMediaUploadEndToEndTest({
@@ -345,7 +345,7 @@ describe("Media Upload API", () => {
     }, 10_000);
 
     it("should allow retrying with correct content length", async () => {
-      const traceId = "test";
+      const traceId = "media-e2e-retry-content-length";
       const field = "input";
 
       const failedResult = await runMediaUploadEndToEndTest({
@@ -428,7 +428,7 @@ describe("Media Upload API", () => {
     }, 10_000);
 
     it("should allow retrying with correct content bytes", async () => {
-      const traceId = "test";
+      const traceId = "media-e2e-retry-content-bytes";
       const field = "input";
 
       const failedResult = await runMediaUploadEndToEndTest({
@@ -511,7 +511,7 @@ describe("Media Upload API", () => {
     }, 10_000);
 
     it("should allow retrying with correct content type", async () => {
-      const traceId = "test";
+      const traceId = "media-e2e-retry-content-type";
       const field = "input";
 
       const failedResult = await runMediaUploadEndToEndTest({
@@ -594,7 +594,7 @@ describe("Media Upload API", () => {
     }, 10_000);
 
     it("should allow reuploading with different content type", async () => {
-      const traceId = "test";
+      const traceId = "media-e2e-reupload-content-type";
       const field = "input";
 
       const firstResult = await runMediaUploadEndToEndTest({
@@ -694,7 +694,7 @@ describe("Media Upload API", () => {
     }, 10_000);
 
     it("should return mediaId without upload URL if media file is already uploaded", async () => {
-      const traceId = "test";
+      const traceId = "media-e2e-already-uploaded";
       const field = "input";
 
       const result = await runMediaUploadEndToEndTest({
@@ -820,7 +820,7 @@ describe("Media Upload API", () => {
 
   describeIfNotAzureBlobStorage("Upload Integrity", () => {
     it("should detect SHA-256 hash mismatch during upload", async () => {
-      const traceId = "test";
+      const traceId = "media-e2e-sha256-mismatch";
       const field = "input";
 
       // Create a modified copy of the PNG file bytes by changing a single byte

--- a/web/src/__tests__/server/unit/media-link-dedup.servertest.ts
+++ b/web/src/__tests__/server/unit/media-link-dedup.servertest.ts
@@ -1,0 +1,155 @@
+const { loggerMock, prismaMock, recordIncrementMock, redisMock } = vi.hoisted(
+  () => ({
+    loggerMock: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    },
+    prismaMock: {
+      $queryRaw: vi.fn(),
+      media: {
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
+    },
+    recordIncrementMock: vi.fn(),
+    redisMock: {
+      del: vi.fn(),
+      disconnect: vi.fn(),
+      set: vi.fn(),
+      status: "end",
+    },
+  }),
+);
+
+vi.mock("@/src/env.mjs", () => ({
+  env: {
+    LANGFUSE_MEDIA_LINK_REQUEST_DEDUP_TTL_SECONDS: 30,
+    LANGFUSE_S3_MEDIA_DOWNLOAD_URL_EXPIRY_SECONDS: 3600,
+    LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: "test-bucket",
+    LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: "",
+  },
+}));
+
+vi.mock("@/src/features/media/server/getMediaStorageClient", () => ({
+  getMediaStorageServiceClient: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared", () => ({
+  InternalServerError: class InternalServerError extends Error {},
+  LangfuseNotFoundError: class LangfuseNotFoundError extends Error {},
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  Prisma: {
+    PrismaClientKnownRequestError: class PrismaClientKnownRequestError extends Error {},
+  },
+  prisma: prismaMock,
+}));
+
+vi.mock("@langfuse/shared/src/server", () => ({
+  ClickHouseClientManager: {
+    getInstance: vi.fn(() => ({
+      closeAllConnections: vi.fn(),
+    })),
+  },
+  getCurrentSpan: vi.fn(() => null),
+  logger: loggerMock,
+  recordHistogram: vi.fn(),
+  recordIncrement: recordIncrementMock,
+  redis: redisMock,
+}));
+
+import { createMediaUploadUrl } from "@/src/features/media/server/mediaService";
+import {
+  MediaContentType,
+  MediaEnabledFields,
+} from "@/src/features/media/validation";
+
+const createTraceMediaUploadRequest = () => ({
+  projectId: "project-1",
+  body: {
+    contentLength: 1,
+    contentType: MediaContentType.PNG,
+    field: MediaEnabledFields.Input,
+    sha256Hash: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    traceId: "trace-1",
+  },
+});
+const traceMediaLinkCacheKey =
+  "langfuse:media-link:trace:3Vge25cSTcp0eOn3YdezuCLvJvGCJX1qPuCYszsbYE4";
+
+describe("media link deduplication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.media.findUnique.mockResolvedValue({
+      contentType: "image/png",
+      id: "media-1",
+      uploadHttpStatus: 200,
+    });
+    prismaMock.$queryRaw.mockResolvedValue([]);
+    redisMock.del.mockResolvedValue(1);
+    redisMock.set.mockResolvedValue("OK");
+  });
+
+  it("skips the database insert when Redis has seen the media link request", async () => {
+    redisMock.set.mockResolvedValue(null);
+
+    await expect(
+      createMediaUploadUrl(createTraceMediaUploadRequest()),
+    ).resolves.toEqual({
+      mediaId: "media-1",
+      uploadUrl: null,
+    });
+
+    expect(redisMock.set).toHaveBeenCalledWith(
+      traceMediaLinkCacheKey,
+      "1",
+      "EX",
+      30,
+      "NX",
+    );
+    expect(prismaMock.$queryRaw).not.toHaveBeenCalled();
+    expect(recordIncrementMock).toHaveBeenCalledWith(
+      "langfuse.media.link.dedup_cache_hit",
+      1,
+      { target: "trace" },
+    );
+  });
+
+  it("writes the media link when Redis marks the request as new", async () => {
+    await createMediaUploadUrl(createTraceMediaUploadRequest());
+
+    expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(String(prismaMock.$queryRaw.mock.calls[0]?.[0])).toContain(
+      'INSERT INTO "trace_media"',
+    );
+    expect(recordIncrementMock).toHaveBeenCalledWith(
+      "langfuse.media.link.dedup_cache_miss",
+      1,
+      { target: "trace" },
+    );
+  });
+
+  it("falls back to the database insert when Redis errors", async () => {
+    redisMock.set.mockRejectedValue(new Error("redis unavailable"));
+
+    await createMediaUploadUrl(createTraceMediaUploadRequest());
+
+    expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "Failed to check media link deduplication cache. Continuing with database write.",
+      expect.any(Error),
+    );
+  });
+
+  it("clears the Redis marker when the database insert fails", async () => {
+    prismaMock.$queryRaw.mockRejectedValue(new Error("database unavailable"));
+
+    await expect(
+      createMediaUploadUrl(createTraceMediaUploadRequest()),
+    ).rejects.toThrow("Failed to get media upload URL");
+
+    expect(redisMock.del).toHaveBeenCalledWith(traceMediaLinkCacheKey);
+  });
+});

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -332,6 +332,11 @@ export const env = createEnv({
       .number()
       .nonnegative()
       .default(3600),
+    LANGFUSE_MEDIA_LINK_REQUEST_DEDUP_TTL_SECONDS: z.coerce
+      .number()
+      .int()
+      .nonnegative()
+      .default(30),
     LANGFUSE_S3_MEDIA_UPLOAD_SSE: z.enum(["AES256", "aws:kms"]).optional(),
     LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID: z.string().optional(),
 
@@ -731,6 +736,8 @@ export const env = createEnv({
       process.env.LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE,
     LANGFUSE_S3_MEDIA_DOWNLOAD_URL_EXPIRY_SECONDS:
       process.env.LANGFUSE_S3_MEDIA_DOWNLOAD_URL_EXPIRY_SECONDS,
+    LANGFUSE_MEDIA_LINK_REQUEST_DEDUP_TTL_SECONDS:
+      process.env.LANGFUSE_MEDIA_LINK_REQUEST_DEDUP_TTL_SECONDS,
     LANGFUSE_S3_MEDIA_UPLOAD_SSE: process.env.LANGFUSE_S3_MEDIA_UPLOAD_SSE,
     LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID:
       process.env.LANGFUSE_S3_MEDIA_UPLOAD_SSE_KMS_KEY_ID,

--- a/web/src/features/media/server/mediaService.ts
+++ b/web/src/features/media/server/mediaService.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 
 import { env } from "@/src/env.mjs";
 import { getFileExtensionFromContentType } from "@/src/features/media/server/getFileExtensionFromContentType";
@@ -17,7 +17,17 @@ import {
   logger,
   recordHistogram,
   recordIncrement,
+  redis,
 } from "@langfuse/shared/src/server";
+
+type MediaLinkTarget = "trace" | "observation";
+type MediaLinkParams = {
+  projectId: string;
+  traceId: string;
+  observationId?: string | null;
+  mediaId: string;
+  field: string;
+};
 
 export async function createMediaUploadUrl(params: {
   projectId: string;
@@ -261,29 +271,97 @@ async function upsertMediaRecord(params: {
   }
 }
 
-async function linkMediaToTraceOrObservation(params: {
-  projectId: string;
-  traceId: string;
-  observationId?: string | null;
-  mediaId: string;
-  field: string;
-}) {
+async function linkMediaToTraceOrObservation(params: MediaLinkParams) {
   const { projectId, traceId, observationId, mediaId, field } = params;
+  const target: MediaLinkTarget = observationId ? "observation" : "trace";
+  const cacheKey = await getMediaLinkCacheKeyIfWriteAllowed(params, target);
 
-  if (observationId) {
+  // Return early if DB write is not allowed by cache
+  if (cacheKey === null) return;
+
+  try {
+    if (observationId) {
+      await prisma.$queryRaw`
+        INSERT INTO "observation_media" ("id", "project_id", "trace_id", "observation_id", "media_id", "field")
+        VALUES (${randomUUID()}, ${projectId}, ${traceId}, ${observationId}, ${mediaId}, ${field})
+        ON CONFLICT DO NOTHING;
+      `;
+
+      return;
+    }
+
     await prisma.$queryRaw`
-      INSERT INTO "observation_media" ("id", "project_id", "trace_id", "observation_id", "media_id", "field")
-      VALUES (${randomUUID()}, ${projectId}, ${traceId}, ${observationId}, ${mediaId}, ${field})
+      INSERT INTO "trace_media" ("id", "project_id", "trace_id", "media_id", "field")
+      VALUES (${randomUUID()}, ${projectId}, ${traceId}, ${mediaId}, ${field})
       ON CONFLICT DO NOTHING;
     `;
-    return;
+  } catch (error) {
+    await clearMediaLinkCacheKey(cacheKey);
+
+    throw error;
+  }
+}
+
+async function getMediaLinkCacheKeyIfWriteAllowed(
+  params: MediaLinkParams,
+  target: MediaLinkTarget,
+): Promise<string | null | undefined> {
+  const ttlSeconds = env.LANGFUSE_MEDIA_LINK_REQUEST_DEDUP_TTL_SECONDS;
+
+  if (!redis || ttlSeconds === 0) {
+    return undefined;
   }
 
-  await prisma.$queryRaw`
-    INSERT INTO "trace_media" ("id", "project_id", "trace_id", "media_id", "field")
-    VALUES (${randomUUID()}, ${projectId}, ${traceId}, ${mediaId}, ${field})
-    ON CONFLICT DO NOTHING;
-  `;
+  const cacheKey = getMediaLinkCacheKey(params, target);
+
+  try {
+    const result = await redis.set(cacheKey, "1", "EX", ttlSeconds, "NX");
+
+    if (result !== "OK") {
+      recordIncrement("langfuse.media.link.dedup_cache_hit", 1, { target });
+
+      return null;
+    }
+
+    recordIncrement("langfuse.media.link.dedup_cache_miss", 1, { target });
+
+    return cacheKey;
+  } catch (error) {
+    recordIncrement("langfuse.media.link.dedup_cache_error", 1, { target });
+    logger.warn(
+      "Failed to check media link deduplication cache. Continuing with database write.",
+      error,
+    );
+
+    return undefined;
+  }
+}
+
+async function clearMediaLinkCacheKey(cacheKey: string | undefined) {
+  if (!cacheKey || !redis) return;
+
+  try {
+    await redis.del(cacheKey);
+  } catch (error) {
+    logger.warn("Failed to clear media link deduplication cache key.", error);
+  }
+}
+
+function getMediaLinkCacheKey(
+  params: MediaLinkParams,
+  target: MediaLinkTarget,
+) {
+  const { projectId, traceId, observationId, mediaId, field } = params;
+  const cachePayload =
+    target === "observation"
+      ? [target, projectId, traceId, observationId, mediaId, field]
+      : [target, projectId, traceId, mediaId, field];
+
+  const hash = createHash("sha256")
+    .update(JSON.stringify(cachePayload))
+    .digest("base64url");
+
+  return `langfuse:media-link:${target}:${hash}`;
 }
 
 function getBucketPath(params: {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Redis-based deduplication for media-link insertion requests (`trace_media` / `observation_media`) to reduce redundant DB writes caused by duplicate SDK calls within a short window.

- A SHA-256 hash of the (target, projectId, traceId, mediaId, field) tuple is used as a Redis key via `SET NX` with a configurable TTL (default 30 s). Cache hits skip the DB `INSERT`; Redis errors fall back gracefully to the existing DB path which already uses `ON CONFLICT DO NOTHING`.
- A new `LANGFUSE_MEDIA_LINK_REQUEST_DEDUP_TTL_SECONDS` env var (default 30, set to 0 to disable) is wired through `env.mjs`.
- E2E test trace IDs were made unique per test to prevent cross-test Redis cache collisions in the new dedup layer.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The dedup logic is well-guarded: Redis errors fall back to the DB, the DB uses ON CONFLICT DO NOTHING, and cache keys are cleared on DB failure to allow retries.

The core dedup flow is correct and thoroughly tested. One minor clarity issue exists in the cache-hit check using !== OK instead of === null, but it is not a correctness problem with today's IORedis behaviour.

No files require special attention. The test traceId uniqueness fix in media.servertest.ts is a good companion change given the new dedup TTL.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant mediaService
    participant Redis
    participant DB

    Client->>mediaService: createMediaUploadUrl(params)
    mediaService->>DB: findUnique(media by sha256)
    DB-->>mediaService: existingMedia

    mediaService->>Redis: SET NX key EX ttl
    alt Cache miss - key not in Redis
        Redis-->>mediaService: "OK"
        mediaService->>DB: INSERT trace_media ON CONFLICT DO NOTHING
        alt DB insert succeeds
            DB-->>mediaService: success
            mediaService-->>Client: mediaId + uploadUrl
        else DB insert fails
            DB-->>mediaService: Error
            mediaService->>Redis: DEL key
            mediaService-->>Client: InternalServerError
        end
    else Cache hit - key already in Redis
        Redis-->>mediaService: null
        mediaService-->>Client: mediaId + uploadUrl (no DB write)
    else Redis error
        Redis-->>mediaService: throws
        mediaService->>DB: INSERT trace_media ON CONFLICT DO NOTHING
        DB-->>mediaService: success
        mediaService-->>Client: mediaId + uploadUrl
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/media/server/mediaService.ts:320
With `NX` the only possible non-"OK" return value from `redis.set` is `null`. Using `result !== "OK"` means any unexpected truthy response (though none exist today in IORedis) would silently be treated as a cache hit and suppress the DB write. Comparing explicitly against `null` makes the intent — key already exists → skip write — clearer and prevents any future surprise.

```suggestion
    if (result === null) {
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["push"](https://github.com/langfuse/langfuse/commit/65291985a87c5bcb325fa48fd5dacbd51aaba184) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36311027)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->