### PR TITLE
fix: Function 'hasAllTokens' supports a max of 64 search tokens

### DIFF
--- a/packages/shared/src/server/queries/clickhouse-sql/fts.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/fts.ts
@@ -18,6 +18,7 @@ export const FTS_MATCH_TARGET_ERROR =
   "`matches` is only supported for input, output, and metadata filters.";
 
 export const FTS_TEXT_NORMALIZER = "lower";
+export const FTS_HAS_ALL_TOKENS_MAX_SEARCH_TOKENS = 64;
 
 export const FTS_EVENTS_TABLES: ReadonlySet<string> = new Set(
   EVENTS_TABLE_NAMES,
@@ -76,17 +77,35 @@ export const hasFtsSearchToken = (value: string): boolean =>
 const normalizeFtsTextExpr = (expr: string): string =>
   `${FTS_TEXT_NORMALIZER}(${expr})`;
 
+const ftsSearchTokensExpr = (valueParam: string, normalize: boolean): string =>
+  `arrayDistinct(tokens(${normalize ? normalizeFtsTextExpr(valueParam) : valueParam}))`;
+
+const ftsSearchTokenPrefilterExpr = (
+  valueParam: string,
+  normalize: boolean,
+): string =>
+  `arraySlice(${ftsSearchTokensExpr(valueParam, normalize)}, 1, ${FTS_HAS_ALL_TOKENS_MAX_SEARCH_TOKENS})`;
+
+// `hasAllTokens` can only accept up to 64 search tokens. This predicate is only
+// an index prefilter; exact equality, ILIKE, or position() enforces semantics.
+const ftsTokenPrefilterPredicate = (
+  fieldExpr: string,
+  valueParam: string,
+  normalizeValue: boolean,
+): string =>
+  `hasAllTokens(${fieldExpr}, ${ftsSearchTokenPrefilterExpr(valueParam, normalizeValue)})`;
+
 export const ftsTextTokenPredicate = (
   fieldExpr: string,
   valueParam: string,
 ): string =>
-  `hasAllTokens(${normalizeFtsTextExpr(fieldExpr)}, ${normalizeFtsTextExpr(valueParam)})`;
+  ftsTokenPrefilterPredicate(normalizeFtsTextExpr(fieldExpr), valueParam, true);
 
 export const ftsTextTokenConjunct = (
   fieldExpr: string,
   valueParam: string,
 ): string =>
-  `(empty(tokens(${normalizeFtsTextExpr(valueParam)})) OR ${ftsTextTokenPredicate(fieldExpr, valueParam)})`;
+  `(empty(${ftsSearchTokensExpr(valueParam, true)}) OR ${ftsTextTokenPredicate(fieldExpr, valueParam)})`;
 
 export const ftsTextIndexedSubstringCondition = (
   fieldExpr: string,
@@ -102,7 +121,7 @@ export const ftsMetadataArrayHas = (
 export const ftsMetadataArrayTokenConjunct = (
   arrayExpr: string,
   valueParam: string,
-): string => `hasAllTokens(${arrayExpr}, ${valueParam})`;
+): string => ftsTokenPrefilterPredicate(arrayExpr, valueParam, false);
 
 type FtsMetadataArrayConditionContext = {
   hasKey: string;

--- a/web/src/__tests__/server/clickhouseSearchCondition.servertest.ts
+++ b/web/src/__tests__/server/clickhouseSearchCondition.servertest.ts
@@ -14,6 +14,9 @@ const maybeEventsTable =
     ? describe
     : describe.skip;
 
+const alphabeticSearchToken = (index: number, prefix: string = "needle") =>
+  `${prefix}${String.fromCharCode(97 + Math.floor(index / 26))}${String.fromCharCode(97 + (index % 26))}`;
+
 const searchFixture = `
   SELECT *
   FROM values(
@@ -163,6 +166,40 @@ describe("clickhouseSearchCondition", () => {
       expect(ftsIds).toEqual(baseIds);
     });
 
+    it("handles FTS-prefiltered searches with more than 64 tokens", async () => {
+      const longQuery = Array.from({ length: 65 }, (_, index) =>
+        alphabeticSearchToken(index),
+      ).join(" ");
+      const search = clickhouseSearchCondition({
+        query: longQuery,
+        searchType: ["content"],
+        tablePrefix: "e",
+        searchColumns: ["id", "name"],
+        useEventsTablePath: true,
+      });
+
+      await expect(
+        queryClickhouse<{ count: number }>({
+          query: `
+            SELECT count() AS count
+            FROM events_full AS e
+            WHERE e.project_id = {projectId: String}
+            ${search.query}
+          `,
+          params: {
+            projectId: randomUUID(),
+            ...search.params,
+          },
+          preferredClickhouseService: "EventsReadOnly",
+          tags: {
+            feature: "clickhouse-search-condition-test",
+            type: "events",
+            kind: "test",
+          },
+        }),
+      ).resolves.toEqual([{ count: 0 }]);
+    });
+
     it("matches JSON-escaped Unicode content on events tables with the FTS prefilter", async () => {
       const search = clickhouseSearchCondition({
         query: "東京",
@@ -177,11 +214,15 @@ describe("clickhouseSearchCondition", () => {
         searchStringEscaped: "%\\u6771\\u4eac%",
       });
       expect(search.query).toContain("{searchStringEscaped: String}");
+      expect(search.query).toContain("arraySlice");
       expect(search.query).toContain(
-        "hasAllTokens(lower(e.input), lower({searchStringEscaped: String}))",
+        "hasAllTokens(lower(e.input), arraySlice(",
       );
       expect(search.query).toContain(
-        "hasAllTokens(lower(e.output), lower({searchStringEscaped: String}))",
+        "hasAllTokens(lower(e.output), arraySlice(",
+      );
+      expect(search.query).toContain(
+        "tokens(lower({searchStringEscaped: String}))",
       );
 
       await expect(

--- a/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
+++ b/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
@@ -310,9 +310,14 @@ describe("createFilterFromFilterState filter type validation", () => {
     const { query, params } = result.apply();
     const paramName = Object.keys(params)[0];
 
-    expect(query).toBe(
-      `(position(lower(e.output), lower({${paramName}: String})) > 0 AND hasAllTokens(lower(e.output), lower({${paramName}: String})))`,
+    expect(query).toContain(
+      `position(lower(e.output), lower({${paramName}: String})) > 0`,
     );
+    expect(query).toContain("arraySlice");
+    expect(query).toContain(
+      `hasAllTokens(lower(e.output), arraySlice(arrayDistinct(tokens(lower({${paramName}: String}))), 1, 64))`,
+    );
+    expect(query).toContain(`tokens(lower({${paramName}: String}))`);
     expect(params).toEqual({ [paramName]: "needle" });
   });
 
@@ -333,7 +338,8 @@ describe("createFilterFromFilterState filter type validation", () => {
     const { query } = result.apply();
 
     expect(query).toContain("e.input =");
-    expect(query).toContain("hasAllTokens(lower(e.input), lower(");
+    expect(query).toContain("arraySlice");
+    expect(query).toContain("hasAllTokens(lower(e.input), arraySlice(");
   });
 
   it("generates case-sensitive FTS SQL for event metadata matches", () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a ClickHouse runtime error that occurs when a search query produces more than 64 tokens: `hasAllTokens` silently fails or throws above that limit. The fix wraps the needle expression in `arraySlice(arrayDistinct(tokens(...)), 1, 64)` to cap tokens before passing them to `hasAllTokens`, preserving correctness because the prefilter is always guarded by a `position()` or exact-equality condition that enforces full semantics.

- **`fts.ts`**: New helpers `ftsSearchTokensExpr`, `ftsSearchTokenPrefilterExpr`, and `ftsTokenPrefilterPredicate` encapsulate the token-capping logic; both the text and metadata array `hasAllTokens` call-sites now go through this path.
- **Tests**: The `>64 token` integration test validates the generated SQL compiles and executes against ClickHouse; unit-test assertions are relaxed from exact SQL strings to `toContain` checks that match the new `arraySlice(arrayDistinct(tokens(...)))` shape.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a safe, targeted fix: the generated SQL changes only add a wrapping arraySlice/arrayDistinct around the existing tokens() call, and full result correctness continues to be enforced by the unchanged position() and exact-equality predicates.

The change is well-scoped — one constant, three small private helpers, and two updated call-sites. The prefilter-only role of hasAllTokens is clearly documented, the empty-token guard in ftsTextTokenConjunct uses the full (unsliced) array correctly, and an integration test validates that a 65-token query compiles and executes against ClickHouse without errors.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Search query string] --> B["tokens(lower(valueParam))"]
    B --> C["arrayDistinct(...)"]
    C --> D{"len > 64?"}
    D -- "yes (truncated)" --> E["arraySlice(..., 1, 64)"]
    D -- "no (unchanged)" --> E
    E --> F["hasAllTokens(fieldExpr, sliced_tokens)\n(FTS index prefilter)"]
    F --> G{Index hit?}
    G -- yes --> H["position(lower(field), lower(value)) > 0\nOR exact equality check\n(semantic enforcer)"]
    G -- no --> I[Row excluded]
    H -- pass --> J[Row included]
    H -- fail --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Function &#39;hasAllTokens&#39; supports a ..."](https://github.com/langfuse/langfuse/commit/600b2febc88526c1a18d43e1c0fd4baf4a15325c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36407144)</sub>

<!-- /greptile_comment -->