### PR TITLE
feat(agent): Add Langfuse Docs MCP

### DIFF
--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -1,5 +1,6 @@
 import { EventType } from "@ag-ui/core";
 import { HttpAgent } from "@ag-ui/client";
+import { Agent } from "@mastra/core/agent";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AgUiEvent } from "@/src/features/in-app-agent/schema";
@@ -65,6 +66,13 @@ vi.mock("@mastra/mcp", () => ({
   MCPClient: vi.fn().mockImplementation(function () {
     return {
       listTools: vi.fn().mockResolvedValue({}),
+      listToolsetsWithErrors: vi.fn().mockResolvedValue({
+        toolsets: {
+          langfuse: { search: { server: "langfuse" } },
+          langfuseDocs: { search: { server: "langfuseDocs" } },
+        },
+        errors: {},
+      }),
       disconnect: adapterEvents.cleanup,
     };
   }),
@@ -173,6 +181,14 @@ describe("createAgUiStream", () => {
 
     expect(streamedText).toContain(EventType.MESSAGES_SNAPSHOT);
     expect(adapterEvents.inputs).toEqual([input]);
+    expect(Agent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: {
+          langfuse_search: { server: "langfuse" },
+          langfuseDocs_search: { server: "langfuseDocs" },
+        },
+      }),
+    );
     expect(persistedEvents.map((event) => event.type)).toEqual([
       EventType.RUN_STARTED,
       EventType.MESSAGES_SNAPSHOT,

--- a/web/src/features/in-app-agent/server/agent.ts
+++ b/web/src/features/in-app-agent/server/agent.ts
@@ -40,6 +40,7 @@ The current time is ${new Date().toDateString()}.
 </world_knowledge>
 `;
 const MAX_AGENT_STEPS = 10;
+const LANGFUSE_DOCS_MCP_URL = "https://langfuse.com/api/mcp";
 
 type CreateAgUiStreamOptions = {
   onEvent?: (event: AgUiEvent) => void | Promise<void>;
@@ -484,11 +485,32 @@ async function createMastraAdapter(params: {
           },
         },
       },
+      langfuseDocs: {
+        url: new URL(LANGFUSE_DOCS_MCP_URL),
+      },
     },
   });
 
   try {
-    const tools = await mcpClient.listTools();
+    const { toolsets, errors } = await mcpClient.listToolsetsWithErrors();
+
+    if (errors.langfuse) {
+      throw new Error(`Failed to initialize Langfuse MCP: ${errors.langfuse}`);
+    }
+
+    if (errors.langfuseDocs) {
+      logger.warn("Failed to initialize Langfuse docs MCP", {
+        error: errors.langfuseDocs,
+        runId: params.input.runId,
+        threadId: params.input.threadId,
+      });
+    }
+
+    const tools = {
+      ...prefixToolsetTools("langfuse", toolsets.langfuse),
+      ...prefixToolsetTools("langfuseDocs", toolsets.langfuseDocs),
+    };
+
     const agent = new Agent({
       id: "langfuse-in-app-assistant",
       name: ASSISTANT_TITLE,
@@ -521,6 +543,18 @@ async function createMastraAdapter(params: {
     });
     throw error;
   }
+}
+
+function prefixToolsetTools<TTool>(
+  serverName: string,
+  toolset: Record<string, TTool> | undefined,
+) {
+  return Object.fromEntries(
+    Object.entries(toolset ?? {}).map(([toolName, tool]) => [
+      `${serverName}_${toolName}`,
+      tool,
+    ]),
+  );
 }
 
 function normalizeAdapterEvent(


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a second MCP server (`langfuseDocs`) to the in-app agent's `MCPClient`, pointing at the public `https://langfuse.com/api/mcp` endpoint so the agent can query Langfuse documentation as a tool.

- A module-level constant `LANGFUSE_DOCS_MCP_URL` is introduced and the new server entry is added alongside the existing authenticated `langfuse` server in `createMastraAdapter`.
- The docs MCP has no authentication headers, which is appropriate for a public endpoint, but it is registered unconditionally on every agent invocation with no opt-out or fallback.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change ties every in-app agent request to the availability of an external public endpoint; any interruption to langfuse.com will break agent initialization entirely.

Because mcpClient.listTools() contacts all registered servers before the agent can start, a transient failure at langfuse.com/api/mcp — or any self-hosted / air-gapped environment where that host is unreachable — will throw and make the agent completely unavailable. The existing langfuse server is operator-controlled; this new one is not. There is currently no timeout configuration, circuit-breaker, or opt-out flag to isolate this dependency from the primary agent path.

web/src/features/in-app-agent/server/agent.ts — specifically the unconditional langfuseDocs registration and the downstream listTools() call that connects to all servers at startup.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant AgentServer as agent.ts (server)
    participant MCPClient as MCPClient
    participant LangfuseMCP as langfuse MCP (self-hosted)
    participant DocsMCP as langfuse.com/api/mcp (external)

    User->>AgentServer: run agent request
    AgentServer->>MCPClient: "new MCPClient({ langfuse, langfuseDocs })"
    AgentServer->>MCPClient: listTools()
    MCPClient->>LangfuseMCP: "connect & list tools"
    LangfuseMCP-->>MCPClient: tools
    MCPClient->>DocsMCP: "connect & list tools"
    alt DocsMCP available
        DocsMCP-->>MCPClient: tools
        MCPClient-->>AgentServer: merged tool list
        AgentServer-->>User: streaming response
    else DocsMCP unavailable / network error
        DocsMCP--xMCPClient: timeout / error
        MCPClient-->>AgentServer: throws error
        AgentServer-->>User: agent initialization failure
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/in-app-agent/server/agent.ts:469-471
**External dependency blocks agent initialization**

The `langfuseDocs` server is registered unconditionally, and `mcpClient.listTools()` (line 476) connects to all registered servers before the agent can start. If `https://langfuse.com/api/mcp` is unreachable — network partition, outage, slow response, DNS failure, or a self-hosted / air-gapped deployment — the entire `createMastraAdapter` call throws and the in-app agent becomes completely unavailable. The existing `langfuse` server is under the operator's own control, so a failure there is recoverable; the docs MCP is an external dependency the operator cannot influence.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agent): Add Langfuse Docs MCP"](https://github.com/langfuse/langfuse/commit/bbc2e13ff03d45c9d62de8ed762b49c5dee3a49b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36408330)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->