### PR TITLE
chore: Allow skipping lint in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,6 +6,15 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 # Define the protected branch
 protected_branch="main"
 
+run_lint() {
+    if [ -n "${LANGFUSE_PRE_COMMIT_SKIP_LINT-}" ]; then
+        echo "Skipping lint because LANGFUSE_PRE_COMMIT_SKIP_LINT is set."
+        return 0
+    fi
+
+    pnpm run lint
+}
+
 # Check if the current branch is the protected branch
 if [ "$current_branch" = "$protected_branch" ]; then
     echo "🚨 You are about to commit to the $protected_branch branch. Are you sure? (y/n)"
@@ -13,7 +22,7 @@ if [ "$current_branch" = "$protected_branch" ]; then
     if [ "$answer" != "${answer#[Yy]}" ]; then
         # Commit approved, run checks
         pnpm run format:check
-        pnpm run lint
+        run_lint
     else
         echo "Commit to $protected_branch branch has been canceled."
         exit 1 # Commit will be blocked
@@ -22,4 +31,4 @@ fi
 
 # If not the protected branch, run checks
 pnpm run format:check
-pnpm run lint
+run_lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,6 +211,15 @@ When you change the shared MCP setup:
    pnpm run prepare  # Sets up Husky pre-commit hooks for code formatting
    ```
 
+   The pre-commit hook runs formatting and lint checks. To skip only the lint
+   check for a commit, set `LANGFUSE_PRE_COMMIT_SKIP_LINT`, for example:
+
+   ```bash
+   LANGFUSE_PRE_COMMIT_SKIP_LINT=1 git commit -m "your commit message"
+   ```
+
+   CI still runs the required checks for pull requests.
+
 4. Create an env file
 
    ```bash


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-out mechanism for the lint step in the pre-commit hook by introducing a `LANGFUSE_PRE_COMMIT_SKIP_LINT` environment variable, and documents the feature in `CONTRIBUTING.md`.

- A `run_lint` function wraps `pnpm run lint` and short-circuits when `LANGFUSE_PRE_COMMIT_SKIP_LINT` is set to any non-empty value; both call-sites (main branch and regular branch paths) are updated to use it.
- The `CONTRIBUTING.md` section on pre-commit hooks is extended with a usage example and a note that CI still enforces the full check on PRs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to an optional env-var escape hatch in the pre-commit hook and documentation; CI checks are unaffected.

Both call-sites in the hook are updated, the variable check uses correct POSIX sh syntax, and the CONTRIBUTING.md example accurately reflects the required non-empty value. No logic paths are removed or weakened.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[git commit] --> B{current_branch == main?}
    B -- Yes --> C[Prompt user y/n]
    C -- No --> D[exit 1 - blocked]
    C -- Yes --> E[pnpm run format:check]
    E --> F[run_lint]
    F --> G{LANGFUSE_PRE_COMMIT_SKIP_LINT set?}
    G -- Yes --> H[Skip lint, return 0]
    G -- No --> I[pnpm run lint]
    H --> J[commit proceeds]
    I --> J
    B -- No --> K[pnpm run format:check]
    K --> L[run_lint]
    L --> G
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Allow skipping lint in pre-commit..."](https://github.com/langfuse/langfuse/commit/79b8abe45bf73e86729df722868d75da0df68f4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36428967)</sub>

<!-- /greptile_comment -->