### PR TITLE
fix(evals): preserve unsafe dataset integers

### DIFF
--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -1,4 +1,5 @@
 import { JSONPath } from "jsonpath-plus";
+import { parseJsonPrioritised } from "../../utils/json";
 
 /**
  * Parses an unknown value to a string representation
@@ -37,19 +38,20 @@ function parseMultiEncodedJson(value: unknown): unknown {
     return value;
   }
 
-  try {
-    const parsed = JSON.parse(value);
+  const parsed = parseJsonPrioritised(value);
 
-    // If result is still a string, it might be double-encoded - recurse
-    if (typeof parsed === "string") {
-      return parseMultiEncodedJson(parsed);
-    }
-
-    return parsed;
-  } catch {
-    // If parsing fails, return original value
+  // If parsing fails, parseJsonPrioritised returns the original string.
+  // Stop here to avoid recursing forever on plain strings.
+  if (parsed === value || parsed === undefined) {
     return value;
   }
+
+  // If result is still a string, it might be double-encoded - recurse
+  if (typeof parsed === "string") {
+    return parseMultiEncodedJson(parsed);
+  }
+
+  return parsed;
 }
 
 function parseJsonDefault(selectedColumn: unknown, jsonSelector: string) {

--- a/packages/shared/src/server/services/DatasetService/DatasetItemValidator.ts
+++ b/packages/shared/src/server/services/DatasetService/DatasetItemValidator.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "../../../db";
 import { FieldValidationError } from "../../../utils/jsonSchemaValidation";
+import { parseJsonPrioritised } from "../../../utils/json";
 import { logger } from "../../logger";
 import { PayloadError } from "../../repositories/dataset-items";
 import { DatasetSchemaValidator } from "./DatasetSchemaValidator";
@@ -124,13 +125,10 @@ export class DatasetItemValidator {
 
       if (typeof data === "string") {
         // Try to parse as JSON first (for tRPC which sends JSON strings like '{"key":"value"}')
-        try {
-          parsed = JSON.parse(data) as Prisma.InputJsonValue;
-        } catch {
-          // If parsing fails, it's a plain string
-          // Store the string as-is
-          parsed = data;
-        }
+        const parsedJson = parseJsonPrioritised(data);
+        parsed = (
+          parsedJson === undefined ? data : parsedJson
+        ) as Prisma.InputJsonValue;
       } else {
         // Public API sends already-parsed values - use directly
         parsed = data as Prisma.InputJsonValue;

--- a/packages/shared/src/utils/json.ts
+++ b/packages/shared/src/utils/json.ts
@@ -389,6 +389,11 @@ export function deepParseJsonIterative(
  * 2. \d[eE] - scientific notation (always use lossless-json for safety)
  */
 const UNSAFE_NUMBER_PATTERN = /[\d.]{13,}|\d[eE]/;
+const JSON_NUMBER_LITERAL_PATTERN =
+  /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+
+export const isJsonNumberLiteral = (value: string): boolean =>
+  JSON_NUMBER_LITERAL_PATTERN.test(value.trim());
 
 export const parseJsonPrioritised = (
   json: string,

--- a/web/src/__tests__/server/datasets-schema-validation.servertest.ts
+++ b/web/src/__tests__/server/datasets-schema-validation.servertest.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { prisma } from "@langfuse/shared/src/db";
+import { Prisma, prisma } from "@langfuse/shared/src/db";
 import {
   makeAPICall,
   makeZodVerifiedAPICall,
@@ -340,6 +340,55 @@ describe("Unit Tests - DatasetItemValidator", () => {
       validateOpts: { normalizeUndefinedToNull: true },
     });
     expect(result.success).toBe(true);
+  });
+
+  it("should preserve unsafe JSON numbers as strings during normalization", () => {
+    const validator = new DatasetItemValidator({
+      inputSchema: null,
+      expectedOutputSchema: null,
+    });
+
+    const result = validator.validateAndNormalize({
+      input: '{"input_number":107505301260286111,"safe_number":42}',
+      expectedOutput: '{"output_number":107505301260286111}',
+      metadata: '{"metadata_number":107505301260286111}',
+      validateOpts: { normalizeUndefinedToNull: true },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.input).toEqual({
+        input_number: "107505301260286111",
+        safe_number: 42,
+      });
+      expect(result.expectedOutput).toEqual({
+        output_number: "107505301260286111",
+      });
+      expect(result.metadata).toEqual({
+        metadata_number: "107505301260286111",
+      });
+    }
+  });
+
+  it("should normalize JSON null literals to database null", () => {
+    const validator = new DatasetItemValidator({
+      inputSchema: null,
+      expectedOutputSchema: null,
+    });
+
+    const result = validator.validateAndNormalize({
+      input: "null",
+      expectedOutput: "null",
+      metadata: "null",
+      validateOpts: { normalizeUndefinedToNull: true },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.input).toBe(Prisma.DbNull);
+      expect(result.expectedOutput).toBe(Prisma.DbNull);
+      expect(result.metadata).toBe(Prisma.DbNull);
+    }
   });
 });
 

--- a/web/src/__tests__/server/zod.servertest.ts
+++ b/web/src/__tests__/server/zod.servertest.ts
@@ -1,4 +1,8 @@
-import { paginationZod, parseJsonPrioritised } from "@langfuse/shared";
+import {
+  isJsonNumberLiteral,
+  paginationZod,
+  parseJsonPrioritised,
+} from "@langfuse/shared";
 import { ZodError } from "zod";
 
 // Create test cases
@@ -55,4 +59,13 @@ describe("parseJsonPrioritised", () => {
       expect(parseJsonPrioritised(input)).toEqual(expectedOutput);
     },
   );
+});
+
+describe("isJsonNumberLiteral", () => {
+  it("validates complete JSON number literals", () => {
+    expect(isJsonNumberLiteral("107505301260286111")).toBe(true);
+    expect(isJsonNumberLiteral("-1.23e+4")).toBe(true);
+    expect(isJsonNumberLiteral("plain107505301260286111")).toBe(false);
+    expect(isJsonNumberLiteral("01")).toBe(false);
+  });
 });

--- a/web/src/features/datasets/components/EditDatasetItemDialog.tsx
+++ b/web/src/features/datasets/components/EditDatasetItemDialog.tsx
@@ -24,17 +24,12 @@ import {
   stringifyDatasetItemData,
   type DatasetSchema,
 } from "../utils/datasetItemUtils";
+import { isValidDatasetJson } from "../utils/parseDatasetJson";
 
 const formSchema = z.object({
   input: z.string().refine(
     (value) => {
-      if (value === "") return true;
-      try {
-        JSON.parse(value);
-        return true;
-      } catch {
-        return false;
-      }
+      return isValidDatasetJson(value);
     },
     {
       message:
@@ -43,13 +38,7 @@ const formSchema = z.object({
   ),
   expectedOutput: z.string().refine(
     (value) => {
-      if (value === "") return true;
-      try {
-        JSON.parse(value);
-        return true;
-      } catch {
-        return false;
-      }
+      return isValidDatasetJson(value);
     },
     {
       message:
@@ -58,13 +47,7 @@ const formSchema = z.object({
   ),
   metadata: z.string().refine(
     (value) => {
-      if (value === "") return true;
-      try {
-        JSON.parse(value);
-        return true;
-      } catch {
-        return false;
-      }
+      return isValidDatasetJson(value);
     },
     {
       message:

--- a/web/src/features/datasets/components/NewDatasetItemForm.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemForm.tsx
@@ -36,18 +36,16 @@ import { Check, ChevronsUpDown } from "lucide-react";
 import { Badge } from "@/src/components/ui/badge";
 import { ScrollArea } from "@/src/components/ui/scroll-area";
 import { DialogBody, DialogFooter } from "@/src/components/ui/dialog";
+import {
+  isValidDatasetJson,
+  parseDatasetJson,
+} from "../utils/parseDatasetJson";
 
 const formSchema = z.object({
   datasetIds: z.array(z.string()).min(1, "Select at least one dataset"),
   input: z.string().refine(
     (value) => {
-      if (value === "") return true;
-      try {
-        JSON.parse(value);
-        return true;
-      } catch {
-        return false;
-      }
+      return isValidDatasetJson(value);
     },
     {
       message:
@@ -56,13 +54,7 @@ const formSchema = z.object({
   ),
   expectedOutput: z.string().refine(
     (value) => {
-      if (value === "") return true;
-      try {
-        JSON.parse(value);
-        return true;
-      } catch {
-        return false;
-      }
+      return isValidDatasetJson(value);
     },
     {
       message:
@@ -71,13 +63,7 @@ const formSchema = z.object({
   ),
   metadata: z.string().refine(
     (value) => {
-      if (value === "") return true;
-      try {
-        JSON.parse(value);
-        return true;
-      } catch {
-        return false;
-      }
+      return isValidDatasetJson(value);
     },
     {
       message:
@@ -92,7 +78,7 @@ const formatJsonValue = (value: Prisma.JsonValue | undefined): string => {
   if (typeof value === "string") {
     try {
       // Parse the string and re-stringify with proper formatting
-      const parsed = JSON.parse(value);
+      const parsed = parseDatasetJson(value);
       return JSON.stringify(parsed, null, 2);
     } catch {
       // If it's not valid JSON, stringify the string itself

--- a/web/src/features/datasets/hooks/useDatasetItemValidation.ts
+++ b/web/src/features/datasets/hooks/useDatasetItemValidation.ts
@@ -1,6 +1,10 @@
 import { useMemo } from "react";
 import { validateFieldAgainstSchema } from "@langfuse/shared";
 import type { Prisma } from "@langfuse/shared";
+import {
+  isDatasetJsonParseFailure,
+  parseDatasetJson,
+} from "../utils/parseDatasetJson";
 
 type Dataset = {
   id: string;
@@ -46,19 +50,23 @@ export const useDatasetItemValidation = (
     let inputData: unknown = null;
     let outputData: unknown = null;
 
-    try {
-      inputData = inputString ? JSON.parse(inputString) : null;
-    } catch (_e) {
-      // Invalid JSON - skip validation (Zod will catch this)
-      return { isValid: true, errors: [], hasSchemas: false };
+    if (inputString) {
+      inputData = parseDatasetJson(inputString);
+      if (isDatasetJsonParseFailure(inputString, inputData)) {
+        // Invalid JSON - skip schema validation (Zod will catch this)
+        return { isValid: true, errors: [], hasSchemas: false };
+      }
     }
 
-    try {
-      outputData = expectedOutputString
-        ? JSON.parse(expectedOutputString)
-        : null;
-    } catch (_e) {
-      // Invalid JSON - skip validation (Zod will catch this)
+    if (expectedOutputString) {
+      outputData = parseDatasetJson(expectedOutputString);
+      if (isDatasetJsonParseFailure(expectedOutputString, outputData)) {
+        // Invalid JSON - skip schema validation (Zod will catch this)
+        return { isValid: true, errors: [], hasSchemas: false };
+      }
+    }
+
+    if (inputData === undefined || outputData === undefined) {
       return { isValid: true, errors: [], hasSchemas: false };
     }
 

--- a/web/src/features/datasets/lib/csv/helpers.clienttest.ts
+++ b/web/src/features/datasets/lib/csv/helpers.clienttest.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { parseValue } from "./helpers";
+
+describe("CSV dataset parsing", () => {
+  it("preserves unsafe integer values as strings", () => {
+    expect(parseValue("107505301260286111")).toBe("107505301260286111");
+    expect(parseValue('{"input_number":107505301260286111}')).toEqual({
+      input_number: "107505301260286111",
+    });
+  });
+
+  it("keeps safe numbers as numbers", () => {
+    expect(parseValue("42")).toBe(42);
+    expect(parseValue("3.4")).toBe(3.4);
+    expect(parseValue('{"safe_number":42}')).toEqual({ safe_number: 42 });
+  });
+
+  it("keeps case-insensitive boolean fallback behavior", () => {
+    expect(parseValue("true")).toBe(true);
+    expect(parseValue("FALSE")).toBe(false);
+  });
+});

--- a/web/src/features/datasets/lib/csv/helpers.clienttest.ts
+++ b/web/src/features/datasets/lib/csv/helpers.clienttest.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseValue } from "./helpers";
+import { parseCsvClient, parseValue } from "./helpers";
 
 describe("CSV dataset parsing", () => {
   it("preserves unsafe integer values as strings", () => {
@@ -13,6 +13,30 @@ describe("CSV dataset parsing", () => {
     expect(parseValue("42")).toBe(42);
     expect(parseValue("3.4")).toBe(3.4);
     expect(parseValue('{"safe_number":42}')).toEqual({ safe_number: 42 });
+  });
+
+  it("preserves unsafe decimal values as strings", () => {
+    expect(parseValue("0.123456789012345678")).toBe("0.123456789012345678");
+    expect(parseValue("12345678901234.567")).toBe("12345678901234.567");
+    expect(parseValue('{"amount":0.123456789012345678}')).toEqual({
+      amount: "0.123456789012345678",
+    });
+  });
+
+  it("infers unsafe decimal columns as strings", async () => {
+    const file = new File(["amount\n0.123456789012345678\n"], "amounts.csv", {
+      type: "text/csv",
+    });
+
+    const preview = await parseCsvClient(file, {
+      isPreview: true,
+      collectSamples: true,
+    });
+
+    expect(preview.columns[0]).toMatchObject({
+      name: "amount",
+      inferredType: "string",
+    });
   });
 
   it("keeps case-insensitive boolean fallback behavior", () => {

--- a/web/src/features/datasets/lib/csv/helpers.ts
+++ b/web/src/features/datasets/lib/csv/helpers.ts
@@ -1,5 +1,5 @@
 import { parse } from "csv-parse";
-import { type Prisma } from "@langfuse/shared";
+import { parseJsonPrioritised, type Prisma } from "@langfuse/shared";
 import type {
   ParseOptions,
   CsvPreviewResult,
@@ -150,30 +150,33 @@ function inferColumnType(samples: string[]): ColumnType {
 function inferTypeFromValue(value: string): ColumnType {
   if (!value || value.toLowerCase() === "null") return "null";
 
-  try {
-    const parsed = JSON.parse(value);
-    if (Array.isArray(parsed)) return "array";
-    if (typeof parsed === "object") return "json";
-    return typeof parsed as ColumnType;
-  } catch {
-    if (value.toLowerCase() === "true") return "boolean";
-    if (value.toLowerCase() === "false") return "boolean";
-    if (!isNaN(Number(value))) return "number";
-    return "string";
-  }
+  const parsed = parseValue(value);
+  if (Array.isArray(parsed)) return "array";
+  if (typeof parsed === "object" && parsed !== null) return "json";
+  return typeof parsed as ColumnType;
 }
 
 // Helper to parse a single value
 export function parseValue(value: string): Prisma.JsonValue {
-  try {
-    return JSON.parse(value);
-  } catch {
-    if (value === "" || value.toLowerCase() === "null") return null;
-    if (value.toLowerCase() === "true") return true;
-    if (value.toLowerCase() === "false") return false;
-    if (!isNaN(Number(value))) return Number(value);
-    return value;
+  if (value === "" || value.toLowerCase() === "null") return null;
+
+  const parsed = parseJsonPrioritised(value);
+  if (parsed !== value && parsed !== undefined) {
+    return parsed as Prisma.JsonValue;
   }
+
+  if (value.toLowerCase() === "true") return true;
+  if (value.toLowerCase() === "false") return false;
+
+  const numericValue = Number(value);
+  if (
+    Number.isFinite(numericValue) &&
+    Math.abs(numericValue) <= Number.MAX_SAFE_INTEGER
+  ) {
+    return numericValue;
+  }
+
+  return value;
 }
 
 // Helper to parse multiple columns into a record

--- a/web/src/features/datasets/lib/csv/helpers.ts
+++ b/web/src/features/datasets/lib/csv/helpers.ts
@@ -1,5 +1,9 @@
 import { parse } from "csv-parse";
-import { parseJsonPrioritised, type Prisma } from "@langfuse/shared";
+import {
+  isJsonNumberLiteral,
+  parseJsonPrioritised,
+  type Prisma,
+} from "@langfuse/shared";
 import type {
   ParseOptions,
   CsvPreviewResult,
@@ -161,7 +165,10 @@ export function parseValue(value: string): Prisma.JsonValue {
   if (value === "" || value.toLowerCase() === "null") return null;
 
   const parsed = parseJsonPrioritised(value);
-  if (parsed !== value && parsed !== undefined) {
+  if (
+    parsed !== undefined &&
+    (parsed !== value || isJsonNumberLiteral(value))
+  ) {
     return parsed as Prisma.JsonValue;
   }
 

--- a/web/src/features/datasets/utils/parseDatasetJson.clienttest.ts
+++ b/web/src/features/datasets/utils/parseDatasetJson.clienttest.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  isDatasetJsonParseFailure,
+  isValidDatasetJson,
+  parseDatasetJson,
+} from "./parseDatasetJson";
+
+describe("parseDatasetJson", () => {
+  it("preserves unsafe JSON numbers as strings", () => {
+    expect(parseDatasetJson("107505301260286111")).toBe("107505301260286111");
+    expect(parseDatasetJson('{"id":107505301260286111}')).toEqual({
+      id: "107505301260286111",
+    });
+  });
+
+  it("validates JSON without rejecting unsafe root numbers", () => {
+    expect(isValidDatasetJson("107505301260286111")).toBe(true);
+    expect(isValidDatasetJson('{"id":107505301260286111}')).toBe(true);
+    expect(isValidDatasetJson("null")).toBe(true);
+    expect(isValidDatasetJson("plain")).toBe(false);
+  });
+
+  it("detects invalid JSON without treating unsafe root numbers as failures", () => {
+    expect(isDatasetJsonParseFailure("plain")).toBe(true);
+    expect(isDatasetJsonParseFailure("{")).toBe(true);
+    expect(isDatasetJsonParseFailure("107505301260286111")).toBe(false);
+    expect(isDatasetJsonParseFailure("null")).toBe(false);
+  });
+});

--- a/web/src/features/datasets/utils/parseDatasetJson.ts
+++ b/web/src/features/datasets/utils/parseDatasetJson.ts
@@ -1,0 +1,25 @@
+import { isJsonNumberLiteral, parseJsonPrioritised } from "@langfuse/shared";
+
+export function parseDatasetJson(value: string): unknown {
+  return parseJsonPrioritised(value);
+}
+
+export function isDatasetJsonParseFailure(
+  value: string,
+  parsed: unknown = parseDatasetJson(value),
+): boolean {
+  if (value === "") return false;
+
+  return (
+    parsed === value && parsed !== undefined && !isJsonNumberLiteral(value)
+  );
+}
+
+export function isValidDatasetJson(value: string): boolean {
+  if (value === "") return true;
+
+  const parsed = parseDatasetJson(value);
+  if (parsed === undefined) return false;
+
+  return !isDatasetJsonParseFailure(value, parsed);
+}

--- a/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
+++ b/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
@@ -46,6 +46,20 @@ describe("extractValueFromObject", () => {
   });
 
   describe("JSONPath single element access (backward compat)", () => {
+    it("should preserve unsafe integers as strings when applying a selector", () => {
+      const obj = {
+        data: '{"id":107505301260286111,"safe":42}',
+      };
+
+      const unsafeResult = extractValueFromObject(obj, "data", "$.id");
+      expect(unsafeResult.value).toBe("107505301260286111");
+      expect(unsafeResult.error).toBeNull();
+
+      const safeResult = extractValueFromObject(obj, "data", "$.safe");
+      expect(safeResult.value).toBe(42);
+      expect(safeResult.error).toBeNull();
+    });
+
     it("should return unwrapped value for $[0]", () => {
       const obj = {
         data: JSON.stringify(["first", "second", "third"]),
@@ -154,6 +168,16 @@ describe("extractValueFromObject", () => {
 
       const result = extractValueFromObject(obj, "data", "$.name");
       expect(result.value).toBe("Alice");
+      expect(result.error).toBeNull();
+    });
+
+    it("should preserve unsafe integers in double-encoded JSON with selector", () => {
+      const obj = {
+        data: JSON.stringify('{"id":107505301260286111}'),
+      };
+
+      const result = extractValueFromObject(obj, "data", "$.id");
+      expect(result.value).toBe("107505301260286111");
       expect(result.error).toBeNull();
     });
   });


### PR DESCRIPTION
## Summary

- Preserve unsafe JSON numbers in eval dataset inputs by using the shared lossless JSON parser when normalizing dataset item `input`, `expectedOutput`, and `metadata`.
- Use lossless parsing for eval JSON selector extraction so stringified or double-encoded JSON does not reintroduce precision loss before prompt/code-eval execution.
- Align dataset item UI validation and CSV import parsing with the same behavior: unsafe integers are stored as strings, safe numbers remain numbers, and existing CSV boolean fallback behavior is preserved.
- Add focused coverage for dataset normalization, eval JSONPath extraction, CSV parsing, and the dataset JSON validation helper.

## Linear

- [LFE-10199](https://linear.app/langfuse/issue/LFE-10199/handle-bigint-values-in-eval)

## Major Decisions

- Unsafe numeric literals are preserved as strings rather than `bigint`, because dataset storage, LLM prompt rendering, code-eval dispatch, and Lambda/runtime boundaries are JSON-based.
- Added `isJsonNumberLiteral` next to `parseJsonPrioritised` so root-level unsafe numbers can be accepted as valid JSON without duplicating number-literal regexes in web code.
- CSV type inference now reflects the parsed storage value, so unsafe integer columns infer as `string` instead of saying `number` while storing strings.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes precision loss for large integers in eval dataset items by threading `parseJsonPrioritised` (backed by lossless-json) through the full pipeline: API normalization, UI form validation, CSV import, eval JSONPath extraction, and multi-encoded JSON unwrapping.

- **Core fix**: `DatasetItemValidator.normalize`, `parseMultiEncodedJson`, and `parseValue` (CSV) now call `parseJsonPrioritised` instead of `JSON.parse`, so unsafe integers like `107505301260286111` are preserved as strings rather than silently rounded.
- **New helpers**: `isJsonNumberLiteral` and `parseDatasetJson`/`isValidDatasetJson` are introduced to centralize the \"unsafe root-number-as-string\" validation edge case, replacing six duplicated `JSON.parse`-based form-field refiners.
- **Behavioural note**: Two catch blocks in `useDatasetItemValidation.ts` and one in `NewDatasetItemForm.tsx` are now dead code because `parseDatasetJson` never throws; they should be cleaned up, though the observable behaviour is unchanged.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the precision-preservation logic is correct throughout the pipeline and the test coverage is focused on the exact edge cases being fixed.

The core lossless-integer fix is sound and well-tested. A few catch blocks in useDatasetItemValidation.ts and formatJsonValue are now unreachable dead code, silently changing the fallback path for invalid JSON input from skip schema validation to pass raw string to validator. In practice Zod form validation prevents invalid JSON from reaching those hooks, so no user-visible regression is expected, but the misleading dead code warrants a cleanup pass.

web/src/features/datasets/hooks/useDatasetItemValidation.ts and web/src/features/datasets/components/NewDatasetItemForm.tsx contain dead catch blocks that should be removed.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/datasets/hooks/useDatasetItemValidation.ts:50-64
**Dead catch blocks — invalid JSON now reaches schema validation as a raw string**

`parseDatasetJson` delegates to `parseJsonPrioritised`, which catches parse errors internally and returns the original string instead of throwing. Both catch blocks (lines 52–54 and 61–63) are therefore unreachable. For invalid JSON input, `inputData`/`outputData` will be set to the raw string and passed into `validateFieldAgainstSchema`, whereas the previous code short-circuited with `{ isValid: true, errors: [], hasSchemas: false }`. In practice this is benign because Zod form validation rejects invalid JSON first, but the dead catch branches are misleading to readers and should be removed.

### Issue 2 of 2
web/src/features/datasets/components/NewDatasetItemForm.tsx:79-86
**Unreachable catch block in `formatJsonValue`**

`parseDatasetJson` never throws — on parse failure it returns the original string. The `catch` branch that was intended to handle invalid JSON is therefore dead code. For an invalid-JSON string `value`, `JSON.stringify(value, null, 2)` in the try path and `JSON.stringify(value, null, 2)` in the catch path produce identical output anyway, so behaviour is unchanged. The dead block should be removed to avoid confusion about the error-handling contract.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): preserve unsafe dataset inte..."](https://github.com/langfuse/langfuse/commit/6cba24d80e2e0b3f13b6874345c98278860bc439) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36433092)</sub>

<!-- /greptile_comment -->