### PR TITLE
fix(chatml): avoid microsoft adapter for pydantic tool responses

### DIFF
--- a/packages/shared/src/utils/chatml/adapters/microsoft-agent.ts
+++ b/packages/shared/src/utils/chatml/adapters/microsoft-agent.ts
@@ -32,6 +32,36 @@ const MicrosoftAgentMessageSchema = z.looseObject({
 // Array of Microsoft Agent messages
 const MicrosoftAgentMessagesSchema = z.array(MicrosoftAgentMessageSchema);
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function hasPydanticAiMessageMarkers(data: unknown): boolean {
+  const messages = Array.isArray(data)
+    ? data
+    : isRecord(data) && Array.isArray(data.messages)
+      ? data.messages
+      : isRecord(data)
+        ? [data]
+        : [];
+
+  return messages.some((msg) => {
+    if (!isRecord(msg)) return false;
+    if (!Array.isArray(msg.parts)) return false;
+
+    return msg.parts.some((part) => {
+      if (!isRecord(part)) return false;
+
+      return (
+        part.type === "thinking" ||
+        part.type === "redacted_thinking" ||
+        (part.type === "tool_call_response" &&
+          ("result" in part || msg.role === "user"))
+      );
+    });
+  });
+}
+
 /**
  * Extract tool calls and text content from parts array
  * Handles: text, tool_call, tool_call_response
@@ -280,6 +310,13 @@ export const microsoftAgentAdapter: ProviderAdapter = {
       "gen_ai.provider.name",
     );
     if (providerName === "microsoft.agent_framework") return true;
+
+    if (
+      hasPydanticAiMessageMarkers(ctx.metadata) ||
+      hasPydanticAiMessageMarkers(ctx.data)
+    ) {
+      return false;
+    }
 
     // STRUCTURAL: Schema-based detection on metadata
     if (MicrosoftAgentMessagesSchema.safeParse(ctx.metadata).success)

--- a/worker/src/__tests__/chatml/adapters/microsoft-agent.test.ts
+++ b/worker/src/__tests__/chatml/adapters/microsoft-agent.test.ts
@@ -59,6 +59,39 @@ describe("Microsoft Agent Framework Adapter", () => {
       expect(microsoftAgentAdapter.detect({ data: input })).toBe(true);
     });
 
+    it("should not detect pydantic-ai tool response messages", () => {
+      const input = [
+        {
+          role: "user",
+          parts: [{ type: "text", content: "Look up the sample record" }],
+        },
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "tool_call",
+              id: "tooluse_123",
+              name: "lookup_sample_record",
+              arguments: '{"record_id":"record-123"}',
+            },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            {
+              type: "tool_call_response",
+              id: "tooluse_123",
+              name: "lookup_sample_record",
+              result: { status: "not_found", message: "No record found" },
+            },
+          ],
+        },
+      ];
+
+      expect(microsoftAgentAdapter.detect({ data: input })).toBe(false);
+    });
+
     it("should not detect OpenAI format without parts", () => {
       expect(
         microsoftAgentAdapter.detect({

--- a/worker/src/__tests__/chatml/adapters/pydantic-ai.test.ts
+++ b/worker/src/__tests__/chatml/adapters/pydantic-ai.test.ts
@@ -152,6 +152,67 @@ describe("Pydantic AI Adapter", () => {
       expect(result.data?.[3].tools).toHaveLength(2); // Available tools attached
     });
 
+    it("should select pydantic-ai for tool response messages without metadata", () => {
+      const input = [
+        {
+          role: "user",
+          parts: [
+            {
+              type: "text",
+              content: "Look up the sample record",
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          parts: [
+            {
+              type: "tool_call",
+              id: "tooluse_123",
+              name: "lookup_sample_record",
+              arguments: '{"record_id":"record-123"}',
+            },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            {
+              type: "tool_call_response",
+              id: "tooluse_123",
+              name: "lookup_sample_record",
+              result: {
+                status: "not_found",
+                message: "No record found",
+              },
+            },
+          ],
+        },
+      ];
+
+      const adapter = selectAdapter({ data: input });
+      expect(adapter.id).toBe("pydantic-ai");
+
+      const result = normalizeInput(input);
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[0]).toMatchObject({
+        role: "user",
+        content: "Look up the sample record",
+      });
+      expect(result.data?.[1].tool_calls?.[0]).toMatchObject({
+        id: "tooluse_123",
+        name: "lookup_sample_record",
+        arguments: '{"record_id":"record-123"}',
+        type: "function",
+      });
+      expect(result.data?.[2]).toMatchObject({
+        role: "tool",
+        tool_call_id: "tooluse_123",
+        content: '{"status":"not_found","message":"No record found"}',
+      });
+    });
+
     it("should extract thinking parts", () => {
       const output = [
         {


### PR DESCRIPTION
## Summary
- prevent the Microsoft Agent ChatML adapter from structurally claiming pydantic-ai tool response messages
- add regressions for pydantic-ai `tool_call_response.result` inputs without explicit metadata

## Impacted packages
- `@langfuse/shared`
- `worker` tests

## Verification
- `pnpm --filter @langfuse/shared run db:generate`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter worker exec vitest run src/__tests__/chatml/adapters/pydantic-ai.test.ts src/__tests__/chatml/adapters/microsoft-agent.test.ts`
- `pnpm --filter @repo/eslint-plugin run build`
- `pnpm --filter @langfuse/shared run lint`
- `pnpm --filter worker run lint`
- commit hook: `prettier --check` and `turbo run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the Microsoft Agent Framework adapter could incorrectly claim pydantic-ai `tool_call_response` messages during adapter detection, because both formats share the same parts-based schema shape and microsoft runs before pydantic-ai in the adapter priority list.

- Adds `hasPydanticAiMessageMarkers()` to `microsoft-agent.ts` — checked after the hint-based fast paths but before the expensive Zod schema scan — which returns `false` for Microsoft if it finds `tool_call_response` parts carrying a `result` key or living in a `user`-role message, both of which are structural signatures of the pydantic-ai format.
- Adds regression tests: one negative test confirming microsoft does not capture pydantic-ai tool responses, and one positive test confirming pydantic-ai is selected and produces correct normalized output when no metadata is present.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The change is a targeted guard in one adapter's detect() method, backed by two regression tests. No normalisation logic is touched.

The change is narrow and backed by two targeted regression tests. The only nit is that isRecord accepts arrays, which is harmless at the current call sites but makes the helper contract slightly broader than intended.

No files require special attention. The guard in microsoft-agent.ts is the only changed production file and its scope is narrow.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/utils/chatml/adapters/microsoft-agent.ts:35-37
**`isRecord` accepts arrays**

`typeof [] === "object"` and `Boolean([])` is `true`, so `isRecord([])` and `isRecord([1])` both return `true`. In the `hasPydanticAiMessageMarkers` ternary this is harmless because `Array.isArray(data)` is checked first, but at the `msg`/`part` level an inadvertent array value would pass the guard, potentially causing `"result" in part` to check inherited Array prototype keys rather than own-object properties. Adding `&& !Array.isArray(value)` would make the intent explicit and guard future callers.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(chatml): avoid microsoft adapter for..."](https://github.com/langfuse/langfuse/commit/2129b588d3e78268e7e70e4883ac333e58f97d5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36455358)</sub>

<!-- /greptile_comment -->