### PR TITLE
fix: use upsert for dataset run creation to prevent race condition (#13829)

### DIFF
--- a/packages/shared/src/server/repositories/dataset-runs.ts
+++ b/packages/shared/src/server/repositories/dataset-runs.ts
@@ -5,27 +5,18 @@ import type z from "zod";
 
 type Json = z.infer<typeof jsonSchema>;
 
-const isUniqueConstraintError = (error: any): boolean => {
-  return (
-    error.code === "P2002" || // Prisma unique constraint
-    error.message?.includes("duplicate key") ||
-    error.message?.toLowerCase().includes("unique constraint") ||
-    error.message?.includes("violates unique constraint")
-  );
-};
-
 /**
- * Create or fetch a dataset run with optimistic concurrency handling.
+ * Create or fetch a dataset run using an atomic upsert.
  *
  * Behavior:
- * - First tries to find an existing run by (projectId, datasetId, name).
- * - If not found, attempts to create it.
- * - If creation fails due to a unique constraint (likely created concurrently),
- *   fetches and returns the existing run.
- * - If all steps fail, throws an error.
+ * - Uses Prisma upsert on the (datasetId, projectId, name) unique constraint
+ *   so concurrent callers all converge to the same run without errors.
+ * - If the run already exists, returns it unchanged.
  *
- * Rationale: The public API can receive many POST requests almost simultaneously,
- * which is not concurrency-safe without this guard.
+ * Rationale: The public API can receive many POST requests almost simultaneously
+ * (e.g. dataset.run_experiment with max_concurrency > 1). The previous
+ * create-then-catch approach worked but logged Prisma unique-constraint errors
+ * on every concurrent call. Upsert is atomic and silent.
  */
 export const createOrFetchDatasetRun = async ({
   projectId,
@@ -42,56 +33,24 @@ export const createOrFetchDatasetRun = async ({
   metadata?: Json | null;
   createdAt?: Date;
 }) => {
-  try {
-    // Attempt to fetch existing run
-    const existingRun = await prisma.datasetRuns.findUnique({
-      where: {
-        datasetId_projectId_name: {
-          datasetId,
-          projectId,
-          name: name,
-        },
-      },
-    });
-    if (existingRun) {
-      return existingRun;
-    }
-
-    // Attempt creation
-    const datasetRun = await prisma.datasetRuns.create({
-      data: {
-        id: v4(),
+  return prisma.datasetRuns.upsert({
+    where: {
+      datasetId_projectId_name: {
         datasetId,
         projectId,
         name,
-        description: description ?? null,
-        metadata: metadata ?? {},
-        createdAt: createdAt ?? new Date(),
-        updatedAt: createdAt ?? new Date(),
       },
-    });
-    return datasetRun;
-  } catch (error) {
-    // Check if it's a unique constraint violation
-    if (isUniqueConstraintError(error)) {
-      // Fetch existing run
-      const existingRun = await prisma.datasetRuns.findUnique({
-        where: {
-          datasetId_projectId_name: {
-            datasetId,
-            projectId,
-            name: name,
-          },
-        },
-      });
-
-      if (existingRun) {
-        return existingRun;
-      }
-    } else {
-      throw error;
-    }
-  }
-
-  throw new Error("Failed to create or fetch dataset run");
+    },
+    create: {
+      id: v4(),
+      datasetId,
+      projectId,
+      name,
+      description: description ?? null,
+      metadata: metadata ?? {},
+      createdAt: createdAt ?? new Date(),
+      updatedAt: createdAt ?? new Date(),
+    },
+    update: {}, // Run already exists, return it unchanged
+  });
 };


### PR DESCRIPTION
## Problem

When calling `dataset.run_experiment()` with `max_concurrency > 1` on a fresh `run_name`, multiple concurrent `POST /api/public/dataset-run-items` calls race to create the same dataset run. The `createOrFetchDatasetRun` function catches the unique-constraint error and re-fetches the existing run, which is functionally correct. However, Prisma still logs the constraint violation at the driver level on every concurrent call:

```
prisma:error
Invalid `prisma.datasetRuns.create()` invocation:
Unique constraint failed on the fields: (`dataset_id`,`project_id`,`name`)
```

With `max_concurrency=5` on a 28-item dataset, this produces 27 error log lines per experiment run.

## Fix

Replace the create-then-catch pattern with a single `prisma.datasetRuns.upsert()` on the `(datasetId, projectId, name)` unique constraint. Upsert is atomic: concurrent callers all converge to the same run without triggering error logs.

The `isUniqueConstraintError` helper is no longer needed and is removed.

## Changes

- `packages/shared/src/server/repositories/dataset-runs.ts`: Replace `findUnique` + `create` + `catch` with `upsert`. 1 file changed, -41 net lines.

## Verification

- The existing `POST /api/public/dataset-run-items` integration tests in `datasets-api.servertest.ts` exercise this code path.
- The Prisma schema confirms `@@unique([datasetId, projectId, name])` on `DatasetRuns`, and `prisma.datasetRuns.upsert` with `datasetId_projectId_name` is already used in the seed script (`packages/shared/scripts/seeder/seed-postgres.ts`).
- `pnpm run lint` passes on the changed file.

## Limitations

- Could not run the full test suite locally (requires Postgres, ClickHouse, Redis, MinIO). CI will verify.
- The experiments TRPC router (`web/src/features/experiments/server/router.ts:250`) also uses a bare `datasetRuns.create()`, but that path creates the run once before queuing items and is not affected by the concurrent race. A follow-up could unify it to use `createOrFetchDatasetRun` for consistency.

Fixes #13829

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces a `findUnique` + `create` + `catch(UniqueConstraintError)` pattern in `createOrFetchDatasetRun` with a single `prisma.datasetRuns.upsert()` call, eliminating spurious Prisma constraint-violation error logs when concurrent requests race to create the same dataset run.

- **`dataset-runs.ts`**: The helper `isUniqueConstraintError` is removed along with its three-step try/catch logic. A single `upsert` on the `(datasetId, projectId, name)` composite unique index replaces it; the `update: {}` empty block means concurrent callers that find an existing run return it unchanged without modifying any fields — preserving the original semantics of the function.
- The sole caller in `publicDatasetService.ts` is unaffected; the function signature and return type are identical.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a focused, mechanical replacement of a three-step optimistic-concurrency pattern with a single upsert; the function signature, return type, and fetch-without-modifying-if-exists semantics are all preserved.

The upsert correctly targets the same composite unique index (datasetId, projectId, name) that the old code relied on. The update: {} empty block is valid in Prisma and reproduces the original return existing row unchanged behaviour. The sole caller in publicDatasetService.ts is unaffected. The deleted isUniqueConstraintError helper has no other references in the codebase.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C1 as Caller 1
    participant C2 as Caller 2 (concurrent)
    participant PG as PostgreSQL

    Note over C1,PG: Before (create-then-catch)
    C1->>PG: findUnique (datasetId, projectId, name)
    C2->>PG: findUnique (datasetId, projectId, name)
    PG-->>C1: null
    PG-->>C2: null
    C1->>PG: INSERT INTO DatasetRuns ...
    C2->>PG: INSERT INTO DatasetRuns ...
    PG-->>C1: row created
    PG--xC2: UNIQUE CONSTRAINT VIOLATION (logged!)
    C2->>PG: findUnique (retry fetch)
    PG-->>C2: existing row

    Note over C1,PG: After (upsert)
    C1->>PG: INSERT ... ON CONFLICT (datasetId,projectId,name) DO UPDATE SET ... (upsert)
    C2->>PG: INSERT ... ON CONFLICT (datasetId,projectId,name) DO UPDATE SET ... (upsert)
    PG-->>C1: row (created or existing)
    PG-->>C2: row (existing, no error logged)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use upsert for dataset run creation..."](https://github.com/langfuse/langfuse/commit/d9f4647d6186717a91e191e525bb690c4e851a1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36470467)</sub>

<!-- /greptile_comment -->