### PR TITLE
fix(ui): improve dialog overlays and command menu motion

### DIFF
--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -5,6 +5,7 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
 import { cn } from "@/src/utils/tailwind";
 import { buttonVariants } from "@/src/components/ui/button";
+import motionStyles from "./dialog-motion.module.css";
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -18,7 +19,8 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+      motionStyles.overlay,
+      "fixed inset-0 z-50 bg-black/50 dark:bg-black/65",
       className,
     )}
     {...props}
@@ -36,7 +38,8 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+        motionStyles.content,
+        "bg-background fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -13,6 +13,8 @@ import {
   DialogHeader,
 } from "@/src/components/ui/dialog";
 
+const commandDialogSurfaceClass = "bg-background dark:bg-[rgb(15_23_42)]";
+
 const Command = React.forwardRef<
   React.ComponentRef<typeof CommandPrimitive>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive>
@@ -38,8 +40,12 @@ const CommandDialog = ({
   return (
     <Dialog {...props}>
       <DialogContent
-        className="overflow-hidden p-0 shadow-lg"
+        className={cn(
+          commandDialogSurfaceClass,
+          "top-[calc(var(--banner-offset)+clamp(4rem,14dvh,8rem))] translate-y-0 overflow-hidden border p-0 shadow-2xl dark:border-slate-700/70 dark:shadow-[0_32px_96px_-28px_rgb(0_0_0/0.95),0_16px_40px_-24px_rgb(0_0_0/0.9),0_0_0_1px_rgb(148_163_184/0.1)]",
+        )}
         closeOnInteractionOutside
+        overlayMode="invisible"
       >
         <DialogHeader className="sr-only p-0">
           <DialogTitle>Search</DialogTitle>
@@ -47,7 +53,10 @@ const CommandDialog = ({
         <DialogBody className="p-0">
           <Command
             filter={filter}
-            className="**:[[cmdk-group-heading]]:text-muted-foreground pb-1 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group]]:px-2 **:[[cmdk-input]]:h-12"
+            className={cn(
+              commandDialogSurfaceClass,
+              "**:[[cmdk-group-heading]]:text-muted-foreground pb-1 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group]]:px-2 **:[[cmdk-input]]:h-12",
+            )}
           >
             {children}
           </Command>

--- a/web/src/components/ui/dialog-motion.module.css
+++ b/web/src/components/ui/dialog-motion.module.css
@@ -1,0 +1,67 @@
+.content {
+  transform-origin: center center;
+}
+
+.content[data-state="open"] {
+  animation: dialogContentIn 800ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.content[data-state="closed"] {
+  animation: dialogContentOut 180ms cubic-bezier(0.4, 0, 1, 1) both;
+}
+
+.overlay[data-state="open"] {
+  animation: dialogOverlayIn 200ms ease-out both;
+}
+
+.overlay[data-state="closed"] {
+  animation: dialogOverlayOut 150ms ease-in both;
+}
+
+@keyframes dialogContentIn {
+  0% {
+    opacity: 0;
+    scale: 0.95;
+  }
+
+  50% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 1;
+    scale: 1;
+  }
+}
+
+@keyframes dialogContentOut {
+  from {
+    opacity: 1;
+    scale: 1;
+  }
+
+  to {
+    opacity: 0;
+    scale: 0.95;
+  }
+}
+
+@keyframes dialogOverlayIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes dialogOverlayOut {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -6,6 +6,7 @@ import { X } from "lucide-react";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/src/utils/tailwind";
+import motionStyles from "./dialog-motion.module.css";
 
 const Dialog = DialogPrimitive.Root;
 
@@ -15,14 +16,26 @@ const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
 
+type DialogOverlayMode = "subtle" | "invisible" | "blocking";
+
+const dialogOverlayClasses: Record<DialogOverlayMode, string> = {
+  invisible: "bg-transparent",
+  subtle: "bg-black/25 dark:bg-black/45",
+  blocking: "bg-black/50 dark:bg-black/65",
+};
+
 const DialogOverlay = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & {
+    overlayMode?: DialogOverlayMode;
+  }
+>(({ className, overlayMode = "subtle", ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "bg-foreground/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50",
+      motionStyles.overlay,
+      "fixed inset-0 z-50",
+      dialogOverlayClasses[overlayMode],
       className,
     )}
     {...props}
@@ -31,7 +44,7 @@ const DialogOverlay = React.forwardRef<
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const dialogContentVariants = cva(
-  "fixed left-[50%] top-[50%] overflow-hidden z-50 flex w-full flex-col translate-x-[-50%] translate-y-[-50%] bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+  "fixed left-[50%] top-[50%] overflow-hidden z-50 flex w-full translate-x-[-50%] translate-y-[-50%] flex-col bg-background shadow-lg sm:rounded-lg",
   {
     variants: {
       size: {
@@ -52,6 +65,7 @@ const DialogContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     closeOnInteractionOutside?: boolean;
     confirmCloseOnEscape?: string;
+    overlayMode?: DialogOverlayMode;
     stopPropagationOnEnterSpace?: boolean;
   } & VariantProps<typeof dialogContentVariants>
 >(
@@ -61,6 +75,7 @@ const DialogContent = React.forwardRef<
       children,
       closeOnInteractionOutside = false,
       confirmCloseOnEscape,
+      overlayMode = "subtle",
       stopPropagationOnEnterSpace = true,
       onEscapeKeyDown,
       size,
@@ -91,10 +106,13 @@ const DialogContent = React.forwardRef<
 
     return (
       <DialogPortal>
-        <DialogOverlay />
+        <DialogOverlay overlayMode={overlayMode} />
         <DialogPrimitive.Content
           ref={ref}
-          className={cn(dialogContentVariants({ size, className }))}
+          className={cn(
+            motionStyles.content,
+            dialogContentVariants({ size, className }),
+          )}
           aria-describedby={undefined}
           onKeyDown={handleKeyDown}
           onEscapeKeyDown={handleEscapeKeyDown}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces Tailwind utility-based dialog animations with a dedicated CSS module (`dialog-motion.module.css`) and introduces an `overlayMode` prop (`subtle` / `invisible` / `blocking`) to `DialogContent`. The `CommandDialog` is updated to use an invisible overlay and a banner-offset-aware top position.

- **Animation refactor**: Custom keyframes handle open (800 ms spring ease) and close (180 ms) for both dialog content and overlays; the `blocking` variant in the `overlayMode` type union is declared but resolved identically to `subtle`, leaving it as dead code.
- **Overlay color change**: The backdrop color changed from `bg-foreground/40` to `bg-black/25` across `dialog.tsx` and `alert-dialog.tsx`; in dark mode this makes the scrim nearly invisible since a 25%-opacity black layer over a dark background provides very little contrast.
- **Command menu**: Gains an invisible overlay and uses `--banner-offset` (globally defined in `globals.css`) for correct vertical positioning when an app banner is shown.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The animation and layout changes are cosmetic, but the overlay colour change may leave dark-mode dialogs without a visible backdrop, and the unused `blocking` mode creates a misleading API surface.

Two issues affect currently rendered output: the `bg-black/25` backdrop is nearly invisible against a dark background, making it hard for dark-mode users to perceive that a dialog is blocking interaction; and the `blocking` overlay mode is defined in the public type but resolves to the same style as `subtle`, so any caller relying on it for stronger visual separation gets no effect.

web/src/components/ui/dialog.tsx and web/src/components/ui/alert-dialog.tsx — overlay colour and the incomplete blocking mode both live here.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant DialogContent
    participant DialogOverlay
    participant CSSModule as dialog-motion.module.css

    User->>DialogContent: open (overlayMode prop)
    DialogContent->>DialogOverlay: render(overlayMode)
    DialogOverlay->>CSSModule: "apply .overlay[data-state=open]"
    CSSModule-->>DialogOverlay: dialogOverlayIn 200ms ease-out
    DialogContent->>CSSModule: "apply .content[data-state=open]"
    CSSModule-->>DialogContent: dialogContentIn 800ms spring

    Note over DialogOverlay: invisible → bg-transparent
    Note over DialogOverlay: subtle/blocking → bg-black/25 (same)

    User->>DialogContent: close
    DialogContent->>CSSModule: "apply .content[data-state=closed]"
    CSSModule-->>DialogContent: dialogContentOut 180ms
    DialogOverlay->>CSSModule: "apply .overlay[data-state=closed]"
    CSSModule-->>DialogOverlay: dialogOverlayOut 150ms
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/ui/dialog.tsx:32
**`blocking` overlay mode has no distinct behavior**

`DialogOverlayMode` declares three variants — `"subtle"`, `"invisible"`, and `"blocking"` — but the implementation only branches on `invisible`. Both `subtle` and `blocking` resolve to the same `bg-black/25` class, making the third variant dead code. Any caller that passes `overlayMode="blocking"` expecting a more opaque backdrop (the natural semantic of "blocking") will get the same lighter overlay as `"subtle"`, silently delivering the wrong visual behaviour.

### Issue 2 of 3
web/src/components/ui/dialog.tsx:29-34
**Dark-mode backdrop becomes nearly invisible**

The previous overlay was `bg-foreground/40`. In dark mode, `--foreground` is near-white (shadcn default: `hsl(210 40% 98%)`), so the scrim was a 40%-opacity light layer — visually clear that a modal is blocking interaction. The new `bg-black/25` is a 25%-opacity black layer; on a typical dark background (`rgb(15 23 42)` as used in `command.tsx`) the contrast difference is almost imperceptible. Users may not realize the page behind the dialog is locked, which is also an accessibility concern (WCAG perceivability). The same regression applies to `alert-dialog.tsx`.

### Issue 3 of 3
web/src/components/ui/dialog-motion.module.css:5-6
**800 ms open animation may feel sluggish**

The `dialogContentIn` keyframe runs for 800 ms while the close animation (`dialogContentOut`) runs for just 180 ms. Although the spring easing `cubic-bezier(0.16, 1, 0.3, 1)` causes the element to reach near-final position well before the 800 ms mark, the animation still technically controls opacity and scale for the full duration. The original Tailwind variants used `duration-200`; 800 ms is a 4× increase and may feel sluggish to users who open dialogs frequently. Consider reducing this to 300–400 ms.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): improve dialog overlays and com..."](https://github.com/langfuse/langfuse/commit/43ade63f05a536baa0eff8512db4889b1df6ce0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36471778)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->