### PR TITLE
docs: preserve README image aspect ratios

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -11,6 +11,9 @@ evaluating, and debugging AI applications.
   bug.
 - For user-visible frontend changes in `web/**`, review the affected flow in a
   real browser before signoff.
+- For documentation screenshots in Markdown, avoid fixed `height` on `<img>`
+  tags; prefer Markdown images or width-only HTML so previews preserve aspect
+  ratio.
 - Never commit secrets or credentials. Keep `.env*.example` files in
   sync with required env vars.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img width="2400" height="600" alt="hero-b (1)" src="https://github.com/user-attachments/assets/5810ae13-15d6-4b60-afd2-927adc501861" />
+<img width="2400" alt="hero-b (1)" src="https://github.com/user-attachments/assets/5810ae13-15d6-4b60-afd2-927adc501861" />
 
 <div align="center">
    <div>
@@ -71,7 +71,7 @@ Langfuse is an **open source LLM engineering** platform. It helps teams collabor
 
 ## ✨ Core Features
 
-<img width="2400" height="1040" alt="features" src="https://github.com/user-attachments/assets/0fad3dee-f3ad-423c-9f0d-7ccd0f26cc2d" />
+<img width="2400" alt="features" src="https://github.com/user-attachments/assets/0fad3dee-f3ad-423c-9f0d-7ccd0f26cc2d" />
 
 - [LLM Application Observability](https://langfuse.com/docs/tracing): Instrument your app and start ingesting traces to Langfuse, thereby tracking LLM calls and other relevant logic in your app such as retrieval, embedding, or agent actions. Inspect and debug complex logs and user sessions. Try the interactive [demo](https://langfuse.com/docs/demo) to see this in action.
 
@@ -87,7 +87,7 @@ Langfuse is an **open source LLM engineering** platform. It helps teams collabor
 
 ## 📦 Deploy Langfuse
 
-<img width="2400" height="880" alt="deploy" src="https://github.com/user-attachments/assets/cf72e7f8-db7f-4e11-a2a1-ecfbe46f262c" />
+<img width="2400" alt="deploy" src="https://github.com/user-attachments/assets/cf72e7f8-db7f-4e11-a2a1-ecfbe46f262c" />
 
 ### Langfuse Cloud
 
@@ -122,7 +122,7 @@ See [self-hosting documentation](https://langfuse.com/self-hosting) to learn mor
 
 ## 🔌 Integrations
 
-<img width="2400" height="980" alt="integrations" src="https://github.com/user-attachments/assets/b85c9a45-68f0-4f76-b545-0e8632abef9f" />
+<img width="2400" alt="integrations" src="https://github.com/user-attachments/assets/b85c9a45-68f0-4f76-b545-0e8632abef9f" />
 
 ### Main Integrations:
 
@@ -211,7 +211,7 @@ main()
 
 See your language model calls and other application logic in Langfuse.
 
-<img width="1600" height="833" alt="example-trace-for-github" src="https://github.com/user-attachments/assets/8f6995b7-285f-441a-b52f-1331d13ceb45" />
+<img width="1600" alt="example-trace-for-github" src="https://github.com/user-attachments/assets/8f6995b7-285f-441a-b52f-1331d13ceb45" />
 
 _[Public example trace in Langfuse](https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/db22d0a442216b485abd83cc9df6d9ee)_
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes hardcoded `height` attributes from five `<img>` tags in `README.md` so images scale proportionally at any viewport width, and adds a matching guideline to `.agents/AGENTS.md` to prevent the pattern from recurring.

- **`README.md`**: drops `height` from four section-banner images and one trace screenshot, keeping only `width="2400"` (or `1600`) so browsers calculate height automatically.
- **`.agents/AGENTS.md`**: adds a documentation guideline to prefer Markdown images or width-only HTML over fixed-height `<img>` tags in Markdown files.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are documentation-only, removing fixed height attributes from README images and adding a matching authoring guideline.

All changes are in README.md and .agents/AGENTS.md. Removing hardcoded height values from img tags is a well-understood HTML practice that has no side effects; the images will simply render at their natural aspect ratio when scaled. No logic, configuration, or runtime behavior is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Browser renders README.md"] --> B{"img has fixed height?"}
    B -- "Before (height=600/1040/880/…)" --> C["Image letterboxed or distorted\nat viewport widths ≠ 2400px"]
    B -- "After (width-only)" --> D["Browser computes height\nfrom intrinsic aspect ratio"]
    D --> E["Image scales correctly\nat all viewport widths"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: preserve README image aspect ratio..."](https://github.com/langfuse/langfuse/commit/89efc2feaa5a6bd019c002e2984b0d7042d25c7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36475770)</sub>

<!-- /greptile_comment -->