### PR TITLE
feat: accelerate contains and startsWith operators on metadata columns

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -479,6 +479,11 @@ SELECT
     is_deleted
 FROM events_full;
 
+-- Event metadata substring acceleration. Keep this as a post-create mutation
+-- while events tables are managed through this dev-table workflow.
+ALTER TABLE events_full ADD INDEX IF NOT EXISTS idx_fts_metadata_values_ngram arrayStringConcat(metadata_values) TYPE ngrambf_v1(4, 32000, 3, 0) GRANULARITY 2 SETTINGS enable_full_text_index = 1;
+ALTER TABLE events_core ADD INDEX IF NOT EXISTS idx_fts_metadata_values_ngram arrayStringConcat(metadata_values) TYPE ngrambf_v1(4, 32000, 3, 0) GRANULARITY 2 SETTINGS enable_full_text_index = 1;
+
 -- Diagnostic table to track event size distributions across projects.
 -- Every insert (including updates) produces a row — no deduplication.
 -- See LFE-9402 for context.

--- a/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts
@@ -4,10 +4,12 @@ import {
   filterOperators,
 } from "../../../interfaces/filters";
 import { clickhouseCompliantRandomCharacters } from "../../repositories";
+import { escapeSqlLikePattern } from "../../utils/sqlLike";
 import {
   assertValidFtsMatchFilter,
   FTS_OPERATOR_DESCRIPTORS,
   isFtsEventsTable,
+  isFtsMetadataField,
   isFtsTextTarget,
 } from "./fts";
 
@@ -26,6 +28,10 @@ type ClickhouseFilter = {
   query: string;
   params: { [x: string]: any } | {};
 };
+
+const NGRAM_ACCELERATED_METADATA_OPERATORS = new Set<
+  (typeof filterOperators)["stringObject"][number]
+>(["contains", "starts with", "ends with"]);
 
 export class StringFilter implements Filter {
   public clickhouseTable: string;
@@ -355,6 +361,16 @@ export class StringObjectFilter implements Filter {
       const valueAccessor = `${valuesColumn}[indexOf(${namesColumn}, {${varKeyName}: String})]`;
       const hasKey = `has(${namesColumn}, {${varKeyName}: String})`;
       const valueParam = `{${varValueName}: String}`;
+      const ngramPrefilterParamName = `stringObjectNgramFilter${clickhouseCompliantRandomCharacters()}`;
+      const shouldUseNgramPrefilter =
+        this.operator !== FTS_MATCH_OPERATOR &&
+        isFtsMetadataField(this.field) &&
+        NGRAM_ACCELERATED_METADATA_OPERATORS.has(this.operator) &&
+        this.value.length > 0;
+      const ngramPrefilter = shouldUseNgramPrefilter
+        ? `like(arrayStringConcat(${valuesColumn}), {${ngramPrefilterParamName}: String})`
+        : undefined;
+      const ngramConjunct = ngramPrefilter ? ` AND ${ngramPrefilter}` : "";
 
       switch (this.operator) {
         case "=":
@@ -366,16 +382,16 @@ export class StringObjectFilter implements Filter {
           });
           break;
         case "contains":
-          query = `${hasKey} AND (position(${valueAccessor}, ${valueParam}) > 0)`;
+          query = `${hasKey}${ngramConjunct} AND (position(${valueAccessor}, ${valueParam}) > 0)`;
           break;
         case "does not contain":
           query = `${hasKey} AND (position(${valueAccessor}, ${valueParam}) = 0)`;
           break;
         case "starts with":
-          query = `${hasKey} AND (startsWith(${valueAccessor}, ${valueParam}))`;
+          query = `${hasKey}${ngramConjunct} AND (startsWith(${valueAccessor}, ${valueParam}))`;
           break;
         case "ends with":
-          query = `${hasKey} AND (endsWith(${valueAccessor}, ${valueParam}))`;
+          query = `${hasKey}${ngramConjunct} AND (endsWith(${valueAccessor}, ${valueParam}))`;
           break;
         case FTS_MATCH_OPERATOR:
           assertValidFtsMatchFilter({
@@ -395,6 +411,17 @@ export class StringObjectFilter implements Filter {
           break;
         default:
           throw new Error(`Unsupported operator: ${this.operator}`);
+      }
+
+      if (ngramPrefilter) {
+        return {
+          query,
+          params: {
+            [varKeyName]: this.key,
+            [varValueName]: this.value,
+            [ngramPrefilterParamName]: `%${escapeSqlLikePattern(this.value)}%`,
+          },
+        };
       }
     } else {
       // For observations/traces tables, use Map access: metadata[key]

--- a/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
+++ b/web/src/__tests__/server/createFilterFromFilterState-filterTypeValidation.servertest.ts
@@ -67,6 +67,13 @@ describe("createFilterFromFilterState filter type validation", () => {
       clickhouseSelect: "metadata",
       queryPrefix: "e",
     },
+    experimentMetadata: {
+      uiTableName: "Metadata",
+      uiTableId: "metadata",
+      clickhouseTableName: "events_proto",
+      clickhouseSelect: "experiment_metadata",
+      queryPrefix: "e",
+    },
     eventName: {
       uiTableName: "Event Name",
       uiTableId: "eventName",
@@ -369,6 +376,64 @@ describe("createFilterFromFilterState filter type validation", () => {
     expect(query).not.toContain("hasAllTokens(e.metadata_values[indexOf");
     expect(query).not.toContain("lower(");
     expect(Object.values(params)).toEqual(["source", "needle"]);
+  });
+
+  it("adds ngram prefilter params for event metadata substring filters", () => {
+    const filters = [
+      {
+        column: "metadata",
+        type: "stringObject",
+        operator: "contains",
+        key: "environment",
+        value: "prod%_\\west",
+      },
+    ] satisfies EventsTableFilterState;
+
+    const [result] = createFilterFromFilterState(
+      filters,
+      [mappings.eventMetadata],
+      columnDefinitions,
+    );
+
+    const { query, params } = result.apply();
+
+    expect(query).toContain("like(arrayStringConcat(e.metadata_values),");
+    expect(query).toContain("has(e.metadata_names,");
+    expect(query).toContain(
+      "position(e.metadata_values[indexOf(e.metadata_names,",
+    );
+    expect(Object.values(params)).toEqual([
+      "environment",
+      "prod%_\\west",
+      "%prod\\%\\_\\\\west%",
+    ]);
+  });
+
+  it("does not add the event metadata ngram prefilter for experiment metadata arrays", () => {
+    const filters = [
+      {
+        column: "metadata",
+        type: "stringObject",
+        operator: "contains",
+        key: "environment",
+        value: "production",
+      },
+    ] satisfies EventsTableFilterState;
+
+    const [result] = createFilterFromFilterState(
+      filters,
+      [mappings.experimentMetadata],
+      columnDefinitions,
+    );
+
+    const { query, params } = result.apply();
+
+    expect(query).toContain("has(e.experiment_metadata_names,");
+    expect(query).toContain(
+      "position(e.experiment_metadata_values[indexOf(e.experiment_metadata_names,",
+    );
+    expect(query).not.toContain("arrayStringConcat");
+    expect(Object.values(params)).toEqual(["environment", "production"]);
   });
 
   it.each([

--- a/web/src/__tests__/server/fts-rewrites.servertest.ts
+++ b/web/src/__tests__/server/fts-rewrites.servertest.ts
@@ -14,6 +14,13 @@ const maybeEventsTable =
     ? describe
     : describe.skip;
 
+const NGRAM_METADATA_TEST_OPERATORS = [
+  "contains",
+  "starts with",
+  "ends with",
+] as const;
+const NGRAM_METADATA_OPERATORS = new Set<string>(NGRAM_METADATA_TEST_OPERATORS);
+
 type FilterResult = {
   query: string;
   params: Record<string, unknown>;
@@ -64,6 +71,10 @@ const filterFixture = `
     ('metadata-phrase-alpha-gap-beta', 'unrelated input', 'unrelated output', ['topic'], ['alpha gap beta']),
     ('metadata-split-alpha-beta', 'unrelated input', 'unrelated output', ['topic', 'other'], ['alpha', 'beta']),
     ('metadata-other-key-alpha', 'unrelated input', 'unrelated output', ['other'], ['alpha']),
+    ('metadata-literal-percent', 'unrelated input', 'unrelated output', ['topic'], ['100% done']),
+    ('metadata-literal-underscore', 'unrelated input', 'unrelated output', ['topic'], ['job_42']),
+    ('metadata-literal-backslash', 'unrelated input', 'unrelated output', ['topic'], ['path\\\\to']),
+    ('metadata-other-key-production-decoy', 'unrelated input', 'unrelated output', ['topic', 'other'], ['topic-value', 'production-west']),
     ('miss', 'unrelated input', 'unrelated output', ['topic'], ['unrelated metadata'])
   ) AS e
 `;
@@ -208,14 +219,101 @@ maybeEventsTable("FTS filter rewrites", () => {
 
       if (operator === "=") {
         expect(rewritten.query).toContain("has(e.metadata_values,");
+      } else if (NGRAM_METADATA_OPERATORS.has(operator)) {
+        expect(rewritten.query).toContain(
+          "like(arrayStringConcat(e.metadata_values),",
+        );
+        expect(rewritten.query).not.toContain("hasAllTokens");
       } else {
         expect(rewritten.query).not.toContain("hasAllTokens");
+        expect(rewritten.query).not.toContain("arrayStringConcat");
       }
       await expect(matchingIds(rewritten)).resolves.toEqual(
         await matchingIds(baseline),
       );
     },
   );
+
+  it.each(
+    Array.from(FTS_EVENTS_TABLES).flatMap((table) =>
+      NGRAM_METADATA_TEST_OPERATORS.map((operator) => ({ table, operator })),
+    ),
+  )(
+    "keeps short $table.metadata `$operator` equivalent to the baseline",
+    async ({ table, operator }) => {
+      const baseline = metadataBaselineFilter({
+        operator,
+        key: "topic",
+        value: "a",
+      });
+      const rewritten = new StringObjectFilter({
+        clickhouseTable: table,
+        field: "metadata",
+        operator,
+        key: "topic",
+        value: "a",
+        tablePrefix: "e",
+      }).apply();
+
+      expect(rewritten.query).toContain(
+        "like(arrayStringConcat(e.metadata_values),",
+      );
+      await expect(matchingIds(rewritten)).resolves.toEqual(
+        await matchingIds(baseline),
+      );
+    },
+  );
+
+  it.each([
+    {
+      operator: "contains",
+      value: "100%",
+      expectedIds: ["metadata-literal-percent"],
+    },
+    {
+      operator: "starts with",
+      value: "job_",
+      expectedIds: ["metadata-literal-underscore"],
+    },
+    {
+      operator: "ends with",
+      value: "h\\to",
+      expectedIds: ["metadata-literal-backslash"],
+    },
+  ] as const)(
+    "matches literal metadata wildcard characters for `$operator` `$value`",
+    async ({ operator, value, expectedIds }) => {
+      const rewritten = new StringObjectFilter({
+        clickhouseTable: "events_core",
+        field: "metadata",
+        operator,
+        key: "topic",
+        value,
+        tablePrefix: "e",
+      }).apply();
+
+      expect(rewritten.query).toContain(
+        "like(arrayStringConcat(e.metadata_values),",
+      );
+      await expect(matchingIds(rewritten)).resolves.toEqual(expectedIds);
+    },
+  );
+
+  it("does not match when only a different metadata key satisfies the ngram prefilter", async () => {
+    const rewritten = new StringObjectFilter({
+      clickhouseTable: "events_core",
+      field: "metadata",
+      operator: "starts with",
+      key: "topic",
+      value: "production",
+      tablePrefix: "e",
+    }).apply();
+
+    expect(rewritten.query).toContain(
+      "like(arrayStringConcat(e.metadata_values),",
+    );
+    await expect(matchingIds(rewritten)).resolves.toEqual([]);
+  });
 
   it.each(
     Array.from(FTS_EVENTS_TABLES).flatMap((table) =>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR accelerates `contains`, `starts with`, and `ends with` operators on metadata columns in events tables by prepending a `like(arrayStringConcat(metadata_values), '%escaped_value%')` prefilter conjunct that the ClickHouse query planner can satisfy using a new `ngrambf_v1(4, 32000, 3, 0)` skip index. SQL LIKE wildcard characters in user-provided values are properly escaped before being bound as parameters.

- A new `escapeSqlLikePattern` utility escapes `\`, `%`, and `_` (in the correct order) so user values are always treated as literals in the LIKE prefilter.
- The prefilter is a no-op for the non-events-table code path (Map column access) and is intentionally skipped for empty values and operators that don't benefit (`=`, `does not contain`, `FTS_MATCH_OPERATOR`).
- Dev-table setup adds the index via `ALTER TABLE … ADD INDEX IF NOT EXISTS`, which registers the index metadata but requires a `MATERIALIZE INDEX` (or new inserts) to build the actual bloom filter data on existing rows — expected behavior for this workflow.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge. The ngram prefilter is strictly an optimization hint — it can produce false positives (handled by the real predicate) but never false negatives, so query correctness is preserved in all cases.

All changed logic is in the isFtsEventsTable branch; correctness is preserved because the prefilter can only produce false positives, never false negatives. Tests cover wildcard escaping and cross-key contamination scenarios. Two minor sub-optimalities exist: short values add LIKE overhead without index benefit, and the ends-with pattern could be more selective.

packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts — specifically the ngramPrefilter construction and the minimum-length guard.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[StringObjectFilter.apply] --> B{isFtsEventsTable?}
    B -->|No| C[Map access metadata-key]
    C --> D[return query plus 2 params]
    B -->|Yes| E[Build namesColumn valuesColumn hasKey]
    E --> F{operator in NGRAM set AND value non-empty?}
    F -->|No| G[switch on operator, ngramPrefix is empty]
    G --> H[return query plus 2 params]
    F -->|Yes| I[ngramPrefilter = like-arrayStringConcat]
    I --> J{operator?}
    J -->|contains| K[ngramPrefix plus has plus position]
    J -->|starts with| L[ngramPrefix plus has plus startsWith]
    J -->|ends with| M[ngramPrefix plus has plus endsWith]
    K --> N[return query plus 3 params including escaped LIKE pattern]
    L --> N
    M --> N
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts:364-367
**Short-value prefilter adds overhead without index benefit**

The `ngrambf_v1(4, ...)` index requires at least 4 characters in the pattern to extract even one 4-gram, so granule-level pruning is impossible for values of length 1–3. With `this.value.length > 0` as the guard, those short values still emit the `like(arrayStringConcat(...), '%x%')` prefilter and run it on every row in every non-pruned granule, adding work with no acceleration benefit. Raising the guard to `this.value.length >= 4` (matching the n-gram size) would skip the prefilter overhead for values too short for the index to act on.

### Issue 2 of 2
packages/shared/src/server/queries/clickhouse-sql/clickhouse-filter.ts:414-423
For `"ends with"`, the prefilter pattern `%value%` is a "contains" check, which produces more false positives in the per-row sequential scan. Since `endsWith(str, suffix)` implies `suffix` is a substring, a tighter `%value` pattern is sufficient. The `ngrambf_v1` bloom filter extracts the same n-grams either way, so granule pruning is unchanged — only the row-level scan benefits.

```suggestion
      if (ngramPrefilter) {
        const likePattern =
          this.operator === "ends with"
            ? `%${escapeSqlLikePattern(this.value)}`
            : `%${escapeSqlLikePattern(this.value)}%`;
        return {
          query,
          params: {
            [varKeyName]: this.key,
            [varValueName]: this.value,
            [ngramPrefilterParamName]: likePattern,
          },
        };
      }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: accelerate contains and startsWith..."](https://github.com/langfuse/langfuse/commit/a4c9b313f5ac8ace46e32368aad59730fcedee81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36487214)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->