### PR TITLE
feat(mcp): support OIDC bearer auth as alternative to BasicAuth

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -60,6 +60,15 @@ CLICKHOUSE_CLUSTER_ENABLED="false"
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="secret"
 
+# MCP server: optional OIDC bearer-token auth (alongside BasicAuth).
+# Clients send `Authorization: Bearer <JWT>` plus `X-Langfuse-Project-Id: <id>`.
+# See web/src/features/mcp/README.md for setup.
+# MCP_AUTH_OIDC_ENABLED="true"
+# MCP_AUTH_OIDC_ISSUER="https://idp.example.com"
+# MCP_AUTH_OIDC_AUDIENCE="langfuse-mcp"
+# MCP_AUTH_OIDC_JWKS_URI=""           # defaults to <issuer>/.well-known/jwks.json
+# MCP_AUTH_OIDC_USER_CLAIM="email"    # JWT claim to map to a Langfuse user (email or sub)
+
 # Langfuse Cloud Environment
 NEXT_PUBLIC_LANGFUSE_CLOUD_REGION="DEV"
 # Dev-only: override the legacy blob-export cutoff date for local testing.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,6 +764,12 @@ importers:
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
+      ip-address:
+        specifier: ^10.2.0
+        version: 10.2.0
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
       json-schema-faker:
         specifier: 0.6.1
         version: 0.6.1

--- a/web/package.json
+++ b/web/package.json
@@ -126,6 +126,8 @@
     "fastest-levenshtein": "^1.0.16",
     "https-proxy-agent": "^7.0.6",
     "ioredis": "^5.10.1",
+    "ip-address": "^10.2.0",
+    "jose": "^5.9.6",
     "json-schema-faker": "0.6.1",
     "jsonpath-plus": "10.3.0",
     "langfuse": "3.38.4",

--- a/web/src/__tests__/server/unit/mcp-oidc-auth.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-oidc-auth.servertest.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for MCP OIDC bearer-token verification.
+ *
+ * These tests exercise the JWT verification + claim extraction logic in
+ * isolation: they generate keys and sign tokens in-memory with `jose`, then
+ * stub `createRemoteJWKSet` so the verifier resolves the local JWK without a
+ * network round-trip. DB-backed user/membership resolution is covered by the
+ * dispatcher integration test surface, not here.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { generateKeyPair, exportJWK, SignJWT } from "jose";
+import type * as Jose from "jose";
+
+const ISSUER = "https://idp.example.com";
+const AUDIENCE = "langfuse-mcp";
+
+vi.mock("@/src/env.mjs", () => ({
+  env: {
+    MCP_AUTH_OIDC_ENABLED: "true",
+    MCP_AUTH_OIDC_ISSUER: ISSUER,
+    MCP_AUTH_OIDC_AUDIENCE: AUDIENCE,
+    MCP_AUTH_OIDC_JWKS_URI: `${ISSUER}/.well-known/jwks.json`,
+    MCP_AUTH_OIDC_USER_CLAIM: "email",
+  },
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: { user: { findUnique: vi.fn() } },
+}));
+
+// Stub out the heavyweight server module so importing the OIDC module under
+// test does not trigger env validation for Clickhouse/S3 etc. The test
+// teardown re-imports redis/logger/ClickHouseClientManager from this module,
+// so provide minimal no-op shapes for those.
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  redis: { status: "end", disconnect: vi.fn() },
+  ClickHouseClientManager: {
+    getInstance: () => ({
+      closeAllConnections: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock("jose", async () => {
+  const actual = await vi.importActual<typeof Jose>("jose");
+  return {
+    ...actual,
+    createRemoteJWKSet: vi.fn(),
+  };
+});
+
+// jose's generateKeyPair returns KeyLike (KeyObject | CryptoKey), not a bare
+// CryptoKey; derive the exact type so this stays correct across jose versions.
+type PrivateKey = Awaited<ReturnType<typeof generateKeyPair>>["privateKey"];
+
+type Keys = {
+  privateKey: PrivateKey;
+  publicJwk: Awaited<ReturnType<typeof exportJWK>>;
+};
+
+async function makeKeys(): Promise<Keys> {
+  const { privateKey, publicKey } = await generateKeyPair("RS256", {
+    extractable: true,
+  });
+  const publicJwk = await exportJWK(publicKey);
+  publicJwk.alg = "RS256";
+  publicJwk.kid = "test-kid";
+  return { privateKey, publicJwk };
+}
+
+async function signToken(
+  privateKey: PrivateKey,
+  payload: Record<string, unknown>,
+  opts: { issuer?: string; audience?: string; expiresIn?: string } = {},
+) {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: "RS256", kid: "test-kid" })
+    .setIssuedAt()
+    .setIssuer(opts.issuer ?? ISSUER)
+    .setAudience(opts.audience ?? AUDIENCE)
+    .setExpirationTime(opts.expiresIn ?? "5m")
+    .sign(privateKey);
+}
+
+describe("MCP OIDC auth — token verification", () => {
+  let keys: Keys;
+
+  beforeEach(async () => {
+    keys = await makeKeys();
+    const jose = await import("jose");
+    const actual = await vi.importActual<typeof Jose>("jose");
+    // Resolve every kid to our test public key so jwtVerify succeeds.
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue(
+      // jose's JWKSet is a function: (header) => Promise<KeyLike>.
+      (async () => actual.importJWK(keys.publicJwk, "RS256")) as never,
+    );
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("verifies a valid token and returns the payload", async () => {
+    const { verifyOidcToken } =
+      await import("@/src/features/mcp/server/auth/oidc");
+    const token = await signToken(keys.privateKey, {
+      email: "user@example.com",
+    });
+    const payload = await verifyOidcToken(token);
+    expect(payload.email).toBe("user@example.com");
+    expect(payload.iss).toBe(ISSUER);
+    expect(payload.aud).toBe(AUDIENCE);
+  });
+
+  it("rejects a token signed by a different issuer", async () => {
+    const { verifyOidcToken } =
+      await import("@/src/features/mcp/server/auth/oidc");
+    const token = await signToken(
+      keys.privateKey,
+      { email: "u@x.com" },
+      {
+        issuer: "https://attacker.example.com",
+      },
+    );
+    await expect(verifyOidcToken(token)).rejects.toThrow(/Invalid OIDC token/);
+  });
+
+  it("rejects a token whose audience does not match", async () => {
+    const { verifyOidcToken } =
+      await import("@/src/features/mcp/server/auth/oidc");
+    const token = await signToken(
+      keys.privateKey,
+      { email: "u@x.com" },
+      {
+        audience: "some-other-app",
+      },
+    );
+    await expect(verifyOidcToken(token)).rejects.toThrow(/Invalid OIDC token/);
+  });
+
+  it("rejects an expired token", async () => {
+    const { verifyOidcToken } =
+      await import("@/src/features/mcp/server/auth/oidc");
+    const token = await new SignJWT({ email: "u@x.com" })
+      .setProtectedHeader({ alg: "RS256", kid: "test-kid" })
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+      .sign(keys.privateKey);
+    await expect(verifyOidcToken(token)).rejects.toThrow(/Invalid OIDC token/);
+  });
+});
+
+describe("MCP OIDC auth — bearer-token extraction & enablement", () => {
+  it("extracts the token from `Bearer <jwt>` (case-insensitive)", async () => {
+    const { extractBearerToken } =
+      await import("@/src/features/mcp/server/auth/oidc");
+    expect(extractBearerToken("Bearer abc.def.ghi")).toBe("abc.def.ghi");
+    expect(extractBearerToken("bearer abc.def.ghi")).toBe("abc.def.ghi");
+  });
+
+  it("returns null for a Basic auth header", async () => {
+    const { extractBearerToken } =
+      await import("@/src/features/mcp/server/auth/oidc");
+    expect(extractBearerToken("Basic abc==")).toBeNull();
+  });
+
+  it("returns null when the header is absent", async () => {
+    const { extractBearerToken } =
+      await import("@/src/features/mcp/server/auth/oidc");
+    expect(extractBearerToken(undefined)).toBeNull();
+  });
+
+  it("reports OIDC enabled when env is configured", async () => {
+    const { isOidcEnabled } =
+      await import("@/src/features/mcp/server/auth/oidc");
+    expect(isOidcEnabled()).toBe(true);
+  });
+});

--- a/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
+++ b/web/src/__tests__/server/unit/mcp-route-in-app-agent-context.servertest.ts
@@ -3,7 +3,7 @@ import {
   createInAppAgentMcpRunOverride,
   InAppAgentMcpRunOverrideSchema,
 } from "@langfuse/shared/in-app-agent/server/human-in-the-loop";
-import { getInAppAgentContext } from "@/src/pages/api/public/mcp";
+import { getInAppAgentContext } from "@/src/features/mcp/server/auth";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
 

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -303,7 +303,10 @@ export const env = createEnv({
     MCP_AUTH_OIDC_ISSUER: z.url().optional(),
     MCP_AUTH_OIDC_AUDIENCE: z.string().optional(),
     MCP_AUTH_OIDC_JWKS_URI: z.url().optional(),
-    MCP_AUTH_OIDC_USER_CLAIM: z.string().optional().default("email"),
+    MCP_AUTH_OIDC_USER_CLAIM: z
+      .enum(["email", "sub"])
+      .optional()
+      .default("email"),
     // EMAIL
     EMAIL_FROM_ADDRESS: z.string().optional(),
     SMTP_CONNECTION_URL: z.string().optional(),

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -297,6 +297,13 @@ export const env = createEnv({
     AUTH_HTTP_PROXY: z.url().optional(),
     AUTH_HTTPS_PROXY: z.url().optional(),
     AUTH_SSO_TIMEOUT: z.coerce.number().int().positive().optional(),
+    // MCP server: optional OIDC bearer-token auth alongside BasicAuth.
+    // See: web/src/features/mcp/README.md
+    MCP_AUTH_OIDC_ENABLED: z.enum(["true", "false"]).optional(),
+    MCP_AUTH_OIDC_ISSUER: z.url().optional(),
+    MCP_AUTH_OIDC_AUDIENCE: z.string().optional(),
+    MCP_AUTH_OIDC_JWKS_URI: z.url().optional(),
+    MCP_AUTH_OIDC_USER_CLAIM: z.string().optional().default("email"),
     // EMAIL
     EMAIL_FROM_ADDRESS: z.string().optional(),
     SMTP_CONNECTION_URL: z.string().optional(),
@@ -823,6 +830,11 @@ export const env = createEnv({
     AUTH_HTTP_PROXY: process.env.AUTH_HTTP_PROXY,
     AUTH_HTTPS_PROXY: process.env.AUTH_HTTPS_PROXY,
     AUTH_SSO_TIMEOUT: process.env.AUTH_SSO_TIMEOUT,
+    MCP_AUTH_OIDC_ENABLED: process.env.MCP_AUTH_OIDC_ENABLED,
+    MCP_AUTH_OIDC_ISSUER: process.env.MCP_AUTH_OIDC_ISSUER,
+    MCP_AUTH_OIDC_AUDIENCE: process.env.MCP_AUTH_OIDC_AUDIENCE,
+    MCP_AUTH_OIDC_JWKS_URI: process.env.MCP_AUTH_OIDC_JWKS_URI,
+    MCP_AUTH_OIDC_USER_CLAIM: process.env.MCP_AUTH_OIDC_USER_CLAIM,
     // Email
     EMAIL_FROM_ADDRESS: process.env.EMAIL_FROM_ADDRESS,
     SMTP_CONNECTION_URL: process.env.SMTP_CONNECTION_URL,

--- a/web/src/features/mcp/README.md
+++ b/web/src/features/mcp/README.md
@@ -112,6 +112,45 @@ Clients like Claude Code can use these annotations to:
 
 All write operations should audit-log entries with before/after snapshots.
 
+### OIDC Bearer Authentication (self-hosted)
+
+Self-hosted deployments can additionally accept OIDC bearer JWTs from a
+configured identity provider, so MCP clients authenticate as a real Langfuse
+user rather than via a shared static API key.
+
+**Enabling:**
+
+```bash
+MCP_AUTH_OIDC_ENABLED=true
+MCP_AUTH_OIDC_ISSUER=https://idp.example.com
+MCP_AUTH_OIDC_AUDIENCE=langfuse-mcp        # optional; if set, `aud` must match
+MCP_AUTH_OIDC_JWKS_URI=                    # optional; defaults to <issuer>/.well-known/jwks.json
+MCP_AUTH_OIDC_USER_CLAIM=email             # `email` (default) or `sub`
+```
+
+**Request flow:**
+
+```
+1. Client sends:
+     Authorization: Bearer <JWT>
+     X-Langfuse-Project-Id: <projectId>
+   ↓
+2. JWT verified against MCP_AUTH_OIDC_ISSUER via its JWKS
+   (issuer + optional audience checked)
+   ↓
+3. Resolve Langfuse user by MCP_AUTH_OIDC_USER_CLAIM (email or sub)
+   ↓
+4. Require ProjectMembership for the requested projectId
+   ↓
+5. Build ServerContext with the real userId; apiKeyId is
+   synthesized as `oidc:<userId>` for audit-log compatibility
+```
+
+The user must already exist in Langfuse and be a member of the target
+project — this PR does not auto-provision users from JWT claims. BasicAuth
+remains the default; OIDC is only consulted when the Authorization header
+carries a Bearer token and `MCP_AUTH_OIDC_ENABLED=true`.
+
 ---
 
 # Connecting Clients

--- a/web/src/features/mcp/README.md
+++ b/web/src/features/mcp/README.md
@@ -147,9 +147,20 @@ MCP_AUTH_OIDC_USER_CLAIM=email             # `email` (default) or `sub`
 ```
 
 The user must already exist in Langfuse and be a member of the target
-project — this PR does not auto-provision users from JWT claims. BasicAuth
-remains the default; OIDC is only consulted when the Authorization header
-carries a Bearer token and `MCP_AUTH_OIDC_ENABLED=true`.
+project — this PR does not auto-provision users from JWT claims.
+
+**Both auth methods are served concurrently** by the same endpoint. The
+dispatch is per-request, based on the `Authorization` header scheme:
+
+| Authorization header  | OIDC enabled? | Path taken            | Typical caller          |
+| --------------------- | ------------- | --------------------- | ----------------------- |
+| `Bearer <JWT>`        | yes           | OIDC                  | Human user via IdP      |
+| `Bearer <JWT>`        | no            | rejected (Basic only) | —                       |
+| `Basic <base64>`      | either        | API key (existing)    | Service / agent / CI    |
+
+So a single deployment can authenticate human users via SSO **and**
+automated processes via project API keys at the same time — there is no
+migration off API keys required to turn OIDC on.
 
 ---
 

--- a/web/src/features/mcp/features/publicApi.ts
+++ b/web/src/features/mcp/features/publicApi.ts
@@ -19,7 +19,10 @@ export type McpPublicApiAuth = {
 };
 
 export const getMcpPublicApiAuth = async (
-  context: ServerContext,
+  // plan / rateLimitOverrides are the fields this function derives, so it must
+  // not require them on input — the OIDC auth path calls it to obtain exactly
+  // those before it can assemble a full ServerContext.
+  context: Omit<ServerContext, "plan" | "rateLimitOverrides">,
 ): Promise<McpPublicApiAuth> => {
   const org = await prisma.organization.findUnique({
     where: { id: context.orgId },

--- a/web/src/features/mcp/server/auth/index.ts
+++ b/web/src/features/mcp/server/auth/index.ts
@@ -1,0 +1,144 @@
+/**
+ * MCP request authentication dispatcher.
+ *
+ * Routes a request to the OIDC bearer-token path when the request carries
+ * `Authorization: Bearer <JWT>` and OIDC is enabled; otherwise falls back to
+ * the existing BasicAuth + API key flow.
+ *
+ * Both paths return a `ServerContext` plus an `ApiAccessScope` suitable for
+ * rate-limiting and downstream public-API consumers.
+ */
+
+import { type NextApiRequest } from "next";
+import { prisma } from "@langfuse/shared/src/db";
+import { addUserToSpan, redis } from "@langfuse/shared/src/server";
+import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
+import { ForbiddenError, UnauthorizedError } from "@langfuse/shared";
+import { type ApiAccessScope } from "@langfuse/shared/src/server";
+import { type ServerContext } from "@/src/features/mcp/types";
+import { getMcpPublicApiAuth } from "@/src/features/mcp/features/publicApi";
+import { IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER } from "@langfuse/shared/in-app-agent";
+import { InAppAgentMcpRunOverrideSchema } from "@langfuse/shared/in-app-agent/server/human-in-the-loop";
+import { safeJsonParse } from "@langfuse/shared";
+import {
+  extractBearerToken,
+  isOidcEnabled,
+  resolveOidcContextFromRequest,
+} from "./oidc";
+
+export type McpAuthResult = {
+  context: ServerContext;
+  scope: ApiAccessScope;
+};
+
+/**
+ * Resolve the in-app-agent authorization state for a BasicAuth request.
+ *
+ * In-app-agent keys need a run override for mutating tools; read-only tools
+ * remain available without it via their MCP `readOnlyHint` annotation. Returns
+ * `undefined` for ordinary project API keys.
+ */
+export function getInAppAgentContext(
+  req: NextApiRequest,
+  isInAppAgentKey: boolean | undefined,
+): ServerContext["inAppAgent"] {
+  if (isInAppAgentKey !== true) {
+    return undefined;
+  }
+
+  const headerValue = req.headers[IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER];
+
+  if (typeof headerValue !== "string") {
+    return { permissions: "read" };
+  }
+
+  const parsedOverride = InAppAgentMcpRunOverrideSchema.safeParse(
+    safeJsonParse(headerValue),
+  );
+
+  return parsedOverride.success
+    ? {
+        permissions: "single-tool-override",
+        allowedToolName: parsedOverride.data.toolName,
+      }
+    : { permissions: "read" };
+}
+
+export async function authenticateMcpRequest(
+  req: NextApiRequest,
+): Promise<McpAuthResult> {
+  const bearerToken = extractBearerToken(req.headers.authorization);
+
+  // OIDC bearer path
+  if (bearerToken && isOidcEnabled()) {
+    const identity = await resolveOidcContextFromRequest(req, bearerToken);
+    // getMcpPublicApiAuth derives plan / rateLimitOverrides from the org's
+    // cloud config; fold them onto the context so plan-based rate limiting in
+    // tools sees the same values the BasicAuth path gets from the API key.
+    const { scope } = await getMcpPublicApiAuth(identity);
+    const context: ServerContext = {
+      ...identity,
+      plan: scope.plan,
+      rateLimitOverrides: scope.rateLimitOverrides,
+    };
+
+    addUserToSpan({
+      userId: context.userId,
+      apiKeyId: scope.apiKeyId,
+      publicKey: scope.publicKey,
+      projectId: scope.projectId,
+      orgId: scope.orgId,
+      plan: scope.plan,
+    });
+
+    return { context, scope };
+  }
+
+  // BasicAuth + API key path (existing behavior)
+  const authCheck = await new ApiAuthService(
+    prisma,
+    redis,
+  ).verifyAuthHeaderAndReturnScope(req.headers.authorization, {
+    allowInAppAgentKey: true,
+  });
+
+  if (!authCheck.validKey) {
+    throw new UnauthorizedError(authCheck.error);
+  }
+
+  if (authCheck.scope.accessLevel !== "project" || !authCheck.scope.projectId) {
+    throw new ForbiddenError(
+      "Access denied: MCP requires project-scoped API keys with BasicAuth",
+    );
+  }
+
+  addUserToSpan({
+    apiKeyId: authCheck.scope.apiKeyId,
+    publicKey: authCheck.scope.publicKey,
+    projectId: authCheck.scope.projectId,
+    orgId: authCheck.scope.orgId,
+    plan: authCheck.scope.plan,
+  });
+
+  if (authCheck.scope.isIngestionSuspended) {
+    throw new ForbiddenError(
+      "Access suspended: Usage threshold exceeded. Please upgrade your plan.",
+    );
+  }
+
+  const context: ServerContext = {
+    projectId: authCheck.scope.projectId,
+    orgId: authCheck.scope.orgId,
+    userId: undefined,
+    apiKeyId: authCheck.scope.apiKeyId,
+    accessLevel: "project",
+    publicKey: authCheck.scope.publicKey,
+    plan: authCheck.scope.plan,
+    rateLimitOverrides: authCheck.scope.rateLimitOverrides,
+    userAgent: req.headers["user-agent"],
+    inAppAgent: getInAppAgentContext(req, authCheck.scope.isInAppAgentKey),
+    authMethod: "api-key",
+  };
+
+  return { context, scope: authCheck.scope };
+}

--- a/web/src/features/mcp/server/auth/oidc.ts
+++ b/web/src/features/mcp/server/auth/oidc.ts
@@ -1,0 +1,171 @@
+/**
+ * OIDC bearer-token authentication for the MCP endpoint.
+ *
+ * Validates `Authorization: Bearer <JWT>` against a configured OIDC issuer
+ * using its JWKS, then resolves the JWT principal to a Langfuse user and
+ * requires a project membership for the project identified by the
+ * `X-Langfuse-Project-Id` request header.
+ *
+ * Project selection is header-based, not claim-based, so the same JWT can
+ * be reused across projects the user is a member of without re-issuing tokens.
+ *
+ * Synthetic `apiKeyId` / `publicKey` strings of the form `oidc:<userId>` and
+ * `oidc` are populated on the resulting ServerContext so audit logs and
+ * downstream public-API helpers keep working unchanged; the real per-user
+ * identity is on `userId` and `authMethod === "oidc"`.
+ */
+
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
+import { type NextApiRequest } from "next";
+import { prisma } from "@langfuse/shared/src/db";
+import { ForbiddenError, UnauthorizedError } from "@langfuse/shared";
+import { env } from "@/src/env.mjs";
+import { logger } from "@langfuse/shared/src/server";
+import { type ServerContext } from "@/src/features/mcp/types";
+
+const PROJECT_ID_HEADER = "x-langfuse-project-id";
+
+type CachedJwks = {
+  issuer: string;
+  jwksUri: string;
+  jwks: ReturnType<typeof createRemoteJWKSet>;
+};
+
+let cachedJwks: CachedJwks | null = null;
+
+function getJwks(issuer: string, jwksUri: string) {
+  if (
+    cachedJwks &&
+    cachedJwks.issuer === issuer &&
+    cachedJwks.jwksUri === jwksUri
+  ) {
+    return cachedJwks.jwks;
+  }
+  const jwks = createRemoteJWKSet(new URL(jwksUri));
+  cachedJwks = { issuer, jwksUri, jwks };
+  return jwks;
+}
+
+export function isOidcEnabled(): boolean {
+  return (
+    env.MCP_AUTH_OIDC_ENABLED === "true" &&
+    typeof env.MCP_AUTH_OIDC_ISSUER === "string" &&
+    env.MCP_AUTH_OIDC_ISSUER.length > 0
+  );
+}
+
+export function extractBearerToken(
+  authHeader: string | string[] | undefined,
+): string | null {
+  const value = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+  if (!value) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(value);
+  return match ? match[1].trim() : null;
+}
+
+export async function verifyOidcToken(token: string): Promise<JWTPayload> {
+  if (!isOidcEnabled() || !env.MCP_AUTH_OIDC_ISSUER) {
+    throw new UnauthorizedError("OIDC authentication is not enabled");
+  }
+
+  const issuer = env.MCP_AUTH_OIDC_ISSUER;
+  const jwksUri =
+    env.MCP_AUTH_OIDC_JWKS_URI ??
+    new URL(
+      "/.well-known/jwks.json",
+      issuer.endsWith("/") ? issuer : `${issuer}/`,
+    ).toString();
+
+  const jwks = getJwks(issuer, jwksUri);
+
+  try {
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer,
+      audience: env.MCP_AUTH_OIDC_AUDIENCE,
+    });
+    return payload;
+  } catch (err) {
+    throw new UnauthorizedError(
+      `Invalid OIDC token: ${err instanceof Error ? err.message : "unknown error"}`,
+    );
+  }
+}
+
+function extractPrincipalIdentifier(payload: JWTPayload): string {
+  const claim = env.MCP_AUTH_OIDC_USER_CLAIM ?? "email";
+  const value = (payload as Record<string, unknown>)[claim];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new UnauthorizedError(`OIDC token missing required claim '${claim}'`);
+  }
+  return value;
+}
+
+// plan / rateLimitOverrides are derived from the org's cloud config by
+// getMcpPublicApiAuth (the caller), so the OIDC identity resolution omits them.
+export async function resolveOidcContextFromRequest(
+  req: NextApiRequest,
+  token: string,
+): Promise<Omit<ServerContext, "plan" | "rateLimitOverrides">> {
+  const payload = await verifyOidcToken(token);
+  const principal = extractPrincipalIdentifier(payload);
+  const claim = env.MCP_AUTH_OIDC_USER_CLAIM ?? "email";
+
+  const user =
+    claim === "sub"
+      ? await prisma.user.findUnique({
+          where: { id: principal },
+          select: { id: true },
+        })
+      : await prisma.user.findUnique({
+          where: { email: principal },
+          select: { id: true },
+        });
+
+  if (!user) {
+    throw new ForbiddenError(
+      `No Langfuse user found for OIDC principal '${principal}'`,
+    );
+  }
+
+  const projectHeader = req.headers[PROJECT_ID_HEADER];
+  const projectId = Array.isArray(projectHeader)
+    ? projectHeader[0]
+    : projectHeader;
+  if (!projectId) {
+    throw new UnauthorizedError(
+      `OIDC authentication requires the '${PROJECT_ID_HEADER}' request header`,
+    );
+  }
+
+  const membership = await prisma.projectMembership.findUnique({
+    where: { projectId_userId: { projectId, userId: user.id } },
+    select: {
+      role: true,
+      organizationMembership: { select: { orgId: true } },
+    },
+  });
+
+  if (!membership) {
+    throw new ForbiddenError(
+      `User '${principal}' is not a member of project '${projectId}'`,
+    );
+  }
+
+  logger.info("MCP request authenticated via OIDC", {
+    projectId,
+    orgId: membership.organizationMembership.orgId,
+    userId: user.id,
+    role: membership.role,
+  });
+
+  return {
+    projectId,
+    orgId: membership.organizationMembership.orgId,
+    userId: user.id,
+    apiKeyId: `oidc:${user.id}`,
+    accessLevel: "project",
+    publicKey: "oidc",
+    userAgent: req.headers["user-agent"],
+    authMethod: "oidc",
+  };
+}

--- a/web/src/features/mcp/server/auth/oidc.ts
+++ b/web/src/features/mcp/server/auth/oidc.ts
@@ -100,6 +100,13 @@ function extractPrincipalIdentifier(payload: JWTPayload): string {
   return value;
 }
 
+// Opaque message used for both "user does not exist" and "user is not a
+// member of the requested project". Distinct messages would let a JWT
+// holder enumerate Langfuse user existence by probing arbitrary project
+// IDs and comparing responses; keep the failure modes indistinguishable
+// to clients. Server-side logs do record which branch fired.
+const OIDC_ACCESS_DENIED = "OIDC authentication failed";
+
 // plan / rateLimitOverrides are derived from the org's cloud config by
 // getMcpPublicApiAuth (the caller), so the OIDC identity resolution omits them.
 export async function resolveOidcContextFromRequest(
@@ -109,6 +116,16 @@ export async function resolveOidcContextFromRequest(
   const payload = await verifyOidcToken(token);
   const principal = extractPrincipalIdentifier(payload);
   const claim = env.MCP_AUTH_OIDC_USER_CLAIM ?? "email";
+
+  const projectHeader = req.headers[PROJECT_ID_HEADER];
+  const projectId = Array.isArray(projectHeader)
+    ? projectHeader[0]
+    : projectHeader;
+  if (!projectId) {
+    throw new UnauthorizedError(
+      `OIDC authentication requires the '${PROJECT_ID_HEADER}' request header`,
+    );
+  }
 
   const user =
     claim === "sub"
@@ -122,32 +139,47 @@ export async function resolveOidcContextFromRequest(
         });
 
   if (!user) {
-    throw new ForbiddenError(
-      `No Langfuse user found for OIDC principal '${principal}'`,
-    );
-  }
-
-  const projectHeader = req.headers[PROJECT_ID_HEADER];
-  const projectId = Array.isArray(projectHeader)
-    ? projectHeader[0]
-    : projectHeader;
-  if (!projectId) {
-    throw new UnauthorizedError(
-      `OIDC authentication requires the '${PROJECT_ID_HEADER}' request header`,
-    );
+    logger.info("MCP OIDC auth: principal does not match a Langfuse user", {
+      claim,
+      principal,
+      projectId,
+    });
+    throw new ForbiddenError(OIDC_ACCESS_DENIED);
   }
 
   const membership = await prisma.projectMembership.findUnique({
     where: { projectId_userId: { projectId, userId: user.id } },
     select: {
       role: true,
-      organizationMembership: { select: { orgId: true } },
+      organizationMembership: {
+        select: {
+          orgId: true,
+          organization: {
+            select: { cloudFreeTierUsageThresholdState: true },
+          },
+        },
+      },
     },
   });
 
   if (!membership) {
+    logger.info(
+      "MCP OIDC auth: user has no membership for the requested project",
+      { userId: user.id, projectId },
+    );
+    throw new ForbiddenError(OIDC_ACCESS_DENIED);
+  }
+
+  // Mirror the BasicAuth path's usage-suspension enforcement so a suspended
+  // org cannot bypass the gate by switching MCP clients to OIDC bearer auth.
+  // BasicAuth derives this from the API key row's denormalized field; OIDC
+  // has no API key, so we read directly from the org's cloud-tier state.
+  if (
+    membership.organizationMembership.organization
+      .cloudFreeTierUsageThresholdState === "BLOCKED"
+  ) {
     throw new ForbiddenError(
-      `User '${principal}' is not a member of project '${projectId}'`,
+      "Access suspended: Usage threshold exceeded. Please upgrade your plan.",
     );
   }
 

--- a/web/src/features/mcp/types.ts
+++ b/web/src/features/mcp/types.ts
@@ -63,6 +63,16 @@ export interface ServerContext {
 
   /** In-app-agent-specific MCP authorization state. */
   inAppAgent?: InAppAgentContext;
+
+  /**
+   * How the request was authenticated.
+   * - "api-key" (default): HTTP Basic with project-scoped API key.
+   * - "oidc": Bearer JWT verified against a configured OIDC issuer. On the
+   *   OIDC path, `userId` carries the real principal and
+   *   `apiKeyId`/`publicKey` hold synthetic identifiers (`oidc:<userId>` and
+   *   `oidc`) so downstream audit-log and public-API consumers keep working.
+   */
+  authMethod?: "api-key" | "oidc";
 }
 
 /**

--- a/web/src/pages/api/public/mcp/index.ts
+++ b/web/src/pages/api/public/mcp/index.ts
@@ -19,7 +19,10 @@
  * the transport layer needs direct response control for both JSON and SSE responses.
  * Error handling, header validation, and CORS are implemented in this route layer.
  *
- * Authentication: BasicAuth (Public Key:Secret Key) - LF-1927
+ * Authentication:
+ * - BasicAuth (Public Key:Secret Key) - LF-1927
+ * - Optional OIDC bearer JWT alongside BasicAuth - see
+ *   web/src/features/mcp/README.md and MCP_AUTH_OIDC_* env vars.
  * Resources: Added in LF-1928
  * Tools: Added in LF-1929
  */
@@ -32,21 +35,12 @@ import {
   validateMcpRequestSecurity,
 } from "@/src/features/mcp/server/security";
 import { formatErrorForUser } from "@/src/features/mcp/core/error-formatting";
-import { type ServerContext } from "@/src/features/mcp/types";
-import { addUserToSpan, logger, redis } from "@langfuse/shared/src/server";
-import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
+import { authenticateMcpRequest } from "@/src/features/mcp/server/auth";
+import { logger } from "@langfuse/shared/src/server";
 import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
-import { prisma } from "@langfuse/shared/src/db";
-import {
-  BaseError,
-  UnauthorizedError,
-  ForbiddenError,
-  safeJsonParse,
-} from "@langfuse/shared";
+import { BaseError } from "@langfuse/shared";
 import { ZodError } from "zod";
 import { isUserInputError } from "@/src/features/mcp/core/errors";
-import { IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER } from "@langfuse/shared/in-app-agent";
-import { InAppAgentMcpRunOverrideSchema } from "@langfuse/shared/in-app-agent/server/human-in-the-loop";
 
 // Bootstrap MCP features - registers all tools at module load time
 import "@/src/features/mcp/server/bootstrap";
@@ -83,47 +77,14 @@ export default async function handler(
       return;
     }
 
-    // Authenticate request using BasicAuth (Public Key:Secret Key)
-    const authCheck = await new ApiAuthService(
-      prisma,
-      redis,
-    ).verifyAuthHeaderAndReturnScope(req.headers.authorization, {
-      allowInAppAgentKey: true,
-    });
+    // Authenticate: dispatches to BasicAuth or OIDC bearer based on the
+    // Authorization header and MCP_AUTH_OIDC_ENABLED.
+    const { context, scope } = await authenticateMcpRequest(req);
 
-    if (!authCheck.validKey) {
-      throw new UnauthorizedError(authCheck.error);
-    }
-
-    // MCP requires project-scoped access (no Bearer auth, no org-level keys)
-    if (
-      authCheck.scope.accessLevel !== "project" ||
-      !authCheck.scope.projectId
-    ) {
-      throw new ForbiddenError(
-        "Access denied: MCP requires project-scoped API keys with BasicAuth",
-      );
-    }
-
-    addUserToSpan({
-      apiKeyId: authCheck.scope.apiKeyId,
-      publicKey: authCheck.scope.publicKey,
-      projectId: authCheck.scope.projectId,
-      orgId: authCheck.scope.orgId,
-      plan: authCheck.scope.plan,
-    });
-
-    // Check if ingestion is suspended due to usage limits
-    if (authCheck.scope.isIngestionSuspended) {
-      throw new ForbiddenError(
-        "Access suspended: Usage threshold exceeded. Please upgrade your plan.",
-      );
-    }
-
-    // Rate limit MCP requests
+    // Rate limit MCP requests (applies to both auth paths)
     const rateLimitCheck =
       await RateLimitService.getInstance().rateLimitRequest(
-        authCheck.scope,
+        scope,
         "public-api",
       );
 
@@ -131,26 +92,11 @@ export default async function handler(
       return rateLimitCheck.sendRestResponseIfLimited(res);
     }
 
-    // Build ServerContext from authenticated scope. In-app-agent keys need a
-    // run override for mutating tools; read-only tools remain available
-    // without it via their MCP readOnlyHint annotation.
-    const context: ServerContext = {
-      projectId: authCheck.scope.projectId,
-      orgId: authCheck.scope.orgId,
-      userId: undefined, // API keys don't have associated users
-      apiKeyId: authCheck.scope.apiKeyId,
-      accessLevel: "project",
-      publicKey: authCheck.scope.publicKey,
-      plan: authCheck.scope.plan,
-      rateLimitOverrides: authCheck.scope.rateLimitOverrides,
-      userAgent: req.headers["user-agent"],
-      inAppAgent: getInAppAgentContext(req, authCheck.scope.isInAppAgentKey),
-    };
-
     logger.debug("MCP request authenticated", {
       method: req.method,
       projectId: context.projectId,
       orgId: context.orgId,
+      authMethod: context.authMethod ?? "api-key",
       userAgent: req.headers["user-agent"],
       contentType: req.headers["content-type"],
       accept: req.headers.accept,
@@ -188,32 +134,6 @@ export default async function handler(
       });
     }
   }
-}
-
-export function getInAppAgentContext(
-  req: NextApiRequest,
-  isInAppAgentKey: boolean | undefined,
-): ServerContext["inAppAgent"] {
-  if (isInAppAgentKey !== true) {
-    return undefined;
-  }
-
-  const headerValue = req.headers[IN_APP_AGENT_MCP_TOOL_OVERRIDE_HEADER];
-
-  if (typeof headerValue !== "string") {
-    return { permissions: "read" };
-  }
-
-  const parsedOverride = InAppAgentMcpRunOverrideSchema.safeParse(
-    safeJsonParse(headerValue),
-  );
-
-  return parsedOverride.success
-    ? {
-        permissions: "single-tool-override",
-        allowedToolName: parsedOverride.data.toolName,
-      }
-    : { permissions: "read" };
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Adds an OIDC bearer-token authentication path alongside the existing BasicAuth flow on the MCP endpoint. Self-hosted deployments can now have MCP clients authenticate as a real Langfuse user via a configured identity provider instead of distributing static project API keys.

When `MCP_AUTH_OIDC_ENABLED=true` and the request carries `Authorization: Bearer <JWT>` plus an `X-Langfuse-Project-Id` header, the request is routed to the OIDC path:

1. JWT verified against the configured issuer's JWKS (issuer + optional audience).
2. Principal resolved to a Langfuse user via the configured claim (default `email`, or `sub`).
3. Access requires an existing `ProjectMembership` for the requested project.

Otherwise the existing BasicAuth + API key flow runs unchanged — no behavior change for current users. **Both auth methods are served concurrently** by the same endpoint; the dispatch is per-request based on the `Authorization` header scheme, so human users can SSO while automated processes keep using project API keys.

**ServerContext shape:** `userId` carries the real principal on the OIDC path; `apiKeyId` and `publicKey` hold synthetic values (`oidc:<userId>` and `oidc`) so existing audit-log and public-API consumers keep working without a downstream refactor. A new `authMethod` field (`"api-key"` / `"oidc"`) distinguishes the two paths for observability.

**Env vars (all optional, OIDC is opt-in):**

```
MCP_AUTH_OIDC_ENABLED=true
MCP_AUTH_OIDC_ISSUER=https://idp.example.com
MCP_AUTH_OIDC_AUDIENCE=langfuse-mcp        # optional
MCP_AUTH_OIDC_JWKS_URI=                    # optional; defaults to <issuer>/.well-known/jwks.json
MCP_AUTH_OIDC_USER_CLAIM=email             # 'email' (default) or 'sub'
```

## Project scoping symmetry with API keys

The OIDC path preserves the same "one project fixed per connection" semantics as today's BasicAuth path; only the place where the project gets chosen differs:

| Path     | Credential carries  | Disambiguation lives in            | Per-connection project |
| -------- | ------------------- | ---------------------------------- | ---------------------- |
| BasicAuth| `pk:sk` → projectId | The key itself (DB-backed)         | Fixed                  |
| OIDC     | JWT → userId        | `X-Langfuse-Project-Id` header     | Fixed                  |

A project API key is created against a single project, so today's clients implicitly have "one MCP registration per project" already. The OIDC path keeps the same shape — the only operational difference is that the project lives in a header instead of being baked into the credential, because a user's JWT can match N project memberships and needs explicit disambiguation.

Example Claude Code registrations:

```bash
claude mcp add lf-foo https://lf.example.com/api/public/mcp \
    --header "Authorization: Bearer $LF_JWT" \
    --header "X-Langfuse-Project-Id: proj-foo"

claude mcp add lf-bar https://lf.example.com/api/public/mcp \
    --header "Authorization: Bearer $LF_JWT" \
    --header "X-Langfuse-Project-Id: proj-bar"
```

## Out of scope for this PR (explicit non-goals)

Happy to follow up with separate PRs/RFCs:

- **Auto-provisioning users from JWT claims** — the user must already exist in Langfuse. JIT user creation + JIT membership granting are a meaningful policy surface that deserves its own design discussion (which IdP claim maps to which Langfuse role, default org/project, etc.).
- **Group/role claim → Langfuse role mapping** — existing `ProjectMembership` role is used; we don't elevate or filter based on JWT claims today.
- **OIDC discovery autoconfig** (`.well-known/openid-configuration`) — only JWKS is fetched. Saves a network call; happy to add discovery if it'd reduce config burden.
- **Project ID in JWT claim** — only the `X-Langfuse-Project-Id` header is supported, so one token can be reused across the user's projects without re-issuing.

## Future work (additive, won't break this PR)

The "one MCP server registration per project" UX wart is real but easy to address in follow-up PRs without breaking the header path:

- **URL-path project selector** — add `/api/public/mcp/p/<projectId>` so users can register `claude mcp add lf-foo https://lf/api/public/mcp/p/proj-foo` without a custom header. Resolves the same way the header does today.
- **Per-call `projectId` argument** — make `ServerContext.projectId` optional and thread project through tool input schemas with per-call membership checks. One MCP registration handles all of a user's projects; the LLM picks per tool call. Bigger lift (touches every tool + audit-log call) but the right long-term shape for SSO users who work across many projects in one agent session.

Both can land later without changing the header behavior shipped here.

Fixes #12738

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- Tests: new `web/src/__tests__/server/unit/mcp-oidc-auth.servertest.ts` covers token verification (valid, wrong issuer, wrong audience, expired) and the bearer-extraction / enablement helpers. The DB-backed user + membership resolution path is intentionally not unit-tested here; integration coverage would belong in the existing `mcp-auth.servertest.ts` once the maintainer agrees on the test fixtures (creating Users + ProjectMemberships in the test DB).
- Docs: `web/src/features/mcp/README.md` gains an "OIDC Bearer Authentication (self-hosted)" section with a coexistence table; `.env.dev.example` documents the new env vars.
- Lint, typecheck, and the new unit test pass locally.

## Notes for review

- **Synthetic apiKeyId** (`oidc:<userId>`) is a pragmatic choice to avoid touching the 6+ downstream call sites that pass `context.apiKeyId` to `auditLog(...)` and `getMcpPublicApiAuth(...)`. The `audit_logs.api_key_id` column is already a free-form string (`String?` in Prisma) with no FK constraint, so synthetic values are harmless and stay queryable. Happy to refactor toward truly optional `apiKeyId`/`publicKey` on `ServerContext` if maintainers prefer — that change would cascade into the audit-log signature union but is otherwise mechanical.
- The OIDC path **still goes through rate limiting** via the same `RateLimitService` call as BasicAuth; `getMcpPublicApiAuth` is reused to build the `ApiAccessScope` from the OIDC `ServerContext`.
- JWKS is cached per (issuer, jwksUri) pair on the module — first request fetches, subsequent requests reuse `jose`'s `createRemoteJWKSet` cache.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an OIDC bearer-token authentication path to the MCP endpoint so self-hosted deployments can authenticate MCP clients as real Langfuse users via an external IdP, running concurrently with the existing BasicAuth API-key flow on the same endpoint.

- New `web/src/features/mcp/server/auth/oidc.ts` handles JWT verification via `jose`, principal→user resolution, and project-membership gating; a new dispatcher in `auth/index.ts` routes requests to either path based on the `Authorization` header scheme and `MCP_AUTH_OIDC_ENABLED`.
- Five new opt-in env vars (`MCP_AUTH_OIDC_*`) configure the issuer, audience, optional JWKS URI, and claim-to-user mapping; a new `authMethod` discriminant on `ServerContext` distinguishes the two paths for audit logging.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The OIDC path introduces a concrete enforcement gap: organizations whose MCP access has been suspended due to usage limits will continue to be served on the OIDC path while BasicAuth clients are blocked. Merging before that is addressed means the two auth methods behave differently under suspension.

The ingestion-suspension check that guards the BasicAuth branch is simply absent from the OIDC branch, giving suspended organizations a bypass they wouldn't expect. The user-enumeration disclosure and the too-permissive env var schema are real but lower-stakes. The JWT verification logic itself looks correct.

web/src/features/mcp/server/auth/index.ts and oidc.ts need the ingestion-suspension check added to the OIDC path; web/src/env.mjs should restrict MCP_AUTH_OIDC_USER_CLAIM to the two supported values.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant MCP Handler
    participant Auth Dispatcher
    participant OIDC Module
    participant BasicAuth Service
    participant IdP JWKS
    participant DB (Prisma)
    participant Rate Limiter

    Client->>MCP Handler: POST /api/public/mcp (Authorization: Bearer/Basic)
    MCP Handler->>Auth Dispatcher: authenticateMcpRequest(req)
    
    alt Bearer token + OIDC enabled
        Auth Dispatcher->>OIDC Module: resolveOidcContextFromRequest(req, token)
        OIDC Module->>IdP JWKS: fetch & cache JWKS (first request only)
        IdP JWKS-->>OIDC Module: public keys
        OIDC Module->>OIDC Module: jwtVerify(token, jwks, {issuer, audience})
        OIDC Module->>DB (Prisma): user.findUnique by email or sub
        DB (Prisma)-->>OIDC Module: User | null
        OIDC Module->>DB (Prisma): projectMembership.findUnique
        DB (Prisma)-->>OIDC Module: Membership | null
        OIDC Module-->>Auth Dispatcher: ServerContext (authMethod: oidc)
        Auth Dispatcher->>DB (Prisma): getMcpPublicApiAuth (fetch org plan)
        DB (Prisma)-->>Auth Dispatcher: ApiAccessScope
    else Bearer token + OIDC disabled, or Basic credentials
        Auth Dispatcher->>BasicAuth Service: verifyAuthHeaderAndReturnScope
        BasicAuth Service->>DB (Prisma): lookup API key, check suspension
        DB (Prisma)-->>BasicAuth Service: scope
        BasicAuth Service-->>Auth Dispatcher: validKey + scope
        Auth Dispatcher->>Auth Dispatcher: check isIngestionSuspended
        Auth Dispatcher-->>Auth Dispatcher: ServerContext (authMethod: api-key)
    end
    
    Auth Dispatcher-->>MCP Handler: context + scope
    MCP Handler->>Rate Limiter: rateLimitRequest(scope)
    Rate Limiter-->>MCP Handler: rateLimitCheck
    MCP Handler->>MCP Handler: createMcpServer(context)
    MCP Handler->>Client: MCP response
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/features/mcp/server/auth/index.ts:37-41
**OIDC path skips ingestion-suspension enforcement**

The BasicAuth path explicitly checks `authCheck.scope.isIngestionSuspended` and throws a `ForbiddenError` (lines 61-65), but the OIDC path calls `getMcpPublicApiAuth` which hard-codes `isIngestionSuspended: false`. This means an org that has exceeded its usage quota and been suspended will have its BasicAuth MCP clients blocked while OIDC clients continue unrestricted.

To match the BasicAuth behavior, `resolveOidcContextFromRequest` (or this dispatcher) should fetch the org's suspension status and throw the same `ForbiddenError` when suspended.

### Issue 2 of 3
web/src/env.mjs:268
The env var is typed as a free-form string but only `"email"` and `"sub"` are handled in `resolveOidcContextFromRequest`. Any other value silently falls through to the email-lookup branch and will never resolve a user. Restricting the schema to the two supported values surfaces misconfiguration at server startup rather than at auth time.

```suggestion
    MCP_AUTH_OIDC_USER_CLAIM: z.enum(["email", "sub"]).optional().default("email"),
```

### Issue 3 of 3
web/src/features/mcp/server/auth/oidc.ts:122-149
**User-existence oracle via distinct error messages**

The two error paths return different `ForbiddenError` messages depending on whether the OIDC principal maps to a Langfuse user at all (`No Langfuse user found`) versus whether that user is a member of the requested project (`User '...' is not a member of project`). A holder of a valid JWT from the IdP can enumerate Langfuse user existence by probing with arbitrary project IDs and comparing the response. Consider returning the same opaque message — e.g., `"OIDC authentication failed"` — for both failure conditions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(mcp): clarify OIDC and BasicAuth co..."](https://github.com/langfuse/langfuse/commit/92111a06fbeac66b236e2c53078f6fa2be510b35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36584028)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->