### PR TITLE
chore: move MCP info logs to debug

### DIFF
--- a/web/src/features/mcp/server/transport.ts
+++ b/web/src/features/mcp/server/transport.ts
@@ -72,7 +72,7 @@ export async function handleMcpRequest(
       // Connect server to transport
       await server.connect(transport);
 
-      logger.info("MCP server connected via Streamable HTTP transport", {
+      logger.debug("MCP server connected via Streamable HTTP transport", {
         method: req.method,
       });
 

--- a/web/src/pages/api/public/mcp/index.ts
+++ b/web/src/pages/api/public/mcp/index.ts
@@ -127,7 +127,7 @@ export default async function handler(
       isInAppAgentKey: authCheck.scope.isInAppAgentKey === true,
     };
 
-    logger.info("MCP request authenticated", {
+    logger.debug("MCP request authenticated", {
       method: req.method,
       projectId: context.projectId,
       orgId: context.orgId,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces log verbosity for two MCP-related info messages, downgrading them to `debug` level to reduce noise in production logs.

- `transport.ts`: "MCP server connected via Streamable HTTP transport" is now logged at `debug` instead of `info`.
- `index.ts`: "MCP request authenticated" is now logged at `debug` instead of `info`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only log levels are changed, with no impact on request handling or authentication logic.

Both changes are isolated to log statements with no effect on control flow, authentication, or data handling. The two messages are informational lifecycle signals that are reasonable to drop to debug level in a high-traffic MCP endpoint.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant MCP API (index.ts)
    participant Transport (transport.ts)

    Client->>MCP API (index.ts): HTTP Request
    MCP API (index.ts)->>MCP API (index.ts): Authenticate request
    Note over MCP API (index.ts): logger.debug("MCP request authenticated") [was info]
    MCP API (index.ts)->>Transport (transport.ts): handleMcpRequest()
    Transport (transport.ts)->>Transport (transport.ts): server.connect(transport)
    Note over Transport (transport.ts): logger.debug("MCP server connected...") [was info]
    Transport (transport.ts)-->>Client: Response
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: move MCP info logs to debug"](https://github.com/langfuse/langfuse/commit/c4d866093b828fa5227c4ad631467a824fe1b273) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36655465)</sub>

<!-- /greptile_comment -->