### PR TITLE
chore: remove unnecessary score log line

### DIFF
--- a/web/src/features/prompts/server/handlers/promptVersionHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptVersionHandler.ts
@@ -30,8 +30,6 @@ export const promptVersionHandler = withMiddlewares({
         newLabels,
       });
 
-      logger.info(`Prompt updated ${JSON.stringify(updatedPrompt)}`);
-
       return updatedPrompt;
     },
   }),

--- a/web/src/features/prompts/server/handlers/promptVersionHandler.ts
+++ b/web/src/features/prompts/server/handlers/promptVersionHandler.ts
@@ -1,4 +1,3 @@
-import { logger } from "@langfuse/shared/src/server";
 import { z } from "zod";
 import { LATEST_PROMPT_LABEL } from "@langfuse/shared";
 

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -7,7 +7,6 @@ import {
   InvalidRequestError,
 } from "@langfuse/shared";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
-import { logger } from "@langfuse/shared/src/server";
 
 export default withMiddlewares({
   GET: createAuthedProjectAPIRoute({

--- a/web/src/pages/api/public/v2/scores/index.ts
+++ b/web/src/pages/api/public/v2/scores/index.ts
@@ -26,10 +26,6 @@ export default withMiddlewares({
       const includesTrace = requestedFields.includes("trace");
       const hasTraceFilters = Boolean(query.userId || query.traceTags);
 
-      logger.info(
-        `fields: ${query.fields}, includesTrace: ${includesTrace}, hasTraceFilters: ${hasTraceFilters}`,
-      );
-
       if (!includesTrace && hasTraceFilters) {
         throw new InvalidRequestError(
           "Cannot filter by trace properties (userId, traceTags) when 'trace' field is not included. Please add 'trace' to the fields parameter or remove trace filters.",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes a `logger.info` debug log line from the v2 scores API endpoint that was logging request field parameters and trace filter state on every call.

- The removed log statement printed `query.fields`, `includesTrace`, and `hasTraceFilters` to the log output on every GET request to `/api/public/v2/scores`, which could be noisy in production and expose query parameters in logs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — removes a single debug log statement with no logic changes.

The only change is deletion of a logger.info call that logged request parameters on every scores API call. No logic, validation, or error handling is modified.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove unnecessary score log line"](https://github.com/langfuse/langfuse/commit/ca70b3a487af4462dd01d748fe0a861219d27495) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36657194)</sub>

<!-- /greptile_comment -->