### PR TITLE
fix(agent): Recent conversations styling issues

### DIFF
--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -26,6 +26,8 @@ import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
 import { cn } from "@/src/utils/tailwind";
 
+const IN_APP_AI_AGENT_WINDOW_Z_INDEX = 51;
+
 export const InAppAiAgentButton = () => {
   const { organization } = useQueryProjectOrOrganization();
   const { isAvailable, open, setOpen, isExpanded, setIsExpanded } =
@@ -129,14 +131,19 @@ export const InAppAiAgentButton = () => {
               ref={panelRef}
               data-ignore-outside-interaction
               className={cn(
-                "fixed z-51 origin-top-left",
+                "fixed origin-top-left",
                 isExpanded
                   ? "inset-x-3 top-[calc(var(--banner-offset)+0.75rem)] bottom-3"
                   : "bottom-2",
               )}
-              style={isExpanded ? undefined : anchorStyle}
+              style={
+                isExpanded
+                  ? { zIndex: IN_APP_AI_AGENT_WINDOW_Z_INDEX }
+                  : { ...anchorStyle, zIndex: IN_APP_AI_AGENT_WINDOW_Z_INDEX }
+              }
             >
               <ControlledInAppAgentWindow
+                zIndex={IN_APP_AI_AGENT_WINDOW_Z_INDEX}
                 isExpanded={isExpanded}
                 onExpandedChange={(nextIsExpanded) => {
                   previousPanelRectRef.current =

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -13,19 +13,23 @@ import {
   type AgUiMessage,
 } from "@/src/ee/features/in-app-agent/schema";
 
-type ControlledInAppAgentWindowProps =
-  | {
-      isExpanded: boolean;
-      showCloseButton: false;
-      onExpandedChange: (isExpanded: boolean) => void;
-      onClose?: () => void;
-    }
-  | {
-      isExpanded: boolean;
-      showCloseButton?: true;
-      onExpandedChange: (isExpanded: boolean) => void;
-      onClose: () => void;
-    };
+type ControlledInAppAgentWindowBaseProps = {
+  zIndex?: number;
+  isExpanded: boolean;
+  onExpandedChange: (isExpanded: boolean) => void;
+};
+
+type ControlledInAppAgentWindowProps = ControlledInAppAgentWindowBaseProps &
+  (
+    | {
+        showCloseButton: false;
+        onClose?: () => void;
+      }
+    | {
+        showCloseButton?: true;
+        onClose: () => void;
+      }
+  );
 
 export function ControlledInAppAgentWindow(
   props: ControlledInAppAgentWindowProps,
@@ -223,6 +227,7 @@ export function ControlledInAppAgentWindow(
       messages={drawerMessages}
       conversations={conversations}
       hasMoreConversations={hasMoreConversations}
+      zIndex={props.zIndex}
       isLoadingMoreConversations={isLoadingMoreConversations}
       selectedConversationId={selectedConversationId}
       onLoadMoreConversations={loadMoreConversations}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -64,6 +64,7 @@ export type InAppAgentWindowProps = {
   onSelectConversation: (conversationId: string) => void;
   onSubmit: (input: string) => boolean | Promise<boolean>;
   selectedConversationId: string | undefined;
+  zIndex?: number;
 } & InAppAgentWindowCloseButtonProps;
 
 export function InAppAgentWindow(props: InAppAgentWindowProps) {
@@ -81,6 +82,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     onSelectConversation,
     onSubmit,
     selectedConversationId,
+    zIndex,
   } = props;
   const viewportRef = useRef<HTMLDivElement>(null);
   const scrollPositionRef = useRef<{
@@ -170,7 +172,13 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 <History className="size-3" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-64">
+            <DropdownMenuContent
+              align="end"
+              className="max-h-80 w-64 overflow-y-auto"
+              style={
+                typeof zIndex === "number" ? { zIndex: zIndex + 1 } : undefined
+              }
+            >
               <DropdownMenuLabel>Recent conversations</DropdownMenuLabel>
               <DropdownMenuSeparator />
               {conversations.length === 0 ? (

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -402,12 +402,16 @@ function InAppAiAgentProviderInner({
 
   const selectConversation = useCallback(
     (conversationId: string | null) => {
+      if (isRunning || conversationId === selectedConversationId) {
+        return;
+      }
+
       setError(null);
       resetAgent();
       setMessages([]);
       setSelectedConversationId(conversationId);
     },
-    [resetAgent, setSelectedConversationId],
+    [isRunning, resetAgent, selectedConversationId, setSelectedConversationId],
   );
 
   const submit = useCallback(


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes styling and z-index issues in the in-app AI agent chat window, particularly around the "Recent conversations" dropdown rendering on top of other UI elements and the dropdown being scrollable when many conversations exist.

- Replaces the non-standard `z-51` Tailwind class with an explicit inline `zIndex: 51` style (backed by a named constant) on the panel, and propagates that value down to `InAppAgentWindow` so the `DropdownMenuContent` can use `zIndex + 1 = 52` to float above the panel.
- Adds `max-h-80 overflow-y-auto` to the `DropdownMenuContent` so the conversation list scrolls instead of overflowing, and removes the `disabled={isInputDisabled}` guard from the History trigger so users can browse past conversations while a response is being generated.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are contained to the in-app AI agent panel and affect only CSS/z-index and dropdown scroll behaviour.

The panel's z-index is now applied via a named constant and inline style (fixing an invalid z-51 Tailwind class), the conversation history dropdown is properly elevated above the panel and capped in height, and the History trigger is unblocked while the AI is responding. All three fixes are self-contained and low-risk.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Button as InAppAiAgentButton
    participant Controlled as ControlledInAppAgentWindow
    participant Window as InAppAgentWindow
    participant Dropdown as DropdownMenuContent (portal)

    Note over Button: IN_APP_AI_AGENT_WINDOW_Z_INDEX = 51

    Button->>Button: Applies zIndex:51 to panel div (inline style)
    Button->>Controlled: "passes zIndex={51}"
    Controlled->>Window: "passes zIndex={51}"
    Window->>Dropdown: "style={{ zIndex: 52 }}"
    Note over Dropdown: Portaled to document.body,<br/>renders above panel (z:51)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Recent conversations styling..."](https://github.com/langfuse/langfuse/commit/6af69f7d0cc08d7bab9903b134b0fa40d730fb3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36662160)</sub>

<!-- /greptile_comment -->