### PR TITLE
chore: update license copyright year to include 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023-2025 Langfuse GmbH
+Copyright (c) 2023-2026 Langfuse GmbH
 
 Portions of this software are licensed as follows:
 

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -13,7 +13,7 @@ END NOTE
 START OF LICENSE
 Langfuse Enterprise license (the “Enterprise License” or "EE license")
 
-Copyright (c) 2023-2025 Langfuse GmbH
+Copyright (c) 2023-2026 Langfuse GmbH
 
 With regard to the Langfuse Enterprise Software:
 This software and associated documentation files (the "Software") may only be


### PR DESCRIPTION
## Summary

- Update the copyright year range from `2023-2025` to `2023-2026` in `LICENSE` and `ee/LICENSE` to reflect the current year.

## Linear

- None

## Review Focus

- Text-only change to the two license files; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the copyright year range from `2023-2025` to `2023-2026` in both `LICENSE` and `ee/LICENSE` to reflect the current year, 2026.

- `LICENSE`: copyright line updated to `Copyright (c) 2023-2026 Langfuse GmbH`
- `ee/LICENSE`: same copyright line updated to `2023-2026`; no other content changed in either file
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Text-only change to two license files; no code, logic, or configuration is affected.

Both files receive a single-line copyright year bump from 2025 to 2026. The change is accurate for the current year and touches nothing other than license text.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update license copyright year to ..."](https://github.com/langfuse/langfuse/commit/b3bfe9e98eb53cb56377c6a26ea2e5b5113e487c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36675089)</sub>

<!-- /greptile_comment -->