### PR TITLE
feat(web): New experimental feature modal

### DIFF
--- a/web/src/__tests__/server/userAccount.servertest.ts
+++ b/web/src/__tests__/server/userAccount.servertest.ts
@@ -1,0 +1,169 @@
+import type { Session } from "next-auth";
+import { randomUUID } from "crypto";
+
+import type { Plan } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import { env } from "@/src/env.mjs";
+import { appRouter } from "@/src/server/api/root";
+import { createInnerTRPCContext } from "@/src/server/api/trpc";
+
+describe("userAccountRouter.setInAppAgentPreviewEnabled", () => {
+  const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+
+  beforeEach(() => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "DEV";
+  });
+
+  afterEach(() => {
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+  });
+
+  it("enables the in-app agent preview for the current user without requiring a project", async () => {
+    const { caller, userId } = await createCaller({
+      includeProjectInSession: false,
+    });
+
+    const result = await caller.userAccount.setInAppAgentPreviewEnabled({
+      enabled: true,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      inAppAgentPreviewEnabled: true,
+    });
+
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: { featureFlags: true },
+    });
+    expect(user.featureFlags).toEqual(["templateFlag", "inAppAgent"]);
+  });
+
+  it("disables the in-app agent preview without requiring a project", async () => {
+    const { caller, userId } = await createCaller({
+      featureFlags: ["templateFlag", "inAppAgent"],
+    });
+
+    const result = await caller.userAccount.setInAppAgentPreviewEnabled({
+      enabled: false,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      inAppAgentPreviewEnabled: false,
+    });
+
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: { featureFlags: true },
+    });
+    expect(user.featureFlags).toEqual(["templateFlag"]);
+  });
+
+  it("rejects enabling in self-hosted deployments", async () => {
+    const { caller } = await createCaller();
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+
+    await expect(
+      caller.userAccount.setInAppAgentPreviewEnabled({
+        enabled: true,
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+  });
+});
+
+async function createCaller({
+  plan = "cloud:hobby",
+  aiFeaturesEnabled = true,
+  featureFlags = ["templateFlag"],
+  includeProjectInSession = true,
+}: {
+  plan?: Plan;
+  aiFeaturesEnabled?: boolean;
+  featureFlags?: string[];
+  includeProjectInSession?: boolean;
+} = {}) {
+  const id = randomUUID();
+  const orgId = `org-${id}`;
+  const projectId = `project-${id}`;
+  const userId = `user-${id}`;
+
+  const org = await prisma.organization.create({
+    data: {
+      id: orgId,
+      name: `User Account Test Org ${id}`,
+      aiFeaturesEnabled,
+    },
+  });
+  const project = await prisma.project.create({
+    data: {
+      id: projectId,
+      orgId,
+      name: `User Account Test Project ${id}`,
+    },
+  });
+  const user = await prisma.user.create({
+    data: {
+      id: userId,
+      email: `${userId}@example.com`,
+      name: "User Account Test User",
+      featureFlags,
+    },
+  });
+
+  const session: Session = {
+    expires: "1",
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      canCreateOrganizations: true,
+      organizations: [
+        {
+          id: org.id,
+          name: org.name,
+          role: "OWNER",
+          plan,
+          cloudConfig: undefined,
+          metadata: {},
+          aiFeaturesEnabled: org.aiFeaturesEnabled,
+          aiTelemetryEnabled: true,
+          projects: includeProjectInSession
+            ? [
+                {
+                  id: project.id,
+                  name: project.name,
+                  role: "ADMIN",
+                  deletedAt: null,
+                  retentionDays: null,
+                  metadata: {},
+                },
+              ]
+            : [],
+        },
+      ],
+      featureFlags: {
+        inAppAgent: featureFlags.includes("inAppAgent"),
+        templateFlag: featureFlags.includes("templateFlag"),
+        excludeClickhouseRead: false,
+        observationEvals: false,
+        v4BetaToggleVisible: false,
+        experimentsV4Enabled: false,
+      },
+      admin: false,
+    },
+    environment: {
+      enableExperimentalFeatures: false,
+      selfHostedInstancePlan: "cloud:enterprise",
+    },
+  };
+
+  const ctx = createInnerTRPCContext({ session, headers: {} });
+
+  return {
+    orgId,
+    projectId,
+    userId,
+    caller: appRouter.createCaller({ ...ctx, prisma }),
+  };
+}

--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -4,7 +4,7 @@
  * Used for all main application pages when user is authenticated
  */
 
-import type { PropsWithChildren } from "react";
+import { useState, type PropsWithChildren } from "react";
 import Head from "next/head";
 import { SidebarProvider, SidebarInset } from "@/src/components/ui/sidebar";
 import { AppSidebar } from "@/src/components/nav/app-sidebar";
@@ -21,6 +21,7 @@ import type { Session } from "next-auth";
 import type { NavigationItem } from "@/src/components/layouts/utilities/routes";
 import type { RouteGroup } from "@/src/components/layouts/routes";
 import dynamic from "next/dynamic";
+import { ControlledFeaturePreviewModal } from "@/src/features/feature-previews/components/ControlledFeaturePreviewModal";
 
 const CommandMenu = dynamic(
   () =>
@@ -102,6 +103,7 @@ export function AuthenticatedLayout({
   onSignOut,
 }: AuthenticatedLayoutProps) {
   const { isLangfuseCloud, region: currentRegion } = useLangfuseCloudRegion();
+  const [featurePreviewOpen, setFeaturePreviewOpen] = useState(false);
 
   // Safe assertion: AuthenticatedLayout is only rendered after auth checks pass
   // in AppLayout, which guarantees session.user exists at this point
@@ -126,6 +128,8 @@ export function AuthenticatedLayout({
     }),
   );
 
+  const hasFeaturePreviews = isLangfuseCloud;
+
   // User navigation items for sidebar dropdown
   const userNavProps = {
     user: {
@@ -136,6 +140,14 @@ export function AuthenticatedLayout({
     items: [
       { name: "Account Settings", href: "/account/settings" },
       { name: "Theme", onClick: () => {}, content: <ThemeToggle /> },
+      ...(hasFeaturePreviews
+        ? [
+            {
+              name: "Feature Preview",
+              onClick: () => setFeaturePreviewOpen(true),
+            },
+          ]
+        : []),
       ...(isLangfuseCloud
         ? [
             {
@@ -190,6 +202,13 @@ export function AuthenticatedLayout({
                 <CommandMenu mainNavigation={navigation.navigation} />
               </SidebarInset>
             </div>
+            {hasFeaturePreviews ? (
+              <ControlledFeaturePreviewModal
+                session={session}
+                open={featurePreviewOpen}
+                onOpenChange={setFeaturePreviewOpen}
+              />
+            ) : null}
           </div>
         </SidebarProvider>
       </TopBannerProvider>

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -6,6 +6,7 @@ import {
   type CSSProperties,
 } from "react";
 import { createPortal } from "react-dom";
+import { useSession } from "next-auth/react";
 import { BotMessageSquare } from "lucide-react";
 
 import { Button } from "@/src/components/ui/button";
@@ -29,10 +30,13 @@ import { cn } from "@/src/utils/tailwind";
 const IN_APP_AI_AGENT_WINDOW_Z_INDEX = 51;
 
 export const InAppAiAgentButton = () => {
+  const session = useSession();
   const { organization } = useQueryProjectOrOrganization();
   const { isAvailable, open, setOpen, isExpanded, setIsExpanded } =
     useInAppAiAgent();
   const hasInAppAgentEntitlement = useHasEntitlement("in-app-agent");
+  const isInAppAgentEnabled =
+    session.data?.user?.featureFlags.inAppAgent === true;
   const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
   const buttonRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -103,7 +107,7 @@ export const InAppAiAgentButton = () => {
     };
   }, [isExpanded, open]);
 
-  if (!isAvailable || !hasInAppAgentEntitlement) {
+  if (!isAvailable || !hasInAppAgentEntitlement || !isInAppAgentEnabled) {
     return null;
   }
 

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -122,11 +122,7 @@ export default async function handler(request: Request) {
       throw new ForbiddenError("User is not a member of this project");
     }
 
-    // This condition should match `useIsFeatureEnabled("inAppAgent")` in the frontend
-    const isInAppAgentEnabled =
-      auth.user.featureFlags.inAppAgent === true ||
-      auth.user.admin === true ||
-      session.environment.enableExperimentalFeatures === true;
+    const isInAppAgentEnabled = auth.user.featureFlags.inAppAgent === true;
 
     if (!isInAppAgentEnabled) {
       throw new ForbiddenError("Assistant is not enabled for this user");

--- a/web/src/ee/features/in-app-agent/server/router.ts
+++ b/web/src/ee/features/in-app-agent/server/router.ts
@@ -215,7 +215,6 @@ async function assertInAppAgentAvailable({
   ctx: {
     session: {
       user: NonNullable<Session["user"]>;
-      environment: { enableExperimentalFeatures?: boolean };
     };
     prisma: PrismaClient;
   };
@@ -230,10 +229,7 @@ async function assertInAppAgentAvailable({
     );
   }
 
-  const isInAppAgentEnabled =
-    ctx.session.user.featureFlags.inAppAgent === true ||
-    ctx.session.user.admin === true ||
-    ctx.session.environment.enableExperimentalFeatures === true;
+  const isInAppAgentEnabled = ctx.session.user.featureFlags.inAppAgent === true;
 
   if (!isInAppAgentEnabled) {
     throw new ForbiddenError("Assistant is not enabled for this user");

--- a/web/src/features/feature-previews/assets/in-app-agent-dark.svg
+++ b/web/src/features/feature-previews/assets/in-app-agent-dark.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="650" height="300" viewBox="0 0 650 300">
+<defs></defs>
+    <rect x="0" y="0" width="650" height="300" fill="hsl(222.2, 84%, 4.9%)"></rect>
+    <g stroke="hsl(210, 40%, 83%)" stroke-width="1" stroke-dasharray="2 4" opacity="0.45" fill="none">
+      <path d="M220 100 C 260 110, 270 138, 296 148"></path>
+      <line x1="220" y1="150" x2="290" y2="150"></line>
+      <path d="M220 200 C 260 190, 270 162, 296 152"></path>
+      <line x1="356" y1="150" x2="430" y2="150"></line>
+    </g>
+    <circle cx="393" cy="150" r="3.5" fill="hsl(246, 55%, 70%)" stroke="hsl(222.2, 84%, 4.9%)" stroke-width="1"></circle>
+    <g font-family="&#39;Geist Mono&#39;, monospace" font-size="11" letter-spacing="0.02em" fill="hsl(210, 40%, 83%)">
+      <rect x="44" y="84" width="176" height="32" rx="6" fill="hsl(222.2, 84%, 4.9%)" stroke="hsl(217.2, 32.6%, 27.5%)"></rect>
+      <circle cx="60" cy="100" r="3" fill="hsl(246, 55%, 70%)"></circle>
+      <text x="74" y="104">trace · 0x9f2a</text>
+      <rect x="44" y="134" width="176" height="32" rx="6" fill="hsl(222.2, 84%, 4.9%)" stroke="hsl(217.2, 32.6%, 27.5%)"></rect>
+      <circle cx="60" cy="150" r="3" fill="hsl(246, 55%, 70%)"></circle>
+      <text x="74" y="154">score · 0.92</text>
+      <rect x="44" y="184" width="176" height="32" rx="6" fill="hsl(222.2, 84%, 4.9%)" stroke="hsl(217.2, 32.6%, 27.5%)"></rect>
+      <circle cx="60" cy="200" r="3" fill="hsl(246, 55%, 70%)"></circle>
+      <text x="74" y="204">prompt · v4</text>
+    </g>
+    <path d="M322 114 C 325 140, 332 147, 358 150 C 332 153, 325 160, 322 186 C 319 160, 312 153, 286 150 C 312 147, 319 140, 322 114 Z" fill="hsl(246, 55%, 70%)" stroke="hsl(246, 50%, 32%)" stroke-width="1.25" stroke-linejoin="round"></path>
+    <path d="M430 150 L416 142 L416 158 Z" fill="hsl(222.2, 84%, 4.9%)" stroke="hsl(217.2, 32.6%, 27.5%)"></path>
+    <rect x="430" y="78" width="176" height="144" rx="8" fill="hsl(222.2, 84%, 4.9%)" stroke="hsl(217.2, 32.6%, 27.5%)"></rect>
+    <text x="448" y="104" font-family="&#39;Geist Mono&#39;, monospace" font-size="10" letter-spacing="0.1em" fill="hsl(215, 20.2%, 65.1%)">ANSWER</text>
+    <g>
+      <rect x="448" y="118" width="140" height="7" rx="3.5" fill="hsl(217.2, 32.6%, 27.5%)"></rect>
+      <rect x="448" y="136" width="118" height="7" rx="3.5" fill="hsl(217.2, 32.6%, 27.5%)"></rect>
+      <rect x="448" y="154" width="132" height="7" rx="3.5" fill="hsl(246, 55%, 70%)"></rect>
+      <rect x="448" y="172" width="92" height="7" rx="3.5" fill="hsl(217.2, 32.6%, 27.5%)"></rect>
+      <rect x="544" y="171" width="6" height="10" fill="hsl(210, 40%, 83%)"></rect>
+    </g>
+    <g stroke="hsl(210, 40%, 83%)" stroke-width="1.5" fill="none" opacity="0.4">
+      <path d="M14 32 V14 H32"></path>
+      <path d="M636 32 V14 H618"></path>
+      <path d="M14 268 V286 H32"></path>
+      <path d="M636 268 V286 H618"></path>
+    </g>
+</svg>

--- a/web/src/features/feature-previews/assets/in-app-agent-light.svg
+++ b/web/src/features/feature-previews/assets/in-app-agent-light.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="650" height="300" viewBox="0 0 650 300">
+<defs></defs>
+    <rect x="0" y="0" width="650" height="300" fill="hsl(0, 0%, 100%)"></rect>
+    <g stroke="hsl(222.2, 84%, 4.9%)" stroke-width="1" stroke-dasharray="2 4" opacity="0.45" fill="none">
+      <path d="M220 100 C 260 110, 270 138, 296 148"></path>
+      <line x1="220" y1="150" x2="290" y2="150"></line>
+      <path d="M220 200 C 260 190, 270 162, 296 152"></path>
+      <line x1="356" y1="150" x2="430" y2="150"></line>
+    </g>
+    <circle cx="393" cy="150" r="3.5" fill="hsl(243, 75.4%, 58.6%)" stroke="hsl(0, 0%, 100%)" stroke-width="1"></circle>
+    <g font-family="&#39;Geist Mono&#39;, monospace" font-size="11" letter-spacing="0.02em" fill="hsl(222.2, 84%, 4.9%)">
+      <rect x="44" y="84" width="176" height="32" rx="6" fill="hsl(0, 0%, 100%)" stroke="hsl(214.3, 31.8%, 91.4%)"></rect>
+      <circle cx="60" cy="100" r="3" fill="hsl(243, 75.4%, 58.6%)"></circle>
+      <text x="74" y="104">trace · 0x9f2a</text>
+      <rect x="44" y="134" width="176" height="32" rx="6" fill="hsl(0, 0%, 100%)" stroke="hsl(214.3, 31.8%, 91.4%)"></rect>
+      <circle cx="60" cy="150" r="3" fill="hsl(243, 75.4%, 58.6%)"></circle>
+      <text x="74" y="154">score · 0.92</text>
+      <rect x="44" y="184" width="176" height="32" rx="6" fill="hsl(0, 0%, 100%)" stroke="hsl(214.3, 31.8%, 91.4%)"></rect>
+      <circle cx="60" cy="200" r="3" fill="hsl(243, 75.4%, 58.6%)"></circle>
+      <text x="74" y="204">prompt · v4</text>
+    </g>
+    <path d="M322 114 C 325 140, 332 147, 358 150 C 332 153, 325 160, 322 186 C 319 160, 312 153, 286 150 C 312 147, 319 140, 322 114 Z" fill="hsl(243, 75.4%, 58.6%)" stroke="hsl(243, 55%, 38%)" stroke-width="1.25" stroke-linejoin="round"></path>
+    <path d="M430 150 L416 142 L416 158 Z" fill="hsl(0, 0%, 100%)" stroke="hsl(214.3, 31.8%, 91.4%)"></path>
+    <rect x="430" y="78" width="176" height="144" rx="8" fill="hsl(0, 0%, 100%)" stroke="hsl(214.3, 31.8%, 91.4%)"></rect>
+    <text x="448" y="104" font-family="&#39;Geist Mono&#39;, monospace" font-size="10" letter-spacing="0.1em" fill="hsl(215.4, 16.3%, 46.9%)">ANSWER</text>
+    <g>
+      <rect x="448" y="118" width="140" height="7" rx="3.5" fill="hsl(214.3, 31.8%, 91.4%)"></rect>
+      <rect x="448" y="136" width="118" height="7" rx="3.5" fill="hsl(214.3, 31.8%, 91.4%)"></rect>
+      <rect x="448" y="154" width="132" height="7" rx="3.5" fill="hsl(243, 75.4%, 58.6%)"></rect>
+      <rect x="448" y="172" width="92" height="7" rx="3.5" fill="hsl(214.3, 31.8%, 91.4%)"></rect>
+      <rect x="544" y="171" width="6" height="10" fill="hsl(222.2, 84%, 4.9%)"></rect>
+    </g>
+    <g stroke="hsl(222.2, 84%, 4.9%)" stroke-width="1.5" fill="none" opacity="0.4">
+      <path d="M14 32 V14 H32"></path>
+      <path d="M636 32 V14 H618"></path>
+      <path d="M14 268 V286 H32"></path>
+      <path d="M636 268 V286 H618"></path>
+    </g>
+</svg>

--- a/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
@@ -1,0 +1,101 @@
+import { useSession } from "next-auth/react";
+import type { Session } from "next-auth";
+
+import { useHasEntitlement } from "@/src/features/entitlements/hooks";
+import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
+import { api } from "@/src/utils/api";
+
+import { FeaturePreviewModal } from "./FeaturePreviewModal";
+
+type ControlledFeaturePreviewModalProps = {
+  session: Session;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function ControlledFeaturePreviewModal({
+  session,
+  open,
+  onOpenChange,
+}: ControlledFeaturePreviewModalProps) {
+  const authSession = useSession();
+  const { project, organization } = useQueryProjectOrOrganization();
+  const hasInAppAgentEntitlement = useHasEntitlement("in-app-agent");
+  const setInAppAgentPreviewEnabled =
+    api.userAccount.setInAppAgentPreviewEnabled.useMutation({
+      onSuccess: async (_data, variables) => {
+        await authSession.update();
+        showSuccessToast({
+          title: "Feature preview updated",
+          description: variables.enabled
+            ? "Langfuse Assistant preview has been enabled."
+            : "Langfuse Assistant preview has been disabled.",
+        });
+      },
+      onError: (error) => {
+        showErrorToast("Failed to update feature preview", error.message);
+      },
+    });
+
+  const user = authSession.data?.user ?? session.user;
+  if (!user) {
+    return null;
+  }
+
+  const inAppAgentEnabledByUser = user.featureFlags.inAppAgent === true;
+  const warningReason = getInAppAgentWarningReason({
+    hasOrganizationContext: Boolean(organization),
+    hasProjectContext: Boolean(project),
+    hasInAppAgentEntitlement,
+    organizationAiFeaturesEnabled: organization?.aiFeaturesEnabled,
+  });
+
+  return (
+    <FeaturePreviewModal
+      open={open}
+      onOpenChange={onOpenChange}
+      inAppAgent={{
+        enabled: inAppAgentEnabledByUser,
+        warningReason,
+        onToggle: (enabled) => {
+          setInAppAgentPreviewEnabled.mutate({
+            enabled,
+          });
+        },
+        isToggling: setInAppAgentPreviewEnabled.isPending,
+      }}
+    />
+  );
+}
+
+function getInAppAgentWarningReason({
+  hasOrganizationContext,
+  hasProjectContext,
+  hasInAppAgentEntitlement,
+  organizationAiFeaturesEnabled,
+}: {
+  hasOrganizationContext: boolean;
+  hasProjectContext: boolean;
+  hasInAppAgentEntitlement: boolean;
+  organizationAiFeaturesEnabled?: boolean;
+}) {
+  if (!hasOrganizationContext) {
+    return "The Assistant button is only shown inside a project. Enabling this preview may not have any visible effect until you open a project.";
+  }
+
+  if (!hasInAppAgentEntitlement) {
+    return "The Langfuse Assistant preview is not available on your current plan. You can enable the preview, but the Assistant button will not be shown here.";
+  }
+
+  if (organizationAiFeaturesEnabled === false) {
+    return "AI features are disabled for this organization. You can enable the preview, but the Assistant will not run here until AI features are enabled.";
+  }
+
+  if (!hasProjectContext) {
+    return "The Assistant button is only shown inside a project. Open a project to use it after enabling the preview.";
+  }
+
+  return undefined;
+}

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.stories.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.stories.tsx
@@ -1,0 +1,81 @@
+import preview from "../../../../.storybook/preview";
+import { useArgs } from "storybook/preview-api";
+import { fn } from "storybook/test";
+
+import {
+  FeaturePreviewModal,
+  type FeaturePreviewModalProps,
+} from "./FeaturePreviewModal";
+
+function StatefulFeaturePreviewModal(args: FeaturePreviewModalProps) {
+  const [, updateArgs] = useArgs<FeaturePreviewModalProps>();
+
+  return (
+    <FeaturePreviewModal
+      {...args}
+      onOpenChange={(open) => {
+        updateArgs({ open });
+        args.onOpenChange(open);
+      }}
+      inAppAgent={{
+        ...args.inAppAgent,
+        onToggle: (enabled) => {
+          updateArgs({
+            inAppAgent: {
+              ...args.inAppAgent,
+              enabled,
+            },
+          });
+          args.inAppAgent.onToggle(enabled);
+        },
+      }}
+    />
+  );
+}
+
+const meta = preview.meta({
+  component: FeaturePreviewModal,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-background flex min-h-screen items-center justify-center p-8">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    open: true,
+    onOpenChange: fn(),
+    inAppAgent: {
+      enabled: true,
+      onToggle: fn(),
+      isToggling: false,
+    },
+  },
+  render: StatefulFeaturePreviewModal,
+});
+
+export const Default = meta.story({});
+
+export const Warning = meta.story({
+  args: {
+    inAppAgent: {
+      enabled: false,
+      warningReason:
+        "The Assistant button is only shown inside a project. Open a project to use it after enabling the preview.",
+      onToggle: fn(),
+    },
+  },
+});
+
+export const Loading = meta.story({
+  args: {
+    inAppAgent: {
+      enabled: true,
+      onToggle: fn(),
+      isToggling: true,
+    },
+  },
+});

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
@@ -1,0 +1,137 @@
+import Image from "next/image";
+
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import { Switch } from "@/src/components/ui/switch";
+
+import inAppAgentDarkIllustration from "../assets/in-app-agent-dark.svg";
+import inAppAgentLightIllustration from "../assets/in-app-agent-light.svg";
+
+const IN_APP_AGENT_PREVIEW_ITEM = {
+  id: "in-app-agent",
+  title: "Langfuse Assistant",
+  sidebarLabel: "Langfuse Assistant",
+  description:
+    "Explore project data, understand connected Langfuse resources, and get practical help while investigating your application.",
+  details:
+    "This experimental preview can help you inspect traces and observations, look up related scores or prompts, and answer practical questions while you work in a project. Today, it is most useful for exploring project data and understanding how different Langfuse resources connect. Over time, the goal is to help teams generate insights faster and improve their agentic products with less manual investigation.",
+} as const;
+
+const FEATURE_PREVIEW_MODAL_TITLE = "Feature Preview";
+const FEATURE_PREVIEW_MODAL_SUBTITLE =
+  "Try upcoming and experimental product experiences before they become generally available.";
+
+export type FeaturePreviewModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  inAppAgent: {
+    enabled: boolean;
+    warningReason?: string;
+    onToggle: (enabled: boolean) => void;
+    isToggling?: boolean;
+  };
+};
+
+export function FeaturePreviewModal({
+  open,
+  onOpenChange,
+  inAppAgent,
+}: FeaturePreviewModalProps) {
+  const inAppAgentToggleDisabled = inAppAgent.isToggling === true;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        size="lg"
+        closeOnInteractionOutside
+        overlayMode="blocking"
+        className="border-border bg-background text-foreground max-h-[88vh] p-0 shadow-2xl sm:rounded-2xl"
+      >
+        <DialogHeader>
+          <DialogTitle className="text-foreground text-lg font-semibold">
+            {FEATURE_PREVIEW_MODAL_TITLE}
+          </DialogTitle>
+          <DialogDescription className="mt-0">
+            {FEATURE_PREVIEW_MODAL_SUBTITLE}
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogBody className="grid min-h-0 gap-0 overflow-hidden p-0 md:grid-cols-[220px_1fr]">
+          <aside className="border-border bg-muted/20 border-b p-3 md:border-r md:border-b-0">
+            <div className="flex gap-2 overflow-x-auto md:flex-col md:overflow-x-visible">
+              <button
+                type="button"
+                className="bg-muted text-foreground flex min-w-48 items-start rounded-md border border-transparent px-3 py-3 text-left transition-colors md:min-w-0"
+              >
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium">
+                    {IN_APP_AGENT_PREVIEW_ITEM.sidebarLabel}
+                  </span>
+                  <span className="text-muted-foreground mt-1 line-clamp-2 block text-xs">
+                    {inAppAgent.enabled ? "Enabled" : "Available"}
+                  </span>
+                </span>
+              </button>
+            </div>
+          </aside>
+
+          <section className="bg-background min-h-0 overflow-y-auto p-6">
+            {inAppAgent.warningReason ? (
+              <div className="mb-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-800 dark:text-yellow-200">
+                {inAppAgent.warningReason}
+              </div>
+            ) : null}
+
+            <div className="flex items-start justify-between gap-6">
+              <div>
+                <h2 className="text-foreground text-xl font-semibold">
+                  {IN_APP_AGENT_PREVIEW_ITEM.title}
+                </h2>
+                <p className="text-muted-foreground mt-2 max-w-2xl text-sm leading-5">
+                  {IN_APP_AGENT_PREVIEW_ITEM.description}
+                </p>
+              </div>
+              <div className="flex shrink-0 flex-col items-end gap-2">
+                <Switch
+                  checked={inAppAgent.enabled}
+                  disabled={inAppAgentToggleDisabled}
+                  onCheckedChange={inAppAgent.onToggle}
+                  aria-label={`Toggle ${IN_APP_AGENT_PREVIEW_ITEM.title}`}
+                />
+              </div>
+            </div>
+
+            <PreviewMockupPanel />
+
+            <p className="text-muted-foreground mt-5 text-sm leading-5">
+              {IN_APP_AGENT_PREVIEW_ITEM.details}
+            </p>
+          </section>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PreviewMockupPanel() {
+  return (
+    <div className="border-border bg-muted/30 mt-6 overflow-hidden rounded-2xl border shadow-inner">
+      <Image
+        src={inAppAgentLightIllustration}
+        alt="Langfuse Assistant connects traces, scores, and prompts to answer project questions."
+        className="block h-auto w-full dark:hidden"
+      />
+      <Image
+        src={inAppAgentDarkIllustration}
+        alt="Langfuse Assistant connects traces, scores, and prompts to answer project questions."
+        className="hidden h-auto w-full dark:block"
+      />
+    </div>
+  );
+}

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -95,6 +95,50 @@ export const userAccountRouter = createTRPCRouter({
       };
     }),
 
+  setInAppAgentPreviewEnabled: authenticatedProcedure
+    .input(
+      z.object({
+        enabled: z.boolean(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const userId = ctx.session.user.id;
+      const currentUser = await ctx.prisma.user.findUnique({
+        where: { id: userId },
+        select: { featureFlags: true },
+      });
+
+      if (!currentUser) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "User not found",
+        });
+      }
+
+      if (input.enabled) {
+        if (!env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "Assistant is not available in self-hosted deployments.",
+          });
+        }
+      }
+
+      const nextFeatureFlags = input.enabled
+        ? Array.from(new Set([...currentUser.featureFlags, "inAppAgent"]))
+        : currentUser.featureFlags.filter((flag) => flag !== "inAppAgent");
+
+      await ctx.prisma.user.update({
+        where: { id: userId },
+        data: { featureFlags: { set: nextFeatureFlags } },
+      });
+
+      return {
+        success: true,
+        inAppAgentPreviewEnabled: input.enabled,
+      };
+    }),
+
   delete: authenticatedProcedure.mutation(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 

--- a/web/types/global.d.ts
+++ b/web/types/global.d.ts
@@ -6,3 +6,14 @@ declare namespace JSX {
     >;
   }
 }
+
+declare module "*.svg" {
+  const content: {
+    src: string;
+    height: number;
+    width: number;
+    blurDataURL?: string;
+  };
+
+  export default content;
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces an experimental "Feature Preview" modal that lets cloud users opt in to the in-app AI assistant on a per-user basis. It replaces the implicit `admin` / `enableExperimentalFeatures` bypass with an explicit `inAppAgent` feature flag stored in `User.featureFlags`, backed by a new `setInAppAgentPreviewEnabled` tRPC mutation with full authorization checks.

- **New modal flow**: `ControlledFeaturePreviewModal` wires the tRPC mutation to `FeaturePreviewModal`, refreshing the next-auth session on success. The "Feature Preview" entry is surfaced in the sidebar user-nav dropdown for cloud environments only.
- **Access-control tightening**: Both `handler.ts` and `router.ts` now require the explicit `featureFlags.inAppAgent` flag, removing the old admin/experimental-features bypass paths.
- **Server tests**: New `userAccount.servertest.ts` covers all precondition and authorization failure cases plus the happy path for enable and disable.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the access-control changes are intentional and server-side checks are thorough. The two UI concerns are non-blocking edge cases.

The server logic and tests are solid. The component reads toggle state from a prop that can briefly lag behind the freshly-refreshed session hook, and the disabled-reason logic doesn't account for the case where an org is present but no project is selected — both surface as minor UX glitches rather than data integrity problems.

web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx — session prop vs hook mismatch and missing project-level disabled reason
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant UI as ControlledFeaturePreviewModal
    participant S as AuthenticatedLayout (session prop)
    participant H as useSession() hook
    participant API as tRPC userAccount.setInAppAgentPreviewEnabled
    participant DB as Prisma / User.featureFlags

    U->>UI: Toggle switch
    UI->>API: "mutate({ enabled, projectId })"
    API->>DB: Validate membership, entitlement, org AI features
    API->>DB: "user.update({ featureFlags })"
    API-->>UI: onSuccess
    UI->>H: authSession.update()
    H-->>S: Session refreshed → parent re-renders
    S-->>UI: Updated session prop
    Note over UI: Brief window where prop is stale and hook is already fresh
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx:42-47
**Stale session prop drives toggle state**

`inAppAgentEnabledByUser` is read from the `session` prop (passed down from the parent layout), but `authSession.update()` is called in the mutation's `onSuccess` handler. The hook update propagates reactively through next-auth, but the prop won't reflect the new value until the parent re-renders — so there's a window where the switch still shows the pre-mutation value even though the session is already refreshed. Using `authSession.data?.user?.featureFlags?.inAppAgent` instead would keep the rendered state in sync with the live session hook.

### Issue 2 of 2
web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx:73-84
**Toggle appears enabled with no project context when an organization is available**

`getInAppAgentDisabledReason` only returns the "select an organization or project" message when `!hasOrganizationContext`. If the user opens the modal from an org-level page (organization is non-null, but `project` is null), `disabledReason` is `undefined` and the switch is rendered as interactive. When the user toggles it on, `setInAppAgentPreviewEnabled.mutate({ enabled: true, projectId: undefined })` is sent, which the server rejects with `PRECONDITION_FAILED`. The error toast is shown so the failure is not silent, but the UI could surface a proactive disabled reason such as "Open a project before enabling the assistant preview" when `!project`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): New experimental feature moda..."](https://github.com/langfuse/langfuse/commit/59b279a447d6912d343aec8e985adde705e18c55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36717131)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->