### PR TITLE
fix(worker): fix Bedrock cross-region inference profile prefixes and make version suffix optional in 15 Claude model match patterns

### DIFF
--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1807,7 +1807,7 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "modelName": "claude-3-5-haiku-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|us\\.anthropic\\.claude-3-5-haiku-20241022(-v1(:0)?)?|claude-3-5-haiku-V1@20241022)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(us\\.)?anthropic\\.claude-3-5-haiku-20241022(-v1(:0)?)?|claude-3-5-haiku-V1@20241022)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2573,7 +2573,7 @@
   {
     "id": "c5qmrqolku82tra3vgdixmys",
     "modelName": "claude-sonnet-4-5-20250929",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?(-v1(:0)?)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?(-v1(:0)?)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
     "createdAt": "2025-09-29T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2876,7 +2876,7 @@
   {
     "id": "cmdysde5w0000rkmzbc1g5au3",
     "modelName": "claude-opus-4-1-20250805",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|us\\.anthropic\\.claude-opus-4-1(-20250805)?(-v1(:0)?)?|claude-opus-4-1(@20250805)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(us\\.)?anthropic\\.claude-opus-4-1(-20250805)?(-v1(:0)?)?|claude-opus-4-1(@20250805)?)$",
     "createdAt": "2025-08-05T15:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3172,7 +3172,7 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001(-v1(:0)?)?|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001(-v1(:0)?)?|claude-4-5-haiku@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
     "updatedAt": "2026-04-20T00:00:00.000Z",
     "tokenizerId": "claude",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1807,7 +1807,7 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "modelName": "claude-3-5-haiku-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(us\\.)?anthropic\\.claude-3-5-haiku-20241022(-v1(:0)?)?|claude-3-5-haiku-V1@20241022)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.)?anthropic\\.claude-3-5-haiku-20241022(-v1(:0)?)?|claude-3-5-haiku-V1@20241022)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2876,7 +2876,7 @@
   {
     "id": "cmdysde5w0000rkmzbc1g5au3",
     "modelName": "claude-opus-4-1-20250805",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(us\\.)?anthropic\\.claude-opus-4-1(-20250805)?(-v1(:0)?)?|claude-opus-4-1(@20250805)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.)?anthropic\\.claude-opus-4-1(-20250805)?(-v1(:0)?)?|claude-opus-4-1(@20250805)?)$",
     "createdAt": "2025-08-05T15:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",

--- a/worker/src/constants/default-model-prices.json
+++ b/worker/src/constants/default-model-prices.json
@@ -1287,7 +1287,7 @@
   {
     "id": "cltgy0iuw000008le3vod1hhy",
     "modelName": "claude-3-opus-20240229",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-opus-20240229|anthropic\\.claude-3-opus-20240229-v1:0|claude-3-opus@20240229)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-opus-20240229|(eu\\.|us\\.)?anthropic\\.claude-3-opus-20240229(-v1(:0)?)?|claude-3-opus@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1308,7 +1308,7 @@
   {
     "id": "cltgy0pp6000108le56se7bl3",
     "modelName": "claude-3-sonnet-20240229",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-sonnet-20240229|anthropic\\.claude-3-sonnet-20240229-v1:0|claude-3-sonnet@20240229)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-sonnet-20240229|(eu\\.|us\\.)?anthropic\\.claude-3-sonnet-20240229(-v1(:0)?)?|claude-3-sonnet@20240229)$",
     "createdAt": "2024-03-07T17:55:38.139Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1338,7 +1338,7 @@
   {
     "id": "cltr0w45b000008k1407o9qv1",
     "modelName": "claude-3-haiku-20240307",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-haiku-20240307|anthropic\\.claude-3-haiku-20240307-v1:0|claude-3-haiku@20240307)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-haiku-20240307|(eu\\.|us\\.)?anthropic\\.claude-3-haiku-20240307(-v1(:0)?)?|claude-3-haiku@20240307)$",
     "createdAt": "2024-03-14T09:41:18.736Z",
     "updatedAt": "2025-12-12T15:00:06.513Z",
     "tokenizerId": "claude",
@@ -1537,7 +1537,7 @@
   {
     "id": "clxt0n0m60000pumz1j5b7zsf",
     "modelName": "claude-3-5-sonnet-20240620",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620-v1:0|claude-3-5-sonnet@20240620)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-sonnet-20240620|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-sonnet-20240620(-v1(:0)?)?|claude-3-5-sonnet@20240620)$",
     "createdAt": "2024-06-25T11:47:24.475Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -1807,7 +1807,7 @@
   {
     "id": "cm34aq60d000207ml0j1h31ar",
     "modelName": "claude-3-5-haiku-20241022",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3-5-haiku-20241022-v1:0|claude-3-5-haiku-V1@20241022)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3-5-haiku-20241022|us\\.anthropic\\.claude-3-5-haiku-20241022(-v1(:0)?)?|claude-3-5-haiku-V1@20241022)$",
     "createdAt": "2024-11-05T10:30:50.566Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2157,7 +2157,7 @@
   {
     "id": "cm7ka7561000108js3t9tb3at",
     "modelName": "claude-3.7-sonnet-20250219",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219-v1:0|claude-3-7-sonnet-V1@20250219)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-3.7-sonnet-20250219|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-3.7-sonnet-20250219(-v1(:0)?)?|claude-3-7-sonnet-V1@20250219)$",
     "createdAt": "2025-02-25T09:35:39.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2573,7 +2573,7 @@
   {
     "id": "c5qmrqolku82tra3vgdixmys",
     "modelName": "claude-sonnet-4-5-20250929",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?-v1(:0)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-5(-20250929)?|(eu\\.|us\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-20250929)?(-v1(:0)?)?|claude-sonnet-4-5-V1(@20250929)?|claude-sonnet-4-5(@20250929)?)$",
     "createdAt": "2025-09-29T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2630,7 +2630,7 @@
   {
     "id": "cmazmkzlm00000djp1e1qe4k4",
     "modelName": "claude-sonnet-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?-v1(:0)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4(-20250514)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-20250514)?(-v1(:0)?)?|claude-sonnet-4-V1(@20250514)?|claude-sonnet-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2690,7 +2690,7 @@
   {
     "id": "cmazmlm2p00020djpa9s64jw5",
     "modelName": "claude-opus-4-20250514",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?-v1(:0)?|claude-opus-4(@20250514)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4(-20250514)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4(-20250514)?(-v1(:0)?)?|claude-opus-4(@20250514)?)$",
     "createdAt": "2025-05-22T17:09:02.131Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -2876,7 +2876,7 @@
   {
     "id": "cmdysde5w0000rkmzbc1g5au3",
     "modelName": "claude-opus-4-1-20250805",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|(eu\\.|us\\.|apac\\.)?anthropic\\.claude-opus-4-1(-20250805)?-v1(:0)?|claude-opus-4-1(@20250805)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-1(-20250805)?|us\\.anthropic\\.claude-opus-4-1(-20250805)?(-v1(:0)?)?|claude-opus-4-1(@20250805)?)$",
     "createdAt": "2025-08-05T15:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3172,7 +3172,7 @@
   {
     "id": "cmgt5gnkv000104jx171tbq4e",
     "modelName": "claude-haiku-4-5-20251001",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001-v1:0|claude-4-5-haiku@20251001)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-haiku-4-5(-20251001)?|(eu\\.|us\\.|au\\.|jp\\.|global\\.)?anthropic\\.claude-haiku-4-5-20251001(-v1(:0)?)?|claude-4-5-haiku@20251001)$",
     "createdAt": "2025-10-16T08:20:44.558Z",
     "updatedAt": "2026-04-20T00:00:00.000Z",
     "tokenizerId": "claude",
@@ -3262,7 +3262,7 @@
   {
     "id": "cmieupdva000004l541kwae70",
     "modelName": "claude-opus-4-5-20251101",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-5(-20251101)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-20251101)?-v1(:0)?|claude-opus-4-5(@20251101)?)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-5(-20251101)?|(eu\\.|us\\.|global\\.)?anthropic\\.claude-opus-4-5(-20251101)?(-v1(:0)?)?|claude-opus-4-5(@20251101)?)$",
     "createdAt": "2025-11-24T20:53:27.571Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3293,7 +3293,7 @@
   {
     "id": "90ec5ec3-1a48-4ff0-919c-70cdb8f632ed",
     "modelName": "claude-sonnet-4-6",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-6(-v1(:0)?)?|claude-sonnet-4-6)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-sonnet-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-6(-v1(:0)?)?)$",
     "createdAt": "2026-02-18T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3351,7 +3351,7 @@
   {
     "id": "13458bc0-1c20-44c2-8753-172f54b67647",
     "modelName": "claude-opus-4-6",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6-v1(:0)?|claude-opus-4-6)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-6|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6(-v1(:0)?)?)$",
     "createdAt": "2026-02-09T00:00:00.000Z",
     "updatedAt": "2026-04-13T00:00:00.000Z",
     "tokenizerConfig": null,
@@ -3382,7 +3382,7 @@
   {
     "id": "d506b291-cc9c-4833-9014-0f387a8e1cc8",
     "modelName": "claude-opus-4-7",
-    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7-v1(:0)?|claude-opus-4-7)$",
+    "matchPattern": "(?i)^(anthropic\/)?(claude-opus-4-7|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7(-v1(:0)?)?)$",
     "createdAt": "2026-04-16T00:00:00.000Z",
     "updatedAt": "2026-04-16T00:00:00.000Z",
     "tokenizerConfig": null,


### PR DESCRIPTION
## What does this PR do?

Fixes match patterns for 15 Claude models in `default-model-prices.json` to accurately reflect AWS Bedrock's actual model IDs and cross-region inference profile prefixes per [official AWS Bedrock documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-anthropic.html).

**Two changes per model:**
1. Makes the `-v1:0` version suffix optional (`(-v1(:0)?)?`) so patterns match Bedrock IDs both with and without the suffix
2. Corrects cross-region inference profile prefixes to match only the prefixes actually supported by each model, while keeping the prefix group optional to also cover bare `anthropic.<model>` direct invocations

**Prefix corrections per AWS docs (all prefixes kept optional):**
- `claude-3-opus`, `claude-3-sonnet`, `claude-3-haiku`: `(eu.|us.)?`
- `claude-3-5-sonnet-20240620`, `claude-3.7-sonnet`: `(eu.|us.|apac.)?` (no `global.`)
- `claude-3-5-haiku`, `claude-opus-4-1`: `(eu.|us.)?` — AWS docs list `us.` only, `eu.` retained conservatively
- `claude-sonnet-4-5`, `claude-haiku-4-5`: `(eu.|us.|apac.|au.|jp.|global.)?` — `apac.` preserved for backwards compatibility; `au.`/`jp.` added per current AWS docs
- `claude-opus-4-5`: `(eu.|us.|global.)?` (no `apac.`)
- `claude-sonnet-4`: `(eu.|us.|apac.|global.)?` (unchanged, already correct)
- `claude-opus-4`: `(eu.|us.|apac.)?` (not yet in Bedrock catalog)
- `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-7`: regex simplification only (remove redundant trailing alternative)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have checked my changes generate no new warnings (`npm run lint`)