### PR TITLE
fix(monitors): coerce string-typed metric values in live preview chart

### DIFF
--- a/web/src/features/monitors/components/MonitorChartPreview.tsx
+++ b/web/src/features/monitors/components/MonitorChartPreview.tsx
@@ -95,18 +95,10 @@ export const MonitorChartPreview = ({
   );
 
   /** data reshapes the query rows into chart points. */
-  const data: DataPoint[] = useMemo(() => {
-    const rows = (queryResult.data ?? []) as Array<Record<string, unknown>>;
-    const metricField = `${aggregation}_${measure}`;
-    return rows.map((row) => {
-      const value = row[metricField];
-      return {
-        time_dimension: row["time_dimension"] as string | undefined,
-        dimension: "metric",
-        metric: typeof value === "number" ? value : 0,
-      } satisfies DataPoint;
-    });
-  }, [queryResult.data, measure, aggregation]);
+  const data: DataPoint[] = useMemo(
+    () => toChartPoints(queryResult.data ?? [], measure, aggregation),
+    [queryResult.data, measure, aggregation],
+  );
 
   /** thresholds lists the warning and alert bands to draw on the chart. */
   const thresholds = useMemo(() => {
@@ -188,4 +180,21 @@ export const MonitorChartPreview = ({
       </CardContent>
     </Card>
   );
+};
+
+/** toChartPoints reshapes executeQuery rows into LINE_TIME_SERIES points, coercing string-typed metric values into numbers. */
+const toChartPoints = (
+  rows: Array<Record<string, unknown>>,
+  measure: string,
+  aggregation: z.infer<typeof metricAggregations>,
+): DataPoint[] => {
+  const metricField = `${aggregation}_${measure}`;
+  return rows.map((row) => {
+    const metric = row[metricField];
+    return {
+      time_dimension: row["time_dimension"] as string | undefined,
+      dimension: "metric",
+      metric: Array.isArray(metric) ? metric : Number(metric || 0),
+    } satisfies DataPoint;
+  });
 };


### PR DESCRIPTION
## Summary

On cloud deployments the monitor form's live preview chart showed no data even though `executeQuery` returned rows in the network response; the same chart in the widget creation form rendered fine.

The preview reshaped each row with `typeof value === "number" ? value : 0`. ClickHouse Cloud serializes 64-bit aggregates (`count`/`sum`) as JSON strings, so every point collapsed to `0` and the line flattened out of view. Local dev returns those values as numbers, so the bug was invisible there.

To achieve this we:
- Reuse the widget form's metric coercion (`Array.isArray(metric) ? metric : Number(metric || 0)`) so string-typed values chart correctly.
- Lift the row reshaping into a small `toChartPoints` helper typed to `executeQuery`'s return shape.

## Verification

- [ ] `pnpm run lint`
- [ ] `pnpm tc`
- [ ] Browser review of the monitor form live preview on a cloud deployment

## Test plan

- [ ] Open the monitor creation form on a cloud deployment with a `count`/`sum` measure; verify the live preview renders the series.
- [ ] Confirm the widget creation form preview still renders.
- [ ] Verify threshold bands still scale to the data.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a cloud-only rendering bug where the monitor form's live preview chart showed a flat line because ClickHouse Cloud serializes 64-bit aggregates (`count`/`sum`) as JSON strings, which the old `typeof value === "number" ? value : 0` guard silently collapsed to `0`.

- Extracts a `toChartPoints` helper that mirrors the coercion already used in `WidgetForm` (`Array.isArray(metric) ? metric : Number(metric || 0)`), converting string-typed metric values to numbers before they reach the chart.
- Reduces the inline `useMemo` body to a single delegating call, making the reshaping logic reusable and independently testable.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is scoped to a single reshaping helper and directly mirrors logic already in production via WidgetForm.

The coercion correctly handles string-typed ClickHouse Cloud values and is consistent with the widget form. One minor gap: a non-numeric string value (e.g. from an unexpected API shape) would silently produce `NaN` rather than `0`, but this is identical to WidgetForm behavior and not a regression introduced here.

web/src/features/monitors/components/MonitorChartPreview.tsx — specifically the `Number(metric || 0)` path if the API ever returns a non-numeric string for a metric field.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["executeQuery response\n(rows: Array<Record<string, unknown>>)"] --> B["toChartPoints(rows, measure, aggregation)"]
    B --> C["row[metricField]"]
    C --> D{Array.isArray?}
    D -- yes --> E["metric = Array<Array<number>>\n(box-plot / multi-value)"]
    D -- no --> F["metric = Number(metric || 0)\ncoerces string '42' → 42"]
    E --> G["DataPoint { time_dimension, dimension, metric }"]
    F --> G
    G --> H["LINE_TIME_SERIES Chart"]
    H --> I["Threshold bands overlay"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(monitors): coerce string-typed metri..."](https://github.com/langfuse/langfuse/commit/76175cd1856262266821b8bf48105d7fefdbb848) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36697676)</sub>

<!-- /greptile_comment -->