### PR TITLE
fix(api): clarify v3 scores field groups and move v4 removal note to v2 endpoints

### DIFF
--- a/fern/apis/server/definition/legacy/scores-v2.yml
+++ b/fern/apis/server/definition/legacy/scores-v2.yml
@@ -8,7 +8,8 @@ service:
   endpoints:
     get-many:
       docs: |
-        **Deprecated.** Use `GET /api/public/v3/scores` instead.
+        **Deprecated.** Use `GET /api/public/v3/scores` instead. This endpoint
+        is no longer available on Langfuse v4 and later.
 
         Get a list of scores (supports both trace and session scores)
       method: GET
@@ -89,7 +90,8 @@ service:
       response: GetScoresResponse
     get-by-id:
       docs: |
-        **Deprecated.** Use `GET /api/public/v3/scores` instead.
+        **Deprecated.** Use `GET /api/public/v3/scores` with the `id` filter
+        instead. This endpoint is no longer available on Langfuse v4 and later.
 
         Get a score (supports both trace and session scores)
       method: GET

--- a/fern/apis/server/definition/scores.yml
+++ b/fern/apis/server/definition/scores.yml
@@ -10,15 +10,22 @@ service:
       docs: |
         Get a list of scores with a polymorphic `value` field (v3).
 
-        This endpoint requires Langfuse v4 or later.
-
         The `value` field type depends on `dataType`:
         - `NUMERIC` → number
         - `BOOLEAN` → boolean
         - `CATEGORICAL`, `TEXT`, `CORRECTION` → string
 
-        Use the `fields` parameter to include optional field groups beyond the
-        default `core`. Unknown group names return HTTP 400.
+        The response always includes the core fields: id, projectId, name,
+        value, dataType, source, timestamp, environment, createdAt, updatedAt.
+
+        Additional field groups can be requested via the `fields` parameter:
+        - `details` — adds comment, configId, metadata
+        - `subject` — adds the subject object describing the entity the score
+          is attached to: kind (trace, observation, session, or experiment),
+          id, and traceId for observation-level scores
+        - `annotation` — adds authorUserId, queueId
+
+        Unknown group names return HTTP 400.
       method: GET
       path: /v3/scores
       request:
@@ -33,8 +40,10 @@ service:
           fields:
             type: optional<string>
             docs: >
-              Comma-separated field groups to include. Allowed: core, details,
-              subject, annotation. Defaults to "core". Unknown names return HTTP 400.
+              Comma-separated field groups to include in addition to the
+              always-returned core fields. Allowed: details, subject,
+              annotation — see the endpoint description for the fields each
+              group adds. Unknown names return HTTP 400.
           id:
             type: optional<string>
             docs: Comma-separated list of score IDs to filter by (OR within, AND across filters).

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -2309,7 +2309,8 @@ paths:
   /api/public/v2/scores:
     get:
       description: |-
-        **Deprecated.** Use `GET /api/public/v3/scores` instead.
+        **Deprecated.** Use `GET /api/public/v3/scores` instead. This endpoint
+        is no longer available on Langfuse v4 and later.
 
         Get a list of scores (supports both trace and session scores)
       operationId: legacy_scoresV2_get-many
@@ -2534,7 +2535,8 @@ paths:
   /api/public/v2/scores/{scoreId}:
     get:
       description: |-
-        **Deprecated.** Use `GET /api/public/v3/scores` instead.
+        **Deprecated.** Use `GET /api/public/v3/scores` with the `id` filter
+        instead. This endpoint is no longer available on Langfuse v4 and later.
 
         Get a score (supports both trace and session scores)
       operationId: legacy_scoresV2_get-by-id
@@ -5575,15 +5577,22 @@ paths:
       description: |-
         Get a list of scores with a polymorphic `value` field (v3).
 
-        This endpoint requires Langfuse v4 or later.
-
         The `value` field type depends on `dataType`:
         - `NUMERIC` → number
         - `BOOLEAN` → boolean
         - `CATEGORICAL`, `TEXT`, `CORRECTION` → string
 
-        Use the `fields` parameter to include optional field groups beyond the
-        default `core`. Unknown group names return HTTP 400.
+        The response always includes the core fields: id, projectId, name,
+        value, dataType, source, timestamp, environment, createdAt, updatedAt.
+
+        Additional field groups can be requested via the `fields` parameter:
+        - `details` — adds comment, configId, metadata
+        - `subject` — adds the subject object describing the entity the score
+          is attached to: kind (trace, observation, session, or experiment),
+          id, and traceId for observation-level scores
+        - `annotation` — adds authorUserId, queueId
+
+        Unknown group names return HTTP 400.
       operationId: scores_getMany
       tags:
         - Scores
@@ -5610,9 +5619,10 @@ paths:
         - name: fields
           in: query
           description: >-
-            Comma-separated field groups to include. Allowed: core, details,
-            subject, annotation. Defaults to "core". Unknown names return HTTP
-            400.
+            Comma-separated field groups to include in addition to the
+            always-returned core fields. Allowed: details, subject, annotation —
+            see the endpoint description for the fields each group adds. Unknown
+            names return HTTP 400.
           required: false
           schema:
             type: string


### PR DESCRIPTION
## What does this PR do?

Docs-only cleanup of the scores API spec:

- Documents how `fields` groups map to response fields on `GET /api/public/v3/scores`: core fields (id, projectId, name, value, dataType, source, timestamp, environment, createdAt, updatedAt) are always returned; `details`, `subject`, and `annotation` are additive. The `core` token remains accepted by the schema for backwards compatibility but is intentionally not documented, since passing it has no effect.
- Removes the incorrect "This endpoint requires Langfuse v4 or later" note from the v3 endpoint. The accurate lifecycle statement now lives on the deprecated v2 GET endpoints: they are no longer available on Langfuse v4 and later. `GET /v2/scores/{scoreId}` additionally points to the v3 list endpoint with the `id` filter as the migration path, since v3 has no get-by-id.
- Regenerates the OpenAPI spec. Python/TS SDK outputs are unchanged.

Impacted packages: `fern/apis/server`, `web` (committed `web/public/generated/api/openapi.yml` only).

Verification: `fern check`, `npx fern-api generate --api server --force`, `pnpm run lint`, `pnpm tc`. No runtime code changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
