### PR TITLE
feat(ui): unify keyboard shortcut keycaps

### DIFF
--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -30,6 +30,7 @@ import { InAppAiAgentButton } from "@/src/components/nav/in-app-ai-agent-button"
 import { BookACallButton } from "@/src/components/nav/book-a-call-button";
 import { V4SidebarToggle } from "@/src/features/events/components/V4SidebarToggle";
 import { SidebarMenuButton } from "@/src/components/ui/sidebar";
+import { KeyboardShortcut } from "@/src/components/ui/keyboard-shortcut";
 import { useCommandMenu } from "@/src/features/command-k-menu/CommandMenuProvider";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { CloudStatusMenu } from "@/src/features/cloud-status-notification/components/CloudStatusMenu";
@@ -277,14 +278,10 @@ function CommandMenuTrigger() {
     >
       <Search className="h-4 w-4" />
       Go to...
-      <kbd className="pointer-events-none ml-auto inline-flex h-5 items-center gap-1 rounded-md border px-1.5 font-mono text-[10px] select-none">
-        {navigator.userAgent.includes("Mac") ? (
-          <span className="text-[12px]">⌘</span>
-        ) : (
-          <span>Ctrl</span>
-        )}
-        <span>K</span>
-      </kbd>
+      <KeyboardShortcut
+        className="ml-auto"
+        keys={[navigator.userAgent.includes("Mac") ? "⌘" : "Ctrl", "K"]}
+      />
     </SidebarMenuButton>
   );
 }

--- a/web/src/components/ui/command.tsx
+++ b/web/src/components/ui/command.tsx
@@ -7,6 +7,10 @@ import { Search } from "lucide-react";
 
 import { cn } from "@/src/utils/tailwind";
 import {
+  KeyboardShortcut,
+  type KeyboardShortcutProps,
+} from "@/src/components/ui/keyboard-shortcut";
+import {
   Dialog,
   DialogBody,
   DialogContent,
@@ -163,19 +167,8 @@ const CommandItem = React.forwardRef<
 
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 
-const CommandShortcut = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-  return (
-    <span
-      className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
-        className,
-      )}
-      {...props}
-    />
-  );
+const CommandShortcut = ({ className, ...props }: KeyboardShortcutProps) => {
+  return <KeyboardShortcut className={cn("ml-auto", className)} {...props} />;
 };
 CommandShortcut.displayName = "CommandShortcut";
 

--- a/web/src/components/ui/input-command.tsx
+++ b/web/src/components/ui/input-command.tsx
@@ -9,6 +9,10 @@ import { Command as CommandPrimitive } from "cmdk";
 import { Search } from "lucide-react";
 
 import { Dialog, DialogBody, DialogContent } from "@/src/components/ui/dialog";
+import {
+  KeyboardShortcut,
+  type KeyboardShortcutProps,
+} from "@/src/components/ui/keyboard-shortcut";
 import { cn } from "@/src/utils/tailwind";
 
 const InputCommand = React.forwardRef<
@@ -146,16 +150,8 @@ InputCommandItem.displayName = CommandPrimitive.Item.displayName;
 const InputCommandShortcut = ({
   className,
   ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-  return (
-    <span
-      className={cn(
-        "ml-auto text-xs tracking-widest text-slate-500 dark:text-slate-400",
-        className,
-      )}
-      {...props}
-    />
-  );
+}: KeyboardShortcutProps) => {
+  return <KeyboardShortcut className={cn("ml-auto", className)} {...props} />;
 };
 InputCommandShortcut.displayName = "CommandShortcut";
 

--- a/web/src/components/ui/keyboard-shortcut.tsx
+++ b/web/src/components/ui/keyboard-shortcut.tsx
@@ -2,13 +2,15 @@ import * as React from "react";
 
 import { cn } from "@/src/utils/tailwind";
 
+type KeyboardShortcutContent =
+  | { children: React.ReactNode; keys?: never }
+  | { children?: never; keys: React.ReactNode[] };
+
 export type KeyboardShortcutProps = Omit<
   React.ComponentPropsWithoutRef<"kbd">,
   "children"
-> & {
-  children?: React.ReactNode;
-  keys?: React.ReactNode[];
-};
+> &
+  KeyboardShortcutContent;
 
 const KeyboardShortcut = React.forwardRef<HTMLElement, KeyboardShortcutProps>(
   ({ className, children, keys, ...props }, ref) => (

--- a/web/src/components/ui/keyboard-shortcut.tsx
+++ b/web/src/components/ui/keyboard-shortcut.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import { cn } from "@/src/utils/tailwind";
+
+export type KeyboardShortcutProps = Omit<
+  React.ComponentPropsWithoutRef<"kbd">,
+  "children"
+> & {
+  children?: React.ReactNode;
+  keys?: React.ReactNode[];
+};
+
+const KeyboardShortcut = React.forwardRef<HTMLElement, KeyboardShortcutProps>(
+  ({ className, children, keys, ...props }, ref) => (
+    <kbd
+      ref={ref}
+      className={cn(
+        "bg-muted text-muted-foreground pointer-events-none inline-flex h-5 min-w-5 items-center justify-center gap-1 rounded-md border px-1.5 font-mono text-[10px] leading-none font-medium shadow-xs select-none",
+        className,
+      )}
+      {...props}
+    >
+      {keys
+        ? keys.map((key, index) => <span key={index}>{key}</span>)
+        : children}
+    </kbd>
+  ),
+);
+KeyboardShortcut.displayName = "KeyboardShortcut";
+
+export { KeyboardShortcut };

--- a/web/src/features/comments/CommentList.tsx
+++ b/web/src/features/comments/CommentList.tsx
@@ -4,6 +4,7 @@ import {
   AvatarImage,
 } from "@/src/components/ui/avatar";
 import { Button } from "@/src/components/ui/button";
+import { KeyboardShortcut } from "@/src/components/ui/keyboard-shortcut";
 import {
   Form,
   FormControl,
@@ -536,16 +537,15 @@ export function CommentList({
                   </Button>
                 )}
                 {!searchQuery && (
-                  <kbd className="bg-muted text-muted-foreground pointer-events-none absolute top-1/2 right-1 h-5 -translate-y-1/2 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-50 select-none sm:inline-flex">
-                    {typeof navigator !== "undefined" &&
-                    navigator.userAgent.includes("Macintosh") ? (
-                      <>
-                        <span className="text-xs">⌘</span>F
-                      </>
-                    ) : (
-                      <>Ctrl+F</>
-                    )}
-                  </kbd>
+                  <KeyboardShortcut
+                    className="absolute top-1/2 right-1 hidden -translate-y-1/2 opacity-50 sm:inline-flex"
+                    keys={
+                      typeof navigator !== "undefined" &&
+                      navigator.userAgent.includes("Macintosh")
+                        ? ["⌘", "F"]
+                        : ["Ctrl", "F"]
+                    }
+                  />
                 )}
               </div>
             </div>
@@ -803,9 +803,7 @@ export function CommentList({
                       >
                         <div className="flex items-center gap-2 text-sm">
                           <span>Send comment</span>
-                          <kbd className="bg-muted text-muted-foreground pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none">
-                            <span className="text-xs">⌘</span>Enter
-                          </kbd>
+                          <KeyboardShortcut keys={["⌘", "Enter"]} />
                         </div>
                       </HoverCardContent>
                     </HoverCard>

--- a/web/src/features/evals/components/code-eval-template-form-body.tsx
+++ b/web/src/features/evals/components/code-eval-template-form-body.tsx
@@ -21,6 +21,7 @@ import {
 import { Loader2 } from "lucide-react";
 
 import { Button } from "@/src/components/ui/button";
+import { KeyboardShortcut } from "@/src/components/ui/keyboard-shortcut";
 import { darkTheme } from "@/src/components/editor/dark-theme";
 import { lightTheme } from "@/src/components/editor/light-theme";
 import {
@@ -399,17 +400,15 @@ export function CodeEvalTemplateFormBody({
               <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
             )}
             Format
-            <kbd className="bg-muted text-muted-foreground pointer-events-none ml-2 hidden h-4 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium select-none sm:inline-flex">
-              {typeof navigator !== "undefined" &&
-              navigator.userAgent.includes("Macintosh") ? (
-                <>
-                  <span className="text-xs">⇧</span>
-                  <span className="text-xs">⌥</span>F
-                </>
-              ) : (
-                <>Shift+Alt+F</>
-              )}
-            </kbd>
+            <KeyboardShortcut
+              className="ml-2 hidden h-4 sm:inline-flex"
+              keys={
+                typeof navigator !== "undefined" &&
+                navigator.userAgent.includes("Macintosh")
+                  ? ["⇧", "⌥", "F"]
+                  : ["Shift", "Alt", "F"]
+              }
+            />
           </Button>
         ) : null}
       </div>

--- a/web/src/features/navigate-detail-pages/DetailPageNav.tsx
+++ b/web/src/features/navigate-detail-pages/DetailPageNav.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/src/components/ui/button";
 import { InputCommandShortcut } from "@/src/components/ui/input-command";
+import { KeyboardShortcut } from "@/src/components/ui/keyboard-shortcut";
 import {
   Tooltip,
   TooltipContent,
@@ -10,9 +11,14 @@ import {
   useDetailPageLists,
 } from "@/src/features/navigate-detail-pages/context";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "@/src/utils/tailwind";
+import { ArrowDown, ArrowUp } from "lucide-react";
 import { useRouter } from "next/router";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const SHORTCUT_PULSE_MS = 160;
+
+type ShortcutPulse = "previous" | "next" | null;
 
 export const DetailPageNav = (props: {
   currentId: string;
@@ -23,6 +29,10 @@ export const DetailPageNav = (props: {
   const { currentId, path, listKey, onNavigate } = props;
   const { detailPagelists } = useDetailPageLists();
   const entries = detailPagelists[listKey] ?? [];
+  const [shortcutPulse, setShortcutPulse] = useState<ShortcutPulse>(null);
+  const shortcutPulseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   const capture = usePostHogClientCapture();
   const router = useRouter();
@@ -49,6 +59,29 @@ export const DetailPageNav = (props: {
     [onNavigate, path, router],
   );
 
+  const pulseShortcut = useCallback(
+    (direction: Exclude<ShortcutPulse, null>) => {
+      if (shortcutPulseTimeoutRef.current) {
+        clearTimeout(shortcutPulseTimeoutRef.current);
+      }
+
+      setShortcutPulse(direction);
+      shortcutPulseTimeoutRef.current = setTimeout(() => {
+        setShortcutPulse(null);
+        shortcutPulseTimeoutRef.current = null;
+      }, SHORTCUT_PULSE_MS);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (shortcutPulseTimeoutRef.current) {
+        clearTimeout(shortcutPulseTimeoutRef.current);
+      }
+    };
+  }, []);
+
   // keyboard shortcuts for buttons k and j
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -67,14 +100,16 @@ export const DetailPageNav = (props: {
       }
 
       if (event.key === "k" && previousPageEntry) {
+        pulseShortcut("previous");
         navigateToEntry(previousPageEntry);
       } else if (event.key === "j" && nextPageEntry) {
+        pulseShortcut("next");
         navigateToEntry(nextPageEntry);
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [previousPageEntry, nextPageEntry, navigateToEntry]);
+  }, [previousPageEntry, nextPageEntry, navigateToEntry, pulseShortcut]);
 
   if (entries.length > 1)
     return (
@@ -84,7 +119,11 @@ export const DetailPageNav = (props: {
             <Button
               variant="outline"
               type="button"
-              className="p-2"
+              className={cn(
+                "gap-1.5 px-2 transition-[background-color,border-color,box-shadow,color] duration-150",
+                shortcutPulse === "previous" &&
+                  "border-primary/60 bg-accent/60 ring-primary/20 ring-2",
+              )}
               disabled={!previousPageEntry}
               onClick={() => {
                 if (previousPageEntry) {
@@ -93,17 +132,13 @@ export const DetailPageNav = (props: {
                 }
               }}
             >
-              <ChevronUp className="h-4 w-4" />
-              <span className="bg-primary/80 text-primary-foreground ml-1 h-4 w-4 rounded-sm text-xs shadow-xs">
-                K
-              </span>
+              <ArrowUp className="h-4 w-4" />
+              <KeyboardShortcut>K</KeyboardShortcut>
             </Button>
           </TooltipTrigger>
           <TooltipContent>
             <span>Navigate up</span>
-            <InputCommandShortcut className="bg-muted ml-2 rounded-sm p-1 px-2">
-              k
-            </InputCommandShortcut>
+            <InputCommandShortcut className="ml-2">K</InputCommandShortcut>
           </TooltipContent>
         </Tooltip>
 
@@ -112,7 +147,11 @@ export const DetailPageNav = (props: {
             <Button
               variant="outline"
               type="button"
-              className="p-2"
+              className={cn(
+                "gap-1.5 px-2 transition-[background-color,border-color,box-shadow,color] duration-150",
+                shortcutPulse === "next" &&
+                  "border-primary/60 bg-accent/60 ring-primary/20 ring-2",
+              )}
               disabled={!nextPageEntry}
               onClick={() => {
                 if (nextPageEntry) {
@@ -121,17 +160,13 @@ export const DetailPageNav = (props: {
                 }
               }}
             >
-              <ChevronDown className="h-4 w-4" />
-              <span className="bg-primary/80 text-primary-foreground ml-1 h-4 w-4 rounded-sm text-xs shadow-xs">
-                J
-              </span>
+              <ArrowDown className="h-4 w-4" />
+              <KeyboardShortcut>J</KeyboardShortcut>
             </Button>
           </TooltipTrigger>
           <TooltipContent>
             <span>Navigate down</span>
-            <InputCommandShortcut className="bg-muted ml-2 rounded-sm p-1 px-2">
-              j
-            </InputCommandShortcut>
+            <InputCommandShortcut className="ml-2">J</InputCommandShortcut>
           </TooltipContent>
         </Tooltip>
       </div>

--- a/web/src/features/playground/page/index.tsx
+++ b/web/src/features/playground/page/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Button } from "@/src/components/ui/button";
+import { KeyboardShortcut } from "@/src/components/ui/keyboard-shortcut";
 import { Play } from "lucide-react";
 import { ResetPlaygroundButton } from "@/src/features/playground/page/components/ResetPlaygroundButton";
 import { useWindowCoordination } from "@/src/features/playground/page/hooks/useWindowCoordination";
@@ -190,14 +191,7 @@ export default function PlaygroundPage() {
                 )}
                 <span className="hidden items-center gap-1 lg:inline-flex">
                   <span>Run All</span>
-                  <kbd className="bg-muted text-muted-foreground pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none">
-                    {isMac ? (
-                      <span className="text-xs">⌘</span>
-                    ) : (
-                      <span>Ctrl</span>
-                    )}
-                    <span>Enter</span>
-                  </kbd>
+                  <KeyboardShortcut keys={[isMac ? "⌘" : "Ctrl", "Enter"]} />
                 </span>
               </Button>
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts all inline `<kbd>` keycap elements across the UI into a single reusable `KeyboardShortcut` component, providing a consistent look (border, background, monospace font, sizing) everywhere keyboard shortcuts are displayed. `DetailPageNav` also gains a short visual pulse animation on the nav buttons when their keyboard shortcut is triggered.

- **New `KeyboardShortcut` component** (`keyboard-shortcut.tsx`): accepts either a `keys` array (each key rendered in its own `<span>`) or freeform `children`, and centralises all keycap styling.
- **`CommandShortcut` / `InputCommandShortcut` refactored**: both now delegate to `KeyboardShortcut` instead of rendering plain `<span>` elements, unifying the command-menu shortcut appearance.
- **`DetailPageNav` pulse animation**: a 160 ms highlight is applied to the K/J navigation buttons when those keyboard shortcuts fire, with proper timeout cleanup on unmount.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are purely visual/component refactoring with no logic regressions and a minor improvement to the search-hint responsive display in CommentList.

All eight changed files are UI-only. The new component works correctly and the pulse animation in DetailPageNav is properly guarded with cleanup. Two minor API-design points remain: array index used as React key in keyboard-shortcut.tsx, and silently ignoring children when keys is also provided.

web/src/components/ui/keyboard-shortcut.tsx — the keys/children precedence and React key strategy are worth a second look before this component gains more callers.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Keyboard shortcut usage site] --> B{Rendering method}
    B -->|keys prop| C["keys.map → span per key"]
    B -->|children prop| D["Render children directly"]
    C --> E[kbd KeyboardShortcut]
    D --> E
    E --> F[Unified keycap style\nbg-muted border rounded-md px-1.5]

    subgraph Callers
        G[routes.tsx CommandMenuTrigger]
        H[command.tsx CommandShortcut]
        I[input-command.tsx InputCommandShortcut]
        J[CommentList.tsx]
        K[code-eval-template-form-body.tsx]
        L[playground/page/index.tsx]
        M[DetailPageNav.tsx + pulse animation]
    end

    G --> E
    H --> E
    I --> E
    J --> E
    K --> E
    L --> E
    M --> E
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/ui/keyboard-shortcut.tsx:23-25
Using array index as the `key` prop is generally discouraged. While keyboard shortcut arrays are static in practice, a stable key derived from the key value is safer and avoids potential reconciliation warnings if the list ever becomes dynamic.

```suggestion
      {keys
        ? keys.map((key, index) => <span key={`${String(key)}-${index}`}>{key}</span>)
        : children}
```

### Issue 2 of 2
web/src/components/ui/keyboard-shortcut.tsx:23-25
**Silent `children` / `keys` precedence**

Both `children` and `keys` are accepted as props, but when `keys` is provided `children` is silently ignored. A caller that inadvertently passes both will see only the `keys` content with no warning. Consider making the two options mutually exclusive via a discriminated union, or at least add a runtime warning (`process.env.NODE_ENV !== "production" && console.warn(...)`) to catch accidental dual-prop usage.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): unify keyboard shortcut keycap..."](https://github.com/langfuse/langfuse/commit/10cdd9e4395453f59f33f75fa57c3857e9cd0207) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36723074)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->