### PR TITLE
feat(eval): add variable diagnostics to judge traces

### DIFF
--- a/worker/src/features/evaluation/evalRuntime.ts
+++ b/worker/src/features/evaluation/evalRuntime.ts
@@ -26,6 +26,7 @@ export type EvalVariableDiagnostics = {
   missingVariables: string[];
   duplicateVariables: string[];
   coverageRatio: number;
+  extractedRatio: number;
 };
 
 export function compileEvalPrompt(params: CompileEvalPromptParams): string {
@@ -66,8 +67,7 @@ export function buildEvalVariableDiagnostics(params: {
       return { variable, status: "missing" as const };
     }
 
-    const stringifiedValue = parseUnknownToString(extractedVariable.value);
-    if (stringifiedValue.trim() === "") {
+    if (isEmptyVariableValue(extractedVariable.value)) {
       return {
         variable,
         status: "empty" as const,
@@ -102,6 +102,11 @@ export function buildEvalVariableDiagnostics(params: {
       params.templateVariables.length === 0
         ? 1
         : resolvedVariables.length / params.templateVariables.length,
+    extractedRatio:
+      params.templateVariables.length === 0
+        ? 1
+        : (resolvedVariables.length + emptyVariables.length) /
+          params.templateVariables.length,
   };
 }
 
@@ -116,6 +121,7 @@ export function buildEvalVariableDiagnosticsMetadata(
     eval_variable_duplicate_count:
       diagnostics.duplicateVariables.length.toString(),
     eval_variable_coverage_ratio: diagnostics.coverageRatio.toFixed(3),
+    eval_variable_extracted_ratio: diagnostics.extractedRatio.toFixed(3),
     ...(diagnostics.emptyVariables.length > 0
       ? { eval_variable_empty_names: diagnostics.emptyVariables.join(",") }
       : {}),
@@ -140,6 +146,7 @@ export function buildEvalVariableDiagnosticsSpanAttributes(
     "eval.variable.missing_count": diagnostics.missingVariables.length,
     "eval.variable.duplicate_count": diagnostics.duplicateVariables.length,
     "eval.variable.coverage_ratio": diagnostics.coverageRatio,
+    "eval.variable.extracted_ratio": diagnostics.extractedRatio,
     ...(diagnostics.emptyVariables.length > 0
       ? { "eval.variable.empty_names": diagnostics.emptyVariables }
       : {}),
@@ -156,6 +163,22 @@ function getVariableValueType(value: unknown): string {
   if (value === null) return "null";
   if (Array.isArray(value)) return "array";
   return typeof value;
+}
+
+function isEmptyVariableValue(value: unknown): boolean {
+  if (parseUnknownToString(value).trim() === "") {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Object.keys(value).length === 0
+  );
 }
 
 export function buildEvalExecutionMetadata(params: {

--- a/worker/src/features/evaluation/evalRuntime.ts
+++ b/worker/src/features/evaluation/evalRuntime.ts
@@ -11,6 +11,23 @@ export interface CompileEvalPromptParams {
   variables: ExtractedVariable[];
 }
 
+export type EvalVariableDiagnosticStatus = "resolved" | "empty" | "missing";
+
+export type EvalVariableDiagnostic = {
+  variable: string;
+  status: EvalVariableDiagnosticStatus;
+  valueType?: string;
+};
+
+export type EvalVariableDiagnostics = {
+  variables: EvalVariableDiagnostic[];
+  resolvedVariables: string[];
+  emptyVariables: string[];
+  missingVariables: string[];
+  duplicateVariables: string[];
+  coverageRatio: number;
+};
+
 export function compileEvalPrompt(params: CompileEvalPromptParams): string {
   // Stringify extracted values here (LLM-judge's consumption boundary) so
   // the upstream extractor can preserve original shapes for code-eval and
@@ -23,6 +40,122 @@ export function compileEvalPrompt(params: CompileEvalPromptParams): string {
   );
 
   return compileTemplateString(params.templatePrompt, variableMap);
+}
+
+export function buildEvalVariableDiagnostics(params: {
+  templateVariables: string[];
+  extractedVariables: ExtractedVariable[];
+}): EvalVariableDiagnostics {
+  const extractedByName = new Map<string, ExtractedVariable>();
+  const seenVariables = new Set<string>();
+  const duplicateVariables = new Set<string>();
+
+  for (const variable of params.extractedVariables) {
+    if (seenVariables.has(variable.var)) {
+      duplicateVariables.add(variable.var);
+      continue;
+    }
+
+    seenVariables.add(variable.var);
+    extractedByName.set(variable.var, variable);
+  }
+
+  const diagnostics = params.templateVariables.map((variable) => {
+    const extractedVariable = extractedByName.get(variable);
+    if (!extractedVariable) {
+      return { variable, status: "missing" as const };
+    }
+
+    const stringifiedValue = parseUnknownToString(extractedVariable.value);
+    if (stringifiedValue.trim() === "") {
+      return {
+        variable,
+        status: "empty" as const,
+        valueType: getVariableValueType(extractedVariable.value),
+      };
+    }
+
+    return {
+      variable,
+      status: "resolved" as const,
+      valueType: getVariableValueType(extractedVariable.value),
+    };
+  });
+
+  const resolvedVariables = diagnostics
+    .filter((diagnostic) => diagnostic.status === "resolved")
+    .map((diagnostic) => diagnostic.variable);
+  const emptyVariables = diagnostics
+    .filter((diagnostic) => diagnostic.status === "empty")
+    .map((diagnostic) => diagnostic.variable);
+  const missingVariables = diagnostics
+    .filter((diagnostic) => diagnostic.status === "missing")
+    .map((diagnostic) => diagnostic.variable);
+
+  return {
+    variables: diagnostics,
+    resolvedVariables,
+    emptyVariables,
+    missingVariables,
+    duplicateVariables: [...duplicateVariables],
+    coverageRatio:
+      params.templateVariables.length === 0
+        ? 1
+        : resolvedVariables.length / params.templateVariables.length,
+  };
+}
+
+export function buildEvalVariableDiagnosticsMetadata(
+  diagnostics: EvalVariableDiagnostics,
+): Record<string, string> {
+  return {
+    eval_variable_resolved_count:
+      diagnostics.resolvedVariables.length.toString(),
+    eval_variable_empty_count: diagnostics.emptyVariables.length.toString(),
+    eval_variable_missing_count: diagnostics.missingVariables.length.toString(),
+    eval_variable_duplicate_count:
+      diagnostics.duplicateVariables.length.toString(),
+    eval_variable_coverage_ratio: diagnostics.coverageRatio.toFixed(3),
+    ...(diagnostics.emptyVariables.length > 0
+      ? { eval_variable_empty_names: diagnostics.emptyVariables.join(",") }
+      : {}),
+    ...(diagnostics.missingVariables.length > 0
+      ? { eval_variable_missing_names: diagnostics.missingVariables.join(",") }
+      : {}),
+    ...(diagnostics.duplicateVariables.length > 0
+      ? {
+          eval_variable_duplicate_names:
+            diagnostics.duplicateVariables.join(","),
+        }
+      : {}),
+  };
+}
+
+export function buildEvalVariableDiagnosticsSpanAttributes(
+  diagnostics: EvalVariableDiagnostics,
+): Record<string, string | number | string[]> {
+  return {
+    "eval.variable.resolved_count": diagnostics.resolvedVariables.length,
+    "eval.variable.empty_count": diagnostics.emptyVariables.length,
+    "eval.variable.missing_count": diagnostics.missingVariables.length,
+    "eval.variable.duplicate_count": diagnostics.duplicateVariables.length,
+    "eval.variable.coverage_ratio": diagnostics.coverageRatio,
+    ...(diagnostics.emptyVariables.length > 0
+      ? { "eval.variable.empty_names": diagnostics.emptyVariables }
+      : {}),
+    ...(diagnostics.missingVariables.length > 0
+      ? { "eval.variable.missing_names": diagnostics.missingVariables }
+      : {}),
+    ...(diagnostics.duplicateVariables.length > 0
+      ? { "eval.variable.duplicate_names": diagnostics.duplicateVariables }
+      : {}),
+  };
+}
+
+function getVariableValueType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
 }
 
 export function buildEvalExecutionMetadata(params: {

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -70,6 +70,9 @@ import { createW3CTraceId } from "../utils";
 import { UnrecoverableError } from "../../errors/UnrecoverableError";
 import { ObservationNotFoundError } from "../../errors/ObservationNotFoundError";
 import {
+  buildEvalVariableDiagnostics,
+  buildEvalVariableDiagnosticsMetadata,
+  buildEvalVariableDiagnosticsSpanAttributes,
   compileEvalPrompt,
   buildEvalMessages,
   buildEvalExecutionMetadata,
@@ -779,6 +782,32 @@ export async function runLLMAsJudgeEvaluation({
         `Executing LLM-as-judge evaluation for job ${jobExecutionId} in project ${projectId}`,
       );
 
+      const variableDiagnostics = buildEvalVariableDiagnostics({
+        templateVariables: template.vars,
+        extractedVariables,
+      });
+      span.setAttributes(
+        buildEvalVariableDiagnosticsSpanAttributes(variableDiagnostics),
+      );
+
+      const evalExecutionMetadata = {
+        ...executionMetadata,
+        ...buildEvalVariableDiagnosticsMetadata(variableDiagnostics),
+      };
+
+      if (
+        variableDiagnostics.missingVariables.length > 0 ||
+        variableDiagnostics.emptyVariables.length > 0
+      ) {
+        logger.warn("Evaluation variables resolved with gaps", {
+          jobExecutionId,
+          jobConfigurationId: config.id,
+          missingVariables: variableDiagnostics.missingVariables,
+          emptyVariables: variableDiagnostics.emptyVariables,
+          coverageRatio: variableDiagnostics.coverageRatio,
+        });
+      }
+
       // Compile the prompt with extracted variables
       let prompt: string;
       try {
@@ -894,7 +923,7 @@ export async function runLLMAsJudgeEvaluation({
                 traceName: `Execute evaluator: ${template.name}`,
                 environment: LangfuseInternalTraceEnvironment.LLMJudge,
                 metadata: {
-                  ...executionMetadata,
+                  ...evalExecutionMetadata,
                 },
               },
             });
@@ -955,7 +984,7 @@ export async function runLLMAsJudgeEvaluation({
       return {
         scores,
         executionTraceId,
-        metadata: executionMetadata,
+        metadata: evalExecutionMetadata,
       };
     },
   );

--- a/worker/src/features/evaluation/evaluationHelpers.test.ts
+++ b/worker/src/features/evaluation/evaluationHelpers.test.ts
@@ -16,6 +16,9 @@ import { type ExtractedVariable } from "@langfuse/shared/src/server";
 import { parseDispatchResult } from "../../../../packages/shared/src/server/evals/codeEvalDispatcherTypes";
 import { createDeterministicEvalScoreId } from "../../../../packages/shared/src/server/evals/evalScoreIds";
 import {
+  buildEvalVariableDiagnostics,
+  buildEvalVariableDiagnosticsMetadata,
+  buildEvalVariableDiagnosticsSpanAttributes,
   buildEvalExecutionMetadata,
   buildEvalMessages,
   compileEvalPrompt,
@@ -358,6 +361,88 @@ describe("evaluation helpers", () => {
       expect(Object.keys(result)).not.toContain("target_trace_id");
       expect(Object.keys(result)).not.toContain("target_observation_id");
       expect(Object.keys(result)).not.toContain("target_dataset_item_id");
+    });
+  });
+
+  describe("buildEvalVariableDiagnostics", () => {
+    it("summarizes resolved, empty, missing, and duplicate evaluator variables", () => {
+      const diagnostics = buildEvalVariableDiagnostics({
+        templateVariables: ["input", "output", "context", "metadata"],
+        extractedVariables: [
+          { var: "input", value: "What is Langfuse?" },
+          { var: "output", value: "" },
+          { var: "metadata", value: { source: "trace", tenant: "acme" } },
+          { var: "input", value: "duplicate value should not win" },
+        ] as ExtractedVariable[],
+      });
+
+      expect(diagnostics).toEqual({
+        variables: [
+          { variable: "input", status: "resolved", valueType: "string" },
+          { variable: "output", status: "empty", valueType: "string" },
+          { variable: "context", status: "missing" },
+          { variable: "metadata", status: "resolved", valueType: "object" },
+        ],
+        resolvedVariables: ["input", "metadata"],
+        emptyVariables: ["output"],
+        missingVariables: ["context"],
+        duplicateVariables: ["input"],
+        coverageRatio: 0.5,
+      });
+    });
+
+    it("treats object and array values as resolved while nulls remain empty", () => {
+      const diagnostics = buildEvalVariableDiagnostics({
+        templateVariables: ["messages", "labels", "score", "missingValue"],
+        extractedVariables: [
+          { var: "messages", value: [{ role: "user", content: "hello" }] },
+          { var: "labels", value: ["correct", "concise"] },
+          { var: "score", value: 0 },
+          { var: "missingValue", value: null },
+        ] as ExtractedVariable[],
+      });
+
+      expect(diagnostics.resolvedVariables).toEqual([
+        "messages",
+        "labels",
+        "score",
+      ]);
+      expect(diagnostics.emptyVariables).toEqual(["missingValue"]);
+      expect(diagnostics.variables).toEqual([
+        { variable: "messages", status: "resolved", valueType: "array" },
+        { variable: "labels", status: "resolved", valueType: "array" },
+        { variable: "score", status: "resolved", valueType: "number" },
+        { variable: "missingValue", status: "empty", valueType: "null" },
+      ]);
+    });
+
+    it("emits metadata and span attributes without leaking variable values", () => {
+      const diagnostics = buildEvalVariableDiagnostics({
+        templateVariables: ["input", "expected", "actual"],
+        extractedVariables: [
+          { var: "input", value: "private prompt text" },
+          { var: "actual", value: "   " },
+        ] as ExtractedVariable[],
+      });
+
+      expect(buildEvalVariableDiagnosticsMetadata(diagnostics)).toEqual({
+        eval_variable_resolved_count: "1",
+        eval_variable_empty_count: "1",
+        eval_variable_missing_count: "1",
+        eval_variable_duplicate_count: "0",
+        eval_variable_coverage_ratio: "0.333",
+        eval_variable_empty_names: "actual",
+        eval_variable_missing_names: "expected",
+      });
+      expect(buildEvalVariableDiagnosticsSpanAttributes(diagnostics)).toEqual({
+        "eval.variable.resolved_count": 1,
+        "eval.variable.empty_count": 1,
+        "eval.variable.missing_count": 1,
+        "eval.variable.duplicate_count": 0,
+        "eval.variable.coverage_ratio": 1 / 3,
+        "eval.variable.empty_names": ["actual"],
+        "eval.variable.missing_names": ["expected"],
+      });
     });
   });
 

--- a/worker/src/features/evaluation/evaluationHelpers.test.ts
+++ b/worker/src/features/evaluation/evaluationHelpers.test.ts
@@ -388,16 +388,26 @@ describe("evaluation helpers", () => {
         missingVariables: ["context"],
         duplicateVariables: ["input"],
         coverageRatio: 0.5,
+        extractedRatio: 0.75,
       });
     });
 
-    it("treats object and array values as resolved while nulls remain empty", () => {
+    it("treats populated containers as resolved and empty containers as empty", () => {
       const diagnostics = buildEvalVariableDiagnostics({
-        templateVariables: ["messages", "labels", "score", "missingValue"],
+        templateVariables: [
+          "messages",
+          "labels",
+          "score",
+          "emptyList",
+          "emptyObject",
+          "missingValue",
+        ],
         extractedVariables: [
           { var: "messages", value: [{ role: "user", content: "hello" }] },
           { var: "labels", value: ["correct", "concise"] },
           { var: "score", value: 0 },
+          { var: "emptyList", value: [] },
+          { var: "emptyObject", value: {} },
           { var: "missingValue", value: null },
         ] as ExtractedVariable[],
       });
@@ -407,13 +417,21 @@ describe("evaluation helpers", () => {
         "labels",
         "score",
       ]);
-      expect(diagnostics.emptyVariables).toEqual(["missingValue"]);
+      expect(diagnostics.emptyVariables).toEqual([
+        "emptyList",
+        "emptyObject",
+        "missingValue",
+      ]);
       expect(diagnostics.variables).toEqual([
         { variable: "messages", status: "resolved", valueType: "array" },
         { variable: "labels", status: "resolved", valueType: "array" },
         { variable: "score", status: "resolved", valueType: "number" },
+        { variable: "emptyList", status: "empty", valueType: "array" },
+        { variable: "emptyObject", status: "empty", valueType: "object" },
         { variable: "missingValue", status: "empty", valueType: "null" },
       ]);
+      expect(diagnostics.coverageRatio).toBe(0.5);
+      expect(diagnostics.extractedRatio).toBe(1);
     });
 
     it("emits metadata and span attributes without leaking variable values", () => {
@@ -431,6 +449,7 @@ describe("evaluation helpers", () => {
         eval_variable_missing_count: "1",
         eval_variable_duplicate_count: "0",
         eval_variable_coverage_ratio: "0.333",
+        eval_variable_extracted_ratio: "0.667",
         eval_variable_empty_names: "actual",
         eval_variable_missing_names: "expected",
       });
@@ -440,6 +459,7 @@ describe("evaluation helpers", () => {
         "eval.variable.missing_count": 1,
         "eval.variable.duplicate_count": 0,
         "eval.variable.coverage_ratio": 1 / 3,
+        "eval.variable.extracted_ratio": 2 / 3,
         "eval.variable.empty_names": ["actual"],
         "eval.variable.missing_names": ["expected"],
       });

--- a/worker/src/features/evaluation/executeLLMAsJudgeEvaluation.test.ts
+++ b/worker/src/features/evaluation/executeLLMAsJudgeEvaluation.test.ts
@@ -488,6 +488,7 @@ describe("executeLLMAsJudgeEvaluation", () => {
               eval_variable_missing_count: "1",
               eval_variable_duplicate_count: "0",
               eval_variable_coverage_ratio: "0.333",
+              eval_variable_extracted_ratio: "0.667",
               eval_variable_empty_names: "output",
               eval_variable_missing_names: "context",
             }),

--- a/worker/src/features/evaluation/executeLLMAsJudgeEvaluation.test.ts
+++ b/worker/src/features/evaluation/executeLLMAsJudgeEvaluation.test.ts
@@ -459,6 +459,48 @@ describe("executeLLMAsJudgeEvaluation", () => {
       );
     });
 
+    it("should include evaluator variable diagnostics in the LLM trace metadata", async () => {
+      const callLLM = mockSuccessfulLLMCall(0.6, "Output was incomplete");
+      const deps = createSuccessfulDeps({ callLLM });
+
+      await executeLLMAsJudgeEvaluation(
+        createExecutionParams({
+          deps,
+          template: {
+            ...mockEvalTemplate,
+            prompt:
+              "Evaluate input {{input}}, output {{output}}, and context {{context}}",
+            vars: ["input", "output", "context"],
+          },
+          variables: [
+            { var: "input", value: "private user input" },
+            { var: "output", value: "" },
+          ],
+        }),
+      );
+
+      expect(callLLM).toHaveBeenCalledWith(
+        expect.objectContaining({
+          traceSinkParams: expect.objectContaining({
+            metadata: expect.objectContaining({
+              eval_variable_resolved_count: "1",
+              eval_variable_empty_count: "1",
+              eval_variable_missing_count: "1",
+              eval_variable_duplicate_count: "0",
+              eval_variable_coverage_ratio: "0.333",
+              eval_variable_empty_names: "output",
+              eval_variable_missing_names: "context",
+            }),
+          }),
+        }),
+      );
+      expect(callLLM.mock.calls[0][0].traceSinkParams.metadata).not.toEqual(
+        expect.objectContaining({
+          input: "private user input",
+        }),
+      );
+    });
+
     it("should pass structured output schema to LLM", async () => {
       const callLLM = mockSuccessfulLLMCall(0.8, "Good response");
       const deps = createSuccessfulDeps({ callLLM });


### PR DESCRIPTION
## What

Adds evaluator variable diagnostics to LLM-as-judge execution traces.

When a judge prompt is built, Langfuse now records whether each template variable was resolved, empty, or missing before the model call. The diagnostics are attached to both the worker span attributes and the internal evaluator trace metadata, so failed or suspicious eval runs are easier to debug without exposing the actual variable values.

## Why

A common failure mode for trace and dataset evaluators is a mapping that does not find the expected trace, observation, dataset field, or JSON selector output. Today that can turn into an empty prompt variable or a later confusing failure. This gives the eval execution trace enough structure to answer: which variables were present, which were empty, and which were never extracted.

## Details

- Adds reusable variable diagnostics helpers in evalRuntime
- Tracks resolved, empty, missing, and duplicate evaluator variables
- Adds count and variable-name metadata to the LLM judge trace
- Adds span attributes for the same diagnostics
- Avoids logging or storing variable values in diagnostics
- Adds helper tests and LLM execution metadata coverage

## Validation

- Passed: ./node_modules/.bin/tsc --noEmit --skipLibCheck from worker
- Passed: worker Prettier check on changed files
- Passed: git diff --check
- Could not run Vitest locally because Rollup fails at startup on this machine with a macOS native binary code-signature error for @rollup/rollup-darwin-arm64 before tests load.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds variable diagnostics to LLM-as-judge evaluation traces, recording whether each template variable was resolved, empty (extracted but blank), or missing (never found) prior to the model call. Diagnostics are attached as both span attributes and internal trace metadata, enabling easier debugging of evaluators without leaking actual variable values.

- New helpers in `evalRuntime.ts` (`buildEvalVariableDiagnostics`, `buildEvalVariableDiagnosticsMetadata`, `buildEvalVariableDiagnosticsSpanAttributes`) compute and format the diagnostics; `evalService.ts` calls them just before prompt compilation and merges the result into the existing execution metadata.
- Tests cover the main categorisation logic (resolved, empty, missing, duplicate), metadata formatting, span attribute formatting, and an integration-level check confirming that actual variable values are not leaked into trace metadata.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is additive and does not alter existing eval execution logic or scoring paths.

The diagnostics helpers are well-isolated and the wiring in evalService correctly slots the new metadata in alongside the existing execution metadata. The one edge case worth attention is that empty arrays and empty objects stringify to non-empty strings (e.g. `"[]"`, `"{}"`), so those values are classified as "resolved" rather than "empty" — the diagnostics would show full coverage for a variable whose extracted value is `[]`, even though the LLM prompt receives a structurally empty placeholder.

worker/src/features/evaluation/evalRuntime.ts — the empty-container classification in buildEvalVariableDiagnostics
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ES as evalService (runLLMAsJudgeEvaluation)
    participant ER as evalRuntime
    participant Span as Worker Span
    participant LLM as callLLM (traceSinkParams)

    ES->>ER: buildEvalVariableDiagnostics(templateVariables, extractedVariables)
    ER-->>ES: "EvalVariableDiagnostics {resolved, empty, missing, duplicate, coverageRatio}"

    ES->>Span: setAttributes(buildEvalVariableDiagnosticsSpanAttributes(diagnostics))

    ES->>ER: buildEvalVariableDiagnosticsMetadata(diagnostics)
    ER-->>ES: "Record<string, string> (counts + names)"

    ES->>ES: "evalExecutionMetadata = {executionMetadata, ...diagnosticsMetadata}"

    alt "missingVariables.length > 0 || emptyVariables.length > 0"
        ES->>ES: logger.warn(Evaluation variables resolved with gaps)
    end

    ES->>ER: compileEvalPrompt(templatePrompt, extractedVariables)
    ER-->>ES: compiled prompt string

    ES->>LLM: "callLLM({ traceSinkParams: { metadata: evalExecutionMetadata } })"
    LLM-->>ES: LLM response + executionTraceId

    ES-->>ES: "return { scores, executionTraceId, metadata: evalExecutionMetadata }"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/evaluation/evalRuntime.ts:69-76
An empty array `[]` or empty object `{}` stringifies to `"[]"` / `"{}"` via `JSON.stringify`, so `.trim() === ""` is false and the variable is classified as `"resolved"` even though it carries no meaningful content. A user whose variable mapping returns an empty list (e.g., no observations found) will see `"resolved"` in the diagnostics while the prompt actually receives `[]`, which can be just as unhelpful as a blank string. Adding an explicit check for these structural empties would keep the diagnostics consistent with the user's intent.

```suggestion
    const stringifiedValue = parseUnknownToString(extractedVariable.value);
    const isStructurallyEmpty =
      (Array.isArray(extractedVariable.value) &&
        extractedVariable.value.length === 0) ||
      (typeof extractedVariable.value === "object" &&
        extractedVariable.value !== null &&
        !Array.isArray(extractedVariable.value) &&
        Object.keys(extractedVariable.value).length === 0);
    if (stringifiedValue.trim() === "" || isStructurallyEmpty) {
      return {
        variable,
        status: "empty" as const,
        valueType: getVariableValueType(extractedVariable.value),
      };
    }
```

### Issue 2 of 2
worker/src/features/evaluation/evalRuntime.ts:95-105
**Coverage ratio only counts strictly-resolved variables**

`coverageRatio` is computed as `resolvedVariables.length / templateVariables.length`, so empty-but-extracted variables reduce the ratio in the same way as truly missing ones. An evaluator that has every variable extracted but one of them blank would report the same ratio as one that never found that variable at all. Depending on how the ratio is surfaced in dashboards or alerting, this distinction could matter — consider also exposing an `extractedRatio` (`(resolved + empty) / total`) alongside the existing ratio, or renaming the current field to `resolvedRatio` to prevent misinterpretation.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(eval): add variable diagnostics to ..."](https://github.com/langfuse/langfuse/commit/efedfb149044617817b5a9459da38349277cca27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36742978)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->