### PR TITLE
feat(blob-storage): apply export field groups to legacy observations export

### DIFF
--- a/fern/apis/server/definition/blob-storage-integrations.yml
+++ b/fern/apis/server/definition/blob-storage-integrations.yml
@@ -64,9 +64,9 @@ types:
   BlobStorageExportSource:
     docs: |
       What data the integration exports.
-      - `LEGACY_TRACES_OBSERVATIONS`: traces, observations, and scores tables with a fixed column set. The `exportFieldGroups` field is not applicable.
+      - `LEGACY_TRACES_OBSERVATIONS`: traces, observations, and scores tables. Observation columns are controlled by `exportFieldGroups`; field groups without a counterpart in this data model (e.g. `trace_context`) are omitted.
       - `OBSERVATIONS_V2`: same data model as the `/api/public/v2/observations` endpoint, plus scores. Columns are controlled by `exportFieldGroups`.
-      - `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: both sets. For the `OBSERVATIONS_V2` portion, columns are controlled by `exportFieldGroups`.
+      - `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: both sets. Observation columns of both portions are controlled by `exportFieldGroups`.
 
       **Note:** `OBSERVATIONS_V2` and the enriched-observations portion of `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` rely on the enriched observations table (Langfuse Fast Preview / v4), which is currently available on Langfuse Cloud only. See https://langfuse.com/docs/v4.
     enum:
@@ -75,7 +75,7 @@ types:
       - LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS
 
   BlobStorageExportFieldGroup:
-    docs: Field group for the OBSERVATIONS_V2 and LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS export.
+    docs: Field group selecting which observation columns are included in the export. Applies to all export sources; groups without a counterpart in the legacy data model (e.g. `trace_context`) are omitted from the legacy observations export.
     enum:
       - core
       - basic
@@ -138,11 +138,7 @@ types:
       exportFieldGroups:
         type: optional<list<BlobStorageExportFieldGroup>>
         docs: |
-          Field groups to include in each exported row.
-
-          For exportSource `OBSERVATIONS_V2` or `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: must include `core` if provided. When omitted on create, the column default (all groups) applies. When omitted on update, the existing value is preserved.
-
-          For exportSource `LEGACY_TRACES_OBSERVATIONS`: this field must be omitted or null. Sending an array (including an empty array) returns 400, because that source uses a fixed column set and does not honor field groups.
+          Field groups to include in each exported observation row. Applies to all export sources; must include `core` if provided. When omitted on create, the column default (all groups) applies. When omitted on update, the existing value is preserved.
 
           `exportFieldGroups` requires `exportSource` to be provided in the same request.
 
@@ -167,7 +163,7 @@ types:
       exportFieldGroups:
         type: nullable<list<BlobStorageExportFieldGroup>>
         docs: |
-          Field groups included in each exported row for `OBSERVATIONS_V2` / `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` sources. Always `null` when exportSource is `LEGACY_TRACES_OBSERVATIONS` (the field does not apply to that source; any legacy DB value is hidden from the public surface).
+          Field groups included in each exported observation row. An empty list is treated as all groups during export.
       nextSyncAt: nullable<datetime>
       lastSyncAt: nullable<datetime>
       lastError: nullable<string>

--- a/packages/shared/src/domain/observation-field-groups.ts
+++ b/packages/shared/src/domain/observation-field-groups.ts
@@ -54,3 +54,55 @@ export const OBSERVATION_FIELD_GROUPS_FULL = [
 
 export type ObservationFieldGroupFull =
   (typeof OBSERVATION_FIELD_GROUPS_FULL)[number];
+
+/**
+ * Blob export contract for the legacy observations table: every output field
+ * of the export and the field group it belongs to, in the column order of the
+ * full export (kept stable so exports with all groups selected are unchanged).
+ *
+ * Field names are the snake_case output columns of the export rows. Groups
+ * missing from this list (trace_context) have no counterpart in the legacy
+ * table: denormalized trace fields only exist on the events table. The SQL
+ * realization (computed expressions for latency, time_to_first_token,
+ * model_id) lives in the repository layer:
+ * packages/shared/src/server/repositories/observations.ts,
+ * `getObservationsForBlobStorageExport`.
+ */
+export const LEGACY_OBSERVATION_EXPORT_FIELDS: ReadonlyArray<{
+  field: string;
+  group: ObservationFieldGroupFull;
+}> = [
+  { field: "id", group: "core" },
+  { field: "trace_id", group: "core" },
+  { field: "project_id", group: "core" },
+  { field: "environment", group: "basic" },
+  { field: "type", group: "core" },
+  { field: "parent_observation_id", group: "core" },
+  { field: "start_time", group: "core" },
+  { field: "end_time", group: "core" },
+  { field: "name", group: "basic" },
+  { field: "metadata", group: "metadata" },
+  { field: "level", group: "basic" },
+  { field: "status_message", group: "basic" },
+  { field: "version", group: "basic" },
+  { field: "input", group: "io" },
+  { field: "output", group: "io" },
+  { field: "provided_model_name", group: "model" },
+  { field: "model_parameters", group: "model" },
+  { field: "usage_details", group: "usage" },
+  { field: "cost_details", group: "usage" },
+  { field: "completion_start_time", group: "time" },
+  { field: "prompt_name", group: "prompt" },
+  { field: "prompt_version", group: "prompt" },
+  { field: "total_cost", group: "usage" },
+  { field: "latency", group: "metrics" },
+  { field: "time_to_first_token", group: "metrics" },
+  { field: "model_id", group: "model" },
+  { field: "created_at", group: "time" },
+  { field: "updated_at", group: "time" },
+  { field: "prompt_id", group: "prompt" },
+  { field: "tool_calls", group: "tools" },
+  { field: "tool_call_names", group: "tools" },
+  { field: "tool_definitions", group: "tools" },
+  { field: "usage_pricing_tier_name", group: "usage" },
+];

--- a/packages/shared/src/features/analytics-integrations/index.ts
+++ b/packages/shared/src/features/analytics-integrations/index.ts
@@ -3,6 +3,7 @@
 
 import { AnalyticsIntegrationExportSource } from "@prisma/client";
 import {
+  LEGACY_OBSERVATION_EXPORT_FIELDS,
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
 } from "../../domain/observation-field-groups";
@@ -93,6 +94,32 @@ const EXPORT_FIELD_GROUP_LABELS = {
   { label: string; description: string }
 >;
 
+// Pricing fields added by the export enrichment (not part of the SQL contract)
+// whenever the model group is selected — for both export paths.
+const MODEL_ENRICHMENT_FIELDS = ["input_price", "output_price", "total_price"];
+
+// The `description` of EXPORT_FIELD_GROUP_LABELS lists the enriched
+// observations fields of each group; the legacy observations table contains
+// fewer columns. Derive the legacy description from the export contract so it
+// stays in sync when the contract changes.
+const legacyDescriptionForGroup = (
+  group: ObservationFieldGroupFull,
+): string => {
+  const fields = LEGACY_OBSERVATION_EXPORT_FIELDS.filter(
+    (f) => f.group === group,
+  ).map((f) => f.field);
+  if (group === "model") {
+    fields.push(...MODEL_ENRICHMENT_FIELDS);
+  }
+  return fields.length > 0
+    ? fields.join(", ")
+    : "Not included in the legacy observations export";
+};
+
 export const EXPORT_FIELD_GROUP_OPTIONS = OBSERVATION_FIELD_GROUPS_FULL.map(
-  (value) => ({ value, ...EXPORT_FIELD_GROUP_LABELS[value] }),
+  (value) => ({
+    value,
+    ...EXPORT_FIELD_GROUP_LABELS[value],
+    legacyDescription: legacyDescriptionForGroup(value),
+  }),
 );

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -46,6 +46,7 @@ import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 import type { AnalyticsGenerationEvent } from "../analytics-integrations/types";
 import { ObservationType } from "../../domain";
 import {
+  LEGACY_OBSERVATION_EXPORT_FIELDS,
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
 } from "../../domain/observation-field-groups";
@@ -1815,55 +1816,16 @@ export const getTraceIdsForObservations = async (
   }));
 };
 
-// Column projections of the legacy observations table per observation field
-// group, in the column order of the full export (kept stable so exports with
-// all groups selected are unchanged). Groups missing from this list
-// (trace_context) have no counterpart in the legacy table: denormalized trace
-// fields only exist on the events table.
-const LEGACY_OBSERVATION_EXPORT_COLUMNS: Array<{
-  sql: string;
-  group: ObservationFieldGroupFull;
-}> = [
-  { sql: "id", group: "core" },
-  { sql: "trace_id", group: "core" },
-  { sql: "project_id", group: "core" },
-  { sql: "environment", group: "basic" },
-  { sql: "type", group: "core" },
-  { sql: "parent_observation_id", group: "core" },
-  { sql: "start_time", group: "core" },
-  { sql: "end_time", group: "core" },
-  { sql: "name", group: "basic" },
-  { sql: "metadata", group: "metadata" },
-  { sql: "level", group: "basic" },
-  { sql: "status_message", group: "basic" },
-  { sql: "version", group: "basic" },
-  { sql: "input", group: "io" },
-  { sql: "output", group: "io" },
-  { sql: "provided_model_name", group: "model" },
-  { sql: "model_parameters", group: "model" },
-  { sql: "usage_details", group: "usage" },
-  { sql: "cost_details", group: "usage" },
-  { sql: "completion_start_time", group: "time" },
-  { sql: "prompt_name", group: "prompt" },
-  { sql: "prompt_version", group: "prompt" },
-  { sql: "total_cost", group: "usage" },
-  {
-    sql: "if(isNull(end_time), NULL, date_diff('millisecond', start_time, end_time) / 1000) as latency",
-    group: "metrics",
-  },
-  {
-    sql: "if(isNull(completion_start_time), NULL, date_diff('millisecond', start_time, completion_start_time) / 1000) as time_to_first_token",
-    group: "metrics",
-  },
-  { sql: "internal_model_id as model_id", group: "model" },
-  { sql: "created_at", group: "time" },
-  { sql: "updated_at", group: "time" },
-  { sql: "prompt_id", group: "prompt" },
-  { sql: "tool_calls", group: "tools" },
-  { sql: "tool_call_names", group: "tools" },
-  { sql: "tool_definitions", group: "tools" },
-  { sql: "usage_pricing_tier_name", group: "usage" },
-];
+// SQL expressions for the export fields of LEGACY_OBSERVATION_EXPORT_FIELDS
+// (the domain-level export contract) that are not plain column reads. Every
+// other field selects the table column of the same name.
+const LEGACY_OBSERVATION_EXPORT_SQL_OVERRIDES: Record<string, string> = {
+  latency:
+    "if(isNull(end_time), NULL, date_diff('millisecond', start_time, end_time) / 1000) as latency",
+  time_to_first_token:
+    "if(isNull(completion_start_time), NULL, date_diff('millisecond', start_time, completion_start_time) / 1000) as time_to_first_token",
+  model_id: "internal_model_id as model_id",
+};
 
 export const getObservationsForBlobStorageExport = function (
   projectId: string,
@@ -1877,13 +1839,16 @@ export const getObservationsForBlobStorageExport = function (
     ...fieldGroups,
   ]);
 
-  const selectedColumns = LEGACY_OBSERVATION_EXPORT_COLUMNS.filter((column) =>
+  const selectedColumns = LEGACY_OBSERVATION_EXPORT_FIELDS.filter((column) =>
     effectiveGroups.has(column.group),
+  ).map(
+    (column) =>
+      LEGACY_OBSERVATION_EXPORT_SQL_OVERRIDES[column.field] ?? column.field,
   );
 
   const query = `
     SELECT
-      ${selectedColumns.map((column) => column.sql).join(",\n      ")}
+      ${selectedColumns.join(",\n      ")}
     FROM observations
     WHERE project_id = {projectId: String}
     AND start_time >= {minTimestamp: DateTime64(3)}

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -45,6 +45,10 @@ import { observationsTableCols } from "../../observationsTable";
 import { ClickHouseClientConfigOptions } from "@clickhouse/client";
 import type { AnalyticsGenerationEvent } from "../analytics-integrations/types";
 import { ObservationType } from "../../domain";
+import {
+  OBSERVATION_FIELD_GROUPS_FULL,
+  type ObservationFieldGroupFull,
+} from "../../domain/observation-field-groups";
 import { recordDistribution } from "../instrumentation";
 import { DEFAULT_RENDERING_PROPS, RenderingProps } from "../utils/rendering";
 import { shouldSkipObservationsFinal } from "../queries/clickhouse-sql/query-options";
@@ -1811,46 +1815,75 @@ export const getTraceIdsForObservations = async (
   }));
 };
 
+// Column projections of the legacy observations table per observation field
+// group, in the column order of the full export (kept stable so exports with
+// all groups selected are unchanged). Groups missing from this list
+// (trace_context) have no counterpart in the legacy table: denormalized trace
+// fields only exist on the events table.
+const LEGACY_OBSERVATION_EXPORT_COLUMNS: Array<{
+  sql: string;
+  group: ObservationFieldGroupFull;
+}> = [
+  { sql: "id", group: "core" },
+  { sql: "trace_id", group: "core" },
+  { sql: "project_id", group: "core" },
+  { sql: "environment", group: "basic" },
+  { sql: "type", group: "core" },
+  { sql: "parent_observation_id", group: "core" },
+  { sql: "start_time", group: "core" },
+  { sql: "end_time", group: "core" },
+  { sql: "name", group: "basic" },
+  { sql: "metadata", group: "metadata" },
+  { sql: "level", group: "basic" },
+  { sql: "status_message", group: "basic" },
+  { sql: "version", group: "basic" },
+  { sql: "input", group: "io" },
+  { sql: "output", group: "io" },
+  { sql: "provided_model_name", group: "model" },
+  { sql: "model_parameters", group: "model" },
+  { sql: "usage_details", group: "usage" },
+  { sql: "cost_details", group: "usage" },
+  { sql: "completion_start_time", group: "time" },
+  { sql: "prompt_name", group: "prompt" },
+  { sql: "prompt_version", group: "prompt" },
+  { sql: "total_cost", group: "usage" },
+  {
+    sql: "if(isNull(end_time), NULL, date_diff('millisecond', start_time, end_time) / 1000) as latency",
+    group: "metrics",
+  },
+  {
+    sql: "if(isNull(completion_start_time), NULL, date_diff('millisecond', start_time, completion_start_time) / 1000) as time_to_first_token",
+    group: "metrics",
+  },
+  { sql: "internal_model_id as model_id", group: "model" },
+  { sql: "created_at", group: "time" },
+  { sql: "updated_at", group: "time" },
+  { sql: "prompt_id", group: "prompt" },
+  { sql: "tool_calls", group: "tools" },
+  { sql: "tool_call_names", group: "tools" },
+  { sql: "tool_definitions", group: "tools" },
+  { sql: "usage_pricing_tier_name", group: "usage" },
+];
+
 export const getObservationsForBlobStorageExport = function (
   projectId: string,
   minTimestamp: Date,
   maxTimestamp: Date,
+  fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
 ) {
+  // core is always required (provides id, trace_id, start/end_time used for deduplication)
+  const effectiveGroups = new Set<ObservationFieldGroupFull>([
+    "core",
+    ...fieldGroups,
+  ]);
+
+  const selectedColumns = LEGACY_OBSERVATION_EXPORT_COLUMNS.filter((column) =>
+    effectiveGroups.has(column.group),
+  );
+
   const query = `
     SELECT
-      id,
-      trace_id,
-      project_id,
-      environment,
-      type,
-      parent_observation_id,
-      start_time,
-      end_time,
-      name,
-      metadata,
-      level,
-      status_message,
-      version,
-      input,
-      output,
-      provided_model_name,
-      model_parameters,
-      usage_details,
-      cost_details,
-      completion_start_time,
-      prompt_name,
-      prompt_version,
-      total_cost,
-      if(isNull(end_time), NULL, date_diff('millisecond', start_time, end_time) / 1000) as latency,
-      if(isNull(completion_start_time), NULL, date_diff('millisecond', start_time, completion_start_time) / 1000) as time_to_first_token,
-      internal_model_id as model_id,
-      created_at,
-      updated_at,
-      prompt_id,
-      tool_calls,
-      tool_call_names,
-      tool_definitions,
-      usage_pricing_tier_name
+      ${selectedColumns.map((column) => column.sql).join(",\n      ")}
     FROM observations
     WHERE project_id = {projectId: String}
     AND start_time >= {minTimestamp: DateTime64(3)}

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -7743,17 +7743,17 @@ components:
       description: >-
         What data the integration exports.
 
-        - `LEGACY_TRACES_OBSERVATIONS`: traces, observations, and scores tables
-        with a fixed column set. The `exportFieldGroups` field is not
-        applicable.
+        - `LEGACY_TRACES_OBSERVATIONS`: traces, observations, and scores tables.
+        Observation columns are controlled by `exportFieldGroups`; field groups
+        without a counterpart in this data model (e.g. `trace_context`) are
+        omitted.
 
         - `OBSERVATIONS_V2`: same data model as the
         `/api/public/v2/observations` endpoint, plus scores. Columns are
         controlled by `exportFieldGroups`.
 
-        - `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: both sets. For the
-        `OBSERVATIONS_V2` portion, columns are controlled by
-        `exportFieldGroups`.
+        - `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: both sets. Observation
+        columns of both portions are controlled by `exportFieldGroups`.
 
 
         **Note:** `OBSERVATIONS_V2` and the enriched-observations portion of
@@ -7776,8 +7776,10 @@ components:
         - tools
         - trace_context
       description: >-
-        Field group for the OBSERVATIONS_V2 and
-        LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS export.
+        Field group selecting which observation columns are included in the
+        export. Applies to all export sources; groups without a counterpart in
+        the legacy data model (e.g. `trace_context`) are omitted from the legacy
+        observations export.
     CreateBlobStorageIntegrationRequest:
       title: CreateBlobStorageIntegrationRequest
       type: object
@@ -7866,19 +7868,10 @@ components:
             $ref: '#/components/schemas/BlobStorageExportFieldGroup'
           nullable: true
           description: >-
-            Field groups to include in each exported row.
-
-
-            For exportSource `OBSERVATIONS_V2` or
-            `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS`: must include `core` if
-            provided. When omitted on create, the column default (all groups)
-            applies. When omitted on update, the existing value is preserved.
-
-
-            For exportSource `LEGACY_TRACES_OBSERVATIONS`: this field must be
-            omitted or null. Sending an array (including an empty array) returns
-            400, because that source uses a fixed column set and does not honor
-            field groups.
+            Field groups to include in each exported observation row. Applies to
+            all export sources; must include `core` if provided. When omitted on
+            create, the column default (all groups) applies. When omitted on
+            update, the existing value is preserved.
 
 
             `exportFieldGroups` requires `exportSource` to be provided in the
@@ -7939,11 +7932,8 @@ components:
             $ref: '#/components/schemas/BlobStorageExportFieldGroup'
           nullable: true
           description: >-
-            Field groups included in each exported row for `OBSERVATIONS_V2` /
-            `LEGACY_TRACES_AND_ENRICHED_OBSERVATIONS` sources. Always `null`
-            when exportSource is `LEGACY_TRACES_OBSERVATIONS` (the field does
-            not apply to that source; any legacy DB value is hidden from the
-            public surface).
+            Field groups included in each exported observation row. An empty
+            list is treated as all groups during export.
         nextSyncAt:
           type: string
           format: date-time

--- a/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
+++ b/web/src/__tests__/blob-storage-form-field-groups.clienttest.ts
@@ -41,6 +41,8 @@ describe("blob storage form — exportFieldGroups validation", () => {
       AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
       ["basic", "io"],
     ],
+    [AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS, []],
+    [AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS, ["basic", "io"]],
   ] as const)(
     "blocks submission when exportSource is %s and core is absent (groups: %s)",
     async (source, exportFieldGroups) => {
@@ -64,14 +66,14 @@ describe("blob storage form — exportFieldGroups validation", () => {
     },
   );
 
-  it("allows submission when exportSource is TRACES_OBSERVATIONS regardless of exportFieldGroups", async () => {
+  it("allows submission when exportSource is TRACES_OBSERVATIONS and core is included", async () => {
     const { result } = renderHook(() =>
       useForm({
         resolver: zodResolver(blobStorageIntegrationFormSchema),
         defaultValues: {
           ...VALID_BASE,
           exportSource: AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
-          exportFieldGroups: [],
+          exportFieldGroups: ["core", "io"],
         },
       }),
     );

--- a/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-api.servertest.ts
@@ -791,7 +791,7 @@ describe("Blob Storage Integrations API", () => {
 
     // ---- LEGACY_TRACES_OBSERVATIONS path ----
 
-    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups omitted -> 200; GET hides field groups", async () => {
+    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups omitted -> 200; GET returns all 11 groups", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -820,10 +820,12 @@ describe("Blob Storage Integrations API", () => {
       );
       expect(integration).toBeDefined();
       expect(integration?.exportSource).toBe("LEGACY_TRACES_OBSERVATIONS");
-      expect(integration?.exportFieldGroups).toBeNull();
+      expect(integration?.exportFieldGroups).toHaveLength(
+        OBSERVATION_FIELD_GROUPS_FULL.length,
+      );
     });
 
-    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=null -> 200; GET hides field groups", async () => {
+    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=null -> 200; GET returns all 11 groups", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -852,10 +854,12 @@ describe("Blob Storage Integrations API", () => {
         (i) => i.projectId === testProject1Id,
       );
       expect(integration).toBeDefined();
-      expect(integration?.exportFieldGroups).toBeNull();
+      expect(integration?.exportFieldGroups).toHaveLength(
+        OBSERVATION_FIELD_GROUPS_FULL.length,
+      );
     });
 
-    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=[] -> 400 with 'not applicable'", async () => {
+    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=[] (missing core) -> 400", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -871,10 +875,10 @@ describe("Blob Storage Integrations API", () => {
       );
       expect(result.status).toBe(400);
       const message = JSON.stringify(result.body);
-      expect(message.toLowerCase()).toContain("not applicable");
+      expect(message.toLowerCase()).toContain("core");
     });
 
-    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=[core,io] -> 400 with 'not applicable'", async () => {
+    it("LEGACY_TRACES_OBSERVATIONS + exportFieldGroups=[core,io] -> 200 and GET returns same value", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -882,18 +886,23 @@ describe("Blob Storage Integrations API", () => {
         exportFieldGroups: ["core", "io"],
       };
 
-      const result = await makeAPICall(
+      const putResponse = await makeZodVerifiedAPICall(
+        BlobStorageIntegrationResponseSchema,
         "PUT",
         "/api/public/integrations/blob-storage",
         requestBody,
         createBasicAuthHeader(testApiKey, testApiSecretKey),
       );
-      expect(result.status).toBe(400);
-      const message = JSON.stringify(result.body);
-      expect(message.toLowerCase()).toContain("not applicable");
+      expect(putResponse.status).toBe(200);
+      expect(putResponse.body.exportFieldGroups).toStrictEqual(["core", "io"]);
+
+      const saved = await prisma.blobStorageIntegration.findUnique({
+        where: { projectId: testProject1Id },
+      });
+      expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
-    it("GET hides exportFieldGroups for legacy LEGACY_TRACES_OBSERVATIONS rows seeded via Prisma", async () => {
+    it("GET returns exportFieldGroups for LEGACY_TRACES_OBSERVATIONS rows seeded via Prisma", async () => {
       await prisma.blobStorageIntegration.create({
         data: {
           projectId: testProject1Id,
@@ -927,7 +936,11 @@ describe("Blob Storage Integrations API", () => {
       );
       expect(integration).toBeDefined();
       expect(integration?.exportSource).toBe("LEGACY_TRACES_OBSERVATIONS");
-      expect(integration?.exportFieldGroups).toBeNull();
+      expect(integration?.exportFieldGroups).toStrictEqual([
+        "core",
+        "io",
+        "metadata",
+      ]);
     });
 
     it("PUT LEGACY_TRACES_OBSERVATIONS preserves existing export_field_groups column in DB", async () => {
@@ -968,13 +981,13 @@ describe("Blob Storage Integrations API", () => {
         where: { projectId: testProject1Id },
       });
       expect(saved?.bucketName).toBe("updated-bucket");
-      // REST never overwrites export_field_groups for this source.
+      // Omitting exportFieldGroups on update preserves the stored value.
       expect(saved?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
     // ---- Response shape ----
 
-    it("PUT response includes exportSource and exportFieldGroups (null for LEGACY_TRACES_OBSERVATIONS)", async () => {
+    it("PUT response includes exportSource and exportFieldGroups for LEGACY_TRACES_OBSERVATIONS", async () => {
       const requestBody = {
         ...validBlobStorageConfig,
         projectId: testProject1Id,
@@ -993,11 +1006,12 @@ describe("Blob Storage Integrations API", () => {
         "exportSource",
         "LEGACY_TRACES_OBSERVATIONS",
       );
-      expect(response.body).toHaveProperty("exportFieldGroups");
-      expect(response.body.exportFieldGroups).toBeNull();
+      expect(response.body.exportFieldGroups).toHaveLength(
+        OBSERVATION_FIELD_GROUPS_FULL.length,
+      );
     });
 
-    it("GET response includes exportSource always and exportFieldGroups with source-conditional null", async () => {
+    it("GET response includes exportSource and exportFieldGroups for all sources", async () => {
       // Seed two integrations on different projects with different sources
       await prisma.blobStorageIntegration.create({
         data: {
@@ -1054,7 +1068,11 @@ describe("Blob Storage Integrations API", () => {
       expect(legacyIntegration?.exportSource).toBe(
         "LEGACY_TRACES_OBSERVATIONS",
       );
-      expect(legacyIntegration?.exportFieldGroups).toBeNull();
+      expect(legacyIntegration?.exportFieldGroups).toStrictEqual([
+        "core",
+        "io",
+        "metadata",
+      ]);
       expect(enrichedIntegration?.exportSource).toBe("OBSERVATIONS_V2");
       expect(enrichedIntegration?.exportFieldGroups).toStrictEqual([
         "core",

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -468,7 +468,7 @@ describe("Blob Storage Integration tRPC Router", () => {
       ).rejects.toThrow();
     });
 
-    it("accepts empty exportFieldGroups when exportSource is TRACES_OBSERVATIONS", async () => {
+    it("rejects empty exportFieldGroups when exportSource is TRACES_OBSERVATIONS", async () => {
       const { caller, project } = await prepare();
       await prisma.project.update({
         where: { id: project.id },
@@ -482,7 +482,27 @@ describe("Blob Storage Integration tRPC Router", () => {
           exportSource: "TRACES_OBSERVATIONS" as const,
           exportFieldGroups: [],
         }),
-      ).resolves.not.toThrow();
+      ).rejects.toThrow();
+    });
+
+    it("accepts a custom subset including core when exportSource is TRACES_OBSERVATIONS", async () => {
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: PRE_CUTOFF },
+      });
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...baseConfig,
+        exportSource: "TRACES_OBSERVATIONS" as const,
+        exportFieldGroups: ["core", "io"],
+      });
+
+      const result = await caller.blobStorageIntegration.get({
+        projectId: project.id,
+      });
+      expect(result?.exportFieldGroups).toStrictEqual(["core", "io"]);
     });
 
     it("overwrites stored subset when a new subset is submitted", async () => {

--- a/web/src/features/blobstorage-integration/validation.ts
+++ b/web/src/features/blobstorage-integration/validation.ts
@@ -1,17 +1,11 @@
 import type { z } from "zod";
-import { AnalyticsIntegrationExportSource } from "@langfuse/shared";
 
 export function validateExportFieldGroups(
   data: { exportSource: string; exportFieldGroups: unknown[] },
   ctx: z.RefinementCtx,
 ) {
-  const requiresFieldGroups =
-    data.exportSource === AnalyticsIntegrationExportSource.EVENTS ||
-    data.exportSource ===
-      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS;
-
-  if (!requiresFieldGroups) return;
-
+  // Field groups apply to all export sources (legacy observations honor them
+  // too), so core is required regardless of the selected source.
   if (!data.exportFieldGroups.includes("core")) {
     ctx.addIssue({
       code: "custom",

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -130,18 +130,6 @@ export const CreateBlobStorageIntegrationRequest = z
       });
       return;
     }
-    if (
-      data.exportSource === "LEGACY_TRACES_OBSERVATIONS" &&
-      data.exportFieldGroups != null
-    ) {
-      ctx.addIssue({
-        code: "custom",
-        message:
-          "exportFieldGroups is not applicable when exportSource is LEGACY_TRACES_OBSERVATIONS",
-        path: ["exportFieldGroups"],
-      });
-      return;
-    }
     if (data.exportFieldGroups != null && data.exportSource != null) {
       validateExportFieldGroups(
         {

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -11,7 +11,6 @@ import {
   type BlobStorageIntegrationResponseType,
 } from "@/src/features/public-api/types/blob-storage-integrations";
 import {
-  AnalyticsIntegrationExportSource,
   type ObservationFieldGroupFull,
   LangfuseNotFoundError,
   UnauthorizedError,
@@ -96,10 +95,7 @@ async function handleGetBlobStorageIntegrations(
       compressed: integration.compressed,
       exportSource: toPublicExportSource(integration.exportSource),
       exportFieldGroups:
-        integration.exportSource ===
-        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
-          ? null
-          : (integration.exportFieldGroups as ObservationFieldGroupFull[]),
+        integration.exportFieldGroups as ObservationFieldGroupFull[],
       nextSyncAt: integration.nextSyncAt,
       lastSyncAt: integration.lastSyncAt,
       lastError: integration.lastError,
@@ -232,10 +228,7 @@ async function handleUpsertBlobStorageIntegration(
     compressed: integration.compressed,
     exportSource: toPublicExportSource(integration.exportSource),
     exportFieldGroups:
-      integration.exportSource ===
-      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS
-        ? null
-        : (integration.exportFieldGroups as ObservationFieldGroupFull[]),
+      integration.exportFieldGroups as ObservationFieldGroupFull[],
     nextSyncAt: integration.nextSyncAt,
     lastSyncAt: integration.lastSyncAt,
     lastError: integration.lastError,

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -329,6 +329,13 @@ const BlobStorageIntegrationSettingsForm = ({
   const isLegacyOnlyExport =
     watchedExportSource ===
     AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
+  // Traces and legacy observations are only exported for the legacy and mixed
+  // sources; an EVENTS-only export produces scores and enriched observations.
+  const includesLegacyExport =
+    watchedExportSource ===
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS ||
+    watchedExportSource ===
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS;
 
   const utils = api.useUtils();
   const mut = api.blobStorageIntegration.update.useMutation({
@@ -758,13 +765,13 @@ const BlobStorageIntegrationSettingsForm = ({
             <FormItem>
               <FormLabel>Export Field Groups</FormLabel>
               <FormDescription>
-                Choose which field groups to include in the observation exports
-                (legacy observations and enriched observations). Deselect large
-                groups (e.g. Input / Output) to reduce export size, or
-                privacy-sensitive groups (e.g. Metadata) to avoid storing user
-                data. Traces and scores are always exported in full. Fields that
-                only exist on the enriched observations (e.g. Trace Context) are
-                omitted from the legacy observations export.
+                Choose which field groups to include in the observation exports.
+                Deselect large groups (e.g. Input / Output) to reduce export
+                size, or privacy-sensitive groups (e.g. Metadata) to avoid
+                storing user data.
+                {includesLegacyExport
+                  ? " Traces and scores are always exported in full. Fields that only exist on the enriched observations (e.g. Trace Context) are omitted from the legacy observations export."
+                  : " Scores are always exported in full."}
               </FormDescription>
               <div className="mt-2 space-y-2">
                 {EXPORT_FIELD_GROUP_OPTIONS.map((option) => {

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -323,6 +323,12 @@ const BlobStorageIntegrationSettingsForm = ({
   }, [state]);
 
   const watchedExportMode = blobStorageForm.watch("exportMode");
+  const watchedExportSource = blobStorageForm.watch("exportSource");
+  // The legacy observations table contains fewer columns than the enriched
+  // observations, so the per-group field lists differ for legacy-only exports.
+  const isLegacyOnlyExport =
+    watchedExportSource ===
+    AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
 
   const utils = api.useUtils();
   const mut = api.blobStorageIntegration.update.useMutation({
@@ -806,7 +812,9 @@ const BlobStorageIntegrationSettingsForm = ({
                           )}
                         </div>
                         <div className="text-muted-foreground text-xs">
-                          {option.description}
+                          {isLegacyOnlyExport
+                            ? option.legacyDescription
+                            : option.description}
                         </div>
                       </label>
                     </div>

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -276,10 +276,11 @@ const BlobStorageIntegrationSettingsForm = ({
           (eventsExportAvailable
             ? AnalyticsIntegrationExportSource.EVENTS
             : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
-      exportFieldGroups:
-        (state?.exportFieldGroups as ObservationFieldGroupFull[]) ?? [
-          ...OBSERVATION_FIELD_GROUPS_FULL,
-        ],
+      // Empty array in the DB means "export everything" (the worker falls back
+      // to all groups), so surface it as the full selection in the form.
+      exportFieldGroups: state?.exportFieldGroups?.length
+        ? (state.exportFieldGroups as ObservationFieldGroupFull[])
+        : [...OBSERVATION_FIELD_GROUPS_FULL],
       compressed: state?.compressed ?? true,
     },
     disabled: isLoading,
@@ -311,16 +312,16 @@ const BlobStorageIntegrationSettingsForm = ({
           (eventsExportAvailable
             ? AnalyticsIntegrationExportSource.EVENTS
             : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS),
-      exportFieldGroups:
-        (state?.exportFieldGroups as ObservationFieldGroupFull[]) ?? [
-          ...OBSERVATION_FIELD_GROUPS_FULL,
-        ],
+      // Empty array in the DB means "export everything" (the worker falls back
+      // to all groups), so surface it as the full selection in the form.
+      exportFieldGroups: state?.exportFieldGroups?.length
+        ? (state.exportFieldGroups as ObservationFieldGroupFull[])
+        : [...OBSERVATION_FIELD_GROUPS_FULL],
       compressed: state?.compressed ?? true,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
 
-  const watchedExportSource = blobStorageForm.watch("exportSource");
   const watchedExportMode = blobStorageForm.watch("exportMode");
 
   const utils = api.useUtils();
@@ -744,94 +745,80 @@ const BlobStorageIntegrationSettingsForm = ({
           />
         )}
 
-        {eventsExportAvailable &&
-          (watchedExportSource === AnalyticsIntegrationExportSource.EVENTS ||
-            watchedExportSource ===
-              AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS) && (
-            <FormField
-              control={blobStorageForm.control}
-              name="exportFieldGroups"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Export Field Groups</FormLabel>
-                  <FormDescription>
-                    Choose which field groups to include in the enriched
-                    observations export. Deselect large groups (e.g. Input /
-                    Output) to reduce export size, or privacy-sensitive groups
-                    (e.g. Metadata) to avoid storing user data. Scores are
-                    always exported.
-                    {watchedExportSource ===
-                      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS &&
-                      " Traces and legacy observations are also exported in full."}
-                  </FormDescription>
-                  <div className="mt-2 space-y-2">
-                    {EXPORT_FIELD_GROUP_OPTIONS.map((option) => {
-                      const isCore = option.value === "core";
-                      return (
-                        <div
-                          key={option.value}
-                          className="flex items-start gap-2"
-                        >
-                          <Checkbox
-                            id={`field-group-${option.value}`}
-                            checked={
-                              isCore
-                                ? true
-                                : (field.value ?? []).includes(option.value)
-                            }
-                            disabled={isCore}
-                            onCheckedChange={
-                              isCore
-                                ? undefined
-                                : (checked) => {
-                                    const current = field.value ?? [];
-                                    const next =
-                                      checked === true
-                                        ? current.includes(option.value)
-                                          ? current
-                                          : [...current, option.value]
-                                        : current.filter(
-                                            (v: ObservationFieldGroupFull) =>
-                                              v !== option.value,
-                                          );
-                                    field.onChange(next);
-                                  }
-                            }
-                          />
-                          <label
-                            htmlFor={`field-group-${option.value}`}
-                            className={
-                              isCore
-                                ? "space-y-0.5"
-                                : "cursor-pointer space-y-0.5"
-                            }
-                          >
-                            <div className="text-sm leading-none font-medium">
-                              {option.label}
-                              {isCore && (
-                                <span className="text-muted-foreground ml-1 font-normal">
-                                  (required)
-                                </span>
-                              )}
-                            </div>
-                            <div className="text-muted-foreground text-xs">
-                              {option.description}
-                            </div>
-                          </label>
+        <FormField
+          control={blobStorageForm.control}
+          name="exportFieldGroups"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Export Field Groups</FormLabel>
+              <FormDescription>
+                Choose which field groups to include in the observation exports
+                (legacy observations and enriched observations). Deselect large
+                groups (e.g. Input / Output) to reduce export size, or
+                privacy-sensitive groups (e.g. Metadata) to avoid storing user
+                data. Traces and scores are always exported in full. Fields that
+                only exist on the enriched observations (e.g. Trace Context) are
+                omitted from the legacy observations export.
+              </FormDescription>
+              <div className="mt-2 space-y-2">
+                {EXPORT_FIELD_GROUP_OPTIONS.map((option) => {
+                  const isCore = option.value === "core";
+                  return (
+                    <div key={option.value} className="flex items-start gap-2">
+                      <Checkbox
+                        id={`field-group-${option.value}`}
+                        checked={
+                          isCore
+                            ? true
+                            : (field.value ?? []).includes(option.value)
+                        }
+                        disabled={isCore}
+                        onCheckedChange={
+                          isCore
+                            ? undefined
+                            : (checked) => {
+                                const current = field.value ?? [];
+                                const next =
+                                  checked === true
+                                    ? current.includes(option.value)
+                                      ? current
+                                      : [...current, option.value]
+                                    : current.filter(
+                                        (v: ObservationFieldGroupFull) =>
+                                          v !== option.value,
+                                      );
+                                field.onChange(next);
+                              }
+                        }
+                      />
+                      <label
+                        htmlFor={`field-group-${option.value}`}
+                        className={
+                          isCore ? "space-y-0.5" : "cursor-pointer space-y-0.5"
+                        }
+                      >
+                        <div className="text-sm leading-none font-medium">
+                          {option.label}
+                          {isCore && (
+                            <span className="text-muted-foreground ml-1 font-normal">
+                              (required)
+                            </span>
+                          )}
                         </div>
-                      );
-                    })}
-                  </div>
-                  <FormMessage>
-                    {
-                      blobStorageForm.formState.errors.exportFieldGroups
-                        ?.message
-                    }
-                  </FormMessage>
-                </FormItem>
-              )}
-            />
+                        <div className="text-muted-foreground text-xs">
+                          {option.description}
+                        </div>
+                      </label>
+                    </div>
+                  );
+                })}
+              </div>
+              <FormMessage>
+                {blobStorageForm.formState.errors.exportFieldGroups?.message}
+              </FormMessage>
+            </FormItem>
           )}
+        />
 
         {watchedExportMode === BlobStorageExportMode.FROM_CUSTOM_DATE && (
           <FormField

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -753,6 +753,90 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     });
   });
 
+  describe("legacy observations export field groups", () => {
+    it("should exclude columns for deselected exportFieldGroups in the legacy observations export", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+      const now = new Date();
+      const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+      const dataTime = now.getTime() - 90 * 60 * 1000;
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId: minioAccessKeyId,
+          secretAccessKey: encrypt(minioAccessKeySecret),
+          region: region ? region : "auto",
+          endpoint: minioEndpoint,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "hourly",
+          exportSource: "TRACES_OBSERVATIONS",
+          exportFieldGroups: ["core", "io"],
+          nextSyncAt: twoHoursAgo,
+          lastSyncAt: twoHoursAgo,
+          compressed: false,
+          fileType: BlobStorageIntegrationFileType.JSONL,
+        },
+      });
+
+      const traceId = randomUUID();
+      await createObservationsCh([
+        createObservation({
+          id: randomUUID(),
+          trace_id: traceId,
+          project_id: projectId,
+          start_time: dataTime,
+          end_time: dataTime + 5000,
+          name: "Legacy Observation",
+          metadata: { secret: "should-not-appear" },
+          usage_details: { input: 100, output: 200, total: 300 },
+        }),
+      ]);
+
+      await handleBlobStorageIntegrationProjectJob({
+        data: { payload: { projectId } },
+      } as Job);
+
+      const files = await s3StorageService.listFiles(s3Prefix);
+      const observationFile = files.find((f) =>
+        f.file.includes("/observations/"),
+      );
+      expect(observationFile).toBeDefined();
+
+      if (observationFile) {
+        const content = await s3StorageService.download(observationFile.file);
+        const row = JSON.parse(content.trim().split("\n")[0]);
+
+        // core + io fields should be present
+        expect(row).toHaveProperty("id");
+        expect(row).toHaveProperty("trace_id");
+        expect(row).toHaveProperty("input");
+        expect(row).toHaveProperty("output");
+
+        // metadata group not selected → must not leak
+        expect(row).not.toHaveProperty("metadata");
+
+        // metrics group not selected → computed fields must not appear
+        expect(row).not.toHaveProperty("latency");
+        expect(row).not.toHaveProperty("time_to_first_token");
+
+        // model group not selected → no model id or pricing enrichment
+        expect(row).not.toHaveProperty("model_id");
+        expect(row).not.toHaveProperty("input_price");
+
+        // other non-selected groups must not appear
+        expect(row).not.toHaveProperty("name");
+        expect(row).not.toHaveProperty("level");
+        expect(row).not.toHaveProperty("usage_details");
+      }
+    });
+  });
+
   describe("BlobStorageExportMode minTimestamp behavior", () => {
     maybeIt(
       "should export old data for FULL_HISTORY mode when data exists",

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -277,10 +277,12 @@ const processBlobStorageExport = async (config: {
             config.projectId,
             config.minTimestamp,
             config.maxTimestamp,
+            exportFieldGroups,
           ),
           config.projectId,
           "model_id",
           false, // v3 query already returns latency in seconds
+          exportFieldGroups,
         );
         break;
       case "scores":


### PR DESCRIPTION
## What does this PR do?

Extends the blob storage export field-group selection to the legacy observations table. Previously, `exportFieldGroups` only controlled the enriched observations (events) export; the legacy `observations` export always shipped all columns.

- `getObservationsForBlobStorageExport` now accepts the configured field groups and only selects the matching columns (`core` is always included; column order of the full export is unchanged). Groups without a counterpart in the legacy table (`trace_context`) are omitted.
- The worker passes `exportFieldGroups` through for the `observations` table and into the enrichment stream, so model-pricing enrichment is skipped when the `model` group is deselected — consistent with the events path.
- The settings UI shows the "Export Field Groups" selection for all export sources (previously only for events-based sources), with updated copy. Stored empty arrays are surfaced as the full selection, matching the worker's "empty means everything" fallback.
- The public REST API accepts `exportFieldGroups` for `LEGACY_TRACES_OBSERVATIONS` (previously rejected with 400) and returns the stored value in GET/PUT responses instead of `null`. The `core`-required validation now applies to all sources. This is a relaxation only; no wire types changed.
- Fern definition updated and OpenAPI spec regenerated.

Tests: new worker test asserting deselected groups are excluded from the legacy observations export file; client form validation tests extended; tRPC/REST server tests updated to the new legacy-source behavior.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
