### PR TITLE
feat(agent): Persist feedback buttons

### DIFF
--- a/packages/shared/prisma/migrations/20260610120000_add_in_app_agent_message_feedback/migration.sql
+++ b/packages/shared/prisma/migrations/20260610120000_add_in_app_agent_message_feedback/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "in_app_agent_run_feedback" (
+    "id" TEXT NOT NULL,
+    "project_id" TEXT NOT NULL,
+    "conversation_id" TEXT NOT NULL,
+    "message_id" TEXT NOT NULL,
+    "created_by_user_id" TEXT,
+    "value" BOOLEAN NOT NULL,
+    "comment" VARCHAR(500),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "in_app_agent_run_feedback_pkey" PRIMARY KEY ("id", "project_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "in_app_agent_run_feedback_project_conversation_message_user_key" ON "in_app_agent_run_feedback"("project_id", "conversation_id", "message_id", "created_by_user_id");
+
+-- CreateIndex
+CREATE INDEX "in_app_agent_run_feedback_project_conversation_idx" ON "in_app_agent_run_feedback"("project_id", "conversation_id");
+
+-- AddForeignKey
+ALTER TABLE "in_app_agent_run_feedback" ADD CONSTRAINT "in_app_agent_run_feedback_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "in_app_agent_run_feedback" ADD CONSTRAINT "in_app_agent_run_feedback_conversation_id_project_id_fkey" FOREIGN KEY ("conversation_id", "project_id") REFERENCES "in_app_agent_conversations"("id", "project_id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "in_app_agent_run_feedback" ADD CONSTRAINT "in_app_agent_run_feedback_created_by_user_id_fkey" FOREIGN KEY ("created_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -79,6 +79,7 @@ model User {
   defaultViews              DefaultView[]               @relation("DefaultViewUser")
   inAppAgentConversations   InAppAgentConversation[]    @relation("InAppAgentConversationCreatedByUser")
   inAppAgentRuns            InAppAgentRun[]             @relation("InAppAgentRunTriggeredByUser")
+  inAppAgentRunFeedback     InAppAgentRunFeedback[]     @relation("InAppAgentRunFeedbackCreatedByUser")
 
   @@map("users")
 }
@@ -175,6 +176,7 @@ model Project {
   InAppAgentConversation    InAppAgentConversation[]
   InAppAgentEvent           InAppAgentEvent[]
   InAppAgentRun             InAppAgentRun[]
+  InAppAgentRunFeedback     InAppAgentRunFeedback[]
 
   @@index([orgId])
   @@map("projects")
@@ -228,8 +230,9 @@ model InAppAgentConversation {
   createdAt         DateTime                              @default(now()) @map("created_at")
   updatedAt         DateTime                              @default(now()) @updatedAt @map("updated_at")
 
-  events InAppAgentEvent[]
-  runs   InAppAgentRun[]
+  events   InAppAgentEvent[]
+  runs     InAppAgentRun[]
+  feedback InAppAgentRunFeedback[]
 
   @@id([id, projectId])
   @@index([projectId, createdByUserId, deletedAt, updatedAt, id], map: "in_app_agent_conversations_project_user_list_idx")
@@ -274,6 +277,26 @@ model InAppAgentRun {
   @@id([id, projectId])
   @@index([projectId, conversationId, createdAt], map: "in_app_agent_runs_project_conversation_created_idx")
   @@map("in_app_agent_runs")
+}
+
+model InAppAgentRunFeedback {
+  id              String
+  projectId       String                 @map("project_id")
+  project         Project                @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  conversationId  String                 @map("conversation_id")
+  conversation    InAppAgentConversation @relation(fields: [conversationId, projectId], references: [id, projectId], onDelete: Cascade)
+  messageId       String                 @map("message_id")
+  createdByUserId String?                @map("created_by_user_id")
+  createdByUser   User?                  @relation("InAppAgentRunFeedbackCreatedByUser", fields: [createdByUserId], references: [id], onDelete: SetNull)
+  value           Boolean
+  comment         String?                @db.VarChar(500)
+  createdAt       DateTime               @default(now()) @map("created_at")
+  updatedAt       DateTime               @default(now()) @updatedAt @map("updated_at")
+
+  @@id([id, projectId])
+  @@unique([projectId, conversationId, messageId, createdByUserId], map: "in_app_agent_run_feedback_project_conversation_message_user_key")
+  @@index([projectId, conversationId], map: "in_app_agent_run_feedback_project_conversation_idx")
+  @@map("in_app_agent_run_feedback")
 }
 
 model BackgroundMigration {

--- a/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
@@ -4,7 +4,10 @@ import { randomUUID } from "crypto";
 
 import type { Plan } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
-import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
+import {
+  createOrgProjectAndApiKey,
+  getScoreById,
+} from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
 import {
   createInAppAgentConversationId,
@@ -23,9 +26,11 @@ import {
 } from "@/src/ee/features/in-app-agent/server/persistence";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
+import waitForExpect from "wait-for-expect";
 
 describe("in-app agent persistence", () => {
   const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+  const originalAiFeaturesProjectId = env.LANGFUSE_AI_FEATURES_PROJECT_ID;
 
   beforeEach(() => {
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "DEV";
@@ -33,6 +38,7 @@ describe("in-app agent persistence", () => {
 
   afterEach(() => {
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+    (env as any).LANGFUSE_AI_FEATURES_PROJECT_ID = originalAiFeaturesProjectId;
   });
 
   const createCaller = async (
@@ -43,7 +49,7 @@ describe("in-app agent persistence", () => {
 
     await prisma.organization.update({
       where: { id: setup.orgId },
-      data: { aiFeaturesEnabled: true },
+      data: { aiFeaturesEnabled: true, aiTelemetryEnabled: true },
     });
 
     await prisma.user.create({
@@ -246,6 +252,43 @@ describe("in-app agent persistence", () => {
     });
   };
 
+  const createPersistedAssistantMessage = async (params: {
+    projectId: string;
+    userId: string;
+    userMessageId: string;
+    userContent: string;
+    assistantMessageId: string;
+    assistantChunks: string[];
+  }) => {
+    const conversation = await createConversation({
+      projectId: params.projectId,
+      userId: params.userId,
+    });
+    const run = await createConversationRun({
+      projectId: params.projectId,
+      conversationId: conversation.id,
+      userId: params.userId,
+    });
+    const events = await startCompactRun({
+      projectId: params.projectId,
+      conversationId: conversation.id,
+      runId: run.id,
+      messageId: params.userMessageId,
+      content: params.userContent,
+    });
+    await appendAssistantText({
+      projectId: params.projectId,
+      conversationId: conversation.id,
+      runId: run.id,
+      events,
+      messageId: params.assistantMessageId,
+      chunks: params.assistantChunks,
+    });
+    await finishRun({ prisma, runId: run.id, projectId: params.projectId });
+
+    return { conversation, run };
+  };
+
   it("stores compacted events and restores multi-turn messages", async () => {
     const { caller, projectId, userId } = await createCaller();
     const conversation = await createConversation({ projectId, userId });
@@ -426,7 +469,210 @@ describe("in-app agent persistence", () => {
     );
   });
 
-  it("requires feedback run ids to match persisted assistant messages", async () => {
+  it("stores feedback, hydrates it on conversation load, and attaches a score to the agent run observation", async () => {
+    const scoreProjectId = `in-app-agent-feedback-${randomUUID()}`;
+    (env as any).LANGFUSE_AI_FEATURES_PROJECT_ID = scoreProjectId;
+
+    const { caller, projectId, userId } = await createCaller();
+    const { conversation, run } = await createPersistedAssistantMessage({
+      projectId,
+      userId,
+      userMessageId: "user-message-feedback",
+      userContent: "Can you summarize this?",
+      assistantMessageId: "assistant-message-feedback",
+      assistantChunks: ["Here is the summary."],
+    });
+
+    const created = await caller.submitFeedback({
+      projectId,
+      conversationId: conversation.id,
+      messageId: "assistant-message-feedback",
+      value: "thumbs_down",
+      comment: "Missed the main point",
+    });
+    const expectedObservationId = run.id;
+    const expectedScoreId = `afbs_assistant-message-feedback_${userId}`;
+
+    expect(created.feedback).toMatchObject({
+      value: "thumbs_down",
+      comment: "Missed the main point",
+    });
+
+    const storedFeedback = await prisma.inAppAgentRunFeedback.findMany({
+      where: { projectId, conversationId: conversation.id },
+    });
+    expect(storedFeedback).toHaveLength(1);
+    expect(storedFeedback[0]).toMatchObject({
+      projectId,
+      conversationId: conversation.id,
+      messageId: "assistant-message-feedback",
+      createdByUserId: userId,
+      value: false,
+      comment: "Missed the main point",
+    });
+
+    const restored = await caller.getConversation({
+      projectId,
+      conversationId: conversation.id,
+    });
+    expect(restored.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "assistant-message-feedback",
+          role: "assistant",
+          feedback: expect.objectContaining({
+            value: "thumbs_down",
+            comment: "Missed the main point",
+          }),
+        }),
+      ]),
+    );
+
+    await waitForExpect(async () => {
+      const score = await getScoreById({
+        projectId: scoreProjectId,
+        scoreId: expectedScoreId,
+      });
+      expect(score).toMatchObject({
+        id: expectedScoreId,
+        projectId: scoreProjectId,
+        traceId: conversation.id,
+        observationId: expectedObservationId,
+        name: "in_app_agent_feedback",
+        value: 0,
+        source: "ANNOTATION",
+        comment: "Missed the main point",
+      });
+    });
+
+    const updated = await caller.submitFeedback({
+      projectId,
+      conversationId: conversation.id,
+      messageId: "assistant-message-feedback",
+      value: "thumbs_up",
+      comment: "   ",
+    });
+    expect(updated.feedback).toMatchObject({
+      value: "thumbs_up",
+      comment: null,
+    });
+
+    const updatedFeedback = await prisma.inAppAgentRunFeedback.findMany({
+      where: { projectId, conversationId: conversation.id },
+    });
+    expect(updatedFeedback).toHaveLength(1);
+    expect(updatedFeedback[0]).toMatchObject({
+      value: true,
+      comment: null,
+    });
+  });
+
+  it("deletes persisted feedback when feedback value is cleared", async () => {
+    (env as any).LANGFUSE_AI_FEATURES_PROJECT_ID =
+      `in-app-agent-feedback-clear-${randomUUID()}`;
+
+    const { caller, projectId, userId } = await createCaller();
+    const { conversation } = await createPersistedAssistantMessage({
+      projectId,
+      userId,
+      userMessageId: "user-message-feedback-clear",
+      userContent: "Can you summarize this?",
+      assistantMessageId: "assistant-message-feedback-clear",
+      assistantChunks: ["Here is the summary."],
+    });
+
+    await caller.submitFeedback({
+      projectId,
+      conversationId: conversation.id,
+      messageId: "assistant-message-feedback-clear",
+      value: "thumbs_up",
+      comment: "Helpful",
+    });
+
+    await expect(
+      prisma.inAppAgentRunFeedback.findMany({
+        where: { projectId, conversationId: conversation.id },
+      }),
+    ).resolves.toHaveLength(1);
+
+    await expect(
+      caller.submitFeedback({
+        projectId,
+        conversationId: conversation.id,
+        messageId: "assistant-message-feedback-clear",
+        value: null,
+      }),
+    ).resolves.toEqual({ feedback: null });
+
+    await expect(
+      prisma.inAppAgentRunFeedback.findMany({
+        where: { projectId, conversationId: conversation.id },
+      }),
+    ).resolves.toEqual([]);
+
+    const restored = await caller.getConversation({
+      projectId,
+      conversationId: conversation.id,
+    });
+    const restoredMessage = restored.messages.find(
+      (message) => message.id === "assistant-message-feedback-clear",
+    );
+    expect(restoredMessage).toMatchObject({
+      id: "assistant-message-feedback-clear",
+      role: "assistant",
+    });
+    expect(restoredMessage).not.toHaveProperty("feedback");
+  });
+
+  it("rejects feedback when AI telemetry is disabled", async () => {
+    const scoreProjectId = `in-app-agent-feedback-disabled-${randomUUID()}`;
+    (env as any).LANGFUSE_AI_FEATURES_PROJECT_ID = scoreProjectId;
+
+    const { caller, orgId, projectId, userId } = await createCaller();
+    await prisma.organization.update({
+      where: { id: orgId },
+      data: { aiTelemetryEnabled: false },
+    });
+
+    const { conversation } = await createPersistedAssistantMessage({
+      projectId,
+      userId,
+      userMessageId: "user-message-feedback-no-telemetry",
+      userContent: "Can you summarize this without telemetry?",
+      assistantMessageId: "assistant-message-feedback-no-telemetry",
+      assistantChunks: ["Here is the private summary."],
+    });
+
+    await expect(
+      caller.submitFeedback({
+        projectId,
+        conversationId: conversation.id,
+        messageId: "assistant-message-feedback-no-telemetry",
+        value: "thumbs_down",
+        comment: "Do not export this comment",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "Assistant feedback is not enabled",
+    });
+    const expectedScoreId = `afbs_assistant-message-feedback-no-telemetry_${userId}`;
+
+    const storedFeedback = await prisma.inAppAgentRunFeedback.findMany({
+      where: { projectId, conversationId: conversation.id },
+    });
+    expect(storedFeedback).toHaveLength(0);
+
+    const score = await getScoreById({
+      projectId: scoreProjectId,
+      scoreId: expectedScoreId,
+    });
+    expect(score).toBeUndefined();
+  });
+
+  it("rejects feedback for non-assistant text messages", async () => {
+    (env as any).LANGFUSE_AI_FEATURES_PROJECT_ID =
+      `in-app-agent-feedback-rejected-${randomUUID()}`;
+
     const { caller, projectId, userId } = await createCaller();
     const conversation = await createConversation({ projectId, userId });
     const run = await createConversationRun({
@@ -434,45 +680,25 @@ describe("in-app agent persistence", () => {
       conversationId: conversation.id,
       userId,
     });
-    const events = await startCompactRun({
+    await startCompactRun({
       projectId,
       conversationId: conversation.id,
       runId: run.id,
-      messageId: "feedback-user",
-      content: "Answer me",
-    });
-    await appendAssistantText({
-      projectId,
-      conversationId: conversation.id,
-      runId: run.id,
-      events,
-      messageId: "feedback-assistant",
-      chunks: ["Here is an answer"],
+      messageId: "user-message-feedback-rejected",
+      content: "This is a user message",
     });
 
     await expect(
       caller.submitFeedback({
         projectId,
         conversationId: conversation.id,
-        messageId: "feedback-assistant",
-        runId: createInAppAgentRunId(),
-        value: null,
-        comment: null,
+        messageId: "user-message-feedback-rejected",
+        value: "thumbs_up",
       }),
-    ).rejects.toThrow(
-      "Feedback can only be submitted for persisted assistant messages",
-    );
-
-    await expect(
-      caller.submitFeedback({
-        projectId,
-        conversationId: conversation.id,
-        messageId: "feedback-assistant",
-        runId: run.id,
-        value: null,
-        comment: null,
-      }),
-    ).resolves.toEqual({ feedback: null });
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Feedback can only be submitted for assistant text messages",
+    });
   });
 
   it("does not reduce partial assistant content before the end event", async () => {

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -34,6 +34,7 @@ export const InAppAiAgentButton = () => {
   const hasInAppAgentEntitlement = useHasEntitlement("in-app-agent");
   const isInAppAgentEnabled =
     session.data?.user?.featureFlags.inAppAgent === true;
+  const isFeedbackEnabled = organization?.aiTelemetryEnabled === true;
   const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
   const buttonRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -130,6 +131,7 @@ export const InAppAiAgentButton = () => {
               {({ isHeaderDragHandleEnabled }) => (
                 <ControlledInAppAgentWindow
                   isHeaderDragHandleEnabled={isHeaderDragHandleEnabled}
+                  isFeedbackEnabled={isFeedbackEnabled}
                   zIndex={IN_APP_AI_AGENT_WINDOW_Z_INDEX}
                   isExpanded={isExpanded}
                   onExpandedChange={(nextIsExpanded) => {

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -7,6 +7,7 @@ import { getDrawerMessages } from "./utils/utils";
 
 type ControlledInAppAgentWindowBaseProps = {
   isHeaderDragHandleEnabled?: boolean;
+  isFeedbackEnabled: boolean;
   zIndex?: number;
   isExpanded: boolean;
   onExpandedChange: (isExpanded: boolean) => void;
@@ -60,6 +61,7 @@ export function ControlledInAppAgentWindow(
       error={error}
       isHeaderDragHandleEnabled={props.isHeaderDragHandleEnabled}
       isExpanded={props.isExpanded}
+      isFeedbackEnabled={props.isFeedbackEnabled}
       isInputDisabled={isInputDisabled}
       messages={drawerMessages}
       conversations={conversations}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -26,8 +26,8 @@ import {
   type ReactNode,
 } from "react";
 import type {
-  InAppAgentMessageFeedback,
-  InAppAgentMessageFeedbackValue,
+  InAppAgentRunFeedback,
+  InAppAgentRunFeedbackValue,
   InAppAgentMessageSource,
 } from "@/src/ee/features/in-app-agent/schema";
 import {
@@ -55,7 +55,7 @@ export type InAppAgentMessageContent =
   | {
       type: "text";
       text: string;
-      feedback?: InAppAgentMessageFeedback;
+      feedback?: InAppAgentRunFeedback;
       redirectAction?: InAppAgentRedirectActionContent;
       sources?: InAppAgentMessageSource[];
     }
@@ -149,7 +149,7 @@ export type InAppAgentMessageProps = {
   isFeedbackDisabled?: boolean;
   windowZIndex?: number;
   onSubmitFeedback?: (params: {
-    value: InAppAgentMessageFeedbackValue | null;
+    value: InAppAgentRunFeedbackValue | null;
     comment?: string | null;
   }) => Promise<void>;
 };
@@ -257,7 +257,7 @@ function AssistantMessageWithFeedback({
   isFeedbackDisabled: boolean;
   windowZIndex?: number;
   onSubmitFeedback?: (params: {
-    value: InAppAgentMessageFeedbackValue | null;
+    value: InAppAgentRunFeedbackValue | null;
     comment?: string | null;
   }) => Promise<void>;
 }) {
@@ -317,12 +317,12 @@ function MessageFeedbackControls({
   windowZIndex,
   onSubmitFeedback,
 }: {
-  feedback?: InAppAgentMessageFeedback;
+  feedback?: InAppAgentRunFeedback;
   isCompact: boolean;
   isFeedbackDisabled: boolean;
   windowZIndex?: number;
   onSubmitFeedback: (params: {
-    value: InAppAgentMessageFeedbackValue | null;
+    value: InAppAgentRunFeedbackValue | null;
     comment?: string | null;
   }) => Promise<void>;
 }) {
@@ -337,7 +337,7 @@ function MessageFeedbackControls({
 
   const [submitFeedback, isSubmittingFeedback] = useWatchedPromiseCallback(
     async (
-      value: InAppAgentMessageFeedbackValue | null,
+      value: InAppAgentRunFeedbackValue | null,
       nextComment: string = committedComment,
     ) => {
       await onSubmitFeedback({
@@ -373,7 +373,7 @@ function MessageFeedbackControls({
     await submitComment().catch(() => undefined);
   };
 
-  const handleSelectFeedback = (value: InAppAgentMessageFeedbackValue) => {
+  const handleSelectFeedback = (value: InAppAgentRunFeedbackValue) => {
     if (selectedValue === value) {
       submitFeedback(null, "")
         .then(() => {

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -426,6 +426,7 @@ const meta = preview.meta({
   args: {
     error: null,
     isExpanded: false,
+    isFeedbackEnabled: true,
     isInputDisabled: false,
     conversations,
     hasMoreConversations: false,

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -30,7 +30,7 @@ import {
   type InAppAgentMessageContent,
   type InAppAgentMessageRole,
 } from "./InAppAgentMessage";
-import type { InAppAgentMessageFeedbackValue } from "@/src/ee/features/in-app-agent/schema";
+import type { InAppAgentRunFeedbackValue } from "@/src/ee/features/in-app-agent/schema";
 
 const AUTO_SCROLL_THRESHOLD_PX = 50;
 const SCROLL_DIRECTION_TOLERANCE_PX = 1;
@@ -90,6 +90,7 @@ export type InAppAgentWindowProps = {
   hasMoreConversations: boolean;
   isHeaderDragHandleEnabled?: boolean;
   isExpanded: boolean;
+  isFeedbackEnabled: boolean;
   isInputDisabled: boolean;
   isLoadingMoreConversations: boolean;
   messages: InAppAgentWindowMessage[];
@@ -100,8 +101,7 @@ export type InAppAgentWindowProps = {
   onSubmit: (input: string) => boolean | Promise<boolean>;
   onSubmitFeedback: (params: {
     messageId: string;
-    runId: string;
-    value: InAppAgentMessageFeedbackValue | null;
+    value: InAppAgentRunFeedbackValue | null;
     comment?: string | null;
   }) => Promise<void>;
   selectedConversationId: string | undefined;
@@ -115,6 +115,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     hasMoreConversations,
     isHeaderDragHandleEnabled = false,
     isExpanded,
+    isFeedbackEnabled,
     isInputDisabled,
     isLoadingMoreConversations,
     messages,
@@ -406,12 +407,11 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 const isLastMessageOfTurn = messages
                   .slice(index + 1, nextTurnStartIndex)
                   .every((nextMessage) => nextMessage.role !== "assistant");
-                const feedbackRunId =
+                const canSubmitFeedback =
                   message.role === "assistant" &&
                   message.content.type === "text" &&
-                  isLastMessageOfTurn
-                    ? message.runId
-                    : undefined;
+                  isLastMessageOfTurn &&
+                  Boolean(message.runId);
 
                 return (
                   <li
@@ -429,11 +429,10 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                       isFeedbackDisabled={isInputDisabled}
                       windowZIndex={zIndex}
                       onSubmitFeedback={
-                        feedbackRunId
+                        isFeedbackEnabled && canSubmitFeedback
                           ? (params) =>
                               onSubmitFeedback({
                                 messageId: message.id,
-                                runId: feedbackRunId,
                                 ...params,
                               })
                           : undefined

--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -22,8 +22,7 @@ import {
 import {
   AgUiMessageSchema,
   type AgUiMessage,
-  type InAppAgentMessageFeedback,
-  type InAppAgentMessageFeedbackValue,
+  type InAppAgentRunFeedbackValue,
   type InAppAgentRuntimeState,
 } from "@/src/ee/features/in-app-agent/schema";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
@@ -34,7 +33,6 @@ import { createInAppAgentScreenContext } from "@/src/ee/features/in-app-agent/co
 const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
 const OPEN_STORAGE_KEY_PREFIX = "langfuse:in-app-ai-agent-open";
-const FEEDBACK_STORAGE_KEY_PREFIX = "langfuse:in-app-ai-agent-feedback";
 
 const getConversationAgentState = (
   projectId: string,
@@ -68,11 +66,6 @@ const NOOP_CONTEXT: InAppAiAgentContextType = {
 
 type InAppAiAgentMessage = AgUiMessage;
 
-type InAppAiAgentFeedbackByConversationId = Record<
-  string,
-  Record<string, InAppAgentMessageFeedback>
->;
-
 export type InAppAiAgentConversation = {
   id: string;
   title: string | null;
@@ -99,8 +92,7 @@ type InAppAiAgentContextType = {
   submit: (content: string) => Promise<boolean>;
   submitFeedback: (params: {
     messageId: string;
-    runId: string;
-    value: InAppAgentMessageFeedbackValue | null;
+    value: InAppAgentRunFeedbackValue | null;
     comment?: string | null;
   }) => Promise<void>;
 };
@@ -175,11 +167,6 @@ function InAppAiAgentProviderInner({
   const [selectedConversationId, setSelectedConversationId] = useSessionStorage<
     string | null
   >(`${SELECTED_CONVERSATION_STORAGE_KEY_PREFIX}:${projectId}`, null);
-  const [feedbackByConversationId, setFeedbackByConversationId] =
-    useSessionStorage<InAppAiAgentFeedbackByConversationId>(
-      `${FEEDBACK_STORAGE_KEY_PREFIX}:${projectId}`,
-      {},
-    );
   const [messages, setMessages] = useState<InAppAiAgentMessage[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -220,16 +207,6 @@ function InAppAiAgentProviderInner({
   );
   const hasMoreConversations = conversationListQuery.hasNextPage === true;
   const isLoadingMoreConversations = conversationListQuery.isFetchingNextPage;
-  const messagesWithFeedback = useMemo(
-    () =>
-      mergeMessagesWithFeedback(
-        messages,
-        selectedConversationId
-          ? feedbackByConversationId[selectedConversationId]
-          : undefined,
-      ),
-    [feedbackByConversationId, messages, selectedConversationId],
-  );
   const fetchNextConversationsPage = conversationListQuery.fetchNextPage;
   const loadMoreConversations = useCallback(() => {
     if (!hasMoreConversations || isLoadingMoreConversations) {
@@ -559,8 +536,7 @@ function InAppAiAgentProviderInner({
   const submitFeedback = useCallback(
     async (params: {
       messageId: string;
-      runId: string;
-      value: InAppAgentMessageFeedbackValue | null;
+      value: InAppAgentRunFeedbackValue | null;
       comment?: string | null;
     }) => {
       if (!selectedConversationId) {
@@ -572,30 +548,21 @@ function InAppAiAgentProviderInner({
           projectId,
           conversationId: selectedConversationId,
           messageId: params.messageId,
-          runId: params.runId,
           value: params.value,
           comment: params.comment ?? null,
         });
 
-        setFeedbackByConversationId((currentFeedback) => {
-          const nextFeedback = { ...currentFeedback };
-          const conversationFeedback = {
-            ...(nextFeedback[selectedConversationId] ?? {}),
-          };
+        setMessages((currentMessages) =>
+          currentMessages.map((message) =>
+            message.role === "assistant" && message.id === params.messageId
+              ? { ...message, feedback: result.feedback ?? undefined }
+              : message,
+          ),
+        );
 
-          if (result.feedback) {
-            conversationFeedback[params.messageId] = result.feedback;
-          } else {
-            delete conversationFeedback[params.messageId];
-          }
-
-          if (Object.keys(conversationFeedback).length > 0) {
-            nextFeedback[selectedConversationId] = conversationFeedback;
-          } else {
-            delete nextFeedback[selectedConversationId];
-          }
-
-          return nextFeedback;
+        await utils.inAppAgent.getConversation.invalidate({
+          projectId,
+          conversationId: selectedConversationId,
         });
       } catch (error) {
         const errorMessage = getAgentErrorMessage(error);
@@ -608,7 +575,7 @@ function InAppAiAgentProviderInner({
       feedbackMutation,
       projectId,
       selectedConversationId,
-      setFeedbackByConversationId,
+      utils.inAppAgent.getConversation,
     ],
   );
 
@@ -629,7 +596,7 @@ function InAppAiAgentProviderInner({
       isSubmitting,
       isSelectedConversationHydrating,
       error,
-      messages: messagesWithFeedback,
+      messages,
       conversations,
       hasMoreConversations,
       isLoadingMoreConversations,
@@ -649,7 +616,7 @@ function InAppAiAgentProviderInner({
       isSelectedConversationHydrating,
       isSubmitting,
       loadMoreConversations,
-      messagesWithFeedback,
+      messages,
       open,
       selectConversation,
       selectedConversationId,
@@ -683,28 +650,6 @@ function getHydratedMessages(
   }
 
   return storedMessages?.filter(isAgentConversationMessage) ?? [];
-}
-
-function mergeMessagesWithFeedback(
-  messages: InAppAiAgentMessage[],
-  feedbackByMessageId: Record<string, InAppAgentMessageFeedback> | undefined,
-): InAppAiAgentMessage[] {
-  if (!feedbackByMessageId || Object.keys(feedbackByMessageId).length === 0) {
-    return messages;
-  }
-
-  return messages.map((message) => {
-    if (message.role !== "assistant") {
-      return message;
-    }
-
-    const feedback = feedbackByMessageId[message.id];
-    if (!feedback) {
-      return message;
-    }
-
-    return { ...message, feedback };
-  });
 }
 
 function attachActiveRunIdToAssistantMessages(

--- a/web/src/ee/features/in-app-agent/ids.ts
+++ b/web/src/ee/features/in-app-agent/ids.ts
@@ -4,3 +4,4 @@ import { createId } from "@paralleldrive/cuid2";
 export const createInAppAgentConversationId = () => `aconv_${createId()}`;
 export const createInAppAgentRunId = () => `arun_${createId()}`;
 export const createInAppAgentMessageId = () => `amsg_${createId()}`;
+export const createInAppAgentRunFeedbackId = () => `afbk_${createId()}`;

--- a/web/src/ee/features/in-app-agent/schema.ts
+++ b/web/src/ee/features/in-app-agent/schema.ts
@@ -29,23 +29,21 @@ const AgUiToolCallSchema = z.object({
   encryptedValue: z.string().optional(),
 });
 
-export const InAppAgentMessageFeedbackValueSchema = z.enum([
+export const InAppAgentRunFeedbackValueSchema = z.enum([
   "thumbs_up",
   "thumbs_down",
 ]);
 
-export type InAppAgentMessageFeedbackValue = z.infer<
-  typeof InAppAgentMessageFeedbackValueSchema
+export type InAppAgentRunFeedbackValue = z.infer<
+  typeof InAppAgentRunFeedbackValueSchema
 >;
 
-export const InAppAgentMessageFeedbackSchema = z.object({
-  value: InAppAgentMessageFeedbackValueSchema,
+export const InAppAgentRunFeedbackSchema = z.object({
+  value: InAppAgentRunFeedbackValueSchema,
   comment: z.string().nullable(),
 });
 
-export type InAppAgentMessageFeedback = z.infer<
-  typeof InAppAgentMessageFeedbackSchema
->;
+export type InAppAgentRunFeedback = z.infer<typeof InAppAgentRunFeedbackSchema>;
 
 // Changes to this schema need to be backwards-compatible as messages with this are already persisted.
 export const InAppAgentRedirectActionToolResultSchema = z.object({
@@ -115,7 +113,7 @@ export const AgUiMessageSchema = z.discriminatedUnion("role", [
     role: z.literal("assistant"),
     content: z.string().optional(),
     toolCalls: z.array(AgUiToolCallSchema).optional(),
-    feedback: InAppAgentMessageFeedbackSchema.optional(),
+    feedback: InAppAgentRunFeedbackSchema.optional(),
     runId: z.string().optional(),
   }),
   AgUiBaseMessageSchema.extend({

--- a/web/src/ee/features/in-app-agent/server/persistence.ts
+++ b/web/src/ee/features/in-app-agent/server/persistence.ts
@@ -5,15 +5,18 @@ import { LangfuseConflictError, LangfuseNotFoundError } from "@langfuse/shared";
 import { logger } from "@langfuse/shared/src/server";
 import type {
   InAppAgentConversation,
+  InAppAgentRunFeedback as PrismaInAppAgentRunFeedback,
   Prisma,
   PrismaClient,
 } from "@langfuse/shared/src/db";
 
+import { createInAppAgentRunFeedbackId } from "@/src/ee/features/in-app-agent/ids";
 import {
   AgUiMessageSchema,
   InAppAgentRedirectActionToolResultSchema,
   type AgUiEvent,
   type AgUiMessage,
+  type InAppAgentRunFeedback,
 } from "@/src/ee/features/in-app-agent/schema";
 import { compactTextMessageChunks } from "@/src/ee/features/in-app-agent/server/eventCompaction";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
@@ -293,6 +296,106 @@ export async function getConversationMessages(params: {
   return getMessagesFromPersistedEvents(await getConversationEvents(params));
 }
 
+export async function getConversationMessagesWithFeedback(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  conversationId: string;
+  userId: string;
+}) {
+  const [messages, feedback] = await Promise.all([
+    getConversationMessages(params),
+    getConversationRunFeedback(params),
+  ]);
+  const feedbackByMessageId = new Map(
+    feedback.map((item) => [item.messageId, serializeRunFeedback(item)]),
+  );
+
+  return messages.map((message): AgUiMessage => {
+    if (message.role !== "assistant") {
+      return message;
+    }
+
+    const messageFeedback = feedbackByMessageId.get(message.id);
+
+    if (!messageFeedback) {
+      return message;
+    }
+
+    return {
+      ...message,
+      feedback: messageFeedback,
+    };
+  });
+}
+
+export async function getConversationRunFeedback(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  conversationId: string;
+  userId: string;
+}) {
+  return params.prisma.inAppAgentRunFeedback.findMany({
+    where: {
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+      createdByUserId: params.userId,
+    },
+  });
+}
+
+export async function deleteRunFeedback(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  conversationId: string;
+  messageId: string;
+  userId: string;
+}) {
+  await params.prisma.inAppAgentRunFeedback.deleteMany({
+    where: {
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+      messageId: params.messageId,
+      createdByUserId: params.userId,
+    },
+  });
+}
+
+export async function upsertRunFeedback(params: {
+  prisma: PrismaClient;
+  projectId: string;
+  conversationId: string;
+  messageId: string;
+  userId: string;
+  value: InAppAgentRunFeedback["value"];
+  comment: string | null;
+}) {
+  const feedback = await params.prisma.inAppAgentRunFeedback.upsert({
+    where: {
+      projectId_conversationId_messageId_createdByUserId: {
+        projectId: params.projectId,
+        conversationId: params.conversationId,
+        messageId: params.messageId,
+        createdByUserId: params.userId,
+      },
+    },
+    create: {
+      id: createInAppAgentRunFeedbackId(),
+      projectId: params.projectId,
+      conversationId: params.conversationId,
+      messageId: params.messageId,
+      createdByUserId: params.userId,
+      value: params.value === "thumbs_up",
+      comment: params.comment,
+    },
+    update: {
+      value: params.value === "thumbs_up",
+      comment: params.comment,
+    },
+  });
+
+  return serializeRunFeedback(feedback);
+}
+
 export async function getConversationMessagesForReplay(params: {
   prisma: PrismaClient;
   projectId: string;
@@ -336,6 +439,15 @@ function sanitizeConversationMessagesForReplay(
   return stripAssistantRunIds(
     dropEmptyAssistantMessages(messagesWithoutOrphanToolCalls),
   );
+}
+
+function serializeRunFeedback(
+  feedback: PrismaInAppAgentRunFeedback,
+): InAppAgentRunFeedback {
+  return {
+    value: feedback.value ? "thumbs_up" : "thumbs_down",
+    comment: feedback.comment,
+  };
 }
 
 export function shouldFlushPersistedEvent(event: AgUiEvent) {

--- a/web/src/ee/features/in-app-agent/server/router.ts
+++ b/web/src/ee/features/in-app-agent/server/router.ts
@@ -15,7 +15,7 @@ import {
   upsertScore,
 } from "@langfuse/shared/src/server";
 import { env } from "@/src/env.mjs";
-import { InAppAgentMessageFeedbackValueSchema } from "@/src/ee/features/in-app-agent/schema";
+import { InAppAgentRunFeedbackValueSchema } from "@/src/ee/features/in-app-agent/schema";
 import { throwIfNoEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
 import {
   createTRPCRouter,
@@ -23,9 +23,12 @@ import {
   protectedProjectProcedureWithoutTracing,
 } from "@/src/server/api/trpc";
 import {
+  deleteRunFeedback,
   getConversationMessages,
+  getConversationMessagesWithFeedback,
   getOwnedConversationOrThrow,
   serializeConversation,
+  upsertRunFeedback,
 } from "@/src/ee/features/in-app-agent/server/persistence";
 
 const CONVERSATION_LIST_LIMIT = 50;
@@ -42,8 +45,7 @@ const ConversationIdInput = z.object({
 
 const SubmitFeedbackInput = ConversationIdInput.extend({
   messageId: z.string(),
-  runId: z.string(),
-  value: InAppAgentMessageFeedbackValueSchema.nullable(),
+  value: InAppAgentRunFeedbackValueSchema.nullable(),
   comment: z.string().trim().max(TEXT_SCORE_MAX_LENGTH).nullable().optional(),
 });
 
@@ -110,10 +112,11 @@ export const inAppAgentRouter = createTRPCRouter({
         userId: ctx.session.user.id,
       });
 
-      const messages = await getConversationMessages({
+      const messages = await getConversationMessagesWithFeedback({
         prisma: ctx.prisma,
         projectId: input.projectId,
         conversationId: input.conversationId,
+        userId: ctx.session.user.id,
       });
 
       return {
@@ -142,6 +145,23 @@ export const inAppAgentRouter = createTRPCRouter({
         userId: ctx.session.user.id,
       });
 
+      if (input.value === null) {
+        await deleteRunFeedback({
+          prisma: ctx.prisma,
+          projectId: input.projectId,
+          conversationId: input.conversationId,
+          messageId: input.messageId,
+          userId: ctx.session.user.id,
+        });
+
+        return { feedback: null };
+      }
+
+      const scoreProjectId = env.LANGFUSE_AI_FEATURES_PROJECT_ID;
+      if (!projectAvailability.aiTelemetryEnabled || !scoreProjectId) {
+        throw new ForbiddenError("Assistant feedback is not enabled");
+      }
+
       const messages = await getConversationMessages({
         prisma: ctx.prisma,
         projectId: input.projectId,
@@ -161,50 +181,52 @@ export const inAppAgentRouter = createTRPCRouter({
         );
       }
 
-      if (targetMessage.runId !== input.runId) {
+      const comment = input.comment?.trim() ? input.comment.trim() : null;
+      if (!targetMessage.runId) {
         throw new InvalidRequestError(
           "Feedback can only be submitted for persisted assistant messages",
         );
       }
-
-      const comment = input.comment?.trim() ? input.comment.trim() : null;
-      if (input.value === null) {
-        return { feedback: null };
-      }
-
       const scoreId = `afbs_${input.messageId}_${ctx.session.user.id}`;
       const now = new Date();
-      const scoreProjectId = env.LANGFUSE_AI_FEATURES_PROJECT_ID;
 
-      if (projectAvailability.aiTelemetryEnabled && scoreProjectId) {
-        await upsertScore({
-          id: scoreId,
-          timestamp: convertDateToClickhouseDateTime(now),
-          project_id: scoreProjectId,
-          environment: IN_APP_AGENT_FEEDBACK_ENVIRONMENT,
-          trace_id: input.conversationId,
-          observation_id: input.runId,
-          session_id: input.conversationId,
-          name: IN_APP_AGENT_FEEDBACK_SCORE_NAME,
-          value: input.value === "thumbs_up" ? 1 : 0,
-          source: ScoreSourceEnum.ANNOTATION,
-          comment,
-          author_user_id: ctx.session.user.id,
-          config_id: null,
-          data_type: ScoreDataTypeEnum.BOOLEAN,
-          string_value: input.value === "thumbs_up" ? "true" : "false",
-          queue_id: null,
-          created_at: convertDateToClickhouseDateTime(now),
-          updated_at: convertDateToClickhouseDateTime(now),
-          metadata: {
-            project_id: input.projectId,
-            conversation_id: input.conversationId,
-            message_id: input.messageId,
-          },
-        });
-      }
+      await upsertScore({
+        id: scoreId,
+        timestamp: convertDateToClickhouseDateTime(now),
+        project_id: scoreProjectId,
+        environment: IN_APP_AGENT_FEEDBACK_ENVIRONMENT,
+        trace_id: input.conversationId,
+        observation_id: targetMessage.runId,
+        session_id: input.conversationId,
+        name: IN_APP_AGENT_FEEDBACK_SCORE_NAME,
+        value: input.value === "thumbs_up" ? 1 : 0,
+        source: ScoreSourceEnum.ANNOTATION,
+        comment,
+        author_user_id: ctx.session.user.id,
+        config_id: null,
+        data_type: ScoreDataTypeEnum.BOOLEAN,
+        string_value: input.value === "thumbs_up" ? "true" : "false",
+        queue_id: null,
+        created_at: convertDateToClickhouseDateTime(now),
+        updated_at: convertDateToClickhouseDateTime(now),
+        metadata: {
+          project_id: input.projectId,
+          conversation_id: input.conversationId,
+          message_id: input.messageId,
+        },
+      });
 
-      return { feedback: { value: input.value, comment } };
+      const feedback = await upsertRunFeedback({
+        prisma: ctx.prisma,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+        messageId: input.messageId,
+        userId: ctx.session.user.id,
+        value: input.value,
+        comment,
+      });
+
+      return { feedback };
     }),
 });
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR persists in-app agent message feedback to a new `in_app_agent_run_feedback` Postgres table and loads it on conversation hydration, replacing the previous session-storage approach. It also gates feedback submission on the organisation's `aiTelemetryEnabled` flag and removes `runId` from the client-facing API surface.

- **New DB table** (`in_app_agent_run_feedback`) with a unique constraint on `(project_id, conversation_id, message_id, created_by_user_id)`, cascading deletes, and an `upsert` / `delete` path in the tRPC router that writes corresponding scores to Clickhouse.
- **Feedback hydration** now happens server-side in `getConversationMessagesWithFeedback`, merging per-user DB feedback onto restored messages, with client-side optimistic update + query invalidation after each mutation.
- **Schema renamed**: `InAppAgentMessageFeedback*` → `InAppAgentRunFeedback*` across the schema, provider, and window components.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core persistence path is correct, but clearing feedback leaves a stale score in Clickhouse analytics that cannot be withdrawn from the UI, causing analytics data to diverge from the user's actual intent.

The DB schema, unique-constraint upsert, and hydration logic are well-structured. The gap is in the feedback-clear path: upsertScore is called on submit but there is no corresponding score removal on delete, so Clickhouse retains a thumbs-up or thumbs-down rating even after the user explicitly retracts it. For a product whose primary value proposition is analytics observability, this data inconsistency is meaningful and should be resolved before merging.

web/src/ee/features/in-app-agent/server/router.ts — specifically the value === null early-return branch (feedback clear path) which skips any Clickhouse score cleanup.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Browser (InAppAiAgentProvider)
    participant Router as tRPC Router (submitFeedback)
    participant PG as Postgres (inAppAgentRunFeedback)
    participant CH as Clickhouse (scores)

    Note over UI,CH: Submit feedback (thumbs_up / thumbs_down)
    UI->>Router: "submitFeedback({ messageId, value, comment })"
    Router->>CH: upsertScore(scoreId, value)
    CH-->>Router: ok
    Router->>PG: upsertRunFeedback(messageId, value, comment)
    PG-->>Router: feedback record
    Router-->>UI: "{ feedback }"

    Note over UI,CH: Clear feedback (value = null)
    UI->>Router: "submitFeedback({ messageId, value: null })"
    Router->>PG: deleteRunFeedback(messageId)
    PG-->>Router: deleted
    Router-->>UI: "{ feedback: null }"
    Note over CH: Clickhouse score NOT removed — stale entry persists
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Browser (InAppAiAgentProvider)
    participant Router as tRPC Router (submitFeedback)
    participant PG as Postgres (inAppAgentRunFeedback)
    participant CH as Clickhouse (scores)

    Note over UI,CH: Submit feedback (thumbs_up / thumbs_down)
    UI->>Router: "submitFeedback({ messageId, value, comment })"
    Router->>CH: upsertScore(scoreId, value)
    CH-->>Router: ok
    Router->>PG: upsertRunFeedback(messageId, value, comment)
    PG-->>Router: feedback record
    Router-->>UI: "{ feedback }"

    Note over UI,CH: Clear feedback (value = null)
    UI->>Router: "submitFeedback({ messageId, value: null })"
    Router->>PG: deleteRunFeedback(messageId)
    PG-->>Router: deleted
    Router-->>UI: "{ feedback: null }"
    Note over CH: Clickhouse score NOT removed — stale entry persists
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/ee/features/in-app-agent/server/router.ts:148-158
**Clickhouse score is not deleted when feedback is cleared**

When the user clears feedback (`value === null`), the DB record is deleted, but the Clickhouse score written by the earlier `upsertScore` call is never removed or tombstoned. On subsequent analytics queries, the score entry remains with its original `thumbs_up` / `thumbs_down` value, misrepresenting the true state — the user explicitly withdrew their rating, yet the platform continues to count it.

The fix requires either calling a `deleteScore` / tombstone equivalent for `scoreId = afbs_${messageId}_${userId}` before returning, or writing a corrected score entry with a cleared/neutral value so the latest-timestamp-wins read path in Clickhouse reflects the deletion.

### Issue 2 of 2
web/src/ee/features/in-app-agent/server/router.ts:193-219
**Clickhouse score written before Postgres feedback — partial failure leaves orphaned score**

`upsertScore` (Clickhouse) is awaited before `upsertRunFeedback` (Postgres). If the Postgres write fails (transient network error, constraint violation), the Clickhouse score is already committed. The user sees an error, but the score persists in analytics even though no feedback exists in the DB. On retry the upsert semantics recover, but during the failure window analytics and the DB are inconsistent.

Reversing the order — write to Postgres first, then Clickhouse — bounds the inconsistency to a missing score rather than a phantom score that cannot be cleared from the UI.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agent): Persist feedback buttons"](https://github.com/langfuse/langfuse/commit/8339d0bfb1252501df799a89370d4c3cc51d56f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37927538)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->