### PR TITLE
feat(agent): Add rate-limits

### DIFF
--- a/packages/shared/src/interfaces/rate-limits.ts
+++ b/packages/shared/src/interfaces/rate-limits.ts
@@ -11,6 +11,7 @@ export const RateLimitResource = z.enum([
   "datasets",
   "trace-delete",
   "score-delete",
+  "in-app-agent-run",
 ]);
 
 // result of the rate limit check.

--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -1,15 +1,65 @@
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+import { env } from "@/src/env.mjs";
 import { prisma } from "@langfuse/shared/src/db";
 import {
   createAndAddApiKeysToDb,
   createBasicAuthHeader,
   createOrgProjectAndApiKey,
 } from "@langfuse/shared/src/server";
+import type { Session } from "next-auth";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { createMocks } from "node-mocks-http";
+import { beforeEach, vi } from "vitest";
 import { z } from "zod";
 
+const authMocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  getAuthOptions: vi.fn().mockResolvedValue({}),
+}));
+
+const entitlementMocks = vi.hoisted(() => ({
+  hasEntitlement: vi.fn(() => true),
+}));
+
+const rateLimitMocks = vi.hoisted(() => ({
+  rateLimitRequest: vi.fn(),
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: authMocks.getServerSession,
+}));
+
+vi.mock("@/src/server/auth", () => ({
+  getAuthOptions: authMocks.getAuthOptions,
+}));
+
+vi.mock("@/src/features/entitlements/server/hasEntitlement", () => ({
+  hasEntitlement: entitlementMocks.hasEntitlement,
+}));
+
+vi.mock("@/src/features/public-api/server/RateLimitService", () => ({
+  RateLimitService: {
+    getInstance: () => ({
+      rateLimitRequest: rateLimitMocks.rateLimitRequest,
+    }),
+  },
+  createHttpHeaderFromRateLimit: () => ({
+    "Retry-After": 60,
+    "X-RateLimit-Limit": 2,
+    "X-RateLimit-Remaining": 0,
+    "X-RateLimit-Reset": "soon",
+  }),
+}));
+
 describe("in-app agent public API route auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rateLimitMocks.rateLimitRequest.mockResolvedValue({
+      isRateLimited: () => false,
+      res: undefined,
+    });
+  });
+
   async function createInAppAgentAuthHeader() {
     const { projectId } = await createOrgProjectAndApiKey();
     const apiKey = await createAndAddApiKeysToDb({
@@ -71,4 +121,211 @@ describe("in-app agent public API route auth", () => {
     expect(res.statusCode).toBe(200);
     expect(res._getJSONData()).toEqual({ ok: true });
   });
+
+  it("returns 429 when an in-app agent run exceeds the rate limit", async () => {
+    const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalBedrockModel = env.LANGFUSE_AWS_BEDROCK_MODEL;
+
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "DEV";
+    (env as any).LANGFUSE_AWS_BEDROCK_MODEL = "test-model";
+
+    const { org, project } = await createOrgProjectAndApiKey();
+
+    try {
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { aiFeaturesEnabled: true },
+      });
+      const session = createInAppAgentSession({
+        orgId: org.id,
+        projectId: project.id,
+      });
+      authMocks.getServerSession.mockResolvedValue(session);
+      rateLimitMocks.rateLimitRequest.mockResolvedValue({
+        isRateLimited: () => true,
+        res: {
+          resource: "in-app-agent-run",
+          scope: {
+            orgId: org.id,
+            plan: "cloud:team",
+            projectId: project.id,
+            accessLevel: "project",
+            rateLimitOverrides: [],
+            apiKeyId: "in-app-agent-session",
+            publicKey: "in-app-agent-session",
+            isIngestionSuspended: false,
+          },
+          points: 2,
+          remainingPoints: 0,
+          msBeforeNext: 60_000,
+          consumedPoints: 2,
+          isFirstInDuration: false,
+        },
+      });
+
+      const { default: handler } =
+        await import("@/src/ee/features/in-app-agent/server/handler");
+      const response = await handler(
+        new Request("http://localhost/api/in-app-agent", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            threadId: "conversation-1",
+            runId: "client-run-1",
+            messages: [{ id: "message-1", role: "user", content: "hello" }],
+            tools: [],
+            context: [],
+            state: {
+              type: "newConversation",
+              projectId: project.id,
+            },
+            forwardedProps: {},
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(429);
+      await expect(response.json()).resolves.toEqual({
+        error: "Rate limit exceeded",
+      });
+      expect(response.headers.get("Retry-After")).toBe("60");
+      expect(rateLimitMocks.rateLimitRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgId: org.id,
+          projectId: project.id,
+        }),
+        "in-app-agent-run",
+      );
+    } finally {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+      (env as any).LANGFUSE_AWS_BEDROCK_MODEL = originalBedrockModel;
+    }
+  });
+
+  it("rate-limits instance admins who are not project members", async () => {
+    const originalCloudRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalBedrockModel = env.LANGFUSE_AWS_BEDROCK_MODEL;
+
+    (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "DEV";
+    (env as any).LANGFUSE_AWS_BEDROCK_MODEL = "test-model";
+
+    const { org, project } = await createOrgProjectAndApiKey();
+
+    try {
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { aiFeaturesEnabled: true, cloudConfig: { plan: "Team" } },
+      });
+      const session = createInAppAgentSession({
+        orgId: org.id,
+        projectId: project.id,
+        admin: true,
+        includeProjectMembership: false,
+      });
+      authMocks.getServerSession.mockResolvedValue(session);
+      rateLimitMocks.rateLimitRequest.mockResolvedValue({
+        isRateLimited: () => true,
+        res: {
+          resource: "in-app-agent-run",
+          scope: {
+            orgId: org.id,
+            plan: "cloud:team",
+            projectId: project.id,
+            accessLevel: "project",
+            rateLimitOverrides: [],
+            apiKeyId: "in-app-agent-session",
+            publicKey: "in-app-agent-session",
+            isIngestionSuspended: false,
+          },
+          points: 2,
+          remainingPoints: 0,
+          msBeforeNext: 60_000,
+          consumedPoints: 2,
+          isFirstInDuration: false,
+        },
+      });
+
+      const { default: handler } =
+        await import("@/src/ee/features/in-app-agent/server/handler");
+      const response = await handler(
+        new Request("http://localhost/api/in-app-agent", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            threadId: "conversation-1",
+            runId: "client-run-1",
+            messages: [{ id: "message-1", role: "user", content: "hello" }],
+            tools: [],
+            context: [],
+            state: {
+              type: "newConversation",
+              projectId: project.id,
+            },
+            forwardedProps: {},
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(429);
+      expect(rateLimitMocks.rateLimitRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgId: org.id,
+          projectId: project.id,
+          plan: "cloud:team",
+        }),
+        "in-app-agent-run",
+      );
+    } finally {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
+      (env as any).LANGFUSE_AWS_BEDROCK_MODEL = originalBedrockModel;
+    }
+  });
 });
+
+function createInAppAgentSession(params: {
+  orgId: string;
+  projectId: string;
+  admin?: boolean;
+  includeProjectMembership?: boolean;
+}): Session {
+  const includeProjectMembership = params.includeProjectMembership ?? true;
+
+  return {
+    expires: new Date(Date.now() + 60_000).toISOString(),
+    environment: { enableExperimentalFeatures: false },
+    user: {
+      id: "user-1",
+      name: "Test User",
+      email: "test@example.com",
+      image: null,
+      admin: params.admin ?? false,
+      featureFlags: { inAppAgent: true },
+      organizations: includeProjectMembership
+        ? [
+            {
+              id: params.orgId,
+              name: "Test Org",
+              plan: "cloud:team",
+              role: "OWNER",
+              metadata: {},
+              aiFeaturesEnabled: true,
+              aiTelemetryEnabled: false,
+              cloudConfig: { plan: "Team" },
+              projects: [
+                {
+                  id: params.projectId,
+                  name: "Test Project",
+                  role: "ADMIN",
+                  retentionDays: 30,
+                  hasTraces: false,
+                  deletedAt: null,
+                  metadata: {},
+                  createdAt: new Date().toISOString(),
+                },
+              ],
+            },
+          ]
+        : [],
+    },
+  } as Session;
+}

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -1,4 +1,5 @@
 import { EventType } from "@ag-ui/core";
+import { type Session } from "next-auth";
 import { getServerSession } from "next-auth";
 
 import { env } from "@/src/env.mjs";
@@ -25,16 +26,27 @@ import {
 } from "@/src/ee/features/in-app-agent/server/persistence";
 import { getAuthOptions } from "@/src/server/auth";
 import { hasEntitlement } from "@/src/features/entitlements/server/hasEntitlement";
+import { getOrganizationPlanServerSide } from "@/src/features/entitlements/server/getPlan";
+import {
+  createHttpHeaderFromRateLimit,
+  RateLimitService,
+} from "@/src/features/public-api/server/RateLimitService";
 import { isProjectMemberOrAdmin } from "@/src/server/utils/checkProjectMembershipOrAdmin";
 import { assertUnreachable } from "@/src/utils/types";
 import {
   BaseError,
   ForbiddenError,
   InvalidRequestError,
+  type RateLimitResult,
   UnauthorizedError,
+  CloudConfigSchema,
 } from "@langfuse/shared";
 import { prisma } from "@langfuse/shared/src/db";
-import { logger, redis } from "@langfuse/shared/src/server";
+import {
+  logger,
+  redis,
+  type ApiAccessScope,
+} from "@langfuse/shared/src/server";
 import {
   createAndAddApiKeysToDb,
   deleteApiKeyFromDb,
@@ -147,6 +159,8 @@ export default async function handler(request: Request) {
       select: {
         organization: {
           select: {
+            id: true,
+            cloudConfig: true,
             aiFeaturesEnabled: true,
             aiTelemetryEnabled: true,
           },
@@ -172,6 +186,22 @@ export default async function handler(request: Request) {
         "Assistant Bedrock model is not configured.",
         true,
       );
+    }
+
+    // TODO: Add an additional user-level cap once the rate-limit service supports non-org keys.
+    const rateLimitScope = getInAppAgentRateLimitScope(
+      auth.user,
+      projectId,
+      project.organization,
+    );
+
+    const rateLimitResponse = await rateLimitInAppAgentRequest(
+      rateLimitScope,
+      "in-app-agent-run",
+    );
+
+    if (rateLimitResponse) {
+      return rateLimitResponse;
     }
 
     const conversation = await ensureOwnedConversation({
@@ -353,6 +383,84 @@ export default async function handler(request: Request) {
 
     throw err;
   }
+}
+
+type SessionUser = NonNullable<Session["user"]>;
+
+function getInAppAgentRateLimitScope(
+  user: SessionUser,
+  projectId: string,
+  projectOrganization: {
+    id: string;
+    cloudConfig: unknown;
+  },
+): ApiAccessScope {
+  const organization = user.organizations.find((org) =>
+    org.projects.some((project) => project.id === projectId),
+  );
+
+  if (!organization) {
+    if (user.admin === true) {
+      const cloudConfig = projectOrganization.cloudConfig
+        ? CloudConfigSchema.parse(projectOrganization.cloudConfig)
+        : undefined;
+
+      return {
+        orgId: projectOrganization.id,
+        plan: getOrganizationPlanServerSide(cloudConfig),
+        projectId,
+        accessLevel: "project",
+        rateLimitOverrides: cloudConfig?.rateLimitOverrides ?? [],
+        apiKeyId: "in-app-agent-session",
+        publicKey: "in-app-agent-session",
+        isIngestionSuspended: false,
+      };
+    }
+
+    throw new ForbiddenError("User is not a member of this project");
+  }
+
+  return {
+    orgId: organization.id,
+    plan: organization.plan,
+    projectId,
+    accessLevel: "project",
+    rateLimitOverrides: organization.cloudConfig?.rateLimitOverrides ?? [],
+    apiKeyId: "in-app-agent-session",
+    publicKey: "in-app-agent-session",
+    isIngestionSuspended: false,
+  };
+}
+
+async function rateLimitInAppAgentRequest(
+  scope: ApiAccessScope,
+  resource: Parameters<RateLimitService["rateLimitRequest"]>[1],
+): Promise<Response | undefined> {
+  const rateLimit = await RateLimitService.getInstance().rateLimitRequest(
+    scope,
+    resource,
+  );
+
+  if (!rateLimit.isRateLimited() || !rateLimit.res) {
+    return undefined;
+  }
+
+  return createInAppAgentRateLimitResponse(rateLimit.res);
+}
+
+function createInAppAgentRateLimitResponse(rateLimitRes: RateLimitResult) {
+  const headers = new Headers();
+
+  for (const [header, value] of Object.entries(
+    createHttpHeaderFromRateLimit(rateLimitRes),
+  )) {
+    headers.set(header, String(value));
+  }
+
+  return Response.json(
+    { error: "Rate limit exceeded" },
+    { status: 429, headers },
+  );
 }
 
 function getLangfuseMcpUrl(): string {

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -299,6 +299,12 @@ const getPlanBasedRateLimitConfig = (
             points: 50,
             durationInSec: 86400, // 50 requests per day
           };
+        case "in-app-agent-run":
+          return {
+            resource: "in-app-agent-run",
+            points: 100,
+            durationInSec: 86400,
+          };
         default:
           const exhaustiveCheck: never = resource;
           throw new Error(`Unhandled resource case: ${exhaustiveCheck}`);
@@ -367,6 +373,12 @@ const getPlanBasedRateLimitConfig = (
             points: 200,
             durationInSec: 86400, // 200 requests per day
           };
+        case "in-app-agent-run":
+          return {
+            resource: "in-app-agent-run",
+            points: 1000,
+            durationInSec: 86400,
+          };
         default:
           const exhaustiveCheck: never = resource;
           throw new Error(`Unhandled resource case: ${exhaustiveCheck}`);
@@ -428,6 +440,12 @@ const getPlanBasedRateLimitConfig = (
             resource: "score-delete",
             points: 1000,
             durationInSec: 86400, // 1000 requests per day
+          };
+        case "in-app-agent-run":
+          return {
+            resource: "in-app-agent-run",
+            points: 1000,
+            durationInSec: 86400,
           };
         default:
           const exhaustiveCheck: never = resource;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds org-level rate limits for the in-app agent feature, introducing two new rate-limit resources — `in-app-agent-run-hourly` and `in-app-agent-run-daily` — with plan-tiered limits across all cloud plans (hobby: 100/h + 500/day, core/pro/team/enterprise: 200/h + 1000/day). OSS and self-hosted plans are explicitly excluded.

- Rate limit scope is built from the authenticated user's session (org plan + `cloudConfig.rateLimitOverrides`), using the fixed sentinel values `\"in-app-agent-session\"` for `apiKeyId`/`publicKey` since no real API key exists for session-based access.
- Both limits are checked sequentially before any expensive operations (DB writes, MCP key creation, AI model calls), and a 429 response with standard `Retry-After` and `X-RateLimit-*` headers is returned on exhaustion.
- A TODO comment acknowledges that only org-level buckets are supported today; per-user capping is deferred until `RateLimitService` supports non-org keys.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. Rate limits are correctly applied before expensive operations (DB writes, AI calls), OSS/self-hosted plans are excluded, and the 429 response includes correct headers. The only notable concern is a sequential-consumption edge case that could surface misleading error messages when daily quota is exhausted but is unlikely to affect typical usage at the configured limits.

The feature is well-scoped: new rate-limit resources are added exhaustively across all cloud plan tiers, the scope is derived safely from the session, and the ordering of checks (auth → entitlements → rate limits → expensive ops) is correct. The sequential consume()-then-check pattern means hourly points can be silently consumed for requests that daily subsequently rejects, but the limits are generous enough that this edge case has minimal practical impact. No missing plan cases, no auth bypass, no data mutations before rate-limit gates.

handler.ts deserves a second look specifically around the sequential consumption behavior and the acknowledged missing user-level cap (TODO comment). RateLimitService.ts is straightforward and well-covered by the exhaustive switch.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as handler.ts
    participant Session as next-auth session
    participant RLS as RateLimitService
    participant Redis

    Client->>Handler: POST /api/in-app-agent
    Handler->>Session: getServerSession()
    Session-->>Handler: session (user, org plan, cloudConfig)
    Handler->>Handler: auth, membership, entitlement checks
    Handler->>Handler: getInAppAgentRateLimitScope(user, projectId)
    Note over Handler: builds ApiAccessScope from session data

    Handler->>RLS: rateLimitRequest(scope, in-app-agent-run-hourly)
    RLS->>Redis: consume(orgId)
    Redis-->>RLS: RateLimiterRes
    RLS-->>Handler: RateLimitHelper

    alt hourly exceeded
        Handler-->>Client: "429 + Retry-After / X-RateLimit-* headers"
    else hourly OK (1 hourly point consumed)
        Handler->>RLS: rateLimitRequest(scope, in-app-agent-run-daily)
        RLS->>Redis: consume(orgId)
        Redis-->>RLS: RateLimiterRes
        RLS-->>Handler: RateLimitHelper

        alt daily exceeded
            Handler-->>Client: "429 + Retry-After / X-RateLimit-* headers"
        else both OK
            Handler->>Handler: ensureOwnedConversation, createRun, createAgUiStream
            Handler-->>Client: 200 SSE stream
        end
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/ee/features/in-app-agent/server/handler.ts:190-202
**Sequential consumption wastes hourly quota when daily is exhausted**

`consume()` in `rate-limiter-flexible` always increments the counter, even when a subsequent check causes the request to be rejected. When hourly passes (1 hourly point consumed) and daily subsequently fails, that hourly point is permanently spent on a request that returned 429. Under sustained post-daily-exhaustion retries, the hourly bucket drains to zero even though no agent runs are served, causing misleading hourly-limit errors when the binding constraint is actually the daily cap.

The current order (hourly → daily) is still the better of the two possible orderings, since hourly points reset every hour while daily resets every day. Reversing the order would instead burn the more precious daily points on hourly-rejected requests. The only fully correct fix is to use `get()` (non-consuming peek) for one of the checks before consuming from either — though that introduces a small TOCTOU window under high concurrency. Given the high limits and the expected usage pattern this is unlikely to cause user-visible issues in practice, but it is worth documenting.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agent): Add rate-limits"](https://github.com/langfuse/langfuse/commit/c68ada33bb1481862a7161d18e196c233c8431a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36814431)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->