### PR TITLE
chore: Switch to eslint-config-prettier

### DIFF
--- a/packages/config-eslint/base.js
+++ b/packages/config-eslint/base.js
@@ -2,7 +2,7 @@ import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 import turboConfig from "eslint-config-turbo/flat";
-import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import eslintConfigPrettier from "eslint-config-prettier";
 import langfusePlugin from "@repo/eslint-plugin";
 import "eslint-plugin-only-warn";
 
@@ -27,8 +27,8 @@ export default tseslint.config(
   // Turbo monorepo rules
   ...turboConfig,
 
-  // Prettier (last for rule precedence)
-  eslintPluginPrettierRecommended,
+  // Disable ESLint rules that conflict with Prettier formatting.
+  eslintConfigPrettier,
 
   // Global settings
   {

--- a/packages/config-eslint/next.js
+++ b/packages/config-eslint/next.js
@@ -1,5 +1,5 @@
 import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
-import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import eslintConfigPrettier from "eslint-config-prettier";
 import turboConfig from "eslint-config-turbo/flat";
 import "eslint-plugin-only-warn";
 import langfusePlugin from "@repo/eslint-plugin";
@@ -54,8 +54,8 @@ export default [
     },
   },
 
-  // Prettier (last)
-  eslintPluginPrettierRecommended,
+  // Disable ESLint rules that conflict with Prettier formatting.
+  eslintConfigPrettier,
 
   // Layer repo-specific TS rules on top of Next's built-in flat TS config.
   // Next already provides the parser and @typescript-eslint plugin here.

--- a/packages/config-eslint/package.json
+++ b/packages/config-eslint/package.json
@@ -21,7 +21,6 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-config-turbo": "2.9.14",
     "eslint-plugin-only-warn": "^1.1.0",
-    "eslint-plugin-prettier": "^5.5.4",
     "globals": "^16.0.0",
     "typescript-eslint": "^8.57.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,9 +122,6 @@ importers:
       eslint-plugin-only-warn:
         specifier: ^1.1.0
         version: 1.2.1
-      eslint-plugin-prettier:
-        specifier: ^5.5.4
-        version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
       globals:
         specifier: ^16.0.0
         version: 16.5.0
@@ -3585,10 +3582,6 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
-
-  '@pkgr/core@0.2.9':
-    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@playwright/test@1.57.0':
     resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
@@ -7442,20 +7435,6 @@ packages:
   eslint-plugin-only-warn@1.2.1:
     resolution: {integrity: sha512-j37hwfaQDEOfkZ1Dpvu/HnWLavlzQxQxfbrU/9Jb4R9qzrE1eTYuRJyrxq7LzLRI8miG5FOV6veoUVhx7AI84w==}
 
-  eslint-plugin-prettier@5.5.4:
-    resolution: {integrity: sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      '@types/eslint': '>=8.0.0'
-      eslint: '>=8.0.0'
-      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
-      prettier: '>=3.0.0'
-    peerDependenciesMeta:
-      '@types/eslint':
-        optional: true
-      eslint-config-prettier:
-        optional: true
-
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
     engines: {node: '>=18'}
@@ -7643,9 +7622,6 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-diff@1.3.0:
-    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
   fast-equals@4.0.3:
     resolution: {integrity: sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==}
@@ -9797,10 +9773,6 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-linter-helpers@1.0.0:
-    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
-    engines: {node: '>=6.0.0'}
-
   prettier-plugin-tailwindcss@0.7.2:
     resolution: {integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==}
     engines: {node: '>=20.19'}
@@ -10727,10 +10699,6 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
-  synckit@0.11.12:
-    resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
 
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
@@ -14972,8 +14940,6 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pkgr/core@0.2.9': {}
-
   '@playwright/test@1.57.0':
     dependencies:
       playwright: 1.57.0
@@ -19186,16 +19152,6 @@ snapshots:
 
   eslint-plugin-only-warn@1.2.1: {}
 
-  eslint-plugin-prettier@5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
-    dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
-      prettier: 3.8.3
-      prettier-linter-helpers: 1.0.0
-      synckit: 0.11.12
-    optionalDependencies:
-      '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
-
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.0
@@ -19487,8 +19443,6 @@ snapshots:
   fast-deep-equal@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
-
-  fast-diff@1.3.0: {}
 
   fast-equals@4.0.3: {}
 
@@ -21976,10 +21930,6 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-linter-helpers@1.0.0:
-    dependencies:
-      fast-diff: 1.3.0
-
   prettier-plugin-tailwindcss@0.7.2(prettier@3.8.3):
     dependencies:
       prettier: 3.8.3
@@ -23108,10 +23058,6 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
-
-  synckit@0.11.12:
-    dependencies:
-      '@pkgr/core': 0.2.9
 
   tailwind-merge@2.6.0: {}
 


### PR DESCRIPTION
This removes `eslint-plugin-prettier` from the shared ESLint config and relies on our existing Prettier checks in CI for formatting enforcement.

Since formatting is already validated separately, running Prettier through ESLint was redundant and one of the largest contributors to lint runtime. On my machine, in the web package, ESLint execution time without a cache decreased from **46s to 31s**, eliminating roughly **14s** of rule execution time while preserving the existing behavior of disabling ESLint rules that conflict with Prettier.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes `eslint-plugin-prettier` from the shared ESLint configs and replaces it with `eslint-config-prettier` directly. `eslint-config-prettier` was already a declared dependency, so this is purely a behavioral change: formatting violations will no longer be reported as ESLint errors, relying instead on the existing standalone Prettier CI check.

- `packages/config-eslint/base.js` and `next.js` now import `eslintConfigPrettier` (disables conflicting rules only) instead of `eslintPluginPrettierRecommended` (which also reported formatting diffs as lint errors).
- `eslint-plugin-prettier` and its transitive dependencies (`synckit`, `@pkgr/core`, `prettier-linter-helpers`, `fast-diff`) are removed from the lockfile, shrinking the install surface.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change removes duplicate formatting enforcement from ESLint while keeping the rule-conflict-disabling behavior intact, and the standalone Prettier CI check already covers formatting.

The diff is a focused tooling swap: `eslint-config-prettier` was already a declared dependency, the placement in both config arrays is unchanged (still positioned after other plugins to correctly override conflicting rules), and the only behavioral difference is that formatting violations are no longer surfaced as ESLint errors. The CI Prettier check independently enforces formatting, so there is no regression in formatting coverage.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before (eslint-plugin-prettier)"]
        A1[ESLint run] --> B1[eslint-plugin-prettier/recommended]
        B1 --> C1[Disable rules conflicting with Prettier]
        B1 --> D1[Run Prettier on each file]
        D1 --> E1[Report formatting diffs as ESLint errors]
        A1 --> F1[CI: Separate prettier --check step]
    end

    subgraph After["After (eslint-config-prettier)"]
        A2[ESLint run] --> B2[eslint-config-prettier]
        B2 --> C2[Disable rules conflicting with Prettier]
        A2 --> F2[CI: Separate prettier --check step]
    end

    style D1 fill:#f99,stroke:#c00
    style E1 fill:#f99,stroke:#c00
    style C2 fill:#9f9,stroke:#090
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: Switch to eslint-config-prettier"](https://github.com/langfuse/langfuse/commit/40280a8955828407278c94e335567900ab223800) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36808837)</sub>

<!-- /greptile_comment -->