### PR TITLE
chore(web): Exclude storybook output from eslint

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,8 +1,11 @@
+import { globalIgnores } from "eslint/config";
 import storybook from "eslint-plugin-storybook";
 
 import nextConfig from "@repo/eslint-config/next";
 
 export default [
+  globalIgnores(["**/storybook-static/"]),
+
   ...nextConfig,
   ...storybook.configs["flat/recommended"],
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates `web/eslint.config.mjs` to exclude the Storybook build output directory (`storybook-static/`) from ESLint analysis using the `globalIgnores` helper from `eslint/config`.

- Adds an import for `globalIgnores` from `eslint/config` and inserts `globalIgnores([\"**/storybook-static/\"])` as the first entry in the flat config array, ensuring generated build artifacts are never linted.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — adds a targeted ignore for the Storybook build output with no effect on production code or existing lint rules.

The change is a single-line config addition that only prevents ESLint from scanning generated build artifacts. It uses the idiomatic globalIgnores helper from ESLint's flat config API and is placed correctly before the other config spreads. No logic, runtime behavior, or existing rules are affected.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(web): Exclude storybook output fro..."](https://github.com/langfuse/langfuse/commit/2cef30e3b7406d9c36932049c3c7f62d3889c3a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36925221)</sub>

<!-- /greptile_comment -->