### PR TITLE
fix: do not mark ingestion span as error on zod parsing issues

### DIFF
--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -14,7 +14,6 @@ import {
   instrumentAsync,
   recordDistribution,
   recordIncrement,
-  traceException,
 } from "../instrumentation";
 import { logger } from "../logger";
 import { QueueJobs } from "../queues";
@@ -446,8 +445,7 @@ export const aggregateBatchResult = (
   });
 
   if (returnedErrors.length > 0) {
-    traceException(errors);
-    logger.error("Error processing events", {
+    logger.warn("Error processing events", {
       errors: returnedErrors,
       "langfuse.project.id": projectId,
     });

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -163,20 +163,20 @@ export default async function handler(
       });
     }
 
+    if (error instanceof z.ZodError) {
+      logger.error(`Zod exception`, error.issues);
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.issues,
+      });
+    }
+
     logger.error("error_handling_ingestion_event", error);
     traceException(error);
 
     if (isPrismaException(error)) {
       return res.status(500).json({
         error: "Internal Server Error",
-      });
-    }
-
-    if (error instanceof z.ZodError) {
-      logger.error(`Zod exception`, error.issues);
-      return res.status(400).json({
-        message: "Invalid request data",
-        error: error.issues,
       });
     }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where Zod schema parsing failures would mark the ingestion OTel span as an error. The fix has two parts: moving the `z.ZodError` handler in `ingestion.ts` before the `traceException` call so client validation errors no longer poison the span, and removing `traceException(errors)` from `aggregateBatchResult` in `processEventBatch.ts` (downgrading to `logger.warn`) since the errors surfaced there are client-originated validation and authentication failures.

- **`web/src/pages/api/public/ingestion.ts`**: `z.ZodError` check is reordered to run before `traceException`, so 400 responses for malformed payloads are no longer recorded as span errors.
- **`packages/shared/src/server/ingestion/processEventBatch.ts`**: `traceException(errors)` removed and `logger.error` downgraded to `logger.warn` in `aggregateBatchResult`; these errors are exclusively client-side (`InvalidRequestError` / `UnauthorizedError`). The `else`-branch that maps unknown errors to status 500 remains dead code but would now silently emit only a warning if ever reached.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The core fix is correct: ZodError is now handled before traceException in ingestion.ts, and client-side validation failures in aggregateBatchResult no longer emit span exception events.

The aggregateBatchResult change blanket-downgrades all batch errors to logger.warn with no tracing. The else branch that covers any unrecognised error type (currently unreachable) would silently emit only a warning if a genuine server error ever landed there. It is dead code today, but the observability gap is real if the function is extended.

packages/shared/src/server/ingestion/processEventBatch.ts — specifically the else-branch in aggregateBatchResult (lines 438-443).
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ingestion.ts
    participant processEventBatch
    participant aggregateBatchResult
    participant OTel as OTel Span

    Note over ingestion.ts,OTel: Before PR — ZodError flow
    Client->>ingestion.ts: POST /api/public/ingestion
    ingestion.ts->>processEventBatch: processEventBatch(batch, authCheck)
    processEventBatch-->>ingestion.ts: throw ZodError (or reaches catch)
    ingestion.ts->>OTel: traceException(error) span marked ERROR
    ingestion.ts->>ingestion.ts: check z.ZodError → 400
    ingestion.ts-->>Client: 400 Bad Request

    Note over ingestion.ts,OTel: After PR — ZodError flow
    Client->>ingestion.ts: POST /api/public/ingestion
    ingestion.ts->>processEventBatch: processEventBatch(batch, authCheck)
    processEventBatch-->>ingestion.ts: throw ZodError (or reaches catch)
    ingestion.ts->>ingestion.ts: check z.ZodError FIRST → 400
    ingestion.ts-->>Client: 400 Bad Request (span not marked error)

    Note over processEventBatch,OTel: aggregateBatchResult — Before PR
    processEventBatch->>aggregateBatchResult: validation/auth errors
    aggregateBatchResult->>OTel: traceException(errors)
    aggregateBatchResult->>aggregateBatchResult: logger.error(...)

    Note over processEventBatch,OTel: aggregateBatchResult — After PR
    processEventBatch->>aggregateBatchResult: validation/auth errors
    aggregateBatchResult->>aggregateBatchResult: logger.warn(...) (no traceException)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/ingestion/processEventBatch.ts:438-443
**500-class errors in batch result silently demoted to warnings**

`aggregateBatchResult`'s `else` branch maps unrecognised errors to status 500 and currently is unreachable (callers only inject `InvalidRequestError` and `UnauthorizedError`). With the PR, if this branch is ever reached (e.g. a future caller passes a raw `Error`), the event will only emit a `logger.warn` — no `traceException`, no error-level log — so a real server-side failure inside the batch would be indistinguishable from a routine client validation issue in your traces and log dashboards. Keeping `traceException` (or at least `logger.error`) scoped to the `else` branch only would preserve the intent of the fix while retaining observability for genuine 500 cases.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: warning logs"](https://github.com/langfuse/langfuse/commit/2d58e84072086fd96fb170969d7ea75630f864cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36947120)</sub>

<!-- /greptile_comment -->