### PR TITLE
feat: detect clickhouse versions on start and set compat flags automagically.

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -195,4 +195,6 @@ LANGFUSE_MIGRATION_V4_NATIVE_OTEL_BEHAVIOUR=dual_write
 LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH=false
 
 CLICKHOUSE_USE_LIGHTWEIGHT_UPDATE="true"
-CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION=true
+# `auto` detects affected ClickHouse versions on startup. Set `true` to force
+# the workaround or `false` to force-disable it.
+CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION=auto

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -106,12 +106,12 @@ const EnvSchema = z.object({
   CLICKHOUSE_UPDATE_PARALLEL_MODE: z
     .enum(["sync", "async", "auto"])
     .default("auto"),
-  // Workaround for a 25.12 bug where lightweight updates/deletes interact
-  // incorrectly with lazy materialization. Remove after ClickHouse 26.4, or
-  // earlier if the fix is backported.
+  // Workaround for ClickHouse analyzer/lazy materialization bugs. In "auto",
+  // Langfuse detects the ClickHouse version on startup and applies known
+  // compatibility settings for affected version bands.
   CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: z
-    .enum(["true", "false"])
-    .default("false"),
+    .enum(["auto", "true", "false"])
+    .default("auto"),
   CLICKHOUSE_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY: z.coerce
     .number()
     .default(32_000_000_000), // ~32GB

--- a/packages/shared/src/server/clickhouse/client.test.ts
+++ b/packages/shared/src/server/clickhouse/client.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type ClickHouseSettings } from "@clickhouse/client";
+
+const mocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  close: vi.fn(async () => undefined),
+  env: {
+    CLICKHOUSE_URL: "http://localhost:8123",
+    CLICKHOUSE_READ_ONLY_URL: undefined,
+    CLICKHOUSE_EVENTS_READ_ONLY_URL: undefined,
+    CLICKHOUSE_USER: "default",
+    CLICKHOUSE_PASSWORD: "",
+    CLICKHOUSE_DB: "default",
+    CLICKHOUSE_KEEP_ALIVE_IDLE_SOCKET_TTL: 9000,
+    CLICKHOUSE_MAX_OPEN_CONNECTIONS: 25,
+    CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE: undefined,
+    CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS: undefined,
+    CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MIN_MS: undefined,
+    CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE: "alter_update",
+    CLICKHOUSE_UPDATE_PARALLEL_MODE: "auto",
+    CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "auto",
+    LANGFUSE_LOG_LEVEL: "error",
+    NEXT_PUBLIC_LANGFUSE_CLOUD_REGION: undefined,
+  },
+}));
+
+vi.mock("../../env", () => ({ env: mocks.env }));
+vi.mock("@clickhouse/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@clickhouse/client")>();
+
+  return {
+    ...actual,
+    createClient: mocks.createClient,
+  };
+});
+
+import { ClickHouseClientManager, clickhouseClient } from "./client";
+import { setClickHouseCompatibilityVersionForTests } from "./compatibility";
+
+describe("ClickHouseClientManager compatibility settings", () => {
+  beforeEach(async () => {
+    await ClickHouseClientManager.getInstance().closeAllConnections();
+
+    mocks.close.mockClear();
+    mocks.createClient.mockReset();
+    mocks.createClient.mockReturnValue({ close: mocks.close });
+    mocks.env.CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION = "auto";
+    setClickHouseCompatibilityVersionForTests(null);
+  });
+
+  it("applies resolved compatibility settings globally", () => {
+    setClickHouseCompatibilityVersionForTests("26.5.1.882");
+
+    clickhouseClient();
+
+    expect(mocks.createClient).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.createClient.mock.calls[0][0].clickhouse_settings,
+    ).toMatchObject({
+      query_plan_optimize_lazy_materialization: 0,
+    });
+  });
+
+  it("lets explicit client settings override compatibility settings", () => {
+    setClickHouseCompatibilityVersionForTests("26.5.1.882");
+
+    clickhouseClient({
+      clickhouse_settings: {
+        query_plan_optimize_lazy_materialization: 1,
+      } as ClickHouseSettings,
+    });
+
+    expect(mocks.createClient).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.createClient.mock.calls[0][0].clickhouse_settings
+        .query_plan_optimize_lazy_materialization,
+    ).toBe(1);
+  });
+
+  it("uses a new cached client key after compatibility settings change", () => {
+    clickhouseClient();
+    setClickHouseCompatibilityVersionForTests("26.5.1.882");
+    clickhouseClient();
+
+    expect(mocks.createClient).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/shared/src/server/clickhouse/client.ts
+++ b/packages/shared/src/server/clickhouse/client.ts
@@ -1,10 +1,11 @@
-import { createClient } from "@clickhouse/client";
+import { createClient, type ClickHouseSettings } from "@clickhouse/client";
 import { env } from "../../env";
 import { VERSION } from "../../constants/VERSION";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
 import { getCurrentSpan } from "../instrumentation";
 import { propagation, context } from "@opentelemetry/api";
 import { ClickHouseLogger, mapLogLevel } from "./clickhouse-logger";
+import { getClickHouseCompatibilitySettings } from "./compatibility";
 
 export type ClickhouseClientType = ReturnType<typeof createClient>;
 
@@ -13,7 +14,7 @@ export type PreferredClickhouseService =
   | "ReadOnly"
   | "EventsReadOnly";
 
-type ServiceClickhouseSettings = {
+type ServiceClickhouseSettings = ClickHouseSettings & {
   enable_full_text_index?: 1;
 };
 
@@ -83,16 +84,25 @@ export class ClickHouseClientManager {
 
       // Include any other relevant config options
     };
-    return { settings: keyParams, serviceClickhouseSettings };
+    return {
+      settings: keyParams,
+      serviceClickhouseSettings,
+    };
   }
 
   private getServiceClickhouseSettings(
     preferredClickhouseService: PreferredClickhouseService,
   ): ServiceClickhouseSettings {
-    return preferredClickhouseService === "EventsReadOnly" &&
+    const eventROSettings: ServiceClickhouseSettings =
+      preferredClickhouseService === "EventsReadOnly" &&
       this.isEventsTableReadPathEnabled()
-      ? { enable_full_text_index: 1 }
-      : {};
+        ? { enable_full_text_index: 1 }
+        : {};
+
+    return {
+      ...getClickHouseCompatibilitySettings(),
+      ...eventROSettings,
+    };
   }
 
   private isEventsTableReadPathEnabled(): boolean {
@@ -191,12 +201,6 @@ export class ClickHouseClientManager {
                 lightweight_delete_mode: env.CLICKHOUSE_LIGHTWEIGHT_DELETE_MODE,
                 update_parallel_mode: env.CLICKHOUSE_UPDATE_PARALLEL_MODE,
               }
-            : {}),
-          // Workaround for a 25.12 bug where lightweight updates/deletes
-          // interact incorrectly with lazy materialization. Remove after
-          // ClickHouse 26.4, or earlier if the fix is backported.
-          ...(env.CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION === "true"
-            ? { query_plan_optimize_lazy_materialization: 0 }
             : {}),
           ...cloudOptions,
           ...serviceClickhouseSettings,

--- a/packages/shared/src/server/clickhouse/compatibility.test.ts
+++ b/packages/shared/src/server/clickhouse/compatibility.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+
+const envMock = vi.hoisted(() => ({
+  env: {
+    CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "auto",
+  },
+}));
+
+vi.mock("../../env", () => envMock);
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import {
+  isClickHouseVersionInBand,
+  parseClickHouseVersion,
+  resolveClickHouseCompatibility,
+} from "./compatibility";
+
+describe("ClickHouse compatibility version parsing", () => {
+  it("parses ClickHouse versions with build components", () => {
+    expect(parseClickHouseVersion("26.5.1.882")).toMatchObject({
+      major: 26,
+      minor: 5,
+      patch: 1,
+      tuple: [26, 5, 1],
+    });
+  });
+
+  it("parses ClickHouse versions with dotted vendor suffixes", () => {
+    expect(parseClickHouseVersion("25.4.1.1.altinitystable")).toMatchObject({
+      major: 25,
+      minor: 4,
+      patch: 1,
+      tuple: [25, 4, 1],
+    });
+  });
+
+  it("matches inclusive lower bounds", () => {
+    const band = { minInclusive: "25.4.0" };
+
+    expect(isClickHouseVersionInBand("25.3.99", band)).toBe(false);
+    expect(isClickHouseVersionInBand("25.4.0", band)).toBe(true);
+    expect(isClickHouseVersionInBand("25.4.1.1234", band)).toBe(true);
+    expect(isClickHouseVersionInBand("25.4.1.1.altinitystable", band)).toBe(
+      true,
+    );
+    expect(isClickHouseVersionInBand("26.5.1.882", band)).toBe(true);
+  });
+
+  it("matches exclusive upper bounds", () => {
+    const band = { minInclusive: "25.4.0", maxExclusive: "26.4.0" };
+
+    expect(isClickHouseVersionInBand("26.3.99", band)).toBe(true);
+    expect(isClickHouseVersionInBand("26.4.0", band)).toBe(false);
+  });
+});
+
+describe("resolveClickHouseCompatibility", () => {
+  it("applies lazy materialization workaround in auto mode for affected versions", () => {
+    expect(
+      resolveClickHouseCompatibility({
+        version: "26.5.1.882",
+        overrides: { CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "auto" },
+      }).settings,
+    ).toEqual({ query_plan_optimize_lazy_materialization: 0 });
+  });
+
+  it("does not apply lazy materialization workaround in auto mode before the affected band", () => {
+    expect(
+      resolveClickHouseCompatibility({
+        version: "25.3.99",
+        overrides: { CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "auto" },
+      }).settings,
+    ).toEqual({});
+  });
+
+  it("allows forcing lazy materialization workaround on", () => {
+    expect(
+      resolveClickHouseCompatibility({
+        version: null,
+        overrides: { CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "true" },
+      }).settings,
+    ).toEqual({ query_plan_optimize_lazy_materialization: 0 });
+  });
+
+  it("allows forcing lazy materialization workaround off", () => {
+    expect(
+      resolveClickHouseCompatibility({
+        version: "26.5.1.882",
+        overrides: { CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "false" },
+      }).settings,
+    ).toEqual({});
+  });
+});

--- a/packages/shared/src/server/clickhouse/compatibility.ts
+++ b/packages/shared/src/server/clickhouse/compatibility.ts
@@ -1,0 +1,215 @@
+import { createClient, type ClickHouseSettings } from "@clickhouse/client";
+import type { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
+
+import { VERSION } from "../../constants/VERSION";
+import { env } from "../../env";
+import { logger } from "../logger";
+import {
+  compareParsedVersions,
+  parseVersionString,
+  type ParsedVersion,
+} from "../utils/compareVersions";
+import { ClickHouseLogger, mapLogLevel } from "./clickhouse-logger";
+
+export type ClickHouseVersion = ParsedVersion;
+
+export type ClickHouseVersionBand = {
+  minInclusive: string;
+  maxExclusive?: string;
+};
+
+type ClickHouseCompatibilityEnvKey = "CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION";
+
+type ClickHouseCompatibilityEnvValue = "auto" | "true" | "false";
+
+type ClickHouseCompatibilityRule = {
+  id: string;
+  setting: string;
+  value: ClickHouseSettings[string];
+  reason: string;
+  versionBands: ClickHouseVersionBand[];
+  overrideEnvKey: ClickHouseCompatibilityEnvKey;
+};
+
+type ResolveClickHouseCompatibilityParams = {
+  version?: string | null;
+  overrides?: Partial<
+    Record<ClickHouseCompatibilityEnvKey, ClickHouseCompatibilityEnvValue>
+  >;
+};
+
+type ResolvedClickHouseCompatibility = {
+  settings: ClickHouseSettings;
+  appliedRules: ClickHouseCompatibilityRule[];
+};
+
+const CLICKHOUSE_COMPATIBILITY_RULES: ClickHouseCompatibilityRule[] = [
+  {
+    id: "disable-lazy-materialization",
+    setting: "query_plan_optimize_lazy_materialization",
+    value: 0,
+    reason:
+      "Work around ClickHouse analyzer failures that can surface as `Not found column and(...)` on compound predicates.",
+    versionBands: [{ minInclusive: "25.4.0" }],
+    overrideEnvKey: "CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION",
+  },
+];
+
+let detectedClickHouseVersion: string | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+export const parseClickHouseVersion = (
+  rawVersion: string,
+): ClickHouseVersion | null => parseVersionString(rawVersion);
+
+const parseVersionBound = (version: string): ClickHouseVersion => {
+  const parsed = parseClickHouseVersion(version);
+  if (!parsed) {
+    throw new Error(
+      `Invalid ClickHouse compatibility version bound: ${version}`,
+    );
+  }
+  return parsed;
+};
+
+export const isClickHouseVersionInBand = (
+  version: string | ClickHouseVersion,
+  band: ClickHouseVersionBand,
+): boolean => {
+  const parsedVersion =
+    typeof version === "string" ? parseClickHouseVersion(version) : version;
+  if (!parsedVersion) return false;
+
+  const min = parseVersionBound(band.minInclusive);
+  if (compareParsedVersions(parsedVersion, min) < 0) {
+    return false;
+  }
+
+  if (band.maxExclusive) {
+    const max = parseVersionBound(band.maxExclusive);
+    return compareParsedVersions(parsedVersion, max) < 0;
+  }
+
+  return true;
+};
+
+export const resolveClickHouseCompatibility = ({
+  version,
+  overrides,
+}: ResolveClickHouseCompatibilityParams = {}): ResolvedClickHouseCompatibility => {
+  const parsedVersion = version ? parseClickHouseVersion(version) : null;
+  const settings: ClickHouseSettings = {};
+  const appliedRules: ClickHouseCompatibilityRule[] = [];
+
+  for (const rule of CLICKHOUSE_COMPATIBILITY_RULES) {
+    const override =
+      overrides?.[rule.overrideEnvKey] ?? env[rule.overrideEnvKey] ?? "auto";
+
+    if (override === "false") continue;
+
+    const shouldApply =
+      override === "true" ||
+      (override === "auto" &&
+        parsedVersion &&
+        rule.versionBands.some((band) =>
+          isClickHouseVersionInBand(parsedVersion, band),
+        ));
+
+    if (shouldApply) {
+      settings[rule.setting] = rule.value;
+      appliedRules.push(rule);
+    }
+  }
+
+  return { settings, appliedRules };
+};
+
+export const getClickHouseCompatibilitySettings = (): ClickHouseSettings =>
+  resolveClickHouseCompatibility({ version: detectedClickHouseVersion })
+    .settings;
+
+export const initializeClickhouseCompatibility = async (): Promise<void> => {
+  if (initializationPromise) return initializationPromise;
+
+  initializationPromise = (async () => {
+    try {
+      detectedClickHouseVersion = await fetchClickHouseVersion();
+      const resolved = resolveClickHouseCompatibility({
+        version: detectedClickHouseVersion,
+      });
+
+      if (resolved.appliedRules.length > 0) {
+        logger.info("Applying ClickHouse compatibility settings", {
+          clickhouseVersion: detectedClickHouseVersion,
+          settings: resolved.settings,
+          rules: resolved.appliedRules.map((rule) => ({
+            id: rule.id,
+            setting: rule.setting,
+            reason: rule.reason,
+          })),
+        });
+      } else {
+        logger.info("No ClickHouse compatibility settings required", {
+          clickhouseVersion: detectedClickHouseVersion,
+        });
+      }
+    } catch (error) {
+      logger.warn(
+        "Failed to detect ClickHouse version; continuing without automatic compatibility settings",
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  })();
+
+  return initializationPromise;
+};
+
+const fetchClickHouseVersion = async (): Promise<string> => {
+  const client = createClient(getClickHouseVersionClientConfig());
+
+  try {
+    const result = await client.query({
+      query: "SELECT version() AS version",
+      format: "JSONEachRow",
+    });
+    const rows = await result.json<{ version: string }>();
+    const version = rows[0]?.version;
+
+    if (!version) {
+      throw new Error("ClickHouse version query returned no version");
+    }
+
+    if (!parseClickHouseVersion(version)) {
+      throw new Error(`ClickHouse returned an unsupported version: ${version}`);
+    }
+
+    return version;
+  } finally {
+    await client.close();
+  }
+};
+
+const getClickHouseVersionClientConfig =
+  (): NodeClickHouseClientConfigOptions => {
+    return {
+      url: env.CLICKHOUSE_URL,
+      username: env.CLICKHOUSE_USER,
+      password: env.CLICKHOUSE_PASSWORD,
+      database: env.CLICKHOUSE_DB,
+      application: `langfuse/${VERSION.replace("v", "")}`,
+      request_timeout: 10_000,
+      log: {
+        LoggerClass: ClickHouseLogger,
+        level: mapLogLevel(env.LANGFUSE_LOG_LEVEL ?? "info"),
+      },
+    };
+  };
+
+export const setClickHouseCompatibilityVersionForTests = (
+  version: string | null,
+): void => {
+  detectedClickHouseVersion = version;
+  initializationPromise = null;
+};

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -49,6 +49,10 @@ export * from "./utils/billingCycleHelpers";
 export * from "./utils/compareVersions";
 export * from "./otel/utils";
 export * from "./clickhouse/client";
+export {
+  getClickHouseCompatibilitySettings,
+  initializeClickhouseCompatibility,
+} from "./clickhouse/compatibility";
 export * from "./clickhouse/schemaUtils";
 export * from "./clickhouse/schema";
 export * from "./clickhouse/queryTracking";

--- a/packages/shared/src/server/utils/compareVersions.test.ts
+++ b/packages/shared/src/server/utils/compareVersions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compareParsedVersions,
+  compareVersions,
+  parseVersionString,
+} from "./compareVersions";
+
+describe("parseVersionString", () => {
+  it("parses the first three numeric version components", () => {
+    expect(parseVersionString("26.5.1.882")).toMatchObject({
+      major: 26,
+      minor: 5,
+      patch: 1,
+      tuple: [26, 5, 1],
+    });
+  });
+
+  it("parses dotted vendor suffixes", () => {
+    expect(parseVersionString("21.8.10.1.altinitystable")).toMatchObject({
+      major: 21,
+      minor: 8,
+      patch: 10,
+      tuple: [21, 8, 10],
+    });
+  });
+});
+
+describe("compareParsedVersions", () => {
+  it("compares parsed versions by major, minor, and patch", () => {
+    const older = parseVersionString("25.3.99");
+    const newer = parseVersionString("25.4.0");
+
+    if (!older || !newer) {
+      throw new Error("Expected versions to parse");
+    }
+
+    expect(compareParsedVersions(older, newer)).toBe(-1);
+  });
+});
+
+describe("compareVersions", () => {
+  it("keeps semantic version update classification behavior", () => {
+    expect(compareVersions("v1.2.3", "v1.3.0")).toBe("minor");
+    expect(compareVersions("v1.2.3-rc.1", "v1.2.3")).toBe("patch");
+    expect(compareVersions("v1.2.3", "v1.2.3")).toBeNull();
+  });
+});

--- a/packages/shared/src/server/utils/compareVersions.ts
+++ b/packages/shared/src/server/utils/compareVersions.ts
@@ -2,6 +2,51 @@ import { z } from "zod";
 
 export const versionSchema = z.string().regex(/^v?\d+\.\d+\.\d+(?:[-+].+)?$/); // e.g. v1.2.3, 1.2.3, v1.2.3-rc.1, v1.2.3+build.123
 
+type VersionTuple = readonly [number, number, number];
+
+export type ParsedVersion = {
+  raw: string;
+  major: number;
+  minor: number;
+  patch: number;
+  tuple: VersionTuple;
+  isPreRelease: boolean;
+};
+
+export const parseVersionString = (
+  rawVersion: string,
+): ParsedVersion | null => {
+  const match = rawVersion.trim().match(/^v?(\d+)\.(\d+)\.(\d+)(?:[.+-].+)?$/);
+  if (!match) return null;
+
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+
+  if (![major, minor, patch].every(Number.isSafeInteger)) return null;
+
+  return {
+    raw: rawVersion,
+    major,
+    minor,
+    patch,
+    tuple: [major, minor, patch],
+    isPreRelease: /[-+]/.test(rawVersion),
+  };
+};
+
+export const compareParsedVersions = (
+  left: ParsedVersion,
+  right: ParsedVersion,
+): number => {
+  for (let i = 0; i < left.tuple.length; i++) {
+    if (left.tuple[i] > right.tuple[i]) return 1;
+    if (left.tuple[i] < right.tuple[i]) return -1;
+  }
+
+  return 0;
+};
+
 /**
  * Compare two semantic versions.
  * @param current - Current version (e.g., "v1.2.3")
@@ -15,44 +60,33 @@ export const compareVersions = (
   const currentValidated = versionSchema.parse(current);
   const latestValidated = versionSchema.parse(latest);
 
-  const parseVersion = (version: string) => {
-    if (version.startsWith("v")) {
-      version = version.slice(1);
-    }
-    // Split into version and pre-release parts
-    const [versionPart, ...rest] = version.split(/[-+]/);
-    const numbers = versionPart.split(".").map(Number);
-    return {
-      numbers,
-      isPreRelease: rest.length > 0,
-    };
-  };
+  const currentParsed = parseVersionString(currentValidated);
+  const latestParsed = parseVersionString(latestValidated);
 
-  const current_parsed = parseVersion(currentValidated);
-  const latest_parsed = parseVersion(latestValidated);
-
-  const [currentMajor, currentMinor, currentPatch] = current_parsed.numbers;
-  const [latestMajor, latestMinor, latestPatch] = latest_parsed.numbers;
+  if (!currentParsed || !latestParsed) {
+    throw new Error("Invalid semantic version");
+  }
 
   // If current is a pre-release (RC) and latest is a full release of the same version,
   // consider it as needing a patch update
   if (
-    current_parsed.isPreRelease &&
-    !latest_parsed.isPreRelease &&
-    currentMajor === latestMajor &&
-    currentMinor === latestMinor &&
-    currentPatch === latestPatch
+    currentParsed.isPreRelease &&
+    !latestParsed.isPreRelease &&
+    compareParsedVersions(currentParsed, latestParsed) === 0
   ) {
     return "patch";
   }
 
-  if (latestMajor > currentMajor) return "major";
-  if (latestMajor === currentMajor && latestMinor > currentMinor)
+  if (latestParsed.major > currentParsed.major) return "major";
+  if (
+    latestParsed.major === currentParsed.major &&
+    latestParsed.minor > currentParsed.minor
+  )
     return "minor";
   if (
-    latestMajor === currentMajor &&
-    latestMinor === currentMinor &&
-    latestPatch > currentPatch
+    latestParsed.major === currentParsed.major &&
+    latestParsed.minor === currentParsed.minor &&
+    latestParsed.patch > currentParsed.patch
   )
     return "patch";
 

--- a/web/src/initialize.ts
+++ b/web/src/initialize.ts
@@ -5,7 +5,12 @@ import { createAndAddApiKeysToDb } from "@langfuse/shared/src/server/auth/apiKey
 import { hasEntitlementBasedOnPlan } from "@/src/features/entitlements/server/hasEntitlement";
 import { getOrganizationPlanServerSide } from "@/src/features/entitlements/server/getPlan";
 import { CloudConfigSchema } from "@langfuse/shared";
-import { logger } from "@langfuse/shared/src/server";
+import {
+  initializeClickhouseCompatibility,
+  logger,
+} from "@langfuse/shared/src/server";
+
+await initializeClickhouseCompatibility();
 
 // Warn if LANGFUSE_INIT_* variables are set but LANGFUSE_INIT_ORG_ID is missing
 if (!env.LANGFUSE_INIT_ORG_ID) {

--- a/worker/src/app.ts
+++ b/worker/src/app.ts
@@ -1,5 +1,3 @@
-import "./initialize";
-
 import express from "express";
 import cors from "cors";
 import * as middlewares from "./middlewares";

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,8 +1,27 @@
 import "./instrumentation"; // instrumenting the application
-import app from "./app";
+import type { Server } from "http";
+import { initializeWorker } from "./initialize";
 import { env } from "./env";
 import { logger } from "@langfuse/shared/src/server";
 
-export const server = app.listen(env.PORT, env.HOSTNAME, () => {
-  logger.info(`Listening: http://${env.HOSTNAME}:${env.PORT}`);
+export let server: Server | undefined;
+
+const startWorker = async (): Promise<void> => {
+  await initializeWorker();
+
+  // worker is CommonJS under NodeNext, so dynamic import wraps the module namespace in default.
+  const {
+    default: { default: app },
+  } = await import("./app.js");
+
+  server = app.listen(env.PORT, env.HOSTNAME, () => {
+    logger.info(`Listening: http://${env.HOSTNAME}:${env.PORT}`);
+  });
+};
+
+startWorker().catch((error) => {
+  logger.error("Failed to start worker", {
+    error: error instanceof Error ? error.message : String(error),
+  });
+  process.exit(1);
 });

--- a/worker/src/initialize.ts
+++ b/worker/src/initialize.ts
@@ -1,7 +1,14 @@
 import { upsertDefaultModelPrices } from "./scripts/upsertDefaultModelPrices";
 import { upsertManagedEvaluators } from "./scripts/upsertManagedEvaluators";
 import { upsertLangfuseDashboards } from "./scripts/upsertLangfuseDashboards";
+import { initializeClickhouseCompatibility } from "@langfuse/shared/src/server";
 
-upsertDefaultModelPrices();
-upsertManagedEvaluators();
-upsertLangfuseDashboards();
+export const initializeWorker = async (): Promise<void> => {
+  await initializeClickhouseCompatibility();
+
+  await Promise.all([
+    upsertDefaultModelPrices(),
+    upsertManagedEvaluators(),
+    upsertLangfuseDashboards(),
+  ]);
+};

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -26,7 +26,7 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
   setSigtermReceived();
 
   // Stop accepting new connections
-  server.close();
+  server?.close();
   logger.info("Server has been closed.");
 
   // Stop batch project cleaners


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces automatic ClickHouse version detection at startup to replace the manual `CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION` flag. A new `compatibility.ts` module fetches the ClickHouse server version once on startup, evaluates it against a table of versioned rules, and injects the appropriate `clickhouse_settings` into every client connection.

- A new `initializeClickhouseCompatibility()` function is called at startup in both the `web` and `worker` services; it queries `SELECT version()`, parses the result, and sets module-level state used by `getClickHouseCompatibilitySettings()` on every subsequent `clickhouseClient()` call.
- The `worker/src/index.ts` start sequence is refactored from a synchronous fire-and-forget style to a proper `async/await` chain that awaits initialization before loading `app.ts` via a dynamic `require()`.
- `compareVersions.ts` gains a reusable `parseVersionString` / `compareParsedVersions` API that `compatibility.ts` relies on, and the existing `compareVersions` function is refactored to use it.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the auto-detection logic is well-tested, the initialization order change in the worker is structurally sound, and the fallback on version-detection failure is graceful.

The only meaningful concern is that the lazy-materialization workaround has no upper version bound, so it will be applied to all future ClickHouse versions in auto mode even after the underlying bug is fixed. This is a forward-looking maintenance issue rather than a present defect. The dynamic require() inside startWorker() is a style violation with a clean fix.

packages/shared/src/server/clickhouse/compatibility.ts — specifically the CLICKHOUSE_COMPATIBILITY_RULES array, which should include a maxExclusive bound once the upstream ClickHouse fix is confirmed backported.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Startup as web/worker startup
    participant Init as initializeClickhouseCompatibility()
    participant CH as ClickHouse
    participant Module as compatibility module state
    participant Client as clickhouseClient()

    Startup->>Init: await initializeClickhouseCompatibility()
    Init->>CH: SELECT version() AS version
    CH-->>Init: "25.5.1.2700"
    Init->>Module: "detectedClickHouseVersion = "25.5.1.2700""
    Init->>Init: "resolveClickHouseCompatibility({ version })"
    note over Init: version in band [25.4.0, ∞) → apply rule
    Init->>Init: logger.info("Applying ClickHouse compatibility settings")
    Init-->>Startup: resolved

    note over Startup: App now accepts requests

    Startup->>Client: clickhouseClient(opts)
    Client->>Module: getClickHouseCompatibilitySettings()
    Module-->>Client: "{ query_plan_optimize_lazy_materialization: 0 }"
    Client->>Client: "merge into createClient({ clickhouse_settings: { ...compat, ...opts } })"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/clickhouse/compatibility.ts:46-56
**Open-ended version band will apply the workaround indefinitely**

The `disable-lazy-materialization` rule has `minInclusive: "25.4.0"` but no `maxExclusive`, so in `auto` mode the setting `query_plan_optimize_lazy_materialization: 0` will be injected for every ClickHouse version ≥ 25.4.0 forever — including releases that ship the upstream fix. The original code comment said "Remove after ClickHouse 26.4"; the infrastructure here supports a `maxExclusive` bound but none is set. Disabling the optimization unnecessarily isn't a correctness issue, but it permanently suppresses a query-planning optimisation that may benefit workloads on fixed versions.

### Issue 2 of 2
worker/src/index.ts:13
**Dynamic `require()` inside a function violates the project import convention**

`require("./app")` is placed inside `startWorker()` rather than at the top of the module. The project rule is to keep all imports at the top of the file. The technical motivation — ensuring `app.ts`'s module body only runs after `initializeWorker()` completes — is valid, but the idiomatic TypeScript equivalent would be a dynamic `import()`: `const { default: app } = await import("./app")`. That preserves the deferred-evaluation semantics, keeps TypeScript's type-checking working without the `as Express` cast, and aligns with the project convention.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: detect clickhouse versions on star..."](https://github.com/langfuse/langfuse/commit/8ca6ae3443e5e00e78c92797d8f82ea6182b9260) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36948128)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->