### PR TITLE
feat(agent): Add conversation starters

### DIFF
--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -34,6 +34,21 @@ import type { InAppAgentMessageFeedbackValue } from "@/src/ee/features/in-app-ag
 
 const AUTO_SCROLL_THRESHOLD_PX = 50;
 const SCROLL_DIRECTION_TOLERANCE_PX = 1;
+const CONVERSATION_STARTERS = [
+  [
+    "Get started with Langfuse",
+    "Where should I start with setting up Langfuse?",
+  ],
+  ["Optimize my setup", "What should I improve in my Langfuse setup?"],
+  [
+    "Find problematic traces",
+    "Show me patterns in failed or low-scoring traces.",
+  ],
+  [
+    "Investigate unusual patterns",
+    "Are there unusual latency or cost patterns recently?",
+  ],
+] as const;
 
 function scrollViewportToBottom(viewport: HTMLDivElement | null) {
   if (!viewport) {
@@ -115,6 +130,31 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   const previousScrollTopRef = useRef(0);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [input, setInput] = useState("");
+  const hasUserMessage = messages.some((message) => message.role === "user");
+
+  const submitInput = (content: string) => {
+    const trimmedContent = content.trim();
+
+    if (!trimmedContent || isInputDisabled) {
+      return;
+    }
+
+    Promise.resolve(onSubmit(trimmedContent))
+      .then((submitted) => {
+        if (submitted) {
+          isAutoScrollAttachedRef.current = true;
+
+          setInput((currentInput) =>
+            currentInput.trim() === trimmedContent ? "" : currentInput,
+          );
+
+          window.requestAnimationFrame(() =>
+            scrollViewportToBottom(viewportRef.current),
+          );
+        }
+      })
+      .catch(() => undefined);
+  };
 
   useEffect(() => {
     if (!isAutoScrollAttachedRef.current) {
@@ -306,8 +346,8 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
               isExpanded ? "px-0" : "px-3",
             )}
           >
-            {messages.length === 0 ? (
-              <div className="flex h-full w-full flex-1 flex-col items-center justify-center">
+            {!hasUserMessage ? (
+              <div className="flex h-full w-full flex-1 flex-col items-center justify-center px-2">
                 <div>
                   <BotMessageSquare className="text-muted-foreground mx-auto h-8 w-8" />
                 </div>
@@ -316,10 +356,28 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
                 </p>
                 <p className="text-muted-foreground/60 mt-2 max-w-xs text-center text-sm leading-relaxed">
                   I can help you with any questions you have about Langfuse or
-                  assist you in exploring your event data.
+                  assist you in exploring your data.
                   <br />
-                  Just ask me anything!
+                  What do you want to do?
                 </p>
+                <div className="mt-6 flex max-w-sm flex-wrap items-center justify-center gap-2">
+                  {CONVERSATION_STARTERS.map(([label, message]) => (
+                    <button
+                      key={label}
+                      type="button"
+                      className={cn(
+                        "bg-card dark:bg-header text-foreground border-border hover:bg-muted/60 border text-[0.775rem] leading-none shadow-xs transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+                        isExpanded
+                          ? "rounded-2xl px-3 py-2"
+                          : "rounded-xl px-2 py-1.5",
+                      )}
+                      disabled={isInputDisabled}
+                      onClick={() => submitInput(message)}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
               </div>
             ) : null}
 
@@ -377,7 +435,11 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
           </div>
         </div>
         <div
-          className={cn("p-1.5", isExpanded ? "pt-0" : "bg-header border-t")}
+          className={cn(
+            "p-1.5",
+            isExpanded ? "pt-0" : "bg-header",
+            !isExpanded && hasUserMessage && "border-t",
+          )}
         >
           <form
             className={cn(
@@ -392,28 +454,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
             }}
             onSubmit={(event) => {
               event.preventDefault();
-
-              const content = input.trim();
-
-              if (!content || isInputDisabled) {
-                return;
-              }
-
-              Promise.resolve(onSubmit(content))
-                .then((submitted) => {
-                  if (submitted) {
-                    isAutoScrollAttachedRef.current = true;
-
-                    setInput((currentInput) =>
-                      currentInput.trim() === content ? "" : currentInput,
-                    );
-
-                    window.requestAnimationFrame(() =>
-                      scrollViewportToBottom(viewportRef.current),
-                    );
-                  }
-                })
-                .catch(() => undefined);
+              submitInput(input);
             }}
           >
             <textarea


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds conversation starter buttons to the in-app agent window that appear before the user has sent any message. The submission logic is refactored into a shared `submitInput` helper used by both the form and the starter buttons.

- Conversation starters are shown in a flex-wrap row above the input when `!hasUserMessage` (changed from `messages.length === 0`), allowing them to persist alongside an optional initial assistant greeting.
- The `submitInput` function centralizes trim/guard/submit/clear/scroll logic that was previously inlined in the `onSubmit` form handler.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The changes are additive — new starter buttons appear in the pre-conversation state and the existing submit path is unchanged in behavior after being refactored into submitInput.

The extraction of submitInput is correct: trim, guard, async-resolve, conditional clear, and scroll are all preserved. The condition widening from messages.length === 0 to !hasUserMessage is intentional and works correctly in the current parent implementation, but leaves a latent layout issue if assistant-only messages are ever injected before the user speaks.

web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx — specifically the welcome-screen condition and the starters section.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant B as StarterButton
    participant F as Form (textarea)
    participant SI as submitInput()
    participant P as Parent (onSubmit prop)

    note over B,F: No user message yet — both paths active

    U->>B: click starter
    B->>SI: submitInput(starterText)
    SI->>SI: trim + guard (isInputDisabled)
    SI->>P: onSubmit(trimmedContent)
    P-->>SI: Promise resolve true
    SI->>SI: "isAutoScrollAttached = true"
    SI->>SI: "setInput (clear only if textarea == trimmedContent)"
    SI->>SI: requestAnimationFrame → scrollToBottom
    P->>P: messages[] updated with user message
    note over B: hasUserMessage=true → starters hidden

    U->>F: type and submit form
    F->>SI: submitInput(input state)
    SI->>SI: trim + guard (isInputDisabled)
    SI->>P: onSubmit(trimmedContent)
    P-->>SI: Promise resolve true
    SI->>SI: clear textarea, scroll to bottom
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx:340-355
**Welcome screen + messages can co-render with assistant-only messages**

The condition was widened from `messages.length === 0` to `!hasUserMessage`. If the parent ever populates `messages` with assistant-only entries (e.g. an initial greeting) before the user speaks, both the centered welcome UI (`h-full flex-1` trying to consume all vertical space) and the rendered assistant messages in the `ol` below it will be visible simultaneously. The `flex-1` on the welcome div would push the assistant messages outside the visible scroll area. Today this appears safe since the parent doesn't send proactive assistant messages, but the contract is no longer guarded by the component itself — worth a comment in the code or adding a guard like `messages.length === 0` for the welcome pane while keeping `!hasUserMessage` for the starters.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agent): Add conversation starters"](https://github.com/langfuse/langfuse/commit/4ee25ff98a42a0e1b4bb9b7951ef779cf11d05f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36952665)</sub>

<!-- /greptile_comment -->