### PR TITLE
feat(support): update support severity drop down

### DIFF
--- a/web/src/__tests__/supportCaseSeverity.clienttest.ts
+++ b/web/src/__tests__/supportCaseSeverity.clienttest.ts
@@ -1,65 +1,60 @@
 // pylonClient imports the shared server logger at module load; stub it so this
-// stays a lightweight client-side unit test of the pure mapping function.
+// stays a lightweight client-side unit test of the pure mapping functions.
 vi.mock("@langfuse/shared/src/server", () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
 }));
 
-import { mapToPylonCaseSeverity } from "@/src/features/support-chat/pylon/pylonClient";
+import {
+  mapToPylonCaseSeverity,
+  mapCaseSeverityToPylonPriority,
+} from "@/src/features/support-chat/pylon/pylonClient";
+import {
+  SEVERITY_1,
+  SEVERITY_2,
+  SEVERITY_3,
+} from "@/src/features/support-chat/formConstants";
 
 describe("mapToPylonCaseSeverity", () => {
   const HIGH_TIER = "cloud:enterprise";
   const LOW_TIER = "cloud:pro";
 
-  it("returns Sev-1 for outages on high-tier plans", () => {
+  it("maps Severity 1 to Sev-1 on high-tier plans", () => {
     expect(
-      mapToPylonCaseSeverity({
-        severity: "Outage, data loss, or data breach",
-        plan: HIGH_TIER,
-      }),
+      mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: HIGH_TIER }),
     ).toBe("Sev-1");
   });
 
-  it("honors a manual high-priority request on high-tier plans", () => {
+  it("downgrades Severity 1 to Sev-2 for non-high-tier plans", () => {
     expect(
-      mapToPylonCaseSeverity({
-        severity: "Question or feature request",
-        plan: HIGH_TIER,
-        isHighPriority: true,
-      }),
-    ).toBe("Sev-1");
+      mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: LOW_TIER }),
+    ).toBe("Sev-2");
   });
 
-  it("ignores the high-priority flag for non-high-tier plans", () => {
-    expect(
-      mapToPylonCaseSeverity({
-        severity: "Question or feature request",
-        plan: LOW_TIER,
-        isHighPriority: true,
-      }),
-    ).toBe("Sev-3");
+  it("downgrades Severity 1 to Sev-2 when no plan is known", () => {
+    expect(mapToPylonCaseSeverity({ severity: SEVERITY_1 })).toBe("Sev-2");
   });
 
-  it("ignores the high-priority flag when no plan is known", () => {
+  it("maps Severity 2 to Sev-2 regardless of plan", () => {
     expect(
-      mapToPylonCaseSeverity({
-        severity: "Question or feature request",
-        isHighPriority: true,
-      }),
-    ).toBe("Sev-3");
-  });
-
-  it("keeps existing mapping when high-priority is not set", () => {
-    expect(
-      mapToPylonCaseSeverity({
-        severity: "Feature is not working at all",
-        plan: HIGH_TIER,
-      }),
+      mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: HIGH_TIER }),
     ).toBe("Sev-2");
     expect(
-      mapToPylonCaseSeverity({
-        severity: "Question or feature request",
-        plan: HIGH_TIER,
-      }),
+      mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: LOW_TIER }),
+    ).toBe("Sev-2");
+  });
+
+  it("maps Severity 3 to Sev-3 regardless of plan", () => {
+    expect(
+      mapToPylonCaseSeverity({ severity: SEVERITY_3, plan: HIGH_TIER }),
     ).toBe("Sev-3");
+    expect(mapToPylonCaseSeverity({ severity: SEVERITY_3 })).toBe("Sev-3");
+  });
+});
+
+describe("mapCaseSeverityToPylonPriority", () => {
+  it("derives Pylon priority from the effective case severity", () => {
+    expect(mapCaseSeverityToPylonPriority("Sev-1")).toBe("urgent");
+    expect(mapCaseSeverityToPylonPriority("Sev-2")).toBe("high");
+    expect(mapCaseSeverityToPylonPriority("Sev-3")).toBe("low");
   });
 });

--- a/web/src/__tests__/supportCaseSeverity.clienttest.ts
+++ b/web/src/__tests__/supportCaseSeverity.clienttest.ts
@@ -13,6 +13,7 @@ import {
   SEVERITY_2,
   SEVERITY_3,
   isSeverityAllowedForPlan,
+  highestSupportPlan,
 } from "@/src/features/support-chat/formConstants";
 
 const HIGH_TIER = "cloud:enterprise"; // may raise Sev-1, Sev-2, Sev-3
@@ -91,6 +92,38 @@ describe("isSeverityAllowedForPlan", () => {
   it("always allows Severity 3", () => {
     expect(isSeverityAllowedForPlan(SEVERITY_3, LOW_TIER)).toBe(true);
     expect(isSeverityAllowedForPlan(SEVERITY_3, undefined)).toBe(true);
+  });
+});
+
+describe("highestSupportPlan", () => {
+  it("returns the plan granting the highest severity from a list", () => {
+    expect(highestSupportPlan(["cloud:hobby", "cloud:enterprise"])).toBe(
+      "cloud:enterprise",
+    );
+    expect(highestSupportPlan(["cloud:hobby", "cloud:pro"])).toBe("cloud:pro");
+  });
+
+  it("ignores undefined/empty entries", () => {
+    expect(highestSupportPlan([undefined, "cloud:team", undefined])).toBe(
+      "cloud:team",
+    );
+  });
+
+  it("returns a low-tier plan when that is all the user has", () => {
+    expect(highestSupportPlan(["cloud:hobby", "cloud:core"])).toBe(
+      "cloud:hobby",
+    );
+  });
+
+  it("returns undefined when there are no plans", () => {
+    expect(highestSupportPlan([])).toBeUndefined();
+    expect(highestSupportPlan([undefined])).toBeUndefined();
+  });
+
+  it("a Team/Enterprise member filing off-context can still raise Sev-1", () => {
+    // Regression: support form opened from a no-org page must not wrongly gate.
+    const best = highestSupportPlan(["cloud:hobby", "cloud:enterprise"]);
+    expect(isSeverityAllowedForPlan(SEVERITY_1, best)).toBe(true);
   });
 });
 

--- a/web/src/__tests__/supportCaseSeverity.clienttest.ts
+++ b/web/src/__tests__/supportCaseSeverity.clienttest.ts
@@ -12,35 +12,56 @@ import {
   SEVERITY_1,
   SEVERITY_2,
   SEVERITY_3,
+  isSeverityAllowedForPlan,
 } from "@/src/features/support-chat/formConstants";
 
-describe("mapToPylonCaseSeverity", () => {
-  const HIGH_TIER = "cloud:enterprise";
-  const LOW_TIER = "cloud:pro";
+const HIGH_TIER = "cloud:enterprise"; // may raise Sev-1, Sev-2, Sev-3
+const MID_TIER = "cloud:pro"; // may raise Sev-2, Sev-3
+const LOW_TIER = "cloud:hobby"; // may raise Sev-3 only
+const CORE = "cloud:core"; // may raise Sev-3 only
 
-  it("maps Severity 1 to Sev-1 on high-tier plans", () => {
+describe("mapToPylonCaseSeverity", () => {
+  it("maps Severity 1 to Sev-1 only on high-tier plans", () => {
     expect(
       mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: HIGH_TIER }),
     ).toBe("Sev-1");
   });
 
-  it("downgrades Severity 1 to Sev-2 for non-high-tier plans", () => {
+  it("downgrades Severity 1 to Sev-2 for Pro-tier plans", () => {
     expect(
-      mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: LOW_TIER }),
+      mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: MID_TIER }),
     ).toBe("Sev-2");
   });
 
-  it("downgrades Severity 1 to Sev-2 when no plan is known", () => {
-    expect(mapToPylonCaseSeverity({ severity: SEVERITY_1 })).toBe("Sev-2");
+  it("downgrades Severity 1 to Sev-3 for Hobby/Core plans", () => {
+    expect(
+      mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: LOW_TIER }),
+    ).toBe("Sev-3");
+    expect(mapToPylonCaseSeverity({ severity: SEVERITY_1, plan: CORE })).toBe(
+      "Sev-3",
+    );
   });
 
-  it("maps Severity 2 to Sev-2 regardless of plan", () => {
+  it("downgrades Severity 1 to Sev-3 when no plan is known", () => {
+    expect(mapToPylonCaseSeverity({ severity: SEVERITY_1 })).toBe("Sev-3");
+  });
+
+  it("maps Severity 2 to Sev-2 for Pro tier and above", () => {
     expect(
       mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: HIGH_TIER }),
     ).toBe("Sev-2");
     expect(
-      mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: LOW_TIER }),
+      mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: MID_TIER }),
     ).toBe("Sev-2");
+  });
+
+  it("downgrades Severity 2 to Sev-3 for Hobby/Core plans", () => {
+    expect(
+      mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: LOW_TIER }),
+    ).toBe("Sev-3");
+    expect(mapToPylonCaseSeverity({ severity: SEVERITY_2, plan: CORE })).toBe(
+      "Sev-3",
+    );
   });
 
   it("maps Severity 3 to Sev-3 regardless of plan", () => {
@@ -48,6 +69,28 @@ describe("mapToPylonCaseSeverity", () => {
       mapToPylonCaseSeverity({ severity: SEVERITY_3, plan: HIGH_TIER }),
     ).toBe("Sev-3");
     expect(mapToPylonCaseSeverity({ severity: SEVERITY_3 })).toBe("Sev-3");
+  });
+});
+
+describe("isSeverityAllowedForPlan", () => {
+  it("allows Severity 1 only for high-tier plans", () => {
+    expect(isSeverityAllowedForPlan(SEVERITY_1, HIGH_TIER)).toBe(true);
+    expect(isSeverityAllowedForPlan(SEVERITY_1, MID_TIER)).toBe(false);
+    expect(isSeverityAllowedForPlan(SEVERITY_1, LOW_TIER)).toBe(false);
+    expect(isSeverityAllowedForPlan(SEVERITY_1, undefined)).toBe(false);
+  });
+
+  it("allows Severity 2 for Pro tier and above but not Hobby/Core", () => {
+    expect(isSeverityAllowedForPlan(SEVERITY_2, HIGH_TIER)).toBe(true);
+    expect(isSeverityAllowedForPlan(SEVERITY_2, MID_TIER)).toBe(true);
+    expect(isSeverityAllowedForPlan(SEVERITY_2, LOW_TIER)).toBe(false);
+    expect(isSeverityAllowedForPlan(SEVERITY_2, CORE)).toBe(false);
+    expect(isSeverityAllowedForPlan(SEVERITY_2, undefined)).toBe(false);
+  });
+
+  it("always allows Severity 3", () => {
+    expect(isSeverityAllowedForPlan(SEVERITY_3, LOW_TIER)).toBe(true);
+    expect(isSeverityAllowedForPlan(SEVERITY_3, undefined)).toBe(true);
   });
 });
 

--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -6,12 +6,15 @@ import { type z } from "zod";
 import {
   MESSAGE_TYPES,
   SEVERITIES,
+  SEVERITY_1,
+  SEVERITY_2,
   SEVERITY_3,
   INTEGRATION_TYPES,
   TopicGroups,
   type MessageType,
   SupportFormSchema,
   isSeverityAllowedForPlan,
+  highestSupportPlan,
 } from "./formConstants";
 
 import { api } from "@/src/utils/api";
@@ -28,11 +31,6 @@ import {
 } from "@/src/components/ui/form";
 import { RadioGroup } from "@/src/components/ui/radio-group";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/src/components/ui/tooltip";
-import {
   Select,
   SelectContent,
   SelectItem,
@@ -41,6 +39,7 @@ import {
 } from "@/src/components/ui/select";
 import { Textarea } from "@/src/components/ui/textarea";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
+import { useSession } from "next-auth/react";
 import { useMemo, useState } from "react";
 
 import {
@@ -168,6 +167,20 @@ export function SupportFormSection({
   onSuccess: () => void;
 }) {
   const { organization, project } = useQueryProjectOrOrganization();
+  const session = useSession();
+
+  // The support drawer is mounted globally and reachable from pages without an
+  // org/project in the URL (home, setup, onboarding, account settings), where
+  // `organization` is null. Fall back to the user's highest-tier org plan so
+  // severity eligibility reflects what the user actually has access to instead
+  // of being wrongly restricted. The server applies the same fallback.
+  const effectivePlan =
+    organization?.plan ??
+    highestSupportPlan(
+      (session.data?.user?.organizations ?? []).map((o) => o.plan),
+    );
+  const isSev1Allowed = isSeverityAllowedForPlan(SEVERITY_1, effectivePlan);
+  const isSev2Allowed = isSeverityAllowedForPlan(SEVERITY_2, effectivePlan);
 
   // Tracks whether we've already warned about a short message
   const [warnedShortOnce, setWarnedShortOnce] = useState(false);
@@ -390,42 +403,28 @@ export function SupportFormSection({
                       <SelectValue placeholder="Select a priority" />
                     </SelectTrigger>
                     <SelectContent>
-                      {SEVERITIES.map((s) => {
-                        const allowed = isSeverityAllowedForPlan(
-                          s,
-                          organization?.plan,
-                        );
-
-                        if (allowed) {
-                          return (
-                            <SelectItem key={s} value={s}>
-                              {s}
-                            </SelectItem>
-                          );
-                        }
-
-                        // Disabled items have `pointer-events: none`, so wrap in
-                        // a trigger element that still receives hover to show
-                        // the "not available on your plan" tooltip.
-                        return (
-                          <Tooltip key={s}>
-                            <TooltipTrigger asChild>
-                              <div className="cursor-not-allowed">
-                                <SelectItem value={s} disabled>
-                                  {s}
-                                </SelectItem>
-                              </div>
-                            </TooltipTrigger>
-                            <TooltipContent className="max-w-xs">
-                              This option is not available on your current
-                              Langfuse plan.
-                            </TooltipContent>
-                          </Tooltip>
-                        );
-                      })}
+                      {SEVERITIES.map((s) => (
+                        <SelectItem
+                          key={s}
+                          value={s}
+                          disabled={!isSeverityAllowedForPlan(s, effectivePlan)}
+                        >
+                          {s}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </FormControl>
+                {/* Explain the gating for all input modalities (keyboard /
+                    screen-reader users can't reach a per-item tooltip, and a
+                    tooltip portal can stack behind the dropdown). */}
+                {!isSev1Allowed && (
+                  <FormDescription>
+                    {isSev2Allowed
+                      ? "Severity 1 is available on the Team and Enterprise plans."
+                      : "Severity 1 (Team and Enterprise) and Severity 2 (Pro and above) are not available on your current plan."}
+                  </FormDescription>
+                )}
                 <FormMessage />
               </FormItem>
             )}

--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -6,13 +6,12 @@ import { type z } from "zod";
 import {
   MESSAGE_TYPES,
   SEVERITIES,
-  SEVERITY_1,
   SEVERITY_3,
   INTEGRATION_TYPES,
   TopicGroups,
   type MessageType,
   SupportFormSchema,
-  isHighTierSupportPlan,
+  isSeverityAllowedForPlan,
 } from "./formConstants";
 
 import { api } from "@/src/utils/api";
@@ -169,9 +168,6 @@ export function SupportFormSection({
   onSuccess: () => void;
 }) {
   const { organization, project } = useQueryProjectOrOrganization();
-
-  // Only Team / Enterprise customers may raise a Severity 1 request.
-  const canRequestHighPriority = isHighTierSupportPlan(organization?.plan);
 
   // Tracks whether we've already warned about a short message
   const [warnedShortOnce, setWarnedShortOnce] = useState(false);
@@ -395,10 +391,12 @@ export function SupportFormSection({
                     </SelectTrigger>
                     <SelectContent>
                       {SEVERITIES.map((s) => {
-                        const isSev1Locked =
-                          s === SEVERITY_1 && !canRequestHighPriority;
+                        const allowed = isSeverityAllowedForPlan(
+                          s,
+                          organization?.plan,
+                        );
 
-                        if (!isSev1Locked) {
+                        if (allowed) {
                           return (
                             <SelectItem key={s} value={s}>
                               {s}

--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -6,6 +6,8 @@ import { type z } from "zod";
 import {
   MESSAGE_TYPES,
   SEVERITIES,
+  SEVERITY_1,
+  SEVERITY_3,
   INTEGRATION_TYPES,
   TopicGroups,
   type MessageType,
@@ -25,7 +27,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/src/components/ui/form";
-import { Checkbox } from "@/src/components/ui/checkbox";
 import { RadioGroup } from "@/src/components/ui/radio-group";
 import {
   Tooltip,
@@ -48,7 +49,7 @@ import {
   DropzoneContent,
   DropzoneEmptyState,
 } from "@/src/components/ui/shadcn-io/dropzone";
-import { Info, Paperclip, Trash2 } from "lucide-react";
+import { Paperclip, Trash2 } from "lucide-react";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { PYLON_MAX_FILE_SIZE_BYTES } from "./pylon/pylonConstants";
 import Spinner from "@/src/components/design-system/Spinner/Spinner";
@@ -169,11 +170,8 @@ export function SupportFormSection({
 }) {
   const { organization, project } = useQueryProjectOrOrganization();
 
-  // Team / Enterprise customers may manually escalate a request to Sev-1.
+  // Only Team / Enterprise customers may raise a Severity 1 request.
   const canRequestHighPriority = isHighTierSupportPlan(organization?.plan);
-
-  // Controlled so the high-priority info tooltip opens on hover and on click.
-  const [highPriorityInfoOpen, setHighPriorityInfoOpen] = useState(false);
 
   // Tracks whether we've already warned about a short message
   const [warnedShortOnce, setWarnedShortOnce] = useState(false);
@@ -192,8 +190,7 @@ export function SupportFormSection({
     resolver: zodResolver(SupportFormSchema),
     defaultValues: {
       messageType: "Question" as MessageType,
-      severity: "Question or feature request",
-      isHighPriority: false,
+      severity: SEVERITY_3,
       topic: "",
       message: "",
       integrationType: "",
@@ -221,8 +218,7 @@ export function SupportFormSection({
         }
         form.reset({
           messageType: "Question",
-          severity: "Question or feature request",
-          isHighPriority: false,
+          severity: SEVERITY_3,
           topic: "",
           message: "",
         });
@@ -297,7 +293,6 @@ export function SupportFormSection({
       await createSupportThread.mutateAsync({
         messageType: parsed.messageType,
         severity: parsed.severity,
-        isHighPriority: parsed.isHighPriority,
         topic: parsed.topic as any,
         integrationType: parsed.integrationType,
         message: parsed.message,
@@ -385,71 +380,54 @@ export function SupportFormSection({
             )}
           />
 
-          {/* Severity */}
+          {/* Priority (maps to Pylon case_severity). Severity 1 is gated to
+              Team / Enterprise plans. */}
           <FormField
             control={form.control}
             name="severity"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Severity</FormLabel>
-                <div className="flex items-center gap-3">
-                  <FormControl>
-                    <Select value={field.value} onValueChange={field.onChange}>
-                      <SelectTrigger className="flex-1">
-                        <SelectValue placeholder="Select severity" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {SEVERITIES.map((s) => (
-                          <SelectItem key={s} value={s}>
-                            {s}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </FormControl>
+                <FormLabel>Priority</FormLabel>
+                <FormControl>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a priority" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SEVERITIES.map((s) => {
+                        const isSev1Locked =
+                          s === SEVERITY_1 && !canRequestHighPriority;
 
-                  {/* High priority (Sev-1) — only for Team / Enterprise plans */}
-                  {canRequestHighPriority && (
-                    <FormField
-                      control={form.control}
-                      name="isHighPriority"
-                      render={({ field: priorityField }) => (
-                        <FormItem className="flex shrink-0 flex-row items-center gap-1.5 space-y-0">
-                          <FormControl>
-                            <Checkbox
-                              checked={priorityField.value ?? false}
-                              onCheckedChange={priorityField.onChange}
-                            />
-                          </FormControl>
-                          <FormLabel className="cursor-pointer text-sm font-normal whitespace-nowrap">
-                            Urgent (Sev-1)
-                          </FormLabel>
-                          <Tooltip
-                            open={highPriorityInfoOpen}
-                            onOpenChange={setHighPriorityInfoOpen}
-                          >
+                        if (!isSev1Locked) {
+                          return (
+                            <SelectItem key={s} value={s}>
+                              {s}
+                            </SelectItem>
+                          );
+                        }
+
+                        // Disabled items have `pointer-events: none`, so wrap in
+                        // a trigger element that still receives hover to show
+                        // the "not available on your plan" tooltip.
+                        return (
+                          <Tooltip key={s}>
                             <TooltipTrigger asChild>
-                              <button
-                                type="button"
-                                onClick={() =>
-                                  setHighPriorityInfoOpen((open) => !open)
-                                }
-                                className="text-muted-foreground hover:text-foreground"
-                                aria-label="High priority info"
-                              >
-                                <Info className="h-3.5 w-3.5" />
-                              </button>
+                              <div className="cursor-not-allowed">
+                                <SelectItem value={s} disabled>
+                                  {s}
+                                </SelectItem>
+                              </div>
                             </TooltipTrigger>
                             <TooltipContent className="max-w-xs">
-                              Mark as high priority only for time-critical
-                              issues such as production outages.
+                              This option is not available on your current
+                              Langfuse plan.
                             </TooltipContent>
                           </Tooltip>
-                        </FormItem>
-                      )}
-                    />
-                  )}
-                </div>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
                 <FormMessage />
               </FormItem>
             )}

--- a/web/src/features/support-chat/formConstants.ts
+++ b/web/src/features/support-chat/formConstants.ts
@@ -64,9 +64,39 @@ export const HIGH_TIER_SUPPORT_PLANS = [
   "self-hosted:enterprise",
 ] as const;
 
+/**
+ * Plans that may raise a Severity 2 (Sev-2) support request — Pro tier and
+ * above. Hobby/Core (and free/unknown plans) are limited to Severity 3.
+ */
+export const SEV2_SUPPORT_PLANS = [
+  "cloud:pro",
+  "cloud:team",
+  "cloud:enterprise",
+  "self-hosted:pro",
+  "self-hosted:enterprise",
+] as const;
+
 /** Whether the given plan may raise a Severity 1 support request. */
 export const isHighTierSupportPlan = (plan?: string): boolean =>
   !!plan && (HIGH_TIER_SUPPORT_PLANS as readonly string[]).includes(plan);
+
+/** Whether the given plan may raise a Severity 2 support request. */
+export const canRaiseSeverity2 = (plan?: string): boolean =>
+  !!plan && (SEV2_SUPPORT_PLANS as readonly string[]).includes(plan);
+
+/**
+ * Whether a given severity level can be selected on the given plan. Used both
+ * to grey out options in the UI and as a server-side safeguard in
+ * `mapToPylonCaseSeverity`.
+ */
+export const isSeverityAllowedForPlan = (
+  severity: string,
+  plan?: string,
+): boolean => {
+  if (severity === SEVERITY_1) return isHighTierSupportPlan(plan);
+  if (severity === SEVERITY_2) return canRaiseSeverity2(plan);
+  return true; // Severity 3 is always available
+};
 
 export const IntegrationTypeSchema = z.enum([
   "Python SDK",

--- a/web/src/features/support-chat/formConstants.ts
+++ b/web/src/features/support-chat/formConstants.ts
@@ -98,6 +98,30 @@ export const isSeverityAllowedForPlan = (
   return true; // Severity 3 is always available
 };
 
+/**
+ * Picks the plan granting the highest support severity from a list. Used as a
+ * fallback when no specific org/project is in context (e.g. the support form is
+ * opened from a page without an org/project in the URL): eligibility should
+ * reflect the best plan the user has access to rather than defaulting to none.
+ */
+export const highestSupportPlan = (
+  plans: Array<string | undefined>,
+): string | undefined => {
+  const rank = (plan?: string) =>
+    isHighTierSupportPlan(plan) ? 3 : canRaiseSeverity2(plan) ? 2 : 1;
+  let best: string | undefined;
+  let bestRank = 0;
+  for (const plan of plans) {
+    if (!plan) continue;
+    const r = rank(plan);
+    if (r > bestRank) {
+      bestRank = r;
+      best = plan;
+    }
+  }
+  return best;
+};
+
 export const IntegrationTypeSchema = z.enum([
   "Python SDK",
   "TypeScript SDK",

--- a/web/src/features/support-chat/formConstants.ts
+++ b/web/src/features/support-chat/formConstants.ts
@@ -38,16 +38,24 @@ export const ALL_TOPICS = [
 export const TopicSchema = z.enum(ALL_TOPICS);
 export type Topic = z.infer<typeof TopicSchema>;
 
+/**
+ * Severity levels shown to the user. Wording mirrors the Pylon issue
+ * "Priority" field. Each maps to a Pylon `case_severity` value
+ * (Sev-1/Sev-2/Sev-3) in `mapToPylonCaseSeverity`.
+ */
 export const SeveritySchema = z.enum([
-  "Question or feature request",
-  "Feature not working as expected",
-  "Feature is not working at all",
-  "Outage, data loss, or data breach",
+  "Severity 1 (Critical Business Impact)",
+  "Severity 2 (Major Business Impact)",
+  "Severity 3 (Minor Business Impact or General Questions)",
 ]);
 export type Severity = z.infer<typeof SeveritySchema>;
 
+export const SEVERITY_1 = SeveritySchema.options[0];
+export const SEVERITY_2 = SeveritySchema.options[1];
+export const SEVERITY_3 = SeveritySchema.options[2];
+
 /**
- * Plans that may manually flag a support request as high priority (Sev-1).
+ * Plans that may raise a Severity 1 (Sev-1) support request.
  * Mirrors the high-tier check in `mapToPylonCaseSeverity`.
  */
 export const HIGH_TIER_SUPPORT_PLANS = [
@@ -56,7 +64,7 @@ export const HIGH_TIER_SUPPORT_PLANS = [
   "self-hosted:enterprise",
 ] as const;
 
-/** Whether the given plan may manually escalate a support request to Sev-1. */
+/** Whether the given plan may raise a Severity 1 support request. */
 export const isHighTierSupportPlan = (plan?: string): boolean =>
   !!plan && (HIGH_TIER_SUPPORT_PLANS as readonly string[]).includes(plan);
 
@@ -79,11 +87,6 @@ export type IntegrationType = z.infer<typeof IntegrationTypeSchema>;
 export const SupportFormSchema = z.object({
   messageType: MessageTypeSchema.default("Question"),
   severity: SeveritySchema,
-  /**
-   * Manual high-priority (Sev-1) escalation. Only honored server-side for
-   * high-tier plans (see {@link isHighTierSupportPlan}).
-   */
-  isHighPriority: z.boolean().default(false),
   integrationType: z.string().optional(),
   topic: z
     .union([TopicSchema, z.literal("")])

--- a/web/src/features/support-chat/pylon/pylonClient.ts
+++ b/web/src/features/support-chat/pylon/pylonClient.ts
@@ -1,6 +1,7 @@
 import { logger } from "@langfuse/shared/src/server";
 import {
   isHighTierSupportPlan,
+  canRaiseSeverity2,
   SEVERITY_1,
   SEVERITY_2,
 } from "../formConstants";
@@ -262,12 +263,14 @@ export function mapMessageTypeToPylonQuestionType(messageType: string): string {
 }
 
 /**
- * Maps the user-selected severity level to the Pylon `case_severity` value.
+ * Maps the user-selected severity level to the Pylon `case_severity` value,
+ * capped by what the plan is eligible for.
  *
- * Severity 1 is only available to high-tier plans (Team/Enterprise). The option
- * is disabled in the UI for other plans, but we also enforce it here as a
- * server-side safeguard: a Severity 1 selection from a non-high-tier plan is
- * downgraded to Sev-2.
+ * Severity 1 requires a high-tier plan (Team/Enterprise); Severity 2 requires
+ * Pro tier or above. These options are disabled in the UI for ineligible plans,
+ * but we also enforce it here as a server-side safeguard: a selection above the
+ * plan's eligibility is downgraded to the highest level it can raise (a
+ * Hobby/Core request therefore never exceeds Sev-3).
  */
 export function mapToPylonCaseSeverity(params: {
   severity: string;
@@ -275,10 +278,13 @@ export function mapToPylonCaseSeverity(params: {
 }): "Sev-1" | "Sev-2" | "Sev-3" {
   const { severity, plan } = params;
 
-  if (severity === SEVERITY_1) {
-    return isHighTierSupportPlan(plan) ? "Sev-1" : "Sev-2";
+  if (severity === SEVERITY_1 && isHighTierSupportPlan(plan)) {
+    return "Sev-1";
   }
-  if (severity === SEVERITY_2) {
+  if (
+    (severity === SEVERITY_1 || severity === SEVERITY_2) &&
+    canRaiseSeverity2(plan)
+  ) {
     return "Sev-2";
   }
   return "Sev-3";

--- a/web/src/features/support-chat/pylon/pylonClient.ts
+++ b/web/src/features/support-chat/pylon/pylonClient.ts
@@ -1,5 +1,9 @@
 import { logger } from "@langfuse/shared/src/server";
-import { isHighTierSupportPlan } from "../formConstants";
+import {
+  isHighTierSupportPlan,
+  SEVERITY_1,
+  SEVERITY_2,
+} from "../formConstants";
 
 const PYLON_API_BASE = "https://api.usepylon.com";
 
@@ -169,17 +173,20 @@ export async function updatePylonAccountCustomFields(
   }
 }
 
-export function mapSeverityToPylonPriority(
-  severity: string,
-): "urgent" | "high" | "medium" | "low" {
-  switch (severity) {
-    case "Outage, data loss, or data breach":
+/**
+ * Maps the effective Pylon `case_severity` to the Pylon issue `priority`.
+ * Derived from the (already plan-gated) case severity so the two fields stay
+ * consistent.
+ */
+export function mapCaseSeverityToPylonPriority(
+  caseSeverity: "Sev-1" | "Sev-2" | "Sev-3",
+): "urgent" | "high" | "low" {
+  switch (caseSeverity) {
+    case "Sev-1":
       return "urgent";
-    case "Feature is not working at all":
+    case "Sev-2":
       return "high";
-    case "Feature not working as expected":
-      return "medium";
-    case "Question or feature request":
+    case "Sev-3":
     default:
       return "low";
   }
@@ -254,31 +261,26 @@ export function mapMessageTypeToPylonQuestionType(messageType: string): string {
   }
 }
 
+/**
+ * Maps the user-selected severity level to the Pylon `case_severity` value.
+ *
+ * Severity 1 is only available to high-tier plans (Team/Enterprise). The option
+ * is disabled in the UI for other plans, but we also enforce it here as a
+ * server-side safeguard: a Severity 1 selection from a non-high-tier plan is
+ * downgraded to Sev-2.
+ */
 export function mapToPylonCaseSeverity(params: {
   severity: string;
   plan?: string;
-  /** Customer manually requested high priority via the support form. */
-  isHighPriority?: boolean;
 }): "Sev-1" | "Sev-2" | "Sev-3" {
-  const { severity, plan, isHighPriority } = params;
-  const isHighTierPlan = isHighTierSupportPlan(plan);
+  const { severity, plan } = params;
 
-  // High-tier customers (Team/Enterprise) get Sev-1 either automatically for
-  // outages, or when they manually flag a time-critical request as urgent.
-  if (
-    isHighTierPlan &&
-    (isHighPriority || severity === "Outage, data loss, or data breach")
-  ) {
-    return "Sev-1";
+  if (severity === SEVERITY_1) {
+    return isHighTierSupportPlan(plan) ? "Sev-1" : "Sev-2";
   }
-
-  if (
-    severity === "Outage, data loss, or data breach" ||
-    severity === "Feature is not working at all"
-  ) {
+  if (severity === SEVERITY_2) {
     return "Sev-2";
   }
-
   return "Sev-3";
 }
 

--- a/web/src/features/support-chat/trpc/supportRouter.ts
+++ b/web/src/features/support-chat/trpc/supportRouter.ts
@@ -15,6 +15,7 @@ import {
   SeveritySchema,
   TopicSchema,
   TopicGroups,
+  highestSupportPlan,
 } from "../formConstants";
 
 import {
@@ -146,6 +147,16 @@ export const supportRouter = createTRPCRouter({
 
         currentSupportRequestContext.plan = organization.plan;
         currentSupportRequestContext.organizationId = organization.id;
+      }
+
+      // When no specific org/project is in context (the support form is
+      // reachable from pages without org/project in the URL), fall back to the
+      // user's highest-tier org plan. This mirrors the client-side gating so a
+      // legitimate Team/Enterprise user is not silently downgraded.
+      if (!currentSupportRequestContext.plan) {
+        currentSupportRequestContext.plan = highestSupportPlan(
+          ctx.session.user.organizations.map((o) => o.plan),
+        );
       }
 
       // Resolve the Pylon case severity (Sev-1/2/3). Sev-1 is gated to

--- a/web/src/features/support-chat/trpc/supportRouter.ts
+++ b/web/src/features/support-chat/trpc/supportRouter.ts
@@ -15,14 +15,13 @@ import {
   SeveritySchema,
   TopicSchema,
   TopicGroups,
-  isHighTierSupportPlan,
 } from "../formConstants";
 
 import {
   createPylonIssue,
   buildPylonIssueBodyHtml,
   buildPylonMetadataString,
-  mapSeverityToPylonPriority,
+  mapCaseSeverityToPylonPriority,
   updatePylonAccountCustomFields,
   mapPlanToPylonCustomerTier,
   mapToPylonCaseSeverity,
@@ -35,8 +34,6 @@ import {
 const CreateSupportThreadInput = z.object({
   messageType: MessageTypeSchema,
   severity: SeveritySchema,
-  /** Manual Sev-1 escalation; only honored for high-tier plans (enforced below). */
-  isHighPriority: z.boolean().optional(),
   topic: TopicSchema,
   message: z.string().trim().min(1),
   url: z.url().optional(),
@@ -151,11 +148,13 @@ export const supportRouter = createTRPCRouter({
         currentSupportRequestContext.organizationId = organization.id;
       }
 
-      // Only honor a manual high-priority request for high-tier plans; ignore
-      // the client-supplied flag otherwise so it cannot be used to force Sev-1.
-      const honorHighPriority =
-        input.isHighPriority === true &&
-        isHighTierSupportPlan(currentSupportRequestContext.plan);
+      // Resolve the Pylon case severity (Sev-1/2/3). Sev-1 is gated to
+      // high-tier plans inside mapToPylonCaseSeverity, so a Severity 1 selection
+      // from a non-high-tier plan is safely downgraded server-side.
+      const caseSeverity = mapToPylonCaseSeverity({
+        severity: input.severity,
+        plan: currentSupportRequestContext.plan,
+      });
 
       const { topLevel, subtype } = splitTopic(input.topic);
 
@@ -199,9 +198,7 @@ export const supportRouter = createTRPCRouter({
             requesterEmail: email,
             requesterName: fullName,
             tags: ["Langfuse"],
-            priority: honorHighPriority
-              ? "urgent"
-              : mapSeverityToPylonPriority(input.severity),
+            priority: mapCaseSeverityToPylonPriority(caseSeverity),
             attachmentUrls: input.pylonAttachmentUrls,
             customFields: [
               ...(input.url
@@ -223,11 +220,7 @@ export const supportRouter = createTRPCRouter({
               { slug: "langfuse_metadata", value: pylonMetadata },
               {
                 slug: "case_severity",
-                value: mapToPylonCaseSeverity({
-                  severity: input.severity,
-                  plan: currentSupportRequestContext.plan,
-                  isHighPriority: honorHighPriority,
-                }),
+                value: caseSeverity,
               },
             ],
           });


### PR DESCRIPTION
## Summary

Follow-up to #14094 (merged). Replaces the manual Sev-1 **checkbox** in the support form with a single **"Priority"** dropdown offering the three severity levels, and removes the old issue-nature "Severity" dropdown (per product decision to consolidate into one field).

The level wording mirrors the Pylon issue **Priority** field:
- `Severity 1 (Critical Business Impact)`
- `Severity 2 (Major Business Impact)`
- `Severity 3 (Minor Business Impact or General Questions)` (default)

### Behavior
- **Plan gating:** `Severity 1` is **disabled (greyed out)** for users not on Team/Enterprise. Hovering the disabled option shows a tooltip: *"This option is not available on your current Langfuse plan."* (Disabled `SelectItem`s have `pointer-events: none`, so the option is wrapped in a tooltip trigger that still receives hover.)
- **Pylon mapping (case_severity):** each level maps directly to the Pylon `case_severity` field — `Severity 1 → Sev-1`, `Severity 2 → Sev-2`, `Severity 3 → Sev-3`.
- **Server-side safeguard:** a `Severity 1` submission from a non-high-tier plan is downgraded to `Sev-2` in `mapToPylonCaseSeverity`, so the gate can't be bypassed by crafting a request.
- **Issue priority** is now derived from the effective (gated) case severity via `mapCaseSeverityToPylonPriority` (`Sev-1 → urgent`, `Sev-2 → high`, `Sev-3 → low`), keeping the two Pylon fields consistent.

### Files
- `formConstants.ts` — new `SeveritySchema` (3 levels) + exported `SEVERITY_1/2/3`; removed `isHighPriority`.
- `SupportFormSection.tsx` — "Priority" dropdown with the gated/greyed Sev-1 option + tooltip; removed checkbox.
- `pylonClient.ts` — `mapToPylonCaseSeverity` rewritten for the new levels with plan gating; replaced `mapSeverityToPylonPriority` with `mapCaseSeverityToPylonPriority`.
- `supportRouter.ts` — computes case severity once, derives priority; removed `isHighPriority` input.
- `supportCaseSeverity.clienttest.ts` — updated unit tests for the new mapping.

## Verification
- ✅ ESLint clean on changed files
- ✅ `tsc --noEmit` clean (0 errors)
- ⚠️ Unit tests not run locally (worktree dep/sandbox limitation); CI runs the vitest suite. Logic is pure and covered by the updated `supportCaseSeverity.clienttest.ts`.
- ⚠️ Not yet reviewed in a running browser — the disabled-option-in-`Select` + tooltip interaction is the part most worth a visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the old "Severity" dropdown + "Urgent (Sev-1)" checkbox with a single **"Priority"** dropdown that maps directly to three Pylon `case_severity` values. A server-side gate in `mapToPylonCaseSeverity` downgrades any `Severity 1` selection from non-high-tier accounts to `Sev-2`, and the issue `priority` field is now derived from the resolved case severity rather than computed separately.

- **`formConstants.ts`** replaces four legacy severity strings with `Severity 1/2/3` constants, removes `isHighPriority`, and exports named `SEVERITY_1/2/3` constants for use in both the UI and the mapping layer.
- **`SupportFormSection.tsx`** renders Sev-1 as a disabled, tooltip-wrapped `SelectItem` for non-high-tier users; the checkbox is removed.
- **`pylonClient.ts` / `supportRouter.ts`** collapse the old dual-path mapping (`mapSeverityToPylonPriority` + manual `isHighPriority` logic) into a single `mapToPylonCaseSeverity` call followed by `mapCaseSeverityToPylonPriority`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core mapping logic and server-side plan gate are correct and well-tested. The only unverified piece is the tooltip rendered inside the SelectContent portal on the disabled Sev-1 item.

The business logic — three-level severity, plan gating, Sev-1 downgrade to Sev-2 server-side, consistent priority derivation — is implemented cleanly and covered by unit tests. The one open question flagged by the PR author (disabled SelectItem + Tooltip inside a Select portal) is real: TooltipContent renders in its own portal and may stack behind the open SelectContent, making the 'not available on your plan' hint invisible to the user. The functionality is not broken (the item remains greyed out and unclickable regardless), but the tooltip that explains why it is disabled could silently fail.

web/src/features/support-chat/SupportFormSection.tsx — the Tooltip-wrapped disabled SelectItem should be verified in a browser to confirm the tooltip appears above the open dropdown.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SupportFormSection
    participant supportRouter
    participant mapToPylonCaseSeverity
    participant mapCaseSeverityToPylonPriority
    participant PylonAPI

    User->>SupportFormSection: Select priority (Sev 1/2/3)
    Note over SupportFormSection: Sev-1 disabled (greyed) for non-high-tier plans
    SupportFormSection->>supportRouter: "mutate({ severity, plan, ... })"
    supportRouter->>mapToPylonCaseSeverity: "{ severity, plan }"
    alt "severity == SEVERITY_1"
        alt isHighTierPlan
            mapToPylonCaseSeverity-->>supportRouter: Sev-1
        else non-high-tier (server-side gate)
            mapToPylonCaseSeverity-->>supportRouter: Sev-2 (downgraded)
        end
    else "severity == SEVERITY_2"
        mapToPylonCaseSeverity-->>supportRouter: Sev-2
    else "severity == SEVERITY_3"
        mapToPylonCaseSeverity-->>supportRouter: Sev-3
    end
    supportRouter->>mapCaseSeverityToPylonPriority: caseSeverity
    mapCaseSeverityToPylonPriority-->>supportRouter: "urgent | high | low"
    supportRouter->>PylonAPI: "createPylonIssue({ priority, case_severity })"
    PylonAPI-->>supportRouter: issue response
    supportRouter-->>SupportFormSection: "{ pylonIssueFailed }"
    SupportFormSection-->>User: success / error toast
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/support-chat/SupportFormSection.tsx:412-426
**Tooltip-inside-SelectContent portal stacking may hide the tooltip**

`TooltipContent` renders in its own portal (attached to `<body>`). When it fires inside Radix `SelectContent` — which is also a portal with a high z-index — the tooltip can end up rendered *behind* the open dropdown. The `div` wrapper receives the hover event correctly (since `pointer-events: none` on the disabled item is bypassed), but the `TooltipContent` may be invisible depending on which portal wins the z-index race.

A safer fallback is to add a `sideOffset` / `z-[100]` override on `TooltipContent`, or — if the tooltip consistently fails — replace the hover hint with a `FormDescription` shown conditionally when Sev-1 is locked, which avoids the portal-inside-portal problem entirely.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(support): replace Sev-1 checkbox wi..."](https://github.com/langfuse/langfuse/commit/29e9a2d4a13735a8309fda5d751b88aadd011140) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36958214)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->