### PR TITLE
fix(experiments): don't mis-route remote-run setup button without a dataset

### DIFF
--- a/web/src/features/experiments/components/CreateExperimentsForm.clienttest.tsx
+++ b/web/src/features/experiments/components/CreateExperimentsForm.clienttest.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { Mock } from "vitest";
+
+import { api } from "@/src/utils/api";
+import { CreateExperimentsForm } from "./CreateExperimentsForm";
+
+// The remote-experiment query is the only tRPC call this component makes.
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    datasets: {
+      getRemoteExperiment: {
+        useQuery: vi.fn(),
+      },
+    },
+  },
+}));
+
+vi.mock("@/src/features/rbac/utils/checkProjectAccess", () => ({
+  useHasProjectAccess: () => true,
+}));
+
+vi.mock("@/src/features/posthog-analytics/usePostHogClientCapture", () => ({
+  usePostHogClientCapture: () => vi.fn(),
+}));
+
+// Radix Dialog primitives need a Dialog context; replace them with plain
+// elements so we can render the form standalone.
+vi.mock("@/src/components/ui/dialog", () => ({
+  DialogHeader: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogBody: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children?: React.ReactNode;
+    href?: string | { pathname?: string };
+  }) => (
+    <a href={typeof href === "string" ? href : "#"} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Stub the heavy sub-forms so we can assert which one the form routes to.
+vi.mock(
+  "@/src/features/experiments/components/MultiStepExperimentForm",
+  () => ({
+    MultiStepExperimentForm: () => (
+      <div data-testid="multi-step-experiment-form" />
+    ),
+  }),
+);
+
+vi.mock(
+  "@/src/features/experiments/components/RemoteExperimentUpsertForm",
+  () => ({
+    RemoteExperimentUpsertForm: () => (
+      <div data-testid="remote-experiment-upsert-form" />
+    ),
+  }),
+);
+
+vi.mock(
+  "@/src/features/experiments/components/RemoteExperimentTriggerModal",
+  () => ({
+    RemoteExperimentTriggerModal: () => (
+      <div data-testid="remote-experiment-trigger-modal" />
+    ),
+  }),
+);
+
+const mockedUseQuery = api.datasets.getRemoteExperiment
+  .useQuery as unknown as Mock;
+
+const PROJECT_ID = "project-1";
+const DATASET_ID = "dataset-1";
+const SETUP_BUTTON_TITLE = "Set up remote dataset run in UI trigger";
+
+function renderForm(
+  props: Partial<React.ComponentProps<typeof CreateExperimentsForm>> = {},
+) {
+  return render(
+    <CreateExperimentsForm
+      projectId={PROJECT_ID}
+      setFormOpen={() => {}}
+      showSDKRunInfoPage
+      {...props}
+    />,
+  );
+}
+
+describe("CreateExperimentsForm – SDK/API info page", () => {
+  afterEach(() => {
+    mockedUseQuery.mockReset();
+  });
+
+  it("does not render the remote-trigger setup button when there is no dataset in context", () => {
+    // Without a datasetId the query is disabled and returns no data.
+    mockedUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    renderForm(); // no defaultValues -> datasetId is undefined
+
+    // The info page is shown...
+    expect(screen.getByText("Run Experiment")).toBeInTheDocument();
+    expect(screen.getByText("via SDK / API")).toBeInTheDocument();
+
+    // ...but the remote-run setup (Zap) button must not be offered, because a
+    // remote experiment is dataset-scoped and clicking it would otherwise fall
+    // through to the UI experiment form (the wrong window).
+    expect(screen.queryByTitle(SETUP_BUTTON_TITLE)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("multi-step-experiment-form"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the remote-experiment upsert form (not the UI experiment form) when the setup button is clicked with a dataset", () => {
+    mockedUseQuery.mockReturnValue({ data: undefined, isLoading: false });
+
+    renderForm({ defaultValues: { datasetId: DATASET_ID } });
+
+    const setupButton = screen.getByTitle(SETUP_BUTTON_TITLE);
+    fireEvent.click(setupButton);
+
+    expect(
+      screen.getByTestId("remote-experiment-upsert-form"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("multi-step-experiment-form"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/features/experiments/components/CreateExperimentsForm.tsx
@@ -159,8 +159,10 @@ export const CreateExperimentsForm = ({
                   via SDK / API
                 </CardTitle>
                 <CardDescription>
-                  Start any dataset run via the Langfuse SDKs. To configure runs
-                  via webhook, use the button below.
+                  Start any dataset run via the Langfuse SDKs.
+                  {datasetId
+                    ? " To configure runs via webhook, use the button below."
+                    : null}
                 </CardDescription>
               </CardHeader>
               <CardContent>
@@ -211,7 +213,7 @@ export const CreateExperimentsForm = ({
                     View Docs
                   </Link>
                 </Button>
-                {!existingRemoteExperiment.data && (
+                {!existingRemoteExperiment.data && datasetId && (
                   <Button
                     variant="outline"
                     title="Set up remote dataset run in UI trigger"


### PR DESCRIPTION
## Problem

In the **Run Experiment** modal, the lightning-bolt (⚡) button on the **via SDK / API** card is meant to open the *remote dataset run* (webhook) setup form. Instead, on the **global experiments page** (`/project/[projectId]/experiments`) it opens the wrong window — the UI experiment "Configure" flow (`MultiStepExperimentForm`).

## Root cause

In `web/src/features/experiments/components/CreateExperimentsForm.tsx`, the ⚡ button sets `showRemoteExperimentUpsertForm`, but the render branch that shows `RemoteExperimentUpsertForm` requires a `datasetId`:

```tsx
if (showRemoteExperimentUpsertForm && datasetId) {
  return <RemoteExperimentUpsertForm ... />;
}
```

The button's only guard was `!existingRemoteExperiment.data`. The `getRemoteExperiment` query is `enabled: !!datasetId`, so when the modal is opened **without** a dataset (the global experiments page passes no `defaultValues.datasetId`), `data` is `undefined`, the button still renders, and clicking it falls through to the default `MultiStepExperimentForm` — the wrong window.

The sibling Run/Cog buttons in the same card are already correctly gated on `datasetId` (`{!!existingRemoteExperiment.data && datasetId && ...}`); the ⚡ button just missed that guard.

## Fix

- Gate the ⚡ setup button on `datasetId`, matching the sibling Run/Cog buttons. Remote experiment triggers are dataset-scoped, so there is nothing to configure without a dataset.
- Only render the "To configure runs via webhook, use the button below." hint when a dataset is in context, so the copy doesn't reference a button that isn't there.

On dataset-scoped pages (dataset detail, compare views) the button is unchanged and continues to open the remote upsert form.

## Tests

Added `CreateExperimentsForm.clienttest.tsx` covering both branches:
- **Without** a dataset: the setup button is not rendered (so it can no longer mis-route).
- **With** a dataset: clicking the setup button opens `RemoteExperimentUpsertForm`, not `MultiStepExperimentForm`.

Written test-first: the no-dataset case failed before the fix and passes after.

## Verification

- `pnpm --filter web exec vitest run --project client CreateExperimentsForm` → 2 passed.
- Repo-wide lint + Prettier (husky pre-commit `turbo run lint`, 8/8 packages) → clean.
- Note: a live browser pass was not run — this worktree is unbootstrapped and the local Docker stack is memory-constrained (the existing containers were OOM-killed), so bringing up ClickHouse/Postgres/seed + dev server reliably wasn't feasible here. The change is purely conditional rendering and is covered by the component test, which renders the real component across both branches. Happy to add a screenshot if you'd like a visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a mis-routing bug in the `CreateExperimentsForm` where clicking the ⚡ setup button on the "via SDK / API" card would fall through to `MultiStepExperimentForm` instead of `RemoteExperimentUpsertForm` when no `datasetId` was in context (e.g., on the global experiments page).

- Gates the ⚡ setup button on `datasetId`, matching the existing pattern on the sibling Run/Cog buttons, so the button is hidden when no dataset is in scope.
- Conditionally renders the "To configure runs via webhook, use the button below." copy to avoid referencing a button that isn't shown.
- Adds a `CreateExperimentsForm.clienttest.tsx` with two cases: no-dataset (button absent) and with-dataset (button click routes to `RemoteExperimentUpsertForm`).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a two-line conditional guard matching the pattern already used by the sibling buttons, and a component test verifies both the absence of the button without a dataset and the correct form rendered when clicked with one.

The fix is minimal and surgical: it closes a single conditional rendering path that was missing a guard, aligning it with adjacent code that already had it. All state transitions that set showRemoteExperimentUpsertForm = true now require datasetId, so the fallthrough to MultiStepExperimentForm is fully closed off. The two new tests exercise both branches directly on the real component, confirming the before/after behavior.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): don&#39;t mis-route remote..."](https://github.com/langfuse/langfuse/commit/04c33e0ccbd80fe061d73fa2cc35eda4b936e31c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36958512)</sub>

<!-- /greptile_comment -->