### PR TITLE
chore(observability): drop redundant aws-ecs and process resource detectors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -479,9 +479,6 @@ importers:
       '@opentelemetry/instrumentation-winston':
         specifier: ^0.57.0
         version: 0.57.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resource-detector-aws':
-        specifier: ^2.13.0
-        version: 2.14.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resource-detector-container':
         specifier: ^0.8.4
         version: 0.8.5(@opentelemetry/api@1.9.0)
@@ -957,9 +954,6 @@ importers:
       '@opentelemetry/instrumentation-winston':
         specifier: ^0.57.0
         version: 0.57.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resource-detector-aws':
-        specifier: ^2.13.0
-        version: 2.14.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resource-detector-container':
         specifier: ^0.8.4
         version: 0.8.5(@opentelemetry/api@1.9.0)
@@ -3353,12 +3347,6 @@ packages:
   '@opentelemetry/redis-common@0.38.2':
     resolution: {integrity: sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==}
     engines: {node: ^18.19.0 || >=20.6.0}
-
-  '@opentelemetry/resource-detector-aws@2.14.0':
-    resolution: {integrity: sha512-1a0YMG6wZuLUfwkSgfe77vN60V5SmK//kM+JsQFT7dOKLyFvpN5A+TpX/eFdaqnhg89CxyF7XpKMBbg1DGv5bw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.0.0
 
   '@opentelemetry/resource-detector-container@0.8.5':
     resolution: {integrity: sha512-vWlfpiCHKWVrT/3EHgJfRLGX8ghVsEZ6CBHhJo5sAQQnwInDNcXjbBJm74Jiyqt0eg7NLeT0EfpXHCUSeYgFaA==}
@@ -14747,13 +14735,6 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/redis-common@0.38.2': {}
-
-  '@opentelemetry/resource-detector-aws@2.14.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/resource-detector-container@0.8.5(@opentelemetry/api@1.9.0)':
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -68,7 +68,6 @@
     "@opentelemetry/instrumentation-http": "^0.218.0",
     "@opentelemetry/instrumentation-ioredis": "^0.61.0",
     "@opentelemetry/instrumentation-winston": "^0.57.0",
-    "@opentelemetry/resource-detector-aws": "^2.13.0",
     "@opentelemetry/resource-detector-container": "^0.8.4",
     "@opentelemetry/resources": "^2.7.1",
     "@opentelemetry/sdk-node": "^0.218.0",

--- a/web/src/observability.config.ts
+++ b/web/src/observability.config.ts
@@ -20,12 +20,7 @@ import { WinstonInstrumentation } from "@opentelemetry/instrumentation-winston";
 import { AwsInstrumentation } from "@opentelemetry/instrumentation-aws-sdk";
 import { BullMQInstrumentation } from "@appsignal/opentelemetry-instrumentation-bullmq";
 import { ioredisRequestHook } from "@langfuse/shared/src/server";
-import {
-  envDetector,
-  processDetector,
-  resourceFromAttributes,
-} from "@opentelemetry/resources";
-import { awsEcsDetector } from "@opentelemetry/resource-detector-aws";
+import { envDetector, resourceFromAttributes } from "@opentelemetry/resources";
 import { containerDetector } from "@opentelemetry/resource-detector-container";
 import { env } from "@/src/env.mjs";
 
@@ -153,12 +148,12 @@ const sdk = new NodeSDK({
     new WinstonInstrumentation({ disableLogSending: true }),
     new BullMQInstrumentation({ useProducerSpanAsConsumerParent: true }),
   ],
-  resourceDetectors: [
-    envDetector,
-    processDetector,
-    awsEcsDetector,
-    containerDetector,
-  ],
+  // Datadog's OTLP intake flattens resource attributes onto every ingested
+  // span, so each detector attribute costs ingest bytes per span. The AWS ECS
+  // and process detectors only duplicated infra tags the Datadog agent adds
+  // itself (~1KB/span). containerDetector must stay: the agent resolves those
+  // infra tags by looking up the container.id resource attribute.
+  resourceDetectors: [envDetector, containerDetector],
   sampler: new TraceIdRatioBasedSampler(env.OTEL_TRACE_SAMPLING_RATIO),
 });
 

--- a/web/src/observability.config.ts
+++ b/web/src/observability.config.ts
@@ -148,11 +148,6 @@ const sdk = new NodeSDK({
     new WinstonInstrumentation({ disableLogSending: true }),
     new BullMQInstrumentation({ useProducerSpanAsConsumerParent: true }),
   ],
-  // Datadog's OTLP intake flattens resource attributes onto every ingested
-  // span, so each detector attribute costs ingest bytes per span. The AWS ECS
-  // and process detectors only duplicated infra tags the Datadog agent adds
-  // itself (~1KB/span). containerDetector must stay: the agent resolves those
-  // infra tags by looking up the container.id resource attribute.
   resourceDetectors: [envDetector, containerDetector],
   sampler: new TraceIdRatioBasedSampler(env.OTEL_TRACE_SAMPLING_RATIO),
 });

--- a/worker/package.json
+++ b/worker/package.json
@@ -41,7 +41,6 @@
     "@opentelemetry/instrumentation-http": "^0.218.0",
     "@opentelemetry/instrumentation-ioredis": "^0.61.0",
     "@opentelemetry/instrumentation-winston": "^0.57.0",
-    "@opentelemetry/resource-detector-aws": "^2.13.0",
     "@opentelemetry/resource-detector-container": "^0.8.4",
     "@opentelemetry/resources": "^2.7.1",
     "@opentelemetry/sdk-node": "^0.218.0",

--- a/worker/src/instrumentation.ts
+++ b/worker/src/instrumentation.ts
@@ -9,12 +9,7 @@ import { WinstonInstrumentation } from "@opentelemetry/instrumentation-winston";
 import { AwsInstrumentation } from "@opentelemetry/instrumentation-aws-sdk";
 import { BullMQInstrumentation } from "@appsignal/opentelemetry-instrumentation-bullmq";
 import { ioredisRequestHook } from "@langfuse/shared/src/server";
-import {
-  envDetector,
-  processDetector,
-  resourceFromAttributes,
-} from "@opentelemetry/resources";
-import { awsEcsDetector } from "@opentelemetry/resource-detector-aws";
+import { envDetector, resourceFromAttributes } from "@opentelemetry/resources";
 import { containerDetector } from "@opentelemetry/resource-detector-container";
 import { env } from "./env";
 
@@ -67,12 +62,12 @@ const sdk = new NodeSDK({
     new WinstonInstrumentation({ disableLogSending: true }),
     new BullMQInstrumentation({ useProducerSpanAsConsumerParent: true }),
   ],
-  resourceDetectors: [
-    envDetector,
-    processDetector,
-    awsEcsDetector,
-    containerDetector,
-  ],
+  // Datadog's OTLP intake flattens resource attributes onto every ingested
+  // span, so each detector attribute costs ingest bytes per span. The AWS ECS
+  // and process detectors only duplicated infra tags the Datadog agent adds
+  // itself (~1KB/span). containerDetector must stay: the agent resolves those
+  // infra tags by looking up the container.id resource attribute.
+  resourceDetectors: [envDetector, containerDetector],
 });
 
 sdk.start();

--- a/worker/src/instrumentation.ts
+++ b/worker/src/instrumentation.ts
@@ -62,11 +62,6 @@ const sdk = new NodeSDK({
     new WinstonInstrumentation({ disableLogSending: true }),
     new BullMQInstrumentation({ useProducerSpanAsConsumerParent: true }),
   ],
-  // Datadog's OTLP intake flattens resource attributes onto every ingested
-  // span, so each detector attribute costs ingest bytes per span. The AWS ECS
-  // and process detectors only duplicated infra tags the Datadog agent adds
-  // itself (~1KB/span). containerDetector must stay: the agent resolves those
-  // infra tags by looking up the container.id resource attribute.
   resourceDetectors: [envDetector, containerDetector],
 });
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the `awsEcsDetector` and `processDetector` resource detectors from the OpenTelemetry SDK configuration in both the `web` and `worker` packages, and drops the `@opentelemetry/resource-detector-aws` dependency entirely.

- The motivation is bandwidth savings: Datadog's OTLP intake flattens resource attributes onto every span, so the removed detectors were adding ~1KB of duplicated infra metadata per span that the Datadog agent already supplies independently.
- `containerDetector` is intentionally preserved because the Datadog agent relies on the `container.id` resource attribute to correlate container-level metadata, and `envDetector` is kept for OTEL environment variable support. The change is applied symmetrically in both packages and includes the matching `pnpm-lock.yaml` update.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change removes two resource detectors whose output was already being supplied by the Datadog agent, reducing per-span ingest overhead without dropping any attributes the tracing pipeline actually depends on.

The removal is symmetric across both packages, the lockfile is updated to match, and the one detector that Datadog requires for container-level correlation (containerDetector) is explicitly kept. The inline comments document the rationale clearly, and no logic outside of resource detection is touched.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into steffen/drop-re..."](https://github.com/langfuse/langfuse/commit/c958ef85f763d0533c42f0613322c103f41a08cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36961070)</sub>

<!-- /greptile_comment -->