### PR TITLE
feat(agent): Allow window to be resized and repositioned

### DIFF
--- a/web/src/components/movable-resizable-panel.clienttest.tsx
+++ b/web/src/components/movable-resizable-panel.clienttest.tsx
@@ -9,36 +9,48 @@ import {
 } from "./movable-resizable-panel";
 
 type TestPanelProps = {
+  boundsPadding?: number;
   initialPosition?: MovableResizablePanelPosition;
   initialSize?: MovableResizablePanelSize;
   maxSize?: MovableResizablePanelSize;
   minSize?: MovableResizablePanelSize;
   ignoreOutsideInteraction?: boolean;
   onActionClick?: () => void;
+  onPositionChange?: (position: MovableResizablePanelPosition) => void;
+  onSizeChange?: (size: MovableResizablePanelSize) => void;
 };
 
 function TestPanel({
+  boundsPadding = 10,
   initialPosition = { left: 100, top: 100 },
   initialSize = { width: 300, height: 240 },
   ignoreOutsideInteraction,
   maxSize,
   minSize = { width: 200, height: 160 },
   onActionClick,
+  onPositionChange,
+  onSizeChange,
 }: TestPanelProps) {
   const [position, setPosition] = useState(initialPosition);
   const [size, setSize] = useState(initialSize);
 
   return (
     <MovableResizablePanel
-      boundsPadding={10}
+      boundsPadding={boundsPadding}
       dragHandleSelector="[data-drag-handle='true']"
       ignoreOutsideInteraction={ignoreOutsideInteraction}
       maxSize={maxSize}
       minSize={minSize}
       position={position}
       size={size}
-      onPositionChange={setPosition}
-      onSizeChange={setSize}
+      onPositionChange={(nextPosition) => {
+        setPosition(nextPosition);
+        onPositionChange?.(nextPosition);
+      }}
+      onSizeChange={(nextSize) => {
+        setSize(nextSize);
+        onSizeChange?.(nextSize);
+      }}
     >
       <div className="h-full w-full">
         <div data-drag-handle="true" data-testid="drag-handle">
@@ -190,6 +202,37 @@ describe("MovableResizablePanel", () => {
     );
   });
 
+  it("keeps the right edge anchored when left resizing hits the viewport", () => {
+    render(
+      <TestPanel
+        boundsPadding={8}
+        initialPosition={{ left: 20, top: 100 }}
+        initialSize={{ width: 200, height: 240 }}
+      />,
+    );
+
+    const panel = screen.getByTestId("movable-resizable-panel");
+    const resizeHandle = screen.getByTestId(
+      "movable-resizable-panel-resize-left",
+    );
+
+    firePointerEvent(resizeHandle, "pointerdown", {
+      pointerId: 1,
+      clientX: 20,
+      clientY: 220,
+    });
+    firePointerEvent(panel, "pointermove", {
+      pointerId: 1,
+      clientX: -80,
+      clientY: 220,
+    });
+    firePointerEvent(panel, "pointerup", { pointerId: 1 });
+
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "8,100,212,240",
+    );
+  });
+
   it("keeps the bottom edge anchored when top resizing hits the min height", () => {
     render(<TestPanel />);
 
@@ -213,6 +256,83 @@ describe("MovableResizablePanel", () => {
     expect(screen.getByTestId("panel-state")).toHaveTextContent(
       "100,180,300,160",
     );
+  });
+
+  it("keeps the bottom edge anchored when top resizing hits the viewport", () => {
+    render(
+      <TestPanel
+        boundsPadding={8}
+        initialPosition={{ left: 100, top: 20 }}
+        initialSize={{ width: 300, height: 240 }}
+      />,
+    );
+
+    const panel = screen.getByTestId("movable-resizable-panel");
+    const resizeHandle = screen.getByTestId(
+      "movable-resizable-panel-resize-top",
+    );
+
+    firePointerEvent(resizeHandle, "pointerdown", {
+      pointerId: 1,
+      clientX: 220,
+      clientY: 20,
+    });
+    firePointerEvent(panel, "pointermove", {
+      pointerId: 1,
+      clientX: 220,
+      clientY: -80,
+    });
+    firePointerEvent(panel, "pointerup", { pointerId: 1 });
+
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "100,8,300,252",
+    );
+  });
+
+  it("ignores window resize while an interaction is in flight", () => {
+    const onPositionChange = vi.fn();
+    const onSizeChange = vi.fn();
+
+    render(
+      <TestPanel
+        initialPosition={{ left: 700, top: 100 }}
+        initialSize={{ width: 300, height: 240 }}
+        onPositionChange={onPositionChange}
+        onSizeChange={onSizeChange}
+      />,
+    );
+
+    const handle = screen.getByTestId("drag-handle");
+
+    firePointerEvent(handle, "pointerdown", {
+      pointerId: 1,
+      clientX: 740,
+      clientY: 150,
+    });
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 900,
+    });
+    fireEvent.resize(window);
+
+    expect(onPositionChange).not.toHaveBeenCalled();
+    expect(onSizeChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "700,100,300,240",
+    );
+  });
+
+  it("does not leave gaps between corner and edge resize handles", () => {
+    render(<TestPanel />);
+
+    expect(
+      screen.getByTestId("movable-resizable-panel-resize-top"),
+    ).toHaveStyle({ left: "5px", right: "5px" });
+    expect(
+      screen.getByTestId("movable-resizable-panel-resize-left"),
+    ).toHaveStyle({ top: "5px", bottom: "5px" });
   });
 
   it("clamps movement to viewport bounds", () => {

--- a/web/src/components/movable-resizable-panel.clienttest.tsx
+++ b/web/src/components/movable-resizable-panel.clienttest.tsx
@@ -13,12 +13,14 @@ type TestPanelProps = {
   initialSize?: MovableResizablePanelSize;
   maxSize?: MovableResizablePanelSize;
   minSize?: MovableResizablePanelSize;
+  ignoreOutsideInteraction?: boolean;
   onActionClick?: () => void;
 };
 
 function TestPanel({
   initialPosition = { left: 100, top: 100 },
   initialSize = { width: 300, height: 240 },
+  ignoreOutsideInteraction,
   maxSize,
   minSize = { width: 200, height: 160 },
   onActionClick,
@@ -30,6 +32,7 @@ function TestPanel({
     <MovableResizablePanel
       boundsPadding={10}
       dragHandleSelector="[data-drag-handle='true']"
+      ignoreOutsideInteraction={ignoreOutsideInteraction}
       maxSize={maxSize}
       minSize={minSize}
       position={position}
@@ -162,6 +165,56 @@ describe("MovableResizablePanel", () => {
     );
   });
 
+  it("keeps the right edge anchored when left resizing hits the min width", () => {
+    render(<TestPanel />);
+
+    const panel = screen.getByTestId("movable-resizable-panel");
+    const resizeHandle = screen.getByTestId(
+      "movable-resizable-panel-resize-left",
+    );
+
+    firePointerEvent(resizeHandle, "pointerdown", {
+      pointerId: 1,
+      clientX: 100,
+      clientY: 220,
+    });
+    firePointerEvent(panel, "pointermove", {
+      pointerId: 1,
+      clientX: 300,
+      clientY: 220,
+    });
+    firePointerEvent(panel, "pointerup", { pointerId: 1 });
+
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "200,100,200,240",
+    );
+  });
+
+  it("keeps the bottom edge anchored when top resizing hits the min height", () => {
+    render(<TestPanel />);
+
+    const panel = screen.getByTestId("movable-resizable-panel");
+    const resizeHandle = screen.getByTestId(
+      "movable-resizable-panel-resize-top",
+    );
+
+    firePointerEvent(resizeHandle, "pointerdown", {
+      pointerId: 1,
+      clientX: 220,
+      clientY: 100,
+    });
+    firePointerEvent(panel, "pointermove", {
+      pointerId: 1,
+      clientX: 220,
+      clientY: 300,
+    });
+    firePointerEvent(panel, "pointerup", { pointerId: 1 });
+
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "100,180,300,160",
+    );
+  });
+
   it("clamps movement to viewport bounds", () => {
     render(<TestPanel />);
 
@@ -209,6 +262,14 @@ describe("MovableResizablePanel", () => {
     expect(onActionClick).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("panel-state")).toHaveTextContent(
       "100,100,300,240",
+    );
+  });
+
+  it("can mark the root as ignored for outside interactions", () => {
+    render(<TestPanel ignoreOutsideInteraction />);
+
+    expect(screen.getByTestId("movable-resizable-panel")).toHaveAttribute(
+      "data-ignore-outside-interaction",
     );
   });
 });

--- a/web/src/components/movable-resizable-panel.clienttest.tsx
+++ b/web/src/components/movable-resizable-panel.clienttest.tsx
@@ -1,0 +1,214 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { vi } from "vitest";
+
+import {
+  MovableResizablePanel,
+  type MovableResizablePanelPosition,
+  type MovableResizablePanelSize,
+} from "./movable-resizable-panel";
+
+type TestPanelProps = {
+  initialPosition?: MovableResizablePanelPosition;
+  initialSize?: MovableResizablePanelSize;
+  maxSize?: MovableResizablePanelSize;
+  minSize?: MovableResizablePanelSize;
+  onActionClick?: () => void;
+};
+
+function TestPanel({
+  initialPosition = { left: 100, top: 100 },
+  initialSize = { width: 300, height: 240 },
+  maxSize,
+  minSize = { width: 200, height: 160 },
+  onActionClick,
+}: TestPanelProps) {
+  const [position, setPosition] = useState(initialPosition);
+  const [size, setSize] = useState(initialSize);
+
+  return (
+    <MovableResizablePanel
+      boundsPadding={10}
+      dragHandleSelector="[data-drag-handle='true']"
+      maxSize={maxSize}
+      minSize={minSize}
+      position={position}
+      size={size}
+      onPositionChange={setPosition}
+      onSizeChange={setSize}
+    >
+      <div className="h-full w-full">
+        <div data-drag-handle="true" data-testid="drag-handle">
+          Drag
+        </div>
+        <div
+          data-drag-handle="true"
+          data-movable-resizable-panel-ignore-drag="true"
+        >
+          <button type="button" onClick={onActionClick}>
+            Action
+          </button>
+        </div>
+        <div data-testid="panel-state">
+          {position.left},{position.top},{size.width},{size.height}
+        </div>
+      </div>
+    </MovableResizablePanel>
+  );
+}
+
+function firePointerEvent(
+  element: Element,
+  type: "pointerdown" | "pointermove" | "pointerup",
+  init: MouseEventInit & { pointerId: number },
+) {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX,
+    clientY: init.clientY,
+  });
+
+  Object.defineProperty(event, "pointerId", { value: init.pointerId });
+  fireEvent(element, event);
+}
+
+describe("MovableResizablePanel", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      writable: true,
+      value: 768,
+    });
+    HTMLElement.prototype.setPointerCapture = vi.fn();
+    HTMLElement.prototype.releasePointerCapture = vi.fn();
+  });
+
+  it("moves by dragging the configured handle", () => {
+    render(<TestPanel />);
+
+    const panel = screen.getByTestId("movable-resizable-panel");
+    const handle = screen.getByTestId("drag-handle");
+
+    firePointerEvent(handle, "pointerdown", {
+      pointerId: 1,
+      clientX: 140,
+      clientY: 150,
+    });
+    firePointerEvent(panel, "pointermove", {
+      pointerId: 1,
+      clientX: 190,
+      clientY: 180,
+    });
+    firePointerEvent(panel, "pointerup", { pointerId: 1 });
+
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "150,130,300,240",
+    );
+  });
+
+  it("resizes from the bottom-right handle", () => {
+    render(<TestPanel />);
+
+    const panel = screen.getByTestId("movable-resizable-panel");
+    const resizeHandle = screen.getByTestId(
+      "movable-resizable-panel-resize-bottom-right",
+    );
+
+    firePointerEvent(resizeHandle, "pointerdown", {
+      pointerId: 1,
+      clientX: 400,
+      clientY: 340,
+    });
+    firePointerEvent(panel, "pointermove", {
+      pointerId: 1,
+      clientX: 460,
+      clientY: 380,
+    });
+    firePointerEvent(panel, "pointerup", { pointerId: 1 });
+
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "100,100,360,280",
+    );
+  });
+
+  it("clamps resizing to the configured max size", () => {
+    render(<TestPanel maxSize={{ width: 500, height: 420 }} />);
+
+    const panel = screen.getByTestId("movable-resizable-panel");
+    const resizeHandle = screen.getByTestId(
+      "movable-resizable-panel-resize-bottom-right",
+    );
+
+    firePointerEvent(resizeHandle, "pointerdown", {
+      pointerId: 1,
+      clientX: 400,
+      clientY: 340,
+    });
+    firePointerEvent(panel, "pointermove", {
+      pointerId: 1,
+      clientX: 900,
+      clientY: 900,
+    });
+    firePointerEvent(panel, "pointerup", { pointerId: 1 });
+
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "100,100,500,420",
+    );
+  });
+
+  it("clamps movement to viewport bounds", () => {
+    render(<TestPanel />);
+
+    const panel = screen.getByTestId("movable-resizable-panel");
+    const handle = screen.getByTestId("drag-handle");
+
+    firePointerEvent(handle, "pointerdown", {
+      pointerId: 1,
+      clientX: 140,
+      clientY: 150,
+    });
+    firePointerEvent(panel, "pointermove", {
+      pointerId: 1,
+      clientX: -500,
+      clientY: -500,
+    });
+    firePointerEvent(panel, "pointerup", { pointerId: 1 });
+
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "10,10,300,240",
+    );
+  });
+
+  it("does not start dragging from explicitly ignored elements inside a handle", () => {
+    const onActionClick = vi.fn();
+
+    render(<TestPanel onActionClick={onActionClick} />);
+
+    const panel = screen.getByTestId("movable-resizable-panel");
+    const action = screen.getByRole("button", { name: "Action" });
+
+    firePointerEvent(action, "pointerdown", {
+      pointerId: 1,
+      clientX: 140,
+      clientY: 150,
+    });
+    firePointerEvent(panel, "pointermove", {
+      pointerId: 1,
+      clientX: 190,
+      clientY: 180,
+    });
+    firePointerEvent(panel, "pointerup", { pointerId: 1 });
+    fireEvent.click(action);
+
+    expect(onActionClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("panel-state")).toHaveTextContent(
+      "100,100,300,240",
+    );
+  });
+});

--- a/web/src/components/movable-resizable-panel.clienttest.tsx
+++ b/web/src/components/movable-resizable-panel.clienttest.tsx
@@ -1,9 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { useState } from "react";
 import { vi } from "vitest";
 
 import {
   MovableResizablePanel,
+  useMovableResizablePanelControl,
+  type MovableResizablePanelGeometry,
   type MovableResizablePanelPosition,
   type MovableResizablePanelSize,
 } from "./movable-resizable-panel";
@@ -16,8 +17,7 @@ type TestPanelProps = {
   minSize?: MovableResizablePanelSize;
   ignoreOutsideInteraction?: boolean;
   onActionClick?: () => void;
-  onPositionChange?: (position: MovableResizablePanelPosition) => void;
-  onSizeChange?: (size: MovableResizablePanelSize) => void;
+  onGeometryChange?: (geometry: MovableResizablePanelGeometry) => void;
 };
 
 function TestPanel({
@@ -28,29 +28,30 @@ function TestPanel({
   maxSize,
   minSize = { width: 200, height: 160 },
   onActionClick,
-  onPositionChange,
-  onSizeChange,
+  onGeometryChange,
 }: TestPanelProps) {
-  const [position, setPosition] = useState(initialPosition);
-  const [size, setSize] = useState(initialSize);
+  const handle = useMovableResizablePanelControl({
+    boundsPadding,
+    getInitialGeometry: () => ({
+      position: initialPosition,
+      size: initialSize,
+    }),
+    maxSize,
+    minSize,
+  });
+  const geometry = handle.getGeometry();
 
   return (
     <MovableResizablePanel
-      boundsPadding={boundsPadding}
       dragHandleSelector="[data-drag-handle='true']"
+      handle={{
+        ...handle,
+        setGeometry: (nextGeometry) => {
+          handle.setGeometry(nextGeometry);
+          onGeometryChange?.(nextGeometry);
+        },
+      }}
       ignoreOutsideInteraction={ignoreOutsideInteraction}
-      maxSize={maxSize}
-      minSize={minSize}
-      position={position}
-      size={size}
-      onPositionChange={(nextPosition) => {
-        setPosition(nextPosition);
-        onPositionChange?.(nextPosition);
-      }}
-      onSizeChange={(nextSize) => {
-        setSize(nextSize);
-        onSizeChange?.(nextSize);
-      }}
     >
       <div className="h-full w-full">
         <div data-drag-handle="true" data-testid="drag-handle">
@@ -65,7 +66,7 @@ function TestPanel({
           </button>
         </div>
         <div data-testid="panel-state">
-          {position.left},{position.top},{size.width},{size.height}
+          {`${geometry.position.left},${geometry.position.top},${geometry.size.width},${geometry.size.height}`}
         </div>
       </div>
     </MovableResizablePanel>
@@ -290,15 +291,13 @@ describe("MovableResizablePanel", () => {
   });
 
   it("ignores window resize while an interaction is in flight", () => {
-    const onPositionChange = vi.fn();
-    const onSizeChange = vi.fn();
+    const onGeometryChange = vi.fn();
 
     render(
       <TestPanel
         initialPosition={{ left: 700, top: 100 }}
         initialSize={{ width: 300, height: 240 }}
-        onPositionChange={onPositionChange}
-        onSizeChange={onSizeChange}
+        onGeometryChange={onGeometryChange}
       />,
     );
 
@@ -317,8 +316,7 @@ describe("MovableResizablePanel", () => {
     });
     fireEvent.resize(window);
 
-    expect(onPositionChange).not.toHaveBeenCalled();
-    expect(onSizeChange).not.toHaveBeenCalled();
+    expect(onGeometryChange).not.toHaveBeenCalled();
     expect(screen.getByTestId("panel-state")).toHaveTextContent(
       "700,100,300,240",
     );

--- a/web/src/components/movable-resizable-panel.tsx
+++ b/web/src/components/movable-resizable-panel.tsx
@@ -53,6 +53,13 @@ type Interaction =
       startSize: MovableResizablePanelSize;
     };
 
+type PanelSizeConstraints = {
+  maxHeight: number;
+  maxWidth: number;
+  minHeight: number;
+  minWidth: number;
+};
+
 type MovableResizablePanelProps = {
   children: ReactNode;
   dragHandleSelector: string;
@@ -61,6 +68,7 @@ type MovableResizablePanelProps = {
   position: MovableResizablePanelPosition;
   size: MovableResizablePanelSize;
   boundsPadding?: number;
+  ignoreOutsideInteraction?: boolean;
   isMovable?: boolean;
   isResizable?: boolean;
   zIndex?: number;
@@ -77,6 +85,9 @@ export function useMovableResizablePanelGeometry({
     useState<MovableResizablePanelGeometry | null>(null);
 
   const getGeometry = () => geometry ?? getInitialGeometry();
+  const initializeGeometry = () => {
+    setGeometry((currentGeometry) => currentGeometry ?? getInitialGeometry());
+  };
   const resetGeometry = () => setGeometry(getInitialGeometry());
   const clearGeometry = () => setGeometry(null);
   const setPosition = (position: MovableResizablePanelPosition) => {
@@ -93,7 +104,9 @@ export function useMovableResizablePanelGeometry({
   };
 
   return {
+    geometry,
     getGeometry,
+    initializeGeometry,
     resetGeometry,
     clearGeometry,
     setPosition,
@@ -143,6 +156,33 @@ function getViewportBounds(boundsPadding: number) {
   };
 }
 
+function getPanelSizeConstraints({
+  boundsPadding,
+  maxSize,
+  minSize,
+}: {
+  boundsPadding: number;
+  maxSize?: MovableResizablePanelSize;
+  minSize: MovableResizablePanelSize;
+}): PanelSizeConstraints {
+  const bounds = getViewportBounds(boundsPadding);
+  const viewportMaxWidth = bounds.maxRight - bounds.minLeft;
+  const viewportMaxHeight = bounds.maxBottom - bounds.minTop;
+
+  return {
+    maxHeight: Math.max(
+      minSize.height,
+      Math.min(maxSize?.height ?? viewportMaxHeight, viewportMaxHeight),
+    ),
+    maxWidth: Math.max(
+      minSize.width,
+      Math.min(maxSize?.width ?? viewportMaxWidth, viewportMaxWidth),
+    ),
+    minHeight: minSize.height,
+    minWidth: minSize.width,
+  };
+}
+
 function clampPanelBounds({
   boundsPadding,
   maxSize,
@@ -157,18 +197,17 @@ function clampPanelBounds({
   size: MovableResizablePanelSize;
 }) {
   const bounds = getViewportBounds(boundsPadding);
-  const viewportMaxWidth = bounds.maxRight - bounds.minLeft;
-  const viewportMaxHeight = bounds.maxBottom - bounds.minTop;
-  const maxWidth = Math.max(
-    minSize.width,
-    Math.min(maxSize?.width ?? viewportMaxWidth, viewportMaxWidth),
+  const constraints = getPanelSizeConstraints({
+    boundsPadding,
+    maxSize,
+    minSize,
+  });
+  const width = clamp(size.width, constraints.minWidth, constraints.maxWidth);
+  const height = clamp(
+    size.height,
+    constraints.minHeight,
+    constraints.maxHeight,
   );
-  const maxHeight = Math.max(
-    minSize.height,
-    Math.min(maxSize?.height ?? viewportMaxHeight, viewportMaxHeight),
-  );
-  const width = clamp(size.width, minSize.width, maxWidth);
-  const height = clamp(size.height, minSize.height, maxHeight);
   const left = clamp(position.left, bounds.minLeft, bounds.maxRight - width);
   const top = clamp(position.top, bounds.minTop, bounds.maxBottom - height);
 
@@ -234,6 +273,7 @@ function getResizedPanel(
   interaction: Extract<Interaction, { type: "resize" }>,
   clientX: number,
   clientY: number,
+  constraints: PanelSizeConstraints,
 ) {
   const deltaX = clientX - interaction.startClientX;
   const deltaY = clientY - interaction.startClientY;
@@ -241,21 +281,43 @@ function getResizedPanel(
   const nextSize = { ...interaction.startSize };
 
   if (interaction.direction.includes("right")) {
-    nextSize.width = interaction.startSize.width + deltaX;
+    nextSize.width = clamp(
+      interaction.startSize.width + deltaX,
+      constraints.minWidth,
+      constraints.maxWidth,
+    );
   }
 
   if (interaction.direction.includes("left")) {
-    nextPosition.left = interaction.startPosition.left + deltaX;
-    nextSize.width = interaction.startSize.width - deltaX;
+    nextSize.width = clamp(
+      interaction.startSize.width - deltaX,
+      constraints.minWidth,
+      constraints.maxWidth,
+    );
+    nextPosition.left =
+      interaction.startPosition.left +
+      interaction.startSize.width -
+      nextSize.width;
   }
 
   if (interaction.direction.includes("bottom")) {
-    nextSize.height = interaction.startSize.height + deltaY;
+    nextSize.height = clamp(
+      interaction.startSize.height + deltaY,
+      constraints.minHeight,
+      constraints.maxHeight,
+    );
   }
 
   if (interaction.direction.includes("top")) {
-    nextPosition.top = interaction.startPosition.top + deltaY;
-    nextSize.height = interaction.startSize.height - deltaY;
+    nextSize.height = clamp(
+      interaction.startSize.height - deltaY,
+      constraints.minHeight,
+      constraints.maxHeight,
+    );
+    nextPosition.top =
+      interaction.startPosition.top +
+      interaction.startSize.height -
+      nextSize.height;
   }
 
   return {
@@ -317,6 +379,7 @@ export function MovableResizablePanel({
   boundsPadding = DEFAULT_BOUNDS_PADDING,
   children,
   dragHandleSelector,
+  ignoreOutsideInteraction = false,
   isMovable = true,
   isResizable = true,
   maxSize,
@@ -442,6 +505,7 @@ export function MovableResizablePanel({
             interaction,
             coordinates.clientX,
             coordinates.clientY,
+            getPanelSizeConstraints({ boundsPadding, maxSize, minSize }),
           )),
     });
 
@@ -468,6 +532,7 @@ export function MovableResizablePanel({
     <div
       ref={panelRef}
       className="fixed origin-top-left"
+      data-ignore-outside-interaction={ignoreOutsideInteraction || undefined}
       data-testid="movable-resizable-panel"
       style={{
         left: livePosition.left,

--- a/web/src/components/movable-resizable-panel.tsx
+++ b/web/src/components/movable-resizable-panel.tsx
@@ -4,6 +4,7 @@ import {
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
+  type RefObject,
   useEffect,
   useRef,
   useState,
@@ -62,15 +63,19 @@ type PanelSizeConstraints = {
 
 type MovableResizablePanelProps = {
   children: ReactNode;
+  className?: string;
   dragHandleSelector: string;
   maxSize?: MovableResizablePanelSize;
   minSize: MovableResizablePanelSize;
+  panelRef?: RefObject<HTMLDivElement | null>;
   position: MovableResizablePanelPosition;
   size: MovableResizablePanelSize;
   boundsPadding?: number;
   ignoreOutsideInteraction?: boolean;
+  isGeometryManaged?: boolean;
   isMovable?: boolean;
   isResizable?: boolean;
+  style?: CSSProperties;
   zIndex?: number;
   onPositionChange: (position: MovableResizablePanelPosition) => void;
   onSizeChange: (size: MovableResizablePanelSize) => void;
@@ -405,14 +410,18 @@ function getResizeHandleStyle(direction: ResizeDirection): CSSProperties {
 export function MovableResizablePanel({
   boundsPadding = DEFAULT_BOUNDS_PADDING,
   children,
+  className,
   dragHandleSelector,
   ignoreOutsideInteraction = false,
+  isGeometryManaged = true,
   isMovable = true,
   isResizable = true,
   maxSize,
   minSize,
+  panelRef: externalPanelRef,
   position,
   size,
+  style,
   zIndex,
   onPositionChange,
   onSizeChange,
@@ -562,16 +571,27 @@ export function MovableResizablePanel({
 
   return (
     <div
-      ref={panelRef}
-      className="fixed origin-top-left"
+      ref={(node) => {
+        panelRef.current = node;
+
+        if (externalPanelRef) {
+          externalPanelRef.current = node;
+        }
+      }}
+      className={`fixed origin-top-left${className ? ` ${className}` : ""}`}
       data-ignore-outside-interaction={ignoreOutsideInteraction || undefined}
       data-testid="movable-resizable-panel"
       style={{
-        left: livePosition.left,
-        top: livePosition.top,
-        width: liveSize.width,
-        height: liveSize.height,
+        ...(isGeometryManaged
+          ? {
+              left: livePosition.left,
+              top: livePosition.top,
+              width: liveSize.width,
+              height: liveSize.height,
+            }
+          : null),
         zIndex,
+        ...style,
       }}
       onPointerDown={(event) => {
         if (!isMovable || interactionRef.current) {

--- a/web/src/components/movable-resizable-panel.tsx
+++ b/web/src/components/movable-resizable-panel.tsx
@@ -1,11 +1,13 @@
 "use client";
-
 import {
   type CSSProperties,
+  type ForwardedRef,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
-  type RefObject,
+  forwardRef,
+  useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -54,72 +56,160 @@ type Interaction =
       startSize: MovableResizablePanelSize;
     };
 
-type PanelSizeConstraints = {
+export type MovableResizablePanelSizeConstraints = {
   maxHeight: number;
   maxWidth: number;
   minHeight: number;
   minWidth: number;
 };
 
+export type MovableResizablePanelViewportBounds = {
+  minLeft: number;
+  minTop: number;
+  maxRight: number;
+  maxBottom: number;
+};
+
+export type MovableResizablePanelResizeContext = {
+  bounds: MovableResizablePanelViewportBounds;
+  constraints: MovableResizablePanelSizeConstraints;
+};
+
+export type MovableResizablePanelHandle = {
+  clampGeometry: (
+    geometry: MovableResizablePanelGeometry,
+  ) => MovableResizablePanelGeometry;
+  geometry: MovableResizablePanelGeometry | null;
+  getResizeContext: () => MovableResizablePanelResizeContext;
+  getGeometry: () => MovableResizablePanelGeometry;
+  keepGeometryWithinBounds: () => void;
+  initializeGeometry: () => void;
+  resetGeometry: () => void;
+  clearGeometry: () => void;
+  setGeometry: (geometry: MovableResizablePanelGeometry) => void;
+};
+
 type MovableResizablePanelProps = {
   children: ReactNode;
   className?: string;
+  handle: MovableResizablePanelHandle;
   dragHandleSelector: string;
-  maxSize?: MovableResizablePanelSize;
-  minSize: MovableResizablePanelSize;
-  panelRef?: RefObject<HTMLDivElement | null>;
-  position: MovableResizablePanelPosition;
-  size: MovableResizablePanelSize;
-  boundsPadding?: number;
   ignoreOutsideInteraction?: boolean;
-  isGeometryManaged?: boolean;
-  isMovable?: boolean;
-  isResizable?: boolean;
   style?: CSSProperties;
   zIndex?: number;
-  onPositionChange: (position: MovableResizablePanelPosition) => void;
-  onSizeChange: (size: MovableResizablePanelSize) => void;
 };
 
-export function useMovableResizablePanelGeometry({
+const DEFAULT_BOUNDS_PADDING = 8;
+
+export function useMovableResizablePanelControl({
+  boundsPadding = DEFAULT_BOUNDS_PADDING,
   getInitialGeometry,
+  maxSize,
+  minSize,
 }: {
+  boundsPadding?: number;
   getInitialGeometry: () => MovableResizablePanelGeometry;
+  maxSize?: MovableResizablePanelSize;
+  minSize: MovableResizablePanelSize;
 }) {
   const [geometry, setGeometry] =
     useState<MovableResizablePanelGeometry | null>(null);
 
-  const getGeometry = () => geometry ?? getInitialGeometry();
-  const initializeGeometry = () => {
-    setGeometry((currentGeometry) => currentGeometry ?? getInitialGeometry());
-  };
-  const resetGeometry = () => setGeometry(getInitialGeometry());
-  const clearGeometry = () => setGeometry(null);
-  const setPosition = (position: MovableResizablePanelPosition) => {
-    setGeometry((currentGeometry) => ({
-      position,
-      size: currentGeometry?.size ?? getInitialGeometry().size,
-    }));
-  };
-  const setSize = (size: MovableResizablePanelSize) => {
-    setGeometry((currentGeometry) => ({
-      position: currentGeometry?.position ?? getInitialGeometry().position,
-      size,
-    }));
-  };
+  const clampGeometry = useCallback(
+    (geometry: MovableResizablePanelGeometry) =>
+      clampPanelBounds({
+        boundsPadding,
+        maxSize,
+        minSize,
+        position: geometry.position,
+        size: geometry.size,
+      }),
+    [boundsPadding, maxSize, minSize],
+  );
 
-  return {
-    geometry,
-    getGeometry,
-    initializeGeometry,
-    resetGeometry,
-    clearGeometry,
-    setPosition,
-    setSize,
-  };
+  const getResizeContext = useCallback(
+    () => ({
+      bounds: getViewportBounds(boundsPadding),
+      constraints: getPanelSizeConstraints({
+        boundsPadding,
+        maxSize,
+        minSize,
+      }),
+    }),
+    [boundsPadding, maxSize, minSize],
+  );
+
+  const getGeometry = useCallback(
+    () => clampGeometry(geometry ?? getInitialGeometry()),
+    [clampGeometry, geometry, getInitialGeometry],
+  );
+
+  const keepGeometryWithinBounds = useCallback(() => {
+    const currentGeometry = geometry ?? getInitialGeometry();
+    const nextGeometry = clampGeometry(currentGeometry);
+
+    if (arePanelsEqual(currentGeometry, nextGeometry)) {
+      return;
+    }
+
+    setGeometry(nextGeometry);
+  }, [clampGeometry, geometry, getInitialGeometry]);
+
+  const initializeGeometry = useCallback(() => {
+    if (geometry) {
+      return;
+    }
+
+    const nextGeometry = clampGeometry(getInitialGeometry());
+
+    setGeometry(nextGeometry);
+  }, [clampGeometry, geometry, getInitialGeometry]);
+
+  const resetGeometry = useCallback(() => {
+    const nextGeometry = clampGeometry(getInitialGeometry());
+
+    setGeometry(nextGeometry);
+  }, [clampGeometry, getInitialGeometry]);
+
+  const clearGeometry = useCallback(() => {
+    setGeometry(null);
+  }, []);
+
+  const setGeometryValue = useCallback(
+    (geometry: MovableResizablePanelGeometry) => {
+      const nextGeometry = clampGeometry(geometry);
+
+      setGeometry(nextGeometry);
+    },
+    [clampGeometry],
+  );
+
+  return useMemo<MovableResizablePanelHandle>(
+    () => ({
+      clampGeometry,
+      geometry,
+      getResizeContext,
+      getGeometry,
+      keepGeometryWithinBounds,
+      initializeGeometry,
+      resetGeometry,
+      clearGeometry,
+      setGeometry: setGeometryValue,
+    }),
+    [
+      clampGeometry,
+      clearGeometry,
+      geometry,
+      getGeometry,
+      getResizeContext,
+      initializeGeometry,
+      keepGeometryWithinBounds,
+      resetGeometry,
+      setGeometryValue,
+    ],
+  );
 }
 
-const DEFAULT_BOUNDS_PADDING = 8;
 const RESIZE_HANDLE_SIZE_PX = 10;
 const IGNORE_DRAG_TARGET_SELECTOR =
   "[data-movable-resizable-panel-ignore-drag='true']";
@@ -143,7 +233,9 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 
-function getViewportBounds(boundsPadding: number) {
+function getViewportBounds(
+  boundsPadding: number,
+): MovableResizablePanelViewportBounds {
   if (typeof window === "undefined") {
     return {
       minLeft: boundsPadding,
@@ -169,7 +261,7 @@ function getPanelSizeConstraints({
   boundsPadding: number;
   maxSize?: MovableResizablePanelSize;
   minSize: MovableResizablePanelSize;
-}): PanelSizeConstraints {
+}): MovableResizablePanelSizeConstraints {
   const bounds = getViewportBounds(boundsPadding);
   const viewportMaxWidth = bounds.maxRight - bounds.minLeft;
   const viewportMaxHeight = bounds.maxBottom - bounds.minTop;
@@ -278,8 +370,8 @@ function getResizedPanel(
   interaction: Extract<Interaction, { type: "resize" }>,
   clientX: number,
   clientY: number,
-  constraints: PanelSizeConstraints,
-  bounds: ReturnType<typeof getViewportBounds>,
+  constraints: MovableResizablePanelSizeConstraints,
+  bounds: MovableResizablePanelViewportBounds,
 ) {
   const deltaX = clientX - interaction.startClientX;
   const deltaY = clientY - interaction.startClientY;
@@ -407,123 +499,110 @@ function getResizeHandleStyle(direction: ResizeDirection): CSSProperties {
   return style;
 }
 
-export function MovableResizablePanel({
-  boundsPadding = DEFAULT_BOUNDS_PADDING,
-  children,
-  className,
-  dragHandleSelector,
-  ignoreOutsideInteraction = false,
-  isGeometryManaged = true,
-  isMovable = true,
-  isResizable = true,
-  maxSize,
-  minSize,
-  panelRef: externalPanelRef,
-  position,
-  size,
-  style,
-  zIndex,
-  onPositionChange,
-  onSizeChange,
-}: MovableResizablePanelProps) {
+function assignForwardedRef<T>(ref: ForwardedRef<T>, value: T | null) {
+  if (typeof ref === "function") {
+    ref(value);
+    return;
+  }
+
+  if (ref) {
+    ref.current = value;
+  }
+}
+
+export const MovableResizablePanel = forwardRef<
+  HTMLDivElement,
+  MovableResizablePanelProps
+>(function MovableResizablePanel(
+  {
+    children,
+    className,
+    dragHandleSelector,
+    handle,
+    ignoreOutsideInteraction = false,
+    style,
+    zIndex,
+  },
+  forwardedRef,
+) {
   const panelRef = useRef<HTMLDivElement>(null);
   const interactionRef = useRef<Interaction | null>(null);
-  const maxSizeHeight = maxSize?.height;
-  const maxSizeWidth = maxSize?.width;
-  const minSizeHeight = minSize.height;
-  const minSizeWidth = minSize.width;
-  const [{ position: livePosition, size: liveSize }, setLivePanel] = useState(
-    () =>
-      clampPanelBounds({
-        boundsPadding,
-        maxSize,
-        minSize,
-        position,
-        size,
-      }),
-  );
-  const livePanelRef = useRef({ position: livePosition, size: liveSize });
-  const onPositionChangeRef = useRef(onPositionChange);
-  const onSizeChangeRef = useRef(onSizeChange);
+  const [draftPanel, setDraftPanel] =
+    useState<MovableResizablePanelGeometry | null>(null);
+  const renderedPanel = draftPanel ?? handle.getGeometry();
+  const renderedPanelRef = useRef(renderedPanel);
+  const draftPanelRef = useRef<MovableResizablePanelGeometry | null>(null);
 
-  onPositionChangeRef.current = onPositionChange;
-  onSizeChangeRef.current = onSizeChange;
+  renderedPanelRef.current = renderedPanel;
 
-  useEffect(() => {
+  function handleMovePointerDown(event: ReactPointerEvent<HTMLDivElement>) {
     if (interactionRef.current) {
       return;
     }
 
-    const nextPanel = clampPanelBounds({
-      boundsPadding,
-      maxSize:
-        typeof maxSizeWidth === "number" && typeof maxSizeHeight === "number"
-          ? { width: maxSizeWidth, height: maxSizeHeight }
-          : undefined,
-      minSize: { width: minSizeWidth, height: minSizeHeight },
-      position,
-      size,
-    });
-
-    livePanelRef.current = nextPanel;
-    setLivePanel((currentPanel) =>
-      arePanelsEqual(currentPanel, nextPanel) ? currentPanel : nextPanel,
-    );
-  }, [
-    boundsPadding,
-    maxSizeHeight,
-    maxSizeWidth,
-    minSizeHeight,
-    minSizeWidth,
-    position,
-    size,
-  ]);
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (interactionRef.current) {
-        return;
-      }
-
-      const nextPanel = clampPanelBounds({
-        boundsPadding,
-        maxSize:
-          typeof maxSizeWidth === "number" && typeof maxSizeHeight === "number"
-            ? { width: maxSizeWidth, height: maxSizeHeight }
-            : undefined,
-        minSize: { width: minSizeWidth, height: minSizeHeight },
-        position: livePanelRef.current.position,
-        size: livePanelRef.current.size,
-      });
-
-      if (arePanelsEqual(livePanelRef.current, nextPanel)) {
-        return;
-      }
-
-      livePanelRef.current = nextPanel;
-      setLivePanel(nextPanel);
-      onPositionChangeRef.current(nextPanel.position);
-      onSizeChangeRef.current(nextPanel.size);
-    };
-
-    window.addEventListener("resize", handleResize);
-
-    return () => window.removeEventListener("resize", handleResize);
-  }, [boundsPadding, maxSizeHeight, maxSizeWidth, minSizeHeight, minSizeWidth]);
-
-  const startInteraction = (
-    event: ReactPointerEvent<HTMLDivElement>,
-    interaction: Interaction,
-  ) => {
     const panel = panelRef.current;
+    const coordinates = getPointerCoordinates(event);
+    const target = event.target instanceof Element ? event.target : null;
+    const handle = target?.closest(dragHandleSelector);
+
+    if (
+      !panel ||
+      !handle ||
+      !panel.contains(handle) ||
+      !coordinates ||
+      isIgnoredDragTarget(target)
+    ) {
+      return;
+    }
 
     event.preventDefault();
     event.stopPropagation();
-    interactionRef.current = interaction;
-    panel?.setPointerCapture(event.pointerId);
-  };
 
-  const updateInteraction = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const { position, size } = renderedPanelRef.current;
+
+    interactionRef.current = {
+      type: "move",
+      pointerId: event.pointerId,
+      startClientX: coordinates.clientX,
+      startClientY: coordinates.clientY,
+      startPosition: position,
+      startSize: size,
+    };
+    panelRef.current?.setPointerCapture(event.pointerId);
+  }
+
+  function handleResizePointerDown(
+    direction: ResizeDirection,
+    event: ReactPointerEvent<HTMLDivElement>,
+  ) {
+    if (interactionRef.current) {
+      return;
+    }
+
+    const coordinates = getPointerCoordinates(event);
+
+    if (!coordinates) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const { position, size } = renderedPanelRef.current;
+
+    interactionRef.current = {
+      type: "resize",
+      direction,
+      pointerId: event.pointerId,
+      startClientX: coordinates.clientX,
+      startClientY: coordinates.clientY,
+      startPosition: position,
+      startSize: size,
+    };
+    panelRef.current?.setPointerCapture(event.pointerId);
+  }
+
+  function handleMovePointerMove(event: ReactPointerEvent<HTMLDivElement>) {
     const interaction = interactionRef.current;
     const coordinates = getPointerCoordinates(event);
 
@@ -535,130 +614,89 @@ export function MovableResizablePanel({
       return;
     }
 
-    const nextPanel = clampPanelBounds({
-      boundsPadding,
-      maxSize,
-      minSize,
-      ...(interaction.type === "move"
+    const { bounds, constraints } = handle.getResizeContext();
+
+    const nextUnclampedPanel =
+      interaction.type === "move"
         ? getMovedPanel(interaction, coordinates.clientX, coordinates.clientY)
         : getResizedPanel(
             interaction,
             coordinates.clientX,
             coordinates.clientY,
-            getPanelSizeConstraints({ boundsPadding, maxSize, minSize }),
-            getViewportBounds(boundsPadding),
-          )),
-    });
+            constraints,
+            bounds,
+          );
 
-    livePanelRef.current = nextPanel;
-    setLivePanel(nextPanel);
-  };
+    const nextPanel = handle.clampGeometry(nextUnclampedPanel);
 
-  const stopInteraction = (event: ReactPointerEvent<HTMLDivElement>) => {
+    draftPanelRef.current = nextPanel;
+    setDraftPanel(nextPanel);
+  }
+
+  function handleMoveStop(event: ReactPointerEvent<HTMLDivElement>) {
     const interaction = interactionRef.current;
 
     if (!interaction || interaction.pointerId !== event.pointerId) {
       return;
     }
 
-    const finalPanel = livePanelRef.current;
+    const finalPanel = draftPanelRef.current ?? renderedPanelRef.current;
 
     interactionRef.current = null;
+    draftPanelRef.current = null;
+    setDraftPanel(null);
     panelRef.current?.releasePointerCapture(event.pointerId);
-    onPositionChange(finalPanel.position);
-    onSizeChange(finalPanel.size);
-  };
+    handle.setGeometry(finalPanel);
+  }
+
+  useEffect(() => {
+    function keepPanelGeometryWithinBounds() {
+      if (interactionRef.current) {
+        return;
+      }
+
+      handle.keepGeometryWithinBounds();
+    }
+
+    window.addEventListener("resize", keepPanelGeometryWithinBounds);
+
+    return () =>
+      window.removeEventListener("resize", keepPanelGeometryWithinBounds);
+  }, [handle]);
 
   return (
     <div
       ref={(node) => {
         panelRef.current = node;
-
-        if (externalPanelRef) {
-          externalPanelRef.current = node;
-        }
+        assignForwardedRef(forwardedRef, node);
       }}
       className={`fixed origin-top-left${className ? ` ${className}` : ""}`}
       data-ignore-outside-interaction={ignoreOutsideInteraction || undefined}
       data-testid="movable-resizable-panel"
       style={{
-        ...(isGeometryManaged
-          ? {
-              left: livePosition.left,
-              top: livePosition.top,
-              width: liveSize.width,
-              height: liveSize.height,
-            }
-          : null),
+        left: renderedPanel.position.left,
+        top: renderedPanel.position.top,
+        width: renderedPanel.size.width,
+        height: renderedPanel.size.height,
         zIndex,
         ...style,
       }}
-      onPointerDown={(event) => {
-        if (!isMovable || interactionRef.current) {
-          return;
-        }
-
-        const panel = panelRef.current;
-        const coordinates = getPointerCoordinates(event);
-        const target = event.target instanceof Element ? event.target : null;
-        const handle = target?.closest(dragHandleSelector);
-
-        if (
-          !panel ||
-          !handle ||
-          !panel.contains(handle) ||
-          !coordinates ||
-          isIgnoredDragTarget(target)
-        ) {
-          return;
-        }
-
-        startInteraction(event, {
-          type: "move",
-          pointerId: event.pointerId,
-          startClientX: coordinates.clientX,
-          startClientY: coordinates.clientY,
-          startPosition: livePosition,
-          startSize: liveSize,
-        });
-      }}
-      onPointerMove={updateInteraction}
-      onPointerUp={stopInteraction}
-      onPointerCancel={stopInteraction}
+      onPointerDown={handleMovePointerDown}
+      onPointerMove={handleMovePointerMove}
+      onPointerUp={handleMoveStop}
+      onPointerCancel={handleMoveStop}
     >
       {children}
-      {isResizable
-        ? resizeDirections.map((direction) => (
-            <div
-              key={direction}
-              aria-hidden="true"
-              data-resize-direction={direction}
-              data-testid={`movable-resizable-panel-resize-${direction}`}
-              style={getResizeHandleStyle(direction)}
-              onPointerDown={(event) => {
-                if (interactionRef.current) {
-                  return;
-                }
-
-                const coordinates = getPointerCoordinates(event);
-
-                if (!coordinates) {
-                  return;
-                }
-
-                startInteraction(event, {
-                  type: "resize",
-                  direction,
-                  pointerId: event.pointerId,
-                  startClientX: coordinates.clientX,
-                  startClientY: coordinates.clientY,
-                  startPosition: livePosition,
-                  startSize: liveSize,
-                });
-              }}
-            />
-          ))
-        : null}
+      {resizeDirections.map((direction) => (
+        <div
+          key={direction}
+          aria-hidden="true"
+          data-resize-direction={direction}
+          data-testid={`movable-resizable-panel-resize-${direction}`}
+          style={getResizeHandleStyle(direction)}
+          onPointerDown={(event) => handleResizePointerDown(direction, event)}
+        />
+      ))}
     </div>
   );
-}
+});

--- a/web/src/components/movable-resizable-panel.tsx
+++ b/web/src/components/movable-resizable-panel.tsx
@@ -274,17 +274,44 @@ function getResizedPanel(
   clientX: number,
   clientY: number,
   constraints: PanelSizeConstraints,
+  bounds: ReturnType<typeof getViewportBounds>,
 ) {
   const deltaX = clientX - interaction.startClientX;
   const deltaY = clientY - interaction.startClientY;
   const nextPosition = { ...interaction.startPosition };
   const nextSize = { ...interaction.startSize };
+  const maxWidth = interaction.direction.includes("left")
+    ? Math.min(
+        constraints.maxWidth,
+        interaction.startPosition.left +
+          interaction.startSize.width -
+          bounds.minLeft,
+      )
+    : interaction.direction.includes("right")
+      ? Math.min(
+          constraints.maxWidth,
+          bounds.maxRight - interaction.startPosition.left,
+        )
+      : constraints.maxWidth;
+  const maxHeight = interaction.direction.includes("top")
+    ? Math.min(
+        constraints.maxHeight,
+        interaction.startPosition.top +
+          interaction.startSize.height -
+          bounds.minTop,
+      )
+    : interaction.direction.includes("bottom")
+      ? Math.min(
+          constraints.maxHeight,
+          bounds.maxBottom - interaction.startPosition.top,
+        )
+      : constraints.maxHeight;
 
   if (interaction.direction.includes("right")) {
     nextSize.width = clamp(
       interaction.startSize.width + deltaX,
       constraints.minWidth,
-      constraints.maxWidth,
+      maxWidth,
     );
   }
 
@@ -292,7 +319,7 @@ function getResizedPanel(
     nextSize.width = clamp(
       interaction.startSize.width - deltaX,
       constraints.minWidth,
-      constraints.maxWidth,
+      maxWidth,
     );
     nextPosition.left =
       interaction.startPosition.left +
@@ -304,7 +331,7 @@ function getResizedPanel(
     nextSize.height = clamp(
       interaction.startSize.height + deltaY,
       constraints.minHeight,
-      constraints.maxHeight,
+      maxHeight,
     );
   }
 
@@ -312,7 +339,7 @@ function getResizedPanel(
     nextSize.height = clamp(
       interaction.startSize.height - deltaY,
       constraints.minHeight,
-      constraints.maxHeight,
+      maxHeight,
     );
     nextPosition.top =
       interaction.startPosition.top +
@@ -353,14 +380,14 @@ function getResizeHandleStyle(direction: ResizeDirection): CSSProperties {
   }
 
   if (direction === "top" || direction === "bottom") {
-    style.left = RESIZE_HANDLE_SIZE_PX;
-    style.right = RESIZE_HANDLE_SIZE_PX;
+    style.left = RESIZE_HANDLE_SIZE_PX / 2;
+    style.right = RESIZE_HANDLE_SIZE_PX / 2;
     style.cursor = "ns-resize";
   }
 
   if (direction === "left" || direction === "right") {
-    style.top = RESIZE_HANDLE_SIZE_PX;
-    style.bottom = RESIZE_HANDLE_SIZE_PX;
+    style.top = RESIZE_HANDLE_SIZE_PX / 2;
+    style.bottom = RESIZE_HANDLE_SIZE_PX / 2;
     style.cursor = "ew-resize";
   }
 
@@ -445,6 +472,10 @@ export function MovableResizablePanel({
 
   useEffect(() => {
     const handleResize = () => {
+      if (interactionRef.current) {
+        return;
+      }
+
       const nextPanel = clampPanelBounds({
         boundsPadding,
         maxSize:
@@ -506,6 +537,7 @@ export function MovableResizablePanel({
             coordinates.clientX,
             coordinates.clientY,
             getPanelSizeConstraints({ boundsPadding, maxSize, minSize }),
+            getViewportBounds(boundsPadding),
           )),
     });
 

--- a/web/src/components/movable-resizable-panel.tsx
+++ b/web/src/components/movable-resizable-panel.tsx
@@ -1,0 +1,547 @@
+"use client";
+
+import {
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+export type MovableResizablePanelPosition = {
+  left: number;
+  top: number;
+};
+
+export type MovableResizablePanelSize = {
+  width: number;
+  height: number;
+};
+
+export type MovableResizablePanelGeometry = {
+  position: MovableResizablePanelPosition;
+  size: MovableResizablePanelSize;
+};
+
+type ResizeDirection =
+  | "top"
+  | "right"
+  | "bottom"
+  | "left"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
+
+type Interaction =
+  | {
+      type: "move";
+      pointerId: number;
+      startClientX: number;
+      startClientY: number;
+      startPosition: MovableResizablePanelPosition;
+      startSize: MovableResizablePanelSize;
+    }
+  | {
+      type: "resize";
+      direction: ResizeDirection;
+      pointerId: number;
+      startClientX: number;
+      startClientY: number;
+      startPosition: MovableResizablePanelPosition;
+      startSize: MovableResizablePanelSize;
+    };
+
+type MovableResizablePanelProps = {
+  children: ReactNode;
+  dragHandleSelector: string;
+  maxSize?: MovableResizablePanelSize;
+  minSize: MovableResizablePanelSize;
+  position: MovableResizablePanelPosition;
+  size: MovableResizablePanelSize;
+  boundsPadding?: number;
+  isMovable?: boolean;
+  isResizable?: boolean;
+  zIndex?: number;
+  onPositionChange: (position: MovableResizablePanelPosition) => void;
+  onSizeChange: (size: MovableResizablePanelSize) => void;
+};
+
+export function useMovableResizablePanelGeometry({
+  getInitialGeometry,
+}: {
+  getInitialGeometry: () => MovableResizablePanelGeometry;
+}) {
+  const [geometry, setGeometry] =
+    useState<MovableResizablePanelGeometry | null>(null);
+
+  const getGeometry = () => geometry ?? getInitialGeometry();
+  const resetGeometry = () => setGeometry(getInitialGeometry());
+  const clearGeometry = () => setGeometry(null);
+  const setPosition = (position: MovableResizablePanelPosition) => {
+    setGeometry((currentGeometry) => ({
+      position,
+      size: currentGeometry?.size ?? getInitialGeometry().size,
+    }));
+  };
+  const setSize = (size: MovableResizablePanelSize) => {
+    setGeometry((currentGeometry) => ({
+      position: currentGeometry?.position ?? getInitialGeometry().position,
+      size,
+    }));
+  };
+
+  return {
+    getGeometry,
+    resetGeometry,
+    clearGeometry,
+    setPosition,
+    setSize,
+  };
+}
+
+const DEFAULT_BOUNDS_PADDING = 8;
+const RESIZE_HANDLE_SIZE_PX = 10;
+const IGNORE_DRAG_TARGET_SELECTOR =
+  "[data-movable-resizable-panel-ignore-drag='true']";
+
+const resizeDirections: ResizeDirection[] = [
+  "top",
+  "right",
+  "bottom",
+  "left",
+  "top-left",
+  "top-right",
+  "bottom-left",
+  "bottom-right",
+];
+
+function clamp(value: number, min: number, max: number) {
+  if (max < min) {
+    return min;
+  }
+
+  return Math.min(Math.max(value, min), max);
+}
+
+function getViewportBounds(boundsPadding: number) {
+  if (typeof window === "undefined") {
+    return {
+      minLeft: boundsPadding,
+      minTop: boundsPadding,
+      maxRight: Number.POSITIVE_INFINITY,
+      maxBottom: Number.POSITIVE_INFINITY,
+    };
+  }
+
+  return {
+    minLeft: boundsPadding,
+    minTop: boundsPadding,
+    maxRight: window.innerWidth - boundsPadding,
+    maxBottom: window.innerHeight - boundsPadding,
+  };
+}
+
+function clampPanelBounds({
+  boundsPadding,
+  maxSize,
+  minSize,
+  position,
+  size,
+}: {
+  boundsPadding: number;
+  maxSize?: MovableResizablePanelSize;
+  minSize: MovableResizablePanelSize;
+  position: MovableResizablePanelPosition;
+  size: MovableResizablePanelSize;
+}) {
+  const bounds = getViewportBounds(boundsPadding);
+  const viewportMaxWidth = bounds.maxRight - bounds.minLeft;
+  const viewportMaxHeight = bounds.maxBottom - bounds.minTop;
+  const maxWidth = Math.max(
+    minSize.width,
+    Math.min(maxSize?.width ?? viewportMaxWidth, viewportMaxWidth),
+  );
+  const maxHeight = Math.max(
+    minSize.height,
+    Math.min(maxSize?.height ?? viewportMaxHeight, viewportMaxHeight),
+  );
+  const width = clamp(size.width, minSize.width, maxWidth);
+  const height = clamp(size.height, minSize.height, maxHeight);
+  const left = clamp(position.left, bounds.minLeft, bounds.maxRight - width);
+  const top = clamp(position.top, bounds.minTop, bounds.maxBottom - height);
+
+  return {
+    position: { left, top },
+    size: { width, height },
+  };
+}
+
+function arePositionsEqual(
+  first: MovableResizablePanelPosition,
+  second: MovableResizablePanelPosition,
+) {
+  return first.left === second.left && first.top === second.top;
+}
+
+function areSizesEqual(
+  first: MovableResizablePanelSize,
+  second: MovableResizablePanelSize,
+) {
+  return first.width === second.width && first.height === second.height;
+}
+
+function arePanelsEqual(
+  first: MovableResizablePanelGeometry,
+  second: MovableResizablePanelGeometry,
+) {
+  return (
+    arePositionsEqual(first.position, second.position) &&
+    areSizesEqual(first.size, second.size)
+  );
+}
+
+function getMovedPanel(
+  interaction: Extract<Interaction, { type: "move" }>,
+  clientX: number,
+  clientY: number,
+) {
+  return {
+    position: {
+      left: interaction.startPosition.left + clientX - interaction.startClientX,
+      top: interaction.startPosition.top + clientY - interaction.startClientY,
+    },
+    size: interaction.startSize,
+  };
+}
+
+function getPointerCoordinates(event: ReactPointerEvent<HTMLDivElement>) {
+  if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
+    return null;
+  }
+
+  return { clientX: event.clientX, clientY: event.clientY };
+}
+
+function isIgnoredDragTarget(target: EventTarget | null) {
+  return (
+    target instanceof Element && target.closest(IGNORE_DRAG_TARGET_SELECTOR)
+  );
+}
+
+function getResizedPanel(
+  interaction: Extract<Interaction, { type: "resize" }>,
+  clientX: number,
+  clientY: number,
+) {
+  const deltaX = clientX - interaction.startClientX;
+  const deltaY = clientY - interaction.startClientY;
+  const nextPosition = { ...interaction.startPosition };
+  const nextSize = { ...interaction.startSize };
+
+  if (interaction.direction.includes("right")) {
+    nextSize.width = interaction.startSize.width + deltaX;
+  }
+
+  if (interaction.direction.includes("left")) {
+    nextPosition.left = interaction.startPosition.left + deltaX;
+    nextSize.width = interaction.startSize.width - deltaX;
+  }
+
+  if (interaction.direction.includes("bottom")) {
+    nextSize.height = interaction.startSize.height + deltaY;
+  }
+
+  if (interaction.direction.includes("top")) {
+    nextPosition.top = interaction.startPosition.top + deltaY;
+    nextSize.height = interaction.startSize.height - deltaY;
+  }
+
+  return {
+    position: nextPosition,
+    size: nextSize,
+  };
+}
+
+function getResizeHandleStyle(direction: ResizeDirection): CSSProperties {
+  const style: CSSProperties = {
+    position: "absolute",
+    touchAction: "none",
+  };
+
+  if (direction.includes("top")) {
+    style.top = -RESIZE_HANDLE_SIZE_PX / 2;
+    style.height = RESIZE_HANDLE_SIZE_PX;
+  }
+
+  if (direction.includes("bottom")) {
+    style.bottom = -RESIZE_HANDLE_SIZE_PX / 2;
+    style.height = RESIZE_HANDLE_SIZE_PX;
+  }
+
+  if (direction.includes("left")) {
+    style.left = -RESIZE_HANDLE_SIZE_PX / 2;
+    style.width = RESIZE_HANDLE_SIZE_PX;
+  }
+
+  if (direction.includes("right")) {
+    style.right = -RESIZE_HANDLE_SIZE_PX / 2;
+    style.width = RESIZE_HANDLE_SIZE_PX;
+  }
+
+  if (direction === "top" || direction === "bottom") {
+    style.left = RESIZE_HANDLE_SIZE_PX;
+    style.right = RESIZE_HANDLE_SIZE_PX;
+    style.cursor = "ns-resize";
+  }
+
+  if (direction === "left" || direction === "right") {
+    style.top = RESIZE_HANDLE_SIZE_PX;
+    style.bottom = RESIZE_HANDLE_SIZE_PX;
+    style.cursor = "ew-resize";
+  }
+
+  if (direction === "top-left" || direction === "bottom-right") {
+    style.cursor = "nwse-resize";
+  }
+
+  if (direction === "top-right" || direction === "bottom-left") {
+    style.cursor = "nesw-resize";
+  }
+
+  return style;
+}
+
+export function MovableResizablePanel({
+  boundsPadding = DEFAULT_BOUNDS_PADDING,
+  children,
+  dragHandleSelector,
+  isMovable = true,
+  isResizable = true,
+  maxSize,
+  minSize,
+  position,
+  size,
+  zIndex,
+  onPositionChange,
+  onSizeChange,
+}: MovableResizablePanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const interactionRef = useRef<Interaction | null>(null);
+  const maxSizeHeight = maxSize?.height;
+  const maxSizeWidth = maxSize?.width;
+  const minSizeHeight = minSize.height;
+  const minSizeWidth = minSize.width;
+  const [{ position: livePosition, size: liveSize }, setLivePanel] = useState(
+    () =>
+      clampPanelBounds({
+        boundsPadding,
+        maxSize,
+        minSize,
+        position,
+        size,
+      }),
+  );
+  const livePanelRef = useRef({ position: livePosition, size: liveSize });
+  const onPositionChangeRef = useRef(onPositionChange);
+  const onSizeChangeRef = useRef(onSizeChange);
+
+  onPositionChangeRef.current = onPositionChange;
+  onSizeChangeRef.current = onSizeChange;
+
+  useEffect(() => {
+    if (interactionRef.current) {
+      return;
+    }
+
+    const nextPanel = clampPanelBounds({
+      boundsPadding,
+      maxSize:
+        typeof maxSizeWidth === "number" && typeof maxSizeHeight === "number"
+          ? { width: maxSizeWidth, height: maxSizeHeight }
+          : undefined,
+      minSize: { width: minSizeWidth, height: minSizeHeight },
+      position,
+      size,
+    });
+
+    livePanelRef.current = nextPanel;
+    setLivePanel((currentPanel) =>
+      arePanelsEqual(currentPanel, nextPanel) ? currentPanel : nextPanel,
+    );
+  }, [
+    boundsPadding,
+    maxSizeHeight,
+    maxSizeWidth,
+    minSizeHeight,
+    minSizeWidth,
+    position,
+    size,
+  ]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const nextPanel = clampPanelBounds({
+        boundsPadding,
+        maxSize:
+          typeof maxSizeWidth === "number" && typeof maxSizeHeight === "number"
+            ? { width: maxSizeWidth, height: maxSizeHeight }
+            : undefined,
+        minSize: { width: minSizeWidth, height: minSizeHeight },
+        position: livePanelRef.current.position,
+        size: livePanelRef.current.size,
+      });
+
+      if (arePanelsEqual(livePanelRef.current, nextPanel)) {
+        return;
+      }
+
+      livePanelRef.current = nextPanel;
+      setLivePanel(nextPanel);
+      onPositionChangeRef.current(nextPanel.position);
+      onSizeChangeRef.current(nextPanel.size);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, [boundsPadding, maxSizeHeight, maxSizeWidth, minSizeHeight, minSizeWidth]);
+
+  const startInteraction = (
+    event: ReactPointerEvent<HTMLDivElement>,
+    interaction: Interaction,
+  ) => {
+    const panel = panelRef.current;
+
+    event.preventDefault();
+    event.stopPropagation();
+    interactionRef.current = interaction;
+    panel?.setPointerCapture(event.pointerId);
+  };
+
+  const updateInteraction = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const interaction = interactionRef.current;
+    const coordinates = getPointerCoordinates(event);
+
+    if (
+      !interaction ||
+      interaction.pointerId !== event.pointerId ||
+      !coordinates
+    ) {
+      return;
+    }
+
+    const nextPanel = clampPanelBounds({
+      boundsPadding,
+      maxSize,
+      minSize,
+      ...(interaction.type === "move"
+        ? getMovedPanel(interaction, coordinates.clientX, coordinates.clientY)
+        : getResizedPanel(
+            interaction,
+            coordinates.clientX,
+            coordinates.clientY,
+          )),
+    });
+
+    livePanelRef.current = nextPanel;
+    setLivePanel(nextPanel);
+  };
+
+  const stopInteraction = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const interaction = interactionRef.current;
+
+    if (!interaction || interaction.pointerId !== event.pointerId) {
+      return;
+    }
+
+    const finalPanel = livePanelRef.current;
+
+    interactionRef.current = null;
+    panelRef.current?.releasePointerCapture(event.pointerId);
+    onPositionChange(finalPanel.position);
+    onSizeChange(finalPanel.size);
+  };
+
+  return (
+    <div
+      ref={panelRef}
+      className="fixed origin-top-left"
+      data-testid="movable-resizable-panel"
+      style={{
+        left: livePosition.left,
+        top: livePosition.top,
+        width: liveSize.width,
+        height: liveSize.height,
+        zIndex,
+      }}
+      onPointerDown={(event) => {
+        if (!isMovable || interactionRef.current) {
+          return;
+        }
+
+        const panel = panelRef.current;
+        const coordinates = getPointerCoordinates(event);
+        const target = event.target instanceof Element ? event.target : null;
+        const handle = target?.closest(dragHandleSelector);
+
+        if (
+          !panel ||
+          !handle ||
+          !panel.contains(handle) ||
+          !coordinates ||
+          isIgnoredDragTarget(target)
+        ) {
+          return;
+        }
+
+        startInteraction(event, {
+          type: "move",
+          pointerId: event.pointerId,
+          startClientX: coordinates.clientX,
+          startClientY: coordinates.clientY,
+          startPosition: livePosition,
+          startSize: liveSize,
+        });
+      }}
+      onPointerMove={updateInteraction}
+      onPointerUp={stopInteraction}
+      onPointerCancel={stopInteraction}
+    >
+      {children}
+      {isResizable
+        ? resizeDirections.map((direction) => (
+            <div
+              key={direction}
+              aria-hidden="true"
+              data-resize-direction={direction}
+              data-testid={`movable-resizable-panel-resize-${direction}`}
+              style={getResizeHandleStyle(direction)}
+              onPointerDown={(event) => {
+                if (interactionRef.current) {
+                  return;
+                }
+
+                const coordinates = getPointerCoordinates(event);
+
+                if (!coordinates) {
+                  return;
+                }
+
+                startInteraction(event, {
+                  type: "resize",
+                  direction,
+                  pointerId: event.pointerId,
+                  startClientX: coordinates.clientX,
+                  startClientY: coordinates.clientY,
+                  startPosition: livePosition,
+                  startSize: liveSize,
+                });
+              }}
+            />
+          ))
+        : null}
+    </div>
+  );
+}

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -88,13 +88,26 @@ export const InAppAiAgentButton = () => {
     );
   }, [isExpanded]);
 
+  useLayoutEffect(() => {
+    if (
+      !open ||
+      !portalContainer ||
+      isExpanded ||
+      floatingPanelGeometry.geometry
+    ) {
+      return;
+    }
+
+    floatingPanelGeometry.initializeGeometry();
+  }, [floatingPanelGeometry, isExpanded, open, portalContainer]);
+
   if (!isAvailable || !hasInAppAgentEntitlement || !isInAppAgentEnabled) {
     return null;
   }
 
   const activeFloatingPanelGeometry =
     open && portalContainer && !isExpanded
-      ? floatingPanelGeometry.getGeometry()
+      ? floatingPanelGeometry.geometry
       : null;
 
   const handleClick = () => {

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -106,8 +106,10 @@ export const InAppAiAgentButton = () => {
   }
 
   const activeFloatingPanelGeometry =
-    open && portalContainer && !isExpanded
-      ? floatingPanelGeometry.geometry
+    open && portalContainer
+      ? isExpanded
+        ? floatingPanelGeometry.getGeometry()
+        : floatingPanelGeometry.geometry
       : null;
 
   const handleClick = () => {

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -3,7 +3,6 @@ import { createPortal } from "react-dom";
 import { useSession } from "next-auth/react";
 import { BotMessageSquare } from "lucide-react";
 
-import { useMovableResizablePanelGeometry } from "@/src/components/movable-resizable-panel";
 import { Button } from "@/src/components/ui/button";
 import {
   Dialog,
@@ -16,8 +15,8 @@ import {
 import { SidebarMenuButton } from "@/src/components/ui/sidebar";
 import { ControlledInAppAgentWindow } from "@/src/ee/features/in-app-agent/components";
 import {
-  getInitialInAppAgentWindowShellGeometry,
   InAppAgentWindowShell,
+  useInAppAgentWindowShellPanelControl,
 } from "@/src/ee/features/in-app-agent/components/InAppAgentWindowShell";
 import { useInAppAiAgent } from "@/src/ee/features/in-app-agent/components/InAppAiAgentProvider";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
@@ -44,18 +43,8 @@ export const InAppAiAgentButton = () => {
   );
   const [enableDialogOpen, setEnableDialogOpen] = useState(false);
 
-  const getInitialFloatingPanelGeometry = () => {
-    const button = buttonRef.current;
-
-    return getInitialInAppAgentWindowShellGeometry({
-      anchorRect: button?.getBoundingClientRect(),
-      viewportHeight: window.innerHeight,
-      viewportWidth: window.innerWidth,
-    });
-  };
-
-  const floatingPanelGeometry = useMovableResizablePanelGeometry({
-    getInitialGeometry: getInitialFloatingPanelGeometry,
+  const floatingPanelHandle = useInAppAgentWindowShellPanelControl({
+    anchorRef: buttonRef,
   });
 
   useEffect(() => {
@@ -93,24 +82,17 @@ export const InAppAiAgentButton = () => {
       !open ||
       !portalContainer ||
       isExpanded ||
-      floatingPanelGeometry.geometry
+      floatingPanelHandle.geometry
     ) {
       return;
     }
 
-    floatingPanelGeometry.initializeGeometry();
-  }, [floatingPanelGeometry, isExpanded, open, portalContainer]);
+    floatingPanelHandle.initializeGeometry();
+  }, [floatingPanelHandle, isExpanded, open, portalContainer]);
 
   if (!isAvailable || !hasInAppAgentEntitlement || !isInAppAgentEnabled) {
     return null;
   }
-
-  const activeFloatingPanelGeometry =
-    open && portalContainer
-      ? isExpanded
-        ? floatingPanelGeometry.getGeometry()
-        : floatingPanelGeometry.geometry
-      : null;
 
   const handleClick = () => {
     if (organization && !organization.aiFeaturesEnabled) {
@@ -124,7 +106,7 @@ export const InAppAiAgentButton = () => {
       const nextOpen = !currentOpen;
 
       if (nextOpen) {
-        floatingPanelGeometry.resetGeometry();
+        floatingPanelHandle.resetGeometry();
       }
 
       return nextOpen;
@@ -140,12 +122,10 @@ export const InAppAiAgentButton = () => {
       {open && portalContainer
         ? createPortal(
             <InAppAgentWindowShell
-              floatingGeometry={activeFloatingPanelGeometry}
+              floatingPanelHandle={floatingPanelHandle}
               isExpanded={isExpanded}
               panelRef={panelRef}
               zIndex={IN_APP_AI_AGENT_WINDOW_Z_INDEX}
-              onPositionChange={floatingPanelGeometry.setPosition}
-              onSizeChange={floatingPanelGeometry.setSize}
             >
               {({ isHeaderDragHandleEnabled }) => (
                 <ControlledInAppAgentWindow
@@ -158,7 +138,7 @@ export const InAppAiAgentButton = () => {
                     setIsExpanded(nextIsExpanded);
                   }}
                   onClose={() => {
-                    floatingPanelGeometry.clearGeometry();
+                    floatingPanelHandle.clearGeometry();
                     setOpen(false);
                   }}
                 />

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -1,14 +1,9 @@
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-} from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSession } from "next-auth/react";
 import { BotMessageSquare } from "lucide-react";
 
+import { useMovableResizablePanelGeometry } from "@/src/components/movable-resizable-panel";
 import { Button } from "@/src/components/ui/button";
 import {
   Dialog,
@@ -20,12 +15,15 @@ import {
 } from "@/src/components/ui/dialog";
 import { SidebarMenuButton } from "@/src/components/ui/sidebar";
 import { ControlledInAppAgentWindow } from "@/src/ee/features/in-app-agent/components";
+import {
+  getInitialInAppAgentWindowShellGeometry,
+  InAppAgentWindowShell,
+} from "@/src/ee/features/in-app-agent/components/InAppAgentWindowShell";
 import { useInAppAiAgent } from "@/src/ee/features/in-app-agent/components/InAppAiAgentProvider";
 import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { AIFeaturesDisabledNotice } from "@/src/features/organizations/components/AIFeaturesDisabledNotice";
 import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
 import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvider";
-import { cn } from "@/src/utils/tailwind";
 
 const IN_APP_AI_AGENT_WINDOW_Z_INDEX = 51;
 
@@ -41,25 +39,24 @@ export const InAppAiAgentButton = () => {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const previousPanelRectRef = useRef<DOMRect | null>(null);
-  const [anchorStyle, setAnchorStyle] = useState<CSSProperties>();
   const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(
     null,
   );
   const [enableDialogOpen, setEnableDialogOpen] = useState(false);
 
-  const updateAnchorStyle = () => {
+  const getInitialFloatingPanelGeometry = () => {
     const button = buttonRef.current;
 
-    if (!button) {
-      return;
-    }
-
-    const rect = button.getBoundingClientRect();
-
-    setAnchorStyle({
-      left: rect.right - 6,
+    return getInitialInAppAgentWindowShellGeometry({
+      anchorRect: button?.getBoundingClientRect(),
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
     });
   };
+
+  const floatingPanelGeometry = useMovableResizablePanelGeometry({
+    getInitialGeometry: getInitialFloatingPanelGeometry,
+  });
 
   useEffect(() => {
     setPortalContainer(document.body);
@@ -91,25 +88,14 @@ export const InAppAiAgentButton = () => {
     );
   }, [isExpanded]);
 
-  useEffect(() => {
-    if (!open || isExpanded) {
-      return;
-    }
-
-    updateAnchorStyle();
-
-    window.addEventListener("resize", updateAnchorStyle);
-    window.addEventListener("scroll", updateAnchorStyle, true);
-
-    return () => {
-      window.removeEventListener("resize", updateAnchorStyle);
-      window.removeEventListener("scroll", updateAnchorStyle, true);
-    };
-  }, [isExpanded, open]);
-
   if (!isAvailable || !hasInAppAgentEntitlement || !isInAppAgentEnabled) {
     return null;
   }
+
+  const activeFloatingPanelGeometry =
+    open && portalContainer && !isExpanded
+      ? floatingPanelGeometry.getGeometry()
+      : null;
 
   const handleClick = () => {
     if (organization && !organization.aiFeaturesEnabled) {
@@ -118,9 +104,16 @@ export const InAppAiAgentButton = () => {
       return;
     }
 
-    updateAnchorStyle();
     setSupportDrawerOpen(false);
-    setOpen((currentOpen) => !currentOpen);
+    setOpen((currentOpen) => {
+      const nextOpen = !currentOpen;
+
+      if (nextOpen) {
+        floatingPanelGeometry.resetGeometry();
+      }
+
+      return nextOpen;
+    });
   };
 
   return (
@@ -131,32 +124,31 @@ export const InAppAiAgentButton = () => {
       </SidebarMenuButton>
       {open && portalContainer
         ? createPortal(
-            <div
-              ref={panelRef}
-              data-ignore-outside-interaction
-              className={cn(
-                "fixed origin-top-left",
-                isExpanded
-                  ? "inset-x-3 top-[calc(var(--banner-offset)+0.75rem)] bottom-3"
-                  : "bottom-2",
-              )}
-              style={
-                isExpanded
-                  ? { zIndex: IN_APP_AI_AGENT_WINDOW_Z_INDEX }
-                  : { ...anchorStyle, zIndex: IN_APP_AI_AGENT_WINDOW_Z_INDEX }
-              }
+            <InAppAgentWindowShell
+              floatingGeometry={activeFloatingPanelGeometry}
+              isExpanded={isExpanded}
+              panelRef={panelRef}
+              zIndex={IN_APP_AI_AGENT_WINDOW_Z_INDEX}
+              onPositionChange={floatingPanelGeometry.setPosition}
+              onSizeChange={floatingPanelGeometry.setSize}
             >
-              <ControlledInAppAgentWindow
-                zIndex={IN_APP_AI_AGENT_WINDOW_Z_INDEX}
-                isExpanded={isExpanded}
-                onExpandedChange={(nextIsExpanded) => {
-                  previousPanelRectRef.current =
-                    panelRef.current?.getBoundingClientRect() ?? null;
-                  setIsExpanded(nextIsExpanded);
-                }}
-                onClose={() => setOpen(false)}
-              />
-            </div>,
+              {({ isHeaderDragHandleEnabled }) => (
+                <ControlledInAppAgentWindow
+                  isHeaderDragHandleEnabled={isHeaderDragHandleEnabled}
+                  zIndex={IN_APP_AI_AGENT_WINDOW_Z_INDEX}
+                  isExpanded={isExpanded}
+                  onExpandedChange={(nextIsExpanded) => {
+                    previousPanelRectRef.current =
+                      panelRef.current?.getBoundingClientRect() ?? null;
+                    setIsExpanded(nextIsExpanded);
+                  }}
+                  onClose={() => {
+                    floatingPanelGeometry.clearGeometry();
+                    setOpen(false);
+                  }}
+                />
+              )}
+            </InAppAgentWindowShell>,
             portalContainer,
           )
         : null}

--- a/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/ControlledInAppAgentWindow.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/src/ee/features/in-app-agent/schema";
 
 type ControlledInAppAgentWindowBaseProps = {
+  isHeaderDragHandleEnabled?: boolean;
   zIndex?: number;
   isExpanded: boolean;
   onExpandedChange: (isExpanded: boolean) => void;
@@ -229,6 +230,7 @@ export function ControlledInAppAgentWindow(
   return (
     <InAppAgentWindow
       error={error}
+      isHeaderDragHandleEnabled={props.isHeaderDragHandleEnabled}
       isExpanded={props.isExpanded}
       isInputDisabled={isInputDisabled}
       messages={drawerMessages}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -1,24 +1,79 @@
 import preview from "../../../../../.storybook/preview";
-import { useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { fn } from "storybook/test";
 import {
   InAppAgentWindow,
   type InAppAgentWindowMessage,
   type InAppAgentWindowProps,
 } from "./InAppAgentWindow";
+import {
+  getInitialInAppAgentWindowShellGeometry,
+  InAppAgentWindowShell,
+} from "./InAppAgentWindowShell";
+import { useMovableResizablePanelGeometry } from "@/src/components/movable-resizable-panel";
+
+function getStoryViewport() {
+  return {
+    height: typeof window === "undefined" ? 768 : window.innerHeight,
+    width: typeof window === "undefined" ? 1024 : window.innerWidth,
+  };
+}
+
+function InAppAgentWindowStoryShell({
+  children,
+  isExpanded,
+}: {
+  children: (props: { isHeaderDragHandleEnabled: boolean }) => ReactNode;
+  isExpanded: boolean;
+}) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const [initialGeometry] = useState(() => {
+    const viewport = getStoryViewport();
+
+    return getInitialInAppAgentWindowShellGeometry({
+      viewportHeight: viewport.height,
+      viewportWidth: viewport.width,
+    });
+  });
+
+  const geometry = useMovableResizablePanelGeometry({
+    getInitialGeometry: () => initialGeometry,
+  });
+
+  const floatingGeometry = isExpanded ? null : geometry.getGeometry();
+
+  return (
+    <InAppAgentWindowShell
+      floatingGeometry={floatingGeometry}
+      isExpanded={isExpanded}
+      panelRef={panelRef}
+      zIndex={1}
+      onPositionChange={geometry.setPosition}
+      onSizeChange={geometry.setSize}
+    >
+      {children}
+    </InAppAgentWindowShell>
+  );
+}
 
 function StatefulInAppAgentWindow(args: InAppAgentWindowProps) {
   const [isExpanded, setIsExpanded] = useState(args.isExpanded);
 
   return (
-    <InAppAgentWindow
-      {...args}
-      isExpanded={isExpanded}
-      onExpandedChange={(isExpanded) => {
-        setIsExpanded(isExpanded);
-        args.onExpandedChange(isExpanded);
-      }}
-    />
+    <InAppAgentWindowStoryShell isExpanded={isExpanded}>
+      {({ isHeaderDragHandleEnabled }) => (
+        <InAppAgentWindow
+          {...args}
+          isHeaderDragHandleEnabled={isHeaderDragHandleEnabled}
+          isExpanded={isExpanded}
+          onExpandedChange={(isExpanded) => {
+            setIsExpanded(isExpanded);
+            args.onExpandedChange(isExpanded);
+          }}
+        />
+      )}
+    </InAppAgentWindowStoryShell>
   );
 }
 
@@ -153,14 +208,23 @@ function StreamingInAppAgentWindow(args: InAppAgentWindowProps) {
   const [messages, setMessages] = useState<InAppAgentWindowMessage[]>(
     streamingSeedMessages,
   );
-  const streamRef = useRef({
+  type StreamingPhase =
+    | "start"
+    | "intro"
+    | "tool-loading"
+    | "tool-done"
+    | "conclusion";
+
+  const streamRef = useRef<{
+    cycle: number;
+    phase: StreamingPhase;
+    phaseTicks: number;
+    introMessageId: string;
+    toolMessageId: string;
+    conclusionMessageId: string;
+  }>({
     cycle: 0,
-    phase: "start" as
-      | "start"
-      | "intro"
-      | "tool-loading"
-      | "tool-done"
-      | "conclusion",
+    phase: "start",
     phaseTicks: 0,
     introMessageId: "",
     toolMessageId: "",
@@ -321,28 +385,33 @@ function StreamingInAppAgentWindow(args: InAppAgentWindowProps) {
   }, []);
 
   return (
-    <InAppAgentWindow
-      {...args}
-      isExpanded={isExpanded}
-      messages={messages}
-      onExpandedChange={(isExpanded) => {
-        setIsExpanded(isExpanded);
-        args.onExpandedChange(isExpanded);
-      }}
-      onSubmit={(input) => {
-        setMessages((currentMessages) => [
-          ...currentMessages,
-          {
-            id: `manual-${currentMessages.length}`,
-            role: "user",
-            content: { type: "text", text: input },
-          },
-        ]);
+    <InAppAgentWindowStoryShell isExpanded={isExpanded}>
+      {({ isHeaderDragHandleEnabled }) => (
+        <InAppAgentWindow
+          {...args}
+          isHeaderDragHandleEnabled={isHeaderDragHandleEnabled}
+          isExpanded={isExpanded}
+          messages={messages}
+          onExpandedChange={(isExpanded) => {
+            setIsExpanded(isExpanded);
+            args.onExpandedChange(isExpanded);
+          }}
+          onSubmit={(input) => {
+            setMessages((currentMessages) => [
+              ...currentMessages,
+              {
+                id: `manual-${currentMessages.length}`,
+                role: "user",
+                content: { type: "text", text: input },
+              },
+            ]);
 
-        args.onSubmit(input);
-        return true;
-      }}
-    />
+            args.onSubmit(input);
+            return true;
+          }}
+        />
+      )}
+    </InAppAgentWindowStoryShell>
   );
 }
 
@@ -391,7 +460,7 @@ const meta = preview.meta({
     onSubmitFeedback: fn(),
     showCloseButton: true,
   },
-  render: StatefulInAppAgentWindow,
+  render: (args) => <StatefulInAppAgentWindow {...args} />,
 });
 
 export const Empty = meta.story({
@@ -556,7 +625,7 @@ export const Streaming = meta.story({
     selectedConversationId: "conversation-1",
     messages: streamingSeedMessages,
   },
-  render: StreamingInAppAgentWindow,
+  render: (args) => <StreamingInAppAgentWindow {...args} />,
 });
 
 export const LoadingResponse = meta.story({

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.stories.tsx
@@ -7,17 +7,9 @@ import {
   type InAppAgentWindowProps,
 } from "./InAppAgentWindow";
 import {
-  getInitialInAppAgentWindowShellGeometry,
   InAppAgentWindowShell,
+  useInAppAgentWindowShellPanelControl,
 } from "./InAppAgentWindowShell";
-import { useMovableResizablePanelGeometry } from "@/src/components/movable-resizable-panel";
-
-function getStoryViewport() {
-  return {
-    height: typeof window === "undefined" ? 768 : window.innerHeight,
-    width: typeof window === "undefined" ? 1024 : window.innerWidth,
-  };
-}
 
 function InAppAgentWindowStoryShell({
   children,
@@ -27,30 +19,18 @@ function InAppAgentWindowStoryShell({
   isExpanded: boolean;
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const floatingPanelHandle = useInAppAgentWindowShellPanelControl({});
 
-  const [initialGeometry] = useState(() => {
-    const viewport = getStoryViewport();
-
-    return getInitialInAppAgentWindowShellGeometry({
-      viewportHeight: viewport.height,
-      viewportWidth: viewport.width,
-    });
-  });
-
-  const geometry = useMovableResizablePanelGeometry({
-    getInitialGeometry: () => initialGeometry,
-  });
-
-  const floatingGeometry = isExpanded ? null : geometry.getGeometry();
+  useEffect(() => {
+    floatingPanelHandle.initializeGeometry();
+  }, [floatingPanelHandle]);
 
   return (
     <InAppAgentWindowShell
-      floatingGeometry={floatingGeometry}
+      floatingPanelHandle={floatingPanelHandle}
       isExpanded={isExpanded}
       panelRef={panelRef}
       zIndex={1}
-      onPositionChange={geometry.setPosition}
-      onSizeChange={geometry.setSize}
     >
       {children}
     </InAppAgentWindowShell>

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -88,6 +88,7 @@ export type InAppAgentWindowProps = {
   conversations: InAppAgentWindowConversation[];
   error: string | null;
   hasMoreConversations: boolean;
+  isHeaderDragHandleEnabled?: boolean;
   isExpanded: boolean;
   isInputDisabled: boolean;
   isLoadingMoreConversations: boolean;
@@ -112,6 +113,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
     conversations,
     error,
     hasMoreConversations,
+    isHeaderDragHandleEnabled = false,
     isExpanded,
     isInputDisabled,
     isLoadingMoreConversations,
@@ -185,21 +187,27 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
   return (
     <section
       aria-label="Assistant"
-      className={cn(
-        "bg-background flex min-w-0 flex-col overflow-hidden rounded-xl border shadow/5",
-        isExpanded
-          ? "h-full min-h-0 w-full"
-          : "h-[min(42rem,calc(100vh-var(--banner-offset)-2rem))] min-h-96 w-[min(28rem,calc(100vw-1rem))]",
-      )}
+      className="bg-background flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden rounded-xl border shadow/5"
     >
-      <header className="bg-header flex min-h-11.25 shrink-0 items-center justify-between gap-2 border-b px-3 py-1">
+      <header
+        data-in-app-agent-window-drag-handle={
+          isHeaderDragHandleEnabled ? "true" : undefined
+        }
+        className={cn(
+          "bg-header flex min-h-11.25 shrink-0 items-center justify-between gap-2 border-b px-3 py-1",
+          isHeaderDragHandleEnabled && "cursor-move select-none",
+        )}
+      >
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <p className="shrink-0 truncate text-sm font-semibold">Assistant</p>
           <span className="text-muted-foreground rounded border px-1.5 py-1 text-xs leading-none font-medium">
             Beta
           </span>
         </div>
-        <div className="flex shrink-0 items-center gap-0.5">
+        <div
+          className="flex shrink-0 items-center gap-0.5"
+          data-movable-resizable-panel-ignore-drag="true"
+        >
           <Tooltip delayDuration={100} disableHoverableContent>
             <TooltipTrigger asChild>
               <Button

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -195,7 +195,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
         }
         className={cn(
           "bg-header flex min-h-11.25 shrink-0 items-center justify-between gap-2 border-b px-3 py-1",
-          isHeaderDragHandleEnabled && "cursor-move select-none",
+          isHeaderDragHandleEnabled && "cursor-move touch-none select-none",
         )}
       >
         <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import type { ReactNode, RefObject } from "react";
+
+import {
+  MovableResizablePanel,
+  type MovableResizablePanelGeometry,
+  type MovableResizablePanelSize,
+} from "@/src/components/movable-resizable-panel";
+
+const IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX = 8;
+const IN_APP_AGENT_WINDOW_SHELL_DEFAULT_WIDTH_PX = 448;
+const IN_APP_AGENT_WINDOW_SHELL_DEFAULT_MAX_HEIGHT_PX = 672;
+const IN_APP_AGENT_WINDOW_SHELL_FULL_WIDTH_CAP_SCREEN_WIDTH_PX = 1440;
+const IN_APP_AGENT_WINDOW_SHELL_WIDE_SCREEN_WIDTH_PX = 2560;
+const IN_APP_AGENT_WINDOW_SHELL_MAX_HEIGHT_PX = 760;
+const IN_APP_AGENT_WINDOW_SHELL_DRAG_HANDLE_SELECTOR =
+  "[data-in-app-agent-window-drag-handle='true']";
+const IN_APP_AGENT_WINDOW_SHELL_MIN_SIZE = {
+  width: 360,
+  height: 420,
+} satisfies MovableResizablePanelSize;
+
+type InitialInAppAgentWindowShellGeometryParams = {
+  viewportWidth: number;
+  viewportHeight: number;
+  anchorRect?: Pick<DOMRect, "right"> | null;
+};
+
+function getInAppAgentWindowShellMaxWidth(viewportWidth: number) {
+  const wideScreenProgress = Math.max(
+    0,
+    Math.min(
+      (viewportWidth -
+        IN_APP_AGENT_WINDOW_SHELL_FULL_WIDTH_CAP_SCREEN_WIDTH_PX) /
+        (IN_APP_AGENT_WINDOW_SHELL_WIDE_SCREEN_WIDTH_PX -
+          IN_APP_AGENT_WINDOW_SHELL_FULL_WIDTH_CAP_SCREEN_WIDTH_PX),
+      1,
+    ),
+  );
+  const maxWidthRatio = 0.9 - wideScreenProgress * 0.3;
+
+  return viewportWidth * maxWidthRatio;
+}
+
+function getInAppAgentWindowShellMaxSize(
+  viewportWidth: number,
+): MovableResizablePanelSize {
+  return {
+    width: getInAppAgentWindowShellMaxWidth(viewportWidth),
+    height: IN_APP_AGENT_WINDOW_SHELL_MAX_HEIGHT_PX,
+  };
+}
+
+export function getInitialInAppAgentWindowShellGeometry({
+  viewportWidth,
+  viewportHeight,
+  anchorRect,
+}: InitialInAppAgentWindowShellGeometryParams): MovableResizablePanelGeometry {
+  const width = Math.min(
+    IN_APP_AGENT_WINDOW_SHELL_DEFAULT_WIDTH_PX,
+    viewportWidth - IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX * 2,
+  );
+  const height = Math.min(
+    IN_APP_AGENT_WINDOW_SHELL_DEFAULT_MAX_HEIGHT_PX,
+    viewportHeight - 32,
+  );
+
+  return {
+    position: {
+      left: anchorRect
+        ? anchorRect.right - 6
+        : viewportWidth - width - IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX,
+      top:
+        viewportHeight - height - IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX,
+    },
+    size: { width, height },
+  };
+}
+
+type InAppAgentWindowShellProps = {
+  children: (props: { isHeaderDragHandleEnabled: boolean }) => ReactNode;
+  floatingGeometry: MovableResizablePanelGeometry | null;
+  isExpanded: boolean;
+  panelRef: RefObject<HTMLDivElement | null>;
+  zIndex: number;
+  onPositionChange: (
+    position: MovableResizablePanelGeometry["position"],
+  ) => void;
+  onSizeChange: (size: MovableResizablePanelGeometry["size"]) => void;
+};
+
+export function InAppAgentWindowShell({
+  children,
+  floatingGeometry,
+  isExpanded,
+  panelRef,
+  zIndex,
+  onPositionChange,
+  onSizeChange,
+}: InAppAgentWindowShellProps) {
+  if (isExpanded) {
+    return (
+      <div
+        ref={panelRef}
+        data-ignore-outside-interaction
+        className="fixed inset-x-3 top-[calc(var(--banner-offset)+0.75rem)] bottom-3 origin-top-left"
+        style={{ zIndex }}
+      >
+        {children({ isHeaderDragHandleEnabled: false })}
+      </div>
+    );
+  }
+
+  if (!floatingGeometry) {
+    return null;
+  }
+
+  return (
+    <MovableResizablePanel
+      boundsPadding={IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX}
+      dragHandleSelector={IN_APP_AGENT_WINDOW_SHELL_DRAG_HANDLE_SELECTOR}
+      maxSize={getInAppAgentWindowShellMaxSize(window.innerWidth)}
+      minSize={IN_APP_AGENT_WINDOW_SHELL_MIN_SIZE}
+      position={floatingGeometry.position}
+      size={floatingGeometry.size}
+      zIndex={zIndex}
+      onPositionChange={onPositionChange}
+      onSizeChange={onSizeChange}
+    >
+      <div
+        ref={panelRef}
+        data-ignore-outside-interaction
+        className="h-full w-full"
+      >
+        {children({ isHeaderDragHandleEnabled: true })}
+      </div>
+    </MovableResizablePanel>
+  );
+}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -78,19 +78,6 @@ export function InAppAgentWindowShell({
   onPositionChange,
   onSizeChange,
 }: InAppAgentWindowShellProps) {
-  if (isExpanded) {
-    return (
-      <div
-        ref={panelRef}
-        data-ignore-outside-interaction
-        className="fixed inset-x-3 top-[calc(var(--banner-offset)+0.75rem)] bottom-3 origin-top-left"
-        style={{ zIndex }}
-      >
-        {children({ isHeaderDragHandleEnabled: false })}
-      </div>
-    );
-  }
-
   if (!floatingGeometry) {
     return null;
   }
@@ -98,10 +85,19 @@ export function InAppAgentWindowShell({
   return (
     <MovableResizablePanel
       boundsPadding={IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX}
+      className={
+        isExpanded
+          ? "inset-x-3 top-[calc(var(--banner-offset)+0.75rem)] bottom-3"
+          : undefined
+      }
       dragHandleSelector={IN_APP_AGENT_WINDOW_SHELL_DRAG_HANDLE_SELECTOR}
       ignoreOutsideInteraction
+      isGeometryManaged={!isExpanded}
+      isMovable={!isExpanded}
+      isResizable={!isExpanded}
       maxSize={IN_APP_AGENT_WINDOW_SHELL_MAX_SIZE}
       minSize={IN_APP_AGENT_WINDOW_SHELL_MIN_SIZE}
+      panelRef={panelRef}
       position={floatingGeometry.position}
       size={floatingGeometry.size}
       zIndex={zIndex}
@@ -109,11 +105,10 @@ export function InAppAgentWindowShell({
       onSizeChange={onSizeChange}
     >
       <div
-        ref={panelRef}
         data-ignore-outside-interaction
-        className="h-full w-full"
+        className="h-full w-full origin-top-left"
       >
-        {children({ isHeaderDragHandleEnabled: true })}
+        {children({ isHeaderDragHandleEnabled: !isExpanded })}
       </div>
     </MovableResizablePanel>
   );

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -11,8 +11,7 @@ import {
 const IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX = 8;
 const IN_APP_AGENT_WINDOW_SHELL_DEFAULT_WIDTH_PX = 448;
 const IN_APP_AGENT_WINDOW_SHELL_DEFAULT_MAX_HEIGHT_PX = 672;
-const IN_APP_AGENT_WINDOW_SHELL_FULL_WIDTH_CAP_SCREEN_WIDTH_PX = 1440;
-const IN_APP_AGENT_WINDOW_SHELL_WIDE_SCREEN_WIDTH_PX = 2560;
+const IN_APP_AGENT_WINDOW_SHELL_MAX_WIDTH_PX = 1296;
 const IN_APP_AGENT_WINDOW_SHELL_MAX_HEIGHT_PX = 760;
 const IN_APP_AGENT_WINDOW_SHELL_DRAG_HANDLE_SELECTOR =
   "[data-in-app-agent-window-drag-handle='true']";
@@ -27,30 +26,10 @@ type InitialInAppAgentWindowShellGeometryParams = {
   anchorRect?: Pick<DOMRect, "right"> | null;
 };
 
-function getInAppAgentWindowShellMaxWidth(viewportWidth: number) {
-  const wideScreenProgress = Math.max(
-    0,
-    Math.min(
-      (viewportWidth -
-        IN_APP_AGENT_WINDOW_SHELL_FULL_WIDTH_CAP_SCREEN_WIDTH_PX) /
-        (IN_APP_AGENT_WINDOW_SHELL_WIDE_SCREEN_WIDTH_PX -
-          IN_APP_AGENT_WINDOW_SHELL_FULL_WIDTH_CAP_SCREEN_WIDTH_PX),
-      1,
-    ),
-  );
-  const maxWidthRatio = 0.9 - wideScreenProgress * 0.3;
-
-  return viewportWidth * maxWidthRatio;
-}
-
-function getInAppAgentWindowShellMaxSize(
-  viewportWidth: number,
-): MovableResizablePanelSize {
-  return {
-    width: getInAppAgentWindowShellMaxWidth(viewportWidth),
-    height: IN_APP_AGENT_WINDOW_SHELL_MAX_HEIGHT_PX,
-  };
-}
+const IN_APP_AGENT_WINDOW_SHELL_MAX_SIZE = {
+  width: IN_APP_AGENT_WINDOW_SHELL_MAX_WIDTH_PX,
+  height: IN_APP_AGENT_WINDOW_SHELL_MAX_HEIGHT_PX,
+} satisfies MovableResizablePanelSize;
 
 export function getInitialInAppAgentWindowShellGeometry({
   viewportWidth,
@@ -120,7 +99,8 @@ export function InAppAgentWindowShell({
     <MovableResizablePanel
       boundsPadding={IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX}
       dragHandleSelector={IN_APP_AGENT_WINDOW_SHELL_DRAG_HANDLE_SELECTOR}
-      maxSize={getInAppAgentWindowShellMaxSize(window.innerWidth)}
+      ignoreOutsideInteraction
+      maxSize={IN_APP_AGENT_WINDOW_SHELL_MAX_SIZE}
       minSize={IN_APP_AGENT_WINDOW_SHELL_MIN_SIZE}
       position={floatingGeometry.position}
       size={floatingGeometry.size}

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import type { ReactNode, RefObject } from "react";
+import { useCallback, type ReactNode, type RefObject } from "react";
 
 import {
   MovableResizablePanel,
-  type MovableResizablePanelGeometry,
+  type MovableResizablePanelHandle,
   type MovableResizablePanelSize,
+  useMovableResizablePanelControl,
 } from "@/src/components/movable-resizable-panel";
 
 const IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX = 8;
@@ -20,95 +21,101 @@ const IN_APP_AGENT_WINDOW_SHELL_MIN_SIZE = {
   height: 420,
 } satisfies MovableResizablePanelSize;
 
-type InitialInAppAgentWindowShellGeometryParams = {
-  viewportWidth: number;
-  viewportHeight: number;
-  anchorRect?: Pick<DOMRect, "right"> | null;
-};
-
 const IN_APP_AGENT_WINDOW_SHELL_MAX_SIZE = {
   width: IN_APP_AGENT_WINDOW_SHELL_MAX_WIDTH_PX,
   height: IN_APP_AGENT_WINDOW_SHELL_MAX_HEIGHT_PX,
 } satisfies MovableResizablePanelSize;
 
-export function getInitialInAppAgentWindowShellGeometry({
-  viewportWidth,
-  viewportHeight,
-  anchorRect,
-}: InitialInAppAgentWindowShellGeometryParams): MovableResizablePanelGeometry {
-  const width = Math.min(
-    IN_APP_AGENT_WINDOW_SHELL_DEFAULT_WIDTH_PX,
-    viewportWidth - IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX * 2,
-  );
-  const height = Math.min(
-    IN_APP_AGENT_WINDOW_SHELL_DEFAULT_MAX_HEIGHT_PX,
-    viewportHeight - 32,
-  );
+export function useInAppAgentWindowShellPanelControl({
+  anchorRef,
+}: {
+  anchorRef?: RefObject<HTMLElement | null>;
+} = {}) {
+  const getInitialGeometry = useCallback(() => {
+    const anchorRect = anchorRef?.current?.getBoundingClientRect();
+    const viewportHeight =
+      typeof window === "undefined" ? 768 : window.innerHeight;
+    const viewportWidth =
+      typeof window === "undefined" ? 1024 : window.innerWidth;
+    const width = Math.min(
+      IN_APP_AGENT_WINDOW_SHELL_DEFAULT_WIDTH_PX,
+      viewportWidth - IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX * 2,
+    );
+    const height = Math.min(
+      IN_APP_AGENT_WINDOW_SHELL_DEFAULT_MAX_HEIGHT_PX,
+      viewportHeight - 32,
+    );
 
-  return {
-    position: {
-      left: anchorRect
-        ? anchorRect.right - 6
-        : viewportWidth - width - IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX,
-      top:
-        viewportHeight - height - IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX,
-    },
-    size: { width, height },
-  };
+    return {
+      position: {
+        left: anchorRect
+          ? anchorRect.right - 6
+          : viewportWidth - width - IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX,
+        top:
+          viewportHeight - height - IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX,
+      },
+      size: { width, height },
+    };
+  }, [anchorRef]);
+
+  return useMovableResizablePanelControl({
+    boundsPadding: IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX,
+    getInitialGeometry,
+    maxSize: IN_APP_AGENT_WINDOW_SHELL_MAX_SIZE,
+    minSize: IN_APP_AGENT_WINDOW_SHELL_MIN_SIZE,
+  });
 }
 
 type InAppAgentWindowShellProps = {
   children: (props: { isHeaderDragHandleEnabled: boolean }) => ReactNode;
-  floatingGeometry: MovableResizablePanelGeometry | null;
+  floatingPanelHandle: MovableResizablePanelHandle;
   isExpanded: boolean;
   panelRef: RefObject<HTMLDivElement | null>;
   zIndex: number;
-  onPositionChange: (
-    position: MovableResizablePanelGeometry["position"],
-  ) => void;
-  onSizeChange: (size: MovableResizablePanelGeometry["size"]) => void;
 };
 
 export function InAppAgentWindowShell({
   children,
-  floatingGeometry,
+  floatingPanelHandle,
   isExpanded,
   panelRef,
   zIndex,
-  onPositionChange,
-  onSizeChange,
 }: InAppAgentWindowShellProps) {
-  if (!floatingGeometry) {
+  if (!isExpanded && !floatingPanelHandle.geometry) {
     return null;
+  }
+
+  if (isExpanded) {
+    return (
+      <div
+        ref={panelRef}
+        className="fixed inset-x-3 top-[calc(var(--banner-offset)+0.75rem)] bottom-3 origin-top-left"
+        data-ignore-outside-interaction
+        style={{ zIndex }}
+      >
+        <div
+          data-ignore-outside-interaction
+          className="h-full w-full origin-top-left"
+        >
+          {children({ isHeaderDragHandleEnabled: false })}
+        </div>
+      </div>
+    );
   }
 
   return (
     <MovableResizablePanel
-      boundsPadding={IN_APP_AGENT_WINDOW_SHELL_BOUNDS_PADDING_PX}
-      className={
-        isExpanded
-          ? "inset-x-3 top-[calc(var(--banner-offset)+0.75rem)] bottom-3"
-          : undefined
-      }
       dragHandleSelector={IN_APP_AGENT_WINDOW_SHELL_DRAG_HANDLE_SELECTOR}
       ignoreOutsideInteraction
-      isGeometryManaged={!isExpanded}
-      isMovable={!isExpanded}
-      isResizable={!isExpanded}
-      maxSize={IN_APP_AGENT_WINDOW_SHELL_MAX_SIZE}
-      minSize={IN_APP_AGENT_WINDOW_SHELL_MIN_SIZE}
-      panelRef={panelRef}
-      position={floatingGeometry.position}
-      size={floatingGeometry.size}
+      ref={panelRef}
+      handle={floatingPanelHandle}
       zIndex={zIndex}
-      onPositionChange={onPositionChange}
-      onSizeChange={onSizeChange}
     >
       <div
         data-ignore-outside-interaction
         className="h-full w-full origin-top-left"
       >
-        {children({ isHeaderDragHandleEnabled: !isExpanded })}
+        {children({ isHeaderDragHandleEnabled: true })}
       </div>
     </MovableResizablePanel>
   );


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a generic `MovableResizablePanel` component with full drag-to-move and 8-direction resize support, then wires it into the in-app AI agent window so users can reposition and resize the floating chat panel.

- `movable-resizable-panel.tsx` implements pointer-capture–based drag/resize with viewport clamping, SSR guards, and a `useMovableResizablePanelGeometry` hook for external state management; tests cover move, resize, bounds, max-size, and ignore-drag cases.
- `InAppAgentWindowShell.tsx` wraps either an expanded full-screen layout or the new `MovableResizablePanel`, and the header of `InAppAgentWindow` gains an opt-in drag handle toggled via `isHeaderDragHandleEnabled`.
- `in-app-ai-agent-button.tsx` replaces the old manual anchor-style tracking (scroll/resize listeners, `setAnchorStyle`) with the new geometry hook and shell component.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge after the resize-handle outside-interaction bug is resolved; the window.innerWidth SSR guard is a low-risk hardening item.

The resize handles rendered by MovableResizablePanel sit outside the data-ignore-outside-interaction subtree, so clicking any resize handle while a peek view is open will not be recognised as an inside interaction and will close the peek panel. This is a real, user-facing regression on an interaction the feature explicitly advertises (resize). The SSR guard omission is lower risk given current call-site protection, but is inconsistent with the established pattern.

web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx — the floating render path needs data-ignore-outside-interaction on the MovableResizablePanel root and a window guard on the maxSize prop.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant InAppAiAgentButton
    participant InAppAgentWindowShell
    participant MovableResizablePanel
    participant InAppAgentWindow

    User->>InAppAiAgentButton: clicks button
    InAppAiAgentButton->>InAppAiAgentButton: resetGeometry() computes initial position from anchorRect
    InAppAiAgentButton->>InAppAgentWindowShell: "renders with floatingGeometry + isExpanded=false"
    InAppAgentWindowShell->>MovableResizablePanel: renders with position, size, maxSize
    MovableResizablePanel->>InAppAgentWindow: "children isHeaderDragHandleEnabled=true"

    User->>MovableResizablePanel: pointerdown on header drag handle
    MovableResizablePanel->>MovableResizablePanel: startInteraction move + setPointerCapture
    User->>MovableResizablePanel: pointermove
    MovableResizablePanel->>MovableResizablePanel: updateInteraction setLivePanel clamped
    User->>MovableResizablePanel: pointerup
    MovableResizablePanel->>InAppAiAgentButton: onPositionChange + onSizeChange
    InAppAiAgentButton->>InAppAiAgentButton: floatingPanelGeometry.setPosition / setSize

    User->>InAppAgentWindow: clicks expand
    InAppAgentWindow->>InAppAiAgentButton: onExpandedChange true
    InAppAiAgentButton->>InAppAgentWindowShell: "floatingGeometry=null isExpanded=true"
    InAppAgentWindowShell->>InAppAgentWindowShell: renders fixed full-screen div instead of MovableResizablePanel
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx:119-139
**Resize handles escape `data-ignore-outside-interaction` coverage**

`data-ignore-outside-interaction` is placed on the inner wrapper `div` (line 133), but `MovableResizablePanel` renders its resize handles as siblings of that div — outside its ancestor chain. `shouldIgnoreOutsideInteraction` calls `target.closest('[data-ignore-outside-interaction]')`, so a pointerdown on any resize handle returns `false`, causing the Radix `onInteractOutside` handler in `peek.tsx` to not call `e.preventDefault()`. The result is that clicking a resize handle while a peek view is open will close the peek panel.

The attribute needs to cover the `MovableResizablePanel` root element (which wraps all resize handles). One approach is to thread `data-ignore-outside-interaction` as a prop through `MovableResizablePanel` onto its root `div`, or wrap the floating path in a zero-size positioned ancestor that carries the attribute.

### Issue 2 of 2
web/src/ee/features/in-app-agent/components/InAppAgentWindowShell.tsx:123
`window.innerWidth` is accessed directly in the render body without an SSR guard. This is inconsistent with the `getViewportBounds` helper in `movable-resizable-panel.tsx` which explicitly handles `typeof window === "undefined"`. If `floatingGeometry` is ever non-null during a server render (e.g., persisted state, future refactor), this will throw a `ReferenceError`.

```suggestion
      maxSize={getInAppAgentWindowShellMaxSize(typeof window !== "undefined" ? window.innerWidth : IN_APP_AGENT_WINDOW_SHELL_FULL_WIDTH_CAP_SCREEN_WIDTH_PX)}
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feature/lfe-102..."](https://github.com/langfuse/langfuse/commit/7d8d983061d6e6232b36597f5c70eaf437f4fcba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37211445)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->