### PR TITLE
chore(agent): Add feedback link to feature preview modal

### DIFF
--- a/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
@@ -12,6 +12,7 @@ import { Switch } from "@/src/components/ui/switch";
 
 import inAppAgentDarkIllustration from "../assets/in-app-agent-dark.svg";
 import inAppAgentLightIllustration from "../assets/in-app-agent-light.svg";
+import { Button } from "@/src/components/ui/button";
 
 const IN_APP_AGENT_PREVIEW_ITEM = {
   id: "in-app-agent",
@@ -21,6 +22,7 @@ const IN_APP_AGENT_PREVIEW_ITEM = {
     "Explore project data, understand connected Langfuse resources, and get practical help while investigating your application.",
   details:
     "This experimental preview can help you inspect traces and observations, look up related scores or prompts, and answer practical questions while you work in a project. Today, it is most useful for exploring project data and understanding how different Langfuse resources connect. Over time, the goal is to help teams generate insights faster and improve their agentic products with less manual investigation.",
+  feedbackUrl: "https://github.com/orgs/langfuse/discussions/14196",
 } as const;
 
 const FEATURE_PREVIEW_MODAL_TITLE = "Feature Preview";
@@ -96,6 +98,15 @@ export function FeaturePreviewModal({
                 <p className="text-muted-foreground mt-2 max-w-2xl text-sm leading-5">
                   {IN_APP_AGENT_PREVIEW_ITEM.description}
                 </p>
+                <Button asChild className="mt-4">
+                  <a
+                    href={IN_APP_AGENT_PREVIEW_ITEM.feedbackUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Give feedback
+                  </a>
+                </Button>
               </div>
               <div className="flex shrink-0 flex-col items-end gap-2">
                 <Switch


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Give feedback" button to the in-app agent Feature Preview modal, linking out to a GitHub Discussions thread (`https://github.com/orgs/langfuse/discussions/14196`) so users can share early impressions of the experimental Langfuse Assistant.

- A `feedbackUrl` field is added to the `IN_APP_AGENT_PREVIEW_ITEM` constant and an `<a>` + `<Button>` pair is rendered beneath the feature description inside the modal.
- The `Button` import is placed after the SVG asset imports rather than alongside the other UI component imports, and the `<Button>` is nested inside an `<a>` tag instead of using the `asChild` pattern, which produces invalid HTML (interactive content inside interactive content).
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change is cosmetic and confined to one modal, but the feedback button nests a rendered `<button>` inside an `<a>` tag, which is invalid HTML and may behave inconsistently across browsers and assistive technologies.

The feedback link is wrapped as `<a href="..."><Button>...</Button></a>`, meaning a rendered `<button>` sits inside an anchor element. The HTML spec forbids interactive content inside `<a>`, so browser rendering and screen-reader announcement are undefined; the `asChild` pattern on `Button` would fix this with a one-line change. Outside that finding, the change is simple and well-scoped.

web/src/features/feature-previews/components/FeaturePreviewModal.tsx — the feedback link rendering and import ordering both need a small fix.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant Modal as FeaturePreviewModal
    participant Browser as Browser Tab

    User->>Modal: Opens Feature Preview Modal
    Modal-->>User: Renders modal with description + "Give feedback" button
    User->>Modal: Clicks "Give feedback"
    Modal->>Browser: "Opens feedbackUrl in new tab (target=_blank)"
    Browser-->>User: GitHub Discussion page (langfuse/discussions/14196)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/feature-previews/components/FeaturePreviewModal.tsx:101-108
Invalid interactive-content nesting: wrapping a `<Button>` (renders as `<button>`) inside an `<a>` tag violates the HTML spec, which forbids interactive content as a descendant of `<a>`. Browsers handle this inconsistently and screen readers may announce it incorrectly. Use `Button`'s `asChild` prop instead so the `<a>` becomes the rendered element.

```suggestion
                <Button asChild className="mt-4">
                  <a
                    href={IN_APP_AGENT_PREVIEW_ITEM.feedbackUrl}
                    target="_blank"
                    rel="noopener noreferrer"
                  >
                    Give feedback
                  </a>
                </Button>
```

### Issue 2 of 2
web/src/features/feature-previews/components/FeaturePreviewModal.tsx:13-15
The `Button` import was appended after the SVG asset imports rather than grouped with the other UI component imports (`Switch`, `Dialog*`). Keeping component imports together before asset imports preserves the established ordering convention in this file.

```suggestion
import { Button } from "@/src/components/ui/button";

import inAppAgentDarkIllustration from "../assets/in-app-agent-dark.svg";
import inAppAgentLightIllustration from "../assets/in-app-agent-light.svg";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(agent): Add feedback link to featu..."](https://github.com/langfuse/langfuse/commit/5ab11864b1122f63187381a4dd084f7f5ebe0c28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36972891)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->