### PR TITLE
chore: decrease default LANGFUSE_MIXPANEL_FLUSH_DELAY_MS

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -124,7 +124,7 @@ const EnvSchema = z.object({
   LANGFUSE_SCORE_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
   // Delay (ms) inserted after each Mixpanel flush to throttle analytics exports
   // and avoid overwhelming the target instance (see issue #12786).
-  LANGFUSE_MIXPANEL_FLUSH_DELAY_MS: z.coerce.number().min(0).default(500),
+  LANGFUSE_MIXPANEL_FLUSH_DELAY_MS: z.coerce.number().min(0).default(100),
   LANGFUSE_DATASET_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
   LANGFUSE_PROJECT_DELETE_CONCURRENCY: z.coerce.number().positive().default(1),
   LANGFUSE_EVAL_EXECUTION_WORKER_CONCURRENCY: z.coerce


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces the default value of `LANGFUSE_MIXPANEL_FLUSH_DELAY_MS` from 500ms to 100ms in `worker/src/env.ts`. The delay is a configurable throttle that prevents overwhelming the Mixpanel analytics endpoint between flush operations, originally introduced to address issue #12786.

- The default inter-flush delay is decreased from 500ms to 100ms, speeding up analytics export throughput by 5× at the default configuration.
- The schema constraint (`min(0)`) and overridability via environment variable are unchanged, so operators can still tune the value up or down as needed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a one-line default value reduction for a configurable analytics throttle delay.

The change lowers the inter-flush delay from 500ms to 100ms, making analytics exports faster at the default configuration. The minimum bound of 0 and env-var overridability are untouched, so operators who need the original behavior can restore it without a code change. No correctness, schema, or runtime concerns were identified.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Mixpanel Flush Loop] --> B[Flush batch to Mixpanel]
    B --> C{Delay}
    C -- "before: 500ms default" --> D[Next flush]
    C -- "after: 100ms default" --> D
    D --> B
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into valeriy/decreas..."](https://github.com/langfuse/langfuse/commit/070ee9d23a606d4e6c42b076a355608bc0a4e7fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36979618)</sub>

<!-- /greptile_comment -->