### PR TITLE
feat(monitors): retire feature flag, raise org limit to 20

### DIFF
--- a/web/src/__tests__/server/monitors.servertest.ts
+++ b/web/src/__tests__/server/monitors.servertest.ts
@@ -24,9 +24,6 @@ const buildSession = (params: {
   projectId: string;
   projectName: string;
   projectRole: RoleName;
-  monitorsFlag?: boolean;
-  admin?: boolean;
-  enableExperimentalFeatures?: boolean;
 }): Session => ({
   expires: "1",
   user: {
@@ -60,22 +57,16 @@ const buildSession = (params: {
       v4BetaToggleVisible: false,
       observationEvals: false,
       experimentsV4Enabled: false,
-      monitors: params.monitorsFlag ?? true,
     },
-    admin: params.admin ?? false,
+    admin: false,
   },
   environment: {
-    enableExperimentalFeatures: params.enableExperimentalFeatures ?? false,
+    enableExperimentalFeatures: false,
     selfHostedInstancePlan: "cloud:hobby",
   },
 });
 
-const prepare = async (overrides?: {
-  projectRole?: RoleName;
-  monitorsFlag?: boolean;
-  admin?: boolean;
-  enableExperimentalFeatures?: boolean;
-}) => {
+const prepare = async (overrides?: { projectRole?: RoleName }) => {
   const { project, org } = await createOrgProjectAndApiKey();
   orgIds.push(org.id);
   const user = await prisma.user.create({
@@ -93,9 +84,6 @@ const prepare = async (overrides?: {
     projectId: project.id,
     projectName: project.name,
     projectRole: overrides?.projectRole ?? "ADMIN",
-    monitorsFlag: overrides?.monitorsFlag,
-    admin: overrides?.admin,
-    enableExperimentalFeatures: overrides?.enableExperimentalFeatures,
   });
 
   const ctx = createInnerTRPCContext({ session, headers: {} });
@@ -244,49 +232,6 @@ describe("monitors trpc", () => {
           metric: { measure: "bogus_measure", aggregation: "count" },
         }),
       ).rejects.toThrow();
-    });
-  });
-
-  describe("feature flag gating", () => {
-    it("rejects monitors.create when the flag is off, user is not admin, experimental is off", async () => {
-      const { project, caller } = await prepare({ monitorsFlag: false });
-      await expect(
-        caller.monitors.create(validMonitorInput(project.id)),
-      ).rejects.toThrow(/monitors/i);
-    });
-
-    it("allows monitors.create when admin (overrides flag)", async () => {
-      const { project, caller } = await prepare({
-        monitorsFlag: false,
-        admin: true,
-      });
-      const created = await caller.monitors.create(
-        validMonitorInput(project.id),
-      );
-      expect(created.id).toBeDefined();
-    });
-
-    it("allows monitors.create when enableExperimentalFeatures is true (overrides flag)", async () => {
-      const { project, caller } = await prepare({
-        monitorsFlag: false,
-        enableExperimentalFeatures: true,
-      });
-      const created = await caller.monitors.create(
-        validMonitorInput(project.id),
-      );
-      expect(created.id).toBeDefined();
-    });
-
-    it("rejects monitors.all when the flag is off", async () => {
-      const { project, caller } = await prepare({ monitorsFlag: false });
-      await expect(
-        caller.monitors.all({
-          projectId: project.id,
-          orderBy: null,
-          page: 1,
-          limit: 50,
-        }),
-      ).rejects.toThrow(/monitors/i);
     });
   });
 

--- a/web/src/__tests__/server/monitors.servertest.ts
+++ b/web/src/__tests__/server/monitors.servertest.ts
@@ -1,5 +1,6 @@
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
+import { entitlementAccess } from "@/src/features/entitlements/constants/entitlements";
 import { prisma } from "@langfuse/shared/src/db";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import type { Session } from "next-auth";
@@ -479,21 +480,29 @@ describe("monitors trpc", () => {
   });
 
   describe("entitlement limit", () => {
+    const monitorLimit =
+      entitlementAccess["cloud:hobby"].entitlementLimits["monitor-count"];
+    if (typeof monitorLimit !== "number") {
+      throw new Error(
+        "expected cloud:hobby monitor-count limit to be a number",
+      );
+    }
+
     it("rejects monitors.create when org is at the monitor-count limit", async () => {
       const { project, caller } = await prepare();
-      await seedMonitors(caller, project.id, 10);
+      await seedMonitors(caller, project.id, monitorLimit);
 
       await expect(
         caller.monitors.create({
           ...validMonitorInput(project.id),
-          name: "Eleventh monitor",
+          name: `Monitor ${monitorLimit + 1}`,
         }),
       ).rejects.toThrow(/monitor-count/i);
     });
 
     it("counts monitors with non-ACTIVE status toward the limit", async () => {
       const { project, caller } = await prepare();
-      await seedMonitors(caller, project.id, 10);
+      await seedMonitors(caller, project.id, monitorLimit);
 
       const seeded = await prisma.monitor.findMany({
         where: { projectId: project.id },
@@ -511,14 +520,14 @@ describe("monitors trpc", () => {
       await expect(
         caller.monitors.create({
           ...validMonitorInput(project.id),
-          name: "Eleventh monitor",
+          name: `Monitor ${monitorLimit + 1}`,
         }),
       ).rejects.toThrow(/monitor-count/i);
     });
 
     it("allows monitors.update when at the limit", async () => {
       const { project, caller } = await prepare();
-      await seedMonitors(caller, project.id, 10);
+      await seedMonitors(caller, project.id, monitorLimit);
 
       const [first] = await prisma.monitor.findMany({
         where: { projectId: project.id },

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -132,7 +132,6 @@ export const ROUTES: Route[] = [
     pathname: "/project/[projectId]/monitors",
     icon: BellRing,
     projectRbacScopes: ["monitors:read"],
-    featureFlag: "monitors",
     show: ({ isLangfuseCloud }) => isLangfuseCloud,
     group: RouteGroup.Observability,
     section: RouteSection.Main,

--- a/web/src/features/automations/components/automationForm.tsx
+++ b/web/src/features/automations/components/automationForm.tsx
@@ -43,7 +43,7 @@ import {
 } from "@langfuse/shared";
 import { InlineFilterBuilder } from "@/src/features/filters/components/filter-builder";
 import { DeleteAutomationButton } from "./DeleteAutomationButton";
-import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
+import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
@@ -206,7 +206,7 @@ const EventSourceField = ({
   onSourceChange: (value: TriggerEventSource) => void;
   disabled: boolean;
 }) => {
-  const isMonitorsEnabled = useIsFeatureEnabled("monitors");
+  const { isLangfuseCloud } = useLangfuseCloudRegion();
   return (
     <FormField
       control={control}
@@ -228,7 +228,7 @@ const EventSourceField = ({
             </FormControl>
             <SelectContent>
               <SelectItem value={TriggerEventSource.Prompt}>Prompt</SelectItem>
-              {(isMonitorsEnabled ||
+              {(isLangfuseCloud ||
                 field.value === TriggerEventSource.Monitor) && (
                 <SelectItem value={TriggerEventSource.Monitor}>
                   Monitor

--- a/web/src/features/entitlements/constants/entitlements.ts
+++ b/web/src/features/entitlements/constants/entitlements.ts
@@ -66,7 +66,7 @@ export const entitlementAccess: Record<
       "annotation-queue-count": 1,
       "model-based-evaluations-count-evaluators": false,
       "prompt-management-count-prompts": false,
-      "monitor-count": 10,
+      "monitor-count": 20,
     },
   },
   "cloud:core": {
@@ -77,7 +77,7 @@ export const entitlementAccess: Record<
       "annotation-queue-count": 3,
       "model-based-evaluations-count-evaluators": false,
       "prompt-management-count-prompts": false,
-      "monitor-count": 10,
+      "monitor-count": 20,
     },
   },
   "cloud:pro": {
@@ -92,7 +92,7 @@ export const entitlementAccess: Record<
       "data-access-days": false,
       "model-based-evaluations-count-evaluators": false,
       "prompt-management-count-prompts": false,
-      "monitor-count": 10,
+      "monitor-count": 20,
     },
   },
   "cloud:team": {
@@ -113,7 +113,7 @@ export const entitlementAccess: Record<
       "data-access-days": false,
       "model-based-evaluations-count-evaluators": false,
       "prompt-management-count-prompts": false,
-      "monitor-count": 10,
+      "monitor-count": 20,
     },
   },
   "cloud:enterprise": {
@@ -134,7 +134,7 @@ export const entitlementAccess: Record<
       "data-access-days": false,
       "model-based-evaluations-count-evaluators": false,
       "prompt-management-count-prompts": false,
-      "monitor-count": 10,
+      "monitor-count": 20,
     },
   },
   oss: {
@@ -145,7 +145,7 @@ export const entitlementAccess: Record<
       "data-access-days": false,
       "model-based-evaluations-count-evaluators": false,
       "prompt-management-count-prompts": false,
-      "monitor-count": 10,
+      "monitor-count": 20,
     },
   },
   "self-hosted:pro": {
@@ -156,7 +156,7 @@ export const entitlementAccess: Record<
       "data-access-days": false,
       "model-based-evaluations-count-evaluators": false,
       "prompt-management-count-prompts": false,
-      "monitor-count": 10,
+      "monitor-count": 20,
     },
   },
   "self-hosted:enterprise": {
@@ -176,7 +176,7 @@ export const entitlementAccess: Record<
       "data-access-days": false,
       "model-based-evaluations-count-evaluators": false,
       "prompt-management-count-prompts": false,
-      "monitor-count": 10,
+      "monitor-count": 20,
     },
   },
 };

--- a/web/src/features/feature-flags/available-flags.ts
+++ b/web/src/features/feature-flags/available-flags.ts
@@ -5,5 +5,4 @@ export const availableFlags = [
   "v4BetaToggleVisible",
   "observationEvals",
   "experimentsV4Enabled",
-  "monitors",
 ] as const;

--- a/web/src/features/monitors/components/MonitorPagePermissions.tsx
+++ b/web/src/features/monitors/components/MonitorPagePermissions.tsx
@@ -2,7 +2,6 @@ import { type ReactNode } from "react";
 
 import { ErrorPage } from "@/src/components/error-page";
 import { SupportOrUpgradePage } from "@/src/ee/features/billing/components/SupportOrUpgradePage";
-import useIsFeatureEnabled from "@/src/features/feature-flags/hooks/useIsFeatureEnabled";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useHasProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
 import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
@@ -10,7 +9,7 @@ import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 /** MonitorScope is the RBAC scope a monitor page can require for entry. */
 type MonitorScope = "monitors:read" | "monitors:CUD";
 
-/** MonitorPagePermissions gates a monitor page on the `monitors` feature flag and a project RBAC scope. */
+/** MonitorPagePermissions gates a monitor page on Langfuse Cloud and a project RBAC scope. */
 export function MonitorPagePermissions({
   scope,
   children,
@@ -19,11 +18,10 @@ export function MonitorPagePermissions({
   children: ReactNode;
 }) {
   const projectId = useProjectIdFromURL();
-  const isEnabled = useIsFeatureEnabled("monitors");
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const hasAccess = useHasProjectAccess({ projectId, scope });
 
-  if (!isEnabled || !isLangfuseCloud) {
+  if (!isLangfuseCloud) {
     return <ErrorPage title="Not found" message="This page does not exist." />;
   }
 

--- a/web/src/server/api/routers/monitors.ts
+++ b/web/src/server/api/routers/monitors.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import {
   createTRPCRouter,
   protectedProjectProcedure,
-  requireFeatureFlag,
   requireLangfuseCloud,
 } from "@/src/server/api/trpc";
 import { throwIfNoProjectAccess } from "@/src/features/rbac/utils/checkProjectAccess";
@@ -19,10 +18,8 @@ import {
   UpdateMonitorSchema,
 } from "@langfuse/shared/monitors/server";
 
-/** monitorsProcedure protects every monitors route behind a Langfuse Cloud check and the `monitors` flag. */
-const monitorsProcedure = protectedProjectProcedure
-  .use(requireLangfuseCloud)
-  .use(requireFeatureFlag("monitors"));
+/** monitorsProcedure protects every monitors route behind a Langfuse Cloud check. */
+const monitorsProcedure = protectedProjectProcedure.use(requireLangfuseCloud);
 
 /** sessionContextFromCtx adapts a tRPC session into a MonitorService SessionContext. */
 const sessionContextFromCtx = (ctx: {


### PR DESCRIPTION
## Summary
Monitors has been gated behind the per-user `monitors` feature flag, which this repo's flag system can only enable per user (no rollout layer or defaults), blocking a general Cloud release.

To achieve this we:
- Retired the `monitors` feature flag from the nav, the tRPC procedure, the page-permission gate, and the automations event-source picker.
- Switched the automations "Monitor" event-source option to the Langfuse Cloud check, since monitors is Cloud-only.
- Raised the per-org `monitor-count` entitlement limit from 10 to 20 across all plans, still enforced on create.

**Note**: Monitors remains Cloud-only (`requireLangfuseCloud` server-side, `isLangfuseCloud` in nav and page gate) and RBAC-gated (`monitors:read` / `monitors:CUD`).

## Verification

- [x] `eslint` on all touched files — no issues
- [x] `tsgo` typecheck — no errors in touched files (pre-existing unrelated errors remain)
- [ ] Browser review on Cloud

## Test plan

- [ ] On Cloud, a non-admin member with no feature flags sees Monitors in the nav and can open the page.
- [ ] On self-hosted, Monitors stays hidden and the tRPC routes 404.
- [ ] Creating a 21st monitor in an org is rejected by the entitlement limit.
- [ ] The automations form shows the Monitor event source on Cloud without the flag.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR retires the `monitors` per-user feature flag and replaces it with the existing Langfuse Cloud check, making Monitors visible to all Cloud users without needing a flag. The per-org `monitor-count` entitlement limit is also raised from 10 to 20 across every plan.

- **Flag removal**: `featureFlag: "monitors"` stripped from the nav route, `requireFeatureFlag("monitors")` removed from `monitorsProcedure`, and `useIsFeatureEnabled("monitors")` replaced with `useLangfuseCloudRegion()` in the automations form and page permission gate — Cloud check retained in all three places.
- **Entitlement increase**: `monitor-count` bumped to 20 uniformly across all plans, including `oss` and `self-hosted:*` where monitors remain unreachable behind `requireLangfuseCloud`.
- **Backward compatibility**: The automations form still shows the Monitor event-source option when an existing automation already has it selected (`field.value === TriggerEventSource.Monitor`), preserving round-trip editing for any pre-existing records.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; Cloud and RBAC guards remain intact throughout the UI and server layers, and the feature flag removal is cleanly applied across all six touched files.

The flag is removed consistently from the nav, tRPC middleware, page permission gate, automations form, and flag registry. The only rough edge is that `monitor-count` is raised to 20 on self-hosted plans where monitors can never be created, which is harmless today but leaves the entitlements table slightly misleading.

web/src/features/entitlements/constants/entitlements.ts — the self-hosted plan limits are worth a second look to confirm the team is comfortable with the inconsistency.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits /monitors page] --> B{isLangfuseCloud?}
    B -- No --> C[ErrorPage: Not found]
    B -- Yes --> D{hasAccess monitors:read?}
    D -- No --> E[SupportOrUpgradePage]
    D -- Yes --> F[Render Monitor page]

    G[tRPC monitors.* call] --> H{requireLangfuseCloud}
    H -- Self-hosted --> I[TRPCError: NOT_FOUND]
    H -- Cloud --> J{throwIfNoProjectAccess RBAC}
    J -- No access --> K[TRPCError: FORBIDDEN]
    J -- Has access --> L{monitors.create only: throwIfExceedsLimit 20}
    L -- Over limit --> M[TRPCError: FORBIDDEN]
    L -- Within limit --> N[MonitorService operation]

    O[Automations form: event source] --> P{isLangfuseCloud OR existing Monitor value?}
    P -- No --> Q[Monitor option hidden]
    P -- Yes --> R[Monitor option shown]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/entitlements/constants/entitlements.ts:140-181
**`monitor-count` raised on unreachable self-hosted plans**

`monitor-count` is now set to 20 for `oss`, `self-hosted:pro`, and `self-hosted:enterprise`. Since `requireLangfuseCloud` in `monitorsProcedure` throws `NOT_FOUND` before the entitlement check is ever reached on self-hosted deployments, this doesn't permit any new behaviour — but it does mean the limits table claims capacity for a feature that literally cannot be exercised. If the intent is Cloud-only monitors, keeping `monitor-count: 0` (or leaving it at the previous 10) on self-hosted plans would make the table self-documenting and prevent silent drift if `requireLangfuseCloud` is ever conditionally loosened in future.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(monitors): retire feature flag, rai..."](https://github.com/langfuse/langfuse/commit/0fe54e1b1c96e09ae4e056ed482e3697abfba0b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36979705)</sub>

<!-- /greptile_comment -->