### PR TITLE
fix(ui): resolve app theme in CodeBlock for dark mode syntax highlighting

### DIFF
--- a/web/src/components/ui/Codeblock.tsx
+++ b/web/src/components/ui/Codeblock.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/src/utils/tailwind";
 import { Check, Copy } from "lucide-react";
 import { type FC, memo, useState } from "react";
 import { Highlight, themes } from "prism-react-renderer";
+import { useTheme } from "next-themes";
 
 interface Props {
   language: string;
@@ -45,6 +46,8 @@ export const programmingLanguages: languageMap = {
 
 const CodeBlock: FC<Props> = memo(({ language, value, theme, className }) => {
   const [isCopied, setIsCopied] = useState(false);
+  const { resolvedTheme } = useTheme();
+  const appliedTheme = theme ?? resolvedTheme;
   const handleCopy = () => {
     setIsCopied(true);
     copyTextToClipboard(value ?? "");
@@ -77,7 +80,7 @@ const CodeBlock: FC<Props> = memo(({ language, value, theme, className }) => {
         </div>
       </div>
       <Highlight
-        theme={theme === "dark" ? themes.vsDark : themes.github}
+        theme={appliedTheme === "dark" ? themes.vsDark : themes.github}
         code={value}
         language={language}
       >


### PR DESCRIPTION
## What does this PR do?

Fixes dark-mode rendering of the code blocks on the project settings **MCP & CLI** page (`/settings/developer-tools`). They rendered with the light GitHub Prism theme (dark text) on the `dark:bg-zinc-950` container, making them unreadable.

Root cause: `CodeBlock` (`web/src/components/ui/Codeblock.tsx`) only switches to the dark Prism theme when a `theme` prop is passed explicitly. `MarkdownViewer` passes it, but `DeveloperToolsSettings` does not.

Fix: `CodeBlock` now falls back to `resolvedTheme` from `next-themes` when no `theme` prop is provided (`theme ?? resolvedTheme`). An explicitly passed prop still takes precedence, so existing callers like `MarkdownViewer` are unchanged, and future callers that omit the prop get correct theming automatically.

Impacted packages: `web`

Verification:
- Reviewed `/settings/developer-tools` in a real browser via the dev server: dark mode now shows the vsDark theme (light tokens on dark background); light mode unchanged.
- `eslint` on the changed file and `tsc --noEmit` (web) pass.
- Pre-commit hook ran prettier and `turbo run lint` successfully.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes dark-mode syntax highlighting in `CodeBlock` by falling back to `next-themes`'s `resolvedTheme` when no explicit `theme` prop is passed.

- `useTheme()` is imported and called inside `CodeBlock`; `appliedTheme = theme ?? resolvedTheme` means an explicit prop still wins, while callers that omit it (like `DeveloperToolsSettings`) now get correct automatic theming.
- The import is placed at module level alongside existing imports, consistent with the project convention.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge — it touches a single presentational component, adds one hook call, and uses a null-coalescing fallback that preserves all existing caller behavior.

The diff is three lines in one file. The `??` fallback guarantees that callers already passing an explicit `theme` string see no change, and callers that omit it now correctly inherit the resolved OS/user theme. The `resolvedTheme` value is `undefined` during SSR just as `theme` was before, so the light-mode default is preserved on server render — no hydration mismatch introduced.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CodeBlock renders] --> B{theme prop provided?}
    B -- Yes --> C[appliedTheme = theme prop]
    B -- No --> D[appliedTheme = resolvedTheme\nfrom next-themes]
    C --> E{appliedTheme === 'dark'?}
    D --> E
    E -- Yes --> F[Use themes.vsDark\nlight tokens on dark bg]
    E -- No --> G[Use themes.github\ndark tokens on light bg]
    F --> H[Highlight component renders]
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): resolve app theme in CodeBlock ..."](https://github.com/langfuse/langfuse/commit/a5582af2ec04e792e163095ba7de55d1f0f64dd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36990532)</sub>

<!-- /greptile_comment -->