### PR TITLE
fix(batch-actions): snapshot v4 events-table flag for session batch actions

### DIFF
--- a/packages/shared/src/features/batchAction/types.ts
+++ b/packages/shared/src/features/batchAction/types.ts
@@ -35,6 +35,11 @@ export const BatchActionQuerySchema = z.object({
   orderBy,
   searchQuery: z.string().optional(),
   searchType: z.array(TracingSearchType).optional(),
+  // Snapshotted at dispatch time from the user's v4 beta flag. When true, the
+  // sessions read stream resolves the selection from the ClickHouse events
+  // table instead of the legacy traces path. Persisted in the job payload so
+  // the worker reads the snapshot, never the live user record.
+  useEventsTable: z.boolean().optional(),
 });
 
 export type BatchActionQuery = z.infer<typeof BatchActionQuerySchema>;

--- a/packages/shared/src/features/batchAction/types.ts
+++ b/packages/shared/src/features/batchAction/types.ts
@@ -35,10 +35,8 @@ export const BatchActionQuerySchema = z.object({
   orderBy,
   searchQuery: z.string().optional(),
   searchType: z.array(TracingSearchType).optional(),
-  // Snapshotted at dispatch time from the user's v4 beta flag. When true, the
-  // sessions read stream resolves the selection from the ClickHouse events
-  // table instead of the legacy traces path. Persisted in the job payload so
-  // the worker reads the snapshot, never the live user record.
+  // Dispatch-time snapshot of the user's v4 beta flag; routes the sessions
+  // read stream to the events table instead of the legacy traces path.
   useEventsTable: z.boolean().optional(),
 });
 

--- a/web/src/features/table/server/createBatchActionJob.ts
+++ b/web/src/features/table/server/createBatchActionJob.ts
@@ -57,9 +57,8 @@ export const createBatchActionJob = async ({
     tableName,
   });
 
-  // Snapshot the user's v4 beta flag into the persisted query so the worker
-  // resolves the selection from the same data source as the UI table the user
-  // selected from, never the live user record. Overrides any client-sent value.
+  // Snapshot the user's v4 beta flag so the worker reads from the same data
+  // source as the UI table; overrides any client-sent value.
   const queryWithSnapshot: BatchActionQuery = {
     ...query,
     useEventsTable: session.user.v4BetaEnabled ?? false,

--- a/web/src/features/table/server/createBatchActionJob.ts
+++ b/web/src/features/table/server/createBatchActionJob.ts
@@ -28,6 +28,7 @@ type CreateBatchActionJob = {
   session: {
     user: {
       id: string;
+      v4BetaEnabled?: boolean | null;
     };
     orgId: string;
     orgRole: Role;
@@ -55,6 +56,14 @@ export const createBatchActionJob = async ({
     searchType: query.searchType,
     tableName,
   });
+
+  // Snapshot the user's v4 beta flag into the persisted query so the worker
+  // resolves the selection from the same data source as the UI table the user
+  // selected from, never the live user record. Overrides any client-sent value.
+  const queryWithSnapshot: BatchActionQuery = {
+    ...query,
+    useEventsTable: session.user.v4BetaEnabled ?? false,
+  };
 
   const batchActionId = generateBatchActionId(projectId, actionId, tableName);
 
@@ -88,7 +97,7 @@ export const createBatchActionJob = async ({
         actionId,
         tableName,
         cutoffCreatedAt: new Date(),
-        query,
+        query: queryWithSnapshot,
         targetId: targetId,
         type: actionType,
       },

--- a/worker/src/__tests__/batchAction.test.ts
+++ b/worker/src/__tests__/batchAction.test.ts
@@ -866,6 +866,86 @@ describe("select all test suite", () => {
 });
 
 maybeDescribe("events table batch actions", () => {
+  it("should add sessions to annotation queue from events table when useEventsTable is true", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+
+    const sessionId1 = uuidv4();
+    const sessionId2 = uuidv4();
+
+    await prisma.traceSession.createMany({
+      data: [
+        { id: sessionId1, projectId },
+        { id: sessionId2, projectId },
+      ],
+    });
+
+    const now = Date.now() * 1000; // Events use microseconds
+
+    // Sessions exist only in the events table — the legacy traces-based
+    // reader cannot resolve them, so the test fails if the snapshotted
+    // useEventsTable flag is not passed through to the read stream.
+    const events = [
+      createEvent({
+        project_id: projectId,
+        trace_id: uuidv4(),
+        session_id: sessionId1,
+        type: "GENERATION",
+        start_time: now,
+        end_time: now + 1000000,
+      }),
+      createEvent({
+        project_id: projectId,
+        trace_id: uuidv4(),
+        session_id: sessionId2,
+        type: "GENERATION",
+        start_time: now,
+        end_time: now + 1000000,
+      }),
+    ];
+
+    await createEventsCh(events);
+
+    const queueId = uuidv4();
+    await prisma.annotationQueue.create({
+      data: {
+        id: queueId,
+        projectId,
+        name: "test-queue-events",
+      },
+    });
+
+    await handleBatchActionJob({
+      id: uuidv4(),
+      timestamp: new Date(),
+      name: QueueJobs.BatchActionProcessingJob as const,
+      payload: {
+        projectId,
+        actionId: "session-add-to-annotation-queue" as const,
+        tableName: BatchExportTableName.Sessions,
+        cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+        targetId: queueId,
+        query: {
+          filter: [],
+          orderBy: { column: "createdAt", order: "DESC" },
+          useEventsTable: true,
+        },
+        type: BatchActionType.Create,
+      },
+    });
+
+    const queueItems = await prisma.annotationQueueItem.findMany({
+      where: { queueId, projectId },
+    });
+
+    expect(queueItems).toHaveLength(2);
+    const objectIds = queueItems.map((item) => item.objectId);
+    expect(objectIds).toContain(sessionId1);
+    expect(objectIds).toContain(sessionId2);
+    expect(queueItems.every((item) => item.objectType === "SESSION")).toBe(
+      true,
+    );
+  });
+
   it("should add observations to dataset from events table with full mapping", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
 

--- a/worker/src/__tests__/batchAction.test.ts
+++ b/worker/src/__tests__/batchAction.test.ts
@@ -881,8 +881,7 @@ maybeDescribe("events table batch actions", () => {
 
     const now = Date.now() * 1000; // Events use microseconds
 
-    // Sessions exist only in the events table — the legacy traces-based
-    // reader cannot resolve them, so the test fails if the snapshotted
+    // Sessions exist only in the events table, so this fails if the
     // useEventsTable flag is not passed through to the read stream.
     const events = [
       createEvent({

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -197,9 +197,6 @@ export const handleBatchActionJob = async (
                 ...streamParams,
                 orderBy: query.orderBy,
                 tableName: tableName as BatchTableNames,
-                // Snapshotted at dispatch time from the user's v4 beta flag;
-                // routes the sessions read to the events table so the resolved
-                // selection matches the UI table the user selected from.
                 useEventsTable: query.useEventsTable,
               });
 

--- a/worker/src/features/batchAction/handleBatchActionJob.ts
+++ b/worker/src/features/batchAction/handleBatchActionJob.ts
@@ -197,6 +197,10 @@ export const handleBatchActionJob = async (
                 ...streamParams,
                 orderBy: query.orderBy,
                 tableName: tableName as BatchTableNames,
+                // Snapshotted at dispatch time from the user's v4 beta flag;
+                // routes the sessions read to the events table so the resolved
+                // selection matches the UI table the user selected from.
+                useEventsTable: query.useEventsTable,
               });
 
     // Process stream in database-sized batches


### PR DESCRIPTION
## What does this PR do?

Session batch actions (select-all → add to annotation queue) follow the same persist-query-then-execute-in-worker pattern as batch exports, but never snapshotted the user's v4 beta flag. The worker therefore always resolved the session set via the legacy traces-based query — even when the user's sessions UI table is backed by the events service. With identical filters the two reads can disagree, so sessions visible in the UI could be skipped (or extra ones included) when the bulk action executes.

This PR mirrors the batch-export fix from #14040:

- Snapshot `ctx.session.user.v4BetaEnabled` as `query.useEventsTable` in `createBatchActionJob` at dispatch time (covers all batch-action call sites; overrides any client-sent value).
- Persist it via `BatchActionQuerySchema` so it travels inside the `BatchActionProcessingEvent` payload.
- Pass it through to `getDatabaseReadStreamPaginated` in `handleBatchActionJob`, whose sessions branch (added in #14040) routes to the events-table reader when the flag is true.
- Regression test: seeds sessions only in the events table and runs `session-add-to-annotation-queue` with `useEventsTable: true`; without the pass-through the legacy reader finds nothing and the test fails.

Deliberately out of scope: observation batch actions switch table names via the `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN` env flag rather than the user flag. Aligning that mechanism to the user flag would disable the events table for self-hosted preview users (the user flag is Cloud-only), so it is left unchanged.

Fixes [LFE-10264](https://linear.app/langfuse/issue/LFE-10264)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a data-consistency bug in session batch actions (e.g. "select-all → add to annotation queue") where the worker always used the legacy ClickHouse traces reader instead of the events-table reader, causing the worker's session set to diverge from what the UI displayed for v4-beta users.

- **Snapshot at dispatch**: `createBatchActionJob` now snapshots `session.user.v4BetaEnabled` as `query.useEventsTable`, overriding any client-sent value, so the worker uses the same data source the UI used when the job was created.
- **Schema and handler update**: `useEventsTable` is added to `BatchActionQuerySchema` (optional, backward-compatible with in-flight jobs) and threaded through to `getDatabaseReadStreamPaginated`, which already contains the branch added in #14040.
- **Regression test**: Seeds session data only in the ClickHouse events table and asserts that `session-add-to-annotation-queue` with `useEventsTable: true` finds and enqueues both sessions; without the pass-through the legacy reader returns nothing.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted fix that mirrors an already-merged pattern from #14040, the schema addition is backward-compatible with in-flight jobs, and a regression test validates the corrected code path end-to-end.

The fix is a one-line pass-through in the handler and a straightforward server-side snapshot in the dispatcher. The schema field is optional so old queued jobs with no useEventsTable will silently fall back to the legacy reader. The ?? false default correctly gates the new path to explicit opt-in users. The regression test is well-constructed and would have caught the original bug. No functional correctness issues found.

No files require special attention. The only observation is a minor comment imprecision in the test file.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Browser / tRPC
    participant Server as createBatchActionJob
    participant Queue as BullMQ Queue
    participant Worker as handleBatchActionJob
    participant CH as ClickHouse (events table)
    participant CHLeg as ClickHouse (legacy traces)
    participant PG as Postgres

    UI->>Server: "createBatchActionJob({ query, session })"
    Note over Server: Snapshot v4BetaEnabled → useEventsTable<br/>(overrides any client value)
    Server->>Queue: "enqueue BatchActionProcessingJob<br/>{ query: { ...query, useEventsTable } }"

    Queue->>Worker: dequeue job

    Worker->>Worker: "route: session-add-to-annotation-queue<br/>tableName = Sessions → getDatabaseReadStreamPaginated"

    alt "useEventsTable = true (v4 beta user)"
        Worker->>CH: getSessionsWithMetricsFromEvents(filter)
        CH-->>Worker: session rows
    else "useEventsTable = false / undefined (legacy)"
        Worker->>CHLeg: getSessionsWithMetrics(filter)
        CHLeg-->>Worker: session rows
    end

    Worker->>PG: traceSession.findMany (bookmarked/public)
    PG-->>Worker: session metadata

    Worker->>PG: processAddSessionsToQueue(sessionIds)
    PG-->>Worker: annotationQueueItem records created
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/__tests__/batchAction.test.ts:884-885
The comment says sessions exist "only in the events table," but `traceSession` records are also created in Postgres above (which the read stream needs for `bookmarked`/`public` metadata and potential FK constraints). What's exclusively in the events table is the trace/generation data that makes sessions discoverable — `getSessionsWithMetrics` (legacy reader) won't find them because no rows exist in the legacy ClickHouse traces table.

```suggestion
    // No trace data is written to the legacy ClickHouse traces table — only to
    // the events table — so the legacy reader (useEventsTable: false) would
    // find no sessions. This verifies the flag is passed through correctly.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: trim comments"](https://github.com/langfuse/langfuse/commit/8d063094d024ad6635fb9237749d86f2287992c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36994657)</sub>

<!-- /greptile_comment -->