### PR TITLE
fix: gate sessions events session_id pushdown on 'any of' operator

### DIFF
--- a/packages/shared/src/server/services/sessions-ui-table-events-service.ts
+++ b/packages/shared/src/server/services/sessions-ui-table-events-service.ts
@@ -182,8 +182,14 @@ const getSessionsTableFromEventsGeneric = async <T>(
       (f.operator === ">=" || f.operator === ">"),
   ) as DateTimeFilter | undefined;
 
+  // Only push the session_id filter into the inner aggregation CTE for
+  // "any of": withSessionIds always emits `session_id IN (...)`, which would
+  // contradict the outer `NOT IN (...)` for "none of" and yield empty results.
   const sessionIdFilter = sessionFilters.find(
-    (f) => f instanceof StringOptionsFilter && f.field === "session_id",
+    (f) =>
+      f instanceof StringOptionsFilter &&
+      f.field === "session_id" &&
+      f.operator === "any of",
   ) as StringOptionsFilter | undefined;
 
   const requiresScoresJoin =

--- a/web/src/__tests__/server/sessions-ui-table.servertest.ts
+++ b/web/src/__tests__/server/sessions-ui-table.servertest.ts
@@ -251,6 +251,44 @@ describe("trpc.sessions", () => {
     expect(uiSessions[0].user_ids).toEqual(["user1"]);
   });
 
+  it("LFE-10268: should GET sessions filtered by session id with 'none of' operator", async () => {
+    const { projectId } = await createOrgProjectAndApiKey();
+    const excludedSessionId = v4();
+    const keptSessionId = v4();
+
+    await prisma.traceSession.createMany({
+      data: [
+        { id: excludedSessionId, projectId },
+        { id: keptSessionId, projectId },
+      ],
+    });
+
+    const traces = [
+      createTrace({ session_id: excludedSessionId, project_id: projectId }),
+      createTrace({ session_id: keptSessionId, project_id: projectId }),
+    ];
+
+    await seedSessionData(traces);
+
+    const uiSessions = await sessionsTable({
+      projectId: projectId,
+      filter: [
+        {
+          column: "id",
+          type: "stringOptions",
+          operator: "none of",
+          value: [excludedSessionId],
+        },
+      ],
+      orderBy: null,
+      limit: 10000,
+      page: 0,
+    });
+
+    expect(uiSessions.length).toBe(1);
+    expect(uiSessions[0].session_id).toBe(keptSessionId);
+  });
+
   it("should GET sessions ordered by total cost", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
     const sessionId1 = v4();


### PR DESCRIPTION
## What does this PR do?

Fixes a v4 events-path bug where the sessions query's `session_id` pushdown optimization ignored the filter operator. `getSessionsTableFromEventsGeneric` pushed any `StringOptionsFilter` on `session_id` into the inner aggregation CTE, which always emits `session_id IN (...)`. With a `none of` filter — reachable via the "Not bookmarked" sessions filter, which is rewritten to `id none of [bookmarked_ids]` — the inner `IN` contradicted the outer `NOT IN`, silently returning zero rows on the v4 sessions list and sessions batch export.

The pushdown now only fires for the `any of` operator; for `none of` the outer filter alone enforces the correct semantics. Adds a `none of` test case to the sessions table parity test, which previously only covered `any of`.

Fixes [LFE-10268](https://linear.app/langfuse/issue/LFE-10268)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in the v4 events-path session listing where a `session_id` filter with the `none of` operator silently returned zero rows. The inner aggregation CTE (`withSessionIds`) always emits `session_id IN (...)`, which directly contradicted the outer `NOT IN (...)` produced by `none of`, yielding an empty result set.

- The fix guards the pushdown optimization with `operator === "any of"`, so `none of` is handled exclusively by the outer `WHERE` clause already applied via `sessionsFilterRes`.
- A new server test (`LFE-10268`) seeds two sessions, filters with `none of [excludedSessionId]`, and asserts only the kept session is returned — covering the previously broken path.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is a minimal, well-scoped guard on an inner-CTE pushdown optimization and does not alter behavior for any operator other than `none of`.

The fix correctly targets the only code path where the `IN` pushdown could contradict an outer `NOT IN`. Confirmed via `withSessionIds` in `EventsSessionAggregationQueryBuilder` — it always emits `IN (...)` and is a no-op when `sessionIds` is `undefined`. Existing `any of` behavior is untouched. The new regression test directly reproduces the reported scenario.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: only push session\_id filter into ev..."](https://github.com/langfuse/langfuse/commit/85c1e44cea3e062f444484bf3e28c74de5ccbfd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36997116)</sub>

<!-- /greptile_comment -->