### PR TITLE
fix(batch-export): read scores trace metadata from events table for v4 users

### DIFF
--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../../db";
 import { Readable } from "stream";
+import type { ClickHouseClientConfigOptions } from "@clickhouse/client";
 import type {
   EventsObservation,
   MetadataDomain,
@@ -3647,6 +3648,7 @@ export const hasAnySessionFromEventsTable = async (
 export const getTraceMetadataByIdsFromEvents = async (props: {
   projectId: string;
   traceIds: string[];
+  clickhouseConfigs?: ClickHouseClientConfigOptions;
 }) => {
   if (props.traceIds.length === 0) return [];
 
@@ -3678,6 +3680,7 @@ export const getTraceMetadataByIdsFromEvents = async (props: {
         query,
         params: input.params,
         tags: input.tags,
+        clickhouseConfigs: props.clickhouseConfigs,
         preferredClickhouseService: "EventsReadOnly",
       }),
   });

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1486,8 +1486,11 @@ export async function getScoresUiTableFromEvents(props: {
   limit?: number;
   offset?: number;
   clickhouseConfigs?: ClickHouseClientConfigOptions;
+  // Defaults to true: the scores UI table only needs the hasMetadata flag.
+  // Batch exports pass false to include the full metadata payload.
+  excludeMetadata?: boolean;
 }) {
-  const { clickhouseConfigs, ...rest } = props;
+  const { clickhouseConfigs, excludeMetadata = true, ...rest } = props;
 
   const rows = await getScoresUiGenericFromEvents<{
     id: string;
@@ -1503,6 +1506,7 @@ export async function getScoresUiTableFromEvents(props: {
     trace_id: string | null;
     session_id: string | null;
     dataset_run_id: string | null;
+    metadata?: Record<string, string>;
     observation_id: string | null;
     author_user_id: string | null;
     config_id: string | null;
@@ -1516,7 +1520,7 @@ export async function getScoresUiTableFromEvents(props: {
   }>({
     select: "rows",
     tags: { kind: "analytic" },
-    excludeMetadata: true,
+    excludeMetadata,
     includeHasMetadataFlag: true,
     clickhouseConfigs,
     ...rest,
@@ -1526,10 +1530,10 @@ export async function getScoresUiTableFromEvents(props: {
     const score = convertClickhouseScoreToDomain(
       {
         ...row,
-        metadata: {},
+        metadata: excludeMetadata ? {} : (row.metadata ?? {}),
         long_string_value: "",
       },
-      false,
+      !excludeMetadata,
     );
     return {
       ...score,

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -1171,6 +1171,7 @@ const getScoresUiGeneric = async <T>(props: {
         ${excludeMetadata ? "" : "s.metadata,"}
         s.trace_id,
         s.session_id,
+        s.dataset_run_id,
         s.observation_id,
         s.author_user_id,
         t.user_id,
@@ -1398,6 +1399,7 @@ const getScoresUiGenericFromEvents = async <T>(props: {
         ${excludeMetadata ? "" : "s.metadata,"}
         s.trace_id,
         s.session_id,
+        s.dataset_run_id,
         s.observation_id,
         s.author_user_id,
         s.created_at,

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -2358,6 +2358,61 @@ describe("batch export test suite", () => {
   // ==================== EVENTS TABLE EXPORT TESTS ====================
 
   maybeDescribe("events table export tests", () => {
+    it("should export scores with trace metadata from the events table when useEventsTable is true", async () => {
+      const { projectId } = await createOrgProjectAndApiKey();
+
+      const traceId = randomUUID();
+      const score = createTraceScore({
+        project_id: projectId,
+        trace_id: traceId,
+        name: "accuracy",
+        value: 0.95,
+        data_type: "NUMERIC",
+        metadata: { reason: "test-metadata" },
+      });
+      await createScoresCh([score]);
+
+      // The trace exists only in the events table (v4 world) — no row is
+      // written to the legacy traces table, so the legacy traces JOIN would
+      // return empty trace metadata.
+      await createEventsCh([
+        createEvent({
+          project_id: projectId,
+          trace_id: traceId,
+          is_app_root: true,
+          trace_name: "events-trace",
+          user_id: "events-user",
+          tags: ["events-tag"],
+        }),
+      ]);
+
+      const stream = await getDatabaseReadStreamPaginated({
+        projectId,
+        tableName: BatchExportTableName.Scores,
+        cutoffCreatedAt: new Date(Date.now() + 1000 * 60 * 60 * 24),
+        filter: [],
+        orderBy: { column: "timestamp", order: "DESC" },
+        useEventsTable: true,
+      });
+
+      const rows: any[] = [];
+      for await (const chunk of stream) {
+        rows.push(chunk);
+      }
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        id: score.id,
+        traceId,
+        name: "accuracy",
+        value: 0.95,
+        traceName: "events-trace",
+        userId: "events-user",
+        traceTags: ["events-tag"],
+        metadata: { reason: "test-metadata" },
+      });
+    });
+
     it("should export sessions from the events table when useEventsTable is true", async () => {
       const { projectId } = await createOrgProjectAndApiKey();
 

--- a/worker/src/__tests__/batchExport.test.ts
+++ b/worker/src/__tests__/batchExport.test.ts
@@ -5,6 +5,7 @@ import {
   createObservationsCh,
   createOrgProjectAndApiKey,
   createTraceScore,
+  createDatasetRunScore,
   createScoresCh,
   createTrace,
   createTracesCh,
@@ -2370,7 +2371,13 @@ describe("batch export test suite", () => {
         data_type: "NUMERIC",
         metadata: { reason: "test-metadata" },
       });
-      await createScoresCh([score]);
+      const runScore = createDatasetRunScore({
+        project_id: projectId,
+        name: "run-accuracy",
+        value: 0.5,
+        data_type: "NUMERIC",
+      });
+      await createScoresCh([score, runScore]);
 
       // The trace exists only in the events table (v4 world) — no row is
       // written to the legacy traces table, so the legacy traces JOIN would
@@ -2400,9 +2407,9 @@ describe("batch export test suite", () => {
         rows.push(chunk);
       }
 
-      expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({
-        id: score.id,
+      expect(rows).toHaveLength(2);
+      const traceScoreRow = rows.find((r) => r.id === score.id);
+      expect(traceScoreRow).toMatchObject({
         traceId,
         name: "accuracy",
         value: 0.95,
@@ -2410,6 +2417,14 @@ describe("batch export test suite", () => {
         userId: "events-user",
         traceTags: ["events-tag"],
         metadata: { reason: "test-metadata" },
+      });
+      // Dataset run scores have no trace; the export must keep the run id.
+      const runScoreRow = rows.find((r) => r.id === runScore.id);
+      expect(runScoreRow).toMatchObject({
+        traceId: null,
+        datasetRunId: runScore.dataset_run_id,
+        name: "run-accuracy",
+        value: 0.5,
       });
     });
 

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -131,11 +131,13 @@ const getScoresWithTraceMetadataFromEvents = async (props: {
 
   return scores.map((score) => {
     const trace = traceMetadata.find((t) => t.id === score.traceId);
+    // `?? null` (not `|| null`): preserve explicit empty strings/arrays so
+    // rows serialize the same as the legacy traces-JOIN export path.
     return {
       ...score,
-      traceName: trace?.name || null,
-      traceUserId: trace?.user_id || null,
-      traceTags: trace?.tags && trace.tags.length > 0 ? trace.tags : null,
+      traceName: trace?.name ?? null,
+      traceUserId: trace?.user_id ?? null,
+      traceTags: trace?.tags ?? null,
     };
   });
 };

--- a/worker/src/features/database-read-stream/getDatabaseReadStream.ts
+++ b/worker/src/features/database-read-stream/getDatabaseReadStream.ts
@@ -13,6 +13,8 @@ import {
   FullObservationsWithScores,
   DatabaseReadStream,
   getScoresUiTable,
+  getScoresUiTableFromEvents,
+  getTraceMetadataByIdsFromEvents,
   getPublicSessionsFilter,
   getSessionsWithMetrics,
   getSessionsWithMetricsFromEvents,
@@ -97,6 +99,47 @@ export const getChunkWithFlattenedScores = <
   });
 };
 
+// Events-backed replacement for the legacy getScoresUiTable traces JOIN:
+// loads score rows without trace enrichment, then fills traceName /
+// traceUserId / traceTags from the events table for the page's trace ids.
+const getScoresWithTraceMetadataFromEvents = async (props: {
+  projectId: string;
+  filter: FilterCondition[];
+  orderBy: OrderByState;
+  limit: number;
+  offset: number;
+  clickhouseConfigs: Parameters<
+    typeof getScoresUiTableFromEvents
+  >[0]["clickhouseConfigs"];
+}) => {
+  const scores = await getScoresUiTableFromEvents({
+    ...props,
+    excludeMetadata: false,
+  });
+
+  const traceMetadata = await getTraceMetadataByIdsFromEvents({
+    projectId: props.projectId,
+    traceIds: [
+      ...new Set(
+        scores
+          .map((score) => score.traceId)
+          .filter((traceId): traceId is string => Boolean(traceId)),
+      ),
+    ],
+    clickhouseConfigs: props.clickhouseConfigs,
+  });
+
+  return scores.map((score) => {
+    const trace = traceMetadata.find((t) => t.id === score.traceId);
+    return {
+      ...score,
+      traceName: trace?.name || null,
+      traceUserId: trace?.user_id || null,
+      traceTags: trace?.tags && trace.tags.length > 0 ? trace.tags : null,
+    };
+  });
+};
+
 export const getDatabaseReadStreamPaginated = async ({
   projectId,
   tableName,
@@ -143,16 +186,31 @@ export const getDatabaseReadStreamPaginated = async ({
     case "scores": {
       return new DatabaseReadStream<unknown>(
         async (pageSize: number, offset: number) => {
-          const scores = await getScoresUiTable({
-            projectId,
-            filter: filter
-              ? [...filter, createdAtCutoffFilter]
-              : [createdAtCutoffFilter],
-            orderBy,
-            limit: pageSize,
-            offset,
-            clickhouseConfigs,
-          });
+          const scoresFilter = filter
+            ? [...filter, createdAtCutoffFilter]
+            : [createdAtCutoffFilter];
+
+          // v4-enabled users (snapshotted as useEventsTable at dispatch) read
+          // scores without the legacy traces JOIN; trace metadata (name,
+          // userId, tags) is loaded from the events table instead, mirroring
+          // the scores UI (scores.allFromEvents + scores.metricsFromEvents).
+          const scores = useEventsTable
+            ? await getScoresWithTraceMetadataFromEvents({
+                projectId,
+                filter: scoresFilter,
+                orderBy,
+                limit: pageSize,
+                offset,
+                clickhouseConfigs,
+              })
+            : await getScoresUiTable({
+                projectId,
+                filter: scoresFilter,
+                orderBy,
+                limit: pageSize,
+                offset,
+                clickhouseConfigs,
+              });
 
           // Get author user info for scores
           // Only users that have valid project write access may write scores


### PR DESCRIPTION
## What does this PR do?

Fixes the scores batch export for v4 (events-table) projects. The export previously always used `getScoresUiTable`, which `LEFT JOIN`s the legacy `traces` table to fill `traceName`, `userId`, and `traceTags` — these come back empty or stale for v4 projects where traces are no longer written, while the scores UI shows them correctly via the events-backed path.

- Branches the worker's `case "scores"` on the dispatch-time `useEventsTable` snapshot (same mechanism as the sessions export from #14040).
- v4 exports read score rows via `getScoresUiTableFromEvents` and enrich them with trace metadata from `getTraceMetadataByIdsFromEvents`, mirroring the scores UI (`scores.allFromEvents` + `scores.metricsFromEvents`).
- Extends `getScoresUiTableFromEvents` with an `excludeMetadata` option (default unchanged) so the export keeps the full score metadata payload.
- Plumbs `clickhouseConfigs` through `getTraceMetadataByIdsFromEvents` so the export's extended HTTP timeouts apply.
- Adds a regression test where the trace exists only in the events table and asserts the export row carries trace metadata and score metadata.

Closes [LFE-10265](https://linear.app/langfuse/issue/LFE-10265)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New worker regression test in `worker/src/__tests__/batchExport.test.ts` (gated behind the v4 preview flag, runs in CI).
- `pnpm turbo run lint typecheck` green for `@langfuse/shared`, `worker`, and `web`.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation (not needed)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Routes the scores batch export through the events-backed ClickHouse path for v4 projects, mirroring how the scores UI already reads from the events table. Previously, the export always used the legacy `getScoresUiTable` with a `LEFT JOIN` on the physical `traces` table, causing `traceName`, `userId`, and `traceTags` to be empty for v4 users.

- Adds an `excludeMetadata` option to `getScoresUiTableFromEvents` (defaults to `true` for the UI, `false` for exports) and wires `clickhouseConfigs` into `getTraceMetadataByIdsFromEvents`.
- Adds `getScoresWithTraceMetadataFromEvents` in the worker, which fetches score rows from the events table and enriches them with trace metadata via a second `getTraceMetadataByIdsFromEvents` call, then branches on `useEventsTable` in the `"scores"` case of the stream dispatcher.
- Adds a regression test that inserts a trace only in the events table and verifies the export row carries trace metadata and score metadata.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the events-backed path is correctly gated on `useEventsTable`, the legacy path is unchanged, and the new test covers the primary regression case.

The fix is well-scoped and mirrors the pattern already used by the sessions export. The two comments are minor consistency and efficiency observations that don't affect correctness for the vast majority of exports.

getDatabaseReadStream.ts — specifically the merge loop in `getScoresWithTraceMetadataFromEvents` and the `traceUserId` coercion.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as Worker (getDatabaseReadStreamPaginated)
    participant SE as getScoresUiTableFromEvents
    participant TM as getTraceMetadataByIdsFromEvents
    participant CH as ClickHouse (EventsReadOnly)

    W->>W: useEventsTable?
    alt "useEventsTable = true (v4)"
        W->>SE: "getScoresUiTableFromEvents(excludeMetadata=false)"
        SE->>CH: SELECT scores + metadata FROM scores s FINAL
        CH-->>SE: score rows (with metadata)
        SE-->>W: score rows
        W->>TM: getTraceMetadataByIdsFromEvents(deduped traceIds)
        TM->>CH: SELECT trace_id, name, user_id, tags FROM events LIMIT 1 BY trace_id
        CH-->>TM: trace metadata rows
        TM-->>W: trace metadata
        W->>W: merge: score + traceName/traceUserId/traceTags
    else "useEventsTable = false (legacy)"
        W->>W: getScoresUiTable (LEFT JOIN traces)
    end
    W-->>W: map to export row (id, traceId, metadata, traceName, userId, traceTags, ...)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/database-read-stream/getDatabaseReadStream.ts:120-134
Linear `find()` inside `map()` gives O(N×M) per page. For the default batch-export page size this is negligible today, but a `Map` indexed by `id` makes the intent clearer and is strictly faster.

```suggestion
  const traceMetadata = await getTraceMetadataByIdsFromEvents({
    projectId: props.projectId,
    traceIds: [
      ...new Set(
        scores
          .map((score) => score.traceId)
          .filter((traceId): traceId is string => Boolean(traceId)),
      ),
    ],
    clickhouseConfigs: props.clickhouseConfigs,
  });

  const traceMetadataMap = new Map(traceMetadata.map((t) => [t.id, t]));

  return scores.map((score) => {
    const trace = score.traceId ? traceMetadataMap.get(score.traceId) : undefined;
    return {
```

### Issue 2 of 2
worker/src/features/database-read-stream/getDatabaseReadStream.ts:137
Using `|| null` instead of `?? null` coerces an empty-string `user_id` to `null`. The legacy path returns the raw `user_id` string (including `""`) from the traces LEFT JOIN, so a trace with an explicitly empty `user_id` would be serialised differently between the two export paths.

```suggestion
      traceUserId: trace?.user_id ?? null,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(batch-export): read scores trace met..."](https://github.com/langfuse/langfuse/commit/8e44a25d0037e0ceba24b90d5a03f2b4b051160b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36993670)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->