### PR TITLE
fix(experiments): add dataset selector to run experiments form

### DIFF
--- a/web/src/features/evals/components/select-evaluator-list.tsx
+++ b/web/src/features/evals/components/select-evaluator-list.tsx
@@ -8,7 +8,7 @@ import {
   DialogTitle,
 } from "@/src/components/ui/dialog";
 import { Button } from "@/src/components/ui/button";
-import { BrainCircuit, Code2 } from "lucide-react";
+import { Bot, Code2 } from "lucide-react";
 import { EvaluatorSelector } from "./evaluator-selector";
 import { EvalTemplateForm } from "./template-form";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
@@ -104,7 +104,7 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
                 handleOpenCreateEvaluator(EvalTemplateType.LLM_AS_JUDGE)
               }
             >
-              <BrainCircuit className="h-5 w-5 shrink-0" />
+              <Bot className="h-5 w-5 shrink-0" />
               <span className="flex flex-col gap-1">
                 <span className="font-medium">LLM as a judge evaluator</span>
                 <span className="text-muted-foreground text-sm font-normal">

--- a/web/src/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/features/experiments/components/CreateExperimentsForm.tsx
@@ -21,6 +21,7 @@ import Link from "next/link";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { type CreateExperiment } from "@/src/features/experiments/types";
 import { MultiStepExperimentForm } from "@/src/features/experiments/components/MultiStepExperimentForm";
+import { RemoteExperimentDatasetStep } from "@/src/features/experiments/components/RemoteExperimentDatasetStep";
 import { RemoteExperimentUpsertForm } from "@/src/features/experiments/components/RemoteExperimentUpsertForm";
 import { RemoteExperimentTriggerModal } from "@/src/features/experiments/components/RemoteExperimentTriggerModal";
 import { Skeleton } from "@/src/components/ui/skeleton";
@@ -57,6 +58,8 @@ export const CreateExperimentsForm = ({
 }) => {
   const capture = usePostHogClientCapture();
   const [showPromptForm, setShowPromptForm] = useState(false);
+  const [showRemoteExperimentDatasetStep, setShowRemoteExperimentDatasetStep] =
+    useState(false);
   const [showRemoteExperimentUpsertForm, setShowRemoteExperimentUpsertForm] =
     useState(false);
   const [
@@ -68,7 +71,11 @@ export const CreateExperimentsForm = ({
     projectId,
     scope: "promptExperiments:CUD",
   });
-  const datasetId = defaultValues.datasetId;
+  const fixedDatasetId = defaultValues.datasetId;
+  const [remoteExperimentDataset, setRemoteExperimentDataset] = useState<
+    { id: string; name?: string } | undefined
+  >(fixedDatasetId ? { id: fixedDatasetId } : undefined);
+  const datasetId = fixedDatasetId ?? remoteExperimentDataset?.id;
 
   const existingRemoteExperiment = api.datasets.getRemoteExperiment.useQuery(
     {
@@ -91,6 +98,7 @@ export const CreateExperimentsForm = ({
   if (
     showSDKRunInfoPage &&
     !showPromptForm &&
+    !showRemoteExperimentDatasetStep &&
     !showRemoteExperimentUpsertForm &&
     !showRemoteExperimentTriggerModal
   ) {
@@ -133,7 +141,12 @@ export const CreateExperimentsForm = ({
               <CardFooter className="mt-auto flex flex-row gap-2">
                 <Button
                   className="w-full"
-                  onClick={() => setShowPromptForm(true)}
+                  onClick={() => {
+                    setShowPromptForm(true);
+                    setShowRemoteExperimentDatasetStep(false);
+                    setShowRemoteExperimentUpsertForm(false);
+                    setShowRemoteExperimentTriggerModal(false);
+                  }}
                 >
                   Configure
                 </Button>
@@ -169,6 +182,11 @@ export const CreateExperimentsForm = ({
                   <li>Custom evaluation logic</li>
                   <li>Integration with your codebase</li>
                 </ul>
+                {!fixedDatasetId && remoteExperimentDataset?.name ? (
+                  <p className="text-muted-foreground mt-4 text-xs">
+                    Selected dataset: {remoteExperimentDataset.name}
+                  </p>
+                ) : null}
               </CardContent>
               <CardFooter className="mt-auto flex flex-row gap-2">
                 {!!existingRemoteExperiment.data && datasetId && (
@@ -188,7 +206,10 @@ export const CreateExperimentsForm = ({
                     <Button
                       className="rounded-l-none rounded-r-md border-l-2 px-2"
                       title="Edit remote trigger settings"
-                      onClick={() => setShowRemoteExperimentUpsertForm(true)}
+                      onClick={() => {
+                        setShowRemoteExperimentDatasetStep(false);
+                        setShowRemoteExperimentUpsertForm(true);
+                      }}
                     >
                       <span className="relative mr-1 text-xs">
                         <Cog className="h-3 w-3" />
@@ -217,7 +238,13 @@ export const CreateExperimentsForm = ({
                     title="Set up remote dataset run in UI trigger"
                     className="h-8 w-8 shrink-0"
                     size="icon"
-                    onClick={() => setShowRemoteExperimentUpsertForm(true)}
+                    onClick={() => {
+                      if (fixedDatasetId) {
+                        setShowRemoteExperimentUpsertForm(true);
+                      } else {
+                        setShowRemoteExperimentDatasetStep(true);
+                      }
+                    }}
                   >
                     <Zap className="h-4 w-4" />
                   </Button>
@@ -227,6 +254,21 @@ export const CreateExperimentsForm = ({
           </div>
         </DialogBody>
       </>
+    );
+  }
+
+  if (showRemoteExperimentDatasetStep) {
+    return (
+      <RemoteExperimentDatasetStep
+        projectId={projectId}
+        initialDatasetId={remoteExperimentDataset?.id}
+        onBack={() => setShowRemoteExperimentDatasetStep(false)}
+        onContinue={(dataset) => {
+          setRemoteExperimentDataset(dataset);
+          setShowRemoteExperimentDatasetStep(false);
+          setShowRemoteExperimentUpsertForm(true);
+        }}
+      />
     );
   }
 
@@ -252,6 +294,14 @@ export const CreateExperimentsForm = ({
         datasetId={datasetId}
         existingRemoteExperiment={existingRemoteExperiment.data}
         setShowRemoteExperimentUpsertForm={setShowRemoteExperimentUpsertForm}
+        onBack={
+          fixedDatasetId
+            ? undefined
+            : () => {
+                setShowRemoteExperimentUpsertForm(false);
+                setShowRemoteExperimentDatasetStep(true);
+              }
+        }
       />
     );
   }

--- a/web/src/features/experiments/components/CreateExperimentsForm.tsx
+++ b/web/src/features/experiments/components/CreateExperimentsForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Button } from "@/src/components/ui/button";
-import { Code2, Wand2, Cog, Zap } from "lucide-react";
+import { CheckIcon, ChevronDown, Code2, Cog, Wand2 } from "lucide-react";
 import { api } from "@/src/utils/api";
 import {
   Card,
@@ -17,14 +17,27 @@ import {
   DialogDescription,
   DialogBody,
 } from "@/src/components/ui/dialog";
+import {
+  InputCommand,
+  InputCommandEmpty,
+  InputCommandGroup,
+  InputCommandInput,
+  InputCommandItem,
+  InputCommandList,
+} from "@/src/components/ui/input-command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
 import Link from "next/link";
 import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 import { type CreateExperiment } from "@/src/features/experiments/types";
 import { MultiStepExperimentForm } from "@/src/features/experiments/components/MultiStepExperimentForm";
-import { RemoteExperimentDatasetStep } from "@/src/features/experiments/components/RemoteExperimentDatasetStep";
 import { RemoteExperimentUpsertForm } from "@/src/features/experiments/components/RemoteExperimentUpsertForm";
 import { RemoteExperimentTriggerModal } from "@/src/features/experiments/components/RemoteExperimentTriggerModal";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import { cn } from "@/src/utils/tailwind";
 
 export const CreateExperimentsForm = ({
   projectId,
@@ -58,14 +71,13 @@ export const CreateExperimentsForm = ({
 }) => {
   const capture = usePostHogClientCapture();
   const [showPromptForm, setShowPromptForm] = useState(false);
-  const [showRemoteExperimentDatasetStep, setShowRemoteExperimentDatasetStep] =
-    useState(false);
   const [showRemoteExperimentUpsertForm, setShowRemoteExperimentUpsertForm] =
     useState(false);
   const [
     showRemoteExperimentTriggerModal,
     setShowRemoteExperimentTriggerModal,
   ] = useState(false);
+  const [datasetPopoverOpen, setDatasetPopoverOpen] = useState(false);
 
   const hasExperimentWriteAccess = useHasProjectAccess({
     projectId,
@@ -76,6 +88,25 @@ export const CreateExperimentsForm = ({
     { id: string; name?: string } | undefined
   >(fixedDatasetId ? { id: fixedDatasetId } : undefined);
   const datasetId = fixedDatasetId ?? remoteExperimentDataset?.id;
+  const remoteExperimentDatasets = api.datasets.allDatasetMeta.useQuery(
+    { projectId },
+    {
+      enabled:
+        showSDKRunInfoPage && !fixedDatasetId && hasExperimentWriteAccess,
+      trpc: {
+        context: {
+          skipBatch: true,
+        },
+      },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
+    },
+  );
+  const selectedRemoteExperimentDataset = remoteExperimentDatasets.data?.find(
+    (dataset) => dataset.id === remoteExperimentDataset?.id,
+  );
 
   const existingRemoteExperiment = api.datasets.getRemoteExperiment.useQuery(
     {
@@ -86,19 +117,33 @@ export const CreateExperimentsForm = ({
       enabled: !!datasetId,
     },
   );
+  const isRemoteExperimentLoading =
+    !!datasetId &&
+    (existingRemoteExperiment.isLoading || existingRemoteExperiment.isFetching);
+  const hasRemoteExperiment = !!existingRemoteExperiment.data;
+  const isRemoteExperimentEnabled =
+    existingRemoteExperiment.data?.enabled !== false;
+  const webhookActionLabel = isRemoteExperimentLoading
+    ? "Loading..."
+    : hasRemoteExperiment
+      ? "Run"
+      : "Configure";
 
   if (!hasExperimentWriteAccess) {
     return null;
   }
 
-  if (existingRemoteExperiment.isLoading && !!datasetId) {
+  if (
+    existingRemoteExperiment.isLoading &&
+    !!datasetId &&
+    !showSDKRunInfoPage
+  ) {
     return <Skeleton className="h-48 w-full" />;
   }
 
   if (
     showSDKRunInfoPage &&
     !showPromptForm &&
-    !showRemoteExperimentDatasetStep &&
     !showRemoteExperimentUpsertForm &&
     !showRemoteExperimentTriggerModal
   ) {
@@ -143,7 +188,6 @@ export const CreateExperimentsForm = ({
                   className="w-full"
                   onClick={() => {
                     setShowPromptForm(true);
-                    setShowRemoteExperimentDatasetStep(false);
                     setShowRemoteExperimentUpsertForm(false);
                     setShowRemoteExperimentTriggerModal(false);
                   }}
@@ -169,56 +213,132 @@ export const CreateExperimentsForm = ({
               <CardHeader>
                 <CardTitle className="flex items-center gap-2 text-lg">
                   <Code2 className="size-4" />
-                  via SDK / API
+                  via Webhook
                 </CardTitle>
                 <CardDescription>
-                  Start any dataset run via the Langfuse SDKs. To configure runs
-                  via webhook, use the button below.
+                  Set up an experiment webhook to start remote experiments from
+                  Langfuse. Your service receives the selected dataset and run
+                  config, executes the experiment, and posts results back.
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 <ul className="text-muted-foreground list-disc space-y-2 pl-4 text-sm">
-                  <li>Full control over dataset run execution</li>
-                  <li>Custom evaluation logic</li>
-                  <li>Integration with your codebase</li>
+                  <li>Run custom evaluation logic in your service</li>
+                  <li>Keep experiment results in Langfuse</li>
                 </ul>
-                {!fixedDatasetId && remoteExperimentDataset?.name ? (
-                  <p className="text-muted-foreground mt-4 text-xs">
-                    Selected dataset: {remoteExperimentDataset.name}
-                  </p>
+                {!fixedDatasetId ? (
+                  <div className="mt-4 space-y-2">
+                    <div className="text-sm font-medium">Dataset</div>
+                    <Popover
+                      open={datasetPopoverOpen}
+                      onOpenChange={setDatasetPopoverOpen}
+                    >
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="outline"
+                          role="combobox"
+                          aria-expanded={datasetPopoverOpen}
+                          disabled={
+                            remoteExperimentDatasets.isPending ||
+                            remoteExperimentDatasets.data?.length === 0
+                          }
+                          className="w-full justify-between px-2 font-normal"
+                        >
+                          {remoteExperimentDatasets.isPending
+                            ? "Loading datasets"
+                            : (selectedRemoteExperimentDataset?.name ??
+                              remoteExperimentDataset?.name ??
+                              "Select a dataset")}
+                          <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        className="w-(--radix-popover-trigger-width) overflow-auto p-0"
+                        align="start"
+                      >
+                        <InputCommand>
+                          <InputCommandInput
+                            placeholder="Search datasets..."
+                            className="h-9"
+                            variant="bottom"
+                          />
+                          <InputCommandList>
+                            <InputCommandEmpty>
+                              No dataset found.
+                            </InputCommandEmpty>
+                            <InputCommandGroup>
+                              {remoteExperimentDatasets.data?.map((dataset) => (
+                                <InputCommandItem
+                                  key={dataset.id}
+                                  value={dataset.name}
+                                  onSelect={() => {
+                                    setRemoteExperimentDataset({
+                                      id: dataset.id,
+                                      name: dataset.name,
+                                    });
+                                    setDatasetPopoverOpen(false);
+                                  }}
+                                >
+                                  {dataset.name}
+                                  <CheckIcon
+                                    className={cn(
+                                      "ml-auto h-4 w-4",
+                                      dataset.id === datasetId
+                                        ? "opacity-100"
+                                        : "opacity-0",
+                                    )}
+                                  />
+                                </InputCommandItem>
+                              ))}
+                            </InputCommandGroup>
+                          </InputCommandList>
+                        </InputCommand>
+                      </PopoverContent>
+                    </Popover>
+                  </div>
                 ) : null}
               </CardContent>
               <CardFooter className="mt-auto flex flex-row gap-2">
-                {!!existingRemoteExperiment.data && datasetId && (
-                  <div className="flex items-start">
+                {hasRemoteExperiment && !isRemoteExperimentLoading ? (
+                  <div className="flex w-full items-start">
                     <Button
-                      className="rounded-r-none"
-                      disabled={existingRemoteExperiment.data.enabled === false}
+                      className="w-full rounded-r-none"
+                      disabled={!datasetId || !isRemoteExperimentEnabled}
                       title={
-                        existingRemoteExperiment.data.enabled === false
-                          ? "Enable in settings to run"
-                          : undefined
+                        isRemoteExperimentEnabled
+                          ? undefined
+                          : "please edit and enable webhook"
                       }
-                      onClick={() => setShowRemoteExperimentTriggerModal(true)}
+                      onClick={() => {
+                        if (!datasetId || !isRemoteExperimentEnabled) return;
+                        setShowRemoteExperimentTriggerModal(true);
+                      }}
                     >
                       Run
                     </Button>
                     <Button
+                      aria-label="Edit remote trigger settings"
                       className="rounded-l-none rounded-r-md border-l-2 px-2"
                       title="Edit remote trigger settings"
-                      onClick={() => {
-                        setShowRemoteExperimentDatasetStep(false);
-                        setShowRemoteExperimentUpsertForm(true);
-                      }}
+                      onClick={() => setShowRemoteExperimentUpsertForm(true)}
                     >
-                      <span className="relative mr-1 text-xs">
-                        <Cog className="h-3 w-3" />
-                      </span>
+                      <Cog className="h-3 w-3" />
                     </Button>
                   </div>
+                ) : (
+                  <Button
+                    className="w-full"
+                    disabled={!datasetId || isRemoteExperimentLoading}
+                    onClick={() => {
+                      if (!datasetId || isRemoteExperimentLoading) return;
+                      setShowRemoteExperimentUpsertForm(true);
+                    }}
+                  >
+                    {webhookActionLabel}
+                  </Button>
                 )}
                 <Button
-                  className="flex-1"
+                  className="w-full"
                   variant="outline"
                   asChild
                   onClick={() =>
@@ -232,43 +352,11 @@ export const CreateExperimentsForm = ({
                     View Docs
                   </Link>
                 </Button>
-                {!existingRemoteExperiment.data && (
-                  <Button
-                    variant="outline"
-                    title="Set up remote dataset run in UI trigger"
-                    className="h-8 w-8 shrink-0"
-                    size="icon"
-                    onClick={() => {
-                      if (fixedDatasetId) {
-                        setShowRemoteExperimentUpsertForm(true);
-                      } else {
-                        setShowRemoteExperimentDatasetStep(true);
-                      }
-                    }}
-                  >
-                    <Zap className="h-4 w-4" />
-                  </Button>
-                )}
               </CardFooter>
             </Card>
           </div>
         </DialogBody>
       </>
-    );
-  }
-
-  if (showRemoteExperimentDatasetStep) {
-    return (
-      <RemoteExperimentDatasetStep
-        projectId={projectId}
-        initialDatasetId={remoteExperimentDataset?.id}
-        onBack={() => setShowRemoteExperimentDatasetStep(false)}
-        onContinue={(dataset) => {
-          setRemoteExperimentDataset(dataset);
-          setShowRemoteExperimentDatasetStep(false);
-          setShowRemoteExperimentUpsertForm(true);
-        }}
-      />
     );
   }
 
@@ -294,14 +382,6 @@ export const CreateExperimentsForm = ({
         datasetId={datasetId}
         existingRemoteExperiment={existingRemoteExperiment.data}
         setShowRemoteExperimentUpsertForm={setShowRemoteExperimentUpsertForm}
-        onBack={
-          fixedDatasetId
-            ? undefined
-            : () => {
-                setShowRemoteExperimentUpsertForm(false);
-                setShowRemoteExperimentDatasetStep(true);
-              }
-        }
       />
     );
   }

--- a/web/src/features/experiments/components/RemoteExperimentDatasetStep.clienttest.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentDatasetStep.clienttest.tsx
@@ -1,0 +1,97 @@
+import { type ComponentProps } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Dialog, DialogContent } from "@/src/components/ui/dialog";
+
+const mocks = vi.hoisted(() => ({
+  allDatasetMetaUseQuery: vi.fn(),
+}));
+
+vi.mock("@/src/utils/api", () => ({
+  api: {
+    datasets: {
+      allDatasetMeta: {
+        useQuery: (...args: unknown[]) => mocks.allDatasetMetaUseQuery(...args),
+      },
+    },
+  },
+}));
+
+import { RemoteExperimentDatasetStep } from "./RemoteExperimentDatasetStep";
+
+const renderStep = (
+  props: Partial<ComponentProps<typeof RemoteExperimentDatasetStep>> = {},
+) =>
+  render(
+    <Dialog open>
+      <DialogContent>
+        <RemoteExperimentDatasetStep
+          projectId="project-1"
+          onBack={vi.fn()}
+          onContinue={vi.fn()}
+          {...props}
+        />
+      </DialogContent>
+    </Dialog>,
+  );
+
+describe("RemoteExperimentDatasetStep", () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  beforeEach(() => {
+    mocks.allDatasetMetaUseQuery.mockReset();
+  });
+
+  it("requires a dataset before continuing", async () => {
+    const onContinue = vi.fn();
+
+    mocks.allDatasetMetaUseQuery.mockReturnValue({
+      data: [
+        { id: "dataset-1", name: "First dataset" },
+        { id: "dataset-2", name: "Remote experiment dataset" },
+      ],
+      isFetching: false,
+      isPending: false,
+    });
+
+    renderStep({ onContinue });
+
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(await screen.findByText("Remote experiment dataset"));
+
+    expect(screen.getByRole("combobox")).toHaveTextContent(
+      "Remote experiment dataset",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(onContinue).toHaveBeenCalledWith({
+      id: "dataset-2",
+      name: "Remote experiment dataset",
+    });
+  });
+
+  it("shows an empty state when no datasets exist", () => {
+    mocks.allDatasetMetaUseQuery.mockReturnValue({
+      data: [],
+      isFetching: false,
+      isPending: false,
+    });
+
+    renderStep();
+
+    expect(screen.getByText("No datasets found")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+  });
+});

--- a/web/src/features/experiments/components/RemoteExperimentDatasetStep.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentDatasetStep.tsx
@@ -155,10 +155,7 @@ export const RemoteExperimentDatasetStep = ({
       </DialogBody>
 
       <DialogFooter>
-        <div className="flex w-full justify-between">
-          <Button type="button" variant="outline" onClick={onBack}>
-            Cancel
-          </Button>
+        <div className="flex w-full justify-end">
           <Button
             type="button"
             disabled={!selectedDataset}

--- a/web/src/features/experiments/components/RemoteExperimentDatasetStep.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentDatasetStep.tsx
@@ -1,0 +1,182 @@
+import { useState } from "react";
+import { CheckIcon, ChevronDown } from "lucide-react";
+
+import Spinner from "@/src/components/design-system/Spinner/Spinner";
+import { Button } from "@/src/components/ui/button";
+import {
+  DialogBody,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/components/ui/dialog";
+import {
+  InputCommand,
+  InputCommandEmpty,
+  InputCommandGroup,
+  InputCommandInput,
+  InputCommandItem,
+  InputCommandList,
+} from "@/src/components/ui/input-command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/src/components/ui/popover";
+import { Skeleton } from "@/src/components/ui/skeleton";
+import { cn } from "@/src/utils/tailwind";
+import { api } from "@/src/utils/api";
+
+type DatasetOption = {
+  id: string;
+  name: string;
+};
+
+export const RemoteExperimentDatasetStep = ({
+  projectId,
+  initialDatasetId,
+  onBack,
+  onContinue,
+}: {
+  projectId: string;
+  initialDatasetId?: string;
+  onBack: () => void;
+  onContinue: (dataset: DatasetOption) => void;
+}) => {
+  const [datasetPopoverOpen, setDatasetPopoverOpen] = useState(false);
+  const [selectedDatasetId, setSelectedDatasetId] = useState(
+    initialDatasetId ?? "",
+  );
+
+  const datasets = api.datasets.allDatasetMeta.useQuery(
+    { projectId },
+    {
+      trpc: {
+        context: {
+          skipBatch: true,
+        },
+      },
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      staleTime: Infinity,
+    },
+  );
+
+  const selectedDataset = datasets.data?.find(
+    (dataset) => dataset.id === selectedDatasetId,
+  );
+
+  return (
+    <>
+      <DialogHeader>
+        <Button
+          variant="ghost"
+          onClick={onBack}
+          className="inline-block self-start"
+        >
+          ← Back
+        </Button>
+        <DialogTitle>Select dataset</DialogTitle>
+        <DialogDescription>
+          Remote dataset run triggers are attached to a dataset. Choose the
+          dataset before configuring the remote experiment.
+        </DialogDescription>
+      </DialogHeader>
+
+      <DialogBody>
+        {datasets.isPending ? (
+          <Skeleton className="h-24 w-full" />
+        ) : datasets.data && datasets.data.length > 0 ? (
+          <div className="space-y-2">
+            <div className="text-sm font-medium">Dataset</div>
+            <Popover
+              open={datasetPopoverOpen}
+              onOpenChange={setDatasetPopoverOpen}
+            >
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={datasetPopoverOpen}
+                  className="w-full justify-between px-2 font-normal"
+                >
+                  {selectedDataset?.name ?? "Select a dataset"}
+                  <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="w-(--radix-popover-trigger-width) overflow-auto p-0"
+                align="start"
+              >
+                <InputCommand>
+                  <InputCommandInput
+                    placeholder="Search datasets..."
+                    className="h-9"
+                    variant="bottom"
+                  />
+                  <InputCommandList>
+                    <InputCommandEmpty>No dataset found.</InputCommandEmpty>
+                    <InputCommandGroup>
+                      {datasets.data.map((dataset) => (
+                        <InputCommandItem
+                          key={dataset.id}
+                          value={dataset.name}
+                          onSelect={() => {
+                            setSelectedDatasetId(dataset.id);
+                            setDatasetPopoverOpen(false);
+                          }}
+                        >
+                          {dataset.name}
+                          <CheckIcon
+                            className={cn(
+                              "ml-auto h-4 w-4",
+                              dataset.id === selectedDatasetId
+                                ? "opacity-100"
+                                : "opacity-0",
+                            )}
+                          />
+                        </InputCommandItem>
+                      ))}
+                    </InputCommandGroup>
+                  </InputCommandList>
+                </InputCommand>
+              </PopoverContent>
+            </Popover>
+          </div>
+        ) : (
+          <div className="rounded-md border p-4 text-sm">
+            <div className="font-medium">No datasets found</div>
+            <p className="text-muted-foreground mt-1">
+              Create a dataset before setting up a remote experiment trigger.
+            </p>
+          </div>
+        )}
+      </DialogBody>
+
+      <DialogFooter>
+        <div className="flex w-full justify-between">
+          <Button type="button" variant="outline" onClick={onBack}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!selectedDataset}
+            onClick={() => {
+              if (selectedDataset) {
+                onContinue(selectedDataset);
+              }
+            }}
+          >
+            {datasets.isFetching ? (
+              <div className="mr-2">
+                <Spinner size="sm" />
+              </div>
+            ) : null}
+            Continue
+          </Button>
+        </div>
+      </DialogFooter>
+    </>
+  );
+};

--- a/web/src/features/experiments/components/RemoteExperimentUpsertForm.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentUpsertForm.tsx
@@ -44,6 +44,7 @@ export const RemoteExperimentUpsertForm = ({
   datasetId,
   existingRemoteExperiment,
   setShowRemoteExperimentUpsertForm,
+  onBack,
 }: {
   projectId: string;
   datasetId: string;
@@ -53,6 +54,7 @@ export const RemoteExperimentUpsertForm = ({
     enabled?: boolean;
   } | null;
   setShowRemoteExperimentUpsertForm: (show: boolean) => void;
+  onBack?: () => void;
 }) => {
   const hasDatasetAccess = useHasProjectAccess({
     projectId,
@@ -164,7 +166,13 @@ export const RemoteExperimentUpsertForm = ({
       <DialogHeader>
         <Button
           variant="ghost"
-          onClick={() => setShowRemoteExperimentUpsertForm(false)}
+          onClick={() => {
+            if (onBack) {
+              onBack();
+            } else {
+              setShowRemoteExperimentUpsertForm(false);
+            }
+          }}
           className="inline-block self-start"
         >
           ← Back

--- a/web/src/features/experiments/components/RemoteExperimentUpsertForm.tsx
+++ b/web/src/features/experiments/components/RemoteExperimentUpsertForm.tsx
@@ -179,11 +179,11 @@ export const RemoteExperimentUpsertForm = ({
         </Button>
         <DialogTitle>
           {existingRemoteExperiment
-            ? "Edit remote dataset run trigger"
-            : "Set up remote dataset run trigger in UI"}
+            ? "Edit remote experiment trigger"
+            : "Set up remote experiment trigger in UI"}
         </DialogTitle>
         <DialogDescription>
-          Enable your team to run custom dataset runs on dataset{" "}
+          Enable your team to run custom experiments on dataset{" "}
           <strong>
             {dataset.isSuccess ? (
               <>&quot;{dataset.data?.name}&quot;</>
@@ -191,7 +191,7 @@ export const RemoteExperimentUpsertForm = ({
               <Spinner size="sm" display="inline" />
             )}
           </strong>
-          . Configure a webhook URL to trigger remote custom dataset runs from
+          . Configure a webhook URL to trigger remote custom experiments from
           UI. We will send dataset info (name, id) and config to your service,
           which can run against the dataset and post results to Langfuse.
         </DialogDescription>
@@ -207,7 +207,7 @@ export const RemoteExperimentUpsertForm = ({
                 <FormItem>
                   <FormLabel>URL</FormLabel>
                   <FormDescription>
-                    The URL that will be called when the remote dataset run is
+                    The URL that will be called when the remote experiment is
                     triggered.
                   </FormDescription>
                   <FormControl>
@@ -228,9 +228,9 @@ export const RemoteExperimentUpsertForm = ({
                 <FormItem>
                   <FormLabel>Default config</FormLabel>
                   <FormDescription>
-                    Set a default config that will be sent to the remote dataset
-                    run URL. This can be modified before starting a new run.
-                    View docs for more details.
+                    Set a default config that will be sent to the remote
+                    experiment run URL. This can be modified before starting a
+                    new run. View docs for more details.
                   </FormDescription>
                   <CodeMirrorEditor
                     value={field.value}
@@ -288,6 +288,7 @@ export const RemoteExperimentUpsertForm = ({
               )}
               <Button
                 type="submit"
+                className="ml-auto"
                 disabled={upsertRemoteExperimentMutation.isPending}
               >
                 {upsertRemoteExperimentMutation.isPending ? (


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new `RemoteExperimentDatasetStep` component that allows users to select a dataset when setting up a remote experiment trigger from a context where no dataset is pre-selected (e.g., the \"via SDK / API\" card on a generic experiments page). The step is inserted between the main card view and `RemoteExperimentUpsertForm`, enabling the full remote trigger setup flow when `fixedDatasetId` is not supplied.

- `CreateExperimentsForm` gains a `remoteExperimentDataset` state slot and new routing logic: the Zap button now conditionally routes through `RemoteExperimentDatasetStep` when there is no `fixedDatasetId`, and `RemoteExperimentUpsertForm` receives an optional `onBack` prop to navigate back to the dataset step.
- `RemoteExperimentDatasetStep` is a new dialog-body component with a searchable dataset combobox, a Continue button that is disabled until a dataset is chosen, and a client test covering the happy path and the empty-data case.
- `select-evaluator-list.tsx` swaps the `BrainCircuit` icon for `Bot` from lucide-react.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with a small fix — the new dataset-selection step works correctly for the happy path but silently mislabels a fetch failure as 'No datasets found'.

The routing logic in CreateExperimentsForm and the RemoteExperimentUpsertForm onBack wiring are both correct. The only concrete defect is in RemoteExperimentDatasetStep: when the allDatasetMeta query errors out, datasets.isError is never checked, so the component falls to the empty-state branch and tells users to create a dataset when the real problem is a network or server error.

web/src/features/experiments/components/RemoteExperimentDatasetStep.tsx — needs an isError branch added before the empty-state fallback.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CreateExperimentsForm] --> B{showSDKRunInfoPage?}
    B -- No --> Z[MultiStepExperimentForm]
    B -- Yes --> C[Two-card UI view]
    C -- Click Zap button --> D{fixedDatasetId?}
    D -- Yes --> F[RemoteExperimentUpsertForm]
    D -- No --> E[RemoteExperimentDatasetStep]
    E -- onBack --> C
    E -- onContinue with dataset --> G[setRemoteExperimentDataset + show UpsertForm]
    G --> F
    F -- onBack defined, no fixedDatasetId --> E
    F -- setShowRemoteExperimentUpsertForm false --> C
    C -- Click Edit Cog, existing config --> F
    C -- Click Run, existing config --> H[RemoteExperimentTriggerModal]
    H -- back --> C
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/experiments/components/RemoteExperimentDatasetStep.tsx:88-90
When the `allDatasetMeta` query fails (e.g., network error or 5xx), `datasets.isPending` is `false` and `datasets.data` is `undefined`, so the component falls into the else branch and shows "No datasets found". A user who actually has datasets will be told to create one, with no indication that an error occurred and no way to retry other than dismissing the dialog.

```suggestion
        {datasets.isPending ? (
          <Skeleton className="h-24 w-full" />
        ) : datasets.isError ? (
          <div className="rounded-md border p-4 text-sm">
            <div className="font-medium">Failed to load datasets</div>
            <p className="text-muted-foreground mt-1">
              An error occurred while loading datasets. Please try again.
            </p>
          </div>
        ) : datasets.data && datasets.data.length > 0 ? (
```

### Issue 2 of 2
web/src/features/experiments/components/RemoteExperimentDatasetStep.tsx:119
The in-popover empty message ("No dataset found.") uses the singular form while the outer empty-state heading uses the plural "No datasets found". Both strings should match for consistency.

```suggestion
                    <InputCommandEmpty>No datasets found.</InputCommandEmpty>
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(experiments): add RemoteExperimentD..."](https://github.com/langfuse/langfuse/commit/705529453d86e11f9bcd667383c57807833e94d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36992837)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->