### PR TITLE
fix(datasets): update id documentation and validation to enforce max length of 255 characters

### DIFF
--- a/fern/apis/server/definition/dataset-items.yml
+++ b/fern/apis/server/definition/dataset-items.yml
@@ -70,7 +70,7 @@ types:
       sourceObservationId: optional<string>
       id:
         type: optional<string>
-        docs: Dataset items are upserted on their id. Id needs to be unique (project-level) and cannot be reused across datasets.
+        docs: Dataset items are upserted on their id. Id needs to be unique (project-level), cannot be reused across datasets, and must be at most 255 characters.
       status:
         type: optional<commons.DatasetStatus>
         docs: Defaults to ACTIVE for newly created items

--- a/web/public/generated/api/openapi.yml
+++ b/web/public/generated/api/openapi.yml
@@ -9901,7 +9901,8 @@ components:
           nullable: true
           description: >-
             Dataset items are upserted on their id. Id needs to be unique
-            (project-level) and cannot be reused across datasets.
+            (project-level), cannot be reused across datasets, and must be at
+            most 255 characters.
         status:
           $ref: '#/components/schemas/DatasetStatus'
           nullable: true

--- a/web/src/features/mcp/features/datasets/schema.ts
+++ b/web/src/features/mcp/features/datasets/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { type JSONValue } from "@langfuse/shared";
+import { publicApiIdSchema } from "@/src/features/public-api/types/datasets";
 
 const paginationSchema = {
   page: z.number().int().positive().default(1),
@@ -76,7 +77,7 @@ export const PostDatasetItemMcpInput = z.object({
   input: z.any().optional(),
   expectedOutput: z.any().optional(),
   metadata: z.any().optional(),
-  id: z.string().optional(),
+  id: publicApiIdSchema.optional(),
   sourceTraceId: z.string().optional(),
   sourceObservationId: z.string().optional(),
   status: z.enum(["ACTIVE", "ARCHIVED"]).optional(),

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -170,7 +170,7 @@ export const GetDatasetRunV1Response = APIDatasetRun.extend({
   datasetRunItems: z.array(APIDatasetRunItem),
 }).strict();
 
-const publicApiIdSchema = z
+export const publicApiIdSchema = z
   .string()
   .min(1, "ID must not be empty")
   .max(255, "ID must be at most 255 characters");

--- a/web/src/features/public-api/types/datasets.ts
+++ b/web/src/features/public-api/types/datasets.ts
@@ -170,13 +170,18 @@ export const GetDatasetRunV1Response = APIDatasetRun.extend({
   datasetRunItems: z.array(APIDatasetRunItem),
 }).strict();
 
+const publicApiIdSchema = z
+  .string()
+  .min(1, "ID must not be empty")
+  .max(255, "ID must be at most 255 characters");
+
 // POST /dataset-items
 export const PostDatasetItemsV1Body = z.object({
   datasetName: z.string(),
   input: z.any().nullish(),
   expectedOutput: z.any().nullish(),
   metadata: z.any().nullish(),
-  id: z.string().nullish(),
+  id: publicApiIdSchema.nullish(),
   sourceTraceId: z.string().nullish(),
   sourceObservationId: z.string().nullish(),
   status: z.enum(["ACTIVE", "ARCHIVED"]).nullish(),


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a 255-character maximum length validation for the `id` field on dataset items when creating/upserting them via the REST API, and updates the documentation in the Fern definition and generated OpenAPI spec to reflect this constraint.

- `publicApiIdSchema` (`min(1)`, `max(255)`) is introduced and applied to `PostDatasetItemsV1Body.id`; the `.nullish()` composition is correct — null/undefined are still accepted, only non-null values are length-checked.
- The parallel MCP upsert path (`PostDatasetItemMcpInput`) retains `id: z.string().optional()` without the new max-length guard, creating an inconsistency where MCP clients can bypass the restriction.
- The Fern definition and generated OpenAPI spec carry the 255-character limit in description prose only, without a machine-readable `maxLength: 255` property that schema validators and SDK generators would consume.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for REST API clients, but the MCP code path is left unguarded and can create dataset items with IDs exceeding 255 characters.

The REST validation change is correct and self-contained. However, PostDatasetItemMcpInput in schema.ts skips the new max(255) check entirely while calling the same underlying service function, meaning the fix is incomplete for MCP-initiated upserts.

web/src/features/mcp/features/datasets/schema.ts — the PostDatasetItemMcpInput.id field needs the same max-length constraint added in this PR.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant REST as REST Client
    participant MCP as MCP Client
    participant RESTAPI as POST /dataset-items<br/>(PostDatasetItemsV1Body)
    participant MCPTool as upsertDatasetItem<br/>(PostDatasetItemMcpInput)
    participant Service as createDatasetItemForApi
    participant DB as Database

    REST->>RESTAPI: POST id (up to 255 chars)
    RESTAPI->>RESTAPI: publicApiIdSchema.nullish() min(1)+max(255)
    RESTAPI->>Service: validated input
    Service->>DB: upsert DatasetItem

    MCP->>MCPTool: upsertDatasetItem id string
    MCPTool->>MCPTool: z.string().optional() no max(255) check
    MCPTool->>Service: unvalidated input bypass possible
    Service->>DB: upsert DatasetItem
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/public/generated/api/openapi.yml:9899-9905
**`maxLength` constraint missing from OpenAPI schema**

The 255-character limit is documented only in the description prose but is not expressed as `maxLength: 255` on the `id` property. OpenAPI-aware tooling — SDK generators, validators, and contract-testing harnesses — rely on the structural constraint rather than the description text. Since `openapi.yml` is generated from the Fern definition in `dataset-items.yml`, the fix belongs in the Fern source: adding a `validation: { maxLength: 255 }` block under the `id` field so the generated spec carries the machine-readable constraint.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(datasets): update id documentation a..."](https://github.com/langfuse/langfuse/commit/221d7a447110110d459dbc242e7a5bd758b89533) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36995585)</sub>

<!-- /greptile_comment -->