### PR TITLE
feat(evals): change icon for llm-as-a-judge evaluator set up

### DIFF
--- a/web/src/features/evals/components/select-evaluator-list.tsx
+++ b/web/src/features/evals/components/select-evaluator-list.tsx
@@ -8,7 +8,7 @@ import {
   DialogTitle,
 } from "@/src/components/ui/dialog";
 import { Button } from "@/src/components/ui/button";
-import { BrainCircuit, Code2 } from "lucide-react";
+import { Bot, Code2 } from "lucide-react";
 import { EvaluatorSelector } from "./evaluator-selector";
 import { EvalTemplateForm } from "./template-form";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
@@ -104,7 +104,7 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
                 handleOpenCreateEvaluator(EvalTemplateType.LLM_AS_JUDGE)
               }
             >
-              <BrainCircuit className="h-5 w-5 shrink-0" />
+              <Bot className="h-5 w-5 shrink-0" />
               <span className="flex flex-col gap-1">
                 <span className="font-medium">LLM as a judge evaluator</span>
                 <span className="text-muted-foreground text-sm font-normal">


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Swaps the icon for the "LLM as a judge evaluator" button from `BrainCircuit` to `Bot` (both from `lucide-react`), updating both the import statement and the JSX usage site.

- The `BrainCircuit` import is replaced with `Bot` at the top of the file; `Code2` for the code evaluator button is unchanged.
- No logic, state, or behavior is altered — this is a purely visual update to a single button icon.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only swaps one Lucide icon for another with no functional impact.

The diff touches exactly two lines: the named import and the JSX element. Both BrainCircuit and Bot are exported by lucide-react, so there is no missing-export risk. No logic, state, routing, or API calls are affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SelectEvaluatorList] --> B{isCodeEvalEnabled?}
    B -- Yes --> C["🖥️ Code evaluator button\n(Code2 icon)"]
    B -- No --> D[Skip code button]
    A --> E["🤖 LLM as a judge evaluator button\n(Bot icon — changed from BrainCircuit)"]
    C --> F[handleOpenCreateEvaluator\nEvalTemplateType.CODE]
    E --> G[handleOpenCreateEvaluator\nEvalTemplateType.LLM_AS_JUDGE]
    F --> H[Open Dialog\nEvalTemplateForm]
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(evals): change icon for llm-as-a-ju..."](https://github.com/langfuse/langfuse/commit/2c64bac7e347c6cd03d61b18d9bc082fc31f100a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36999155)</sub>

<!-- /greptile_comment -->