### PR TITLE
fix(seeder): align agentic seed summaries

### DIFF
--- a/packages/shared/scripts/seeder/scenarios/many-traces.ts
+++ b/packages/shared/scripts/seeder/scenarios/many-traces.ts
@@ -12,6 +12,8 @@ import {
 import { utcDayStartMs } from "./rng";
 import { countRows, escapeLike, tracesListLink } from "./verify";
 
+const SESSION_POOL_SIZE = 100;
+
 /**
  * Loads the bundled large fixtures, sliced exactly like SeederOrchestrator so
  * the inline INSERT ... SELECT FROM numbers() SQL stays under ClickHouse's
@@ -71,6 +73,7 @@ const run = async (
   const builder = new ClickHouseQueryBuilder();
   const fileContent = richPayloads ? loadFileContent() : undefined;
   const counts: Record<string, number> = {
+    sessions: SESSION_POOL_SIZE,
     traces: count,
     observations: count * observationsPerTrace,
     scores: count * scoresPerTrace,
@@ -158,7 +161,7 @@ const run = async (
   // session detail page 404s without the Postgres trace_sessions rows
   // (same contract long-session handles for its own session).
   await prisma.traceSession.createMany({
-    data: Array.from({ length: 100 }, (_, i) => ({
+    data: Array.from({ length: SESSION_POOL_SIZE }, (_, i) => ({
       id: `${ctx.idPrefix}-session_${i}`,
       projectId: ctx.projectId,
       environment: ctx.environment,

--- a/packages/shared/scripts/seeder/scenarios/trace-tree.ts
+++ b/packages/shared/scripts/seeder/scenarios/trace-tree.ts
@@ -114,7 +114,7 @@ const run = async (
   const startedAt = Date.now();
   const observationCount = params["observations"] as number;
   const requestedDepth = params["depth"] as number;
-  const breadth = params["breadth"] as number;
+  const requestedBreadth = params["breadth"] as number;
   // depth deeper than the observation count is geometrically impossible;
   // clamping it down is helpful, not a silent rewrite of intent (the
   // validator below enforces the >= 2 lower bound on the requested value)
@@ -135,9 +135,9 @@ const run = async (
       "pass at least 2 (root plus one level), e.g. --depth 8",
     );
   }
-  if (breadth < 1) {
+  if (requestedBreadth < 1) {
     throw new SeedError(
-      `--breadth must be >= 1, got ${breadth}`,
+      `--breadth must be >= 1, got ${requestedBreadth}`,
       "pass a positive integer, e.g. --breadth 30",
     );
   }
@@ -154,6 +154,10 @@ const run = async (
     );
   }
 
+  const breadth = Math.min(
+    requestedBreadth,
+    Math.max(0, observationCount - depth),
+  );
   const rng = new Rng(ctx.seed);
   const traceId = `${ctx.idPrefix}-trace`;
   const traceTimestamp = utcDayStartMs();

--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -243,7 +243,7 @@ export class ClickHouseQueryBuilder {
           if(h2 % 10 >= 7, '${escapedNestedJson}', '${escapedChatMl}'),
           NULL) AS output,
         if(type = 'GENERATION', 'gpt-4', NULL) AS provided_model_name,
-        if(type = 'GENERATION', concat('model_', toString(h2 % 1000)), NULL) AS internal_model_id,
+        NULL AS internal_model_id,
         if(type = 'GENERATION', '{"temperature": 0.7}', '{}') AS model_parameters,
         if(type = 'GENERATION', map('input', toUInt64(20 + h1 % 181), 'output', toUInt64(10 + h2 % 91), 'total', toUInt64(30 + h1 % 181 + h2 % 91)), map()) AS provided_usage_details,
         if(type = 'GENERATION', map('input', toUInt64(20 + h1 % 181), 'output', toUInt64(10 + h2 % 91), 'total', toUInt64(30 + h1 % 181 + h2 % 91)), map()) AS usage_details,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes three reporting/alignment issues in the agentic seeder: it introduces a named constant for the session pool size and adds it to the `many-traces` summary counts, corrects `breadth` in `trace-tree` metadata so it reflects the actual clamped value rather than the raw user input, and removes a fake synthetic `internal_model_id` from bulk observations so that field is consistently `NULL` across all seeder scenarios.

- **`many-traces.ts`**: Extracts the hard-coded `100` into `SESSION_POOL_SIZE` and surfaces it in the `counts` summary so tooling that reads the seed output can accurately report how many session rows were created.
- **`trace-tree.ts`**: Renames the raw `breadth` parameter to `requestedBreadth`, then derives a clamped `breadth = Math.min(requestedBreadth, observationCount − depth)`. Without the clamp, `buildTreeShape` still produced the geometrically correct tree (the loop can only assign fan-out to nodes that actually exist), but the trace metadata field `"shape.breadth"` was reporting the over-specified requested value instead of the effective one.
- **`clickhouse-builder.ts`**: Changes `internal_model_id` from `concat('model_', toString(h2 % 1000))` to `NULL`, matching the explicit `internal_model_id: null` already set by the `trace-tree` scenario; the synthetic IDs referenced model records that don't exist in any project database.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three changes are narrow reporting fixes with no behavioral side-effects on the actual data written to ClickHouse or Postgres.

The breadth clamping in trace-tree produces an identical tree to what was generated before (buildTreeShape could never assign more fan-out nodes than were available), so no seeded data changes. The NULL internal_model_id removes fake IDs that never resolved to real model records. The SESSION_POOL_SIZE constant is a pure rename with a count added to the summary. There are no schema changes, no query logic changes, and no data paths that could regress.

No files require special attention; the changes are self-contained within the seeder package.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User calls seeder with --breadth N, --depth D, --observations O]) --> B[Validate requestedDepth >= 2\nrequestedBreadth >= 1\nobservations >= 1]
    B --> C[depth = Math.min requestedDepth, observationCount]
    C --> D{dryRun?}
    D -- yes --> E[Return dry-run summary\nwith params as-is]
    D -- no --> F[breadth = Math.min\nrequestedBreadth,\nmax 0 observationCount-depth]
    F --> G[buildTreeShape observationCount, depth, breadth]
    G --> H[backbone chain: nodes 0..depth-1]
    G --> I[hub fan-out: nodes depth..depth+breadth-1]
    G --> J[random nodes: remaining]
    H & I & J --> K[trace metadata:\nshape.breadth = clamped breadth\nnot requested breadth]
    K --> L[Insert into ClickHouse\ninternal_model_id = NULL]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(seeder): align agentic seed summarie..."](https://github.com/langfuse/langfuse/commit/eb10806c268137d32f0c9a8f3713c5a10472fb19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37015821)</sub>

<!-- /greptile_comment -->