### PR TITLE
feat(corrections): remove beta label

### DIFF
--- a/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
+++ b/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
@@ -167,7 +167,7 @@ export function CorrectedOutputField({
                   compact ? "text-xs" : "text-sm",
                 )}
               >
-                {compact ? "" : "Corrected Output (Beta)"}
+                {compact ? "" : "Corrected Output"}
               </span>
               <HoverCard>
                 <HoverCardTrigger asChild>


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the `(Beta)` suffix from the "Corrected Output" field label in the `CorrectedOutputField` component, graduating the feature out of beta status.

- The label string `"Corrected Output (Beta)"` is changed to `"Corrected Output"` in the non-compact display path.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single-character label change with no logic impact.

The change is limited to removing a "(Beta)" suffix from a display string. No logic, data flow, or API contracts are affected. The only note is a now-stale inline comment that still says "JSON Beta view".

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CorrectedOutputField renders] --> B{compact?}
    B -- true --> C[Render empty string for label]
    B -- false --> D[Render 'Corrected Output']
    D --> E[Show HoverCard info icon]
    C --> E
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx:29
The inline comment on the `compact` prop still references "Beta" after the feature has been graduated. It should be updated to match.

```suggestion
  compact?: boolean; // Use smaller font size for compact view
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(corrections): remove beta label"](https://github.com/langfuse/langfuse/commit/641b7e5ff2c4286567dab7733d299cba2b6f31fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37021708)</sub>

<!-- /greptile_comment -->