### PR TITLE
fix: refine API error logging and prompt validation handling

### DIFF
--- a/web/src/__tests__/server/trpc-error-formatting.servertest.ts
+++ b/web/src/__tests__/server/trpc-error-formatting.servertest.ts
@@ -1,7 +1,17 @@
+vi.mock("@langfuse/shared/src/server", async () => ({
+  ...(await vi.importActual("@langfuse/shared/src/server")),
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 import type { Session } from "next-auth";
 import { TRPCError } from "@trpc/server";
 import * as z from "zod";
-import { ClickHouseResourceError } from "@langfuse/shared/src/server";
+import { ClickHouseResourceError, logger } from "@langfuse/shared/src/server";
 import {
   createInnerTRPCContext,
   createTRPCRouter,
@@ -9,6 +19,10 @@ import {
 } from "@/src/server/api/trpc";
 
 describe("tRPC error formatting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("ClickHouseResourceError", async () => {
     const session = {
       user: {
@@ -62,6 +76,11 @@ describe("tRPC error formatting", () => {
     expect(formatted.data["errorName"]).toBe("ClickHouseResourceError");
     expect(formatted.data["stack"]).toBeNull();
     expect(formatted.data["zodError"]).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "middleware intercepted error with code UNPROCESSABLE_CONTENT",
+      { error: expect.any(TRPCError) },
+    );
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
   it("preserves the default stack behavior for non-ClickHouse errors", () => {

--- a/web/src/__tests__/server/trpc-error-formatting.servertest.ts
+++ b/web/src/__tests__/server/trpc-error-formatting.servertest.ts
@@ -76,9 +76,13 @@ describe("tRPC error formatting", () => {
     expect(formatted.data["errorName"]).toBe("ClickHouseResourceError");
     expect(formatted.data["stack"]).toBeNull();
     expect(formatted.data["zodError"]).toBeNull();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(
-      "middleware intercepted error with code UNPROCESSABLE_CONTENT",
-      { error: expect.any(TRPCError) },
+      "ClickHouse resource limit exceeded",
+      expect.objectContaining({
+        errorType: "MEMORY_LIMIT",
+        message: "Memory limit exceeded",
+      }),
     );
     expect(logger.error).not.toHaveBeenCalled();
   });

--- a/web/src/__tests__/server/withMiddlewares.servertest.ts
+++ b/web/src/__tests__/server/withMiddlewares.servertest.ts
@@ -216,9 +216,6 @@ describe("withMiddlewares error handling", () => {
         ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
       );
       expect(jsonData["error"]).toBe("Request timed out");
-      expect(logger.warn).toHaveBeenCalledWith(resourceError);
-      expect(logger.error).not.toHaveBeenCalled();
-      expect(traceException).not.toHaveBeenCalled();
     });
 
     it("should include tags from the error in the warn log", async () => {
@@ -245,6 +242,7 @@ describe("withMiddlewares error handling", () => {
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(422);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
       expect(logger.warn).toHaveBeenCalledWith(
         "ClickHouse resource limit exceeded",
         expect.objectContaining({

--- a/web/src/__tests__/server/withMiddlewares.servertest.ts
+++ b/web/src/__tests__/server/withMiddlewares.servertest.ts
@@ -60,6 +60,9 @@ describe("withMiddlewares error handling", () => {
         message: "Bad Request",
         error: "BadRequest",
       });
+      expect(logger.warn).toHaveBeenCalledWith(error);
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(traceException).not.toHaveBeenCalled();
     });
 
     it("should handle BaseError with 5xx status code and trace exception", async () => {
@@ -213,6 +216,9 @@ describe("withMiddlewares error handling", () => {
         ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
       );
       expect(jsonData["error"]).toBe("Request timed out");
+      expect(logger.warn).toHaveBeenCalledWith(resourceError);
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(traceException).not.toHaveBeenCalled();
     });
 
     it("should include tags from the error in the warn log", async () => {
@@ -355,6 +361,9 @@ describe("withMiddlewares error handling", () => {
           }),
         ]),
       });
+      expect(logger.warn).toHaveBeenCalledWith(expect.any(z.ZodError));
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(traceException).not.toHaveBeenCalled();
     });
   });
 

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -142,23 +142,11 @@ export function withMiddlewares(
             logger.error(error);
           }
 
-          if (
-            error instanceof BaseError &&
-            error.httpCode >= 500 &&
-            error.httpCode < 600
-          ) {
-            traceException(error);
-          }
-
-          if (isPrismaException(error)) {
-            traceException(error);
-          }
-
-          if (
-            !(error instanceof BaseError) &&
-            !(error instanceof ClickHouseResourceError) &&
-            !isZodError(error)
-          ) {
+          if (error instanceof BaseError) {
+            if (error.httpCode >= 500 && error.httpCode < 600) {
+              traceException(error);
+            }
+          } else if (!isZodError(error)) {
             traceException(error);
           }
 

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -62,6 +62,27 @@ type MiddlewareOptions = {
   clickHouseResourceErrorMessage?: string;
 };
 
+const logApiError = (error: unknown) => {
+  if (
+    error instanceof LangfuseNotFoundError ||
+    error instanceof UnauthorizedError
+  ) {
+    logger.info(error);
+    return;
+  }
+
+  if (
+    (error instanceof BaseError && error.isUserError()) ||
+    error instanceof ClickHouseResourceError ||
+    isZodError(error)
+  ) {
+    logger.warn(error);
+    return;
+  }
+
+  logger.error(error);
+};
+
 export function withMiddlewares(
   handlers: Handlers,
   options?: MiddlewareOptions,
@@ -91,14 +112,7 @@ export function withMiddlewares(
 
         return await finalHandlers[method](req, res);
       } catch (error) {
-        if (
-          error instanceof LangfuseNotFoundError ||
-          error instanceof UnauthorizedError
-        ) {
-          logger.info(error);
-        } else {
-          logger.error(error);
-        }
+        logApiError(error);
 
         if (options?.errorContract === unstablePublicEvalsErrorContract) {
           if (

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -62,7 +62,7 @@ type MiddlewareOptions = {
   clickHouseResourceErrorMessage?: string;
 };
 
-const logApiError = (error: unknown) => {
+const logBaseError = (error: BaseError) => {
   if (
     error instanceof LangfuseNotFoundError ||
     error instanceof UnauthorizedError
@@ -71,11 +71,7 @@ const logApiError = (error: unknown) => {
     return;
   }
 
-  if (
-    (error instanceof BaseError && error.isUserError()) ||
-    error instanceof ClickHouseResourceError ||
-    isZodError(error)
-  ) {
+  if (error.isUserError()) {
     logger.warn(error);
     return;
   }
@@ -112,9 +108,40 @@ export function withMiddlewares(
 
         return await finalHandlers[method](req, res);
       } catch (error) {
-        logApiError(error);
+        if (error instanceof ClickHouseResourceError) {
+          const errorMessage =
+            options?.clickHouseResourceErrorMessage ??
+            DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE;
+
+          logger.warn("ClickHouse resource limit exceeded", {
+            errorType: error.errorType,
+            message: error.message,
+            suggestion: errorMessage,
+            tags: error.tags,
+          });
+
+          if (options?.errorContract === unstablePublicEvalsErrorContract) {
+            return sendUnstablePublicApiErrorResponse(
+              res,
+              toUnstablePublicApiError(error),
+            );
+          }
+
+          return res.status(422).json({
+            message: errorMessage,
+            error: "Request timed out",
+          });
+        }
 
         if (options?.errorContract === unstablePublicEvalsErrorContract) {
+          if (error instanceof BaseError) {
+            logBaseError(error);
+          } else if (isZodError(error)) {
+            logger.warn(error);
+          } else {
+            logger.error(error);
+          }
+
           if (
             error instanceof BaseError &&
             error.httpCode >= 500 &&
@@ -142,6 +169,7 @@ export function withMiddlewares(
         }
 
         if (error instanceof BaseError) {
+          logBaseError(error);
           if (error.httpCode >= 500 && error.httpCode < 600) {
             traceException(error);
           }
@@ -151,27 +179,8 @@ export function withMiddlewares(
           });
         }
 
-        // Handle ClickHouse resource errors
-        if (error instanceof ClickHouseResourceError) {
-          const resourceError = error as ClickHouseResourceError;
-          const errorMessage =
-            options?.clickHouseResourceErrorMessage ??
-            DEFAULT_CLICKHOUSE_RESOURCE_ERROR_MESSAGE;
-
-          logger.warn("ClickHouse resource limit exceeded", {
-            errorType: resourceError.errorType,
-            message: resourceError.message,
-            suggestion: errorMessage,
-            tags: resourceError.tags,
-          });
-
-          return res.status(422).json({
-            message: errorMessage,
-            error: "Request timed out",
-          });
-        }
-
         if (isPrismaException(error)) {
+          logger.error(error);
           traceException(error);
           return res.status(500).json({
             message: "Internal Server Error",
@@ -181,12 +190,14 @@ export function withMiddlewares(
 
         // Instanceof check fails here as shared package zod has different instances
         if (isZodError(error)) {
+          logger.warn(error);
           return res.status(400).json({
             message: "Invalid request data",
             error: error.issues,
           });
         }
 
+        logger.error(error);
         traceException(error);
         return res.status(500).json({
           message: "Internal Server Error",

--- a/web/src/pages/api/public/prompts.ts
+++ b/web/src/pages/api/public/prompts.ts
@@ -2,10 +2,10 @@ import { createPrompt } from "@/src/features/prompts/server/actions/createPrompt
 import { getPromptByName } from "@/src/features/prompts/server/actions/getPromptByName";
 import { ApiAuthService } from "@/src/features/public-api/server/apiAuth";
 import { cors, runMiddleware } from "@/src/features/public-api/server/cors";
+import { isZodError } from "@/src/features/public-api/server/withMiddlewares";
 import { prisma } from "@langfuse/shared/src/db";
 import { isPrismaException } from "@/src/utils/exceptions";
 import { type NextApiRequest, type NextApiResponse } from "next";
-import { z } from "zod";
 import {
   UnauthorizedError,
   LangfuseNotFoundError,
@@ -120,7 +120,7 @@ export default async function handler(
       });
     }
 
-    if (error instanceof z.ZodError) {
+    if (isZodError(error)) {
       logger.warn(`Zod exception`, error.issues);
       return res.status(400).json({
         message: "Invalid request data",

--- a/web/src/pages/api/public/prompts.ts
+++ b/web/src/pages/api/public/prompts.ts
@@ -121,7 +121,7 @@ export default async function handler(
     }
 
     if (isZodError(error)) {
-      logger.warn(`Zod exception`, error.issues);
+      logger.warn(`Zod exception`, { issues: error.issues });
       return res.status(400).json({
         message: "Invalid request data",
         error: error.issues,

--- a/web/src/pages/api/public/prompts.ts
+++ b/web/src/pages/api/public/prompts.ts
@@ -120,19 +120,20 @@ export default async function handler(
       });
     }
 
+    if (error instanceof z.ZodError) {
+      logger.warn(`Zod exception`, error.issues);
+      return res.status(400).json({
+        message: "Invalid request data",
+        error: error.issues,
+      });
+    }
+
     logger.error(error);
     traceException(error);
 
     if (isPrismaException(error)) {
       return res.status(500).json({
         error: "Internal Server Error",
-      });
-    }
-
-    if (error instanceof z.ZodError) {
-      return res.status(400).json({
-        message: "Invalid request data",
-        error: error.issues,
       });
     }
 

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -184,11 +184,6 @@ const withErrorHandling = t.middleware(async ({ ctx, next }) => {
         message: res.error.cause.message,
         tags: res.error.cause.tags,
       });
-      logErrorByStatus({
-        errorCode: "UNPROCESSABLE_CONTENT",
-        httpStatus: 422,
-        error: res.error,
-      });
       res.error = new TRPCError({
         code: "UNPROCESSABLE_CONTENT",
         message: ClickHouseResourceError.ERROR_ADVICE_MESSAGE,

--- a/web/src/server/api/trpc.ts
+++ b/web/src/server/api/trpc.ts
@@ -147,12 +147,20 @@ const resolveError = (error: TRPCError) => {
   return { code: error.code, httpStatus: getHTTPStatusCodeFromError(error) };
 };
 
-const logErrorByCode = (errorCode: TRPCError["code"], error: TRPCError) => {
+const logErrorByStatus = ({
+  errorCode,
+  httpStatus,
+  error,
+}: {
+  errorCode: TRPCError["code"];
+  httpStatus: number;
+  error: TRPCError;
+}) => {
   if (errorCode === "NOT_FOUND" || errorCode === "UNAUTHORIZED") {
     logger.info(`middleware intercepted error with code ${errorCode}`, {
       error,
     });
-  } else if (errorCode === "UNPROCESSABLE_CONTENT") {
+  } else if (httpStatus >= 400 && httpStatus < 500) {
     logger.warn(`middleware intercepted error with code ${errorCode}`, {
       error,
     });
@@ -176,7 +184,11 @@ const withErrorHandling = t.middleware(async ({ ctx, next }) => {
         message: res.error.cause.message,
         tags: res.error.cause.tags,
       });
-      logErrorByCode("UNPROCESSABLE_CONTENT", res.error);
+      logErrorByStatus({
+        errorCode: "UNPROCESSABLE_CONTENT",
+        httpStatus: 422,
+        error: res.error,
+      });
       res.error = new TRPCError({
         code: "UNPROCESSABLE_CONTENT",
         message: ClickHouseResourceError.ERROR_ADVICE_MESSAGE,
@@ -193,7 +205,7 @@ const withErrorHandling = t.middleware(async ({ ctx, next }) => {
         ? "We have been notified and are working on it."
         : "Please check error logs in your self-hosted deployment.";
 
-      logErrorByCode(code, res.error);
+      logErrorByStatus({ errorCode: code, httpStatus, error: res.error });
       res.error = new TRPCError({
         code,
         cause: null, // do not expose stack traces


### PR DESCRIPTION
## Summary
- Route public API and tRPC errors to `info`, `warn`, or `error` based on severity instead of treating all non-404/401 cases as errors
- Log `ZodError` from the public prompts endpoint as a warning and return a 400 response before generic error handling
- Update server tests to assert the new logging behavior and verify no unnecessary error tracing occurs for user-facing validation and resource errors

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refines error log routing across the public REST API and tRPC layer, replacing a blanket `logger.error` with severity-appropriate `info`/`warn`/`error` calls. It also moves `ZodError` handling in `prompts.ts` before the `logger.error`/`traceException` calls so validation failures no longer produce spurious error traces.

- `withMiddlewares.ts` gains a `logApiError` helper that routes 404/401 to `info`, user-facing errors and ClickHouse resource errors to `warn`, and everything else to `error`, eliminating noisy error logs for expected client errors.
- `trpc.ts` replaces the code-specific `UNPROCESSABLE_CONTENT` warn check with a broader `httpStatus >= 400 && httpStatus < 500` range, so all 4xx tRPC errors are downgraded to warn.
- `prompts.ts` reorders its catch block so `ZodError` is handled (and returned as 400) before `logger.error`/`traceException` are reached.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are limited to log routing and error response ordering with no impact on API behavior or data.

The core fix (ZodError short-circuit before traceException in prompts.ts) is correct. The tRPC log-level broadening from UNPROCESSABLE_CONTENT-only to all 4xx is a straightforward improvement. The one rough edge is that ClickHouseResourceError in withMiddlewares now triggers two separate warn log calls — one from logApiError and one from the existing dedicated handler — producing noisy logs rather than incorrect behavior. The instanceof z.ZodError check in prompts.ts may silently fall through for ZodErrors thrown by shared-package schemas, but this was already the pre-existing behavior before the reorder.

web/src/features/public-api/server/withMiddlewares.ts (double-warn for ClickHouseResourceError) and web/src/pages/api/public/prompts.ts (instanceof vs duck-typing ZodError check)
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    E[Error caught] --> A{Error type?}
    A -->|LangfuseNotFoundError or UnauthorizedError| B[logger.info]
    A -->|BaseError.isUserError or ClickHouseResourceError or ZodError| C[logger.warn]
    A -->|Anything else| D[logger.error + traceException]
    B --> R[Return HTTP response]
    C --> R
    D --> R

    subgraph tRPC withErrorHandling
      T[TRPCError] --> TH{errorCode?}
      TH -->|NOT_FOUND / UNAUTHORIZED| TI[logger.info]
      TH -->|4xx HTTP status| TW[logger.warn]
      TH -->|5xx HTTP status| TE[logger.error]
    end

    subgraph prompts.ts catch block
      P[Error] --> P1{instanceof BaseError?}
      P1 -->|yes, !isUserError| P3[logger.error + traceException]
      P1 -->|no| P4{instanceof z.ZodError?}
      P4 -->|yes| P5[logger.warn → 400]
      P4 -->|no| P6[logger.error + traceException → 5xx]
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/public-api/server/withMiddlewares.ts:65-84
**Redundant warn log for `ClickHouseResourceError`**

`logApiError` now emits `logger.warn(error)` for every `ClickHouseResourceError`. The dedicated handler below (lines 155–172) then immediately emits a second `logger.warn("ClickHouse resource limit exceeded", { errorType, message, suggestion, tags })` for the same event. Every ClickHouse resource error in `withMiddlewares` now produces two warn entries. The test asserts `toHaveBeenCalledWith(resourceError)` without checking call count, so this redundancy isn't caught. The detailed handler log is more useful; consider excluding `ClickHouseResourceError` from `logApiError`'s warn branch so only the contextual log fires.

### Issue 2 of 2
web/src/pages/api/public/prompts.ts:123-129
**`instanceof z.ZodError` may silently miss ZodErrors from `@langfuse/shared` schemas**

`GetPromptSchema` and `LegacyCreatePromptSchema` are imported from `@langfuse/shared`, which may bundle its own `zod` instance. If it does, the `ZodError` they throw will fail `instanceof z.ZodError` (local zod), falling through to `logger.error` + `traceException` + a 500 response. `withMiddlewares.ts` already documents this exact problem at line 182 and uses the duck-typing `isZodError()` guard instead. For consistency and reliability, the check in `prompts.ts` should use `isZodError` (or the same duck-typing pattern) rather than `instanceof z.ZodError`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Adjust API error logging by severity"](https://github.com/langfuse/langfuse/commit/01671e91ba3ca8083ec926dcd9fb923c20e2f81c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37188813)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->