### PR TITLE
fix(api): don't let scores value operator override timestamp filters

### DIFF
--- a/packages/shared/src/server/queries/public-api-filter-builder.ts
+++ b/packages/shared/src/server/queries/public-api-filter-builder.ts
@@ -244,15 +244,11 @@ export function convertApiProvidedFilterToClickhouseFilter(
       let filterInstance;
       switch (columnMapping.filterType) {
         case "DateTimeFilter": {
-          // get filter options from the filterOperators
-          // validate that the user provided operator is in the list of available operators
-          const availableOperators = z.enum(filterOperators.datetime);
-          const parsedOperator = availableOperators.safeParse(filter.operator);
-
-          // otherwise fall back to the operator provided in the column mapping
-          const finalOperator = parsedOperator.success
-            ? parsedOperator.data
-            : columnMapping.operator;
+          // The operator of a datetime column is fixed in the column mapping
+          // (e.g. fromTimestamp => ">=", toTimestamp => "<"). The user-provided
+          // `operator` query param targets the value filter and must not
+          // override it (#8630).
+          const finalOperator = columnMapping.operator;
 
           finalOperator &&
           typeof value === "string" &&

--- a/web/src/__tests__/server/scores-api-v1.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v1.servertest.ts
@@ -1124,6 +1124,66 @@ describe("/api/public/scores API Endpoint", () => {
             );
           }
         });
+
+        // Regression tests for #8630: the value operator must not override
+        // the fixed >= / < operators of the fromTimestamp/toTimestamp filters.
+        describe("operator combined with timestamp window", () => {
+          const fromTimestamp = new Date(
+            Date.now() - 24 * 60 * 60 * 1000,
+          ).toISOString();
+          const toTimestamp = new Date(
+            Date.now() + 24 * 60 * 60 * 1000,
+          ).toISOString();
+          const timestampWindow = `fromTimestamp=${fromTimestamp}&toTimestamp=${toTimestamp}`;
+
+          it("test operator > with timestamp window", async () => {
+            const getScore = await makeZodVerifiedAPICall(
+              GetScoresResponseV1,
+              "GET",
+              `/api/public/scores?${queryUserName}&operator=>&value=100&${timestampWindow}`,
+              undefined,
+              authentication,
+            );
+            expect(getScore.status).toBe(200);
+            expect(getScore.body.meta).toMatchObject({
+              page: 1,
+              limit: 50,
+              totalItems: 1,
+              totalPages: 1,
+            });
+            expect(getScore.body.data).toMatchObject([
+              {
+                id: scoreId_3,
+                name: scoreName,
+                value: 100.8,
+              },
+            ]);
+          });
+
+          it("test operator < with timestamp window", async () => {
+            const getScore = await makeZodVerifiedAPICall(
+              GetScoresResponseV1,
+              "GET",
+              `/api/public/scores?${queryUserName}&operator=<&value=50&${timestampWindow}`,
+              undefined,
+              authentication,
+            );
+            expect(getScore.status).toBe(200);
+            expect(getScore.body.meta).toMatchObject({
+              page: 1,
+              limit: 50,
+              totalItems: 1,
+              totalPages: 1,
+            });
+            expect(getScore.body.data).toMatchObject([
+              {
+                id: scoreId_1,
+                name: scoreName,
+                value: 10.5,
+              },
+            ]);
+          });
+        });
       });
 
       it("should filter scores by score IDs", async () => {

--- a/web/src/__tests__/server/scores-api-v2.servertest.ts
+++ b/web/src/__tests__/server/scores-api-v2.servertest.ts
@@ -1164,6 +1164,66 @@ describe("/api/public/v2/scores API Endpoint", () => {
             );
           }
         });
+
+        // Regression tests for #8630: the value operator must not override
+        // the fixed >= / < operators of the fromTimestamp/toTimestamp filters.
+        describe("operator combined with timestamp window", () => {
+          const fromTimestamp = new Date(
+            Date.now() - 24 * 60 * 60 * 1000,
+          ).toISOString();
+          const toTimestamp = new Date(
+            Date.now() + 24 * 60 * 60 * 1000,
+          ).toISOString();
+          const timestampWindow = `fromTimestamp=${fromTimestamp}&toTimestamp=${toTimestamp}`;
+
+          it("test operator > with timestamp window", async () => {
+            const getScore = await makeZodVerifiedAPICall(
+              GetScoresResponseV2,
+              "GET",
+              `/api/public/v2/scores?${queryUserName}&operator=>&value=100&${timestampWindow}`,
+              undefined,
+              authentication,
+            );
+            expect(getScore.status).toBe(200);
+            expect(getScore.body.meta).toMatchObject({
+              page: 1,
+              limit: 50,
+              totalItems: 1,
+              totalPages: 1,
+            });
+            expect(getScore.body.data).toMatchObject([
+              {
+                id: scoreId_3,
+                name: scoreName,
+                value: 100.8,
+              },
+            ]);
+          });
+
+          it("test operator < with timestamp window", async () => {
+            const getScore = await makeZodVerifiedAPICall(
+              GetScoresResponseV2,
+              "GET",
+              `/api/public/v2/scores?${queryUserName}&operator=<&value=50&${timestampWindow}`,
+              undefined,
+              authentication,
+            );
+            expect(getScore.status).toBe(200);
+            expect(getScore.body.meta).toMatchObject({
+              page: 1,
+              limit: 50,
+              totalItems: 1,
+              totalPages: 1,
+            });
+            expect(getScore.body.data).toMatchObject([
+              {
+                id: scoreId_1,
+                name: scoreName,
+                value: 10.5,
+              },
+            ]);
+          });
+        });
       });
 
       describe("should validate pagination", () => {


### PR DESCRIPTION
## What does this PR do?

The `operator` query param on `GET /api/public/scores` and `GET /api/public/v2/scores` is documented to apply to the `value` filter, but it also overrode the fixed operators of the `fromTimestamp` (`>=`) and `toTimestamp` (`<`) filters in `convertApiProvidedFilterToClickhouseFilter`.

As a result, `operator=>` flipped the `toTimestamp` filter to `timestamp > toTimestamp`, returning zero results for any window ending at "now"; `operator=<` flipped `fromTimestamp` to `timestamp < fromTimestamp`, silently returning scores from before the requested window.

This PR makes `DateTimeFilter` columns always use the operator from their column mapping. Every `DateTimeFilter` mapping in the codebase defines a fixed operator, and the scores v1/v2 endpoints are the only ones that accept a request-level `operator` param, so no other behavior changes.

Regression tests combine `operator` + `value` with a `fromTimestamp`/`toTimestamp` window on both the v1 and v2 scores endpoints; they fail with `totalItems: 0` before the fix and pass after.

Fixes #8630

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked that my changes generate no new warnings (`npm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the user-supplied `operator` query parameter (intended for numeric score value filtering) was incorrectly leaking into the `DateTimeFilter` path and overriding the fixed `>=`/`<` operators on `fromTimestamp`/`toTimestamp` columns. The one-line fix in `convertApiProvidedFilterToClickhouseFilter` always uses `columnMapping.operator` for datetime columns, ignoring `filter.operator` entirely.

- **Core fix** (`public-api-filter-builder.ts`): removes the Zod-parse-then-fallback logic for the `DateTimeFilter` case and reads directly from `columnMapping.operator`, which is always set to a fixed value (`>=` or `<`) for every datetime column definition in the codebase.
- **Regression tests** (v1 and v2 scores API): two new `describe` blocks verify that combining `operator=>` or `operator=<` with a timestamp window returns the correct records filtered by value only, without disturbing the timestamp bounds.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is a one-line deletion that removes incorrect user-operator bleed-through into fixed datetime column filters, and all datetime column definitions in the codebase carry explicit operators so no silent-skip regressions are possible.

The fix is minimal and surgically targeted: one line replaces a Zod parse-then-fallback with a direct read of the already-fixed column operator. The existing test suite's operator-only tests still pass (NumberFilter path is untouched), and two new regression tests for both API versions directly cover the broken scenario. No other filter paths are affected.

No files require special attention. All three changed files are straightforward and well-scoped.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["API Request\n?operator=>&value=100\n&fromTimestamp=T1&toTimestamp=T2"] --> B["convertApiProvidedFilterToClickhouseFilter"]

    B --> C{columnMapping.filterType?}

    C -- "NumberFilter\n(score value)" --> D["Use filter.operator\n(user-supplied '>')"]
    D --> E["NumberFilter: score_value > 100 ✓"]

    C -- "DateTimeFilter\n(fromTimestamp)" --> F["BEFORE: parse filter.operator\nif valid, use it (BUG: leaked in)"]
    F -- "buggy path" --> G["DateTimeFilter: timestamp > T1 ✗\n(should be >=)"]

    C -- "DateTimeFilter\n(fromTimestamp)" --> H["AFTER (this PR):\nuse columnMapping.operator directly"]
    H --> I["DateTimeFilter: timestamp >= T1 ✓"]

    C -- "DateTimeFilter\n(toTimestamp)" --> J["DateTimeFilter: timestamp < T2 ✓\n(always fixed, same logic)"]

    E & I & J --> K["FilterList → Clickhouse Query"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): don&#39;t let scores value operato..."](https://github.com/langfuse/langfuse/commit/6c593455ca75d2ece3698504997c8b6dc4287cee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37205394)</sub>

<!-- /greptile_comment -->