### PR TITLE
fix(worker): resolve app default export under tsx ESM interop

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -9,10 +9,12 @@ export let server: Server | undefined;
 const startWorker = async (): Promise<void> => {
   await initializeWorker();
 
-  // worker is CommonJS under NodeNext, so dynamic import wraps the module namespace in default.
-  const {
-    default: { default: app },
-  } = await import("./app.js");
+  type AppDefault = typeof import("./app.js").default;
+  const mod = (await import("./app.js")) as unknown as {
+    default: AppDefault | { default: AppDefault };
+  };
+  const app: AppDefault =
+    typeof mod.default === "function" ? mod.default : mod.default.default;
 
   server = app.listen(env.PORT, env.HOSTNAME, () => {
     logger.info(`Listening: http://${env.HOSTNAME}:${env.PORT}`);
@@ -22,6 +24,7 @@ const startWorker = async (): Promise<void> => {
 startWorker().catch((error) => {
   logger.error("Failed to start worker", {
     error: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
   });
   process.exit(1);
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a startup crash in the worker caused by a mismatch in how `app.js`'s default export is unwrapped when the process is run under tsx ESM interop (as opposed to the original CommonJS/NodeNext assumption). It also adds the error stack trace to the startup-failure log message.

- **ESM interop unwrapping**: The import of `./app.js` now detects whether the resolved `mod.default` carries a nested `.default` (the CJS-wrapped case) or is itself the Express app (the ESM/tsx case), choosing the correct value via a runtime `"default" in` check.
- **Error logging improvement**: `stack` is now included in the startup-error log object, giving better diagnostics when `startWorker` throws.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is a targeted startup-path fix that handles both CJS and ESM module shapes and adds helpful stack trace logging.

The interop detection logic is correct for both expected shapes. The only concern is that the ?? mod.default fallback in the CJS branch could substitute a namespace object for the Express app if the nested default is unexpectedly absent, turning a clear misconfiguration into a cryptic listen is not a function error at startup. This is a minor diagnostic hazard, not a correctness failure under the expected build configurations.

worker/src/index.ts — specifically the fallback inside the CJS interop branch.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[startWorker] --> B[initializeWorker]
    B --> C[import app.js]
    C --> D{mod.default has nested default?}
    D -- Yes CJS interop --> E[use mod.default.default or mod.default]
    D -- No ESM/tsx direct --> F[use mod.default]
    E --> G[app = Express Application]
    F --> G
    G --> H[app.listen on PORT and HOSTNAME]
    H --> I[Server running]
    A -- throws --> J[logger.error with message and stack]
    J --> K[process.exit 1]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/index.ts:17-20
The `?? mod.default` fallback in the truthy branch silently swaps in the namespace object itself as the app when `mod.default.default` is nullish. If the CJS shape is ever malformed (e.g. a build misconfiguration leaves the nested `default` as `undefined`), the call to `app.listen()` will fail with a confusing `TypeError: app.listen is not a function` instead of a clear "module export not found" message. Letting it throw immediately is more debuggable.

```suggestion
  const app =
    "default" in mod.default
      ? mod.default.default ?? (() => { throw new Error("app.js default export has a 'default' key but its value is nullish — check the build output"); })()
      : mod.default;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): resolve app default export ..."](https://github.com/langfuse/langfuse/commit/3df2d9a6b0f9f3299fc25bb91dad5315e1fb002b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37218427)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->