### PR TITLE
feat(session): add root observation filter to session detail

### DIFF
--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -646,12 +646,9 @@ export const SessionEventsPage: React.FC<{
         ...observationEventsFilterConfig.columnDefinitions,
         positionInTraceColumn,
       ],
-      migrateFilterState: undefined,
       facets: observationEventsFilterConfig.facets.filter(
         (facet) =>
-          facet.column !== "sessionId" &&
-          facet.column !== "isRootObservation" &&
-          facet.column !== "environment",
+          facet.column !== "sessionId" && facet.column !== "environment",
       ),
     };
   }, [positionInTraceColumn, sessionEventsTableName]);
@@ -706,7 +703,6 @@ export const SessionEventsPage: React.FC<{
         (column) =>
           column.id !== "sessionId" &&
           column.id !== "hasParentObservation" &&
-          column.id !== "isRootObservation" &&
           column.id !== "environment" &&
           column.id !== "traceId" &&
           column.id !== "traceName" &&
@@ -814,8 +810,6 @@ export const SessionEventsPage: React.FC<{
           filter.column !== "sessionId" &&
           filter.column !== "Has Parent Observation" &&
           filter.column !== "hasParentObservation" &&
-          filter.column !== "Is Root Observation" &&
-          filter.column !== "isRootObservation" &&
           filter.column !== "environment" &&
           filter.column !== "traceId" &&
           filter.column !== "traceName" &&


### PR DESCRIPTION
## What changed
- Exposes the existing `Is Root Observation` events facet in the events-backed session detail filter builder.
- Keeps legacy `Has Parent Observation` hidden while allowing the canonical root-observation filter to render and pass through to the per-trace observation query.

## Why
Tracing already treats root observations as either top-level spans or SDK-marked app roots. Session detail was still hiding that canonical facet, so users could not apply the same root/app-root observation filter inside a session.

## Impacted packages
- `web`

## Verification
- `pnpm --filter @langfuse/shared run db:generate`
- `pnpm --filter @langfuse/shared run build`
- `pnpm --filter @repo/eslint-plugin run build`
- `pnpm --filter web run test-client src/features/filters/filter-integration.clienttest.ts`
- `pnpm --filter web run typecheck`
- `pnpm --filter web run lint`
- Browser review: seeded a v4 long session, opened the session detail page on the patched worktree at `localhost:3001`, enabled Fast Preview, confirmed `Is Root Observation` is available in the session-detail filter column picker, applied `Is Root Observation = true`, and confirmed the URL/filter count updated with `isRootObservation` and the query used the app-root-aware predicate.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes the existing `isRootObservation` filter facet inside the session-detail filter builder by removing it from three exclusion lists (facets, column picker, and visible filter badge). It also removes the explicit `migrateFilterState: undefined` override in `sessionEventsFilterConfig`, allowing the base `migrateLegacyRootObservationFilters` function to be inherited and run automatically for URL/sessionStorage filter state.

- `isRootObservation` is now selectable in the session-detail `PopoverFilterBuilder`, updates the filter-count badge, and passes through to the per-trace observation query.
- Removing `migrateFilterState: undefined` unblocks migration of legacy `hasParentObservation` URL/sessionStorage filters to the app-root-aware `isRootObservation` predicate; the `useTableViewManager` validation context does not yet receive the migration function, so saved-view presets with that legacy filter still bypass migration (pre-existing gap, but now more noticeable).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is narrow and browser-verified. The only gap is that saved-view presets carrying a legacy hasParentObservation filter will not be automatically upgraded to the app-root-aware predicate.

The three exclusion-list removals are clean and symmetrical. Removing the explicit migrateFilterState: undefined override is correct and needed, and the migration function works for the URL/sessionStorage path. The only finding is that useTableViewManager.validationContext does not receive migrateFilterState, creating an inconsistency with how EventsTable handles the same migration — but this is a pre-existing gap that this PR did not introduce.

web/src/components/session/index.tsx — the useTableViewManager call's validationContext is missing migrateFilterState.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Session Detail] --> B[sessionEventsFilterConfig built from observationEventsFilterConfig spread]
    B --> C{Filter source?}
    C -->|URL / sessionStorage| D[useSidebarFilterState reads config.migrateFilterState]
    C -->|Saved View Preset| E[useTableViewManager validationContext has no migrateFilterState]
    D --> F[migrateLegacyRootObservationFilters runs: hasParentObservation to isRootObservation]
    E --> G[validateFilters runs without migration: hasParentObservation passes through as-is]
    F --> H[filterColumns includes isRootObservation]
    G --> H
    H --> I[PopoverFilterBuilder shows Is Root Observation facet]
    I --> J[visibleFilterState shows isRootObservation in filter badge count]
    J --> K[Per-trace observation query receives isRootObservation filter]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/session/index.tsx:847-853
The `useTableViewManager` call here does not forward `migrateFilterState` to its `validationContext`, so users who load a saved-view preset that was saved with a legacy `hasParentObservation` boolean filter will see it applied as-is (raw `hasParentObservation` SQL) instead of being upgraded to the app-root-aware `isRootObservation` predicate. `EventsTable.tsx` correctly passes `eventsFilterConfig.migrateFilterState` in the same position — the session detail should match that pattern now that the migration function is active in `sessionEventsFilterConfig`.

```suggestion
    validationContext: {
      columns: [],
      filterColumnDefinition: sessionEventsFilterConfig.columnDefinitions,
      expandableFilterColumns: sessionEventsFilterConfig.facets.map(
        (facet) => facet.column,
      ),
      migrateFilterState: sessionEventsFilterConfig.migrateFilterState,
    },
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/session-d..."](https://github.com/langfuse/langfuse/commit/dcc3744b531f2c022042a4c1f9de6ec27d146004) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37223712)</sub>

<!-- /greptile_comment -->