### PR TITLE
docs(agents): record that is_deleted is unused on tracing tables (LFE-10208)

### DIFF
--- a/.agents/skills/clickhouse-best-practices/SKILL.md
+++ b/.agents/skills/clickhouse-best-practices/SKILL.md
@@ -32,6 +32,15 @@ Comprehensive guidance for ClickHouse covering schema design, query optimization
   you first confirm the query builder cannot express the query.
 - Never use `FINAL` on the `events` table; it is designed so `FINAL` is not
   required and the keyword hurts performance.
+- The `is_deleted` column on the tracing tables (`traces`, `observations`,
+  `scores`, `events`) is declared in the `ReplacingMergeTree` engine but never
+  set to `1`: ingestion always writes `is_deleted: 0`, and deletion goes
+  through lightweight `DELETE FROM` mutations, not delete-marker rows. Do not
+  add `is_deleted` filters to queries on these tables for correctness, and do
+  not expect delete-marker semantics when reasoning about dedup or `FINAL`
+  behavior. (The `events` query builder emits a defensive `is_deleted = 0`;
+  keep it.) The only table that really uses `is_deleted = 1` marker rows is
+  `blob_storage_file_log` (see `worker/src/features/batch-project-blob-cleaner`).
 - Any migration in `packages/shared/clickhouse/migrations/clustered/**` with
   more than one `ALTER` on the same table must end every metadata `ALTER`
   (`ADD/DROP/MODIFY COLUMN`, `ADD/DROP INDEX`) with `SETTINGS alter_sync = 2`,


### PR DESCRIPTION
## What does this PR do?

Records in the agentic docs (`clickhouse-best-practices` skill, Langfuse-specific rules) that the `is_deleted` column on the ClickHouse tracing tables (`traces`, `observations`, `scores`, `events`) is never written as `1`: ingestion always writes `is_deleted: 0` and deletion goes through lightweight `DELETE FROM` mutations, not delete-marker rows. Agents reviewing or writing queries against these tables should not add `is_deleted` filters for correctness or assume delete-marker semantics. The only table that actually uses `is_deleted = 1` marker rows is `blob_storage_file_log`.

Surfaced while investigating the scores API v3 query ORDER BY alignment.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] I have checked if my PR needs changes to the documentation

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a note to the ClickHouse best practices skill file documenting that the `is_deleted` column on tracing tables (`traces`, `observations`, `scores`, `events`) is always written as `0` during ingestion, and that row deletion uses lightweight `DELETE FROM` mutations rather than delete-marker rows — meaning `is_deleted = 1` filter logic has no effect on these tables.

- Documents that `blob_storage_file_log` is the only table that genuinely uses `is_deleted = 1` markers (verified in `worker/src/features/batch-project-blob-cleaner`).
- Notes that the `EventsQueryBuilder`'s existing `is_deleted = 0` filters are defensive/legacy and should be kept as-is.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a documentation-only change with no executable code modified; it is safe to merge.

The added note accurately reflects the codebase: ingestion always writes is_deleted: 0 (confirmed in IngestionService), deletion uses DELETE FROM mutations (confirmed in the traces repository), blob_storage_file_log is the only table using is_deleted = 1 markers (confirmed in batch-project-blob-cleaner), and the EventsQueryBuilder's defensive is_deleted = 0 filters are present and correctly flagged as keep. No code is changed, only developer guidance is added.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): record that is\_deleted is ..."](https://github.com/langfuse/langfuse/commit/e16c639c4088aa91ea869222550a31fa6e5bb274) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37228225)</sub>

<!-- /greptile_comment -->