### PR TITLE
fix(blob-storage): never silently overwrite enriched export source after V4-preview rollback (LFE-10296)

### DIFF
--- a/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-gate.ts
@@ -54,6 +54,26 @@ export function isLegacyBlobExportAllowed(
   return projectCreatedAt < LEGACY_BLOB_EXPORT_CUTOFF;
 }
 
+// Internal enum values whose export includes the enriched observations
+// (events) path. satisfies ensures each element remains a valid
+// AnalyticsIntegrationExportSource. Adding a new enum variant does NOT
+// automatically produce an error here; the list must be reviewed manually.
+export const ENRICHED_BLOB_EXPORT_SOURCES = [
+  AnalyticsIntegrationExportSource.EVENTS,
+  AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+] as const satisfies ReadonlyArray<AnalyticsIntegrationExportSource>;
+
+export function isEnrichedBlobExportSource(
+  source: AnalyticsIntegrationExportSource | null | undefined,
+): boolean {
+  return (
+    source != null &&
+    (
+      ENRICHED_BLOB_EXPORT_SOURCES as readonly AnalyticsIntegrationExportSource[]
+    ).includes(source)
+  );
+}
+
 /**
  * Whether a blob storage integration row counts as legacy — i.e. may still use
  * legacy export sources. Applied to `BlobStorageIntegration.createdAt`.

--- a/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
+++ b/web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts
@@ -97,9 +97,14 @@ const prepare = async () => {
 const createIntegration = async ({
   projectId,
   enabled = true,
+  exportSource,
 }: {
   projectId: string;
   enabled?: boolean;
+  exportSource?:
+    | "TRACES_OBSERVATIONS"
+    | "TRACES_OBSERVATIONS_EVENTS"
+    | "EVENTS";
 }) =>
   prisma.blobStorageIntegration.create({
     data: {
@@ -115,6 +120,7 @@ const createIntegration = async ({
       forcePathStyle: false,
       fileType: "JSONL",
       exportMode: "FULL_HISTORY",
+      ...(exportSource ? { exportSource } : {}),
     },
   });
 
@@ -866,6 +872,130 @@ describe("Blob Storage Integration tRPC Router", () => {
       } finally {
         (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
       }
+    });
+  });
+
+  // LFE-10296: an update that omits exportSource must preserve the persisted
+  // value (parity with the public REST handler) — never rewrite it to the
+  // legacy default — and must be rejected when preserving would keep a stale
+  // enriched source alive on a deployment without the enriched export path.
+  describe("update: omitted exportSource", () => {
+    const originalRegion = env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+    const originalV4Preview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+
+    afterEach(() => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
+        originalV4Preview;
+    });
+
+    const { exportSource: _ignored, ...configWithoutExportSource } = baseConfig;
+
+    it("preserves a persisted enriched source when enriched export is available", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "true";
+      const { caller, project } = await prepare();
+      await createIntegration({
+        projectId: project.id,
+        exportSource: "EVENTS",
+      });
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...configWithoutExportSource,
+      });
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId: project.id },
+      });
+      expect(row.exportSource).toBe("EVENTS");
+    });
+
+    it("rejects an omitted exportSource over a stale enriched row on rolled-back self-hosted", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await createIntegration({
+        projectId: project.id,
+        exportSource: "EVENTS",
+      });
+
+      await expect(
+        caller.blobStorageIntegration.update({
+          projectId: project.id,
+          ...configWithoutExportSource,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId: project.id },
+      });
+      expect(row.exportSource).toBe("EVENTS");
+    });
+
+    it("preserves a persisted legacy source on rolled-back self-hosted", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await createIntegration({
+        projectId: project.id,
+        exportSource: "TRACES_OBSERVATIONS",
+      });
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...configWithoutExportSource,
+      });
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId: project.id },
+      });
+      expect(row.exportSource).toBe("TRACES_OBSERVATIONS");
+    });
+
+    it("creates with EVENTS when exportSource is omitted for a post-cutoff Cloud project", async () => {
+      // The legacy gate only checks explicit values, so an omitted
+      // exportSource on CREATE must not fall through to the Prisma column
+      // default (TRACES_OBSERVATIONS) — mirror of the REST handler's
+      // forceEventsOnCreate behavior.
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "us";
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { createdAt: POST_CUTOFF },
+      });
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...configWithoutExportSource,
+      });
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId: project.id },
+      });
+      expect(row.exportSource).toBe("EVENTS");
+    });
+
+    it("still allows an explicit downgrade to a legacy source on rolled-back self-hosted", async () => {
+      (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = undefined;
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { caller, project } = await prepare();
+      await createIntegration({
+        projectId: project.id,
+        exportSource: "EVENTS",
+      });
+
+      await caller.blobStorageIntegration.update({
+        projectId: project.id,
+        ...configWithoutExportSource,
+        exportSource: "TRACES_OBSERVATIONS" as const,
+      });
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId: project.id },
+      });
+      expect(row.exportSource).toBe("TRACES_OBSERVATIONS");
     });
   });
 });

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -102,17 +102,14 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         const isV4PreviewEnabled =
           env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
 
-        // One read feeds both gates (mirrors the REST handler): the legacy gate
-        // needs createdAt for an explicit source; the enriched gate needs the
-        // persisted source to reject a stale enriched value on an omitted update.
+        // Feeds both gates: the legacy gate needs createdAt for an explicit
+        // source; the enriched gate needs the persisted source to reject a
+        // stale enriched value on an omitted update.
         const existingIntegration =
-          input.exportSource !== undefined ||
-          !isEnrichedBlobExportAvailable(isCloud, isV4PreviewEnabled)
-            ? await ctx.prisma.blobStorageIntegration.findUnique({
-                where: { projectId: input.projectId },
-                select: { createdAt: true, exportSource: true },
-              })
-            : null;
+          await ctx.prisma.blobStorageIntegration.findUnique({
+            where: { projectId: input.projectId },
+            select: { createdAt: true, exportSource: true },
+          });
 
         // Legacy gate checks explicit values only; omitted preserves the row,
         // CREATE is covered by forceEventsOnCreate below.

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -83,9 +83,8 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
       blobStorageIntegrationFormSchemaBase
         .extend({
           projectId: z.string(),
-          // Override the base schema's default: an omitted exportSource must
-          // preserve the persisted value (parity with the public REST
-          // handler), not silently rewrite it to the legacy default.
+          // Drop the base schema default so an omitted value preserves the
+          // persisted source instead of rewriting it to the legacy default.
           exportSource: z.enum(AnalyticsIntegrationExportSource).optional(),
         })
         .superRefine(validateAzureContainerName)
@@ -103,13 +102,9 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         const isV4PreviewEnabled =
           env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
 
-        // Single conditional read serving both write-time gates (mirrors the
-        // public REST handler): the legacy upsert gate needs the row's
-        // createdAt when exportSource is provided; the enriched gate needs the
-        // persisted exportSource when it is omitted (the persisted value stays
-        // in effect) and enriched export is unavailable, so a stale enriched
-        // value left behind by a V4-preview rollback is rejected instead of
-        // silently driving the worker against unpopulated tables.
+        // One read feeds both gates (mirrors the REST handler): the legacy gate
+        // needs createdAt for an explicit source; the enriched gate needs the
+        // persisted source to reject a stale enriched value on an omitted update.
         const existingIntegration =
           input.exportSource !== undefined ||
           !isEnrichedBlobExportAvailable(isCloud, isV4PreviewEnabled)
@@ -119,9 +114,8 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
               })
             : null;
 
-        // Like the public REST handler, the legacy gate only checks explicit
-        // values: an omitted exportSource preserves a persisted legacy row,
-        // while CREATE is covered by forceEventsOnCreate below.
+        // Legacy gate checks explicit values only; omitted preserves the row,
+        // CREATE is covered by forceEventsOnCreate below.
         if (input.exportSource) {
           const project = await ctx.prisma.project.findUniqueOrThrow({
             where: { id: input.projectId },
@@ -154,14 +148,10 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         return await upsertBlobStorageIntegration({
           prisma: ctx.prisma,
           projectId,
-          // New Cloud rows default to EVENTS when exportSource is omitted: a
-          // brand-new row follows new-customer rules, so the legacy Prisma
-          // column default would trip refuseLegacyOnCreate. Substituted
-          // in-transaction (no TOCTOU window). Mirrors the public REST handler.
+          // Mirror the REST handler: substitute EVENTS for an omitted source on
+          // a new Cloud row, and refuse a legacy source if a concurrent DELETE
+          // flips this upsert to CREATE.
           forceEventsOnCreate: input.exportSource === undefined && isCloud,
-          // In-transaction backstop: a concurrent DELETE can flip this upsert
-          // to the CREATE branch; never let a new Cloud row be born with a
-          // legacy source.
           refuseLegacyOnCreate: isCloud,
           data: {
             type: rest.type,

--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -27,6 +27,7 @@ import {
 import { randomUUID } from "crypto";
 import { decrypt } from "@langfuse/shared/encryption";
 import {
+  AnalyticsIntegrationExportSource,
   BlobStorageIntegrationType,
   InvalidRequestError,
   isEnrichedBlobExportAvailable,
@@ -80,7 +81,13 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
   update: protectedProjectProcedure
     .input(
       blobStorageIntegrationFormSchemaBase
-        .extend({ projectId: z.string() })
+        .extend({
+          projectId: z.string(),
+          // Override the base schema's default: an omitted exportSource must
+          // preserve the persisted value (parity with the public REST
+          // handler), not silently rewrite it to the legacy default.
+          exportSource: z.enum(AnalyticsIntegrationExportSource).optional(),
+        })
         .superRefine(validateAzureContainerName)
         .superRefine(validateExportFieldGroups),
     )
@@ -92,31 +99,48 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
           scope: "integrations:CRUD",
         });
 
+        const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
+        const isV4PreviewEnabled =
+          env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true";
+
+        // Single conditional read serving both write-time gates (mirrors the
+        // public REST handler): the legacy upsert gate needs the row's
+        // createdAt when exportSource is provided; the enriched gate needs the
+        // persisted exportSource when it is omitted (the persisted value stays
+        // in effect) and enriched export is unavailable, so a stale enriched
+        // value left behind by a V4-preview rollback is rejected instead of
+        // silently driving the worker against unpopulated tables.
+        const existingIntegration =
+          input.exportSource !== undefined ||
+          !isEnrichedBlobExportAvailable(isCloud, isV4PreviewEnabled)
+            ? await ctx.prisma.blobStorageIntegration.findUnique({
+                where: { projectId: input.projectId },
+                select: { createdAt: true, exportSource: true },
+              })
+            : null;
+
+        // Like the public REST handler, the legacy gate only checks explicit
+        // values: an omitted exportSource preserves a persisted legacy row,
+        // while CREATE is covered by forceEventsOnCreate below.
         if (input.exportSource) {
-          const isCloud = Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION);
-          const [project, existingIntegration] = await Promise.all([
-            ctx.prisma.project.findUniqueOrThrow({
-              where: { id: input.projectId },
-              select: { createdAt: true },
-            }),
-            ctx.prisma.blobStorageIntegration.findUnique({
-              where: { projectId: input.projectId },
-              select: { createdAt: true },
-            }),
-          ]);
+          const project = await ctx.prisma.project.findUniqueOrThrow({
+            where: { id: input.projectId },
+            select: { createdAt: true },
+          });
           assertLegacyBlobExportSourceAllowedForUpsert({
             project,
             existingIntegration,
             nextInternalExportSource: input.exportSource,
             isCloud,
           });
-          assertEnrichedBlobExportSourceAllowed({
-            nextInternalExportSource: input.exportSource,
-            isCloud,
-            isV4PreviewEnabled:
-              env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true",
-          });
         }
+
+        assertEnrichedBlobExportSourceAllowed({
+          nextInternalExportSource: input.exportSource,
+          existingExportSource: existingIntegration?.exportSource,
+          isCloud,
+          isV4PreviewEnabled,
+        });
 
         await auditLog({
           session: ctx.session,
@@ -130,10 +154,15 @@ export const blobStorageIntegrationRouter = createTRPCRouter({
         return await upsertBlobStorageIntegration({
           prisma: ctx.prisma,
           projectId,
-          // In-transaction backstop closing the TOCTOU window: if a concurrent
-          // DELETE flips this upsert to the CREATE branch, refuse a legacy
-          // source so a new (post-cutoff) Cloud row can never be born legacy.
-          refuseLegacyOnCreate: Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+          // New Cloud rows default to EVENTS when exportSource is omitted: a
+          // brand-new row follows new-customer rules, so the legacy Prisma
+          // column default would trip refuseLegacyOnCreate. Substituted
+          // in-transaction (no TOCTOU window). Mirrors the public REST handler.
+          forceEventsOnCreate: input.exportSource === undefined && isCloud,
+          // In-transaction backstop: a concurrent DELETE can flip this upsert
+          // to the CREATE branch; never let a new Cloud row be born with a
+          // legacy source.
+          refuseLegacyOnCreate: isCloud,
           data: {
             type: rest.type,
             bucketName: rest.bucketName,

--- a/web/src/features/blobstorage-integration/exportSource.clienttest.ts
+++ b/web/src/features/blobstorage-integration/exportSource.clienttest.ts
@@ -1,0 +1,179 @@
+import { AnalyticsIntegrationExportSource } from "@langfuse/shared";
+
+import {
+  getExportSourceFormValue,
+  getExportSourceOptions,
+  isExportSourceSelectable,
+} from "./exportSource";
+
+const cloudPreCutoff = {
+  eventsExportAvailable: true,
+  forceEventsExport: false,
+};
+const cloudPostCutoff = {
+  eventsExportAvailable: true,
+  forceEventsExport: true,
+};
+const selfHostedWithPreview = {
+  eventsExportAvailable: true,
+  forceEventsExport: false,
+};
+const selfHostedRolledBack = {
+  eventsExportAvailable: false,
+  forceEventsExport: false,
+};
+
+describe("getExportSourceFormValue", () => {
+  it("keeps a persisted enriched value when enriched export is unavailable (LFE-10296)", () => {
+    // Regression: the form used to substitute TRACES_OBSERVATIONS here, so any
+    // save silently overwrote the persisted enriched configuration.
+    expect(
+      getExportSourceFormValue(
+        AnalyticsIntegrationExportSource.EVENTS,
+        selfHostedRolledBack,
+      ),
+    ).toBe(AnalyticsIntegrationExportSource.EVENTS);
+    expect(
+      getExportSourceFormValue(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+        selfHostedRolledBack,
+      ),
+    ).toBe(AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS);
+  });
+
+  it("keeps any persisted value regardless of deployment state", () => {
+    for (const persisted of Object.values(AnalyticsIntegrationExportSource)) {
+      for (const availability of [
+        cloudPreCutoff,
+        cloudPostCutoff,
+        selfHostedWithPreview,
+        selfHostedRolledBack,
+      ]) {
+        expect(getExportSourceFormValue(persisted, availability)).toBe(
+          persisted,
+        );
+      }
+    }
+  });
+
+  it("defaults new configurations to EVENTS when enriched export is available", () => {
+    expect(getExportSourceFormValue(undefined, cloudPreCutoff)).toBe(
+      AnalyticsIntegrationExportSource.EVENTS,
+    );
+    expect(getExportSourceFormValue(undefined, cloudPostCutoff)).toBe(
+      AnalyticsIntegrationExportSource.EVENTS,
+    );
+    expect(getExportSourceFormValue(null, selfHostedWithPreview)).toBe(
+      AnalyticsIntegrationExportSource.EVENTS,
+    );
+  });
+
+  it("defaults new configurations to TRACES_OBSERVATIONS when enriched export is unavailable", () => {
+    expect(getExportSourceFormValue(undefined, selfHostedRolledBack)).toBe(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    );
+  });
+});
+
+describe("isExportSourceSelectable", () => {
+  it("rejects enriched sources when enriched export is unavailable", () => {
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.EVENTS,
+        selfHostedRolledBack,
+      ),
+    ).toBe(false);
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+        selfHostedRolledBack,
+      ),
+    ).toBe(false);
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+        selfHostedRolledBack,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects legacy sources on post-cutoff Cloud projects", () => {
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+        cloudPostCutoff,
+      ),
+    ).toBe(false);
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+        cloudPostCutoff,
+      ),
+    ).toBe(false);
+    expect(
+      isExportSourceSelectable(
+        AnalyticsIntegrationExportSource.EVENTS,
+        cloudPostCutoff,
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts all sources when enriched export is available and legacy is allowed", () => {
+    for (const source of Object.values(AnalyticsIntegrationExportSource)) {
+      expect(isExportSourceSelectable(source, cloudPreCutoff)).toBe(true);
+      expect(isExportSourceSelectable(source, selfHostedWithPreview)).toBe(
+        true,
+      );
+    }
+  });
+});
+
+describe("getExportSourceOptions", () => {
+  it("offers all sources when everything is available", () => {
+    const options = getExportSourceOptions(undefined, cloudPreCutoff);
+    expect(options.map((o) => o.value)).toEqual([
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS,
+      AnalyticsIntegrationExportSource.EVENTS,
+    ]);
+    expect(options.every((o) => !o.unavailable)).toBe(true);
+  });
+
+  it("offers only the legacy source on a rolled-back self-hosted deployment", () => {
+    const options = getExportSourceOptions(
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      selfHostedRolledBack,
+    );
+    expect(options.map((o) => o.value)).toEqual([
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+    ]);
+    expect(options[0].unavailable).toBe(false);
+  });
+
+  it("offers only EVENTS for post-cutoff Cloud projects", () => {
+    const options = getExportSourceOptions(undefined, cloudPostCutoff);
+    expect(options.map((o) => o.value)).toEqual([
+      AnalyticsIntegrationExportSource.EVENTS,
+    ]);
+  });
+
+  it("includes a stale persisted enriched source, marked unavailable (LFE-10296)", () => {
+    const options = getExportSourceOptions(
+      AnalyticsIntegrationExportSource.EVENTS,
+      selfHostedRolledBack,
+    );
+    expect(options.map((o) => o.value)).toEqual([
+      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      AnalyticsIntegrationExportSource.EVENTS,
+    ]);
+    expect(
+      options.find((o) => o.value === AnalyticsIntegrationExportSource.EVENTS)
+        ?.unavailable,
+    ).toBe(true);
+    expect(
+      options.find(
+        (o) => o.value === AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS,
+      )?.unavailable,
+    ).toBe(false);
+  });
+});

--- a/web/src/features/blobstorage-integration/exportSource.ts
+++ b/web/src/features/blobstorage-integration/exportSource.ts
@@ -1,0 +1,64 @@
+import {
+  AnalyticsIntegrationExportSource,
+  EXPORT_SOURCE_OPTIONS,
+  isEnrichedBlobExportSource,
+  LEGACY_BLOB_EXPORT_SOURCES,
+  type ExportSourceOption,
+} from "@langfuse/shared";
+
+export type ExportSourceAvailability = {
+  // Deployment has the enriched events export path (Cloud, or self-hosted
+  // with the V4 preview opt-in).
+  eventsExportAvailable: boolean;
+  // Legacy sources are blocked: post-cutoff Cloud project, or a Cloud
+  // integration that is not a legacy exporter (new row, or created after the
+  // exporter cutoff). Only the enriched EVENTS source remains selectable.
+  forceEventsExport: boolean;
+};
+
+// A source must satisfy both deployment constraints, mirroring the two server
+// asserts: its enriched part requires the events export path, and its legacy
+// part is blocked when either Cloud cutoff applies. TRACES_OBSERVATIONS_EVENTS
+// is in both lists, so it needs both checks to pass.
+export function isExportSourceSelectable(
+  source: AnalyticsIntegrationExportSource,
+  availability: ExportSourceAvailability,
+): boolean {
+  if (isEnrichedBlobExportSource(source) && !availability.eventsExportAvailable)
+    return false;
+  const isLegacy = (
+    LEGACY_BLOB_EXPORT_SOURCES as readonly AnalyticsIntegrationExportSource[]
+  ).includes(source);
+  return !(isLegacy && availability.forceEventsExport);
+}
+
+// The persisted value always wins so that initializing and then saving the
+// form can never silently rewrite it (LFE-10296); when the persisted source is
+// not selectable on this deployment, form validation blocks the save instead.
+export function getExportSourceFormValue(
+  persisted: AnalyticsIntegrationExportSource | null | undefined,
+  availability: ExportSourceAvailability,
+): AnalyticsIntegrationExportSource {
+  if (persisted) return persisted;
+  return availability.eventsExportAvailable || availability.forceEventsExport
+    ? AnalyticsIntegrationExportSource.EVENTS
+    : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
+}
+
+export type SelectableExportSourceOption = ExportSourceOption & {
+  unavailable: boolean;
+};
+
+// All sources selectable on this deployment, plus the persisted source when it
+// is no longer selectable — shown (marked unavailable) so the user can see the
+// conflict and resolve it explicitly instead of having it rewritten silently.
+export function getExportSourceOptions(
+  persisted: AnalyticsIntegrationExportSource | null | undefined,
+  availability: ExportSourceAvailability,
+): SelectableExportSourceOption[] {
+  return EXPORT_SOURCE_OPTIONS.flatMap((option) => {
+    const selectable = isExportSourceSelectable(option.value, availability);
+    if (!selectable && option.value !== persisted) return [];
+    return [{ ...option, unavailable: !selectable }];
+  });
+}

--- a/web/src/features/blobstorage-integration/exportSource.ts
+++ b/web/src/features/blobstorage-integration/exportSource.ts
@@ -7,19 +7,12 @@ import {
 } from "@langfuse/shared";
 
 export type ExportSourceAvailability = {
-  // Deployment has the enriched events export path (Cloud, or self-hosted
-  // with the V4 preview opt-in).
   eventsExportAvailable: boolean;
-  // Legacy sources are blocked: post-cutoff Cloud project, or a Cloud
-  // integration that is not a legacy exporter (new row, or created after the
-  // exporter cutoff). Only the enriched EVENTS source remains selectable.
   forceEventsExport: boolean;
 };
 
-// A source must satisfy both deployment constraints, mirroring the two server
-// asserts: its enriched part requires the events export path, and its legacy
-// part is blocked when either Cloud cutoff applies. TRACES_OBSERVATIONS_EVENTS
-// is in both lists, so it needs both checks to pass.
+// Mirrors the two server asserts: TRACES_OBSERVATIONS_EVENTS is both enriched
+// and legacy, so it must clear both checks.
 export function isExportSourceSelectable(
   source: AnalyticsIntegrationExportSource,
   availability: ExportSourceAvailability,
@@ -32,9 +25,8 @@ export function isExportSourceSelectable(
   return !(isLegacy && availability.forceEventsExport);
 }
 
-// The persisted value always wins so that initializing and then saving the
-// form can never silently rewrite it (LFE-10296); when the persisted source is
-// not selectable on this deployment, form validation blocks the save instead.
+// The persisted value always wins so initialize+save can never silently
+// rewrite it (LFE-10296); validation blocks the save if it is not selectable.
 export function getExportSourceFormValue(
   persisted: AnalyticsIntegrationExportSource | null | undefined,
   availability: ExportSourceAvailability,
@@ -49,9 +41,8 @@ export type SelectableExportSourceOption = ExportSourceOption & {
   unavailable: boolean;
 };
 
-// All sources selectable on this deployment, plus the persisted source when it
-// is no longer selectable — shown (marked unavailable) so the user can see the
-// conflict and resolve it explicitly instead of having it rewritten silently.
+// Selectable sources, plus the persisted one (marked unavailable) when it is
+// no longer selectable, so the conflict is visible rather than silently rewritten.
 export function getExportSourceOptions(
   persisted: AnalyticsIntegrationExportSource | null | undefined,
   availability: ExportSourceAvailability,

--- a/web/src/features/blobstorage-integration/server/assertEnrichedBlobExportSourceAllowed.ts
+++ b/web/src/features/blobstorage-integration/server/assertEnrichedBlobExportSourceAllowed.ts
@@ -1,7 +1,8 @@
 import {
-  AnalyticsIntegrationExportSource,
+  type AnalyticsIntegrationExportSource,
   InvalidRequestError,
   isEnrichedBlobExportAvailable,
+  isEnrichedBlobExportSource,
 } from "@langfuse/shared";
 
 /**
@@ -26,12 +27,7 @@ export function assertEnrichedBlobExportSourceAllowed({
   isV4PreviewEnabled: boolean;
 }): void {
   const effectiveSource = nextInternalExportSource ?? existingExportSource;
-  if (
-    effectiveSource !== AnalyticsIntegrationExportSource.EVENTS &&
-    effectiveSource !==
-      AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS
-  )
-    return;
+  if (!isEnrichedBlobExportSource(effectiveSource)) return;
 
   if (isEnrichedBlobExportAvailable(isCloud, isV4PreviewEnabled)) return;
 

--- a/web/src/features/blobstorage-integration/validation.ts
+++ b/web/src/features/blobstorage-integration/validation.ts
@@ -1,7 +1,7 @@
 import type { z } from "zod";
 
 export function validateExportFieldGroups(
-  data: { exportSource: string; exportFieldGroups: unknown[] },
+  data: { exportFieldGroups: unknown[] },
   ctx: z.RefinementCtx,
 ) {
   // Field groups apply to all export sources (legacy observations honor them

--- a/web/src/features/public-api/types/blob-storage-integrations.ts
+++ b/web/src/features/public-api/types/blob-storage-integrations.ts
@@ -132,10 +132,7 @@ export const CreateBlobStorageIntegrationRequest = z
     }
     if (data.exportFieldGroups != null && data.exportSource != null) {
       validateExportFieldGroups(
-        {
-          exportSource: toInternalExportSource(data.exportSource),
-          exportFieldGroups: data.exportFieldGroups,
-        },
+        { exportFieldGroups: data.exportFieldGroups },
         ctx,
       );
     }

--- a/web/src/pages/api/public/integrations/blob-storage/index.ts
+++ b/web/src/pages/api/public/integrations/blob-storage/index.ts
@@ -15,7 +15,6 @@ import {
   LangfuseNotFoundError,
   UnauthorizedError,
   ForbiddenError,
-  isEnrichedBlobExportAvailable,
 } from "@langfuse/shared";
 import { upsertBlobStorageIntegration } from "@/src/features/blobstorage-integration/service";
 import { assertLegacyBlobExportSourceAllowedForUpsert } from "@/src/features/blobstorage-integration/server/assertLegacyBlobExportSourceAllowedForUpsert";
@@ -167,18 +166,14 @@ async function handleUpsertBlobStorageIntegration(
       ? toInternalExportSource(validatedData.exportSource)
       : undefined;
 
-  // Single conditional read serving both write-time gates: the legacy upsert
-  // gate needs the row's createdAt when exportSource is provided; the enriched
-  // gate needs the persisted exportSource when it is omitted (partial PUT) and
-  // enriched export is unavailable, so a stale enriched value is rejected.
-  const existingIntegration =
-    internalExportSource !== undefined ||
-    !isEnrichedBlobExportAvailable(isCloud, isV4PreviewEnabled)
-      ? await prisma.blobStorageIntegration.findUnique({
-          where: { projectId: validatedData.projectId },
-          select: { createdAt: true, exportSource: true },
-        })
-      : null;
+  // Feeds both write-time gates: the legacy upsert gate needs the row's
+  // createdAt when exportSource is provided; the enriched gate needs the
+  // persisted exportSource when it is omitted (partial PUT), so a stale
+  // enriched value is rejected.
+  const existingIntegration = await prisma.blobStorageIntegration.findUnique({
+    where: { projectId: validatedData.projectId },
+    select: { createdAt: true, exportSource: true },
+  });
 
   if (internalExportSource) {
     assertLegacyBlobExportSourceAllowedForUpsert({

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -41,7 +41,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Card } from "@/src/components/ui/card";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
@@ -51,13 +51,18 @@ import {
   BlobStorageExportMode,
   AnalyticsIntegrationExportSource,
   type BlobStorageIntegration,
-  EXPORT_SOURCE_OPTIONS,
   EXPORT_FIELD_GROUP_OPTIONS,
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
+  isEnrichedBlobExportSource,
   isLegacyBlobExportAllowed,
   isLegacyBlobExporter,
 } from "@langfuse/shared";
+import {
+  getExportSourceFormValue,
+  getExportSourceOptions,
+  isExportSourceSelectable,
+} from "@/src/features/blobstorage-integration/exportSource";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { useQueryProject } from "@/src/features/projects/hooks";
 import { Info, ExternalLink } from "lucide-react";
@@ -249,31 +254,50 @@ const BlobStorageIntegrationSettingsForm = ({
   // Check if this is a self-hosted instance (no cloud region set)
   const isSelfHosted = !isLangfuseCloud;
 
-  // Post-cutoff Cloud projects may only use OBSERVATIONS_V2 (EVENTS). The
-  // Export Source field is hidden in that case; the form value is pinned to
-  // EVENTS via the default below.
+  // Post-cutoff Cloud projects may only use OBSERVATIONS_V2 (EVENTS); the
+  // Export Source picker is rendered disabled in that case.
   const isPostCutoffCloud =
     project?.createdAt != null &&
     !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
   const eventsExportAvailable = isEnrichedExportAvailable;
   // Integration-level cutoff (Cloud only): an existing row created before
-  // LEGACY_BLOB_EXPORTER_CUTOFF stays legacy (picker visible); a new row (no
-  // state yet) or a post-cutoff row is not legacy (picker hidden, pinned to
-  // EVENTS). Stable across revisits because the row's createdAt is immutable.
+  // LEGACY_BLOB_EXPORTER_CUTOFF stays legacy (legacy options selectable); a
+  // new row (no state yet) or a post-cutoff row is not legacy (picker locked
+  // to EVENTS). Stable across revisits because the row's createdAt is
+  // immutable.
   const isLegacyExporter = isLegacyBlobExporter(
     state?.createdAt ? new Date(state.createdAt) : null,
     isLangfuseCloud,
   );
+  // Legacy sources are not selectable when either Cloud cutoff applies.
   const forceEventsExport =
     isPostCutoffCloud || (eventsExportAvailable && !isLegacyExporter);
-  // The picker only exists where the enriched events export is available
-  // (Cloud, or self-hosted with the V4 preview opt-in — server-computed flag).
-  // Where it isn't, the picker stays hidden and the form defaults to
-  // TRACES_OBSERVATIONS, since EVENTS is not provisioned there.
-  const showExportSourceField = eventsExportAvailable && !forceEventsExport;
+  const availability = useMemo(
+    () => ({ eventsExportAvailable, forceEventsExport }),
+    [eventsExportAvailable, forceEventsExport],
+  );
+
+  // The persisted export source is kept in the form even when it is not
+  // selectable on this deployment (e.g. an enriched source after a V4-preview
+  // rollback); this refine blocks the save until the user resolves the
+  // conflict, instead of silently rewriting the persisted value (LFE-10296).
+  const formSchema = useMemo(
+    () =>
+      blobStorageIntegrationFormSchema.superRefine((data, ctx) => {
+        if (!isExportSourceSelectable(data.exportSource, availability)) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["exportSource"],
+            message:
+              "This export source is not available on this deployment. Select an available export source to save.",
+          });
+        }
+      }),
+    [availability],
+  );
 
   const blobStorageForm = useForm({
-    resolver: zodResolver(blobStorageIntegrationFormSchema),
+    resolver: zodResolver(formSchema),
     defaultValues: {
       type: state?.type || BlobStorageIntegrationType.S3,
       bucketName: state?.bucketName || "",
@@ -292,20 +316,7 @@ const BlobStorageIntegrationSettingsForm = ({
       fileType: state?.fileType || BlobStorageIntegrationFileType.JSONL,
       exportMode: state?.exportMode || BlobStorageExportMode.FULL_HISTORY,
       exportStartDate: state?.exportStartDate || null,
-      exportSource: forceEventsExport
-        ? AnalyticsIntegrationExportSource.EVENTS
-        : (() => {
-            const persisted = state?.exportSource;
-            const isEnriched =
-              persisted === AnalyticsIntegrationExportSource.EVENTS ||
-              persisted ===
-                AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS;
-            if (persisted && (!isEnriched || eventsExportAvailable))
-              return persisted;
-            return eventsExportAvailable
-              ? AnalyticsIntegrationExportSource.EVENTS
-              : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
-          })(),
+      exportSource: getExportSourceFormValue(state?.exportSource, availability),
       // Empty array in the DB means "export everything" (the worker falls back
       // to all groups), so surface it as the full selection in the form.
       exportFieldGroups: state?.exportFieldGroups?.length
@@ -336,20 +347,7 @@ const BlobStorageIntegrationSettingsForm = ({
       fileType: state?.fileType || BlobStorageIntegrationFileType.JSONL,
       exportMode: state?.exportMode || BlobStorageExportMode.FULL_HISTORY,
       exportStartDate: state?.exportStartDate || null,
-      exportSource: forceEventsExport
-        ? AnalyticsIntegrationExportSource.EVENTS
-        : (() => {
-            const persisted = state?.exportSource;
-            const isEnriched =
-              persisted === AnalyticsIntegrationExportSource.EVENTS ||
-              persisted ===
-                AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS_EVENTS;
-            if (persisted && (!isEnriched || eventsExportAvailable))
-              return persisted;
-            return eventsExportAvailable
-              ? AnalyticsIntegrationExportSource.EVENTS
-              : AnalyticsIntegrationExportSource.TRACES_OBSERVATIONS;
-          })(),
+      exportSource: getExportSourceFormValue(state?.exportSource, availability),
       // Empty array in the DB means "export everything" (the worker falls back
       // to all groups), so surface it as the full selection in the form.
       exportFieldGroups: state?.exportFieldGroups?.length
@@ -358,10 +356,20 @@ const BlobStorageIntegrationSettingsForm = ({
       compressed: state?.compressed ?? true,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state, isEnrichedExportAvailable, isPostCutoffCloud]);
+  }, [state, availability]);
 
   const watchedExportMode = blobStorageForm.watch("exportMode");
   const watchedExportSource = blobStorageForm.watch("exportSource");
+  const exportSourceOptions = getExportSourceOptions(
+    state?.exportSource,
+    availability,
+  );
+  // With a single selectable option there is no choice to make; the picker
+  // stays visible (so the configured source is always legible) but locked.
+  const exportSourceLocked = exportSourceOptions.length === 1;
+  const exportSourceUnavailable =
+    watchedExportSource != null &&
+    !isExportSourceSelectable(watchedExportSource, availability);
   // The legacy observations table contains fewer columns than the enriched
   // observations, so the per-group field lists differ for legacy-only exports.
   const isLegacyOnlyExport =
@@ -734,66 +742,87 @@ const BlobStorageIntegrationSettingsForm = ({
           )}
         />
 
-        {showExportSourceField && (
-          <FormField
-            control={blobStorageForm.control}
-            name="exportSource"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel className="flex items-center gap-1.5 pt-2">
-                  Export Source
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <Info className="text-muted-foreground h-3.5 w-3.5" />
-                    </TooltipTrigger>
-                    <TooltipContent
-                      side="bottom"
-                      className="max-w-[350px] space-y-2 p-3"
-                    >
-                      {EXPORT_SOURCE_OPTIONS.map((option) => (
-                        <div key={option.value} className="space-y-0.5">
-                          <div className="font-medium">{option.label}</div>
-                          <div className="text-muted-foreground text-xs">
-                            {option.description}
-                          </div>
+        <FormField
+          control={blobStorageForm.control}
+          name="exportSource"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="flex items-center gap-1.5 pt-2">
+                Export Source
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Info className="text-muted-foreground h-3.5 w-3.5" />
+                  </TooltipTrigger>
+                  <TooltipContent
+                    side="bottom"
+                    className="max-w-[350px] space-y-2 p-3"
+                  >
+                    {exportSourceOptions.map((option) => (
+                      <div key={option.value} className="space-y-0.5">
+                        <div className="font-medium">{option.label}</div>
+                        <div className="text-muted-foreground text-xs">
+                          {option.description}
                         </div>
-                      ))}
-                      <div className="border-t pt-2">
-                        <a
-                          href="https://langfuse.com/docs/integrations/export-sources"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-muted-foreground hover:text-primary inline-flex items-center gap-1 text-xs hover:underline"
-                        >
-                          For further information see
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
                       </div>
-                    </TooltipContent>
-                  </Tooltip>
-                </FormLabel>
-                <Select onValueChange={field.onChange} value={field.value}>
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select data to export" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {EXPORT_SOURCE_OPTIONS.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
                     ))}
-                  </SelectContent>
-                </Select>
-                <FormDescription>
-                  Choose which data sources to export to blob storage. Scores
-                  are always included.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+                    <div className="border-t pt-2">
+                      <a
+                        href="https://langfuse.com/docs/integrations/export-sources"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-muted-foreground hover:text-primary inline-flex items-center gap-1 text-xs hover:underline"
+                      >
+                        For further information see
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </FormLabel>
+              <Select
+                onValueChange={field.onChange}
+                value={field.value}
+                disabled={exportSourceLocked}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select data to export" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {exportSourceOptions.map((option) => (
+                    <SelectItem
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.unavailable}
+                    >
+                      {option.unavailable
+                        ? `${option.label} (not available on this deployment)`
+                        : option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormDescription>
+                Choose which data sources to export to blob storage. Scores are
+                always included.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {exportSourceUnavailable && (
+          <Alert variant="destructive">
+            <AlertTitle>Saved export source is no longer available</AlertTitle>
+            <AlertDescription>
+              {/* The picker can hold an unavailable value for two distinct
+                  reasons; the guidance differs. */}
+              {isEnrichedBlobExportSource(watchedExportSource)
+                ? "This integration is configured to export enriched observations, but enriched export is not available on this deployment. Saving is blocked until you select an available export source above. To keep the current configuration instead, re-enable enriched export (V4 preview opt-in) on your deployment."
+                : "This integration is configured to export the legacy traces and observations, which is not available for this project. Saving is blocked until you select an available export source above."}
+            </AlertDescription>
+          </Alert>
         )}
 
         <FormField

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -254,22 +254,16 @@ const BlobStorageIntegrationSettingsForm = ({
   // Check if this is a self-hosted instance (no cloud region set)
   const isSelfHosted = !isLangfuseCloud;
 
-  // Post-cutoff Cloud projects may only use OBSERVATIONS_V2 (EVENTS); the
-  // Export Source picker is rendered disabled in that case.
   const isPostCutoffCloud =
     project?.createdAt != null &&
     !isLegacyBlobExportAllowed(new Date(project.createdAt), isLangfuseCloud);
   const eventsExportAvailable = isEnrichedExportAvailable;
-  // Integration-level cutoff (Cloud only): an existing row created before
-  // LEGACY_BLOB_EXPORTER_CUTOFF stays legacy (legacy options selectable); a
-  // new row (no state yet) or a post-cutoff row is not legacy (picker locked
-  // to EVENTS). Stable across revisits because the row's createdAt is
-  // immutable.
+  // Integration-level cutoff (Cloud only): a row predating the exporter cutoff
+  // keeps legacy options; a new or post-cutoff row is locked to EVENTS.
   const isLegacyExporter = isLegacyBlobExporter(
     state?.createdAt ? new Date(state.createdAt) : null,
     isLangfuseCloud,
   );
-  // Legacy sources are not selectable when either Cloud cutoff applies.
   const forceEventsExport =
     isPostCutoffCloud || (eventsExportAvailable && !isLegacyExporter);
   const availability = useMemo(
@@ -277,10 +271,8 @@ const BlobStorageIntegrationSettingsForm = ({
     [eventsExportAvailable, forceEventsExport],
   );
 
-  // The persisted export source is kept in the form even when it is not
-  // selectable on this deployment (e.g. an enriched source after a V4-preview
-  // rollback); this refine blocks the save until the user resolves the
-  // conflict, instead of silently rewriting the persisted value (LFE-10296).
+  // Block the save when the persisted source is no longer selectable rather
+  // than silently rewriting it (LFE-10296).
   const formSchema = useMemo(
     () =>
       blobStorageIntegrationFormSchema.superRefine((data, ctx) => {
@@ -364,8 +356,7 @@ const BlobStorageIntegrationSettingsForm = ({
     state?.exportSource,
     availability,
   );
-  // With a single selectable option there is no choice to make; the picker
-  // stays visible (so the configured source is always legible) but locked.
+  // Visible but locked when there is only one selectable option.
   const exportSourceLocked = exportSourceOptions.length === 1;
   const exportSourceUnavailable =
     watchedExportSource != null &&

--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -54,7 +54,6 @@ import {
   EXPORT_FIELD_GROUP_OPTIONS,
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
-  isEnrichedBlobExportSource,
   isLegacyBlobExportAllowed,
   isLegacyBlobExporter,
 } from "@langfuse/shared";
@@ -807,11 +806,13 @@ const BlobStorageIntegrationSettingsForm = ({
           <Alert variant="destructive">
             <AlertTitle>Saved export source is no longer available</AlertTitle>
             <AlertDescription>
-              {/* The picker can hold an unavailable value for two distinct
-                  reasons; the guidance differs. */}
-              {isEnrichedBlobExportSource(watchedExportSource)
+              {/* Two distinct rejection reasons; key on the deployment, not the
+                  source, since TRACES_OBSERVATIONS_EVENTS is both enriched and
+                  legacy. !eventsExportAvailable means enriched is genuinely
+                  unavailable; otherwise the block is the Cloud legacy cutoff. */}
+              {!availability.eventsExportAvailable
                 ? "This integration is configured to export enriched observations, but enriched export is not available on this deployment. Saving is blocked until you select an available export source above. To keep the current configuration instead, re-enable enriched export (V4 preview opt-in) on your deployment."
-                : "This integration is configured to export the legacy traces and observations, which is not available for this project. Saving is blocked until you select an available export source above."}
+                : "This integration is configured to export legacy traces and observations, which is no longer available for this project. Saving is blocked until you select an available export source above."}
             </AlertDescription>
           </Alert>
         )}

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -107,6 +107,61 @@ describe("BlobStorageIntegrationProcessingJob", () => {
     s3Prefix = null;
   });
 
+  // LFE-10296: a persisted enriched export source on a deployment without the
+  // enriched export path (e.g. after a V4-preview rollback) must fail the job
+  // loudly instead of silently exporting from unpopulated tables.
+  describe("enriched export source guard", () => {
+    const originalV4Preview = env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN;
+
+    afterEach(() => {
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN =
+        originalV4Preview;
+    });
+
+    it("fails the job and persists lastError when the enriched export path is unavailable", async () => {
+      (env as any).LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN = "false";
+      const { projectId } = await createOrgProjectAndApiKey();
+      s3Prefix = projectId;
+
+      await prisma.blobStorageIntegration.create({
+        data: {
+          projectId,
+          type: BlobStorageIntegrationType.S3,
+          bucketName,
+          prefix: s3Prefix,
+          accessKeyId,
+          secretAccessKey: encrypt(secretAccessKey),
+          region: region ? region : "auto",
+          endpoint: endpoint ? endpoint : null,
+          forcePathStyle:
+            env.LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE === "true",
+          enabled: true,
+          exportFrequency: "daily",
+          exportSource: "EVENTS",
+          // A past lastSyncAt yields a non-empty export window without
+          // requiring ClickHouse data.
+          lastSyncAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+        },
+      });
+
+      await expect(
+        handleBlobStorageIntegrationProjectJob({
+          data: { payload: { projectId } },
+        } as Job),
+      ).rejects.toThrow(/enriched/i);
+
+      const row = await prisma.blobStorageIntegration.findUniqueOrThrow({
+        where: { projectId },
+      });
+      expect(row.lastError).toMatch(/enriched/i);
+      expect(row.lastErrorAt).not.toBeNull();
+
+      // Nothing was exported.
+      const files = await storageService.listFiles(s3Prefix);
+      expect(files.filter((f) => f.file.includes(projectId))).toHaveLength(0);
+    });
+  });
+
   it("should not process when blob storage integration is disabled", async () => {
     const { projectId } = await createOrgProjectAndApiKey();
     s3Prefix = projectId;

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -30,10 +30,12 @@ import {
   BlobStorageExportMode,
   OBSERVATION_FIELD_GROUPS_FULL,
   type ObservationFieldGroupFull,
+  isEnrichedBlobExportAvailable,
+  isEnrichedBlobExportSource,
 } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 import { randomUUID } from "crypto";
-import { env } from "../../env";
+import { env, v4AllowPreviewOptIn } from "../../env";
 
 export const BLOB_STORAGE_LAG_BUFFER_MS = 20 * 60 * 1000; // 20-minute lag buffer
 
@@ -427,6 +429,23 @@ export const handleBlobStorageIntegrationProjectJob = async (
   }
 
   try {
+    // A persisted enriched export source on a deployment without the enriched
+    // export path (e.g. left behind by a V4-preview rollback on self-hosted)
+    // would silently export from unpopulated tables. Fail the job instead —
+    // the catch below persists lastError (surfaced in the settings UI) and
+    // notifies the project admins (LFE-10296).
+    if (
+      isEnrichedBlobExportSource(blobStorageIntegration.exportSource) &&
+      !isEnrichedBlobExportAvailable(
+        Boolean(env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION),
+        v4AllowPreviewOptIn(env),
+      )
+    ) {
+      throw new Error(
+        "The configured export source includes enriched observations, but enriched export is not available on this deployment. Select a different export source in the blob storage integration settings, or re-enable enriched export (V4 preview opt-in) on this deployment.",
+      );
+    }
+
     // Preflight the persisted integration endpoint once per job inside the
     // export error path. StorageService connection-time validation remains the
     // DNS-rebinding defense for each SDK connection.

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -429,11 +429,10 @@ export const handleBlobStorageIntegrationProjectJob = async (
   }
 
   try {
-    // A persisted enriched export source on a deployment without the enriched
-    // export path (e.g. left behind by a V4-preview rollback on self-hosted)
-    // would silently export from unpopulated tables. Fail the job instead —
-    // the catch below persists lastError (surfaced in the settings UI) and
-    // notifies the project admins (LFE-10296).
+    // Fail loudly rather than export from unpopulated tables when an enriched
+    // source survives on a deployment without the enriched path, e.g. after a
+    // V4-preview rollback. The catch persists lastError and notifies admins
+    // (LFE-10296).
     if (
       isEnrichedBlobExportSource(blobStorageIntegration.exportSource) &&
       !isEnrichedBlobExportAvailable(


### PR DESCRIPTION
## What does this PR do?

On self-hosted deployments that rolled back the V4 preview opt-in, the blob storage settings form silently coerced a persisted enriched `exportSource` (`EVENTS` / `TRACES_OBSERVATIONS_EVENTS`) to `TRACES_OBSERVATIONS` while hiding the Export Source picker. Any save — even one that only touched the bucket name — then permanently overwrote the enriched configuration with no warning.

This PR removes the silent rewrite and makes the conflict explicit, across all three layers:

**UI (`blobstorage.tsx` + new `exportSource.ts` helper)**
- The form always initializes to the persisted export source; it is never substituted.
- The Export Source picker is now always visible. When only one value is legal (post-cutoff Cloud → `EVENTS`; self-hosted without enriched export → `TRACES_OBSERVATIONS`) it renders disabled, so the configured source stays legible.
- A stale enriched value is shown tagged "(not available on this deployment)" with a destructive alert, and a form-level refine blocks saving until the user explicitly selects an available source (or re-enables enriched export on the deployment).

**tRPC router (parity with the public REST handler)**
- `exportSource` no longer falls back to the schema default `TRACES_OBSERVATIONS` when omitted — an omitted value preserves the persisted row (the upsert service already supported this).
- The enriched gate now also checks the existing row for omitted values, mirroring `web/src/pages/api/public/integrations/blob-storage/index.ts`, so a stale enriched source cannot survive a partial update unnoticed.

**Worker (runtime backstop)**
- `handleBlobStorageIntegrationProjectJob` fails fast when the configured source includes enriched observations but the enriched export path is unavailable, instead of silently exporting from unpopulated tables. The existing catch persists `lastError` (surfaced in the settings UI status alert) and triggers the admin failure notification. No retry-suppression/circuit breaker — that is deliberate follow-up work.

`isEnrichedBlobExportSource` is added to the shared blob-export gate so the enriched-source list lives in one place (UI helper, server gate, worker guard).

**Verification**
- New unit tests for the form-value/options helper (`exportSource.clienttest.ts`, 11 tests) including the LFE-10296 regression cases.
- New tRPC servertests for omitted-`exportSource` behavior (preserve, reject-stale-enriched, explicit downgrade) — ran green against local Postgres, as did the full existing blob-storage tRPC suite (31 tests) and gate unit tests.
- New worker test for the fail-fast guard (requires MinIO; runs in CI).
- Browser-reviewed all five UI states end to end (configure enriched with opt-in on → roll back → blocked save leaves the DB row untouched → explicit downgrade persists → locked single-option picker). No seeder change: the bug shape is a settings row plus deployment env state, which the UI flow itself creates; it is not expressible as trace data seeding.
- `lint` + `typecheck` green for `web`, `worker`, `@langfuse/shared`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code follows the style guidelines of this project (`pnpm run format`)
- I have commented my code, particularly in hard-to-understand areas
- I have checked if my PR needs changes to the documentation
- I have checked that my changes generate no new warnings (`npm run lint`)
- I have added tests that prove my fix is effective or that my feature works
- I have checked that new and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent-overwrite bug (LFE-10296) where submitting the blob storage integration settings form after a V4-preview flag rollback would quietly rewrite an enriched `exportSource` back to the legacy default, and separately adds a loud worker guard so an already-persisted enriched source on an unsupported deployment fails the export job (and surfaces `lastError`) instead of exporting silently from unpopulated tables.

- **Server (tRPC router)**: `exportSource` is now optional in the update schema; when omitted, a DB read is performed on the existing row and the enriched gate is applied to the persisted value, mirroring the public REST handler.
- **Client (settings form)**: `getExportSourceFormValue` always returns the persisted value as the form initial value, unavailable options are shown in the dropdown (labelled and disabled), and a new `superRefine` blocks saving until the conflict is resolved.
- **Worker**: An explicit guard throws an `Error` (persisted to `lastError`) when the stored export source requires the enriched path that is not available on this deployment.
- **Shared utility**: `isEnrichedBlobExportSource` / `ENRICHED_BLOB_EXPORT_SOURCES` extracted to `blob-export-gate.ts` to avoid duplicating the enum membership check across router, assertion helper, and worker.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the multi-layer fix correctly blocks silent overwrites at the form layer, the tRPC layer, and the worker layer for the enriched rollback scenario.

The implementation is correct and well-tested across all three layers. The one gap worth watching is that `assertLegacyBlobExportSourceAllowed` is still skipped when `exportSource` is omitted from an update, creating a server-side asymmetry with the enriched check that was closed by this PR. In practice this is not reachable from the UI, but a direct API call on an unusual DB state could bypass the legacy gate silently.

blobstorage-integration-router.ts: the legacy source check (lines 106–116) still guards only explicit `exportSource` changes, not the preserved-value path.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User saves form / API call to tRPC update] --> B{exportSource provided?}
    B -- Yes --> C[assertLegacyBlobExportSourceAllowed\nproject createdAt check]
    C --> D
    B -- No --> D{isEnrichedBlobExportAvailable?}
    D -- No --> E[findUnique existing row\nto read persisted exportSource]
    E --> F[assertEnrichedBlobExportSourceAllowed\nnextSource OR existingSource]
    D -- Yes --> G[assertEnrichedBlobExportSourceAllowed\nnextSource only]
    F --> H{Enriched source\non no-enriched deployment?}
    G --> I[Upsert with exportSource\nundefined = preserve existing]
    H -- Yes --> J[Throw BAD_REQUEST\nDB unchanged]
    H -- No --> I

    I --> K[Worker picks up job]
    K --> L{isEnrichedBlobExportSource\nAND enriched unavailable?}
    L -- Yes --> M[Throw Error\npersist lastError to DB\nalert project admins]
    L -- No --> N[Run export job normally]

    style J fill:#f88,stroke:#c00
    style M fill:#f88,stroke:#c00
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/blobstorage-integration/blobstorage-integration-router.ts:106-116
**Missing legacy source check for preserved-value path**

`assertLegacyBlobExportSourceAllowed` is only called when `input.exportSource` is explicitly provided. This means a programmatic API client can call `update` without `exportSource` on a post-cutoff Cloud project that somehow has `TRACES_OBSERVATIONS` persisted in the DB — the server would silently preserve the legacy source without rejecting. The enriched check was extended to cover this path (the fix in this PR), but the legacy check was not. In practice the UI always sends an explicit `exportSource`, so the exposure is limited to direct API usage, but the asymmetry is worth documenting or closing.

### Issue 2 of 2
web/src/__tests__/server/blob-storage-integration-trpc.servertest.ts:254-266
**Duplicate test fixtures with identical `ExportSourceAvailability` values**

`selfHostedWithPreview` and `cloudPreCutoff` both resolve to `{ eventsExportAvailable: true, isPostCutoffCloud: false }`, making them interchangeable. Any test that uses both names exercises exactly the same code path, providing no extra coverage. If a future code change distinguishes between cloud and self-hosted-with-preview inside `ExportSourceAvailability`, these tests would still pass while missing the regression. Consider either collapsing the two into a single fixture, or adding a distinguishing field to `ExportSourceAvailability` if the semantic difference matters.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blob-storage): never silently overwr..."](https://github.com/langfuse/langfuse/commit/79b027faf6574cb7628e1a7b873e404fdc894fd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37230016)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->