### PR TITLE
feat(experiments): increase experiment selection limit on compare view

### DIFF
--- a/web/src/features/experiments/components/table/ExperimentsTable.tsx
+++ b/web/src/features/experiments/components/table/ExperimentsTable.tsx
@@ -571,12 +571,12 @@ export default function ExperimentsTable({
     );
   }, [selectedExperimentIds, projectId, router]);
 
-  // Build table actions - Compare is disabled (not hidden) when >5 rows selected
+  // Build table actions - Compare is disabled (not hidden) when >10 rows selected
   const tableActions: TableAction[] = useMemo(() => {
     const actions: TableAction[] = [];
 
-    // Compare action: disabled when >5 experiments selected
-    const tooManySelected = selectedExperimentIds.length > 5;
+    // Compare action: disabled when >10 experiments selected
+    const tooManySelected = selectedExperimentIds.length > 10;
     actions.push({
       id: ActionId.ExperimentCompare,
       type: BatchActionType.Create,
@@ -586,7 +586,7 @@ export default function ExperimentsTable({
       customDialog: true,
       disabled: tooManySelected,
       disabledReason: tooManySelected
-        ? "Select only up to 5 experiments to compare"
+        ? "Select only up to 10 experiments to compare"
         : undefined,
       accessCheck: {
         scope: "project:read",

--- a/web/src/features/experiments/hooks/useExperimentResultsState.ts
+++ b/web/src/features/experiments/hooks/useExperimentResultsState.ts
@@ -5,7 +5,7 @@ import {
   StringParam,
 } from "use-query-params";
 
-const MAX_COMPARISONS = 4;
+const MAX_COMPARISONS = 9;
 
 export function useExperimentResultsState() {
   const [state, setState] = useQueryParams({

--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -374,7 +374,7 @@ export const experimentsRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        experimentIds: z.array(z.string()),
+        experimentIds: z.array(z.string()).max(10),
         filter: z.array(singleFilter).nullable(),
       }),
     )
@@ -498,7 +498,7 @@ export const experimentsRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         baseExperimentId: z.string().nullish(),
-        compExperimentIds: z.array(z.string()),
+        compExperimentIds: z.array(z.string()).max(9),
         filterByExperiment: z
           .array(
             z.object({
@@ -637,7 +637,7 @@ export const experimentsRouter = createTRPCRouter({
       z.object({
         projectId: z.string(),
         baseExperimentId: z.string().nullish(),
-        compExperimentIds: z.array(z.string()),
+        compExperimentIds: z.array(z.string()).max(9),
         filterByExperiment: z
           .array(
             z.object({
@@ -678,7 +678,7 @@ export const experimentsRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        experimentIds: z.array(z.string()).min(1),
+        experimentIds: z.array(z.string()).min(1).max(10),
       }),
     )
     .query(async ({ input, ctx }) => {
@@ -698,7 +698,7 @@ export const experimentsRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        experimentIds: z.array(z.string()).min(1),
+        experimentIds: z.array(z.string()).min(1).max(10),
       }),
     )
     .query(async ({ input, ctx }) => {
@@ -720,7 +720,7 @@ export const experimentsRouter = createTRPCRouter({
         projectId: z.string(),
         itemIds: z.array(z.string()),
         baseExperimentId: z.string().nullish(),
-        compExperimentIds: z.array(z.string()),
+        compExperimentIds: z.array(z.string()).max(9),
       }),
     )
     .query(async ({ input, ctx }) => {

--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -698,7 +698,7 @@ export const experimentsRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        experimentIds: z.array(z.string()).min(1).max(10),
+        experimentIds: z.array(z.string()).min(1),
       }),
     )
     .query(async ({ input, ctx }) => {

--- a/web/src/features/experiments/server/router.ts
+++ b/web/src/features/experiments/server/router.ts
@@ -374,7 +374,7 @@ export const experimentsRouter = createTRPCRouter({
     .input(
       z.object({
         projectId: z.string(),
-        experimentIds: z.array(z.string()).max(10),
+        experimentIds: z.array(z.string()),
         filter: z.array(singleFilter).nullable(),
       }),
     )


### PR DESCRIPTION
The metrics endpoint is used by the experiments list table which can
have more than 10 rows per page. Only comparison-specific endpoints
should have the limit.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR increases the experiment selection limit for the compare view from 5 to 10 (1 baseline + 9 comparisons), adds server-side validation caps to comparison-specific endpoints, and widens the corresponding UI guard and client-side `MAX_COMPARISONS` constant.

- The UI disable threshold (`> 10`), the `MAX_COMPARISONS = 9` hook constant, and the `compExperimentIds.max(9)` server limits are internally consistent and correctly scoped to the compare view.
- `scoreOptions` and `itemsFilterOptions` receive a new `.max(10)` constraint, but `scoreOptions` is also called from the experiments list table (default page size 50), so this limit will silently break the charts panel for any project with more than 10 experiments visible at once.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The compare-view changes are internally consistent and safe, but adding `.max(10)` to the `scoreOptions` endpoint will silently break the charts panel on the list table for any project showing more than 10 experiments per page.

The `scoreOptions` endpoint is consumed by both the compare view and the list table's `ExperimentChartsGrid`. The list table defaults to 50 rows per page, so any user with more than 10 experiments visible will receive a Zod validation error and lose all chart data — a regression in the list view introduced by this PR.

web/src/features/experiments/server/router.ts — specifically the `scoreOptions` and, secondarily, `itemsFilterOptions` endpoint definitions where `.max(10)` was added.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ListTable as ExperimentsTable (list, up to 50 rows)
    participant CompareView as ExperimentItemsTable (compare view)
    participant ChartsGrid as ExperimentChartsGrid
    participant API as tRPC experimentsRouter

    ListTable->>ChartsGrid: chartExperiments (all page rows, up to 50)
    ChartsGrid->>API: "scoreOptions({ experimentIds: up to 50 }) - max(10) now blocks >10"
    API-->>ChartsGrid: "ZodError if >10 IDs"

    CompareView->>API: "itemsFilterOptions({ experimentIds: max 10 })"
    API-->>CompareView: OK (max 10 enforced by compare-view limit)

    CompareView->>API: "items({ compExperimentIds: max 9 })"
    API-->>CompareView: OK

    CompareView->>API: "metrics({ compExperimentIds: max 9 })"
    API-->>CompareView: OK

    CompareView->>API: "batchIO({ compExperimentIds: max 9 })"
    API-->>CompareView: OK
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/experiments/server/router.ts:697-701
**`scoreOptions` capped at 10 but called with full page of experiments**

The `scoreOptions` endpoint (and, to a lesser extent, `itemsFilterOptions`) is queried from `ExperimentChartsGrid` → `useExperimentChartsGridSelection`, which is mounted inside `ExperimentsTable` and receives `chartExperiments` — the entire current table page. `ExperimentsTable` defaults to 50 rows per page (`usePaginationState(1, 50)`), so any project with more than 10 experiments on screen will get a validation error from this new `.max(10)` constraint, silently breaking the charts panel.

The PR description states "only comparison-specific endpoints should have the limit," but `scoreOptions` is also used by the list table, not just the compare view. The `compExperimentIds` endpoints correctly carry `.max(9)`, but `scoreOptions` and `itemsFilterOptions` should only be constrained if they are exclusively consumed by the compare view (where the 10-experiment cap is enforced upstream).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments): remove max limit from ..."](https://github.com/langfuse/langfuse/commit/520d664572dcd817b3ebfc1e621d206c7d3ab752) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37233004)</sub>

<!-- /greptile_comment -->