### PR TITLE
perf(api): add redundant timestamp bound to scores v3 cursor for index pruning (LFE-10208)

### DIFF
--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2858,8 +2858,12 @@ const buildV3ListQuery = (
   FROM scores s
   WHERE s.project_id = {projectId: String}
   ${
+    // The simple timestamp bound is redundant with the tuple comparison but
+    // required for index pruning: ClickHouse does not decompose tuple
+    // comparisons, so only the simple bound activates the partition key and
+    // the (project_id, toDate(timestamp)) primary-key prefix.
     withCursor
-      ? "AND (s.timestamp, s.id) < ({lastTimestamp: DateTime64(3)}, {lastId: String})"
+      ? "AND (s.timestamp, s.id) < ({lastTimestamp: DateTime64(3)}, {lastId: String}) AND s.timestamp <= {lastTimestamp: DateTime64(3)}"
       : ""
   }
   ${filterClause ? `AND ${filterClause}` : ""}


### PR DESCRIPTION
## What does this PR do?

Speeds up cursor pagination in the scores v3 public API. ClickHouse does not decompose the tuple cursor comparison `(s.timestamp, s.id) < ({lastTimestamp}, {lastId})` during primary-key analysis, so every cursor page scanned all granules of the project (`EXPLAIN indexes=1` showed the PrimaryKey condition using only `project_id`, with no partition pruning). Adding the logically implied simple bound `s.timestamp <= {lastTimestamp}` activates the partition key (`toYYYYMM(timestamp)`), the MinMax index, and the `(project_id, toDate(timestamp))` primary-key prefix.

Measured on a 4.1M-row synthetic clone of the scores table (ClickHouse 25.12, 12 monthly partitions, cursor at mid-pagination depth): granules scanned dropped from 263/512 to 117/512 and parts from 24/24 to 12/24. Pruning improves the deeper the pagination goes.

Results are byte-identical: `(a, b) < (x, y)` implies `a <= x`, so the added clause filters nothing the tuple comparison does not already filter. Existing v3 cursor pagination servertests (full-walk without duplicates/skips, page boundaries, stale cursors) cover the behavior.

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have checked that new and existing unit tests pass locally with my changes (lint + typecheck; servertests run in CI)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a redundant simple timestamp bound (`s.timestamp <= {lastTimestamp}`) alongside the existing tuple cursor condition `(s.timestamp, s.id) < ({lastTimestamp}, {lastId})` in the ClickHouse scores v3 pagination query, to enable index pruning on the partition key and primary-key prefix.

- **Index pruning hint**: ClickHouse cannot decompose tuple comparisons to activate partition/primary-key pruning, so the scalar `s.timestamp <=` condition is added purely for that purpose — it is logically implied by the tuple and does not change result semantics.
- **Correctness**: `<=` (rather than `<`) is the correct scalar bound because the tuple condition admits rows where `s.timestamp == lastTimestamp AND s.id < lastId`, so a strict `<` would incorrectly exclude those rows.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change adds a logically redundant WHERE predicate that only helps ClickHouse skip partitions and does not alter which rows are returned.

The added scalar bound s.timestamp <= lastTimestamp is always implied by the existing tuple condition, so it cannot introduce incorrect results. The <= operator (rather than <) is intentional and correct because the tuple condition permits rows where timestamp == lastTimestamp AND id < lastId. The named parameter {lastTimestamp} is reused in the same query, which ClickHouse handles correctly. The comment fully explains the ClickHouse-specific motivation.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[listScoresV3ForPublicApi called] --> B{cursor present?}
    B -- No --> C[buildV3ListQuery withCursor=false\nNo cursor WHERE clause]
    B -- Yes --> D[buildV3ListQuery withCursor=true]
    D --> E["WHERE s.project_id = {projectId}\nAND (s.timestamp, s.id) < (lastTimestamp, lastId)\nAND s.timestamp <= lastTimestamp  ← NEW index hint"]
    E --> F[ClickHouse evaluates query]
    F --> G["Tuple condition: handles correct row filtering\n(timestamp < last) OR (timestamp == last AND id < lastId)"]
    F --> H["Scalar condition: activates partition key pruning\non toDate(timestamp) and primary-key prefix"]
    G --> I[ORDER BY timestamp DESC, id DESC\nLIMIT 1 BY id, project_id\nLIMIT N+1]
    H --> I
    I --> J{len > limit?}
    J -- Yes --> K[Encode next cursor from last record]
    J -- No --> L[Return page, no next cursor]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(api): add redundant timestamp bound..."](https://github.com/langfuse/langfuse/commit/2160bb8f31f52fba913548d2416b145211b8f321) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37235881)</sub>

<!-- /greptile_comment -->