### PR TITLE
feat(scores): add api_version to ClickHouse log_comment tags

### DIFF
--- a/packages/shared/src/server/repositories/scores-utils.ts
+++ b/packages/shared/src/server/repositories/scores-utils.ts
@@ -16,6 +16,7 @@ export const _handleGetScoreById = async ({
   scoreScope,
   scoreDataTypes,
   preferredClickhouseService,
+  apiVersion,
 }: {
   projectId: string;
   scoreId: string;
@@ -23,6 +24,7 @@ export const _handleGetScoreById = async ({
   scoreScope: "traces_only" | "all";
   scoreDataTypes?: readonly ScoreDataTypeType[];
   preferredClickhouseService?: PreferredClickhouseService;
+  apiVersion?: "v1" | "v2";
 }): Promise<ScoreDomain | undefined> => {
   const query = `
   SELECT *
@@ -52,6 +54,7 @@ export const _handleGetScoreById = async ({
       type: "score",
       kind: "byId",
       projectId,
+      ...(apiVersion ? { api_version: apiVersion } : {}),
     },
     preferredClickhouseService,
   });
@@ -69,12 +72,14 @@ export const _handleGetScoresByIds = async ({
   source,
   scoreScope,
   dataTypes,
+  apiVersion,
 }: {
   projectId: string;
   scoreId: string[];
   source?: ScoreSourceType;
   scoreScope: "traces_only" | "all";
   dataTypes?: readonly ScoreDataTypeType[];
+  apiVersion?: "v1" | "v2";
 }): Promise<ScoreDomain[]> => {
   const query = `
   SELECT *
@@ -101,6 +106,7 @@ export const _handleGetScoresByIds = async ({
       type: "score",
       kind: "byId",
       projectId,
+      ...(apiVersion ? { api_version: apiVersion } : {}),
     },
   });
   return rows.map((row) => convertClickhouseScoreToDomain(row));

--- a/packages/shared/src/server/repositories/scores-utils.ts
+++ b/packages/shared/src/server/repositories/scores-utils.ts
@@ -72,14 +72,12 @@ export const _handleGetScoresByIds = async ({
   source,
   scoreScope,
   dataTypes,
-  apiVersion,
 }: {
   projectId: string;
   scoreId: string[];
   source?: ScoreSourceType;
   scoreScope: "traces_only" | "all";
   dataTypes?: readonly ScoreDataTypeType[];
-  apiVersion?: "v1" | "v2";
 }): Promise<ScoreDomain[]> => {
   const query = `
   SELECT *
@@ -106,7 +104,6 @@ export const _handleGetScoresByIds = async ({
       type: "score",
       kind: "byId",
       projectId,
-      ...(apiVersion ? { api_version: apiVersion } : {}),
     },
   });
   return rows.map((row) => convertClickhouseScoreToDomain(row));

--- a/packages/shared/src/server/repositories/scores.ts
+++ b/packages/shared/src/server/repositories/scores.ts
@@ -2421,6 +2421,7 @@ export const _handleGenerateScoresForPublicApi = async ({
   includeTrace,
   needsTraceJoin,
   pagination,
+  apiVersion,
 }: {
   projectId: string;
   scoresFilter: FilterList;
@@ -2429,6 +2430,7 @@ export const _handleGenerateScoresForPublicApi = async ({
   includeTrace: boolean;
   needsTraceJoin: boolean;
   pagination?: { limit: number; page: number };
+  apiVersion?: "v1" | "v2";
 }) => {
   const appliedScoresFilter = scoresFilter.apply();
   const appliedTracesFilter = tracesFilter.apply();
@@ -2512,6 +2514,7 @@ export const _handleGenerateScoresForPublicApi = async ({
         scoreScope,
         operation_name: "_handleGenerateScoresForPublicApi",
         includeTrace: includeTrace.toString(),
+        ...(apiVersion ? { api_version: apiVersion } : {}),
       },
     },
     fn: async (input) => {
@@ -2555,6 +2558,7 @@ export const _handleGetScoresCountForPublicApi = async ({
   scoreScope,
   includeTrace,
   needsTraceJoin,
+  apiVersion,
 }: {
   projectId: string;
   scoresFilter: FilterList;
@@ -2562,6 +2566,7 @@ export const _handleGetScoresCountForPublicApi = async ({
   scoreScope: "traces_only" | "all";
   includeTrace: boolean;
   needsTraceJoin: boolean;
+  apiVersion?: "v1" | "v2";
 }) => {
   const appliedScoresFilter = scoresFilter.apply();
   const appliedTracesFilter = tracesFilter.apply();
@@ -2611,6 +2616,7 @@ export const _handleGetScoresCountForPublicApi = async ({
         scoreScope,
         operation_name: "_handleGetScoresCountForPublicApi",
         includeTrace: includeTrace.toString(),
+        ...(apiVersion ? { api_version: apiVersion } : {}),
       },
     },
     fn: async (input) => {
@@ -2999,6 +3005,7 @@ export async function listScoresV3ForPublicApi(
         type: "score",
         projectId: params.projectId,
         operation_name: "listScoresV3ForPublicApi",
+        api_version: "v3",
       },
     },
     fn: async (input) => {

--- a/web/src/__tests__/server/unit/buildScoreFilters.servertest.ts
+++ b/web/src/__tests__/server/unit/buildScoreFilters.servertest.ts
@@ -189,3 +189,33 @@ describe("determineTraceJoinRequirement", () => {
     expect(needsTraceJoin).toBe(true);
   });
 });
+
+describe("apiVersion forwarding for query tagging", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHandleGenerateScores.mockResolvedValue([]);
+    mockHandleGetScoresCount.mockResolvedValue(0);
+  });
+
+  it.each(["v1", "v2"] as const)(
+    "%s service passes apiVersion to the list handler",
+    async (version) => {
+      await new ScoresApiService(version).generateScoresForPublicApi(BASE);
+
+      expect(mockHandleGenerateScores.mock.calls[0][0].apiVersion).toBe(
+        version,
+      );
+    },
+  );
+
+  it.each(["v1", "v2"] as const)(
+    "%s service passes apiVersion to the count handler",
+    async (version) => {
+      await new ScoresApiService(version).getScoresCountForPublicApi(BASE);
+
+      expect(mockHandleGetScoresCount.mock.calls[0][0].apiVersion).toBe(
+        version,
+      );
+    },
+  );
+});

--- a/web/src/features/public-api/server/scores-api-service.ts
+++ b/web/src/features/public-api/server/scores-api-service.ts
@@ -238,6 +238,7 @@ export class ScoresApiService {
           scoreDataTypes:
             this.apiVersion === "v1" ? LISTABLE_SCORE_TYPES : undefined,
           preferredClickhouseService: "ReadOnly",
+          apiVersion: this.apiVersion,
         })
       : undefined;
 
@@ -335,6 +336,7 @@ export class ScoresApiService {
       scoreDataTypes:
         this.apiVersion === "v1" ? LISTABLE_SCORE_TYPES : undefined,
       preferredClickhouseService: "ReadOnly",
+      apiVersion: this.apiVersion,
     });
 
     if (!score) {
@@ -368,6 +370,7 @@ export class ScoresApiService {
       includeTrace,
       needsTraceJoin,
       pagination: { limit: props.limit, page: props.page },
+      apiVersion: this.apiVersion,
     });
     // Apply API-shape transformation (moves longStringValue→stringValue for
     // CORRECTION, strips longStringValue for others). Must happen here because
@@ -402,6 +405,7 @@ export class ScoresApiService {
       scoreScope: this.apiVersion === "v1" ? "traces_only" : "all",
       includeTrace,
       needsTraceJoin,
+      apiVersion: this.apiVersion,
     });
   }
 }


### PR DESCRIPTION
## What does this PR do?

Adds an explicit `api_version` tag to the ClickHouse query tags for all scores public-API read queries. The tags are serialized into the ClickHouse `log_comment` setting and attached to Datadog spans via `measureAndReturn`, so the public API version serving a query becomes directly filterable in `system.query_log` and APM.

Previously the version was only indirectly recoverable from `operation_name` + `scoreScope` for list/count queries, and not recoverable at all for by-id lookups, which share a single tag set across v1 and v2.

- `_handleGenerateScoresForPublicApi`, `_handleGetScoresCountForPublicApi`, and `_handleGetScoreById` accept an optional `apiVersion: "v1" | "v2"`, included in tags as `api_version` when present (internal non-API callers are unchanged and emit no version tag)
- `ScoresApiService` passes its `apiVersion` through at all of its call sites (list, count, get-by-id, and the createScore audit lookup)
- `listScoresV3ForPublicApi` tags `api_version: "v3"` unconditionally since it is version-specific by construction

No API contract or behavior change; observability tagging only.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested?

- `pnpm turbo run lint typecheck --filter=web --filter=@langfuse/shared` (8/8 green)
- `web` unit tests: `src/__tests__/server/unit/buildScoreFilters.servertest.ts` (13 passed)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an explicit `api_version` tag to the ClickHouse `log_comment` for all scores public-API read queries, making the serving API version directly filterable in `system.query_log` and APM without any change to API contracts or behavior.

- `_handleGenerateScoresForPublicApi`, `_handleGetScoresCountForPublicApi`, and `_handleGetScoreById` now accept an optional `apiVersion: "v1" | "v2"` forwarded from `ScoresApiService`, while `listScoresV3ForPublicApi` unconditionally emits `api_version: "v3"`.
- `_handleGetScoresByIds` also receives the new parameter, but its only active call site (`getScoresByIds` in `scores.ts`) does not supply it, so the tag will be absent on that code path.
- The `createScore` write-path now tags its internal audit pre-flight `_handleGetScoreById` lookup with `api_version`, which may surface in read-query dashboards filtered by that tag.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Observability-only change with no API contract or data behavior impact; safe to merge with minor tag-coverage gaps.

The core tagging for list, count, and by-ID read queries is correctly wired. Two gaps exist: the `apiVersion` param added to `_handleGetScoresByIds` is never exercised because its sole wrapper doesn't forward it, and the write-path audit lookup in `createScore` will emit an `api_version` tag that could mix into read-query observability tooling. Neither affects correctness or API behavior.

`scores-utils.ts` (`_handleGetScoresByIds` wiring) and `scores-api-service.ts` (`createScore` audit lookup tagging) are the two spots worth a second look.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ScoresApiService
    participant scores_ts as scores.ts / scores-utils.ts
    participant ClickHouse

    Client->>ScoresApiService: "GET /v1/scores (v1|v2)"
    ScoresApiService->>scores_ts: "_handleGenerateScoresForPublicApi({..., apiVersion})"
    scores_ts->>ClickHouse: "query [log_comment: {api_version: v1|v2}]"
    ClickHouse-->>ScoresApiService: rows

    Client->>ScoresApiService: GET /v1/scores/:id
    ScoresApiService->>scores_ts: "_handleGetScoreById({..., apiVersion})"
    scores_ts->>ClickHouse: "query [log_comment: {api_version: v1|v2}]"
    ClickHouse-->>ScoresApiService: row

    Client->>ScoresApiService: POST /v1/scores (create)
    ScoresApiService->>scores_ts: "_handleGetScoreById({..., apiVersion}) [audit pre-flight]"
    scores_ts->>ClickHouse: "query [log_comment: {api_version: v1|v2}] note: write path"
    ClickHouse-->>ScoresApiService: existing score or undefined

    Note over scores_ts,ClickHouse: _handleGetScoresByIds accepts apiVersion but getScoresByIds() never passes it - tag always absent
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/repositories/scores-utils.ts:69-82
**`apiVersion` parameter has no active call site**

`_handleGetScoresByIds` now accepts `apiVersion`, but its only caller — `getScoresByIds` in `scores.ts` (line 153) — does not pass the parameter. `ScoresApiService` has no method that calls this function either, so the new parameter will always be `undefined` and the `api_version` tag will never appear on queries routed through this code path. The PR description lists this function alongside the three others that are actually wired up, which may indicate the corresponding `ScoresApiService` call site was intended but omitted.

### Issue 2 of 2
web/src/features/public-api/server/scores-api-service.ts:233-243
**`api_version` tag on write-path audit lookup may skew read metrics**

The `_handleGetScoreById` call inside `createScore` is a pre-flight audit-lookup used only to determine whether to log the event as "create" or "update". With `apiVersion: this.apiVersion` now passed, every POST `/scores` request will emit a ClickHouse query tagged `api_version: v1|v2`, `kind: "byId"`. Dashboards or alerts that filter on `api_version` to count score-read queries will inadvertently include these write-path side-effects, inflating read counts per API version. The PR description describes the intent as tagging "public API read queries", which this lookup is not.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(scores): assert apiVersion is forwa..."](https://github.com/langfuse/langfuse/commit/0dc26da3a2ef3ab33da38f2ca911c8e06dd5a3ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37250368)</sub>

<!-- /greptile_comment -->
