### PR TITLE
feat(i18n): add initial localization infrastructure

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -94,7 +94,7 @@ const nextConfig = {
    * @see https://github.com/vercel/next.js/issues/41980
    */
   i18n: {
-    locales: ["en"],
+    locales: ["en", "zh-CN"],
     defaultLocale: "en",
   },
   output: "standalone",

--- a/web/src/features/i18n/I18nProvider.tsx
+++ b/web/src/features/i18n/I18nProvider.tsx
@@ -8,15 +8,17 @@ import {
 import { useRouter } from "next/router";
 import {
   defaultLocale,
+  formatMessage,
   isSupportedLocale,
   messages,
   type SupportedLocale,
   type TranslationKey,
+  type TranslationValues,
 } from "@/src/features/i18n/messages";
 
 type I18nContextValue = {
   locale: SupportedLocale;
-  t: (key: TranslationKey) => string;
+  t: (key: TranslationKey, values?: TranslationValues) => string;
 };
 
 const I18nContext = createContext<I18nContextValue | null>(null);
@@ -29,8 +31,11 @@ export function I18nProvider({ children }: { children: ReactNode }) {
       : defaultLocale;
 
   const t = useCallback(
-    (key: TranslationKey) =>
-      messages[locale][key] ?? messages[defaultLocale][key],
+    (key: TranslationKey, values?: TranslationValues) =>
+      formatMessage(
+        messages[locale][key] ?? messages[defaultLocale][key],
+        values,
+      ),
     [locale],
   );
 

--- a/web/src/features/i18n/I18nProvider.tsx
+++ b/web/src/features/i18n/I18nProvider.tsx
@@ -1,0 +1,50 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+} from "react";
+import { useRouter } from "next/router";
+import {
+  defaultLocale,
+  isSupportedLocale,
+  messages,
+  type SupportedLocale,
+  type TranslationKey,
+} from "@/src/features/i18n/messages";
+
+type I18nContextValue = {
+  locale: SupportedLocale;
+  t: (key: TranslationKey) => string;
+};
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const locale =
+    router.locale && isSupportedLocale(router.locale)
+      ? router.locale
+      : defaultLocale;
+
+  const t = useCallback(
+    (key: TranslationKey) =>
+      messages[locale][key] ?? messages[defaultLocale][key],
+    [locale],
+  );
+
+  const value = useMemo(() => ({ locale, t }), [locale, t]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+
+  if (!context) {
+    throw new Error("useI18n must be used within I18nProvider");
+  }
+
+  return context;
+}

--- a/web/src/features/i18n/LanguageSwitcher.tsx
+++ b/web/src/features/i18n/LanguageSwitcher.tsx
@@ -1,0 +1,44 @@
+import { useRouter } from "next/router";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/src/components/ui/select";
+import {
+  supportedLocales,
+  type SupportedLocale,
+} from "@/src/features/i18n/messages";
+import { useI18n } from "@/src/features/i18n/I18nProvider";
+
+export function LanguageSwitcher() {
+  const router = useRouter();
+  const { locale, t } = useI18n();
+
+  const onLocaleChange = (nextLocale: SupportedLocale) => {
+    router
+      .push(router.asPath, router.asPath, {
+        locale: nextLocale,
+        scroll: false,
+      })
+      .catch(() => undefined);
+  };
+
+  return (
+    <Select value={locale} onValueChange={onLocaleChange}>
+      <SelectTrigger aria-label={t("i18n.language")} className="w-[11rem]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {supportedLocales.map((supportedLocale) => (
+          <SelectItem key={supportedLocale} value={supportedLocale}>
+            {supportedLocale === "en"
+              ? t("i18n.english")
+              : t("i18n.chineseSimplified")}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/web/src/features/i18n/LanguageSwitcher.tsx
+++ b/web/src/features/i18n/LanguageSwitcher.tsx
@@ -15,6 +15,10 @@ import { useI18n } from "@/src/features/i18n/I18nProvider";
 export function LanguageSwitcher() {
   const router = useRouter();
   const { locale, t } = useI18n();
+  const localeLabels: Record<SupportedLocale, string> = {
+    en: t("i18n.english"),
+    "zh-CN": t("i18n.chineseSimplified"),
+  };
 
   const onLocaleChange = (nextLocale: SupportedLocale) => {
     router
@@ -33,9 +37,7 @@ export function LanguageSwitcher() {
       <SelectContent>
         {supportedLocales.map((supportedLocale) => (
           <SelectItem key={supportedLocale} value={supportedLocale}>
-            {supportedLocale === "en"
-              ? t("i18n.english")
-              : t("i18n.chineseSimplified")}
+            {localeLabels[supportedLocale]}
           </SelectItem>
         ))}
       </SelectContent>

--- a/web/src/features/i18n/LanguageSwitcher.tsx
+++ b/web/src/features/i18n/LanguageSwitcher.tsx
@@ -7,6 +7,7 @@ import {
   SelectValue,
 } from "@/src/components/ui/select";
 import {
+  localeMetadata,
   supportedLocales,
   type SupportedLocale,
 } from "@/src/features/i18n/messages";
@@ -15,10 +16,6 @@ import { useI18n } from "@/src/features/i18n/I18nProvider";
 export function LanguageSwitcher() {
   const router = useRouter();
   const { locale, t } = useI18n();
-  const localeLabels: Record<SupportedLocale, string> = {
-    en: t("i18n.english"),
-    "zh-CN": t("i18n.chineseSimplified"),
-  };
 
   const onLocaleChange = (nextLocale: SupportedLocale) => {
     router
@@ -37,7 +34,7 @@ export function LanguageSwitcher() {
       <SelectContent>
         {supportedLocales.map((supportedLocale) => (
           <SelectItem key={supportedLocale} value={supportedLocale}>
-            {localeLabels[supportedLocale]}
+            {t(localeMetadata[supportedLocale].labelKey)}
           </SelectItem>
         ))}
       </SelectContent>

--- a/web/src/features/i18n/messages/en.ts
+++ b/web/src/features/i18n/messages/en.ts
@@ -1,0 +1,19 @@
+export const en = {
+  "auth.signIn.pageTitle": "Sign in | Langfuse",
+  "auth.signIn.heading": "Sign in to your account",
+  "auth.signIn.emailLabel": "Email",
+  "auth.signIn.passwordLabel": "Password",
+  "auth.signIn.forgotPassword": "(forgot password?)",
+  "auth.signIn.submit": "Sign in",
+  "auth.signIn.continue": "Continue",
+  "auth.signIn.lastUsed": "Last used",
+  "auth.signIn.contactSupport": "Contact support if this error is unexpected.",
+  "auth.signIn.cloudRegionHint":
+    "Make sure you are using the correct cloud data region.",
+  "auth.signIn.noAccount": "No account yet?",
+  "auth.signIn.signUp": "Sign up",
+  "auth.cloudPrivacyNotice.signingIn": "signing in",
+  "i18n.language": "Language",
+  "i18n.english": "English",
+  "i18n.chineseSimplified": "Chinese (Simplified)",
+} as const;

--- a/web/src/features/i18n/messages/index.ts
+++ b/web/src/features/i18n/messages/index.ts
@@ -6,6 +6,19 @@ export const supportedLocales = ["en", "zh-CN"] as const;
 
 export type SupportedLocale = (typeof supportedLocales)[number];
 export type TranslationKey = keyof typeof en;
+export type TranslationValues = Record<string, number | string>;
+
+export const localeMetadata: Record<
+  SupportedLocale,
+  { labelKey: TranslationKey }
+> = {
+  en: {
+    labelKey: "i18n.english",
+  },
+  "zh-CN": {
+    labelKey: "i18n.chineseSimplified",
+  },
+};
 
 export const messages: Record<
   SupportedLocale,
@@ -17,4 +30,17 @@ export const messages: Record<
 
 export function isSupportedLocale(locale: string): locale is SupportedLocale {
   return supportedLocales.includes(locale as SupportedLocale);
+}
+
+export function formatMessage(
+  message: string,
+  values?: TranslationValues,
+): string {
+  if (!values) return message;
+
+  return message.replace(/\{(\w+)\}/g, (placeholder, key) =>
+    Object.prototype.hasOwnProperty.call(values, key)
+      ? String(values[key])
+      : placeholder,
+  );
 }

--- a/web/src/features/i18n/messages/index.ts
+++ b/web/src/features/i18n/messages/index.ts
@@ -1,0 +1,20 @@
+import { en } from "@/src/features/i18n/messages/en";
+import { zhCN } from "@/src/features/i18n/messages/zh-CN";
+
+export const defaultLocale = "en";
+export const supportedLocales = ["en", "zh-CN"] as const;
+
+export type SupportedLocale = (typeof supportedLocales)[number];
+export type TranslationKey = keyof typeof en;
+
+export const messages: Record<
+  SupportedLocale,
+  Record<TranslationKey, string>
+> = {
+  en,
+  "zh-CN": zhCN,
+};
+
+export function isSupportedLocale(locale: string): locale is SupportedLocale {
+  return supportedLocales.includes(locale as SupportedLocale);
+}

--- a/web/src/features/i18n/messages/zh-CN.ts
+++ b/web/src/features/i18n/messages/zh-CN.ts
@@ -1,0 +1,20 @@
+import { type TranslationKey } from "@/src/features/i18n/messages";
+
+export const zhCN: Record<TranslationKey, string> = {
+  "auth.signIn.pageTitle": "登录 | Langfuse",
+  "auth.signIn.heading": "登录你的账户",
+  "auth.signIn.emailLabel": "邮箱",
+  "auth.signIn.passwordLabel": "密码",
+  "auth.signIn.forgotPassword": "(忘记密码？)",
+  "auth.signIn.submit": "登录",
+  "auth.signIn.continue": "继续",
+  "auth.signIn.lastUsed": "上次使用",
+  "auth.signIn.contactSupport": "如果这个错误不符合预期，请联系支持团队。",
+  "auth.signIn.cloudRegionHint": "请确认你正在使用正确的云数据区域。",
+  "auth.signIn.noAccount": "还没有账户？",
+  "auth.signIn.signUp": "注册",
+  "auth.cloudPrivacyNotice.signingIn": "登录",
+  "i18n.language": "语言",
+  "i18n.english": "English",
+  "i18n.chineseSimplified": "简体中文",
+};

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -80,6 +80,7 @@ import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { ScoreCacheProvider } from "@/src/features/scores/contexts/ScoreCacheContext";
 import { CorrectionCacheProvider } from "@/src/features/corrections/contexts/CorrectionCacheContext";
 import { V4_BETA_ENABLED_POSTHOG_PROPERTY } from "@/src/features/posthog-analytics/usePostHogClientCapture";
+import { I18nProvider } from "@/src/features/i18n/I18nProvider";
 
 // Check that PostHog is client-side (used to handle Next.js SSR) and that env vars are set
 if (
@@ -153,10 +154,12 @@ const MyApp: AppType<{ session: Session | null }> = ({
                       <CorrectionCacheProvider>
                         <SupportDrawerProvider defaultOpen={false}>
                           <InAppAiAgentProvider defaultOpen={false}>
-                            <AppLayout>
-                              <Component {...pageProps} />
-                              <UserTracking />
-                            </AppLayout>
+                            <I18nProvider>
+                              <AppLayout>
+                                <Component {...pageProps} />
+                                <UserTracking />
+                              </AppLayout>
+                            </I18nProvider>
                           </InAppAiAgentProvider>
                         </SupportDrawerProvider>
                       </CorrectionCacheProvider>

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -45,6 +45,8 @@ import { AuthProviderButton } from "@/src/features/auth/components/AuthProviderB
 import { cn } from "@/src/utils/tailwind";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { getSafeRedirectPath } from "@/src/utils/redirect";
+import { useI18n } from "@/src/features/i18n/I18nProvider";
+import { LanguageSwitcher } from "@/src/features/i18n/LanguageSwitcher";
 
 const credentialAuthForm = z.object({
   email: z.email(),
@@ -537,6 +539,7 @@ export default function SignIn({
   runningOnHuggingFaceSpaces,
 }: PageProps) {
   const router = useRouter();
+  const { t } = useI18n();
   useHuggingFaceRedirect(runningOnHuggingFaceSpaces);
 
   // handle NextAuth error codes: https://next-auth.js.org/configuration/pages#sign-in-page
@@ -722,13 +725,16 @@ export default function SignIn({
   return (
     <>
       <Head>
-        <title>Sign in | Langfuse</title>
+        <title>{t("auth.signIn.pageTitle")}</title>
       </Head>
       <div className="flex flex-1 flex-col py-6 sm:min-h-full sm:justify-center sm:px-6 sm:py-12 lg:px-8">
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
           <LangfuseIcon className="mx-auto" />
+          <div className="mt-4 flex justify-center">
+            <LanguageSwitcher />
+          </div>
           <h2 className="text-primary mt-4 text-center text-2xl leading-9 font-bold tracking-tight">
-            Sign in to your account
+            {t("auth.signIn.heading")}
           </h2>
         </div>
 
@@ -770,7 +776,7 @@ export default function SignIn({
                       name="email"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Email</FormLabel>
+                          <FormLabel>{t("auth.signIn.emailLabel")}</FormLabel>
                           <FormControl>
                             <Input
                               placeholder="jsdoe@example.com"
@@ -792,14 +798,14 @@ export default function SignIn({
                         render={({ field }) => (
                           <FormItem>
                             <FormLabel>
-                              Password{" "}
+                              {t("auth.signIn.passwordLabel")}{" "}
                               <Link
                                 href="/auth/reset-password"
                                 className="text-primary-accent hover:text-hover-primary-accent ml-1 text-xs"
                                 tabIndex={-1}
                                 title="What is this?"
                               >
-                                (forgot password?)
+                                {t("auth.signIn.forgotPassword")}
                               </Link>
                             </FormLabel>
                             <FormControl>
@@ -827,7 +833,9 @@ export default function SignIn({
                       }
                       data-testid="submit-email-password-sign-in-form"
                     >
-                      {showPasswordStep ? "Sign in" : "Continue"}
+                      {showPasswordStep
+                        ? t("auth.signIn.submit")
+                        : t("auth.signIn.continue")}
                     </Button>
                   </form>
                 </Form>
@@ -840,7 +848,7 @@ export default function SignIn({
                       : "hidden",
                   )}
                 >
-                  Last used
+                  {t("auth.signIn.lastUsed")}
                 </div>
               </div>
             )}
@@ -848,9 +856,8 @@ export default function SignIn({
               <div className="text-destructive text-center text-sm font-medium">
                 {credentialsFormError}
                 <br />
-                Contact support if this error is unexpected.{" "}
-                {isLangfuseCloud &&
-                  "Make sure you are using the correct cloud data region."}
+                {t("auth.signIn.contactSupport")}{" "}
+                {isLangfuseCloud && t("auth.signIn.cloudRegionHint")}
               </div>
             ) : null}
             <SSOButtons
@@ -864,17 +871,17 @@ export default function SignIn({
           env.NEXT_PUBLIC_SIGN_UP_DISABLED !== "true" &&
           authProviders.credentials ? (
             <p className="text-muted-foreground mt-10 text-center text-sm">
-              No account yet?{" "}
+              {t("auth.signIn.noAccount")}{" "}
               <Link
                 href={`/auth/sign-up${router.asPath.includes("?") ? router.asPath.substring(router.asPath.indexOf("?")) : ""}`}
                 className="text-primary-accent hover:text-hover-primary-accent leading-6 font-semibold"
               >
-                Sign up
+                {t("auth.signIn.signUp")}
               </Link>
             </p>
           ) : null}
         </div>
-        <CloudPrivacyNotice action="signing in" />
+        <CloudPrivacyNotice action={t("auth.cloudPrivacyNotice.signingIn")} />
       </div>
     </>
   );


### PR DESCRIPTION
## What

This PR adds a small initial i18n foundation for the Langfuse web app and uses the sign-in page as the first narrow trial surface.

It intentionally does not attempt a full-product localization. The goal is to establish the basic structure first so additional locales and pages can be migrated incrementally.

## Changes

- Adds typed locale/message catalogs for `en` and `zh-CN`
- Adds an `I18nProvider` and `useI18n` hook
- Adds a minimal language switcher component
- Extends Next.js locales from `en` to `en` + `zh-CN`
- Migrates selected sign-in page strings to translation keys as an initial example

## Motivation

This is a small first step toward community-maintainable localization support. It should make it easier to review the i18n approach before translating larger parts of the product.

Related community interest: #12890

## Verification

- `pnpm exec prettier --check web/next.config.mjs web/src/pages/_app.tsx web/src/pages/auth/sign-in.tsx web/src/features/i18n/I18nProvider.tsx web/src/features/i18n/LanguageSwitcher.tsx web/src/features/i18n/messages/en.ts web/src/features/i18n/messages/zh-CN.ts web/src/features/i18n/messages/index.ts`
- `pnpm --filter web run lint`
- `pnpm --filter web run typecheck`
- `NEXT_IGNORE_BUILD_ERRORS=true INLINE_RUNTIME_CHUNK=false pnpm --filter web run build`
- Pre-commit hook: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli` and `turbo run lint`
- Local Docker/OrbStack smoke test with a standalone web image built from the verified production build output
- Playwright smoke test for English sign-in, switching to Simplified Chinese, `/zh-CN/auth/sign-in`, and a 390px mobile viewport

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a lightweight i18n foundation for the Langfuse web app: a typed message catalog (`en` + `zh-CN`), an `I18nProvider`/`useI18n` hook reading locale from Next.js router, a `LanguageSwitcher` dropdown, and a first migration of the sign-in page strings.

- **Provider placement** — `I18nProvider` is correctly inserted inside `_app.tsx` around `AppLayout` and `Component`, so all pages have access to the i18n context without any changes to individual page wrappers.
- **Type safety** — `TranslationKey` is derived from `keyof typeof en`, ensuring `zh-CN` must supply every key that exists in English; the TypeScript compiler enforces catalog completeness at build time.
- **Scalability notes** — The `LanguageSwitcher` uses a binary `"en"` vs. else check for locale labels (silently broken for a third locale), all locale bundles are eagerly co-bundled (will grow with locale count), and `zh-CN.ts` imports `TranslationKey` from the barrel that imports it back (a circular type reference, harmless at runtime but avoidable).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all changes are additive, the sign-in page is the only affected user-facing surface, and the i18n context is always present for it via _app.tsx.

The infrastructure is correct and the sign-in migration is clean. The three flagged items (binary locale-label check in LanguageSwitcher, circular type import in zh-CN.ts, and eager bundle loading of all locales) are all non-blocking and won’t affect current users — but the LanguageSwitcher label bug would silently surface as soon as a third locale is added, which is the stated direction of this PR.

web/src/features/i18n/LanguageSwitcher.tsx (locale label mapping won’t generalize) and web/src/features/i18n/messages/zh-CN.ts (circular type import avoidable).
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant NextRouter as Next.js Router (i18n)
    participant App as _app.tsx
    participant I18nProvider
    participant SignIn as SignIn Page
    participant LanguageSwitcher

    User->>NextRouter: Request /zh-CN/auth/sign-in
    NextRouter-->>App: "router.locale = "zh-CN""
    App->>I18nProvider: Wrap Component with locale
    I18nProvider->>I18nProvider: isSupportedLocale("zh-CN") → true
    I18nProvider->>I18nProvider: Build t() from messages["zh-CN"]
    I18nProvider->>SignIn: "Provide { locale, t } via context"
    SignIn->>SignIn: "useI18n() → { t }"
    SignIn->>SignIn: t("auth.signIn.heading") → "登录你的账户"
    SignIn->>LanguageSwitcher: Render with current locale
    LanguageSwitcher->>LanguageSwitcher: "useI18n() → { locale="zh-CN", t }"
    User->>LanguageSwitcher: Select "English"
    LanguageSwitcher->>NextRouter: "router.push(path, path, { locale: "en" })"
    NextRouter-->>App: "router.locale = "en""
    I18nProvider->>I18nProvider: Rebuild t() from messages["en"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/features/i18n/LanguageSwitcher.tsx:34-40
The locale label lookup is a hardcoded binary check — any locale that isn't `"en"` will display the Chinese Simplified label. Adding a third locale (e.g. `"de"`) would silently render it as `"Chinese (Simplified)"` instead of its own name. A locale-keyed record avoids this and makes adding new locales a one-liner.

```suggestion
        {supportedLocales.map((supportedLocale) => {
          const localeLabel: Record<typeof supportedLocale, string> = {
            en: t("i18n.english"),
            "zh-CN": t("i18n.chineseSimplified"),
          };
          return (
            <SelectItem key={supportedLocale} value={supportedLocale}>
              {localeLabel[supportedLocale]}
            </SelectItem>
          );
        })}
```

### Issue 2 of 3
web/src/features/i18n/messages/zh-CN.ts:1-3
This file imports `TranslationKey` from the barrel index, which itself imports `zhCN` from this file — a circular module reference. The `type`-only import is erased at compile time so there is no runtime issue, but some bundler configurations can still be confused. Using `typeof en` directly avoids the cycle and is the idiomatic pattern for "mirror the shape of the English catalog".

```suggestion
import { en } from "@/src/features/i18n/messages/en";

export const zhCN: Record<keyof typeof en, string> = {
```

### Issue 3 of 3
web/src/features/i18n/messages/index.ts:1-16
**All locale bundles are eagerly loaded together**

Both `en` and `zh-CN` message objects are statically imported and included in every page bundle regardless of the visitor's locale. For 19 short strings this is negligible, but as translations expand to cover the full product (hundreds of keys across multiple locales), the combined payload grows linearly with locale count. Using dynamic `import()` per locale or leveraging Next.js's built-in `next-intl` / `next-i18next` i18n loaders would keep each user's download limited to their chosen locale.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(i18n): add initial localization inf..."](https://github.com/langfuse/langfuse/commit/deb4ee3b9909b20c27e3efd16a9f46309ee5fb05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37350661)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->