### PR TITLE
feat(monitors): add in-progress leading window to live preview

### DIFF
--- a/packages/shared/src/features/monitors/processor/processor.ts
+++ b/packages/shared/src/features/monitors/processor/processor.ts
@@ -24,6 +24,7 @@ import {
 } from "../scheduler/types";
 import { monitorFromPrisma, windowToMs } from "../service/helpers";
 import {
+  monitorEvaluationOffsetMs,
   MonitorSeveritySchema,
   MonitorStatusSchema,
   type MonitorAlert,
@@ -34,8 +35,7 @@ import { applyStateMachine, type MonitorCompletion } from "./applyStateMachine";
 import { computeSeverity } from "./computeSeverity";
 import { renderAlertMessage } from "./renderAlertMessage";
 
-/** monitorEvaluationOffsetMs shifts the query window back so ClickHouse reads data settled past the events-table write lag. */
-export const monitorEvaluationOffsetMs = 30 * 1000;
+export { monitorEvaluationOffsetMs } from "../types";
 
 /** ErrorBadQuery sentinels a metric whose shape doesn't resolve against the v2 data model or whose batch query failed to execute. */
 export const ErrorBadQuery = Symbol("ErrorBadQuery");

--- a/packages/shared/src/features/monitors/types.ts
+++ b/packages/shared/src/features/monitors/types.ts
@@ -14,6 +14,9 @@ import { granularities, metric as MetricSchema, viewsV2 } from "../query/types";
 import { isValidQuery } from "./isValidQuery";
 import { isValidThresholdOrder } from "./isValidThresholdOrder";
 
+/** monitorEvaluationOffsetMs shifts the query window back so ClickHouse reads settled data past the events-table write lag. */
+export const monitorEvaluationOffsetMs = 30 * 1000;
+
 /** ErrorNameRequired is the message emitted when the Monitor name is missing or empty. */
 export const ErrorNameRequired = "Name is a required field";
 

--- a/web/src/features/monitors/components/MonitorChartPreview.clienttest.ts
+++ b/web/src/features/monitors/components/MonitorChartPreview.clienttest.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  monitorEvaluationOffsetMs,
+  windowToMs,
+} from "@langfuse/shared/monitors";
+
+import { __test } from "./MonitorChartPreview";
+
+const { leadingWindowRange, toLeadingPoint } = __test;
+
+describe("leadingWindowRange", () => {
+  it("returns [now−offset−windowMs, now−offset] for a 5m window", () => {
+    const now = 1_700_000_000_000;
+    const windowMs = Number(windowToMs("5m"));
+    const result = leadingWindowRange("5m", now);
+    expect(result.toTimestamp).toBe(
+      new Date(now - monitorEvaluationOffsetMs).toISOString(),
+    );
+    expect(result.fromTimestamp).toBe(
+      new Date(now - monitorEvaluationOffsetMs - windowMs).toISOString(),
+    );
+  });
+
+  it("returns [now−offset−windowMs, now−offset] for a 1h window", () => {
+    const now = 1_700_000_000_000;
+    const windowMs = Number(windowToMs("1h"));
+    const result = leadingWindowRange("1h", now);
+    expect(result.toTimestamp).toBe(
+      new Date(now - monitorEvaluationOffsetMs).toISOString(),
+    );
+    expect(result.fromTimestamp).toBe(
+      new Date(now - monitorEvaluationOffsetMs - windowMs).toISOString(),
+    );
+  });
+});
+
+describe("toLeadingPoint", () => {
+  it("pins the scalar value to the provided toTimestamp", () => {
+    const ts = "2024-01-15T12:00:00.000Z";
+    const row = { count_count: "42" };
+    const pt = toLeadingPoint(row, ts, "count", "count");
+    expect(pt.time_dimension).toBe(ts);
+    expect(pt.dimension).toBe("metric");
+    expect(pt.metric).toBe(42);
+  });
+
+  it("coerces missing metric to 0", () => {
+    const ts = "2024-01-15T12:00:00.000Z";
+    const pt = toLeadingPoint({}, ts, "count", "count");
+    expect(pt.metric).toBe(0);
+  });
+});

--- a/web/src/features/monitors/components/MonitorChartPreview.tsx
+++ b/web/src/features/monitors/components/MonitorChartPreview.tsx
@@ -13,6 +13,7 @@ import {
   RESOURCE_LIMIT_ERROR_MESSAGE,
 } from "@langfuse/shared";
 import {
+  monitorEvaluationOffsetMs,
   type MonitorThresholdOperator,
   type MonitorView,
   type MonitorWindow,
@@ -46,7 +47,7 @@ export const MonitorChartPreview = ({
   alertThreshold: number | null | undefined;
   warningThreshold: number | null | undefined;
 }) => {
-  /** fromTimestamp and toTimestamp span 20 complete window buckets ending at the last floored boundary. */
+  /** bucketRange spans 20 complete window buckets ending at the last floored boundary. */
   const { fromTimestamp, toTimestamp } = useMemo(() => {
     const ms = Number(windowToMs(window));
     const to = Math.floor(Date.now() / ms) * ms;
@@ -57,7 +58,13 @@ export const MonitorChartPreview = ({
     };
   }, [window]);
 
-  /** queryResult runs the preview query for the draft monitor. */
+  /** leadingRange is the [now−offset−windowMs, now−offset] scalar query range matching the processor's evaluationWindow. */
+  const leadingRange = useMemo(
+    () => leadingWindowRange(window, Date.now()),
+    [window],
+  );
+
+  /** queryResult runs the 20-bucket time-series preview query. */
   const queryResult = api.dashboard.executeQuery.useQuery(
     {
       projectId,
@@ -81,11 +88,39 @@ export const MonitorChartPreview = ({
     },
   );
 
-  /** data reshapes the query rows into chart points. */
-  const data: DataPoint[] = useMemo(
-    () => toChartPoints(queryResult.data ?? [], measure, aggregation),
-    [queryResult.data, measure, aggregation],
+  /** scalarResult runs the full-window scalar query for the leading point. */
+  const scalarResult = api.dashboard.executeQuery.useQuery(
+    {
+      projectId,
+      version: "v2",
+      query: {
+        view,
+        dimensions: [],
+        metrics: [{ measure, aggregation }],
+        filters,
+        timeDimension: null,
+        fromTimestamp: leadingRange.fromTimestamp,
+        toTimestamp: leadingRange.toTimestamp,
+        orderBy: null,
+        chartConfig: { type: "LINE_TIME_SERIES" },
+      },
+    },
+    {
+      trpc: { context: { skipBatch: true } },
+      meta: { silentHttpCodes: [422] },
+      refetchOnWindowFocus: false,
+    },
   );
+
+  /** data merges the 20-bucket series with an optional leading point. */
+  const data: DataPoint[] = useMemo(() => {
+    const points = toChartPoints(queryResult.data ?? [], measure, aggregation);
+    const scalarRow = scalarResult.data?.[0];
+    if (scalarRow !== undefined) {
+      points.push(toLeadingPoint(scalarRow, toTimestamp, measure, aggregation));
+    }
+    return points;
+  }, [queryResult.data, scalarResult.data, toTimestamp, measure, aggregation]);
 
   /** thresholds lists the warning and alert bands to draw on the chart. */
   const thresholds = useMemo(() => {
@@ -177,3 +212,35 @@ const toChartPoints = (
     } satisfies DataPoint;
   });
 };
+
+/** leadingWindowRange returns the [now−offset−windowMs, now−offset] range for the scalar leading-point query. */
+const leadingWindowRange = (
+  window: MonitorWindow,
+  now: number,
+): { fromTimestamp: string; toTimestamp: string } => {
+  const windowMs = Number(windowToMs(window));
+  const to = now - monitorEvaluationOffsetMs;
+  const from = to - windowMs;
+  return {
+    toTimestamp: new Date(to).toISOString(),
+    fromTimestamp: new Date(from).toISOString(),
+  };
+};
+
+/** toLeadingPoint converts a scalar executeQuery row into a DataPoint pinned to toTimestamp. */
+const toLeadingPoint = (
+  row: Record<string, unknown>,
+  toTimestamp: string,
+  measure: string,
+  aggregation: z.infer<typeof metricAggregations>,
+): DataPoint => {
+  const metricField = `${aggregation}_${measure}`;
+  const metric = row[metricField];
+  return {
+    time_dimension: toTimestamp,
+    dimension: "metric",
+    metric: Array.isArray(metric) ? metric : Number(metric || 0),
+  } satisfies DataPoint;
+};
+
+export const __test = { leadingWindowRange, toLeadingPoint };


### PR DESCRIPTION
## Summary

The monitor live preview rendered only 20 complete floored buckets and excluded the still-accumulating current window, making it impossible to see what the monitor would evaluate right now.

To achieve this we:
- Added a second scalar `executeQuery` with `timeDimension: null` over the processor's exact evaluation window (`[now − offset − windowMs, now − offset]`)
- Merged the scalar result as a 21st DataPoint pinned to the clean bucket boundary `toTimestamp`
- Moved `monitorEvaluationOffsetMs` from `processor.ts` into `types.ts` so the client-safe `@langfuse/shared/monitors` barrel exposes it without pulling in server-only code
- Added 4 unit tests covering `leadingWindowRange` and `toLeadingPoint` helper purity

**Note**: Faithful no-data semantics (COUNT gate, `noData` severity logic) are out of scope for preview. Tracked separately.

Fixes [LFE-10274](https://linear.app/langfuse/issue/LFE-10274/add-in-progress-leading-window-to-monitor-live-preview)

## Verification

- [x] `pnpm --filter web run lint`
- [x] `pnpm --filter web run typecheck`
- [x] `pnpm --filter @langfuse/shared run typecheck`
- [x] 4 new client tests pass (`MonitorChartPreview.clienttest.ts`)
- [ ] Browser review on create/edit monitor flow

## Test plan

- [ ] Open create-monitor form, set a 5m window and a metric — confirm the preview chart shows 21 points with the rightmost reflecting a live full-window aggregate
- [ ] Confirm the chart still renders with only 20 points if the scalar query returns no data (graceful degradation)
- [ ] Confirm existing create/edit monitor flow has no visual regressions

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the monitor live-preview chart with a 21st "leading" data point representing the still-accumulating current evaluation window, matching what the monitor processor would query right now. It also moves `monitorEvaluationOffsetMs` from `processor.ts` into `types.ts` so the client-safe `@langfuse/shared/monitors` barrel can export it without pulling in server-only code.

- A second `executeQuery` call (scalar, `timeDimension: null`) runs over `[now − offset − windowMs, now − offset]` and its result is appended as a 21st `DataPoint` pinned to the floored bucket boundary (`bucketRange.toTimestamp`), making the chart show the in-progress bucket alongside the 20 complete ones.
- `monitorEvaluationOffsetMs` is re-homed to `types.ts` with a re-export shim in `processor.ts` preserving the existing import surface; four unit tests cover the new pure helpers (`leadingWindowRange`, `toLeadingPoint`).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are additive and contained to the preview chart component with no impact on monitor execution or persistence logic.

The constant relocation and re-export shim are straightforward. The new scalar query and merge logic are well-isolated. The main concerns are the scalar query carrying a LINE_TIME_SERIES chart config despite having timeDimension: null, stale Date.now() in both range memos meaning the leading point ages silently while the form is open, and the __test shim leaking helper functions into the production bundle — all quality issues rather than correctness failures.

MonitorChartPreview.tsx — scalar query chart config and memo staleness are worth a second look before the browser review milestone is checked off.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as MonitorChartPreview
    participant Q1 as dashboard.executeQuery (20-bucket time-series)
    participant Q2 as dashboard.executeQuery (scalar leading point)
    participant CH as Chart

    C->>C: "bucketRange = floor(now/ms)*ms − 20*ms … floor(now/ms)*ms"
    C->>C: "leadingRange = now−30s−windowMs … now−30s"

    C->>Q1: view, metrics, timeDimension: granularity, [from, to]
    C->>Q2: view, metrics, timeDimension: null, [leadingFrom, leadingTo]

    Q1-->>C: rows[] (up to 20 bucketed points)
    Q2-->>C: rows[] (single scalar row, or empty)

    C->>C: toChartPoints(rows) → 20 DataPoints
    alt scalarResult.data [0] exists
        C->>C: toLeadingPoint(row, bucketRange.toTimestamp) → 21st DataPoint
    end

    C->>CH: data (20 or 21 DataPoints) + thresholds
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/features/monitors/components/MonitorChartPreview.tsx:101-105
The scalar query uses `chartConfig: { type: "LINE_TIME_SERIES" }` even though `timeDimension` is explicitly `null`. If the server routes or processes queries differently based on `chartConfig.type`, this mismatch could cause the backend to attempt time-bucketing on a no-dimension query, or return an unexpected shape. A scalar-appropriate chart type (or `null`) keeps intent clear and avoids any server-side misinterpretation.

```suggestion
        timeDimension: null,
        fromTimestamp: leadingRange.fromTimestamp,
        toTimestamp: leadingRange.toTimestamp,
        orderBy: null,
        chartConfig: { type: "TABLE" },
```

### Issue 2 of 3
web/src/features/monitors/components/MonitorChartPreview.tsx:62-65
**Stale `Date.now()` inside memoized leading range**

`leadingWindowRange` captures `Date.now()` once and caches it until `window` changes. For a user who opens the form, picks a window, and then idles, the leading point query will use increasingly stale timestamps — potentially fetching a window that ended minutes ago and displaying it as "current". The same pattern exists in `bucketRange`, so this is consistent, but the leading point is the one most expected to reflect "right now". Adding a `refetchInterval` to both `queryResult` and `scalarResult` (and dropping the memo cache dependency on wall time) would keep the live preview honest.

### Issue 3 of 3
web/src/features/monitors/components/MonitorChartPreview.tsx:246
**`__test` export leaks internals into the production bundle**

`__test` ships `leadingWindowRange` and `toLeadingPoint` to every client bundle. Since both are pure functions with no side effects, they can be moved to a co-located helper module (e.g., `monitorChartHelpers.ts`) and imported by both the component and the test file directly — no `__test` shim needed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(monitors): add in-progress leading ..."](https://github.com/langfuse/langfuse/commit/d48c6a99fdd43a7cdbb641454b65fa74986fbb52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37603786)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->