### PR TITLE
docs(agents): update weekly production review skill

### DIFF
--- a/.agents/skills/weekly-production-review/SKILL.md
+++ b/.agents/skills/weekly-production-review/SKILL.md
@@ -1,33 +1,34 @@
 ---
 name: weekly-production-review
 description: |
-  Prepare Langfuse weekly production reviews that explain what broke, what was
-  fixed, what remains open, and where alerting or tracking needs cleanup. Use
-  when asked for a production review, "what broke last week", fixed/open bugs,
-  Datadog alerted monitors/pages, Datadog error log patterns, incident.io
-  incidents or pager load, or an engineering-team overview that combines
-  Datadog, incident.io, and Linear production signals.
+  Prepare Langfuse weekly production reviews that audit what broke, what was
+  fixed, what remains open, and where Datadog, incident.io, or Linear tracking
+  needs cleanup. Use when asked for a production review, "what broke last week",
+  fixed/open production bugs, Datadog alerted monitors/pages, Datadog error log
+  patterns, incident.io incidents, or a four-table engineering review across
+  incident.io, Linear bugs, Datadog alerts, and Datadog logs.
 ---
 
 # Weekly Production Review
 
 Use this skill to produce a source-grounded production review across Datadog,
-incident.io, and Linear. The report should help engineering understand the
-week while keeping each source's evidence easy to audit.
+incident.io, and Linear. Keep the output factual, table-first, and easy to
+audit from the linked source rows.
 
 ## Scope
 
 - Default "last week" to the previous Monday through Sunday in the user's
-  timezone. State both local and UTC query windows.
+  timezone. State both local and UTC query windows in one short scope line.
 - Cover all production environments unless the user narrows scope:
   `prod-us`, `prod-eu`, `prod-hipaa`, and `prod-jp`.
 - Keep the first pass read-only. Do not create or update Linear issues,
-  comments, incident.io records, follow-ups, alerts, or Datadog monitors unless
-  the user explicitly asks after reviewing the findings.
+  comments, incident.io records, follow-ups, alerts, Datadog monitors, files,
+  Slack messages, or production systems unless the user explicitly asks after
+  reviewing the findings.
 - For chat-only reviews, avoid creating report artifacts or local analysis
   workspaces unless a required tool workflow explicitly does so or the user asks
   for a file. If incident.io analysis tooling requires a local playbook
-  workspace, mention it briefly inline when relevant and keep production systems
+  workspace, mention it only when relevant and keep production systems
   unchanged.
 - Write `No measurements found` when a requested signal cannot be queried or
   measured.
@@ -43,153 +44,162 @@ week while keeping each source's evidence easy to audit.
 
 1. Confirm the review window and timezone. If the user says "last week", use the
    previous calendar week, not a rolling seven-day window.
-2. Gather public incidents from incident.io. Prefer incident.io for accepted
-   incidents, public incident visibility, and follow-ups. Always produce the
-   incident.io public incident table below, even when no rows are found.
-3. Gather Datadog alert/page signals for the window. Use incident.io alerts or
-   escalations when they represent pages; use Datadog monitor/event data when
-   available. Always produce the incident.io pager-load day/night table below,
-   even when escalation data is unavailable; in that case, follow the section's
-   `No measurements found` fallback. First build the exhaustive alert universe
-   by paginating through Datadog events until no more results remain for the
-   window; do not rely on a truncated first page, sampled titles, or a few spot
-   checks. Cover all prod envs in scope even when one site is noisy or one env
-   looks quiet. After the full pass, group repeated firings of the same monitor
-   instead of counting every notification as a separate event. If the user also
-   asks for unalerted API route or queue consumer degradation, run that
-   proactive Datadog sweep as a separate phased pass inside this review:
-   retrieve all recent/baseline route and queue measurements across environments
-   first, perform a focused root-cause investigation for each ranked finding,
-   then cross-reference incident.io and Linear.
-4. For each Datadog alert/page signal row, perform a deeper investigation
-   before writing the final report. Do not stop at the monitor title or
-   top-level count. Inspect matching APM spans, representative traces, related
-   logs, error records, exception details, and dependency spans. For failed
-   traces, explicitly query the related Datadog logs and errors to find the
-   underlying issue; do not infer root cause from span status or monitor title
-   alone. For API routes and failed queue jobs, use the Datadog Issue Deep
-   Dives section below. Even
-   `expected/test` and `monitor noise` rows need a concise verification deep
-   dive explaining why they are classified that way.
-5. Gather Datadog error log patterns for the window. Use logs with
-   `status:error`, scope to production environments, and group by clustered
-   message pattern plus service/env where available. Always produce the Datadog
-   Error Log Pattern Review section below, even when no rows are found.
-6. Gather Linear bugs from the `bug` label first. Include all `bug`-labeled
-   tickets created, updated, completed, or still-open with production evidence
+2. Gather public/customer-facing incidents from incident.io. Prefer incident.io
+   for accepted incidents, public incident visibility, follow-ups, and incident
+   status. Always produce the incident.io table below, even when no rows are
+   found.
+3. Gather Linear bugs from the `bug` label first. Include all `bug`-labeled
+   tickets created, updated, completed, or still open with production evidence
    during the window. Inspect likely production bugs with issue details and
-   comments when status, owner, or evidence is unclear. Use Linear as the
-   source of truth for deduplication and follow-up ownership: search existing
-   issues, comments, and linked source URLs before treating a signal as new.
-7. Classify each bug, alert, and error-log pattern. Separate production
-   breakage from staging, self-hosted, internal-only, duplicate, canceled, test,
-   or monitor-noise signals.
-8. Cross-reference the source tables. Link Datadog rows to matching incident.io
-   incidents or Linear bugs when evidence supports the relationship. Link
-   incident.io rows to Datadog alerts/monitors and Linear follow-ups when
-   present. Link Linear rows to Datadog or incident.io evidence when available.
-   If a relationship is inferential, say so in the row.
-9. Present source-focused sections only. Do not create a synthesized
-   cross-source summary table.
+   comments when status, owner, or evidence is unclear. Always produce the
+   Linear bug table below.
+4. Gather Datadog alert/page signals for the window. Use incident.io alerts or
+   escalations when they represent pages; use Datadog monitor/event data when
+   available. Build the exhaustive alert universe by paginating until no more
+   results remain for the window. Cover every production environment in scope.
+   Group repeated firings by monitor/page title or ID, environment, service/team,
+   and trigger reason.
+5. For every Datadog alert/page cluster, perform the deep dive before writing the
+   final row. Do not stop at the monitor title or count. Inspect matching APM
+   spans, representative traces, related logs, error records, exception details,
+   failed job logs, dependency spans, queue backlog/delay context, and monitor
+   time windows. Put the relevant trace/span evidence and relevant logs/errors
+   directly in the Datadog alerts table. Do not create a separate Datadog Issue
+   Deep Dives table.
+6. Gather Datadog error log patterns for the window. Use logs with
+   `status:error`, scope to production environments, and group by the clustered
+   `message` pattern plus service/env where available. Always produce the
+   Datadog logs table below. Preserve exact Datadog patterns, including wildcard
+   tokens, instead of paraphrasing them.
+7. Classify each incident, bug, alert, and log pattern. Separate production
+   breakage from self-hosted, internal-only, duplicate, canceled, expected/test,
+   staging/dev, monitor-noise, or unknown signals.
+8. Cross-reference source rows on a best-effort basis. Link Datadog rows to
+   matching incident.io incidents or Linear bugs when evidence supports the
+   relationship. Link incident.io and Linear rows back to Datadog evidence when
+   available. If a relationship is inferential, say so in the row.
+
+## Output Contract
+
+Return one short scope line followed by exactly these four source tables, in
+this order:
+
+1. incident.io
+2. Linear Bugs
+3. Datadog Alerts
+4. Datadog Logs
+
+Do not add an executive summary, narrative summary, event-centric view, summary
+table, source synthesis table, pager-load day/night table, or separate Datadog
+Issue Deep Dives table. Put counts and classifications inside the source tables.
+
+If a table has no rows, keep the table heading and write one row or sentence
+with `No rows found` or `No measurements found` plus the scoped source/query.
+If a row is unclear, classify it as `unclear` or `unknown/no measurements`
+instead of dropping it.
 
 ## Cross-Source Linking
 
-Keep Datadog, incident.io, and Linear as separate output sections. Use links
-inside each source table to show relationships instead of synthesizing a
-separate cross-source table.
+Keep incident.io, Linear, Datadog alerts, and Datadog logs as separate output
+tables. Use links inside each table to show relationships instead of
+synthesizing a separate cross-source table.
 
 Use Linear as the source of truth for deduplication across weeks and workflows.
 Before reporting a bug, security finding, cost concern, or alert as new, search
 Linear for matching issue keys, titles, source URLs, and comments. If an
-existing issue covers it, link to that issue and mark the review row as already
+existing issue covers it, link to that issue and mark the row as already
 tracked instead of reporting it again as fresh work.
 
-Use this table to decide what each source should link to:
-
-| Source Row | Should Link To | How To Represent In Review |
-| --- | --- | --- |
-| Datadog alert/page | incident.io incident/follow-up, Linear issue, monitor/query/log/span links | Datadog row with `incident.io / Linear Link` populated when known |
-| Datadog error-log pattern | matching Datadog alert/page deep dive, incident.io incident, Linear issue, representative logs | log pattern row with `Related Signal / Link` populated when known |
-| incident.io incident | Datadog alert/monitor/query links, Linear follow-ups | incident.io row with linked source URLs |
-| Linear production bug | Datadog monitor/query/trace/log links, incident.io incident if any | Linear row with production evidence links |
-
-Do not write links, create follow-ups, or update external systems unless the
-user explicitly asks for changes after reviewing the report.
-
-### Proposed Link Titles
-
-When proposing or later creating links, use short stable titles:
+Use short stable link labels:
 
 - `Datadog monitor: <monitor name>`
 - `Datadog logs: <env/service/symptom>`
 - `Datadog spans: <env/route/symptom>`
 - `Datadog trace: <trace id or route>`
 - `incident.io: <INC reference>`
-- `Linear follow-up: <issue key>`
+- `Linear: <issue key>`
 
-Do not write any of these links unless the user explicitly asks for changes
-after reviewing the report.
+Do not write links, create follow-ups, or update external systems unless the
+user explicitly asks for changes after reviewing the report.
 
-## Output Table Rules
+## incident.io Table
 
-Use the tables defined below as the default output contract. Keep the table
-names, column names, and section order stable across runs so reviewers can scan
-the same shape every week. Do not add extra source-specific tables unless the
-user asks or the existing columns cannot represent an important finding.
+Use this table for incident.io incidents with public or customer-facing impact
+in the review window. Query incident.io with `incident_list` scoped to the
+review window and relevant team when known. Include `summary`, `roles`,
+`custom_fields`, `timestamps`, `durations`, and `escalation_urgency` when the
+tool supports them. If the tool cannot filter by visibility server-side, list
+the scoped incidents and include only rows where `visibility` is `public` or
+the evidence supports customer-facing impact.
 
-If a section has no rows, keep the section and write `No rows found` or
-`No measurements found` with the query/source that was checked. If a row is
-unclear, classify it as `unclear` or `unknown/no measurements` instead of
-dropping it.
+| Incident | Severity / Status | Start / End / Duration | Impact | Linked Sources | Follow-ups / Notes |
+| --- | --- | --- | --- | --- | --- |
 
-## Datadog Alert/Page Signals
+Column rules:
 
-Use this table as the evidence layer:
+- `Incident`: incident.io reference linked to the incident.
+- `Severity / Status`: severity and current lifecycle status.
+- `Start / End / Duration`: reported, identified, resolved, and duration when
+  available.
+- `Impact`: short impact statement grounded in the incident summary.
+- `Linked Sources`: Datadog alerts/pages, Datadog logs/spans, Linear issues, or
+  `none found`.
+- `Follow-ups / Notes`: follow-up count/status or `none found`.
 
-| Monitor/Page Signal | Env | Count / Window | Why It Alerted | Verdict | incident.io / Linear Link |
-| --- | --- | ---: | --- | --- | --- |
+## Linear Bugs Table
 
-The Datadog table answers "what alerted or paged?" Use these verdicts:
+Start from all Linear tickets with the `bug` label that were touched by the
+window. Do not rely only on text searches for `prod`, `incident`, or `Datadog`;
+those searches are useful for enrichment but are not the source universe. This
+table is the Linear source inventory. A Linear bug can be classified as
+non-production, duplicate, canceled, or no-action.
 
-- `customer incident`
-- `confirmed bug`
-- `infra/dependency`
-- `expected/test`
-- `monitor noise`
-- `unknown/no measurements`
+| Linear | Title | Summary | Owner | Status | Touched Last Week Because | Production Evidence | Classification | Counted? |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
 
-Group repeated pages by monitor name or ID, environment, service/team, and
-trigger reason. Exclude or clearly mark SLO/burn-rate monitors, test monitors,
-and maintenance-window noise when the review is about actionable breakage.
-The table must still account for every production Datadog alert cluster found
-in the full Datadog alert/event pass, including clusters later classified as
+Column rules:
+
+- `Linear`: issue key linked to Linear, such as `LFE-123`.
+- `Title`: Linear issue title in a separate column.
+- `Summary`: one operational sentence based on the issue body, comments, and
+  evidence. Avoid fix guesses.
+- `Owner`: assignee if present; otherwise owning team if clear; otherwise
+  `Unassigned`.
+- `Status`: Linear status or state, plus completion timing when useful.
+- `Touched Last Week Because`: `created`, `updated`, `completed`, or
+  `open production bug`.
+- `Production Evidence`: prod env, customer impact, incident.io incident,
+  Datadog link, measured logs/spans/errors, or `No measurements found`.
+- `Classification`: use `production/customer-impacting`, `internal-only`,
+  `self-hosted`, `staging/dev`, `duplicate/canceled/no-action`, or `unclear`.
+- `Counted?`: `yes` only when the bug label and production/customer-impacting
+  evidence support including it in fixed/open production bug counts.
+
+## Datadog Alerts Table
+
+Use this table for every production Datadog alert/page cluster found in the full
+paginated alert/event pass, including clusters later classified as
 `expected/test`, `monitor noise`, or `unknown/no measurements`.
 
-Before finalizing the review, perform a completeness check:
+| Monitor / Page Signal | Env / Service | Count / Window | Why It Alerted | Trace / Span Evidence | Relevant Logs / Errors | Verdict | incident.io / Linear Link |
+| --- | --- | ---: | --- | --- | --- | --- | --- |
 
-1. Compare the final Datadog table against the full paginated Datadog
-   alert/event sweep.
-2. Confirm every production monitor title seen during the window appears in the
-   table or is explicitly excluded as non-prod.
-3. If a known title is missing, add it before writing the narrative summary.
+Column rules:
 
-`incident.io / Linear Link` should contain the matching incident.io reference,
-Linear issue key, or explicit disposition such as `monitor noise` or
-`unknown/no measurements`. Do not leave a real page as `none` unless the next
-action is to classify the alert.
-
-## Datadog Issue Deep Dives
-
-Use this section for every row in the Datadog Alert/Page Signals table. There
-must be a one-to-one mapping: each monitor/page signal row has exactly one
-corresponding deep-dive row with the same signal name or ID. If repeated
-firings were grouped into one alert/page cluster above, create one deep dive for
-that cluster. If the user asks for individual firings instead of clusters,
-create one deep dive per firing.
-
-Include confirmed bugs, customer incidents, infra/dependency issues, unknowns
-that need classification, and concise verification rows for `expected/test` or
-`monitor noise`.
+- `Monitor / Page Signal`: monitor/page title or stable ID.
+- `Env / Service`: production env and service/team labels.
+- `Count / Window`: grouped firing/page count and relevant time window.
+- `Why It Alerted`: monitor threshold, trigger condition, route, queue, status
+  code, latency, or backlog signal.
+- `Trace / Span Evidence`: representative trace/span links, error counts,
+  latency, status codes, dependency spans, or `No measurements found`.
+- `Relevant Logs / Errors`: explicit exception class/message, exact or
+  normalized log message, failed job IDs when visible, DB/downstream errors,
+  retry exhaustion, validation failures, or `No measurements found`.
+- `Verdict`: use `customer incident`, `confirmed bug`, `infra/dependency`,
+  `expected/test`, `monitor noise`, or `unknown/no measurements`.
+- `incident.io / Linear Link`: matching incident.io reference, Linear issue key,
+  explicit disposition, or `none found`.
 
 For API route and queue consumer errors, start from APM spans matching:
 
@@ -198,45 +208,20 @@ operation_name:(http.server OR bullmq.consumer) status:error env:<prod-env>
 ```
 
 Then narrow by `service`, `resource_name`, route, queue, consumer, status code,
-error type, or monitor time window. For each failed trace sample, explicitly
-query related Datadog logs and error records using the trace ID, span ID,
-service, resource name, environment, and same time window. Use those logs and
-errors to identify the underlying issue, such as application exceptions,
-database errors, downstream timeouts, retry exhaustion, validation failures,
-capacity pressure, or deploy regressions. If no related logs or error records
-are found, state `No measurements found`.
+error type, or monitor time window. For failed trace samples, explicitly query
+related Datadog logs and error records using the trace ID, span ID, service,
+resource name, environment, and same time window. If no related logs or error
+records are found, write `No measurements found`.
 
-For queue jobs, include failed job logs, exception class/message, queue name,
-consumer service, backlog or delay context, and whether retries succeeded. For
-API routes, include HTTP method/status, route/resource, exception class/message,
-slow or failed database/downstream spans, and whether failures are
-customer-facing or internal.
+Before finalizing, compare the final Datadog alerts table against the full
+paginated alert/event sweep. Confirm every production monitor title seen during
+the window appears in the table or is explicitly excluded as non-prod.
 
-Use this table:
+## Datadog Logs Table
 
-| Datadog Issue | Scope | Trace / Span Evidence | Logs / Error Details | Likely Cause | Links / Next Action |
-| --- | --- | --- | --- | --- | --- |
-
-Column rules:
-
-- `Datadog Issue`: same monitor/page signal name, monitor ID, route, queue
-  consumer, or measured regression used in the Datadog Alert/Page Signals row.
-- `Scope`: env, service, route/resource, queue, and time window.
-- `Trace / Span Evidence`: representative trace links, error counts, latency,
-  status codes, dependency spans, or `No measurements found`.
-- `Logs / Error Details`: exception class/message, failed job IDs when visible,
-  stack/log summary, or `No measurements found`.
-- `Likely Cause`: use a grounded class such as `application exception`,
-  `slow database`, `downstream dependency`, `queue backlog`, `capacity`,
-  `deploy/regression`, `monitor noise`, or `unknown`.
-- `Links / Next Action`: incident.io incident, Linear issue, Datadog trace/log
-  links, or concrete follow-up such as `needs owner review`.
-
-## Datadog Error Log Pattern Review
-
-Use this section to review the most frequent production error-log patterns from
-the review window. This is a broad log-health pass and is separate from the
-alert/page deep dives above.
+Use this table for the most frequent production error-log patterns from the
+review window. This is a broad log-health pass and is separate from the alert
+cluster rows above, though rows should cross-link when possible.
 
 Start from a Datadog Logs query shaped like:
 
@@ -251,141 +236,37 @@ and sort by count descending. Review at least the top 10 patterns overall, plus
 any additional top pattern per production environment when the global top 10 is
 dominated by one env or service.
 
-Use this table:
-
-| Error Log Pattern | Env / Service | Count / Share | Representative Error | Related Signal / Link | Disposition |
+| Exact Log Pattern | Env / Service | Count / Share | Representative Error | Related Signal / Link | Disposition |
 | --- | --- | ---: | --- | --- | --- |
 
 Column rules:
 
-- `Error Log Pattern`: clustered message pattern or concise normalized error.
+- `Exact Log Pattern`: exact Datadog clustered pattern or exact raw log message.
+  Preserve Datadog wildcard syntax such as `[wildcard]...[/wildcard]`. Do not
+  paraphrase this column.
 - `Env / Service`: affected production envs and services.
 - `Count / Share`: count in the review window and share if available.
-- `Representative Error`: one short representative message, exception class,
-  or stack/log summary. Do not paste long stack traces.
-- `Related Signal / Link`: related Datadog alert/page deep dive, trace, log
-  query, incident.io incident, Linear issue, or `none found`.
-- `Disposition`: `known incident`, `tracked bug`, `needs investigation`,
+- `Representative Error`: one exact short representative message, exception
+  class, or stack/log summary. Avoid long stack traces.
+- `Related Signal / Link`: related Datadog alert row, trace, log query,
+  incident.io incident, Linear issue, or `none found`.
+- `Disposition`: use `known incident`, `tracked bug`, `needs investigation`,
   `expected/test`, `monitor noise`, or `unknown`.
 
 If a high-volume pattern maps to a failed API route or queue consumer, ensure
-the matching Datadog Issue Deep Dive includes the trace/log/error investigation.
-If a high-volume pattern has no alert/page row, keep it in this table anyway and
+the matching Datadog alert row includes the trace/log/error investigation. If a
+high-volume pattern has no alert/page row, keep it in this table anyway and
 mark it `needs investigation` or `unknown` based on evidence.
-
-## incident.io Public Incident Table
-
-Use this section for incident.io incidents with public visibility in the review
-window. Query incident.io with `incident_list` scoped to the review window and
-relevant team when known. Include `summary`, `roles`, `custom_fields`,
-`timestamps`, `durations`, and `escalation_urgency` when the tool supports
-them. If the tool cannot filter by visibility server-side, list the scoped
-incidents and include only rows where `visibility` is `public`.
-
-| Incident | Severity / Status | Start / End / Duration | Impact | Linked Sources |
-| --- | --- | --- | --- | --- |
-
-Lead each incident summary with its incident.io reference or URL. Preserve
-uncertainty when timestamps, severity, linked alerts, or Linear follow-ups are
-missing. If no public incident.io incidents are found, write one sentence with
-the scoped query window and `No measurements found`.
-
-## Pager-Load Day/Night Table
-
-Use this section for incident.io escalation/page volume by time of day. Prefer
-`escalation_stats` filtered to the relevant escalation path or team-owned path.
-Group by `time_of_day`; add `status` and `priority` groupings when useful for
-context.
-
-incident.io `time_of_day` buckets are UTC:
-
-- `working_hours`: 09:00-18:00 Monday-Friday.
-- `late_evening`: 18:00-23:00 any day plus weekend daytime.
-- `overnight`: 23:00-09:00.
-
-For the headline split, calculate `day/evening` as `working_hours +
-late_evening` and `night` as `overnight`. Be explicit that this is pager-load
-from escalations, not raw alert volume, unless the source tool provides raw
-alert day/night breakdowns.
-
-| Bucket | Count | Share | Priority / Outcome | Notes |
-| --- | ---: | ---: | --- | --- |
-
-Include rows for `working_hours`, `late_evening`, `overnight`, `day/evening
-total`, and `night total` when measurements exist. If incident.io escalation
-stats are unavailable, write `No measurements found` and fall back to Datadog
-monitor/page clusters without inventing a day/night split.
-
-## Linear Bug Table
-
-Start from all Linear tickets with the `bug` label that were touched by the
-window. Do not rely only on text searches for `prod`, `incident`, or `Datadog`;
-those searches are useful for enrichment but are not the source universe. This
-table is the Linear source inventory, not a cross-source summary. A Linear bug
-can be classified as non-production, duplicate, canceled, or no-action.
-
-Use this table for the bug section:
-
-| Linear | Title | Summary | Owner | Status | Touched Last Week Because | Production Evidence | Classification | Counted? |
-| ------ | ----- | ------- | ----- | ------ | ------------------------- | ------------------- | -------------- | -------- |
-
-Column rules:
-
-- `Linear`: the issue key linked to Linear, such as `LFE-123`.
-- `Title`: the Linear issue title in a separate column. Do not collapse the
-  title into the `Linear` link because reviewers need to scan IDs and titles
-  independently.
-- `Summary`: one operational sentence based on issue body, comments, and
-  evidence. Avoid fix guesses.
-- `Owner`: assignee if present; otherwise owning team if clear; otherwise
-  `Unassigned`.
-- `Status`: the Linear status or state, plus completion timing when useful
-  such as `Done May 18`, `Todo`, `Triage`, or `Canceled`.
-- `Touched Last Week Because`: `created`, `updated`, `completed`, or
-  `open production bug`.
-- `Production Evidence`: prod env, customer impact, incident.io incident,
-  Datadog link, measured logs/spans/errors, or `No measurements found`.
-- `Classification`: use one of `production/customer-impacting`,
-  `internal-only`, `self-hosted`, `staging/dev`, `duplicate/canceled/no-action`,
-  or `unclear`.
-- `Counted?`: `yes` only when the bug label and production/customer-impacting
-  evidence support including it in fixed/open production bug counts. Do not use
-  this field as a cross-source issue count.
-
-For headline counts, report fixed and open production bugs separately from the
-total number of bug-labeled tickets reviewed.
-
-## Executive Summary
-
-Start the final report with:
-
-- Review window and environments checked.
-- Number of incident.io public incidents.
-- Pager-load total with day/evening versus night split.
-- Number of Datadog alert/page clusters, plus noisy/test clusters if relevant.
-- Number of Datadog issues deep-dived and the top likely cause classes.
-- Number of Datadog error-log patterns reviewed and the highest-volume pattern.
-- Number of `bug`-labeled Linear tickets reviewed.
-- Production bug count split by fixed and open.
-- Highest open risk and why.
-
-Then present sections in this order:
-
-1. Datadog Alert/Page Signals.
-2. Datadog Issue Deep Dives.
-3. Datadog Error Log Pattern Review.
-4. incident.io Public Incident Table.
-5. Pager-Load Day/Night Table.
-6. Linear Bug Table.
 
 ## Output Format
 
 Return valid Markdown only.
 
-- Use valid Markdown syntax for headings, bullets, links, and tables.
+- Use valid Markdown syntax for headings, links, and tables.
 - Include a space after list markers such as `-`, `*`, and `1.`.
 - Close links and parentheses correctly.
 - Do not emit malformed tables, dangling backticks, or partially opened code
   fences.
+- Escape table pipes inside log patterns or error messages when needed.
 - If a section would be fragile to format, prefer a plain paragraph over broken
   Markdown.

--- a/.agents/skills/weekly-production-review/agents/openai.yaml
+++ b/.agents/skills/weekly-production-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Weekly Production Review"
-  short_description: "Review Datadog, incident.io, and Linear production signals"
-  default_prompt: "Use $weekly-production-review to prepare a source-grounded production review across Datadog alert/page signals, Datadog error log patterns, incident.io incidents and pager load, and Linear bugs."
+  short_description: "Four-table production review"
+  default_prompt: "Use $weekly-production-review to prepare a four-table production review for last week across incident.io incidents, Linear bugs, Datadog alerts, and exact Datadog log patterns."


### PR DESCRIPTION
## Summary
- Update the weekly production review skill to produce five source tables: incident.io, incident.io alert load, Linear bugs, Datadog alerts, and Datadog logs.
- Add an incident.io alert-load table grouped by engineer and time bucket: working hours, late evening, and overnight.
- Require exact Datadog log patterns in the logs table and explicit relevant logs/errors in Datadog alert rows.
- Refresh the OpenAI skill metadata prompt/description to match the source-table output contract.

## Impacted packages
- Agent setup only: `.agents/skills/weekly-production-review`

## Verification
- `pnpm run agents:sync`
- `pnpm run agents:check`
- `.agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/weekly-production-review`
- Pre-commit hook: `prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli`
- Pre-commit hook: `turbo run lint`