### PR TITLE
ci: fix `label-prs-with-conflicts.yml`

### DIFF
--- a/.github/workflows/label-prs-with-conflicts.yml
+++ b/.github/workflows/label-prs-with-conflicts.yml
@@ -20,7 +20,10 @@ jobs:
     steps:
       - name: Check mergeability and update label
         env:
-          GH_TOKEN: ${{ github.token }}
+          # The token should only have the following permissions:
+          # - Issues: read/write
+          # - Pull requests: read-only.
+          GH_TOKEN: ${{ secrets.PR_LABELER_TOKEN }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           LABEL_NAME: has-conflicts
@@ -32,28 +35,62 @@ jobs:
             local pr_number="$1"
             local remove_stale_label="${2:-false}"
 
-            mergeable=$(gh api "repos/${REPO}/pulls/${pr_number}" --jq '.mergeable')
-            for delay in 3 6 12 24; do
-              if [ "${mergeable}" != "null" ]; then
+            get_mergeable() {
+              local pr_number="$1"
+              local response
+              local mergeable
+
+              if ! response=$(gh api "repos/${REPO}/pulls/${pr_number}" 2>&1); then
+                response="${response//$'\n'/ }"
+                echo "::warning::PR #${pr_number}: failed to fetch mergeability: ${response}" >&2
+                return 1
+              fi
+
+              if ! mergeable=$(jq -r '
+                if .mergeable == false or .mergeable_state == "dirty" then "false"
+                elif .mergeable == true then "true"
+                else "unknown"
+                end
+              ' <<<"${response}" 2>&1); then
+                response="${response//$'\n'/ }"
+                mergeable="${mergeable//$'\n'/ }"
+                echo "::warning::PR #${pr_number}: failed to parse mergeability: ${mergeable}; response: ${response}" >&2
+                return 1
+              fi
+
+              printf '%s\n' "${mergeable}"
+            }
+
+            if ! mergeable=$(get_mergeable "${pr_number}"); then
+              return 1
+            fi
+
+            for delay in 3 6; do
+              if [ "${mergeable}" != "unknown" ]; then
                 break
               fi
 
               sleep "${delay}"
-              mergeable=$(gh api "repos/${REPO}/pulls/${pr_number}" --jq '.mergeable')
+              if ! mergeable=$(get_mergeable "${pr_number}"); then
+                return 1
+              fi
             done
 
             echo "PR #${pr_number}: mergeable=${mergeable}"
 
-            if [ "${mergeable}" = "null" ]; then
+            if [ "${mergeable}" = "unknown" ]; then
               echo "::warning::PR #${pr_number}: mergeability was not computed after retries"
               return 1
             fi
 
             if [ "${mergeable}" = "false" ]; then
-              gh api \
+              if ! gh api \
                 --method POST \
                 "repos/${REPO}/issues/${pr_number}/labels" \
-                -f "labels[]=${LABEL_NAME}"
+                -f "labels[]=${LABEL_NAME}"; then
+                echo "::warning::PR #${pr_number}: failed to add ${LABEL_NAME} label" >&2
+                return 1
+              fi
             elif [ "${mergeable}" = "true" ] && [ "${remove_stale_label}" = "true" ]; then
               gh api \
                 --method DELETE \


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors `label-prs-with-conflicts.yml` to use a dedicated fine-grained PAT (`PR_LABELER_TOKEN`) instead of the default `github.token`, and substantially improves the mergeability-checking logic with proper error handling and a more accurate conflict detection strategy.

- Introduces `get_mergeable` as a nested helper inside `update_label_if_needed`, adding structured error handling for both the API call and the `jq` parse step; also expands conflict detection to cover `mergeable_state == \"dirty\"` (not just `.mergeable == false`).
- Switches to a custom `PR_LABELER_TOKEN` with the documented minimum-permission set (Issues read/write, PRs read-only), replacing the previous `github.token` that had wider implicit permissions.
- Reduces the maximum retry window from four attempts (3+6+12+24 s) to two (3+6 s), which trades resilience on slow GitHub mergeability computation for faster workflow completion.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the changes are a net improvement over the previous workflow with no regressions introduced.

The switch to a dedicated PAT is straightforward, the new get_mergeable helper adds meaningful error handling, and the mergeable_state == dirty check is a correct improvement. The only asymmetry is that label-removal failures are silently dropped while label-add failures are surfaced — but this does not cause incorrect labeling, just quieter diagnostics.

No files require special attention beyond confirming PR_LABELER_TOKEN is set in repository secrets.
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: Fix \`label-prs-with-conflicts.yml\`"](https://github.com/langfuse/langfuse/commit/a158f2190f07ea53cf1c14d66f63b34066827db2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37615699)</sub>

<!-- /greptile_comment -->