### PR TITLE
chore: one more place to fix 422 alerting

### DIFF
--- a/web/src/pages/api/trpc/[trpc].ts
+++ b/web/src/pages/api/trpc/[trpc].ts
@@ -25,6 +25,7 @@ export default createNextApiHandler({
       "FORBIDDEN",
       "BAD_REQUEST",
       "PRECONDITION_FAILED",
+      "UNPROCESSABLE_CONTENT",
     ];
 
     if (userErrorCodes.includes(error.code)) {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `"UNPROCESSABLE_CONTENT"` (HTTP 422) to the list of tRPC error codes treated as user errors in the `onError` handler, preventing 422 responses from being escalated to Sentry or logged as system errors.

- Adds `"UNPROCESSABLE_CONTENT"` to `userErrorCodes` in `web/src/pages/api/trpc/[trpc].ts`, so 422 errors are now logged at `info` level rather than `error` level and are not sent to `traceException`.
- Consistent with the existing treatment of `BAD_REQUEST`, `PRECONDITION_FAILED`, and other client-originated error codes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, one-line addition to an existing allowlist with no side effects beyond suppressing noisy Sentry alerts for 422 responses.

The only modified file is the tRPC error handler, and the change is a single string added to an allowlist that controls log level and Sentry routing. UNPROCESSABLE_CONTENT is a valid tRPC error code (HTTP 422), and it fits naturally alongside the existing client-error codes already in the list. There are no logic changes, no new code paths, and no risk of masking genuine system errors.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tRPC onError triggered] --> B{error.code in userErrorCodes?}
    B -- "NOT_FOUND / UNAUTHORIZED / FORBIDDEN\nBAD_REQUEST / PRECONDITION_FAILED\nUNPROCESSABLE_CONTENT ← new" --> C[logger.info — user error, no Sentry]
    B -- "INTERNAL_SERVER_ERROR\nor any other code" --> D[logger.error + traceException → Sentry]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: one more place to fix 422 alertin..."](https://github.com/langfuse/langfuse/commit/d335a3ed355245589ea899dc297deefda5fb4c1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37617360)</sub>

<!-- /greptile_comment -->