### PR TITLE
perf: restrict scores subquery to relevant trace IDs in dataset runs CTEs

### DIFF
--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -353,11 +353,11 @@ const getDatasetRunsTableInternal = async <T>(
           avg(value) as avg_value
         FROM scores s FINAL
         WHERE ${appliedScoresFilter.query}
-          AND s.trace_id IN (
-            SELECT dri.trace_id
-            FROM dataset_run_items_rmt dri
-            WHERE ${baseFilter.query}
-          )
+        AND s.trace_id IN (
+          SELECT dri.trace_id
+          FROM dataset_run_items_rmt dri
+          WHERE ${baseFilter.query}
+        )
         GROUP BY
           project_id,
           trace_id,
@@ -775,6 +775,7 @@ const getDatasetRunItemsTableInternal = async <
     projectId,
     datasetId,
   );
+  const baseFilter = datasetRunItemsFilter.apply();
 
   datasetRunItemsFilter.push(
     ...createFilterFromFilterState(
@@ -852,12 +853,11 @@ const getDatasetRunItemsTableInternal = async <
          avg(value) as avg_value
        FROM scores s FINAL
        WHERE ${appliedScoresFilter.query}
-         AND s.trace_id IN (
-           SELECT dri.trace_id
-           FROM dataset_run_items_rmt dri
-           WHERE dri.project_id = {projectId: String}
-             ${datasetId ? "AND dri.dataset_id = {datasetId: String}" : ""}
-         )
+       AND s.trace_id IN (
+        SELECT dri.trace_id
+        FROM dataset_run_items_rmt dri
+        WHERE ${baseFilter.query}
+      )
        GROUP BY
          project_id,
          trace_id,
@@ -897,6 +897,7 @@ const getDatasetRunItemsTableInternal = async <
   const res = await queryClickhouse<T>({
     query,
     params: {
+      ...baseFilter.params,
       ...appliedFilter.params,
       ...appliedScoresFilter.params,
       ...(limit !== undefined && offset !== undefined ? { limit, offset } : {}),

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -672,6 +672,11 @@ const getQualifyingDatasetItems = async <T>(opts: {
          avg(value) as avg_value
        FROM scores s FINAL
        WHERE ${appliedScoresFilter.query}
+       AND s.trace_id IN (
+         SELECT dri.trace_id
+         FROM dataset_run_items_rmt dri
+         WHERE ${baseFilter.query}
+       )
        GROUP BY
          project_id,
          trace_id,

--- a/packages/shared/src/server/repositories/dataset-run-items.ts
+++ b/packages/shared/src/server/repositories/dataset-run-items.ts
@@ -353,6 +353,11 @@ const getDatasetRunsTableInternal = async <T>(
           avg(value) as avg_value
         FROM scores s FINAL
         WHERE ${appliedScoresFilter.query}
+          AND s.trace_id IN (
+            SELECT dri.trace_id
+            FROM dataset_run_items_rmt dri
+            WHERE ${baseFilter.query}
+          )
         GROUP BY
           project_id,
           trace_id,
@@ -847,6 +852,12 @@ const getDatasetRunItemsTableInternal = async <
          avg(value) as avg_value
        FROM scores s FINAL
        WHERE ${appliedScoresFilter.query}
+         AND s.trace_id IN (
+           SELECT dri.trace_id
+           FROM dataset_run_items_rmt dri
+           WHERE dri.project_id = {projectId: String}
+             ${datasetId ? "AND dri.dataset_id = {datasetId: String}" : ""}
+         )
        GROUP BY
          project_id,
          trace_id,

--- a/web/src/__tests__/server/dataset-service.servertest.ts
+++ b/web/src/__tests__/server/dataset-service.servertest.ts
@@ -3071,4 +3071,216 @@ describe("Fetch datasets for UI presentation", () => {
       });
     });
   });
+
+  // Regression test for https://github.com/langfuse/langfuse/issues/13788
+  // The scores_aggregated CTE was scanning the full project scores table (no trace_id filter),
+  // causing resource limit errors on projects with millions of scores from unrelated datasets.
+  describe("scores subquery isolation across datasets", () => {
+    it("getDatasetRunsTableMetricsCh should not include scores from unrelated dataset traces", async () => {
+      const datasetAId = v4();
+      const datasetBId = v4();
+
+      await prisma.dataset.createMany({
+        data: [
+          { id: datasetAId, name: v4(), projectId },
+          { id: datasetBId, name: v4(), projectId },
+        ],
+      });
+
+      const runAId = v4();
+      const runBId = v4();
+      await prisma.datasetRuns.createMany({
+        data: [
+          {
+            id: runAId,
+            name: "run-a",
+            datasetId: datasetAId,
+            metadata: {},
+            projectId,
+          },
+          {
+            id: runBId,
+            name: "run-b",
+            datasetId: datasetBId,
+            metadata: {},
+            projectId,
+          },
+        ],
+      });
+
+      const itemAId = v4();
+      const itemBId = v4();
+      await prisma.datasetItem.createMany({
+        data: [
+          { id: itemAId, datasetId: datasetAId, metadata: {}, projectId },
+          { id: itemBId, datasetId: datasetBId, metadata: {}, projectId },
+        ],
+      });
+
+      const traceAId = v4();
+      const traceBId = v4();
+      const scoreName = v4();
+
+      await createDatasetRunItemsCh([
+        createDatasetRunItem({
+          id: v4(),
+          dataset_run_id: runAId,
+          trace_id: traceAId,
+          project_id: projectId,
+          dataset_item_id: itemAId,
+          dataset_id: datasetAId,
+          dataset_run_name: "run-a",
+        }),
+        createDatasetRunItem({
+          id: v4(),
+          dataset_run_id: runBId,
+          trace_id: traceBId,
+          project_id: projectId,
+          dataset_item_id: itemBId,
+          dataset_id: datasetBId,
+          dataset_run_name: "run-b",
+        }),
+      ]);
+
+      // Score on Dataset A's trace — should appear in Dataset A query
+      const scoreForA = createTraceScore({
+        id: v4(),
+        trace_id: traceAId,
+        project_id: projectId,
+        name: scoreName,
+        value: 0.9,
+      });
+      // Score on Dataset B's trace — must NOT bleed into Dataset A query
+      const scoreForB = createTraceScore({
+        id: v4(),
+        trace_id: traceBId,
+        project_id: projectId,
+        name: scoreName,
+        value: 0.1,
+      });
+      await createScoresCh([scoreForA, scoreForB]);
+
+      const runsA = await getDatasetRunsTableMetricsCh({
+        projectId,
+        datasetId: datasetAId,
+        runIds: [runAId],
+        filter: [],
+      });
+
+      expect(runsA).toHaveLength(1);
+      expect(runsA[0].id).toEqual(runAId);
+
+      // Assert directly on aggScoresAvg — the field populated by the scores_aggregated CTE
+      // that was modified. If the CTE regresses to a full-project scan the join still works
+      // correctly (UUIDs are unique), but if it ever incorrectly scopes to wrong traces this
+      // will catch it. Value should be 0.9 (Dataset A only), not averaged with B's 0.1.
+      const scoreEntry = runsA[0].aggScoresAvg.find(
+        ([name]) => name === scoreName,
+      );
+      expect(scoreEntry).toBeDefined();
+      expect(scoreEntry?.[1]).toBeCloseTo(0.9);
+    });
+
+    it("getDatasetRunItemsByDatasetIdCh should not include scores from unrelated dataset traces", async () => {
+      const datasetAId = v4();
+      const datasetBId = v4();
+
+      await prisma.dataset.createMany({
+        data: [
+          { id: datasetAId, name: v4(), projectId },
+          { id: datasetBId, name: v4(), projectId },
+        ],
+      });
+
+      const runAId = v4();
+      const runBId = v4();
+      await prisma.datasetRuns.createMany({
+        data: [
+          {
+            id: runAId,
+            name: "run-a",
+            datasetId: datasetAId,
+            metadata: {},
+            projectId,
+          },
+          {
+            id: runBId,
+            name: "run-b",
+            datasetId: datasetBId,
+            metadata: {},
+            projectId,
+          },
+        ],
+      });
+
+      const itemAId = v4();
+      const itemBId = v4();
+      await prisma.datasetItem.createMany({
+        data: [
+          { id: itemAId, datasetId: datasetAId, metadata: {}, projectId },
+          { id: itemBId, datasetId: datasetBId, metadata: {}, projectId },
+        ],
+      });
+
+      const traceAId = v4();
+      const traceBId = v4();
+      const scoreName = v4();
+
+      await createDatasetRunItemsCh([
+        createDatasetRunItem({
+          id: v4(),
+          dataset_run_id: runAId,
+          trace_id: traceAId,
+          project_id: projectId,
+          dataset_item_id: itemAId,
+          dataset_id: datasetAId,
+          dataset_run_name: "run-a",
+        }),
+        createDatasetRunItem({
+          id: v4(),
+          dataset_run_id: runBId,
+          trace_id: traceBId,
+          project_id: projectId,
+          dataset_item_id: itemBId,
+          dataset_id: datasetBId,
+          dataset_run_name: "run-b",
+        }),
+      ]);
+
+      const scoreForA = createTraceScore({
+        id: v4(),
+        trace_id: traceAId,
+        project_id: projectId,
+        name: scoreName,
+        value: 0.9,
+      });
+      const scoreForB = createTraceScore({
+        id: v4(),
+        trace_id: traceBId,
+        project_id: projectId,
+        name: scoreName,
+        value: 0.1,
+      });
+      await createScoresCh([scoreForA, scoreForB]);
+
+      // Filter by score name to exercise the scores_aggregated CTE in getDatasetRunItemsTableInternal
+      const items = await getDatasetRunItemsByDatasetIdCh({
+        projectId,
+        datasetId: datasetAId,
+        filter: [
+          {
+            type: "numberObject" as const,
+            column: "agg_scores_avg",
+            key: scoreName,
+            operator: ">=" as const,
+            value: 0.8,
+          },
+        ],
+      });
+
+      // Only Dataset A's run item (score 0.9) should match; B's item (score 0.1) must not appear
+      expect(items).toHaveLength(1);
+      expect(items[0].traceId).toEqual(traceAId);
+    });
+  });
 });


### PR DESCRIPTION
(#13803)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a performance regression in dataset run CTE queries where the `scores_aggregated` CTE was scanning the full project scores table without a `trace_id` predicate, causing resource-limit errors on large projects. The fix adds an `IN` subquery to both `getDatasetRunsTableInternal` and `getDatasetRunItemsTableInternal` to pre-filter scores to only the trace IDs that belong to the queried dataset runs.

- In `getDatasetRunsTableInternal`, the new subquery reuses `${baseFilter.query}` (which includes `runIds` when provided), matching the pattern already used in the `filteredObservationsCte` for the same table.
- In `getDatasetRunItemsTableInternal`, the subquery filters by `project_id` and `dataset_id` using the same hardcoded parameter names (`{projectId: String}`, `{datasetId: String}`) that are already included in the query's `params` object.
- Two integration regression tests are added that create cross-dataset scores and assert no bleed-over between datasets.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change narrows the scores scan to relevant trace IDs, follows existing patterns already used in the same file, and is covered by two new integration tests.

Both subqueries reuse either an already-proven baseFilter pattern (first function) or the same hardcoded parameter names already present in the params object (second function). The params contract is maintained in both cases. The regression tests exercise the exact bleed-over scenario from the linked issue. No logic paths are removed — only an additional predicate is added, so the change can only make the result set equal or smaller, never incorrectly larger.

No files require special attention. Both changed files are straightforward and well-tested.
</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Client calls getDatasetRunsTableMetricsCh / getDatasetRunItemsByDatasetIdCh"]
    A --> B["scores_aggregated CTE"]

    subgraph CTE["scores_aggregated CTE (patched)"]
        B --> C["FROM dataset_run_items_rmt dri\n(outer join source)"]
        C --> D["LEFT JOIN scores subquery"]
        D --> E["FROM scores s FINAL\nWHERE appliedScoresFilter\nAND s.trace_id IN (...)"]
        E --> F["IN subquery:\nSELECT trace_id\nFROM dataset_run_items_rmt\nWHERE project_id + dataset_id\n(+ runIds if provided)"]
        F -->|"only relevant trace IDs"| E
    end

    D --> G["GROUP BY dataset_run_id, project_id\n(+ trace_id in items query)"]
    G --> H["Main SELECT with\nLEFT JOIN scores_aggregated sa ON ..."]
    H --> I["WHERE appliedFilter (user filters)"]
    I --> J["Final result: scores scoped\nto dataset's traces only"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: clean up subquery formatting a..."](https://github.com/langfuse/langfuse/commit/d7a1fbe95b93db093be0bfd02bbd9158bfdcef46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37638903)</sub>

<!-- /greptile_comment -->