### PR TITLE
feat(agent,mcp): Include resource urls

### DIFF
--- a/web/src/__tests__/server/mcp-tools-read.servertest.ts
+++ b/web/src/__tests__/server/mcp-tools-read.servertest.ts
@@ -51,6 +51,12 @@ import {
 import { env } from "@/src/env.mjs";
 import "@/src/features/mcp/server/bootstrap";
 import { toolRegistry } from "@/src/features/mcp/server/registry";
+import {
+  buildEvaluatorUrl,
+  buildObservationUrl,
+  buildPromptUrl,
+  buildTraceUrl,
+} from "@/src/utils/product-url";
 
 // Import MCP tool handlers directly
 import {
@@ -347,9 +353,15 @@ describe("MCP Read Tools", () => {
       const result = (await handleListEvaluators(
         { page: 1, limit: 50 },
         context,
-      )) as { data: Array<{ id: string }> };
+      )) as { data: Array<{ id: string; url: string }> };
 
       expect(result.data.map((item) => item.id)).toContain(evaluator.id);
+      expect(result.data.find((item) => item.id === evaluator.id)?.url).toBe(
+        buildEvaluatorUrl({
+          projectId: setup.projectId,
+          evaluatorId: evaluator.id,
+        }),
+      );
     });
   });
 
@@ -374,7 +386,14 @@ describe("MCP Read Tools", () => {
 
       await expect(
         handleGetEvaluator({ evaluatorId: evaluator.id }, setup.context),
-      ).resolves.toMatchObject({ id: evaluator.id, name: evaluator.name });
+      ).resolves.toMatchObject({
+        id: evaluator.id,
+        name: evaluator.name,
+        url: buildEvaluatorUrl({
+          projectId: setup.projectId,
+          evaluatorId: evaluator.id,
+        }),
+      });
     });
   });
 
@@ -723,6 +742,11 @@ describe("MCP Read Tools", () => {
         type: "GENERATION",
         level: "DEFAULT",
         providedModelName: "gpt-4o-mini",
+        url: buildObservationUrl({
+          projectId,
+          traceId,
+          observationId: observation.id,
+        }),
       });
       expect(createdObservation?.input).toBeUndefined();
       expect(createdObservation?.output).toBeUndefined();
@@ -744,9 +768,16 @@ describe("MCP Read Tools", () => {
       const result = (await handleListObservations(
         { traceId, fields: ["id"], limit: 100 },
         { ...context, isInAppAgentKey: true },
-      )) as { data: Array<{ id: string }> };
+      )) as { data: Array<{ id: string; url: string }> };
 
       expect(result.data.map((item) => item.id)).toContain(observation.id);
+      expect(result.data.find((item) => item.id === observation.id)?.url).toBe(
+        buildObservationUrl({
+          projectId,
+          traceId,
+          observationId: observation.id,
+        }),
+      );
     });
 
     it("should project only requested fields", async () => {
@@ -773,6 +804,11 @@ describe("MCP Read Tools", () => {
         id: observation.id,
         name: observation.name,
         type: "GENERATION",
+        url: buildObservationUrl({
+          projectId,
+          traceId,
+          observationId: observation.id,
+        }),
       });
     });
 
@@ -838,11 +874,18 @@ describe("MCP Read Tools", () => {
           limit: 100,
         },
         context,
-      )) as { data: Array<{ id: string; userId: string | null }> };
+      )) as { data: Array<{ id: string; userId: string | null; url: string }> };
 
-      expect(result.data).toEqual([
-        { userId: matchingUserId, id: expect.any(String) },
-      ]);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toEqual({
+        userId: matchingUserId,
+        id: expect.any(String),
+        url: buildObservationUrl({
+          projectId,
+          traceId,
+          observationId: result.data[0]!.id,
+        }),
+      });
     });
 
     it("should match advanced input filters beyond the events_core truncation boundary", async () => {
@@ -879,9 +922,18 @@ describe("MCP Read Tools", () => {
           limit: 100,
         },
         context,
-      )) as { data: Array<{ id: string }> };
+      )) as { data: Array<{ id: string; url: string }> };
 
-      expect(result.data).toEqual([{ id: matchingObservation.id }]);
+      expect(result.data).toEqual([
+        {
+          id: matchingObservation.id,
+          url: buildObservationUrl({
+            projectId,
+            traceId,
+            observationId: matchingObservation.id,
+          }),
+        },
+      ]);
     });
 
     it("should require selective scope for full io and metadata access", async () => {
@@ -974,10 +1026,18 @@ describe("MCP Read Tools", () => {
           limit: 100,
         },
         context,
-      )) as { data: Array<{ id: string; name: string }> };
+      )) as { data: Array<{ id: string; name: string; url: string }> };
 
       expect(result.data).toEqual([
-        { id: matchingObservation.id, name: matchingObservation.name },
+        {
+          id: matchingObservation.id,
+          name: matchingObservation.name,
+          url: buildObservationUrl({
+            projectId,
+            traceId,
+            observationId: matchingObservation.id,
+          }),
+        },
       ]);
     });
 
@@ -1076,9 +1136,18 @@ describe("MCP Read Tools", () => {
           limit: 100,
         },
         context,
-      )) as { data: Array<{ id: string }> };
+      )) as { data: Array<{ id: string; url: string }> };
 
-      expect(result.data).toEqual([{ id: matchingObservation.id }]);
+      expect(result.data).toEqual([
+        {
+          id: matchingObservation.id,
+          url: buildObservationUrl({
+            projectId,
+            traceId,
+            observationId: matchingObservation.id,
+          }),
+        },
+      ]);
     });
 
     it("should return a cursor when more results are available", async () => {
@@ -1550,6 +1619,11 @@ describe("MCP Read Tools", () => {
         name: observation.name,
         type: "GENERATION",
         providedModelName: "gpt-4o-mini",
+        url: buildObservationUrl({
+          projectId,
+          traceId: observation.trace_id,
+          observationId: observation.id,
+        }),
       });
       expect(result.input).toBeUndefined();
       expect(result.output).toBeUndefined();
@@ -1570,7 +1644,14 @@ describe("MCP Read Tools", () => {
         { ...context, isInAppAgentKey: true },
       )) as Record<string, unknown>;
 
-      expect(result).toEqual({ id: observation.id });
+      expect(result).toEqual({
+        id: observation.id,
+        url: buildObservationUrl({
+          projectId,
+          traceId: observation.trace_id,
+          observationId: observation.id,
+        }),
+      });
     });
 
     it("should return requested fields for a single observation", async () => {
@@ -1591,6 +1672,11 @@ describe("MCP Read Tools", () => {
       expect(result).toEqual({
         id: observation.id,
         metadata: { customer: "acme" },
+        url: buildObservationUrl({
+          projectId,
+          traceId: observation.trace_id,
+          observationId: observation.id,
+        }),
       });
     });
 
@@ -1887,6 +1973,10 @@ describe("MCP Read Tools", () => {
         expect.objectContaining({
           id: matchingScore.id,
           dataType: "NUMERIC",
+          url: buildTraceUrl({
+            projectId,
+            traceId: matchingScore.trace_id,
+          }),
         }),
       ]);
       expect(data).toEqual([
@@ -1941,6 +2031,7 @@ describe("MCP Read Tools", () => {
         name: score.name,
         dataType: "NUMERIC",
         value: 0.8,
+        url: buildTraceUrl({ projectId, traceId: score.trace_id }),
       });
     });
 
@@ -1971,11 +2062,12 @@ describe("MCP Read Tools", () => {
     it("should create a score using v1 route semantics", async () => {
       const { context, projectId, apiKeyId } = await createMcpTestSetup();
       const scoreId = randomUUID();
+      const traceId = randomUUID();
 
       const result = await handleCreateScore(
         {
           id: scoreId,
-          traceId: randomUUID(),
+          traceId,
           name: `mcp-create-score-${nanoid(8)}`,
           value: 1,
           dataType: "NUMERIC",
@@ -1985,7 +2077,10 @@ describe("MCP Read Tools", () => {
         context,
       );
 
-      expect(result).toEqual({ id: scoreId });
+      expect(result).toEqual({
+        id: scoreId,
+        url: buildTraceUrl({ projectId, traceId }),
+      });
       await expect(
         verifyAuditLog({
           projectId,
@@ -2458,12 +2553,16 @@ describe("MCP Read Tools", () => {
         version: number;
         prompt: string;
         labels: string[];
+        url: string;
       };
 
       expect(result.name).toBe(promptName);
       expect(result.version).toBe(2);
       expect(result.prompt).toBe("Latest prompt");
       expect(result.labels).toContain("latest");
+      expect(result.url).toBe(
+        buildPromptUrl({ projectId, name: promptName, version: 2 }),
+      );
     });
 
     it("should fetch production prompt when production label is explicit", async () => {

--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -9,8 +9,10 @@ import {
   ThumbsUp,
   Wrench,
 } from "lucide-react";
+import Link from "next/link";
 import { Streamdown } from "streamdown";
 import { getSafeLinkUrl } from "@/src/components/ui/safe-url";
+import { stripBasePath } from "@/src/utils/redirect";
 import { cn } from "@/src/utils/tailwind";
 import {
   forwardRef,
@@ -34,6 +36,7 @@ import {
 import { useElementSize } from "@/src/hooks/useElementSize";
 import { useCopyToClipboard } from "@/src/hooks/useCopyToClipboard";
 import { useWatchedPromiseCallback } from "@/src/hooks/useWatchedPromiseCallback";
+import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import styles from "./InAppAgentMessage.module.css";
 
 export type InAppAgentMessageRole = "assistant" | "user";
@@ -59,6 +62,74 @@ export type InAppAgentToolCallContent = {
   result?: string;
   error?: string;
 };
+
+const parseAbsoluteUrl = (href: string): URL | null => {
+  try {
+    return new URL(href);
+  } catch {
+    return null;
+  }
+};
+
+// Uses client-side navigation for links within the current project
+// and opens all other links in a new tab.
+function SmartLink({
+  children,
+  className,
+  href,
+}: {
+  children: ReactNode;
+  className?: string;
+  href?: string;
+}) {
+  const safeHref = getSafeLinkUrl(href);
+  const currentProjectId = useProjectIdFromURL();
+
+  if (!safeHref) {
+    return <span className="text-muted-foreground underline">{children}</span>;
+  }
+
+  try {
+    const currentOrigin =
+      typeof window === "undefined" ? null : window.location.origin;
+    const absoluteUrl = parseAbsoluteUrl(safeHref);
+    const parsedUrl = absoluteUrl ?? new URL(safeHref, currentOrigin ?? "");
+    const pathname = stripBasePath(parsedUrl.pathname);
+    const [, projectSegment, linkProjectId] = pathname.split("/");
+
+    if (
+      currentProjectId &&
+      projectSegment === "project" &&
+      decodeURIComponent(linkProjectId ?? "") === currentProjectId &&
+      (!absoluteUrl ||
+        ((parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:") &&
+          currentOrigin &&
+          parsedUrl.origin === currentOrigin))
+    ) {
+      return (
+        <Link
+          href={`${pathname}${parsedUrl.search}${parsedUrl.hash}`}
+          className={className}
+        >
+          {children}
+        </Link>
+      );
+    }
+  } catch {
+    // Fall through to opening sanitized but non-routable URLs in a new tab.
+  }
+
+  return (
+    <a
+      href={safeHref}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+    >
+      {children}
+    </a>
+  );
+}
 
 export type InAppAgentMessageProps = {
   role: InAppAgentMessageRole;
@@ -648,23 +719,9 @@ function MessageText({
           h6: ({ children }) => <h6>{children}</h6>,
 
           p: ({ children }) => <p>{children}</p>,
-          a: ({ children, href }) => {
-            const safeHref = getSafeLinkUrl(href);
-
-            if (!safeHref) {
-              return (
-                <span className="text-muted-foreground underline">
-                  {children}
-                </span>
-              );
-            }
-
-            return (
-              <a href={safeHref} target="_blank" rel="noopener noreferrer">
-                {children}
-              </a>
-            );
-          },
+          a: ({ children, href }) => (
+            <SmartLink href={href}>{children}</SmartLink>
+          ),
           hr: ({ children }) => <hr>{children}</hr>,
           ul: ({ children }) => <ul>{children}</ul>,
           ol: ({ children }) => <ol>{children}</ol>,

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -36,6 +36,8 @@ If you think it would be helpful, ask the user for clarification or follow up qu
 Be concise, factual, and useful. Unless asked for a detailed explanation, keep your answers short and to the point.
 Use markdown in your responses when appropriate, especially for tables and lists.
 When you answer using Langfuse documentation tool results, answer normally. The product will attach source links automatically.
+When mentioning Langfuse entity IDs from MCP tool results, render them as markdown links.
+Never construct Langfuse URLs yourself, only use URLs included in tool-calls. If no url is available, mention the ID as plain text or fetch the entity with a tool first.
 IMPORTANT: You should minimize output tokens as much as possible while maintaining helpfulness, quality, and accuracy. Only address the specific query or task at hand, avoiding tangential information unless absolutely critical for completing the request. If you can answer in 1-3 sentences or a short paragraph, please do.
 IMPORTANT: You should NOT answer with unnecessary preamble or postamble (such as explaining your code or summarizing your action), unless the user asks you to.
 </behavioral_rules>

--- a/web/src/features/mcp/features/annotationQueues/tools/createAnnotationQueue.ts
+++ b/web/src/features/mcp/features/annotationQueues/tools/createAnnotationQueue.ts
@@ -4,6 +4,7 @@ import {
   CreateAnnotationQueueResponse,
 } from "@/src/features/public-api/types/annotation-queues";
 import { defineTool } from "../../../core/define-tool";
+import { buildAnnotationQueueUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { getMcpPublicApiAuth } from "../../publicApi";
 import { z } from "zod";
@@ -38,7 +39,15 @@ export const [createAnnotationQueueTool, handleCreateAnnotationQueue] =
             auditScope: context,
           });
 
-          return CreateAnnotationQueueResponse.parse(result);
+          const queue = CreateAnnotationQueueResponse.parse(result);
+
+          return {
+            ...queue,
+            url: buildAnnotationQueueUrl({
+              projectId: context.projectId,
+              queueId: queue.id,
+            }),
+          };
         },
       }),
   });

--- a/web/src/features/mcp/features/annotationQueues/tools/createAnnotationQueueItem.ts
+++ b/web/src/features/mcp/features/annotationQueues/tools/createAnnotationQueueItem.ts
@@ -1,6 +1,7 @@
 import { createAnnotationQueueItemForApi } from "@/src/features/annotation-queues/server/publicAnnotationQueueService";
 import { CreateAnnotationQueueItemResponse } from "@/src/features/public-api/types/annotation-queues";
 import { defineTool } from "../../../core/define-tool";
+import { buildAnnotationQueueItemUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { CreateAnnotationQueueItemToolSchema } from "../schema";
 
@@ -24,7 +25,16 @@ export const [createAnnotationQueueItemTool, handleCreateAnnotationQueueItem] =
             auditScope: context,
           });
 
-          return CreateAnnotationQueueItemResponse.parse(result);
+          const item = CreateAnnotationQueueItemResponse.parse(result);
+
+          return {
+            ...item,
+            url: buildAnnotationQueueItemUrl({
+              projectId: context.projectId,
+              queueId: input.queueId,
+              itemId: item.id,
+            }),
+          };
         },
       }),
   });

--- a/web/src/features/mcp/features/annotationQueues/tools/getAnnotationQueue.ts
+++ b/web/src/features/mcp/features/annotationQueues/tools/getAnnotationQueue.ts
@@ -4,6 +4,7 @@ import {
 } from "@/src/features/public-api/types/annotation-queues";
 import { getAnnotationQueueForApi } from "@/src/features/annotation-queues/server/publicAnnotationQueueService";
 import { defineTool } from "../../../core/define-tool";
+import { buildAnnotationQueueUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 export const [getAnnotationQueueTool, handleGetAnnotationQueue] = defineTool({
@@ -23,7 +24,15 @@ export const [getAnnotationQueueTool, handleGetAnnotationQueue] = defineTool({
           queueId: input.queueId,
         });
 
-        return GetAnnotationQueueByIdResponse.parse(result);
+        const queue = GetAnnotationQueueByIdResponse.parse(result);
+
+        return {
+          ...queue,
+          url: buildAnnotationQueueUrl({
+            projectId: context.projectId,
+            queueId: queue.id,
+          }),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/annotationQueues/tools/getAnnotationQueueItem.ts
+++ b/web/src/features/mcp/features/annotationQueues/tools/getAnnotationQueueItem.ts
@@ -4,6 +4,7 @@ import {
 } from "@/src/features/public-api/types/annotation-queues";
 import { getAnnotationQueueItemForApi } from "@/src/features/annotation-queues/server/publicAnnotationQueueService";
 import { defineTool } from "../../../core/define-tool";
+import { buildAnnotationQueueItemUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 export const [getAnnotationQueueItemTool, handleGetAnnotationQueueItem] =
@@ -28,7 +29,16 @@ export const [getAnnotationQueueItemTool, handleGetAnnotationQueueItem] =
             itemId: input.itemId,
           });
 
-          return GetAnnotationQueueItemByIdResponse.parse(result);
+          const item = GetAnnotationQueueItemByIdResponse.parse(result);
+
+          return {
+            ...item,
+            url: buildAnnotationQueueItemUrl({
+              projectId: context.projectId,
+              queueId: item.queueId,
+              itemId: item.id,
+            }),
+          };
         },
       }),
     readOnlyHint: true,

--- a/web/src/features/mcp/features/annotationQueues/tools/listAnnotationQueueItems.ts
+++ b/web/src/features/mcp/features/annotationQueues/tools/listAnnotationQueueItems.ts
@@ -4,6 +4,7 @@ import {
 } from "@/src/features/public-api/types/annotation-queues";
 import { listAnnotationQueueItemsForApi } from "@/src/features/annotation-queues/server/publicAnnotationQueueService";
 import { defineTool } from "../../../core/define-tool";
+import { buildAnnotationQueueItemUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 export const [listAnnotationQueueItemsTool, handleListAnnotationQueueItems] =
@@ -31,7 +32,19 @@ export const [listAnnotationQueueItemsTool, handleListAnnotationQueueItems] =
             status: input.status,
           });
 
-          return GetAnnotationQueueItemsResponse.parse(result);
+          const parsed = GetAnnotationQueueItemsResponse.parse(result);
+
+          return {
+            ...parsed,
+            data: parsed.data.map((item) => ({
+              ...item,
+              url: buildAnnotationQueueItemUrl({
+                projectId: context.projectId,
+                queueId: item.queueId,
+                itemId: item.id,
+              }),
+            })),
+          };
         },
       }),
     readOnlyHint: true,

--- a/web/src/features/mcp/features/annotationQueues/tools/listAnnotationQueues.ts
+++ b/web/src/features/mcp/features/annotationQueues/tools/listAnnotationQueues.ts
@@ -4,6 +4,7 @@ import {
 } from "@/src/features/public-api/types/annotation-queues";
 import { listAnnotationQueuesForApi } from "@/src/features/annotation-queues/server/publicAnnotationQueueService";
 import { defineTool } from "../../../core/define-tool";
+import { buildAnnotationQueueUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 export const [listAnnotationQueuesTool, handleListAnnotationQueues] =
@@ -28,7 +29,18 @@ export const [listAnnotationQueuesTool, handleListAnnotationQueues] =
             limit: input.limit,
           });
 
-          return GetAnnotationQueuesResponse.parse(result);
+          const parsed = GetAnnotationQueuesResponse.parse(result);
+
+          return {
+            ...parsed,
+            data: parsed.data.map((queue) => ({
+              ...queue,
+              url: buildAnnotationQueueUrl({
+                projectId: context.projectId,
+                queueId: queue.id,
+              }),
+            })),
+          };
         },
       }),
     readOnlyHint: true,

--- a/web/src/features/mcp/features/annotationQueues/tools/updateAnnotationQueueItem.ts
+++ b/web/src/features/mcp/features/annotationQueues/tools/updateAnnotationQueueItem.ts
@@ -1,6 +1,7 @@
 import { updateAnnotationQueueItemForApi } from "@/src/features/annotation-queues/server/publicAnnotationQueueService";
 import { UpdateAnnotationQueueItemResponse } from "@/src/features/public-api/types/annotation-queues";
 import { defineTool } from "../../../core/define-tool";
+import { buildAnnotationQueueItemUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { UpdateAnnotationQueueItemToolSchema } from "../schema";
 
@@ -28,7 +29,16 @@ export const [updateAnnotationQueueItemTool, handleUpdateAnnotationQueueItem] =
             auditScope: context,
           });
 
-          return UpdateAnnotationQueueItemResponse.parse(result);
+          const item = UpdateAnnotationQueueItemResponse.parse(result);
+
+          return {
+            ...item,
+            url: buildAnnotationQueueItemUrl({
+              projectId: context.projectId,
+              queueId: input.queueId,
+              itemId: item.id,
+            }),
+          };
         },
       }),
     destructiveHint: true,

--- a/web/src/features/mcp/features/comments/tools/createComment.ts
+++ b/web/src/features/mcp/features/comments/tools/createComment.ts
@@ -6,6 +6,7 @@ import {
   PostCommentsV1Response,
 } from "@/src/features/public-api/types/comments";
 import { defineTool } from "../../../core/define-tool";
+import { buildCommentObjectUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 const CreateCommentToolBaseSchema = z
@@ -45,7 +46,14 @@ export const [createCommentTool, handleCreateComment] = defineTool({
           auditScope: context,
         });
 
-        return PostCommentsV1Response.parse(result);
+        const comment = PostCommentsV1Response.parse(result);
+        const url = buildCommentObjectUrl({
+          projectId: context.projectId,
+          objectType: input.objectType,
+          objectId: input.objectId,
+        });
+
+        return url ? { ...comment, url } : comment;
       },
     }),
 });

--- a/web/src/features/mcp/features/comments/tools/getComment.ts
+++ b/web/src/features/mcp/features/comments/tools/getComment.ts
@@ -4,6 +4,7 @@ import {
   GetCommentV1Response,
 } from "@/src/features/public-api/types/comments";
 import { defineTool } from "../../../core/define-tool";
+import { buildCommentObjectUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 export const [getCommentTool, handleGetComment] = defineTool({
@@ -22,7 +23,14 @@ export const [getCommentTool, handleGetComment] = defineTool({
           projectId: context.projectId,
         });
 
-        return GetCommentV1Response.parse(result);
+        const comment = GetCommentV1Response.parse(result);
+        const url = buildCommentObjectUrl({
+          projectId: context.projectId,
+          objectType: comment.objectType,
+          objectId: comment.objectId,
+        });
+
+        return url ? { ...comment, url } : comment;
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/comments/tools/listComments.ts
+++ b/web/src/features/mcp/features/comments/tools/listComments.ts
@@ -6,6 +6,7 @@ import {
   GetCommentsV1Response,
 } from "@/src/features/public-api/types/comments";
 import { defineTool } from "../../../core/define-tool";
+import { buildCommentObjectUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 const ListCommentsBaseSchema = z
@@ -39,7 +40,20 @@ export const [listCommentsTool, handleListComments] = defineTool({
           projectId: context.projectId,
         });
 
-        return GetCommentsV1Response.parse(result);
+        const parsed = GetCommentsV1Response.parse(result);
+
+        return {
+          ...parsed,
+          data: parsed.data.map((comment) => {
+            const url = buildCommentObjectUrl({
+              projectId: context.projectId,
+              objectType: comment.objectType,
+              objectId: comment.objectId,
+            });
+
+            return url ? { ...comment, url } : comment;
+          }),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/datasets/tools/getDataset.ts
+++ b/web/src/features/mcp/features/datasets/tools/getDataset.ts
@@ -1,5 +1,6 @@
 import { GetDatasetV2Response } from "@/src/features/public-api/types/datasets";
 import { defineTool } from "../../../core/define-tool";
+import { buildDatasetUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { getDatasetByIdForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { GetDatasetMcpInput } from "../schema";
@@ -21,7 +22,15 @@ export const [getDatasetTool, handleGetDataset] = defineTool({
           datasetId: input.datasetId,
         });
 
-        return GetDatasetV2Response.parse(result);
+        const dataset = GetDatasetV2Response.parse(result);
+
+        return {
+          ...dataset,
+          url: buildDatasetUrl({
+            projectId: context.projectId,
+            datasetId: dataset.id,
+          }),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/datasets/tools/getDatasetItem.ts
+++ b/web/src/features/mcp/features/datasets/tools/getDatasetItem.ts
@@ -4,6 +4,7 @@ import {
 } from "@/src/features/public-api/types/datasets";
 import { getDatasetItemForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { defineTool } from "../../../core/define-tool";
+import { buildDatasetItemUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 export const [getDatasetItemTool, handleGetDatasetItem] = defineTool({
@@ -23,7 +24,16 @@ export const [getDatasetItemTool, handleGetDatasetItem] = defineTool({
           projectId: context.projectId,
         });
 
-        return GetDatasetItemV1Response.parse(result);
+        const datasetItem = GetDatasetItemV1Response.parse(result);
+
+        return {
+          ...datasetItem,
+          url: buildDatasetItemUrl({
+            projectId: context.projectId,
+            datasetId: datasetItem.datasetId,
+            datasetItemId: datasetItem.id,
+          }),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/datasets/tools/getDatasetRun.ts
+++ b/web/src/features/mcp/features/datasets/tools/getDatasetRun.ts
@@ -1,6 +1,7 @@
 import { GetDatasetRunV1Response } from "@/src/features/public-api/types/datasets";
 import { getDatasetRunByIdForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { defineTool } from "../../../core/define-tool";
+import { buildDatasetRunUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { GetDatasetRunMcpInput } from "../schema";
 
@@ -25,7 +26,16 @@ export const [getDatasetRunTool, handleGetDatasetRun] = defineTool({
           datasetRunId: input.datasetRunId,
         });
 
-        return GetDatasetRunV1Response.parse(result);
+        const datasetRun = GetDatasetRunV1Response.parse(result);
+
+        return {
+          ...datasetRun,
+          url: buildDatasetRunUrl({
+            projectId: context.projectId,
+            datasetId: datasetRun.datasetId,
+            datasetRunId: datasetRun.id,
+          }),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/datasets/tools/listDatasetItems.ts
+++ b/web/src/features/mcp/features/datasets/tools/listDatasetItems.ts
@@ -1,6 +1,7 @@
 import { GetDatasetItemsV1Response } from "@/src/features/public-api/types/datasets";
 import { listDatasetItemsForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { defineTool } from "../../../core/define-tool";
+import { buildDatasetItemUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import {
   GetDatasetItemsMcpBaseSchema,
@@ -28,7 +29,19 @@ export const [listDatasetItemsTool, handleListDatasetItems] = defineTool({
           projectId: context.projectId,
         });
 
-        return GetDatasetItemsV1Response.parse(result);
+        const parsed = GetDatasetItemsV1Response.parse(result);
+
+        return {
+          ...parsed,
+          data: parsed.data.map((datasetItem) => ({
+            ...datasetItem,
+            url: buildDatasetItemUrl({
+              projectId: context.projectId,
+              datasetId: datasetItem.datasetId,
+              datasetItemId: datasetItem.id,
+            }),
+          })),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/datasets/tools/listDatasetRunItems.ts
+++ b/web/src/features/mcp/features/datasets/tools/listDatasetRunItems.ts
@@ -1,6 +1,7 @@
 import { listDatasetRunItemsByRunIdForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { GetDatasetRunItemsV1Response } from "@/src/features/public-api/types/datasets";
 import { defineTool } from "../../../core/define-tool";
+import { buildDatasetRunUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { paginationMeta } from "../../publicApi";
 import { GetDatasetRunItemsMcpInput } from "../schema";
@@ -28,10 +29,22 @@ export const [listDatasetRunItemsTool, handleListDatasetRunItems] = defineTool({
           page: input.page,
         });
 
-        return GetDatasetRunItemsV1Response.parse({
+        const parsed = GetDatasetRunItemsV1Response.parse({
           data: result.data,
           meta: paginationMeta(result.meta),
         });
+
+        return {
+          ...parsed,
+          data: parsed.data.map((datasetRunItem) => ({
+            ...datasetRunItem,
+            url: buildDatasetRunUrl({
+              projectId: context.projectId,
+              datasetId: input.datasetId,
+              datasetRunId: datasetRunItem.datasetRunId,
+            }),
+          })),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/datasets/tools/listDatasetRuns.ts
+++ b/web/src/features/mcp/features/datasets/tools/listDatasetRuns.ts
@@ -1,6 +1,7 @@
 import { GetDatasetRunsV1Response } from "@/src/features/public-api/types/datasets";
 import { listDatasetRunsByDatasetIdForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { defineTool } from "../../../core/define-tool";
+import { buildDatasetRunUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { GetDatasetRunsMcpInput } from "../schema";
 
@@ -23,7 +24,19 @@ export const [listDatasetRunsTool, handleListDatasetRuns] = defineTool({
           limit: input.limit,
         });
 
-        return GetDatasetRunsV1Response.parse(result);
+        const parsed = GetDatasetRunsV1Response.parse(result);
+
+        return {
+          ...parsed,
+          data: parsed.data.map((datasetRun) => ({
+            ...datasetRun,
+            url: buildDatasetRunUrl({
+              projectId: context.projectId,
+              datasetId: datasetRun.datasetId,
+              datasetRunId: datasetRun.id,
+            }),
+          })),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/datasets/tools/listDatasets.ts
+++ b/web/src/features/mcp/features/datasets/tools/listDatasets.ts
@@ -1,5 +1,6 @@
 import { GetDatasetsV2Response } from "@/src/features/public-api/types/datasets";
 import { defineTool } from "../../../core/define-tool";
+import { buildDatasetUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { listDatasetsForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { GetDatasetsMcpInput } from "../schema";
@@ -27,7 +28,18 @@ export const [listDatasetsTool, handleListDatasets] = defineTool({
           limit: input.limit,
         });
 
-        return GetDatasetsV2Response.parse(result);
+        const parsed = GetDatasetsV2Response.parse(result);
+
+        return {
+          ...parsed,
+          data: parsed.data.map((dataset) => ({
+            ...dataset,
+            url: buildDatasetUrl({
+              projectId: context.projectId,
+              datasetId: dataset.id,
+            }),
+          })),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/datasets/tools/upsertDataset.ts
+++ b/web/src/features/mcp/features/datasets/tools/upsertDataset.ts
@@ -6,6 +6,7 @@ import {
 } from "@/src/features/public-api/types/datasets";
 import { DatasetJSONSchema } from "@langfuse/shared/src/server";
 import { defineTool } from "../../../core/define-tool";
+import { buildDatasetUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 const idField = z.string().min(1).optional();
@@ -62,7 +63,15 @@ export const [upsertDatasetTool, handleUpsertDataset] = defineTool({
           auditScope: context,
         });
 
-        return PostDatasetsV2Response.parse(dataset);
+        const parsed = PostDatasetsV2Response.parse(dataset);
+
+        return {
+          ...parsed,
+          url: buildDatasetUrl({
+            projectId: context.projectId,
+            datasetId: parsed.id,
+          }),
+        };
       },
     }),
   destructiveHint: true,

--- a/web/src/features/mcp/features/datasets/tools/upsertDatasetItem.ts
+++ b/web/src/features/mcp/features/datasets/tools/upsertDatasetItem.ts
@@ -1,6 +1,7 @@
 import { createDatasetItemForApi } from "@/src/features/datasets/server/publicDatasetService";
 import { PostDatasetItemsV1Response } from "@/src/features/public-api/types/datasets";
 import { defineTool } from "../../../core/define-tool";
+import { buildDatasetItemUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { PostDatasetItemMcpInput } from "../schema";
 
@@ -21,7 +22,16 @@ export const [upsertDatasetItemTool, handleUpsertDatasetItem] = defineTool({
           auditScope: context,
         });
 
-        return PostDatasetItemsV1Response.parse(result);
+        const datasetItem = PostDatasetItemsV1Response.parse(result);
+
+        return {
+          ...datasetItem,
+          url: buildDatasetItemUrl({
+            projectId: context.projectId,
+            datasetId: input.datasetId,
+            datasetItemId: datasetItem.id,
+          }),
+        };
       },
     }),
   destructiveHint: true,

--- a/web/src/features/mcp/features/evals/tools/getEvaluator.ts
+++ b/web/src/features/mcp/features/evals/tools/getEvaluator.ts
@@ -4,6 +4,7 @@ import {
 } from "@/src/features/public-api/types/unstable-evaluators";
 import { getPublicEvaluator } from "@/src/features/evals/server/unstable-public-api";
 import { defineTool } from "../../../core/define-tool";
+import { buildEvaluatorUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 export const [getEvaluatorTool, handleGetEvaluator] = defineTool({
@@ -23,7 +24,15 @@ export const [getEvaluatorTool, handleGetEvaluator] = defineTool({
           evaluatorId: input.evaluatorId,
         });
 
-        return GetUnstableEvaluatorResponse.parse(result);
+        const evaluator = GetUnstableEvaluatorResponse.parse(result);
+
+        return {
+          ...evaluator,
+          url: buildEvaluatorUrl({
+            projectId: context.projectId,
+            evaluatorId: evaluator.id,
+          }),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/evals/tools/listEvaluators.ts
+++ b/web/src/features/mcp/features/evals/tools/listEvaluators.ts
@@ -4,6 +4,7 @@ import {
 } from "@/src/features/public-api/types/unstable-evaluators";
 import { listPublicEvaluators } from "@/src/features/evals/server/unstable-public-api";
 import { defineTool } from "../../../core/define-tool";
+import { buildEvaluatorUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 export const [listEvaluatorsTool, handleListEvaluators] = defineTool({
@@ -27,7 +28,18 @@ export const [listEvaluatorsTool, handleListEvaluators] = defineTool({
           limit: input.limit,
         });
 
-        return GetUnstableEvaluatorsResponse.parse(result);
+        const parsed = GetUnstableEvaluatorsResponse.parse(result);
+
+        return {
+          ...parsed,
+          data: parsed.data.map((evaluator) => ({
+            ...evaluator,
+            url: buildEvaluatorUrl({
+              projectId: context.projectId,
+              evaluatorId: evaluator.id,
+            }),
+          })),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/evals/tools/upsertEvaluator.ts
+++ b/web/src/features/mcp/features/evals/tools/upsertEvaluator.ts
@@ -11,6 +11,7 @@ import {
 } from "@/src/features/public-api/types/unstable-public-evals-contract";
 import { createPublicEvaluator } from "@/src/features/evals/server/unstable-public-api";
 import { defineTool } from "../../../core/define-tool";
+import { buildEvaluatorUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import {
   EvaluatorModelConfigBaseSchema,
@@ -64,7 +65,15 @@ export const [upsertEvaluatorTool, handleUpsertEvaluator] = defineTool({
 
         span.setAttribute("mcp.evaluator_id", evaluator.id);
 
-        return PostUnstableEvaluatorResponse.parse(evaluator);
+        const parsed = PostUnstableEvaluatorResponse.parse(evaluator);
+
+        return {
+          ...parsed,
+          url: buildEvaluatorUrl({
+            projectId: context.projectId,
+            evaluatorId: parsed.id,
+          }),
+        };
       },
     }),
   destructiveHint: true,

--- a/web/src/features/mcp/features/models/tools/createModel.ts
+++ b/web/src/features/mcp/features/models/tools/createModel.ts
@@ -4,6 +4,7 @@ import {
 } from "@/src/features/public-api/types/models";
 import { createModelForApi } from "@/src/features/models/server/publicApiModelService";
 import { defineTool } from "../../../core/define-tool";
+import { buildModelUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { z } from "zod";
 
@@ -45,7 +46,15 @@ export const [createModelTool, handleCreateModel] = defineTool({
           auditScope: context,
         });
 
-        return PostModelsV1Response.parse(result);
+        const model = PostModelsV1Response.parse(result);
+
+        return {
+          ...model,
+          url: buildModelUrl({
+            projectId: context.projectId,
+            modelId: model.id,
+          }),
+        };
       },
     }),
 });

--- a/web/src/features/mcp/features/models/tools/getModel.ts
+++ b/web/src/features/mcp/features/models/tools/getModel.ts
@@ -4,6 +4,7 @@ import {
 } from "@/src/features/public-api/types/models";
 import { getModelForApi } from "@/src/features/models/server/publicApiModelService";
 import { defineTool } from "../../../core/define-tool";
+import { buildModelUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 export const [getModelTool, handleGetModel] = defineTool({
@@ -22,7 +23,15 @@ export const [getModelTool, handleGetModel] = defineTool({
           modelId: input.modelId,
         });
 
-        return GetModelV1Response.parse(result);
+        const model = GetModelV1Response.parse(result);
+
+        return {
+          ...model,
+          url: buildModelUrl({
+            projectId: context.projectId,
+            modelId: model.id,
+          }),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/models/tools/listModels.ts
+++ b/web/src/features/mcp/features/models/tools/listModels.ts
@@ -4,6 +4,7 @@ import {
 } from "@/src/features/public-api/types/models";
 import { listModelsForApi } from "@/src/features/models/server/publicApiModelService";
 import { defineTool } from "../../../core/define-tool";
+import { buildModelUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 export const [listModelsTool, handleListModels] = defineTool({
@@ -27,7 +28,18 @@ export const [listModelsTool, handleListModels] = defineTool({
           limit: input.limit,
         });
 
-        return GetModelsV1Response.parse(result);
+        const parsed = GetModelsV1Response.parse(result);
+
+        return {
+          ...parsed,
+          data: parsed.data.map((model) => ({
+            ...model,
+            url: buildModelUrl({
+              projectId: context.projectId,
+              modelId: model.id,
+            }),
+          })),
+        };
       },
     }),
   readOnlyHint: true,

--- a/web/src/features/mcp/features/observations/tools/getObservation.ts
+++ b/web/src/features/mcp/features/observations/tools/getObservation.ts
@@ -2,6 +2,7 @@ import { LangfuseNotFoundError } from "@langfuse/shared";
 import { z } from "zod";
 import { getObservationsV2FromEventsTableForPublicApi } from "@langfuse/shared/src/server";
 import { defineTool } from "../../../core/define-tool";
+import { buildObservationUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import {
   ExpandMetadataKeysSchema,
@@ -71,7 +72,7 @@ export const [getObservationTool, handleGetObservation] = defineTool({
           );
         }
 
-        return projectObservation(
+        const projectedObservation = projectObservation(
           {
             ...observation,
             parentObservationId:
@@ -81,6 +82,19 @@ export const [getObservationTool, handleGetObservation] = defineTool({
           },
           projectionFields,
         );
+
+        return {
+          ...projectedObservation,
+          ...(observation.traceId
+            ? {
+                url: buildObservationUrl({
+                  projectId: context.projectId,
+                  traceId: observation.traceId,
+                  observationId: observation.id,
+                }),
+              }
+            : {}),
+        };
       },
     });
   },

--- a/web/src/features/mcp/features/observations/tools/listObservations.ts
+++ b/web/src/features/mcp/features/observations/tools/listObservations.ts
@@ -22,6 +22,7 @@ import {
   encodeCursor,
 } from "@/src/features/public-api/types/observations";
 import { defineTool } from "../../../core/define-tool";
+import { buildObservationUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import {
   ExpandMetadataKeysSchema,
@@ -356,8 +357,8 @@ export const [listObservationsTool, handleListObservations] = defineTool({
         const hasMore = items.length > input.limit;
         const dataToReturn = hasMore ? items.slice(0, input.limit) : items;
 
-        const data = dataToReturn.map((item) =>
-          projectObservation(
+        const data = dataToReturn.map((item) => {
+          const projectedObservation = projectObservation(
             {
               ...item,
               parentObservationId:
@@ -366,8 +367,21 @@ export const [listObservationsTool, handleListObservations] = defineTool({
                   : item.parentObservationId,
             },
             projectionFields,
-          ),
-        );
+          );
+
+          return {
+            ...projectedObservation,
+            ...(item.traceId
+              ? {
+                  url: buildObservationUrl({
+                    projectId: context.projectId,
+                    traceId: item.traceId,
+                    observationId: item.id,
+                  }),
+                }
+              : {}),
+          };
+        });
 
         const lastItem = dataToReturn[dataToReturn.length - 1];
 

--- a/web/src/features/mcp/features/prompts/tools/createChatPrompt.ts
+++ b/web/src/features/mcp/features/prompts/tools/createChatPrompt.ts
@@ -15,6 +15,7 @@ import {
   PROMPT_NAME_MAX_LENGTH,
 } from "@langfuse/shared";
 import { createPromptForApi } from "@/src/features/prompts/server/prompt-api-service";
+import { buildPromptUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 /**
@@ -129,6 +130,11 @@ export const [createChatPromptTool, handleCreateChatPrompt] = defineTool({
           config: createdPrompt.config,
           createdAt: createdPrompt.createdAt,
           createdBy: createdPrompt.createdBy,
+          url: buildPromptUrl({
+            projectId: context.projectId,
+            name: createdPrompt.name,
+            version: createdPrompt.version,
+          }),
           message: `Successfully created chat prompt '${createdPrompt.name}' version ${createdPrompt.version}${createdPrompt.labels.length > 0 ? ` with labels: ${createdPrompt.labels.join(", ")}` : ""}`,
         };
       },

--- a/web/src/features/mcp/features/prompts/tools/createTextPrompt.ts
+++ b/web/src/features/mcp/features/prompts/tools/createTextPrompt.ts
@@ -15,6 +15,7 @@ import {
   PROMPT_NAME_MAX_LENGTH,
 } from "@langfuse/shared";
 import { createPromptForApi } from "@/src/features/prompts/server/prompt-api-service";
+import { buildPromptUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 /**
@@ -117,6 +118,11 @@ export const [createTextPromptTool, handleCreateTextPrompt] = defineTool({
           config: createdPrompt.config,
           createdAt: createdPrompt.createdAt,
           createdBy: createdPrompt.createdBy,
+          url: buildPromptUrl({
+            projectId: context.projectId,
+            name: createdPrompt.name,
+            version: createdPrompt.version,
+          }),
           message: `Successfully created text prompt '${createdPrompt.name}' version ${createdPrompt.version}${createdPrompt.labels.length > 0 ? ` with labels: ${createdPrompt.labels.join(", ")}` : ""}`,
         };
       },

--- a/web/src/features/mcp/features/prompts/tools/listPrompts.ts
+++ b/web/src/features/mcp/features/prompts/tools/listPrompts.ts
@@ -14,6 +14,7 @@ import {
 } from "../validation";
 import { ParamLimit, ParamPage } from "../../../core/validation";
 import { listPromptsForApi } from "@/src/features/prompts/server/prompt-api-service";
+import { buildPromptUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { paginationMeta } from "../../publicApi";
 
@@ -121,15 +122,27 @@ export const [listPromptsTool, handleListPrompts] = defineTool({
 
         // Return formatted response
         return {
-          data: result.data.map((prompt) => ({
-            name: prompt.name,
-            type: prompt.type,
-            versions: prompt.versions,
-            labels: prompt.labels,
-            tags: prompt.tags,
-            lastUpdatedAt: prompt.lastUpdatedAt,
-            lastConfig: prompt.lastConfig,
-          })),
+          data: result.data.map((prompt) => {
+            const latestVersion =
+              prompt.versions.length > 0
+                ? Math.max(...prompt.versions)
+                : undefined;
+
+            return {
+              name: prompt.name,
+              type: prompt.type,
+              versions: prompt.versions,
+              labels: prompt.labels,
+              tags: prompt.tags,
+              lastUpdatedAt: prompt.lastUpdatedAt,
+              lastConfig: prompt.lastConfig,
+              url: buildPromptUrl({
+                projectId: context.projectId,
+                name: prompt.name,
+                version: latestVersion,
+              }),
+            };
+          }),
           meta: paginationMeta({
             page: result.pagination.page,
             limit: result.pagination.limit,

--- a/web/src/features/mcp/features/prompts/tools/promptReadToolFactory.ts
+++ b/web/src/features/mcp/features/prompts/tools/promptReadToolFactory.ts
@@ -4,6 +4,7 @@ import { LATEST_PROMPT_LABEL, type Prompt } from "@langfuse/shared";
 import { getPromptForApi } from "@/src/features/prompts/server/prompt-api-service";
 
 import { defineTool } from "../../../core/define-tool";
+import { buildPromptUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { UserInputError } from "../../../core/errors";
 import {
@@ -39,6 +40,11 @@ const formatPromptResponse = (prompt: Prompt) => ({
   updatedAt: prompt.updatedAt,
   createdBy: prompt.createdBy,
   projectId: prompt.projectId,
+  url: buildPromptUrl({
+    projectId: prompt.projectId,
+    name: prompt.name,
+    version: prompt.version,
+  }),
 });
 
 const buildPromptNotFoundMessage = (params: {

--- a/web/src/features/mcp/features/prompts/tools/updatePromptLabels.ts
+++ b/web/src/features/mcp/features/prompts/tools/updatePromptLabels.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { defineTool } from "../../../core/define-tool";
 import { ParamPromptName, ParamNewLabels } from "../validation";
 import { updatePromptLabelsForApi } from "@/src/features/prompts/server/prompt-api-service";
+import { buildPromptUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 
 import { PROMPT_NAME_MAX_LENGTH } from "@langfuse/shared";
@@ -94,6 +95,11 @@ export const [updatePromptLabelsTool, handleUpdatePromptLabels] = defineTool({
           name: updatedPrompt.name,
           version: updatedPrompt.version,
           labels: updatedPrompt.labels,
+          url: buildPromptUrl({
+            projectId: context.projectId,
+            name: updatedPrompt.name,
+            version: updatedPrompt.version,
+          }),
           message: `Successfully updated labels for '${updatedPrompt.name}' version ${updatedPrompt.version}. Labels are now: ${updatedPrompt.labels.length > 0 ? updatedPrompt.labels.join(", ") : "(none)"}`,
         };
       },

--- a/web/src/features/mcp/features/scores/tools/createScore.ts
+++ b/web/src/features/mcp/features/scores/tools/createScore.ts
@@ -8,6 +8,7 @@ import {
 } from "@langfuse/shared";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
 import { defineTool } from "../../../core/define-tool";
+import { buildScoreTargetUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { ApiServerError } from "../../../core/errors";
 import { z } from "zod";
@@ -113,7 +114,15 @@ export const [createScoreTool, handleCreateScore] = defineTool({
           throw new ApiServerError("Failed to create score");
         }
 
-        return PostScoresResponseV1.parse({ id: scoreId });
+        const score = PostScoresResponseV1.parse({ id: scoreId });
+        const url = buildScoreTargetUrl({
+          projectId: context.projectId,
+          traceId: input.traceId,
+          observationId: input.observationId,
+          sessionId: input.sessionId,
+        });
+
+        return url ? { ...score, url } : score;
       },
     });
   },

--- a/web/src/features/mcp/features/scores/tools/getScore.ts
+++ b/web/src/features/mcp/features/scores/tools/getScore.ts
@@ -6,6 +6,7 @@ import {
 } from "@langfuse/shared";
 import { logger, traceException } from "@langfuse/shared/src/server";
 import { defineTool } from "../../../core/define-tool";
+import { buildScoreTargetUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
 
@@ -40,7 +41,15 @@ export const [getScoreTool, handleGetScore] = defineTool({
           throw new InternalServerError("Requested score is corrupted");
         }
 
-        return parsedScore.data;
+        const { traceId, observationId, sessionId } = parsedScore.data;
+        const url = buildScoreTargetUrl({
+          projectId: context.projectId,
+          traceId,
+          observationId,
+          sessionId,
+        });
+
+        return url ? { ...parsedScore.data, url } : parsedScore.data;
       },
     });
   },

--- a/web/src/features/mcp/features/scores/tools/listScores.ts
+++ b/web/src/features/mcp/features/scores/tools/listScores.ts
@@ -9,6 +9,7 @@ import {
 import { z } from "zod";
 import { defineTool } from "../../../core/define-tool";
 import { McpAdvancedFilterBaseSchema } from "../../../core/filter-schema";
+import { buildScoreTargetUrl } from "@/src/utils/product-url";
 import { runMcpTool } from "../../../core/run-mcp-tool";
 import { ScoresApiService } from "@/src/features/public-api/server/scores-api-service";
 import { paginationMeta } from "../../publicApi";
@@ -132,7 +133,16 @@ export const [listScoresTool, handleListScores] = defineTool({
         ]);
 
         const totalItems = count ?? 0;
-        const data = filterAndValidateV2GetScoreList(items);
+        const data = filterAndValidateV2GetScoreList(items).map((score) => {
+          const url = buildScoreTargetUrl({
+            projectId: context.projectId,
+            traceId: score.traceId,
+            observationId: score.observationId,
+            sessionId: score.sessionId,
+          });
+
+          return url ? { ...score, url } : score;
+        });
         span.setAttribute("mcp.result_count", data.length);
 
         return {

--- a/web/src/utils/product-url.ts
+++ b/web/src/utils/product-url.ts
@@ -1,0 +1,175 @@
+import { env } from "@/src/env.mjs";
+
+const LOCALHOST_HOST_PATTERN = /^(localhost|127\.0\.0\.1|\[::1\])(?::|\/|$)/i;
+
+const getProductBaseUrl = () => {
+  const rawBaseUrl = env.NEXTAUTH_URL;
+  const baseUrl = new URL(
+    /^https?:\/\//i.test(rawBaseUrl)
+      ? rawBaseUrl
+      : `${LOCALHOST_HOST_PATTERN.test(rawBaseUrl) ? "http" : "https"}://${rawBaseUrl}`,
+  );
+
+  baseUrl.pathname = baseUrl.pathname.replace(/\/api\/auth\/?$/, "/");
+  baseUrl.search = "";
+  baseUrl.hash = "";
+
+  return baseUrl;
+};
+
+const buildProductUrl = (path: string, query?: Record<string, string>) => {
+  const baseUrl = getProductBaseUrl();
+  const basePath = baseUrl.pathname.replace(/\/$/, "");
+  const url = new URL(`${basePath}${path}`, baseUrl);
+
+  for (const [key, value] of Object.entries(query ?? {})) {
+    url.searchParams.set(key, value);
+  }
+
+  return url.toString();
+};
+
+export const buildTraceUrl = (params: { projectId: string; traceId: string }) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/traces/${encodeURIComponent(params.traceId)}`,
+  );
+
+export const buildObservationUrl = (params: {
+  projectId: string;
+  traceId: string;
+  observationId: string;
+}) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/traces/${encodeURIComponent(params.traceId)}`,
+    { observation: params.observationId },
+  );
+
+export const buildSessionUrl = (params: {
+  projectId: string;
+  sessionId: string;
+}) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/sessions/${encodeURIComponent(params.sessionId)}`,
+  );
+
+export const buildCommentObjectUrl = (params: {
+  projectId: string;
+  objectType: string;
+  objectId: string;
+}) => {
+  if (params.objectType === "TRACE") {
+    return buildTraceUrl({
+      projectId: params.projectId,
+      traceId: params.objectId,
+    });
+  }
+
+  if (params.objectType === "SESSION") {
+    return buildSessionUrl({
+      projectId: params.projectId,
+      sessionId: params.objectId,
+    });
+  }
+
+  return undefined;
+};
+
+export const buildScoreTargetUrl = (params: {
+  projectId: string;
+  traceId?: string | null;
+  observationId?: string | null;
+  sessionId?: string | null;
+}) => {
+  if (params.traceId && params.observationId) {
+    return buildObservationUrl({
+      projectId: params.projectId,
+      traceId: params.traceId,
+      observationId: params.observationId,
+    });
+  }
+
+  if (params.traceId) {
+    return buildTraceUrl({
+      projectId: params.projectId,
+      traceId: params.traceId,
+    });
+  }
+
+  if (params.sessionId) {
+    return buildSessionUrl({
+      projectId: params.projectId,
+      sessionId: params.sessionId,
+    });
+  }
+
+  return undefined;
+};
+
+export const buildPromptUrl = (params: {
+  projectId: string;
+  name: string;
+  version?: number;
+}) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/prompts/${encodeURIComponent(params.name)}`,
+    params.version === undefined
+      ? undefined
+      : { version: String(params.version) },
+  );
+
+export const buildDatasetUrl = (params: {
+  projectId: string;
+  datasetId: string;
+}) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/datasets/${encodeURIComponent(params.datasetId)}/items`,
+  );
+
+export const buildDatasetItemUrl = (params: {
+  projectId: string;
+  datasetId: string;
+  datasetItemId: string;
+}) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/datasets/${encodeURIComponent(params.datasetId)}/items/${encodeURIComponent(params.datasetItemId)}`,
+  );
+
+export const buildDatasetRunUrl = (params: {
+  projectId: string;
+  datasetId: string;
+  datasetRunId: string;
+}) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/datasets/${encodeURIComponent(params.datasetId)}/runs/${encodeURIComponent(params.datasetRunId)}`,
+  );
+
+export const buildAnnotationQueueUrl = (params: {
+  projectId: string;
+  queueId: string;
+}) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/annotation-queues/${encodeURIComponent(params.queueId)}`,
+  );
+
+export const buildAnnotationQueueItemUrl = (params: {
+  projectId: string;
+  queueId: string;
+  itemId: string;
+}) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/annotation-queues/${encodeURIComponent(params.queueId)}/items/${encodeURIComponent(params.itemId)}`,
+    { singleItem: "true" },
+  );
+
+export const buildModelUrl = (params: { projectId: string; modelId: string }) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/settings/models/${encodeURIComponent(params.modelId)}`,
+  );
+
+export const buildEvaluatorUrl = (params: {
+  projectId: string;
+  evaluatorId: string;
+}) =>
+  buildProductUrl(
+    `/project/${encodeURIComponent(params.projectId)}/evals/templates/${encodeURIComponent(params.evaluatorId)}`,
+  );


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches MCP tool responses across the entire Langfuse feature surface (observations, scores, prompts, datasets, evaluators, models, annotation queues, comments) with direct `url` fields pointing to the corresponding UI pages, and updates the in-app agent's markdown renderer to perform client-side navigation for same-project links instead of always opening a new tab.

- A new `web/src/utils/product-url.ts` module centralises URL construction from `NEXTAUTH_URL`, encoding all path segments with `encodeURIComponent` and handling both bare-origin and `/api/auth`-suffixed `NEXTAUTH_URL` values. Each MCP tool imports the relevant builder and attaches the `url` field (conditionally where the necessary IDs may be absent).
- The `SmartLink` React component in `InAppAgentMessage.tsx` replaces the previous inline anchor renderer; it detects whether a link belongs to the current project and origin, and uses Next.js `<Link>` for client-side routing in that case while falling back to a safe external anchor otherwise.
- The system prompt for the in-app agent now instructs the model to render entity IDs as markdown links using only URLs present in tool results, preventing the model from hallucinating Langfuse URLs.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the changes are additive and well-tested. The one edge case (empty versions array in listPrompts) is unlikely to occur in production and would only produce a malformed URL rather than an error.

The implementation is consistent across all 30+ tool files, URL construction is correctly encoded, and tests cover the new url fields. The only concern is Math.max(...prompt.versions) in listPrompts.ts, which yields -Infinity for an empty array — unlikely in practice since every stored prompt has at least one version, but the absence of a guard is worth fixing.

web/src/features/mcp/features/prompts/tools/listPrompts.ts — the Math.max spread on versions should be guarded against an empty array.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent as In-App Agent
    participant MCP as MCP Tool Handler
    participant DB as Database
    participant URLUtil as product-url.ts
    participant UI as SmartLink (React)

    Agent->>MCP: Invoke tool (e.g. getObservation)
    MCP->>DB: Fetch entity data
    DB-->>MCP: Raw entity record
    MCP->>URLUtil: "buildObservationUrl({projectId, traceId, observationId})"
    URLUtil-->>MCP: "https://host/project/{id}/traces/{id}?observation={id}"
    MCP-->>Agent: "{ ...entity, url }"

    Agent->>UI: Render markdown with [label](url)
    UI->>UI: getSafeLinkUrl(href) — safety check
    UI->>UI: "Compare link origin & project segment vs current location"
    alt "Same project & same origin"
        UI-->>Agent: Next.js Link (client-side navigation)
    else External or different project
        UI-->>Agent: "a href target=_blank rel=noopener noreferrer"
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/mcp/features/prompts/tools/listPrompts.ts:136
**`Math.max` on an empty array spreads to `-Infinity`**

`Math.max(...[])` returns `-Infinity` in JavaScript. If `prompt.versions` were ever empty (e.g., due to a data inconsistency), `buildPromptUrl` would be called with `version: -Infinity`, producing a URL like `…/prompts/name?version=-Infinity`. Consider guarding with `Math.max(...prompt.versions, 0)` or skipping the `url` field when `versions` is empty.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agent,mcp): Include resource urls"](https://github.com/langfuse/langfuse/commit/a88df455a0290cf17d91895b0de93fb51cb02ec9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37655761)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->