### PR TITLE
chore(prisma): bound job executions fk drop migration

### DIFF
--- a/packages/shared/prisma/migrations/20260612000000_drop_job_executions_job_template_id_fkey/migration.sql
+++ b/packages/shared/prisma/migrations/20260612000000_drop_job_executions_job_template_id_fkey/migration.sql
@@ -1,2 +1,9 @@
 -- DropForeignKey
+-- Warning: this metadata-only change still needs an ACCESS EXCLUSIVE lock on
+-- job_executions. Run with blocker monitoring and cancel/retry if lock
+-- acquisition would queue behind long-running transactions.
+SET lock_timeout = '5s';
+SET statement_timeout = '5s';
 ALTER TABLE "job_executions" DROP CONSTRAINT IF EXISTS "job_executions_job_template_id_fkey";
+RESET statement_timeout;
+RESET lock_timeout;


### PR DESCRIPTION
## Summary

- Adds a warning comment to the `job_executions.job_template_id` FK-drop migration explaining the required table lock.
- Adds short `lock_timeout` and `statement_timeout` guards so the migration fails quickly instead of waiting indefinitely behind long-running transactions.

## Linear

- None

## Major Decisions

- Kept the migration inside Prisma's default transaction wrapper and used session-scoped timeout settings with explicit resets to avoid nested transaction warnings.

## Review Focus

- Timeout values: both lock acquisition and statement execution are capped at `5s`.
- Migration behavior when lock acquisition fails during deploy.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `lock_timeout` and `statement_timeout` guards (both 5 s) to the existing `DROP CONSTRAINT` migration for `job_executions_job_template_id_fkey`, so a deployment that cannot quickly acquire the required ACCESS EXCLUSIVE lock fails fast rather than queuing indefinitely.

- Adds warning comment explaining the ACCESS EXCLUSIVE lock requirement for this metadata-only constraint drop.
- Sets session-scoped `lock_timeout` and `statement_timeout` to 5 s before the `ALTER TABLE`, with explicit `RESET` calls afterwards.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the migration is a metadata-only FK drop with timeout guards that ensure it fails fast rather than blocking indefinitely; the IF EXISTS clause makes it idempotent.

The timeout approach using session-scoped SET + explicit RESET works correctly inside Prisma's transaction wrapper (the SET is also rolled back on lock-timeout abort), but SET LOCAL would express the same intent more cleanly and eliminate the need for the RESET statements. No functional defect is present; the question is only about the more idiomatic PostgreSQL pattern for transaction-scoped settings.

The single migration file is the only change and is worth a quick read for the SET vs SET LOCAL distinction.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as Prisma Runner
    participant DB as PostgreSQL

    P->>DB: BEGIN (implicit transaction wrapper)
    P->>DB: "SET lock_timeout = '5s'"
    P->>DB: "SET statement_timeout = '5s'"
    
    alt Lock acquired within 5s
        DB-->>P: OK
        P->>DB: ALTER TABLE job_executions DROP CONSTRAINT IF EXISTS ...
        DB-->>P: OK (metadata-only, near-instant)
        P->>DB: RESET statement_timeout
        P->>DB: RESET lock_timeout
        P->>DB: COMMIT
        DB-->>P: Migration successful
    else Lock not acquired within 5s
        DB-->>P: ERROR: lock timeout (transaction rolled back)
        Note over DB: SET commands also rolled back — session timeouts revert to original
        P-->>P: Migration fails — operator must retry
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/prisma/migrations/20260612000000_drop_job_executions_job_template_id_fkey/migration.sql:5-9
`SET LOCAL` is the more idiomatic choice inside a Prisma-wrapped transaction. It automatically scopes both settings to the current transaction, so they revert to their previous values on commit *and* rollback — making the explicit `RESET` statements at the end redundant and removing any risk of the session retaining the 5 s caps if execution is interrupted before those lines are reached. `SET` (session-scope) inside a transaction is also rolled back on abort, so both approaches are safe here, but `SET LOCAL` makes the intent clearer and simplifies the script.

```suggestion
SET LOCAL lock_timeout = '5s';
SET LOCAL statement_timeout = '5s';
ALTER TABLE "job_executions" DROP CONSTRAINT IF EXISTS "job_executions_job_template_id_fkey";
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(prisma): bound job executions fk d..."](https://github.com/langfuse/langfuse/commit/c2bd2e1d581eb2ce9abd1b3bda44ae89afc61342) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37731997)</sub>

<!-- /greptile_comment -->