### PR TITLE
fix(monitors): populate Level and Type filter options from API

### DIFF
--- a/web/src/features/monitors/components/MonitorForm.tsx
+++ b/web/src/features/monitors/components/MonitorForm.tsx
@@ -297,7 +297,7 @@ export const MonitorForm = ({
       modelOptions: data?.providedModelName ?? [],
       toolNamesOptions: data?.toolNames ?? [],
       calledToolNamesOptions: data?.calledToolNames ?? [],
-      observationLevelOptions: [],
+      observationLevelOptions: data?.level ?? [],
       experimentNameOptions: data?.experimentName ?? [],
       experimentDatasetOptions: (() => {
         const ids = new Set(
@@ -312,7 +312,7 @@ export const MonitorForm = ({
             })) ?? []
         );
       })(),
-      observationTypeOptions: [],
+      observationTypeOptions: data?.type ?? [],
     };
   }, [eventsFilterOptions.data, datasets.data, watched.view]);
 


### PR DESCRIPTION
## Problem

In the New Monitor form, the filter value dropdowns for **Level** and **Type** always showed "No results found", even though the `events.filterOptions` API returns the values (e.g. `level: DEFAULT, ERROR`; `type: GENERATION, SPAN, EVENT`). Other filters (Environment, Model, Tags, …) worked.

## Cause

`MonitorForm` hardcoded `observationLevelOptions` and `observationTypeOptions` to `[]`, so those two column definitions never received the API-backed options while every other dynamic filter was wired to its `data` key. Incomplete wiring from the original feature.

## Fix

Two lines — wire the options to `data?.level` / `data?.type`, matching the sibling options:

```diff
- observationLevelOptions: [],
+ observationLevelOptions: data?.level ?? [],
...
- observationTypeOptions: [],
+ observationTypeOptions: data?.type ?? [],
```

No normalization needed: `count` is only rendered as raw JSX, and the sibling fields don't normalize. The selected values round-trip correctly — both columns are first-class entries in the UI→view filter mapping (`dashboardUiTableToViewMapping.ts`, `uiTableId: "level"` / `"type"`), and the same `mapWidgetUiTableFilterToView` runs for the Live Preview and the create/update mutation, so a chosen filter both updates the preview and persists into the monitor's metric query.

## Impacted packages

- `web`

## Verification

- `pnpm --filter web run typecheck` — clean
- lint — clean (pre-commit)
- Browser (local, v4 events seed): Level dropdown lists DEFAULT/DEBUG/WARNING/ERROR and Type lists SPAN/GENERATION/EVENT in the New Monitor form (Observations view); previously "No results found".