### PR TITLE
fix(blob-storage): surface SDK error cause in validation failure messages

### DIFF
--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -39,8 +39,16 @@ const getAuditLogErrorType = (error: unknown) =>
       ? error.name
       : "UnknownError";
 
-const getErrorMessage = (error: unknown, fallback: string) =>
-  error instanceof Error ? error.message : fallback;
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  if (!(error instanceof Error)) return fallback;
+  // Walk one level of cause to surface the SDK error (e.g. "Access Denied")
+  // without exposing arbitrarily deep internal details.
+  const cause = error.cause;
+  if (cause instanceof Error && cause.message) {
+    return `${error.message}: ${cause.message}`.slice(0, 500);
+  }
+  return error.message;
+};
 
 export const blobStorageIntegrationRouter = createTRPCRouter({
   get: protectedProjectProcedure


### PR DESCRIPTION
## What does this PR do?

Surfaces the underlying SDK error message in blob storage validation failures. Previously, users only saw the generic wrapper (`"Failed to upload file to S3 or generate signed URL"`). Now they see the actual cause appended (e.g. `"…: The AWS Access Key Id you provided does not exist in our records."`).

### Context

Datadog showed ~3,000 validation errors in prod-eu over the past week from a single project — the user kept retrying because the error gave no actionable information. The worker export path already surfaces the cause chain via `formatErrorChain`, but the validate endpoint's `getErrorMessage` helper only read `error.message` without unwrapping `error.cause`.

### Changes

- Updated `getErrorMessage` in `blobstorage-integration-router.ts` to unwrap one level of `error.cause` and append the SDK message
- Capped output at 500 chars to limit exposure surface
- Only walks one cause level (not the full chain) to avoid leaking deeply nested internal details

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have performed a self-review of my own code
- [x] Verified lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the error UX for blob storage validation by unwrapping one level of `error.cause` and appending the underlying SDK message (e.g. from AWS/Azure) to the error returned to the client. A 500-character cap limits how much of the cause chain is exposed.

- `getErrorMessage` now walks one level of `error.cause` and concatenates the messages, falling back to the wrapper message alone when no cause exists.
- The combined string is capped at 500 chars only in the cause-present branch; the no-cause path returns `error.message` uncapped.
- The change is isolated to the `validate` endpoint; other endpoints (`update`, `delete`, `runNow`) use their own fixed error strings and are unaffected.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is narrowly scoped to one helper function used only in the validate endpoint's catch block, and the SDK cause message is returned to the authenticated user who owns the integration.

The logic is straightforward and the fix directly addresses the reported UX problem. The only wrinkle is that the 500-char truncation guard is applied in the cause-present branch but not the no-cause branch, creating a small inconsistency in the stated goal of capping exposure.

web/src/features/blobstorage-integration/blobstorage-integration-router.ts — specifically the no-cause return path in `getErrorMessage`.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as blobstorage-integration-router
    participant StorageService
    participant SDK as AWS/Azure SDK

    Client->>Router: validate(projectId)
    Router->>Router: throwIfNoProjectAccess()
    Router->>Router: prisma.findUnique(integration)
    Router->>Router: decrypt(secretAccessKey)
    Router->>StorageService: StorageServiceFactory.getInstance(config)
    Router->>StorageService: uploadWithSignedUrl(testFile)
    StorageService->>SDK: SDK call
    SDK-->>StorageService: Error (e.g. "Access Key does not exist")
    StorageService-->>Router: Error wrapping SDK error as cause

    Note over Router: getErrorMessage(error, fallback)
    Router->>Router: error instanceof Error? Yes
    Router->>Router: "cause = error.cause (instanceof Error?)"
    alt cause is an Error with message
        Router->>Router: return (error.message + ": " + cause.message).slice(0, 500)
    else no cause
        Router->>Router: return error.message
    end

    Router-->>Client: "TRPCError BAD_REQUEST "Validation failed: <combined message>""
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as blobstorage-integration-router
    participant StorageService
    participant SDK as AWS/Azure SDK

    Client->>Router: validate(projectId)
    Router->>Router: throwIfNoProjectAccess()
    Router->>Router: prisma.findUnique(integration)
    Router->>Router: decrypt(secretAccessKey)
    Router->>StorageService: StorageServiceFactory.getInstance(config)
    Router->>StorageService: uploadWithSignedUrl(testFile)
    StorageService->>SDK: SDK call
    SDK-->>StorageService: Error (e.g. "Access Key does not exist")
    StorageService-->>Router: Error wrapping SDK error as cause

    Note over Router: getErrorMessage(error, fallback)
    Router->>Router: error instanceof Error? Yes
    Router->>Router: "cause = error.cause (instanceof Error?)"
    alt cause is an Error with message
        Router->>Router: return (error.message + ": " + cause.message).slice(0, 500)
    else no cause
        Router->>Router: return error.message
    end

    Router-->>Client: "TRPCError BAD_REQUEST "Validation failed: <combined message>""
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/blobstorage-integration/blobstorage-integration-router.ts:47-50
The 500-char cap is only applied when a `cause` is present; when the error has no cause, `error.message` is returned without any truncation. The PR description states the cap is intended to "limit exposure surface," so applying it uniformly would be more consistent.

```suggestion
  if (cause instanceof Error && cause.message) {
    return `${error.message}: ${cause.message}`.slice(0, 500);
  }
  return error.message.slice(0, 500);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blob-storage): surface SDK error cau..."](https://github.com/langfuse/langfuse/commit/97f219e945254ca935791b7994aaaaae0dcef567) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37846378)</sub>

<!-- /greptile_comment -->