### PR TITLE
fix(ui): show 'Pending' instead of 'Inactive' for idle blob exporter

### DIFF
--- a/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
+++ b/web/src/pages/project/[projectId]/settings/integrations/blobstorage.tsx
@@ -97,7 +97,7 @@ export default function BlobStorageIntegrationSettings() {
   const syncStatusToBadge: Record<BlobStorageSyncStatus, string> = {
     up_to_date: "active",
     queued: "queued",
-    idle: "inactive",
+    idle: "pending",
     disabled: "disabled",
     error: "error",
   };


### PR DESCRIPTION
## What does this PR do?

Changes the blob storage integration status badge from "Inactive" (gray) to "Pending" (yellow) when the integration is enabled but has never exported yet.

"Inactive" was misleading — it suggested the integration was turned off, when it was simply waiting for its first scheduled run. "Pending" communicates the correct state: enabled and awaiting first export.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] UI-only change — the public API `syncStatus` value `idle` is unchanged (no breaking change)
- [x] The `StatusBadge` component already supports `"pending"` as a type (yellow badge with animated dot)
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a misleading status badge on the Blob Storage integration settings page: when the integration is enabled but has never completed an export (`idle` sync state), the badge now shows yellow "Pending" instead of gray "Inactive".

- The `syncStatusToBadge` map is updated to map `idle → "pending"` instead of `idle → "inactive"`, which correctly leverages the existing yellow animated-dot style in `StatusBadge`.
- The internal `BlobStorageSyncStatus` type and the `syncStatus` API value (`idle`) are unchanged — this is a display-only fix with no breaking changes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Single-line display-only change with no API or type contract impact — safe to merge.

The change touches one mapping entry in one file, swapping "inactive" for "pending" in the badge lookup. The StatusBadge component already has "pending" as a recognised category with the correct yellow/animated-dot styling, and the internal BlobStorageSyncStatus type and the public API syncStatus value are both untouched. No edge cases in deriveSyncStatus are affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deriveSyncStatus called] --> B{enabled?}
    B -- No --> C[disabled]
    B -- Yes --> D{lastError?}
    D -- Yes --> E[error]
    D -- No --> F{lastSyncAt is null?}
    F -- Yes --> G["idle (internal)"]
    F -- No --> H{nextSyncAt <= now?}
    H -- Yes --> I[queued]
    H -- No --> J[up_to_date]

    G --> K["syncStatusToBadge: 'pending'"]
    I --> L["syncStatusToBadge: 'queued'"]
    J --> M["syncStatusToBadge: 'active'"]
    C --> N["syncStatusToBadge: 'disabled'"]
    E --> O["syncStatusToBadge: 'error'"]

    K --> P["StatusBadge: yellow + animated dot"]
    L --> P
    M --> Q["StatusBadge: green + animated dot"]
    N --> R["StatusBadge: gray (inactive category)"]
    O --> S["StatusBadge: red, no dot"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[deriveSyncStatus called] --> B{enabled?}
    B -- No --> C[disabled]
    B -- Yes --> D{lastError?}
    D -- Yes --> E[error]
    D -- No --> F{lastSyncAt is null?}
    F -- Yes --> G["idle (internal)"]
    F -- No --> H{nextSyncAt <= now?}
    H -- Yes --> I[queued]
    H -- No --> J[up_to_date]

    G --> K["syncStatusToBadge: 'pending'"]
    I --> L["syncStatusToBadge: 'queued'"]
    J --> M["syncStatusToBadge: 'active'"]
    C --> N["syncStatusToBadge: 'disabled'"]
    E --> O["syncStatusToBadge: 'error'"]

    K --> P["StatusBadge: yellow + animated dot"]
    L --> P
    M --> Q["StatusBadge: green + animated dot"]
    N --> R["StatusBadge: gray (inactive category)"]
    O --> S["StatusBadge: red, no dot"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): show &#39;Pending&#39; instead of &#39;Inac..."](https://github.com/langfuse/langfuse/commit/2811fc3b1373c86c6c5b9900a896fd723d3c583a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37846432)</sub>

<!-- /greptile_comment -->