### PR TITLE
fix(blob-storage): surface SDK root cause in validation error messages

### DIFF
--- a/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
+++ b/web/src/features/blobstorage-integration/blobstorage-integration-router.ts
@@ -39,8 +39,28 @@ const getAuditLogErrorType = (error: unknown) =>
       ? error.name
       : "UnknownError";
 
-const getErrorMessage = (error: unknown, fallback: string) =>
-  error instanceof Error ? error.message : fallback;
+const formatRootCause = (err: Error): string => {
+  // SDK errors (e.g. S3, GCS) carry a descriptive name like
+  // "SignatureDoesNotMatch" while .message is often generic ("Invalid argument.").
+  const name = err.name && err.name !== "Error" ? err.name : "";
+  if (name && err.message) return `${name}: ${err.message}`;
+  return name || err.message;
+};
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  if (!(error instanceof Error)) return fallback;
+  // Walk the full cause chain to find the deepest (most specific) error.
+  // StorageService wraps SDK errors in multiple layers of handleStorageError.
+  let deepest: Error = error;
+  while (deepest.cause instanceof Error) {
+    deepest = deepest.cause;
+  }
+  if (deepest !== error) {
+    const rootCause = formatRootCause(deepest);
+    if (rootCause) return `${error.message}: ${rootCause}`.slice(0, 500);
+  }
+  return error.message;
+};
 
 export const blobStorageIntegrationRouter = createTRPCRouter({
   get: protectedProjectProcedure
@@ -416,15 +436,14 @@ This file can be safely deleted.`;
           signedUrl: result.signedUrl,
         };
       } catch (e) {
-        logger.error(
-          `Blob storage validation failed for project ${input.projectId}`,
-          e,
-        );
-
-        // Extract meaningful error message
         const errorMessage = getErrorMessage(
           e,
           "Unknown error occurred during validation",
+        );
+
+        logger.error(
+          `Blob storage validation failed for project ${input.projectId}: ${errorMessage}`,
+          e,
         );
 
         await auditLog({


### PR DESCRIPTION
## What does this PR do?

Improves blob storage validation error messages by walking the full `.cause` chain instead of showing only the top-level wrapper message. Users now see the actual SDK error (e.g. `SignatureDoesNotMatch: Invalid argument.`) instead of generic `Failed to upload file to S3` wrappers.

Changes:
- Replace the one-liner `getErrorMessage` with a cause-chain walker that finds the deepest (most specific) error from StorageService's multiple `handleStorageError` wrapping layers
- Include SDK error `.name` (e.g. `SignatureDoesNotMatch`, `NoSuchBucket`) alongside `.message` in the surfaced error, since SDK names are often more actionable than the generic message text
- Interpolate the extracted error message into the server log line so Datadog shows the root cause inline

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I haven't introduced new `any` or `as` type assertions in TypeScript


🤖 Generated with [Claude Code](https://claude.com/claude-code)