### PR TITLE
feat(observations-v2): add shadow query validation for subquery-IN rewrite

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -446,6 +446,11 @@ const EnvSchema = z.object({
   LANGFUSE_OBSERVATIONS_V2_SUBQUERY_REWRITE: z
     .enum(["true", "false"])
     .default("false"),
+  // Run the subquery-IN rewrite as a shadow query alongside the CTE+JOIN
+  // path and emit comparison metrics. Remove after validation.
+  LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY: z
+    .enum(["true", "false"])
+    .default("false"),
   // Enable Redis-based tracking of projects using OTEL API to optimize ClickHouse queries.
   // When enabled, projects ingesting via OTEL API skip the FINAL modifier on some observations queries for better performance.
   LANGFUSE_SKIP_FINAL_FOR_OTEL_PROJECTS: z

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -451,6 +451,11 @@ const EnvSchema = z.object({
   LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY: z
     .enum(["true", "false"])
     .default("false"),
+  LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY_SAMPLE_RATE: z.coerce
+    .number()
+    .min(0)
+    .max(1)
+    .default(0.01),
   // Enable Redis-based tracking of projects using OTEL API to optimize ClickHouse queries.
   // When enabled, projects ingesting via OTEL API skip the FINAL modifier on some observations queries for better performance.
   LANGFUSE_SKIP_FINAL_FOR_OTEL_PROJECTS: z

--- a/packages/shared/src/server/queries/clickhouse-sql/query-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-options.ts
@@ -44,5 +44,8 @@ export function shouldUseObservationsSubqueryRewrite(): boolean {
 }
 
 export function shouldRunObservationsShadowQuery(): boolean {
-  return env.LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY === "true";
+  return (
+    env.LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY === "true" &&
+    Math.random() < env.LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY_SAMPLE_RATE
+  );
 }

--- a/packages/shared/src/server/queries/clickhouse-sql/query-options.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/query-options.ts
@@ -42,3 +42,7 @@ export async function shouldSkipObservationsFinal(
 export function shouldUseObservationsSubqueryRewrite(): boolean {
   return env.LANGFUSE_OBSERVATIONS_V2_SUBQUERY_REWRITE === "true";
 }
+
+export function shouldRunObservationsShadowQuery(): boolean {
+  return env.LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY === "true";
+}

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -17,7 +17,7 @@ import {
   PreferredClickhouseService,
 } from "../clickhouse/client";
 import { measureAndReturn } from "../clickhouse/measureAndReturn";
-import { recordDistribution } from "../instrumentation";
+import { recordDistribution, recordIncrement } from "../instrumentation";
 import { logger } from "../logger";
 import {
   convertClickhouseToDomain,
@@ -102,7 +102,10 @@ import {
   type SessionEventsMetricsRow,
   OrderByEntry,
 } from "../queries/clickhouse-sql/event-query-builder";
-import { shouldUseObservationsSubqueryRewrite } from "../queries/clickhouse-sql/query-options";
+import {
+  shouldUseObservationsSubqueryRewrite,
+  shouldRunObservationsShadowQuery,
+} from "../queries/clickhouse-sql/query-options";
 import { type EventsObservationPublic } from "../queries/createGenerationsQuery";
 import {
   eventsTableCols,
@@ -1466,6 +1469,86 @@ export const getObservationsFromEventsTableForPublicApi = async (
   return observations;
 };
 
+// ── Shadow query validation (remove after subquery-rewrite rollout) ──────────
+
+/**
+ * Fire-and-forget: run the subquery-rewrite path alongside the authoritative
+ * cte-join result and emit Datadog comparison metrics. Never throws; errors
+ * are caught and counted. Called only when LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY
+ * is enabled and the query would normally take the cte-join path.
+ */
+function runSubqueryRewriteShadowQuery(
+  opts: PublicApiObservationsQuery & {
+    fields: ObservationFieldGroupPublicApi[];
+  },
+  options: BuildObservationsQueryComponentsOptions,
+  primaryRecords: Array<ObservationsTableQueryResultWitouhtTraceFields>,
+  primaryDurationMs: number,
+): void {
+  const { projectId } = opts;
+  const requestedFields = opts.fields ?? ["core", "basic"];
+  const METRIC_PREFIX = "langfuse.observations_v2.shadow_query";
+
+  const run = async () => {
+    const { queryBuilder: shadowBuilder } = buildObservationsQueryComponents(
+      opts,
+      eventsTableNativeUiColumnDefinitions,
+      options,
+    );
+    applyOrderByForObservationsQuery(shadowBuilder);
+    applyCursorPagination(opts, shadowBuilder);
+
+    const shadowQueryBuilder = buildEventsFullTableSubqueryQuery({
+      projectId,
+      innerBuilder: shadowBuilder,
+      fieldSetNames: ["core", ...requestedFields],
+    });
+
+    const start = Date.now();
+    const shadowRecords =
+      await getObservationsRowsFromBuilder<ObservationsTableQueryResultWitouhtTraceFields>(
+        projectId,
+        shadowQueryBuilder,
+        "getObservationsV2_shadow_subquery_rewrite",
+        { queryPath: "shadow-subquery-rewrite" },
+      );
+    const shadowDurationMs = Date.now() - start;
+
+    recordDistribution(`${METRIC_PREFIX}.duration_ms`, shadowDurationMs);
+    recordDistribution(
+      `${METRIC_PREFIX}.duration_delta_ms`,
+      shadowDurationMs - primaryDurationMs,
+    );
+
+    const primaryIds = primaryRecords.map((r) => r.id);
+    const shadowIds = shadowRecords.map((r) => r.id);
+
+    if (primaryIds.length !== shadowIds.length) {
+      recordIncrement(`${METRIC_PREFIX}.row_count_mismatch`, 1);
+      logger.warn("Shadow query row count mismatch", {
+        projectId,
+        primaryCount: primaryIds.length,
+        shadowCount: shadowIds.length,
+      });
+    } else {
+      const orderMatch = primaryIds.every((id, i) => id === shadowIds[i]);
+      if (!orderMatch) {
+        recordIncrement(`${METRIC_PREFIX}.order_mismatch`, 1);
+        logger.warn("Shadow query order mismatch", { projectId });
+      } else {
+        recordIncrement(`${METRIC_PREFIX}.match`, 1);
+      }
+    }
+  };
+
+  run().catch((err) => {
+    recordIncrement(`${METRIC_PREFIX}.error`, 1);
+    logger.error("Shadow query failed", { projectId, error: err });
+  });
+}
+
+// ── End shadow query validation ─────────────────────────────────────────────
+
 /**
  * V2 API: Get observations list from events table for public API
  * Returns partial observations based on requested field groups
@@ -1520,6 +1603,12 @@ export const getObservationsV2FromEventsTableForPublicApi = async (
       ? "subquery-rewrite"
       : "cte-join";
 
+  // Shadow query eligibility: cte-join path, no external CTEs, flag enabled.
+  const shouldShadow =
+    queryPath === "cte-join" &&
+    externalCTEs.length === 0 &&
+    shouldRunObservationsShadowQuery();
+
   // Field groups projected on the base builder by the non-rewrite paths.
   // `io` (and `metadata` when it must come untruncated from events_full) is
   // fetched by the io CTE instead; selecting it on events_core would return
@@ -1565,6 +1654,7 @@ export const getObservationsV2FromEventsTableForPublicApi = async (
       break;
   }
 
+  const primaryStart = Date.now();
   const records =
     await getObservationsRowsFromBuilder<ObservationsTableQueryResultWitouhtTraceFields>(
       projectId,
@@ -1572,6 +1662,11 @@ export const getObservationsV2FromEventsTableForPublicApi = async (
       undefined,
       { queryPath },
     );
+  const primaryDurationMs = Date.now() - primaryStart;
+
+  if (shouldShadow) {
+    runSubqueryRewriteShadowQuery(opts, options, records, primaryDurationMs);
+  }
 
   return await enrichObservationsWithModelData(
     records,

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1552,7 +1552,10 @@ function runSubqueryRewriteShadowQuery(
     const orderMatch = primaryIds.every((id, i) => id === shadowIds[i]);
     if (!orderMatch) {
       const primarySet = new Set(primaryIds);
-      const sameContent = shadowIds.every((id) => primarySet.has(id));
+      const shadowSet = new Set(shadowIds);
+      const sameContent =
+        primarySet.size === shadowSet.size &&
+        shadowIds.every((id) => primarySet.has(id));
       if (!sameContent) {
         recordIncrement(`${METRIC_PREFIX}.content_mismatch`, 1);
         logger.warn("Shadow query content mismatch", {

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1474,6 +1474,7 @@ export const getObservationsFromEventsTableForPublicApi = async (
 export type ShadowQueryOutcome =
   | "match"
   | "row_count_mismatch"
+  | "content_mismatch"
   | "order_mismatch"
   | "error";
 
@@ -1542,12 +1543,25 @@ function runSubqueryRewriteShadowQuery(
         projectId,
         primaryCount: primaryIds.length,
         shadowCount: shadowIds.length,
+        primarySample: primaryIds.slice(0, 5),
+        shadowSample: shadowIds.slice(0, 5),
       });
       return "row_count_mismatch";
     }
 
     const orderMatch = primaryIds.every((id, i) => id === shadowIds[i]);
     if (!orderMatch) {
+      const primarySet = new Set(primaryIds);
+      const sameContent = shadowIds.every((id) => primarySet.has(id));
+      if (!sameContent) {
+        recordIncrement(`${METRIC_PREFIX}.content_mismatch`, 1);
+        logger.warn("Shadow query content mismatch", {
+          projectId,
+          primarySample: primaryIds.slice(0, 5),
+          shadowSample: shadowIds.slice(0, 5),
+        });
+        return "content_mismatch";
+      }
       recordIncrement(`${METRIC_PREFIX}.order_mismatch`, 1);
       logger.warn("Shadow query order mismatch", { projectId });
       return "order_mismatch";

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1471,6 +1471,19 @@ export const getObservationsFromEventsTableForPublicApi = async (
 
 // ── Shadow query validation (remove after subquery-rewrite rollout) ──────────
 
+export type ShadowQueryOutcome =
+  | "match"
+  | "row_count_mismatch"
+  | "order_mismatch"
+  | "error";
+
+/** Test-only hook: captures the last shadow promise. Set `forceShadow` to
+ *  bypass env checks (avoids module-identity issues in vitest). */
+export const _shadowQueryTestHook: {
+  promise: Promise<ShadowQueryOutcome> | null;
+  forceShadow: boolean;
+} = { promise: null, forceShadow: false };
+
 /**
  * Fire-and-forget: run the subquery-rewrite path alongside the authoritative
  * cte-join result and emit Datadog comparison metrics. Never throws; errors
@@ -1489,7 +1502,7 @@ function runSubqueryRewriteShadowQuery(
   const requestedFields = opts.fields ?? ["core", "basic"];
   const METRIC_PREFIX = "langfuse.observations_v2.shadow_query";
 
-  const run = async () => {
+  const run = async (): Promise<ShadowQueryOutcome> => {
     const { queryBuilder: shadowBuilder } = buildObservationsQueryComponents(
       opts,
       eventsTableNativeUiColumnDefinitions,
@@ -1530,20 +1543,24 @@ function runSubqueryRewriteShadowQuery(
         primaryCount: primaryIds.length,
         shadowCount: shadowIds.length,
       });
-    } else {
-      const orderMatch = primaryIds.every((id, i) => id === shadowIds[i]);
-      if (!orderMatch) {
-        recordIncrement(`${METRIC_PREFIX}.order_mismatch`, 1);
-        logger.warn("Shadow query order mismatch", { projectId });
-      } else {
-        recordIncrement(`${METRIC_PREFIX}.match`, 1);
-      }
+      return "row_count_mismatch";
     }
+
+    const orderMatch = primaryIds.every((id, i) => id === shadowIds[i]);
+    if (!orderMatch) {
+      recordIncrement(`${METRIC_PREFIX}.order_mismatch`, 1);
+      logger.warn("Shadow query order mismatch", { projectId });
+      return "order_mismatch";
+    }
+
+    recordIncrement(`${METRIC_PREFIX}.match`, 1);
+    return "match";
   };
 
-  run().catch((err) => {
+  _shadowQueryTestHook.promise = run().catch((err): ShadowQueryOutcome => {
     recordIncrement(`${METRIC_PREFIX}.error`, 1);
     logger.error("Shadow query failed", { projectId, error: err });
+    return "error";
   });
 }
 
@@ -1607,7 +1624,7 @@ export const getObservationsV2FromEventsTableForPublicApi = async (
   const shouldShadow =
     queryPath === "cte-join" &&
     externalCTEs.length === 0 &&
-    shouldRunObservationsShadowQuery();
+    (_shadowQueryTestHook.forceShadow || shouldRunObservationsShadowQuery());
 
   // Field groups projected on the base builder by the non-rewrite paths.
   // `io` (and `metadata` when it must come untruncated from events_full) is

--- a/web/src/__tests__/server/observations-v2-shadow-query.servertest.ts
+++ b/web/src/__tests__/server/observations-v2-shadow-query.servertest.ts
@@ -1,0 +1,160 @@
+// Shadow query validation tests (remove with shadow query code).
+// Calls the repository function directly — no HTTP server needed.
+import {
+  createEvent,
+  createEventsCh,
+  createOrgProjectAndApiKey,
+  getObservationsV2FromEventsTableForPublicApi,
+  _shadowQueryTestHook,
+} from "@langfuse/shared/src/server";
+import { randomUUID } from "crypto";
+
+let projectId: string;
+
+const seedObservations = async (
+  traceId: string,
+  count: number,
+  opts?: { withIO?: boolean; withMetadata?: boolean },
+) => {
+  const base = Date.now() * 1000;
+  const events = Array.from({ length: count }, (_, i) => {
+    const obsId = randomUUID();
+    return createEvent({
+      id: obsId,
+      span_id: obsId,
+      trace_id: traceId,
+      project_id: projectId,
+      name: `shadow-obs-${i}`,
+      type: "GENERATION",
+      level: "DEFAULT",
+      start_time: base + i * 1000 * 1000,
+      ...(opts?.withIO && {
+        input: `input-${i}-${"x".repeat(300)}`,
+        output: `output-${i}-${"y".repeat(300)}`,
+      }),
+      ...(opts?.withMetadata && {
+        metadata: { env: "test", idx: String(i) },
+        metadata_names: ["env", "idx"],
+        metadata_values: ["test", String(i)],
+      }),
+    });
+  });
+  await createEventsCh(events);
+};
+
+describe("shadow query validation", () => {
+  beforeEach(async () => {
+    const fixture = await createOrgProjectAndApiKey();
+    projectId = fixture.projectId;
+    _shadowQueryTestHook.promise = null;
+    _shadowQueryTestHook.forceShadow = false;
+  });
+
+  afterEach(() => {
+    _shadowQueryTestHook.promise = null;
+    _shadowQueryTestHook.forceShadow = false;
+  });
+
+  it("reports match for IO queries", async () => {
+    const traceId = randomUUID();
+    await seedObservations(traceId, 3, { withIO: true });
+
+    _shadowQueryTestHook.forceShadow = true;
+    const results = await getObservationsV2FromEventsTableForPublicApi({
+      projectId,
+      page: 1,
+      limit: 50,
+      traceId,
+      fields: ["core", "basic", "io"],
+    });
+
+    expect(results.length).toBe(3);
+    expect(_shadowQueryTestHook.promise).not.toBeNull();
+    expect(await _shadowQueryTestHook.promise).toBe("match");
+  });
+
+  it("reports match with metadata expansion", async () => {
+    const traceId = randomUUID();
+    await seedObservations(traceId, 2, { withMetadata: true });
+
+    _shadowQueryTestHook.forceShadow = true;
+    const results = await getObservationsV2FromEventsTableForPublicApi({
+      projectId,
+      page: 1,
+      limit: 50,
+      traceId,
+      fields: ["metadata"],
+      expandMetadataKeys: ["env", "idx"],
+    });
+
+    expect(results.length).toBe(2);
+    expect(_shadowQueryTestHook.promise).not.toBeNull();
+    expect(await _shadowQueryTestHook.promise).toBe("match");
+  });
+
+  it("reports match for empty result sets", async () => {
+    _shadowQueryTestHook.forceShadow = true;
+    const results = await getObservationsV2FromEventsTableForPublicApi({
+      projectId,
+      page: 1,
+      limit: 50,
+      traceId: randomUUID(),
+      fields: ["core", "io"],
+    });
+
+    expect(results.length).toBe(0);
+    expect(_shadowQueryTestHook.promise).not.toBeNull();
+    expect(await _shadowQueryTestHook.promise).toBe("match");
+  });
+
+  it("does not run for simple queries (no IO/metadata expansion)", async () => {
+    const traceId = randomUUID();
+    await seedObservations(traceId, 2, {});
+
+    _shadowQueryTestHook.forceShadow = true;
+    await getObservationsV2FromEventsTableForPublicApi({
+      projectId,
+      page: 1,
+      limit: 50,
+      traceId,
+      fields: ["core", "basic"],
+    });
+
+    // Simple path (no IO) — shadow never fires even with forceShadow,
+    // because queryPath is "simple" not "cte-join".
+    expect(_shadowQueryTestHook.promise).toBeNull();
+  });
+
+  it("reports match across multiple field group combos", async () => {
+    const traceId = randomUUID();
+    await seedObservations(traceId, 3, { withIO: true, withMetadata: true });
+
+    const fieldCombos: Array<{
+      fields: string[];
+      expandMetadataKeys?: string[];
+    }> = [
+      { fields: ["core", "basic", "io"] },
+      { fields: ["core", "basic", "model", "usage", "io", "metadata"] },
+      { fields: ["io", "metadata"] },
+      { fields: ["metadata"], expandMetadataKeys: ["env", "idx"] },
+    ];
+
+    for (const combo of fieldCombos) {
+      _shadowQueryTestHook.promise = null;
+      _shadowQueryTestHook.forceShadow = true;
+
+      const results = await getObservationsV2FromEventsTableForPublicApi({
+        projectId,
+        page: 1,
+        limit: 50,
+        traceId,
+        fields: combo.fields as any,
+        expandMetadataKeys: combo.expandMetadataKeys,
+      });
+
+      expect(results.length).toBe(3);
+      expect(_shadowQueryTestHook.promise).not.toBeNull();
+      expect(await _shadowQueryTestHook.promise).toBe("match");
+    }
+  });
+});

--- a/web/src/__tests__/server/observations-v2-shadow-query.servertest.ts
+++ b/web/src/__tests__/server/observations-v2-shadow-query.servertest.ts
@@ -7,7 +7,13 @@ import {
   getObservationsV2FromEventsTableForPublicApi,
   _shadowQueryTestHook,
 } from "@langfuse/shared/src/server";
+import { env } from "@/src/env.mjs";
 import { randomUUID } from "crypto";
+
+const maybe =
+  env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+    ? describe
+    : describe.skip;
 
 let projectId: string;
 
@@ -42,7 +48,7 @@ const seedObservations = async (
   await createEventsCh(events);
 };
 
-describe("shadow query validation", () => {
+maybe("shadow query validation", () => {
   beforeEach(async () => {
     const fixture = await createOrgProjectAndApiKey();
     projectId = fixture.projectId;

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -445,6 +445,9 @@ export const env = createEnv({
     LANGFUSE_OBSERVATIONS_V2_SUBQUERY_REWRITE: z
       .enum(["true", "false"])
       .default("false"),
+    LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY: z
+      .enum(["true", "false"])
+      .default("false"),
 
     // Blocked users for chat completion API (userId:reason format)
     LANGFUSE_BLOCKED_USERIDS_CHATCOMPLETION: z
@@ -858,6 +861,8 @@ export const env = createEnv({
       process.env.LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH,
     LANGFUSE_OBSERVATIONS_V2_SUBQUERY_REWRITE:
       process.env.LANGFUSE_OBSERVATIONS_V2_SUBQUERY_REWRITE,
+    LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY:
+      process.env.LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY,
     LANGFUSE_BLOCKED_USERIDS_CHATCOMPLETION:
       process.env.LANGFUSE_BLOCKED_USERIDS_CHATCOMPLETION,
   },

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -448,6 +448,11 @@ export const env = createEnv({
     LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY: z
       .enum(["true", "false"])
       .default("false"),
+    LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY_SAMPLE_RATE: z.coerce
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.01),
 
     // Blocked users for chat completion API (userId:reason format)
     LANGFUSE_BLOCKED_USERIDS_CHATCOMPLETION: z
@@ -863,6 +868,8 @@ export const env = createEnv({
       process.env.LANGFUSE_OBSERVATIONS_V2_SUBQUERY_REWRITE,
     LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY:
       process.env.LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY,
+    LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY_SAMPLE_RATE:
+      process.env.LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY_SAMPLE_RATE,
     LANGFUSE_BLOCKED_USERIDS_CHATCOMPLETION:
       process.env.LANGFUSE_BLOCKED_USERIDS_CHATCOMPLETION,
   },


### PR DESCRIPTION
## What does this PR do?

Adds a **shadow-query validation mode** for the observations v2 subquery-IN rewrite. When `LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY=true`, every V2 observations query that takes the `cte-join` path also fires the `subquery-rewrite` path fire-and-forget, compares result IDs/ordering, and emits Datadog metrics.

The shadow path **never affects the API response** — it runs asynchronously after the primary query returns.

### Metrics emitted (`langfuse.observations_v2.shadow_query.*`)

| Metric | Meaning |
|---|---|
| `.match` | Both paths returned identical IDs in identical order |
| `.row_count_mismatch` | Different number of rows returned |
| `.order_mismatch` | Same rows, different sort order |
| `.error` | Shadow path threw an exception |
| `.duration_ms` | Absolute shadow path latency |
| `.duration_delta_ms` | Shadow minus primary (negative = shadow is faster) |

### Rollout plan

1. Enable `LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY=true` in one region
2. Monitor metrics for 48h — expect 0 mismatches
3. If clean: enable remaining regions for 24h
4. Cutover: flip `LANGFUSE_OBSERVATIONS_V2_SUBQUERY_REWRITE=true`, disable shadow
5. Remove shadow code after 1 week bake

### Isolation for removal

All shadow logic is in a single `runSubqueryRewriteShadowQuery()` function with boundary comments. Removal = delete the function, its one call site, and the env var.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring

## Checklist

- [x] Tested with `pnpm run lint`, `pnpm run typecheck`, and unit tests
- [x] Shadow path is fire-and-forget — never blocks or changes the API response
- [x] New env var defaults to `false` — no behavioral change without opt-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a fire-and-forget shadow validation layer for the observations V2 subquery-IN rewrite. When `LANGFUSE_OBSERVATIONS_V2_SHADOW_QUERY=true`, every query that takes the `cte-join` path also runs the `subquery-rewrite` path asynchronously and emits Datadog comparison metrics — the shadow never blocks or modifies the API response.

- The shadow function (`runSubqueryRewriteShadowQuery`) is cleanly isolated with boundary comments and a clear removal plan; all new imports are correctly placed at the module top level in accordance with project conventions.
- The comparison logic conflates "same count, different IDs" with "same IDs, wrong order" under a single `order_mismatch` metric, which can mask real correctness regressions (see inline comment).
- The `externalCTEs.length === 0` guard in `shouldShadow` is redundant given the preceding `queryPath` derivation, but does not cause incorrect behavior.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with the shadow path being truly fire-and-forget; the one logic gap in the comparison metrics does not affect the API response or data correctness.

The shadow query is well-isolated and never touches the response path. The main concern is that the ID comparison logic collapses "different IDs, same count" and "same IDs, wrong order" into a single order_mismatch metric, which would make it hard to diagnose a real correctness problem during the validation window — operators might dismiss what is actually a content difference as a minor sort issue. The env var defaults to false, so there is no production impact until explicitly opted in.

The comparison logic in runSubqueryRewriteShadowQuery inside packages/shared/src/server/repositories/events.ts deserves a second look before the shadow mode is enabled in production.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant getObservationsV2 as getObservationsV2FromEventsTableForPublicApi
    participant CH_Primary as ClickHouse (cte-join)
    participant ShadowFn as runSubqueryRewriteShadowQuery
    participant CH_Shadow as ClickHouse (subquery-rewrite)
    participant DD as Datadog Metrics

    Client->>getObservationsV2: request (fields, filters, pagination)
    getObservationsV2->>getObservationsV2: determine queryPath (simple / cte-join / subquery-rewrite)
    getObservationsV2->>getObservationsV2: "evaluate shouldShadow (queryPath=cte-join AND no externalCTEs AND flag=true)"
    getObservationsV2->>CH_Primary: execute cte-join query
    CH_Primary-->>getObservationsV2: primaryRecords + primaryDurationMs
    getObservationsV2-->>Client: return enriched observations (synchronous)

    alt "shouldShadow = true"
        getObservationsV2--)ShadowFn: fire-and-forget (non-blocking)
        ShadowFn->>CH_Shadow: execute subquery-rewrite query
        CH_Shadow-->>ShadowFn: shadowRecords + shadowDurationMs
        ShadowFn->>ShadowFn: compare IDs (length + per-position)
        alt row count differs
            ShadowFn->>DD: increment row_count_mismatch
        else "orderMatch = false"
            ShadowFn->>DD: increment order_mismatch
        else
            ShadowFn->>DD: increment match
        end
        ShadowFn->>DD: distribution duration_ms, duration_delta_ms
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant getObservationsV2 as getObservationsV2FromEventsTableForPublicApi
    participant CH_Primary as ClickHouse (cte-join)
    participant ShadowFn as runSubqueryRewriteShadowQuery
    participant CH_Shadow as ClickHouse (subquery-rewrite)
    participant DD as Datadog Metrics

    Client->>getObservationsV2: request (fields, filters, pagination)
    getObservationsV2->>getObservationsV2: determine queryPath (simple / cte-join / subquery-rewrite)
    getObservationsV2->>getObservationsV2: "evaluate shouldShadow (queryPath=cte-join AND no externalCTEs AND flag=true)"
    getObservationsV2->>CH_Primary: execute cte-join query
    CH_Primary-->>getObservationsV2: primaryRecords + primaryDurationMs
    getObservationsV2-->>Client: return enriched observations (synchronous)

    alt "shouldShadow = true"
        getObservationsV2--)ShadowFn: fire-and-forget (non-blocking)
        ShadowFn->>CH_Shadow: execute subquery-rewrite query
        CH_Shadow-->>ShadowFn: shadowRecords + shadowDurationMs
        ShadowFn->>ShadowFn: compare IDs (length + per-position)
        alt row count differs
            ShadowFn->>DD: increment row_count_mismatch
        else "orderMatch = false"
            ShadowFn->>DD: increment order_mismatch
        else
            ShadowFn->>DD: increment match
        end
        ShadowFn->>DD: distribution duration_ms, duration_delta_ms
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/repositories/events.ts:1526-1541
**`order_mismatch` fires for content differences, not just ordering**

When `primaryIds.length === shadowIds.length` but some IDs are entirely different values, the `every((id, i) => id === shadowIds[i])` check returns `false` and emits `.order_mismatch`. The PR description defines `order_mismatch` as "same rows, different sort order," but this branch cannot distinguish "same IDs reordered" from "completely different IDs at the same count." An operator who sees `.order_mismatch` in Datadog will assume a trivial sort-order divergence while the shadow is actually returning a different result set — masking a real correctness regression in the subquery-rewrite path. A set-equality check should gate the two cases: emit a separate `content_mismatch` (or `id_mismatch`) metric when the ID sets differ, and reserve `order_mismatch` for when the sets are equal but the sequence differs.

### Issue 2 of 2
packages/shared/src/server/repositories/events.ts:1606-1610
**Redundant `externalCTEs.length === 0` guard in `shouldShadow`**

`queryPath === "cte-join"` is already set by `externalCTEs.length > 0 || !shouldUseObservationsSubqueryRewrite()`. When `queryPath === "cte-join"` and `externalCTEs.length > 0`, both conditions together make the shadow always `false` for that case — which is the correct behavior since the shadow only targets the rewrite path. The extra `externalCTEs.length === 0` check is harmless but slightly misleading: it implies the two guards are independent when in fact `queryPath === "cte-join" && externalCTEs.length === 0` already implies the rewrite flag is off. A comment clarifying this invariant would help the next reader.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(observations-v2): add shadow query ..."](https://github.com/langfuse/langfuse/commit/e9477c7c3242d781f3f6c5648839a63b5d08ce79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37885673)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->