### PR TITLE
chore(web): Forbid className and style props in design system components

### DIFF
--- a/packages/eslint-plugin/src/component-prop-types.ts
+++ b/packages/eslint-plugin/src/component-prop-types.ts
@@ -1,0 +1,397 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+type PropTypeCallbacks = {
+  onPropProperty: (node: TSESTree.TSPropertySignature) => void;
+  onDestructuredProp?: (node: TSESTree.Property) => void;
+};
+
+const REACT_COMPONENT_TYPES = new Set([
+  "FC",
+  "FunctionComponent",
+  "VFC",
+  "VoidFunctionComponent",
+]);
+
+function isCapitalizedName(name: string): boolean {
+  return /^[A-Z]/.test(name);
+}
+
+function isJsxNode(node: TSESTree.Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.JSXElement ||
+    node.type === AST_NODE_TYPES.JSXFragment
+  );
+}
+
+function isNullLiteral(node: TSESTree.Node): boolean {
+  return node.type === AST_NODE_TYPES.Literal && node.value === null;
+}
+
+function isReactCreateElementCall(node: TSESTree.CallExpression): boolean {
+  const callee = node.callee;
+  return (
+    (callee.type === AST_NODE_TYPES.Identifier &&
+      callee.name === "createElement") ||
+    (callee.type === AST_NODE_TYPES.MemberExpression &&
+      callee.object.type === AST_NODE_TYPES.Identifier &&
+      callee.object.name === "React" &&
+      callee.property.type === AST_NODE_TYPES.Identifier &&
+      callee.property.name === "createElement")
+  );
+}
+
+function expressionReturnsJsxOrNull(
+  node: TSESTree.Node | null | undefined,
+): boolean {
+  if (!node) return false;
+  if (isJsxNode(node) || isNullLiteral(node)) return true;
+
+  switch (node.type) {
+    case AST_NODE_TYPES.ConditionalExpression:
+      return [node.consequent, node.alternate].some(expressionReturnsJsxOrNull);
+    case AST_NODE_TYPES.LogicalExpression:
+      return [node.left, node.right].some(expressionReturnsJsxOrNull);
+    case AST_NODE_TYPES.CallExpression:
+      return (
+        isReactCreateElementCall(node) ||
+        node.arguments.some((argument) => expressionReturnsJsxOrNull(argument))
+      );
+    case AST_NODE_TYPES.ArrowFunctionExpression:
+    case AST_NODE_TYPES.FunctionExpression:
+      return functionReturnsJsxOrNull(node);
+    case AST_NODE_TYPES.TSAsExpression:
+    case AST_NODE_TYPES.TSNonNullExpression:
+    case AST_NODE_TYPES.TSSatisfiesExpression:
+    case AST_NODE_TYPES.TSTypeAssertion:
+      return expressionReturnsJsxOrNull(node.expression);
+    default:
+      return false;
+  }
+}
+
+function statementReturnsJsxOrNull(
+  statement: TSESTree.Statement | null | undefined,
+): boolean {
+  if (!statement) return false;
+  switch (statement.type) {
+    case AST_NODE_TYPES.ReturnStatement:
+      return expressionReturnsJsxOrNull(statement.argument);
+    case AST_NODE_TYPES.BlockStatement:
+      return statement.body.some(statementReturnsJsxOrNull);
+    case AST_NODE_TYPES.IfStatement:
+      return [statement.consequent, statement.alternate].some(
+        statementReturnsJsxOrNull,
+      );
+    case AST_NODE_TYPES.SwitchStatement:
+      return statement.cases.some((switchCase) =>
+        switchCase.consequent.some(statementReturnsJsxOrNull),
+      );
+    case AST_NODE_TYPES.TryStatement:
+      return [
+        statement.block,
+        statement.handler?.body,
+        statement.finalizer,
+      ].some(statementReturnsJsxOrNull);
+    default:
+      return false;
+  }
+}
+
+function functionReturnsJsxOrNull(
+  node:
+    | TSESTree.ArrowFunctionExpression
+    | TSESTree.FunctionDeclaration
+    | TSESTree.FunctionExpression,
+): boolean {
+  if (node.type === AST_NODE_TYPES.ArrowFunctionExpression && node.expression) {
+    return expressionReturnsJsxOrNull(node.body);
+  }
+
+  return (node.body as TSESTree.BlockStatement).body.some(
+    statementReturnsJsxOrNull,
+  );
+}
+
+function getTypeName(typeName: TSESTree.EntityName): string | null {
+  if (typeName.type === AST_NODE_TYPES.Identifier) return typeName.name;
+  return getTypeName((typeName as TSESTree.TSQualifiedName).right);
+}
+
+function getTypeReferenceArguments(
+  node: TSESTree.TSTypeReference,
+): TSESTree.TypeNode[] {
+  return node.typeArguments?.params ?? [];
+}
+
+function getCallTypeArguments(
+  node: TSESTree.CallExpression,
+): TSESTree.TypeNode[] {
+  return node.typeArguments?.params ?? [];
+}
+
+function getReactComponentPropsType(
+  annotation: TSESTree.TypeNode,
+): TSESTree.TypeNode | null {
+  if (annotation.type !== AST_NODE_TYPES.TSTypeReference) return null;
+  const typeName = getTypeName(annotation.typeName);
+  if (!typeName || !REACT_COMPONENT_TYPES.has(typeName)) return null;
+  return getTypeReferenceArguments(annotation)[0] ?? null;
+}
+
+function getClassPropsType(
+  node: TSESTree.ClassDeclaration | TSESTree.ClassExpression,
+): TSESTree.TypeNode | null {
+  const superClass = node.superClass;
+  if (!superClass) return null;
+  const isComponentSuperclass =
+    (superClass.type === AST_NODE_TYPES.Identifier &&
+      superClass.name === "Component") ||
+    (superClass.type === AST_NODE_TYPES.MemberExpression &&
+      superClass.property.type === AST_NODE_TYPES.Identifier &&
+      superClass.property.name === "Component");
+
+  if (!isComponentSuperclass) {
+    return null;
+  }
+  return node.superTypeArguments?.params[0] ?? null;
+}
+
+function getForwardRefPropsType(
+  node: TSESTree.CallExpression,
+): TSESTree.TypeNode | null {
+  const callee = node.callee;
+  const isForwardRef =
+    (callee.type === AST_NODE_TYPES.Identifier &&
+      callee.name === "forwardRef") ||
+    (callee.type === AST_NODE_TYPES.MemberExpression &&
+      callee.property.type === AST_NODE_TYPES.Identifier &&
+      callee.property.name === "forwardRef");
+
+  if (!isForwardRef) return null;
+  return getCallTypeArguments(node)[1] ?? null;
+}
+
+function isComponentWrapperCall(
+  node: TSESTree.Node,
+): node is TSESTree.CallExpression {
+  if (node.type !== AST_NODE_TYPES.CallExpression) return false;
+  const callee = node.callee;
+  return (
+    (callee.type === AST_NODE_TYPES.Identifier &&
+      (callee.name === "memo" || callee.name === "forwardRef")) ||
+    (callee.type === AST_NODE_TYPES.MemberExpression &&
+      callee.property.type === AST_NODE_TYPES.Identifier &&
+      (callee.property.name === "memo" ||
+        callee.property.name === "forwardRef"))
+  );
+}
+
+function unwrapComponentInit(node: TSESTree.Node): TSESTree.Node {
+  let current = node;
+  while (isComponentWrapperCall(current) && current.arguments[0]) {
+    const firstArg = current.arguments[0];
+    if (
+      firstArg.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
+      firstArg.type !== AST_NODE_TYPES.FunctionExpression &&
+      firstArg.type !== AST_NODE_TYPES.CallExpression
+    ) {
+      break;
+    }
+    current = firstArg;
+  }
+  return current;
+}
+
+function getWrappedForwardRefPropsType(
+  node: TSESTree.Node,
+): TSESTree.TypeNode | null {
+  let current = node;
+  while (isComponentWrapperCall(current)) {
+    const propsType = getForwardRefPropsType(current);
+    if (propsType) return propsType;
+
+    const firstArg = current.arguments[0];
+    if (firstArg?.type !== AST_NODE_TYPES.CallExpression) break;
+    current = firstArg;
+  }
+  return null;
+}
+
+function getFunctionPropsType(
+  node:
+    | TSESTree.ArrowFunctionExpression
+    | TSESTree.FunctionDeclaration
+    | TSESTree.FunctionExpression,
+): TSESTree.TypeNode | null {
+  const firstParam = node.params[0];
+  if (!firstParam || firstParam.type === AST_NODE_TYPES.TSParameterProperty) {
+    return null;
+  }
+  return firstParam.typeAnnotation?.typeAnnotation ?? null;
+}
+
+function visitDestructuredProps(
+  node:
+    | TSESTree.ArrowFunctionExpression
+    | TSESTree.FunctionDeclaration
+    | TSESTree.FunctionExpression,
+  callbacks: PropTypeCallbacks,
+): void {
+  const firstParam = node.params[0];
+  if (firstParam?.type !== AST_NODE_TYPES.ObjectPattern) return;
+  firstParam.properties.forEach((property) => {
+    if (property.type === AST_NODE_TYPES.Property) {
+      callbacks.onDestructuredProp?.(property);
+    }
+  });
+}
+
+export function createComponentPropTypeVisitors(callbacks: PropTypeCallbacks) {
+  const typeDeclarations = new Map<
+    string,
+    TSESTree.TSInterfaceDeclaration | TSESTree.TSTypeAliasDeclaration
+  >();
+  const propTypeRoots: TSESTree.TypeNode[] = [];
+
+  function addPropTypeRoot(typeNode: TSESTree.TypeNode | null): void {
+    if (typeNode) propTypeRoots.push(typeNode);
+  }
+
+  function visitTypeNode(
+    node: TSESTree.TypeNode,
+    seen = new Set<string>(),
+  ): void {
+    switch (node.type) {
+      case AST_NODE_TYPES.TSTypeLiteral:
+        node.members.forEach((member) => {
+          if (member.type === AST_NODE_TYPES.TSPropertySignature) {
+            callbacks.onPropProperty(member);
+          }
+        });
+        return;
+      case AST_NODE_TYPES.TSIntersectionType:
+      case AST_NODE_TYPES.TSUnionType:
+        node.types.forEach((type) => visitTypeNode(type, seen));
+        return;
+      case AST_NODE_TYPES.TSTypeReference: {
+        const typeName = getTypeName(node.typeName);
+        const reactPropsType = getReactComponentPropsType(node);
+        if (reactPropsType) {
+          visitTypeNode(reactPropsType, seen);
+          return;
+        }
+
+        if (!typeName || seen.has(typeName)) return;
+        const declaration = typeDeclarations.get(typeName);
+        if (!declaration) return;
+        seen.add(typeName);
+
+        visitDeclaration(declaration, seen);
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  function getHeritageName(
+    expression: TSESTree.Identifier | TSESTree.MemberExpression,
+  ): string | null {
+    if (expression.type === AST_NODE_TYPES.Identifier) return expression.name;
+    return (expression.property as TSESTree.Identifier).name;
+  }
+
+  function visitDeclaration(
+    declaration:
+      | TSESTree.TSInterfaceDeclaration
+      | TSESTree.TSTypeAliasDeclaration,
+    seen: Set<string>,
+  ): void {
+    if (declaration.type === AST_NODE_TYPES.TSInterfaceDeclaration) {
+      declaration.body.body.forEach((member) => {
+        if (member.type === AST_NODE_TYPES.TSPropertySignature) {
+          callbacks.onPropProperty(member);
+        }
+      });
+      declaration.extends?.forEach((heritage) => {
+        const heritageTypeName = getHeritageName(
+          heritage.expression as
+            | TSESTree.Identifier
+            | TSESTree.MemberExpression,
+        );
+        visitDeclarationByName(heritageTypeName, seen);
+      });
+      return;
+    }
+    visitTypeNode(declaration.typeAnnotation, seen);
+  }
+
+  function visitDeclarationByName(
+    typeName: string | null,
+    seen: Set<string>,
+  ): void {
+    if (!typeName || seen.has(typeName)) return;
+    const declaration = typeDeclarations.get(typeName);
+    if (!declaration) return;
+    seen.add(typeName);
+    visitDeclaration(declaration, seen);
+  }
+
+  function maybeAddFunctionComponent(
+    node:
+      | TSESTree.ArrowFunctionExpression
+      | TSESTree.FunctionDeclaration
+      | TSESTree.FunctionExpression,
+    name: string | null,
+  ): void {
+    if (name && !isCapitalizedName(name)) return;
+    if (!functionReturnsJsxOrNull(node)) return;
+    addPropTypeRoot(getFunctionPropsType(node));
+    visitDestructuredProps(node, callbacks);
+  }
+
+  return {
+    TSInterfaceDeclaration(node: TSESTree.TSInterfaceDeclaration) {
+      typeDeclarations.set(node.id.name, node);
+    },
+    TSTypeAliasDeclaration(node: TSESTree.TSTypeAliasDeclaration) {
+      typeDeclarations.set(node.id.name, node);
+    },
+    FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+      maybeAddFunctionComponent(node, node.id?.name ?? null);
+    },
+    VariableDeclarator(node: TSESTree.VariableDeclarator) {
+      if (node.id.type !== AST_NODE_TYPES.Identifier) return;
+      if (!isCapitalizedName(node.id.name)) return;
+
+      const variableType = node.id.typeAnnotation?.typeAnnotation;
+      if (variableType) {
+        addPropTypeRoot(getReactComponentPropsType(variableType));
+      }
+
+      if (!node.init) return;
+
+      const init = unwrapComponentInit(node.init);
+      if (
+        init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        init.type === AST_NODE_TYPES.FunctionExpression
+      ) {
+        maybeAddFunctionComponent(init, node.id.name);
+      }
+      if (init.type === AST_NODE_TYPES.ClassExpression) {
+        addPropTypeRoot(getClassPropsType(init));
+      }
+      if (node.init.type === AST_NODE_TYPES.CallExpression) {
+        addPropTypeRoot(getWrappedForwardRefPropsType(node.init));
+      }
+    },
+    ClassDeclaration(node: TSESTree.ClassDeclaration) {
+      if (!node.id || !isCapitalizedName(node.id.name)) return;
+      addPropTypeRoot(getClassPropsType(node));
+    },
+    "Program:exit"() {
+      const seen = new Set<string>();
+      propTypeRoots.forEach((typeNode) => visitTypeNode(typeNode, seen));
+    },
+  };
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,9 +1,11 @@
 import { default as noTailwindOverflowScroll } from "./rules/no-tailwind-overflow-scroll.js";
 import { default as noInSourceVitest } from "./rules/no-in-source-vitest.js";
+import { default as noStyleProps } from "./rules/no-style-props.js";
 
 export const plugin = {
   rules: {
     "no-in-source-vitest": noInSourceVitest,
+    "no-style-props": noStyleProps,
     "no-tailwind-overflow-scroll": noTailwindOverflowScroll,
   },
 };

--- a/packages/eslint-plugin/src/rules/no-style-props.test.ts
+++ b/packages/eslint-plugin/src/rules/no-style-props.test.ts
@@ -1,0 +1,319 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as typescriptEslintParser from "@typescript-eslint/parser";
+import rule from "./no-style-props.js";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: typescriptEslintParser,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run("no-style-props", rule, {
+  valid: [
+    `type InternalConfig = { style: "compact"; className: "token" };`,
+    `interface InternalConfig { style: "compact"; className: "token"; }`,
+    `type ButtonProps = { variant?: "primary"; size: "sm" | "md" };
+     export default function Button(props: ButtonProps) { return <div className="font-medium" />; }`,
+    `type ButtonProps = { variant?: "primary" };
+     const Button = ({ variant }: ButtonProps) => <div className="font-medium" />;`,
+    `type BaseProps = { variant?: "primary" };
+     interface ButtonProps extends BaseProps { size?: "sm"; }
+     function Button(props: ButtonProps) { return <div />; }`,
+    `const propName = "className";
+     type ButtonProps = { [propName]?: string };
+     function Button(props: ButtonProps) { return <div />; }`,
+    `type ButtonProps = Pick<BaseProps, "variant">;
+     function Button(props: ButtonProps) { return <div />; }`,
+    `type ButtonProps = number;
+     function Button(props: ButtonProps) { return <div />; }`,
+    `type ButtonProps = this;
+     function Button(props: ButtonProps) { return <div />; }`,
+    `function renderHelper({ className }: { className?: string }) { return <div />; }`,
+    `function Button({ ...rest }: { variant?: "primary" }) { return <div />; }`,
+    `function Button(props: { className?: string }) { return 1; }`,
+    `function Button(props: { className?: string }) { if (props.className) { return 1; } return 2; }`,
+    `function Button() { return; }`,
+    `function Button() { const variant = "primary"; return <div />; }`,
+    `function Button() { return <>content</>; }`,
+    `function Button(props: string) { return <div />; }`,
+    `const Button: string = "not a component";`,
+    `let Button: React.FC;`,
+    `const button = (props: { className?: string }) => <div />;`,
+    `const { Button } = components;`,
+    `class Button { props: { className?: string }; }`,
+    `class Button extends BaseComponent<{ className?: string }> { render() { return <div />; } }`,
+    `class Button extends React.PureComponent<{ className?: string }> { render() { return <div />; } }`,
+    `class Button extends React.Component { render() { return <div />; } }`,
+    `export default class extends React.Component<{ className?: string }> { render() { return <div />; } }`,
+    `type ButtonProps = { ["class" + "Name"]?: string };
+     function Button(props: ButtonProps) { return <div />; }`,
+    `type ButtonProps = { (): void; variant?: "primary"; };
+     function Button(props: ButtonProps) { return <div />; }`,
+    `type ButtonProps = ButtonProps & { variant?: "primary"; };
+     function Button(props: ButtonProps) { return <div />; }`,
+    `interface ButtonProps { (): void; variant?: "primary"; }
+     function Button(props: ButtonProps) { return <div />; }`,
+    `const buttonBase = (props: { className?: string }) => <div />;
+     const Button = React.memo(buttonBase);`,
+    `const Button = forwardRef((props: { variant?: "primary" }) => <div />);`,
+    `interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> { variant?: "primary"; }
+     function Button(props: ButtonProps) { return <div />; }`,
+  ],
+  invalid: [
+    {
+      code: `type ButtonProps = { className?: string };
+             function Button(props: ButtonProps) { return <div />; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { style?: React.CSSProperties };
+             function Button(props: ButtonProps) { return <div />; }`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `interface ButtonProps { className?: string; }
+             function Button(props: ButtonProps) { return <div />; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `interface ButtonProps { "style"?: React.CSSProperties; }
+             function Button(props: ButtonProps) { return <div />; }`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `type ButtonProps = { className?: string } & { variant?: "primary" };
+             function Button(props: ButtonProps) { return <div />; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string } | { variant?: "primary" };
+             function Button(props: ButtonProps) { return <div />; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type BaseProps = { style?: React.CSSProperties };
+             interface ButtonProps extends BaseProps { variant?: "primary"; }
+             function Button(props: ButtonProps) { return <div />; }`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `function Button({ className }: { className?: string }) { return <div />; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `function Button({ style }) { return <div />; }`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `function Button(props: { style?: React.CSSProperties }) { return null; }`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `export default function (props: { className?: string }) { return <div />; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `const Button = (props: { className?: string }) => null;`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `interface ButtonProps extends ButtonProps { style?: React.CSSProperties; }
+             function Button(props: ButtonProps) { return <div />; }`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `type ButtonProps = { style?: React.CSSProperties };
+             const Button: React.FC<ButtonProps> = (props) => <div />;`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `const Button: React.FC<{ style?: React.CSSProperties }> = (props) => <div />;`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `type ButtonProps = { style?: React.CSSProperties };
+             function Button(props: React.FC<ButtonProps>) { return <div />; }`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             function Button(props: ButtonProps) { return props.className ? <div /> : null; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             function Button(props: ButtonProps) { return props.className && <div />; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             function Button(props: ButtonProps) { if (!props.className) return null; return <div />; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             function Button(props: ButtonProps) { if (props.className) { return <div />; } return null; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             function Button(props: ButtonProps) { switch (props.className) { case "x": return <div />; default: return null; } }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             function Button(props: ButtonProps) { try { return <div />; } catch { return null; } }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             function Button(props: ButtonProps) { return React.createElement("div"); }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             function Button(props: ButtonProps) { return createElement("div"); }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = (props: ButtonProps) => <div /> as React.ReactNode;`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = (props: ButtonProps) => <div /> satisfies React.ReactNode;`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = (props: ButtonProps) => (<div />)!;`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string; items: string[] };
+             function Button(props: ButtonProps) { return props.items.map((item) => <div key={item} />); }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string; items: string[] };
+             function Button(props: ButtonProps) { return props.items.map(function Item(item) { return <div key={item} />; }); }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { style?: React.CSSProperties };
+             const Button: React.FunctionComponent<ButtonProps> = (props) => <div />;`,
+      errors: [{ messageId: "unexpectedProp", data: { propName: "style" } }],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = React.memo((props: ButtonProps) => <div />);`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = memo((props: ButtonProps) => <div />);`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => <div ref={ref} />);`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => <div ref={ref} />);`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = memo(forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => <div ref={ref} />));`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             class Button extends React.Component<ButtonProps> { render() { return <div />; } }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             class Button extends Component<ButtonProps> { render() { return <div />; } }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             const Button = class extends Component<ButtonProps> { render() { return <div />; } };`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+    {
+      code: `type ButtonProps = { className?: string };
+             function Button(props: ButtonProps) { return <div />; }
+             function IconButton(props: ButtonProps) { return <div />; }`,
+      errors: [
+        { messageId: "unexpectedProp", data: { propName: "className" } },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-style-props.ts
+++ b/packages/eslint-plugin/src/rules/no-style-props.ts
@@ -1,0 +1,55 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createComponentPropTypeVisitors } from "../component-prop-types.js";
+import { createRule } from "../util.js";
+
+const FORBIDDEN_PROP_NAMES = new Set(["className", "style"]);
+
+function getPropertyName(
+  key: TSESTree.PropertyName | TSESTree.PrivateIdentifier,
+): string | null {
+  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
+  if (key.type === AST_NODE_TYPES.Literal && typeof key.value === "string") {
+    return key.value;
+  }
+  return null;
+}
+
+const rule = createRule({
+  name: "no-style-props",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow className and style props.",
+    },
+    schema: [],
+    messages: {
+      unexpectedProp:
+        "Components must not expose {{propName}} props. Add explicit variant props instead.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    function reportForbiddenProp(
+      node: TSESTree.Node,
+      propName: string | null,
+    ): void {
+      if (!propName || !FORBIDDEN_PROP_NAMES.has(propName)) return;
+      context.report({
+        node,
+        messageId: "unexpectedProp",
+        data: { propName },
+      });
+    }
+
+    return createComponentPropTypeVisitors({
+      onPropProperty(node) {
+        reportForbiddenProp(node.key, getPropertyName(node.key));
+      },
+      onDestructuredProp(node) {
+        reportForbiddenProp(node.key, getPropertyName(node.key));
+      },
+    });
+  },
+});
+
+export default rule;

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -9,6 +9,16 @@ export default [
   ...nextConfig,
   ...storybook.configs["flat/recommended"],
 
+  // Design-system component APIs must use explicit variants instead of styling escape hatches.
+  {
+    name: "langfuse/web/design-system-no-style-props",
+    files: ["src/components/design-system/**/*.{ts,tsx}"],
+    ignores: ["src/components/design-system/**/*.stories.tsx"],
+    rules: {
+      "@repo/no-style-props": "error",
+    },
+  },
+
   // Tests legitimately exercise backwards-compatible (deprecated) read paths
   // such as getTraceById/getObservationById, so allow them in test code.
   {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a custom ESLint rule (`no-style-props`) that forbids `className` and `style` props on design-system components, enforcing explicit variant props instead. It adds a shared AST-visitor utility (`component-prop-types.ts`) to detect React components and their prop type shapes, a well-tested rule implementation, and scopes the rule to `src/components/design-system/**` in `web/eslint.config.mjs`.

- **New rule and utility**: `createComponentPropTypeVisitors` handles function components, class components, `memo`/`forwardRef` wrappers, and named/inline type annotations, with a `seen` guard to prevent infinite recursion through self-referential types.
- **Coverage gaps in component detection**: `functionReturnsJsxOrNull` does not recognise components whose top-level return is a ternary or logical-AND expression; `getClassPropsType` only matches `React.Component` as a `MemberExpression` and silently skips `extends Component<...>` (bare identifier). Both produce false negatives where forbidden props go unreported.
- **ESLint config**: The rule is correctly scoped to design-system files and excludes Storybook stories.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the rule adds enforcement without touching runtime code. The two coverage gaps are heuristic limitations that produce false negatives, not false positives, so no valid design-system components will break.

The implementation is correct for the common component patterns and has thorough tests. Two heuristics in `component-prop-types.ts` quietly skip components with conditional top-level returns and class components extending bare `Component`, meaning some forbidden props could go undetected after the rule is enabled.

`packages/eslint-plugin/src/component-prop-types.ts` — specifically `functionReturnsJsxOrNull` and `getClassPropsType`.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ESLint visits file] --> B{Node type?}
    B -->|TSInterfaceDeclaration| C[Store in typeDeclarations map]
    B -->|TSTypeAliasDeclaration| C
    B -->|FunctionDeclaration| D[maybeAddFunctionComponent]
    B -->|VariableDeclarator| E{Capitalized name?}
    B -->|ClassDeclaration| F[getClassPropsType → addPropTypeRoot]
    E -->|Yes| G[unwrapComponentInit + check FC type annotation]
    G --> D
    G --> H[getForwardRefPropsType → addPropTypeRoot]
    D --> I{functionReturnsJsxOrNull?}
    I -->|direct JSX / return null| J[getFunctionPropsType → addPropTypeRoot]
    I -->|ternary / logical AND| K[Not detected as component]
    J --> L[visitDestructuredProps → onDestructuredProp callback]
    I -->|false| M[Skip — not a component]
    B -->|Program:exit| N[Visit all propTypeRoots]
    N --> O{TypeNode type?}
    O -->|TSTypeLiteral| P[onPropProperty for each TSPropertySignature]
    O -->|TSIntersectionType / TSUnionType| O
    O -->|TSTypeReference| Q{Resolve named type from declarations map}
    Q -->|Found| O
    Q -->|Not found / external| R[Skip silently]
    P --> S{Prop name in forbidden set?}
    L --> S
    S -->|className or style| T[Report error]
    S -->|other| U[No error]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ESLint visits file] --> B{Node type?}
    B -->|TSInterfaceDeclaration| C[Store in typeDeclarations map]
    B -->|TSTypeAliasDeclaration| C
    B -->|FunctionDeclaration| D[maybeAddFunctionComponent]
    B -->|VariableDeclarator| E{Capitalized name?}
    B -->|ClassDeclaration| F[getClassPropsType → addPropTypeRoot]
    E -->|Yes| G[unwrapComponentInit + check FC type annotation]
    G --> D
    G --> H[getForwardRefPropsType → addPropTypeRoot]
    D --> I{functionReturnsJsxOrNull?}
    I -->|direct JSX / return null| J[getFunctionPropsType → addPropTypeRoot]
    I -->|ternary / logical AND| K[Not detected as component]
    J --> L[visitDestructuredProps → onDestructuredProp callback]
    I -->|false| M[Skip — not a component]
    B -->|Program:exit| N[Visit all propTypeRoots]
    N --> O{TypeNode type?}
    O -->|TSTypeLiteral| P[onPropProperty for each TSPropertySignature]
    O -->|TSIntersectionType / TSUnionType| O
    O -->|TSTypeReference| Q{Resolve named type from declarations map}
    Q -->|Found| O
    Q -->|Not found / external| R[Skip silently]
    P --> S{Prop name in forbidden set?}
    L --> S
    S -->|className or style| T[Report error]
    S -->|other| U[No error]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/eslint-plugin/src/component-prop-types.ts:27-48
**`functionReturnsJsxOrNull` misses conditional return expressions**

The function only recognises a component when a `ReturnStatement`'s direct argument is a `JSXElement`, `JSXFragment`, or `null` literal. When the return value is a ternary (`return condition ? <div /> : null`) or a logical AND (`return condition && <div />`), `statement.argument` is a `ConditionalExpression` or `LogicalExpression` — neither branch matches, so `functionReturnsJsxOrNull` returns `false` and the function is never treated as a component. Any `className` or `style` props on such a component will silently pass the lint rule.

### Issue 2 of 2
packages/eslint-plugin/src/component-prop-types.ts:76-89
**`getClassPropsType` only handles `React.Component`, not bare `Component`**

The guard `superClass.type !== AST_NODE_TYPES.MemberExpression` causes the function to return `null` for `class Button extends Component<ButtonProps>` (where `Component` is imported directly and used as a plain `Identifier`). The rule will silently allow `className`/`style` props in this case. While class components are rare in modern React, the design system code base may contain some.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(web): Forbid className and style p..."](https://github.com/langfuse/langfuse/commit/f556905f95772f8be55487afb8b7db20eb51090a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37899588)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->