### PR TITLE
fix(experiments-backfill): skip only if DRI linked trace already has experiment-enriched events

### DIFF
--- a/worker/src/features/eventPropagation/handleExperimentBackfill.ts
+++ b/worker/src/features/eventPropagation/handleExperimentBackfill.ts
@@ -139,6 +139,7 @@ export async function getDatasetRunItemsSinceLastRun(
     LEFT ANTI JOIN events_core AS ec
       ON dri.project_id = ec.project_id
       AND dri.trace_id = ec.trace_id
+      AND ec.experiment_id != ''
     WHERE dri.created_at > {lastRun: DateTime64(3)}
       AND dri.created_at <= {upperBound: DateTime64(3)}
       AND (dri.project_id, dri.trace_id) IN (SELECT project_id, trace_id FROM candidate_dris)


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens the deduplication guard in the experiment backfill query. Previously, the `LEFT ANTI JOIN` against `events_core` excluded any dataset-run-item whose trace had *any* record in `events_core`, including records with an empty `experiment_id` (i.e. non-experiment events). This caused the backfill to silently skip traces that had never been experiment-enriched. The fix adds `AND ec.experiment_id != ''` to the join predicate so that only traces already carrying experiment-enriched events are skipped.

- The single-line SQL change to `getDatasetRunItemsSinceLastRun` narrows the anti-join condition to match only `events_core` rows that have a non-empty `experiment_id`, correctly expressing "skip only if already experiment-enriched."
- All other backfill logic (chunking, locking, cursor advancement, span enrichment) is unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a one-line SQL predicate fix that restores the intended backfill behaviour without touching any write path or cursor logic.

The fix is minimal and correctly targets the root cause: the old anti-join was too broad, filtering out DRIs whose traces had any events_core row regardless of experiment enrichment. The new predicate restricts the match to rows where experiment_id is non-empty, which matches exactly the semantics described in the PR title. No side effects on writing, locking, or cursor advancement are introduced.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(experiments-backfill): skip only if ..."](https://github.com/langfuse/langfuse/commit/1149033ff86e9d2f87d9439007af5a0b2ae3549e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37921997)</sub>

<!-- /greptile_comment -->