### PR TITLE
fix(agent): Avoid unrecognized stream chunk warnings

### DIFF
--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -6,6 +6,8 @@ import { describe, expect, it, vi } from "vitest";
 import type { AgUiEvent } from "@/src/ee/features/in-app-agent/schema";
 import { decodeFiltersGeneric } from "@/src/features/filters/lib/filter-query-encoding";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
+import { patchMastraToolCallInputStreaming } from "@/src/ee/features/in-app-agent/server/agent";
+import type { MastraAgent } from "@ag-ui/mastra";
 
 const adapterEvents = vi.hoisted(() => ({
   items: [] as AgUiEvent[],
@@ -38,7 +40,6 @@ vi.mock("@ag-ui/mastra", () => ({
           complete: () => void;
         }) => {
           adapterEvents.inputs.push(input);
-
           for (const event of adapterEvents.items) {
             subscriber.next(event);
           }
@@ -118,6 +119,211 @@ vi.mock("@/src/ee/features/in-app-agent/server/instrumentation", () => ({
   createInAppAgentInstrumentation:
     instrumentationMocks.createInAppAgentInstrumentation,
 }));
+
+const createPatchedChunkProcessor = () => {
+  const forwardedChunks: unknown[] = [];
+  const onError = vi.fn();
+  const flush = vi.fn();
+  const adapter = {
+    createChunkProcessor: vi.fn(() => ({
+      handleChunk: (chunk: unknown) => {
+        forwardedChunks.push(chunk);
+        return false;
+      },
+      flush,
+    })),
+  };
+
+  patchMastraToolCallInputStreaming(adapter as unknown as MastraAgent);
+
+  const processor = adapter.createChunkProcessor({ onError });
+
+  return { forwardedChunks, onError, processor, flush };
+};
+
+describe("patchMastraToolCallInputStreaming", () => {
+  it("converts streamed tool-call input chunks to one native tool-call", () => {
+    const { forwardedChunks, onError, processor } =
+      createPatchedChunkProcessor();
+
+    processor.handleChunk({
+      type: "tool-call-input-streaming-start",
+      payload: {
+        toolCallId: "tool-call-1",
+        toolName: "langfuseDocs_search",
+      },
+    });
+    processor.handleChunk({
+      type: "tool-call-delta",
+      payload: {
+        toolCallId: "tool-call-1",
+        argsTextDelta: '{"query":"invite',
+      },
+    });
+    processor.handleChunk({
+      type: "tool-call-delta",
+      payload: {
+        toolCallId: "tool-call-1",
+        argsTextDelta: ' users"}',
+      },
+    });
+    processor.handleChunk({
+      type: "tool-call-input-streaming-end",
+      payload: { toolCallId: "tool-call-1" },
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(forwardedChunks).toEqual([
+      {
+        type: "tool-call",
+        payload: {
+          toolCallId: "tool-call-1",
+          toolName: "langfuseDocs_search",
+          args: { query: "invite users" },
+        },
+      },
+    ]);
+  });
+
+  it("uses empty args when streamed tool-call input is malformed JSON", () => {
+    const { forwardedChunks, onError, processor } =
+      createPatchedChunkProcessor();
+
+    processor.handleChunk({
+      type: "tool-call-input-streaming-start",
+      payload: {
+        toolCallId: "tool-call-1",
+        toolName: "langfuseDocs_search",
+      },
+    });
+    processor.handleChunk({
+      type: "tool-call-delta",
+      payload: {
+        toolCallId: "tool-call-1",
+        argsTextDelta: '{"query":"invite users"',
+      },
+    });
+    processor.handleChunk({
+      type: "tool-call-input-streaming-end",
+      payload: { toolCallId: "tool-call-1" },
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(forwardedChunks).toEqual([
+      {
+        type: "tool-call",
+        payload: {
+          toolCallId: "tool-call-1",
+          toolName: "langfuseDocs_search",
+          args: {},
+        },
+      },
+    ]);
+  });
+
+  it("suppresses one duplicate native tool-call after synthesizing it", () => {
+    const { forwardedChunks, processor } = createPatchedChunkProcessor();
+
+    processor.handleChunk({
+      type: "tool-call-input-streaming-start",
+      payload: {
+        toolCallId: "tool-call-1",
+        toolName: "langfuseDocs_search",
+      },
+    });
+    processor.handleChunk({
+      type: "tool-call-delta",
+      payload: {
+        toolCallId: "tool-call-1",
+        argsTextDelta: '{"query":"invite users"}',
+      },
+    });
+    processor.handleChunk({
+      type: "tool-call-input-streaming-end",
+      payload: { toolCallId: "tool-call-1" },
+    });
+    processor.handleChunk({
+      type: "tool-call",
+      payload: {
+        toolCallId: "tool-call-1",
+        toolName: "langfuseDocs_search",
+        args: { query: "invite users" },
+      },
+    });
+    processor.handleChunk({
+      type: "tool-call",
+      payload: {
+        toolCallId: "tool-call-2",
+        toolName: "langfuse_search",
+        args: { traceId: "trace-1" },
+      },
+    });
+
+    expect(forwardedChunks).toEqual([
+      {
+        type: "tool-call",
+        payload: {
+          toolCallId: "tool-call-1",
+          toolName: "langfuseDocs_search",
+          args: { query: "invite users" },
+        },
+      },
+      {
+        type: "tool-call",
+        payload: {
+          toolCallId: "tool-call-2",
+          toolName: "langfuse_search",
+          args: { traceId: "trace-1" },
+        },
+      },
+    ]);
+  });
+
+  it("passes through native tool-calls that were not synthesized", () => {
+    const { forwardedChunks, processor } = createPatchedChunkProcessor();
+
+    processor.handleChunk({
+      type: "tool-call",
+      payload: {
+        toolCallId: "tool-call-1",
+        toolName: "langfuse_search",
+        args: { query: "errors" },
+      },
+    });
+
+    expect(forwardedChunks).toEqual([
+      {
+        type: "tool-call",
+        payload: {
+          toolCallId: "tool-call-1",
+          toolName: "langfuse_search",
+          args: { query: "errors" },
+        },
+      },
+    ]);
+  });
+
+  it("reports malformed tool-call deltas with no known tool name", () => {
+    const { forwardedChunks, onError, processor } =
+      createPatchedChunkProcessor();
+
+    const shouldStop = processor.handleChunk({
+      type: "tool-call-delta",
+      payload: {
+        toolCallId: "tool-call-1",
+        argsTextDelta: '{"query":"invite users"}',
+      },
+    });
+
+    expect(shouldStop).toBe(true);
+    expect(onError).toHaveBeenCalledWith(
+      new Error(
+        "Malformed tool-call-delta: missing toolName for unknown toolCallId in payload",
+      ),
+    );
+    expect(forwardedChunks).toEqual([]);
+  });
+});
 
 describe("createAgUiStream", () => {
   beforeEach(() => {

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -579,11 +579,16 @@ async function createMastraAdapter(params: {
       },
     });
 
+    const adapter = new MastraAgent({
+      agent,
+      resourceId: params.input.threadId,
+    });
+    // @ag-ui/mastra@1.0.3 does not understand Mastra's newer streaming
+    // tool-call chunks yet, so translate them locally to avoid warning noise.
+    patchMastraToolCallInputStreaming(adapter);
+
     return {
-      adapter: new MastraAgent({
-        agent,
-        resourceId: params.input.threadId,
-      }),
+      adapter,
       interrupt: () => agent.abortRunStream(params.input.runId),
       cleanup: () => mcpClient.disconnect(),
     };
@@ -609,6 +614,161 @@ function prefixToolsetTools<TTool>(
       tool,
     ]),
   );
+}
+
+type MastraChunkProcessor = {
+  handleChunk: (chunk: unknown) => boolean;
+  flush: () => void;
+};
+
+type MastraStreamCallbacks = {
+  onError: (error: Error) => void;
+};
+
+type PatchableMastraAgent = {
+  createChunkProcessor?: (
+    callbacks: MastraStreamCallbacks,
+  ) => MastraChunkProcessor;
+};
+
+type MastraStreamChunk = {
+  type?: string;
+  payload?: {
+    toolCallId?: string;
+    toolName?: string;
+    argsTextDelta?: string;
+    args?: unknown;
+  };
+};
+
+type StreamingToolCall = {
+  toolCallId: string;
+  toolName: string;
+  argsText: string;
+};
+
+export function patchMastraToolCallInputStreaming(adapter: MastraAgent) {
+  const patchableAdapter = adapter as unknown as PatchableMastraAgent;
+  const createChunkProcessor = patchableAdapter.createChunkProcessor;
+
+  if (typeof createChunkProcessor !== "function") {
+    return;
+  }
+
+  patchableAdapter.createChunkProcessor = function patchedCreateChunkProcessor(
+    this: PatchableMastraAgent,
+    callbacks: MastraStreamCallbacks,
+  ) {
+    const processor = createChunkProcessor.call(this, callbacks);
+    const streamingToolCalls = new Map<string, StreamingToolCall>();
+    const synthesizedToolCallIds = new Set<string>();
+
+    const parseStreamingToolCallArgs = (argsText: string): unknown => {
+      try {
+        return JSON.parse(argsText || "{}");
+      } catch {
+        return {};
+      }
+    };
+
+    return {
+      handleChunk(chunk: unknown) {
+        const mastraChunk = chunk as MastraStreamChunk;
+
+        switch (mastraChunk.type) {
+          case "tool-call-input-streaming-start": {
+            const { toolCallId, toolName } = mastraChunk.payload ?? {};
+            if (!toolCallId || !toolName) {
+              callbacks.onError(
+                new Error(
+                  "Malformed tool-call-input-streaming-start: missing toolCallId or toolName in payload",
+                ),
+              );
+              return true;
+            }
+
+            streamingToolCalls.set(toolCallId, {
+              toolCallId,
+              toolName,
+              argsText: "",
+            });
+            return false;
+          }
+          case "tool-call-delta": {
+            const { toolCallId, toolName, argsTextDelta } =
+              mastraChunk.payload ?? {};
+            if (!toolCallId) {
+              callbacks.onError(
+                new Error(
+                  "Malformed tool-call-delta: missing toolCallId in payload",
+                ),
+              );
+              return true;
+            }
+
+            let streamingToolCall = streamingToolCalls.get(toolCallId);
+            if (!streamingToolCall) {
+              if (!toolName) {
+                callbacks.onError(
+                  new Error(
+                    "Malformed tool-call-delta: missing toolName for unknown toolCallId in payload",
+                  ),
+                );
+                return true;
+              }
+
+              streamingToolCall = { toolCallId, toolName, argsText: "" };
+              streamingToolCalls.set(toolCallId, streamingToolCall);
+            }
+
+            streamingToolCall.argsText += argsTextDelta ?? "";
+            return false;
+          }
+          case "tool-call-input-streaming-end": {
+            const { toolCallId } = mastraChunk.payload ?? {};
+            const streamingToolCall = toolCallId
+              ? streamingToolCalls.get(toolCallId)
+              : undefined;
+            if (streamingToolCall) {
+              synthesizedToolCallIds.add(streamingToolCall.toolCallId);
+              const shouldStop = processor.handleChunk({
+                type: "tool-call",
+                payload: {
+                  toolCallId: streamingToolCall.toolCallId,
+                  toolName: streamingToolCall.toolName,
+                  args: parseStreamingToolCallArgs(streamingToolCall.argsText),
+                },
+              });
+              streamingToolCalls.delete(streamingToolCall.toolCallId);
+              return shouldStop;
+            }
+            return false;
+          }
+          case "tool-call": {
+            const { toolCallId } = mastraChunk.payload ?? {};
+            if (toolCallId && synthesizedToolCallIds.has(toolCallId)) {
+              synthesizedToolCallIds.delete(toolCallId);
+              return false;
+            }
+            break;
+          }
+          case "tool-call-suspended": {
+            const { toolCallId } = mastraChunk.payload ?? {};
+            if (toolCallId) {
+              streamingToolCalls.delete(toolCallId);
+              synthesizedToolCallIds.delete(toolCallId);
+            }
+            break;
+          }
+        }
+
+        return processor.handleChunk(chunk);
+      },
+      flush() {
+        processor.flush();
+      },
+    };
+  };
 }
 
 function normalizeAdapterEvent(


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `patchMastraToolCallInputStreaming`, which monkey-patches the `createChunkProcessor` method on a freshly constructed `MastraAgent` to translate Mastra's newer streaming tool-call chunk types (`tool-call-input-streaming-start`, `tool-call-delta`, `tool-call-input-streaming-end`) into the single `tool-call` chunk format that `@ag-ui/mastra@1.0.3` already understands, eliminating unrecognized-chunk warning noise.

- The patch accumulates streamed arg deltas per `toolCallId`, synthesizes a `tool-call` chunk on `streaming-end`, and suppresses the subsequent native `tool-call` duplicate emitted by Mastra to avoid double-processing.
- Three unit tests cover the happy path (streaming → synthesized chunk), the duplicate-suppression path, and the pass-through of unrelated native tool-calls.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is well-scoped, applies only to newly constructed adapters, and includes tests for the main code paths. The two non-critical edge cases noted do not affect the happy path.

The core streaming-translation logic is correct and well-tested. The fallback in parseStreamingToolCallArgs that returns a raw string on JSON parse failure could surface unexpected behaviour in tool execution if args are ever malformed. A tool-call-delta that arrives with no preceding streaming-start and no toolName is silently discarded without an error signal, which could make debugging difficult in production.

agent.ts contains the two edge cases worth addressing; in-app-agent-stream.servertest.ts is in good shape but lacks a test for the tool-call-suspended cleanup path.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant M as Mastra (newer)
    participant P as patchedCreateChunkProcessor
    participant O as Original Processor

    M->>P: "tool-call-input-streaming-start {toolCallId, toolName}"
    Note over P: stores in streamingToolCalls map
    P-->>M: false (consumed, not forwarded)

    M->>P: "tool-call-delta {toolCallId, argsTextDelta}"
    Note over P: appends to streamingToolCall.argsText
    P-->>M: false (consumed)

    M->>P: "tool-call-input-streaming-end {toolCallId}"
    Note over P: adds toolCallId to synthesizedToolCallIds
    P->>O: "synthesized tool-call {toolCallId, toolName, args}"
    O-->>P: shouldStop
    Note over P: removes from streamingToolCalls
    P-->>M: shouldStop

    M->>P: "tool-call {toolCallId} (native duplicate)"
    Note over P: found in synthesizedToolCallIds → suppress
    P-->>M: false (suppressed)

    M->>P: "tool-call {toolCallId2} (unrelated native)"
    P->>O: "tool-call {toolCallId2}"
    O-->>P: result
    P-->>M: result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant M as Mastra (newer)
    participant P as patchedCreateChunkProcessor
    participant O as Original Processor

    M->>P: "tool-call-input-streaming-start {toolCallId, toolName}"
    Note over P: stores in streamingToolCalls map
    P-->>M: false (consumed, not forwarded)

    M->>P: "tool-call-delta {toolCallId, argsTextDelta}"
    Note over P: appends to streamingToolCall.argsText
    P-->>M: false (consumed)

    M->>P: "tool-call-input-streaming-end {toolCallId}"
    Note over P: adds toolCallId to synthesizedToolCallIds
    P->>O: "synthesized tool-call {toolCallId, toolName, args}"
    O-->>P: shouldStop
    Note over P: removes from streamingToolCalls
    P-->>M: shouldStop

    M->>P: "tool-call {toolCallId} (native duplicate)"
    Note over P: found in synthesizedToolCallIds → suppress
    P-->>M: false (suppressed)

    M->>P: "tool-call {toolCallId2} (unrelated native)"
    P->>O: "tool-call {toolCallId2}"
    O-->>P: result
    P-->>M: result
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/ee/features/in-app-agent/server/agent.ts:648-654
**Malformed-JSON fallback returns raw string instead of object**

When `JSON.parse` fails on `argsText`, the function returns the raw string. Any downstream consumer that received a synthesized `tool-call` chunk will see `args` as a `string` instead of an object, which can cause type errors or silent misbehaviour in whatever executes the tool. A safer fallback would be to return `{}` (effectively treating the args as empty) or to surface the error through `callbacks.onError` so the stream is cleanly aborted rather than forwarding a malformed payload.

### Issue 2 of 2
web/src/ee/features/in-app-agent/server/agent.ts:691-695
**Silent data drop when delta arrives with no known `toolCallId` and no `toolName`**

If a `tool-call-delta` chunk arrives with a `toolCallId` that has no prior `streaming-start` entry in `streamingToolCalls`, and the delta itself carries no `toolName`, the function returns `false` and silently discards both the delta and any subsequent `tool-call-input-streaming-end` for that `toolCallId`. No error is reported via `callbacks.onError`, making this a silent black hole. In production, this means the tool call's args accumulation is quietly skipped, yielding an incomplete synthesized `tool-call` chunk (or none at all) with no observable signal.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Avoid unrecognized stream ch..."](https://github.com/langfuse/langfuse/commit/c0dfbbd2f33b26121db853d86ffe61c4a1b27674) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38098513)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->