### PR TITLE
chore(deps): bump form-data to 2.5.6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7669,8 +7669,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@2.5.5:
-    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
+  form-data@2.5.6:
+    resolution: {integrity: sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==}
     engines: {node: '>= 0.12'}
 
   form-data@4.0.6:
@@ -16855,7 +16855,7 @@ snapshots:
       '@types/caseless': 0.12.5
       '@types/node': 24.3.0
       '@types/tough-cookie': 4.0.5
-      form-data: 2.5.5
+      form-data: 2.5.6
 
   '@types/resolve@1.20.6': {}
 
@@ -19295,7 +19295,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@2.5.5:
+  form-data@2.5.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ minimumReleaseAge: 7200
 # the exclusions are temporary so that we can set the 5 day limit without downgrading packages.
 # this list is version-specific
 minimumReleaseAgeExclude:
-  - form-data@4.0.6
+  - "form-data@2.5.6||4.0.6"
   - esbuild@0.28.1
   - "@esbuild/aix-ppc64@0.28.1"
   - "@esbuild/android-arm@0.28.1"


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps `form-data` from 2.5.5 to 2.5.6, a patch release in the 2.x line. It also adds `form-data@2.5.6` to the `minimumReleaseAgeExclude` list in `pnpm-workspace.yaml` so the freshly published version can be installed before the 5-day release-age gate elapses.

- `pnpm-lock.yaml` swaps the resolution integrity hash for `form-data@2.5.5` → `2.5.6` and updates the `@types/request` snapshot that depends on it.
- `pnpm-workspace.yaml` collapses the previous single-version exclude entry (`form-data@4.0.6`) into a semver-OR entry (`form-data@2.5.6||4.0.6`), which is the documented pnpm syntax for excluding multiple versions of the same package in a single list item.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to updating a lockfile integrity hash and adding a temporary release-age exclusion for the new version.

The only touched files are the lockfile and workspace config. No application code is modified, and the `||` range syntax used in `minimumReleaseAgeExclude` is the format shown in pnpm's own documentation. The bump keeps the existing `form-data@4.0.6` exclusion intact while adding the new patch release.

No files require special attention. The `minimumReleaseAgeExclude` entry for `form-data@4.0.6` is now older than the 5-day threshold and can be cleaned up in a follow-up once the exclusion list is reviewed.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm install] --> B{minimumReleaseAge\ncheck passes?}
    B -- age is old enough --> D[Allow install]
    B -- too recent --> C{In minimumReleaseAgeExclude?}
    C -- Yes: form-data 2.5.6 or 4.0.6 --> D
    C -- No --> E[Block install]
    D --> F[Resolve form-data 2.5.6\nnew integrity hash]
    F --> G[types/request snapshot\nupdated to form-data 2.5.6]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pnpm install] --> B{minimumReleaseAge\ncheck passes?}
    B -- age is old enough --> D[Allow install]
    B -- too recent --> C{In minimumReleaseAgeExclude?}
    C -- Yes: form-data 2.5.6 or 4.0.6 --> D
    C -- No --> E[Block install]
    D --> F[Resolve form-data 2.5.6\nnew integrity hash]
    F --> G[types/request snapshot\nupdated to form-data 2.5.6]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump form-data to 2.5.6"](https://github.com/langfuse/langfuse/commit/9f94437df284eaee1e3c876eef8c9b1a566286b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37935619)</sub>

<!-- /greptile_comment -->