### PR TITLE
feat(public-api): events-table shadow-comparison experiment for traces

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -193,6 +193,13 @@ LANGFUSE_MIGRATION_V4_WRITE_MODE=dual
 LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN=true
 # OTel ingestion behaviour: `dual_write` (SDK-version dispatch) or `direct`.
 LANGFUSE_MIGRATION_V4_NATIVE_OTEL_BEHAVIOUR=dual_write
+# Shadow-comparison experiment for the Traces public API (GET /api/public/traces
+# and /api/public/traces/{id}). Fraction of requests (0..1) on which the API
+# also runs the *other* read path (events table vs legacy traces/observations),
+# compares the results field-by-field, and records latency + diff metrics
+# (langfuse.events_table_experiment.*). Does not change the data returned to the
+# caller. 0 = off.
+LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE=0
 
 # Legacy tracing UI controls
 LANGFUSE_DISABLE_LEGACY_TRACING_IO_SEARCH=false

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -276,6 +276,17 @@ const EnvSchema = z.object({
     .enum(["legacy", "dual", "events_only"])
     .default("legacy"),
 
+  // Shadow-comparison experiment for the Traces public API: on this fraction of
+  // requests (0..1), the API also runs the *other* read path (events table vs
+  // legacy traces/observations), compares the results field-by-field, and
+  // records latency + diff metrics. The data returned to the caller is
+  // unaffected. Default 0 = experiment off.
+  LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE: z.coerce
+    .number()
+    .min(0)
+    .max(1)
+    .default(0),
+
   LANGFUSE_S3_LIST_MAX_KEYS: z.coerce.number().positive().default(200),
   LANGFUSE_S3_RATE_ERROR_SLOWDOWN_ENABLED: z
     .enum(["true", "false"])

--- a/packages/shared/src/server/repositories/eventsTableExperiment.test.ts
+++ b/packages/shared/src/server/repositories/eventsTableExperiment.test.ts
@@ -1,9 +1,43 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   diffResults,
+  runEventsTableExperiment,
   shouldRunEventsTableExperiment,
 } from "./eventsTableExperiment";
+
+// Mock the module's dependencies so the runner can be exercised deterministically
+// without a real ClickHouse/env/metrics backend. `mocks.env` is mutated per test
+// to control the sample rate.
+const mocks = vi.hoisted(() => ({
+  env: { LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE: 0 },
+  recordHistogram: vi.fn(),
+  recordIncrement: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock("../../env", () => ({ env: mocks.env }));
+vi.mock("../instrumentation", () => ({
+  recordHistogram: mocks.recordHistogram,
+  recordIncrement: mocks.recordIncrement,
+}));
+vi.mock("../logger", () => ({
+  logger: {
+    info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 0;
+  mocks.recordHistogram.mockClear();
+  mocks.recordIncrement.mockClear();
+  mocks.loggerInfo.mockClear();
+  mocks.loggerWarn.mockClear();
+});
 
 describe("diffResults", () => {
   it("returns no diffs for identical objects", () => {
@@ -30,10 +64,27 @@ describe("diffResults", () => {
     expect(diffResults(legacy, events)).toEqual([]);
   });
 
+  it("reports a difference in nested JSON metadata values", () => {
+    const legacy = { metadata: { nested: { a: 1, b: 2 } } };
+    const events = { metadata: { nested: { a: 1, b: 3 } } };
+    expect(diffResults(legacy, events)).toEqual([
+      expect.objectContaining({
+        path: "metadata.nested.b",
+        field: "b",
+        legacy: 2,
+        events: 3,
+      }),
+    ]);
+  });
+
   it("treats null and undefined as equal", () => {
     const legacy = { userId: null };
     const events = { userId: undefined };
     expect(diffResults(legacy, events)).toEqual([]);
+  });
+
+  it("treats empty arrays as equal", () => {
+    expect(diffResults({ observations: [] }, { observations: [] })).toEqual([]);
   });
 
   it("treats Date and equal epoch millis as equal", () => {
@@ -41,6 +92,22 @@ describe("diffResults", () => {
     const legacy = { timestamp: ts };
     const events = { timestamp: new Date(ts.getTime()) };
     expect(diffResults(legacy, events)).toEqual([]);
+  });
+
+  it("reports a Date difference", () => {
+    const legacy = { timestamp: new Date("2024-01-01T00:00:00.000Z") };
+    const events = { timestamp: new Date("2024-01-01T00:00:01.000Z") };
+    expect(diffResults(legacy, events)).toHaveLength(1);
+    expect(diffResults(legacy, events)[0]).toMatchObject({
+      field: "timestamp",
+    });
+  });
+
+  it("reports a type mismatch (number vs string)", () => {
+    const diffs = diffResults({ value: 5 }, { value: "5" });
+    expect(diffs).toEqual([
+      expect.objectContaining({ field: "value", legacy: 5, events: "5" }),
+    ]);
   });
 
   it("applies numeric tolerance only to configured fields", () => {
@@ -52,6 +119,21 @@ describe("diffResults", () => {
     // latency within epsilon -> ignored; count differs -> reported
     expect(diffs).toHaveLength(1);
     expect(diffs[0]).toMatchObject({ field: "count", legacy: 1, events: 2 });
+  });
+
+  it("respects a custom epsilon", () => {
+    const within = diffResults(
+      { x: 1.0 },
+      { x: 1.4 },
+      { numericFields: new Set(["x"]), epsilon: 0.5 },
+    );
+    expect(within).toEqual([]);
+    const outside = diffResults(
+      { x: 1.0 },
+      { x: 1.6 },
+      { numericFields: new Set(["x"]), epsilon: 0.5 },
+    );
+    expect(outside).toHaveLength(1);
   });
 
   it("compares Decimal-like values by number with epsilon tolerance", () => {
@@ -126,11 +208,250 @@ describe("diffResults", () => {
       }),
     ]);
   });
+
+  it("reports multiple differing fields within aligned array objects", () => {
+    const legacy = {
+      data: [{ id: "o1", name: "a", level: "DEFAULT" }],
+    };
+    const events = {
+      data: [{ id: "o1", name: "b", level: "ERROR" }],
+    };
+    const diffs = diffResults(legacy, events);
+    expect(diffs.map((d) => d.field).sort()).toEqual(["level", "name"]);
+  });
 });
 
 describe("shouldRunEventsTableExperiment", () => {
-  it("is off by default (sample rate 0)", () => {
-    // LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE defaults to 0 in tests.
+  it("is off when the sample rate is 0", () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 0;
     expect(shouldRunEventsTableExperiment()).toBe(false);
+  });
+
+  it("always runs when the sample rate is 1", () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 1;
+    // Math.random() is always < 1, so this is deterministically true.
+    expect(shouldRunEventsTableExperiment()).toBe(true);
+  });
+
+  it("honours the rate via Math.random", () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 0.5;
+    const spy = vi.spyOn(Math, "random");
+    spy.mockReturnValueOnce(0.4);
+    expect(shouldRunEventsTableExperiment()).toBe(true);
+    spy.mockReturnValueOnce(0.6);
+    expect(shouldRunEventsTableExperiment()).toBe(false);
+    spy.mockRestore();
+  });
+});
+
+describe("runEventsTableExperiment", () => {
+  const baseParams = {
+    feature: "traces.test",
+    projectId: "p1",
+  };
+
+  it("not sampled: returns the selected path and runs nothing else", async () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 0;
+    const events = vi.fn().mockResolvedValue("EVENTS");
+    const legacy = vi.fn().mockResolvedValue("LEGACY");
+    const compare = vi.fn().mockReturnValue([]);
+
+    const result = await runEventsTableExperiment({
+      ...baseParams,
+      selected: "events",
+      events,
+      legacy,
+      compare,
+    });
+
+    expect(result).toBe("EVENTS");
+    expect(events).toHaveBeenCalledTimes(1);
+    expect(legacy).not.toHaveBeenCalled();
+    expect(compare).not.toHaveBeenCalled();
+    // No experiment metrics on the fast path.
+    expect(mocks.recordHistogram).not.toHaveBeenCalled();
+    expect(mocks.recordIncrement).not.toHaveBeenCalled();
+  });
+
+  it("not sampled with selected=legacy: returns the legacy path", async () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 0;
+    const events = vi.fn().mockResolvedValue("EVENTS");
+    const legacy = vi.fn().mockResolvedValue("LEGACY");
+
+    const result = await runEventsTableExperiment({
+      ...baseParams,
+      selected: "legacy",
+      events,
+      legacy,
+      compare: vi.fn().mockReturnValue([]),
+    });
+
+    expect(result).toBe("LEGACY");
+    expect(legacy).toHaveBeenCalledTimes(1);
+    expect(events).not.toHaveBeenCalled();
+  });
+
+  it("sampled + identical results: runs both, returns selected, records match", async () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 1;
+    const events = vi.fn().mockResolvedValue({ a: 1 });
+    const legacy = vi.fn().mockResolvedValue({ a: 1 });
+
+    const result = await runEventsTableExperiment({
+      ...baseParams,
+      selected: "legacy",
+      events,
+      legacy,
+      compare: (l, e) => diffResults(l, e),
+    });
+
+    expect(result).toEqual({ a: 1 });
+    expect(events).toHaveBeenCalledTimes(1);
+    expect(legacy).toHaveBeenCalledTimes(1);
+    // Both latencies recorded, one per source.
+    expect(mocks.recordHistogram).toHaveBeenCalledTimes(2);
+    expect(mocks.recordHistogram).toHaveBeenCalledWith(
+      "langfuse.events_table_experiment.latency_ms",
+      expect.any(Number),
+      { feature: "traces.test", source: "legacy" },
+    );
+    expect(mocks.recordHistogram).toHaveBeenCalledWith(
+      "langfuse.events_table_experiment.latency_ms",
+      expect.any(Number),
+      { feature: "traces.test", source: "events" },
+    );
+    expect(mocks.recordIncrement).toHaveBeenCalledWith(
+      "langfuse.events_table_experiment.result",
+      1,
+      { feature: "traces.test", match: "true" },
+    );
+    // No field mismatch recorded for identical results.
+    expect(mocks.recordIncrement).not.toHaveBeenCalledWith(
+      "langfuse.events_table_experiment.field_mismatch",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("sampled + mismatch: records field_mismatch, match=false, and logs", async () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 1;
+    const events = vi.fn().mockResolvedValue({ name: "X" });
+    const legacy = vi.fn().mockResolvedValue({ name: "Y" });
+
+    const result = await runEventsTableExperiment({
+      ...baseParams,
+      selected: "events",
+      events,
+      legacy,
+      compare: (l, e) => diffResults(l, e),
+    });
+
+    expect(result).toEqual({ name: "X" });
+    expect(mocks.recordIncrement).toHaveBeenCalledWith(
+      "langfuse.events_table_experiment.result",
+      1,
+      { feature: "traces.test", match: "false" },
+    );
+    expect(mocks.recordIncrement).toHaveBeenCalledWith(
+      "langfuse.events_table_experiment.field_mismatch",
+      1,
+      { feature: "traces.test", field: "name" },
+    );
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      "events table experiment mismatch",
+      expect.objectContaining({ feature: "traces.test", projectId: "p1" }),
+    );
+  });
+
+  it("sampled + shadow read fails: returns selected, records shadow_error, no throw", async () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 1;
+    const events = vi.fn().mockResolvedValue("EVENTS"); // selected
+    const legacy = vi.fn().mockRejectedValue(new Error("shadow boom")); // shadow
+    const compare = vi.fn();
+
+    const result = await runEventsTableExperiment({
+      ...baseParams,
+      selected: "events",
+      events,
+      legacy,
+      compare,
+    });
+
+    expect(result).toBe("EVENTS");
+    expect(compare).not.toHaveBeenCalled();
+    expect(mocks.recordIncrement).toHaveBeenCalledWith(
+      "langfuse.events_table_experiment.shadow_error",
+      1,
+      { feature: "traces.test" },
+    );
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      "events table experiment shadow read failed",
+      expect.objectContaining({ shadowSource: "legacy" }),
+    );
+  });
+
+  it("sampled + selected read fails: propagates the error", async () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 1;
+    const events = vi.fn().mockRejectedValue(new Error("selected boom")); // selected
+    const legacy = vi.fn().mockResolvedValue("LEGACY"); // shadow
+
+    await expect(
+      runEventsTableExperiment({
+        ...baseParams,
+        selected: "events",
+        events,
+        legacy,
+        compare: vi.fn(),
+      }),
+    ).rejects.toThrow("selected boom");
+  });
+
+  it("runs both read paths concurrently when sampled", async () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 1;
+    let active = 0;
+    let maxActive = 0;
+    const slow = (value: string) =>
+      vi.fn().mockImplementation(async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 15));
+        active -= 1;
+        return value;
+      });
+    const events = slow("EVENTS");
+    const legacy = slow("LEGACY");
+
+    await runEventsTableExperiment({
+      ...baseParams,
+      selected: "events",
+      events,
+      legacy,
+      compare: vi.fn().mockReturnValue([]),
+    });
+
+    // If the reads were serial, maxActive would be 1.
+    expect(maxActive).toBe(2);
+  });
+
+  it("does not break the response when compare throws", async () => {
+    mocks.env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE = 1;
+    const events = vi.fn().mockResolvedValue("EVENTS");
+    const legacy = vi.fn().mockResolvedValue("LEGACY");
+    const compare = vi.fn().mockImplementation(() => {
+      throw new Error("compare boom");
+    });
+
+    const result = await runEventsTableExperiment({
+      ...baseParams,
+      selected: "events",
+      events,
+      legacy,
+      compare,
+    });
+
+    expect(result).toBe("EVENTS");
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      "events table experiment comparison failed",
+      expect.objectContaining({ feature: "traces.test" }),
+    );
   });
 });

--- a/packages/shared/src/server/repositories/eventsTableExperiment.test.ts
+++ b/packages/shared/src/server/repositories/eventsTableExperiment.test.ts
@@ -54,6 +54,28 @@ describe("diffResults", () => {
     expect(diffs[0]).toMatchObject({ field: "count", legacy: 1, events: 2 });
   });
 
+  it("compares Decimal-like values by number with epsilon tolerance", () => {
+    const decimal = (n: number) => ({ toNumber: () => n });
+    const legacy = { totalCost: decimal(0.08) };
+    const events = { totalCost: decimal(0.08 + 1e-9) };
+    expect(
+      diffResults(legacy, events, { numericFields: new Set(["totalCost"]) }),
+    ).toEqual([]);
+
+    const mismatch = diffResults(
+      { totalCost: decimal(0.08) },
+      { totalCost: decimal(0.09) },
+      { numericFields: new Set(["totalCost"]) },
+    );
+    expect(mismatch).toEqual([
+      expect.objectContaining({
+        field: "totalCost",
+        legacy: 0.08,
+        events: 0.09,
+      }),
+    ]);
+  });
+
   it("reports an array length mismatch as a diff", () => {
     const legacy = { data: ["o1", "o2"] };
     const events = { data: ["o1"] };

--- a/packages/shared/src/server/repositories/eventsTableExperiment.test.ts
+++ b/packages/shared/src/server/repositories/eventsTableExperiment.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  diffResults,
+  shouldRunEventsTableExperiment,
+} from "./eventsTableExperiment";
+
+describe("diffResults", () => {
+  it("returns no diffs for identical objects", () => {
+    const a = { id: "t1", name: "trace", tags: ["a", "b"] };
+    const b = { id: "t1", name: "trace", tags: ["a", "b"] };
+    expect(diffResults(a, b)).toEqual([]);
+  });
+
+  it("ignores ordering differences in primitive arrays (e.g. tags)", () => {
+    const legacy = { tags: ["b", "a", "c"] };
+    const events = { tags: ["a", "c", "b"] };
+    expect(diffResults(legacy, events)).toEqual([]);
+  });
+
+  it("ignores ordering differences in id arrays (observations/scores)", () => {
+    const legacy = { observations: ["o2", "o1"], scores: ["s1"] };
+    const events = { observations: ["o1", "o2"], scores: ["s1"] };
+    expect(diffResults(legacy, events)).toEqual([]);
+  });
+
+  it("treats JSON-string metadata and parsed-object metadata as equal", () => {
+    const legacy = { metadata: { foo: "bar", n: 1 } };
+    const events = { metadata: '{"n":1,"foo":"bar"}' };
+    expect(diffResults(legacy, events)).toEqual([]);
+  });
+
+  it("treats null and undefined as equal", () => {
+    const legacy = { userId: null };
+    const events = { userId: undefined };
+    expect(diffResults(legacy, events)).toEqual([]);
+  });
+
+  it("treats Date and equal epoch millis as equal", () => {
+    const ts = new Date("2024-01-01T00:00:00.000Z");
+    const legacy = { timestamp: ts };
+    const events = { timestamp: new Date(ts.getTime()) };
+    expect(diffResults(legacy, events)).toEqual([]);
+  });
+
+  it("applies numeric tolerance only to configured fields", () => {
+    const legacy = { latency: 1.0000001, count: 1 };
+    const events = { latency: 1.0000002, count: 2 };
+    const diffs = diffResults(legacy, events, {
+      numericFields: new Set(["latency"]),
+    });
+    // latency within epsilon -> ignored; count differs -> reported
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]).toMatchObject({ field: "count", legacy: 1, events: 2 });
+  });
+
+  it("reports an array length mismatch as a diff", () => {
+    const legacy = { data: ["o1", "o2"] };
+    const events = { data: ["o1"] };
+    const diffs = diffResults(legacy, events);
+    expect(diffs).toEqual([
+      expect.objectContaining({
+        field: "data",
+        legacy: "length=2",
+        events: "length=1",
+      }),
+    ]);
+  });
+
+  it("reports the leaf field name for a nested scalar difference", () => {
+    const legacy = { meta: { totalItems: 5 } };
+    const events = { meta: { totalItems: 6 } };
+    const diffs = diffResults(legacy, events);
+    expect(diffs).toEqual([
+      expect.objectContaining({
+        path: "meta.totalItems",
+        field: "totalItems",
+        legacy: 5,
+        events: 6,
+      }),
+    ]);
+  });
+
+  it("aligns object arrays by id and reports per-field diffs", () => {
+    const legacy = {
+      data: [
+        { id: "t1", name: "first" },
+        { id: "t2", name: "second" },
+      ],
+    };
+    const events = {
+      // reversed order + one differing field
+      data: [
+        { id: "t2", name: "SECOND" },
+        { id: "t1", name: "first" },
+      ],
+    };
+    const diffs = diffResults(legacy, events);
+    expect(diffs).toEqual([
+      expect.objectContaining({
+        field: "name",
+        legacy: "second",
+        events: "SECOND",
+      }),
+    ]);
+  });
+});
+
+describe("shouldRunEventsTableExperiment", () => {
+  it("is off by default (sample rate 0)", () => {
+    // LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE defaults to 0 in tests.
+    expect(shouldRunEventsTableExperiment()).toBe(false);
+  });
+});

--- a/packages/shared/src/server/repositories/eventsTableExperiment.ts
+++ b/packages/shared/src/server/repositories/eventsTableExperiment.ts
@@ -1,0 +1,312 @@
+import { env } from "../../env";
+import { logger } from "../logger";
+import { recordHistogram, recordIncrement } from "../instrumentation";
+
+/**
+ * Shadow-comparison experiment for the Traces public API.
+ *
+ * On a configurable fraction of requests we run *both* read paths (the new
+ * events table and the legacy traces/observations tables), compare the results
+ * field-by-field, and record latency + diff metrics. The data returned to the
+ * caller is never affected: the caller always receives the result of the path
+ * it selected (via `useEventsTable`). The other path runs purely as a shadow
+ * read for validation.
+ */
+
+export type ExperimentSource = "events" | "legacy";
+
+export type FieldDiff = {
+  /** Full path to the differing value, e.g. "data[2].metadata.foo". */
+  path: string;
+  /** Leaf field name, used as a low-cardinality metric tag, e.g. "metadata". */
+  field: string;
+  legacy: unknown;
+  events: unknown;
+};
+
+export type DiffOptions = {
+  /** Leaf field names compared with `epsilon` tolerance instead of strict equality. */
+  numericFields?: Set<string>;
+  epsilon?: number;
+};
+
+const DEFAULT_EPSILON = 1e-6;
+
+/**
+ * Decide whether to run the shadow comparison for the current request.
+ * Returns false fast when the sample rate is 0 (experiment disabled).
+ */
+export const shouldRunEventsTableExperiment = (): boolean => {
+  const rate = env.LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE;
+  if (!rate || rate <= 0) return false;
+  return Math.random() < rate;
+};
+
+/**
+ * Normalize a value into a stable, comparable structure:
+ * - null/undefined collapse to null (JSON serialization drops undefined)
+ * - Dates become epoch millis
+ * - JSON-looking strings are parsed so structural equality is order-independent
+ * - object keys are sorted; arrays are sorted by a stable key (`id` when present)
+ */
+const normalize = (value: unknown): unknown => {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.getTime();
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const looksLikeJson =
+      (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+      (trimmed.startsWith("[") && trimmed.endsWith("]"));
+    if (looksLikeJson) {
+      try {
+        return normalize(JSON.parse(trimmed));
+      } catch {
+        return value;
+      }
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const normalized = value.map(normalize);
+    return [...normalized].sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
+  }
+
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(obj).sort()) {
+      out[key] = normalize(obj[key]);
+    }
+    return out;
+  }
+
+  return value;
+};
+
+const sortKey = (value: unknown): string => {
+  if (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).id === "string"
+  ) {
+    return (value as Record<string, string>).id;
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return String(value);
+  }
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const collectDiffs = (
+  legacy: unknown,
+  events: unknown,
+  path: string,
+  field: string,
+  opts: DiffOptions,
+  out: FieldDiff[],
+): void => {
+  if (typeof legacy === "number" && typeof events === "number") {
+    const tol = opts.numericFields?.has(field)
+      ? (opts.epsilon ?? DEFAULT_EPSILON)
+      : 0;
+    if (Math.abs(legacy - events) > tol) {
+      out.push({ path, field, legacy, events });
+    }
+    return;
+  }
+
+  if (Array.isArray(legacy) && Array.isArray(events)) {
+    if (legacy.length !== events.length) {
+      out.push({
+        path,
+        field,
+        legacy: `length=${legacy.length}`,
+        events: `length=${events.length}`,
+      });
+    }
+    const n = Math.min(legacy.length, events.length);
+    for (let i = 0; i < n; i++) {
+      collectDiffs(legacy[i], events[i], `${path}[${i}]`, field, opts, out);
+    }
+    return;
+  }
+
+  if (isPlainObject(legacy) && isPlainObject(events)) {
+    const keys = new Set([...Object.keys(legacy), ...Object.keys(events)]);
+    for (const key of keys) {
+      collectDiffs(
+        legacy[key],
+        events[key],
+        path ? `${path}.${key}` : key,
+        key,
+        opts,
+        out,
+      );
+    }
+    return;
+  }
+
+  // primitives or mismatched types
+  if (JSON.stringify(legacy) !== JSON.stringify(events)) {
+    out.push({ path, field, legacy, events });
+  }
+};
+
+/**
+ * Field-by-field diff of two results after normalization. Returns an empty
+ * array when the two results are considered identical.
+ */
+export const diffResults = (
+  legacy: unknown,
+  events: unknown,
+  opts: DiffOptions = {},
+): FieldDiff[] => {
+  const out: FieldDiff[] = [];
+  collectDiffs(normalize(legacy), normalize(events), "", "", opts, out);
+  return out;
+};
+
+const MAX_LOGGED_DIFFS = 50;
+const MAX_LOGGED_VALUE_LENGTH = 500;
+
+const truncateForLog = (value: unknown): unknown => {
+  let serialized: string;
+  try {
+    serialized = typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    serialized = String(value);
+  }
+  if (serialized && serialized.length > MAX_LOGGED_VALUE_LENGTH) {
+    return `${serialized.slice(0, MAX_LOGGED_VALUE_LENGTH)}…[truncated]`;
+  }
+  return value;
+};
+
+const recordExperimentDiffs = (params: {
+  feature: string;
+  projectId: string;
+  diffs: FieldDiff[];
+  logContext?: Record<string, unknown>;
+}): void => {
+  const { feature, projectId, diffs, logContext } = params;
+  const match = diffs.length === 0;
+
+  recordIncrement("langfuse.events_table_experiment.result", 1, {
+    feature,
+    match: match ? "true" : "false",
+  });
+
+  if (match) return;
+
+  // Dedupe by leaf field name to keep metric cardinality bounded and avoid
+  // inflating counts when an array of objects differs in the same field.
+  const seenFields = new Set<string>();
+  for (const diff of diffs) {
+    if (seenFields.has(diff.field)) continue;
+    seenFields.add(diff.field);
+    recordIncrement("langfuse.events_table_experiment.field_mismatch", 1, {
+      feature,
+      field: diff.field || "root",
+    });
+  }
+
+  logger.info("events table experiment mismatch", {
+    feature,
+    projectId,
+    diffCount: diffs.length,
+    fields: Array.from(seenFields),
+    diffs: diffs.slice(0, MAX_LOGGED_DIFFS).map((diff) => ({
+      path: diff.path || "root",
+      field: diff.field || "root",
+      legacy: truncateForLog(diff.legacy),
+      events: truncateForLog(diff.events),
+    })),
+    ...logContext,
+  });
+};
+
+/**
+ * Runs the experiment for a single request.
+ *
+ * The `selected` path (matching `useEventsTable`) is always awaited and
+ * returned. When sampled, the other path is also run as a shadow read, both
+ * latencies are recorded, and the results are compared via `compare`. Shadow
+ * failures never break the response.
+ */
+export const runEventsTableExperiment = async <T>(params: {
+  /** Low-cardinality feature label, e.g. "traces.list" or "traces.byId". */
+  feature: string;
+  projectId: string;
+  selected: ExperimentSource;
+  events: () => Promise<T>;
+  legacy: () => Promise<T>;
+  /** Compute field-level diffs between the legacy and events results. */
+  compare: (legacyResult: T, eventsResult: T) => FieldDiff[];
+  logContext?: Record<string, unknown>;
+}): Promise<T> => {
+  const { feature, projectId, selected, events, legacy, compare, logContext } =
+    params;
+
+  const selectedFn = selected === "events" ? events : legacy;
+  const selectedStart = Date.now();
+  const selectedResult = await selectedFn();
+  recordHistogram(
+    "langfuse.events_table_experiment.latency_ms",
+    Date.now() - selectedStart,
+    { feature, source: selected },
+  );
+
+  if (!shouldRunEventsTableExperiment()) {
+    return selectedResult;
+  }
+
+  const otherSource: ExperimentSource =
+    selected === "events" ? "legacy" : "events";
+  const otherFn = selected === "events" ? legacy : events;
+
+  let otherResult: T;
+  try {
+    const otherStart = Date.now();
+    otherResult = await otherFn();
+    recordHistogram(
+      "langfuse.events_table_experiment.latency_ms",
+      Date.now() - otherStart,
+      { feature, source: otherSource },
+    );
+  } catch (error) {
+    recordIncrement("langfuse.events_table_experiment.shadow_error", 1, {
+      feature,
+    });
+    logger.warn("events table experiment shadow read failed", {
+      feature,
+      projectId,
+      shadowSource: otherSource,
+      error: error instanceof Error ? error.message : String(error),
+      ...logContext,
+    });
+    return selectedResult;
+  }
+
+  try {
+    const legacyResult = selected === "events" ? otherResult : selectedResult;
+    const eventsResult = selected === "events" ? selectedResult : otherResult;
+    const diffs = compare(legacyResult, eventsResult);
+    recordExperimentDiffs({ feature, projectId, diffs, logContext });
+  } catch (error) {
+    logger.warn("events table experiment comparison failed", {
+      feature,
+      projectId,
+      error: error instanceof Error ? error.message : String(error),
+      ...logContext,
+    });
+  }
+
+  return selectedResult;
+};

--- a/packages/shared/src/server/repositories/eventsTableExperiment.ts
+++ b/packages/shared/src/server/repositories/eventsTableExperiment.ts
@@ -53,6 +53,15 @@ const normalize = (value: unknown): unknown => {
   if (value === null || value === undefined) return null;
   if (value instanceof Date) return value.getTime();
 
+  // Decimal-like values (e.g. Decimal.js) -> number, so they compare by value
+  // and benefit from the numeric epsilon tolerance.
+  if (
+    typeof value === "object" &&
+    typeof (value as { toNumber?: unknown }).toNumber === "function"
+  ) {
+    return (value as { toNumber: () => number }).toNumber();
+  }
+
   if (typeof value === "string") {
     const trimmed = value.trim();
     const looksLikeJson =
@@ -232,13 +241,39 @@ const recordExperimentDiffs = (params: {
   });
 };
 
+type TimedResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
+
+/** Run a read path, timing it and recording the latency histogram on success. */
+const timeRead = async <T>(
+  feature: string,
+  source: ExperimentSource,
+  fn: () => Promise<T>,
+): Promise<TimedResult<T>> => {
+  const start = Date.now();
+  try {
+    const value = await fn();
+    recordHistogram(
+      "langfuse.events_table_experiment.latency_ms",
+      Date.now() - start,
+      { feature, source },
+    );
+    return { ok: true, value };
+  } catch (error) {
+    return { ok: false, error };
+  }
+};
+
 /**
  * Runs the experiment for a single request.
  *
- * The `selected` path (matching `useEventsTable`) is always awaited and
- * returned. When sampled, the other path is also run as a shadow read, both
- * latencies are recorded, and the results are compared via `compare`. Shadow
- * failures never break the response.
+ * When NOT sampled, the `selected` path (matching `useEventsTable`) is run and
+ * returned with zero experiment overhead — no extra read, no metrics.
+ *
+ * When sampled, both read paths run CONCURRENTLY (so the added wall-clock cost
+ * is roughly the slower read rather than the sum), their latencies are
+ * recorded, and the results are compared via `compare`. The caller always
+ * receives the `selected` path's result; a shadow read failure never breaks the
+ * response, and the `selected` path's error always propagates.
  */
 export const runEventsTableExperiment = async <T>(params: {
   /** Low-cardinality feature label, e.g. "traces.list" or "traces.byId". */
@@ -255,32 +290,29 @@ export const runEventsTableExperiment = async <T>(params: {
     params;
 
   const selectedFn = selected === "events" ? events : legacy;
-  const selectedStart = Date.now();
-  const selectedResult = await selectedFn();
-  recordHistogram(
-    "langfuse.events_table_experiment.latency_ms",
-    Date.now() - selectedStart,
-    { feature, source: selected },
-  );
 
+  // Fast path: experiment disabled / not sampled. No second read, no metrics.
   if (!shouldRunEventsTableExperiment()) {
-    return selectedResult;
+    return selectedFn();
   }
 
   const otherSource: ExperimentSource =
     selected === "events" ? "legacy" : "events";
   const otherFn = selected === "events" ? legacy : events;
 
-  let otherResult: T;
-  try {
-    const otherStart = Date.now();
-    otherResult = await otherFn();
-    recordHistogram(
-      "langfuse.events_table_experiment.latency_ms",
-      Date.now() - otherStart,
-      { feature, source: otherSource },
-    );
-  } catch (error) {
+  // Run both paths concurrently so the shadow read does not add its full
+  // latency on top of the response we return.
+  const [selectedRes, otherRes] = await Promise.all([
+    timeRead(feature, selected, selectedFn),
+    timeRead(feature, otherSource, otherFn),
+  ]);
+
+  // The selected path is the real response: its failure must propagate.
+  if (!selectedRes.ok) {
+    throw selectedRes.error;
+  }
+
+  if (!otherRes.ok) {
     recordIncrement("langfuse.events_table_experiment.shadow_error", 1, {
       feature,
     });
@@ -288,15 +320,20 @@ export const runEventsTableExperiment = async <T>(params: {
       feature,
       projectId,
       shadowSource: otherSource,
-      error: error instanceof Error ? error.message : String(error),
+      error:
+        otherRes.error instanceof Error
+          ? otherRes.error.message
+          : String(otherRes.error),
       ...logContext,
     });
-    return selectedResult;
+    return selectedRes.value;
   }
 
   try {
-    const legacyResult = selected === "events" ? otherResult : selectedResult;
-    const eventsResult = selected === "events" ? selectedResult : otherResult;
+    const legacyResult =
+      selected === "events" ? otherRes.value : selectedRes.value;
+    const eventsResult =
+      selected === "events" ? selectedRes.value : otherRes.value;
     const diffs = compare(legacyResult, eventsResult);
     recordExperimentDiffs({ feature, projectId, diffs, logContext });
   } catch (error) {
@@ -308,5 +345,5 @@ export const runEventsTableExperiment = async <T>(params: {
     });
   }
 
-  return selectedResult;
+  return selectedRes.value;
 };

--- a/packages/shared/src/server/repositories/index.ts
+++ b/packages/shared/src/server/repositories/index.ts
@@ -2,6 +2,7 @@ export * from "./scores";
 export * from "./traces";
 export * from "./observations";
 export * from "./events";
+export * from "./eventsTableExperiment";
 export * from "./types";
 export * from "./dashboards";
 export * from "./traces_converters";

--- a/web/src/__tests__/server/traces-api.servertest.ts
+++ b/web/src/__tests__/server/traces-api.servertest.ts
@@ -2110,6 +2110,85 @@ describe("/api/public/traces API Endpoint", () => {
           expect(trace.latency).toBeGreaterThan(0);
         });
 
+        it("should fetch a single trace with all field groups via /traces/{id}", async () => {
+          const timestamp = new Date();
+          const traceId = randomUUID();
+          const createdTrace = createTrace({
+            id: traceId,
+            name: "single-trace-fields",
+            user_id: "user-single-test",
+            session_id: "session-single-test",
+            timestamp: timestamp.getTime(),
+            project_id: projectId,
+            metadata: { testKey: "testValue" },
+            release: "1.0.0",
+            version: "2.0.0",
+            environment: "production",
+          });
+
+          await createTraceWithObservations(useEventsTable, createdTrace, [
+            {
+              trace_id: traceId,
+              project_id: projectId,
+              name: "generation-1",
+              type: "GENERATION",
+              start_time: timestamp.getTime(),
+              end_time: timestamp.getTime() + 1000,
+              input: "What is the capital of France?",
+              output: "The capital of France is Paris.",
+              cost_details: {
+                total: 0.05,
+              },
+              total_cost: 0.05,
+              metadata: { testKey: "testValue" },
+            },
+            {
+              trace_id: traceId,
+              project_id: projectId,
+              name: "span-1",
+              type: "SPAN",
+              start_time: timestamp.getTime() + 500,
+              end_time: timestamp.getTime() + 2000,
+              cost_details: {
+                total: 0.03,
+              },
+              total_cost: 0.03,
+              metadata: { testKey: "testValue" },
+            },
+          ]);
+
+          const singleTracePath = useEventsTable
+            ? `/api/public/traces/${traceId}?useEventsTable=true&fields=core,io,observations,metrics`
+            : `/api/public/traces/${traceId}?fields=core,io,observations,metrics`;
+
+          const res = await makeZodVerifiedAPICall(
+            GetTraceV1Response,
+            "GET",
+            singleTracePath,
+            undefined,
+            auth,
+          );
+
+          expect(res.body.id).toBe(traceId);
+          expect(res.body.name).toBe("single-trace-fields");
+          expect(res.body.userId).toBe("user-single-test");
+          expect(res.body.sessionId).toBe("session-single-test");
+          expect(res.body.environment).toBe("production");
+          expect(res.body.version).toBe("2.0.0");
+          expect(res.body.metadata).toMatchObject({ testKey: "testValue" });
+          // >= 2 because the events-table model also surfaces the root trace
+          // event as an observation, whereas the legacy model keeps the trace
+          // separate from its observations.
+          expect(res.body.observations.length).toBeGreaterThanOrEqual(2);
+          // totalCost/latency come from the metrics field group; exact cost is
+          // asserted by the list-endpoint test (single-trace derives cost from
+          // cost_details, which the shared helper does not wire for the legacy
+          // path), so here we just assert the metrics field group is populated.
+          expect(typeof res.body.totalCost).toBe("number");
+          expect(res.body.totalCost).toBeGreaterThanOrEqual(0);
+          expect(res.body.latency).toBeGreaterThan(0);
+        });
+
         it("should filter traces by userId", async () => {
           const userId = randomUUID();
           const traceId = randomUUID();

--- a/web/src/features/public-api/types/observations.ts
+++ b/web/src/features/public-api/types/observations.ts
@@ -177,6 +177,14 @@ export const transformDbToApiObservation = (
     bookmarked,
 
     public: _public,
+
+    // Exclude events-table-only aggregate/trace fields that are not part of the
+    // V1 APIObservation contract. These appear when observations are read via
+    // the by-trace events path (FullEventsObservation) but not in the legacy
+    // observation shape.
+    traceTimestamp,
+    toolDefinitionsCount,
+    toolCallsCount,
     ...rest
   } = observation as EventsObservation &
     ObservationPriceFields & {
@@ -185,6 +193,10 @@ export const transformDbToApiObservation = (
       // either `tags` or `traceTags` may exist on the input observation.
       // This is not part of the standard `EventsObservation` type.
       traceTags?: string[];
+      // Present only on FullEventsObservation (by-trace events read).
+      traceTimestamp?: unknown;
+      toolDefinitionsCount?: unknown;
+      toolCallsCount?: unknown;
     };
 
   return {

--- a/web/src/features/public-api/types/traces.ts
+++ b/web/src/features/public-api/types/traces.ts
@@ -134,6 +134,7 @@ export const GetTraceV1Query = z.object({
       return parsed.length > 0 ? parsed : null;
     })
     .pipe(z.array(z.enum(TRACE_FIELD_GROUPS)).nullable()),
+  useEventsTable: useEventsTableSchema,
 });
 export const GetTraceV1Response = APIExtendedTrace.extend({
   scores: z.array(APIScoreSchemaV1),

--- a/web/src/pages/api/public/traces/[traceId].ts
+++ b/web/src/pages/api/public/traces/[traceId].ts
@@ -20,10 +20,14 @@ import {
 import { prisma } from "@langfuse/shared/src/db";
 import {
   getObservationsForTrace,
+  getObservationsForTraceFromEventsTable,
   getScoresForTraces,
   getTraceById,
+  getTraceByIdFromEventsTable,
   traceException,
   traceDeletionProcessor,
+  runEventsTableExperiment,
+  diffResults,
 } from "@langfuse/shared/src/server";
 import Decimal from "decimal.js";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
@@ -56,137 +60,245 @@ export default withMiddlewares(
         const includeScores = requestedFields.includes("scores");
         const includeMetrics = requestedFields.includes("metrics");
 
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        const trace = await getTraceById({
-          traceId,
-          projectId: auth.scope.projectId,
-          clickhouseFeatureTag: "tracing-public-api",
-          preferredClickhouseService: "ReadOnly",
-          excludeInputOutput: !includeIO,
-          excludeMetadata: !includeIO,
-        });
+        // Builds the public API response from the parts fetched by either read
+        // path. Kept as a single function so the events-table and legacy paths
+        // produce a byte-identical response shape, which is what the experiment
+        // comparison relies on.
+        const assembleTraceResponse = (parts: {
+          trace: NonNullable<
+            Awaited<ReturnType<typeof getTraceByIdFromEventsTable>>
+          >;
+          outObservations: ReturnType<typeof transformDbToApiObservation>[];
+          validatedScores: ReturnType<
+            typeof filterAndValidateDbLegacyTraceScoreList
+          >;
+          rawObservations: Array<{ startTime: Date; endTime: Date | null }>;
+        }) => {
+          const { trace, outObservations, validatedScores, rawObservations } =
+            parts;
 
-        if (!trace) {
-          throw new LangfuseNotFoundError(
-            `Trace ${traceId} not found within authorized project`,
-          );
-        }
+          const obsStartTimes = rawObservations
+            .map((o) => o.startTime)
+            .sort((a, b) => a.getTime() - b.getTime());
+          const obsEndTimes = rawObservations
+            .map((o) => o.endTime)
+            .filter((t) => t)
+            .sort((a, b) => (a as Date).getTime() - (b as Date).getTime());
 
-        const [observations, scores] = await Promise.all([
-          includeObservations || includeMetrics
-            ? getObservationsForTrace({
-                traceId,
-                projectId: auth.scope.projectId,
-                timestamp: trace?.timestamp,
-                includeIO: includeObservations,
-                preferredClickhouseService: "ReadOnly",
-              })
-            : Promise.resolve([]),
-          includeScores
-            ? getScoresForTraces({
-                projectId: auth.scope.projectId,
-                traceIds: [traceId],
-                timestamp: trace?.timestamp,
-                preferredClickhouseService: "ReadOnly",
-              })
-            : Promise.resolve([]),
-        ]);
-
-        const uniqueModels: string[] = Array.from(
-          new Set(
-            observations
-              .map((r) => r.internalModelId)
-              .filter((r): r is string => Boolean(r)),
-          ),
-        );
-
-        const models =
-          uniqueModels.length > 0
-            ? await prisma.model.findMany({
-                where: {
-                  id: {
-                    in: uniqueModels,
-                  },
-                  OR: [
-                    { projectId: auth.scope.projectId },
-                    { projectId: null },
-                  ],
-                },
-                include: {
-                  Price: true,
-                },
-              })
-            : [];
-
-        const observationsView = observations.map((o) => {
-          const model = models.find((m) => m.id === o.internalModelId);
-          const inputPrice =
-            model?.Price.find((p) => p.usageType === "input")?.price ??
-            new Decimal(0);
-          const outputPrice =
-            model?.Price.find((p) => p.usageType === "output")?.price ??
-            new Decimal(0);
-          const totalPrice =
-            model?.Price.find((p) => p.usageType === "total")?.price ??
-            new Decimal(0);
-          return {
-            ...o,
-            inputPrice,
-            outputPrice,
-            totalPrice,
-          };
-        });
-
-        const outObservations = observationsView.map(
-          transformDbToApiObservation,
-        );
-        // As these are traces scores, we expect all scores to have a traceId set
-        // For type consistency, we validate the scores against the v1 schema which requires a traceId
-        const validatedScores = filterAndValidateDbLegacyTraceScoreList({
-          scores,
-          onParseError: traceException,
-        });
-
-        const obsStartTimes = observations
-          .map((o) => o.startTime)
-          .sort((a, b) => a.getTime() - b.getTime());
-        const obsEndTimes = observations
-          .map((o) => o.endTime)
-          .filter((t) => t)
-          .sort((a, b) => (a as Date).getTime() - (b as Date).getTime());
-
-        const latencyMs =
-          obsStartTimes.length > 0
-            ? obsEndTimes.length > 0
-              ? (obsEndTimes[obsEndTimes.length - 1] as Date).getTime() -
-                obsStartTimes[0]!.getTime()
-              : obsStartTimes.length > 1
-                ? obsStartTimes[obsStartTimes.length - 1]!.getTime() -
+          const latencyMs =
+            obsStartTimes.length > 0
+              ? obsEndTimes.length > 0
+                ? (obsEndTimes[obsEndTimes.length - 1] as Date).getTime() -
                   obsStartTimes[0]!.getTime()
-                : undefined
-            : undefined;
-        return {
-          ...trace,
-          externalId: null,
-          metadata: includeIO ? trace.metadata : {},
-          scores: includeScores ? validatedScores : [],
-          latency: includeMetrics
-            ? latencyMs !== undefined
-              ? latencyMs / 1000
-              : 0
-            : -1,
-          observations: includeObservations ? outObservations : [],
-          htmlPath: `/project/${auth.scope.projectId}/traces/${traceId}`,
-          totalCost: includeMetrics
-            ? outObservations
-                .reduce(
-                  (acc, obs) =>
-                    acc.add(obs.calculatedTotalCost ?? new Decimal(0)),
-                  new Decimal(0),
-                )
-                .toNumber()
-            : -1,
+                : obsStartTimes.length > 1
+                  ? obsStartTimes[obsStartTimes.length - 1]!.getTime() -
+                    obsStartTimes[0]!.getTime()
+                  : undefined
+              : undefined;
+
+          return {
+            ...trace,
+            externalId: null,
+            metadata: includeIO ? trace.metadata : {},
+            scores: includeScores ? validatedScores : [],
+            latency: includeMetrics
+              ? latencyMs !== undefined
+                ? latencyMs / 1000
+                : 0
+              : -1,
+            observations: includeObservations ? outObservations : [],
+            htmlPath: `/project/${auth.scope.projectId}/traces/${traceId}`,
+            totalCost: includeMetrics
+              ? outObservations
+                  .reduce(
+                    (acc, obs) =>
+                      acc.add(obs.calculatedTotalCost ?? new Decimal(0)),
+                    new Decimal(0),
+                  )
+                  .toNumber()
+              : -1,
+          };
         };
+
+        // Legacy read path: traces + observations tables, with per-observation
+        // model prices resolved from Postgres.
+        const buildLegacyResult = async () => {
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
+          const trace = await getTraceById({
+            traceId,
+            projectId: auth.scope.projectId,
+            clickhouseFeatureTag: "tracing-public-api",
+            preferredClickhouseService: "ReadOnly",
+            excludeInputOutput: !includeIO,
+            excludeMetadata: !includeIO,
+          });
+
+          if (!trace) {
+            throw new LangfuseNotFoundError(
+              `Trace ${traceId} not found within authorized project`,
+            );
+          }
+
+          const [observations, scores] = await Promise.all([
+            includeObservations || includeMetrics
+              ? getObservationsForTrace({
+                  traceId,
+                  projectId: auth.scope.projectId,
+                  timestamp: trace?.timestamp,
+                  includeIO: includeObservations,
+                  preferredClickhouseService: "ReadOnly",
+                })
+              : Promise.resolve([]),
+            includeScores
+              ? getScoresForTraces({
+                  projectId: auth.scope.projectId,
+                  traceIds: [traceId],
+                  timestamp: trace?.timestamp,
+                  preferredClickhouseService: "ReadOnly",
+                })
+              : Promise.resolve([]),
+          ]);
+
+          const uniqueModels: string[] = Array.from(
+            new Set(
+              observations
+                .map((r) => r.internalModelId)
+                .filter((r): r is string => Boolean(r)),
+            ),
+          );
+
+          const models =
+            uniqueModels.length > 0
+              ? await prisma.model.findMany({
+                  where: {
+                    id: {
+                      in: uniqueModels,
+                    },
+                    OR: [
+                      { projectId: auth.scope.projectId },
+                      { projectId: null },
+                    ],
+                  },
+                  include: {
+                    Price: true,
+                  },
+                })
+              : [];
+
+          const observationsView = observations.map((o) => {
+            const model = models.find((m) => m.id === o.internalModelId);
+            const inputPrice =
+              model?.Price.find((p) => p.usageType === "input")?.price ??
+              new Decimal(0);
+            const outputPrice =
+              model?.Price.find((p) => p.usageType === "output")?.price ??
+              new Decimal(0);
+            const totalPrice =
+              model?.Price.find((p) => p.usageType === "total")?.price ??
+              new Decimal(0);
+            return {
+              ...o,
+              inputPrice,
+              outputPrice,
+              totalPrice,
+            };
+          });
+
+          const outObservations = observationsView.map(
+            transformDbToApiObservation,
+          );
+          // As these are traces scores, we expect all scores to have a traceId set
+          // For type consistency, we validate the scores against the v1 schema which requires a traceId
+          const validatedScores = filterAndValidateDbLegacyTraceScoreList({
+            scores,
+            onParseError: traceException,
+          });
+
+          return assembleTraceResponse({
+            trace,
+            outObservations,
+            validatedScores,
+            rawObservations: observations,
+          });
+        };
+
+        // Events-table read path: trace fields are aggregated from the root
+        // observation (see eventsTableIsRootObservationSql) and observations are
+        // already enriched with model prices server-side.
+        const buildEventsResult = async () => {
+          const trace = await getTraceByIdFromEventsTable({
+            traceId,
+            projectId: auth.scope.projectId,
+            clickhouseFeatureTag: "tracing-public-api",
+            excludeInputOutput: !includeIO,
+            excludeMetadata: !includeIO,
+          });
+
+          if (!trace) {
+            throw new LangfuseNotFoundError(
+              `Trace ${traceId} not found within authorized project`,
+            );
+          }
+
+          const [observationsResult, scores] = await Promise.all([
+            includeObservations || includeMetrics
+              ? getObservationsForTraceFromEventsTable({
+                  traceId,
+                  projectId: auth.scope.projectId,
+                  timestamp: trace?.timestamp,
+                  selectIOAndMetadata: includeObservations,
+                })
+              : Promise.resolve({ observations: [], totalCount: 0 }),
+            includeScores
+              ? getScoresForTraces({
+                  projectId: auth.scope.projectId,
+                  traceIds: [traceId],
+                  timestamp: trace?.timestamp,
+                  preferredClickhouseService: "ReadOnly",
+                })
+              : Promise.resolve([]),
+          ]);
+
+          const observations = observationsResult.observations;
+
+          const outObservations = observations.map(transformDbToApiObservation);
+          const validatedScores = filterAndValidateDbLegacyTraceScoreList({
+            scores,
+            onParseError: traceException,
+          });
+
+          return assembleTraceResponse({
+            trace,
+            outObservations,
+            validatedScores,
+            rawObservations: observations,
+          });
+        };
+
+        // The caller still gets the path it selected via `useEventsTable`. On a
+        // sampled fraction of requests we also run the other path as a shadow
+        // read and compare the two results (latency + field diffs).
+        return runEventsTableExperiment({
+          feature: "traces.byId",
+          projectId: auth.scope.projectId,
+          selected: query.useEventsTable ? "events" : "legacy",
+          events: buildEventsResult,
+          legacy: buildLegacyResult,
+          compare: (legacyResult, eventsResult) =>
+            diffResults(legacyResult, eventsResult, {
+              numericFields: new Set([
+                "latency",
+                "totalCost",
+                "inputPrice",
+                "outputPrice",
+                "totalPrice",
+                "calculatedInputCost",
+                "calculatedOutputCost",
+                "calculatedTotalCost",
+              ]),
+            }),
+          logContext: { traceId, fields: requestedFields },
+        });
       },
     }),
 

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -21,6 +21,8 @@ import {
   traceDeletionProcessor,
   getTracesFromEventsTableForPublicApi,
   getTracesCountFromEventsTableForPublicApi,
+  runEventsTableExperiment,
+  diffResults,
 } from "@langfuse/shared/src/server";
 import { v4 } from "uuid";
 import { telemetry } from "@/src/features/telemetry";
@@ -127,7 +129,9 @@ export default withMiddlewares(
           toTimestamp: query.toTimestamp ?? undefined,
         };
 
-        if (query.useEventsTable) {
+        // Events-table read path (new). Aggregates trace fields from the root
+        // observation; see eventsTableIsRootObservationSql.
+        const buildEventsResult = async () => {
           const [items, count] = await Promise.all([
             getTracesFromEventsTableForPublicApi({
               ...filterProps,
@@ -152,34 +156,64 @@ export default withMiddlewares(
               totalPages: Math.ceil(count / query.limit),
             },
           };
-        }
+        };
 
-        // Legacy code path using traces table
-        const [items, count] = await Promise.all([
-          generateTracesForPublicApi({
-            props: filterProps,
-            advancedFilters: query.filter,
-            orderBy: query.orderBy ?? null,
-          }),
-          getTracesCountForPublicApi({
-            props: filterProps,
-            advancedFilters: query.filter,
-          }),
-        ]);
+        // Legacy code path using traces + observations tables.
+        const buildLegacyResult = async () => {
+          const [items, count] = await Promise.all([
+            generateTracesForPublicApi({
+              props: filterProps,
+              advancedFilters: query.filter,
+              orderBy: query.orderBy ?? null,
+            }),
+            getTracesCountForPublicApi({
+              props: filterProps,
+              advancedFilters: query.filter,
+            }),
+          ]);
 
-        const finalCount = count || 0;
-        return {
-          data: items.map((item) => ({
-            ...item,
-            externalId: null,
-          })),
-          meta: {
+          const finalCount = count || 0;
+          return {
+            data: items.map((item) => ({
+              ...item,
+              externalId: null,
+            })),
+            meta: {
+              page: query.page,
+              limit: query.limit,
+              totalItems: finalCount,
+              totalPages: Math.ceil(finalCount / query.limit),
+            },
+          };
+        };
+
+        // The caller still gets the path it selected via `useEventsTable`.
+        // On a sampled fraction of requests we also run the other path as a
+        // shadow read and compare the two results (latency + field diffs).
+        return runEventsTableExperiment({
+          feature: "traces.list",
+          projectId: auth.scope.projectId,
+          selected: query.useEventsTable ? "events" : "legacy",
+          events: buildEventsResult,
+          legacy: buildLegacyResult,
+          compare: (legacyResult, eventsResult) =>
+            diffResults(
+              {
+                data: legacyResult.data,
+                totalItems: legacyResult.meta.totalItems,
+              },
+              {
+                data: eventsResult.data,
+                totalItems: eventsResult.meta.totalItems,
+              },
+              { numericFields: new Set(["totalCost", "latency"]) },
+            ),
+          logContext: {
             page: query.page,
             limit: query.limit,
-            totalItems: finalCount,
-            totalPages: Math.ceil(finalCount / query.limit),
+            fields: effectiveFields,
           },
-        };
+        });
       },
     }),
 


### PR DESCRIPTION
## Context

We're migrating trace/observation reads on the public API from the legacy `traces` + `observations` ClickHouse tables to the unified **events table** (via the `useEventsTable` toggle). Before cutting over, we need confidence that the events-table read returns **identical data** to the legacy read.

This PR adds a sampled **shadow-comparison experiment** for `GET /api/public/traces` and `GET /api/public/traces/{id}`: on a configurable fraction of requests, the API runs **both** read paths, compares the results field-by-field, and records latency + diff metrics. The data returned to the caller is unaffected — they still get the path selected by `useEventsTable`; the other path runs purely as a background shadow read.

## How it works

- **Env var** `LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE` (0..1, default `0` = off) controls the sampling rate.
- When sampled, the runner times both paths (`recordHistogram langfuse.events_table_experiment.latency_ms` tagged by `source`), diffs the normalized results, and records:
  - `langfuse.events_table_experiment.result` (counter, `match=true|false`)
  - `langfuse.events_table_experiment.field_mismatch` (counter, tagged by leaf field)
  - a structured `logger.info("events table experiment mismatch", …)` with the differing field paths
- Shadow read failures never break the response.
- Trace-level fields on the events path come from the **root observation** (the existing `eventsTableIsRootObservationSql` heuristic: `parent_span_id = '' OR is_app_root = true`).

## Changes

- New shared helper `eventsTableExperiment.ts` (sampling gate, experiment runner, normalized field-diff) + unit tests.
- List endpoint refactored to run through the experiment runner (behavior unchanged for callers).
- Single-trace endpoint gains a `useEventsTable` read path (trace + observations from the events table) with a shared response-assembly helper so both paths produce a byte-identical shape.
- Hardened the V1 `transformDbToApiObservation` to strip events-table-only fields (`traceTimestamp`, `toolDefinitionsCount`, `toolCallsCount`) that aren't part of the V1 `APIObservation` contract.
- Added a dual-path integration test for the single-trace endpoint.

`useEventsTable` is kept as an internal toggle and intentionally **not** added to the Fern/public contract.

## Known events-vs-legacy differences surfaced by the experiment

These are expected and will show up as `field_mismatch` metrics, not bugs in this PR:
- The events model surfaces the **root trace event as an observation**, so the single-trace observation list has one extra entry vs legacy.
- The single-trace endpoint derives `totalCost` from `cost_details` while the list endpoint uses `total_cost`.

## Testing

- `traces-api.servertest.ts`: 82 passed (both events + legacy paths)
- `observations-api.servertest.ts` (V1): 24 passed
- `observations-api-v2.servertest.ts`: 37 passed
- `eventsTableExperiment.test.ts` (diff util): 11 passed
- typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a sampled shadow-comparison experiment for `GET /api/public/traces` and `GET /api/public/traces/{id}`: on a configurable fraction of requests both read paths (legacy `traces`/`observations` tables and the new events table) are executed, their results are diffed field-by-field, and latency + mismatch metrics are emitted. The data returned to the caller is never changed.

- New `eventsTableExperiment.ts` module provides `runEventsTableExperiment`, `diffResults`, and `shouldRunEventsTableExperiment` with unit tests covering normalization, ordering tolerance, and numeric epsilon.
- `[traceId].ts` gains a full events-table read path (`getTraceByIdFromEventsTable` + `getObservationsForTraceFromEventsTable`) and a shared `assembleTraceResponse` helper; both paths now route through the experiment runner.
- `transformDbToApiObservation` is hardened to strip events-table-only fields (`traceTimestamp`, `toolDefinitionsCount`, `toolCallsCount`) that are not part of the V1 `APIObservation` contract.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change is safe for callers — returned data is unaffected — but the shadow read runs synchronously in the request path, so turning the experiment on at any non-trivial sample rate will visibly increase p99 latency for trace API consumers.

The experiment runner always awaits the shadow path before returning, which means every sampled request pays the full round-trip cost of a second ClickHouse query. With a sample rate as low as 10%, one in ten API calls would experience roughly doubled response time. The metric emission when the sample rate is 0 is a lesser concern but adds surprising cardinality to the observability stack. These issues are confined to eventsTableExperiment.ts and the two route handlers — the correctness of the diff logic and the data-path isolation look solid.

packages/shared/src/server/repositories/eventsTableExperiment.ts — specifically the sequential shadow-read execution and the unconditional histogram emission.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as API Caller
    participant Handler as Route Handler
    participant Exp as runEventsTableExperiment
    participant Sel as Selected Path (events/legacy)
    participant Shadow as Shadow Path (other)
    participant Metrics as OTel Metrics

    Caller->>Handler: "GET /api/public/traces[/{id}]"
    Handler->>Exp: "runEventsTableExperiment({selected, events, legacy, compare})"
    Exp->>Sel: await selectedFn()
    Sel-->>Exp: selectedResult
    Exp->>Metrics: "recordHistogram(latency_ms, source=selected)"
    alt "shouldRunEventsTableExperiment() == false"
        Exp-->>Handler: selectedResult
    else "shouldRunEventsTableExperiment() == true (sampled)"
        Exp->>Shadow: await otherFn() [SERIAL - blocks response]
        Shadow-->>Exp: otherResult
        Exp->>Metrics: "recordHistogram(latency_ms, source=other)"
        Exp->>Exp: compare(legacyResult, eventsResult)
        Exp->>Metrics: "recordIncrement(result, match=true/false)"
        opt diffs present
            Exp->>Metrics: recordIncrement(field_mismatch, per field)
            Exp->>Exp: logger.info(mismatch, diffs)
        end
        Exp-->>Handler: selectedResult
    end
    Handler-->>Caller: HTTP response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as API Caller
    participant Handler as Route Handler
    participant Exp as runEventsTableExperiment
    participant Sel as Selected Path (events/legacy)
    participant Shadow as Shadow Path (other)
    participant Metrics as OTel Metrics

    Caller->>Handler: "GET /api/public/traces[/{id}]"
    Handler->>Exp: "runEventsTableExperiment({selected, events, legacy, compare})"
    Exp->>Sel: await selectedFn()
    Sel-->>Exp: selectedResult
    Exp->>Metrics: "recordHistogram(latency_ms, source=selected)"
    alt "shouldRunEventsTableExperiment() == false"
        Exp-->>Handler: selectedResult
    else "shouldRunEventsTableExperiment() == true (sampled)"
        Exp->>Shadow: await otherFn() [SERIAL - blocks response]
        Shadow-->>Exp: otherResult
        Exp->>Metrics: "recordHistogram(latency_ms, source=other)"
        Exp->>Exp: compare(legacyResult, eventsResult)
        Exp->>Metrics: "recordIncrement(result, match=true/false)"
        opt diffs present
            Exp->>Metrics: recordIncrement(field_mismatch, per field)
            Exp->>Exp: logger.info(mismatch, diffs)
        end
        Exp-->>Handler: selectedResult
    end
    Handler-->>Caller: HTTP response
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/shared/src/server/repositories/eventsTableExperiment.ts:266-295
**Shadow read runs serially, blocking the API response**

The shadow path is `await`-ed sequentially after the selected path has already completed. For any sampled request the total handler time becomes `selected_latency + shadow_latency` instead of `max(selected_latency, shadow_latency)`. Since both paths hit ClickHouse for the same trace data, shadow latency will typically be comparable to selected latency, meaning sampled requests could take roughly 2× longer than unshadowed ones.

Running both paths in parallel with `Promise.allSettled` eliminates the additive cost: the response latency is bounded by whichever path takes longer, and the shadow error-handling logic already present can stay identical.

### Issue 2 of 3
packages/shared/src/server/repositories/eventsTableExperiment.ts:258-264
**Latency histogram is emitted on every request even when the experiment is off**

`recordHistogram("langfuse.events_table_experiment.latency_ms", ...)` is called unconditionally for the selected path — before the `shouldRunEventsTableExperiment()` gate — so it fires on 100% of trace API requests regardless of `LANGFUSE_EVENTS_TABLE_EXPERIMENT_SAMPLE_RATE`. Setting the rate to `0` disables the shadow read and comparison metrics but still emits the latency metric. This may cause unexpected high-cardinality metric volume in deployments where the experiment is "off".

### Issue 3 of 3
packages/shared/src/server/repositories/eventsTableExperiment.ts:115-123
**`numericFields` epsilon tolerance silently skips `Decimal` observation fields**

`collectDiffs` only applies the epsilon tolerance when `typeof legacy === "number" && typeof events === "number"`. Observation price fields (`calculatedTotalCost`, `inputPrice`, `outputPrice`, `totalPrice`) are `Decimal | null` objects returned by `transformDbToApiObservation`, not JS primitives. These fields are listed in the `numericFields` set at the call site, but they'll fall through to the object comparison branch, meaning tiny floating-point variations between the two ClickHouse paths could register as false-positive diffs.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add events-table shado..."](https://github.com/langfuse/langfuse/commit/98c4afefcd061d4054377d2f974ed8436b27c910) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37994487)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->