### PR TITLE
feat(worker): add blob_storage_integrations to core data S3 export (LFE-10061)

### DIFF
--- a/worker/src/queues/coreDataS3ExportQueue.ts
+++ b/worker/src/queues/coreDataS3ExportQueue.ts
@@ -126,6 +126,7 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
     projectMemberships,
     billingMeterBackup,
     surveys,
+    blobStorageIntegrations,
   ] = await Promise.all([
     prisma.project.findMany({
       select: {
@@ -188,6 +189,32 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
         createdAt: true,
       },
     }),
+    prisma.blobStorageIntegration.findMany({
+      select: {
+        projectId: true,
+        type: true,
+        bucketName: true,
+        prefix: true,
+        region: true,
+        endpoint: true,
+        forcePathStyle: true,
+        nextSyncAt: true,
+        lastSyncAt: true,
+        enabled: true,
+        exportFrequency: true,
+        fileType: true,
+        exportMode: true,
+        exportStartDate: true,
+        exportSource: true,
+        exportFieldGroups: true,
+        compressed: true,
+        lastError: true,
+        lastErrorAt: true,
+        lastFailureNotificationSentAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    }),
   ]);
 
   // Iterate through the tables and upload them to S3 as JSONLs
@@ -200,6 +227,7 @@ export const coreDataS3ExportProcessor: Processor = async (): Promise<void> => {
       projectMemberships,
       billingMeterBackup,
       surveys,
+      blobStorageIntegrations,
     }).map(async ([key, value]) =>
       s3Client.uploadFile({
         fileName: `${env.LANGFUSE_S3_CORE_DATA_UPLOAD_PREFIX}${key}.jsonl`,


### PR DESCRIPTION
## What does this PR do?

Adds the `blob_storage_integrations` Postgres table to the `coreDataS3ExportProcessor`, following the same pattern as existing tables (projects, users, organizations, etc.).

- Fetches `BlobStorageIntegration` rows via Prisma `findMany` with an explicit `select` of safe fields only
- **Credentials excluded**: `accessKeyId` and `secretAccessKey` are intentionally omitted from the select to ensure they are never written to S3
- Uploads as `blobStorageIntegrations.jsonl` alongside the other core data JSONL files

### Fields exported
`projectId`, `type`, `bucketName`, `prefix`, `region`, `endpoint`, `forcePathStyle`, `nextSyncAt`, `lastSyncAt`, `enabled`, `exportFrequency`, `fileType`, `exportMode`, `exportStartDate`, `exportSource`, `exportFieldGroups`, `compressed`, `lastError`, `lastErrorAt`, `lastFailureNotificationSentAt`, `createdAt`, `updatedAt`

## Type of change

- [x] Feature (non-breaking change which adds functionality)

## Checklist

- [x] Selected the correct base branch
- [x] Linter and typechecker pass
- [x] Credentials (`accessKeyId`, `secretAccessKey`) explicitly excluded from Prisma select

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the `coreDataS3ExportProcessor` to include the `blob_storage_integrations` Postgres table in the existing core-data S3 export job, following the same pattern used for projects, users, organizations, and other metadata tables.

- A new `prisma.blobStorageIntegration.findMany()` call with an explicit field `select` is added to the parallel fetch block; `accessKeyId` and `secretAccessKey` are correctly excluded.
- The fetched rows are serialised as `blobStorageIntegrations.jsonl` and uploaded alongside the other JSONL files.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a straightforward, low-risk addition that follows the existing export pattern; the deliberate exclusion of credential fields is the most important concern and was handled correctly.

The two findings are non-blocking quality concerns: the `lastError` field warrants a security audit of what error messages are stored, and the unbounded `findMany` is consistent with all other tables in the same function but could become a memory issue as the table grows. Neither represents an immediate defect in the changed code path.

worker/src/queues/coreDataS3ExportQueue.ts — specifically the `lastError` field inclusion and the lack of pagination on the new `findMany` call.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Potential sensitive data in `lastError` field** (`coreDataS3ExportQueue.ts`, `blobStorageIntegration` select): Error messages from failed cloud-storage connections can embed endpoint URLs, bucket names, or SDK-level credential hints. The explicit exclusion of `accessKeyId` / `secretAccessKey` is correct, but `lastError` content is not sanitised before storage and may carry equivalent information depending on SDK verbosity.
- No other credential leakage or injection vectors were identified in the changed code.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant W as Worker (coreDataS3ExportProcessor)
    participant DB as Postgres (Prisma)
    participant S3 as S3 Bucket

    W->>DB: Promise.all([project, user, org, orgMembership, projectMembership,\n billingMeterBackup, survey, blobStorageIntegration].findMany())
    DB-->>W: All rows (credentials excluded from blobStorageIntegration)

    par Upload JSONL files
        W->>S3: projects.jsonl
        W->>S3: users.jsonl
        W->>S3: organizations.jsonl
        W->>S3: orgMemberships.jsonl
        W->>S3: projectMemberships.jsonl
        W->>S3: billingMeterBackup.jsonl
        W->>S3: surveys.jsonl
        W->>S3: blobStorageIntegrations.jsonl  [NEW]
    end

    W->>DB: prompt.findMany() (paginated)
    DB-->>W: prompt pages
    W->>S3: prompts.jsonl (buffered multipart)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant W as Worker (coreDataS3ExportProcessor)
    participant DB as Postgres (Prisma)
    participant S3 as S3 Bucket

    W->>DB: Promise.all([project, user, org, orgMembership, projectMembership,\n billingMeterBackup, survey, blobStorageIntegration].findMany())
    DB-->>W: All rows (credentials excluded from blobStorageIntegration)

    par Upload JSONL files
        W->>S3: projects.jsonl
        W->>S3: users.jsonl
        W->>S3: organizations.jsonl
        W->>S3: orgMemberships.jsonl
        W->>S3: projectMemberships.jsonl
        W->>S3: billingMeterBackup.jsonl
        W->>S3: surveys.jsonl
        W->>S3: blobStorageIntegrations.jsonl  [NEW]
    end

    W->>DB: prompt.findMany() (paginated)
    DB-->>W: prompt pages
    W->>S3: prompts.jsonl (buffered multipart)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/queues/coreDataS3ExportQueue.ts:213
**`lastError` may contain sensitive configuration data**

The `lastError` field is included in the export, but error messages from failed blob-storage connections sometimes embed the endpoint URL, bucket name, region, or — in verbose SDK output — partial credential hints. Since `accessKeyId` and `secretAccessKey` are explicitly excluded to prevent credential leakage, it is worth auditing whether the error messages stored in this column can contain equivalent information (e.g., `InvalidAccessKeyId` responses that echo the key ID, or SDK debug strings). If error messages are not sanitised before storage, consider omitting or redacting `lastError` from the export.

### Issue 2 of 2
worker/src/queues/coreDataS3ExportQueue.ts:192-217
**Unbounded `findMany` on a potentially large table**

`blobStorageIntegration.findMany()` loads the entire table into memory in a single query, consistent with the other tables in this export. For most of those tables (users, organizations, projects) the row counts are bounded by customer count. `blob_storage_integrations` is per-project, so at scale it can grow significantly larger. If the table is large, this will cause high memory pressure and could OOM the worker process. Consider adding pagination (similar to `uploadPromptsCoreDataJsonl`) or at least an upper-bound sanity check, especially as this table grows with product adoption.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): add blob\_storage\_integrati..."](https://github.com/langfuse/langfuse/commit/ab43df03cb53302e9e76f0aed2a6ca40baa60041) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38083391)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->