### PR TITLE
fix(blob-storage): trim credentials before encryption to prevent SignatureDoesNotMatch

### DIFF
--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -74,6 +74,9 @@ export async function upsertBlobStorageIntegration(params: {
   const canUseHostCredentials =
     isSelfHosted && data.type === BlobStorageIntegrationType.S3;
 
+  const accessKeyId = data.accessKeyId?.trim() || null;
+  const secretAccessKey = data.secretAccessKey?.trim() || null;
+
   if (data.endpoint) {
     try {
       await validateBlobStorageEndpoint(data.endpoint);
@@ -84,7 +87,7 @@ export async function upsertBlobStorageIntegration(params: {
     }
   }
 
-  if (!canUseHostCredentials && !data.accessKeyId) {
+  if (!canUseHostCredentials && !accessKeyId) {
     throw new InvalidRequestError(
       "Access Key ID and Secret Access Key are required",
     );
@@ -100,7 +103,7 @@ export async function upsertBlobStorageIntegration(params: {
     bucketName: data.bucketName,
     endpoint: data.endpoint,
     region: data.region,
-    accessKeyId: data.accessKeyId?.trim() || null,
+    accessKeyId,
     prefix: data.prefix,
     exportFrequency: data.exportFrequency,
     enabled: data.enabled,
@@ -122,8 +125,8 @@ export async function upsertBlobStorageIntegration(params: {
     // Require secret key for new integrations (unless using host credentials)
     if (!existing) {
       const isUsingHostCredentials =
-        canUseHostCredentials && (!data.accessKeyId || !data.secretAccessKey);
-      if (!isUsingHostCredentials && !data.secretAccessKey) {
+        canUseHostCredentials && (!accessKeyId || !secretAccessKey);
+      if (!isUsingHostCredentials && !secretAccessKey) {
         throw new InvalidRequestError(
           "Secret access key is required for new configuration",
         );
@@ -131,8 +134,7 @@ export async function upsertBlobStorageIntegration(params: {
     }
 
     const modeChanged = existing && existing.exportMode !== data.exportMode;
-    const trimmedSecret = data.secretAccessKey?.trim() || null;
-    const encryptedSecret = trimmedSecret ? encrypt(trimmedSecret) : null;
+    const encryptedSecret = secretAccessKey ? encrypt(secretAccessKey) : null;
 
     // exportSource for the CREATE payload. The !existing guard was previously
     // here, but it created a residual TOCTOU: READ COMMITTED isolation means

--- a/web/src/features/blobstorage-integration/service.ts
+++ b/web/src/features/blobstorage-integration/service.ts
@@ -100,7 +100,7 @@ export async function upsertBlobStorageIntegration(params: {
     bucketName: data.bucketName,
     endpoint: data.endpoint,
     region: data.region,
-    accessKeyId: data.accessKeyId,
+    accessKeyId: data.accessKeyId?.trim() || null,
     prefix: data.prefix,
     exportFrequency: data.exportFrequency,
     enabled: data.enabled,
@@ -131,9 +131,8 @@ export async function upsertBlobStorageIntegration(params: {
     }
 
     const modeChanged = existing && existing.exportMode !== data.exportMode;
-    const encryptedSecret = data.secretAccessKey
-      ? encrypt(data.secretAccessKey)
-      : null;
+    const trimmedSecret = data.secretAccessKey?.trim() || null;
+    const encryptedSecret = trimmedSecret ? encrypt(trimmedSecret) : null;
 
     // exportSource for the CREATE payload. The !existing guard was previously
     // here, but it created a residual TOCTOU: READ COMMITTED isolation means


### PR DESCRIPTION
## What does this PR do?

Trims `accessKeyId` and `secretAccessKey` before encryption in the blob storage integration upsert service. Users pasting AWS credentials from terminals or password managers often include trailing whitespace or newlines. Since there was no `.trim()` anywhere in the write path, the whitespace was faithfully encrypted, stored, decrypted, and passed to the AWS SDK — causing S3 to reject the request with `SignatureDoesNotMatch`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to test
1. Configure a blob storage integration with a secret key that has trailing whitespace
2. Verify the exporter connects successfully (previously would fail with `SignatureDoesNotMatch`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I ran linting and formatting checks locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR trims `accessKeyId` and `secretAccessKey` before storage and encryption to fix `SignatureDoesNotMatch` errors caused by trailing whitespace in pasted AWS credentials. The core fix is correct and targets the right point in the write path.

- `accessKeyId` is trimmed in the `writeData` object (line 103) and `secretAccessKey` is trimmed before `encrypt()` (line 134), so whitespace is stripped before anything reaches the DB or AWS SDK.
- Both validation guards (`!data.accessKeyId` at line 87 and `!data.secretAccessKey` at line 126) still operate on the original, untrimmed values. A whitespace-only string is truthy and passes validation, but the trimmed result is `null` — so a new integration can be created with `secretAccessKey: null` without triggering the \"required\" error, and an update can silently overwrite a valid existing key with `null`.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The fix correctly addresses the pasted-credential whitespace bug, but the validation guards were not updated to match, leaving a gap where whitespace-only inputs silently bypass required-field checks and produce null in the database.

The trimming happens after the two 'is this field present?' guards, so a user submitting only whitespace for accessKeyId or secretAccessKey passes validation but ends up with null stored. On a CREATE this produces an integration with a missing secret key; on an UPDATE this can silently wipe the existing key. The fix is otherwise targeted and correct for its stated goal.

web/src/features/blobstorage-integration/service.ts — the two validation guards before the transaction and inside the 'new integration' block need to reference the trimmed values.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Service as upsertBlobStorageIntegration
    participant DB as Prisma / DB
    participant AWS as AWS S3

    Client->>Service: "data { accessKeyId, secretAccessKey }"
    Service->>Service: validate endpoint (if set)
    Service->>Service: "check !canUseHostCredentials && !accessKeyId"
    Service->>Service: "accessKeyId = data.accessKeyId?.trim() || null"
    Service->>DB: BEGIN TRANSACTION
    DB-->>Service: existing row (or null)
    Service->>Service: "check !existing && !secretAccessKey"
    Service->>Service: "trimmedSecret = data.secretAccessKey?.trim() || null"
    Service->>Service: "encryptedSecret = trimmedSecret ? encrypt(trimmedSecret) : null"
    Service->>DB: UPSERT blobStorageIntegration (accessKeyId trimmed, secret encrypted)
    DB-->>Service: result row
    Service->>Service: validate refuseLegacyOnCreate if applicable
    Service->>DB: COMMIT
    DB-->>Service: committed
    Service-->>Client: result

    Note over Service,AWS: Later — exporter uses trimmed credentials
    AWS-->>Service: no SignatureDoesNotMatch
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Service as upsertBlobStorageIntegration
    participant DB as Prisma / DB
    participant AWS as AWS S3

    Client->>Service: "data { accessKeyId, secretAccessKey }"
    Service->>Service: validate endpoint (if set)
    Service->>Service: "check !canUseHostCredentials && !accessKeyId"
    Service->>Service: "accessKeyId = data.accessKeyId?.trim() || null"
    Service->>DB: BEGIN TRANSACTION
    DB-->>Service: existing row (or null)
    Service->>Service: "check !existing && !secretAccessKey"
    Service->>Service: "trimmedSecret = data.secretAccessKey?.trim() || null"
    Service->>Service: "encryptedSecret = trimmedSecret ? encrypt(trimmedSecret) : null"
    Service->>DB: UPSERT blobStorageIntegration (accessKeyId trimmed, secret encrypted)
    DB-->>Service: result row
    Service->>Service: validate refuseLegacyOnCreate if applicable
    Service->>DB: COMMIT
    DB-->>Service: committed
    Service-->>Client: result

    Note over Service,AWS: Later — exporter uses trimmed credentials
    AWS-->>Service: no SignatureDoesNotMatch
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/blobstorage-integration/service.ts:87-91
The two validation guards still read untrimmed values while the stored values are trimmed. A whitespace-only `accessKeyId` (e.g. `"   "`) is truthy, so the guard at line 87 passes, but `"   ".trim() || null` → `null` gets written to the DB. On an UPDATE this silently replaces a valid existing key with `null`; on a CREATE it stores `null` and bypasses the "required" error. The same mismatch exists for `secretAccessKey` at line 126. Trimming before validation keeps the two paths consistent.

```suggestion
  const trimmedAccessKeyId = data.accessKeyId?.trim() || null;
  if (!canUseHostCredentials && !trimmedAccessKeyId) {
    throw new InvalidRequestError(
      "Access Key ID and Secret Access Key are required",
    );
  }
```

### Issue 2 of 2
web/src/features/blobstorage-integration/service.ts:126-130
Similarly, the "secret required for new integrations" guard at line 126 tests the untrimmed `data.secretAccessKey`. A whitespace-only secret passes this check but `trimmedSecret` becomes `null`, so a brand-new integration gets `secretAccessKey: null` stored without any error being raised. Checking the already-computed `trimmedSecret` keeps validation in sync with what actually gets persisted.

```suggestion
      if (!isUsingHostCredentials && !trimmedSecret) {
        throw new InvalidRequestError(
          "Secret access key is required for new configuration",
        );
      }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blob-storage): trim credentials befo..."](https://github.com/langfuse/langfuse/commit/4a16618073febb93801877a13741b3a5755261cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38084964)</sub>

<!-- /greptile_comment -->