### PR TITLE
chore(deps): bump protobufjs to 7.6.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,8 +715,8 @@ importers:
         specifier: ^6.19.3
         version: 6.19.3(magicast@0.5.2)(typescript@5.9.2)
       protobufjs:
-        specifier: 7.6.1
-        version: 7.6.1
+        specifier: 7.6.3
+        version: 7.6.3
       rate-limiter-flexible:
         specifier: ^5.0.4
         version: 5.0.5
@@ -9799,8 +9799,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.6.1:
-    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
+  protobufjs@7.6.3:
+    resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
     engines: {node: '>=12.0.0'}
 
   protocols@2.0.2:
@@ -13271,7 +13271,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.1
+      protobufjs: 7.6.3
       yargs: 17.7.2
 
   '@heroicons/react@2.2.0(react@19.2.4)':
@@ -14482,7 +14482,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.6.1
+      protobufjs: 7.6.3
 
   '@opentelemetry/otlp-transformer@0.218.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -21697,7 +21697,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.6.1:
+  protobufjs@7.6.3:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/web/package.json
+++ b/web/package.json
@@ -146,7 +146,7 @@
     "prexit": "^2.2.0",
     "prism-react-renderer": "^2.4.1",
     "prisma": "^6.19.3",
-    "protobufjs": "7.6.1",
+    "protobufjs": "7.6.3",
     "rate-limiter-flexible": "^5.0.4",
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Bumps `protobufjs` from `7.6.1` to `7.6.3` in `web/package.json` and regenerates the lockfile accordingly.

- Version pin updated in `web/package.json`; the exact-version constraint (no `^`/`~`) is preserved as before.
- `pnpm-lock.yaml` snapshots updated for `protobufjs` itself and its two consumers — `@opentelemetry/otlp-transformer` and the `@protobufjs/codegen` snapshot.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Routine patch-level dependency bump with no logic changes; lockfile is consistent with the manifest update.

Both changed files are mechanical: one manifest line and the corresponding lockfile regeneration. The 7.6.3 release is within the maintained 7.x line and both known CVEs for that line (RCE via type-name injection and unbounded JSON recursion) were patched at 7.5.5 and 7.5.8 respectively — versions well below 7.6.1, so 7.6.1 was not actually vulnerable to those CVEs either. The bump still picks up any intermediate bug fixes in 7.6.2/7.6.3.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["web/package.json\n(protobufjs 7.6.1 → 7.6.3)"] --> B["pnpm-lock.yaml\nimporters section updated"]
    B --> C["packages section\nresolution integrity hash updated"]
    C --> D["snapshots section\n@protobufjs/codegen snapshot updated"]
    C --> E["snapshots section\n@opentelemetry/otlp-transformer snapshot updated"]
    D --> F["protobufjs@7.6.3\n(resolved, all deps unchanged)"]
    E --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["web/package.json\n(protobufjs 7.6.1 → 7.6.3)"] --> B["pnpm-lock.yaml\nimporters section updated"]
    B --> C["packages section\nresolution integrity hash updated"]
    C --> D["snapshots section\n@protobufjs/codegen snapshot updated"]
    C --> E["snapshots section\n@opentelemetry/otlp-transformer snapshot updated"]
    D --> F["protobufjs@7.6.3\n(resolved, all deps unchanged)"]
    E --> F
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into nimar/protobufj..."](https://github.com/langfuse/langfuse/commit/6720a60d129e57f419d39619361ec37c15cbc29d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38095101)</sub>

<!-- /greptile_comment -->