### PR TITLE
chore(deps): bump dompurify to 3.4.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,8 +652,8 @@ importers:
         specifier: ^8.0.4
         version: 8.0.4
       dompurify:
-        specifier: ^3.4.6
-        version: 3.4.6
+        specifier: ^3.4.9
+        version: 3.4.9
       fastest-levenshtein:
         specifier: ^1.0.16
         version: 1.0.16
@@ -7109,8 +7109,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.6:
-    resolution: {integrity: sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==}
+  dompurify@3.4.9:
+    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -18465,7 +18465,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.6:
+  dompurify@3.4.9:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -20680,7 +20680,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.6
+      dompurify: 3.4.9
       es-toolkit: 1.45.1
       katex: 0.16.45
       khroma: 2.1.0
@@ -21620,7 +21620,7 @@ snapshots:
       '@posthog/core': 1.27.9
       '@posthog/types': 1.372.5
       core-js: 3.38.1
-      dompurify: 3.4.6
+      dompurify: 3.4.9
       fflate: 0.4.8
       preact: 10.28.2
       query-selector-shadow-dom: 1.0.1

--- a/web/package.json
+++ b/web/package.json
@@ -125,7 +125,7 @@
     "dd-trace": "5.97.0",
     "decimal.js": "^10.4.3",
     "diff": "^8.0.4",
-    "dompurify": "^3.4.6",
+    "dompurify": "^3.4.9",
     "fastest-levenshtein": "^1.0.16",
     "https-proxy-agent": "^7.0.6",
     "ioredis": "^5.10.1",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps DOMPurify from `3.4.6` to `3.4.9` in the `web` package to pull in the latest patch releases of the HTML sanitization library.

- `web/package.json` specifier is updated from `^3.4.6` to `^3.4.9`, and `pnpm-lock.yaml` is updated with the new resolved version and integrity hash.
- The lockfile shows DOMPurify is consumed both directly by the `web` package and transitively by `mermaid` and `posthog-js`; all three snapshots are updated consistently.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a routine patch version bump of a well-maintained HTML sanitization library with no known vulnerabilities at the new version.

The change is limited to updating DOMPurify from 3.4.6 to 3.4.9 across the manifest and lockfile. The integrity hash is correctly updated, all three lockfile snapshots (direct, mermaid, posthog-js) are consistently updated, and Snyk reports no known vulnerabilities in 3.4.9.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump dompurify to 3.4.9"](https://github.com/langfuse/langfuse/commit/f07dfc659234d50865385552bd16cf594765e938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38103741)</sub>

<!-- /greptile_comment -->