### PR TITLE
fix(support): restore hover message for gated priority options

### DIFF
--- a/web/src/features/support-chat/SupportFormSection.tsx
+++ b/web/src/features/support-chat/SupportFormSection.tsx
@@ -7,7 +7,6 @@ import {
   MESSAGE_TYPES,
   SEVERITIES,
   SEVERITY_1,
-  SEVERITY_2,
   SEVERITY_3,
   INTEGRATION_TYPES,
   TopicGroups,
@@ -30,6 +29,11 @@ import {
   FormMessage,
 } from "@/src/components/ui/form";
 import { RadioGroup } from "@/src/components/ui/radio-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/src/components/ui/tooltip";
 import {
   Select,
   SelectContent,
@@ -179,8 +183,6 @@ export function SupportFormSection({
     highestSupportPlan(
       (session.data?.user?.organizations ?? []).map((o) => o.plan),
     );
-  const isSev1Allowed = isSeverityAllowedForPlan(SEVERITY_1, effectivePlan);
-  const isSev2Allowed = isSeverityAllowedForPlan(SEVERITY_2, effectivePlan);
 
   // Tracks whether we've already warned about a short message
   const [warnedShortOnce, setWarnedShortOnce] = useState(false);
@@ -403,28 +405,36 @@ export function SupportFormSection({
                       <SelectValue placeholder="Select a priority" />
                     </SelectTrigger>
                     <SelectContent>
-                      {SEVERITIES.map((s) => (
-                        <SelectItem
-                          key={s}
-                          value={s}
-                          disabled={!isSeverityAllowedForPlan(s, effectivePlan)}
-                        >
-                          {s}
-                        </SelectItem>
-                      ))}
+                      {SEVERITIES.map((s) =>
+                        isSeverityAllowedForPlan(s, effectivePlan) ? (
+                          <SelectItem key={s} value={s}>
+                            {s}
+                          </SelectItem>
+                        ) : (
+                          // disableHoverableContent: without it, the grace
+                          // area between item and tooltip swallows the hover
+                          // when moving between the two adjacent gated items.
+                          <Tooltip key={s} disableHoverableContent>
+                            {/* Disabled items are pointer-events-none, so the
+                                wrapper div must catch the hover instead. */}
+                            <TooltipTrigger asChild>
+                              <div>
+                                <SelectItem value={s} disabled>
+                                  {s}
+                                </SelectItem>
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-xs">
+                              {s === SEVERITY_1
+                                ? "Severity 1 is available on the Team and Enterprise plans."
+                                : "Severity 2 is available on the Pro plan and above."}
+                            </TooltipContent>
+                          </Tooltip>
+                        ),
+                      )}
                     </SelectContent>
                   </Select>
                 </FormControl>
-                {/* Explain the gating for all input modalities (keyboard /
-                    screen-reader users can't reach a per-item tooltip, and a
-                    tooltip portal can stack behind the dropdown). */}
-                {!isSev1Allowed && (
-                  <FormDescription>
-                    {isSev2Allowed
-                      ? "Severity 1 is available on the Team and Enterprise plans."
-                      : "Severity 1 (Team and Enterprise) and Severity 2 (Pro and above) are not available on your current plan."}
-                  </FormDescription>
-                )}
                 <FormMessage />
               </FormItem>
             )}


### PR DESCRIPTION
## What does this PR do?

The "Email a Support Engineer" support form has a **Priority** dropdown that greys out severity levels not available on the user's plan. The hover message explaining *why* a level is unavailable was no longer shown.

In #14190 the per-item hover tooltip was deliberately replaced with a static `FormDescription` below the dropdown, because the tooltip rendered behind the open dropdown (portal z-index) and was unreachable for keyboard/screen-reader users (Radix Select skips disabled items).

This PR restores the per-option hover tooltip and removes the description text:

- Each gated (disabled) `SelectItem` is wrapped in a `TooltipTrigger` via a plain `div` — disabled items are `pointer-events-none` and never receive hover, so the wrapper catches it instead.
- The current `TooltipContent` renders at `z-9999` (above the select's `z-50`), so the original portal-stacking problem no longer applies.
- `disableHoverableContent` is set so the tooltip hands off cleanly when sliding the cursor between the two adjacent gated items (otherwise the grace area swallows the transition).
- Per-option copy: **Severity 1** → Team/Enterprise, **Severity 2** → Pro and above.

### Reviewer note

This intentionally reverses the accessibility trade-off from #14190: because Radix Select skips disabled items during keyboard navigation, keyboard/screen-reader users will no longer encounter the plan explanation. The static `FormDescription` was the accessible fallback; it has been removed per the requested design.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Verification

Reviewed in a real browser (Playwright MCP) on a Hobby-plan org via the seeded demo user:

- Severity 1 and Severity 2 show greyed out; hovering each shows its tooltip **above** the open dropdown.
- Sliding the cursor between the two gated items hands the tooltip over correctly in both directions, with only one tooltip visible at a time.
- `pnpm --filter web run lint` passes; all 1299 web client tests pass (`supportCaseSeverity.clienttest.ts` included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores per-option hover tooltips for gated Priority dropdown items in the support form, replacing the static `FormDescription` added in #14190. Each disabled `SelectItem` is wrapped in a `Tooltip` whose `div` trigger catches hover events (since disabled items carry `pointer-events: none`), with `disableHoverableContent` preventing grace-area bleed when the cursor slides between the two adjacent gated items.

- Removes the pre-computed `isSev1Allowed`/`isSev2Allowed` booleans and calls `isSeverityAllowedForPlan` inline per item, splitting the map into two branches (enabled vs disabled).
- Adds `Tooltip`/`TooltipTrigger`/`TooltipContent` imports; `TooltipProvider` is already global in `_app.tsx` so no local wrapper is needed.
- Removes the conditional `FormDescription` fallback; the PR description explicitly notes this reverses the keyboard/screen-reader accessibility trade-off from #14190.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is limited to the support form Priority dropdown and only affects how plan-gating tooltips appear on disabled items.

The div-wrapper/TooltipTrigger pattern, disableHoverableContent flag, and z-9999 stacking are all implemented correctly. TooltipProvider is global in _app.tsx so no local wrapper is needed. The only notable fragility is the else-branch tooltip message hardcoding "Severity 2" without using a constant, but this cannot produce wrong output with the current data model.

web/src/features/support-chat/SupportFormSection.tsx — specifically the else-branch tooltip message at lines 427–431 if the severity schema is ever extended.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/support-chat/SupportFormSection.tsx:427-431
**Hardcoded "Severity 2" message in the else branch**

The `else` branch implicitly assumes any non-`SEVERITY_1` gated item is Severity 2. This is correct today because `isSeverityAllowedForPlan` only gates `SEVERITY_1` and `SEVERITY_2` (Severity 3 always returns `true`), but the constant `SEVERITY_2` was removed from the import list as part of this PR. If a future Severity 4 were added and gated, the else branch would silently show the wrong message ("Severity 2…") for it. Re-importing `SEVERITY_2` and using `s === SEVERITY_2 ? ... : ...` (with an explicit fallback) would make the mapping exhaustive and easier to audit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(support): restore hover message for ..."](https://github.com/langfuse/langfuse/commit/a72a3a90a35726b9be5ecf08aef49ac6fe2db580) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38106078)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->