### PR TITLE
fix(callouts): ratelimits should fail open

### DIFF
--- a/web/src/__tests__/server/unit/web-callout-rate-limit.servertest.ts
+++ b/web/src/__tests__/server/unit/web-callout-rate-limit.servertest.ts
@@ -59,11 +59,6 @@ describe("web callout rate limiting", () => {
     }) as any;
 
   const pending = () => new Promise<never>(() => undefined);
-  const expectUnavailable = (promise: Promise<unknown>) =>
-    expect(promise).rejects.toMatchObject({
-      code: "TOO_MANY_REQUESTS",
-      message: "Web callout invocation is temporarily unavailable.",
-    });
 
   beforeEach(() => {
     (env as any).LANGFUSE_RATE_LIMITS_ENABLED = "true";
@@ -80,7 +75,7 @@ describe("web callout rate limiting", () => {
     resetWebCalloutInFlightLimitsForTests();
   });
 
-  it("uses scoped 10/60 Redis buckets, shares cold connects, and fails closed", async () => {
+  it("uses scoped 10/60 Redis buckets, shares cold connects, and fails open when Redis is unavailable", async () => {
     const client = redis();
     await WebCalloutRateLimitService.getInstance(client).consume(context);
 
@@ -139,17 +134,20 @@ describe("web callout rate limiting", () => {
     (env as any).LANGFUSE_RATE_LIMITS_ENABLED = "true";
 
     WebCalloutRateLimitService.shutdown();
-    await expectUnavailable(
+    await expect(
       WebCalloutRateLimitService.getInstance(null).consume(context),
-    );
+    ).resolves.toBeUndefined();
 
     WebCalloutRateLimitService.shutdown();
+    mocks.consume.mockClear();
     mocks.consume.mockRejectedValueOnce(new Error("redis down"));
-    await expectUnavailable(
+    await expect(
       WebCalloutRateLimitService.getInstance(redis()).consume(context),
-    );
+    ).resolves.toBeUndefined();
+    expect(mocks.consume).toHaveBeenCalledTimes(1);
 
     WebCalloutRateLimitService.shutdown();
+    mocks.consume.mockReset();
     mocks.consume.mockRejectedValueOnce(new (RateLimiterRes as any)(2300));
     await expect(
       WebCalloutRateLimitService.getInstance(redis()).consume(context),

--- a/web/src/__tests__/server/unit/web-callout-rate-limit.servertest.ts
+++ b/web/src/__tests__/server/unit/web-callout-rate-limit.servertest.ts
@@ -148,6 +148,19 @@ describe("web callout rate limiting", () => {
 
     WebCalloutRateLimitService.shutdown();
     mocks.consume.mockReset();
+    mocks.consume
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("redis down"));
+    await expect(
+      WebCalloutRateLimitService.getInstance(redis()).consume(context),
+    ).resolves.toBeUndefined();
+    expect(mocks.consume.mock.calls).toEqual([
+      ["org-1:project-1:endpoint-1:user-1"],
+      ["org-1:project-1:endpoint-1"],
+    ]);
+
+    WebCalloutRateLimitService.shutdown();
+    mocks.consume.mockReset();
     mocks.consume.mockRejectedValueOnce(new (RateLimiterRes as any)(2300));
     await expect(
       WebCalloutRateLimitService.getInstance(redis()).consume(context),

--- a/web/src/features/web-callouts/server/rateLimit.ts
+++ b/web/src/features/web-callouts/server/rateLimit.ts
@@ -116,17 +116,26 @@ export class WebCalloutRateLimitService {
     const redis = WebCalloutRateLimitService.redis;
 
     if (!redis) {
-      this.failClosed(context, "Redis is not configured for web callouts");
+      this.allowBecauseRateLimitUnavailable(
+        context,
+        "Redis is not configured for web callouts",
+      );
+      return;
     }
 
     if (Date.now() < this.redisUnavailableUntilMs) {
-      this.failClosed(context, "Redis is temporarily unavailable");
+      this.allowBecauseRateLimitUnavailable(
+        context,
+        "Redis is temporarily unavailable",
+      );
+      return;
     }
 
     try {
       await this.ensureRedisReady(redis);
     } catch (error) {
       this.markRedisUnavailable(context, error);
+      return;
     }
 
     const keys = limitKey(context);
@@ -145,7 +154,15 @@ export class WebCalloutRateLimitService {
       rejectIfRedisNotReady: true,
     });
 
-    await this.consumeLimiter(userLimiter, keys.user, context);
+    const userLimitAvailable = await this.consumeLimiter(
+      userLimiter,
+      keys.user,
+      context,
+    );
+    if (!userLimitAvailable) {
+      return;
+    }
+
     await this.consumeLimiter(endpointLimiter, keys.endpoint, context);
   }
 
@@ -165,9 +182,10 @@ export class WebCalloutRateLimitService {
     limiter: RateLimiterRedis,
     key: string,
     context: WebCalloutLimitContext,
-  ) {
+  ): Promise<boolean> {
     try {
       await limiter.consume(key);
+      return true;
     } catch (error) {
       if (error instanceof RateLimiterRes) {
         recordWebCalloutInvokeMetric("rate_limited", context);
@@ -178,13 +196,14 @@ export class WebCalloutRateLimitService {
       }
 
       this.markRedisUnavailable(context, error);
+      return false;
     }
   }
 
   private markRedisUnavailable(
     context: WebCalloutLimitContext,
     error: unknown,
-  ): never {
+  ) {
     this.redisUnavailableUntilMs = Date.now() + REDIS_RETRY_COOLDOWN_MS;
     logger.warn("Web callout rate limiter unavailable", {
       orgId: context.orgId,
@@ -192,18 +211,23 @@ export class WebCalloutRateLimitService {
       endpointId: context.endpointId,
       error: error instanceof Error ? error.message : "Unknown error",
     });
-    this.failClosed(context, "Redis is temporarily unavailable");
+    this.allowBecauseRateLimitUnavailable(
+      context,
+      "Redis is temporarily unavailable",
+    );
   }
 
-  private failClosed(context: WebCalloutLimitContext, reason: string): never {
+  private allowBecauseRateLimitUnavailable(
+    context: WebCalloutLimitContext,
+    reason: string,
+  ) {
     recordWebCalloutInvokeMetric("rate_limit_unavailable", context);
-    logger.warn("Web callout invocation blocked because rate limiting failed", {
+    logger.warn("Web callout invocation allowed because rate limiting failed", {
       orgId: context.orgId,
       projectId: context.projectId,
       endpointId: context.endpointId,
       reason,
     });
-    throw tooManyRequests("Web callout invocation is temporarily unavailable.");
   }
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes the web-callout rate limiter from **fail-closed** to **fail-open**: when Redis is unavailable (null client, connection cooldown, connect error, or a non-rate-limit error from `consume`), requests are now allowed through instead of rejected with `TOO_MANY_REQUESTS`. A metric (`rate_limit_unavailable`) and a warning log are still emitted so the degraded state is observable.

- `WebCalloutRateLimitService.consume` gains explicit `return` guards after every unavailability path now that `allowBecauseRateLimitUnavailable` is `void` (previously `failClosed` was typed as `never`, making returns unnecessary).
- `consumeLimiter` is updated to return `boolean` (`true` = consumed, `false` = Redis error allowed through); the user-limiter result is checked, but the endpoint-limiter result is currently ignored (harmless today but asymmetric).
- Tests are updated to assert `.resolves.toBeUndefined()` instead of `.rejects.toMatchObject({ code: "TOO_MANY_REQUESTS" })` for the unavailability cases.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The fail-open logic is correctly wired — all Redis-unavailable code paths now have explicit return statements, the actual rate-limit rejection (RateLimiterRes) is preserved, and the tests cover the key scenarios.

The core logic change is sound and the important behavioral paths are tested. Two minor gaps remain: the endpoint-limiter return value is silently discarded (asymmetric with user-limiter handling, creates a maintenance risk), and there is no test for the path where the user limiter succeeds but the endpoint limiter hits a Redis error.

The rateLimit.ts endpoint-limiter call at line 166 and the corresponding gap in web-callout-rate-limit.servertest.ts are the areas worth a second look.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[consume called] --> B{Rate limits enabled?}
    B -- No --> Z[return undefined - allowed]
    B -- Yes --> C{Redis configured?}
    C -- No --> D[allowBecauseRateLimitUnavailable]
    D --> Z
    C -- Yes --> E{Redis in cooldown?}
    E -- Yes --> F[allowBecauseRateLimitUnavailable]
    F --> Z
    E -- No --> G[ensureRedisReady]
    G -- Error --> H[markRedisUnavailable]
    H --> I[allowBecauseRateLimitUnavailable + return]
    I --> Z
    G -- OK --> J[consumeLimiter - user]
    J -- true --> K[consumeLimiter - endpoint]
    J -- RateLimiterRes --> L[throw TOO_MANY_REQUESTS]
    J -- Redis error --> M[markRedisUnavailable, return false]
    M --> N{userLimitAvailable?}
    N -- false --> Z
    N -- true --> K
    K -- true --> Z
    K -- RateLimiterRes --> L
    K -- Redis error --> O[markRedisUnavailable, return false - IGNORED]
    O --> Z
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[consume called] --> B{Rate limits enabled?}
    B -- No --> Z[return undefined - allowed]
    B -- Yes --> C{Redis configured?}
    C -- No --> D[allowBecauseRateLimitUnavailable]
    D --> Z
    C -- Yes --> E{Redis in cooldown?}
    E -- Yes --> F[allowBecauseRateLimitUnavailable]
    F --> Z
    E -- No --> G[ensureRedisReady]
    G -- Error --> H[markRedisUnavailable]
    H --> I[allowBecauseRateLimitUnavailable + return]
    I --> Z
    G -- OK --> J[consumeLimiter - user]
    J -- true --> K[consumeLimiter - endpoint]
    J -- RateLimiterRes --> L[throw TOO_MANY_REQUESTS]
    J -- Redis error --> M[markRedisUnavailable, return false]
    M --> N{userLimitAvailable?}
    N -- false --> Z
    N -- true --> K
    K -- true --> Z
    K -- RateLimiterRes --> L
    K -- Redis error --> O[markRedisUnavailable, return false - IGNORED]
    O --> Z
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/web-callouts/server/rateLimit.ts:166
**Endpoint limiter return value silently ignored**

`consumeLimiter` now returns `boolean` — `true` on success, `false` on a Redis error (fail-open). The `userLimiter` result is checked explicitly, but the `endpointLimiter` result is dropped. Today this is harmless because `false` and `true` both fall through to the implicit `return undefined` at the end of the function. However, the asymmetry is a maintenance trap: anyone adding logic after this line in the future may silently allow requests that hit a Redis error on the endpoint limiter without realising the limiter returned `false`. Consider checking the return value consistently with the user-limiter pattern.

### Issue 2 of 2
web/src/__tests__/server/unit/web-callout-rate-limit.servertest.ts:141-148
**Missing test: user limiter succeeds, endpoint limiter fails with Redis error**

The Redis-error scenario is only tested when it fires on the *first* `consume` call (user limiter), which triggers the early-return via `!userLimitAvailable`. The code path where the user limiter consumes successfully and the *endpoint* limiter then throws a non-`RateLimiterRes` error is untested — in that path the `false` return from `consumeLimiter` is silently discarded and the function returns `undefined` without an explicit early return. A targeted test (e.g. `mockResolvedValueOnce({})` then `mockRejectedValueOnce(new Error("redis down"))`) would pin this fail-open behaviour and guard against regressions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into nimar/callout-r..."](https://github.com/langfuse/langfuse/commit/7bc66a4f638cc4e5f64ce3d29c1c6d98287fd0b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38145844)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->