### PR TITLE
feat(otel): map Flue framework spans to the Langfuse data model

### DIFF
--- a/packages/shared/src/server/otel/ObservationTypeMapper.ts
+++ b/packages/shared/src/server/otel/ObservationTypeMapper.ts
@@ -409,10 +409,34 @@ export class ObservationTypeMapperRegistry {
       () => "TOOL",
     ),
 
-    // Priority 8: LiveKit spans: use span name to determine observation type
+    // Priority 8: Flue (https://flueframework.com) tool and delegated-task spans.
+    // The @flue/opentelemetry adapter emits model-turn spans with
+    // gen_ai.operation.name (handled above as GENERATION); tool and task spans
+    // only carry flue.* attributes, so they are detected here.
+    new CustomAttributeMapper(
+      "Flue",
+      8,
+      (attributes) =>
+        hasMeaningfulValue(attributes["flue.tool.name"]) ||
+        hasMeaningfulValue(attributes["flue.tool.call_id"]) ||
+        hasMeaningfulValue(attributes["flue.task.id"]) ||
+        hasMeaningfulValue(attributes["flue.task.agent"]),
+      (attributes) => {
+        if (
+          hasMeaningfulValue(attributes["flue.tool.name"]) ||
+          hasMeaningfulValue(attributes["flue.tool.call_id"])
+        ) {
+          return "TOOL";
+        }
+        // A Flue `task` is a delegated sub-agent run.
+        return "AGENT";
+      },
+    ),
+
+    // Priority 9: LiveKit spans: use span name to determine observation type
     new CustomAttributeMapper(
       "LiveKit_SpanName",
-      8,
+      9,
       (_attributes, _resourceAttributes, scopeData, spanName) => {
         if (scopeData?.name !== "livekit-agents") return false;
 
@@ -430,10 +454,10 @@ export class ObservationTypeMapperRegistry {
       },
     ),
 
-    // Priority 9: Model-based fallback
+    // Priority 10: Model-based fallback
     new CustomAttributeMapper(
       "ModelBased",
-      9,
+      10,
       (attributes, _resourceAttributes, _scopeData) => {
         const modelKeys = [
           LangfuseOtelSpanAttributes.OBSERVATION_MODEL,

--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1492,6 +1492,16 @@ export class OtelIngestionProcessor {
       // Genkit
       "genkit:input",
       "genkit:output",
+      // Flue (@flue/opentelemetry)
+      "flue.turn.input",
+      "flue.turn.output",
+      "flue.tool.arguments",
+      "flue.tool.result",
+      "flue.task.prompt",
+      "flue.task.result",
+      "flue.operation.result",
+      "flue.workflow.payload",
+      "flue.workflow.result",
     ];
 
     // Delete simple keys
@@ -1598,6 +1608,33 @@ export class OtelIngestionProcessor {
       }
 
       return { input, output, filteredAttributes };
+    }
+
+    // Flue (https://flueframework.com)
+    // The @flue/opentelemetry adapter emits content under flue.* attributes that
+    // differ by span type (model turn, tool call, delegated task, workflow,
+    // operation). Pick the input/output pair for whichever span this is. The
+    // flue.* namespace is unique, so attribute presence is a safe gate.
+    {
+      const flueInput =
+        attributes["flue.turn.input"] ??
+        attributes["flue.tool.arguments"] ??
+        attributes["flue.task.prompt"] ??
+        attributes["flue.workflow.payload"];
+      const flueOutput =
+        attributes["flue.turn.output"] ??
+        attributes["flue.tool.result"] ??
+        attributes["flue.task.result"] ??
+        attributes["flue.operation.result"] ??
+        attributes["flue.workflow.result"];
+
+      if (flueInput != null || flueOutput != null) {
+        return {
+          input: this.parseJsonPayload(flueInput) ?? flueInput ?? null,
+          output: this.parseJsonPayload(flueOutput) ?? flueOutput ?? null,
+          filteredAttributes,
+        };
+      }
     }
 
     const inputEvents = events.filter(

--- a/worker/src/queues/__tests__/otelFlueMapping.test.ts
+++ b/worker/src/queues/__tests__/otelFlueMapping.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for mapping Flue (https://flueframework.com) OpenTelemetry spans to the
+ * Langfuse data model.
+ *
+ * Flue's @flue/opentelemetry adapter converts its observe() event stream into
+ * OTel spans. Model-turn spans use the GenAI semantic conventions; workflow,
+ * operation, tool and delegated-task spans carry flue.* attributes only. This
+ * suite verifies observation types and input/output extraction for each.
+ *
+ * Flow tested: ResourceSpan -> OtelIngestionProcessor.processToEvent()
+ */
+import { describe, it, expect } from "vitest";
+import { OtelIngestionProcessor } from "@langfuse/shared/src/server";
+
+const FLUE_SCOPE = "@flue/opentelemetry";
+
+function createNanoTimestamp(nanoTime: bigint): {
+  low: number;
+  high: number;
+  unsigned: boolean;
+} {
+  const low = Number(nanoTime & BigInt(0xffffffff));
+  const high = Number(nanoTime >> BigInt(32));
+  return { low, high, unsigned: true };
+}
+
+function createBufferId(hexString: string): { type: "Buffer"; data: number[] } {
+  const buffer = Buffer.from(hexString, "hex");
+  return { type: "Buffer", data: Array.from(buffer) };
+}
+
+type Attr = { key: string; value: { stringValue: string } };
+
+function attrs(record: Record<string, string>): Attr[] {
+  return Object.entries(record).map(([key, value]) => ({
+    key,
+    value: { stringValue: value },
+  }));
+}
+
+/**
+ * Build a single-span ResourceSpan under the Flue instrumentation scope and
+ * return the processed event for that span.
+ */
+function processFlueSpan(params: {
+  name: string;
+  attributes: Record<string, string>;
+}): any {
+  const resourceSpan = {
+    resource: {
+      attributes: attrs({ "service.name": "flue-app" }),
+    },
+    scopeSpans: [
+      {
+        scope: { name: FLUE_SCOPE, version: "1.0.0-beta.1", attributes: [] },
+        spans: [
+          {
+            traceId: createBufferId("a11bbc4370b42e3646f4fb2e9ff33b53"),
+            spanId: createBufferId("57f0255417974100"),
+            name: params.name,
+            kind: 1,
+            startTimeUnixNano: createNanoTimestamp(BigInt(1714488530686000000)),
+            endTimeUnixNano: createNanoTimestamp(BigInt(1714488530687000000)),
+            attributes: attrs(params.attributes),
+          },
+        ],
+      },
+    ],
+  };
+
+  const processor = new OtelIngestionProcessor({ projectId: "test-project" });
+  const events = processor.processToEvent([resourceSpan]);
+  expect(events).toHaveLength(1);
+  return events[0];
+}
+
+describe("Flue OTel span mapping", () => {
+  it("maps a model-turn span to a GENERATION with flue.turn.input/output", () => {
+    const event = processFlueSpan({
+      name: "chat gpt-4o-mini",
+      attributes: {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.request.model": "gpt-4o-mini",
+        "gen_ai.provider.name": "openai",
+        "flue.turn.input": JSON.stringify({
+          systemPrompt: "You are a helpful assistant.",
+          messages: [{ role: "user", content: "Weather in Berlin?" }],
+        }),
+        "flue.turn.output": JSON.stringify({
+          role: "assistant",
+          content: [{ type: "text", text: "Berlin: sunny, 72 F" }],
+        }),
+      },
+    });
+
+    expect(event.type).toBe("GENERATION");
+    expect(event.input).toEqual({
+      systemPrompt: "You are a helpful assistant.",
+      messages: [{ role: "user", content: "Weather in Berlin?" }],
+    });
+    expect(event.output).toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "Berlin: sunny, 72 F" }],
+    });
+    // content attributes should not be duplicated into metadata
+    expect(event.metadata?.attributes?.["flue.turn.input"]).toBeUndefined();
+    expect(event.metadata?.attributes?.["flue.turn.output"]).toBeUndefined();
+  });
+
+  it("maps a tool span to a TOOL observation with flue.tool.arguments/result", () => {
+    const event = processFlueSpan({
+      name: "flue.tool lookup_weather",
+      attributes: {
+        "flue.tool.name": "lookup_weather",
+        "flue.tool.call_id": "call_eMtDs10B2Ijsp2DawyuUeE0r",
+        "flue.tool.arguments": JSON.stringify({ city: "Berlin" }),
+        "flue.tool.result": JSON.stringify({
+          content: [{ type: "text", text: "Berlin: sunny, 72 F" }],
+        }),
+      },
+    });
+
+    expect(event.type).toBe("TOOL");
+    expect(event.input).toEqual({ city: "Berlin" });
+    expect(event.output).toEqual({
+      content: [{ type: "text", text: "Berlin: sunny, 72 F" }],
+    });
+    expect(event.metadata?.attributes?.["flue.tool.arguments"]).toBeUndefined();
+    expect(event.metadata?.attributes?.["flue.tool.result"]).toBeUndefined();
+  });
+
+  it("maps a delegated-task span to an AGENT observation with prompt/result", () => {
+    const event = processFlueSpan({
+      name: "flue.task summarizer",
+      attributes: {
+        "flue.task.id": "task_01",
+        "flue.task.agent": "summarizer",
+        "flue.task.prompt": "Summarize the meeting notes.",
+        "flue.task.result": "The team shipped the integration.",
+      },
+    });
+
+    expect(event.type).toBe("AGENT");
+    expect(event.input).toBe("Summarize the meeting notes.");
+    expect(event.output).toBe("The team shipped the integration.");
+  });
+
+  it("maps a workflow span to a SPAN with payload/result", () => {
+    const event = processFlueSpan({
+      name: "flue.workflow tools",
+      attributes: {
+        "flue.workflow.name": "tools",
+        "flue.workflow.payload": JSON.stringify({ city: "Berlin" }),
+        "flue.workflow.result": JSON.stringify({
+          message: "The current weather in Berlin is sunny.",
+        }),
+      },
+    });
+
+    expect(event.type).toBe("SPAN");
+    expect(event.input).toEqual({ city: "Berlin" });
+    expect(event.output).toEqual({
+      message: "The current weather in Berlin is sunny.",
+    });
+  });
+
+  it("maps an operation span to a SPAN with result as output and no input", () => {
+    const event = processFlueSpan({
+      name: "flue.operation prompt",
+      attributes: {
+        "flue.operation.id": "op_01",
+        "flue.operation.kind": "prompt",
+        "flue.operation.result": JSON.stringify({ text: "done" }),
+      },
+    });
+
+    expect(event.type).toBe("SPAN");
+    expect(event.input).toBeNull();
+    expect(event.output).toEqual({ text: "done" });
+  });
+});


### PR DESCRIPTION
## Summary

Improves how spans emitted by [**Flue**](https://flueframework.com) (`@flue/opentelemetry`) map into the Langfuse data model.

Flue's OTel adapter emits spans under the `flue.*` namespace. Model-turn spans already mapped well via the GenAI semantic conventions (`gen_ai.*` → `GENERATION` with model/usage/cost), but the other span types landed as generic `SPAN`s with their prompts/results buried in `metadata.attributes` instead of the dedicated input/output fields.

This change maps the full Flue span tree correctly:

| Flue span | Type | Input | Output |
|---|---|---|---|
| `flue.workflow` | SPAN | `flue.workflow.payload` | `flue.workflow.result` |
| `flue.operation` | SPAN | — | `flue.operation.result` |
| `chat {model}` | GENERATION *(unchanged)* | `flue.turn.input` | `flue.turn.output` |
| `flue.tool` | **TOOL** | `flue.tool.arguments` | `flue.tool.result` |
| `flue.task` | **AGENT** | `flue.task.prompt` | `flue.task.result` |

## Changes

- **`ObservationTypeMapper.ts`** — new mapper: `flue.tool` spans → `TOOL`, delegated `flue.task` spans → `AGENT`. Model-turn spans continue to map via `gen_ai.operation.name`.
- **`OtelIngestionProcessor.ts`** — `extractInputAndOutput` now pulls observation input/output from the per-span-type `flue.*` attributes, and those keys are added to `potentialInputOutputKeys` so they are stripped from `metadata` (no duplication).
- **`otelFlueMapping.test.ts`** — new tests covering every Flue span type (type + input/output + metadata filtering), driven through `OtelIngestionProcessor.processToEvent`.

## Validation

Verified end-to-end against Langfuse Cloud with a real Flue agent (`openai/gpt-4o-mini` + a tool call): traces now show the tool call as a `TOOL` observation and prompts/responses in the dedicated input/output panels rather than metadata. New unit tests pass; existing OTel processor tests unaffected.

This is the platform-side fix backing the Flue integration docs page (langfuse/langfuse-docs#3123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds first-class mapping support for Flue (`@flue/opentelemetry`) spans into the Langfuse data model, covering all five Flue span types and ensuring their content lands in the dedicated `input`/`output` fields rather than `metadata.attributes`.

- **`ObservationTypeMapper.ts`**: Inserts a new Priority 8 mapper that classifies `flue.tool.*` spans as `TOOL` and `flue.task.*` spans as `AGENT`; renumbers LiveKit (8→9) and ModelBased (9→10) accordingly.
- **`OtelIngestionProcessor.ts`**: Adds nine `flue.*` keys to `potentialInputOutputKeys` for metadata deduplication, and a new extraction block in `extractInputAndOutput` that selects the correct input/output pair per span type.
- **`otelFlueMapping.test.ts`**: New test file exercising all five Flue span types end-to-end through `processToEvent`, verifying observation type, input/output values, and absence of those attributes in metadata.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the Flue mapping is additive and isolated from existing span processing paths.

The extraction block in OtelIngestionProcessor relies on attribute presence rather than a scope-name guard (unlike the Genkit and Vercel AI SDK handlers), meaning any span from an unrelated framework that happens to carry a flue.* attribute would have its input/output silently redirected. In practice the flue.* namespace is unique, but the inconsistency is worth a follow-up. All other aspects of the change—priority numbering, attribute-to-type mapping, metadata deduplication, and test coverage—are correct.

OtelIngestionProcessor.ts — the new Flue extraction block at the bottom of extractInputAndOutput.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming OTel Span] --> B{ObservationTypeMapper\npriority chain}
    B -->|Priority 1-6: Langfuse / GenAI attrs| C[GENERATION / SPAN / EVENT]
    B -->|Priority 7: gen_ai.tool.name\nor gen_ai.tool.call.id| D[TOOL]
    B -->|Priority 8 NEW: flue.tool.name\nor flue.tool.call_id| E[TOOL]
    B -->|Priority 8 NEW: flue.task.id\nor flue.task.agent| F[AGENT]
    B -->|Priority 9: livekit-agents scope| G[AGENT / TOOL]
    B -->|Priority 10: model key present| H[GENERATION]
    A --> I{extractInputAndOutput}
    I -->|langfuse.* attrs| J[Return Langfuse input/output]
    I -->|scope = genkit-tracer| K[Return genkit:input/output]
    I -->|scope = ai| L[Return Vercel AI SDK input/output]
    I -->|flue.* attrs present NEW| M[Return flue.* input/output]
    I -->|gen_ai events| N[Return gen_ai message events]
    M --> O[potentialInputOutputKeys strips flue.* from metadata]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Incoming OTel Span] --> B{ObservationTypeMapper\npriority chain}
    B -->|Priority 1-6: Langfuse / GenAI attrs| C[GENERATION / SPAN / EVENT]
    B -->|Priority 7: gen_ai.tool.name\nor gen_ai.tool.call.id| D[TOOL]
    B -->|Priority 8 NEW: flue.tool.name\nor flue.tool.call_id| E[TOOL]
    B -->|Priority 8 NEW: flue.task.id\nor flue.task.agent| F[AGENT]
    B -->|Priority 9: livekit-agents scope| G[AGENT / TOOL]
    B -->|Priority 10: model key present| H[GENERATION]
    A --> I{extractInputAndOutput}
    I -->|langfuse.* attrs| J[Return Langfuse input/output]
    I -->|scope = genkit-tracer| K[Return genkit:input/output]
    I -->|scope = ai| L[Return Vercel AI SDK input/output]
    I -->|flue.* attrs present NEW| M[Return flue.* input/output]
    I -->|gen_ai events| N[Return gen_ai message events]
    M --> O[potentialInputOutputKeys strips flue.* from metadata]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/otel/OtelIngestionProcessor.ts:1613-1638
**Flue extraction block lacks scope-name gate**

Every other SDK-specific handler in this function is guarded by `instrumentationScopeName` before touching attributes (Genkit on `"genkit-tracer"`, Vercel AI SDK on `"ai"`). The Flue block instead relies purely on attribute presence. While the `flue.*` namespace is unlikely to collide today, any third-party instrumentation library that happens to emit an attribute whose name starts with `flue.` would have its input/output silently hijacked and removed from metadata. Adding `instrumentationScopeName === "@flue/opentelemetry"` as a primary guard (consistent with the other handlers) would eliminate the ambiguity.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(otel): map Flue framework spans to ..."](https://github.com/langfuse/langfuse/commit/e43d3a675deb6ee199bceab997a9e868b1d80dfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38150743)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->