### PR TITLE
chore: retool the new style tagged time metrics with distribution

### DIFF
--- a/.agents/skills/datadog-query-recipes/references/queue-consumers.md
+++ b/.agents/skills/datadog-query-recipes/references/queue-consumers.md
@@ -194,8 +194,8 @@ Prefer the newer tagged metrics:
 <metric_base>.rate{env:<env>,type:request}
 <metric_base>.rate{env:<env>,type:failed}
 <metric_base>.rate{env:<env>,type:error}
-<metric_base>.time{env:<env>,type:wait}
-<metric_base>.time{env:<env>,type:processing}
+<metric_base>.time_distribution{env:<env>,type:wait}
+<metric_base>.time_distribution{env:<env>,type:processing}
 ```
 
 For sharded queues, use the `shard` tag when present. `shard:all` is emitted by

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -4,6 +4,7 @@ import {
   createBullMQWorkerOptionsWithRedis,
   logger,
   QueueName,
+  recordDistribution,
   recordGauge,
   recordHistogram,
   recordIncrement,
@@ -56,7 +57,7 @@ export class WorkerManager {
       recordHistogram(oldMetric + ".wait_time", waitTime, {
         unit: "milliseconds",
       });
-      recordHistogram(baseMetric + ".time", waitTime, {
+      recordDistribution(baseMetric + ".time_distribution", waitTime, {
         type: "wait",
         unit: "milliseconds",
         ...shardTag,
@@ -97,7 +98,7 @@ export class WorkerManager {
       recordHistogram(oldMetric + ".processing_time", processingTime, {
         unit: "milliseconds",
       });
-      recordHistogram(baseMetric + ".time", processingTime, {
+      recordDistribution(baseMetric + ".time_distribution", processingTime, {
         type: "processing",
         unit: "milliseconds",
         ...shardTag,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces two `recordHistogram` calls with `recordDistribution` calls for the new-style tagged worker timing metrics (`baseMetric + ".time"`). The old-metric histogram calls (`oldMetric + ".wait_time"` and `oldMetric + ".processing_time"`) are preserved, providing backward compatibility during a metric migration.

- The `wait` and `processing` time metrics under `baseMetric + ".time"` now use Datadog's server-side distribution aggregation instead of agent-side histogram aggregation, which provides globally accurate percentiles (p50/p95/p99) across multi-agent deployments.
- The `recordDistribution` function was already defined and exported from `@langfuse/shared/src/server/instrumentation/index.ts` and used in other parts of the codebase, so this is a consistent, low-risk adoption of an existing utility.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a drop-in swap from Datadog histogram to distribution for two timing metric calls, with the legacy histogram metrics left intact.

Two-line metric type swap with no logic changes and no risk to job processing. The recordDistribution helper was already in production use elsewhere in the codebase. Legacy histogram calls are preserved for backward compatibility during transition, so there is no metric gap.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BullMQ as BullMQ Job
    participant MW as metricWrapper
    participant DD as Datadog StatsD

    BullMQ->>MW: job arrives
    MW->>DD: recordIncrement(oldMetric + ".request")
    MW->>DD: "recordIncrement(baseMetric + ".rate", {type: "request"})"
    MW->>DD: recordHistogram(oldMetric + ".wait_time") [legacy]
    MW->>DD: "recordDistribution(baseMetric + ".time", {type: "wait"}) [new]"
    MW->>BullMQ: await processor(job)
    MW->>DD: recordHistogram(oldMetric + ".processing_time") [legacy]
    MW->>DD: "recordDistribution(baseMetric + ".time", {type: "processing"}) [new]"
    MW->>BullMQ: return result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BullMQ as BullMQ Job
    participant MW as metricWrapper
    participant DD as Datadog StatsD

    BullMQ->>MW: job arrives
    MW->>DD: recordIncrement(oldMetric + ".request")
    MW->>DD: "recordIncrement(baseMetric + ".rate", {type: "request"})"
    MW->>DD: recordHistogram(oldMetric + ".wait_time") [legacy]
    MW->>DD: "recordDistribution(baseMetric + ".time", {type: "wait"}) [new]"
    MW->>BullMQ: await processor(job)
    MW->>DD: recordHistogram(oldMetric + ".processing_time") [legacy]
    MW->>DD: "recordDistribution(baseMetric + ".time", {type: "processing"}) [new]"
    MW->>BullMQ: return result
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: retool the new style tagged time ..."](https://github.com/langfuse/langfuse/commit/c50a6777f28153ec8be8b7f51abb2da0da43a7ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38184914)</sub>

<!-- /greptile_comment -->