### PR TITLE
refactor(otel): gate Flue input/output extraction on instrumentation scope

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -1613,9 +1613,10 @@ export class OtelIngestionProcessor {
     // Flue (https://flueframework.com)
     // The @flue/opentelemetry adapter emits content under flue.* attributes that
     // differ by span type (model turn, tool call, delegated task, workflow,
-    // operation). Pick the input/output pair for whichever span this is. The
-    // flue.* namespace is unique, so attribute presence is a safe gate.
-    {
+    // operation). Gate on the instrumentation scope (like the Genkit and Vercel
+    // AI SDK handlers above) so a foreign span that happens to carry a flue.*
+    // attribute is never affected.
+    if (instrumentationScopeName === "@flue/opentelemetry") {
       const flueInput =
         attributes["flue.turn.input"] ??
         attributes["flue.tool.arguments"] ??


### PR DESCRIPTION
Follow-up to #14332 (already merged), addressing the review comment from `greptile-apps` on that PR.

## What

Guard the Flue input/output extraction in `extractInputAndOutput` (`packages/shared/src/server/otel/OtelIngestionProcessor.ts`) with `instrumentationScopeName === "@flue/opentelemetry"`.

## Why

Every other SDK-specific handler in that function is gated by `instrumentationScopeName` (Genkit on `"genkit-tracer"`, Vercel AI SDK on `"ai"`). The Flue block was the exception — it relied purely on `flue.*` attribute presence. While the `flue.*` namespace is very unlikely to collide today, any third-party instrumentation that emitted an attribute starting with `flue.` would have its input/output silently picked up (and stripped from metadata). Gating on the scope name removes that ambiguity and matches the established pattern.

No behavior change for real Flue spans (scope is always `@flue/opentelemetry`). The observation-type mapper is intentionally left attribute-based, consistent with the `gen_ai.*` / OpenInference type mappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR follows up on #14332 by adding an `instrumentationScopeName === "@flue/opentelemetry"` guard around the Flue input/output attribute extraction in `extractInputAndOutput`, bringing it in line with the established pattern already used for Genkit (`"genkit-tracer"`) and Vercel AI SDK (`"ai"`).

- The single-line change wraps the bare `{}` block with a proper `if` guard, ensuring that `flue.*` attributes are only promoted to input/output when the span originates from the `@flue/opentelemetry` instrumentation scope — no behavior change for real Flue spans.
- The `potentialInputOutputKeys` list (lines 1495–1504) still unconditionally strips `flue.*` attributes from `filteredAttributes` for all spans, consistent with how every other SDK's keys are handled in that list, but meaning a non-Flue span with those exact attribute names would silently lose them from metadata (a pre-existing pattern, not introduced by this PR).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a one-line guard that aligns the Flue handler with every other SDK-specific handler in the same function and has no effect on real Flue spans.

The change correctly narrows the Flue input/output extraction to spans that actually originate from the `@flue/opentelemetry` scope. The only residual concern is that `flue.*` attribute names are still unconditionally stripped from `filteredAttributes` via the `potentialInputOutputKeys` list for all spans, so a hypothetical non-Flue span with those exact attribute names would lose them from metadata silently — but this is consistent with the pre-existing pattern for every other SDK's keys in that list and effectively a carry-over from PR #14332 rather than a new regression here.

No files require special attention beyond the noted residual in `OtelIngestionProcessor.ts`.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[extractInputAndOutput called] --> B{Langfuse SDK attrs?}
    B -- yes --> C[return input/output]
    B -- no --> D{instrumentationScopeName == 'genkit-tracer'?}
    D -- yes --> E[Extract Genkit input/output - return]
    D -- no --> F{instrumentationScopeName == 'ai'?}
    F -- yes --> G[Extract Vercel AI SDK input/output - return]
    F -- no --> H{instrumentationScopeName == '@flue/opentelemetry'? NEW GATE}
    H -- yes --> I{flue.* attrs present?}
    I -- yes --> J[Extract Flue input/output - return]
    I -- no --> K[fall through]
    H -- no --> K
    K --> L[gen_ai.* events / other handlers]
    L --> M[return input/output]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[extractInputAndOutput called] --> B{Langfuse SDK attrs?}
    B -- yes --> C[return input/output]
    B -- no --> D{instrumentationScopeName == 'genkit-tracer'?}
    D -- yes --> E[Extract Genkit input/output - return]
    D -- no --> F{instrumentationScopeName == 'ai'?}
    F -- yes --> G[Extract Vercel AI SDK input/output - return]
    F -- no --> H{instrumentationScopeName == '@flue/opentelemetry'? NEW GATE}
    H -- yes --> I{flue.* attrs present?}
    I -- yes --> J[Extract Flue input/output - return]
    I -- no --> K[fall through]
    H -- no --> K
    K --> L[gen_ai.* events / other handlers]
    L --> M[return input/output]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/otel/OtelIngestionProcessor.ts:1495-1504
**Residual attribute stripping for non-Flue spans**

The `potentialInputOutputKeys` list at these lines unconditionally deletes all exact `flue.*` keys from `filteredAttributes` for every span, regardless of instrumentation scope. With this PR's gate in place, a hypothetical non-Flue span carrying one of these exact attribute names (e.g. `flue.turn.input`) will have those attributes silently dropped from metadata without them ever being promoted to input/output — they just vanish. The same pre-existing unconditional pattern applies to `ai.*` and `genkit:*` keys too, so this is consistent with the codebase, but it does mean the fix is incomplete: the input/output extraction is now properly gated, but the metadata filtering side is not.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(otel): gate Flue input/output e..."](https://github.com/langfuse/langfuse/commit/ff0a5af890d255af2bbf161d970c7f098e15e188) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38200444)</sub>

<!-- /greptile_comment -->