### PR TITLE
feat(search-bar): make the grammar search bar GA on the v4 events tables

### DIFF
--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -409,16 +409,17 @@ export default function ObservationsEventsTable({
     queryFilterOptions,
   );
 
-  // Grammar search bar (per-user Feature Preview opt-in): an ADDITIONAL editor
-  // that coexists with the facet sidebar and the two stay in sync (Datadog model).
-  // The sidebar's FilterState (+ the table's full-text search) remains the
-  // single source of truth — the bar reads from and writes to it. Only the
-  // legacy toolbar search field is replaced (full-text search — bare text and
-  // content:/input:/output: — goes inline in the bar); the sidebar and
-  // time/refresh controls stay.
-  const searchBarFlagEnabled = useSearchBarEnabled();
+  // Grammar search bar: an ADDITIONAL editor that coexists with the facet
+  // sidebar, and the two stay in sync. Generally available on the v4 events
+  // tables (no longer a per-user Feature Preview opt-in — useSearchBarEnabled()
+  // is now always true). The sidebar's FilterState (+ the table's full-text
+  // search) remains the single source of truth — the bar reads from and writes
+  // to it. Only the legacy toolbar search field is replaced (full-text search —
+  // bare text and content:/input:/output: — goes inline in the bar); the
+  // sidebar and time/refresh controls stay.
+  const searchBarEnabled = useSearchBarEnabled();
   const searchBarMode =
-    searchBarFlagEnabled &&
+    searchBarEnabled &&
     !hideControls &&
     !externalFilterState &&
     !peekContext &&

--- a/web/src/features/feature-flags/available-flags.ts
+++ b/web/src/features/feature-flags/available-flags.ts
@@ -1,5 +1,9 @@
 export const availableFlags = [
   "inAppAgent",
+  // TODO(remove ~2026-06-19): "searchBar" is retired — the grammar search bar
+  // is now GA on the v4 events tables for everyone (see useSearchBarEnabled),
+  // no longer a per-user Feature Preview opt-in. Kept as dead plumbing for a
+  // safe rollback; drop once the GA rollout is confirmed stable.
   "searchBar",
   "templateFlag",
   "excludeClickhouseRead",

--- a/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
@@ -85,15 +85,14 @@ export function ControlledFeaturePreviewModal({
       onToggle: onToggle("inAppAgent"),
       isToggling: isToggling("inAppAgent"),
     },
-    searchBar: {
-      enabled: user.featureFlags.searchBar === true,
-      // The bar renders on the new (v4) Observations and Traces tables, so flag it.
-      warningReason: user.v4BetaEnabled
-        ? undefined
-        : "The search bar appears on the new (v4) Observations and Traces tables. Turn on Fast (Preview) in the sidebar to use it after enabling this preview.",
-      onToggle: onToggle("searchBar"),
-      isToggling: isToggling("searchBar"),
-    },
+    // The "Filter Search Bar" preview is retired — the bar is now generally
+    // available on the v4 events tables for everyone (see useSearchBarEnabled),
+    // so it no longer renders a tile here. The `searchBar` flag plumbing
+    // (PreviewFlag type, PREVIEW_LABEL, registry entry, the userAccount
+    // allowlist) is kept for now so a rollback is a one-line revert; restore
+    // the `searchBar: { ... }` state entry to bring the tile back.
+    // TODO(remove ~2026-06-19): delete the dead searchBar plumbing once the GA
+    // rollout is confirmed stable — see useSearchBarEnabled for the full list.
   };
 
   return (

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
@@ -19,7 +19,11 @@ import filterSearchBarDarkIllustration from "../assets/filter-search-bar-dark.sv
 import filterSearchBarLightIllustration from "../assets/filter-search-bar-light.svg";
 
 /** Flags the Feature Preview modal can toggle. Keep in sync with the
- *  userAccount.setFeaturePreviewEnabled allowlist and available-flags.ts. */
+ *  userAccount.setFeaturePreviewEnabled allowlist and available-flags.ts.
+ *  NOTE: "searchBar" is retired (the bar is GA on the v4 events tables) and no
+ *  longer renders a tile — see ControlledFeaturePreviewModal. It is kept in the
+ *  type + registry below only as dead code for a safe rollback.
+ *  TODO(remove ~2026-06-19): drop "searchBar" here once GA is confirmed. */
 export type PreviewFlag = "inAppAgent" | "searchBar";
 
 type PreviewIllustration = {
@@ -65,6 +69,10 @@ const PREVIEW_REGISTRY: PreviewRegistryItem[] = [
       alt: "Langfuse Assistant connects traces, scores, and prompts to answer project questions.",
     },
   },
+  // TODO(remove ~2026-06-19): dead registry entry — "searchBar" is GA on the v4
+  // events tables and no longer surfaced in the dialog (no state entry in
+  // ControlledFeaturePreviewModal), so this is filtered out and never renders.
+  // Kept for a safe rollback; delete with the rest of the searchBar plumbing.
   {
     flag: "searchBar",
     title: "Filter Search Bar",

--- a/web/src/features/search-bar/README.md
+++ b/web/src/features/search-bar/README.md
@@ -6,24 +6,30 @@ coexists with the sidebar and stays in sync with it. The facet
 sidebar's `FilterState` (+ the table's full-text search) remains the single
 source of truth; the bar reads from and writes to it. Only the legacy toolbar
 search field is replaced (full-text search goes inline in the bar).
-Per-user **Feature Preview** opt-in. Based on the `langfuse-search-bar` prototype.
+Generally available on the v4 events tables (no opt-in). Based on the
+`langfuse-search-bar` prototype.
 
 ## Enablement
 
-- Per-user **Feature Preview** opt-in (sidebar user menu → Feature Preview →
-  "Filter Search Bar"), exactly like the Langfuse Assistant. Stored on
-  `user.featureFlags` (the `searchBar` flag, see
-  `features/feature-flags/available-flags.ts`); toggled via
-  `userAccount.setFeaturePreviewEnabled({ flag, enabled })`; read through the
-  session by `hooks/useSearchBarEnabled.ts`
-  (`session.user.featureFlags.searchBar`). No project metadata, no `project:update`
-  RBAC. The Feature Preview menu is Cloud-only, so the flag is Cloud-enableable.
-- `EventsTable` activates the bar only when the user enabled the preview, the
-  viewer has the **v4 beta** (the bar only renders on the v4 Observations
-  table), and the table is a full-page surface
+- **Generally available on the v4 events tables** — every user gets the bar; it
+  is no longer a per-user Feature Preview opt-in. `hooks/useSearchBarEnabled.ts`
+  now returns `true` for everyone, so the bar renders wherever the v4 events
+  table does.
+- `EventsTable` activates the bar when the table is a full-page surface
   (`!hideControls && !externalFilterState && !peekContext && !userId && !sessionId`).
-  Default off — zero changes for users who don't opt in. The Feature Preview
-  modal warns that the v4 beta is also required.
+  The **v4 beta** gate is implicit: `EventsTable` only mounts on the v4
+  Observations/Traces tables, so call sites still read as
+  `isBetaEnabled && useSearchBarEnabled()`.
+- **Rollout/rollback (temporary).** GA was shipped by force-on shim, not by
+  deleting the opt-in: `useSearchBarEnabled` hard-returns `true` and the
+  "Filter Search Bar" tile was removed from the Feature Preview modal, but the
+  `searchBar` flag plumbing is intentionally **left as dead code** for a day or
+  two so a rollback is a one-line revert. The pieces still present and marked
+  `TODO(remove ~2026-06-19)`: the `searchBar` entry in
+  `features/feature-flags/available-flags.ts`, the
+  `userAccount.setFeaturePreviewEnabled` allowlist, and the modal's
+  `PreviewFlag`/registry entry (`features/feature-previews/`). Once the rollout
+  is confirmed stable, delete those and inline `true` at the call site.
 
 ## Query language
 
@@ -180,9 +186,9 @@ committedText ──resetTo──▶ store.draft ──(type/pick/remove)──�
     sticky stack around the composer + toolbar). The time-range + refresh
     controls live in the toolbar row below the composer (next to the filter
     toggle and views), via `DataTableToolbar`'s `timeRange`/`refreshConfig`
-    props — same as non-bar mode, not in the page header. The enablement toggle
-    lives in the shared Feature Preview modal (`features/feature-previews/`),
-    not in this feature.
+    props — same as non-bar mode, not in the page header. The bar is now GA on
+    the v4 tables, so there is no enablement toggle (the retired Feature Preview
+    tile lived in `features/feature-previews/`; see Enablement above).
 
 ## Integration (EventsTable)
 

--- a/web/src/features/search-bar/hooks/useSearchBarEnabled.ts
+++ b/web/src/features/search-bar/hooks/useSearchBarEnabled.ts
@@ -1,13 +1,25 @@
-import { useSession } from "next-auth/react";
-
 /**
- * Whether the current user has opted into the grammar search bar via the
- * Feature Preview menu (sidebar user dropdown → Feature Preview → "Filter
- * Search Bar"). Per-user, stored on `user.featureFlags` (no project metadata,
- * no admin RBAC). The bar still only renders on the v4 events tables, so call
- * sites gate on `isBetaEnabled && useSearchBarEnabled()`.
+ * Whether the grammar search bar should render. It is now **generally available
+ * on the v4 events tables** — every user gets it, no longer a per-user Feature
+ * Preview opt-in. The bar still only renders on the v4 Observations/Traces
+ * tables, so call sites keep gating on `isBetaEnabled && useSearchBarEnabled()`
+ * (EventsTable only mounts in v4 mode, so the v4 gate is implicit there).
+ *
+ * TODO(remove ~2026-06-19, after the GA rollout has been stable for a day or
+ * two): this hook is now a force-on shim kept only so a rollback to the opt-in
+ * is a one-line revert (restore the `useSession` read below). Once we're
+ * confident, delete this hook and inline `true` at the call site, and remove
+ * the dead `searchBar` Feature Preview plumbing:
+ *   - `features/feature-flags/available-flags.ts` ("searchBar")
+ *   - `server/api/routers/userAccount.ts` (setFeaturePreviewEnabled allowlist)
+ *   - `features/feature-previews/components/FeaturePreviewModal.tsx` (registry
+ *     entry + `PreviewFlag` type + filter-search-bar illustration assets)
+ *   - the `searchBar` rows in `userAccount.servertest.ts` /
+ *     `FeaturePreviewModal.stories.tsx`
  */
 export function useSearchBarEnabled(): boolean {
-  const session = useSession();
-  return session.data?.user?.featureFlags.searchBar === true;
+  return true;
+  // Rollback to the per-user Feature Preview opt-in by restoring:
+  //   return useSession().data?.user?.featureFlags.searchBar === true;
+  // (re-add `import { useSession } from "next-auth/react";` above).
 }

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -100,6 +100,10 @@ export const userAccountRouter = createTRPCRouter({
       z.object({
         // Allowlist of user-toggleable Feature Preview flags (the Feature
         // Preview modal). Keep in sync with the modal's preview registry.
+        // TODO(remove ~2026-06-19): "searchBar" is retired — the bar is now GA
+        // on the v4 events tables (see useSearchBarEnabled) and no longer has a
+        // dialog tile. Kept in the allowlist as dead plumbing for a safe
+        // rollback; drop once the GA rollout is confirmed stable.
         flag: z.enum(["inAppAgent", "searchBar"]),
         enabled: z.boolean(),
       }),


### PR DESCRIPTION
## Summary

The new filter/search bar has proven good in the Feature Preview, so this makes it **generally available to everyone on the v4 Observations/Traces tables** instead of keeping it behind a per-user opt-in.

- `useSearchBarEnabled()` now returns `true` for everyone. The v4 gate stays implicit — `EventsTable` only mounts in v4 mode, and the bar still only renders on full-page surfaces (`!hideControls && !externalFilterState && !peekContext && !userId && !sessionId`), so embedded/peek/external tables are unaffected.
- The **"Filter Search Bar" tile is removed** from the Feature Preview modal (it's no longer an opt-in).

## Dead code kept for a safe rollback

Per the "play it safe" plan, the previous opt-in plumbing is **intentionally left as dead code** so a rollback is a one-line revert (restore the `useSession` read in `useSearchBarEnabled`). All marked `TODO(remove ~2026-06-19)`:

- `features/feature-flags/available-flags.ts` — the `searchBar` flag
- `server/api/routers/userAccount.ts` — the `setFeaturePreviewEnabled` allowlist entry
- `features/feature-previews/components/FeaturePreviewModal.tsx` — the `PreviewFlag` type + registry entry (+ illustration assets)
- the `searchBar` rows in `userAccount.servertest.ts` / `FeaturePreviewModal.stories.tsx`

To be deleted in a day or two once the rollout is confirmed stable.

## Notes

- The legacy toolbar full-text search field is **not** dead — it still serves the embedded (userId/sessionId) tables where the bar stays off, so it is untouched.
- `web/src/features/search-bar/README.md` Enablement section updated to document GA + the temporary rollback shim.

## Verification

- `pnpm --filter web run lint` — clean
- `pnpm --filter web run typecheck` — clean
- No client/unit tests assert the removed tile; `userAccount.servertest.ts` still passes (the `searchBar` flag remains allowlisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR promotes the grammar search bar from a per-user Feature Preview opt-in to generally available on the v4 Observations and Traces tables. `useSearchBarEnabled()` now hard-returns `true`; the "Filter Search Bar" tile is removed from the Feature Preview modal; and the old opt-in plumbing (`searchBar` flag, allowlist entry, registry entry, illustration imports) is intentionally left as dead code so a one-line rollback is possible.

- `useSearchBarEnabled` is replaced with a force-on shim, with the original session-read preserved in a comment for easy rollback.
- The `searchBar` entry is removed from `ControlledFeaturePreviewModal`'s state object so the tile disappears from the dialog, while the type, registry entry, and server-side allowlist remain as dead code marked `TODO(remove ~2026-06-19)`.
- `EventsTable` still gates bar rendering on the full-page surface conditions (`!hideControls && !externalFilterState && !peekContext && !userId && !sessionId`), keeping embedded/peek tables unaffected.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal one-line hook shim with no new logic paths, and all removed UI is gated behind an explicit state-entry check that already filters it out at runtime.

The surface area of this change is very small: one hook now returns a constant, one modal state object loses an entry, and everything else is comment/doc updates. The dead-code rollback strategy is clearly documented and mechanically simple. The bar's existing surface guards (hideControls, externalFilterState, peekContext, userId, sessionId) are untouched and continue to protect embedded tables. No schema changes, no server-side logic changes, and no new code paths are introduced.

No files require special attention. The illustration imports (filterSearchBarDarkIllustration, filterSearchBarLightIllustration) in FeaturePreviewModal.tsx will become genuinely unused once the dead searchBar registry entry is removed in the follow-up cleanup, but they are currently still referenced.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EventsTable mounts in v4 mode] --> B[useSearchBarEnabled]
    B --> C[returns true - GA shim]
    C --> D{Full-page surface check}
    D -- hideControls or externalFilter or peek or userId or sessionId --> F[Legacy toolbar search]
    D -- none of the above --> E[Grammar search bar rendered]

    subgraph Rollback
      R1[Restore useSession read in hook]
      R2[Re-add searchBar state in ControlledModal]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[EventsTable mounts in v4 mode] --> B[useSearchBarEnabled]
    B --> C[returns true - GA shim]
    C --> D{Full-page surface check}
    D -- hideControls or externalFilter or peek or userId or sessionId --> F[Legacy toolbar search]
    D -- none of the above --> E[Grammar search bar rendered]

    subgraph Rollback
      R1[Restore useSession read in hook]
      R2[Re-add searchBar state in ControlledModal]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(search-bar): make the grammar searc..."](https://github.com/langfuse/langfuse/commit/d07ff8c6fa71bc7cc7a925c5b11b3997b5b42acc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38219454)</sub>

<!-- /greptile_comment -->