### PR TITLE
feat(public-api): add v2 migration hint to rate-limit errors

### DIFF
--- a/web/src/__tests__/server/rate-limit.servertest.ts
+++ b/web/src/__tests__/server/rate-limit.servertest.ts
@@ -2,7 +2,9 @@ import {
   createHttpHeaderFromRateLimit,
   RATE_LIMIT_REDIS_KEY_PREFIX,
   RateLimitService,
+  sendRateLimitResponse,
 } from "@/src/features/public-api/server/RateLimitService";
+import { type NextApiResponse } from "next";
 import { randomUUID } from "crypto";
 import {
   clearRedisKeysByPatternSafely,
@@ -389,5 +391,61 @@ describe("RateLimitService", () => {
     await expect(
       redis.get(`${RATE_LIMIT_REDIS_KEY_PREFIX}:ingestion:${orgId}`),
     ).resolves.toBeDefined();
+  });
+
+  describe("sendRateLimitResponse migration message", () => {
+    const rateLimitRes = {
+      points: 30,
+      remainingPoints: 0,
+      msBeforeNext: 1000,
+      resource: "public-api" as const,
+      scope: {
+        orgId,
+        plan: "cloud:hobby" as const,
+        projectId,
+        accessLevel: "project" as const,
+        rateLimitOverrides: [],
+      },
+      consumedPoints: 31,
+      isFirstInDuration: false,
+    };
+
+    const createMockResponse = () => {
+      const captured: { status?: number; body?: string } = {};
+      const res = {
+        setHeader: () => {},
+        status: (code: number) => {
+          captured.status = code;
+          return res;
+        },
+        end: (body?: string) => {
+          captured.body = body;
+          return res;
+        },
+      } as unknown as NextApiResponse;
+      return { res, captured };
+    };
+
+    it("returns the default 429 body when no migration message is provided", () => {
+      const { res, captured } = createMockResponse();
+
+      sendRateLimitResponse(res, rateLimitRes);
+
+      expect(captured.status).toBe(429);
+      expect(captured.body).toBe("429 - rate limit exceeded");
+    });
+
+    it("appends the migration message to the 429 body when provided", () => {
+      const { res, captured } = createMockResponse();
+      const migrationMessage =
+        "Migrate to the v2/traces endpoint (GET /api/public/v2/traces) for improved performance and higher rate limits. Learn more at https://langfuse.com/docs/v4";
+
+      sendRateLimitResponse(res, rateLimitRes, undefined, migrationMessage);
+
+      expect(captured.status).toBe(429);
+      expect(captured.body).toBe(
+        `429 - rate limit exceeded. ${migrationMessage}`,
+      );
+    });
   });
 });

--- a/web/src/features/public-api/server/RateLimitService.ts
+++ b/web/src/features/public-api/server/RateLimitService.ts
@@ -177,6 +177,7 @@ export class RateLimitHelper {
   sendRestResponseIfLimited(
     nextResponse: NextApiResponse,
     errorContract?: PublicApiErrorContract,
+    migrationMessage?: string,
   ) {
     if (!this.res || !this.isRateLimited()) {
       logger.error("Trying to send rate limit response without being limited.");
@@ -184,7 +185,12 @@ export class RateLimitHelper {
         "Trying to send rate limit response without being limited.",
       );
     }
-    return sendRateLimitResponse(nextResponse, this.res, errorContract);
+    return sendRateLimitResponse(
+      nextResponse,
+      this.res,
+      errorContract,
+      migrationMessage,
+    );
   }
 }
 
@@ -192,6 +198,7 @@ export const sendRateLimitResponse = (
   res: NextApiResponse,
   rateLimitRes: RateLimitResult,
   errorContract?: PublicApiErrorContract,
+  migrationMessage?: string,
 ) => {
   const httpHeader = createHttpHeaderFromRateLimit(rateLimitRes);
 
@@ -206,7 +213,11 @@ export const sendRateLimitResponse = (
     );
   }
 
-  res.status(429).end("429 - rate limit exceeded");
+  const body = migrationMessage
+    ? `429 - rate limit exceeded. ${migrationMessage}`
+    : "429 - rate limit exceeded";
+
+  res.status(429).end(body);
 };
 
 export const createHttpHeaderFromRateLimit = (res: RateLimitResult) => {

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -40,6 +40,12 @@ export type AuthedProjectAPIRouteConfig<
   successStatusCode?: number;
   rateLimitResource?: z.infer<typeof RateLimitResource>; // defaults to public-api
   /**
+   * Optional message appended to the 429 plain-text rate limit response body.
+   * Use this to point callers of legacy endpoints at their v2 successor (e.g.
+   * the v2/metrics and v2/traces endpoints) which offer higher rate limits.
+   */
+  rateLimitMigrationMessage?: string;
+  /**
    * Allow authentication via ADMIN_API_KEY for self-hosted instances only.
    * When enabled, the endpoint will accept admin API key authentication in addition to regular API keys.
    *
@@ -367,6 +373,7 @@ export const createAuthedProjectAPIRoute = <
       return rateLimitResponse.sendRestResponseIfLimited(
         res,
         routeConfig.errorContract,
+        routeConfig.rateLimitMigrationMessage,
       );
     }
 

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -9,13 +9,20 @@ import {
   GetMetricsV1Response,
 } from "@/src/features/public-api/types/metrics";
 import { executeQuery } from "@langfuse/shared/query/server";
+import { env } from "@/src/env.mjs";
 export default withMiddlewares(
   {
     GET: createAuthedProjectAPIRoute({
       name: "Get Metrics",
       rateLimitResource: "public-api-metrics",
+      // Only surface the migration hint where the v2 endpoint is actually
+      // reachable (v2 APIs 404 unless the v4 preview opt-in is enabled). Note
+      // v2/metrics reuses the same `public-api-metrics` rate-limit bucket as
+      // v1, so the hint advertises improved performance, not higher limits.
       rateLimitMigrationMessage:
-        "Migrate to the v2/metrics endpoint (GET /api/public/v2/metrics) for improved performance and higher rate limits. Learn more at https://langfuse.com/docs/v4",
+        env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+          ? "Migrate to the v2/metrics endpoint (GET /api/public/v2/metrics) for improved performance. Learn more at https://langfuse.com/docs/v4"
+          : undefined,
       querySchema: GetMetricsV1Query,
       responseSchema: GetMetricsV1Response,
       // v1 metrics executes QueryBuilder against the legacy traces/observations

--- a/web/src/pages/api/public/metrics/index.ts
+++ b/web/src/pages/api/public/metrics/index.ts
@@ -14,6 +14,8 @@ export default withMiddlewares(
     GET: createAuthedProjectAPIRoute({
       name: "Get Metrics",
       rateLimitResource: "public-api-metrics",
+      rateLimitMigrationMessage:
+        "Migrate to the v2/metrics endpoint (GET /api/public/v2/metrics) for improved performance and higher rate limits. Learn more at https://langfuse.com/docs/v4",
       querySchema: GetMetricsV1Query,
       responseSchema: GetMetricsV1Response,
       // v1 metrics executes QueryBuilder against the legacy traces/observations

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -25,6 +25,8 @@ export default withMiddlewares(
     GET: createAuthedProjectAPIRoute({
       name: "Get Observations",
       allowInAppAgentKey: true,
+      rateLimitMigrationMessage:
+        "Migrate to the v2/traces endpoint (GET /api/public/v2/traces) for improved performance and higher rate limits. Learn more at https://langfuse.com/docs/v4",
       querySchema: GetObservationsV1Query,
       responseSchema: GetObservationsV1Response,
       rejectInEventsOnlyMode: true,

--- a/web/src/pages/api/public/observations/index.ts
+++ b/web/src/pages/api/public/observations/index.ts
@@ -9,6 +9,7 @@ import {
   withMiddlewares,
 } from "@/src/features/public-api/server/withMiddlewares";
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
+import { env } from "@/src/env.mjs";
 
 import {
   GetObservationsV1Query,
@@ -25,8 +26,13 @@ export default withMiddlewares(
     GET: createAuthedProjectAPIRoute({
       name: "Get Observations",
       allowInAppAgentKey: true,
+      // Only surface the migration hint where v4 APIs are enabled; the v4
+      // preview opt-in gates the v2 surface. Keep this dormant otherwise so we
+      // never point callers at an endpoint that is not yet reachable.
       rateLimitMigrationMessage:
-        "Migrate to the v2/traces endpoint (GET /api/public/v2/traces) for improved performance and higher rate limits. Learn more at https://langfuse.com/docs/v4",
+        env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+          ? "Migrate to the v2/traces endpoint (GET /api/public/v2/traces) for improved performance and higher rate limits. Learn more at https://langfuse.com/docs/v4"
+          : undefined,
       querySchema: GetObservationsV1Query,
       responseSchema: GetObservationsV1Response,
       rejectInEventsOnlyMode: true,

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -70,8 +70,13 @@ export default withMiddlewares(
 
     GET: createAuthedProjectAPIRoute({
       name: "Get Traces",
+      // Only surface the migration hint where v4 APIs are enabled; the v4
+      // preview opt-in gates the v2 surface. Keep this dormant otherwise so we
+      // never point callers at an endpoint that is not yet reachable.
       rateLimitMigrationMessage:
-        "Migrate to the v2/traces endpoint (GET /api/public/v2/traces) for improved performance and higher rate limits. Learn more at https://langfuse.com/docs/v4",
+        env.LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN === "true"
+          ? "Migrate to the v2/traces endpoint (GET /api/public/v2/traces) for improved performance and higher rate limits. Learn more at https://langfuse.com/docs/v4"
+          : undefined,
       querySchema: GetTracesV1Query,
       responseSchema: GetTracesV1Response,
       rejectInEventsOnlyMode: true,

--- a/web/src/pages/api/public/traces/index.ts
+++ b/web/src/pages/api/public/traces/index.ts
@@ -70,6 +70,8 @@ export default withMiddlewares(
 
     GET: createAuthedProjectAPIRoute({
       name: "Get Traces",
+      rateLimitMigrationMessage:
+        "Migrate to the v2/traces endpoint (GET /api/public/v2/traces) for improved performance and higher rate limits. Learn more at https://langfuse.com/docs/v4",
       querySchema: GetTracesV1Query,
       responseSchema: GetTracesV1Response,
       rejectInEventsOnlyMode: true,


### PR DESCRIPTION
## Problem

When callers hit rate limits on the legacy `/metrics`, `/observations`, and `/traces` read endpoints, the 429 response body is just `429 - rate limit exceeded` with no guidance on what to do next.

## Change

Append a migration hint to the 429 plain-text body on these three endpoints, pointing callers at their higher-limit v2 successors:

- `/api/public/metrics` → **v2/metrics**
- `/api/public/observations` (GET) → **v2/traces**
- `/api/public/traces` (GET) → **v2/traces**

Body becomes, e.g.:
> `429 - rate limit exceeded. Migrate to the v2/traces endpoint (GET /api/public/v2/traces) for improved performance and higher rate limits. Learn more at https://langfuse.com/docs/v4`

### Mechanism (opt-in, per-route)

- `sendRestResponseIfLimited` / `sendRateLimitResponse` take an optional `migrationMessage` appended to the plain-text body. The structured (unstable evals) error-contract path is unchanged.
- New optional `rateLimitMigrationMessage` field on the route config, threaded into the 429 branch in `createAuthedProjectAPIRoute`.
- Only the three named endpoints set it; all other endpoints keep the existing body verbatim.

## Tests

Added two cases to `rate-limit.servertest.ts` verifying the default body is preserved and the migration message is appended when provided.

## Notes

- Rate limits only apply on Langfuse Cloud, so this surfaces only there (self-hosted/OSS are exempt).
- **`v2/traces` does not exist in the repo yet** (only `v2/metrics` and `v2/observations` do today). The observations + traces hints point to `/api/public/v2/traces` as the forward-looking target — the endpoint/docs should land before users can fully act on it.
- Scoped to the collection GET endpoints. Single-item routes (`traces/[traceId]`, `observations/[observationId]`) and `metrics/daily` are not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Appends an optional migration hint to the 429 plain-text body on three legacy read endpoints (`/metrics`, `/observations`, `/traces`) to point callers at their v2 successors. The mechanism is clean and additive — a new optional `rateLimitMigrationMessage` field on the route config threads into `sendRateLimitResponse`, leaving the structured evals error path and all other endpoints unchanged.

- `sendRateLimitResponse` and `sendRestResponseIfLimited` each accept an optional `migrationMessage` parameter; when present it is appended to the `"429 - rate limit exceeded"` body.
- `createAuthedProjectAPIRoute` exposes `rateLimitMigrationMessage` on the route config and passes it through to the rate-limit helper.
- The three legacy endpoints (`metrics`, `observations`, `traces`) now each carry a hardcoded migration message; unit tests cover the default and appended-message cases of `sendRateLimitResponse`.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge once the two migration hints pointing at non-existent v2/traces are resolved; all other changes are additive and low-risk.

Both the observations and traces endpoints now ship a rate-limit body that directs Cloud users to GET /api/public/v2/traces — an endpoint that does not exist in the repository. Any user who hits the rate limit and follows the hint will receive a 404, making the hint actively harmful during the gap between this deployment and when v2/traces actually lands.

web/src/pages/api/public/observations/index.ts and web/src/pages/api/public/traces/index.ts — both carry migration messages that reference an endpoint not yet deployed.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant RouteHandler as createAuthedProjectAPIRoute
    participant RateLimitService
    participant RateLimitHelper
    participant sendRateLimitResponse

    Client->>RouteHandler: GET /api/public/traces (or observations, metrics)
    RouteHandler->>RateLimitService: rateLimitRequest(scope, resource)
    RateLimitService-->>RouteHandler: RateLimitHelper (with result)

    alt Not rate limited
        RouteHandler->>RouteHandler: execute handler fn()
        RouteHandler-->>Client: 200 OK + data
    else Rate limited
        RouteHandler->>RateLimitHelper: sendRestResponseIfLimited(res, errorContract, rateLimitMigrationMessage)
        RateLimitHelper->>sendRateLimitResponse: (nextResponse, this.res, errorContract, migrationMessage)
        
        alt "errorContract === unstablePublicEvalsErrorContract"
            sendRateLimitResponse-->>Client: 429 structured JSON error
        else plain-text path (all 3 modified endpoints)
            Note over sendRateLimitResponse: body = migrationMessage ? '429 - rate limit exceeded. ' + migrationMessage : '429 - rate limit exceeded'
            sendRateLimitResponse-->>Client: 429 plain-text body + Retry-After headers
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant RouteHandler as createAuthedProjectAPIRoute
    participant RateLimitService
    participant RateLimitHelper
    participant sendRateLimitResponse

    Client->>RouteHandler: GET /api/public/traces (or observations, metrics)
    RouteHandler->>RateLimitService: rateLimitRequest(scope, resource)
    RateLimitService-->>RouteHandler: RateLimitHelper (with result)

    alt Not rate limited
        RouteHandler->>RouteHandler: execute handler fn()
        RouteHandler-->>Client: 200 OK + data
    else Rate limited
        RouteHandler->>RateLimitHelper: sendRestResponseIfLimited(res, errorContract, rateLimitMigrationMessage)
        RateLimitHelper->>sendRateLimitResponse: (nextResponse, this.res, errorContract, migrationMessage)
        
        alt "errorContract === unstablePublicEvalsErrorContract"
            sendRateLimitResponse-->>Client: 429 structured JSON error
        else plain-text path (all 3 modified endpoints)
            Note over sendRateLimitResponse: body = migrationMessage ? '429 - rate limit exceeded. ' + migrationMessage : '429 - rate limit exceeded'
            sendRateLimitResponse-->>Client: 429 plain-text body + Retry-After headers
        end
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/api/public/observations/index.ts:26-30
**Migration hint points to a non-existent endpoint**

The `observations` endpoint's message directs users to `GET /api/public/v2/traces`, but `/api/public/v2/traces` does not exist in the repository today. A user who hits the rate limit, follows the hint, and issues a `GET /api/public/v2/traces` will receive a **404** rather than the improved endpoint they were promised.

`/api/public/v2/observations` does exist today (though gated behind `LANGFUSE_MIGRATION_V4_ALLOW_PREVIEW_OPT_IN`). If `v2/traces` is the intended long-term target for both endpoints, consider pointing the `observations` hint there only once `v2/traces` is deployed, or point it at `v2/observations` in the interim so the hint is actionable today.

### Issue 2 of 2
web/src/pages/api/public/traces/index.ts:71-74
**Migration hint points to a non-existent endpoint**

Same as the `observations` endpoint: `GET /api/public/v2/traces` does not exist in the codebase yet. Any Cloud user who hits the traces rate limit and follows this hint will land on a 404. The PR description acknowledges this is "forward-looking", but there is a real deployment window — from when this code ships to when `v2/traces` is released — during which the hint actively misleads users.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(public-api): add v2 migration hint ..."](https://github.com/langfuse/langfuse/commit/6960981f6a47721aefd0992fc9b9bde029cc4e4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38221535)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->