### PR TITLE
feat(ui): add overlay layer system; fix clipped search-bar error tooltip

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -114,6 +114,17 @@ changes.
   `top-banner-offset`, `pt-banner-offset`, `h-screen-with-banner`, or
   `min-h-screen-with-banner` instead of raw `top-0` so banners do not overlap
   the UI.
+- **Z-index / layers — key idea: we are migrating from z-indexes to a layer
+  system** (start of a developing design system; extend it, don't work around
+  it). **To put something on top of something else, use a layer, not a
+  z-index.** The app renders inside `#__next`, isolated into one stacking
+  context (`globals.css`), so its z-indexes can't escape; overlays go in layers
+  that sit outside it and always win. Today there's one layer, `tooltip`:
+  containers declared in `_document.tsx`, ordered by `LAYER_ORDER` (later = on
+  top), no z-index; render via `<Layer name="…">` (`src/components/ui/layer.tsx`).
+  Add a layer only when an overlay must escape the app (else use a Radix
+  `*.Portal`) by adding a name to `LAYER_ORDER`. z-index stays local to a layer
+  or component (1–2 max), never to escape the app.
 - Public API routes should use
   `src/features/public-api/server/withMiddlewares.ts`, define strict request and
   response types in `src/features/public-api/types/*`, add server tests, and

--- a/web/src/components/ui/layer.tsx
+++ b/web/src/components/ui/layer.tsx
@@ -15,6 +15,12 @@ import { createPortal } from "react-dom";
  * a LOCAL tool for ordering content WITHIN one layer (or within the app), never
  * a global escalation. To add a layer, append its name here — `_document.tsx`
  * maps this list to the containers — and render `<Layer name="…">`.
+ *
+ * TODO (follow-up): integrate Radix overlays into this system. Today they
+ * portal to `<body>` at `z-50` and so sit above these (z-index-less) layers by
+ * virtue of that number. The end state is to route them through layers too
+ * (e.g. a `popover`/`modal`/`toast` layer above `tooltip`), retiring the last
+ * app-wide z-index numbers so ordering everywhere is layer order.
  */
 export const LAYER_ORDER = ["tooltip"] as const;
 export type LayerName = (typeof LAYER_ORDER)[number];

--- a/web/src/components/ui/layer.tsx
+++ b/web/src/components/ui/layer.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * App overlay layers — the seed of an app-wide layer system.
+ *
+ * The whole app renders inside `#__next`, isolated into its own stacking
+ * context (`isolation: isolate`, in globals.css). That caps every z-index in
+ * the app, so nothing inside can escape it. The overlay layer containers are
+ * declared once in `_document.tsx` as `<body>` siblings AFTER `#__next`, so
+ * they paint on top purely by DOM order — no z-index anywhere in this system.
+ *
+ * Layers stack by ORDER, not z-index: the containers are rendered in this order
+ * (later = on top) and each is its own isolated stacking context. z-index stays
+ * a LOCAL tool for ordering content WITHIN one layer (or within the app), never
+ * a global escalation. To add a layer, append its name here — `_document.tsx`
+ * maps this list to the containers — and render `<Layer name="…">`.
+ */
+export const LAYER_ORDER = ["tooltip"] as const;
+export type LayerName = (typeof LAYER_ORDER)[number];
+
+function useLayerContainer(name: LayerName): HTMLElement | null {
+  // null on the server and the first client render (SSR parity), then the
+  // matching container declared in _document. It is static HTML, so it always
+  // exists post-hydration — no creation, no ordering, no teardown here.
+  const [container, setContainer] = React.useState<HTMLElement | null>(null);
+  React.useEffect(() => {
+    setContainer(
+      document.querySelector<HTMLElement>(
+        `[data-overlay-root] > [data-layer="${CSS.escape(name)}"]`,
+      ),
+    );
+  }, [name]);
+  return container;
+}
+
+/**
+ * Renders its children into the named overlay layer (see {@link LAYER_ORDER}),
+ * escaping ancestor `overflow` clipping and stacking contexts. Renders nothing
+ * until mounted, so it is SSR-safe. Children position themselves (`fixed` /
+ * `absolute`) and opt back into pointer events as needed.
+ *
+ * Prefer the Radix primitives' built-in `*.Portal` for Radix overlays; reach
+ * for `<Layer>` when portaling bespoke, imperatively-positioned content (e.g. a
+ * contenteditable's anchored tooltip) that isn't a Radix component.
+ */
+export function Layer({
+  name,
+  children,
+}: {
+  name: LayerName;
+  children: React.ReactNode;
+}) {
+  const container = useLayerContainer(name);
+  return container ? createPortal(children, container) : null;
+}

--- a/web/src/features/search-bar/README.md
+++ b/web/src/features/search-bar/README.md
@@ -335,10 +335,18 @@ unused planners).
     operators, or leave it. Entangled with `tidyQueryText`/chip-removal (which
     strips redundant parens and would bail on a now-"invalid" paren) and
     removes documented top-level grouping — needs its own pass.
-- App-wide **layer system** (z-index): the bar's overlays use a hardcoded local
-  ladder (X z-20 < error tooltip z-30 < popover z-50) because the app has no
-  shared z scale (overlays are just `z-50` + Radix portals). A proper layering
-  system is a separate, app-level ticket.
+- **Layer system**: the bar's in-flow overlays use a hardcoded local ladder (X
+  z-20 < autocomplete popover z-50, both drop into the table below the bar). The
+  **error tooltip is the exception**: when the popover is open it flips ABOVE
+  the bar, into the page header's band, where no in-flow z-index can win —
+  `#page > main` is `overflow:hidden` (clips anything above the bar) and the
+  header is inside the app's isolated stacking context. So that one tooltip
+  renders through the `"tooltip"` `<Layer>` (`components/ui/layer.tsx`), which
+  puts it in a `<body>`-level overlay layer that paints above the whole app by
+  DOM order — no z-index needed. `<Layer>` is the seed of an app-wide layer
+  system (one layer today, ordered by `LAYER_ORDER`). New overlays that must
+  escape clipping/stacking should reuse `<Layer>` rather than a one-off portal +
+  z-index.
 - Optional: extract `SearchComposer`'s contenteditable selection/`beforeinput`
   machinery into a `useContentEditableController` hook to fully separate the
   imperative integration from the React component.

--- a/web/src/features/search-bar/components/SearchComposer.tsx
+++ b/web/src/features/search-bar/components/SearchComposer.tsx
@@ -18,6 +18,7 @@ import * as React from "react";
 import { useShallow } from "zustand/react/shallow";
 import { AlertCircle, X } from "lucide-react";
 
+import { Layer } from "@/src/components/ui/layer";
 import { cn } from "@/src/utils/tailwind";
 
 import {
@@ -1221,10 +1222,15 @@ export function SearchComposer({
   } | null>(null);
   // Anchors for the per-token error tooltip — left edge of the token, plus its
   // bottom (default placement, just under the block) and top (used to flip the
-  // tooltip ABOVE the block while the suggestions popover is open below).
+  // tooltip ABOVE the block while the suggestions popover is open below). These
+  // are VIEWPORT coordinates (not container-relative): the tooltip portals to
+  // document.body and is positioned `fixed`, so it reads the token's own
+  // getClientRects() directly. The bar's band is sticky (it doesn't scroll out
+  // from under the token), so a fixed anchor stays put; it re-measures on draft
+  // change and the container ResizeObserver below, same as the X button.
   const [errorPosition, setErrorPosition] = React.useState<{
     left: number;
-    top: number;
+    belowTop: number;
     aboveTop: number;
   } | null>(null);
   const removeTargetIdActual = removeTarget?.id ?? null;
@@ -1254,9 +1260,9 @@ export function SearchComposer({
       top: rect.top - containerRect.top - 8,
     });
     setErrorPosition({
-      left: firstRect.left - containerRect.left,
-      top: firstRect.bottom - containerRect.top + 6,
-      aboveTop: firstRect.top - containerRect.top,
+      left: firstRect.left,
+      belowTop: firstRect.bottom + 6,
+      aboveTop: firstRect.top,
     });
   }, [removeTargetIdActual]);
 
@@ -1360,41 +1366,21 @@ export function SearchComposer({
             scoreTypes={scoreTypes}
           />
         </div>
-        {/* Bar-local overlay stacking ladder (hardcoded for now — a proper
-            app-wide layer system is a separate ticket): token text (base) <
-            remove-X (z-20) < error tooltip (z-30) < autocomplete popover
-            (z-50). The popover drops BELOW the bar; when it's open the error
-            tooltip flips ABOVE the offending block (see errorAbove), so the two
-            never overlap and the z order only needs to be self-consistent. */}
+        {/* Bar-local overlay stacking ladder: token text (base) < remove-X
+            (z-20) < autocomplete popover (z-50). Both the X and the popover drop
+            BELOW the bar, staying in-flow inside the table. The error tooltip is
+            the exception: when the popover is open it flips ABOVE the offending
+            block, into the page header's band — an ancestor it can't beat
+            in-flow (`#page > main` is overflow:hidden and the header is its own
+            z-50 stacking context). So it renders through the "tooltip" <Layer>,
+            which portals it to a body-level layer container (see the render
+            below + components/ui/layer.tsx). */}
         {removeTarget !== null && removePosition !== null && (
           <RemoveTokenButton
             segment={removeTarget}
             position={removePosition}
             onRemove={removeSegment}
           />
-        )}
-        {errorTarget !== null && errorPosition !== null && (
-          <div
-            role="tooltip"
-            style={
-              plan !== null
-                ? {
-                    left: errorPosition.left,
-                    top: errorPosition.aboveTop,
-                    transform: "translateY(calc(-100% - 6px))",
-                  }
-                : { left: errorPosition.left, top: errorPosition.top }
-            }
-            // pointer-events-none so moving onto the tooltip doesn't change the
-            // hovered token (which would make it flicker away).
-            className={cn(
-              "pointer-events-none absolute z-30 max-w-[min(360px,calc(100vw-32px))]",
-              "border-destructive/40 bg-popover text-destructive rounded-md border",
-              "px-2 py-1 font-sans text-xs leading-snug shadow-md",
-            )}
-          >
-            {errorTarget.message}
-          </div>
         )}
       </div>
 
@@ -1426,6 +1412,36 @@ export function SearchComposer({
           anchorLeft={0}
           containerRef={containerRef}
         />
+      )}
+
+      {/* Per-token error tooltip. The "tooltip" <Layer> renders it on a
+          body-level container so it escapes the page header's overflow:hidden
+          clip and z-50 stacking context when it flips above the bar — an
+          in-flow z-index can't win against either. `fixed` + viewport anchors.
+          pointer-events-none so moving onto it doesn't change the hovered token
+          (which would flicker it away). */}
+      {errorTarget !== null && errorPosition !== null && (
+        <Layer name="tooltip">
+          <div
+            role="tooltip"
+            style={
+              plan !== null
+                ? {
+                    left: errorPosition.left,
+                    top: errorPosition.aboveTop,
+                    transform: "translateY(calc(-100% - 6px))",
+                  }
+                : { left: errorPosition.left, top: errorPosition.belowTop }
+            }
+            className={cn(
+              "pointer-events-none fixed max-w-[min(360px,calc(100vw-32px))]",
+              "border-destructive/40 bg-popover text-destructive rounded-md border",
+              "px-2 py-1 font-sans text-xs leading-snug shadow-md",
+            )}
+          >
+            {errorTarget.message}
+          </div>
+        </Layer>
       )}
     </div>
   );

--- a/web/src/pages/_document.tsx
+++ b/web/src/pages/_document.tsx
@@ -1,0 +1,26 @@
+import { Html, Head, Main, NextScript } from "next/document";
+
+import { LAYER_ORDER } from "@/src/components/ui/layer";
+
+// The app renders inside #__next (<Main />), which is isolated into its own
+// stacking context (globals.css). The overlay layer containers are declared
+// here as <body> siblings AFTER #__next, so they paint above the whole app by
+// DOM order — no z-index needed. They are static HTML (present at SSR), ordered
+// by LAYER_ORDER (later = on top); <Layer> (components/ui/layer.tsx) finds its
+// container and portals into it. Styling lives in globals.css.
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <div data-overlay-root>
+          {LAYER_ORDER.map((name) => (
+            <div key={name} data-layer={name} />
+          ))}
+        </div>
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/web/src/pages/_document.tsx
+++ b/web/src/pages/_document.tsx
@@ -10,7 +10,10 @@ import { LAYER_ORDER } from "@/src/components/ui/layer";
 // container and portals into it. Styling lives in globals.css.
 export default function Document() {
   return (
-    <Html>
+    // lang is set explicitly (not left to the i18n config, which is being
+    // phased out in App Router) so screen readers always get the document
+    // language — WCAG 2.1 SC 3.1.1.
+    <Html lang="en">
       <Head />
       <body>
         <Main />

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -396,6 +396,33 @@
   div#__next > div {
     height: 100%;
   }
+
+  /* The whole app renders inside #__next. Isolating it into its own stacking
+     context caps every z-index in the app (page header, modals, popovers, …)
+     so none can escape it. The overlay layer containers (declared in
+     _document.tsx) are <body> siblings AFTER #__next and paint on top purely by
+     DOM order — see components/ui/layer.tsx. This is what lets layers carry no
+     z-index of their own; z-index stays a LOCAL tool for ordering within a
+     single layer. */
+  div#__next {
+    isolation: isolate;
+  }
+
+  /* Overlay layer roots (see _document.tsx + components/ui/layer.tsx). The
+     stack is click-through; each layer is its own isolated stacking context and
+     they order by DOM order (later = on top). Overlay content opts back into
+     pointer events on itself. */
+  [data-overlay-root] {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+  }
+  [data-overlay-root] > [data-layer] {
+    position: absolute;
+    inset: 0;
+    isolation: isolate;
+    pointer-events: none;
+  }
 }
 
 @layer base {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a body-level overlay layer system to fix a clipped error tooltip in the search bar. When the autocomplete popover is open and an error token is hovered, the tooltip must flip above the bar into the page header band — an area that is clipped by `overflow:hidden` and protected by the header's own stacking context, making in-flow z-index escalation impossible.

- **Layer system** (`layer.tsx`, `_document.tsx`, `globals.css`): layer containers are declared as static HTML siblings of `#__next`, positioned after it in the DOM so they win by DOM order without any z-index. `#__next` receives `isolation: isolate`, capping all in-app z-indexes so nothing inside can escape.
- **SearchComposer tooltip migration**: `errorPosition` is switched from container-relative offsets to viewport coordinates, and the tooltip is moved into `<Layer name=\"tooltip\">` using `position: fixed`, escaping both the clip and the stacking context.
- **Documentation**: `AGENTS.md`, `README.md`, and inline comments are updated to describe the layer system and the rationale for each decision.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The layer system itself is correctly implemented and well-documented; the main concern before merging is the missing `lang` attribute on `<Html>` in the new `_document.tsx`, which is an accessibility regression.

The tooltip fix and overlay architecture are sound. The `_document.tsx` replaces the Next.js default document but omits the `lang` attribute that the default scaffold includes, breaking WCAG 3.1.1. The `isolation: isolate` addition to `#__next` is intentional and correct for Radix-portal-based apps, but any bespoke overlay inside `#__next` relying on z-index escalation could silently regress.

`web/src/pages/_document.tsx` — missing `lang` attribute. `web/src/styles/globals.css` — the `isolation: isolate` rule is broad; worth verifying no existing non-portaled overlay is affected.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant NextDoc as _document.tsx (SSR)
    participant Globals as globals.css
    participant App as #__next (Main)
    participant OverlayRoot as [data-overlay-root]
    participant Layer as Layer component
    participant Tooltip as Error Tooltip (fixed)

    NextDoc->>Browser: Render body: Main then [data-overlay-root] then NextScript
    Globals->>App: "isolation: isolate caps all z-indexes inside #__next"
    Globals->>OverlayRoot: position:fixed inset:0 pointer-events:none
    Note over App: Page header, search bar, popovers z-indexed inside isolation context
    Browser->>Layer: User hovers error token
    Layer->>Browser: useEffect resolves data-layer tooltip container
    Layer->>Tooltip: createPortal(children, tooltipContainer)
    Tooltip->>Browser: "Rendered in [data-overlay-root], wins over #__next by DOM order"
    Note over Tooltip: position:fixed + viewport coords from getClientRects()
    Note over Tooltip: Escapes page header overflow:hidden clip
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant NextDoc as _document.tsx (SSR)
    participant Globals as globals.css
    participant App as #__next (Main)
    participant OverlayRoot as [data-overlay-root]
    participant Layer as Layer component
    participant Tooltip as Error Tooltip (fixed)

    NextDoc->>Browser: Render body: Main then [data-overlay-root] then NextScript
    Globals->>App: "isolation: isolate caps all z-indexes inside #__next"
    Globals->>OverlayRoot: position:fixed inset:0 pointer-events:none
    Note over App: Page header, search bar, popovers z-indexed inside isolation context
    Browser->>Layer: User hovers error token
    Layer->>Browser: useEffect resolves data-layer tooltip container
    Layer->>Tooltip: createPortal(children, tooltipContainer)
    Tooltip->>Browser: "Rendered in [data-overlay-root], wins over #__next by DOM order"
    Note over Tooltip: position:fixed + viewport coords from getClientRects()
    Note over Tooltip: Escapes page header overflow:hidden clip
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/pages/_document.tsx:13
**Missing `lang` attribute on `<Html>`**

The new custom `_document.tsx` replaces Next.js's default document, which would have included `lang="en"` on the `<Html>` element. Without a `lang` attribute, screen readers cannot determine the document language — this is a WCAG 2.1 Level A failure (Success Criterion 3.1.1). If the project uses a Next.js i18n config that sets `lang` automatically, this can be ignored, but that would require verification.

### Issue 2 of 2
web/src/styles/globals.css:407-409
**`isolation: isolate` on `#__next` is app-wide in scope**

This caps every z-index inside `#__next`. Radix primitives using the default `document.body` portal are unaffected. However, any component that uses a Radix primitive with a custom `container` prop pointing to an element inside `#__next` — or any bespoke positioned overlay that intentionally escalates its z-index to escape a sibling stacking context — would now have that z-index capped. It may be worth a quick audit of existing usages before merging.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): add overlay layer system; fix ..."](https://github.com/langfuse/langfuse/commit/1f62c15426af4c949982437ad020cc8db3583ca8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38237208)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->