### PR TITLE
feat(observability): capture final ClickHouse query profile on stream spans

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -276,6 +276,9 @@ export async function* queryClickhouseStream<T>(
       opts.tags,
     );
   } finally {
+    if (queryId) {
+      await recordQueryProfileOnSpan(span, queryId);
+    }
     span.end();
   }
 }
@@ -601,6 +604,88 @@ export {
 
 export function parseClickhouseUTCDateTimeFormat(dateStr: string): Date {
   return new Date(`${dateStr.replace(" ", "T")}Z`);
+}
+
+const PROFILE_EVENT_KEYS = [
+  "NetworkSendElapsedMicroseconds",
+  "NetworkSendBytes",
+  "OSCPUVirtualTimeMicroseconds",
+  "UserTimeMicroseconds",
+  "SystemTimeMicroseconds",
+  "OSIOWaitMicroseconds",
+  "DiskS3ReadMicroseconds",
+  "ReadBufferFromS3Bytes",
+  "SelectedRows",
+  "SelectedBytes",
+  "RealTimeMicroseconds",
+] as const;
+
+function systemQueryLogRef(): string {
+  if (env.CLICKHOUSE_CLUSTER_ENABLED === "true") {
+    return `clusterAllReplicas('${env.CLICKHOUSE_CLUSTER_NAME}', 'system.query_log')`;
+  }
+  return "system.query_log";
+}
+
+async function recordQueryProfileOnSpan(
+  span: Span,
+  queryId: string,
+): Promise<void> {
+  try {
+    const result = await queryClickhouse<{
+      query_duration_ms: string;
+      read_rows: string;
+      read_bytes: string;
+      result_rows: string;
+      result_bytes: string;
+      memory_usage: string;
+      profile_events: Record<string, number>;
+    }>({
+      query: `
+        SELECT
+          query_duration_ms,
+          read_rows,
+          read_bytes,
+          result_rows,
+          result_bytes,
+          memory_usage,
+          ProfileEvents as profile_events
+        FROM ${systemQueryLogRef()}
+        WHERE query_id = {queryId: String}
+          AND type = 'QueryFinish'
+        ORDER BY event_time_microseconds DESC
+        LIMIT 1
+      `,
+      params: { queryId },
+      clickhouseConfigs: { request_timeout: 10_000 },
+      clickhouseSettings: { skip_unavailable_shards: 1 },
+      tags: {
+        feature: "query-tracking",
+        operation: "recordQueryProfileOnSpan",
+      },
+    });
+
+    if (result.length === 0) return;
+
+    const row = result[0];
+    span.setAttribute("ch.final.query_duration_ms", row.query_duration_ms);
+    span.setAttribute("ch.final.read_rows", row.read_rows);
+    span.setAttribute("ch.final.read_bytes", row.read_bytes);
+    span.setAttribute("ch.final.result_rows", row.result_rows);
+    span.setAttribute("ch.final.result_bytes", row.result_bytes);
+    span.setAttribute("ch.final.memory_usage", row.memory_usage);
+
+    if (row.profile_events) {
+      for (const key of PROFILE_EVENT_KEYS) {
+        const value = row.profile_events[key];
+        if (value !== undefined) {
+          span.setAttribute(`ch.final.pe.${key}`, String(value));
+        }
+      }
+    }
+  } catch (error) {
+    logger.debug("Failed to record query profile on span", error);
+  }
 }
 
 export function clickhouseCompliantRandomCharacters() {


### PR DESCRIPTION
## What does this PR do?

After a streaming ClickHouse query completes, queries `system.query_log` for the authoritative final stats and key ProfileEvents, recording them as `ch.final.*` span attributes on the existing `clickhouse-query-stream` OTel span.

**Why:** The existing `x-clickhouse-summary` HTTP header only captures partial/initial stats for streaming queries (time-to-first-byte, not totals). For a blob export query that streamed 3.41M rows over 85 minutes, the header showed only 42K rows. The `ch.final.*` attributes give Datadog the real numbers.

**Attributes added:**
- `ch.final.query_duration_ms`, `ch.final.read_rows`, `ch.final.read_bytes`, `ch.final.result_rows`, `ch.final.result_bytes`, `ch.final.memory_usage`
- `ch.final.pe.NetworkSendElapsedMicroseconds`, `ch.final.pe.OSCPUVirtualTimeMicroseconds`, `ch.final.pe.UserTimeMicroseconds`, `ch.final.pe.SystemTimeMicroseconds`, `ch.final.pe.OSIOWaitMicroseconds`, `ch.final.pe.DiskS3ReadMicroseconds`, `ch.final.pe.ReadBufferFromS3Bytes`, `ch.final.pe.NetworkSendBytes`, `ch.final.pe.SelectedRows`, `ch.final.pe.SelectedBytes`, `ch.final.pe.RealTimeMicroseconds`

## Type of change
- [x] Observability / monitoring improvement

## Checklist
- [x] Lint and typecheck pass (`pnpm turbo run lint typecheck --filter=@langfuse/shared --filter=web --filter=worker`)
- [x] No circular dependency — function lives in `repositories/clickhouse.ts` alongside `queryClickhouse`
- [x] Failure is silent (try/catch with `logger.debug`) — won't break queries if `system.query_log` is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds best-effort ClickHouse execution profile capture to `queryClickhouseStream` spans by querying `system.query_log` after each stream completes and writing the retrieved metrics as span attributes.

- A new `recordQueryProfileOnSpan` helper queries `system.query_log` by `query_id` (with a 10 s timeout and cluster-awareness) and writes fields like `query_duration_ms`, `read_rows`, and selected `ProfileEvents` to the active span before `span.end()`.
- The profile lookup is `await`-ed in the `finally` block, adding a mandatory ClickHouse round-trip to every stream generator's completion path; a slow or timed-out lookup can stall callers for up to 10 seconds.
- ClickHouse flushes `system.query_log` asynchronously by default (every ~7.5 s), so the log entry will typically not be present immediately after the stream finishes, meaning the feature silently no-ops in most standard deployments.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change is additive and errors are caught, but the profile lookup is on the critical path of every streaming query and may stall callers for up to 10 seconds on timeout.

Two real defects in the changed code: the `await` in the `finally` block adds up to 10 s of blocking latency to every `queryClickhouseStream` call, and ClickHouse's async `system.query_log` flush means the feature silently captures nothing in the common case without a non-default server configuration. Both issues affect all callers of the stream path.

packages/shared/src/server/repositories/clickhouse.ts — specifically the `finally` block in `queryClickhouseStream` and the `recordQueryProfileOnSpan` implementation.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant queryClickhouseStream
    participant ClickHouse_main as ClickHouse (main)
    participant recordQueryProfileOnSpan
    participant ClickHouse_log as ClickHouse (system.query_log)

    Caller->>queryClickhouseStream: for await rows
    queryClickhouseStream->>ClickHouse_main: sendClickhouseQuery (gets queryId)
    ClickHouse_main-->>queryClickhouseStream: stream rows
    queryClickhouseStream-->>Caller: yield rows (one by one)
    Note over ClickHouse_main: Async flush to system.query_log (default every 7500ms)
    Note over queryClickhouseStream: Stream exhausted — finally block
    queryClickhouseStream->>recordQueryProfileOnSpan: await (queryId)
    recordQueryProfileOnSpan->>ClickHouse_log: "SELECT from system.query_log WHERE query_id=? timeout 10s"
    ClickHouse_log-->>recordQueryProfileOnSpan: 0 rows (log not flushed yet) OR profile row
    recordQueryProfileOnSpan-->>queryClickhouseStream: setAttribute on span (or no-op)
    queryClickhouseStream->>queryClickhouseStream: span.end()
    queryClickhouseStream-->>Caller: generator complete
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant queryClickhouseStream
    participant ClickHouse_main as ClickHouse (main)
    participant recordQueryProfileOnSpan
    participant ClickHouse_log as ClickHouse (system.query_log)

    Caller->>queryClickhouseStream: for await rows
    queryClickhouseStream->>ClickHouse_main: sendClickhouseQuery (gets queryId)
    ClickHouse_main-->>queryClickhouseStream: stream rows
    queryClickhouseStream-->>Caller: yield rows (one by one)
    Note over ClickHouse_main: Async flush to system.query_log (default every 7500ms)
    Note over queryClickhouseStream: Stream exhausted — finally block
    queryClickhouseStream->>recordQueryProfileOnSpan: await (queryId)
    recordQueryProfileOnSpan->>ClickHouse_log: "SELECT from system.query_log WHERE query_id=? timeout 10s"
    ClickHouse_log-->>recordQueryProfileOnSpan: 0 rows (log not flushed yet) OR profile row
    recordQueryProfileOnSpan-->>queryClickhouseStream: setAttribute on span (or no-op)
    queryClickhouseStream->>queryClickhouseStream: span.end()
    queryClickhouseStream-->>Caller: generator complete
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/shared/src/server/repositories/clickhouse.ts:279-281
**Latency added to every stream generator's completion**

`recordQueryProfileOnSpan` is `await`-ed in the `finally` block, adding at least one extra ClickHouse round-trip to the critical path of every `queryClickhouseStream` call. Because `request_timeout: 10_000` is passed to the inner `queryClickhouse` call, a slow or unavailable `system.query_log` (e.g., under heavy load or during a transient failure) will stall the generator for the full 10 seconds before the caught timeout error allows `span.end()` to proceed. The profile collection is best-effort telemetry and doesn't need to block the caller. Consider firing it without blocking the generator (but before calling `span.end()`) or using a shorter timeout, e.g., `request_timeout: 2_000`.

### Issue 2 of 4
packages/shared/src/server/repositories/clickhouse.ts:640-648
**`system.query_log` async flush timing makes this unreliable by default**

ClickHouse writes to `system.query_log` asynchronously (default `flush_interval_milliseconds = 7500`). Querying the log immediately after the stream completes will almost always return 0 rows — causing the function to return silently and record nothing. Without a configured `flush_logs_synchronously = 1` on the ClickHouse server or a short delay/retry before querying, the feature will rarely capture any profile data in a default deployment.

### Issue 3 of 4
packages/shared/src/server/repositories/clickhouse.ts:621-625
**`CLICKHOUSE_CLUSTER_NAME` is interpolated into the query string**

`env.CLICKHOUSE_CLUSTER_NAME` is embedded directly into the query rather than passed as a parameterized value. While this env variable is set at server startup and is not user-controlled, it deviates from the parameterized pattern used elsewhere in this file. Consider validating the cluster name against an allowlist or asserting it only contains alphanumeric and hyphen characters at startup.

### Issue 4 of 4
packages/shared/src/server/repositories/clickhouse.ts:490-537
**`queryClickhouseWithProgress` does not receive the same profile capture**

`queryClickhouseWithProgress` creates its own span and also streams ClickHouse results, but its `finally` block only calls `span.end()` without the `recordQueryProfileOnSpan` call added to `queryClickhouseStream`. If profile capture is useful for stream spans, the same observability data would be valuable for progress-streaming spans. Was this omission intentional?

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(observability): capture final Click..."](https://github.com/langfuse/langfuse/commit/4b23637cd181ad9b3c5f5d3c0da5ec938e94a06f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38350964)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->