### PR TITLE
feat(observability): add application-level timing to blob export pipeline

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -220,13 +220,12 @@ async function* countedStream<T>(
   source: AsyncGenerator<T>,
   stats: { rows: number; sourceWaitMs: number },
 ): AsyncGenerator<T> {
-  for (;;) {
-    const t0 = performance.now();
-    const { value, done } = await source.next();
-    stats.sourceWaitMs += performance.now() - t0;
-    if (done) break;
+  let lastYield = performance.now();
+  for await (const value of source) {
+    stats.sourceWaitMs += performance.now() - lastYield;
     stats.rows++;
     yield value;
+    lastYield = performance.now();
   }
 }
 
@@ -328,7 +327,7 @@ const processBlobStorageExport = async (config: {
               ),
               config.projectId,
               "model_id",
-              false,
+              false, // v3 query already returns latency in seconds
               exportFieldGroups,
             );
             break;
@@ -339,7 +338,7 @@ const processBlobStorageExport = async (config: {
               config.maxTimestamp,
             );
             break;
-          case "observations_v2":
+          case "observations_v2": // observations_v2 is the events table
             rawStream = enrichObservationStream(
               getEventsForBlobStorageExport(
                 config.projectId,
@@ -389,36 +388,43 @@ const processBlobStorageExport = async (config: {
               pipelineCallback,
             );
 
-        const uploadStartMs = performance.now();
+        // Upload the file to cloud storage
+        // For CSV exports, use larger part size to handle big files
+        // 100 MB parts support files up to ~1 TB (100 MB × 10,000 AWS limit)
+        // This prevents hitting AWS's 10,000 part limit on large exports
+        let uploadStartMs: number | undefined;
+        try {
+          uploadStartMs = performance.now();
 
-        await storageService.uploadFileBuffered({
-          fileName: filePath,
-          fileType: uploadContentType,
-          data: fileStream,
-          partSizeBytes: 100 * 1024 * 1024,
-        });
+          await storageService.uploadFileBuffered({
+            fileName: filePath,
+            fileType: uploadContentType,
+            data: fileStream,
+            partSizeBytes: 100 * 1024 * 1024, // 100 MB part size
+          });
 
-        const uploadDurationMs = performance.now() - uploadStartMs;
-
-        span.setAttribute("blob.rows", sourceStats.rows);
-        span.setAttribute(
-          "blob.sourceWaitMs",
-          Math.round(sourceStats.sourceWaitMs),
-        );
-        span.setAttribute("blob.serializedBytes", serializedCounter.bytes);
-        span.setAttribute(
-          "blob.uploadDurationMs",
-          Math.round(uploadDurationMs),
-        );
-        if (compressedCounter) {
-          span.setAttribute("blob.compressedBytes", compressedCounter.bytes);
+          logger.info(
+            `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
+              `rows=${sourceStats.rows} sourceWaitMs=${Math.round(sourceStats.sourceWaitMs)} ` +
+              `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${Math.round(performance.now() - uploadStartMs)}`,
+          );
+        } finally {
+          span.setAttribute("blob.rows", sourceStats.rows);
+          span.setAttribute(
+            "blob.sourceWaitMs",
+            Math.round(sourceStats.sourceWaitMs),
+          );
+          span.setAttribute("blob.serializedBytes", serializedCounter.bytes);
+          if (uploadStartMs !== undefined) {
+            span.setAttribute(
+              "blob.uploadDurationMs",
+              Math.round(performance.now() - uploadStartMs),
+            );
+          }
+          if (compressedCounter) {
+            span.setAttribute("blob.compressedBytes", compressedCounter.bytes);
+          }
         }
-
-        logger.info(
-          `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
-            `rows=${sourceStats.rows} sourceWaitMs=${Math.round(sourceStats.sourceWaitMs)} ` +
-            `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${Math.round(uploadDurationMs)}`,
-        );
       } catch (error) {
         logger.error(
           `[BLOB INTEGRATION] Error exporting ${config.table} for project ${config.projectId}`,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1,4 +1,4 @@
-import { pipeline } from "stream";
+import { pipeline, Transform } from "stream";
 import { createGzip } from "zlib";
 import { Job } from "bullmq";
 import { prisma } from "@langfuse/shared/src/db";
@@ -14,6 +14,7 @@ import {
   getScoresForBlobStorageExport,
   getEventsForBlobStorageExport,
   getCurrentSpan,
+  instrumentAsync,
   BlobStorageIntegrationProcessingQueue,
   queryClickhouse,
   QueueJobs,
@@ -35,6 +36,7 @@ import {
 } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
 import { randomUUID } from "crypto";
+import { SpanKind } from "@opentelemetry/api";
 import { env, v4AllowPreviewOptIn } from "../../env";
 
 export const BLOB_STORAGE_LAG_BUFFER_MS = 20 * 60 * 1000; // 20-minute lag buffer
@@ -202,6 +204,32 @@ const getFileTypeProperties = (fileType: BlobStorageIntegrationFileType) => {
   }
 };
 
+class ByteCounter extends Transform {
+  bytes = 0;
+  _transform(
+    chunk: Buffer,
+    _encoding: string,
+    callback: (error: Error | null, data?: Buffer) => void,
+  ) {
+    this.bytes += chunk.length;
+    callback(null, chunk);
+  }
+}
+
+async function* countedStream<T>(
+  source: AsyncGenerator<T>,
+  stats: { rows: number; sourceWaitMs: number },
+): AsyncGenerator<T> {
+  for (;;) {
+    const t0 = performance.now();
+    const { value, done } = await source.next();
+    stats.sourceWaitMs += performance.now() - t0;
+    if (done) break;
+    stats.rows++;
+    yield value;
+  }
+}
+
 const processBlobStorageExport = async (config: {
   projectId: string;
   minTimestamp: Date;
@@ -241,113 +269,165 @@ const processBlobStorageExport = async (config: {
     connectionValidation: blobStorageEndpointConnectionValidationOptions(),
   });
 
-  try {
-    const blobStorageProps = getFileTypeProperties(config.fileType);
+  await instrumentAsync(
+    {
+      name: `blob-export-table`,
+      spanKind: SpanKind.INTERNAL,
+    },
+    async (span) => {
+      span.setAttribute("blob.table", config.table);
+      span.setAttribute("blob.projectId", config.projectId);
+      span.setAttribute("blob.compressed", config.compressed);
+      span.setAttribute("blob.fileType", config.fileType);
+      span.setAttribute(
+        "blob.window.minTimestamp",
+        config.minTimestamp.toISOString(),
+      );
+      span.setAttribute(
+        "blob.window.maxTimestamp",
+        config.maxTimestamp.toISOString(),
+      );
 
-    // Create the file path with prefix if available
-    const timestamp = config.maxTimestamp
-      .toISOString()
-      .replace(/:/g, "-")
-      .substring(0, 19);
-    const extension = config.compressed
-      ? `${blobStorageProps.extension}.gz`
-      : blobStorageProps.extension;
-    const filePath = `${config.prefix ?? ""}${config.projectId}/${config.table}/${timestamp}.${extension}`;
-    const uploadContentType = config.compressed
-      ? "application/gzip"
-      : blobStorageProps.contentType;
+      try {
+        const blobStorageProps = getFileTypeProperties(config.fileType);
 
-    // Fetch data based on table type
-    const exportFieldGroups =
-      config.exportFieldGroups && config.exportFieldGroups.length > 0
-        ? config.exportFieldGroups
-        : [...OBSERVATION_FIELD_GROUPS_FULL];
+        const timestamp = config.maxTimestamp
+          .toISOString()
+          .replace(/:/g, "-")
+          .substring(0, 19);
+        const extension = config.compressed
+          ? `${blobStorageProps.extension}.gz`
+          : blobStorageProps.extension;
+        const filePath = `${config.prefix ?? ""}${config.projectId}/${config.table}/${timestamp}.${extension}`;
+        const uploadContentType = config.compressed
+          ? "application/gzip"
+          : blobStorageProps.contentType;
 
-    let dataStream: AsyncGenerator<Record<string, unknown>>;
+        const exportFieldGroups =
+          config.exportFieldGroups && config.exportFieldGroups.length > 0
+            ? config.exportFieldGroups
+            : [...OBSERVATION_FIELD_GROUPS_FULL];
 
-    switch (config.table) {
-      case "traces":
-        dataStream = getTracesForBlobStorageExport(
-          config.projectId,
-          config.minTimestamp,
-          config.maxTimestamp,
+        let rawStream: AsyncGenerator<Record<string, unknown>>;
+
+        switch (config.table) {
+          case "traces":
+            rawStream = getTracesForBlobStorageExport(
+              config.projectId,
+              config.minTimestamp,
+              config.maxTimestamp,
+            );
+            break;
+          case "observations":
+            rawStream = enrichObservationStream(
+              getObservationsForBlobStorageExport(
+                config.projectId,
+                config.minTimestamp,
+                config.maxTimestamp,
+                exportFieldGroups,
+              ),
+              config.projectId,
+              "model_id",
+              false,
+              exportFieldGroups,
+            );
+            break;
+          case "scores":
+            rawStream = getScoresForBlobStorageExport(
+              config.projectId,
+              config.minTimestamp,
+              config.maxTimestamp,
+            );
+            break;
+          case "observations_v2":
+            rawStream = enrichObservationStream(
+              getEventsForBlobStorageExport(
+                config.projectId,
+                config.minTimestamp,
+                config.maxTimestamp,
+                exportFieldGroups,
+              ),
+              config.projectId,
+              "model_id",
+              config.convertV4LatencyToSeconds,
+              exportFieldGroups,
+            );
+            break;
+          default:
+            throw new Error(`Unsupported table type: ${config.table}`);
+        }
+
+        const sourceStats = { rows: 0, sourceWaitMs: 0 };
+        const dataStream = countedStream(rawStream, sourceStats);
+
+        const pipelineCallback = (err: NodeJS.ErrnoException | null) => {
+          if (err) {
+            logger.error(
+              "[BLOB INTEGRATION] Getting data from DB for blob storage integration failed: ",
+              err,
+            );
+          }
+        };
+
+        const serializedCounter = new ByteCounter();
+        const compressedCounter = config.compressed ? new ByteCounter() : null;
+        const formatTransform = streamTransformations[config.fileType]();
+
+        const fileStream = compressedCounter
+          ? pipeline(
+              dataStream,
+              formatTransform,
+              serializedCounter,
+              createGzip(),
+              compressedCounter,
+              pipelineCallback,
+            )
+          : pipeline(
+              dataStream,
+              formatTransform,
+              serializedCounter,
+              pipelineCallback,
+            );
+
+        const uploadStartMs = performance.now();
+
+        await storageService.uploadFileBuffered({
+          fileName: filePath,
+          fileType: uploadContentType,
+          data: fileStream,
+          partSizeBytes: 100 * 1024 * 1024,
+        });
+
+        const uploadDurationMs = performance.now() - uploadStartMs;
+
+        span.setAttribute("blob.rows", sourceStats.rows);
+        span.setAttribute(
+          "blob.sourceWaitMs",
+          Math.round(sourceStats.sourceWaitMs),
         );
-        break;
-      case "observations":
-        dataStream = enrichObservationStream(
-          getObservationsForBlobStorageExport(
-            config.projectId,
-            config.minTimestamp,
-            config.maxTimestamp,
-            exportFieldGroups,
-          ),
-          config.projectId,
-          "model_id",
-          false, // v3 query already returns latency in seconds
-          exportFieldGroups,
+        span.setAttribute("blob.serializedBytes", serializedCounter.bytes);
+        span.setAttribute(
+          "blob.uploadDurationMs",
+          Math.round(uploadDurationMs),
         );
-        break;
-      case "scores":
-        dataStream = getScoresForBlobStorageExport(
-          config.projectId,
-          config.minTimestamp,
-          config.maxTimestamp,
-        );
-        break;
-      case "observations_v2": // observations_v2 is the events table
-        dataStream = enrichObservationStream(
-          getEventsForBlobStorageExport(
-            config.projectId,
-            config.minTimestamp,
-            config.maxTimestamp,
-            exportFieldGroups,
-          ),
-          config.projectId,
-          "model_id",
-          config.convertV4LatencyToSeconds,
-          exportFieldGroups,
-        );
-        break;
-      default:
-        throw new Error(`Unsupported table type: ${config.table}`);
-    }
+        if (compressedCounter) {
+          span.setAttribute("blob.compressedBytes", compressedCounter.bytes);
+        }
 
-    const pipelineCallback = (err: NodeJS.ErrnoException | null) => {
-      if (err) {
+        logger.info(
+          `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
+            `rows=${sourceStats.rows} sourceWaitMs=${Math.round(sourceStats.sourceWaitMs)} ` +
+            `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${Math.round(uploadDurationMs)}`,
+        );
+      } catch (error) {
         logger.error(
-          "[BLOB INTEGRATION] Getting data from DB for blob storage integration failed: ",
-          err,
+          `[BLOB INTEGRATION] Error exporting ${config.table} for project ${config.projectId}`,
+          error,
         );
+        throw error;
       }
-    };
-
-    const formatTransform = streamTransformations[config.fileType]();
-    const fileStream = config.compressed
-      ? pipeline(dataStream, formatTransform, createGzip(), pipelineCallback)
-      : pipeline(dataStream, formatTransform, pipelineCallback);
-
-    // Upload the file to cloud storage
-    // For CSV exports, use larger part size to handle big files
-    // 100 MB parts support files up to ~1 TB (100 MB × 10,000 AWS limit)
-    // This prevents hitting AWS's 10,000 part limit on large exports
-
-    await storageService.uploadFileBuffered({
-      fileName: filePath,
-      fileType: uploadContentType,
-      data: fileStream,
-      partSizeBytes: 100 * 1024 * 1024, // 100 MB part size
-    });
-
-    logger.info(
-      `[BLOB INTEGRATION] Successfully exported ${config.table} records for project ${config.projectId}`,
-    );
-  } catch (error) {
-    logger.error(
-      `[BLOB INTEGRATION] Error exporting ${config.table} for project ${config.projectId}`,
-      error,
-    );
-    throw error;
-  }
+    },
+  );
 };
 
 export const handleBlobStorageIntegrationProjectJob = async (


### PR DESCRIPTION
## What does this PR do?

Instruments the blob export streaming pipeline with per-table OTel spans and counters so we can see where wall-clock time is spent from the application side — without querying `system.query_log`.

Each `processBlobStorageExport` call (one per table) is now wrapped in a `blob-export-table` child span under the existing BullMQ job span, with these attributes:

| Attribute | What it measures |
|---|---|
| `blob.rows` | Total rows consumed from the ClickHouse stream |
| `blob.sourceWaitMs` | Cumulative ms blocked on `next()` — time waiting for ClickHouse + enrichment |
| `blob.serializedBytes` | Bytes after JSONL/CSV/JSON serialization (before gzip) |
| `blob.compressedBytes` | Bytes after gzip compression (when enabled) |
| `blob.uploadDurationMs` | Wall-clock ms for the entire pipeline-to-upload |
| `blob.table` | Which table: traces / observations / scores / observations_v2 |
| `blob.window.minTimestamp` / `blob.window.maxTimestamp` | Export time window |

**Implementation:**
- `ByteCounter` — a pass-through Transform stream that counts bytes flowing through it, inserted between serialization→gzip and gzip→upload
- `countedStream` — wraps the async generator to count rows and measure cumulative time spent in `next()` calls (ClickHouse fetch + enrichment)

## Type of change
- [x] Observability / monitoring improvement

## Checklist
- [x] Lint and typecheck pass
- [x] No new dependencies
- [x] No behavioral changes to the export pipeline — counters are pass-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds application-level timing and byte-counting instrumentation to the blob export pipeline in `handleBlobStorageIntegrationProjectJob.ts`. It wraps `processBlobStorageExport` in an OpenTelemetry span via `instrumentAsync` and introduces two lightweight helpers — `ByteCounter` (a passthrough `Transform` that accumulates byte counts) and `countedStream` (an async generator wrapper that tracks row counts and source-wait latency).

- Adds `ByteCounter` Transform streams placed after the format serializer and after gzip compression to capture pre- and post-compression byte sizes, which are recorded as span attributes and included in the success log line.
- Introduces `countedStream` to measure per-row time spent awaiting the upstream async generator (`sourceWaitMs`) alongside an exact row count, both exposed as span attributes.
- Wraps the entire export operation in an OTel `INTERNAL` span with table, project, file type, time-window, and all collected metrics as attributes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is additive instrumentation only — no business logic is altered, and failures inside the span are caught and re-thrown identically to the previous behavior.

The instrumentation is correct and the pipeline ordering preserves the pre-PR behavior exactly. Two metric names cover broader work than their names imply, which could lead to incorrect conclusions when operators try to isolate slow components — but this does not affect export correctness.

worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts — specifically the two new metric definitions and the span attribute naming around lines 390–418.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant J as BullMQ Job
    participant P as processBlobStorageExport
    participant I as instrumentAsync (OTel Span)
    participant CS as countedStream
    participant RS as rawStream (ClickHouse/Enriched)
    participant FT as formatTransform (JSON/JSONL/CSV)
    participant SC as serializedCounter (ByteCounter)
    participant GZ as createGzip (optional)
    participant CC as compressedCounter (ByteCounter, optional)
    participant US as uploadFileBuffered (S3/GCS/Azure)

    J->>P: processBlobStorageExport(config)
    P->>I: instrumentAsync(span, callback)
    I->>I: span.setAttribute(table, projectId, timestamps)
    I->>CS: countedStream(rawStream, sourceStats)
    loop streaming pipeline
        CS->>RS: source.next() [measures sourceWaitMs]
        RS-->>CS: row (or done)
        CS->>FT: yield row [increments sourceStats.rows]
        FT->>SC: formatted chunk [ByteCounter accumulates serializedBytes]
        SC->>GZ: chunk (if compressed)
        GZ->>CC: compressed chunk [ByteCounter accumulates compressedBytes]
        CC-->>US: compressed bytes
    end
    P->>US: uploadFileBuffered(fileStream) [measures uploadDurationMs]
    US-->>P: resolved
    P->>I: span.setAttribute(rows, sourceWaitMs, serializedBytes, uploadDurationMs, compressedBytes)
    I-->>J: span ends
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant J as BullMQ Job
    participant P as processBlobStorageExport
    participant I as instrumentAsync (OTel Span)
    participant CS as countedStream
    participant RS as rawStream (ClickHouse/Enriched)
    participant FT as formatTransform (JSON/JSONL/CSV)
    participant SC as serializedCounter (ByteCounter)
    participant GZ as createGzip (optional)
    participant CC as compressedCounter (ByteCounter, optional)
    participant US as uploadFileBuffered (S3/GCS/Azure)

    J->>P: processBlobStorageExport(config)
    P->>I: instrumentAsync(span, callback)
    I->>I: span.setAttribute(table, projectId, timestamps)
    I->>CS: countedStream(rawStream, sourceStats)
    loop streaming pipeline
        CS->>RS: source.next() [measures sourceWaitMs]
        RS-->>CS: row (or done)
        CS->>FT: yield row [increments sourceStats.rows]
        FT->>SC: formatted chunk [ByteCounter accumulates serializedBytes]
        SC->>GZ: chunk (if compressed)
        GZ->>CC: compressed chunk [ByteCounter accumulates compressedBytes]
        CC-->>US: compressed bytes
    end
    P->>US: uploadFileBuffered(fileStream) [measures uploadDurationMs]
    US-->>P: resolved
    P->>I: span.setAttribute(rows, sourceWaitMs, serializedBytes, uploadDurationMs, compressedBytes)
    I-->>J: span ends
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:390-399
**`uploadDurationMs` measures more than network upload time**

`uploadStartMs` is captured immediately before `uploadFileBuffered`, but that call drives the entire streaming pipeline — data is pulled from ClickHouse, serialized, optionally compressed, and transferred in one streaming operation. The resulting `uploadDurationMs` value therefore encompasses source-fetch, serialization, gzip, and network transfer all at once, making it hard to isolate actual network latency from the already-tracked `sourceWaitMs`. Consider renaming to `pipelineDurationMs` or `totalExportDurationMs` to reflect that it is the end-to-end wall-clock time for the whole export, not just the S3/GCS/Azure write.

### Issue 2 of 2
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:358-359
**`sourceWaitMs` includes model-enrichment time for observation tables**

`countedStream` wraps `rawStream`, which for the `observations` and `observations_v2` cases is already the output of `enrichObservationStream`. That enrichment performs per-row Postgres model lookups via `createModelCache`. So `sourceWaitMs` accumulates both ClickHouse query time and model-cache/DB round-trip time rather than pure data-source latency. The metric name and span attribute `blob.sourceWaitMs` may mislead operators debugging performance (e.g., attributing slow model lookups to a slow data source). Consider wrapping only the innermost `rawStream` generators before enrichment, or rename the metric to something like `streamReadMs` / `sourceAndEnrichmentWaitMs`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(observability): add application-lev..."](https://github.com/langfuse/langfuse/commit/95fef6fbc5d4ffa2492a1fcceaa5f7503387c6a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38352173)</sub>

<!-- /greptile_comment -->