### PR TITLE
feat(playground): Add image attachment support via inline message media

### DIFF
--- a/packages/shared/src/server/llm/compileChatMessages.test.ts
+++ b/packages/shared/src/server/llm/compileChatMessages.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compileChatMessages,
+  compileChatMessagesWithIds,
+} from "./compileChatMessages";
+import {
+  ChatMessageRole,
+  ChatMessageType,
+  type ChatMessageWithId,
+} from "./types";
+
+describe("compileChatMessages variable substitution", () => {
+  it("substitutes variables in plain-string content (unchanged behaviour)", () => {
+    const [compiled] = compileChatMessages(
+      [{ role: ChatMessageRole.User, content: "Hello {{name}}" }],
+      {},
+      { name: "World" },
+    );
+    expect(compiled.content).toBe("Hello World");
+  });
+
+  it("substitutes variables inside text parts of multimodal content", () => {
+    const messages: ChatMessageWithId[] = [
+      {
+        id: "1",
+        type: ChatMessageType.User,
+        role: ChatMessageRole.User,
+        content: [
+          { type: "text", text: "Describe {{subject}}" },
+          {
+            type: "media",
+            mediaId: "m1",
+            mimeType: "image/png",
+            reference: "@@@langfuseMedia:type=image/png|id=m1|source=base64@@@",
+          },
+        ],
+      },
+    ];
+
+    const [compiled] = compileChatMessagesWithIds(
+      messages,
+      {},
+      {
+        subject: "this image",
+      },
+    );
+
+    expect(compiled.content).toEqual([
+      { type: "text", text: "Describe this image" },
+      {
+        type: "media",
+        mediaId: "m1",
+        mimeType: "image/png",
+        reference: "@@@langfuseMedia:type=image/png|id=m1|source=base64@@@",
+      },
+    ]);
+  });
+});

--- a/packages/shared/src/server/llm/compileChatMessages.ts
+++ b/packages/shared/src/server/llm/compileChatMessages.ts
@@ -13,7 +13,7 @@ export type MessagePlaceholderValues = Record<string, unknown[]>;
 export type PromptMessage = z.infer<typeof PromptChatMessageSchema>;
 
 export function isPlaceholder(
-  message: PromptMessage,
+  message: PromptMessage | ChatMessageWithId,
 ): message is PlaceholderMessage {
   return "type" in message && message.type === ChatMessageType.Placeholder;
 }
@@ -29,6 +29,35 @@ function replaceTextVariables(
     result = result.replace(variablePattern, varValue);
   }
   return result;
+}
+
+/**
+ * Substitute {{variables}} in a message's content. Plain-string content is
+ * replaced directly; multimodal array content has variables substituted inside
+ * its text parts only (media parts pass through untouched). Any other shape is
+ * returned unchanged.
+ */
+function replaceContentVariables(
+  content: unknown,
+  textVariables: Record<string, string>,
+): unknown {
+  if (typeof content === "string") {
+    return replaceTextVariables(content, textVariables);
+  }
+  if (Array.isArray(content)) {
+    return content.map((part) =>
+      part && typeof part === "object" && (part as any).type === "text"
+        ? {
+            ...part,
+            text: replaceTextVariables(
+              String((part as any).text ?? ""),
+              textVariables,
+            ),
+          }
+        : part,
+    );
+  }
+  return content;
 }
 
 function expandPlaceholder(
@@ -79,14 +108,14 @@ export function compileChatMessages(
   }
 
   return expandedMessages.map((message) => {
-    if (!message.content || typeof message.content !== "string") {
+    if (!message.content) {
       return message;
     }
 
     return {
       ...message,
-      content: replaceTextVariables(message.content, textVariables),
-    };
+      content: replaceContentVariables(message.content, textVariables),
+    } as ChatMessage;
   });
 }
 
@@ -112,14 +141,14 @@ export function compileChatMessagesWithIds(
   }
 
   return expandedMessages.map((message) => {
-    if (!message.content || typeof message.content !== "string") {
+    if (!message.content) {
       return message;
     }
 
     return {
       ...message,
-      content: replaceTextVariables(message.content, textVariables),
-    };
+      content: replaceContentVariables(message.content, textVariables),
+    } as ChatMessageWithIdNoPlaceholders;
   });
 }
 

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -36,6 +36,7 @@ import GCPServiceAccountKeySchema, {
 } from "../../interfaces/customLLMProviderConfigSchemas";
 import {
   ChatMessage,
+  type ChatMessageContent,
   ChatMessageRole,
   ChatMessageType,
   isOpenAIReasoningModel,
@@ -232,14 +233,69 @@ function shouldNormalizeContentBlocks(modelParams: ModelParams): boolean {
   );
 }
 
+/**
+ * The single conversion boundary for multimodal input. A Langfuse message's
+ * `content` (provider-agnostic: string, or text + media parts) is turned into
+ * LangChain message content. LangChain then translates this one block shape
+ * into each provider's native multimodal format, so we never branch per
+ * provider here.
+ *
+ * Media parts must already carry resolved base64 `data` (injected by the web
+ * media resolver before the call); a missing payload is a programming error and
+ * fails loudly rather than silently dropping the attachment.
+ */
+export function buildHumanMessageContent(
+  content: ChatMessageContent,
+): string | ContentBlock[] {
+  if (typeof content === "string") return content;
+
+  const blocks: ContentBlock[] = [];
+  for (const part of content) {
+    if (part.type === "text") {
+      // Skip empty text spans so an image-only message isn't filtered out later.
+      if (part.text.length > 0)
+        blocks.push({ type: "text", text: part.text } as ContentBlock);
+      continue;
+    }
+
+    if (!part.data) {
+      throw new LLMCompletionError({
+        message: `Media attachment ${part.mediaId} was not resolved before the model call`,
+        responseStatusCode: 500,
+      });
+    }
+
+    if (part.mimeType.startsWith("image/")) {
+      // Legacy `source_type` data block: the one multimodal shape accepted by
+      // every provider's LangChain input converter (OpenAI/Anthropic/Google/
+      // Bedrock). Base64 (not a URL) keeps private media out of provider fetches.
+      blocks.push({
+        type: "image",
+        source_type: "base64",
+        mime_type: part.mimeType,
+        data: part.data,
+      } as unknown as ContentBlock);
+    } else {
+      // Audio/video are an intentional extension point: upload + UI may accept
+      // them later, but we don't claim provider support we haven't verified.
+      throw new LLMCompletionError({
+        message: `Unsupported media type for model input: ${part.mimeType}. Only images are currently supported.`,
+        responseStatusCode: 400,
+      });
+    }
+  }
+
+  return blocks;
+}
+
 const transformSystemMessageToUserMessage = (
   messages: ChatMessage[],
 ): BaseMessage[] => {
-  const safeContent =
-    typeof messages[0].content === "string"
-      ? messages[0].content
-      : JSON.stringify(messages[0].content);
-  return [new HumanMessage(safeContent)];
+  return [
+    new HumanMessage({
+      content: buildHumanMessageContent(messages[0].content),
+    }),
+  ];
 };
 
 const googleProviderOptionsSchema = z
@@ -420,7 +476,11 @@ export async function fetchLLMCompletion(
           : safeStringify(message.content);
 
       if (message.role === ChatMessageRole.User)
-        return new HumanMessage(safeContent);
+        // User content may be multimodal (string stays a string, parts become
+        // LangChain content blocks). All other roles remain string-only.
+        return new HumanMessage({
+          content: buildHumanMessageContent(message.content),
+        });
       if (
         message.role === ChatMessageRole.System ||
         message.role === ChatMessageRole.Developer

--- a/packages/shared/src/server/llm/multimodalContent.test.ts
+++ b/packages/shared/src/server/llm/multimodalContent.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addMediaPart,
+  buildMediaReferenceString,
+  type ChatMessageMediaContentPart,
+  ChatMessageRole,
+  ChatMessageType,
+  ChatMessageSchema,
+  getMediaParts,
+  getMessageText,
+  hasMediaParts,
+  removeMediaPart,
+  setMessageText,
+  UserMessageSchema,
+} from "./types";
+import { buildHumanMessageContent } from "./fetchLLMCompletion";
+
+const mediaPart = (mediaId: string): ChatMessageMediaContentPart => ({
+  type: "media",
+  mediaId,
+  mimeType: "image/png",
+  reference: buildMediaReferenceString({ mediaId, mimeType: "image/png" }),
+});
+
+describe("multimodal content helpers", () => {
+  it("treats plain strings as text-only", () => {
+    expect(getMessageText("hello")).toBe("hello");
+    expect(hasMediaParts("hello")).toBe(false);
+    expect(getMediaParts("hello")).toEqual([]);
+    // setMessageText keeps string content a string (text-only stays untouched)
+    expect(setMessageText("hello", "world")).toBe("world");
+  });
+
+  it("extracts and edits text while preserving media parts", () => {
+    const content = addMediaPart("before", mediaPart("m1"));
+
+    expect(getMessageText(content)).toBe("before");
+    expect(hasMediaParts(content)).toBe(true);
+
+    const edited = setMessageText(content, "after");
+    expect(getMessageText(edited)).toBe("after");
+    expect(getMediaParts(edited).map((p) => p.mediaId)).toEqual(["m1"]);
+  });
+
+  it("collapses back to a plain string when the last media is removed", () => {
+    const withMedia = addMediaPart("caption", mediaPart("m1"));
+    const removed = removeMediaPart(withMedia, "m1");
+    expect(removed).toBe("caption");
+    expect(typeof removed).toBe("string");
+  });
+
+  it("keeps array form while other media remain", () => {
+    let content = addMediaPart("caption", mediaPart("m1"));
+    content = addMediaPart(content, mediaPart("m2"));
+    const removed = removeMediaPart(content, "m1");
+    expect(Array.isArray(removed)).toBe(true);
+    expect(getMediaParts(removed).map((p) => p.mediaId)).toEqual(["m2"]);
+  });
+
+  it("builds the canonical media reference token", () => {
+    expect(
+      buildMediaReferenceString({ mediaId: "abc", mimeType: "image/png" }),
+    ).toBe("@@@langfuseMedia:type=image/png|id=abc|source=base64@@@");
+  });
+});
+
+describe("ChatMessage schema with multimodal user content", () => {
+  it("accepts a plain-string user message (unchanged behaviour)", () => {
+    const parsed = UserMessageSchema.parse({
+      type: ChatMessageType.User,
+      role: ChatMessageRole.User,
+      content: "just text",
+    });
+    expect(parsed.content).toBe("just text");
+  });
+
+  it("accepts structured user content with text + media parts", () => {
+    const parsed = ChatMessageSchema.parse({
+      type: ChatMessageType.User,
+      role: ChatMessageRole.User,
+      content: [{ type: "text", text: "describe this" }, mediaPart("m1")],
+    });
+    expect(Array.isArray(parsed.content)).toBe(true);
+    expect(getMediaParts(parsed.content).length).toBe(1);
+  });
+});
+
+describe("buildHumanMessageContent (conversion boundary)", () => {
+  it("passes plain strings through unchanged", () => {
+    expect(buildHumanMessageContent("hello")).toBe("hello");
+  });
+
+  it("builds a base64 image block alongside text", () => {
+    const blocks = buildHumanMessageContent([
+      { type: "text", text: "what is this?" },
+      { ...mediaPart("m1"), data: "QUJD" },
+    ]);
+    expect(blocks).toEqual([
+      { type: "text", text: "what is this?" },
+      {
+        type: "image",
+        source_type: "base64",
+        mime_type: "image/png",
+        data: "QUJD",
+      },
+    ]);
+  });
+
+  it("drops empty text spans so image-only messages survive filtering", () => {
+    const blocks = buildHumanMessageContent([
+      { type: "text", text: "" },
+      { ...mediaPart("m1"), data: "QUJD" },
+    ]);
+    expect(blocks).toEqual([
+      {
+        type: "image",
+        source_type: "base64",
+        mime_type: "image/png",
+        data: "QUJD",
+      },
+    ]);
+  });
+
+  it("throws when a media part was not resolved", () => {
+    expect(() =>
+      buildHumanMessageContent([{ type: "text", text: "x" }, mediaPart("m1")]),
+    ).toThrow(/was not resolved/);
+  });
+
+  it("rejects non-image media for now", () => {
+    expect(() =>
+      buildHumanMessageContent([
+        {
+          type: "media",
+          mediaId: "a1",
+          mimeType: "audio/mpeg",
+          reference: buildMediaReferenceString({
+            mediaId: "a1",
+            mimeType: "audio/mpeg",
+          }),
+          data: "QUJD",
+        },
+      ]),
+    ).toThrow(/Unsupported media type/);
+  });
+});

--- a/packages/shared/src/server/llm/types.ts
+++ b/packages/shared/src/server/llm/types.ts
@@ -133,6 +133,146 @@ export enum ChatMessageType {
   Placeholder = "placeholder",
 }
 
+/**
+ * Provider-agnostic multimodal message content.
+ *
+ * A message's content is either a plain string (text-only, the default and by
+ * far the most common case) or an ordered array of parts. A part is either a
+ * text span or a reference to a media file stored in Langfuse media storage.
+ *
+ * This is intentionally a Langfuse-internal representation: it carries NO
+ * provider-specific shape and NO inlined bytes. The per-provider format is
+ * produced later by `fetchLLMCompletion` via LangChain (the single conversion
+ * boundary), and the media bytes are resolved server-side just before the call.
+ * Keeping references (not base64) here means results/caches stay small and
+ * remain a faithful record of "what was sent".
+ */
+export const ChatMessageTextContentPartSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
+export type ChatMessageTextContentPart = z.infer<
+  typeof ChatMessageTextContentPartSchema
+>;
+
+export const ChatMessageMediaContentPartSchema = z.object({
+  type: z.literal("media"),
+  mediaId: z.string(),
+  mimeType: z.string(), // e.g. "image/png" — drives image/audio/video routing downstream
+  // Canonical Langfuse media reference token, kept so the part is self-describing
+  // and renders with the existing media tooling: "@@@langfuseMedia:type=…|id=…|source=base64@@@"
+  reference: z.string(),
+  // Transient base64 bytes (no data: prefix), injected server-side right before
+  // the LLM call by the media resolver. Clients never send it and it is never
+  // persisted in caches/results — those keep only the reference above.
+  data: z.string().optional(),
+});
+export type ChatMessageMediaContentPart = z.infer<
+  typeof ChatMessageMediaContentPartSchema
+>;
+
+export const ChatMessageContentPartSchema = z.union([
+  ChatMessageTextContentPartSchema,
+  ChatMessageMediaContentPartSchema,
+]);
+export type ChatMessageContentPart = z.infer<
+  typeof ChatMessageContentPartSchema
+>;
+
+export const ChatMessageContentSchema = z.union([
+  z.string(),
+  z.array(ChatMessageContentPartSchema),
+]);
+export type ChatMessageContent = z.infer<typeof ChatMessageContentSchema>;
+
+// --- Multimodal content helpers (pure, frontend-safe) -----------------------
+// These keep the rest of the codebase working with the `string | parts[]`
+// content shape without scattering `typeof content === "string"` checks.
+
+/**
+ * Build the canonical Langfuse media reference token for a stored media object.
+ * Format mirrors `MediaReferenceStringSchema`:
+ *   `@@@langfuseMedia:type=<mime>|id=<mediaId>|source=base64@@@`
+ */
+export function buildMediaReferenceString(params: {
+  mediaId: string;
+  mimeType: string;
+}): string {
+  return `@@@langfuseMedia:type=${params.mimeType}|id=${params.mediaId}|source=base64@@@`;
+}
+
+/** True when content carries structured parts (i.e. is not a plain string). */
+export function isStructuredContent(
+  content: ChatMessageContent,
+): content is ChatMessageContentPart[] {
+  return Array.isArray(content);
+}
+
+/** The media parts of a content value (empty for plain-string content). */
+export function getMediaParts(
+  content: ChatMessageContent,
+): ChatMessageMediaContentPart[] {
+  if (!isStructuredContent(content)) return [];
+  return content.filter(
+    (part): part is ChatMessageMediaContentPart => part.type === "media",
+  );
+}
+
+/** Whether the content has at least one media part. */
+export function hasMediaParts(content: ChatMessageContent): boolean {
+  return getMediaParts(content).length > 0;
+}
+
+/** Extract the plain text of a message (joins text parts of structured content). */
+export function getMessageText(content: ChatMessageContent): string {
+  if (!isStructuredContent(content)) return content;
+  return content
+    .filter((part): part is ChatMessageTextContentPart => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
+
+/**
+ * Set the text of a message, preserving any media parts. Plain-string content
+ * stays a plain string; structured content keeps its media parts with a single
+ * leading text part.
+ */
+export function setMessageText(
+  content: ChatMessageContent,
+  text: string,
+): ChatMessageContent {
+  if (!isStructuredContent(content)) return text;
+  const mediaParts = getMediaParts(content);
+  return [{ type: "text" as const, text }, ...mediaParts];
+}
+
+/** Append a media part, converting plain-string content to structured form. */
+export function addMediaPart(
+  content: ChatMessageContent,
+  part: ChatMessageMediaContentPart,
+): ChatMessageContentPart[] {
+  if (!isStructuredContent(content)) {
+    return [{ type: "text", text: content }, part];
+  }
+  return [...content, part];
+}
+
+/**
+ * Remove a media part by id. Collapses back to a plain string once no media
+ * remains, so text-only messages round-trip and serialize like before.
+ */
+export function removeMediaPart(
+  content: ChatMessageContent,
+  mediaId: string,
+): ChatMessageContent {
+  if (!isStructuredContent(content)) return content;
+  const remaining = content.filter(
+    (part) => part.type !== "media" || part.mediaId !== mediaId,
+  );
+  if (remaining.some((part) => part.type === "media")) return remaining;
+  return getMessageText(remaining);
+}
+
 export const SystemMessageSchema = z.object({
   type: z.literal(ChatMessageType.System),
   role: z.literal(ChatMessageRole.System),
@@ -150,7 +290,10 @@ export type DeveloperMessage = z.infer<typeof DeveloperMessageSchema>;
 export const UserMessageSchema = z.object({
   type: z.literal(ChatMessageType.User),
   role: z.literal(ChatMessageRole.User),
-  content: z.string(),
+  // User messages may carry multimodal content (text + media). All other roles
+  // remain text-only: media is user input, and keeping the rest as strings
+  // minimizes blast radius across compile/serialization paths.
+  content: ChatMessageContentSchema,
 });
 export type UserMessage = z.infer<typeof UserMessageSchema>;
 

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -235,6 +235,13 @@ export interface StorageService {
 
   download(path: string): Promise<string>;
 
+  /**
+   * Download raw bytes. Unlike `download`, which decodes the body as utf-8 (and
+   * therefore corrupts binary files), this returns the bytes untouched — use it
+   * for media (images/audio/video) that must be base64-encoded or streamed.
+   */
+  downloadBytes(path: string): Promise<Uint8Array>;
+
   listFiles(prefix: string): Promise<{ file: string; createdAt: Date }[]>;
 
   getSignedUrl(
@@ -478,6 +485,21 @@ class AzureBlobStorageService implements StorageService {
     });
   }
 
+  private async streamToBuffer(
+    readableStream: NodeJS.ReadableStream,
+  ): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      readableStream.on("data", (data) => {
+        chunks.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
+      });
+      readableStream.on("end", () => {
+        resolve(Buffer.concat(chunks));
+      });
+      readableStream.on("error", reject);
+    });
+  }
+
   public async download(path: string): Promise<string> {
     try {
       await this.createContainerIfNotExists();
@@ -488,6 +510,25 @@ class AzureBlobStorageService implements StorageService {
         throw Error("No stream body available");
       }
       return this.streamToString(downloadResponse.readableStreamBody);
+    } catch (err) {
+      logger.error(
+        `Failed to download file from Azure Blob Storage ${path}`,
+        err,
+      );
+      handleStorageError(err, "download file from Azure Blob Storage");
+    }
+  }
+
+  public async downloadBytes(path: string): Promise<Uint8Array> {
+    try {
+      await this.createContainerIfNotExists();
+
+      const blobClient = this.client.getBlobClient(path);
+      const downloadResponse = await blobClient.download();
+      if (!downloadResponse.readableStreamBody) {
+        throw Error("No stream body available");
+      }
+      return this.streamToBuffer(downloadResponse.readableStreamBody);
     } catch (err) {
       logger.error(
         `Failed to download file from Azure Blob Storage ${path}`,
@@ -836,6 +877,21 @@ class S3StorageService implements StorageService {
     }
   }
 
+  public async downloadBytes(path: string): Promise<Uint8Array> {
+    const getCommand = new GetObjectCommand({
+      Bucket: this.bucketName,
+      Key: path,
+    });
+
+    try {
+      const response = await this.client.send(getCommand);
+      return (await response.Body?.transformToByteArray()) ?? new Uint8Array();
+    } catch (err) {
+      logger.error(`Failed to download file from S3 ${path}`, err);
+      handleStorageError(err, "download file from S3");
+    }
+  }
+
   public async listFiles(
     prefix: string,
   ): Promise<{ file: string; createdAt: Date }[]> {
@@ -1084,6 +1140,21 @@ class GoogleCloudStorageService implements StorageService {
       const [content] = await file.download();
 
       return content.toString();
+    } catch (err) {
+      logger.error(
+        `Failed to download file from Google Cloud Storage ${path}`,
+        err,
+      );
+      handleStorageError(err, "download file from Google Cloud Storage");
+    }
+  }
+
+  public async downloadBytes(path: string): Promise<Uint8Array> {
+    try {
+      const file = this.bucket.file(path);
+      const [content] = await file.download();
+
+      return new Uint8Array(content);
     } catch (err) {
       logger.error(
         `Failed to download file from Google Cloud Storage ${path}`,
@@ -1533,6 +1604,94 @@ class OCIObjectStorageService implements StorageService {
       );
       handleStorageError(err, "download file from OCI Object Storage ");
     }
+  }
+
+  public async downloadBytes(path: string): Promise<Uint8Array> {
+    try {
+      const { client, namespaceName } = await this.getClientAndNamespace();
+      const req: objectstorage.requests.GetObjectRequest = {
+        namespaceName,
+        bucketName: this.bucketName,
+        objectName: path,
+      };
+      const response = await client.getObject(req);
+      const bodyStream = (response as any).value;
+      return await this.streamToBuffer(bodyStream);
+    } catch (err) {
+      logger.error(
+        `Failed to download file from OCI Object Storage  ${path}`,
+        err,
+      );
+      handleStorageError(err, "download file from OCI Object Storage ");
+    }
+  }
+
+  private async streamToBuffer(readable: any): Promise<Uint8Array> {
+    if (!readable) return new Uint8Array();
+
+    const toBuffer = (chunk: any): Buffer => {
+      if (Buffer.isBuffer(chunk)) return chunk;
+      if (typeof chunk === "string") return Buffer.from(chunk, "binary");
+      if (chunk instanceof ArrayBuffer) return Buffer.from(chunk);
+      if (ArrayBuffer.isView(chunk)) {
+        return Buffer.from(
+          (chunk as Uint8Array).buffer,
+          (chunk as any).byteOffset ?? 0,
+          (chunk as any).byteLength ?? undefined,
+        );
+      }
+      return Buffer.from(chunk);
+    };
+
+    // Node.js Readable (EventEmitter style)
+    if (
+      typeof readable.on === "function" &&
+      typeof readable.read !== "undefined"
+    ) {
+      return await new Promise<Buffer>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        readable.on("data", (chunk: any) => chunks.push(toBuffer(chunk)));
+        readable.on("error", (err: any) => reject(err));
+        readable.on("end", () => resolve(Buffer.concat(chunks)));
+      });
+    }
+
+    // WHATWG ReadableStream
+    if (typeof readable.getReader === "function") {
+      const reader = readable.getReader();
+      const chunks: Buffer[] = [];
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(toBuffer(value));
+        }
+        return Buffer.concat(chunks);
+      } finally {
+        try {
+          if (reader.releaseLock) reader.releaseLock();
+        } catch (_err) {
+          // intentionally ignore releaseLock errors
+        }
+      }
+    }
+
+    // Direct buffer-like values
+    if (Buffer.isBuffer(readable)) return readable;
+    if (readable instanceof Uint8Array) return Buffer.from(readable);
+    if (readable instanceof ArrayBuffer) return Buffer.from(readable);
+    if (typeof Blob !== "undefined" && readable instanceof Blob) {
+      return Buffer.from(await readable.arrayBuffer());
+    }
+
+    // Async iterable
+    if (typeof readable[Symbol.asyncIterator] === "function") {
+      const chunks: Buffer[] = [];
+      for await (const chunk of readable) chunks.push(toBuffer(chunk));
+      return Buffer.concat(chunks);
+    }
+
+    throw new TypeError("Unsupported body type passed to streamToBuffer");
   }
 
   public async listFiles(

--- a/web/src/__tests__/server/playgroundMedia.servertest.ts
+++ b/web/src/__tests__/server/playgroundMedia.servertest.ts
@@ -1,0 +1,112 @@
+import crypto from "crypto";
+
+import {
+  createMediaUploadUrl,
+  updateMediaUploadStatus,
+} from "@/src/features/media/server/mediaService";
+import { resolveMessageMedia } from "@/src/features/media/server/resolveMessageMedia";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  buildMediaReferenceString,
+  ChatMessageRole,
+  ChatMessageType,
+  type ChatMessage,
+} from "@langfuse/shared";
+import { MediaContentType } from "@/src/features/media/validation";
+
+// End-to-end backend verification of the playground media flow against the real
+// running services (Postgres + MinIO): a trace-less media upload (as the
+// server-side upload handler performs it) and base64 resolution via the new
+// downloadBytes. The HTTP handler is thin glue over these functions.
+describe("Playground media (trace-less upload + resolution)", () => {
+  const projectId = "7a88fb47-b4e2-43b8-a06c-a5ce950dc53a";
+
+  it("uploads media without a trace link and resolves it to base64", async () => {
+    // Unique bytes -> unique sha256 -> unique mediaId (no dedupe collisions).
+    const fileBytes = crypto.randomBytes(2048);
+    const contentType = MediaContentType.PNG;
+    const sha256Hash = crypto
+      .createHash("sha256")
+      .update(fileBytes)
+      .digest("base64");
+
+    // 1) Create the upload URL without a traceId/field (in-app upload).
+    const { mediaId, uploadUrl } = await createMediaUploadUrl({
+      projectId,
+      body: {
+        contentType,
+        contentLength: fileBytes.length,
+        sha256Hash,
+      },
+    });
+    expect(mediaId).toBeTruthy();
+    expect(uploadUrl).toBeTruthy();
+
+    // 2) Server-side PUT to storage (same contract as the SDK / public API).
+    const putResponse = await fetch(uploadUrl as string, {
+      method: "PUT",
+      body: fileBytes,
+      headers: {
+        "Content-Type": contentType,
+        "X-Amz-Checksum-Sha256": sha256Hash,
+      },
+    });
+    expect(putResponse.ok).toBe(true);
+
+    // 3) Mark the upload complete.
+    await updateMediaUploadStatus({
+      projectId,
+      mediaId,
+      body: {
+        uploadedAt: new Date(),
+        uploadHttpStatus: putResponse.status,
+      },
+    });
+
+    // The media row exists and is NOT linked to any trace/observation.
+    const mediaRow = await prisma.media.findUnique({
+      where: { projectId_id: { projectId, id: mediaId } },
+    });
+    expect(mediaRow?.uploadHttpStatus).toBe(200);
+
+    expect(
+      await prisma.traceMedia.count({ where: { projectId, mediaId } }),
+    ).toBe(0);
+    expect(
+      await prisma.observationMedia.count({ where: { projectId, mediaId } }),
+    ).toBe(0);
+
+    // 4) Resolve the message media -> inline base64 (round-trips the bytes).
+    const message: ChatMessage = {
+      type: ChatMessageType.User,
+      role: ChatMessageRole.User,
+      content: [
+        { type: "text", text: "what is in this image?" },
+        {
+          type: "media",
+          mediaId,
+          mimeType: contentType,
+          reference: buildMediaReferenceString({
+            mediaId,
+            mimeType: contentType,
+          }),
+        },
+      ],
+    };
+
+    const [resolved] = await resolveMessageMedia({
+      projectId,
+      messages: [message],
+    });
+
+    const resolvedMediaPart = (resolved.content as any[]).find(
+      (p) => p.type === "media",
+    );
+    expect(resolvedMediaPart.data).toBe(fileBytes.toString("base64"));
+    expect(resolvedMediaPart.mimeType).toBe(contentType);
+    expect((resolved.content as any[])[0]).toEqual({
+      type: "text",
+      text: "what is in this image?",
+    });
+  });
+});

--- a/web/src/__tests__/server/unit/resolveMessageMedia.servertest.ts
+++ b/web/src/__tests__/server/unit/resolveMessageMedia.servertest.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ChatMessageRole,
+  ChatMessageType,
+  type ChatMessage,
+} from "@langfuse/shared";
+
+const { findUniqueMock, downloadBytesMock } = vi.hoisted(() => ({
+  findUniqueMock: vi.fn(),
+  downloadBytesMock: vi.fn(),
+}));
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: { media: { findUnique: findUniqueMock } },
+}));
+
+vi.mock("@/src/features/media/server/getMediaStorageClient", () => ({
+  getMediaStorageServiceClient: () => ({ downloadBytes: downloadBytesMock }),
+}));
+
+vi.mock("@/src/env.mjs", () => ({
+  env: { LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH: 10_000_000 },
+}));
+
+import { resolveMessageMedia } from "@/src/features/media/server/resolveMessageMedia";
+
+const mediaMessage = (mediaId: string): ChatMessage => ({
+  type: ChatMessageType.User,
+  role: ChatMessageRole.User,
+  content: [
+    { type: "text", text: "what is this?" },
+    {
+      type: "media",
+      mediaId,
+      mimeType: "image/png",
+      reference: `@@@langfuseMedia:type=image/png|id=${mediaId}|source=base64@@@`,
+    },
+  ],
+});
+
+const uploadedImageRow = (id: string) => ({
+  id,
+  uploadHttpStatus: 200,
+  contentType: "image/png",
+  contentLength: BigInt(3),
+  bucketName: "bucket",
+  bucketPath: `path/${id}.png`,
+});
+
+describe("resolveMessageMedia", () => {
+  beforeEach(() => {
+    findUniqueMock.mockReset();
+    downloadBytesMock.mockReset();
+  });
+
+  it("returns text-only messages untouched without any storage access", async () => {
+    const messages: ChatMessage[] = [
+      {
+        type: ChatMessageType.System,
+        role: ChatMessageRole.System,
+        content: "system",
+      },
+      {
+        type: ChatMessageType.User,
+        role: ChatMessageRole.User,
+        content: "hello",
+      },
+    ];
+
+    const result = await resolveMessageMedia({ projectId: "p1", messages });
+
+    expect(result).toBe(messages);
+    expect(findUniqueMock).not.toHaveBeenCalled();
+    expect(downloadBytesMock).not.toHaveBeenCalled();
+  });
+
+  it("inlines base64 for image media parts", async () => {
+    findUniqueMock.mockResolvedValue(uploadedImageRow("m1"));
+    downloadBytesMock.mockResolvedValue(new Uint8Array([65, 66, 67])); // "ABC"
+
+    const [resolved] = await resolveMessageMedia({
+      projectId: "p1",
+      messages: [mediaMessage("m1")],
+    });
+
+    expect(Array.isArray(resolved.content)).toBe(true);
+    const part = (resolved.content as any[]).find((p) => p.type === "media");
+    expect(part.data).toBe(Buffer.from([65, 66, 67]).toString("base64"));
+    expect(part.mimeType).toBe("image/png");
+    // text part is preserved
+    expect((resolved.content as any[])[0]).toEqual({
+      type: "text",
+      text: "what is this?",
+    });
+  });
+
+  it("throws when the media row is missing", async () => {
+    findUniqueMock.mockResolvedValue(null);
+    await expect(
+      resolveMessageMedia({ projectId: "p1", messages: [mediaMessage("m1")] }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it("throws when upload has not completed", async () => {
+    findUniqueMock.mockResolvedValue({
+      ...uploadedImageRow("m1"),
+      uploadHttpStatus: null,
+    });
+    await expect(
+      resolveMessageMedia({ projectId: "p1", messages: [mediaMessage("m1")] }),
+    ).rejects.toThrow(/not finished uploading/);
+  });
+
+  it("rejects non-image media", async () => {
+    findUniqueMock.mockResolvedValue({
+      ...uploadedImageRow("m1"),
+      contentType: "audio/mpeg",
+    });
+    await expect(
+      resolveMessageMedia({ projectId: "p1", messages: [mediaMessage("m1")] }),
+    ).rejects.toThrow(/Unsupported media type/);
+  });
+
+  it("rejects media that exceeds the size limit", async () => {
+    findUniqueMock.mockResolvedValue({
+      ...uploadedImageRow("m1"),
+      contentLength: BigInt(20_000_000),
+    });
+    await expect(
+      resolveMessageMedia({ projectId: "p1", messages: [mediaMessage("m1")] }),
+    ).rejects.toThrow(/exceeds the maximum/);
+  });
+});

--- a/web/src/app/api/playground/media/route.ts
+++ b/web/src/app/api/playground/media/route.ts
@@ -1,0 +1,6 @@
+import mediaUploadHandler from "@/src/features/playground/server/mediaUploadHandler";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+export const POST = mediaUploadHandler;

--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -14,8 +14,10 @@ import {
   ChatMessageRole,
   ChatMessageType,
   type ChatMessageWithId,
+  getMessageText,
   type LLMToolCall,
   type PlaceholderMessage,
+  setMessageText,
 } from "@langfuse/shared";
 import { Button } from "@/src/components/ui/button";
 import { Card, CardContent } from "@/src/components/ui/card";
@@ -33,6 +35,8 @@ import {
   SelectValue,
 } from "@/src/components/ui/select";
 import { useOptionalPlaygroundContext } from "@/src/features/playground/page/context";
+import { MessageMediaAttachments } from "@/src/features/playground/page/components/media/MessageMediaAttachments";
+import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import {
   useOptionalMessageSearchActions,
   useOptionalMessageSearchPageId,
@@ -97,6 +101,7 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
 }) => {
   const [roleIndex, setRoleIndex] = useState(1);
   const playgroundContext = useOptionalPlaygroundContext();
+  const projectId = useProjectIdFromURL();
   const searchPageId = useOptionalMessageSearchPageId();
   const messageSearchActions = useOptionalMessageSearchActions();
   const pageId = playgroundContext?.windowId ?? searchPageId;
@@ -129,6 +134,10 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
     // Only allow role toggling for messages that have a role property (not placeholder messages)
     if (!("role" in message)) return;
 
+    // Media attaches to user messages only, so flatten to text when changing
+    // role. The plain text is preserved; any attachments are dropped.
+    const flattenedContent = getMessageText(message.content);
+
     // if user has set custom roles, available roles will be non-empty and we toggle through custom and default roles (assistant, user)
     if (!!availableRoles && Boolean(availableRoles.length)) {
       let randomRole = availableRoles[roleIndex % availableRoles.length];
@@ -136,7 +145,7 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
         randomRole = availableRoles[(roleIndex + 1) % availableRoles.length];
       }
       replaceMessage(message.id, {
-        content: message.content,
+        content: flattenedContent,
         role: randomRole,
         type: ChatMessageType.PublicAPICreated,
       });
@@ -157,38 +166,38 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
 
       if (nextRole === ChatMessageRole.User) {
         replaceMessage(message.id, {
-          content: message.content,
+          content: flattenedContent,
           role: nextRole,
           type: ChatMessageType.User,
         });
       } else if (nextRole === ChatMessageRole.Assistant) {
         replaceMessage(message.id, {
-          content: message.content,
+          content: flattenedContent,
           role: nextRole,
           type: ChatMessageType.AssistantText,
         });
       } else if (nextRole === ChatMessageRole.Tool) {
         replaceMessage(message.id, {
-          content: message.content,
+          content: flattenedContent,
           role: nextRole,
           type: ChatMessageType.ToolResult,
           toolCallId: toolCallIds?.[0] ?? "",
         });
       } else if (nextRole === ChatMessageRole.Developer) {
         replaceMessage(message.id, {
-          content: message.content,
+          content: flattenedContent,
           role: nextRole,
           type: ChatMessageType.Developer,
         });
       } else if (nextRole === ChatMessageRole.System) {
         replaceMessage(message.id, {
-          content: message.content,
+          content: flattenedContent,
           role: nextRole,
           type: ChatMessageType.System,
         });
       } else if (nextRole === ChatMessageRole.Model) {
         replaceMessage(message.id, {
-          content: message.content,
+          content: flattenedContent,
           role: nextRole,
           type: ChatMessageType.ModelText,
         });
@@ -204,10 +213,16 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
       if (message.type === ChatMessageType.Placeholder) {
         updateMessage(message.type, message.id, "name", value);
       } else {
-        updateMessage(message.type, message.id, "content", value);
+        // Preserve any media parts; only the text span changes.
+        updateMessage(
+          message.type,
+          message.id,
+          "content",
+          setMessageText(message.content, value),
+        );
       }
     },
-    [message.id, message.type, updateMessage],
+    [message, updateMessage],
   );
 
   const onPlaceholderNameChange = useCallback(
@@ -221,6 +236,12 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
 
   const showToolCallSelect = message.type === ChatMessageType.ToolResult;
   const isPlaceholder = message.type === ChatMessageType.Placeholder;
+  // Media attachments are a playground-only affordance on user messages.
+  const showMediaAttachments =
+    Boolean(playgroundContext) &&
+    Boolean(projectId) &&
+    "role" in message &&
+    message.role === ChatMessageRole.User;
 
   useEffect(() => {
     if (!pageId || !registerMessageTarget || !unregisterMessageTarget) {
@@ -333,7 +354,7 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
                 />
               ) : (
                 <MemoizedEditor
-                  value={message.content}
+                  value={getMessageText(message.content)}
                   onChange={onValueChange}
                   role={message.role}
                   editorRef={editorRef}
@@ -342,6 +363,15 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
                 />
               )}
             </div>
+            {showMediaAttachments && "content" in message && (
+              <MessageMediaAttachments
+                projectId={projectId as string}
+                content={message.content}
+                onChange={(content) =>
+                  updateMessage(message.type, message.id, "content", content)
+                }
+              />
+            )}
             {message.type === ChatMessageType.AssistantToolCall && (
               <ToolCalls toolCalls={message.toolCalls as LLMToolCall[]} />
             )}

--- a/web/src/features/media/server/mediaService.ts
+++ b/web/src/features/media/server/mediaService.ts
@@ -7,6 +7,7 @@ import {
   GetMediaResponseSchema,
   type GetMediaUploadUrlQuery,
   GetMediaUploadUrlResponseSchema,
+  MediaEnabledFields,
   type MediaContentType,
   type PatchMediaBody,
 } from "@/src/features/media/validation";
@@ -26,7 +27,13 @@ import {
 
 export async function createMediaUploadUrl(params: {
   projectId: string;
-  body: GetMediaUploadUrlQuery;
+  // traceId/field are optional: in-app uploads (e.g. the playground) create a
+  // media record that isn't linked to any trace. The public REST path always
+  // passes both, so its behaviour is unchanged.
+  body: Omit<GetMediaUploadUrlQuery, "traceId" | "field"> & {
+    traceId?: string | null;
+    field?: MediaEnabledFields;
+  };
 }) {
   const { projectId, body } = params;
   const {

--- a/web/src/features/media/server/resolveMessageMedia.ts
+++ b/web/src/features/media/server/resolveMessageMedia.ts
@@ -45,10 +45,22 @@ export async function resolveMessageMedia(params: {
   const base64ById = new Map<string, string>();
   const mimeById = new Map<string, string>();
 
-  for (const mediaId of mediaIds) {
-    const media = await prisma.media.findUnique({
-      where: { projectId_id: { projectId, id: mediaId } },
-    });
+  // Resolve metadata for all referenced media in parallel, then download
+  // the bytes concurrently. This reduces latency when a message references
+  // multiple media items.
+  const ids = Array.from(mediaIds);
+
+  // Fetch media rows in parallel
+  const mediaRows = await Promise.all(
+    ids.map((id) =>
+      prisma.media.findUnique({ where: { projectId_id: { projectId, id } } }),
+    ),
+  );
+
+  // Validate metadata first (fail fast with clear errors)
+  for (let i = 0; i < ids.length; i++) {
+    const mediaId = ids[i];
+    const media = mediaRows[i];
 
     if (!media) {
       throw new LangfuseNotFoundError(`Media asset ${mediaId} not found`);
@@ -70,10 +82,21 @@ export async function resolveMessageMedia(params: {
         `Media asset ${mediaId} exceeds the maximum allowed size`,
       );
     }
+  }
 
-    const bytes = await getMediaStorageServiceClient(
-      media.bucketName,
-    ).downloadBytes(media.bucketPath);
+  // Download all bytes concurrently and map results back to ids order
+  const downloadPromises = mediaRows.map((media) =>
+    getMediaStorageServiceClient(media!.bucketName).downloadBytes(
+      media!.bucketPath,
+    ),
+  );
+
+  const bytesResults = await Promise.all(downloadPromises);
+
+  for (let i = 0; i < ids.length; i++) {
+    const mediaId = ids[i];
+    const media = mediaRows[i]!;
+    const bytes = bytesResults[i];
 
     base64ById.set(mediaId, Buffer.from(bytes).toString("base64"));
     mimeById.set(mediaId, media.contentType);

--- a/web/src/features/media/server/resolveMessageMedia.ts
+++ b/web/src/features/media/server/resolveMessageMedia.ts
@@ -1,0 +1,100 @@
+import { getMediaStorageServiceClient } from "@/src/features/media/server/getMediaStorageClient";
+import { env } from "@/src/env.mjs";
+import { InvalidRequestError, LangfuseNotFoundError } from "@langfuse/shared";
+import { prisma } from "@langfuse/shared/src/db";
+import {
+  type ChatMessage,
+  getMediaParts,
+  isStructuredContent,
+} from "@langfuse/shared";
+
+/**
+ * Resolve Langfuse-stored media referenced by message content into inline
+ * base64, just before the LLM call.
+ *
+ * This is the layer that owns "our storage": it loads each referenced media
+ * row, validates it, downloads the raw bytes and base64-encodes them. The
+ * provider-specific formatting happens later in `fetchLLMCompletion` (the single
+ * conversion boundary), which only needs the resolved bytes — so the shared LLM
+ * function stays free of DB/storage dependencies.
+ *
+ * The returned messages are a transient copy used only for the call; the
+ * persisted/echoed messages keep the lightweight media references (no base64),
+ * so caches and results remain small and a faithful record of what was sent.
+ *
+ * v1 supports images only; other media types are rejected with a clear error.
+ */
+export async function resolveMessageMedia(params: {
+  projectId: string;
+  messages: ChatMessage[];
+}): Promise<ChatMessage[]> {
+  const { projectId, messages } = params;
+
+  // Collect referenced media ids (media parts only ever appear in array content).
+  const mediaIds = new Set<string>();
+  for (const message of messages) {
+    if (!("content" in message)) continue;
+    for (const part of getMediaParts(message.content)) {
+      if (part.mediaId) mediaIds.add(part.mediaId);
+    }
+  }
+
+  if (mediaIds.size === 0) return messages;
+
+  // Resolve each unique media once, then fan the result back out to all parts.
+  const base64ById = new Map<string, string>();
+  const mimeById = new Map<string, string>();
+
+  for (const mediaId of mediaIds) {
+    const media = await prisma.media.findUnique({
+      where: { projectId_id: { projectId, id: mediaId } },
+    });
+
+    if (!media) {
+      throw new LangfuseNotFoundError(`Media asset ${mediaId} not found`);
+    }
+    if (media.uploadHttpStatus !== 200) {
+      throw new InvalidRequestError(
+        `Media asset ${mediaId} has not finished uploading`,
+      );
+    }
+    if (!media.contentType.startsWith("image/")) {
+      throw new InvalidRequestError(
+        `Unsupported media type ${media.contentType}. Only images can currently be sent to the model.`,
+      );
+    }
+    if (
+      Number(media.contentLength) > env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH
+    ) {
+      throw new InvalidRequestError(
+        `Media asset ${mediaId} exceeds the maximum allowed size`,
+      );
+    }
+
+    const bytes = await getMediaStorageServiceClient(
+      media.bucketName,
+    ).downloadBytes(media.bucketPath);
+
+    base64ById.set(mediaId, Buffer.from(bytes).toString("base64"));
+    mimeById.set(mediaId, media.contentType);
+  }
+
+  return messages.map((message) => {
+    if (!("content" in message) || !isStructuredContent(message.content)) {
+      return message;
+    }
+
+    const content = message.content.map((part) => {
+      if (part.type !== "media") return part;
+      const data = base64ById.get(part.mediaId);
+      if (!data) return part;
+      return {
+        ...part,
+        mimeType: mimeById.get(part.mediaId) ?? part.mimeType,
+        data,
+      };
+    });
+
+    return { ...message, content } as ChatMessage;
+  });
+}

--- a/web/src/features/playground/page/components/media/MessageMediaAttachments.tsx
+++ b/web/src/features/playground/page/components/media/MessageMediaAttachments.tsx
@@ -1,0 +1,100 @@
+import { Loader2, Paperclip, X } from "lucide-react";
+import { useRef } from "react";
+
+import { Button } from "@/src/components/ui/button";
+import { LangfuseMediaView } from "@/src/components/ui/LangfuseMediaView";
+import { useMediaUpload } from "./useMediaUpload";
+import {
+  addMediaPart,
+  type ChatMessageContent,
+  getMediaParts,
+  removeMediaPart,
+} from "@langfuse/shared";
+
+/**
+ * Attach images to a (user) chat message and show what's attached. The text of
+ * the message keeps being edited in the CodeMirror editor; media lives here as
+ * structured content parts that are uploaded to Langfuse media storage and
+ * referenced by token.
+ */
+export const MessageMediaAttachments = ({
+  projectId,
+  content,
+  onChange,
+}: {
+  projectId: string;
+  content: ChatMessageContent;
+  onChange: (content: ChatMessageContent) => void;
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { uploadFile, isUploading } = useMediaUpload(projectId);
+
+  const mediaParts = getMediaParts(content);
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+
+    let next: ChatMessageContent = content;
+    for (const file of Array.from(files)) {
+      const part = await uploadFile(file);
+      if (part) next = addMediaPart(next, part);
+    }
+    onChange(next);
+
+    // Reset so selecting the same file again re-triggers onChange.
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={isUploading}
+          onClick={() => inputRef.current?.click()}
+          className="text-muted-foreground h-6 gap-1 px-2 text-[10px]"
+        >
+          {isUploading ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Paperclip className="h-3 w-3" />
+          )}
+          Attach image
+        </Button>
+      </div>
+
+      {mediaParts.length > 0 && (
+        <div className="flex flex-row flex-wrap gap-2">
+          {mediaParts.map((part) => (
+            <div key={part.mediaId} className="group relative">
+              <LangfuseMediaView
+                mediaReferenceString={part.reference}
+                asFileIcon
+              />
+              <Button
+                type="button"
+                variant="secondary"
+                size="icon"
+                aria-label="Remove attachment"
+                onClick={() => onChange(removeMediaPart(content, part.mediaId))}
+                className="absolute -top-1 -right-1 h-5 w-5 rounded-full p-0 opacity-80 shadow-xs transition-opacity hover:opacity-100"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web/src/features/playground/page/components/media/MessageMediaAttachments.tsx
+++ b/web/src/features/playground/page/components/media/MessageMediaAttachments.tsx
@@ -27,19 +27,19 @@ export const MessageMediaAttachments = ({
   onChange: (content: ChatMessageContent) => void;
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const { uploadFile, isUploading } = useMediaUpload(projectId);
+  const { uploadFiles, isUploading } = useMediaUpload(projectId);
 
   const mediaParts = getMediaParts(content);
 
   const handleFiles = async (files: FileList | null) => {
     if (!files || files.length === 0) return;
 
-    let next: ChatMessageContent = content;
-    for (const file of Array.from(files)) {
-      const part = await uploadFile(file);
-      if (part) next = addMediaPart(next, part);
+    const parts = await uploadFiles(Array.from(files));
+    if (parts.length > 0) {
+      let next: ChatMessageContent = content;
+      for (const part of parts) next = addMediaPart(next, part);
+      onChange(next);
     }
-    onChange(next);
 
     // Reset so selecting the same file again re-triggers onChange.
     if (inputRef.current) inputRef.current.value = "";

--- a/web/src/features/playground/page/components/media/useMediaUpload.ts
+++ b/web/src/features/playground/page/components/media/useMediaUpload.ts
@@ -1,0 +1,95 @@
+import { useCallback, useState } from "react";
+
+import { env } from "@/src/env.mjs";
+import { showErrorToast } from "@/src/features/notifications/showErrorToast";
+import {
+  MediaContentType,
+  MediaFileExtension,
+} from "@/src/features/media/validation";
+import { type ChatMessageMediaContentPart } from "@langfuse/shared";
+
+const CONTENT_TYPE_VALUES = new Set<string>(Object.values(MediaContentType));
+
+/**
+ * Best-effort content type for a file. Browsers usually set `file.type`, but
+ * fall back to the extension for the handful of media types they leave blank.
+ */
+function resolveContentType(file: File): MediaContentType | null {
+  if (file.type && CONTENT_TYPE_VALUES.has(file.type)) {
+    return file.type as MediaContentType;
+  }
+  const extension = file.name.split(".").pop()?.toLowerCase();
+  if (!extension) return null;
+  const match = Object.entries(MediaFileExtension).find(
+    ([, value]) => value === extension,
+  );
+  if (!match) return null;
+  const byEnumKey = (MediaContentType as Record<string, string>)[match[0]];
+  return byEnumKey && CONTENT_TYPE_VALUES.has(byEnumKey)
+    ? (byEnumKey as MediaContentType)
+    : null;
+}
+
+export function useMediaUpload(projectId: string) {
+  const [isUploading, setIsUploading] = useState(false);
+
+  const uploadFile = useCallback(
+    async (file: File): Promise<ChatMessageMediaContentPart | null> => {
+      const contentType = resolveContentType(file);
+      if (!contentType || !contentType.startsWith("image/")) {
+        showErrorToast(
+          "Unsupported file type",
+          "Only image files can currently be attached.",
+        );
+        return null;
+      }
+
+      setIsUploading(true);
+      try {
+        // Upload to our own origin (allowed by CSP). The server performs the
+        // actual storage upload, so we avoid browser->storage CORS/CSP issues.
+        const response = await fetch(
+          `${env.NEXT_PUBLIC_BASE_PATH ?? ""}/api/playground/media?projectId=${encodeURIComponent(
+            projectId,
+          )}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": contentType },
+            body: file,
+          },
+        );
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(
+            errorData.message ?? `Upload failed with status ${response.status}`,
+          );
+        }
+
+        const data = (await response.json()) as {
+          mediaId: string;
+          mimeType: string;
+          reference: string;
+        };
+
+        return {
+          type: "media",
+          mediaId: data.mediaId,
+          mimeType: data.mimeType,
+          reference: data.reference,
+        };
+      } catch (error) {
+        showErrorToast(
+          "Failed to attach media",
+          error instanceof Error ? error.message : "An error occurred",
+        );
+        return null;
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [projectId],
+  );
+
+  return { uploadFile, isUploading };
+}

--- a/web/src/features/playground/page/components/media/useMediaUpload.ts
+++ b/web/src/features/playground/page/components/media/useMediaUpload.ts
@@ -44,7 +44,6 @@ export function useMediaUpload(projectId: string) {
         return null;
       }
 
-      setIsUploading(true);
       try {
         // Upload to our own origin (allowed by CSP). The server performs the
         // actual storage upload, so we avoid browser->storage CORS/CSP issues.
@@ -84,12 +83,31 @@ export function useMediaUpload(projectId: string) {
           error instanceof Error ? error.message : "An error occurred",
         );
         return null;
-      } finally {
-        setIsUploading(false);
       }
     },
     [projectId],
   );
 
-  return { uploadFile, isUploading };
+  // Upload a batch of files, holding `isUploading` for the whole batch. Tracking
+  // the flag here rather than inside `uploadFile` keeps the attach button
+  // disabled until every file finishes; flipping it per file would briefly
+  // re-enable the button between files and let a second batch race this one.
+  const uploadFiles = useCallback(
+    async (files: File[]): Promise<ChatMessageMediaContentPart[]> => {
+      setIsUploading(true);
+      try {
+        const parts: ChatMessageMediaContentPart[] = [];
+        for (const file of files) {
+          const part = await uploadFile(file);
+          if (part) parts.push(part);
+        }
+        return parts;
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [uploadFile],
+  );
+
+  return { uploadFile, uploadFiles, isUploading };
 }

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -18,6 +18,7 @@ import useProjectIdFromURL from "@/src/hooks/useProjectIdFromURL";
 import {
   ChatMessageRole,
   extractVariables,
+  getMessageText,
   type ChatMessageWithId,
   type ChatMessageWithIdNoPlaceholders,
   type PromptVariable,
@@ -335,7 +336,13 @@ export const PlaygroundProvider: React.FC<PlaygroundProviderProps> = ({
 
         const leftOverVariables = extractVariables(
           finalMessages
-            .map((m) => (typeof m.content === "string" ? m.content : ""))
+            .map((m) =>
+              typeof m.content === "string"
+                ? m.content
+                : Array.isArray(m.content)
+                  ? getMessageText(m.content)
+                  : "",
+            )
             .join("\n"),
         );
 

--- a/web/src/features/playground/server/chatCompletionHandler.ts
+++ b/web/src/features/playground/server/chatCompletionHandler.ts
@@ -10,6 +10,7 @@ import {
 import { PosthogCallbackHandler } from "./analytics/posthogCallback";
 import { authorizeRequestOrThrow } from "./authorizeRequest";
 import { validateChatCompletionBody } from "./validateChatCompletionBody";
+import { resolveMessageMedia } from "@/src/features/media/server/resolveMessageMedia";
 
 import { env } from "@/src/env.mjs";
 import { prisma } from "@langfuse/shared/src/db";
@@ -40,12 +41,19 @@ export default async function chatCompletionHandler(req: NextRequest) {
 
     return await opentelemetry.context.with(baggageCtx, async () => {
       const {
-        messages,
+        messages: rawMessages,
         modelParams,
         tools,
         structuredOutputSchema,
         streaming,
       } = body;
+
+      // Resolve any attached media (image references) to inline base64 right
+      // before the call. Text-only requests pass through untouched.
+      const messages = await resolveMessageMedia({
+        projectId: body.projectId,
+        messages: rawMessages,
+      });
 
       const LLMApiKey = await prisma.llmApiKeys.findFirst({
         where: {

--- a/web/src/features/playground/server/mediaUploadHandler.ts
+++ b/web/src/features/playground/server/mediaUploadHandler.ts
@@ -47,6 +47,22 @@ export default async function mediaUploadHandler(req: NextRequest) {
       );
     }
 
+    // Pre-check declared content length to avoid buffering obviously-oversized uploads.
+    // Note: `Content-Length` may be absent or spoofed, so keep the post-buffer
+    // check below as the authoritative guard.
+    const declaredLengthHeader = req.headers.get("content-length");
+    if (declaredLengthHeader) {
+      const declaredLength = Number(declaredLengthHeader);
+      if (
+        !Number.isNaN(declaredLength) &&
+        declaredLength > env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH
+      ) {
+        throw new InvalidRequestError(
+          `File size must be less than ${env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH} bytes`,
+        );
+      }
+    }
+
     const bytes = Buffer.from(await req.arrayBuffer());
     if (bytes.length === 0) {
       throw new InvalidRequestError("Empty file");

--- a/web/src/features/playground/server/mediaUploadHandler.ts
+++ b/web/src/features/playground/server/mediaUploadHandler.ts
@@ -1,0 +1,121 @@
+import { createHash } from "crypto";
+
+import { NextResponse, type NextRequest } from "next/server";
+
+import { env } from "@/src/env.mjs";
+import {
+  createMediaUploadUrl,
+  updateMediaUploadStatus,
+} from "@/src/features/media/server/mediaService";
+import { MediaContentType } from "@/src/features/media/validation";
+import { authorizeRequestOrThrow } from "./authorizeRequest";
+import {
+  BaseError,
+  buildMediaReferenceString,
+  InvalidRequestError,
+} from "@langfuse/shared";
+import { logger } from "@langfuse/shared/src/server";
+
+const IMAGE_CONTENT_TYPES = new Set<string>(
+  Object.values(MediaContentType).filter((type) => type.startsWith("image/")),
+);
+
+/**
+ * Server-side media upload for the playground.
+ *
+ * The browser cannot upload directly to object storage: the app's CSP
+ * `connect-src` does not allow the storage endpoint, and self-hosted/prod
+ * buckets would each need their own CORS + CSP configuration. Instead the
+ * browser POSTs the file to this same-origin endpoint and the server—which
+ * already holds storage credentials—performs the upload. This mirrors how the
+ * SDK uploads media (presigned URL + status PATCH), just executed server-side,
+ * and creates a media record that is not linked to any trace.
+ */
+export default async function mediaUploadHandler(req: NextRequest) {
+  try {
+    const projectId = req.nextUrl.searchParams.get("projectId");
+    if (!projectId) {
+      throw new InvalidRequestError("Missing projectId");
+    }
+
+    await authorizeRequestOrThrow(projectId);
+
+    const contentType = req.headers.get("content-type")?.split(";")[0]?.trim();
+    if (!contentType || !IMAGE_CONTENT_TYPES.has(contentType)) {
+      throw new InvalidRequestError(
+        "Unsupported content type. Only image files can currently be attached.",
+      );
+    }
+
+    const bytes = Buffer.from(await req.arrayBuffer());
+    if (bytes.length === 0) {
+      throw new InvalidRequestError("Empty file");
+    }
+    if (bytes.length > env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH) {
+      throw new InvalidRequestError(
+        `File size must be less than ${env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH} bytes`,
+      );
+    }
+
+    const sha256Hash = createHash("sha256").update(bytes).digest("base64");
+
+    const { mediaId, uploadUrl } = await createMediaUploadUrl({
+      projectId,
+      body: {
+        contentType: contentType as MediaContentType,
+        contentLength: bytes.length,
+        sha256Hash,
+      },
+    });
+
+    // A null uploadUrl means the content already exists in storage (dedupe).
+    if (uploadUrl) {
+      const startedAt = Date.now();
+      const uploadResponse = await fetch(uploadUrl, {
+        method: "PUT",
+        headers: {
+          "Content-Type": contentType,
+          "x-amz-checksum-sha256": sha256Hash,
+        },
+        body: bytes,
+      });
+
+      if (!uploadResponse.ok) {
+        throw new Error(
+          `Storage upload failed with status ${uploadResponse.status}`,
+        );
+      }
+
+      await updateMediaUploadStatus({
+        projectId,
+        mediaId,
+        body: {
+          uploadedAt: new Date(),
+          uploadHttpStatus: uploadResponse.status,
+          uploadTimeMs: Date.now() - startedAt,
+        },
+      });
+    }
+
+    return NextResponse.json({
+      mediaId,
+      mimeType: contentType,
+      reference: buildMediaReferenceString({ mediaId, mimeType: contentType }),
+    });
+  } catch (err) {
+    logger.error("Failed to handle playground media upload", err);
+
+    if (err instanceof BaseError) {
+      return NextResponse.json(
+        { error: err.name, message: err.message },
+        { status: err.httpCode },
+      );
+    }
+
+    const message = err instanceof Error ? err.message : "An error occurred";
+    return NextResponse.json(
+      { error: "InternalServerError", message },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/features/prompts/components/NewPromptForm/index.tsx
+++ b/web/src/features/prompts/components/NewPromptForm/index.tsx
@@ -30,6 +30,7 @@ import {
   PromptType,
   extractVariables,
   getIsCharOrUnderscore,
+  getMessageText,
 } from "@langfuse/shared";
 import { PromptChatMessages } from "./PromptChatMessages";
 import { ReviewPromptDialog } from "./ReviewPromptDialog";
@@ -187,7 +188,15 @@ export const NewPromptForm: React.FC<NewPromptFormProps> = (props) => {
 
     if (shouldLoadPlaygroundCache && playgroundCache) {
       form.setValue("type", PromptType.Chat);
-      setInitialMessages(playgroundCache.messages);
+      // Prompts are text-only; flatten any multimodal message content to its
+      // text so it round-trips into the prompt (attached media is dropped).
+      setInitialMessages(
+        playgroundCache.messages.map((message) =>
+          "content" in message
+            ? { ...message, content: getMessageText(message.content) }
+            : message,
+        ),
+      );
     } else if (initialPrompt?.type === PromptType.Chat) {
       setInitialMessages(initialPrompt.prompt);
     }


### PR DESCRIPTION
## What does this PR do?

Add inline image attachment support for playground chat messages and wire it through media storage + LLM resolution.

- new playground media upload endpoint and server-side upload flow
- inline message attachment UI in the playground message composer
- shared multimodal ChatMessageContent support in shared
- media resolution layer that replaces message references with base64 before model calls
- tests for playground media upload, media resolution, and multimodal message compilation

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

[x] Checked that my changes generate no new warnings (`npm run lint`)
[x] Added tests that prove that my feature works
[x] Checked that new and existing unit tests pass locally with my changes

<img width="944" height="922" alt="Screenshot 2026-06-18 at 10 07 47" src="https://github.com/user-attachments/assets/e1862598-c838-40d6-9a70-9e7af2575967" />

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds inline image attachment support to the playground chat interface. Images are uploaded through a new same-origin server-side endpoint, stored via the existing media service (creating trace-unlinked media records), and resolved to inline base64 immediately before LLM calls — keeping stored messages lightweight.

- **New upload pathway**: `POST /api/playground/media` buffers the file server-side, uploads it to object storage using the existing presigned-URL flow, and returns the `mediaId`/reference token. The existing deduplication path in `createMediaUploadUrl` is reused.
- **New `ChatMessageContent` type**: User messages now accept `string | ContentPart[]`; all helper functions (`getMessageText`, `setMessageText`, `addMediaPart`, `removeMediaPart`) keep callers free of inline type checks, and non-user roles remain string-only.
- **Media resolution layer**: `resolveMessageMedia` resolves stored image references to base64 in `chatCompletionHandler` before the model call, while persisted messages retain only the lightweight reference tokens.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The core feature logic is sound, but the upload endpoint buffers the entire request body in memory before applying the size limit, which authenticated users could exploit to spike server memory.

The media upload handler reads the full request body with `req.arrayBuffer()` before checking whether it exceeds `LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH`. Any authenticated project member can trigger large allocations by sending oversized uploads. The rest of the PR — content-type modelling, schema design, storage abstraction, and LLM integration — is well-structured and tested.

web/src/features/playground/server/mediaUploadHandler.ts (size check ordering) and web/src/app/api/playground/media/route.ts (body size limit alignment)
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Memory exhaustion before size gate** (`mediaUploadHandler.ts` line 50): `req.arrayBuffer()` fully buffers the request body before the `LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH` check is applied. An authenticated user can send a multi-hundred-megabyte payload that the server must allocate in full before rejecting it. A pre-check on the `Content-Length` header would close the window. Authentication is required so the exposure is limited to authenticated project members, not arbitrary users.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant PlaygroundAPI as /api/playground/chat
    participant MediaAPI as /api/playground/media
    participant MediaService
    participant Storage as Object Storage
    participant LLM

    Browser->>MediaAPI: "POST /api/playground/media?projectId=... (image bytes)"
    MediaAPI->>MediaAPI: authorizeRequestOrThrow(projectId)
    MediaAPI->>MediaAPI: buffer req.arrayBuffer()
    MediaAPI->>MediaService: "createMediaUploadUrl({sha256, contentType, ...})"
    MediaService-->>MediaAPI: "{ mediaId, uploadUrl }"
    alt uploadUrl present (new file)
        MediaAPI->>Storage: PUT uploadUrl (image bytes)
        Storage-->>MediaAPI: 200 OK
        MediaAPI->>MediaService: updateMediaUploadStatus(200)
    end
    MediaAPI-->>Browser: "{ mediaId, mimeType, reference }"

    Browser->>PlaygroundAPI: POST /api/playground/chat (messages with media refs)
    PlaygroundAPI->>PlaygroundAPI: authorizeRequestOrThrow
    PlaygroundAPI->>PlaygroundAPI: resolveMessageMedia(projectId, messages)
    loop for each unique mediaId
        PlaygroundAPI->>MediaService: prisma.media.findUnique
        PlaygroundAPI->>Storage: downloadBytes(bucketPath)
        Storage-->>PlaygroundAPI: raw bytes
    end
    PlaygroundAPI->>LLM: fetchLLMCompletion (messages with base64 data)
    LLM-->>PlaygroundAPI: completion
    PlaygroundAPI-->>Browser: streamed response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant PlaygroundAPI as /api/playground/chat
    participant MediaAPI as /api/playground/media
    participant MediaService
    participant Storage as Object Storage
    participant LLM

    Browser->>MediaAPI: "POST /api/playground/media?projectId=... (image bytes)"
    MediaAPI->>MediaAPI: authorizeRequestOrThrow(projectId)
    MediaAPI->>MediaAPI: buffer req.arrayBuffer()
    MediaAPI->>MediaService: "createMediaUploadUrl({sha256, contentType, ...})"
    MediaService-->>MediaAPI: "{ mediaId, uploadUrl }"
    alt uploadUrl present (new file)
        MediaAPI->>Storage: PUT uploadUrl (image bytes)
        Storage-->>MediaAPI: 200 OK
        MediaAPI->>MediaService: updateMediaUploadStatus(200)
    end
    MediaAPI-->>Browser: "{ mediaId, mimeType, reference }"

    Browser->>PlaygroundAPI: POST /api/playground/chat (messages with media refs)
    PlaygroundAPI->>PlaygroundAPI: authorizeRequestOrThrow
    PlaygroundAPI->>PlaygroundAPI: resolveMessageMedia(projectId, messages)
    loop for each unique mediaId
        PlaygroundAPI->>MediaService: prisma.media.findUnique
        PlaygroundAPI->>Storage: downloadBytes(bucketPath)
        Storage-->>PlaygroundAPI: raw bytes
    end
    PlaygroundAPI->>LLM: fetchLLMCompletion (messages with base64 data)
    LLM-->>PlaygroundAPI: completion
    PlaygroundAPI-->>Browser: streamed response
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
web/src/features/playground/server/mediaUploadHandler.ts:50-58
**Entire body buffered before size check**

`req.arrayBuffer()` reads the complete request body into a Node.js `Buffer` on line 50 before the size limit is enforced on line 54. A client that sends a multi-hundred-megabyte payload causes the server to allocate that memory before the request is rejected. Checking the `Content-Length` request header *before* calling `req.arrayBuffer()` closes the window for this memory exhaustion: `const declaredLength = Number(req.headers.get("content-length")); if (declaredLength > env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH) throw new InvalidRequestError(...)`. Note that `Content-Length` can be spoofed so the existing post-buffer check should stay, but the pre-check prevents buffering obviously oversized uploads.

### Issue 2 of 4
web/src/features/media/server/resolveMessageMedia.ts:48-80
**Sequential storage downloads per media ID**

The `for…of` loop serially awaits both the Prisma `findUnique` and the `downloadBytes` call for each media ID. A message with three images makes six sequential round-trips before the LLM call is issued. `Promise.all` over the collected IDs (validate first, then download) would issue the storage fetches concurrently and meaningfully reduce latency for multi-image messages.

### Issue 3 of 4
web/src/features/playground/page/components/media/useMediaUpload.ts:87-89
**`isUploading` flickers between sequential file uploads**

`finally { setIsUploading(false) }` fires after *each* `uploadFile` call. When `handleFiles` in `MessageMediaAttachments.tsx` iterates over a multi-file selection, the flag briefly resets to `false` between files, re-enabling the "Attach image" button momentarily. A quick second click during that window starts a new `handleFiles` loop whose `onChange(next)` call can race with the still-running first loop, producing an incorrect final content value. Consider tracking uploading state at the `handleFiles` level rather than within individual `uploadFile` calls.

### Issue 4 of 4
web/src/app/api/playground/media/route.ts:1-6
**Missing `bodySizeLimit` export**

Next.js App Router applies a default body size limit (4 MB for most runtimes) to Route Handlers. The upload handler validates against `LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH` (10 MB in tests), so any file between the framework default and that limit will be silently truncated or rejected by the runtime before the handler runs. Exporting `export const bodySizeLimit = env.LANGFUSE_S3_MEDIA_MAX_CONTENT_LENGTH` (or a string like `"10mb"`) aligns the two limits.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(playground): Add image attachment s..."](https://github.com/langfuse/langfuse/commit/9db4c484a783e427976b78db936b862e2b1941dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38362727)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->