### PR TITLE
fix: Add orderBy to comments pagination for stable pages

### DIFF
--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -132,7 +132,7 @@ export const listCommentsForApi = async ({
       where,
       take: limit,
       skip: (page - 1) * limit,
-      orderBy: { createdAt: "asc" },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
     }),
     prisma.comment.count({ where }),
   ]);

--- a/web/src/features/comments/server/publicCommentService.ts
+++ b/web/src/features/comments/server/publicCommentService.ts
@@ -132,6 +132,7 @@ export const listCommentsForApi = async ({
       where,
       take: limit,
       skip: (page - 1) * limit,
+      orderBy: { createdAt: "asc" },
     }),
     prisma.comment.count({ where }),
   ]);


### PR DESCRIPTION
`listCommentsForApi` was calling `prisma.comment.findMany` without an `orderBy`, so paginated results were non-deterministic — pages could overlap or skip rows depending on how the query planner ordered things.

Added `orderBy: { createdAt: 'asc' }` to the `findMany` in `publicCommentService.ts`. Both the public REST API and the MCP `listComments` tool go through this shared function, so one change covers both.

Closes #13812

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `orderBy: { createdAt: "asc" }` to the `findMany` call in `listCommentsForApi`, fixing non-deterministic pagination that could cause rows to be skipped or duplicated across pages. Both the public REST API and the MCP `listComments` tool share this function, so a single one-line change covers both surfaces.

- **Fix**: `orderBy` was missing from `prisma.comment.findMany` in `publicCommentService.ts`, making offset-based pagination non-deterministic; the added clause ensures a consistent row order.
- **Scope**: Only `listCommentsForApi` is changed; `getCommentRecordOrThrow`, `createCommentForApi`, and `getCommentForApi` are unaffected.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a one-line addition of a deterministic sort to a read-only query with no risk of data mutation or regressions.

The fix correctly addresses non-deterministic pagination. The only gap is that createdAt alone is not a unique key, so two comments sharing the same timestamp would still be ordered arbitrarily relative to each other. Adding id as a tiebreaker would make pagination fully stable, but the current change is already a substantial improvement over the prior state.

No files require special attention beyond the minor tiebreaker suggestion on publicCommentService.ts.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant API as Public REST API / MCP listComments
    participant Service as listCommentsForApi
    participant DB as Prisma (comment table)

    Client->>API: "GET /comments?page=N&limit=M"
    API->>Service: "listCommentsForApi({ page, limit, ... })"
    Service->>DB: "findMany({ where, take, skip, orderBy: [createdAt asc] })"
    DB-->>Service: ordered comment rows
    Service->>DB: "count({ where })"
    DB-->>Service: totalItems
    Service-->>API: "{ data, meta: { page, limit, totalItems, totalPages } }"
    API-->>Client: paginated response (stable ordering)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant API as Public REST API / MCP listComments
    participant Service as listCommentsForApi
    participant DB as Prisma (comment table)

    Client->>API: "GET /comments?page=N&limit=M"
    API->>Service: "listCommentsForApi({ page, limit, ... })"
    Service->>DB: "findMany({ where, take, skip, orderBy: [createdAt asc] })"
    DB-->>Service: ordered comment rows
    Service->>DB: "count({ where })"
    DB-->>Service: totalItems
    Service-->>API: "{ data, meta: { page, limit, totalItems, totalPages } }"
    API-->>Client: paginated response (stable ordering)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/comments/server/publicCommentService.ts:135
Tiebreaker needed for true stability — two comments created within the same millisecond (e.g. a bulk-insert or rapid sequential creates) will still have non-deterministic relative ordering because `createdAt` alone is not unique. Adding `id` as a secondary sort key makes page boundaries fully stable regardless of timestamp collisions.

```suggestion
      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: Add orderBy to comments findMany fo..."](https://github.com/langfuse/langfuse/commit/0d031fc7a57ae600433bcc229a6ac873b91c2911) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38371080)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->