### PR TITLE
fix(search-bar): fix sync issues between filters filter sidebar and search bar

### DIFF
--- a/web/src/features/filters/filter-integration.clienttest.ts
+++ b/web/src/features/filters/filter-integration.clienttest.ts
@@ -1014,7 +1014,6 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
   const strip = (explicitFilters: FilterState) =>
     stripImplicitEnvironmentFilterFromExplicitState({
       explicitFilters,
-      availableEnvironmentValues: [...availableValues],
       config: managedEnvironmentConfig,
     });
 
@@ -1055,7 +1054,11 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
     ).toEqual([]);
   });
 
-  it("strips default-equivalent env filters before URL/session persistence", () => {
+  it("strips only the system-shaped implicit default, keeping user-authored selections", () => {
+    // The implicit default the sidebar auto-derives — and that the facet
+    // re-creates when the user clears back to the default selection — is the
+    // `none of [hidden]` shape. That is the ONLY env filter we strip before
+    // persistence, so returning to default leaves a clean URL.
     const explicitWithExactDefault: FilterState = [
       {
         column: "environment",
@@ -1080,16 +1083,19 @@ describe("Implicit Environment Defaults (sidebar only)", () => {
       },
     ]);
 
-    expect(
-      strip([
-        {
-          column: "environment",
-          type: "stringOptions",
-          operator: "any of",
-          value: ["production", "staging"],
-        },
-      ]),
-    ).toEqual([]);
+    // A user-authored POSITIVE selection (typed in the search bar or stored in a
+    // saved view) is kept explicit even when it happens to equal the current
+    // default set — we never silently remove what the user committed to. The
+    // user returns to the default by removing the filter, not by us guessing.
+    const userAuthoredDefaultSet: FilterState = [
+      {
+        column: "environment",
+        type: "stringOptions",
+        operator: "any of",
+        value: ["production", "staging"],
+      },
+    ];
+    expect(strip(userAuthoredDefaultSet)).toEqual(userAuthoredDefaultSet);
   });
 
   it("keeps explicit overrides that enable hidden environments", () => {

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -554,14 +554,6 @@ export function useSidebarFilterState(
   const managedEnvironmentColumn =
     managedEnvironmentPolicyConfig.managedEnvironmentColumn;
 
-  const availableEnvironmentValues = useMemo(() => {
-    const rawOptions = options[managedEnvironmentColumn];
-    if (!Array.isArray(rawOptions)) return [];
-    return rawOptions.map((option) =>
-      typeof option === "string" ? option : option.value,
-    );
-  }, [options, managedEnvironmentColumn]);
-
   const effectiveEnvironmentFilterState: FilterState = useMemo(
     () =>
       buildEffectiveEnvironmentFilter({
@@ -587,7 +579,6 @@ export function useSidebarFilterState(
     (newFilters: FilterState) => {
       const explicitFilters = stripImplicitEnvironmentFilterFromExplicitState({
         explicitFilters: newFilters,
-        availableEnvironmentValues,
         config: managedEnvironmentPolicyConfig,
       });
 
@@ -617,7 +608,6 @@ export function useSidebarFilterState(
       setUrlFiltersQuery,
       setStoredFiltersQuery,
       managedEnvironmentPolicyConfig,
-      availableEnvironmentValues,
     ],
   );
 

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -25,7 +25,6 @@ import {
   stripImplicitEnvironmentFilterFromExplicitState,
   type ManagedEnvironmentPolicyInput,
 } from "../lib/managedEnvironmentPolicy";
-import { areStringSetsEqual } from "../lib/stringSetUtils";
 import { useKeyedSessionStorageState } from "./useKeyedSessionStorageState";
 import useSessionStorage from "@/src/components/useSessionStorage";
 import type { FilterConfig, FilterStateMigration } from "../lib/filter-config";
@@ -1596,27 +1595,30 @@ export function useSidebarFilterState(
         const isManagedEnvironmentFacet =
           facet.column === managedEnvironmentColumn &&
           managedEnvironmentPolicyConfig.hiddenEnvironments.length > 0;
-        const hasManagedEnvironmentSelectionOverride =
+        // A user-authored environment filter lives in EXPLICIT state; the
+        // implicit hidden-env default (`none of [hidden]`) is added to EFFECTIVE
+        // state only and stripped from explicit state by the managed-environment
+        // policy. So "explicit env filter present" is exactly "the user committed
+        // to an environment selection" — including `environment:default` (any-of
+        // the default set), which now persists. Keying the facet's active state
+        // off this keeps it in sync with the search bar, which renders any
+        // explicit env filter as a chip.
+        const hasExplicitManagedEnvironmentFilter =
           isManagedEnvironmentFacet &&
-          !areStringSetsEqual(
-            selectedValues,
-            availableValues.filter(
-              (value) =>
-                !managedEnvironmentPolicyConfig.hiddenEnvironments.includes(
-                  value,
-                ),
-            ),
+          explicitFilterState.some(
+            (filter) => filter.column === managedEnvironmentColumn,
           );
 
         // isActive check:
-        // - Managed environment facet: active only when selection differs from default
-        //   (implicit hidden-env default should not surface a "Clear" badge).
+        // - Managed environment facet: active whenever the user authored an
+        //   explicit env filter (the implicit hidden-env default lives only in
+        //   effective state, so it never surfaces a "Clear" badge).
         // - Other facets: active when text filters exist or checkbox selections differ from unfiltered.
         //   Special case: "all of" with all values selected is still active.
         const isActive =
           hasTextFilters ||
           (isManagedEnvironmentFacet
-            ? hasManagedEnvironmentSelectionOverride
+            ? hasExplicitManagedEnvironmentFilter
             : (currentOperator === "all of" &&
                 (selectedValues.length === availableValues.length ||
                   hasExplicitCheckboxFilterWhileLoading)) ||
@@ -1697,6 +1699,7 @@ export function useSidebarFilterState(
     options,
     loading,
     filterState,
+    explicitFilterState,
     updateFilter,
     updateFilterOnly,
     updateOperator,

--- a/web/src/features/filters/lib/managedEnvironmentPolicy.ts
+++ b/web/src/features/filters/lib/managedEnvironmentPolicy.ts
@@ -1,5 +1,4 @@
 import type { FilterState } from "@langfuse/shared";
-import { computeSelectedValues } from "./filter-query-encoding";
 import { areStringSetsEqual } from "./stringSetUtils";
 
 type EnvironmentFilter = Extract<
@@ -26,41 +25,33 @@ export function buildManagedEnvironmentPolicyConfig(
   };
 }
 
+// Only the SYSTEM-shaped implicit default — the `none of [hidden]` filter the
+// sidebar auto-derives, and that the facet re-creates when the user clears back
+// to the default selection — counts as "no real filter" and is stripped before
+// persistence. A user-authored POSITIVE selection (`any of [...]`, e.g. typed in
+// the search bar or stored in a saved view) is NEVER stripped, even when it
+// happens to select exactly the current default set: if the user committed to a
+// value we keep it explicit and visible. Returning to the default is the user's
+// action (remove the filter / uncheck back to default), not something we infer.
 function isEquivalentToImplicitEnvironmentDefault(params: {
   envFilter: EnvironmentFilter;
   hiddenEnvironments: string[];
-  availableEnvironmentValues: string[];
 }): boolean {
-  const { envFilter, hiddenEnvironments, availableEnvironmentValues } = params;
+  const { envFilter, hiddenEnvironments } = params;
 
   if (hiddenEnvironments.length === 0) return false;
 
-  const exactDefaultMatch =
+  return (
     envFilter.operator === "none of" &&
-    areStringSetsEqual(envFilter.value, hiddenEnvironments);
-
-  if (exactDefaultMatch) return true;
-
-  if (availableEnvironmentValues.length === 0) return false;
-
-  const selectedFromFilter = computeSelectedValues(
-    availableEnvironmentValues,
-    envFilter,
+    areStringSetsEqual(envFilter.value, hiddenEnvironments)
   );
-  const hiddenSet = new Set(hiddenEnvironments);
-  const selectedFromDefault = availableEnvironmentValues.filter(
-    (value) => !hiddenSet.has(value),
-  );
-
-  return areStringSetsEqual(selectedFromFilter, selectedFromDefault);
 }
 
 export function stripImplicitEnvironmentFilterFromExplicitState(params: {
   explicitFilters: FilterState;
-  availableEnvironmentValues: string[];
   config: ManagedEnvironmentPolicyConfig;
 }): FilterState {
-  const { explicitFilters, availableEnvironmentValues, config } = params;
+  const { explicitFilters, config } = params;
   const { managedEnvironmentColumn, hiddenEnvironments } = config;
 
   if (hiddenEnvironments.length === 0) return explicitFilters;
@@ -84,7 +75,6 @@ export function stripImplicitEnvironmentFilterFromExplicitState(params: {
     isEquivalentToImplicitEnvironmentDefault({
       envFilter,
       hiddenEnvironments,
-      availableEnvironmentValues,
     })
   ) {
     return otherFilters;

--- a/web/src/features/search-bar/README.md
+++ b/web/src/features/search-bar/README.md
@@ -142,7 +142,10 @@ committedText ──resetTo──▶ store.draft ──(type/pick/remove)──�
 - **Negation is not a primitive.** `-`/`NOT` lower to existing inverse
   operators (`none of`, `does not contain`, `is null`) or flip a comparison /
   boolean. Anything without a native inverse is a diagnostic (`fields.ts`
-  `negationIssue` is the spec) — the backend has no general NOT.
+  `negationIssue` is the spec) — the backend has no general NOT. (Negated exact
+  on a `textSearch` field — `-name:=v` — is representable: it lowers to a
+  `stringOptions none of`, the exact-inequality form the facet emits when one
+  value is unchecked. It is NOT `does not contain`.)
 
 ## Ownership map
 

--- a/web/src/features/search-bar/README.md
+++ b/web/src/features/search-bar/README.md
@@ -146,6 +146,15 @@ committedText ──resetTo──▶ store.draft ──(type/pick/remove)──�
   on a `textSearch` field — `-name:=v` — is representable: it lowers to a
   `stringOptions none of`, the exact-inequality form the facet emits when one
   value is unchecked. It is NOT `does not contain`.)
+- **User-authored filters are never auto-removed.** The bar reads the sidebar's
+  **explicit** `FilterState`, so the managed-environment implicit default
+  (`environment none of [hidden internal envs]`, derived into _effective_ state
+  by `features/filters/lib/managedEnvironmentPolicy.ts`) never shows as a token.
+  That policy strips exactly one shape from explicit state — that same implicit
+  `none of [hidden]` default (which the facet also re-creates on "clear back to
+  default"). A user-authored positive selection (`environment:default`, typed or
+  saved) is kept explicit even when it equals the current default set; the user
+  returns to the default by removing the filter, never by us inferring it.
 
 ## Ownership map
 

--- a/web/src/features/search-bar/lib/adapter.clienttest.ts
+++ b/web/src/features/search-bar/lib/adapter.clienttest.ts
@@ -391,6 +391,22 @@ describe("astToFilterState", () => {
     ]);
   });
 
+  it("lowers negated exact on id/name to stringOptions none-of (exact inequality)", () => {
+    // `-name:=abc` is exact-inequality — the faithful flat form is
+    // stringOptions none-of (there is no `string !=`). It is the inverse of the
+    // positive `name:=abc` (`string =`) and the shape the facet emits when one
+    // value is unchecked, so it must lower cleanly rather than error.
+    for (const column of ["id", "name"]) {
+      const r = lower(`-${column}:=abc`);
+      expect(r.errors).toEqual([]);
+      expect(r.filters).toEqual([
+        { type: "stringOptions", column, operator: "none of", value: ["abc"] },
+      ]);
+    }
+    // The commit gate accepts it (no longer a "not representable" error).
+    expect(validateQuery("-name:=abc").valid).toBe(true);
+  });
+
   it("lowers input:/output: to real column filters (not searchType)", () => {
     const r = lower("input:refund");
     expect(r.errors).toEqual([]);
@@ -765,19 +781,30 @@ describe("filterStateToQueryText", () => {
     expect(astToFilterState(validateQuery(text).ast).filters).toEqual(filters);
   });
 
-  it("preserves a single-value stringOptions none-of on id/name via skippedFilters", () => {
-    // `-id:=abc` (negated exact) is not representable, so rather than rewrite it
-    // to `does not contain` (a substring flip), the bar must skip + preserve it.
-    const filters: FilterState = [
-      {
-        type: "stringOptions",
-        column: "name",
-        operator: "none of",
-        value: ["abc"],
-      },
-    ];
-    const { skippedFilters } = filterStateToQueryText(filters);
-    expect(skippedFilters).toEqual(filters);
+  it("renders a single-value stringOptions none-of on id/name as negated exact", () => {
+    // A single none-of on a textSearch field is exact-inequality. The faithful
+    // grammar form is the negated exact `-name:=abc` (which lowers back to
+    // stringOptions none-of), NOT `-name:abc` (does-not-contain / substring).
+    // This is the facet "uncheck one value" shape — it must render in the bar,
+    // not vanish into skippedFilters.
+    for (const column of ["id", "name"]) {
+      const filters: FilterState = [
+        {
+          type: "stringOptions",
+          column,
+          operator: "none of",
+          value: ["abc"],
+        },
+      ];
+      const { text, skipped, skippedFilters } = filterStateToQueryText(filters);
+      expect(skipped).toEqual([]);
+      expect(skippedFilters).toEqual([]);
+      expect(text).toBe(`-${column}:=abc`);
+      // And it round-trips back to the same stringOptions none-of filter.
+      expect(astToFilterState(validateQuery(text).ast).filters).toEqual(
+        filters,
+      );
+    }
   });
 
   it("round-trips option values with operator-prefix, keyword, and empty forms", () => {

--- a/web/src/features/search-bar/lib/adapter.ts
+++ b/web/src/features/search-bar/lib/adapter.ts
@@ -336,13 +336,25 @@ function lowerText(
   }
 
   if (node.op === "exact" && field.syncMode === "textSearch") {
-    // negationIssue blocks the negated case before we get here.
+    // Grouped exact values are an exact-match SET — any-of (positive) /
+    // none-of (negated) via stringOptions (string columns accept it). A single
+    // NEGATED exact (`-name:=abc`) is exact-inequality: its only faithful flat
+    // form is stringOptions none-of, since there is no `string !=`. A single
+    // POSITIVE exact stays the plain `string =`.
     if (node.values.length > 1) {
-      // Multiple exact values are any-of: representable via stringOptions.
       out.push({
         type: "stringOptions",
         column: field.id,
-        operator: "any of",
+        operator: negated ? "none of" : "any of",
+        value: node.values,
+      });
+      return;
+    }
+    if (negated) {
+      out.push({
+        type: "stringOptions",
+        column: field.id,
+        operator: "none of",
         value: node.values,
       });
       return;

--- a/web/src/features/search-bar/lib/completions.clienttest.ts
+++ b/web/src/features/search-bar/lib/completions.clienttest.ts
@@ -348,7 +348,7 @@ describe("planInputCompletions", () => {
     expect(labels).toContain("*abc*");
   });
 
-  it("does NOT offer scope switches for a negated input/output value", () => {
+  it("offers contains + exact for a negated input/output value, but no scope switches", () => {
     // tokenSpan covers the leading `-`, so a scope rewrite would splice it away
     // and flip `does not contain` → `contains` (the complement). The value
     // stage must suppress the switches when negated (match-op refinements stay).
@@ -359,15 +359,28 @@ describe("planInputCompletions", () => {
       expect(ids, q).not.toContain("scope:output");
       expect(ids, q).not.toContain("scope:input");
       expect(ids, q).not.toContain("scope:default");
-      // Only the contains glob survives negation: starts/ends/exact have no
-      // inverse operator, so offering them would yield drafts the validator
-      // rejects. Contains stays; the other three are gone.
+      // Starts/ends-with have no inverse operator, so they are gone. Contains
+      // stays, and on a textSearch field exact stays too: `-input:=refund`
+      // lowers to a `stringOptions none of` (exact inequality), distinct from
+      // the substring `-input:refund` (does not contain).
       const labels = opts.map((o) => o.label);
-      expect(labels, q).toContain("*refund*");
+      expect(labels, q).toContain("*refund*"); // contains (does not contain)
+      expect(labels, q).toContain("=refund"); // exact (does not equal)
       expect(labels, q).not.toContain("refund*"); // starts with
       expect(labels, q).not.toContain("*refund"); // ends with
-      expect(labels, q).not.toContain("=refund"); // exact
     }
+  });
+
+  it("offers exact on a negated id/name value (none-of), distinct from contains", () => {
+    // id/name are textSearch fields with observed-value pickers. `-name:=foo`
+    // is representable (-> stringOptions none of) and meaningfully different from
+    // the substring `-name:foo` (does not contain), so the value stage offers it.
+    const opts = flattenOptions(plan("-name:foo", "-name:foo".length));
+    const labels = opts.map((o) => o.label);
+    expect(labels).toContain("*foo*"); // contains (does not contain)
+    expect(labels).toContain("=foo"); // exact (does not equal -> none of)
+    expect(labels).not.toContain("foo*"); // starts with — no inverse op
+    expect(labels).not.toContain("*foo"); // ends with — no inverse op
   });
 
   it("offers only contains on a negated exactOption value", () => {

--- a/web/src/features/search-bar/lib/completions.ts
+++ b/web/src/features/search-bar/lib/completions.ts
@@ -356,6 +356,13 @@ function datetimeOperatorOptions(fieldId: string): CompletionOption[] {
 function matchOperatorOptions(
   typed: string,
   negated = false,
+  // textSearch fields only: under negation, `-name:=v` is representable and
+  // DISTINCT from the bare `-name:v`. The bare form lowers to `does not contain`
+  // (substring); the exact form lowers to a `stringOptions none of` (exact
+  // inequality — the facet "uncheck one value" shape). For option/metadata
+  // fields the bare negated value already IS exact none-of, so exact is
+  // redundant there and stays suppressed.
+  allowNegatedExact = false,
 ): CompletionOption[] {
   // Quote the value through the serializer so a value with whitespace/grammar
   // chars (`My Test`) becomes `*"My Test"*` — one lexer token — instead of a
@@ -368,10 +375,18 @@ function matchOperatorOptions(
     detail: "contains (same as the bare value)",
     insert: `*${v}*`,
   };
-  // Under negation only "contains" is representable (-> "does not contain").
-  // Negated starts/ends/exact have no inverse operator, so the validator would
-  // reject them on the next derive — don't offer drafts that can't commit.
-  if (negated) return [contains];
+  const exact: CompletionOption = {
+    id: "vop:exact",
+    kind: "pattern",
+    label: `=${v}`,
+    detail: negated ? "exact (does not equal)" : "exact match",
+    insert: `=${v}`,
+  };
+  // Under negation, starts/ends-with have no inverse operator (the validator
+  // would reject them on the next derive), so only "contains" — and, on a
+  // textSearch field, the distinct "exact" (-> does-not-equal / none-of) — are
+  // offered; never drafts that can't commit.
+  if (negated) return allowNegatedExact ? [contains, exact] : [contains];
   return [
     contains,
     {
@@ -388,13 +403,7 @@ function matchOperatorOptions(
       detail: "ends with",
       insert: `*${v}`,
     },
-    {
-      id: "vop:exact",
-      kind: "pattern",
-      label: `=${v}`,
-      detail: "exact match",
-      insert: `=${v}`,
-    },
+    exact,
   ];
 }
 
@@ -644,7 +653,12 @@ function valueStageSections(
             : [];
         return {
           sections: [
-            ...section(SECTION_MATCH_OPS, matchOperatorOptions(typed, negated)),
+            ...section(
+              SECTION_MATCH_OPS,
+              // Pure textSearch (input/output): negated exact is representable
+              // and distinct from the bare contains, so offer it.
+              matchOperatorOptions(typed, negated, true),
+            ),
             ...section(SECTION_SEARCH_IN, scopeSwitches),
           ],
           loading: false,
@@ -665,11 +679,13 @@ function valueStageSections(
       // Array fields reject match operators — operatorIssue routes them to
       // value/any-of/all-of groups — so don't suggest them. For other option
       // fields, once a value is typed offer glob/exact refinements that wrap it.
-      // Pass `negated` so a negated value only offers contains (the lone
-      // refinement with an inverse op), mirroring the metadata/textSearch sites.
+      // Under negation only contains is offered for option fields (bare negated
+      // value already IS exact none-of), but textSearch fields with observed
+      // values (id/name) also offer exact (`-name:=v` -> none-of, distinct from
+      // the substring `-name:v`).
       const ops =
         typed.length > 0 && f.syncMode !== "arrayOption"
-          ? matchOperatorOptions(typed, negated)
+          ? matchOperatorOptions(typed, negated, f.syncMode === "textSearch")
           : [];
       if (values.length + ops.length === 0) return null;
       return {

--- a/web/src/features/search-bar/lib/fields.ts
+++ b/web/src/features/search-bar/lib/fields.ts
@@ -302,9 +302,10 @@ export function negationIssue(
         return `negated equality on "${f.id}" is not representable — use comparisons (${f.id}:<n or ${f.id}:>n)`;
       }
       if (f.kind === "boolean") return null; // inverts the value
-      if (f.kind === "text" && f.syncMode === "textSearch" && op === "exact") {
-        return `negated exact match on "${f.id}" is not representable — use -${f.id}:*value* (does not contain)`;
-      }
+      // Negated exact on a textSearch field (`-name:=abc`) IS representable: it
+      // is exact-inequality, which lowers to a stringOptions `none of` (there is
+      // no `string !=`, but the option-set form covers it — and it is the shape
+      // the facet emits when one value is unchecked). So no negation gap here.
       return null;
     }
   }

--- a/web/src/features/search-bar/lib/filter-state-to-query.ts
+++ b/web/src/features/search-bar/lib/filter-state-to-query.ts
@@ -79,18 +79,21 @@ function lowerSingle(filter: FilterState[number]): ASTNode | null {
       if (id === null || filter.value.length === 0) return null;
       // A stringOptions/arrayOptions filter is EXACT-set semantics. On a
       // `textSearch` field (id/name) the bar reads a bare single value as
-      // `contains`, so a single-value any-of would silently flip exact→substring
-      // on the next commit (and a single-value none-of → does-not-contain). The
-      // grouped multi-value forms reparse to exact any-of/none-of, so only the
-      // single-value forms need care.
+      // `contains`, so a single-value any-of/none-of would silently flip
+      // exact→substring on the next commit. The single-value forms therefore use
+      // the explicit exact operator (`name:=abc` / `-name:=abc`); the grouped
+      // multi-value forms already reparse to exact any-of/none-of.
       const ref = resolveField(id);
       const isTextSearch =
         ref?.type === "field" && ref.field.syncMode === "textSearch";
       if (filter.operator === "none of") {
-        // `-id:=abc` (negated exact) is not representable, so a single none-of on
-        // a textSearch field has no faithful grammar form — skip it (preserved via
-        // skippedFilters) rather than rewrite it to `does not contain`.
-        if (isTextSearch && filter.value.length === 1) return null;
+        // On a textSearch field a single none-of is exact-inequality: emit the
+        // negated exact form (`-name:=abc`), which lowers back to stringOptions
+        // none-of — NOT the bare `-name:abc`, which is does-not-contain
+        // (substring). The grouped/option forms use the bare `=` any-of shape.
+        if (isTextSearch && filter.value.length === 1) {
+          return negate(filterNode(id, "exact", filter.value));
+        }
         return negate(filterNode(id, "=", filter.value));
       }
       if (filter.operator === "all of") {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related sync bugs between the filter sidebar and the search bar. It makes negated exact matches on `textSearch` fields (e.g. `-name:=abc`) representable — lowering them to `stringOptions none of` — and simplifies the managed-environment implicit-default stripping to only remove the system-shaped `none of [hidden]` filter, never a user-authored positive selection.

- **Negated exact on textSearch fields**: Removes the `negationIssue` guard that blocked `-name:=abc`, wires the `lowerText` path to emit `stringOptions none of`, and updates the reverse adapter (`filter-state-to-query.ts`) to serialize a single-value `none of` back to `-name:=abc` (rather than putting it in `skippedFilters`).
- **Managed environment policy**: Strips only the exact `none of [hidden]` shape; any user-authored `any of [...]` selection — even one that equals the current visible set — is now preserved in explicit state rather than silently removed.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the core round-trip for single-value negated exact on textSearch fields is correctly implemented end-to-end, and the managed environment policy change is a deliberate narrowing of the stripping heuristic.

The single-value path for `-name:=abc` lowers, commits, and re-serializes cleanly. The only gap is a cosmetic commit-echo rewrite for the rare multi-value grouped negated exact form (`-name:=(abc def)` → `-name:(abc def)`), which is a pre-existing limitation now inherited for the negated case. No filter data is lost and no behavioral regression is introduced.

The multi-value negated exact path in `web/src/features/search-bar/lib/adapter.ts` (lines 344-361) is where the commit-echo rewrite gap lives; a future fix would touch `foldDerivedNegation` in `filter-state-to-query.ts` to fold negated `exact` → `=` for multi-value textSearch, mirroring the existing positive-exact fold.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Sidebar as Filter Sidebar
    participant Policy as managedEnvironmentPolicy
    participant FsToQ as filterStateToQueryText
    participant Bar as Search Bar
    participant Adapter as astToFilterState

    Note over Sidebar,Policy: User selects environment filter
    Sidebar->>Policy: stripImplicit(explicitFilters, config)
    alt filter is "none of [hidden]" (system default shape)
        Policy-->>Sidebar: strip it (clean URL)
    else filter is "any of [...]" (user selection)
        Policy-->>Sidebar: keep it (explicit state)
    end

    Sidebar->>FsToQ: filterStateToQueryText(explicitFilters)
    alt stringOptions none of [v] on textSearch field (single value)
        FsToQ-->>Bar: "negate(exact) → "-name:=abc""
    else stringOptions none of [v1,v2] on textSearch field
        FsToQ-->>Bar: "negate(=) → "-name:(v1 v2)""
    end

    Note over Bar,Adapter: User commits search bar text
    Bar->>Adapter: "astToFilterState("-name:=abc")"
    Adapter->>Adapter: negationIssue → null (representable)
    Adapter->>Adapter: lowerText: negated+exact+single → stringOptions none of
    Adapter-->>Sidebar: stringOptions none of ["abc"]
    Sidebar->>Policy: stripImplicit(newFilters, config)
    Policy-->>Sidebar: keep (user-authored, not system shape)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Sidebar as Filter Sidebar
    participant Policy as managedEnvironmentPolicy
    participant FsToQ as filterStateToQueryText
    participant Bar as Search Bar
    participant Adapter as astToFilterState

    Note over Sidebar,Policy: User selects environment filter
    Sidebar->>Policy: stripImplicit(explicitFilters, config)
    alt filter is "none of [hidden]" (system default shape)
        Policy-->>Sidebar: strip it (clean URL)
    else filter is "any of [...]" (user selection)
        Policy-->>Sidebar: keep it (explicit state)
    end

    Sidebar->>FsToQ: filterStateToQueryText(explicitFilters)
    alt stringOptions none of [v] on textSearch field (single value)
        FsToQ-->>Bar: "negate(exact) → "-name:=abc""
    else stringOptions none of [v1,v2] on textSearch field
        FsToQ-->>Bar: "negate(=) → "-name:(v1 v2)""
    end

    Note over Bar,Adapter: User commits search bar text
    Bar->>Adapter: "astToFilterState("-name:=abc")"
    Adapter->>Adapter: negationIssue → null (representable)
    Adapter->>Adapter: lowerText: negated+exact+single → stringOptions none of
    Adapter-->>Sidebar: stringOptions none of ["abc"]
    Sidebar->>Policy: stripImplicit(newFilters, config)
    Policy-->>Sidebar: keep (user-authored, not system shape)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/search-bar/lib/adapter.ts:344-361
**Multi-value negated exact produces a commit-echo rewrite**

When a user types `-name:=(abc def)`, it now lowers correctly to `stringOptions none of ["abc", "def"]`. However, the reverse adapter (`filterStateToQueryText`) serializes a multi-value `none of` on a textSearch field as `-name:(abc def)` (without the `=`). Because `foldDerivedNegation` normalizes the typed AST's op to `"exact"` while the derived AST uses `"="`, `astEquals` returns false and `resetTo` clobbers the typed form on the commit echo.

The single-value path (`-name:=abc`) round-trips correctly. Only multi-value grouped negated exact (`-name:=(a b)`) is affected — the same pre-existing gap that exists for the positive case (`name:=(a b)` → reseeds as `name:(a b)`). Given how rarely users type grouped exact with multiple values, this is low-impact, but worth noting for a follow-up fix in `foldDerivedNegation` (fold negated `exact` to `=` for multi-value textSearch, mirroring the existing positive-exact fold).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(filters): keep user-authored env fil..."](https://github.com/langfuse/langfuse/commit/08ab94c66e1a18b3b63789d41b1fb1677c7a7e1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38371912)</sub>

<!-- /greptile_comment -->