### PR TITLE
feat(blob-storage): log S3 signing diagnostics on upload failures

### DIFF
--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -27,6 +27,7 @@ import { BufferedStreamUploader } from "./BufferedStreamUploader";
 import { S3ChunkedUploadStrategy } from "./S3ChunkedUploadStrategy";
 import {
   buildS3RequestDiagnostics,
+  isS3SigningError,
   type S3SigningDiagnosticsContext,
 } from "./s3SigningDiagnostics";
 import * as objectstorage from "oci-objectstorage";
@@ -119,14 +120,19 @@ function createS3RequestHandler(
 }
 
 /**
- * Register a diagnostics middleware on an {@link S3Client} that logs, on any
- * failed request, the framing headers actually sent and the structured error.
+ * Register a diagnostics middleware on an {@link S3Client} that logs the
+ * framing headers actually sent and the structured error when a request fails
+ * with a signing/authorization error (e.g. `SignatureDoesNotMatch`).
  *
  * It runs at the `deserialize` step with `high` priority so it wraps the SDK's
  * own deserializer: by then the request is fully built and signed (so the
  * framing headers are final), and the SDK has turned an error response into a
  * thrown `S3ServiceException` (so we see the typed error, not a raw response).
- * Diagnostics are best-effort and never alter or mask the original failure.
+ *
+ * Logging is gated to signing-related error codes so unrelated failures
+ * (`NoSuchKey`, `AccessDenied`, throttling, timeouts) don't emit a misleading
+ * signing-themed log or one line per SDK retry. Diagnostics are best-effort and
+ * never alter or mask the original failure.
  */
 function addS3SigningDiagnosticsMiddleware(
   client: S3Client,
@@ -141,10 +147,17 @@ function addS3SigningDiagnosticsMiddleware(
         return await next(args);
       } catch (err) {
         try {
-          logger.warn(
-            "S3 request failed; emitting signing diagnostics (helps debug SignatureDoesNotMatch / non-AWS S3-compatible interop)",
-            buildS3RequestDiagnostics(args.request, err, context),
+          const diagnostics = buildS3RequestDiagnostics(
+            args.request,
+            err,
+            context,
           );
+          if (isS3SigningError(diagnostics.error)) {
+            logger.warn(
+              "S3 request failed with a signing/authorization error; emitting diagnostics (helps debug SignatureDoesNotMatch on non-AWS S3-compatible backends such as GCS interop)",
+              diagnostics,
+            );
+          }
         } catch {
           // Never let diagnostics logging mask the original failure.
         }

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -25,6 +25,10 @@ import { backOff } from "exponential-backoff";
 import { ServiceUnavailableError } from "../../errors";
 import { BufferedStreamUploader } from "./BufferedStreamUploader";
 import { S3ChunkedUploadStrategy } from "./S3ChunkedUploadStrategy";
+import {
+  buildS3RequestDiagnostics,
+  type S3SigningDiagnosticsContext,
+} from "./s3SigningDiagnostics";
 import * as objectstorage from "oci-objectstorage";
 import * as common from "oci-common";
 import { UploadManager as OciUploadManager } from "oci-objectstorage";
@@ -112,6 +116,57 @@ function createS3RequestHandler(
     httpAgent,
     httpsAgent,
   });
+}
+
+/**
+ * Register a diagnostics middleware on an {@link S3Client} that logs, on any
+ * failed request, the framing headers actually sent and the structured error.
+ *
+ * It runs at the `deserialize` step with `high` priority so it wraps the SDK's
+ * own deserializer: by then the request is fully built and signed (so the
+ * framing headers are final), and the SDK has turned an error response into a
+ * thrown `S3ServiceException` (so we see the typed error, not a raw response).
+ * Diagnostics are best-effort and never alter or mask the original failure.
+ */
+function addS3SigningDiagnosticsMiddleware(
+  client: S3Client,
+  context: S3SigningDiagnosticsContext,
+): void {
+  type S3MiddlewareArgs = { request?: unknown };
+  type S3MiddlewareNext = (args: S3MiddlewareArgs) => Promise<unknown>;
+
+  const diagnosticsMiddleware =
+    (next: S3MiddlewareNext) => async (args: S3MiddlewareArgs) => {
+      try {
+        return await next(args);
+      } catch (err) {
+        try {
+          logger.warn(
+            "S3 request failed; emitting signing diagnostics (helps debug SignatureDoesNotMatch / non-AWS S3-compatible interop)",
+            buildS3RequestDiagnostics(args.request, err, context),
+          );
+        } catch {
+          // Never let diagnostics logging mask the original failure.
+        }
+        throw err;
+      }
+    };
+
+  client.middlewareStack.add(
+    // Bridge the structural middleware to the SDK's middleware union without
+    // taking a direct dependency on @smithy/types. The handler reads only
+    // `request`, so the unused `input` field of the SDK's arg type is elided.
+    diagnosticsMiddleware as unknown as Parameters<
+      typeof client.middlewareStack.add
+    >[0],
+    {
+      step: "deserialize",
+      priority: "high",
+      name: "langfuseS3SigningDiagnostics",
+      tags: ["LANGFUSE", "DIAGNOSTICS"],
+      override: true,
+    },
+  );
 }
 
 function createAzureBlobPipeline(
@@ -593,6 +648,16 @@ class S3StorageService implements StorageService {
       requestChecksumCalculation: "WHEN_REQUIRED",
       responseChecksumValidation: "WHEN_REQUIRED",
       requestHandler,
+    });
+
+    // Log signing/framing diagnostics for any failed S3 request on the upload
+    // client. Surfaces checksum/`aws-chunked` framing that non-AWS backends
+    // (e.g. GCS) reject with SignatureDoesNotMatch despite valid credentials.
+    addS3SigningDiagnosticsMiddleware(this.client, {
+      bucketName: params.bucketName,
+      endpoint: params.endpoint,
+      region: params.region,
+      forcePathStyle: params.forcePathStyle,
     });
 
     // Create a separate client for generating presigned URLs

--- a/packages/shared/src/server/services/s3SigningDiagnostics.test.ts
+++ b/packages/shared/src/server/services/s3SigningDiagnostics.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildS3RequestDiagnostics,
   classifyContentSha256Mode,
+  isS3SigningError,
   summarizeS3Error,
   summarizeS3SigningHeaders,
 } from "./s3SigningDiagnostics";
@@ -123,7 +124,7 @@ describe("buildS3RequestDiagnostics", () => {
     const request = {
       method: "PUT",
       hostname: "storage.googleapis.com",
-      path: "/ct-langfuse-test/langfuse-validation-test.txt",
+      path: "/ct-langfuse-test/org-123/user-456/secret-key.txt",
       headers: {
         "content-encoding": "aws-chunked",
         "x-amz-content-sha256": "STREAMING-UNSIGNED-PAYLOAD-TRAILER",
@@ -142,10 +143,17 @@ describe("buildS3RequestDiagnostics", () => {
     expect(diagnostics.region).toBe("europe-west1");
     expect(diagnostics.forcePathStyle).toBe(true);
     expect(diagnostics.request.method).toBe("PUT");
+    expect(diagnostics.request.hostname).toBe("storage.googleapis.com");
     expect(diagnostics.request.usesAwsChunkedEncoding).toBe(true);
     expect(diagnostics.request.hasChecksumTrailer).toBe(true);
     expect(diagnostics.error.name).toBe("SignatureDoesNotMatch");
-    expect(JSON.stringify(diagnostics)).not.toContain("AWS4-HMAC-SHA256");
+
+    const serialized = JSON.stringify(diagnostics);
+    // Never surface credentials or the object key (may embed tenant/user ids).
+    expect(serialized).not.toContain("AWS4-HMAC-SHA256");
+    expect(serialized).not.toContain("org-123");
+    expect(serialized).not.toContain("user-456");
+    expect(serialized).not.toContain("secret-key.txt");
   });
 
   it("tolerates a non-HttpRequest value without throwing", () => {
@@ -153,5 +161,33 @@ describe("buildS3RequestDiagnostics", () => {
     expect(diagnostics.request.method).toBeUndefined();
     expect(diagnostics.request.contentSha256Mode).toBe("absent");
     expect(diagnostics.error.message).toBe("boom");
+  });
+});
+
+describe("isS3SigningError", () => {
+  it("matches signing/authorization error codes by name or Code", () => {
+    for (const code of [
+      "SignatureDoesNotMatch",
+      "InvalidSignatureException",
+      "AuthorizationQueryParametersError",
+      "AuthorizationHeaderMalformed",
+      "RequestTimeTooSkewed",
+    ]) {
+      expect(isS3SigningError({ name: code })).toBe(true);
+      expect(isS3SigningError({ code })).toBe(true);
+    }
+  });
+
+  it("does not match unrelated S3 errors (so they are not logged)", () => {
+    expect(isS3SigningError({ name: "NoSuchKey", code: "NoSuchKey" })).toBe(
+      false,
+    );
+    expect(
+      isS3SigningError({ name: "AccessDenied", code: "AccessDenied" }),
+    ).toBe(false);
+    expect(isS3SigningError({ name: "SlowDown", code: "SlowDown" })).toBe(
+      false,
+    );
+    expect(isS3SigningError({})).toBe(false);
   });
 });

--- a/packages/shared/src/server/services/s3SigningDiagnostics.test.ts
+++ b/packages/shared/src/server/services/s3SigningDiagnostics.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildS3RequestDiagnostics,
+  classifyContentSha256Mode,
+  summarizeS3Error,
+  summarizeS3SigningHeaders,
+} from "./s3SigningDiagnostics";
+
+describe("classifyContentSha256Mode", () => {
+  it("reports a single-chunk signed payload for a hex digest", () => {
+    expect(classifyContentSha256Mode("a".repeat(64))).toBe(
+      "single-chunk-sha256",
+    );
+    // mixed case hex is still a valid digest
+    expect(classifyContentSha256Mode("ABCDEF" + "0".repeat(58))).toBe(
+      "single-chunk-sha256",
+    );
+  });
+
+  it("passes streaming/trailer modes through verbatim", () => {
+    expect(
+      classifyContentSha256Mode("STREAMING-UNSIGNED-PAYLOAD-TRAILER"),
+    ).toBe("STREAMING-UNSIGNED-PAYLOAD-TRAILER");
+    expect(
+      classifyContentSha256Mode("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"),
+    ).toBe("STREAMING-AWS4-HMAC-SHA256-PAYLOAD");
+    expect(classifyContentSha256Mode("UNSIGNED-PAYLOAD")).toBe(
+      "UNSIGNED-PAYLOAD",
+    );
+  });
+
+  it("handles absent and unexpected values without throwing", () => {
+    expect(classifyContentSha256Mode(undefined)).toBe("absent");
+    expect(classifyContentSha256Mode("")).toBe("absent");
+    expect(classifyContentSha256Mode("not-a-hash")).toBe("other");
+  });
+});
+
+describe("summarizeS3SigningHeaders", () => {
+  it("flags the checksum/aws-chunked framing that GCS rejects", () => {
+    const summary = summarizeS3SigningHeaders({
+      "Content-Encoding": "aws-chunked",
+      "x-amz-content-sha256": "STREAMING-UNSIGNED-PAYLOAD-TRAILER",
+      "x-amz-trailer": "x-amz-checksum-crc32",
+      "x-amz-sdk-checksum-algorithm": "CRC32",
+    });
+
+    expect(summary.usesAwsChunkedEncoding).toBe(true);
+    expect(summary.hasChecksumTrailer).toBe(true);
+    expect(summary.contentSha256Mode).toBe(
+      "STREAMING-UNSIGNED-PAYLOAD-TRAILER",
+    );
+    expect(summary.checksumHeaders).toEqual(["x-amz-sdk-checksum-algorithm"]);
+  });
+
+  it("reports a clean single-chunk PUT (the curl-equivalent request)", () => {
+    const summary = summarizeS3SigningHeaders({
+      "x-amz-content-sha256": "b".repeat(64),
+    });
+
+    expect(summary.usesAwsChunkedEncoding).toBe(false);
+    expect(summary.hasChecksumTrailer).toBe(false);
+    expect(summary.contentSha256Mode).toBe("single-chunk-sha256");
+    expect(summary.checksumHeaders).toEqual([]);
+    expect(summary.contentEncoding).toBeUndefined();
+  });
+
+  it("is case-insensitive on header names and tolerates missing headers", () => {
+    expect(summarizeS3SigningHeaders(undefined).contentSha256Mode).toBe(
+      "absent",
+    );
+    const summary = summarizeS3SigningHeaders({
+      "X-Amz-Checksum-Crc32": "abc",
+      "X-AMZ-TRAILER": "x-amz-checksum-crc32",
+    });
+    expect(summary.hasChecksumTrailer).toBe(true);
+    expect(summary.checksumHeaders).toEqual(["x-amz-checksum-crc32"]);
+  });
+});
+
+describe("summarizeS3Error", () => {
+  it("extracts structured fields from an AWS SDK service exception", () => {
+    const err = Object.assign(
+      new Error("The request signature we calculated"),
+      {
+        name: "SignatureDoesNotMatch",
+        Code: "SignatureDoesNotMatch",
+        $fault: "client",
+        $metadata: {
+          httpStatusCode: 403,
+          requestId: "req-123",
+          extendedRequestId: "ext-456",
+        },
+      },
+    );
+
+    expect(summarizeS3Error(err)).toEqual({
+      name: "SignatureDoesNotMatch",
+      code: "SignatureDoesNotMatch",
+      fault: "client",
+      httpStatusCode: 403,
+      requestId: "req-123",
+      extendedRequestId: "ext-456",
+      message: "The request signature we calculated",
+    });
+  });
+
+  it("never throws on non-object errors", () => {
+    expect(summarizeS3Error("boom")).toEqual({ message: "boom" });
+    expect(summarizeS3Error(undefined)).toEqual({ message: "undefined" });
+  });
+});
+
+describe("buildS3RequestDiagnostics", () => {
+  const context = {
+    bucketName: "ct-langfuse-test",
+    endpoint: "https://storage.googleapis.com",
+    region: "europe-west1",
+    forcePathStyle: true,
+  };
+
+  it("combines signing context, request framing, and error", () => {
+    const request = {
+      method: "PUT",
+      hostname: "storage.googleapis.com",
+      path: "/ct-langfuse-test/langfuse-validation-test.txt",
+      headers: {
+        "content-encoding": "aws-chunked",
+        "x-amz-content-sha256": "STREAMING-UNSIGNED-PAYLOAD-TRAILER",
+        "x-amz-trailer": "x-amz-checksum-crc32",
+        // Authorization must never be surfaced.
+        authorization: "AWS4-HMAC-SHA256 Credential=GOOG.../...",
+      },
+    };
+
+    const diagnostics = buildS3RequestDiagnostics(
+      request,
+      Object.assign(new Error("mismatch"), { name: "SignatureDoesNotMatch" }),
+      context,
+    );
+
+    expect(diagnostics.region).toBe("europe-west1");
+    expect(diagnostics.forcePathStyle).toBe(true);
+    expect(diagnostics.request.method).toBe("PUT");
+    expect(diagnostics.request.usesAwsChunkedEncoding).toBe(true);
+    expect(diagnostics.request.hasChecksumTrailer).toBe(true);
+    expect(diagnostics.error.name).toBe("SignatureDoesNotMatch");
+    expect(JSON.stringify(diagnostics)).not.toContain("AWS4-HMAC-SHA256");
+  });
+
+  it("tolerates a non-HttpRequest value without throwing", () => {
+    const diagnostics = buildS3RequestDiagnostics(undefined, "boom", context);
+    expect(diagnostics.request.method).toBeUndefined();
+    expect(diagnostics.request.contentSha256Mode).toBe("absent");
+    expect(diagnostics.error.message).toBe("boom");
+  });
+});

--- a/packages/shared/src/server/services/s3SigningDiagnostics.ts
+++ b/packages/shared/src/server/services/s3SigningDiagnostics.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure helpers for diagnosing S3 SigV4 `SignatureDoesNotMatch` failures, with a
+ * focus on Google Cloud Storage and other non-AWS S3-compatible backends.
+ *
+ * Recent AWS SDK versions enable data-integrity checksums and `aws-chunked`
+ * trailer-based upload framing by default. GCS's S3 interop layer does not
+ * verify that framing the way AWS does, so the canonical request it
+ * reconstructs differs from what the SDK signed and it returns
+ * `SignatureDoesNotMatch` (or `412`). This is invisible from the error message
+ * alone: a raw `curl --aws-sigv4` PUT sends a plain single-chunk signed
+ * payload and succeeds, while the SDK request silently fails on the same
+ * credentials.
+ *
+ * These helpers summarize the *signing inputs* of the request that failed so
+ * the difference shows up in logs. They never read credentials (no
+ * `Authorization` header), the secret, or the payload — only the framing
+ * headers and the structured error fields.
+ */
+
+export interface S3SigningDiagnosticsContext {
+  bucketName: string;
+  endpoint?: string;
+  region?: string;
+  forcePathStyle: boolean;
+}
+
+/**
+ * Classify the `x-amz-content-sha256` header into a *mode* without exposing the
+ * actual content hash. The mode is what matters for signature debugging:
+ * a 64-char hex value is a single-chunk signed payload (what a plain PUT or
+ * `curl --aws-sigv4` sends), whereas `STREAMING-*` / `UNSIGNED-PAYLOAD`
+ * indicate chunked or trailer-based framing that GCS rejects.
+ */
+export function classifyContentSha256Mode(value: string | undefined): string {
+  if (!value) return "absent";
+  if (value.startsWith("STREAMING-")) return value;
+  if (value === "UNSIGNED-PAYLOAD") return "UNSIGNED-PAYLOAD";
+  if (/^[0-9a-f]{64}$/i.test(value)) return "single-chunk-sha256";
+  return "other";
+}
+
+function lowercaseHeaderKeys(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    out[key.toLowerCase()] = value;
+  }
+  return out;
+}
+
+export interface S3SigningHeaderSummary {
+  contentEncoding?: string;
+  contentSha256Mode: string;
+  usesAwsChunkedEncoding: boolean;
+  hasChecksumTrailer: boolean;
+  checksumHeaders: string[];
+}
+
+/**
+ * Summarize the framing headers that determine whether GCS can verify the
+ * SigV4 signature. The presence of `aws-chunked` encoding, an `x-amz-trailer`,
+ * or `x-amz-checksum-*` / `x-amz-sdk-checksum-*` headers is the smoking gun for
+ * a checksum/streaming mismatch.
+ */
+export function summarizeS3SigningHeaders(
+  headers: Record<string, string> | undefined,
+): S3SigningHeaderSummary {
+  const lower = lowercaseHeaderKeys(headers ?? {});
+  const contentEncoding = lower["content-encoding"];
+  return {
+    contentEncoding,
+    contentSha256Mode: classifyContentSha256Mode(lower["x-amz-content-sha256"]),
+    usesAwsChunkedEncoding: (contentEncoding ?? "")
+      .toLowerCase()
+      .includes("aws-chunked"),
+    hasChecksumTrailer: "x-amz-trailer" in lower,
+    checksumHeaders: Object.keys(lower)
+      .filter(
+        (key) =>
+          key.startsWith("x-amz-checksum-") ||
+          key.startsWith("x-amz-sdk-checksum-"),
+      )
+      .sort(),
+  };
+}
+
+export interface S3ErrorSummary {
+  name?: string;
+  code?: string;
+  fault?: string;
+  httpStatusCode?: number;
+  requestId?: string;
+  extendedRequestId?: string;
+  message?: string;
+}
+
+/**
+ * Extract the structured fields an AWS SDK `ServiceException` carries beyond
+ * its message string (`Code`, `$fault`, and the `$metadata` request IDs that
+ * let support correlate the failure with the storage provider's own logs).
+ */
+export function summarizeS3Error(err: unknown): S3ErrorSummary {
+  if (!err || typeof err !== "object") {
+    return { message: String(err) };
+  }
+  const e = err as {
+    name?: string;
+    message?: string;
+    Code?: string;
+    $fault?: string;
+    $metadata?: {
+      httpStatusCode?: number;
+      requestId?: string;
+      extendedRequestId?: string;
+    };
+  };
+  return {
+    name: e.name,
+    code: e.Code,
+    fault: e.$fault,
+    httpStatusCode: e.$metadata?.httpStatusCode,
+    requestId: e.$metadata?.requestId,
+    extendedRequestId: e.$metadata?.extendedRequestId,
+    message: e.message,
+  };
+}
+
+interface MaybeHttpRequest {
+  method?: string;
+  hostname?: string;
+  path?: string;
+  headers?: Record<string, string>;
+}
+
+export interface S3RequestDiagnostics extends S3SigningDiagnosticsContext {
+  request: {
+    method?: string;
+    hostname?: string;
+    path?: string;
+  } & S3SigningHeaderSummary;
+  error: S3ErrorSummary;
+}
+
+/**
+ * Build the structured payload logged when an S3 request fails. Combines the
+ * configured signing context (region, endpoint, path-style) with the framing
+ * headers of the request that was actually sent and the structured error,
+ * tolerating any non-`HttpRequest` shape without throwing. The query string is
+ * intentionally omitted so presigned-URL credentials can never leak.
+ */
+export function buildS3RequestDiagnostics(
+  request: unknown,
+  err: unknown,
+  context: S3SigningDiagnosticsContext,
+): S3RequestDiagnostics {
+  const req: MaybeHttpRequest =
+    request && typeof request === "object" ? (request as MaybeHttpRequest) : {};
+  return {
+    ...context,
+    request: {
+      method: req.method,
+      hostname: req.hostname,
+      path: req.path,
+      ...summarizeS3SigningHeaders(req.headers),
+    },
+    error: summarizeS3Error(err),
+  };
+}

--- a/packages/shared/src/server/services/s3SigningDiagnostics.ts
+++ b/packages/shared/src/server/services/s3SigningDiagnostics.ts
@@ -126,10 +126,36 @@ export function summarizeS3Error(err: unknown): S3ErrorSummary {
   };
 }
 
+/**
+ * Error `name`/`Code` values that indicate a signing or request-authorization
+ * canonicalization failure — the class of error this diagnostics module exists
+ * to debug. Used to gate logging so unrelated failures (`NoSuchKey`,
+ * `AccessDenied`, `SlowDown`, network timeouts) don't emit a signing-themed
+ * `warn`. These are also non-retryable client (4xx) errors, so gating on them
+ * avoids one log line per SDK retry attempt.
+ */
+const S3_SIGNING_ERROR_CODES = new Set<string>([
+  "SignatureDoesNotMatch",
+  "InvalidSignatureException",
+  "AuthorizationQueryParametersError",
+  "AuthorizationHeaderMalformed", // region mismatch in the credential scope
+  "RequestTimeTooSkewed", // clock skew, breaks the computed signature
+]);
+
+/**
+ * Whether a summarized error is a signing/authorization failure worth a
+ * signing-themed diagnostic log, as opposed to an unrelated S3 error.
+ */
+export function isS3SigningError(error: S3ErrorSummary): boolean {
+  return (
+    (error.name !== undefined && S3_SIGNING_ERROR_CODES.has(error.name)) ||
+    (error.code !== undefined && S3_SIGNING_ERROR_CODES.has(error.code))
+  );
+}
+
 interface MaybeHttpRequest {
   method?: string;
   hostname?: string;
-  path?: string;
   headers?: Record<string, string>;
 }
 
@@ -137,7 +163,6 @@ export interface S3RequestDiagnostics extends S3SigningDiagnosticsContext {
   request: {
     method?: string;
     hostname?: string;
-    path?: string;
   } & S3SigningHeaderSummary;
   error: S3ErrorSummary;
 }
@@ -146,8 +171,12 @@ export interface S3RequestDiagnostics extends S3SigningDiagnosticsContext {
  * Build the structured payload logged when an S3 request fails. Combines the
  * configured signing context (region, endpoint, path-style) with the framing
  * headers of the request that was actually sent and the structured error,
- * tolerating any non-`HttpRequest` shape without throwing. The query string is
- * intentionally omitted so presigned-URL credentials can never leak.
+ * tolerating any non-`HttpRequest` shape without throwing.
+ *
+ * Deliberately omits the request `path` (the S3 object key, which can embed
+ * tenant/user identifiers) and the query string (which can carry presigned-URL
+ * credentials). `hostname` is kept because it reveals path- vs virtual-hosted
+ * addressing without exposing the key.
  */
 export function buildS3RequestDiagnostics(
   request: unknown,
@@ -161,7 +190,6 @@ export function buildS3RequestDiagnostics(
     request: {
       method: req.method,
       hostname: req.hostname,
-      path: req.path,
       ...summarizeS3SigningHeaders(req.headers),
     },
     error: summarizeS3Error(err),


### PR DESCRIPTION
## What does this PR do?

Adds a diagnostics middleware to the S3 upload client so that, on **any failed S3 request**, we log the request's signing/framing headers alongside the structured AWS SDK error. This makes `SignatureDoesNotMatch` failures on non-AWS S3-compatible backends (notably **Google Cloud Storage interop**) debuggable.

**Why:** Recent AWS SDK versions enable data-integrity checksums and `aws-chunked` trailer-based upload framing by default. GCS's S3 interop layer doesn't verify that framing the way AWS does, so it rejects the request with `SignatureDoesNotMatch` even though the credentials are valid — a plain `curl --aws-sigv4` PUT (single-chunk signed payload) succeeds on the same keys. Today the error message alone gives no way to tell whether a failure is a bad secret or this framing mismatch. This PR surfaces exactly that signal.

The middleware logs (at `warn`, only on failure):
- **Signing context:** `region`, `endpoint`, `forcePathStyle`, `bucketName`.
- **Request framing:** `content-encoding` (is it `aws-chunked`?), `x-amz-content-sha256` *mode* (single-chunk hex vs `STREAMING-*`/`UNSIGNED-PAYLOAD`), presence of `x-amz-trailer`, and any `x-amz-checksum-*` / `x-amz-sdk-checksum-*` headers.
- **Structured error:** `name`, `Code`, `$fault`, `$metadata` HTTP status + request IDs.

It runs at the `deserialize` step with `high` priority so it wraps the SDK's own deserializer: by then the request is fully built and signed (final framing headers) and the error is the typed `S3ServiceException`. It is best-effort and never alters or masks the original failure.

**Privacy:** never logs the `Authorization` header, the secret, the payload body, or the query string (so presigned-URL credentials can't leak). Header values for checksum headers are not logged — only their presence/names and the sha256 *mode*.

Pure helpers live in a dedicated `s3SigningDiagnostics.ts` module so they're unit-testable without the env/SDK import graph.

Fixes # (no issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

This is observability-only: no behavior change to uploads, no public API change.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code.

## Checklist

- [x] Code follows the style guidelines of this project (`pnpm run format`)
- [x] Commented the code, particularly in hard-to-understand areas
- [x] Changes generate no new warnings (`pnpm run lint` — shared)
- [x] Added unit tests covering the helpers (`s3SigningDiagnostics.test.ts`, 10 cases)
- [x] Verified: shared lint + typecheck, worker typecheck, web typecheck, unit tests all pass

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a best-effort diagnostics middleware to the S3 upload client that, on any failed S3 request, logs the request's signing/framing headers and the structured AWS SDK error. The motivation is to make `SignatureDoesNotMatch` failures on GCS's S3 interop layer debuggable by surfacing `aws-chunked` / checksum-trailer framing that GCS cannot verify.

- A new `addS3SigningDiagnosticsMiddleware` function registers a `deserialize`-step middleware on `this.client` that catches errors, calls `buildS3RequestDiagnostics`, logs at `warn`, and re-throws unchanged.
- Pure helpers (`classifyContentSha256Mode`, `summarizeS3SigningHeaders`, `summarizeS3Error`, `buildS3RequestDiagnostics`) are isolated in `s3SigningDiagnostics.ts` with full unit-test coverage. The `Authorization` header and query string are intentionally excluded from the payload.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; observability-only change that never alters upload behavior or masks original errors.

The middleware is correctly wired at `deserialize` with a double try/catch so it can never break uploads. The two concerns are about log hygiene: the middleware fires on all S3 failures (not just signing errors) and the log message always references `SignatureDoesNotMatch`, which is misleading for unrelated failures like 404 or 429; and the S3 object key is included in the logged payload, which may carry internal identifiers depending on how keys are structured.

The `deserialize` middleware in `StorageService.ts` and the `buildS3RequestDiagnostics` path field in `s3SigningDiagnostics.ts` are worth a second look for the concerns above.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Application
    participant MW as langfuseS3SigningDiagnostics<br/>(deserialize, high)
    participant SDK as AWS SDK Deserializer
    participant S3 as S3 / GCS

    App->>SDK: client.send(PutObjectCommand)
    SDK->>S3: HTTP PUT (signed, aws-chunked framing)
    S3-->>SDK: 403 SignatureDoesNotMatch
    SDK->>MW: throw S3ServiceException
    MW->>MW: buildS3RequestDiagnostics(request, err, context)
    MW->>MW: logger.warn(signing diagnostics)
    MW-->>App: re-throw original error
    App->>App: logger.error("Failed to upload...")
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Application
    participant MW as langfuseS3SigningDiagnostics<br/>(deserialize, high)
    participant SDK as AWS SDK Deserializer
    participant S3 as S3 / GCS

    App->>SDK: client.send(PutObjectCommand)
    SDK->>S3: HTTP PUT (signed, aws-chunked framing)
    S3-->>SDK: 403 SignatureDoesNotMatch
    SDK->>MW: throw S3ServiceException
    MW->>MW: buildS3RequestDiagnostics(request, err, context)
    MW->>MW: logger.warn(signing diagnostics)
    MW-->>App: re-throw original error
    App->>App: logger.error("Failed to upload...")
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/services/StorageService.ts:139-152
**Diagnostics fire on every S3 failure, not just signing errors**

The middleware intercepts all throws at the `deserialize` step — including `NoSuchKey` (404), `AccessDenied` (403 unrelated to signing), `SlowDown` (429), network timeouts, etc. — and emits a `warn` log whose text explicitly names `SignatureDoesNotMatch` and GCS interop. That message is actively misleading when the root cause is a missing file or a throttle, and because the AWS SDK's own retry loop also runs inside `deserialize`, a single operation that is retried N times generates N separate `warn` entries.

The cleanest fix is to inspect the error before logging and skip (or use `debug` level for) anything whose `name`/`Code` isn't in the set of signing-related codes (`SignatureDoesNotMatch`, `InvalidSignatureException`, `AuthorizationQueryParametersError`). This keeps the signal clean without losing coverage for the GCS interop case the feature targets.

### Issue 2 of 2
packages/shared/src/server/services/s3SigningDiagnostics.ts:159-165
**`req.path` (S3 object key) is logged on every failure**

`hostname` and `path` are included in the emitted diagnostic payload. `path` maps directly to the S3 key, which in Langfuse can embed user IDs, organization IDs, or other internal identifiers. The PR description explicitly calls out not logging the query string to prevent presigned-URL credential leakage, but does not address PII in the key path. Logging the full key at `warn` level on every failure means it surfaces in any log-aggregation backend that indexes that field. Consider omitting `path` from the logged payload or stripping tenant/user path segments, similar to how `Authorization` is already excluded.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(blob-storage): log S3 signing diagn..."](https://github.com/langfuse/langfuse/commit/d35af8338ee00290b348958df482c306c7633d1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38389423)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->