### PR TITLE
chore(shared): add OTel trace ID to ClickHouse log_comment

### DIFF
--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -9,7 +9,13 @@ import { getTracer, instrumentAsync } from "../instrumentation";
 import { randomUUID } from "crypto";
 import { getClickhouseEntityType } from "../clickhouse/schemaUtils";
 import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
-import { type Span, context, SpanKind, trace } from "@opentelemetry/api";
+import {
+  type Span,
+  context,
+  isSpanContextValid,
+  SpanKind,
+  trace,
+} from "@opentelemetry/api";
 import { backOff } from "exponential-backoff";
 import {
   StorageService,
@@ -370,13 +376,12 @@ function setSpanQueryAttributes(span: Span, query: string): void {
   span.setAttribute("db.operation.name", "SELECT");
 }
 
-function tagsWithTraceId(
+export function tagsWithTraceId(
   tags: Record<string, string> | undefined,
 ): Record<string, string> {
-  const traceId = trace.getActiveSpan()?.spanContext().traceId;
-  if (!traceId || traceId === "00000000000000000000000000000000")
-    return tags ?? {};
-  return { ...tags, traceId };
+  const ctx = trace.getActiveSpan()?.spanContext();
+  if (!ctx || !isSpanContextValid(ctx)) return tags ?? {};
+  return { ...tags, traceId: ctx.traceId };
 }
 
 async function sendClickhouseQuery<F extends DataFormat>(opts: {

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -381,7 +381,11 @@ export function tagsWithTraceId(
 ): Record<string, string> {
   const ctx = trace.getActiveSpan()?.spanContext();
   if (!ctx || !isSpanContextValid(ctx)) return tags ?? {};
-  return { ...tags, traceId: ctx.traceId };
+  // Use a distinct, OTel-specific key so this never collides with a
+  // caller-supplied `traceId` tag (e.g. the Langfuse business trace ID used
+  // for query_log JOINs in dataset-run-items). A single log_comment row can
+  // then carry both identifiers.
+  return { ...tags, otel_trace_id: ctx.traceId };
 }
 
 async function sendClickhouseQuery<F extends DataFormat>(opts: {

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -180,7 +180,7 @@ export async function upsertClickhouse<
               ],
               format: "JSONEachRow",
               clickhouse_settings: {
-                log_comment: JSON.stringify(opts.tags ?? {}),
+                log_comment: JSON.stringify(tagsWithTraceId(opts.tags)),
               },
             });
           }
@@ -206,7 +206,7 @@ export async function upsertClickhouse<
         })),
         format: "JSONEachRow",
         clickhouse_settings: {
-          log_comment: JSON.stringify(opts.tags ?? {}),
+          log_comment: JSON.stringify(tagsWithTraceId(opts.tags)),
         },
       });
       // same logic as for prisma. we want to see queries in development
@@ -370,6 +370,14 @@ function setSpanQueryAttributes(span: Span, query: string): void {
   span.setAttribute("db.operation.name", "SELECT");
 }
 
+function tagsWithTraceId(
+  tags: Record<string, string> | undefined,
+): Record<string, string> {
+  const traceId = trace.getActiveSpan()?.spanContext().traceId;
+  if (!traceId) return tags ?? {};
+  return { ...tags, traceId };
+}
+
 async function sendClickhouseQuery<F extends DataFormat>(opts: {
   query: string;
   params?: Record<string, unknown>;
@@ -389,7 +397,7 @@ async function sendClickhouseQuery<F extends DataFormat>(opts: {
     query_params: opts.params,
     clickhouse_settings: {
       ...opts.clickhouseSettings,
-      log_comment: JSON.stringify(opts.tags ?? {}),
+      log_comment: JSON.stringify(tagsWithTraceId(opts.tags)),
     },
   });
 
@@ -567,7 +575,7 @@ export async function commandClickhouse(opts: {
         ...(opts.abortSignal ? { abort_signal: opts.abortSignal } : {}),
         clickhouse_settings: {
           ...opts.clickhouseSettings,
-          log_comment: JSON.stringify(opts.tags ?? {}),
+          log_comment: JSON.stringify(tagsWithTraceId(opts.tags)),
         },
       });
       // same logic as for prisma. we want to see queries in development

--- a/packages/shared/src/server/repositories/clickhouse.ts
+++ b/packages/shared/src/server/repositories/clickhouse.ts
@@ -374,7 +374,8 @@ function tagsWithTraceId(
   tags: Record<string, string> | undefined,
 ): Record<string, string> {
   const traceId = trace.getActiveSpan()?.spanContext().traceId;
-  if (!traceId) return tags ?? {};
+  if (!traceId || traceId === "00000000000000000000000000000000")
+    return tags ?? {};
   return { ...tags, traceId };
 }
 

--- a/worker/src/services/ClickhouseWriter/index.ts
+++ b/worker/src/services/ClickhouseWriter/index.ts
@@ -13,6 +13,7 @@ import {
   TraceNullRecordInsertType,
   DatasetRunItemRecordInsertType,
   EventRecordInsertType,
+  tagsWithTraceId,
 } from "@langfuse/shared/src/server";
 
 import { Decimal } from "decimal.js";
@@ -577,15 +578,16 @@ export class ClickhouseWriter {
         format: "JSONEachRow",
         values: params.records,
         clickhouse_settings: {
-          log_comment: JSON.stringify({
-            feature: "ingestion",
-            type: params.table,
-            operation_name: "writeToClickhouse",
-            projectId:
-              params.records.length > 0
-                ? params.records[0].project_id
-                : undefined,
-          }),
+          log_comment: JSON.stringify(
+            tagsWithTraceId({
+              feature: "ingestion",
+              type: params.table,
+              operation_name: "writeToClickhouse",
+              ...(params.records.length > 0 && params.records[0].project_id
+                ? { projectId: params.records[0].project_id }
+                : {}),
+            }),
+          ),
         },
       })
       .catch((err) => {

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -49,6 +49,7 @@ import {
   getDatasetItemById,
   normalizeToolsForObservation,
   hasNoEvalConfigsCache,
+  tagsWithTraceId,
 } from "@langfuse/shared/src/server";
 
 import { tokenCountAsync } from "../../features/tokenisation/async-usage";
@@ -1435,10 +1436,12 @@ export class IngestionService {
           format: "JSONEachRow",
           query_params: { projectId, entityId, ...additionalFilters.params },
           clickhouse_settings: {
-            log_comment: JSON.stringify({
-              feature: "ingestion",
-              projectId,
-            }),
+            log_comment: JSON.stringify(
+              tagsWithTraceId({
+                feature: "ingestion",
+                projectId,
+              }),
+            ),
           },
         });
 


### PR DESCRIPTION
## What does this PR do?

Injects the active OpenTelemetry trace ID into the `log_comment` JSON on every ClickHouse query, insert, and command. This lets you JOIN `system.query_log` with Datadog/application logs by trace ID to attribute any ClickHouse query to the request that triggered it.

### Example

```sql
SELECT query_id, event_time, query_duration_ms, result_rows, query
FROM system.query_log
WHERE JSONExtractString(log_comment, 'traceId') = '<trace-id-from-datadog-log>'
  AND type = 'QueryFinish'
```

## Type of change

- [x] Non-breaking enhancement

## Checklist

- [x] All 4 `log_comment` sites in `clickhouse.ts` use the new `tagsWithTraceId()` helper
- [x] No-op when no active OTel span exists (e.g. background jobs without tracing)
- [x] Lint + typecheck pass
- [x] No changes to query behavior — only metadata in `log_comment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `tagsWithTraceId()` helper that reads the active OpenTelemetry span's trace ID and injects it into the `log_comment` JSON on every ClickHouse query, insert, and command, enabling correlation between `system.query_log` entries and distributed traces.

- All four `log_comment` sites in `clickhouse.ts` are updated to use `tagsWithTraceId()`, and the `trace` symbol needed was already imported from `@opentelemetry/api`.
- The helper is a no-op (returns `tags ?? {}`) when no active OTel span is present, making it safe for background jobs and non-traced contexts.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are limited to enriching log_comment metadata and do not touch query logic, data processing, or authentication.

The change is narrow and well-scoped: one new helper function and four identical call-site substitutions. The trace import was already present, and the helper is a no-op when no span is active. The only concern is the all-zeros OTel invalid trace ID being truthy and slipping through the falsiness check, which could produce misleading entries in system.query_log in unusual propagation scenarios, but it has no impact on query correctness or application behavior.

No files require special attention — packages/shared/src/server/repositories/clickhouse.ts is the sole changed file and the change is minimal.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Application Code
    participant CH as clickhouse.ts helpers
    participant OTel as OTel API (trace)
    participant CK as ClickHouse Client

    App->>CH: queryClickhouse / upsertClickhouse / commandClickhouse
    CH->>OTel: trace.getActiveSpan()?.spanContext().traceId
    alt Active span exists
        OTel-->>CH: traceId (hex string)
        CH->>CH: "tagsWithTraceId → { ...tags, traceId }"
    else No active span
        OTel-->>CH: undefined
        CH->>CH: "tagsWithTraceId → tags ?? {}"
    end
    CH->>CK: "query/insert/command with log_comment=JSON.stringify(tags)"
    CK-->>CH: result
    Note over CK: system.query_log records log_comment with traceId
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Application Code
    participant CH as clickhouse.ts helpers
    participant OTel as OTel API (trace)
    participant CK as ClickHouse Client

    App->>CH: queryClickhouse / upsertClickhouse / commandClickhouse
    CH->>OTel: trace.getActiveSpan()?.spanContext().traceId
    alt Active span exists
        OTel-->>CH: traceId (hex string)
        CH->>CH: "tagsWithTraceId → { ...tags, traceId }"
    else No active span
        OTel-->>CH: undefined
        CH->>CH: "tagsWithTraceId → tags ?? {}"
    end
    CH->>CK: "query/insert/command with log_comment=JSON.stringify(tags)"
    CK-->>CH: result
    Note over CK: system.query_log records log_comment with traceId
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/repositories/clickhouse.ts:376-377
OpenTelemetry represents an invalid/non-recording span context with the all-zeros trace ID `"00000000000000000000000000000000"`, which is a truthy string and will pass the current `!traceId` guard. In contexts where a propagated-but-invalid span is active (e.g. headers carrying an invalid `traceparent`), this would inject the zero ID into `log_comment`, producing misleading entries in `system.query_log` that look like valid trace correlations but aren't.

```suggestion
  const traceId = trace.getActiveSpan()?.spanContext().traceId;
  if (!traceId || traceId === "00000000000000000000000000000000") return tags ?? {};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(shared): add OTel trace ID to Click..."](https://github.com/langfuse/langfuse/commit/f01f7922fa16e226ec66da3d4612aaee35b6f566) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38390685)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->