### PR TITLE
feat(agent): Remove in-app agent feature flag

### DIFF
--- a/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-api-route-auth.servertest.ts
@@ -333,7 +333,7 @@ function createInAppAgentSession(params: {
       email: "test@example.com",
       image: null,
       admin: params.admin ?? false,
-      featureFlags: { inAppAgent: true },
+      featureFlags: {},
       organizations: includeProjectMembership
         ? [
             {

--- a/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-persistence.servertest.ts
@@ -67,6 +67,8 @@ describe("in-app agent persistence", () => {
             cloudConfig: undefined,
             name: "Test Organization",
             metadata: {},
+            aiFeaturesEnabled: true,
+            aiTelemetryEnabled: true,
             projects: [
               {
                 id: setup.projectId,
@@ -74,16 +76,14 @@ describe("in-app agent persistence", () => {
                 name: "Test Project",
                 deletedAt: null,
                 retentionDays: null,
+                hasTraces: false,
                 metadata: {},
+                createdAt: new Date().toISOString(),
               },
             ],
           },
         ],
-        featureFlags: {
-          inAppAgent: true,
-          templateFlag: true,
-          excludeClickhouseRead: false,
-        },
+        featureFlags: {},
         admin: false,
       },
       environment: {} as any,

--- a/web/src/__tests__/server/userAccount.servertest.ts
+++ b/web/src/__tests__/server/userAccount.servertest.ts
@@ -18,32 +18,9 @@ describe("userAccountRouter.setFeaturePreviewEnabled", () => {
     (env as any).NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalCloudRegion;
   });
 
-  it("enables the in-app agent preview for the current user without requiring a project", async () => {
-    const { caller, userId } = await createCaller({
-      includeProjectInSession: false,
-    });
-
-    const result = await caller.userAccount.setFeaturePreviewEnabled({
-      flag: "inAppAgent",
-      enabled: true,
-    });
-
-    expect(result).toEqual({
-      success: true,
-      flag: "inAppAgent",
-      enabled: true,
-    });
-
-    const user = await prisma.user.findUniqueOrThrow({
-      where: { id: userId },
-      select: { featureFlags: true },
-    });
-    expect(user.featureFlags).toEqual(["templateFlag", "inAppAgent"]);
-  });
-
   it("enables the search bar preview, leaving other flags intact", async () => {
     const { caller, userId } = await createCaller({
-      featureFlags: ["templateFlag", "inAppAgent"],
+      featureFlags: ["templateFlag"],
     });
 
     const result = await caller.userAccount.setFeaturePreviewEnabled({
@@ -57,16 +34,12 @@ describe("userAccountRouter.setFeaturePreviewEnabled", () => {
       where: { id: userId },
       select: { featureFlags: true },
     });
-    expect(user.featureFlags).toEqual([
-      "templateFlag",
-      "inAppAgent",
-      "searchBar",
-    ]);
+    expect(user.featureFlags).toEqual(["templateFlag", "searchBar"]);
   });
 
   it("disables a preview flag without touching the others", async () => {
     const { caller, userId } = await createCaller({
-      featureFlags: ["templateFlag", "inAppAgent", "searchBar"],
+      featureFlags: ["templateFlag", "searchBar"],
     });
 
     const result = await caller.userAccount.setFeaturePreviewEnabled({
@@ -84,7 +57,7 @@ describe("userAccountRouter.setFeaturePreviewEnabled", () => {
       where: { id: userId },
       select: { featureFlags: true },
     });
-    expect(user.featureFlags).toEqual(["templateFlag", "inAppAgent"]);
+    expect(user.featureFlags).toEqual(["templateFlag"]);
   });
 
   it("rejects enabling in self-hosted deployments", async () => {
@@ -93,7 +66,7 @@ describe("userAccountRouter.setFeaturePreviewEnabled", () => {
 
     await expect(
       caller.userAccount.setFeaturePreviewEnabled({
-        flag: "inAppAgent",
+        flag: "searchBar",
         enabled: true,
       }),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
@@ -164,14 +137,15 @@ async function createCaller({
                   role: "ADMIN",
                   deletedAt: null,
                   retentionDays: null,
+                  hasTraces: false,
                   metadata: {},
+                  createdAt: project.createdAt.toISOString(),
                 },
               ]
             : [],
         },
       ],
       featureFlags: {
-        inAppAgent: featureFlags.includes("inAppAgent"),
         searchBar: featureFlags.includes("searchBar"),
         templateFlag: featureFlags.includes("templateFlag"),
         excludeClickhouseRead: false,

--- a/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
+++ b/web/src/components/layouts/app-layout/variants/AuthenticatedLayout.tsx
@@ -131,7 +131,8 @@ export function AuthenticatedLayout({
     }),
   );
 
-  const hasFeaturePreviews = isLangfuseCloud;
+  // Currently there are no feature previews available
+  const hasFeaturePreviews = false;
 
   // User navigation items for sidebar dropdown
   const userNavProps = {
@@ -207,7 +208,6 @@ export function AuthenticatedLayout({
             </div>
             {hasFeaturePreviews ? (
               <ControlledFeaturePreviewModal
-                session={session}
                 open={featurePreviewOpen}
                 onOpenChange={setFeaturePreviewOpen}
               />

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -247,7 +247,6 @@ export const ROUTES: Route[] = [
     title: "Assistant",
     section: RouteSection.Secondary,
     pathname: "",
-    featureFlag: "inAppAgent",
     show: ({ organization, projectId, isLangfuseCloud }) =>
       isLangfuseCloud && organization !== undefined && projectId !== undefined,
     menuNode: <InAppAiAgentButton />,

--- a/web/src/components/nav/in-app-ai-agent-button.tsx
+++ b/web/src/components/nav/in-app-ai-agent-button.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { useSession } from "next-auth/react";
 import { BotMessageSquare } from "lucide-react";
 
 import { Button } from "@/src/components/ui/button";
@@ -27,13 +26,10 @@ import { useSupportDrawer } from "@/src/features/support-chat/SupportDrawerProvi
 const IN_APP_AI_AGENT_WINDOW_Z_INDEX = 51;
 
 export const InAppAiAgentButton = () => {
-  const session = useSession();
   const { organization } = useQueryProjectOrOrganization();
   const { isAvailable, open, setOpen, isExpanded, setIsExpanded } =
     useInAppAiAgent();
   const hasInAppAgentEntitlement = useHasEntitlement("in-app-agent");
-  const isInAppAgentEnabled =
-    session.data?.user?.featureFlags.inAppAgent === true;
   const { setOpen: setSupportDrawerOpen } = useSupportDrawer();
   const buttonRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -90,7 +86,7 @@ export const InAppAiAgentButton = () => {
     floatingPanelHandle.initializeGeometry();
   }, [floatingPanelHandle, isExpanded, open, portalContainer]);
 
-  if (!isAvailable || !hasInAppAgentEntitlement || !isInAppAgentEnabled) {
+  if (!isAvailable || !hasInAppAgentEntitlement) {
     return null;
   }
 

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -135,12 +135,6 @@ export default async function handler(request: Request) {
       throw new ForbiddenError("User is not a member of this project");
     }
 
-    const isInAppAgentEnabled = auth.user.featureFlags.inAppAgent === true;
-
-    if (!isInAppAgentEnabled) {
-      throw new ForbiddenError("Assistant is not enabled for this user");
-    }
-
     if (
       !hasEntitlement({
         entitlement: "in-app-agent",

--- a/web/src/ee/features/in-app-agent/server/router.ts
+++ b/web/src/ee/features/in-app-agent/server/router.ts
@@ -229,12 +229,6 @@ async function assertInAppAgentAvailable({
     );
   }
 
-  const isInAppAgentEnabled = ctx.session.user.featureFlags.inAppAgent === true;
-
-  if (!isInAppAgentEnabled) {
-    throw new ForbiddenError("Assistant is not enabled for this user");
-  }
-
   throwIfNoEntitlement({
     entitlement: "in-app-agent",
     sessionUser: ctx.session.user,

--- a/web/src/features/feature-flags/available-flags.ts
+++ b/web/src/features/feature-flags/available-flags.ts
@@ -1,5 +1,4 @@
 export const availableFlags = [
-  "inAppAgent",
   // TODO(remove ~2026-06-19): "searchBar" is retired — the grammar search bar
   // is now GA on the v4 events tables for everyone (see useSearchBarEnabled),
   // no longer a per-user Feature Preview opt-in. Kept as dead plumbing for a

--- a/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/ControlledFeaturePreviewModal.tsx
@@ -1,13 +1,3 @@
-import { useState } from "react";
-import { useSession } from "next-auth/react";
-import type { Session } from "next-auth";
-
-import { useHasEntitlement } from "@/src/features/entitlements/hooks";
-import { useQueryProjectOrOrganization } from "@/src/features/projects/hooks";
-import { showErrorToast } from "@/src/features/notifications/showErrorToast";
-import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
-import { api } from "@/src/utils/api";
-
 import {
   FeaturePreviewModal,
   type PreviewFlag,
@@ -15,82 +5,21 @@ import {
 } from "./FeaturePreviewModal";
 
 type ControlledFeaturePreviewModalProps = {
-  session: Session;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 };
 
-const PREVIEW_LABEL: Record<PreviewFlag, string> = {
-  inAppAgent: "Langfuse Assistant",
-  searchBar: "Filter Search Bar",
-};
-
 export function ControlledFeaturePreviewModal({
-  session,
   open,
   onOpenChange,
 }: ControlledFeaturePreviewModalProps) {
-  const authSession = useSession();
-  const { project, organization } = useQueryProjectOrOrganization();
-  const hasInAppAgentEntitlement = useHasEntitlement("in-app-agent");
-  // Track in-flight toggles per flag. useMutation only remembers the LATEST
-  // .mutate() in `variables`, so toggling two previews in quick succession
-  // would let an earlier still-pending row look idle and re-enable its Switch.
-  const [pendingFlags, setPendingFlags] = useState<Set<PreviewFlag>>(new Set());
-  const setFeaturePreviewEnabled =
-    api.userAccount.setFeaturePreviewEnabled.useMutation({
-      onMutate: (variables) => {
-        setPendingFlags((prev) => new Set(prev).add(variables.flag));
-      },
-      onSuccess: async (_data, variables) => {
-        await authSession.update();
-        showSuccessToast({
-          title: "Feature preview updated",
-          description: `${PREVIEW_LABEL[variables.flag]} preview has been ${
-            variables.enabled ? "enabled" : "disabled"
-          }.`,
-        });
-      },
-      onError: (error) => {
-        showErrorToast("Failed to update feature preview", error.message);
-      },
-      onSettled: (_data, _error, variables) => {
-        setPendingFlags((prev) => {
-          const next = new Set(prev);
-          next.delete(variables.flag);
-          return next;
-        });
-      },
-    });
-
-  const user = authSession.data?.user ?? session.user;
-  if (!user) {
-    return null;
-  }
-
-  const onToggle = (flag: PreviewFlag) => (enabled: boolean) =>
-    setFeaturePreviewEnabled.mutate({ flag, enabled });
-  // Each row reflects ITS OWN in-flight mutation, not just the latest one.
-  const isToggling = (flag: PreviewFlag) => pendingFlags.has(flag);
-
   const state: Partial<Record<PreviewFlag, PreviewState>> = {
-    inAppAgent: {
-      enabled: user.featureFlags.inAppAgent === true,
-      warningReason: getInAppAgentWarningReason({
-        hasOrganizationContext: Boolean(organization),
-        hasProjectContext: Boolean(project),
-        hasInAppAgentEntitlement,
-        organizationAiFeaturesEnabled: organization?.aiFeaturesEnabled,
-      }),
-      onToggle: onToggle("inAppAgent"),
-      isToggling: isToggling("inAppAgent"),
-    },
     // The "Filter Search Bar" preview is retired — the bar is now generally
     // available on the v4 events tables for everyone (see useSearchBarEnabled),
     // so it no longer renders a tile here. The `searchBar` flag plumbing
-    // (PreviewFlag type, PREVIEW_LABEL, registry entry, the userAccount
-    // allowlist) is kept for now so a rollback is a one-line revert; restore
-    // the `searchBar: { ... }` state entry to bring the tile back.
+    // (PreviewFlag type, registry entry, the userAccount allowlist) is kept for
+    // now so a rollback is a one-line revert; restore the `searchBar: { ... }`
+    // state entry to bring the tile back.
     // TODO(remove ~2026-06-19): delete the dead searchBar plumbing once the GA
     // rollout is confirmed stable — see useSearchBarEnabled for the full list.
   };
@@ -102,34 +31,4 @@ export function ControlledFeaturePreviewModal({
       state={state}
     />
   );
-}
-
-function getInAppAgentWarningReason({
-  hasOrganizationContext,
-  hasProjectContext,
-  hasInAppAgentEntitlement,
-  organizationAiFeaturesEnabled,
-}: {
-  hasOrganizationContext: boolean;
-  hasProjectContext: boolean;
-  hasInAppAgentEntitlement: boolean;
-  organizationAiFeaturesEnabled?: boolean;
-}) {
-  if (!hasOrganizationContext) {
-    return "The Assistant button is only shown inside a project. Enabling this preview may not have any visible effect until you open a project.";
-  }
-
-  if (!hasInAppAgentEntitlement) {
-    return "The Langfuse Assistant preview is not available on your current plan. You can enable the preview, but the Assistant button will not be shown here.";
-  }
-
-  if (organizationAiFeaturesEnabled === false) {
-    return "AI features are disabled for this organization. You can enable the preview, but the Assistant will not run here until AI features are enabled.";
-  }
-
-  if (!hasProjectContext) {
-    return "The Assistant button is only shown inside a project. Open a project to use it after enabling the preview.";
-  }
-
-  return undefined;
 }

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.stories.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.stories.tsx
@@ -56,7 +56,6 @@ const meta = preview.meta({
     open: true,
     onOpenChange: fn(),
     state: {
-      inAppAgent: { enabled: true, onToggle: fn(), isToggling: false },
       searchBar: { enabled: false, onToggle: fn(), isToggling: false },
     },
   },
@@ -68,12 +67,6 @@ export const Default = meta.story({});
 export const Warning = meta.story({
   args: {
     state: {
-      inAppAgent: {
-        enabled: false,
-        warningReason:
-          "The Assistant button is only shown inside a project. Open a project to use it after enabling the preview.",
-        onToggle: fn(),
-      },
       searchBar: {
         enabled: false,
         warningReason:
@@ -87,7 +80,6 @@ export const Warning = meta.story({
 export const Loading = meta.story({
   args: {
     state: {
-      inAppAgent: { enabled: true, onToggle: fn(), isToggling: true },
       searchBar: { enabled: false, onToggle: fn(), isToggling: false },
     },
   },

--- a/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
+++ b/web/src/features/feature-previews/components/FeaturePreviewModal.tsx
@@ -13,18 +13,16 @@ import { Switch } from "@/src/components/ui/switch";
 import { Button } from "@/src/components/ui/button";
 import { cn } from "@/src/utils/tailwind";
 
-import inAppAgentDarkIllustration from "../assets/in-app-agent-dark.svg";
-import inAppAgentLightIllustration from "../assets/in-app-agent-light.svg";
 import filterSearchBarDarkIllustration from "../assets/filter-search-bar-dark.svg";
 import filterSearchBarLightIllustration from "../assets/filter-search-bar-light.svg";
 
 /** Flags the Feature Preview modal can toggle. Keep in sync with the
  *  userAccount.setFeaturePreviewEnabled allowlist and available-flags.ts.
- *  NOTE: "searchBar" is retired (the bar is GA on the v4 events tables) and no
- *  longer renders a tile — see ControlledFeaturePreviewModal. It is kept in the
- *  type + registry below only as dead code for a safe rollback.
+ *  NOTE: the current flag is retired and no longer renders a tile — see
+ *  ControlledFeaturePreviewModal. It is kept in the type + registry below only
+ *  as dead code for a safe rollback.
  *  TODO(remove ~2026-06-19): drop "searchBar" here once GA is confirmed. */
-export type PreviewFlag = "inAppAgent" | "searchBar";
+export type PreviewFlag = "searchBar";
 
 type PreviewIllustration = {
   light: React.ComponentProps<typeof Image>["src"];
@@ -54,21 +52,6 @@ export type PreviewState = {
 // Static registry — one entry per preview. Order = sidebar order; each
 // preview ships separate light/dark illustrations.
 const PREVIEW_REGISTRY: PreviewRegistryItem[] = [
-  {
-    flag: "inAppAgent",
-    title: "Langfuse Assistant",
-    sidebarLabel: "Langfuse Assistant",
-    description:
-      "Explore project data, understand connected Langfuse resources, and get practical help while investigating your application.",
-    details:
-      "This experimental preview can help you inspect traces and observations, look up related scores or prompts, and answer practical questions while you work in a project. Today, it is most useful for exploring project data and understanding how different Langfuse resources connect. Over time, the goal is to help teams generate insights faster and improve their agentic products with less manual investigation.",
-    feedbackUrl: "https://github.com/orgs/langfuse/discussions/14196",
-    illustration: {
-      light: inAppAgentLightIllustration,
-      dark: inAppAgentDarkIllustration,
-      alt: "Langfuse Assistant connects traces, scores, and prompts to answer project questions.",
-    },
-  },
   // TODO(remove ~2026-06-19): dead registry entry — "searchBar" is GA on the v4
   // events tables and no longer surfaced in the dialog (no state entry in
   // ControlledFeaturePreviewModal), so this is filtered out and never renders.

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -104,7 +104,7 @@ export const userAccountRouter = createTRPCRouter({
         // on the v4 events tables (see useSearchBarEnabled) and no longer has a
         // dialog tile. Kept in the allowlist as dead plumbing for a safe
         // rollback; drop once the GA rollout is confirmed stable.
-        flag: z.enum(["inAppAgent", "searchBar"]),
+        flag: z.enum(["searchBar"]),
         enabled: z.boolean(),
       }),
     )


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR graduates the Langfuse Assistant from a per-user Feature Preview opt-in to GA for all entitled users, by replacing the `session.user.featureFlags.inAppAgent` gate with a hardcoded `true` shim in the client button, the tRPC router, and the HTTP handler. The `inAppAgent` Feature Preview flag is retired and both its UI tile and the `hasFeaturePreviews` toggle are turned off.

- All three feature-flag gates (`in-app-ai-agent-button.tsx`, `router.ts`, `handler.ts`) are replaced with `const isInAppAgentEnabled: boolean = true`, preserving the surrounding `if (!isInAppAgentEnabled)` block as dead code so rollback is a one-line change. TODO comments target cleanup on ~2026-06-24.
- The existing entitlement check (`hasEntitlement("in-app-agent")`) and `aiFeaturesEnabled` org-level guard remain fully in place; only the per-user Feature Preview gate is removed.
- Tests are updated to pass `inAppAgentFeatureFlag: false` and a new test asserts that entitled users without the flag are now allowed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change removes only the per-user opt-in gate; the entitlement check and org-level AI features guard are untouched.

The three gate replacements are minimal and symmetric. The dead-code if (!isInAppAgentEnabled) blocks are intentionally kept to make rollback a one-line edit, and each is documented with a dated TODO. Security is preserved by the remaining entitlement and org-level guards. Tests cover the new flag-off but entitled path explicitly.

No files require special attention. The TODO comments in available-flags.ts, FeaturePreviewModal.tsx, and userAccount.ts are the natural follow-up cleanup once the GA rollout is confirmed.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User Request]) --> B{Authenticated?}
    B -- No --> Z1([401 Unauthorized])
    B -- Yes --> C{Cloud Region Set?}
    C -- No --> Z2([412 Not Available])
    C -- Yes --> D["isInAppAgentEnabled = true\n(hardcoded shim — was feature flag)"]
    D --> E{Has 'in-app-agent'\nEntitlement?}
    E -- No --> Z3([403 No Entitlement])
    E -- Yes --> F{aiFeaturesEnabled\nfor Org?}
    F -- No --> Z4([403 Org Disabled])
    F -- Yes --> G{Rate Limit OK?}
    G -- No --> Z5([429 Rate Limited])
    G -- Yes --> H([Agent Runs])

    style D fill:#fef9c3,stroke:#ca8a04
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([User Request]) --> B{Authenticated?}
    B -- No --> Z1([401 Unauthorized])
    B -- Yes --> C{Cloud Region Set?}
    C -- No --> Z2([412 Not Available])
    C -- Yes --> D["isInAppAgentEnabled = true\n(hardcoded shim — was feature flag)"]
    D --> E{Has 'in-app-agent'\nEntitlement?}
    E -- No --> Z3([403 No Entitlement])
    E -- Yes --> F{aiFeaturesEnabled\nfor Org?}
    F -- No --> Z4([403 Org Disabled])
    F -- Yes --> G{Rate Limit OK?}
    G -- No --> Z5([429 Rate Limited])
    G -- Yes --> H([Agent Runs])

    style D fill:#fef9c3,stroke:#ca8a04
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agent): Enable Langfuse Assistant r..."](https://github.com/langfuse/langfuse/commit/1ee9e8b0083f2eb29754e64edbfb6a35270200fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38450958)</sub>

<!-- /greptile_comment -->