### PR TITLE
chore: issue debug logging information as we detect clickhouse compatibility settings

### DIFF
--- a/packages/shared/src/server/clickhouse/compatibility.test.ts
+++ b/packages/shared/src/server/clickhouse/compatibility.test.ts
@@ -7,12 +7,6 @@ const envMock = vi.hoisted(() => ({
 }));
 
 vi.mock("../../env", () => envMock);
-vi.mock("../logger", () => ({
-  logger: {
-    info: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
 
 import {
   isClickHouseVersionInBand,
@@ -61,21 +55,47 @@ describe("ClickHouse compatibility version parsing", () => {
 
 describe("resolveClickHouseCompatibility", () => {
   it("applies lazy materialization workaround in auto mode for affected versions", () => {
-    expect(
-      resolveClickHouseCompatibility({
-        version: "26.5.1.882",
-        overrides: { CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "auto" },
-      }).settings,
-    ).toEqual({ query_plan_optimize_lazy_materialization: 0 });
+    const resolved = resolveClickHouseCompatibility({
+      version: "26.5.1.882",
+      overrides: { CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "auto" },
+    });
+
+    expect(resolved.settings).toEqual({
+      query_plan_optimize_lazy_materialization: 0,
+    });
+    expect(resolved.parsedVersion).toMatchObject({
+      major: 26,
+      minor: 5,
+      patch: 1,
+      tuple: [26, 5, 1],
+    });
+    expect(resolved.flags).toEqual([
+      expect.objectContaining({
+        id: "disable-lazy-materialization",
+        setting: "query_plan_optimize_lazy_materialization",
+        value: 0,
+        override: "auto",
+        matchesVersionBand: true,
+        applied: true,
+      }),
+    ]);
   });
 
   it("does not apply lazy materialization workaround in auto mode before the affected band", () => {
-    expect(
-      resolveClickHouseCompatibility({
-        version: "25.3.99",
-        overrides: { CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "auto" },
-      }).settings,
-    ).toEqual({});
+    const resolved = resolveClickHouseCompatibility({
+      version: "25.3.99",
+      overrides: { CLICKHOUSE_DISABLE_LAZY_MATERIALIZATION: "auto" },
+    });
+
+    expect(resolved.settings).toEqual({});
+    expect(resolved.flags).toEqual([
+      expect.objectContaining({
+        id: "disable-lazy-materialization",
+        override: "auto",
+        matchesVersionBand: false,
+        applied: false,
+      }),
+    ]);
   });
 
   it("allows forcing lazy materialization workaround on", () => {

--- a/packages/shared/src/server/clickhouse/compatibility.ts
+++ b/packages/shared/src/server/clickhouse/compatibility.ts
@@ -31,6 +31,17 @@ type ClickHouseCompatibilityRule = {
   overrideEnvKey: ClickHouseCompatibilityEnvKey;
 };
 
+type ComputedClickHouseCompatibilityFlag = {
+  id: string;
+  setting: string;
+  value: ClickHouseSettings[string];
+  reason: string;
+  override: ClickHouseCompatibilityEnvValue;
+  versionBands: ClickHouseVersionBand[];
+  matchesVersionBand: boolean;
+  applied: boolean;
+};
+
 type ResolveClickHouseCompatibilityParams = {
   version?: string | null;
   overrides?: Partial<
@@ -41,6 +52,8 @@ type ResolveClickHouseCompatibilityParams = {
 type ResolvedClickHouseCompatibility = {
   settings: ClickHouseSettings;
   appliedRules: ClickHouseCompatibilityRule[];
+  parsedVersion: ClickHouseVersion | null;
+  flags: ComputedClickHouseCompatibilityFlag[];
 };
 
 const CLICKHOUSE_COMPATIBILITY_RULES: ClickHouseCompatibilityRule[] = [
@@ -100,28 +113,38 @@ export const resolveClickHouseCompatibility = ({
   const parsedVersion = version ? parseClickHouseVersion(version) : null;
   const settings: ClickHouseSettings = {};
   const appliedRules: ClickHouseCompatibilityRule[] = [];
+  const flags: ComputedClickHouseCompatibilityFlag[] = [];
 
   for (const rule of CLICKHOUSE_COMPATIBILITY_RULES) {
     const override =
       overrides?.[rule.overrideEnvKey] ?? env[rule.overrideEnvKey] ?? "auto";
+    const matchesVersionBand =
+      parsedVersion !== null &&
+      rule.versionBands.some((band) =>
+        isClickHouseVersionInBand(parsedVersion, band),
+      );
 
-    if (override === "false") continue;
+    const applied =
+      override === "true" || (override === "auto" && matchesVersionBand);
 
-    const shouldApply =
-      override === "true" ||
-      (override === "auto" &&
-        parsedVersion &&
-        rule.versionBands.some((band) =>
-          isClickHouseVersionInBand(parsedVersion, band),
-        ));
+    flags.push({
+      id: rule.id,
+      setting: rule.setting,
+      value: rule.value,
+      reason: rule.reason,
+      override,
+      versionBands: rule.versionBands,
+      matchesVersionBand,
+      applied,
+    });
 
-    if (shouldApply) {
+    if (applied) {
       settings[rule.setting] = rule.value;
       appliedRules.push(rule);
     }
   }
 
-  return { settings, appliedRules };
+  return { settings, appliedRules, parsedVersion, flags };
 };
 
 export const getClickHouseCompatibilitySettings = (): ClickHouseSettings =>
@@ -133,14 +156,29 @@ export const initializeClickhouseCompatibility = async (): Promise<void> => {
 
   initializationPromise = (async () => {
     try {
-      detectedClickHouseVersion = await fetchClickHouseVersion();
+      const clickHouseVersion = await fetchClickHouseVersion();
       const resolved = resolveClickHouseCompatibility({
-        version: detectedClickHouseVersion,
+        version: clickHouseVersion,
       });
+
+      logger.info("Resolved ClickHouse compatibility from version", {
+        clickhouseVersion: clickHouseVersion,
+        parsedClickHouseVersion: resolved.parsedVersion,
+        computedCompatibilityFlags: resolved.flags,
+        settings: resolved.settings,
+      });
+
+      if (!resolved.parsedVersion) {
+        throw new Error(
+          `ClickHouse returned an unsupported version: ${clickHouseVersion}`,
+        );
+      }
+
+      detectedClickHouseVersion = clickHouseVersion;
 
       if (resolved.appliedRules.length > 0) {
         logger.info("Applying ClickHouse compatibility settings", {
-          clickhouseVersion: detectedClickHouseVersion,
+          clickhouseVersion: clickHouseVersion,
           settings: resolved.settings,
           rules: resolved.appliedRules.map((rule) => ({
             id: rule.id,
@@ -150,7 +188,7 @@ export const initializeClickhouseCompatibility = async (): Promise<void> => {
         });
       } else {
         logger.info("No ClickHouse compatibility settings required", {
-          clickhouseVersion: detectedClickHouseVersion,
+          clickhouseVersion: clickHouseVersion,
         });
       }
     } catch (error) {
@@ -179,10 +217,6 @@ const fetchClickHouseVersion = async (): Promise<string> => {
 
     if (!version) {
       throw new Error("ClickHouse version query returned no version");
-    }
-
-    if (!parseClickHouseVersion(version)) {
-      throw new Error(`ClickHouse returned an unsupported version: ${version}`);
     }
 
     return version;


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds structured debug logging to the ClickHouse compatibility detection flow and refactors `resolveClickHouseCompatibility` to return richer output including the parsed version and per-rule `ComputedClickHouseCompatibilityFlag` entries.

- A new `ComputedClickHouseCompatibilityFlag` type captures per-rule resolution details (`matchesVersionBand`, `applied`, `override`, etc.) and these flags are logged via a new `logger.info` call before any version-parse error is thrown — ensuring full observability even on failure paths.
- Rules with `override === "false"` that were previously skipped entirely (via `continue`) now contribute an `applied: false` entry to `flags`, improving visibility into explicitly-disabled rules; version-parse validation was moved from `fetchClickHouseVersion` into `initializeClickhouseCompatibility` so that the version string and flags are always logged before the error propagates.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are additive logging and a clean refactor with no functional regressions on the settings-application path.

The core compatibility logic (settings applied to queries) is unchanged. The refactoring correctly moves version-parse validation to after the debug log and only assigns detectedClickHouseVersion on success, which matches the previous behavior. The only behavioral delta — override=false rules now appearing in flags — is an intentional observability improvement that doesn't affect anything downstream.

Both changed files are straightforward; compatibility.ts is worth a quick read to confirm the three logger.info calls on the happy path don't produce unexpectedly noisy duplicate fields.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant initializeClickhouseCompatibility
    participant fetchClickHouseVersion
    participant resolveClickHouseCompatibility
    participant logger

    App->>initializeClickhouseCompatibility: call (once)
    initializeClickhouseCompatibility->>fetchClickHouseVersion: await
    fetchClickHouseVersion-->>initializeClickhouseCompatibility: raw version string (no parse check)
    initializeClickhouseCompatibility->>resolveClickHouseCompatibility: "{ version }"
    resolveClickHouseCompatibility-->>initializeClickhouseCompatibility: "{ settings, appliedRules, parsedVersion, flags }"
    initializeClickhouseCompatibility->>logger: "info(Resolved ClickHouse compatibility, { flags, settings, parsedVersion })"
    alt parsedVersion is null
        initializeClickhouseCompatibility->>logger: warn(Failed to detect ClickHouse version)
    else parsedVersion valid
        initializeClickhouseCompatibility->>initializeClickhouseCompatibility: "detectedClickHouseVersion = clickHouseVersion"
        alt "appliedRules.length > 0"
            initializeClickhouseCompatibility->>logger: info(Applying ClickHouse compatibility settings)
        else no rules
            initializeClickhouseCompatibility->>logger: info(No ClickHouse compatibility settings required)
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant initializeClickhouseCompatibility
    participant fetchClickHouseVersion
    participant resolveClickHouseCompatibility
    participant logger

    App->>initializeClickhouseCompatibility: call (once)
    initializeClickhouseCompatibility->>fetchClickHouseVersion: await
    fetchClickHouseVersion-->>initializeClickhouseCompatibility: raw version string (no parse check)
    initializeClickhouseCompatibility->>resolveClickHouseCompatibility: "{ version }"
    resolveClickHouseCompatibility-->>initializeClickhouseCompatibility: "{ settings, appliedRules, parsedVersion, flags }"
    initializeClickhouseCompatibility->>logger: "info(Resolved ClickHouse compatibility, { flags, settings, parsedVersion })"
    alt parsedVersion is null
        initializeClickhouseCompatibility->>logger: warn(Failed to detect ClickHouse version)
    else parsedVersion valid
        initializeClickhouseCompatibility->>initializeClickhouseCompatibility: "detectedClickHouseVersion = clickHouseVersion"
        alt "appliedRules.length > 0"
            initializeClickhouseCompatibility->>logger: info(Applying ClickHouse compatibility settings)
        else no rules
            initializeClickhouseCompatibility->>logger: info(No ClickHouse compatibility settings required)
        end
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/clickhouse/compatibility.test.ts:101-117
**Missing `flags` assertion for `override === "false"`**

The refactored loop now always pushes a flag entry — even when `override` is `"false"` (previously a `continue` skipped the rule entirely). The "allows forcing lazy materialization workaround off" test only checks `.settings`, so the new flags output for an explicit `false` override is untested. If a future change accidentally reverts to the old `continue` behavior, or begins omitting `applied: false` entries from `flags`, this test won't catch it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: issue debug logging information a..."](https://github.com/langfuse/langfuse/commit/b4be8055dc638da22410987efa8928befbc7a7bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38414963)</sub>

<!-- /greptile_comment -->