### PR TITLE
fix(agent): Update system prompt to exclude `langfuse-*` envs

### DIFF
--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -4,9 +4,10 @@ import { Agent } from "@mastra/core/agent";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AgUiEvent } from "@/src/ee/features/in-app-agent/schema";
-import { decodeFiltersGeneric } from "@/src/features/filters/lib/filter-query-encoding";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
 import { patchMastraToolCallInputStreaming } from "@/src/ee/features/in-app-agent/server/agent";
+import { DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS } from "@/src/features/filters/constants/internal-environments";
+import { decodeFiltersGeneric } from "@/src/features/filters/lib/filter-query-encoding";
 import type { MastraAgent } from "@ag-ui/mastra";
 
 const adapterEvents = vi.hoisted(() => ({
@@ -495,6 +496,9 @@ describe("createAgUiStream", () => {
         currentDate: expect.any(String),
         redirectToolName: IN_APP_AGENT_REDIRECT_TOOL_NAME,
         screenContext: "",
+        sidebarHiddenEnvironments: DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS.map(
+          (environment) => `"${environment}"`,
+        ).join(", "),
       }),
     );
     expect(Agent).toHaveBeenCalledWith(

--- a/web/src/ee/features/in-app-agent/server/agent.ts
+++ b/web/src/ee/features/in-app-agent/server/agent.ts
@@ -19,6 +19,7 @@ import type {
 } from "@/src/ee/features/in-app-agent/server/instrumentation";
 import { createInAppAgentInstrumentation } from "@/src/ee/features/in-app-agent/server/instrumentation";
 import { createRedirectActionTool } from "@/src/ee/features/in-app-agent/server/tools";
+import { DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS } from "@/src/features/filters/constants/internal-environments";
 import { logger } from "@langfuse/shared/src/server";
 import { IN_APP_AGENT_REDIRECT_TOOL_NAME } from "@/src/ee/features/in-app-agent/constants";
 
@@ -93,6 +94,9 @@ export async function createAgUiStream(params: {
       currentDate: new Date().toISOString(),
       redirectToolName: IN_APP_AGENT_REDIRECT_TOOL_NAME,
       screenContext: formatScreenContext(params.input.context),
+      sidebarHiddenEnvironments: DEFAULT_SIDEBAR_HIDDEN_ENVIRONMENTS.map(
+        (environment) => `"${environment}"`,
+      ).join(", "),
     },
   });
   const instrumentation = createInAppAgentInstrumentation({
@@ -754,6 +758,7 @@ async function getSystemPromptInstructions(params: {
     currentDate: string;
     redirectToolName: string;
     screenContext: string;
+    sidebarHiddenEnvironments: string;
   };
 }): Promise<{ instructions: string; prompt: InAppAgentPromptMetadata }> {
   if (params.useLocalPrompt) {

--- a/web/src/features/in-app-agent/prompts/in-app-agent-system-prompt.txt
+++ b/web/src/features/in-app-agent/prompts/in-app-agent-system-prompt.txt
@@ -27,6 +27,14 @@ IMPORTANT: You should NOT answer with unnecessary preamble or postamble (such as
 Use the docs tools to find relevant general information about Langfuse or best practices.
 </tools>
 
+<data_scope>
+Langfuse uses internal environments for Langfuse-managed product workflows, such as evaluations, prompt experiments or code evals. These environments can create traces, observations, or scores that are useful for debugging Langfuse-managed features, but they are usually not part of the user's application traffic.
+
+When answering questions about project data, exclude these environments by default: {{sidebarHiddenEnvironments}}.
+Tell the user about these environments and their purpose when relevant, and give them the option to include them in your answers when appropriate.
+Only include them if the user explicitly asks for internal or Langfuse-managed environments, or asks for all environments.
+</data_scope>
+
 <permissions>
 Currently, you only have read access to user's project. All your tools enforce this restriction so no need to worry about it.
 If the user asks you to perform an action, you have two options:


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the in-app agent system prompt with a `<data_scope>` section that instructs the assistant to exclude Langfuse-internal environments (prefixed `langfuse-`) from default project-data answers, while proactively explaining their purpose and offering to include them on explicit user request.

- The new section prevents internal evaluation/experiment traffic from polluting answers about user application data, with a clear opt-in path for users who need visibility into those environments.
- One minor wording issue exists on the last sentence of the block: a missing `or` before "asks for all environments" makes the condition list grammatically incomplete.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to a single prompt text file with a well-scoped instruction block.

A focused prompt-only change that correctly implements the intended filtering behavior. The only nit is a missing "or" in the condition list, which is unlikely to cause the model to misbehave in practice.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User query about project data] --> B{Does query explicitly request\nlangfuse-* environments?}
    B -- No --> C[Exclude langfuse-* environments\nfrom answer]
    C --> D{Are langfuse-* envs\nrelevant context?}
    D -- Yes --> E[Mention internal environments\nand offer to include them]
    D -- No --> F[Return answer without mention]
    B -- Yes --> G[Include langfuse-* environments\nin answer]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User query about project data] --> B{Does query explicitly request\nlangfuse-* environments?}
    B -- No --> C[Exclude langfuse-* environments\nfrom answer]
    C --> D{Are langfuse-* envs\nrelevant context?}
    D -- Yes --> E[Mention internal environments\nand offer to include them]
    D -- No --> F[Return answer without mention]
    B -- Yes --> G[Include langfuse-* environments\nin answer]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/in-app-agent/prompts/in-app-agent-system-prompt.txt:35
Missing conjunction makes the condition list grammatically incomplete and potentially ambiguous for the LLM parser. The second clause ("asks for all environments") is left without an `or`, so a model following the instruction precisely might not recognize it as a separate trigger condition.

```suggestion
Only include them if the user explicitly asks for internal or Langfuse-managed environments, or asks for all environments.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Update system prompt to excl..."](https://github.com/langfuse/langfuse/commit/7aa752166eea5b75eb61a12f405bda357f014f82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38420519)</sub>

<!-- /greptile_comment -->