### PR TITLE
feat(search-bar): support quoted score/metadata names with spaces 

### DIFF
--- a/.agents/skills/seed-test-data/SKILL.md
+++ b/.agents/skills/seed-test-data/SKILL.md
@@ -35,6 +35,7 @@ this.
 | The same tree readable in the v4 events UI | add `--v4` (writes `events_full`; `events_core` fills via MV) |
 | A super tough session (v3 legacy session view) | `pnpm run seed -- long-session --traces 300 --observations-per-trace 8` |
 | Many traces for list/filter performance | `pnpm run seed -- many-traces --count 100000 --days 14` |
+| Scores with spaces in the name (filter/grammar testing) | `pnpm run seed -- scored-traces --traces 24 --v4` |
 | Huge/malformed/unicode payloads | `pnpm run seed -- trace-tree --payload-bytes 1000000 --payload-style malformed` (styles: json, text, malformed, unicode) |
 | See all scenarios and flags | `pnpm run seed -- list --json` |
 | Predict without writing | add `--dry-run` |

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 skip = .git,*.pdf,*.svg,package-lock.json,*.prisma,pnpm-lock.yaml,./worker/src/__tests__/chatml/framework-traces
-ignore-words-list = afterall,vertx,notIn,alue,allTime
+ignore-words-list = afterall,vertx,notIn,alue,allTime,rouge
 

--- a/packages/shared/scripts/seeder/AGENTS.md
+++ b/packages/shared/scripts/seeder/AGENTS.md
@@ -11,6 +11,7 @@ pnpm run seed -- list          # scenarios and flags (--json for machines)
 pnpm run seed -- trace-tree --observations 5000 --breadth 500 --v4
 pnpm run seed -- long-session --traces 300 --observations-per-trace 8
 pnpm run seed -- many-traces --count 100000 --days 14
+pnpm run seed -- scored-traces --traces 24 --v4   # scores w/ spaces in the name
 ```
 
 The last stdout line of a run is a JSON summary with `traceIds`,

--- a/packages/shared/scripts/seeder/scenarios/index.ts
+++ b/packages/shared/scripts/seeder/scenarios/index.ts
@@ -1,5 +1,6 @@
 import { longSessionScenario } from "./long-session";
 import { manyTracesScenario } from "./many-traces";
+import { scoredTracesScenario } from "./scored-traces";
 import { traceTreeScenario } from "./trace-tree";
 import { ScenarioDefinition } from "./types";
 
@@ -10,6 +11,7 @@ export const scenarios: Record<string, ScenarioDefinition> = {
   "trace-tree": traceTreeScenario,
   "long-session": longSessionScenario,
   "many-traces": manyTracesScenario,
+  "scored-traces": scoredTracesScenario,
 };
 
 export * from "./types";

--- a/packages/shared/scripts/seeder/scenarios/scored-traces.ts
+++ b/packages/shared/scripts/seeder/scenarios/scored-traces.ts
@@ -12,7 +12,7 @@ import {
   TraceRecordInsertType,
 } from "../../../src/server";
 import { observationToEvent, traceToEvent } from "./event-mirror";
-import { jitter, Rng } from "./rng";
+import { jitter, Rng, utcDayStartMs } from "./rng";
 import {
   chunk,
   ScenarioContext,
@@ -58,11 +58,14 @@ const run = async (
   const traceCount = Math.max(1, Number(params.traces ?? 24));
   const withV4 = params.v4 === true;
 
-  // Spread traces across the last 6 hours so they fall inside the default
-  // "Past 1 day" window. jitter() (not rng) keeps timestamps — which land in
-  // ClickHouse ORDER BY keys — stable across re-runs with the same flags.
+  // Anchor on utcDayStartMs() (today's UTC midnight), NOT Date.now(): these
+  // timestamps land in ClickHouse ORDER BY keys, and the seeder contract
+  // requires them to be deterministic so re-runs with the same flags overwrite
+  // in place (a wall-clock anchor would shift every row and duplicate under
+  // ReplacingMergeTree). The window spans the 6h before midnight; jitter()
+  // (stateless) adds per-row variation.
   const windowMs = 6 * 60 * 60 * 1000;
-  const endMs = Date.now();
+  const endMs = utcDayStartMs();
   const startMs = endMs - windowMs;
   const stepMs = windowMs / traceCount;
 

--- a/packages/shared/scripts/seeder/scenarios/scored-traces.ts
+++ b/packages/shared/scripts/seeder/scenarios/scored-traces.ts
@@ -1,0 +1,326 @@
+import {
+  createTrace,
+  createObservation,
+  createTraceScore,
+  createTracesCh,
+  createObservationsCh,
+  createScoresCh,
+  createEventsCh,
+  EventRecordInsertType,
+  ObservationRecordInsertType,
+  ScoreRecordInsertType,
+  TraceRecordInsertType,
+} from "../../../src/server";
+import { observationToEvent, traceToEvent } from "./event-mirror";
+import { jitter, Rng } from "./rng";
+import {
+  chunk,
+  ScenarioContext,
+  ScenarioDefinition,
+  SeedError,
+  SeedSummary,
+} from "./types";
+import { countRows, traceLink, tracesListLink } from "./verify";
+
+// Score names deliberately containing SPACES (and mixed case) to exercise the
+// filter sidebar + grammar search bar with names the grammar must quote, e.g.
+// `scores."Rouge Score">=1` / `traceScores."Hallucination Check":faithful`.
+// Observation-level scores surface under the `scores.` grammar prefix;
+// trace-level scores under `traceScores.`. Both numeric and categorical are
+// covered. One no-space score ("accuracy") is included as a control.
+const OBSERVATION_NUMERIC_SCORES = [
+  "Rouge Score",
+  "Score With A Space",
+] as const;
+const OBSERVATION_CATEGORICAL_SCORE = "Answer Relevancy";
+const OBSERVATION_CATEGORIES = [
+  "relevant",
+  "partially relevant",
+  "irrelevant",
+] as const;
+const TRACE_NUMERIC_SCORE = "Faithfulness Score";
+const TRACE_NUMERIC_CONTROL_SCORE = "accuracy"; // no space — control
+const TRACE_CATEGORICAL_SCORE = "Hallucination Check";
+const TRACE_CATEGORIES = ["faithful", "hallucinated"] as const;
+
+const TRACE_NAMES = [
+  "qa-eval-run",
+  "summarize-doc",
+  "rag-answer",
+  "classify-intent",
+] as const;
+
+const run = async (
+  ctx: ScenarioContext,
+  params: Record<string, string | number | boolean>,
+): Promise<SeedSummary> => {
+  const startedAt = Date.now();
+  const traceCount = Math.max(1, Number(params.traces ?? 24));
+  const withV4 = params.v4 === true;
+
+  // Spread traces across the last 6 hours so they fall inside the default
+  // "Past 1 day" window. jitter() (not rng) keeps timestamps — which land in
+  // ClickHouse ORDER BY keys — stable across re-runs with the same flags.
+  const windowMs = 6 * 60 * 60 * 1000;
+  const endMs = Date.now();
+  const startMs = endMs - windowMs;
+  const stepMs = windowMs / traceCount;
+
+  if (ctx.dryRun) {
+    return {
+      scenario: "scored-traces",
+      target: "clickhouse",
+      params,
+      projectId: ctx.projectId,
+      environment: ctx.environment,
+      traceIds: [`${ctx.idPrefix}-t0`],
+      sessionIds: [],
+      counts: {
+        traces: traceCount,
+        observations: traceCount,
+        // 3 observation-level + 3 trace-level scores per trace
+        scores: traceCount * 6,
+        events: withV4 ? traceCount * 2 : 0,
+      },
+      verified: {},
+      links: [tracesListLink(ctx), traceLink(ctx, `${ctx.idPrefix}-t0`, endMs)],
+      dryRun: true,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  const rng = new Rng(ctx.seed);
+  const traces: TraceRecordInsertType[] = [];
+  const observations: ObservationRecordInsertType[] = [];
+  const scores: ScoreRecordInsertType[] = [];
+  const events: EventRecordInsertType[] = [];
+
+  for (let t = 0; t < traceCount; t++) {
+    const traceId = `${ctx.idPrefix}-t${t}`;
+    const timestamp =
+      startMs + Math.floor(t * stepMs) + jitter(ctx.seed, t, 1000);
+
+    const trace = createTrace({
+      id: traceId,
+      project_id: ctx.projectId,
+      environment: ctx.environment,
+      session_id: null,
+      timestamp,
+      name: rng.pick(TRACE_NAMES),
+      user_id: `user-${ctx.idPrefix}-${t % 6}`,
+      tags: ["seed", "scored-traces"],
+      public: false,
+      bookmarked: false,
+      metadata: { scenario: "scored-traces" },
+      input: JSON.stringify({ question: "What is Langfuse used for?" }),
+      output: "Langfuse is an LLM engineering platform.",
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      event_ts: Date.now(),
+    });
+    traces.push(trace);
+
+    const obsId = `${traceId}-o0`;
+    const observation = createObservation({
+      id: obsId,
+      trace_id: traceId,
+      project_id: ctx.projectId,
+      environment: ctx.environment,
+      type: "GENERATION",
+      parent_observation_id: null,
+      name: "answer-generation",
+      start_time: timestamp,
+      end_time: timestamp + rng.int(300, 3000),
+      completion_start_time: timestamp + rng.int(90, 250),
+      level: "DEFAULT",
+      status_message: null,
+      input: JSON.stringify({ prompt: "Answer the question." }),
+      output: "Langfuse is an LLM engineering platform.",
+      created_at: Date.now(),
+      updated_at: Date.now(),
+      event_ts: Date.now(),
+    });
+    observations.push(observation);
+
+    // Observation-level scores (-> `scores.<name>` in the grammar).
+    for (const name of OBSERVATION_NUMERIC_SCORES) {
+      scores.push(
+        createTraceScore({
+          id: `${obsId}-score-${name}`,
+          project_id: ctx.projectId,
+          trace_id: traceId,
+          observation_id: obsId,
+          environment: ctx.environment,
+          name,
+          value: Math.round(rng.next() * 100) / 100,
+          data_type: "NUMERIC",
+          source: "EVAL",
+          comment: null,
+          metadata: {},
+          timestamp,
+        }),
+      );
+    }
+    scores.push(
+      createTraceScore({
+        id: `${obsId}-score-${OBSERVATION_CATEGORICAL_SCORE}`,
+        project_id: ctx.projectId,
+        trace_id: traceId,
+        observation_id: obsId,
+        environment: ctx.environment,
+        name: OBSERVATION_CATEGORICAL_SCORE,
+        value: 0,
+        string_value: rng.pick(OBSERVATION_CATEGORIES),
+        data_type: "CATEGORICAL",
+        source: "EVAL",
+        comment: null,
+        metadata: {},
+        timestamp,
+      }),
+    );
+
+    // Trace-level scores (-> `traceScores.<name>` in the grammar). These are the
+    // eval-style scores attached to the whole trace (observation_id stays null).
+    for (const name of [TRACE_NUMERIC_SCORE, TRACE_NUMERIC_CONTROL_SCORE]) {
+      scores.push(
+        createTraceScore({
+          id: `${traceId}-score-${name}`,
+          project_id: ctx.projectId,
+          trace_id: traceId,
+          environment: ctx.environment,
+          name,
+          value: Math.round(rng.next() * 100) / 100,
+          data_type: "NUMERIC",
+          source: "EVAL",
+          comment: null,
+          metadata: {},
+          timestamp,
+        }),
+      );
+    }
+    scores.push(
+      createTraceScore({
+        id: `${traceId}-score-${TRACE_CATEGORICAL_SCORE}`,
+        project_id: ctx.projectId,
+        trace_id: traceId,
+        environment: ctx.environment,
+        name: TRACE_CATEGORICAL_SCORE,
+        value: 0,
+        string_value: rng.pick(TRACE_CATEGORIES),
+        data_type: "CATEGORICAL",
+        source: "EVAL",
+        comment: null,
+        metadata: {},
+        timestamp,
+      }),
+    );
+
+    if (withV4) {
+      events.push(traceToEvent(trace));
+      events.push(observationToEvent(observation, trace));
+    }
+  }
+
+  const counts: Record<string, number> = {
+    traces: traces.length,
+    observations: observations.length,
+    scores: scores.length,
+    events: events.length,
+  };
+
+  ctx.log(
+    `writing ${traces.length} traces, ${observations.length} observations, ${scores.length} scores${withV4 ? `, ${events.length} events` : ""}`,
+  );
+  for (const batch of chunk(traces, 1000)) {
+    await createTracesCh(batch);
+  }
+  for (const batch of chunk(observations, 1000)) {
+    await createObservationsCh(batch);
+  }
+  for (const batch of chunk(scores, 1000)) {
+    await createScoresCh(batch);
+  }
+  for (const batch of chunk(events, 500)) {
+    await createEventsCh(batch);
+  }
+
+  // uniqExact(id): count() would see pre-merge ReplacingMergeTree duplicates
+  // after re-runs with the same id prefix.
+  const traceIds = traces.map((tr) => tr.id);
+  const verified: Record<string, number> = {
+    traces: await countRows(
+      "traces",
+      `project_id = {projectId: String} AND id IN {traceIds: Array(String)}`,
+      { projectId: ctx.projectId, traceIds },
+      "uniqExact(id)",
+    ),
+    scores: await countRows(
+      "scores",
+      `project_id = {projectId: String} AND trace_id IN {traceIds: Array(String)}`,
+      { projectId: ctx.projectId, traceIds },
+      "uniqExact(id)",
+    ),
+  };
+  if (withV4) {
+    verified.events = await countRows(
+      "events_full",
+      `project_id = {projectId: String} AND trace_id IN {traceIds: Array(String)}`,
+      { projectId: ctx.projectId, traceIds },
+      "uniqExact(span_id)",
+    );
+  }
+
+  if (verified.traces < traces.length) {
+    throw new SeedError(
+      `Readback mismatch: expected ${traces.length} traces, found ${verified.traces}`,
+    );
+  }
+  if (verified.scores < scores.length) {
+    throw new SeedError(
+      `Readback mismatch: expected ${scores.length} scores, found ${verified.scores}`,
+    );
+  }
+  if (withV4 && verified.events < events.length) {
+    throw new SeedError(
+      `Readback mismatch: expected ${events.length} events_full rows, found ${verified.events}`,
+    );
+  }
+
+  return {
+    scenario: "scored-traces",
+    target: "clickhouse",
+    params,
+    projectId: ctx.projectId,
+    environment: ctx.environment,
+    traceIds: traceIds.slice(0, 5),
+    sessionIds: [],
+    counts,
+    verified,
+    links: [tracesListLink(ctx), traceLink(ctx, traces[0].id, endMs)],
+    dryRun: false,
+    durationMs: Date.now() - startedAt,
+  };
+};
+
+export const scoredTracesScenario: ScenarioDefinition = {
+  name: "scored-traces",
+  description:
+    'Standalone traces each carrying numeric + categorical scores whose names contain SPACES (e.g. "Rouge Score", "Score With A Space") at both observation level (scores.) and trace level (traceScores.). For exercising the score filter sidebar and the grammar search bar with quoted score names.',
+  supportsV4: true,
+  flags: [
+    {
+      flag: "traces",
+      type: "number",
+      default: 24,
+      description: "number of standalone traces to create",
+    },
+    {
+      flag: "v4",
+      type: "boolean",
+      default: false,
+      description:
+        "also mirror traces/observations into v4 events_full/events_core",
+    },
+  ],
+  run,
+};

--- a/packages/shared/scripts/seeder/scenarios/scored-traces.ts
+++ b/packages/shared/scripts/seeder/scenarios/scored-traces.ts
@@ -68,6 +68,10 @@ const run = async (
   const endMs = utcDayStartMs();
   const startMs = endMs - windowMs;
   const stepMs = windowMs / traceCount;
+  // The trace-detail link's `?timestamp=` hint must match trace[0]'s actual
+  // timestamp (window START + jitter), not the window END — the detail page
+  // prunes by `toDate(timestamp)`, so a different-day hint 404s.
+  const firstTraceTimestamp = startMs + jitter(ctx.seed, 0, 1000);
 
   if (ctx.dryRun) {
     return {
@@ -86,7 +90,10 @@ const run = async (
         events: withV4 ? traceCount * 2 : 0,
       },
       verified: {},
-      links: [tracesListLink(ctx), traceLink(ctx, `${ctx.idPrefix}-t0`, endMs)],
+      links: [
+        tracesListLink(ctx),
+        traceLink(ctx, `${ctx.idPrefix}-t0`, firstTraceTimestamp),
+      ],
       dryRun: true,
       durationMs: Date.now() - startedAt,
     };
@@ -299,7 +306,10 @@ const run = async (
     sessionIds: [],
     counts,
     verified,
-    links: [tracesListLink(ctx), traceLink(ctx, traces[0].id, endMs)],
+    links: [
+      tracesListLink(ctx),
+      traceLink(ctx, traces[0].id, firstTraceTimestamp),
+    ],
     dryRun: false,
     durationMs: Date.now() - startedAt,
   };

--- a/web/src/features/search-bar/README.md
+++ b/web/src/features/search-bar/README.md
@@ -46,6 +46,10 @@ Generally available on the v4 events tables (no opt-in). Based on the
   (quote a literal `*`, e.g. `statusMessage:"a*b"`). `name:`/`id:` work the same
   way (bare = contains, `:=` = exact) but still suggest observed values.
 - `metadata.region:eu`, `scores.accuracy:>0.8`, `traceScores.nps:positive`
+- dot-path names with spaces/grammar chars are **quoted after the prefix**:
+  `scores."Rouge Score":>=1`, `traceScores."Hallucination Check":faithful`,
+  `metadata."my key":eu` (the quotes are stripped to the real key when lowering;
+  the reverse adapter and completions re-quote them — so they round-trip)
 - `has:endTime` / `-has:endTime` null checks
 - full-text search (see below): bare text, or `input:`/`output:`/`name:`/`id:`
 
@@ -130,9 +134,10 @@ committedText ──resetTo──▶ store.draft ──(type/pick/remove)──�
 
 - **No silent drops or rewrites.** Every filter is either rendered in the bar,
   preserved untouched via `skippedFilters` (shapes the grammar can't express —
-  `positionInTrace`, keys with grammar chars, single-value `all of`), or a
-  commit-blocking diagnostic. Never silently dropped, reordered into a
-  different filter, or rewritten.
+  `positionInTrace`, single-value `all of`), or a commit-blocking diagnostic.
+  Never silently dropped, reordered into a different filter, or rewritten.
+  (Score/metadata keys with grammar chars are no longer skipped — they render
+  with a quoted segment, `scores."Rouge Score"`, and round-trip.)
 - **validate ↔ lower parity, across _every_ site.** `draftValid` (store),
   token classification (`deriveComposerSegments`), and the commit gate
   (`planCommit` → `validateQuery` + `astToFilterState`) must all lower with the

--- a/web/src/features/search-bar/components/ComposerTokens.clienttest.tsx
+++ b/web/src/features/search-bar/components/ComposerTokens.clienttest.tsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import {
+  ComposerTokens,
+  WORD_JOINER,
+} from "@/src/features/search-bar/components/ComposerTokens";
+
+/** Rendered text of the draft, with the layout-only word joiners stripped. */
+function renderedText(draft: string): string {
+  const { container } = render(
+    <ComposerTokens draft={draft} showDiagnostics={false} />,
+  );
+  return (container.textContent ?? "").split(WORD_JOINER).join("");
+}
+
+describe("ComposerTokens", () => {
+  it("renders a quoted dot-path key without mangling the value", () => {
+    // The field/value split must land at the colon OUTSIDE the quoted key
+    // segment. A quote-blind `indexOf(":")` would split inside `"foo:bar"` and
+    // render the value as `bar":*x*` (the pill would show a different filter
+    // than the one committed, and the broken text can re-enter the draft).
+    expect(renderedText('metadata."foo:bar":*x*')).toBe(
+      'metadata."foo:bar":*x*',
+    );
+    // Spaced score name (no inner colon) must also round-trip.
+    expect(renderedText('scores."Rouge Score":>=1')).toBe(
+      'scores."Rouge Score":>=1',
+    );
+  });
+});

--- a/web/src/features/search-bar/components/ComposerTokens.tsx
+++ b/web/src/features/search-bar/components/ComposerTokens.tsx
@@ -17,6 +17,7 @@ import {
   deriveComposerSegments,
   type FilterSegment,
 } from "@/src/features/search-bar/lib/composer-segments";
+import { indexOfOutsideQuotes } from "@/src/features/search-bar/lib/langQ";
 
 // Word joiner around pills: gives the DOM caret boundaries between tokens
 // without changing the query text. Stripped before the text reaches the model
@@ -61,7 +62,11 @@ function FilterTokenBody({ segment }: { segment: FilterSegment }) {
   const raw = segment.raw;
   const dash = segment.negated ? "-" : "";
   const body = segment.negated ? raw.slice(1) : raw;
-  const colon = body.indexOf(":");
+  // Quote-aware split: a dot-path key may carry a quoted segment with an inner
+  // colon (`metadata."foo:bar":*x*`), so the field/value separator is the first
+  // colon OUTSIDE quotes — exactly where the parser splits. A bare indexOf(":")
+  // would cut inside the quoted key and mis-render the value.
+  const colon = indexOfOutsideQuotes(body, ":");
   const value = colon === -1 ? "" : body.slice(colon + 1);
   // Numeric values (latency:>2, totalTokens:100, totalCost:0.5) read as number
   // literals, not strings — color them distinctly. Grouped/text/boolean values

--- a/web/src/features/search-bar/lib/adapter.clienttest.ts
+++ b/web/src/features/search-bar/lib/adapter.clienttest.ts
@@ -477,6 +477,26 @@ describe("astToFilterState", () => {
     ]);
     expect(validateQuery('scores."Rouge Score":>=1').valid).toBe(true);
   });
+
+  it("quotes grammar-char keys in error-message example syntax", () => {
+    // The suggested example syntax in diagnostics must itself parse for a
+    // spaced/colon key — i.e. show the quoted form, not the bare one.
+    const errsFor = (text: string) => lower(text).errors.join(" • ");
+    // metadata any-of group → "supports a single value"
+    expect(errsFor('metadata."my key":(a OR b)')).toContain(
+      'metadata."my key"',
+    );
+    // negated metadata exact → suggestion quotes the key
+    expect(errsFor('-metadata."my key":=foo')).toContain('-metadata."my key"');
+    // numeric score any-of → "expects a single numeric value"
+    expect(errsFor('scores."Rouge Score":(0.1 OR 0.2)')).toContain(
+      'scores."Rouge Score"',
+    );
+    // string-glob op on a score → operatorIssue example quotes the key
+    expect(errsFor('scores."Rouge Score":foo*')).toContain(
+      'scores."Rouge Score"',
+    );
+  });
 });
 
 describe("validateQuery / adapter parity", () => {

--- a/web/src/features/search-bar/lib/adapter.clienttest.ts
+++ b/web/src/features/search-bar/lib/adapter.clienttest.ts
@@ -441,6 +441,42 @@ describe("astToFilterState", () => {
       expect(r.errors.length, `expected errors: ${text}`).toBeGreaterThan(0);
     }
   });
+
+  it("lowers quoted dot-path keys (score/metadata names with spaces)", () => {
+    // A score or metadata name containing spaces is addressed with a quoted
+    // segment after the prefix: `scores."Rouge Score"`. The quotes are stripped
+    // to the real key in the lowered FilterState.
+    expect(lower('scores."Rouge Score":>=1').filters).toEqual([
+      {
+        type: "numberObject",
+        column: "scores_avg",
+        key: "Rouge Score",
+        operator: ">=",
+        value: 1,
+      },
+    ]);
+    expect(lower('traceScores."Hallucination Check":faithful').filters).toEqual(
+      [
+        {
+          type: "categoryOptions",
+          column: "trace_score_categories",
+          key: "Hallucination Check",
+          operator: "any of",
+          value: ["faithful"],
+        },
+      ],
+    );
+    expect(lower('metadata."my key":eu').filters).toEqual([
+      {
+        type: "stringObject",
+        column: "metadata",
+        key: "my key",
+        operator: "=",
+        value: "eu",
+      },
+    ]);
+    expect(validateQuery('scores."Rouge Score":>=1').valid).toBe(true);
+  });
 });
 
 describe("validateQuery / adapter parity", () => {
@@ -601,10 +637,10 @@ describe("filterStateToQueryText", () => {
     expect(back.filters).toEqual([multi]);
   });
 
-  it("skips keyed filters whose key carries grammar chars (would mis-parse)", () => {
-    // `metadata.foo:bar` would reparse as key `metadata.foo` value `bar:…` and
-    // silently corrupt the filter — so a key with a colon (or any NEEDS_QUOTES
-    // char) must be preserved via skippedFilters, not serialized into text.
+  it("renders keyed filters whose key carries grammar chars via a quoted segment", () => {
+    // A metadata/score key with spaces, colons, or other grammar chars is now
+    // addressable with a quoted segment after the prefix (`metadata."foo:bar"`,
+    // `scores."rate test"`); it round-trips instead of being skipped.
     const colonKeyMeta: FilterState[number] = {
       type: "stringObject",
       column: "metadata",
@@ -612,20 +648,59 @@ describe("filterStateToQueryText", () => {
       operator: "contains",
       value: "x",
     };
-    const colonKeyScore: FilterState[number] = {
+    const spacedScore: FilterState[number] = {
       type: "categoryOptions",
       column: "score_categories",
-      key: "rate:test",
+      key: "rate test",
       operator: "any of",
-      value: ["5"],
+      value: ["high"],
     };
-    const r = filterStateToQueryText([colonKeyMeta, colonKeyScore]);
-    expect(r.text).toBe("");
-    expect(r.skippedFilters).toEqual([colonKeyMeta, colonKeyScore]);
-    // A normal key still serializes into the query text (contains → `*x*`).
+    const r = filterStateToQueryText([colonKeyMeta, spacedScore]);
+    expect(r.skippedFilters).toEqual([]);
+    expect(r.text).toBe('metadata."foo:bar":*x* scores."rate test":high');
+    // Both round-trip back to the same FilterState.
+    expect(astToFilterState(validateQuery(r.text).ast).filters).toEqual([
+      colonKeyMeta,
+      spacedScore,
+    ]);
+    // A normal key still serializes bare (contains → `*x*`).
     expect(
       filterStateToQueryText([{ ...colonKeyMeta, key: "region" }]).text,
     ).toBe("metadata.region:*x*");
+  });
+
+  it("round-trips score names with spaces (numeric + categorical, no skip)", () => {
+    const numeric: FilterState = [
+      {
+        type: "numberObject",
+        column: "scores_avg",
+        key: "Rouge Score",
+        operator: ">=",
+        value: 1,
+      },
+    ];
+    const numericResult = filterStateToQueryText(numeric);
+    expect(numericResult.skipped).toEqual([]);
+    expect(numericResult.text).toBe('scores."Rouge Score":>=1');
+    expect(
+      astToFilterState(validateQuery(numericResult.text).ast).filters,
+    ).toEqual(numeric);
+
+    const categorical: FilterState = [
+      {
+        type: "categoryOptions",
+        column: "trace_score_categories",
+        key: "Hallucination Check",
+        operator: "any of",
+        value: ["faithful"],
+      },
+    ];
+    const catResult = filterStateToQueryText(categorical);
+    expect(catResult.skipped).toEqual([]);
+    expect(catResult.text).toBe('traceScores."Hallucination Check":faithful');
+    expect(astToFilterState(validateQuery(catResult.text).ast).filters).toEqual(
+      categorical,
+    );
   });
 
   it("serializes metadata equality as the bare form, not :=value", () => {

--- a/web/src/features/search-bar/lib/adapter.clienttest.ts
+++ b/web/src/features/search-bar/lib/adapter.clienttest.ts
@@ -700,7 +700,7 @@ describe("filterStateToQueryText", () => {
       },
     ];
     const numericResult = filterStateToQueryText(numeric);
-    expect(numericResult.skipped).toEqual([]);
+    expect(numericResult.skippedFilters).toEqual([]);
     expect(numericResult.text).toBe('scores."Rouge Score":>=1');
     expect(
       astToFilterState(validateQuery(numericResult.text).ast).filters,
@@ -716,7 +716,7 @@ describe("filterStateToQueryText", () => {
       },
     ];
     const catResult = filterStateToQueryText(categorical);
-    expect(catResult.skipped).toEqual([]);
+    expect(catResult.skippedFilters).toEqual([]);
     expect(catResult.text).toBe('traceScores."Hallucination Check":faithful');
     expect(astToFilterState(validateQuery(catResult.text).ast).filters).toEqual(
       categorical,

--- a/web/src/features/search-bar/lib/adapter.ts
+++ b/web/src/features/search-bar/lib/adapter.ts
@@ -31,6 +31,7 @@ import {
   SCORE_COLUMNS,
   type FieldDef,
 } from "./fields";
+import { quoteIfNeeded } from "./quoting";
 
 export type SingleEventsFilter = FilterState[number];
 
@@ -554,7 +555,7 @@ function lowerMetadata(
 ): void {
   if (node.values.length > 1) {
     errors.push(
-      `metadata.${key} supports a single value — any-of metadata groups are not supported`,
+      `metadata.${quoteIfNeeded(key)} supports a single value — any-of metadata groups are not supported`,
     );
     return;
   }
@@ -586,7 +587,7 @@ function lowerMetadata(
   // surface the same suggestion.
   if (negated) {
     errors.push(
-      `negated equality on metadata is not representable — use -metadata.${key}:*value* (does not contain)`,
+      `negated equality on metadata is not representable — use -metadata.${quoteIfNeeded(key)}:*value* (does not contain)`,
     );
     return;
   }
@@ -614,7 +615,13 @@ function lowerScores(
   scoreTypes?: ScoreTypeContext,
 ): void {
   const columns = SCORE_COLUMNS[level];
-  const path = level === "trace" ? `traceScores.${key}` : `scores.${key}`;
+  // Quoted so the example syntax in error messages parses for grammar-char
+  // names (`scores."Rouge Score":<n`). `path` is used only in messages here;
+  // the lowered columns come from SCORE_COLUMNS.
+  const path =
+    level === "trace"
+      ? `traceScores.${quoteIfNeeded(key)}`
+      : `scores.${quoteIfNeeded(key)}`;
 
   const lowerNumeric = (): void => {
     const numbers = parseNumbers(node, path, errors);

--- a/web/src/features/search-bar/lib/completions.clienttest.ts
+++ b/web/src/features/search-bar/lib/completions.clienttest.ts
@@ -396,25 +396,28 @@ describe("planInputCompletions", () => {
     expect(labels).not.toContain("=foo"); // exact — redundant w/ bare value
   });
 
-  it("does not suggest observed metadata/score names with grammar chars", () => {
-    // An observed score named `foo:bar` can't be suggested as `scores.foo:bar`:
-    // picking it would reparse with the key split at the first colon and commit
-    // a filter on a different key. Filter such names out of the key-path stage.
+  it("offers observed metadata/score names with grammar chars, quoted for insertion", () => {
+    // An observed score named `foo:bar` (or a name with spaces) IS suggested:
+    // the INSERTED text quotes the segment (`scores."foo:bar"`) so it re-lexes
+    // as one token, while the LABEL stays the readable bare form (so it ranks
+    // against the user's typed prefix).
     const observed = {
       ...OBSERVED,
       scores_avg: [{ value: "accuracy" }, { value: "foo:bar" }],
-      metadata: [{ value: "region" }, { value: "a:b" }],
+      metadata: [{ value: "region" }, { value: "a b" }],
     };
-    const scoreLabels = flattenOptions(plan("scores.", 7, { observed })).map(
-      (o) => o.label,
+    const scoreOpts = flattenOptions(plan("scores.", 7, { observed }));
+    expect(scoreOpts.map((o) => o.label)).toContain("scores.accuracy");
+    const fooBar = scoreOpts.find((o) => o.label === "scores.foo:bar");
+    expect(fooBar && "fieldId" in fooBar && fooBar.fieldId).toBe(
+      'scores."foo:bar"',
     );
-    expect(scoreLabels).toContain("scores.accuracy");
-    expect(scoreLabels).not.toContain("scores.foo:bar");
-    const metaLabels = flattenOptions(plan("metadata.", 9, { observed })).map(
-      (o) => o.label,
+    const metaOpts = flattenOptions(plan("metadata.", 9, { observed }));
+    expect(metaOpts.map((o) => o.label)).toContain("metadata.region");
+    const spaced = metaOpts.find((o) => o.label === "metadata.a b");
+    expect(spaced && "fieldId" in spaced && spaced.fieldId).toBe(
+      'metadata."a b"',
     );
-    expect(metaLabels).toContain("metadata.region");
-    expect(metaLabels).not.toContain("metadata.a:b");
   });
 
   it("keeps the value stage live for a glob value (re-form + re-scope)", () => {

--- a/web/src/features/search-bar/lib/completions.clienttest.ts
+++ b/web/src/features/search-bar/lib/completions.clienttest.ts
@@ -420,6 +420,39 @@ describe("planInputCompletions", () => {
     );
   });
 
+  it("keeps the key-path popover open while typing the quote for a spaced name", () => {
+    // The documented syntax is `scores."Rouge Score"`; typing the leading quote
+    // must keep ranking the (bare-labelled) options instead of closing the
+    // popover. Works the same for metadata.
+    const observed = {
+      ...OBSERVED,
+      scores_avg: [{ value: "Rouge Score" }],
+      metadata: [{ value: "my key" }],
+    };
+    for (const q of ['scores."', 'scores."Rou', 'scores."Rouge Score']) {
+      const opts = flattenOptions(plan(q, q.length, { observed }));
+      const hit = opts.find(
+        (o) => "fieldId" in o && o.fieldId === 'scores."Rouge Score"',
+      );
+      expect(hit, q).toBeDefined();
+    }
+    const metaOpts = flattenOptions(plan('metadata."my', 12, { observed }));
+    expect(
+      metaOpts.find((o) => "fieldId" in o && o.fieldId === 'metadata."my key"'),
+    ).toBeDefined();
+  });
+
+  it("quotes a spaced score name in the numeric compare-op example", () => {
+    const observed = { ...OBSERVED, scores_avg: [{ value: "Rouge Score" }] };
+    const q = 'scores."Rouge Score":';
+    const details = flattenOptions(plan(q, q.length, { observed }))
+      .map((o) => ("detail" in o ? o.detail : undefined))
+      .filter(Boolean);
+    expect(details.some((d) => d?.includes('scores."Rouge Score":'))).toBe(
+      true,
+    );
+  });
+
   it("keeps the value stage live for a glob value (re-form + re-scope)", () => {
     // `output:*ole*` is a contains glob. Clicking into the value must still
     // plan the value stage: a leading `*` is a glob ANCHOR, not a value-

--- a/web/src/features/search-bar/lib/completions.ts
+++ b/web/src/features/search-bar/lib/completions.ts
@@ -566,7 +566,7 @@ function valueStageSections(
       const categoricalColumn =
         ref.level === "trace" ? "trace_score_categories" : "score_categories";
       // Quoted for the example shown in the compare-op tooltip — a spaced score
-      // name must read as `scores."Rouge Score":>0.8`, not the unparseable bare
+      // name must read as `scores."Rouge Score":>0.8`, not the unparsable bare
       // form. (The data lookups above use the unquoted column names.)
       const path =
         ref.level === "trace"

--- a/web/src/features/search-bar/lib/completions.ts
+++ b/web/src/features/search-bar/lib/completions.ts
@@ -14,7 +14,6 @@
 import {
   indexOfOutsideQuotes,
   lexTokens,
-  NEEDS_QUOTES,
   parseGlob,
   serializeValue,
   splitOutsideQuotes,
@@ -27,6 +26,7 @@ import {
   type FieldDef,
   type FieldRef,
 } from "./fields";
+import { quoteIfNeeded } from "./quoting";
 import type { ObservedOptions } from "./observed-options";
 
 export type CompletionStage =
@@ -449,22 +449,19 @@ function keyPathOptions(
   typedKey: string,
   observed: ObservedOptions | undefined,
 ): { title: string; options: CompletionOption[] } {
-  // Observed names with grammar chars (a colon, space, …) can't be suggested:
-  // picking `scores.foo:bar` would reparse with the key split at the FIRST
-  // colon and silently commit a filter on a different/non-existent key. The
-  // reverse adapter already drops these (filter-state-to-query NEEDS_QUOTES
-  // guards); mirror that here so they're never offered.
-  const suggestable = (name: string) => !NEEDS_QUOTES.test(name);
+  // Observed names with grammar chars (a colon, space, …) are offered with the
+  // segment QUOTED so they re-lex as one token (`scores."Rouge Score"`):
+  // `fieldId` is the inserted text (quoted), while `label` stays the bare,
+  // readable form so it matches the user's typed prefix during ranking.
+  const keyText = (name: string) => `${kind.canonical}${quoteIfNeeded(name)}`;
   if (kind.canonical === "metadata.") {
-    const options = observedValues(observed, "metadata")
-      .filter((o) => suggestable(o.value))
-      .map((o) => ({
-        id: `key:metadata.${o.value}`,
-        kind: "field" as const,
-        label: `metadata.${o.value}`,
-        detail: o.count !== undefined ? String(o.count) : undefined,
-        fieldId: `metadata.${o.value}`,
-      }));
+    const options = observedValues(observed, "metadata").map((o) => ({
+      id: `key:metadata.${o.value}`,
+      kind: "field" as const,
+      label: `metadata.${o.value}`,
+      detail: o.count !== undefined ? String(o.count) : undefined,
+      fieldId: keyText(o.value),
+    }));
     return {
       title: SECTION_KEYS,
       options: rankFilter(options, `metadata.${typedKey}`),
@@ -476,9 +473,8 @@ function keyPathOptions(
     kind.level === "trace" ? "trace_score_categories" : "score_categories";
   const seen = new Map<string, string>();
   for (const o of observedValues(observed, numericColumn))
-    if (suggestable(o.value)) seen.set(o.value, "numeric score");
+    seen.set(o.value, "numeric score");
   for (const o of observedValues(observed, categoricalColumn)) {
-    if (!suggestable(o.value)) continue;
     seen.set(
       o.value,
       seen.has(o.value) ? "numeric + categorical score" : "categorical score",
@@ -489,7 +485,7 @@ function keyPathOptions(
     kind: "field" as const,
     label: `${kind.canonical}${name}`,
     detail,
-    fieldId: `${kind.canonical}${name}`,
+    fieldId: keyText(name),
   }));
   return {
     title: SECTION_SCORE_NAMES,

--- a/web/src/features/search-bar/lib/completions.ts
+++ b/web/src/features/search-bar/lib/completions.ts
@@ -454,6 +454,11 @@ function keyPathOptions(
   // `fieldId` is the inserted text (quoted), while `label` stays the bare,
   // readable form so it matches the user's typed prefix during ranking.
   const keyText = (name: string) => `${kind.canonical}${quoteIfNeeded(name)}`;
+  // The user types the documented quoting syntax (`scores."Rou`), but labels are
+  // bare — strip the surrounding quote chars from the typed segment so ranking
+  // still matches (otherwise the first `"` drops every option and the popover
+  // silently closes).
+  const rankKey = typedKey.replace(/^"/, "").replace(/"$/, "");
   if (kind.canonical === "metadata.") {
     const options = observedValues(observed, "metadata").map((o) => ({
       id: `key:metadata.${o.value}`,
@@ -464,7 +469,7 @@ function keyPathOptions(
     }));
     return {
       title: SECTION_KEYS,
-      options: rankFilter(options, `metadata.${typedKey}`),
+      options: rankFilter(options, `metadata.${rankKey}`),
     };
   }
   const numericColumn =
@@ -489,7 +494,7 @@ function keyPathOptions(
   }));
   return {
     title: SECTION_SCORE_NAMES,
-    options: rankFilter(options, `${kind.canonical}${typedKey}`),
+    options: rankFilter(options, `${kind.canonical}${rankKey}`),
   };
 }
 
@@ -560,8 +565,13 @@ function valueStageSections(
         ref.level === "trace" ? "trace_scores_avg" : "scores_avg";
       const categoricalColumn =
         ref.level === "trace" ? "trace_score_categories" : "score_categories";
+      // Quoted for the example shown in the compare-op tooltip — a spaced score
+      // name must read as `scores."Rouge Score":>0.8`, not the unparseable bare
+      // form. (The data lookups above use the unquoted column names.)
       const path =
-        ref.level === "trace" ? `traceScores.${ref.key}` : `scores.${ref.key}`;
+        ref.level === "trace"
+          ? `traceScores.${quoteIfNeeded(ref.key)}`
+          : `scores.${quoteIfNeeded(ref.key)}`;
       const isNumeric = observedValues(observed, numericColumn).some(
         (o) => o.value === ref.key,
       );

--- a/web/src/features/search-bar/lib/fields.ts
+++ b/web/src/features/search-bar/lib/fields.ts
@@ -17,6 +17,7 @@
 // is a substring search) yet keep their observed-value picker.
 
 import type { CompareOp } from "./ast";
+import { quoteIfNeeded, unquote } from "./quoting";
 
 export type FieldKind = "text" | "number" | "datetime" | "boolean";
 export type SyncMode = "exactOption" | "arrayOption" | "textSearch";
@@ -126,19 +127,22 @@ export type FieldRef =
  */
 export function resolveField(name: string): FieldRef | null {
   const lower = name.toLowerCase();
+  // The segment after a dot-path prefix may be quoted to carry spaces/grammar
+  // chars (`scores."Rouge Score"`, `metadata."my key"`); unquote it to the real
+  // key. refName re-quotes it on the way back out.
   if (lower.startsWith(METADATA_PREFIX)) {
-    const key = name.slice(METADATA_PREFIX.length);
+    const key = unquote(name.slice(METADATA_PREFIX.length)).value;
     return key.length > 0 ? { type: "metadata", key } : null;
   }
   for (const prefix of TRACE_SCORE_PREFIXES) {
     if (lower.startsWith(prefix)) {
-      const key = name.slice(prefix.length);
+      const key = unquote(name.slice(prefix.length)).value;
       return key.length > 0 ? { type: "scores", key, level: "trace" } : null;
     }
   }
   for (const prefix of SCORE_PREFIXES) {
     if (lower.startsWith(prefix)) {
-      const key = name.slice(prefix.length);
+      const key = unquote(name.slice(prefix.length)).value;
       return key.length > 0
         ? { type: "scores", key, level: "observation" }
         : null;
@@ -317,11 +321,11 @@ export function refName(ref: FieldRef): string {
     case "field":
       return ref.field.id;
     case "metadata":
-      return `metadata.${ref.key}`;
+      return `metadata.${quoteIfNeeded(ref.key)}`;
     case "scores":
       return ref.level === "trace"
-        ? `traceScores.${ref.key}`
-        : `scores.${ref.key}`;
+        ? `traceScores.${quoteIfNeeded(ref.key)}`
+        : `scores.${quoteIfNeeded(ref.key)}`;
     case "pseudo":
       return ref.id;
   }

--- a/web/src/features/search-bar/lib/fields.ts
+++ b/web/src/features/search-bar/lib/fields.ts
@@ -232,7 +232,7 @@ export function operatorIssue(
       return null;
     case "scores":
       if (STRING_OPS.has(op) && op !== "exact") {
-        return `score filters compare numbers (scores.${ref.key}:>0.8) or match categories (scores.${ref.key}:positive) — ${label(op)} is not supported`;
+        return `score filters compare numbers (${refName(ref)}:>0.8) or match categories (${refName(ref)}:positive) — ${label(op)} is not supported`;
       }
       return null;
     case "field": {
@@ -293,7 +293,7 @@ export function negationIssue(
     if (ref.type === "metadata") {
       // stringObject has no "does not equal" — only does-not-contain.
       return op === "exact"
-        ? `negated exact match on metadata is not representable — use -metadata.${ref.key}:*value* (does not contain)`
+        ? `negated exact match on metadata is not representable — use -${refName(ref)}:*value* (does not contain)`
         : null; // '=' on metadata negates via categoryOptions? No — handled below.
     }
     if (ref.type === "scores") {

--- a/web/src/features/search-bar/lib/filter-state-to-query.ts
+++ b/web/src/features/search-bar/lib/filter-state-to-query.ts
@@ -22,7 +22,8 @@ import {
 } from "./adapter";
 import type { ASTNode, FilterNode } from "./ast";
 import { resolveField, SCORE_COLUMNS, type FieldRef } from "./fields";
-import { NEEDS_QUOTES, serialize } from "./langQ";
+import { serialize } from "./langQ";
+import { quoteIfNeeded } from "./quoting";
 
 // Legacy filters address columns by id ("userId") or display name ("User ID").
 const COLUMN_ID_BY_KEY = new Map<string, string>();
@@ -49,17 +50,19 @@ function negate(node: FilterNode): ASTNode {
 }
 
 function scorePathOf(column: string, key: string): string | null {
+  // Quote the score name iff it has grammar chars so it re-lexes as one token
+  // (`scores."Rouge Score"`); resolveField unquotes it on the way back.
   if (
     column === SCORE_COLUMNS.observation.numeric ||
     column === SCORE_COLUMNS.observation.categorical
   ) {
-    return `scores.${key}`;
+    return `scores.${quoteIfNeeded(key)}`;
   }
   if (
     column === SCORE_COLUMNS.trace.numeric ||
     column === SCORE_COLUMNS.trace.categorical
   ) {
-    return `traceScores.${key}`;
+    return `traceScores.${quoteIfNeeded(key)}`;
   }
   return null;
 }
@@ -175,11 +178,9 @@ function lowerSingle(filter: FilterState[number]): ASTNode | null {
     case "stringObject": {
       const id = columnIdOf(filter.column);
       if (id !== "metadata") return null;
-      // A key with grammar chars (`:`, space, …) would reparse as a different
-      // key/value pair, silently corrupting the filter. Can't be expressed in
-      // the grammar — skip so the container preserves it (no silent rewrite).
-      if (NEEDS_QUOTES.test(filter.key)) return null;
-      const key = `metadata.${filter.key}`;
+      // A key with grammar chars (`:`, space, …) is quoted so it re-lexes as one
+      // token (`metadata."my key"`); resolveField unquotes it on the way back.
+      const key = `metadata.${quoteIfNeeded(filter.key)}`;
       if (filter.operator === "does not contain") {
         return negate(filterNode(key, "~", [filter.value]));
       }
@@ -193,14 +194,12 @@ function lowerSingle(filter: FilterState[number]): ASTNode | null {
       return filterNode(key, op, [filter.value]);
     }
     case "numberObject": {
-      if (NEEDS_QUOTES.test(filter.key)) return null;
       const path = scorePathOf(filter.column, filter.key);
       if (path === null) return null;
       const op = filter.operator === "=" ? "=" : filter.operator;
       return filterNode(path, op, [String(filter.value)]);
     }
     case "categoryOptions": {
-      if (NEEDS_QUOTES.test(filter.key)) return null;
       const path = scorePathOf(filter.column, filter.key);
       if (path === null || filter.value.length === 0) return null;
       const node = filterNode(path, "=", filter.value);

--- a/web/src/features/search-bar/lib/langQ.clienttest.ts
+++ b/web/src/features/search-bar/lib/langQ.clienttest.ts
@@ -158,8 +158,16 @@ describe("langQ parser", () => {
     expect(parse('input:*""').valid).toBe(true);
   });
 
-  it("rejects a key with quotes or spaces", () => {
-    expect(parse('metadata."foo":bar').valid).toBe(false);
+  it("accepts a quoted dot-path key (score/metadata names with spaces)", () => {
+    // Quoting the segment after a dot prefix is how a score/metadata name with
+    // spaces or grammar chars is addressed; it parses and round-trips.
+    expect(parse('metadata."foo":bar').valid).toBe(true);
+    expect(parse('scores."Rouge Score":>=1').valid).toBe(true);
+    expect(parse('traceScores."Hallucination Check":faithful').valid).toBe(
+      true,
+    );
+    // A quoted UNKNOWN plain field is still rejected (resolves to nothing).
+    expect(parse('"level":ERROR').valid).toBe(false);
   });
 
   it("emits a single diagnostic for a bare AND, not a doubled one", () => {

--- a/web/src/features/search-bar/lib/langQ.ts
+++ b/web/src/features/search-bar/lib/langQ.ts
@@ -19,6 +19,11 @@
 
 import type { ASTNode, CompareOp, FilterNode, Span, TextNode } from "./ast";
 import { canonicalKey, operatorIssue, resolveField } from "./fields";
+import { NEEDS_QUOTES, unquote } from "./quoting";
+
+// Re-exported for back-compat: quoting primitives now live in the shared
+// dependency-free `quoting.ts` (so `fields.ts` can use them too).
+export { NEEDS_QUOTES };
 
 export type Diagnostic = {
   from: number;
@@ -195,15 +200,6 @@ export function indexOfOutsideQuotes(s: string, ch: string): number {
   return -1;
 }
 
-function unquote(s: string): { value: string; quoted: boolean } {
-  const t = s.trim();
-  if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
-    // Inverse of serializeValue: \" and \\ are escapes, everything else literal.
-    return { value: t.slice(1, -1).replace(/\\(["\\])/g, "$1"), quoted: true };
-  }
-  return { value: t, quoted: false };
-}
-
 // ---- term classification ----
 
 function isKeyword(raw: string): "and" | "or" | "not" | null {
@@ -295,17 +291,12 @@ function parseTermNode(
       severity: "error",
       message: `Unknown field "${keyRaw}"`,
     });
-  } else if (NEEDS_QUOTES.test(keyRaw)) {
-    // A key with quotes/spaces/grammar chars (e.g. `metadata."foo"`) has no
-    // representable form — the reverse adapter routes it to skippedFilters, so
-    // committing would silently clear the bar. Reject it at parse time instead.
-    diagnostics.push({
-      from: span.from,
-      to: span.from + colon,
-      severity: "error",
-      message: `Field name "${keyRaw}" cannot contain quotes or spaces`,
-    });
   }
+  // A dot-path key segment with grammar chars (`scores."Rouge Score"`,
+  // `metadata."my key"`) is allowed: resolveField unquotes it, and the
+  // serializer/reverse adapter re-quote it — so it round-trips instead of being
+  // rejected. Plain field keys never need quoting; a quoted unknown key falls
+  // out as "Unknown field" above.
 
   const key = ref === null ? keyRaw : canonicalKey(ref);
 
@@ -837,7 +828,6 @@ export function termAt(
 
 // ---- serializer ----
 
-export const NEEDS_QUOTES = /[\s:,()"\\]/;
 // A value/term that STARTS with an operator prefix would otherwise be reparsed
 // as that operator (`name:>5` → comparison, `name:=x` → exact), and a leading
 // `-` would be read as negation when the term is free text (`-foo`). Only the

--- a/web/src/features/search-bar/lib/quoting.ts
+++ b/web/src/features/search-bar/lib/quoting.ts
@@ -1,0 +1,34 @@
+// Quoting primitives — the single source of truth for how the grammar quotes
+// and unquotes a token (a value, or a dot-path key segment like the score name
+// in `scores."Rouge Score"`). Kept in a dependency-free leaf module so both the
+// lexer/serializer (langQ.ts) and the field registry (fields.ts) can share it
+// without a circular import. The escape and the unquote are exact inverses.
+
+/** Chars that force a token to be quoted so the lexer keeps it as one piece. */
+export const NEEDS_QUOTES = /[\s:,()"\\]/;
+
+/** Escape a string for inside double quotes (inverse of {@link unquote}). */
+function escapeQuoted(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Quote `value` iff it contains grammar chars, so it re-lexes as a single
+ * token. Used for dot-path key segments (`scores."Rouge Score"`) and is the
+ * same quoting `serializeValue` applies to values.
+ */
+export function quoteIfNeeded(value: string): string {
+  return NEEDS_QUOTES.test(value) ? `"${escapeQuoted(value)}"` : value;
+}
+
+/**
+ * Strip a surrounding pair of double quotes and unescape `\"`/`\\`. Returns
+ * `quoted` so callers can tell an explicitly-quoted token from a bare one.
+ */
+export function unquote(s: string): { value: string; quoted: boolean } {
+  const t = s.trim();
+  if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
+    return { value: t.slice(1, -1).replace(/\\(["\\])/g, "$1"), quoted: true };
+  }
+  return { value: t, quoted: false };
+}

--- a/web/src/features/search-bar/lib/searchBarInvariants.clienttest.ts
+++ b/web/src/features/search-bar/lib/searchBarInvariants.clienttest.ts
@@ -18,6 +18,11 @@ const eventsView: RegistryUnderTest = {
     "metadata.region",
     "scores.accuracy",
     "traceScores.nps",
+    // Quoted dot-path segments: score/metadata names with spaces + grammar
+    // chars must round-trip through the quoting just like bare keys.
+    'scores."Rouge Score"',
+    'traceScores."Hallucination Check"',
+    'metadata."my key"',
     "has:endTime",
     "has:latency",
   ],


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables score and metadata names that contain spaces or other grammar characters (e.g. `"Rouge Score"`, `"Hallucination Check"`) to be expressed in the search-bar query language by quoting the segment after the dot-path prefix (`scores."Rouge Score":>=1`). Previously such names were silently skipped by the reverse adapter; they now round-trip correctly through parsing, lowering, and completion.

- **`quoting.ts` (new leaf module)**: extracts `NEEDS_QUOTES`, `quoteIfNeeded`, and `unquote` from `langQ.ts` into a dependency-free module shared by both the lexer and the field registry, avoiding a circular import.
- **`fields.ts` + `filter-state-to-query.ts`**: `resolveField` now calls `unquote()` on the key segment after every dot-path prefix; `refName`, `scorePathOf`, and the `stringObject` lowering branch all call `quoteIfNeeded()` so the serialized text re-lexes as one token.
- **`completions.ts`**: spaced names are now suggested, with `label` kept bare for prefix-matching while `fieldId` (inserted text) carries the quoted form.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The quoting round-trip (parse → lower → serialize → reparse) is correct and well-tested; the main change is two diagnostic message strings that now produce syntactically invalid example queries when the key contains spaces.

The core feature — parsing, lowering, and completing score/metadata names with spaces — is implemented correctly and covered by round-trip tests. The two diagnostic strings in `operatorIssue` and `negationIssue` that embed `ref.key` directly into example query snippets will now show malformed examples (e.g. `scores.Rouge Score:>0.8`) whenever a user triggers those error paths with a spaced name, which is a new possibility introduced by this PR. Functional behavior is unaffected.

web/src/features/search-bar/lib/fields.ts — two error-message string templates in `operatorIssue` and `negationIssue` that will render invalid example queries for spaced key names.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User types:\nscores.Rouge Score:>=1"] --> B["Lexer (langQ.ts)\nfinds colon outside quotes"]
    B --> C["keyRaw = 'scores.Rouge Score'"]
    C --> D["resolveField(keyRaw)\n→ unquote segment after 'scores.'"]
    D --> E["FieldRef: {type:'scores', key:'Rouge Score'}"]
    E --> F["Parser: FilterNode\nop='>=', values=['1']"]
    F --> G["astToFilterState (adapter)\n→ FilterState numberObject key='Rouge Score'"]
    G --> H["filterStateToQueryText\nscorePathOf → quoteIfNeeded('Rouge Score')"]
    H --> I["Serialized: scores.Rouge Score:>=1\n✓ round-trip complete"]
    J["Completion: user types 'scores.'"] --> K["keyPathOptions\nfetch observed score names"]
    K --> L["name='Rouge Score'\nlabel='scores.Rouge Score' (for matching)"]
    L --> M["fieldId=quoteIfNeeded → 'scores.Rouge Score'\n(inserted text)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User types:\nscores.Rouge Score:>=1"] --> B["Lexer (langQ.ts)\nfinds colon outside quotes"]
    B --> C["keyRaw = 'scores.Rouge Score'"]
    C --> D["resolveField(keyRaw)\n→ unquote segment after 'scores.'"]
    D --> E["FieldRef: {type:'scores', key:'Rouge Score'}"]
    E --> F["Parser: FilterNode\nop='>=', values=['1']"]
    F --> G["astToFilterState (adapter)\n→ FilterState numberObject key='Rouge Score'"]
    G --> H["filterStateToQueryText\nscorePathOf → quoteIfNeeded('Rouge Score')"]
    H --> I["Serialized: scores.Rouge Score:>=1\n✓ round-trip complete"]
    J["Completion: user types 'scores.'"] --> K["keyPathOptions\nfetch observed score names"]
    K --> L["name='Rouge Score'\nlabel='scores.Rouge Score' (for matching)"]
    L --> M["fieldId=quoteIfNeeded → 'scores.Rouge Score'\n(inserted text)"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/features/search-bar/lib/fields.ts:234-236
**Diagnostic examples use unquoted key, producing invalid syntax for spaced names**

`operatorIssue` builds example query snippets using `ref.key` directly (`scores.${ref.key}:>0.8`). Before this PR, score names with spaces were rejected at parse time, so they could never reach `operatorIssue`. Now they can — for example, when a user types `scores."Rouge Score":*foo*`, the error message would read `"score filters compare numbers (scores.Rouge Score:>0.8)…"`, which itself isn't valid syntax. `refName(ref)` already handles quoting and would produce `scores."Rouge Score":>0.8` instead.

### Issue 2 of 3
web/src/features/search-bar/lib/fields.ts:295-296
**`negationIssue` suggestion uses unquoted key for metadata**

The suggested fix in `negationIssue` is hardcoded as `` -metadata.${ref.key}:*value* ``. With a key like `"my key"` (now expressible), this renders as `-metadata.my key:*value*`, which is invalid — the space splits it into two tokens. Using `refName(ref)` (which already calls `quoteIfNeeded`) would produce the correct `-metadata."my key":*value*`.

### Issue 3 of 3
web/src/features/search-bar/lib/adapter.clienttest.ts:510-526
**Test checks `skipped` (string descriptions) not `skippedFilters` (filter objects)**

Both the new assertions (`numericResult.skipped` / `catResult.skipped`) check the human-readable `string[]` description array, while all surrounding tests in the same block use `r.skippedFilters` (the actual `FilterState` items). Both happen to equal `[]` when nothing is skipped, so the assertions pass, but checking `skippedFilters` is the property that guards against silent drops, which is the invariant these tests are meant to enforce.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(search-bar): support quoted score/m..."](https://github.com/langfuse/langfuse/commit/4723addddde0babf3bc6afdb3c8996ca560c73c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38430012)</sub>

<!-- /greptile_comment -->