### PR TITLE
fix(agent): Minor styling fixes

### DIFF
--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.module.css
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.module.css
@@ -12,6 +12,14 @@
   @apply prose-headings:my-2.5 text-sm leading-4.5;
 }
 
+.Streamdown blockquote {
+  @apply text-muted-foreground;
+}
+
+.Streamdown a {
+  @apply text-primary-accent;
+}
+
 .Streamdown > div > *:first-child {
   @apply mt-0!;
 }

--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.stories.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.stories.tsx
@@ -120,7 +120,7 @@ export const AssistantMarkdown = meta.story({
         "##### Heading 5",
         "###### Heading 6",
         "",
-        "You can use **Langfuse** to inspect _production traces_ and compare `input`, `output`, `metadata` and `scores` across releases.",
+        "You can use **[Langfuse](https://langfuse.com)** to inspect _production traces_ and compare `input`, `output`, `metadata` and `scores` across releases.",
         "",
         "- Inspect traces with nested observations",
         "- Evaluate outputs with scores",

--- a/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentWindow.tsx
@@ -349,7 +349,7 @@ export function InAppAgentWindow(props: InAppAgentWindowProps) {
         >
           <div
             className={cn(
-              "flex h-full w-full flex-col gap-4 py-4",
+              "flex h-full w-full flex-col py-4",
               isExpanded && "mx-auto max-w-3xl",
               isExpanded ? "px-0" : "px-3",
             )}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes minor visual polish fixes to the in-app agent chat UI: it applies design-token colors to blockquotes and links rendered inside the markdown component, removes a redundant outer-container gap that was superseded by per-list spacing, and adds a hyperlink example to the Storybook story to exercise the new link style.

- **`InAppAgentMessage.module.css`**: Adds `.Streamdown blockquote` (`text-muted-foreground`) and `.Streamdown a` (`text-primary-accent`) rules so markdown-rendered quotes and links respect the design token palette.
- **`InAppAgentWindow.tsx`**: Drops `gap-4` from the outer scroll-content wrapper; the `<ol>` of messages already carries `gap-3`, so no visual regression occurs.
- **`InAppAgentMessage.stories.tsx`**: Updates the `AssistantMarkdown` story to include a linked word, giving the new anchor style a concrete test surface in Storybook.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Pure CSS and minor Tailwind class tweaks with no logic changes; safe to merge.

All three changed files touch only styling: two new CSS token rules, one removed Tailwind class, and one Storybook story update. The removed `gap-4` is not a regression because the `<ol>` message list already applies its own `gap-3`. No JS logic, data flows, or API contracts are affected.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Markdown content rendered by Streamdown] --> B{Element type?}
    B -->|blockquote| C["Apply text-muted-foreground\n(NEW via .Streamdown blockquote)"]
    B -->|anchor link| D["Apply text-primary-accent\n(NEW via .Streamdown a)"]
    B -->|other prose| E[Existing rules: headings, code, table, hr, …]

    subgraph InAppAgentWindow layout
        F[Outer scroll container] --> G["flex-col py-4\n(gap-4 removed)"]
        G --> H[Empty state welcome screen]
        G --> I["<ol> gap-3 — message list\n(spacing unchanged)"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Markdown content rendered by Streamdown] --> B{Element type?}
    B -->|blockquote| C["Apply text-muted-foreground\n(NEW via .Streamdown blockquote)"]
    B -->|anchor link| D["Apply text-primary-accent\n(NEW via .Streamdown a)"]
    B -->|other prose| E[Existing rules: headings, code, table, hr, …]

    subgraph InAppAgentWindow layout
        F[Outer scroll container] --> G["flex-col py-4\n(gap-4 removed)"]
        G --> H[Empty state welcome screen]
        G --> I["<ol> gap-3 — message list\n(spacing unchanged)"]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Minor styling fixes"](https://github.com/langfuse/langfuse/commit/cda41dfd8154e50d255fcc0b1467235ea7e625e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38432441)</sub>

<!-- /greptile_comment -->