### PR TITLE
fix: bound OTel trace request bodies

### DIFF
--- a/web/src/__tests__/server/unit/otelTraceRequestLimits.servertest.ts
+++ b/web/src/__tests__/server/unit/otelTraceRequestLimits.servertest.ts
@@ -1,0 +1,133 @@
+import { Readable } from "node:stream";
+import { gzipSync } from "node:zlib";
+import {
+  OTEL_TRACE_REQUEST_BODY_MAX_BYTES,
+  OTEL_TRACE_REQUEST_MAX_RESOURCE_SPANS,
+  OTEL_TRACE_REQUEST_MAX_SPANS,
+  OtelTraceRequestLimitError,
+  decompressGzipWithByteLimit,
+  getOtelTraceBatchCounts,
+  readStreamWithByteLimit,
+  validateOtelTraceContentLength,
+} from "@/src/features/public-api/server/otelTraceRequestLimits";
+
+const expectLimitError = (
+  fn: () => void,
+  statusCode: number,
+  message: string,
+) => {
+  try {
+    fn();
+    throw new Error("Expected function to throw");
+  } catch (error) {
+    expect(error).toBeInstanceOf(OtelTraceRequestLimitError);
+    expect(error).toMatchObject({ statusCode, message });
+  }
+};
+
+describe("OTel trace request limits", () => {
+  it("should reject the request if Content-Length is missing", () => {
+    expectLimitError(
+      () => validateOtelTraceContentLength({}),
+      411,
+      "Content-Length header is required",
+    );
+  });
+
+  it("should reject the request if Content-Length exceeds the raw body limit", () => {
+    expectLimitError(
+      () =>
+        validateOtelTraceContentLength({
+          "content-length": String(OTEL_TRACE_REQUEST_BODY_MAX_BYTES + 1),
+        }),
+      413,
+      `OTel trace request body exceeds the ${OTEL_TRACE_REQUEST_BODY_MAX_BYTES} byte limit`,
+    );
+  });
+
+  it("should stop reading the raw body if the stream exceeds the byte limit", async () => {
+    await expect(
+      readStreamWithByteLimit(
+        Readable.from([Buffer.alloc(3), Buffer.alloc(3)]),
+        5,
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 413,
+      message: "OTel trace request body exceeds the 5 byte limit",
+    });
+  });
+
+  it("should resume instead of destroying the stream if configured to drain on limit", async () => {
+    const stream = new Readable({ read() {} });
+    const destroySpy = vi.spyOn(stream, "destroy");
+    const resumeSpy = vi.spyOn(stream, "resume");
+
+    const result = readStreamWithByteLimit(stream, 5, {
+      limitExceededAction: "resume",
+    });
+    stream.emit("data", Buffer.alloc(3));
+    stream.emit("data", Buffer.alloc(3));
+
+    await expect(result).rejects.toMatchObject({
+      statusCode: 413,
+      message: "OTel trace request body exceeds the 5 byte limit",
+    });
+
+    expect(resumeSpy).toHaveBeenCalled();
+    expect(destroySpy).not.toHaveBeenCalled();
+  });
+
+  it("should stop decompressing gzip if the inflated body exceeds the byte limit", async () => {
+    await expect(
+      decompressGzipWithByteLimit(gzipSync(Buffer.alloc(10)), 5),
+    ).rejects.toMatchObject({
+      statusCode: 413,
+      message: "OTel trace request body exceeds the 5 byte limit",
+    });
+  });
+
+  it("should count resource spans and spans for valid batches", () => {
+    expect(
+      getOtelTraceBatchCounts([
+        { scopeSpans: [{ spans: [{}, {}] }] },
+        { scopeSpans: [{ spans: [{}] }] },
+      ]),
+    ).toEqual({ resourceSpanCount: 2, spanCount: 3 });
+  });
+
+  it("should reject the request if the resource span count exceeds the limit", () => {
+    expectLimitError(
+      () =>
+        getOtelTraceBatchCounts(
+          Array.from(
+            { length: OTEL_TRACE_REQUEST_MAX_RESOURCE_SPANS + 1 },
+            () => ({
+              scopeSpans: [],
+            }),
+          ),
+        ),
+      413,
+      `OTel trace request exceeds the ${OTEL_TRACE_REQUEST_MAX_RESOURCE_SPANS} resourceSpans limit`,
+    );
+  });
+
+  it("should reject the request if the span count exceeds the limit", () => {
+    expectLimitError(
+      () =>
+        getOtelTraceBatchCounts([
+          {
+            scopeSpans: [
+              {
+                spans: Array.from(
+                  { length: OTEL_TRACE_REQUEST_MAX_SPANS + 1 },
+                  () => ({}),
+                ),
+              },
+            ],
+          },
+        ]),
+      413,
+      `OTel trace request exceeds the ${OTEL_TRACE_REQUEST_MAX_SPANS} spans limit`,
+    );
+  });
+});

--- a/web/src/features/public-api/server/otelTraceRequestLimits.ts
+++ b/web/src/features/public-api/server/otelTraceRequestLimits.ts
@@ -1,0 +1,178 @@
+import { Readable } from "node:stream";
+import { createGunzip } from "node:zlib";
+import { type IncomingHttpHeaders } from "node:http";
+
+export const OTEL_TRACE_REQUEST_BODY_MAX_BYTES = 16 * 1024 * 1024;
+export const OTEL_TRACE_REQUEST_MAX_RESOURCE_SPANS = 10_000;
+export const OTEL_TRACE_REQUEST_MAX_SPANS = 100_000;
+
+export class OtelTraceRequestLimitError extends Error {
+  public readonly statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = "OtelTraceRequestLimitError";
+    this.statusCode = statusCode;
+  }
+}
+
+type LimitExceededAction = "destroy" | "resume";
+
+type ReadStreamWithByteLimitOptions = {
+  limitExceededAction?: LimitExceededAction;
+};
+
+const getSingleHeaderValue = (
+  headers: IncomingHttpHeaders,
+  name: string,
+): string | undefined => {
+  const value = headers[name];
+  if (typeof value === "string") return value;
+  return value?.[0];
+};
+
+export const validateOtelTraceContentLength = (
+  headers: IncomingHttpHeaders,
+) => {
+  const contentLengthHeader = getSingleHeaderValue(headers, "content-length");
+
+  if (!contentLengthHeader) {
+    throw new OtelTraceRequestLimitError(
+      411,
+      "Content-Length header is required",
+    );
+  }
+
+  const contentLength = Number(contentLengthHeader);
+  if (
+    !Number.isSafeInteger(contentLength) ||
+    contentLength < 0 ||
+    String(contentLength) !== contentLengthHeader.trim()
+  ) {
+    throw new OtelTraceRequestLimitError(400, "Invalid Content-Length header");
+  }
+
+  if (contentLength > OTEL_TRACE_REQUEST_BODY_MAX_BYTES) {
+    throw new OtelTraceRequestLimitError(
+      413,
+      `OTel trace request body exceeds the ${OTEL_TRACE_REQUEST_BODY_MAX_BYTES} byte limit`,
+    );
+  }
+};
+
+export const readStreamWithByteLimit = async (
+  stream: Readable,
+  maxBytes: number,
+  options: ReadStreamWithByteLimitOptions = {},
+): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let bytes = 0;
+    let settled = false;
+    const limitExceededAction = options.limitExceededAction ?? "destroy";
+
+    const cleanup = () => {
+      stream.off("data", onData);
+      stream.off("end", onEnd);
+      stream.off("error", onError);
+    };
+
+    const rejectOnce = (error: Error, action?: LimitExceededAction) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (action === "destroy") {
+        stream.destroy();
+      } else if (action === "resume") {
+        stream.resume();
+      }
+      reject(error);
+    };
+
+    const onData = (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      bytes += buffer.byteLength;
+
+      if (bytes > maxBytes) {
+        rejectOnce(
+          new OtelTraceRequestLimitError(
+            413,
+            `OTel trace request body exceeds the ${maxBytes} byte limit`,
+          ),
+          limitExceededAction,
+        );
+        return;
+      }
+
+      chunks.push(buffer);
+    };
+
+    const onEnd = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(Buffer.concat(chunks, bytes));
+    };
+
+    const onError = (error: Error) => {
+      rejectOnce(error);
+    };
+
+    stream.on("data", onData);
+    stream.on("end", onEnd);
+    stream.on("error", onError);
+  });
+
+export const decompressGzipWithByteLimit = async (
+  body: Buffer,
+  maxBytes = OTEL_TRACE_REQUEST_BODY_MAX_BYTES,
+): Promise<Buffer> => {
+  const gunzip = createGunzip();
+  const source = Readable.from([body]);
+  source.pipe(gunzip);
+
+  try {
+    return await readStreamWithByteLimit(gunzip, maxBytes);
+  } finally {
+    source.destroy();
+  }
+};
+
+export const getOtelTraceBatchCounts = (
+  resourceSpans: unknown,
+): { resourceSpanCount: number; spanCount: number } => {
+  if (!Array.isArray(resourceSpans)) {
+    throw new OtelTraceRequestLimitError(400, "Invalid OTel resourceSpans");
+  }
+
+  if (resourceSpans.length > OTEL_TRACE_REQUEST_MAX_RESOURCE_SPANS) {
+    throw new OtelTraceRequestLimitError(
+      413,
+      `OTel trace request exceeds the ${OTEL_TRACE_REQUEST_MAX_RESOURCE_SPANS} resourceSpans limit`,
+    );
+  }
+
+  let spanCount = 0;
+  for (const resourceSpan of resourceSpans) {
+    const scopeSpans = Array.isArray(resourceSpan?.scopeSpans)
+      ? resourceSpan.scopeSpans
+      : [];
+
+    for (const scopeSpan of scopeSpans) {
+      if (Array.isArray(scopeSpan?.spans)) {
+        spanCount += scopeSpan.spans.length;
+        if (spanCount > OTEL_TRACE_REQUEST_MAX_SPANS) {
+          throw new OtelTraceRequestLimitError(
+            413,
+            `OTel trace request exceeds the ${OTEL_TRACE_REQUEST_MAX_SPANS} spans limit`,
+          );
+        }
+      }
+    }
+  }
+
+  return {
+    resourceSpanCount: resourceSpans.length,
+    spanCount,
+  };
+};

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -7,9 +7,16 @@ import {
 } from "@langfuse/shared/src/server";
 import { z } from "zod";
 import { $root } from "@/src/pages/api/public/otel/otlp-proto/generated/root";
-import { gunzip } from "node:zlib";
 import { ForbiddenError } from "@langfuse/shared";
 import { env } from "@/src/env.mjs";
+import {
+  OTEL_TRACE_REQUEST_BODY_MAX_BYTES,
+  OtelTraceRequestLimitError,
+  decompressGzipWithByteLimit,
+  getOtelTraceBatchCounts,
+  readStreamWithByteLimit,
+  validateOtelTraceContentLength,
+} from "@/src/features/public-api/server/otelTraceRequestLimits";
 
 /** Read a Langfuse header that may arrive with hyphens or underscores. */
 function getLangfuseHeader(
@@ -22,6 +29,14 @@ function getLangfuseHeader(
   if (typeof underscoreVal === "string") return underscoreVal;
   return undefined;
 }
+
+const headerIncludes = (
+  header: string | string[] | undefined,
+  searchValue: string,
+) =>
+  Array.isArray(header)
+    ? header.some((value) => value.toLowerCase().includes(searchValue))
+    : (header?.toLowerCase().includes(searchValue) ?? false);
 
 export const config = {
   api: {
@@ -46,35 +61,6 @@ export default withMiddlewares({
       // Mark project as using OTEL API
       await markProjectAsOtelUser(auth.scope.projectId);
 
-      let body: Buffer;
-      try {
-        body = await new Promise((resolve, reject) => {
-          let data: any[] = [];
-          req.on("data", (chunk) => data.push(chunk));
-          req.on("end", () => resolve(Buffer.concat(data)));
-          req.on("error", reject);
-        });
-      } catch (e) {
-        logger.error(`Failed to read request body`, e);
-        res.status(400);
-        return { error: "Failed to read request body" };
-      }
-
-      if (req.headers["content-encoding"]?.includes("gzip")) {
-        try {
-          body = await new Promise((resolve, reject) => {
-            gunzip(new Uint8Array(body), (err, result) =>
-              err ? reject(err) : resolve(result),
-            );
-          });
-        } catch (e) {
-          logger.error(`Failed to decompress request body`, e);
-          res.status(400);
-          return { error: "Failed to decompress request body" };
-        }
-      }
-
-      let resourceSpans: any;
       const contentType = req.headers["content-type"]?.toLowerCase();
       // Strict content-type matching does not work if something like `content-type: text/javascript; charset=utf-8` is sent.
       if (
@@ -86,6 +72,52 @@ export default withMiddlewares({
         res.status(400);
         return { error: "Invalid content type" };
       }
+
+      let body: Buffer;
+      try {
+        validateOtelTraceContentLength(req.headers);
+        body = await readStreamWithByteLimit(
+          req,
+          OTEL_TRACE_REQUEST_BODY_MAX_BYTES,
+          { limitExceededAction: "resume" },
+        );
+      } catch (e) {
+        if (e instanceof OtelTraceRequestLimitError) {
+          logger.warn(`Rejected OTel trace request body`, {
+            projectId: auth.scope.projectId,
+            statusCode: e.statusCode,
+            error: e.message,
+          });
+          res.status(e.statusCode);
+          return { error: e.message };
+        }
+
+        logger.error(`Failed to read request body`, e);
+        res.status(400);
+        return { error: "Failed to read request body" };
+      }
+
+      if (headerIncludes(req.headers["content-encoding"], "gzip")) {
+        try {
+          body = await decompressGzipWithByteLimit(body);
+        } catch (e) {
+          if (e instanceof OtelTraceRequestLimitError) {
+            logger.warn(`Rejected OTel trace request body`, {
+              projectId: auth.scope.projectId,
+              statusCode: e.statusCode,
+              error: e.message,
+            });
+            res.status(e.statusCode);
+            return { error: e.message };
+          }
+
+          logger.error(`Failed to decompress request body`, e);
+          res.status(400);
+          return { error: "Failed to decompress request body" };
+        }
+      }
+
+      let resourceSpans: any;
       if (contentType.includes("application/x-protobuf")) {
         try {
           const parsed =
@@ -112,24 +144,29 @@ export default withMiddlewares({
         }
       }
 
-      if (!resourceSpans || resourceSpans.length === 0) {
+      if (!resourceSpans) {
         return {};
       }
 
-      // Warn on oversized OTEL request bodies (16MB threshold)
-      const bodyBytes = body.byteLength;
-      if (bodyBytes > 16 * 1024 * 1024) {
-        let spanCount = 0;
-        for (const rs of resourceSpans) {
-          for (const ss of rs?.scopeSpans ?? []) {
-            spanCount += ss?.spans?.length ?? 0;
-          }
+      let batchCounts: { resourceSpanCount: number; spanCount: number };
+      try {
+        batchCounts = getOtelTraceBatchCounts(resourceSpans);
+      } catch (e) {
+        if (e instanceof OtelTraceRequestLimitError) {
+          logger.warn(`Rejected OTel trace request batch`, {
+            projectId: auth.scope.projectId,
+            statusCode: e.statusCode,
+            error: e.message,
+          });
+          res.status(e.statusCode);
+          return { error: e.message };
         }
-        logger.warn("OTEL request body exceeds 16MB", {
-          projectId: auth.scope.projectId,
-          bodyBytes,
-          spanCount,
-        });
+
+        throw e;
+      }
+
+      if (batchCounts.resourceSpanCount === 0) {
+        return {};
       }
 
       // Extract SDK headers for write path decision (supports both hyphen and underscore formats)


### PR DESCRIPTION
## What
- Adds a strict 16 MiB raw-body limit for OTel trace ingestion, including required and bounded `Content-Length`.
- Replaces one-shot gzip decompression with bounded streaming decompression so inflated payloads are capped too.
- Rejects oversized OTel batches by resource span and span count before enqueueing.
- Keeps missing `resourceSpans` behavior as an empty batch for compatibility.

## Why
The OTel traces endpoint owns request body parsing and previously buffered the full raw body, then gunzipped it without a decompressed-size cap. That made authenticated ingestion requests able to spend memory and CPU before normal validation.

## Validation
- `pnpm --filter web exec vitest run --project server-unit src/__tests__/server/unit/otelTraceRequestLimits.servertest.ts`
- `pnpm --filter web exec eslint src/features/public-api/server/otelTraceRequestLimits.ts src/pages/api/public/otel/v1/traces/index.ts src/__tests__/server/unit/otelTraceRequestLimits.servertest.ts --max-warnings 0 --no-cache`
- Commit hook ran `prettier --check` and `turbo run lint` successfully.

Note: this fresh local checkout is on Node 25.8.2 while the repo asks for Node 24, so the commands print engine warnings.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a dedicated `otelTraceRequestLimits` module and integrates it into the OTel traces ingestion handler to bound memory and CPU exposure from authenticated but oversized requests. The content-type check is promoted ahead of body reading, `Content-Length` is now required and validated before any data is consumed, raw and decompressed body reads are capped at 16 MiB each via bounded streaming, and parsed batches are rejected above 10,000 resource spans or 100,000 total spans.

- **Bounded streaming reads**: `readStreamWithByteLimit` replaces the old unbounded `data`/`end` accumulator and the one-shot `gunzip` call, capping both compressed and decompressed sizes independently.
- **Batch-count enforcement**: `getOtelTraceBatchCounts` validates resource-span and span counts after parsing, replacing the old warn-only over-16 MiB log with an actual 413 rejection.
- **Empty-batch compatibility**: the early `!resourceSpans` guard is preserved; an empty `resourceSpans` array now travels through `getOtelTraceBatchCounts` and returns early on `resourceSpanCount === 0`.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The protection goals are sound but the over-limit rejection path destroys the HTTP socket before the 413 response can be written, so affected clients get a connection reset rather than a proper error response.

The socket-destruction path is exercised only when a raw body exceeds 16 MiB, so normal traffic is unaffected. However, the new utility is purpose-built to enforce that limit, making the mis-delivery of the 413 a direct consequence of the intended defense. Fixing it before merge avoids confusing client retry behaviour and potential server-side write-after-destroy noise in logs.

web/src/features/public-api/server/otelTraceRequestLimits.ts — the rejectOnce path in readStreamWithByteLimit needs attention, particularly the stream.destroy() call when the stream is the raw HTTP IncomingMessage.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant H as OTel Traces Handler
    participant V as validateOtelTraceContentLength
    participant R as readStreamWithByteLimit
    participant D as decompressGzipWithByteLimit
    participant B as getOtelTraceBatchCounts
    participant Q as OtelIngestionProcessor

    C->>H: POST /api/public/otel/v1/traces
    H->>H: Auth + ingestion-suspended check
    H->>H: Check content-type (JSON or protobuf)
    H->>V: validate Content-Length header
    V-->>H: 411 (missing) / 400 (invalid) / 413 (too large)
    H->>R: readStreamWithByteLimit(req, 16 MiB)
    R-->>H: Buffer (raw body) or 413 OtelTraceRequestLimitError
    alt content-encoding: gzip
        H->>D: decompressGzipWithByteLimit(body, 16 MiB)
        D->>R: readStreamWithByteLimit(gunzipStream, 16 MiB)
        R-->>D: decompressed Buffer or 413 OtelTraceRequestLimitError
        D-->>H: decompressed Buffer
    end
    H->>H: Parse JSON / Protobuf → resourceSpans
    H->>B: getOtelTraceBatchCounts(resourceSpans)
    B-->>H: counts or 400/413 OtelTraceRequestLimitError
    H->>Q: publishToOtelIngestionQueue(resourceSpans)
    Q-->>H: result
    H-->>C: 200 OK / 4xx error
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant H as OTel Traces Handler
    participant V as validateOtelTraceContentLength
    participant R as readStreamWithByteLimit
    participant D as decompressGzipWithByteLimit
    participant B as getOtelTraceBatchCounts
    participant Q as OtelIngestionProcessor

    C->>H: POST /api/public/otel/v1/traces
    H->>H: Auth + ingestion-suspended check
    H->>H: Check content-type (JSON or protobuf)
    H->>V: validate Content-Length header
    V-->>H: 411 (missing) / 400 (invalid) / 413 (too large)
    H->>R: readStreamWithByteLimit(req, 16 MiB)
    R-->>H: Buffer (raw body) or 413 OtelTraceRequestLimitError
    alt content-encoding: gzip
        H->>D: decompressGzipWithByteLimit(body, 16 MiB)
        D->>R: readStreamWithByteLimit(gunzipStream, 16 MiB)
        R-->>D: decompressed Buffer or 413 OtelTraceRequestLimitError
        D-->>H: decompressed Buffer
    end
    H->>H: Parse JSON / Protobuf → resourceSpans
    H->>B: getOtelTraceBatchCounts(resourceSpans)
    B-->>H: counts or 400/413 OtelTraceRequestLimitError
    H->>Q: publishToOtelIngestionQueue(resourceSpans)
    Q-->>H: result
    H-->>C: 200 OK / 4xx error
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/public-api/server/otelTraceRequestLimits.ts:72-78
**Destroying the HTTP request socket prevents the error response from being sent**

`stream.destroy()` is called after `cleanup()` removes all listeners. When the stream passed in is the raw HTTP `req` (`IncomingMessage`), `req.destroy()` synchronously sets `socket.writable = false` and schedules handle closure — sharing the socket with `res`. Any response write (`res.status(413).json(...)`) that the framework attempts immediately after the awaited rejection will silently fail or emit an unhandled write-after-destroy error, so the client receives a TCP RST instead of a `413` body.

The decompression path is safe because it passes the `gunzip` Transform, not `req`. Only the initial `readStreamWithByteLimit(req, …)` call at line 79 of `index.ts` triggers this. Consider removing the `stream.destroy()` call (Node.js will garbage-collect the stream once the socket drains) or replacing it with `stream.resume()` to drain and discard remaining bytes without destroying the socket.

### Issue 2 of 2
web/src/features/public-api/server/otelTraceRequestLimits.ts:113-120
The `decompressGzipWithByteLimit` pipe does not track the anonymous source `Readable`. When `readStreamWithByteLimit` destroys the `gunzip` destination, Node.js unpiped the source automatically, but the source stream is never explicitly cleaned up. Storing the source and destroying it explicitly prevents any lingering handles if the gunzip stream errors during decompression before `pipe` cleanup fires.

```suggestion
export const decompressGzipWithByteLimit = async (
  body: Buffer,
  maxBytes = OTEL_TRACE_REQUEST_BODY_MAX_BYTES,
): Promise<Buffer> => {
  const gunzip = createGunzip();
  const source = Readable.from([body]);
  source.pipe(gunzip);
  try {
    return await readStreamWithByteLimit(gunzip, maxBytes);
  } finally {
    source.destroy();
  }
};
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bound OTel trace request bodies"](https://github.com/langfuse/langfuse/commit/1e29df6e9c991a2eedaf624c00861b75352ae737) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38447246)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->