### PR TITLE
fix(sessions): time sorting by createdAt

### DIFF
--- a/web/src/components/table/use-cases/session-row-data.clienttest.ts
+++ b/web/src/components/table/use-cases/session-row-data.clienttest.ts
@@ -1,0 +1,71 @@
+import { joinSessionCoreAndMetrics } from "@/src/components/table/use-cases/session-row-data";
+
+describe("joinSessionCoreAndMetrics", () => {
+  it("keeps filtered core session fields when metrics contain all-time values", () => {
+    const filteredCreatedAt = new Date("2026-06-17T08:53:47.000Z");
+    const allTimeCreatedAt = new Date("2026-05-21T16:29:48.000Z");
+
+    const result = joinSessionCoreAndMetrics(
+      [
+        {
+          id: "session-1",
+          createdAt: filteredCreatedAt,
+          bookmarked: false,
+          public: false,
+          userIds: ["filtered-user"],
+          countTraces: 1,
+          traceTags: ["filtered-tag"],
+          environment: "dev",
+        },
+      ],
+      [
+        {
+          id: "session-1",
+          createdAt: allTimeCreatedAt,
+          bookmarked: true,
+          public: true,
+          userIds: ["all-time-user"],
+          countTraces: 5,
+          traceTags: ["old-tag"],
+          environment: "prod",
+          sessionDuration: 42,
+          totalTokens: 123,
+        },
+      ],
+    );
+
+    expect(result.status).toBe("success");
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows?.[0]).toMatchObject({
+      id: "session-1",
+      bookmarked: false,
+      public: false,
+      userIds: ["filtered-user"],
+      countTraces: 1,
+      traceTags: ["filtered-tag"],
+      environment: "dev",
+      sessionDuration: 42,
+      totalTokens: 123,
+    });
+    expect(result.rows?.[0]?.createdAt).toBe(filteredCreatedAt);
+  });
+
+  it("returns core rows while metrics are loading", () => {
+    const createdAt = new Date("2026-06-17T08:53:47.000Z");
+
+    const result = joinSessionCoreAndMetrics([
+      {
+        id: "session-1",
+        createdAt,
+      },
+    ]);
+
+    expect(result.status).toBe("success");
+    expect(result.rows).toEqual([
+      {
+        id: "session-1",
+        createdAt,
+      },
+    ]);
+  });
+});

--- a/web/src/components/table/use-cases/session-row-data.ts
+++ b/web/src/components/table/use-cases/session-row-data.ts
@@ -1,0 +1,58 @@
+import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
+
+type SessionCoreFields = {
+  id: string;
+  createdAt?: Date;
+  bookmarked?: boolean;
+  public?: boolean;
+  userIds?: string[];
+  countTraces?: number;
+  traceTags?: string[];
+  environment?: string;
+};
+
+const pickSessionCoreFields = <Core extends SessionCoreFields>(core: Core) => ({
+  id: core.id,
+  createdAt: core.createdAt,
+  bookmarked: core.bookmarked,
+  public: core.public,
+  userIds: core.userIds,
+  countTraces: core.countTraces,
+  traceTags: core.traceTags,
+  environment: core.environment,
+});
+
+export function joinSessionCoreAndMetrics<
+  Core extends SessionCoreFields,
+  Metric extends { id: string },
+>(
+  sessionCoreData?: Core[],
+  sessionMetricsData?: Metric[],
+): {
+  status: "loading" | "error" | "success";
+  rows: (Core & Partial<Metric>)[] | undefined;
+} {
+  const joinedData = joinTableCoreAndMetrics<Core, Metric>(
+    sessionCoreData,
+    sessionMetricsData,
+  );
+
+  if (!joinedData.rows || !sessionCoreData) {
+    return joinedData;
+  }
+
+  const coreById = sessionCoreData.reduce<Record<string, Core>>((acc, core) => {
+    acc[core.id] = core;
+    return acc;
+  }, {});
+
+  return {
+    ...joinedData,
+    rows: joinedData.rows.map((row) => {
+      const core = coreById[row.id];
+
+      // Session metrics can be all-time scoped in v3, while core rows are filtered and sorted.
+      return core ? { ...row, ...pickSessionCoreFields(core) } : row;
+    }),
+  };
+}

--- a/web/src/components/table/use-cases/sessions.tsx
+++ b/web/src/components/table/use-cases/sessions.tsx
@@ -46,7 +46,7 @@ import { useEffect, useState, useMemo, useRef, useCallback } from "react";
 import { usePaginationState } from "@/src/hooks/usePaginationState";
 import { useTableDateRange } from "@/src/hooks/useTableDateRange";
 import { toAbsoluteTimeRange } from "@/src/utils/date-range-utils";
-import { joinTableCoreAndMetrics } from "@/src/components/table/utils/joinTableCoreAndMetrics";
+import { joinSessionCoreAndMetrics } from "@/src/components/table/use-cases/session-row-data";
 import TagList from "@/src/features/tag/components/TagList";
 import { useRowHeightLocalStorage } from "@/src/components/table/data-table-row-height-switch";
 import { cn } from "@/src/utils/tailwind";
@@ -379,7 +379,7 @@ export default function SessionsTable({
 
   const sessionRowData = useMemo(
     () =>
-      joinTableCoreAndMetrics<SessionCoreOutput, SessionMetricOutput>(
+      joinSessionCoreAndMetrics<SessionCoreOutput, SessionMetricOutput>(
         sessions.data?.sessions,
         sessionMetrics.data,
       ),


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR attempts to fix `createdAt` time sorting in the sessions table by replacing the generic `joinTableCoreAndMetrics` join function with a new session-specific `joinSessionCoreAndMetrics` from `session-row-data`.

- The import target `@/src/components/table/use-cases/session-row-data` does not exist anywhere in the repository — neither the file nor the exported function `joinSessionCoreAndMetrics` was included in this PR.
- This will cause a compile-time module-resolution failure, breaking the sessions page entirely until the missing file is created or the import is reverted.
</details>

<details><summary><h3>Confidence Score: 1/5</h3></summary>

Not safe to merge — the only changed file imports from a module that does not exist, which will break the build.

The PR swaps one import for another, but the new import target (session-row-data) was never created. The function joinSessionCoreAndMetrics does not exist anywhere in the codebase, so the TypeScript compiler will fail to resolve this module and the sessions table will be completely non-functional.

web/src/components/table/use-cases/sessions.tsx — the import on line 49 references a file that needs to be created before this change can land.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sessions.tsx] -->|imports| B[session-row-data.ts\njoinSessionCoreAndMetrics]
    B:::missing
    C[joinTableCoreAndMetrics.ts\noriginal import] -->|removed| A

    classDef missing fill:#f66,color:#fff,stroke:#c00
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[sessions.tsx] -->|imports| B[session-row-data.ts\njoinSessionCoreAndMetrics]
    B:::missing
    C[joinTableCoreAndMetrics.ts\noriginal import] -->|removed| A

    classDef missing fill:#f66,color:#fff,stroke:#c00
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/components/table/use-cases/sessions.tsx:49
**Missing module — build will fail**

The file `@/src/components/table/use-cases/session-row-data` does not exist anywhere in the repository, and `joinSessionCoreAndMetrics` is not defined in any file. This import will cause a module-resolution error at compile time, meaning the sessions page (and likely the entire app build) will be broken. The file containing `joinSessionCoreAndMetrics` needs to be created alongside this change, or the import should be reverted to the existing `joinTableCoreAndMetrics` from `@/src/components/table/utils/joinTableCoreAndMetrics`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sessions): time sorting by createdAt"](https://github.com/langfuse/langfuse/commit/8a33daa94b4fdc93672635c551a44c953e2b67f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38448094)</sub>

<!-- /greptile_comment -->