### PR TITLE
docs(agent): Update in-app agent documentation

### DIFF
--- a/web/src/ee/features/in-app-agent/AGENTS.md
+++ b/web/src/ee/features/in-app-agent/AGENTS.md
@@ -1,3 +1,0 @@
-## Working with AG-UI
-* always check the AG-UI docs here: https://docs.ag-ui.com/llms.txt
-* always append .md when trying to access the docs, a lot more precise

--- a/web/src/ee/features/in-app-agent/README.md
+++ b/web/src/ee/features/in-app-agent/README.md
@@ -1,0 +1,62 @@
+# In-App Agent
+
+The in-app agent is Langfuse's project-scoped foreground assistant inside the authenticated product UI.
+
+## Core Model
+
+AG-UI is the durable contract for live streaming, persistence, replay, and rendering.
+
+The browser owns interaction state and submits intent. The server owns authorization, run/message IDs, request sanitization, MCP credentials, runtime configuration, tool access, persistence, and replay.
+
+Runs are foreground-only. A conversation can have one active run; stale unfinished runs are closed before a new run starts.
+
+## Major Files
+
+- `schema.ts`: runtime-neutral AG-UI schemas and types shared by browser, server, persistence, replay, and rendering.
+- `server/handler.ts`: streaming route and authority boundary for auth, request sanitization, run creation, MCP credentials, and terminal state.
+- `server/agent.ts`: Mastra/Bedrock/MCP runtime setup, custom tool wiring, AG-UI event normalization, and cleanup.
+- `server/tools.ts`: custom agent tools with strict schemas and scoped, user-visible behavior.
+- `server/persistence.ts`: conversations, runs, events, replay, active-run locking, and stale-run recovery.
+- `server/router.ts`: non-streaming tRPC routes for conversation lists, replay, and feedback.
+- `server/instrumentation.ts`: optional Langfuse tracing for agent runs, prompts, events, and errors.
+- `constants.ts`: stable names shared across prompts, tools, persistence, and rendering.
+- `components/*`: client controller and prop-driven render components.
+
+## File Relationships
+
+```mermaid
+flowchart TB
+  Provider["InAppAiAgentProvider.tsx\nclient controller"]
+  Provider --> Controlled["ControlledInAppAgentWindow.tsx\nconnecting pure render components to context"]
+  Controlled --> Window["InAppAgentWindow.tsx\nmain UI entrypoint"]
+  Window --> Message["InAppAgentMessage.tsx\nmessage rendering"]
+
+  Provider -->|AG-UI HttpAgent + SSE| Handler["server/handler.ts\nserver route for agent runs"]
+  Provider -->|tRPC| Router["server/router.ts\ntRPC routes (non-streaming)"]
+
+  Schema["schema.ts\nshared AG-UI contract"] -.-> Provider
+  Schema -.-> Handler
+  Schema -.-> Router
+  Schema -.-> Persistence["server/persistence.ts"]
+
+  Handler --> Persistence
+  Handler --> Agent["server/agent.ts\nagent runtime"]
+  Agent --> Tools["server/tools.ts\ncustom tools"]
+  Agent --> Instrumentation["server/instrumentation.ts\nLangfuse telemetry"]
+  Router --> Persistence
+```
+
+## Run Lifecycle
+
+1. Browser sends the latest message, conversation state, and screen context through `HttpAgent`.
+2. `server/handler.ts` validates the request and creates a server-owned run.
+3. `server/agent.ts` streams normalized AG-UI events and calls telemetry hooks.
+4. `server/instrumentation.ts` records prompt metadata, stream events, completion, aborts, and errors.
+5. `server/persistence.ts` stores compacted events and reconstructs replay messages.
+6. `InAppAiAgentProvider.tsx` renders live AG-UI state and hydrates selected conversations through `server/router.ts`.
+
+## Change Rules
+
+- Check AG-UI docs at `https://docs.ag-ui.com/llms.txt` before changing event semantics, ordering, stream handling, compaction, tools, state, or `HttpAgent` integration.
+- Keep persisted schemas backward-compatible unless there is an explicit migration.
+- Keep presentational components prop-driven; connect tRPC, streaming, and persistence at provider/router/handler boundaries.


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the minimal `AGENTS.md` stub with a comprehensive `README.md` that documents the in-app agent's architecture, file responsibilities, component relationships (including an embedded Mermaid flowchart), run lifecycle, and change rules.

- The new README accurately reflects the existing file structure and provides a clear entry point for developers working on this feature.
- The AG-UI docs reference from the deleted `AGENTS.md` is preserved in the "Change Rules" section, but loses the automatic discovery advantage that the `AGENTS.md` convention provides to AI coding assistants.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no runtime impact; safe to merge.

All referenced file paths are accurate, the embedded Mermaid diagram is correct, and the run lifecycle description matches the actual code. The only notable tradeoff is that deleting AGENTS.md removes the auto-discovery hook that AI coding assistants use to find per-directory instructions — the AG-UI docs reminder will now only surface if a developer or agent reads the README directly.

web/src/ee/features/in-app-agent/README.md — review the Change Rules section to decide whether AGENTS.md should be retained alongside the README.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as Browser (InAppAiAgentProvider)
    participant Handler as server/handler.ts
    participant Agent as server/agent.ts
    participant Tools as server/tools.ts
    participant Instrumentation as server/instrumentation.ts
    participant Persistence as server/persistence.ts
    participant Router as server/router.ts

    Browser->>Handler: POST (latest message, conversation state, screen context) via HttpAgent SSE
    Handler->>Handler: Validate request, authorize, close stale run
    Handler->>Persistence: Create server-owned run
    Handler->>Agent: Start streaming (AG-UI events)
    Agent->>Tools: Invoke custom tools
    Agent->>Instrumentation: "Record prompt metadata & stream events"
    Instrumentation-->>Agent: Telemetry hooks
    Agent-->>Handler: Normalized AG-UI event stream
    Handler-->>Browser: SSE stream (live AG-UI state)
    Agent->>Persistence: Store compacted events
    Agent->>Instrumentation: Record completion / abort / error
    Browser->>Router: tRPC (conversation list, replay, feedback)
    Router->>Persistence: Reconstruct replay messages
    Router-->>Browser: Hydrated conversation data
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as Browser (InAppAiAgentProvider)
    participant Handler as server/handler.ts
    participant Agent as server/agent.ts
    participant Tools as server/tools.ts
    participant Instrumentation as server/instrumentation.ts
    participant Persistence as server/persistence.ts
    participant Router as server/router.ts

    Browser->>Handler: POST (latest message, conversation state, screen context) via HttpAgent SSE
    Handler->>Handler: Validate request, authorize, close stale run
    Handler->>Persistence: Create server-owned run
    Handler->>Agent: Start streaming (AG-UI events)
    Agent->>Tools: Invoke custom tools
    Agent->>Instrumentation: "Record prompt metadata & stream events"
    Instrumentation-->>Agent: Telemetry hooks
    Agent-->>Handler: Normalized AG-UI event stream
    Handler-->>Browser: SSE stream (live AG-UI state)
    Agent->>Persistence: Store compacted events
    Agent->>Instrumentation: Record completion / abort / error
    Browser->>Router: tRPC (conversation list, replay, feedback)
    Router->>Persistence: Reconstruct replay messages
    Router-->>Browser: Hydrated conversation data
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/ee/features/in-app-agent/README.md:57-61
**AGENTS.md deletion loses automatic AI-agent discovery**

The deleted `AGENTS.md` was a convention-based file that AI coding assistants (Claude Code, Codex, Copilot, etc.) discover and apply automatically when working in this directory. Moving its content into `README.md` under "Change Rules" means an AI agent making edits here will no longer automatically receive the instruction to check `https://docs.ag-ui.com/llms.txt` before touching event semantics, stream handling, or `HttpAgent` integration. Consider keeping `AGENTS.md` alongside this README — even if it just references the README's Change Rules section — so the agent-discovery mechanism continues to work.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agent): Update in-app agent documen..."](https://github.com/langfuse/langfuse/commit/06660358fce2fd9ba13df2dc06327b1571976682) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38450473)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->