### PR TITLE
fix(annotation-queues): make queue dropdown scrollable

### DIFF
--- a/web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
+++ b/web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx
@@ -136,7 +136,7 @@ export const CreateNewAnnotationQueueItem = ({
           )}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent>
+      <DropdownMenuContent className="max-h-[min(300px,var(--radix-dropdown-menu-content-available-height))] overflow-y-auto">
         <DropdownMenuLabel>In queue(s)</DropdownMenuLabel>
         {queues.data?.queues.length ? (
           queues.data?.queues.map((queue) => (


### PR DESCRIPTION
## What does this PR do?

Fixes #14049.

Constrains the annotation queue dropdown to the smaller of 300px or the height available to the Radix dropdown within the viewport. When the queue list exceeds that height, it becomes vertically scrollable so every queue remains accessible in short browser windows.

Impacted package: `web`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

- Browser-tested the actual component with 25 annotation queues at 1600×900 and 800×260
- Verified mouse and keyboard scrolling, access to the final queue and Manage queues action, viewport fit, and a clean browser console
- Targeted ESLint and Prettier checks passed
- Full pre-commit formatting and lint checks passed (8/8 lint tasks)
- `git diff --check` passed

## Mandatory Tasks

- [x] Self-reviewed the code and confirmed the PR contains only the annotation queue dropdown fix

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a UX bug where the annotation queue dropdown became inaccessible in short browser windows by capping the `DropdownMenuContent` height and enabling vertical scrolling.

- Adds `max-h-[min(300px,var(--radix-dropdown-menu-content-available-height))]` so the dropdown never overflows the viewport, using the Radix-supplied CSS custom property for the available space.
- Adds `overflow-y-auto` to introduce a scrollbar only when the queue list exceeds the capped height.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is a one-line CSS addition with no logic or data-flow impact.

The fix correctly uses the Radix-supplied CSS custom property alongside a Tailwind arbitrary max-height to keep the dropdown within the viewport. The only trade-off is that "Manage queues" scrolls with the queue list instead of staying pinned at the bottom, which is a minor UX inconvenience rather than a functional breakage.

No files require special attention; the single changed file is straightforward.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks ChevronDown button] --> B{hasAccess?}
    B -- No --> C[Dropdown disabled]
    B -- Yes --> D[DropdownMenu opens]
    D --> E[DropdownMenuContent\nmax-h: min 300px, radix available height\noverflow-y-auto]
    E --> F[DropdownMenuLabel: In queue s]
    F --> G{queues.data?.queues.length?}
    G -- Yes --> H[DropdownMenuCheckboxItems\nper queue]
    G -- No --> I[No queues defined item]
    H --> J[DropdownMenuSeparator]
    I --> J
    J --> K[Manage queues link]
    H --> L{User clicks item}
    L -- itemId absent --> M[addToQueueMutation]
    L -- itemId present --> N[confirm dialog]
    N -- confirmed --> O[removeFromQueueMutation]
    M --> P[invalidate byObjectId query]
    O --> P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User clicks ChevronDown button] --> B{hasAccess?}
    B -- No --> C[Dropdown disabled]
    B -- Yes --> D[DropdownMenu opens]
    D --> E[DropdownMenuContent\nmax-h: min 300px, radix available height\noverflow-y-auto]
    E --> F[DropdownMenuLabel: In queue s]
    F --> G{queues.data?.queues.length?}
    G -- Yes --> H[DropdownMenuCheckboxItems\nper queue]
    G -- No --> I[No queues defined item]
    H --> J[DropdownMenuSeparator]
    I --> J
    J --> K[Manage queues link]
    H --> L{User clicks item}
    L -- itemId absent --> M[addToQueueMutation]
    L -- itemId present --> N[confirm dialog]
    N -- confirmed --> O[removeFromQueueMutation]
    M --> P[invalidate byObjectId query]
    O --> P
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/annotation-queues/components/CreateNewAnnotationQueueItem.tsx:139-189
**"Manage queues" action is inside the scrollable region**

The `DropdownMenuSeparator` and "Manage queues" link sit at the bottom of the same scrollable container as the queue list. With many queues in a short viewport, users must scroll to the very bottom to find the action — it's not pinned or always visible. Consider wrapping only the queue list items in a scrollable inner `div` (keeping the separator and "Manage queues" outside) so the action is always visible without scrolling.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/fix-annot..."](https://github.com/langfuse/langfuse/commit/4bfadfec9b5d9750c4b093d4e304ba4e84aa546a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38465250)</sub>

<!-- /greptile_comment -->