### PR TITLE
feat(worker): add BullMQ stall + blob export observability (LFE-10388)

### DIFF
--- a/worker/src/__tests__/inFlightExports.unit.test.ts
+++ b/worker/src/__tests__/inFlightExports.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // The tracker only needs a logger; stub the heavy shared server barrel.
 vi.mock("@langfuse/shared/src/server", () => ({
@@ -10,6 +10,7 @@ import {
   unregisterInFlightBlobExport,
   getInFlightBlobExportCount,
   logInFlightBlobExportsOnShutdown,
+  resetInFlightBlobExports,
 } from "../features/blobstorage/inFlightExports";
 
 const makeEntry = (table: string) => ({
@@ -22,6 +23,10 @@ const makeEntry = (table: string) => ({
 });
 
 describe("inFlightExports", () => {
+  // The registry is a module-level singleton; drain it before each test so the
+  // suite is order-independent and survives an early assertion failure.
+  beforeEach(() => resetInFlightBlobExports());
+
   it("tracks and clears in-flight exports by handle", () => {
     expect(getInFlightBlobExportCount()).toBe(0);
 

--- a/worker/src/__tests__/inFlightExports.unit.test.ts
+++ b/worker/src/__tests__/inFlightExports.unit.test.ts
@@ -23,8 +23,7 @@ const makeEntry = (table: string) => ({
 });
 
 describe("inFlightExports", () => {
-  // The registry is a module-level singleton; drain it before each test so the
-  // suite is order-independent and survives an early assertion failure.
+  // Singleton registry — drain it so tests are order-independent.
   beforeEach(() => resetInFlightBlobExports());
 
   it("tracks and clears in-flight exports by handle", () => {

--- a/worker/src/__tests__/inFlightExports.unit.test.ts
+++ b/worker/src/__tests__/inFlightExports.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The tracker only needs a logger; stub the heavy shared server barrel.
+vi.mock("@langfuse/shared/src/server", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  registerInFlightBlobExport,
+  unregisterInFlightBlobExport,
+  getInFlightBlobExportCount,
+  logInFlightBlobExportsOnShutdown,
+} from "../features/blobstorage/inFlightExports";
+
+const makeEntry = (table: string) => ({
+  jobId: `job-${table}`,
+  projectId: "p-1",
+  table,
+  minTimestamp: "2025-12-01T00:00:00.000Z",
+  maxTimestamp: "2025-12-02T00:00:00.000Z",
+  startedAt: 1,
+});
+
+describe("inFlightExports", () => {
+  it("tracks and clears in-flight exports by handle", () => {
+    expect(getInFlightBlobExportCount()).toBe(0);
+
+    const h1 = registerInFlightBlobExport(makeEntry("traces"));
+    const h2 = registerInFlightBlobExport(makeEntry("scores"));
+    expect(getInFlightBlobExportCount()).toBe(2);
+
+    unregisterInFlightBlobExport(h1);
+    expect(getInFlightBlobExportCount()).toBe(1);
+
+    unregisterInFlightBlobExport(h2);
+    expect(getInFlightBlobExportCount()).toBe(0);
+  });
+
+  it("keeps distinct entries for the same project/table pair", () => {
+    const h1 = registerInFlightBlobExport(makeEntry("observations"));
+    const h2 = registerInFlightBlobExport(makeEntry("observations"));
+    expect(h1).not.toBe(h2);
+    expect(getInFlightBlobExportCount()).toBe(2);
+
+    unregisterInFlightBlobExport(h1);
+    unregisterInFlightBlobExport(h2);
+    expect(getInFlightBlobExportCount()).toBe(0);
+  });
+
+  it("logInFlightBlobExportsOnShutdown does not throw whether empty or populated", () => {
+    expect(() => logInFlightBlobExportsOnShutdown()).not.toThrow();
+
+    const h = registerInFlightBlobExport(makeEntry("traces"));
+    expect(() => logInFlightBlobExportsOnShutdown()).not.toThrow();
+    unregisterInFlightBlobExport(h);
+  });
+});

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -255,10 +255,8 @@ const processBlobStorageExport = async (config: {
   compressed: boolean;
   convertV4LatencyToSeconds: boolean;
   exportFieldGroups?: ObservationFieldGroupFull[];
-  // BullMQ job identity, threaded through so spans/logs from concurrent
-  // duplicate executions of the same window can be grouped by jobId (LFE-10388).
-  jobId: string | undefined;
-  attemptsMade: number;
+  bullmqJobId: string | undefined;
+  bullmqAttemptsMade: number;
 }) => {
   logger.info(
     `[BLOB INTEGRATION] Processing ${config.table} export for project ${config.projectId}`,
@@ -301,10 +299,10 @@ const processBlobStorageExport = async (config: {
       );
       // Job identity + host so concurrent duplicate executions of the same
       // window (the LFE-10063 re-enqueue storm) can be grouped and counted.
-      if (config.jobId !== undefined) {
-        span.setAttribute("messaging.bullmq.job.id", config.jobId);
+      if (config.bullmqJobId !== undefined) {
+        span.setAttribute("messaging.bullmq.job.id", config.bullmqJobId);
       }
-      span.setAttribute("job.attemptsMade", config.attemptsMade);
+      span.setAttribute("job.attemptsMade", config.bullmqAttemptsMade);
       span.setAttribute("host.name", HOST_NAME);
 
       // Sample event-loop delay across the streaming export. If macrotask delay
@@ -319,7 +317,7 @@ const processBlobStorageExport = async (config: {
       // Track this table export as in-flight so a SIGTERM-induced abort can be
       // logged distinctly from a stall-timeout on graceful shutdown (LFE-10388).
       const inFlightHandle = registerInFlightBlobExport({
-        jobId: config.jobId,
+        jobId: config.bullmqJobId,
         projectId: config.projectId,
         table: config.table,
         minTimestamp: config.minTimestamp.toISOString(),
@@ -445,7 +443,7 @@ const processBlobStorageExport = async (config: {
 
           logger.info(
             `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
-              `jobId=${config.jobId} attemptsMade=${config.attemptsMade} host=${HOST_NAME} ` +
+              `jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${HOST_NAME} ` +
               `rows=${sourceStats.rows} sourceWaitMs=${Math.round(sourceStats.sourceWaitMs)} ` +
               `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${Math.round(performance.now() - uploadStartMs)}`,
           );
@@ -469,7 +467,7 @@ const processBlobStorageExport = async (config: {
       } catch (error) {
         logger.error(
           `[BLOB INTEGRATION] Error exporting ${config.table} for project ${config.projectId} ` +
-            `(jobId=${config.jobId} attemptsMade=${config.attemptsMade} host=${HOST_NAME})`,
+            `(jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${HOST_NAME})`,
           error,
         );
         throw error;
@@ -641,8 +639,8 @@ export const handleBlobStorageIntegrationProjectJob = async (
       convertV4LatencyToSeconds,
       exportFieldGroups:
         blobStorageIntegration.exportFieldGroups as ObservationFieldGroupFull[],
-      jobId: job.id,
-      attemptsMade: job.attemptsMade,
+      bullmqJobId: job.id,
+      bullmqAttemptsMade: job.attemptsMade,
     };
 
     // Check if this project should only export traces (legacy behavior via env var)

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1,5 +1,7 @@
 import { pipeline, Transform } from "stream";
 import { createGzip } from "zlib";
+import { hostname } from "os";
+import { monitorEventLoopDelay } from "perf_hooks";
 import { Job } from "bullmq";
 import { prisma } from "@langfuse/shared/src/db";
 import {
@@ -15,6 +17,7 @@ import {
   getEventsForBlobStorageExport,
   getCurrentSpan,
   instrumentAsync,
+  recordGauge,
   BlobStorageIntegrationProcessingQueue,
   queryClickhouse,
   QueueJobs,
@@ -25,6 +28,10 @@ import {
   blobStorageEndpointConnectionValidationOptions,
   validateBlobStorageEndpoint,
 } from "@langfuse/shared/src/server";
+import {
+  registerInFlightBlobExport,
+  unregisterInFlightBlobExport,
+} from "./inFlightExports";
 import {
   BlobStorageIntegrationType,
   BlobStorageIntegrationFileType,
@@ -40,6 +47,8 @@ import { SpanKind } from "@opentelemetry/api";
 import { env, v4AllowPreviewOptIn } from "../../env";
 
 export const BLOB_STORAGE_LAG_BUFFER_MS = 20 * 60 * 1000; // 20-minute lag buffer
+
+const HOST_NAME = hostname();
 
 export async function* enrichObservationStream(
   stream: AsyncGenerator<Record<string, unknown>>,
@@ -246,6 +255,10 @@ const processBlobStorageExport = async (config: {
   compressed: boolean;
   convertV4LatencyToSeconds: boolean;
   exportFieldGroups?: ObservationFieldGroupFull[];
+  // BullMQ job identity, threaded through so spans/logs from concurrent
+  // duplicate executions of the same window can be grouped by jobId (LFE-10388).
+  jobId: string | undefined;
+  attemptsMade: number;
 }) => {
   logger.info(
     `[BLOB INTEGRATION] Processing ${config.table} export for project ${config.projectId}`,
@@ -286,6 +299,33 @@ const processBlobStorageExport = async (config: {
         "blob.window.maxTimestamp",
         config.maxTimestamp.toISOString(),
       );
+      // Job identity + host so concurrent duplicate executions of the same
+      // window (the LFE-10063 re-enqueue storm) can be grouped and counted.
+      if (config.jobId !== undefined) {
+        span.setAttribute("messaging.bullmq.job.id", config.jobId);
+      }
+      span.setAttribute("job.attemptsMade", config.attemptsMade);
+      span.setAttribute("host.name", HOST_NAME);
+
+      // Sample event-loop delay across the streaming export. If macrotask delay
+      // spikes to tens of seconds mid-stream, BullMQ's lock-renewal timer can't
+      // fire and the job gets re-enqueued as stalled — this signal confirms or
+      // refutes the lock-renewal-starvation hypothesis (LFE-10063). The
+      // histogram samples on a timer at negligible cost and is torn down in the
+      // finally below.
+      const eventLoopDelay = monitorEventLoopDelay({ resolution: 20 });
+      eventLoopDelay.enable();
+
+      // Track this table export as in-flight so a SIGTERM-induced abort can be
+      // logged distinctly from a stall-timeout on graceful shutdown (LFE-10388).
+      const inFlightHandle = registerInFlightBlobExport({
+        jobId: config.jobId,
+        projectId: config.projectId,
+        table: config.table,
+        minTimestamp: config.minTimestamp.toISOString(),
+        maxTimestamp: config.maxTimestamp.toISOString(),
+        startedAt: Date.now(),
+      });
 
       try {
         const blobStorageProps = getFileTypeProperties(config.fileType);
@@ -405,6 +445,7 @@ const processBlobStorageExport = async (config: {
 
           logger.info(
             `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
+              `jobId=${config.jobId} attemptsMade=${config.attemptsMade} host=${HOST_NAME} ` +
               `rows=${sourceStats.rows} sourceWaitMs=${Math.round(sourceStats.sourceWaitMs)} ` +
               `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${Math.round(performance.now() - uploadStartMs)}`,
           );
@@ -427,10 +468,38 @@ const processBlobStorageExport = async (config: {
         }
       } catch (error) {
         logger.error(
-          `[BLOB INTEGRATION] Error exporting ${config.table} for project ${config.projectId}`,
+          `[BLOB INTEGRATION] Error exporting ${config.table} for project ${config.projectId} ` +
+            `(jobId=${config.jobId} attemptsMade=${config.attemptsMade} host=${HOST_NAME})`,
           error,
         );
         throw error;
+      } finally {
+        unregisterInFlightBlobExport(inFlightHandle);
+
+        // Emit the event-loop-delay signal for this export. monitorEventLoopDelay
+        // reports in nanoseconds; convert to milliseconds for the dashboard. The
+        // histogram yields NaN/Infinity when no samples were collected (very fast
+        // exports), so coerce to a finite number before emitting.
+        eventLoopDelay.disable();
+        const toFiniteMs = (ns: number): number =>
+          Number.isFinite(ns) ? ns / 1e6 : 0;
+        const maxMs = toFiniteMs(eventLoopDelay.max);
+        const p99Ms = toFiniteMs(eventLoopDelay.percentile(99));
+        const meanMs = toFiniteMs(eventLoopDelay.mean);
+        const delayTags = { table: config.table, unit: "milliseconds" };
+        recordGauge(
+          "langfuse.blobstorage.event_loop_delay.max",
+          maxMs,
+          delayTags,
+        );
+        recordGauge(
+          "langfuse.blobstorage.event_loop_delay.p99",
+          p99Ms,
+          delayTags,
+        );
+        span.setAttribute("blob.eventLoopDelay.maxMs", Math.round(maxMs));
+        span.setAttribute("blob.eventLoopDelay.p99Ms", Math.round(p99Ms));
+        span.setAttribute("blob.eventLoopDelay.meanMs", Math.round(meanMs));
       }
     },
   );
@@ -445,6 +514,13 @@ export const handleBlobStorageIntegrationProjectJob = async (
   if (span) {
     span.setAttribute("messaging.bullmq.job.input.jobId", job.data.id);
     span.setAttribute("messaging.bullmq.job.input.projectId", projectId);
+    // The BullMQ job id (distinct from the payload id above) + attempt count:
+    // identify concurrent duplicate runs of the same window (LFE-10388).
+    if (job.id !== undefined) {
+      span.setAttribute("messaging.bullmq.job.id", job.id);
+    }
+    span.setAttribute("job.attemptsMade", job.attemptsMade);
+    span.setAttribute("host.name", HOST_NAME);
   }
 
   logger.info(
@@ -565,6 +641,8 @@ export const handleBlobStorageIntegrationProjectJob = async (
       convertV4LatencyToSeconds,
       exportFieldGroups:
         blobStorageIntegration.exportFieldGroups as ObservationFieldGroupFull[],
+      jobId: job.id,
+      attemptsMade: job.attemptsMade,
     };
 
     // Check if this project should only export traces (legacy behavior via env var)

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -297,25 +297,19 @@ const processBlobStorageExport = async (config: {
         "blob.window.maxTimestamp",
         config.maxTimestamp.toISOString(),
       );
-      // Job identity + host so concurrent duplicate executions of the same
-      // window (the LFE-10063 re-enqueue storm) can be grouped and counted.
+      // Identity + host to group concurrent duplicate runs of the same window.
       if (config.bullmqJobId !== undefined) {
         span.setAttribute("messaging.bullmq.job.id", config.bullmqJobId);
       }
       span.setAttribute("job.attemptsMade", config.bullmqAttemptsMade);
       span.setAttribute("host.name", HOST_NAME);
 
-      // Sample event-loop delay across the streaming export. If macrotask delay
-      // spikes to tens of seconds mid-stream, BullMQ's lock-renewal timer can't
-      // fire and the job gets re-enqueued as stalled — this signal confirms or
-      // refutes the lock-renewal-starvation hypothesis (LFE-10063). The
-      // histogram samples on a timer at negligible cost and is torn down in the
-      // finally below.
+      // Event-loop delay during the stream: if it spikes, lock renewal can't
+      // fire and the job re-enqueues as stalled (LFE-10063). Torn down below.
       const eventLoopDelay = monitorEventLoopDelay({ resolution: 20 });
       eventLoopDelay.enable();
 
-      // Track this table export as in-flight so a SIGTERM-induced abort can be
-      // logged distinctly from a stall-timeout on graceful shutdown (LFE-10388).
+      // In-flight so a SIGTERM abort is loggable distinctly from a stall-timeout.
       const inFlightHandle = registerInFlightBlobExport({
         jobId: config.bullmqJobId,
         projectId: config.projectId,
@@ -474,10 +468,7 @@ const processBlobStorageExport = async (config: {
       } finally {
         unregisterInFlightBlobExport(inFlightHandle);
 
-        // Emit the event-loop-delay signal for this export. monitorEventLoopDelay
-        // reports in nanoseconds; convert to milliseconds for the dashboard. The
-        // histogram yields NaN/Infinity when no samples were collected (very fast
-        // exports), so coerce to a finite number before emitting.
+        // ns → ms; the histogram yields NaN/Infinity with zero samples.
         eventLoopDelay.disable();
         const toFiniteMs = (ns: number): number =>
           Number.isFinite(ns) ? ns / 1e6 : 0;
@@ -512,8 +503,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
   if (span) {
     span.setAttribute("messaging.bullmq.job.input.jobId", job.data.id);
     span.setAttribute("messaging.bullmq.job.input.projectId", projectId);
-    // The BullMQ job id (distinct from the payload id above) + attempt count:
-    // identify concurrent duplicate runs of the same window (LFE-10388).
+    // BullMQ job id (distinct from the payload id above) + attempt count.
     if (job.id !== undefined) {
       span.setAttribute("messaging.bullmq.job.id", job.id);
     }

--- a/worker/src/features/blobstorage/inFlightExports.ts
+++ b/worker/src/features/blobstorage/inFlightExports.ts
@@ -47,8 +47,10 @@ export const logInFlightBlobExportsOnShutdown = (): void => {
 
   const now = Date.now();
   for (const entry of inFlightExports.values()) {
+    // "in-flight at shutdown", not "aborted": worker.close() drains gracefully,
+    // so this export may still complete within the grace period.
     logger.warn(
-      `[BLOB INTEGRATION] Blob storage export aborted by shutdown on host ${HOST_NAME}: ` +
+      `[BLOB INTEGRATION] Blob storage export in-flight at shutdown signal on host ${HOST_NAME}: ` +
         `jobId=${entry.jobId} projectId=${entry.projectId} table=${entry.table} ` +
         `window=[${entry.minTimestamp}, ${entry.maxTimestamp}] ` +
         `elapsedMs=${now - entry.startedAt}`,

--- a/worker/src/features/blobstorage/inFlightExports.ts
+++ b/worker/src/features/blobstorage/inFlightExports.ts
@@ -12,21 +12,11 @@ export type InFlightBlobExport = {
   startedAt: number;
 };
 
-/**
- * Registry of blob-storage export table-jobs currently mid-flight on this pod.
- *
- * BullMQ stall-timeouts and SIGTERM-induced aborts look identical from
- * Postgres (both freeze `lastSyncAt` without writing `lastError`). On graceful
- * shutdown we log exactly which exports were interrupted so that deploy/scale
- * churn can be separated from genuine lock-renewal stalls (LFE-10388 / -10063).
- */
+// Stall-timeouts and SIGTERM aborts look identical from Postgres (both freeze
+// `lastSyncAt`); logging the survivors on shutdown separates the two.
 const inFlightExports = new Map<symbol, InFlightBlobExport>();
 
-/**
- * Mark a table export as started. Returns a handle that MUST be passed to
- * {@link unregisterInFlightBlobExport} in a `finally` block so the entry is
- * always cleared regardless of success, error, or abort.
- */
+// Returns a handle that MUST be passed to unregister in a `finally`.
 export const registerInFlightBlobExport = (
   entry: InFlightBlobExport,
 ): symbol => {
@@ -39,22 +29,14 @@ export const unregisterInFlightBlobExport = (handle: symbol): void => {
   inFlightExports.delete(handle);
 };
 
-/** Test helper — current count of mid-flight exports. */
 export const getInFlightBlobExportCount = (): number => inFlightExports.size;
 
-/**
- * Test helper — clear the registry so the module-level Map can't leak state
- * across tests (e.g. when an earlier assertion fails before its cleanup runs).
- */
+// Test helper — clear leaked state between tests.
 export const resetInFlightBlobExports = (): void => {
   inFlightExports.clear();
 };
 
-/**
- * Log every blob export still mid-flight. Called on graceful shutdown, before
- * the workers are closed, so SIGTERM-aborted jobs are distinguishable from
- * stall-timeouts in the logs.
- */
+// Called on graceful shutdown, before workers close.
 export const logInFlightBlobExportsOnShutdown = (): void => {
   if (inFlightExports.size === 0) {
     logger.info(

--- a/worker/src/features/blobstorage/inFlightExports.ts
+++ b/worker/src/features/blobstorage/inFlightExports.ts
@@ -43,6 +43,14 @@ export const unregisterInFlightBlobExport = (handle: symbol): void => {
 export const getInFlightBlobExportCount = (): number => inFlightExports.size;
 
 /**
+ * Test helper — clear the registry so the module-level Map can't leak state
+ * across tests (e.g. when an earlier assertion fails before its cleanup runs).
+ */
+export const resetInFlightBlobExports = (): void => {
+  inFlightExports.clear();
+};
+
+/**
  * Log every blob export still mid-flight. Called on graceful shutdown, before
  * the workers are closed, so SIGTERM-aborted jobs are distinguishable from
  * stall-timeouts in the logs.

--- a/worker/src/features/blobstorage/inFlightExports.ts
+++ b/worker/src/features/blobstorage/inFlightExports.ts
@@ -1,0 +1,67 @@
+import { hostname } from "os";
+import { logger } from "@langfuse/shared/src/server";
+
+const HOST_NAME = hostname();
+
+export type InFlightBlobExport = {
+  jobId: string | undefined;
+  projectId: string;
+  table: string;
+  minTimestamp: string;
+  maxTimestamp: string;
+  startedAt: number;
+};
+
+/**
+ * Registry of blob-storage export table-jobs currently mid-flight on this pod.
+ *
+ * BullMQ stall-timeouts and SIGTERM-induced aborts look identical from
+ * Postgres (both freeze `lastSyncAt` without writing `lastError`). On graceful
+ * shutdown we log exactly which exports were interrupted so that deploy/scale
+ * churn can be separated from genuine lock-renewal stalls (LFE-10388 / -10063).
+ */
+const inFlightExports = new Map<symbol, InFlightBlobExport>();
+
+/**
+ * Mark a table export as started. Returns a handle that MUST be passed to
+ * {@link unregisterInFlightBlobExport} in a `finally` block so the entry is
+ * always cleared regardless of success, error, or abort.
+ */
+export const registerInFlightBlobExport = (
+  entry: InFlightBlobExport,
+): symbol => {
+  const handle = Symbol(`${entry.projectId}:${entry.table}`);
+  inFlightExports.set(handle, entry);
+  return handle;
+};
+
+export const unregisterInFlightBlobExport = (handle: symbol): void => {
+  inFlightExports.delete(handle);
+};
+
+/** Test helper — current count of mid-flight exports. */
+export const getInFlightBlobExportCount = (): number => inFlightExports.size;
+
+/**
+ * Log every blob export still mid-flight. Called on graceful shutdown, before
+ * the workers are closed, so SIGTERM-aborted jobs are distinguishable from
+ * stall-timeouts in the logs.
+ */
+export const logInFlightBlobExportsOnShutdown = (): void => {
+  if (inFlightExports.size === 0) {
+    logger.info(
+      `[BLOB INTEGRATION] No blob storage exports in-flight at shutdown on host ${HOST_NAME}`,
+    );
+    return;
+  }
+
+  const now = Date.now();
+  for (const entry of inFlightExports.values()) {
+    logger.warn(
+      `[BLOB INTEGRATION] Blob storage export aborted by shutdown on host ${HOST_NAME}: ` +
+        `jobId=${entry.jobId} projectId=${entry.projectId} table=${entry.table} ` +
+        `window=[${entry.minTimestamp}, ${entry.maxTimestamp}] ` +
+        `elapsedMs=${now - entry.startedAt}`,
+    );
+  }
+};

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -1,3 +1,4 @@
+import { hostname } from "os";
 import { Job, Processor, Worker, WorkerOptions } from "bullmq";
 import {
   convertQueueNameToMetricName,
@@ -15,6 +16,8 @@ import {
   resolveQueueInstance,
   SHARDED_QUEUE_BASE_NAMES,
 } from "./shardedQueueRegistry";
+
+const HOST_NAME = hostname();
 
 export class WorkerManager {
   private static workers: { [key: string]: Worker } = {};
@@ -177,6 +180,22 @@ export class WorkerManager {
       recordIncrement(oldMetric + ".error");
       recordIncrement(baseMetric + ".rate", 1, {
         type: "error",
+        ...shardTag,
+      });
+    });
+    // A "stalled" event fires each time BullMQ detects a job whose lock expired
+    // (lock-renewal starvation) and re-enqueues it. These intermediate
+    // re-enqueues are otherwise invisible — only the terminal "stalled more
+    // than allowable limit" surfaces, via the "failed" handler above, once
+    // maxStalledCount is exhausted. Counting detections lets us measure the
+    // re-enqueue rate and the cross-pod job-multiplication factor (LFE-10063).
+    worker.on("stalled", (jobId: string) => {
+      logger.warn(
+        `Queue job ${jobId} in ${queueName} stalled (lock expired, re-enqueued) on host ${HOST_NAME}`,
+      );
+      recordIncrement(oldMetric + ".stalled");
+      recordIncrement(baseMetric + ".rate", 1, {
+        type: "stalled",
         ...shardTag,
       });
     });

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -190,8 +190,11 @@ export class WorkerManager {
     // maxStalledCount is exhausted. Counting detections lets us measure the
     // re-enqueue rate and the cross-pod job-multiplication factor (LFE-10063).
     worker.on("stalled", (jobId: string) => {
+      // HOST_NAME is the pod running the stall checker (checkStalledJobs),
+      // which may differ from the pod whose lock expired — hence
+      // "detectedOnHost", not the executing host.
       logger.warn(
-        `Queue job ${jobId} in ${queueName} stalled (lock expired, re-enqueued) on host ${HOST_NAME}`,
+        `Queue job ${jobId} in ${queueName} stalled (lock expired, re-enqueued) detectedOnHost=${HOST_NAME}`,
       );
       recordIncrement(oldMetric + ".stalled");
       recordIncrement(baseMetric + ".rate", 1, {

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -183,16 +183,11 @@ export class WorkerManager {
         ...shardTag,
       });
     });
-    // A "stalled" event fires each time BullMQ detects a job whose lock expired
-    // (lock-renewal starvation) and re-enqueues it. These intermediate
-    // re-enqueues are otherwise invisible — only the terminal "stalled more
-    // than allowable limit" surfaces, via the "failed" handler above, once
-    // maxStalledCount is exhausted. Counting detections lets us measure the
-    // re-enqueue rate and the cross-pod job-multiplication factor (LFE-10063).
+    // Counts intermediate re-enqueues (LFE-10063), not just the terminal
+    // "stalled more than allowable limit" the "failed" handler catches.
     worker.on("stalled", (jobId: string) => {
-      // HOST_NAME is the pod running the stall checker (checkStalledJobs),
-      // which may differ from the pod whose lock expired — hence
-      // "detectedOnHost", not the executing host.
+      // detectedOnHost: the stall-checker pod, which may differ from the pod
+      // whose lock expired.
       logger.warn(
         `Queue job ${jobId} in ${queueName} stalled (lock expired, re-enqueued) detectedOnHost=${HOST_NAME}`,
       );

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -63,9 +63,7 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
     runner.stop();
   }
 
-  // Log blob storage exports still mid-flight so SIGTERM-aborted jobs are
-  // distinguishable from stall-timeouts in the logs (LFE-10388). Must run
-  // before closeWorkers() while the in-flight registry is still populated.
+  // Before closeWorkers(), while the registry is still populated (LFE-10388).
   logInFlightBlobExportsOnShutdown();
 
   // Shutdown workers (https://docs.bullmq.io/guide/going-to-production#gracefully-shut-down-workers)

--- a/worker/src/utils/shutdown.ts
+++ b/worker/src/utils/shutdown.ts
@@ -7,6 +7,7 @@ import { server } from "../index";
 import { freeAllTokenizers } from "../features/tokenisation/usage";
 import { getTokenCountWorkerManager } from "../features/tokenisation/async-usage";
 import { WorkerManager } from "../queues/workerManager";
+import { logInFlightBlobExportsOnShutdown } from "../features/blobstorage/inFlightExports";
 import { prisma } from "@langfuse/shared/src/db";
 import { BackgroundMigrationManager } from "../backgroundMigrations/backgroundMigrationManager";
 import {
@@ -61,6 +62,11 @@ export const onShutdown: NodeJS.SignalsListener = async (signal) => {
   for (const runner of monitorRunners) {
     runner.stop();
   }
+
+  // Log blob storage exports still mid-flight so SIGTERM-aborted jobs are
+  // distinguishable from stall-timeouts in the logs (LFE-10388). Must run
+  // before closeWorkers() while the in-flight registry is still populated.
+  logInFlightBlobExportsOnShutdown();
 
   // Shutdown workers (https://docs.bullmq.io/guide/going-to-production#gracefully-shut-down-workers)
   await WorkerManager.closeWorkers();


### PR DESCRIPTION
## What does this PR do?

Adds observability for the BullMQ stall / re-enqueue behavior on blob storage exports — the precursor work for LFE-10063. **Observability only: no changes to queue config, retry behavior, or export output.**

LFE-10063 documents a stall storm: a ClickHouse query longer than the 60s job lock starves lock renewal → `stalledInterval` re-enqueues the job while it's still running → concurrent duplicate copies → ClickHouse OOM. We could see terminal stalls but lacked telemetry to measure the mechanism. This PR adds that telemetry.

### Changes

1. **Stall-event instrumentation** (`workerManager.ts`) — new `worker.on("stalled")` handler next to the existing `failed`/`error` hooks. Emits a dedicated `<queue>.stalled` counter plus `<queue>.rate{type:stalled}`, and a `logger.warn` with jobId, queue name, and host. Applies to all queues. This counts intermediate re-enqueues (previously invisible — only the terminal "stalled more than allowable limit" surfaced via the `failed` handler).

2. **jobId + attempt on export span and per-table logs** (`handleBlobStorageIntegrationProjectJob.ts`) — the `blob-export-table` span and per-table success/error logs now carry the BullMQ `jobId`, `attemptsMade`, and host, so concurrent duplicate executions of the same window can be grouped.

3. **Event-loop-lag signal during export** — samples `perf_hooks.monitorEventLoopDelay()` across the streaming export and emits `langfuse.blobstorage.event_loop_delay.max`/`.p99` gauges (tagged by table) plus span attributes. Torn down in `finally`. If macrotask delay spikes mid-stream, lock renewal genuinely can't fire — this confirms or refutes the lock-renewal-starvation hypothesis.

4. **In-flight-on-SIGTERM logging** (`inFlightExports.ts` + `shutdown.ts`) — each table export registers itself as in-flight and unregisters in `finally`; on graceful shutdown we log the survivors (jobId + projectId + table + window + elapsed). Separates deploy/scale-induced aborts from genuine stall-timeouts, which otherwise look identical (both freeze `lastSyncAt` without writing `lastError`).

5. **Per-project dimension (optional, partially deferred)** — per-project attribution is now available through the in-flight shutdown logs and the jobId/projectId span+log tags. A dedicated per-project metric dimension was deferred to avoid high `projectId` tag cardinality on metrics.

## Type of change

- [x] Observability / instrumentation (no functional change)

## Checklist

- [x] `pnpm turbo run typecheck --filter=worker` passes
- [x] `pnpm turbo run lint --filter=worker` passes (and pre-commit lint over all packages)
- [x] Unit test added for the in-flight export tracker (`inFlightExports.unit.test.ts`)
- [x] No changes to queue config, retry behavior, or export output

## Verification

Re-run the LFE-10063 analysis on a project with a long export and confirm the new signals make the stall/re-enqueue loop visible:
- per-queue `.stalled` rate distinct from `.failed`
- `blob-export-table` spans groupable by `messaging.bullmq.job.id`
- `langfuse.blobstorage.event_loop_delay.*` gauges during a long export
- SIGTERM-aborted exports logged distinctly at shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds observability instrumentation to the blob-storage export worker to help diagnose BullMQ job stall and SIGTERM-abort scenarios (LFE-10388 / LFE-10063). No export logic is changed.

- **In-flight registry** (`inFlightExports.ts`): a module-level `Map<symbol, InFlightBlobExport>` tracks every active table export; on SIGTERM, `logInFlightBlobExportsOnShutdown` (called before `closeWorkers()`) logs whichever exports were interrupted, making SIGTERM-aborts distinguishable from genuine lock-renewal stalls.
- **Event-loop delay sampling**: `monitorEventLoopDelay` is started at the beginning of each `processBlobStorageExport` span and disabled in the `finally` block; max and p99 (in ms) are emitted as gauges and added to the span to confirm or refute the lock-starvation hypothesis.
- **Stalled-event handler**: every BullMQ worker now listens for the `stalled` event and increments both the legacy and new-style rate metrics, surfacing intermediate re-enqueues that were previously invisible.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — all changes are additive observability instrumentation with no modifications to export logic or data paths.

The core export pipeline is untouched; every new code path is either a log statement, a metric emission, or a passive registry operation in a finally block. The stalled-event host attribution could mislead operators in multi-replica deployments, and the test suite has no between-test state reset which could produce cascading failures on a mid-test assertion error, but neither issue affects production behavior.

worker/src/__tests__/inFlightExports.unit.test.ts (test isolation) and worker/src/queues/workerManager.ts (stalled-event host attribution)
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BullMQ
    participant Worker as WorkerManager
    participant Handler as handleBlobStorageIntegrationProjectJob
    participant Registry as inFlightExports (Map)
    participant OTel as Span/Metrics

    BullMQ->>Worker: job picked up
    Worker->>Handler: process(job)
    Handler->>OTel: span.setAttribute(jobId, attemptsMade, host)
    Handler->>Handler: monitorEventLoopDelay.enable()
    Handler->>Registry: registerInFlightBlobExport(handle)
    Handler->>Handler: "stream & upload to blob storage"
    Handler->>OTel: recordGauge(event_loop_delay.max/p99)
    Handler->>Registry: unregisterInFlightBlobExport(handle)
    Handler->>OTel: span.setAttribute(eventLoopDelay stats)

    Note over BullMQ,Worker: If lock expires before job completes
    BullMQ-->>Worker: emit stalled (jobId)
    Worker->>OTel: recordIncrement(.stalled)
    Worker->>Worker: logger.warn(jobId, detectedOnHost)

    Note over Handler,Registry: On SIGTERM before job finishes
    BullMQ-->>Registry: exports still registered
    Registry->>Registry: logInFlightBlobExportsOnShutdown()
    Note right of Registry: logs interrupted exports before closeWorkers()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BullMQ
    participant Worker as WorkerManager
    participant Handler as handleBlobStorageIntegrationProjectJob
    participant Registry as inFlightExports (Map)
    participant OTel as Span/Metrics

    BullMQ->>Worker: job picked up
    Worker->>Handler: process(job)
    Handler->>OTel: span.setAttribute(jobId, attemptsMade, host)
    Handler->>Handler: monitorEventLoopDelay.enable()
    Handler->>Registry: registerInFlightBlobExport(handle)
    Handler->>Handler: "stream & upload to blob storage"
    Handler->>OTel: recordGauge(event_loop_delay.max/p99)
    Handler->>Registry: unregisterInFlightBlobExport(handle)
    Handler->>OTel: span.setAttribute(eventLoopDelay stats)

    Note over BullMQ,Worker: If lock expires before job completes
    BullMQ-->>Worker: emit stalled (jobId)
    Worker->>OTel: recordIncrement(.stalled)
    Worker->>Worker: logger.warn(jobId, detectedOnHost)

    Note over Handler,Registry: On SIGTERM before job finishes
    BullMQ-->>Registry: exports still registered
    Registry->>Registry: logInFlightBlobExportsOnShutdown()
    Note right of Registry: logs interrupted exports before closeWorkers()
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/__tests__/inFlightExports.unit.test.ts:23-56
**Shared module state not reset between tests**

The `inFlightExports` Map is a module-level singleton. If any test assertion fires before the `unregisterInFlightBlobExport` cleanup calls are reached (e.g., test 1 fails its `toBe(1)` check with two entries still live), the Map retains those entries and subsequent tests' count expectations will be wrong. A `beforeEach` that drains the registry via `unregisterInFlightBlobExport` on all live handles — or simply re-exports a `resetInFlightExports` helper gated behind `process.env.NODE_ENV === 'test'` — would make the suite order-independent and failure-resilient.

### Issue 2 of 2
worker/src/queues/workerManager.ts:192-200
**`HOST_NAME` in the stalled handler refers to the detecting pod, not the executing pod**

BullMQ's `stalled` event fires on the pod that runs the periodic stall checker (`checkStalledJobs`), which may be a different pod from the one whose lock expired. Logging `HOST_NAME` alongside `jobId` will therefore name the wrong host when the detecting pod and executing pod differ, making the "which pod ran the stalled job" diagnostic misleading in multi-replica deployments. Consider either omitting the host from this log line or adding a qualifier like `detectedOnHost=${HOST_NAME}` to make the attribution explicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): add BullMQ stall + blob ex..."](https://github.com/langfuse/langfuse/commit/681f2bc2f624e35391c41d7b5edd5cc2a1039b0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38491627)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->