### PR TITLE
fix(deps): pin @types/nodemailer to v7 to unbreak next-auth typecheck

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -150,7 +150,7 @@
     "@repo/typescript-config": "workspace:*",
     "@types/lodash": "^4.17.24",
     "@types/node": "^24.3.0",
-    "@types/nodemailer": "^8.0.1",
+    "@types/nodemailer": "^7.0.11",
     "@types/pg": "^8.11.10",
     "@types/react": "19.2.14",
     "eslint": "^9.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,8 +328,8 @@ importers:
         specifier: ^24.3.0
         version: 24.3.0
       '@types/nodemailer':
-        specifier: ^8.0.1
-        version: 8.0.1
+        specifier: ^7.0.11
+        version: 7.0.12
       '@types/pg':
         specifier: ^8.11.10
         version: 8.15.6
@@ -5630,8 +5630,8 @@ packages:
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
 
-  '@types/nodemailer@8.0.1':
-    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
+  '@types/nodemailer@7.0.12':
+    resolution: {integrity: sha512-80vKwiIsVSyFA1rRovH59jNPLBOuc6dRZIHEu40gXTkBkZnQv8vog1xSGEb9j5q/tdMAs5ivvDR2pLTU0hGHXA==}
 
   '@types/opossum@4.1.1':
     resolution: {integrity: sha512-9TMnd8AWRVtnZMqBbbzceQoJdafErgUViogFaQ3eetsbeLtiFFZ695mepNaLtlfJi4uRP3GmHfe3CJ2DZKaxYA==}
@@ -16925,7 +16925,7 @@ snapshots:
     dependencies:
       undici-types: 7.10.0
 
-  '@types/nodemailer@8.0.1':
+  '@types/nodemailer@7.0.12':
     dependencies:
       '@types/node': 24.3.0
 


### PR DESCRIPTION
## What does this PR do?

`main` is red: `web#typecheck` fails with 8 errors (`OAuthConfig<any>` not assignable to `Provider`) in `web/src/server/auth.ts` and `web/src/ee/features/multi-tenant-sso/utils.ts`.

**Root cause:** the nodemailer v8 bump (#14305) also bumped `@types/nodemailer` to v8. `next-auth@4.24.13`'s bundled `email.d.ts` builds `EmailConfig` from nodemailer's transport types, and the v8 type shapes break the `Provider` discriminated union — so OAuth providers no longer typecheck. The error was latent on `main` (masked by Turbo cache) until the `v3.192.1` release commit changed `web/package.json`, busting the `web#typecheck` cache and forcing the first fresh typecheck.

**Fix:** keep the runtime on `nodemailer@8` (retaining the v8 security fixes that motivated #14305) and pin only `@types/nodemailer` back to `^7.0.11` — the last-green type version `next-auth@4` is compatible with. Types don't affect runtime, and the sole documented v8 runtime breaking change is an error-code rename we don't reference.

Verified locally: fresh `lint` + `typecheck` for `web` and `@langfuse/shared` pass (typecheck ran with 0 cached).

Supersedes #14376 (which reverts the runtime to nodemailer v7 and gives up the security fixes). Dependabot #14374 (nodemailer v9) would reintroduce the same break and should be held/closed until `next-auth`'s type expectation changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR pins `@types/nodemailer` to v7 (`^7.0.11`, resolving to `7.0.12`) in `packages/shared/package.json` to resolve a TypeScript typecheck breakage caused by incompatibilities between `@types/nodemailer@8` and `next-auth`.

- The `pnpm-lock.yaml` is updated to resolve the type package to `7.0.12` instead of `8.0.1`.
- The actual `nodemailer` runtime dependency remains at `^8.0.11`, so there is a deliberate mismatch between the type definitions (v7) and the installed library (v8). Current nodemailer usage in `transport.ts` relies only on stable core APIs that haven't changed between v7 and v8, keeping immediate risk low.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge as a targeted unblock for the typecheck pipeline; the runtime behavior is unchanged and current nodemailer usage in transport.ts relies only on stable APIs shared between v7 and v8.

The change intentionally decouples the type-definition version (v7) from the installed runtime (v8). nodemailer v8 renamed the NoAuth error code to ENOAUTH, so any code checking that constant would compile cleanly against v7 types but fail at runtime. Today's transport.ts code doesn't reference error codes, keeping the practical risk low — but the divergence is worth tracking if nodemailer usage grows.

packages/shared/package.json — the nodemailer runtime vs. type-definition version gap deserves a follow-up once next-auth compatibility with @types/nodemailer v8 is resolved.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["packages/shared/package.json<br/>nodemailer: ^8.0.11 (runtime)<br/>@types/nodemailer: ^7.0.11 (types)"] -->|"Type mismatch"| B["TypeScript compiler uses v7 types"]
    A -->|"Runtime uses"| C["nodemailer v8.0.11"]
    B --> D["next-auth typecheck passes ✓"]
    C --> E["v8 API at runtime<br/>(ENOAUTH, etc.)"]
    D -.->|"v7 types don't cover v8 API changes"| E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["packages/shared/package.json<br/>nodemailer: ^8.0.11 (runtime)<br/>@types/nodemailer: ^7.0.11 (types)"] -->|"Type mismatch"| B["TypeScript compiler uses v7 types"]
    A -->|"Runtime uses"| C["nodemailer v8.0.11"]
    B --> D["next-auth typecheck passes ✓"]
    C --> E["v8 API at runtime<br/>(ENOAUTH, etc.)"]
    D -.->|"v7 types don't cover v8 API changes"| E
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/package.json:153
**Type/runtime version mismatch introduced**

`nodemailer` runtime is pinned to `^8.0.11` (line 138), but `@types/nodemailer` is now capped at v7. Nodemailer v8 introduced a breaking API change (`NoAuth` error code renamed to `ENOAUTH`). TypeScript will now validate all nodemailer call-sites against the v7 surface, meaning usage of the renamed `ENOAUTH` constant won't be caught at compile time, and any v8-only API additions also go unchecked. Current usage in `transport.ts` sticks to stable core APIs (`createTransport`, `SESTransport.Options`, `parseConnectionUrl`) so the immediate blast radius is small, but the mismatch is worth addressing — either by patching `next-auth` to accept v8 types, or by upgrading `next-auth` to a version that supports them.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deps): pin @types/nodemailer to v7 t..."](https://github.com/langfuse/langfuse/commit/dca8b34ac425e39c66bf29cfa1c926fb84419a67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38503079)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->