### PR TITLE
feat(events): metadata value filter shortcuts in JSON view

### DIFF
--- a/packages/shared/scripts/seeder/scenarios/trace-tree.ts
+++ b/packages/shared/scripts/seeder/scenarios/trace-tree.ts
@@ -339,6 +339,16 @@ const run = async (
         scenario: "trace-tree",
         "node.depth": String(node.depth),
         ...(isFailedToolRetryPair ? { "retry.count": "2" } : {}),
+        // Nested, OTel-style metadata so the metadata view's filter shortcuts
+        // exercise both top-level (=) and nested-branch (contains) shapes.
+        scope: {
+          name: "@flue/opentelemetry",
+          version: "1.0.0-beta.1",
+        },
+        attributes: {
+          "flue.tool.name": isGeneration ? "lookup_weather" : "noop",
+          "flue.tool.call_id": `call_${node.index}`,
+        },
       },
       provided_model_name: isGeneration ? "gpt-4o" : null,
       internal_model_id: null,

--- a/packages/shared/scripts/seeder/scenarios/trace-tree.ts
+++ b/packages/shared/scripts/seeder/scenarios/trace-tree.ts
@@ -339,16 +339,18 @@ const run = async (
         scenario: "trace-tree",
         "node.depth": String(node.depth),
         ...(isFailedToolRetryPair ? { "retry.count": "2" } : {}),
-        // Nested, OTel-style metadata so the metadata view's filter shortcuts
-        // exercise both top-level (=) and nested-branch (contains) shapes.
-        scope: {
+        // Nested branches are JSON-encoded strings, mirroring how OTel metadata
+        // round-trips through the Map(String, String) column (each value is
+        // parsed back into a tree for display). This is what lets the metadata
+        // view's nested-branch "contains" filter shortcut land on real data.
+        scope: JSON.stringify({
           name: "@flue/opentelemetry",
           version: "1.0.0-beta.1",
-        },
-        attributes: {
+        }),
+        attributes: JSON.stringify({
           "flue.tool.name": isGeneration ? "lookup_weather" : "noop",
           "flue.tool.call_id": `call_${node.index}`,
-        },
+        }),
       },
       provided_model_name: isGeneration ? "gpt-4o" : null,
       internal_model_id: null,

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -218,9 +218,14 @@ function ValueCellActionsMenu({
   const router = useRouter();
   const { value, type, hasChildren } = row.original;
 
+  const filterValue = String(value);
   const isScalarLeaf =
     !hasChildren &&
-    (type === "string" || type === "number" || type === "boolean");
+    (type === "string" || type === "number" || type === "boolean") &&
+    // Skip empty values: `contains ""` matches every row (ClickHouse
+    // position(x, "") === 1, and Map[missingKey] defaults to "") while
+    // `does not contain ""` matches none — both shortcuts would be no-ops.
+    filterValue.length > 0;
 
   // Metadata is a flat Map(String, String), so a nested value can only be
   // matched as a substring of its top-level branch. We use contains/does not
@@ -229,7 +234,6 @@ function ValueCellActionsMenu({
   const metadataKey = resolveTopLevelMetadataKey(row);
   const includeOperator: MetadataFilterOperator = "contains";
   const excludeOperator: MetadataFilterOperator = "does not contain";
-  const filterValue = String(value);
   const displayValue = type === "string" ? `"${filterValue}"` : filterValue;
 
   const handleCopyData = () => {

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -223,8 +223,14 @@ function ValueCellActionsMenu({
   // branch, but `filterValue` is the JSON-parsed (unescaped) form shown in the
   // tree. When the value carries JSON-escapable characters (quotes,
   // backslashes, newlines) the two differ, so `contains` would never match —
-  // hide the shortcut rather than build a confidently-wrong filter. Top-level
-  // scalars are stored raw, so they are unaffected.
+  // hide the shortcut rather than build a confidently-wrong filter.
+  //
+  // Top-level scalars are *usually* stored raw (ingestion keeps top-level
+  // strings as-is), so we skip the check there. This heuristic misses the rare
+  // case of a top-level value that was itself JSON-encoded with escapes; we
+  // accept that miss because the alternative — always applying the check —
+  // would wrongly hide the far more common top-level raw string with literal
+  // newlines (which filters fine), since its encoded form also differs.
   const valueMatchesStoredForm =
     level === 0 || JSON.stringify(filterValue).slice(1, -1) === filterValue;
   const isScalarLeaf =

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -1,10 +1,36 @@
 import { memo, type JSX, useState } from "react";
+import { useRouter } from "next/router";
 import { type Row } from "@tanstack/react-table";
 import { urlRegex } from "@langfuse/shared";
-import { type JsonTableRow } from "@/src/components/table/utils/jsonExpansionUtils";
+import {
+  type JsonTableRow,
+  convertRowIdToKeyPath,
+} from "@/src/components/table/utils/jsonExpansionUtils";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { Button } from "@/src/components/ui/button";
-import { Copy, Check } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/src/components/ui/dropdown-menu";
+import {
+  buildEventsTablePathForMetadataFilter,
+  type MetadataFilterOperator,
+} from "@/src/features/events/lib/eventsTablePaths";
+import { Copy, Check, EllipsisVertical, Filter, FilterX } from "lucide-react";
+
+/**
+ * Enables the per-row actions menu in a metadata JSON view: copy value/
+ * structure/path plus "Include in / Exclude from filter" shortcuts that land on
+ * the matching events table. Passed only by the metadata view, so input/output
+ * cells keep their plain one-click copy button.
+ */
+export type MetadataFilterActions = {
+  projectId: string;
+  filterTarget: "observations" | "traces";
+};
 
 const MAX_STRING_LENGTH_FOR_LINK_DETECTION = 1500;
 export const MAX_CELL_DISPLAY_CHARS = 2000;
@@ -154,17 +180,137 @@ function getCopyValue(value: unknown): string {
   }
 }
 
+/** Walks up to the top-level (level 0) ancestor key for a metadata row. */
+function resolveTopLevelMetadataKey(row: Row<JsonTableRow>): string {
+  let cursor: Row<JsonTableRow> | undefined = row;
+  while (cursor && cursor.original.level > 0) {
+    cursor = cursor.getParentRow() ?? undefined;
+  }
+  return cursor?.original.key ?? row.original.key;
+}
+
+/**
+ * The per-row overflow menu shown in metadata views. Containers offer "Copy
+ * structure"; scalar leaves offer "Copy value" plus filter shortcuts. Rendered
+ * only when `metadataActions` is provided, so `useRouter` stays off the hot
+ * path for the (far more numerous) input/output JSON cells.
+ */
+function ValueCellActionsMenu({
+  row,
+  metadataActions,
+}: {
+  row: Row<JsonTableRow>;
+  metadataActions: MetadataFilterActions;
+}) {
+  const router = useRouter();
+  const { value, type, hasChildren, level } = row.original;
+
+  const isScalarLeaf =
+    !hasChildren &&
+    (type === "string" || type === "number" || type === "boolean");
+
+  // Top-level scalars filter their own key by "="; nested scalars can only be
+  // matched as a "contains" on their top-level branch (metadata is a flat map).
+  const metadataKey =
+    level === 0 ? row.original.key : resolveTopLevelMetadataKey(row);
+  const includeOperator: MetadataFilterOperator =
+    level === 0 ? "=" : "contains";
+  const filterValue = String(value);
+  const displayValue = type === "string" ? `"${filterValue}"` : filterValue;
+
+  const handleCopyData = () => {
+    copyTextToClipboard(getCopyValue(value));
+  };
+  const handleCopyPath = () => {
+    copyTextToClipboard(convertRowIdToKeyPath(row.id));
+  };
+  const navigateWithFilter = (operator: MetadataFilterOperator) => {
+    router.push(
+      buildEventsTablePathForMetadataFilter({
+        currentPath: router.asPath,
+        projectId: metadataActions.projectId,
+        metadataKey,
+        value: filterValue,
+        operator,
+        target: metadataActions.filterTarget,
+      }),
+    );
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Value actions"
+          title="Actions"
+          className="bg-background/80 hover:bg-background absolute top-1/2 right-1 h-4 w-4 -translate-y-1/2 border p-0 opacity-0 shadow-xs transition-opacity duration-200 group-hover:opacity-100 data-[state=open]:opacity-100"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <EllipsisVertical className="h-3 w-3" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="max-w-[320px]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DropdownMenuItem className="text-xs" onSelect={handleCopyData}>
+          <Copy className="mr-2 h-3.5 w-3.5 shrink-0" />
+          {hasChildren ? "Copy structure" : "Copy value"}
+        </DropdownMenuItem>
+        <DropdownMenuItem className="text-xs" onSelect={handleCopyPath}>
+          <Copy className="mr-2 h-3.5 w-3.5 shrink-0" />
+          Copy path
+        </DropdownMenuItem>
+        {isScalarLeaf && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-xs"
+              onSelect={() => navigateWithFilter(includeOperator)}
+            >
+              <Filter className="mr-2 h-3.5 w-3.5 shrink-0" />
+              <span className="flex min-w-0 flex-col">
+                <span>Include in filter</span>
+                <span className="text-muted-foreground truncate font-mono">
+                  metadata.{metadataKey} {includeOperator} {displayValue}
+                </span>
+              </span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-xs"
+              onSelect={() => navigateWithFilter("does not contain")}
+            >
+              <FilterX className="mr-2 h-3.5 w-3.5 shrink-0" />
+              <span className="flex min-w-0 flex-col">
+                <span>Exclude from filter</span>
+                <span className="text-muted-foreground truncate font-mono">
+                  metadata.{metadataKey} does not contain {displayValue}
+                </span>
+              </span>
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export const ValueCell = memo(
   ({
     row,
     expandedCells,
     toggleCellExpansion,
     preserveStringWhitespace = false,
+    metadataActions,
   }: {
     row: Row<JsonTableRow>;
     expandedCells: Set<string>;
     toggleCellExpansion: (cellId: string) => void;
     preserveStringWhitespace?: boolean;
+    metadataActions?: MetadataFilterActions;
   }) => {
     const { value, type } = row.original;
     const cellId = `${row.id}-value`;
@@ -300,21 +446,26 @@ export const ValueCell = memo(
           </div>
         )}
 
-        {/* Copy button - appears on hover */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="bg-background/80 hover:bg-background absolute top-0 right-0 h-5 w-5 border p-0.5 opacity-0 shadow-xs transition-opacity duration-200 group-hover:opacity-100"
-          onClick={handleCopy}
-          title="Copy value"
-          aria-label="Copy cell value"
-        >
-          {showCopySuccess ? (
-            <Check className="h-2.5 w-2.5 text-green-600" />
-          ) : (
-            <Copy className="h-2.5 w-2.5" />
-          )}
-        </Button>
+        {/* Hover affordance: a one-click copy by default, or an actions menu
+            (copy + filter shortcuts) in metadata views. */}
+        {metadataActions ? (
+          <ValueCellActionsMenu row={row} metadataActions={metadataActions} />
+        ) : (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="bg-background/80 hover:bg-background absolute top-0 right-0 h-5 w-5 border p-0.5 opacity-0 shadow-xs transition-opacity duration-200 group-hover:opacity-100"
+            onClick={handleCopy}
+            title="Copy value"
+            aria-label="Copy cell value"
+          >
+            {showCopySuccess ? (
+              <Check className="h-2.5 w-2.5 text-green-600" />
+            ) : (
+              <Copy className="h-2.5 w-2.5" />
+            )}
+          </Button>
+        )}
       </div>
     );
   },

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -2,10 +2,7 @@ import { memo, type JSX, useState } from "react";
 import { useRouter } from "next/router";
 import { type Row } from "@tanstack/react-table";
 import { urlRegex } from "@langfuse/shared";
-import {
-  type JsonTableRow,
-  convertRowIdToKeyPath,
-} from "@/src/components/table/utils/jsonExpansionUtils";
+import { type JsonTableRow } from "@/src/components/table/utils/jsonExpansionUtils";
 import { copyTextToClipboard } from "@/src/utils/clipboard";
 import { Button } from "@/src/components/ui/button";
 import {
@@ -190,6 +187,22 @@ function resolveTopLevelMetadataKey(row: Row<JsonTableRow>): string {
 }
 
 /**
+ * Builds the dotted key path from the row's actual keys (root → leaf). Unlike
+ * `convertRowIdToKeyPath`, which reconstructs the path from the hyphen-joined
+ * row id, this is lossless for keys that themselves contain `-` (e.g.
+ * `x-request-id`).
+ */
+function resolveKeyPath(row: Row<JsonTableRow>): string {
+  const keys: string[] = [];
+  let cursor: Row<JsonTableRow> | undefined = row;
+  while (cursor) {
+    keys.unshift(String(cursor.original.key));
+    cursor = cursor.getParentRow() ?? undefined;
+  }
+  return keys.join(".");
+}
+
+/**
  * The per-row overflow menu shown in metadata views. Containers offer "Copy
  * structure"; scalar leaves offer "Copy value" plus filter shortcuts. Rendered
  * only when `metadataActions` is provided, so `useRouter` stays off the hot
@@ -203,18 +216,19 @@ function ValueCellActionsMenu({
   metadataActions: MetadataFilterActions;
 }) {
   const router = useRouter();
-  const { value, type, hasChildren, level } = row.original;
+  const { value, type, hasChildren } = row.original;
 
   const isScalarLeaf =
     !hasChildren &&
     (type === "string" || type === "number" || type === "boolean");
 
-  // Top-level scalars filter their own key by "="; nested scalars can only be
-  // matched as a "contains" on their top-level branch (metadata is a flat map).
-  const metadataKey =
-    level === 0 ? row.original.key : resolveTopLevelMetadataKey(row);
-  const includeOperator: MetadataFilterOperator =
-    level === 0 ? "=" : "contains";
+  // Metadata is a flat Map(String, String), so a nested value can only be
+  // matched as a substring of its top-level branch. We use contains/does not
+  // contain uniformly (top-level included) so Include and Exclude stay exact
+  // complements — stringObject has no "!=" to invert an exact "=".
+  const metadataKey = resolveTopLevelMetadataKey(row);
+  const includeOperator: MetadataFilterOperator = "contains";
+  const excludeOperator: MetadataFilterOperator = "does not contain";
   const filterValue = String(value);
   const displayValue = type === "string" ? `"${filterValue}"` : filterValue;
 
@@ -222,7 +236,7 @@ function ValueCellActionsMenu({
     copyTextToClipboard(getCopyValue(value));
   };
   const handleCopyPath = () => {
-    copyTextToClipboard(convertRowIdToKeyPath(row.id));
+    copyTextToClipboard(resolveKeyPath(row));
   };
   const navigateWithFilter = (operator: MetadataFilterOperator) => {
     router.push(
@@ -281,13 +295,13 @@ function ValueCellActionsMenu({
             </DropdownMenuItem>
             <DropdownMenuItem
               className="text-xs"
-              onSelect={() => navigateWithFilter("does not contain")}
+              onSelect={() => navigateWithFilter(excludeOperator)}
             >
               <FilterX className="mr-2 h-3.5 w-3.5 shrink-0" />
               <span className="flex min-w-0 flex-col">
                 <span>Exclude from filter</span>
                 <span className="text-muted-foreground truncate font-mono">
-                  metadata.{metadataKey} does not contain {displayValue}
+                  metadata.{metadataKey} {excludeOperator} {displayValue}
                 </span>
               </span>
             </DropdownMenuItem>

--- a/web/src/components/table/ValueCell.tsx
+++ b/web/src/components/table/ValueCell.tsx
@@ -216,16 +216,25 @@ function ValueCellActionsMenu({
   metadataActions: MetadataFilterActions;
 }) {
   const router = useRouter();
-  const { value, type, hasChildren } = row.original;
+  const { value, type, hasChildren, level } = row.original;
 
   const filterValue = String(value);
+  // A nested value is matched as a substring of its JSON-ENCODED top-level
+  // branch, but `filterValue` is the JSON-parsed (unescaped) form shown in the
+  // tree. When the value carries JSON-escapable characters (quotes,
+  // backslashes, newlines) the two differ, so `contains` would never match —
+  // hide the shortcut rather than build a confidently-wrong filter. Top-level
+  // scalars are stored raw, so they are unaffected.
+  const valueMatchesStoredForm =
+    level === 0 || JSON.stringify(filterValue).slice(1, -1) === filterValue;
   const isScalarLeaf =
     !hasChildren &&
     (type === "string" || type === "number" || type === "boolean") &&
     // Skip empty values: `contains ""` matches every row (ClickHouse
     // position(x, "") === 1, and Map[missingKey] defaults to "") while
     // `does not contain ""` matches none — both shortcuts would be no-ops.
-    filterValue.length > 0;
+    filterValue.length > 0 &&
+    valueMatchesStoredForm;
 
   // Metadata is a flat Map(String, String), so a nested value can only be
   // matched as a substring of its top-level branch. We use contains/does not

--- a/web/src/components/trace/components/IOPreview/IOPreviewPretty.tsx
+++ b/web/src/components/trace/components/IOPreview/IOPreviewPretty.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { type Prisma, type ScoreDomain, deepParseJson } from "@langfuse/shared";
 import { PrettyJsonView } from "@/src/components/ui/PrettyJsonView";
+import { type MetadataFilterActions } from "@/src/components/table/ValueCell";
 import { MARKDOWN_RENDER_CHARACTER_LIMIT } from "@/src/utils/constants";
 import { type MediaReturnType } from "@/src/features/media/validation";
 import { useChatMLParser } from "./hooks/useChatMLParser";
@@ -156,6 +157,16 @@ export function IOPreviewPretty({
     : (preParsedMetadata ??
       deepParseJson(metadata, { maxSize: 100_000, maxDepth: 2 }));
 
+  // Enable the metadata rows' actions menu (copy + add-to-filter). Observation
+  // metadata filters the observations table; trace metadata the traces table.
+  const metadataActions = useMemo<MetadataFilterActions>(
+    () => ({
+      projectId,
+      filterTarget: observationId ? "observations" : "traces",
+    }),
+    [projectId, observationId],
+  );
+
   // Parse ChatML format
   const {
     canDisplayAsChat,
@@ -299,6 +310,7 @@ export function IOPreviewPretty({
             currentView="pretty"
             externalExpansionState={metadataExpansionState}
             onExternalExpansionChange={onMetadataExpansionChange}
+            metadataActions={metadataActions}
           />
         </div>
       )}

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -57,6 +57,7 @@ import {
 import {
   ValueCell,
   getValueStringLength,
+  type MetadataFilterActions,
 } from "@/src/components/table/ValueCell";
 import { ItemBadge, type LangfuseItemType } from "@/src/components/ItemBadge";
 
@@ -541,6 +542,7 @@ function JsonPrettyTable({
   toggleCellExpansion,
   stickyTopLevelKey = false,
   showObservationTypeBadge = false,
+  metadataActions,
 }: {
   data: JsonTableRow[];
   expandAllRef?: React.RefObject<(() => void) | null>;
@@ -557,6 +559,7 @@ function JsonPrettyTable({
   toggleCellExpansion: (cellId: string) => void;
   stickyTopLevelKey?: boolean;
   showObservationTypeBadge?: boolean;
+  metadataActions?: MetadataFilterActions;
 }) {
   const headerRef = useRef<HTMLTableRowElement>(null);
   const topLevelRowRef = useRef<HTMLTableRowElement>(null);
@@ -685,6 +688,7 @@ function JsonPrettyTable({
           preserveStringWhitespace={
             row.original.key === "code_eval_source_code"
           }
+          metadataActions={metadataActions}
         />
       ),
     },
@@ -878,6 +882,9 @@ export function PrettyJsonView(props: {
   showObservationTypeBadge?: boolean;
   /** Content to render between header and main content (e.g., thinking blocks) */
   afterHeader?: React.ReactNode;
+  /** When set, rows show an actions menu with copy + add-to-filter shortcuts
+      (metadata views only). */
+  metadataActions?: MetadataFilterActions;
 }) {
   // Use pre-parsed data if available, otherwise parse on-demand
   const parsedJson = useMemo(() => {
@@ -1408,6 +1415,7 @@ export function PrettyJsonView(props: {
                   toggleCellExpansion={toggleCellExpansion}
                   stickyTopLevelKey={props.stickyTopLevelKey}
                   showObservationTypeBadge={props.showObservationTypeBadge}
+                  metadataActions={props.metadataActions}
                 />
               )}
             </div>

--- a/web/src/features/events/lib/eventsTablePaths.clienttest.ts
+++ b/web/src/features/events/lib/eventsTablePaths.clienttest.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { type FilterState } from "@langfuse/shared";
+import {
+  decodeFiltersGeneric,
+  encodeFiltersGeneric,
+} from "@/src/features/filters/lib/filter-query-encoding";
+import { buildEventsTablePathForMetadataFilter } from "./eventsTablePaths";
+
+const PROJECT = "p1";
+
+const meta = (
+  key: string,
+  operator: "=" | "contains" | "does not contain" | "starts with" | "ends with",
+  value: string,
+): FilterState[number] =>
+  ({
+    column: "metadata",
+    type: "stringObject",
+    key,
+    operator,
+    value,
+  }) as FilterState[number];
+
+/** Build a `currentPath` the same way the events table encodes its URL. */
+const currentPathWith = (
+  filters: FilterState,
+  opts: { dateRange?: string } = {},
+): string => {
+  const params = new URLSearchParams();
+  if (filters.length > 0) params.set("filter", encodeFiltersGeneric(filters));
+  if (opts.dateRange) params.set("dateRange", opts.dateRange);
+  const q = params.toString();
+  return `/project/${PROJECT}/observations${q ? `?${q}` : ""}`;
+};
+
+/** Decode the filters the builder produced back out of the result path. */
+const filtersOf = (path: string): FilterState => {
+  const url = new URL(path, "https://x.local");
+  return decodeFiltersGeneric(url.searchParams.get("filter") ?? "");
+};
+
+const build = (
+  currentPath: string,
+  operator: "contains" | "does not contain",
+  opts: {
+    metadataKey?: string;
+    value?: string;
+    target?: "observations" | "traces";
+  } = {},
+) =>
+  buildEventsTablePathForMetadataFilter({
+    currentPath,
+    projectId: PROJECT,
+    metadataKey: opts.metadataKey ?? "scope",
+    value: opts.value ?? "alpha",
+    operator,
+    target: opts.target ?? "observations",
+  });
+
+describe("buildEventsTablePathForMetadataFilter", () => {
+  it("adds a single clause from an empty filter state", () => {
+    const path = build("/project/p1/observations", "contains");
+    expect(path.startsWith("/project/p1/observations?")).toBe(true);
+    expect(filtersOf(path)).toEqual([meta("scope", "contains", "alpha")]);
+  });
+
+  it("routes to the requested table", () => {
+    const path = build("/project/p1/traces", "contains", { target: "traces" });
+    expect(path.startsWith("/project/p1/traces?")).toBe(true);
+  });
+
+  it("preserves the dateRange param", () => {
+    const path = build(
+      currentPathWith([], { dateRange: "All time" }),
+      "contains",
+    );
+    const url = new URL(path, "https://x.local");
+    expect(url.searchParams.get("dateRange")).toBe("All time");
+  });
+
+  it("toggles Include -> Exclude on the same value (replace, not AND)", () => {
+    const path = build(
+      currentPathWith([meta("scope", "contains", "alpha")]),
+      "does not contain",
+    );
+    expect(filtersOf(path)).toEqual([
+      meta("scope", "does not contain", "alpha"),
+    ]);
+  });
+
+  it("toggles Exclude -> Include on the same value", () => {
+    const path = build(
+      currentPathWith([meta("scope", "does not contain", "alpha")]),
+      "contains",
+    );
+    expect(filtersOf(path)).toEqual([meta("scope", "contains", "alpha")]);
+  });
+
+  it("is idempotent when re-adding the same clause", () => {
+    const path = build(
+      currentPathWith([meta("scope", "contains", "alpha")]),
+      "contains",
+    );
+    expect(filtersOf(path)).toEqual([meta("scope", "contains", "alpha")]);
+  });
+
+  it("AND-merges clauses on a different key", () => {
+    const path = build(
+      currentPathWith([meta("env", "contains", "prod")]),
+      "contains",
+      { metadataKey: "scope", value: "alpha" },
+    );
+    expect(filtersOf(path)).toEqual([
+      meta("env", "contains", "prod"),
+      meta("scope", "contains", "alpha"),
+    ]);
+  });
+
+  it("AND-merges clauses on the same key but a different value", () => {
+    const path = build(
+      currentPathWith([meta("scope", "contains", "alpha")]),
+      "contains",
+      { value: "beta" },
+    );
+    expect(filtersOf(path)).toEqual([
+      meta("scope", "contains", "alpha"),
+      meta("scope", "contains", "beta"),
+    ]);
+  });
+
+  it("Include preserves a stricter '=' clause (no broadening)", () => {
+    const path = build(
+      currentPathWith([meta("scope", "=", "production")]),
+      "contains",
+      { value: "production" },
+    );
+    // `= production` is kept; the redundant `contains production` ANDs with it.
+    expect(filtersOf(path)).toEqual([
+      meta("scope", "=", "production"),
+      meta("scope", "contains", "production"),
+    ]);
+  });
+
+  it("Exclude drops a contradicting '=' clause on the same value", () => {
+    const path = build(
+      currentPathWith([meta("scope", "=", "production")]),
+      "does not contain",
+      { value: "production" },
+    );
+    // `= v AND does not contain v` is always false — the `=` must be dropped.
+    expect(filtersOf(path)).toEqual([
+      meta("scope", "does not contain", "production"),
+    ]);
+  });
+
+  it("Exclude drops a contradicting 'starts with' clause on the same value", () => {
+    const path = build(
+      currentPathWith([meta("scope", "starts with", "production")]),
+      "does not contain",
+      { value: "production" },
+    );
+    expect(filtersOf(path)).toEqual([
+      meta("scope", "does not contain", "production"),
+    ]);
+  });
+});

--- a/web/src/features/events/lib/eventsTablePaths.ts
+++ b/web/src/features/events/lib/eventsTablePaths.ts
@@ -118,27 +118,32 @@ export function buildEventsTablePathForMetadataFilter({
     url.searchParams.get("filter") ?? "",
   );
 
-  // The Include/Exclude menu items are a toggle on one key+value: clicking the
-  // opposite must replace, not AND, since `contains "v" AND does not contain
-  // "v"` is always false. So drop an existing clause on the same key+value
-  // ONLY when it carries an operator this menu emits (contains / does not
-  // contain). Stricter clauses set elsewhere (the filter-builder defaults
-  // stringObject to `=`, plus starts/ends with) are preserved so a one-click
-  // Include doesn't silently broaden a user's exact filter — the new clause
-  // just ANDs with them. Clauses on other keys/values are untouched.
-  const withoutSameTarget = existingFilters.filter(
-    (f) =>
-      !(
-        f.column === "metadata" &&
-        f.type === "stringObject" &&
-        f.key === metadataKey &&
-        f.value === value &&
-        (f.operator === "contains" || f.operator === "does not contain")
-      ),
-  );
+  // Reconcile the new clause against any existing clause on this same
+  // key+value, direction-aware:
+  //  - Include (`contains`) only toggles the menu's OWN operators (contains /
+  //    does not contain). A stricter clause set elsewhere — the filter-builder
+  //    defaults stringObject to `=`, plus starts/ends with — is preserved, so a
+  //    one-click Include never broadens an exact filter (`= v AND contains v`
+  //    reduces to `= v`).
+  //  - Exclude (`does not contain`) contradicts EVERY positive clause on the
+  //    value (`= v`, `starts/ends with v` all imply it contains v), so it drops
+  //    them all; otherwise `= v AND does not contain v` is always false and
+  //    silently empties the table.
+  // Clauses on other keys/values are always left untouched (AND-merge).
+  const isExclude = operator === "does not contain";
+  const withoutConflicting = existingFilters.filter((f) => {
+    const sameTarget =
+      f.column === "metadata" &&
+      f.type === "stringObject" &&
+      f.key === metadataKey &&
+      f.value === value;
+    if (!sameTarget) return true;
+    if (isExclude) return false;
+    return f.operator !== "contains" && f.operator !== "does not contain";
+  });
 
   const filters: FilterState = [
-    ...withoutSameTarget,
+    ...withoutConflicting,
     {
       column: "metadata",
       type: "stringObject",

--- a/web/src/features/events/lib/eventsTablePaths.ts
+++ b/web/src/features/events/lib/eventsTablePaths.ts
@@ -118,18 +118,22 @@ export function buildEventsTablePathForMetadataFilter({
     url.searchParams.get("filter") ?? "",
   );
 
-  // A given metadata key+value can only be Included OR Excluded, never both:
-  // `contains "v" AND does not contain "v"` is always false. Drop any existing
-  // clause on the same key+value (regardless of operator) before appending, so
-  // the paired Include/Exclude menu items act as a toggle and repeated clicks
-  // stay idempotent. Clauses on other keys/values are left untouched (AND).
+  // The Include/Exclude menu items are a toggle on one key+value: clicking the
+  // opposite must replace, not AND, since `contains "v" AND does not contain
+  // "v"` is always false. So drop an existing clause on the same key+value
+  // ONLY when it carries an operator this menu emits (contains / does not
+  // contain). Stricter clauses set elsewhere (the filter-builder defaults
+  // stringObject to `=`, plus starts/ends with) are preserved so a one-click
+  // Include doesn't silently broaden a user's exact filter — the new clause
+  // just ANDs with them. Clauses on other keys/values are untouched.
   const withoutSameTarget = existingFilters.filter(
     (f) =>
       !(
         f.column === "metadata" &&
         f.type === "stringObject" &&
         f.key === metadataKey &&
-        f.value === value
+        f.value === value &&
+        (f.operator === "contains" || f.operator === "does not contain")
       ),
   );
 

--- a/web/src/features/events/lib/eventsTablePaths.ts
+++ b/web/src/features/events/lib/eventsTablePaths.ts
@@ -118,27 +118,31 @@ export function buildEventsTablePathForMetadataFilter({
     url.searchParams.get("filter") ?? "",
   );
 
-  const isDuplicate = existingFilters.some(
+  // A given metadata key+value can only be Included OR Excluded, never both:
+  // `contains "v" AND does not contain "v"` is always false. Drop any existing
+  // clause on the same key+value (regardless of operator) before appending, so
+  // the paired Include/Exclude menu items act as a toggle and repeated clicks
+  // stay idempotent. Clauses on other keys/values are left untouched (AND).
+  const withoutSameTarget = existingFilters.filter(
     (f) =>
-      f.column === "metadata" &&
-      f.type === "stringObject" &&
-      f.key === metadataKey &&
-      f.operator === operator &&
-      f.value === value,
+      !(
+        f.column === "metadata" &&
+        f.type === "stringObject" &&
+        f.key === metadataKey &&
+        f.value === value
+      ),
   );
 
-  const filters: FilterState = isDuplicate
-    ? existingFilters
-    : [
-        ...existingFilters,
-        {
-          column: "metadata",
-          type: "stringObject",
-          key: metadataKey,
-          operator,
-          value,
-        },
-      ];
+  const filters: FilterState = [
+    ...withoutSameTarget,
+    {
+      column: "metadata",
+      type: "stringObject",
+      key: metadataKey,
+      operator,
+      value,
+    },
+  ];
 
   params.set("filter", encodeFiltersGeneric(filters));
 

--- a/web/src/features/events/lib/eventsTablePaths.ts
+++ b/web/src/features/events/lib/eventsTablePaths.ts
@@ -1,5 +1,8 @@
 import { type FilterState } from "@langfuse/shared";
-import { encodeFiltersGeneric } from "@/src/features/filters/lib/filter-query-encoding";
+import {
+  decodeFiltersGeneric,
+  encodeFiltersGeneric,
+} from "@/src/features/filters/lib/filter-query-encoding";
 
 type BuildEventsTablePathForSpanNameParams = {
   currentPath: string;
@@ -72,4 +75,74 @@ export function buildEventsTablePathForObservationType({
     column: "type",
     value: observationType,
   });
+}
+
+export type MetadataFilterOperator = "=" | "contains" | "does not contain";
+
+type BuildEventsTablePathForMetadataFilterParams = {
+  currentPath: string;
+  projectId: string;
+  metadataKey: string;
+  value: string;
+  operator: MetadataFilterOperator;
+  /** Whether to land on the observations or traces events table. */
+  target: "observations" | "traces";
+};
+
+/**
+ * Builds an events-table URL that adds a `metadata` filter (a `stringObject`
+ * clause). Unlike the name/type helpers above, this MERGES into any filters
+ * already present in `currentPath` (e.g. the list filter behind a peek) so the
+ * action reads as "add to filter" rather than "replace". The clicked value is
+ * matched against the top-level metadata key — metadata is stored as a flat
+ * `Map(String, String)`, so a nested value is filtered as a `contains` on its
+ * top-level branch (the caller chooses the operator accordingly).
+ */
+export function buildEventsTablePathForMetadataFilter({
+  currentPath,
+  projectId,
+  metadataKey,
+  value,
+  operator,
+  target,
+}: BuildEventsTablePathForMetadataFilterParams) {
+  const url = new URL(currentPath, "https://langfuse.local");
+  const params = new URLSearchParams();
+
+  const dateRange = url.searchParams.get("dateRange");
+  if (dateRange) {
+    params.set("dateRange", dateRange);
+  }
+
+  const existingFilters = decodeFiltersGeneric(
+    url.searchParams.get("filter") ?? "",
+  );
+
+  const isDuplicate = existingFilters.some(
+    (f) =>
+      f.column === "metadata" &&
+      f.type === "stringObject" &&
+      f.key === metadataKey &&
+      f.operator === operator &&
+      f.value === value,
+  );
+
+  const filters: FilterState = isDuplicate
+    ? existingFilters
+    : [
+        ...existingFilters,
+        {
+          column: "metadata",
+          type: "stringObject",
+          key: metadataKey,
+          operator,
+          value,
+        },
+      ];
+
+  params.set("filter", encodeFiltersGeneric(filters));
+
+  const query = params.toString();
+
+  return `/project/${projectId}/${target}${query ? `?${query}` : ""}`;
 }


### PR DESCRIPTION
Per-row actions menu in the metadata PrettyJsonView: copy value/structure/path plus "Include in / Exclude from filter". Filter shortcuts build a `metadata` stringObject clause and navigate to the matching events table, merging into existing filters (the same URL filter contract the v4 search bar reads).

- ValueCell: ValueCellActionsMenu, gated by a `metadataActions` prop so input/output JSON keeps its one-click copy and useRouter stays off the hot path.
- eventsTablePaths: buildEventsTablePathForMetadataFilter (merge + dedupe).
- PrettyJsonView: thread metadataActions through to the value cell.
- IOPreviewPretty: enable on the metadata view only; observation metadata -> observations table, trace metadata -> traces table.
- seeder(trace-tree): nested OTel-style metadata to exercise nested (contains) vs top-level (=) filter shapes.

WIP: not browser-verified yet. Top-level scalars filter by "=", nested scalars by "contains" on their top-level branch (metadata is a flat Map(String,String), so nested keys have no exact target).

## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds per-row context menus to the metadata `PrettyJsonView`: each scalar cell gets "Copy value", "Copy path", "Include in filter", and "Exclude from filter" actions. Filter shortcuts build a `stringObject` URL clause that merges into existing filters and navigates to the matching observations or traces table.

- `ValueCell` gains a new `ValueCellActionsMenu` component (gated by a `metadataActions` prop) and a `MetadataFilterActions` type; input/output cells are unaffected.
- `buildEventsTablePathForMetadataFilter` in `eventsTablePaths.ts` decodes existing filters, deduplicates, appends the new clause, and preserves `dateRange`, navigating to either `/observations` or `/traces` based on context.
- The seeder gains OTel-style nested metadata to exercise both exact-match and contains filter paths.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The filter shortcuts will produce incorrect results for some common cases before the operator asymmetry and key-path bugs are fixed.

The Exclude action hardcodes 'does not contain' for top-level scalar rows whose Include uses '='. Because 'does not contain' is a substring test, it excludes a broader set of records — a value like 'inactive' would be excluded by 'does not contain active' even though the include filter '= active' would never have matched it. Separately, the Copy path feature uses convertRowIdToKeyPath which replaces every hyphen with a dot, so metadata keys with hyphens silently produce wrong paths. Both issues affect the core user-facing functionality introduced by this PR.

web/src/components/table/ValueCell.tsx — the operator selection logic for the exclude action and the path-copy utility both need attention before this lands.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant ValueCell
    participant ValueCellActionsMenu
    participant eventsTablePaths
    participant Router

    User->>ValueCell: hover metadata row
    ValueCell->>ValueCellActionsMenu: render (metadataActions prop)
    User->>ValueCellActionsMenu: click Include in filter
    ValueCellActionsMenu->>ValueCellActionsMenu: resolveTopLevelMetadataKey(row)
    Note over ValueCellActionsMenu: level=0 operator =, level>0 operator contains
    ValueCellActionsMenu->>eventsTablePaths: buildEventsTablePathForMetadataFilter()
    eventsTablePaths->>eventsTablePaths: decodeFiltersGeneric(currentPath.filter)
    eventsTablePaths->>eventsTablePaths: deduplicate + append stringObject filter
    eventsTablePaths->>eventsTablePaths: encodeFiltersGeneric(mergedFilters)
    eventsTablePaths-->>ValueCellActionsMenu: "/project/id/observations|traces?filter=..."
    ValueCellActionsMenu->>Router: router.push(url)
    Router-->>User: navigate to events table with merged filter
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant ValueCell
    participant ValueCellActionsMenu
    participant eventsTablePaths
    participant Router

    User->>ValueCell: hover metadata row
    ValueCell->>ValueCellActionsMenu: render (metadataActions prop)
    User->>ValueCellActionsMenu: click Include in filter
    ValueCellActionsMenu->>ValueCellActionsMenu: resolveTopLevelMetadataKey(row)
    Note over ValueCellActionsMenu: level=0 operator =, level>0 operator contains
    ValueCellActionsMenu->>eventsTablePaths: buildEventsTablePathForMetadataFilter()
    eventsTablePaths->>eventsTablePaths: decodeFiltersGeneric(currentPath.filter)
    eventsTablePaths->>eventsTablePaths: deduplicate + append stringObject filter
    eventsTablePaths->>eventsTablePaths: encodeFiltersGeneric(mergedFilters)
    eventsTablePaths-->>ValueCellActionsMenu: "/project/id/observations|traces?filter=..."
    ValueCellActionsMenu->>Router: router.push(url)
    Router-->>User: navigate to events table with merged filter
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
web/src/components/table/ValueCell.tsx:222-230
**Exclude operator is semantically broader than the inverse of Include for top-level keys**

For top-level scalars (level === 0), the Include filter applies `=` (exact match), but the Exclude filter hardcodes `"does not contain"` regardless of level. These operators are not inverses. For example, if `status = "active"`, the include filter `metadata.status = active` matches only the exact value; but the exclude filter `metadata.status does not contain active` would also exclude records with `status = "inactive"` or `"super_active"` (since they both contain the substring). The symmetric inverse of `"contains"/"does not contain"` makes sense for nested keys, but for top-level keys the exclude should either use a `!=` operator (not currently available in `filterOperators.stringObject`) or always use `"contains"` for includes so that the include/exclude pair stays symmetric.

### Issue 2 of 3
web/src/components/table/ValueCell.tsx:196-201
**`convertRowIdToKeyPath` produces wrong paths for keys containing hyphens**

Row IDs are constructed by joining segments with `-` (e.g., `${parentId}-${key}`), and `convertRowIdToKeyPath` blindly replaces every `-` with `.`. If a metadata key itself contains a hyphen — e.g., `{ "my-key": "value" }` — the top-level row ID is `my-key` and the copied path becomes `my.key` instead of `my-key`. The "Copy path" feature will silently produce incorrect results for any kebab-case metadata key.

### Issue 3 of 3
web/src/components/table/ValueCell.tsx:216-218
The Exclude display hint for top-level scalar rows shows `does not contain` while the Include hint shows `=`, so the two operators look unrelated to users. Extracting an explicit `excludeOperator` variable makes the level-dependent pair more readable and easier to adjust.

```suggestion
  const includeOperator: MetadataFilterOperator =
    level === 0 ? "=" : "contains";
  const excludeOperator: MetadataFilterOperator = "does not contain";
  const filterValue = String(value);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(events): metadata value filter shor..."](https://github.com/langfuse/langfuse/commit/8b6ab903668b29b89b825a8b1e5aa23e29e5395b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38626609)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->