### PR TITLE
fix(annotation-queues): enforce unique (project, queue, object) constraint on queue items

### DIFF
--- a/packages/shared/prisma/migrations/20260618000000_unique_annotation_queue_items/migration.sql
+++ b/packages/shared/prisma/migrations/20260618000000_unique_annotation_queue_items/migration.sql
@@ -1,12 +1,18 @@
--- Enforce uniqueness on (project_id, queue_id, object_id, object_type) for
--- annotation_queue_items. See langfuse/langfuse#12938.
+-- Pre-flight check for the upcoming unique index on annotation_queue_items.
+-- See langfuse/langfuse#12938.
 --
 -- This migration deliberately does NOT delete existing duplicate rows. If the
--- table has duplicates, the pre-flight check below aborts the migration with a
--- clear error so the operator can review and dedupe explicitly before
--- re-running. Cleanup SQL is documented in the PR description so operators can
--- pick their own survivor rule (newest, oldest, or based on attached
--- lock/annotator/status state) and back up first.
+-- table has duplicates, the DO block below aborts the migration with a clear
+-- error so the operator can review and dedupe explicitly before re-running.
+-- Cleanup SQL is documented in the PR description so operators can pick their
+-- own survivor rule (newest, oldest, or based on attached lock/annotator/
+-- status state) and back up first.
+--
+-- The actual CREATE UNIQUE INDEX is in the next migration so it can use
+-- CONCURRENTLY without taking a ShareLock on annotation_queue_items during
+-- index creation. Splitting the file mirrors prior Langfuse precedents
+-- (see 20240513082204_scores_unique_id_and_projectid_instead_of_id_and_traceid_index
+-- and 20251210133946_dataset_items_create_idx_id_project_id_valid_from).
 DO $$
 DECLARE
   dup_groups integer;
@@ -25,7 +31,3 @@ BEGIN
       dup_groups;
   END IF;
 END $$;
-
--- CreateIndex
-CREATE UNIQUE INDEX "annotation_queue_items_proj_queue_obj_type_key"
-  ON "annotation_queue_items"("project_id", "queue_id", "object_id", "object_type");

--- a/packages/shared/prisma/migrations/20260618000000_unique_annotation_queue_items/migration.sql
+++ b/packages/shared/prisma/migrations/20260618000000_unique_annotation_queue_items/migration.sql
@@ -1,0 +1,31 @@
+-- Enforce uniqueness on (project_id, queue_id, object_id, object_type) for
+-- annotation_queue_items. See langfuse/langfuse#12938.
+--
+-- This migration deliberately does NOT delete existing duplicate rows. If the
+-- table has duplicates, the pre-flight check below aborts the migration with a
+-- clear error so the operator can review and dedupe explicitly before
+-- re-running. Cleanup SQL is documented in the PR description so operators can
+-- pick their own survivor rule (newest, oldest, or based on attached
+-- lock/annotator/status state) and back up first.
+DO $$
+DECLARE
+  dup_groups integer;
+BEGIN
+  SELECT COUNT(*) INTO dup_groups FROM (
+    SELECT 1
+    FROM annotation_queue_items
+    GROUP BY project_id, queue_id, object_id, object_type
+    HAVING COUNT(*) > 1
+  ) duplicates;
+
+  IF dup_groups > 0 THEN
+    RAISE EXCEPTION
+      'Cannot create unique index on annotation_queue_items: % duplicate (project_id, queue_id, object_id, object_type) group(s) exist. '
+      'Review duplicates and dedupe explicitly before re-running migrations. See langfuse/langfuse#12938 for the inspect/cleanup queries.',
+      dup_groups;
+  END IF;
+END $$;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "annotation_queue_items_proj_queue_obj_type_key"
+  ON "annotation_queue_items"("project_id", "queue_id", "object_id", "object_type");

--- a/packages/shared/prisma/migrations/20260618000001_unique_annotation_queue_items_index/migration.sql
+++ b/packages/shared/prisma/migrations/20260618000001_unique_annotation_queue_items_index/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+-- Uses CONCURRENTLY so this does NOT take a ShareLock on annotation_queue_items
+-- during index creation; concurrent writes to the table are not blocked.
+-- IF NOT EXISTS keeps the migration retry-safe if a previous CONCURRENTLY run
+-- was interrupted and left an invalid index behind (see langfuse/langfuse#12938
+-- review thread). Pattern mirrors 20251210133946_dataset_items_create_idx_id_project_id_valid_from.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "annotation_queue_items_proj_queue_obj_type_key"
+  ON "annotation_queue_items"("project_id", "queue_id", "object_id", "object_type");

--- a/packages/shared/prisma/schema.prisma
+++ b/packages/shared/prisma/schema.prisma
@@ -610,6 +610,7 @@ model AnnotationQueueItem {
   createdAt       DateTime                  @default(now()) @map("created_at")
   updatedAt       DateTime                  @default(now()) @updatedAt @map("updated_at")
 
+  @@unique([projectId, queueId, objectId, objectType], map: "annotation_queue_items_proj_queue_obj_type_key")
   @@index([id, projectId])
   @@index([projectId, queueId, status])
   @@index([objectId, objectType, projectId, queueId])

--- a/web/src/__tests__/server/annotation-queues-api.servertest.ts
+++ b/web/src/__tests__/server/annotation-queues-api.servertest.ts
@@ -652,6 +652,41 @@ describe("Annotation Queues API Endpoints", () => {
       expect(observationItem?.status).toBe(AnnotationQueueStatus.PENDING);
     });
 
+    it("should reject duplicate (objectId, objectType) for the same queue", async () => {
+      const objectId = uuidv4();
+      const body = {
+        objectId,
+        objectType: AnnotationQueueObjectType.TRACE,
+      };
+
+      const first = await makeZodVerifiedAPICall(
+        CreateAnnotationQueueItemResponse,
+        "POST",
+        `/api/public/annotation-queues/${queueId}/items`,
+        body,
+        auth,
+      );
+      expect(first.status).toBe(200);
+
+      const second = await makeAPICall(
+        "POST",
+        `/api/public/annotation-queues/${queueId}/items`,
+        body,
+        auth,
+      );
+      expect(second.status).toBe(409);
+
+      const rows = await prisma.annotationQueueItem.findMany({
+        where: {
+          projectId,
+          queueId,
+          objectId,
+          objectType: AnnotationQueueObjectType.TRACE,
+        },
+      });
+      expect(rows).toHaveLength(1);
+    });
+
     it("should return 404 for non-existent queue", async () => {
       const nonExistentId = uuidv4();
       const response = await makeAPICall(

--- a/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
+++ b/web/src/features/annotation-queues/server/publicAnnotationQueueService.ts
@@ -408,16 +408,29 @@ export const createAnnotationQueueItemForApi = async ({
   const completedAt =
     status === AnnotationQueueStatus.COMPLETED ? new Date() : null;
 
-  const item = await prisma.annotationQueueItem.create({
-    data: {
-      queueId,
-      objectId: input.objectId,
-      objectType: input.objectType,
-      status,
-      completedAt,
-      projectId,
-    },
-  });
+  let item;
+  try {
+    item = await prisma.annotationQueueItem.create({
+      data: {
+        queueId,
+        objectId: input.objectId,
+        objectType: input.objectType,
+        status,
+        completedAt,
+        projectId,
+      },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw new LangfuseConflictError(
+        `An item for ${input.objectType.toLowerCase()} ${input.objectId} already exists in this annotation queue.`,
+      );
+    }
+    throw error;
+  }
 
   if (auditScope) {
     await auditLog({

--- a/worker/src/features/batchAction/processAddToQueue.ts
+++ b/worker/src/features/batchAction/processAddToQueue.ts
@@ -12,10 +12,9 @@ const addToQueue = async ({
   objectType: AnnotationQueueObjectType;
   targetId: string;
 }) => {
-  // cannot use prisma `createMany` operation as we do not have unique constraint enforced on schema level
-  // conflict must be handled on query level by reading existing items and filtering out traces that already exist
-
-  // First get existing items
+  // Pre-filter to avoid round-tripping objects we already have; `skipDuplicates`
+  // closes the race window between this SELECT and the INSERT now that the DB
+  // enforces (project_id, queue_id, object_id, object_type) uniqueness.
   const existingItems = await prisma.annotationQueueItem.findMany({
     where: {
       projectId,
@@ -26,7 +25,6 @@ const addToQueue = async ({
     select: { objectId: true },
   });
 
-  // Filter out objects that already exist
   const existingObjectIds = new Set(existingItems.map((item) => item.objectId));
   const newObjectIds = objectIds.filter((id) => !existingObjectIds.has(id));
 
@@ -38,6 +36,7 @@ const addToQueue = async ({
         objectId,
         objectType,
       })),
+      skipDuplicates: true,
     });
   }
 };


### PR DESCRIPTION
## What does this PR do?

Fixes #12938 by adding a database-level uniqueness invariant on `(project_id, queue_id, object_id, object_type)` for `annotation_queue_items`. Today the same trace can be added to the same annotation queue more than once via the public API, producing duplicate `PENDING` items that pollute reviewer queues and skew per-queue stats.

Related: #9865 (proposed `traceIds` filter on `GET /items`). That PR lets API callers work around the bug client-side; this PR fixes it at the database level so the workaround stops being necessary for every Langfuse user.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed

## Changes

### 1. Schema + migrations (`packages/shared/prisma/`)

- Add `@@unique([projectId, queueId, objectId, objectType])` to `AnnotationQueueItem`. Explicit `map:` so the index name stays under PostgreSQL's 63-char limit (`annotation_queue_items_proj_queue_obj_type_key`).
- Two new migrations:
  - `20260618000000_unique_annotation_queue_items` — fail-loud preflight `DO` block that aborts if duplicate `(project_id, queue_id, object_id, object_type)` groups exist. Details under "Pre-existing duplicate rows" below.
  - `20260618000001_unique_annotation_queue_items_index` — creates the unique index via `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS`, so it does **not** take a `ShareLock` on `annotation_queue_items` during index creation and concurrent writes are not blocked. Split into its own file because `CONCURRENTLY` cannot run inside a transaction. Pattern mirrors prior Langfuse precedents (`20240513082204_scores_unique_id_and_projectid_instead_of_id_and_traceid_index` and `20251210133946_dataset_items_create_idx_id_project_id_valid_from`).

### 2. Direct public API (`createAnnotationQueueItemForApi`)

- Catches Prisma `P2002` on insert and throws `LangfuseConflictError` (HTTP 409). Matches the existing P2002 patterns in `publicDatasetService.ts:647` and `verifiedDomainRouter.ts:227`.

### 3. Batch worker (`worker/src/features/batchAction/processAddToQueue.ts`)

- Adds `skipDuplicates: true` to the `createMany` call so the race window between the fetch-and-filter SELECT and the INSERT does not fail an entire batch when two concurrent batches add the same trace. (The existing `skipDuplicates: true` flag on the tRPC-side `createMany` was a no-op before this PR — Prisma's docs are explicit that `skipDuplicates` only works against an existing unique constraint.)
- Updates the now-stale comment that said "no constraint enforced".

## Pre-existing duplicate rows

This is the migration's risk surface and the only meaningful operational question. Any Langfuse instance already hit by #12938 has duplicate rows in `annotation_queue_items` today. A naive `CREATE UNIQUE INDEX` would fail at deploy time, blocking the upgrade until duplicates are removed.

I considered two options:

1. **Silent dedupe in the migration** — matches the `20250403153555_membership_invitations_no_duplicates` precedent. Smallest deploy story, but silently deletes customer data on upgrade.
2. **Fail loud and require explicit operator cleanup** — what this PR ships.

I chose option 2 because annotation queue items contain reviewer work (locks, annotator assignments, completion state), which is materially different from pending invites in the membership precedent. Silently deleting that data on an upgrade felt wrong for an external-contributor PR to decide on Langfuse's behalf. Happy to flip to option 1 (remove the preflight migration entirely; keep the CONCURRENTLY index migration) if the maintainers prefer the silent-dedupe approach — easy to walk in that direction, much harder to walk back.

### What the fail-loud check does

The preflight migration counts duplicate `(project_id, queue_id, object_id, object_type)` groups in a `DO` block. If any exist, the migration aborts with:

```
ERROR: Cannot create unique index on annotation_queue_items:
       N duplicate (project_id, queue_id, object_id, object_type) group(s) exist.
       Review duplicates and dedupe explicitly before re-running migrations.
       See langfuse/langfuse#12938 for the inspect/cleanup queries.
```

The deploy stops until the operator acts. No silent data loss.

### Pre-migration cleanup (only needed if your DB has duplicates)

If you see the preflight error above, here's the full operator path:

**1. Inspect** — counts duplicates and shows the worst offenders:

```sql
SELECT project_id, queue_id, object_id, object_type, COUNT(*) AS dup_count
FROM annotation_queue_items
GROUP BY 1, 2, 3, 4
HAVING COUNT(*) > 1
ORDER BY dup_count DESC;
```

**2. Cleanup** — keep the most-recently-updated row per group, delete the rest. Take a backup first. Pick a different survivor rule if it fits your data better (e.g. oldest by `created_at`, or based on attached lock/annotator state):

```sql
WITH ranked_items AS (
  SELECT id, ROW_NUMBER() OVER (
    PARTITION BY project_id, queue_id, object_id, object_type
    ORDER BY updated_at DESC, id DESC
  ) AS rn
  FROM annotation_queue_items
)
DELETE FROM annotation_queue_items
WHERE id IN (SELECT id FROM ranked_items WHERE rn > 1);
```

**3. Mark the failed migration as rolled back** so Prisma will retry it. After the preflight `RAISE EXCEPTION`, Prisma records the migration as failed in `_prisma_migrations`; without this step the next `migrate deploy` exits with **P3009** instead of re-running it:

```bash
pnpm --filter=shared exec prisma migrate resolve --rolled-back 20260618000000_unique_annotation_queue_items
```

**4. Re-run migrations:**

```bash
pnpm --filter=shared run db:migrate-deploy
# or whatever your normal deploy step is
```

The preflight now passes, the CONCURRENTLY index migration runs, and the unique constraint is in place.

## Verification

Per `.agents/AGENTS.md` verification matrix for `packages/shared/prisma/**` and public API contract changes:

- `pnpm --filter=shared run db:generate` — clean
- `pnpm --filter=shared run build` — clean
- `pnpm --filter=shared run lint` — clean
- `pnpm --filter web run lint` — clean
- `pnpm --filter worker run lint` — clean
- `pnpm --filter worker run typecheck` — clean
- `pnpm --filter web run test src/__tests__/server/annotation-queues-api.servertest.ts` — **31/31 pass**, including the new `should reject duplicate (objectId, objectType) for the same queue` test
- **Manual end-to-end on a local dev stack**:
  - Bug reproduces on the same code with the unique index dropped (multi-select add via the UI creates a duplicate row).
  - Fix prevents the dupe with the index in place (multi-select add silently no-ops on the second attempt; only one row exists).
  - **Operator-recovery path verified end-to-end**: inserted dups in psql → `migrate deploy` aborted at the preflight with the documented P0001 error → ran the cleanup SQL → ran `prisma migrate resolve --rolled-back` → re-ran `migrate deploy` → both migrations applied cleanly and the unique index landed.
- Fern: no API-shape change (`createQueueItem` response is unchanged). No `errors` block exists on any endpoint in `fern/apis/server/definition/annotation-queues.yml` (errors are middleware-uniform). No Fern regeneration needed.
