### PR TITLE
fix(web): trace only 5xx tRPC errors

### DIFF
--- a/web/src/__tests__/server/unit/trpc-utils.servertest.ts
+++ b/web/src/__tests__/server/unit/trpc-utils.servertest.ts
@@ -1,0 +1,59 @@
+import { TRPCError } from "@trpc/server";
+import {
+  getTRPCErrorCodeFromHTTPStatusCode,
+  getTRPCErrorReporting,
+} from "@/src/server/utils/trpc-utils";
+
+describe("trpc-utils", () => {
+  it("maps HTTP status codes to tRPC error codes", () => {
+    expect(getTRPCErrorCodeFromHTTPStatusCode(409)).toBe("CONFLICT");
+    expect(getTRPCErrorCodeFromHTTPStatusCode(422)).toBe(
+      "UNPROCESSABLE_CONTENT",
+    );
+    expect(getTRPCErrorCodeFromHTTPStatusCode(599)).toBe(
+      "INTERNAL_SERVER_ERROR",
+    );
+  });
+
+  it("only traces 5xx tRPC errors", () => {
+    expect(
+      getTRPCErrorReporting(new TRPCError({ code: "CONFLICT" })),
+    ).toMatchObject({
+      httpStatus: 409,
+      logLevel: "warn",
+      shouldTrace: false,
+    });
+
+    expect(
+      getTRPCErrorReporting(new TRPCError({ code: "UNAUTHORIZED" })),
+    ).toMatchObject({
+      httpStatus: 401,
+      logLevel: "info",
+      shouldTrace: false,
+    });
+
+    expect(
+      getTRPCErrorReporting(new TRPCError({ code: "NOT_FOUND" })),
+    ).toMatchObject({
+      httpStatus: 404,
+      logLevel: "info",
+      shouldTrace: false,
+    });
+
+    expect(
+      getTRPCErrorReporting(new TRPCError({ code: "FORBIDDEN" })),
+    ).toMatchObject({
+      httpStatus: 403,
+      logLevel: "warn",
+      shouldTrace: false,
+    });
+
+    expect(
+      getTRPCErrorReporting(new TRPCError({ code: "INTERNAL_SERVER_ERROR" })),
+    ).toMatchObject({
+      httpStatus: 500,
+      logLevel: "error",
+      shouldTrace: true,
+    });
+  });
+});

--- a/web/src/pages/api/trpc/[trpc].ts
+++ b/web/src/pages/api/trpc/[trpc].ts
@@ -3,6 +3,7 @@ import { createTRPCContext } from "@/src/server/api/trpc";
 import { appRouter } from "@/src/server/api/root";
 import { env } from "@/src/env.mjs";
 import { logger, traceException } from "@langfuse/shared/src/server";
+import { getTRPCErrorReporting } from "@/src/server/utils/trpc-utils";
 
 export const config = {
   maxDuration: 240,
@@ -18,29 +19,21 @@ export default createNextApiHandler({
   router: appRouter,
   createContext: createTRPCContext,
   onError: ({ path, error }) => {
-    // User errors that should not be reported to Sentry
-    const userErrorCodes = [
-      "NOT_FOUND",
-      "UNAUTHORIZED",
-      "FORBIDDEN",
-      "BAD_REQUEST",
-      "PRECONDITION_FAILED",
-      "UNPROCESSABLE_CONTENT",
-    ];
+    const { logLevel, shouldTrace } = getTRPCErrorReporting(error);
+    const message = `tRPC route failed on ${path ?? "<no-path>"}: ${error.message}`;
 
-    if (userErrorCodes.includes(error.code)) {
-      logger.info(
-        `tRPC route failed on ${path ?? "<no-path>"}: ${error.message}`,
-        error,
-      );
+    if (logLevel === "error") {
+      logger.error(message, error);
+    } else if (logLevel === "warn") {
+      logger.warn(message, error);
     } else {
-      logger.error(
-        `tRPC route failed on ${path ?? "<no-path>"}: ${error.message}`,
-        error,
-      );
-      // Only report system errors to Sentry, not user errors
+      logger.info(message, error);
+    }
+
+    if (shouldTrace) {
       traceException(error);
     }
+
     return error;
   },
   responseMeta() {

--- a/web/src/server/utils/trpc-utils.ts
+++ b/web/src/server/utils/trpc-utils.ts
@@ -1,4 +1,5 @@
-import type { TRPC_ERROR_CODE_KEY } from "@trpc/server";
+import type { TRPCError, TRPC_ERROR_CODE_KEY } from "@trpc/server";
+import { getHTTPStatusCodeFromError } from "@trpc/server/http";
 
 // Note: copied from official documentation: https://trpc.io/docs/server/error-handling#error-codes
 const HTTP_STATUS_CODE_TO_TRPC_ERROR_CODE: Record<number, TRPC_ERROR_CODE_KEY> =
@@ -30,4 +31,31 @@ export const getTRPCErrorCodeFromHTTPStatusCode = (
   httpStatus: number,
 ): TRPC_ERROR_CODE_KEY => {
   return HTTP_STATUS_CODE_TO_TRPC_ERROR_CODE[httpStatus] ?? DEFAULT_ERROR_CODE;
+};
+
+type TRPCErrorLogLevel = "info" | "warn" | "error";
+
+const isServerErrorStatus = (httpStatus: number) =>
+  httpStatus >= 500 && httpStatus < 600;
+
+const getLogLevelFromHTTPStatus = (httpStatus: number): TRPCErrorLogLevel => {
+  if (isServerErrorStatus(httpStatus)) return "error";
+  if (httpStatus === 401 || httpStatus === 404) return "info";
+  return "warn";
+};
+
+export const getTRPCErrorReporting = (
+  error: TRPCError,
+): {
+  httpStatus: number;
+  logLevel: TRPCErrorLogLevel;
+  shouldTrace: boolean;
+} => {
+  const httpStatus = getHTTPStatusCodeFromError(error);
+
+  return {
+    httpStatus,
+    logLevel: getLogLevelFromHTTPStatus(httpStatus),
+    shouldTrace: isServerErrorStatus(httpStatus),
+  };
 };


### PR DESCRIPTION
## Summary
- classify tRPC errors by their HTTP status code
- only call `traceException` for 5xx responses
- log 401/404 at info, other 4xx at warn, and 5xx at error
- add server-unit coverage for 409/422/599 mapping and trace behavior

## Validation
- `pnpm --filter shared run db:generate`
- `pnpm --filter @langfuse/shared run build`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres NEXTAUTH_URL=http://localhost:3000 SALT=0123456789abcdef0123456789abcdef CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_USER=default CLICKHOUSE_PASSWORD=password LANGFUSE_S3_EVENT_UPLOAD_BUCKET=dummy-bucket pnpm --filter web run test src/__tests__/server/unit/trpc-utils.servertest.ts`
- `pnpm exec eslint 'src/pages/api/trpc/[trpc].ts' src/server/utils/trpc-utils.ts src/__tests__/server/unit/trpc-utils.servertest.ts --max-warnings 0`
- commit hook: `prettier --check` and full `turbo run lint`

Note: local shell uses Node v26.3.0 while the repo declares Node 24, so pnpm emitted engine warnings during validation.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the tRPC error handler to classify errors by their HTTP status code instead of a static allowlist of error codes, then traces only 5xx errors to Sentry and applies differentiated log levels (error for 5xx, info for 401/404, warn for everything else).

- `getTRPCErrorReporting` utility is extracted into `trpc-utils.ts`, using `getHTTPStatusCodeFromError` to derive HTTP status and computing both log level and trace decision from it.
- The old static allowlist (NOT_FOUND, UNAUTHORIZED, FORBIDDEN, BAD_REQUEST, PRECONDITION_FAILED, UNPROCESSABLE_CONTENT → info, no trace) is replaced; 403/400/412/422 now log at `warn`, and previously un-allowlisted 4xx codes (409, 429, 499, etc.) no longer trigger `traceException`.
- Unit tests cover the 409/422/599 mapping and the 409/401/500 reporting paths, but do not assert the 404→info or the FORBIDDEN→warn (changed from info) behaviors.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the refactor is well-scoped and the core logic is correct.

The HTTP-status-based classification is sound and the new utility is straightforward. The only gap is that the test suite does not cover the 404→info path or the FORBIDDEN→warn behavior change, which is a meaningful shift from the previous allowlist.

The test file could use two additional cases to fully document the 404 and FORBIDDEN log-level decisions.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tRPC onError callback] --> B[getTRPCErrorReporting]
    B --> C[getHTTPStatusCodeFromError]
    C --> D{httpStatus}
    D -->|>= 500| E[logLevel: error\nshouldTrace: true]
    D -->|401 or 404| F[logLevel: info\nshouldTrace: false]
    D -->|other 4xx| G[logLevel: warn\nshouldTrace: false]
    E --> H[logger.error]
    F --> I[logger.info]
    G --> J[logger.warn]
    E --> K[traceException called]
    F --> L[no traceException]
    G --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[tRPC onError callback] --> B[getTRPCErrorReporting]
    B --> C[getHTTPStatusCodeFromError]
    C --> D{httpStatus}
    D -->|>= 500| E[logLevel: error\nshouldTrace: true]
    D -->|401 or 404| F[logLevel: info\nshouldTrace: false]
    D -->|other 4xx| G[logLevel: warn\nshouldTrace: false]
    E --> H[logger.error]
    F --> I[logger.info]
    G --> J[logger.warn]
    E --> K[traceException called]
    F --> L[no traceException]
    G --> L
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/unit/trpc-utils.servertest.ts:18-43
**Missing coverage for 404 and the FORBIDDEN behavior change**

The `getLogLevelFromHTTPStatus` function explicitly maps `404` to `"info"`, but no test asserts this path. More importantly, `FORBIDDEN` (403) changed from `"info"` (it was in the old `userErrorCodes` allowlist) to `"warn"` — that behavioral shift is untested. Adding a case for `new TRPCError({ code: "NOT_FOUND" })` (expecting `info`) and `new TRPCError({ code: "FORBIDDEN" })` (expecting `warn`) would lock in both intentions and guard against future regressions.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): trace only 5xx tRPC errors"](https://github.com/langfuse/langfuse/commit/2393b195def5d9cd8f2eb5823add892d38a6782c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38598479)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->