### PR TITLE
fix(worker): resolve real ECS host id instead of os.hostname() 0.0.0.0 (LFE-10388)

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1,6 +1,5 @@
 import { pipeline, Transform } from "stream";
 import { createGzip } from "zlib";
-import { hostname } from "os";
 import { monitorEventLoopDelay } from "perf_hooks";
 import { Job } from "bullmq";
 import { prisma } from "@langfuse/shared/src/db";
@@ -32,6 +31,7 @@ import {
   registerInFlightBlobExport,
   unregisterInFlightBlobExport,
 } from "./inFlightExports";
+import { WORKER_HOST_ID } from "../../utils/hostId";
 import {
   BlobStorageIntegrationType,
   BlobStorageIntegrationFileType,
@@ -47,8 +47,6 @@ import { SpanKind } from "@opentelemetry/api";
 import { env, v4AllowPreviewOptIn } from "../../env";
 
 export const BLOB_STORAGE_LAG_BUFFER_MS = 20 * 60 * 1000; // 20-minute lag buffer
-
-const HOST_NAME = hostname();
 
 export async function* enrichObservationStream(
   stream: AsyncGenerator<Record<string, unknown>>,
@@ -302,7 +300,7 @@ const processBlobStorageExport = async (config: {
         span.setAttribute("messaging.bullmq.job.id", config.bullmqJobId);
       }
       span.setAttribute("job.attemptsMade", config.bullmqAttemptsMade);
-      span.setAttribute("host.name", HOST_NAME);
+      span.setAttribute("host.name", WORKER_HOST_ID);
 
       // Event-loop delay during the stream: if it spikes, lock renewal can't
       // fire and the job re-enqueues as stalled (LFE-10063). Torn down below.
@@ -437,7 +435,7 @@ const processBlobStorageExport = async (config: {
 
           logger.info(
             `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
-              `jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${HOST_NAME} ` +
+              `jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${WORKER_HOST_ID} ` +
               `rows=${sourceStats.rows} sourceWaitMs=${Math.round(sourceStats.sourceWaitMs)} ` +
               `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${Math.round(performance.now() - uploadStartMs)}`,
           );
@@ -461,7 +459,7 @@ const processBlobStorageExport = async (config: {
       } catch (error) {
         logger.error(
           `[BLOB INTEGRATION] Error exporting ${config.table} for project ${config.projectId} ` +
-            `(jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${HOST_NAME})`,
+            `(jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${WORKER_HOST_ID})`,
           error,
         );
         throw error;
@@ -508,7 +506,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
       span.setAttribute("messaging.bullmq.job.id", job.id);
     }
     span.setAttribute("job.attemptsMade", job.attemptsMade);
-    span.setAttribute("host.name", HOST_NAME);
+    span.setAttribute("host.name", WORKER_HOST_ID);
   }
 
   logger.info(

--- a/worker/src/features/blobstorage/inFlightExports.ts
+++ b/worker/src/features/blobstorage/inFlightExports.ts
@@ -1,7 +1,5 @@
-import { hostname } from "os";
 import { logger } from "@langfuse/shared/src/server";
-
-const HOST_NAME = hostname();
+import { WORKER_HOST_ID } from "../../utils/hostId";
 
 export type InFlightBlobExport = {
   jobId: string | undefined;
@@ -40,7 +38,7 @@ export const resetInFlightBlobExports = (): void => {
 export const logInFlightBlobExportsOnShutdown = (): void => {
   if (inFlightExports.size === 0) {
     logger.info(
-      `[BLOB INTEGRATION] No blob storage exports in-flight at shutdown on host ${HOST_NAME}`,
+      `[BLOB INTEGRATION] No blob storage exports in-flight at shutdown on host ${WORKER_HOST_ID}`,
     );
     return;
   }
@@ -50,7 +48,7 @@ export const logInFlightBlobExportsOnShutdown = (): void => {
     // "in-flight at shutdown", not "aborted": worker.close() drains gracefully,
     // so this export may still complete within the grace period.
     logger.warn(
-      `[BLOB INTEGRATION] Blob storage export in-flight at shutdown signal on host ${HOST_NAME}: ` +
+      `[BLOB INTEGRATION] Blob storage export in-flight at shutdown signal on host ${WORKER_HOST_ID}: ` +
         `jobId=${entry.jobId} projectId=${entry.projectId} table=${entry.table} ` +
         `window=[${entry.minTimestamp}, ${entry.maxTimestamp}] ` +
         `elapsedMs=${now - entry.startedAt}`,

--- a/worker/src/queues/workerManager.ts
+++ b/worker/src/queues/workerManager.ts
@@ -1,4 +1,3 @@
-import { hostname } from "os";
 import { Job, Processor, Worker, WorkerOptions } from "bullmq";
 import {
   convertQueueNameToMetricName,
@@ -12,12 +11,11 @@ import {
   traceException,
 } from "@langfuse/shared/src/server";
 import { env } from "../env";
+import { WORKER_HOST_ID } from "../utils/hostId";
 import {
   resolveQueueInstance,
   SHARDED_QUEUE_BASE_NAMES,
 } from "./shardedQueueRegistry";
-
-const HOST_NAME = hostname();
 
 export class WorkerManager {
   private static workers: { [key: string]: Worker } = {};
@@ -189,7 +187,7 @@ export class WorkerManager {
       // detectedOnHost: the stall-checker pod, which may differ from the pod
       // whose lock expired.
       logger.warn(
-        `Queue job ${jobId} in ${queueName} stalled (lock expired, re-enqueued) detectedOnHost=${HOST_NAME}`,
+        `Queue job ${jobId} in ${queueName} stalled (lock expired, re-enqueued) detectedOnHost=${WORKER_HOST_ID}`,
       );
       recordIncrement(oldMetric + ".stalled");
       recordIncrement(baseMetric + ".rate", 1, {

--- a/worker/src/utils/hostId.ts
+++ b/worker/src/utils/hostId.ts
@@ -20,7 +20,8 @@ function resolveWorkerHostId(): string {
   if (osHost && osHost !== "0.0.0.0" && osHost !== "localhost") return osHost;
 
   const envHost = process.env.HOSTNAME;
-  if (envHost && envHost !== "0.0.0.0") return envHost;
+  if (envHost && envHost !== "0.0.0.0" && envHost !== "localhost")
+    return envHost;
 
   return "unknown";
 }

--- a/worker/src/utils/hostId.ts
+++ b/worker/src/utils/hostId.ts
@@ -1,0 +1,28 @@
+/* eslint-disable turbo/no-undeclared-env-vars -- runtime-only ECS/host detection, not a build input */
+import { hostname } from "os";
+
+/**
+ * Stable per-task identifier for logs/metrics/spans.
+ *
+ * os.hostname() is unreliable on our ECS tasks — it returns the bind address
+ * "0.0.0.0" — so prefer the container id embedded in the ECS task-metadata URI
+ * (the same id Datadog exposes as the `container_id` tag). Fall back to
+ * os.hostname()/HOSTNAME for local/dev where the metadata endpoint is absent.
+ */
+function resolveWorkerHostId(): string {
+  const ecsUri =
+    process.env.ECS_CONTAINER_METADATA_URI_V4 ??
+    process.env.ECS_CONTAINER_METADATA_URI;
+  const ecsContainerId = ecsUri?.split("/").filter(Boolean).pop();
+  if (ecsContainerId) return ecsContainerId;
+
+  const osHost = hostname();
+  if (osHost && osHost !== "0.0.0.0" && osHost !== "localhost") return osHost;
+
+  const envHost = process.env.HOSTNAME;
+  if (envHost && envHost !== "0.0.0.0") return envHost;
+
+  return "unknown";
+}
+
+export const WORKER_HOST_ID = resolveWorkerHostId();


### PR DESCRIPTION
## What does this PR do?

Follow-up to #14379 (LFE-10388). Fixes host attribution: `os.hostname()` → `0.0.0.0`.

The observability added in #14379 stamps a host on stall logs (`detectedOnHost`), the SIGTERM in-flight-export logs, the per-table export logs, and the `host.name` span attribute. In **prod-hipaa** all of these showed `0.0.0.0`: `os.hostname()` returns the bind address on our ECS tasks, so the field was non-discriminating — which defeats the cross-pod job-multiplication-factor goal from LFE-10063.

New shared `WORKER_HOST_ID` helper (`worker/src/utils/hostId.ts`) resolves the identifier in priority order:
1. container id parsed from the ECS task-metadata URI (`ECS_CONTAINER_METADATA_URI_V4` / `_URI`) — the same id Datadog exposes as the `container_id` tag, so it correlates with infra tags;
2. `os.hostname()` when it isn't `0.0.0.0`/`localhost` (local/dev);
3. `HOSTNAME` env, else `"unknown"`.

This also de-duplicates the three copies of the host constant that #14379 introduced. The ECS metadata endpoint is already relied on by the OTel `awsEcsDetector` in `worker/src/instrumentation.ts`, so no new infra dependency.

## Type of change

- [x] Bug fix (observability correctness)

## Checklist

- [x] `pnpm turbo run typecheck --filter=worker` passes
- [x] `pnpm turbo run lint --filter=worker` passes
- [x] Existing `inFlightExports.unit.test.ts` still passes
- [x] No behavior change to the export itself — observability only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
