### PR TITLE
feat(worker): per-project blob export tuning via exportTuning column (LFE-10394)

### DIFF
--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
@@ -1,111 +1,355 @@
 import { describe, it, expect } from "vitest";
-import { resolveBlobExportTuning } from "./blob-export-tuning";
+
+import {
+  resolveBlobExportTuning,
+  BlobExportTuningSchema,
+  BLOB_EXPORT_TUNING_BOUNDS,
+  DEFAULT_BLOB_EXPORT_PART_SIZE_BYTES,
+  type BlobExportTuningDefaults,
+  type ResolvedBlobExportTuning,
+} from "./blob-export-tuning";
+
+const DEFAULTS: BlobExportTuningDefaults = {
+  partSizeBytes: DEFAULT_BLOB_EXPORT_PART_SIZE_BYTES, // 100 MiB
+};
+
+// Fully-resolved object with the defaults applied; override per assertion.
+// Concurrency/attempts default to undefined (operator did not set them) so the
+// backend keeps its native default.
+function resolved(
+  overrides: Partial<ResolvedBlobExportTuning> = {},
+): ResolvedBlobExportTuning {
+  return {
+    rawPassthrough: false,
+    gzipLevel: undefined,
+    partSizeBytes: DEFAULTS.partSizeBytes,
+    maxConcurrentParts: undefined,
+    maxPartAttempts: undefined,
+    skipEnrichment: false,
+    ...overrides,
+  };
+}
 
 describe("resolveBlobExportTuning", () => {
-  it("defaults to rawPassthrough=false for null/undefined", () => {
-    expect(resolveBlobExportTuning(null)).toEqual({
-      resolved: { rawPassthrough: false, gzipLevel: undefined },
-      warnings: [],
+  describe("null / absent / malformed → defaults, byte-for-byte unchanged", () => {
+    it("returns defaults with no warnings for null", () => {
+      expect(resolveBlobExportTuning(null, DEFAULTS)).toEqual({
+        resolved: resolved(),
+        warnings: [],
+      });
     });
-    expect(resolveBlobExportTuning(undefined)).toEqual({
-      resolved: { rawPassthrough: false, gzipLevel: undefined },
-      warnings: [],
+
+    it("returns defaults with no warnings for undefined", () => {
+      expect(resolveBlobExportTuning(undefined, DEFAULTS)).toEqual({
+        resolved: resolved(),
+        warnings: [],
+      });
+    });
+
+    it("returns defaults with no warnings for an empty object", () => {
+      expect(resolveBlobExportTuning({}, DEFAULTS)).toEqual({
+        resolved: resolved(),
+        warnings: [],
+      });
+    });
+
+    it("warns and uses defaults when the value is not an object", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        "garbage",
+        DEFAULTS,
+      );
+      expect(res).toEqual(resolved());
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("expected an object");
+    });
+
+    it("warns and uses defaults for an array (objects only)", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        [1, 2],
+        DEFAULTS,
+      );
+      expect(res).toEqual(resolved());
+      expect(warnings[0]).toContain("expected an object");
     });
   });
 
-  it("honors rawPassthrough=true", () => {
-    expect(resolveBlobExportTuning({ rawPassthrough: true })).toEqual({
-      resolved: { rawPassthrough: true, gzipLevel: undefined },
-      warnings: [],
+  describe("rawPassthrough (LFE-10402)", () => {
+    it("honors rawPassthrough=true", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { rawPassthrough: true },
+        DEFAULTS,
+      );
+      expect(res).toEqual(resolved({ rawPassthrough: true }));
+      expect(warnings).toEqual([]);
+    });
+
+    it("honors rawPassthrough=false explicitly", () => {
+      const { resolved: res } = resolveBlobExportTuning(
+        { rawPassthrough: false },
+        DEFAULTS,
+      );
+      expect(res.rawPassthrough).toBe(false);
+    });
+
+    it("falls back to false and warns on a wrong-typed rawPassthrough", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { rawPassthrough: "yes" },
+        DEFAULTS,
+      );
+      expect(res.rawPassthrough).toBe(false);
+      expect(warnings.some((w) => w.includes("expected a boolean"))).toBe(true);
+    });
+
+    it("composes rawPassthrough with upload knobs", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        {
+          rawPassthrough: true,
+          partSizeBytes: 200 * 1024 * 1024,
+          maxConcurrentParts: 8,
+          skipEnrichment: true,
+        },
+        DEFAULTS,
+      );
+      expect(res).toEqual(
+        resolved({
+          rawPassthrough: true,
+          partSizeBytes: 200 * 1024 * 1024,
+          maxConcurrentParts: 8,
+          skipEnrichment: true,
+        }),
+      );
+      expect(warnings).toEqual([]);
     });
   });
 
-  it("honors rawPassthrough=false explicitly", () => {
-    expect(resolveBlobExportTuning({ rawPassthrough: false })).toEqual({
-      resolved: { rawPassthrough: false, gzipLevel: undefined },
-      warnings: [],
+  describe("gzipLevel (LFE-10402)", () => {
+    it("honors a valid gzipLevel independently of rawPassthrough", () => {
+      expect(
+        resolveBlobExportTuning(
+          { rawPassthrough: true, gzipLevel: 1 },
+          DEFAULTS,
+        ).resolved,
+      ).toEqual(resolved({ rawPassthrough: true, gzipLevel: 1 }));
+      // level 0 (store) and 9 (max) are both valid
+      expect(
+        resolveBlobExportTuning({ gzipLevel: 0 }, DEFAULTS).resolved.gzipLevel,
+      ).toBe(0);
+      expect(
+        resolveBlobExportTuning({ gzipLevel: 9 }, DEFAULTS).resolved.gzipLevel,
+      ).toBe(9);
+    });
+
+    it("drops an out-of-range gzipLevel to the zlib default without disabling rawPassthrough", () => {
+      const tooHigh = resolveBlobExportTuning(
+        { rawPassthrough: true, gzipLevel: 12 },
+        DEFAULTS,
+      );
+      expect(tooHigh.resolved.rawPassthrough).toBe(true);
+      expect(tooHigh.resolved.gzipLevel).toBeUndefined();
+      expect(
+        tooHigh.warnings.some((w) => w.includes("out of range [0, 9]")),
+      ).toBe(true);
+
+      expect(
+        resolveBlobExportTuning({ gzipLevel: -1 }, DEFAULTS).resolved.gzipLevel,
+      ).toBeUndefined();
+    });
+
+    it("reports gzipLevel failure modes with accurate, distinct messages", () => {
+      // non-integer in range → "not an integer", NOT "out of range"
+      const frac = resolveBlobExportTuning({ gzipLevel: 5.5 }, DEFAULTS);
+      expect(frac.resolved.gzipLevel).toBeUndefined();
+      expect(frac.warnings.some((w) => w.includes("is not an integer"))).toBe(
+        true,
+      );
+      expect(frac.warnings.some((w) => w.includes("out of range"))).toBe(false);
+
+      // wrong type → "expected a finite number", NOT "out of range"
+      const str = resolveBlobExportTuning({ gzipLevel: "high" }, DEFAULTS);
+      expect(str.resolved.gzipLevel).toBeUndefined();
+      expect(
+        str.warnings.some((w) => w.includes("expected a finite number")),
+      ).toBe(true);
+      expect(str.warnings.some((w) => w.includes("out of range"))).toBe(false);
     });
   });
 
-  it("defaults rawPassthrough when the key is absent from a valid object", () => {
-    expect(resolveBlobExportTuning({})).toEqual({
-      resolved: { rawPassthrough: false, gzipLevel: undefined },
-      warnings: [],
+  describe("valid in-range upload knobs are honoured silently", () => {
+    it("passes through values within bounds", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        {
+          partSizeBytes: 200 * 1024 * 1024,
+          maxConcurrentParts: 16,
+          maxPartAttempts: 5,
+          skipEnrichment: true,
+        },
+        DEFAULTS,
+      );
+      expect(res).toEqual(
+        resolved({
+          partSizeBytes: 200 * 1024 * 1024,
+          maxConcurrentParts: 16,
+          maxPartAttempts: 5,
+          skipEnrichment: true,
+        }),
+      );
+      expect(warnings).toEqual([]);
     });
   });
 
-  it("ignores unknown keys (forward-compat with LFE-10394 knobs)", () => {
-    const result = resolveBlobExportTuning({
-      rawPassthrough: true,
-      partSizeBytes: 200,
-      maxConcurrentParts: 8,
-      skipEnrichment: true,
+  describe("out-of-range numbers are clamped (not defaulted) and warned", () => {
+    it("clamps maxConcurrentParts above the ceiling to 32", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { maxConcurrentParts: 50 },
+        DEFAULTS,
+      );
+      expect(res.maxConcurrentParts).toBe(
+        BLOB_EXPORT_TUNING_BOUNDS.maxConcurrentParts.max,
+      );
+      expect(warnings.some((w) => w.includes("clamped to 32"))).toBe(true);
     });
-    expect(result.resolved).toEqual({
-      rawPassthrough: true,
-      gzipLevel: undefined,
+
+    it("clamps maxConcurrentParts below the floor to 1", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { maxConcurrentParts: 0 },
+        DEFAULTS,
+      );
+      expect(res.maxConcurrentParts).toBe(1);
+      expect(warnings.some((w) => w.includes("clamped to 1"))).toBe(true);
     });
-    expect(result.warnings).toEqual([]);
+
+    it("clamps maxPartAttempts above 10 to 10", () => {
+      const { resolved: res } = resolveBlobExportTuning(
+        { maxPartAttempts: 99 },
+        DEFAULTS,
+      );
+      expect(res.maxPartAttempts).toBe(10);
+    });
+
+    it("clamps partSizeBytes below 5 MiB to the floor", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { partSizeBytes: 1024 },
+        DEFAULTS,
+      );
+      expect(res.partSizeBytes).toBe(
+        BLOB_EXPORT_TUNING_BOUNDS.partSizeBytes.min,
+      );
+      expect(warnings.some((w) => w.includes("clamped"))).toBe(true);
+    });
+
+    it("clamps partSizeBytes above 5 GiB to the ceiling", () => {
+      const { resolved: res } = resolveBlobExportTuning(
+        { partSizeBytes: 9 * 1024 * 1024 * 1024 },
+        DEFAULTS,
+      );
+      expect(res.partSizeBytes).toBe(
+        BLOB_EXPORT_TUNING_BOUNDS.partSizeBytes.max,
+      );
+    });
   });
 
-  it("falls back to defaults and warns on a wrong-typed rawPassthrough", () => {
-    const result = resolveBlobExportTuning({ rawPassthrough: "yes" });
-    expect(result.resolved).toEqual({
-      rawPassthrough: false,
-      gzipLevel: undefined,
+  describe("in-range non-integers are rounded, not reported as out of range", () => {
+    it("rounds an in-range float and warns about rounding only", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { maxConcurrentParts: 3.5 },
+        DEFAULTS,
+      );
+      expect(res.maxConcurrentParts).toBe(4);
+      expect(warnings.some((w) => w.includes("rounded to 4"))).toBe(true);
+      // Must NOT claim the in-range value was out of range.
+      expect(warnings.some((w) => w.includes("out of range"))).toBe(false);
     });
-    expect(result.warnings.length).toBe(1);
+
+    it("reports both rounding and clamping for an out-of-range float", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { maxConcurrentParts: 41.6 },
+        DEFAULTS,
+      );
+      expect(res.maxConcurrentParts).toBe(32);
+      expect(warnings.some((w) => w.includes("rounded to 42"))).toBe(true);
+      expect(warnings.some((w) => w.includes("clamped to 32"))).toBe(true);
+    });
   });
 
-  it("falls back to defaults and warns on a non-object column", () => {
-    const result = resolveBlobExportTuning("garbage");
-    expect(result.resolved).toEqual({
-      rawPassthrough: false,
-      gzipLevel: undefined,
+  describe("wrong-typed / non-finite values fall back to defaults and warn", () => {
+    it("falls back to undefined (backend default) when a concurrency knob is a string", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { maxConcurrentParts: "x" },
+        DEFAULTS,
+      );
+      expect(res.maxConcurrentParts).toBeUndefined();
+      expect(warnings.some((w) => w.includes("expected a finite number"))).toBe(
+        true,
+      );
     });
-    expect(result.warnings.length).toBe(1);
+
+    it("falls back to the partSize default when partSizeBytes is NaN", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { partSizeBytes: NaN },
+        DEFAULTS,
+      );
+      expect(res.partSizeBytes).toBe(DEFAULTS.partSizeBytes);
+      expect(warnings.some((w) => w.includes("expected a finite number"))).toBe(
+        true,
+      );
+    });
+
+    it("falls back to false when skipEnrichment is not a boolean", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { skipEnrichment: "yes" },
+        DEFAULTS,
+      );
+      expect(res.skipEnrichment).toBe(false);
+      expect(warnings.some((w) => w.includes("expected a boolean"))).toBe(true);
+    });
   });
 
-  it("honors a valid gzipLevel and keeps rawPassthrough independent", () => {
+  it("never throws across a range of hostile inputs", () => {
+    const inputs: unknown[] = [
+      0,
+      "",
+      true,
+      [],
+      12345,
+      { partSizeBytes: -1, maxConcurrentParts: Infinity },
+      { skipEnrichment: 1, maxPartAttempts: {} },
+      { rawPassthrough: [], gzipLevel: "x" },
+      Symbol("x") as unknown,
+    ];
+    for (const input of inputs) {
+      expect(() => resolveBlobExportTuning(input, DEFAULTS)).not.toThrow();
+    }
+  });
+});
+
+describe("BlobExportTuningSchema (write schema)", () => {
+  it("accepts an in-range partial object", () => {
     expect(
-      resolveBlobExportTuning({ rawPassthrough: true, gzipLevel: 1 }),
-    ).toEqual({
-      resolved: { rawPassthrough: true, gzipLevel: 1 },
-      warnings: [],
-    });
-    // level 0 (store) is valid
-    expect(resolveBlobExportTuning({ gzipLevel: 0 })).toEqual({
-      resolved: { rawPassthrough: false, gzipLevel: 0 },
-      warnings: [],
-    });
-    expect(resolveBlobExportTuning({ gzipLevel: 9 })).toEqual({
-      resolved: { rawPassthrough: false, gzipLevel: 9 },
-      warnings: [],
-    });
+      BlobExportTuningSchema.safeParse({ maxConcurrentParts: 10 }).success,
+    ).toBe(true);
   });
 
-  it("clamps an out-of-range gzipLevel to default without disabling rawPassthrough", () => {
-    const tooHigh = resolveBlobExportTuning({
-      rawPassthrough: true,
-      gzipLevel: 12,
-    });
-    expect(tooHigh.resolved).toEqual({
-      rawPassthrough: true,
-      gzipLevel: undefined,
-    });
-    expect(tooHigh.warnings.length).toBe(1);
-
-    const negative = resolveBlobExportTuning({ gzipLevel: -1 });
-    expect(negative.resolved.gzipLevel).toBeUndefined();
-    expect(negative.warnings.length).toBe(1);
-
-    const fractional = resolveBlobExportTuning({ gzipLevel: 3.5 });
-    expect(fractional.resolved.gzipLevel).toBeUndefined();
-    expect(fractional.warnings.length).toBe(1);
+  it("accepts rawPassthrough and gzipLevel", () => {
+    expect(
+      BlobExportTuningSchema.safeParse({ rawPassthrough: true, gzipLevel: 6 })
+        .success,
+    ).toBe(true);
   });
 
-  it("never throws", () => {
-    expect(() => resolveBlobExportTuning(12345)).not.toThrow();
-    expect(() => resolveBlobExportTuning([])).not.toThrow();
+  it("rejects out-of-range values (writes reject; reads clamp)", () => {
+    expect(
+      BlobExportTuningSchema.safeParse({ maxConcurrentParts: 50 }).success,
+    ).toBe(false);
+    expect(BlobExportTuningSchema.safeParse({ gzipLevel: 12 }).success).toBe(
+      false,
+    );
+  });
+
+  it("strips unknown keys (forward-compat, not strict)", () => {
+    const parsed = BlobExportTuningSchema.safeParse({ bogus: 1 });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data).not.toHaveProperty("bogus");
+    }
   });
 });

--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
@@ -2,14 +2,20 @@
 // (`BlobStorageIntegration.exportTuning`) and set via the DB directly for now
 // (no UI/tRPC write path yet). Validated and resolved at job time.
 //
-// This module is client-safe (no logger / server imports) so a future settings
-// UI can reuse the schema for write-validation. The worker logs the warnings
-// returned by the resolver.
+// This is a client-safe file (no logger / server imports) so a future settings
+// UI can reuse the schema for write-validation. The read-side resolver does NOT
+// log — it returns a `warnings` array so the (server-side) caller can log
+// without pulling a server logger into this module.
 //
-// Shared with LFE-10394 (upload tuning knobs: partSizeBytes / maxConcurrentParts
-// / maxPartAttempts / skipEnrichment). Extend this schema rather than forking
-// it. Unknown keys are stripped (zod default) so a key written by a newer
-// writer is harmless to an older worker.
+// Several overlapping feature sets share this module — extend, don't fork:
+//   - LFE-10402: `rawPassthrough` (stream ClickHouse JSONEachRow bytes straight
+//     to gzip → upload) and `gzipLevel` (zlib deflate level for compressed
+//     exports).
+//   - LFE-10394: upload tuning (`partSizeBytes` / `maxConcurrentParts` /
+//     `maxPartAttempts`) + `skipEnrichment`.
+// Unknown keys are stripped (zod default) so a key written by a newer writer is
+// harmless to an older worker.
+
 import { z } from "zod";
 
 // Minimum ClickHouse version for safe raw passthrough. The passthrough relies on
@@ -22,6 +28,28 @@ import { z } from "zod";
 // Langfuse Cloud runs a newer ClickHouse, so this only affects self-hosters.
 export const RAW_PASSTHROUGH_MIN_CLICKHOUSE_VERSION = "25.11";
 
+// Bounds applied by the resolver (clamp) and the write schema (reject).
+//
+// NOTE on the original ranges — keep visible for orientation and future revert:
+//   - maxConcurrentParts: env `LANGFUSE_S3_UPLOAD_MAX_CONCURRENT_PARTS` is 1–10
+//     (default 3). Deliberately WIDENED to 1–32 here for per-project
+//     experimentation. Restore `max: 10` to return to env parity.
+//   - maxPartAttempts: env `LANGFUSE_S3_UPLOAD_MAX_PART_ATTEMPTS` is 1–10
+//     (default 3). UNCHANGED.
+//   - partSizeBytes: previously hardcoded to 100 MiB. S3 multipart limits are a
+//     5 MiB minimum and 5 GiB maximum per part; we allow that full range. Azure
+//     caps a stage-block at 4000 MiB (< 5 GiB), so the Azure upload path clamps
+//     partSize to its own limit rather than constraining this shared S3 range.
+export const BLOB_EXPORT_TUNING_BOUNDS = {
+  partSizeBytes: { min: 5 * 1024 * 1024, max: 5 * 1024 * 1024 * 1024 },
+  maxConcurrentParts: { min: 1, max: 32 },
+  maxPartAttempts: { min: 1, max: 10 },
+} as const;
+
+// Default part size when the column does not specify one. Matches the value
+// that was previously hardcoded in handleBlobStorageIntegrationProjectJob.ts.
+export const DEFAULT_BLOB_EXPORT_PART_SIZE_BYTES = 100 * 1024 * 1024; // 100 MiB
+
 export const BlobExportTuningSchema = z.object({
   // LFE-10402 raw-passthrough export path: stream ClickHouse JSONEachRow row text
   // straight to gzip → upload, skipping the per-row JS parse/enrich/serialize
@@ -33,71 +61,245 @@ export const BlobExportTuningSchema = z.object({
   // detection. Do not enable on older self-hosted ClickHouse.
   rawPassthrough: z.boolean().optional(),
   // LFE-10402 gzip tuning: zlib deflate level for compressed exports. Lower
-  // levels trade output size for markedly less worker CPU (the gzip step is the
-  // dominant remaining cost on large passthrough exports). Only honored when the
-  // integration has compression enabled. zlib accepts 0 (store, no compression)
-  // through 9 (max); absent / out-of-range falls back to the zlib default (6).
-  gzipLevel: z.number().optional(),
+  // levels trade output size for markedly less worker CPU. Only honored when the
+  // integration has compression enabled. zlib accepts 0 (store) through 9 (max);
+  // absent / out-of-range falls back to the zlib default (6).
+  gzipLevel: z.number().int().min(0).max(9).optional(),
+  // LFE-10394 upload tuning. Out-of-range values are REJECTED here (write path)
+  // but CLAMPED by the read-side resolver.
+  partSizeBytes: z
+    .number()
+    .int()
+    .min(BLOB_EXPORT_TUNING_BOUNDS.partSizeBytes.min)
+    .max(BLOB_EXPORT_TUNING_BOUNDS.partSizeBytes.max)
+    .optional(),
+  maxConcurrentParts: z
+    .number()
+    .int()
+    .min(BLOB_EXPORT_TUNING_BOUNDS.maxConcurrentParts.min)
+    .max(BLOB_EXPORT_TUNING_BOUNDS.maxConcurrentParts.max)
+    .optional(),
+  maxPartAttempts: z
+    .number()
+    .int()
+    .min(BLOB_EXPORT_TUNING_BOUNDS.maxPartAttempts.min)
+    .max(BLOB_EXPORT_TUNING_BOUNDS.maxPartAttempts.max)
+    .optional(),
+  skipEnrichment: z.boolean().optional(),
 });
 
 export type BlobExportTuning = z.infer<typeof BlobExportTuningSchema>;
+
+// Default the resolver falls back to for partSizeBytes when the column is absent
+// or invalid. Concurrency/attempts intentionally have NO default here — see
+// ResolvedBlobExportTuning for why they resolve to `undefined`.
+export interface BlobExportTuningDefaults {
+  partSizeBytes: number;
+}
 
 export type ResolvedBlobExportTuning = {
   rawPassthrough: boolean;
   // undefined => use the zlib default (6); a concrete 0-9 otherwise.
   gzipLevel: number | undefined;
+  partSizeBytes: number;
+  // undefined => the operator did not set the knob; each StorageService backend
+  // applies its own native default (S3 buffered → env var, Azure → 5, OCI → 5).
+  // Resolving these to a concrete env value here would silently override those
+  // per-backend defaults — e.g. dropping Azure concurrency 5→3 — and break the
+  // "null column reproduces today's behaviour" contract (LFE-10394 review).
+  maxConcurrentParts: number | undefined;
+  maxPartAttempts: number | undefined;
+  skipEnrichment: boolean;
 };
 
-/**
- * Resolve the persisted `exportTuning` JSON into concrete export settings.
- * Pure and total: never throws. A null / non-object / malformed column resolves
- * to the safe defaults (today's behaviour) and records a warning the caller can
- * log. Unknown keys are ignored.
- */
-export function resolveBlobExportTuning(raw: unknown): {
+export interface ResolveBlobExportTuningResult {
   resolved: ResolvedBlobExportTuning;
   warnings: string[];
-} {
-  const defaults: ResolvedBlobExportTuning = {
+}
+
+type Bound = { min: number; max: number };
+
+function resolveNumber(
+  field: string,
+  value: unknown,
+  bound: Bound,
+  fallback: number,
+  warnings: string[],
+): number {
+  if (value === undefined) return fallback; // absent → default, silent
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    warnings.push(
+      `${field}: expected a finite number, got ${JSON.stringify(value)}; using default ${fallback}`,
+    );
+    return fallback;
+  }
+  // Separate the two corrections so the warning text is accurate: a non-integer
+  // within bounds was rounded (not out of range), while a value outside the
+  // bounds was clamped. Reporting both as "out of range" would mislead an
+  // operator reading the log into thinking an in-range float was rejected.
+  const rounded = Math.round(value);
+  const clamped = Math.min(bound.max, Math.max(bound.min, rounded));
+  if (rounded !== value) {
+    warnings.push(
+      `${field}: ${value} is not an integer; rounded to ${rounded}`,
+    );
+  }
+  if (clamped !== rounded) {
+    warnings.push(
+      `${field}: ${rounded} out of range [${bound.min}, ${bound.max}]; clamped to ${clamped}`,
+    );
+  }
+  return clamped;
+}
+
+// Like resolveNumber, but returns `undefined` when the field is absent so the
+// caller can tell "operator did not set this" from "operator set the default".
+// Wrong-typed values also resolve to undefined (with a warning) so a malformed
+// knob falls back to the backend default rather than throwing.
+function resolveOptionalNumber(
+  field: string,
+  value: unknown,
+  bound: Bound,
+  warnings: string[],
+): number | undefined {
+  if (value === undefined) return undefined; // absent → backend default, silent
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    warnings.push(
+      `${field}: expected a finite number, got ${JSON.stringify(value)}; using backend default`,
+    );
+    return undefined;
+  }
+  const rounded = Math.round(value);
+  const clamped = Math.min(bound.max, Math.max(bound.min, rounded));
+  if (rounded !== value) {
+    warnings.push(
+      `${field}: ${value} is not an integer; rounded to ${rounded}`,
+    );
+  }
+  if (clamped !== rounded) {
+    warnings.push(
+      `${field}: ${rounded} out of range [${bound.min}, ${bound.max}]; clamped to ${clamped}`,
+    );
+  }
+  return clamped;
+}
+
+function resolveBoolean(
+  field: string,
+  value: unknown,
+  warnings: string[],
+): boolean {
+  if (value === undefined) return false; // absent → false, silent
+  if (typeof value !== "boolean") {
+    warnings.push(
+      `${field}: expected a boolean, got ${JSON.stringify(value)}; using default false`,
+    );
+    return false;
+  }
+  return value;
+}
+
+// gzipLevel uses clamp-to-DEFAULT (not clamp-to-bound): an out-of-range level is
+// dropped so the zlib default (6) applies, rather than silently snapping to 0/9.
+function resolveGzipLevel(
+  value: unknown,
+  warnings: string[],
+): number | undefined {
+  if (value === undefined) return undefined;
+  // Distinct failure modes get accurate messages (mirrors resolveNumber): a
+  // wrong type, a non-integer, and a true out-of-range value are different
+  // problems and "out of range" would mislead for the first two.
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    warnings.push(
+      `gzipLevel: expected a finite number, got ${JSON.stringify(value)}; using zlib default`,
+    );
+    return undefined;
+  }
+  if (!Number.isInteger(value)) {
+    warnings.push(`gzipLevel: ${value} is not an integer; using zlib default`);
+    return undefined;
+  }
+  if (value < 0 || value > 9) {
+    warnings.push(
+      `gzipLevel: ${value} out of range [0, 9]; using zlib default`,
+    );
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Read-side resolver for the `exportTuning` JSON column. Never throws.
+ *
+ * Semantics (LFE-10394 grilling + LFE-10402 rawPassthrough/gzipLevel):
+ *   - null / undefined / non-object   → all defaults (non-object is warned).
+ *   - upload knob numeric out of range → CLAMPED to the bound (warned).
+ *   - gzipLevel out of range           → dropped → zlib default (warned).
+ *   - field of the wrong type / NaN    → default (warned).
+ *   - absent field                     → default (silent).
+ *
+ * The caller is expected to log each returned warning.
+ */
+export function resolveBlobExportTuning(
+  raw: unknown,
+  defaults: BlobExportTuningDefaults,
+): ResolveBlobExportTuningResult {
+  const warnings: string[] = [];
+
+  const fallback: ResolvedBlobExportTuning = {
     rawPassthrough: false,
     gzipLevel: undefined,
+    partSizeBytes: defaults.partSizeBytes,
+    maxConcurrentParts: undefined,
+    maxPartAttempts: undefined,
+    skipEnrichment: false,
   };
 
   if (raw === null || raw === undefined) {
-    return { resolved: defaults, warnings: [] };
+    return { resolved: fallback, warnings };
   }
 
-  const parsed = BlobExportTuningSchema.safeParse(raw);
-  if (!parsed.success) {
-    return {
-      resolved: defaults,
-      warnings: [
-        `Malformed exportTuning column, falling back to defaults: ${parsed.error.message}`,
-      ],
-    };
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    warnings.push(
+      `exportTuning: expected an object, got ${JSON.stringify(raw)}; using defaults`,
+    );
+    return { resolved: fallback, warnings };
   }
 
-  const warnings: string[] = [];
-
-  // Clamp-to-default rather than fail: a bad gzipLevel must not also disable a
-  // valid rawPassthrough. An out-of-range / non-integer level is dropped (zlib
-  // default applies) with a warning the caller logs.
-  let gzipLevel: number | undefined;
-  const rawLevel = parsed.data.gzipLevel;
-  if (rawLevel !== undefined) {
-    if (Number.isInteger(rawLevel) && rawLevel >= 0 && rawLevel <= 9) {
-      gzipLevel = rawLevel;
-    } else {
-      warnings.push(
-        `Ignoring out-of-range gzipLevel ${rawLevel} (expected integer 0-9), using zlib default`,
-      );
-    }
-  }
+  const obj = raw as Record<string, unknown>;
 
   return {
     resolved: {
-      rawPassthrough: parsed.data.rawPassthrough ?? false,
-      gzipLevel,
+      rawPassthrough: resolveBoolean(
+        "rawPassthrough",
+        obj.rawPassthrough,
+        warnings,
+      ),
+      gzipLevel: resolveGzipLevel(obj.gzipLevel, warnings),
+      partSizeBytes: resolveNumber(
+        "partSizeBytes",
+        obj.partSizeBytes,
+        BLOB_EXPORT_TUNING_BOUNDS.partSizeBytes,
+        defaults.partSizeBytes,
+        warnings,
+      ),
+      maxConcurrentParts: resolveOptionalNumber(
+        "maxConcurrentParts",
+        obj.maxConcurrentParts,
+        BLOB_EXPORT_TUNING_BOUNDS.maxConcurrentParts,
+        warnings,
+      ),
+      maxPartAttempts: resolveOptionalNumber(
+        "maxPartAttempts",
+        obj.maxPartAttempts,
+        BLOB_EXPORT_TUNING_BOUNDS.maxPartAttempts,
+        warnings,
+      ),
+      skipEnrichment: resolveBoolean(
+        "skipEnrichment",
+        obj.skipEnrichment,
+        warnings,
+      ),
     },
     warnings,
   };

--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
@@ -102,11 +102,9 @@ export type ResolvedBlobExportTuning = {
   // undefined => use the zlib default (6); a concrete 0-9 otherwise.
   gzipLevel: number | undefined;
   partSizeBytes: number;
-  // undefined => the operator did not set the knob; each StorageService backend
-  // applies its own native default (S3 buffered → env var, Azure → 5, OCI → 5).
-  // Resolving these to a concrete env value here would silently override those
-  // per-backend defaults — e.g. dropping Azure concurrency 5→3 — and break the
-  // "null column reproduces today's behaviour" contract (LFE-10394 review).
+  // undefined => not set by the operator; each backend keeps its native default
+  // (S3 buffered → env var, Azure → 5, OCI → 5). A concrete default here would
+  // override those per-backend defaults.
   maxConcurrentParts: number | undefined;
   maxPartAttempts: number | undefined;
   skipEnrichment: boolean;
@@ -133,10 +131,7 @@ function resolveNumber(
     );
     return fallback;
   }
-  // Separate the two corrections so the warning text is accurate: a non-integer
-  // within bounds was rounded (not out of range), while a value outside the
-  // bounds was clamped. Reporting both as "out of range" would mislead an
-  // operator reading the log into thinking an in-range float was rejected.
+  // Rounding and clamping warn separately so the message reflects what happened.
   const rounded = Math.round(value);
   const clamped = Math.min(bound.max, Math.max(bound.min, rounded));
   if (rounded !== value) {
@@ -152,10 +147,8 @@ function resolveNumber(
   return clamped;
 }
 
-// Like resolveNumber, but returns `undefined` when the field is absent so the
-// caller can tell "operator did not set this" from "operator set the default".
-// Wrong-typed values also resolve to undefined (with a warning) so a malformed
-// knob falls back to the backend default rather than throwing.
+// resolveNumber variant returning undefined when absent or wrong-typed, so the
+// caller can distinguish "unset" (use backend default) from a set value.
 function resolveOptionalNumber(
   field: string,
   value: unknown,
@@ -206,9 +199,8 @@ function resolveGzipLevel(
   warnings: string[],
 ): number | undefined {
   if (value === undefined) return undefined;
-  // Distinct failure modes get accurate messages (mirrors resolveNumber): a
-  // wrong type, a non-integer, and a true out-of-range value are different
-  // problems and "out of range" would mislead for the first two.
+  // Wrong type / non-integer / out-of-range warn distinctly; all fall back to
+  // the zlib default.
   if (typeof value !== "number" || !Number.isFinite(value)) {
     warnings.push(
       `gzipLevel: expected a finite number, got ${JSON.stringify(value)}; using zlib default`,
@@ -231,7 +223,7 @@ function resolveGzipLevel(
 /**
  * Read-side resolver for the `exportTuning` JSON column. Never throws.
  *
- * Semantics (LFE-10394 grilling + LFE-10402 rawPassthrough/gzipLevel):
+ * Semantics:
  *   - null / undefined / non-object   → all defaults (non-object is warned).
  *   - upload knob numeric out of range → CLAMPED to the bound (warned).
  *   - gzipLevel out of range           → dropped → zlib default (warned).

--- a/packages/shared/src/server/services/BufferedStreamUploader.ts
+++ b/packages/shared/src/server/services/BufferedStreamUploader.ts
@@ -221,10 +221,8 @@ export class BufferedStreamUploader {
         if (!isTransientError(error)) {
           return false;
         }
-        // exponential-backoff invokes this callback before its own attempt-limit
-        // check, so it also fires on the final failing attempt where no retry
-        // follows. Only count (and log "Retrying...") when an attempt remains, so
-        // partRetries reflects actual retries rather than total failures.
+        // backoff also invokes this on the final failing attempt; skip counting
+        // it so partRetries reflects actual retries, not total failures.
         if (attemptNumber >= this.params.maxPartAttempts) {
           return true;
         }

--- a/packages/shared/src/server/services/BufferedStreamUploader.ts
+++ b/packages/shared/src/server/services/BufferedStreamUploader.ts
@@ -34,12 +34,29 @@ export interface ChunkedUploadStrategy {
   uploadSingleObject(data: Buffer): Promise<void>;
 }
 
+// Upload counters surfaced for telemetry. `partRetries` is the total number of
+// retry attempts across all parts (not distinct parts retried); `partFailures`
+// is the number of parts that exhausted their attempts; `partsUploaded` is the
+// number of completed parts.
+export interface UploadPartStats {
+  partsUploaded: number;
+  partRetries: number;
+  partFailures: number;
+}
+
+export function emptyUploadPartStats(): UploadPartStats {
+  return { partsUploaded: 0, partRetries: 0, partFailures: 0 };
+}
+
 export interface BufferedStreamUploaderParams {
   strategy: ChunkedUploadStrategy;
   partSizeBytes: number;
   maxPartAttempts: number;
   maxConcurrentParts: number;
   key: string; // for logging
+  // Optional mutable sink the caller owns. Incremented live so counts are
+  // readable even when upload() throws. A fresh one is used when omitted.
+  stats?: UploadPartStats;
 }
 
 // Collects errors from concurrent part uploads. Append-only by design so
@@ -74,12 +91,14 @@ export class BufferedStreamUploader {
   private isCompleted = false;
   private inFlightUploads: Map<symbol, Promise<void>> = new Map();
   private readonly errors = new ErrorSink();
+  private readonly stats: UploadPartStats;
 
   constructor(params: BufferedStreamUploaderParams) {
     this.params = params;
+    this.stats = params.stats ?? emptyUploadPartStats();
   }
 
-  async upload(stream: Readable): Promise<void> {
+  async upload(stream: Readable): Promise<UploadPartStats> {
     try {
       await this.params.strategy.initialize();
 
@@ -131,7 +150,7 @@ export class BufferedStreamUploader {
         );
         await this.params.strategy.uploadSingleObject(Buffer.alloc(0));
         this.isCompleted = true;
-        return;
+        return this.stats;
       }
 
       const sortedParts = [...this.completedParts].sort(
@@ -145,6 +164,8 @@ export class BufferedStreamUploader {
         await this.params.strategy.abort("upload failed or incomplete");
       }
     }
+
+    return this.stats;
   }
 
   private async flushBuffer(): Promise<void> {
@@ -171,11 +192,13 @@ export class BufferedStreamUploader {
     const promise = this.uploadPartWithRetry(data, partNumber)
       .then((result) => {
         this.completedParts.push(result);
+        this.stats.partsUploaded++;
         logger.debug(
           `Uploaded part ${partNumber} (${(data.byteLength / 1024 / 1024).toFixed(1)} MiB) for key ${this.params.key}`,
         );
       })
       .catch((err) => {
+        this.stats.partFailures++;
         this.errors.capture(err);
       })
       .finally(() => {
@@ -198,6 +221,14 @@ export class BufferedStreamUploader {
         if (!isTransientError(error)) {
           return false;
         }
+        // exponential-backoff invokes this callback before its own attempt-limit
+        // check, so it also fires on the final failing attempt where no retry
+        // follows. Only count (and log "Retrying...") when an attempt remains, so
+        // partRetries reflects actual retries rather than total failures.
+        if (attemptNumber >= this.params.maxPartAttempts) {
+          return true;
+        }
+        this.stats.partRetries++;
         logger.warn(
           `Part ${partNumber} upload failed (attempt ${attemptNumber}/${this.params.maxPartAttempts}): ${error.message}. Retrying...`,
         );

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -793,14 +793,9 @@ class S3StorageService implements StorageService {
     stats,
   }: UploadFileBuffered): Promise<UploadPartStats | undefined> {
     if (env.LANGFUSE_S3_UPLOAD_ENABLE_BUFFERED !== "true") {
-      // All speed-tuning knobs (part size, concurrency, attempts) and part-level
-      // stats apply only on the buffered path. The non-buffered fallback
-      // intentionally forwards NO overrides so a null/default exportTuning
-      // reproduces pre-tuning behaviour byte-for-byte — lib-storage keeps its
-      // own 5 MiB partSize / default queueSize. Forwarding the resolved 100 MiB
-      // default here would silently ~20x the per-upload memory of every existing
-      // S3 deployment (buffered is off by default). Tuning requires
-      // LANGFUSE_S3_UPLOAD_ENABLE_BUFFERED=true.
+      // Tuning applies only on the buffered path. Forward no overrides so the
+      // fallback keeps lib-storage's defaults — forwarding the resolved 100 MiB
+      // partSize would ~20x per-upload memory (buffered is off by default).
       await this.uploadFile({ fileName, fileType, data });
       return undefined;
     }
@@ -1515,13 +1510,9 @@ class OCIObjectStorageService implements StorageService {
     data,
     partSizeBytes,
     maxConcurrentParts,
-    // maxPartAttempts is intentionally not destructured/forwarded: OCI's
-    // UploadManager owns its retry policy and exposes no per-part attempt knob
-    // (mirrors the Azure path, which warns; OCI is not reached by the blob-export
-    // integration today, so a comment suffices over a runtime warning).
+    // maxPartAttempts omitted: OCI's UploadManager owns retries, no per-part knob.
   }: UploadFileBuffered): Promise<UploadPartStats | undefined> {
-    // OCI's uploadFile maps queueSize → UploadManager.maxConcurrentUploads, so
-    // forward the concurrency knob (undefined keeps OCI's default of 5).
+    // queueSize maps to UploadManager.maxConcurrentUploads (undefined => OCI's 5).
     await this.uploadFile({
       fileName,
       fileType,

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -23,7 +23,10 @@ import { logger } from "../logger";
 import { env } from "../../env";
 import { backOff } from "exponential-backoff";
 import { ServiceUnavailableError } from "../../errors";
-import { BufferedStreamUploader } from "./BufferedStreamUploader";
+import {
+  BufferedStreamUploader,
+  type UploadPartStats,
+} from "./BufferedStreamUploader";
 import { S3ChunkedUploadStrategy } from "./S3ChunkedUploadStrategy";
 import {
   buildS3RequestDiagnostics,
@@ -71,6 +74,13 @@ type UploadFileBuffered = {
   fileType: string;
   data: Readable;
   partSizeBytes: number;
+  // Optional per-call overrides. Default to env vars when absent (S3 only; Azure
+  // maps maxConcurrentParts to its upload concurrency and ignores maxPartAttempts).
+  maxConcurrentParts?: number;
+  maxPartAttempts?: number;
+  // Optional mutable sink populated with upload counters; readable by the caller
+  // even when the upload throws. Only the S3 buffered path populates it.
+  stats?: UploadPartStats;
 };
 
 type UploadWithSignedUrl = UploadFile & {
@@ -222,7 +232,11 @@ function createSecureAzureBlobRequestPolicyFactory(
 export interface StorageService {
   uploadFile(params: UploadFile): Promise<void>;
 
-  uploadFileBuffered(params: UploadFileBuffered): Promise<void>;
+  // Returns upload counters when the implementation produces them (S3 buffered
+  // path); undefined otherwise. Backward-compatible — existing callers ignore it.
+  uploadFileBuffered(
+    params: UploadFileBuffered,
+  ): Promise<UploadPartStats | undefined>;
 
   uploadWithSignedUrl(
     params: UploadWithSignedUrl,
@@ -387,7 +401,7 @@ class AzureBlobStorageService implements StorageService {
   }
 
   public async uploadFile(params: UploadFile): Promise<void> {
-    const { fileName, fileType, data, partSize } = params;
+    const { fileName, fileType, data, partSize, queueSize } = params;
     try {
       await this.createContainerIfNotExists();
 
@@ -400,7 +414,7 @@ class AzureBlobStorageService implements StorageService {
       } else if (data instanceof Readable) {
         // bufferSize controls the block size (default 8MB supports ~800GB files)
         const bufferSize = partSize ?? 8 * 1024 * 1024; // Default 8MB per block
-        const maxConcurrency = 5; // Default value
+        const maxConcurrency = queueSize ?? 5; // Default value
 
         await blockBlobClient.uploadStream(data, bufferSize, maxConcurrency, {
           blobHTTPHeaders: { blobContentType: fileType },
@@ -419,13 +433,36 @@ class AzureBlobStorageService implements StorageService {
     }
   }
 
-  public async uploadFileBuffered(params: UploadFileBuffered): Promise<void> {
+  public async uploadFileBuffered(
+    params: UploadFileBuffered,
+  ): Promise<UploadPartStats | undefined> {
+    // Azure has no per-part retry knob — its SDK pipeline owns retries — so
+    // maxPartAttempts has no effect here. Warn so an operator isn't surprised.
+    if (params.maxPartAttempts !== undefined) {
+      logger.warn(
+        `Azure blob upload for ${params.fileName}: maxPartAttempts is set but has no effect on the Azure path (SDK manages retries)`,
+      );
+    }
+    // partSizeBytes -> block size, maxConcurrentParts -> upload concurrency.
+    // Azure rejects a stageBlock larger than BLOCK_BLOB_MAX_STAGE_BLOCK_BYTES
+    // (4000 MiB). The shared tuning bound allows up to 5 GiB (S3's per-part max),
+    // so clamp here to keep the Azure path within its own limit and warn.
+    const AZURE_MAX_BLOCK_BYTES = 4000 * 1024 * 1024;
+    let partSize = params.partSizeBytes;
+    if (partSize > AZURE_MAX_BLOCK_BYTES) {
+      logger.warn(
+        `Azure blob upload for ${params.fileName}: partSizeBytes ${partSize} exceeds Azure's per-block max ${AZURE_MAX_BLOCK_BYTES}; clamping to the max`,
+      );
+      partSize = AZURE_MAX_BLOCK_BYTES;
+    }
     await this.uploadFile({
       fileName: params.fileName,
       fileType: params.fileType,
       data: params.data,
-      partSize: params.partSizeBytes,
+      partSize,
+      queueSize: params.maxConcurrentParts,
     });
+    return undefined; // Azure does not produce part-level stats.
   }
 
   public async uploadWithSignedUrl(
@@ -751,9 +788,21 @@ class S3StorageService implements StorageService {
     fileType,
     data,
     partSizeBytes,
-  }: UploadFileBuffered): Promise<void> {
+    maxConcurrentParts,
+    maxPartAttempts,
+    stats,
+  }: UploadFileBuffered): Promise<UploadPartStats | undefined> {
     if (env.LANGFUSE_S3_UPLOAD_ENABLE_BUFFERED !== "true") {
-      return this.uploadFile({ fileName, fileType, data });
+      // All speed-tuning knobs (part size, concurrency, attempts) and part-level
+      // stats apply only on the buffered path. The non-buffered fallback
+      // intentionally forwards NO overrides so a null/default exportTuning
+      // reproduces pre-tuning behaviour byte-for-byte — lib-storage keeps its
+      // own 5 MiB partSize / default queueSize. Forwarding the resolved 100 MiB
+      // default here would silently ~20x the per-upload memory of every existing
+      // S3 deployment (buffered is off by default). Tuning requires
+      // LANGFUSE_S3_UPLOAD_ENABLE_BUFFERED=true.
+      await this.uploadFile({ fileName, fileType, data });
+      return undefined;
     }
 
     const strategy = new S3ChunkedUploadStrategy({
@@ -770,13 +819,16 @@ class S3StorageService implements StorageService {
     const uploader = new BufferedStreamUploader({
       strategy,
       partSizeBytes,
-      maxPartAttempts: env.LANGFUSE_S3_UPLOAD_MAX_PART_ATTEMPTS,
-      maxConcurrentParts: env.LANGFUSE_S3_UPLOAD_MAX_CONCURRENT_PARTS,
+      maxPartAttempts:
+        maxPartAttempts ?? env.LANGFUSE_S3_UPLOAD_MAX_PART_ATTEMPTS,
+      maxConcurrentParts:
+        maxConcurrentParts ?? env.LANGFUSE_S3_UPLOAD_MAX_CONCURRENT_PARTS,
       key: fileName,
+      stats,
     });
 
     try {
-      await uploader.upload(data);
+      return await uploader.upload(data);
     } catch (err) {
       logger.error(`Failed to upload file (buffered) to ${fileName}`, err);
       handleStorageError(err, "upload file to S3 (buffered)");
@@ -1030,12 +1082,15 @@ class GoogleCloudStorageService implements StorageService {
     }
   }
 
-  public async uploadFileBuffered(params: UploadFileBuffered): Promise<void> {
+  public async uploadFileBuffered(
+    params: UploadFileBuffered,
+  ): Promise<UploadPartStats | undefined> {
     await this.uploadFile({
       fileName: params.fileName,
       fileType: params.fileType,
       data: params.data,
     });
+    return undefined; // GCS does not produce part-level stats.
   }
 
   public async uploadWithSignedUrl({
@@ -1459,13 +1514,22 @@ class OCIObjectStorageService implements StorageService {
     fileType,
     data,
     partSizeBytes,
-  }: UploadFileBuffered): Promise<void> {
+    maxConcurrentParts,
+    // maxPartAttempts is intentionally not destructured/forwarded: OCI's
+    // UploadManager owns its retry policy and exposes no per-part attempt knob
+    // (mirrors the Azure path, which warns; OCI is not reached by the blob-export
+    // integration today, so a comment suffices over a runtime warning).
+  }: UploadFileBuffered): Promise<UploadPartStats | undefined> {
+    // OCI's uploadFile maps queueSize → UploadManager.maxConcurrentUploads, so
+    // forward the concurrency knob (undefined keeps OCI's default of 5).
     await this.uploadFile({
       fileName,
       fileType,
       data,
       partSize: partSizeBytes,
+      queueSize: maxConcurrentParts,
     });
+    return undefined; // OCI does not produce part-level stats.
   }
 
   public async uploadWithSignedUrl({

--- a/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
+++ b/worker/src/__tests__/blobStorageTuningWiring.unit.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Records of every uploadFileBuffered call so we can assert the resolved tuning
+// was threaded through. Hoisted so the module mock can close over it.
+const uploadCalls = vi.hoisted(() => [] as any[]);
+
+vi.mock("@langfuse/shared/src/db", () => ({
+  prisma: {
+    blobStorageIntegration: {
+      findUnique: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    project: { findUnique: vi.fn().mockResolvedValue({ name: "p" }) },
+  },
+}));
+
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  async function* empty(): AsyncGenerator<Record<string, unknown>> {
+    // no rows
+  }
+  return {
+    ...mod,
+    StorageServiceFactory: {
+      getInstance: () => ({
+        uploadFileBuffered: vi.fn(async (params: any) => {
+          uploadCalls.push(params);
+          // Drain the pipeline stream so it does not hang.
+          for await (const _chunk of params.data) {
+            void _chunk;
+          }
+          return undefined;
+        }),
+      }),
+    },
+    getTracesForBlobStorageExport: () => empty(),
+    getObservationsForBlobStorageExport: () => empty(),
+    getScoresForBlobStorageExport: () => empty(),
+    getEventsForBlobStorageExport: () => empty(),
+    createModelCache: () => ({ getModel: async () => null }),
+    blobStorageEndpointConnectionValidationOptions: () => undefined,
+  };
+});
+
+import { prisma } from "@langfuse/shared/src/db";
+import { handleBlobStorageIntegrationProjectJob } from "../features/blobstorage/handleBlobStorageIntegrationProjectJob";
+import type { Job } from "bullmq";
+
+function makeJob(): Job<any> {
+  return {
+    id: "job-1",
+    attemptsMade: 0,
+    data: { id: "payload-1", payload: { projectId: "project-1" } },
+  } as unknown as Job<any>;
+}
+
+function baseRow(exportTuning: unknown) {
+  return {
+    projectId: "project-1",
+    type: "S3",
+    bucketName: "bucket",
+    prefix: "",
+    accessKeyId: "k",
+    secretAccessKey: null,
+    region: "auto",
+    endpoint: null,
+    forcePathStyle: false,
+    enabled: true,
+    exportFrequency: "daily",
+    fileType: "CSV",
+    exportMode: "FROM_CUSTOM_DATE",
+    exportStartDate: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    exportSource: "TRACES_OBSERVATIONS", // legacy, non-enriched → no gate
+    exportFieldGroups: ["core"],
+    compressed: false,
+    // 2h ago so minTimestamp = lastSyncAt and we skip the ClickHouse min query.
+    lastSyncAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    exportTuning,
+  };
+}
+
+describe("handleBlobStorageIntegrationProjectJob tuning wiring", () => {
+  beforeEach(() => {
+    uploadCalls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("clamps out-of-range tuning and threads it into uploadFileBuffered", async () => {
+    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue(
+      baseRow({
+        partSizeBytes: 1024, // below 5 MiB floor → clamped up
+        maxConcurrentParts: 50, // above 32 ceiling → clamped to 32
+        maxPartAttempts: 7, // in range
+        skipEnrichment: true,
+      }),
+    );
+
+    await handleBlobStorageIntegrationProjectJob(makeJob());
+
+    expect(uploadCalls.length).toBeGreaterThan(0);
+    for (const call of uploadCalls) {
+      expect(call.partSizeBytes).toBe(5 * 1024 * 1024); // floor
+      expect(call.maxConcurrentParts).toBe(32); // ceiling
+      expect(call.maxPartAttempts).toBe(7);
+      expect(call.stats).toEqual({
+        partsUploaded: 0,
+        partRetries: 0,
+        partFailures: 0,
+      });
+    }
+  });
+
+  it("uses defaults when exportTuning is null", async () => {
+    (prisma.blobStorageIntegration.findUnique as any).mockResolvedValue(
+      baseRow(null),
+    );
+
+    await handleBlobStorageIntegrationProjectJob(makeJob());
+
+    expect(uploadCalls.length).toBeGreaterThan(0);
+    for (const call of uploadCalls) {
+      expect(call.partSizeBytes).toBe(100 * 1024 * 1024); // 100 MiB default
+      // Concurrency/attempts are undefined when unset so each StorageService
+      // backend keeps its native default (Azure 5, buffered S3 env, etc.).
+      expect(call.maxConcurrentParts).toBeUndefined();
+      expect(call.maxPartAttempts).toBeUndefined();
+    }
+  });
+});

--- a/worker/src/__tests__/bufferedStreamUploader.test.ts
+++ b/worker/src/__tests__/bufferedStreamUploader.test.ts
@@ -341,6 +341,81 @@ describe("BufferedStreamUploader", () => {
       expect(parts.map((p) => p.partNumber)).toEqual([1, 2, 3]);
     });
 
+    it("should report counters that the caller's stats sink can read", async () => {
+      const mock = createMockStrategy();
+      const stats = { partsUploaded: 0, partRetries: 0, partFailures: 0 };
+      const uploader = new BufferedStreamUploader({
+        ...defaultParams(mock.strategy),
+        partSizeBytes: 5,
+        maxConcurrentParts: 2,
+        stats,
+      });
+
+      const returned = await uploader.upload(
+        streamFrom(["aaaaa", "bbbbb", "ccccc"]),
+      );
+
+      // 3 parts uploaded, no retries, no failures.
+      expect(stats).toEqual({
+        partsUploaded: 3,
+        partRetries: 0,
+        partFailures: 0,
+      });
+      // The return value mirrors the caller's sink.
+      expect(returned).toEqual(stats);
+    });
+
+    it("should count retries on transient failures", async () => {
+      let attempts = 0;
+      const mock = createMockStrategy({
+        uploadPartImpl: async (data, partNumber) => {
+          attempts++;
+          if (attempts <= 2) {
+            throw new Error("socket hang up");
+          }
+          return { partIdentifier: `etag-${partNumber}`, partNumber };
+        },
+      });
+      const stats = { partsUploaded: 0, partRetries: 0, partFailures: 0 };
+      const uploader = new BufferedStreamUploader({
+        ...defaultParams(mock.strategy),
+        maxPartAttempts: 5,
+        stats,
+      });
+
+      await uploader.upload(streamFrom(["hello"]));
+
+      expect(stats.partsUploaded).toBe(1);
+      expect(stats.partRetries).toBe(2); // two transient retries before success
+      expect(stats.partFailures).toBe(0);
+    });
+
+    it("should count a part failure and keep stats readable after throw", async () => {
+      const mock = createMockStrategy({
+        uploadPartImpl: async () => {
+          throw new Error("socket hang up");
+        },
+      });
+      const stats = { partsUploaded: 0, partRetries: 0, partFailures: 0 };
+      const uploader = new BufferedStreamUploader({
+        ...defaultParams(mock.strategy),
+        maxPartAttempts: 2,
+        stats,
+      });
+
+      await expect(uploader.upload(streamFrom(["hello"]))).rejects.toThrow(
+        "socket hang up",
+      );
+
+      // The caller's sink survives the throw with accurate counts. With
+      // maxPartAttempts=2 the part fails attempt 1 (one real retry follows) then
+      // fails attempt 2 (no retry) — so exactly 1 retry, not 2 (the final
+      // failing attempt must not be counted as a retry).
+      expect(stats.partsUploaded).toBe(0);
+      expect(stats.partFailures).toBe(1);
+      expect(stats.partRetries).toBe(1);
+    });
+
     it("should stop scheduling new parts when a concurrent part fails", async () => {
       let partsStarted = 0;
 

--- a/worker/src/__tests__/enrichObservationStream.unit.test.ts
+++ b/worker/src/__tests__/enrichObservationStream.unit.test.ts
@@ -158,3 +158,81 @@ describe("enrichObservationStream field group filtering", () => {
     expect(results[0]).toHaveProperty("total_price");
   });
 });
+
+describe("enrichObservationStream skipEnrichment", () => {
+  it("is byte-for-byte unchanged when skipEnrichment is false (default)", async () => {
+    const rows = [
+      { id: "obs-1", model_id: "gpt-4", latency: 2000, metadata: {} },
+    ];
+    const baseline = await collect(
+      enrichObservationStream(rowStream(rows), "project-1", "model_id", true, [
+        "core" as ObservationFieldGroupFull,
+        "model" as ObservationFieldGroupFull,
+        "metrics" as ObservationFieldGroupFull,
+      ]),
+    );
+    const explicitFalse = await collect(
+      enrichObservationStream(
+        rowStream(rows),
+        "project-1",
+        "model_id",
+        true,
+        [
+          "core" as ObservationFieldGroupFull,
+          "model" as ObservationFieldGroupFull,
+          "metrics" as ObservationFieldGroupFull,
+        ],
+        false,
+      ),
+    );
+    expect(explicitFalse).toEqual(baseline);
+    // Pricing fields present (as null from the mock).
+    expect(explicitFalse[0]).toHaveProperty("input_price");
+    expect(explicitFalse[0]).toHaveProperty("output_price");
+    expect(explicitFalse[0]).toHaveProperty("total_price");
+  });
+
+  it("drops only the three price fields when skipEnrichment is true", async () => {
+    const rows = [
+      { id: "obs-1", model_id: "gpt-4", latency: 2000, metadata: {} },
+    ];
+    const results = await collect(
+      enrichObservationStream(
+        rowStream(rows),
+        "project-1",
+        "model_id",
+        true,
+        [
+          "core" as ObservationFieldGroupFull,
+          "model" as ObservationFieldGroupFull,
+          "metrics" as ObservationFieldGroupFull,
+        ],
+        true,
+      ),
+    );
+
+    // Price fields dropped...
+    expect(results[0]).not.toHaveProperty("input_price");
+    expect(results[0]).not.toHaveProperty("output_price");
+    expect(results[0]).not.toHaveProperty("total_price");
+    // ...but model_id is preserved (it is a source column, not enrichment)...
+    expect(results[0]).toHaveProperty("model_id");
+    // ...and latency conversion (ms→s) still happens.
+    expect(results[0].latency).toBe(2);
+  });
+
+  it("still cleans up the metadata map when skipEnrichment is true", async () => {
+    const rows = [{ id: "obs-1", metadata: {} }];
+    const results = await collect(
+      enrichObservationStream(
+        rowStream(rows),
+        "project-1",
+        "model_id",
+        false,
+        ["core" as ObservationFieldGroupFull],
+        true,
+      ),
+    );
+    expect(results[0]).not.toHaveProperty("metadata");
+  });
+});

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -50,9 +50,7 @@ import {
   DEFAULT_BLOB_EXPORT_PART_SIZE_BYTES,
 } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
-// LANGFUSE_S3_UPLOAD_ENABLE_BUFFERED lives in the shared env (read by
-// StorageService); used here to gate part-level upload stats, which only the
-// S3 buffered path produces.
+// Shared env for the buffered-upload flag (gates part-level upload stats).
 import { env as sharedEnv } from "@langfuse/shared/src/env";
 import { randomUUID } from "crypto";
 import { SpanKind } from "@opentelemetry/api";
@@ -70,9 +68,7 @@ export async function* enrichObservationStream(
 ): AsyncGenerator<Record<string, unknown>> {
   const { getModel } = createModelCache(projectId);
 
-  // Only the per-row model-price lookup is skipped when skipEnrichment is true;
-  // latency conversion and metadata-map cleanup below always run, so output is
-  // byte-for-byte unchanged when the flag is off.
+  // skipEnrichment drops only the model-price lookup; latency + metadata cleanup still run.
   const includeModelId =
     !skipEnrichment && (!fieldGroups || fieldGroups.includes("model"));
 
@@ -285,9 +281,7 @@ const processBlobStorageExport = async (config: {
   convertV4LatencyToSeconds: boolean;
   exportFieldGroups?: ObservationFieldGroupFull[];
   rawPassthrough: boolean;
-  // LFE-10394 upload tuning (resolved + clamped). partSizeBytes always concrete
-  // (100 MB default); concurrency/attempts are undefined unless the operator set
-  // them, so each StorageService backend keeps its native default.
+  // undefined concurrency/attempts => backend keeps its native default.
   partSizeBytes: number;
   maxConcurrentParts: number | undefined;
   maxPartAttempts: number | undefined;
@@ -341,10 +335,9 @@ const processBlobStorageExport = async (config: {
       span.setAttribute("job.attemptsMade", config.bullmqAttemptsMade);
       span.setAttribute("host.name", WORKER_HOST_ID);
 
-      // Resolved per-project tuning (after clamp/fallback) for correlation.
+      // Resolved per-project tuning. Concurrency/attempts omitted when unset
+      // (no single value — the backend default applies).
       span.setAttribute("blob.config.partSizeBytes", config.partSizeBytes);
-      // Only set when the operator tuned them; otherwise the backend default
-      // applies and there is no single value to report.
       if (config.maxConcurrentParts !== undefined) {
         span.setAttribute(
           "blob.config.maxConcurrentParts",
@@ -598,11 +591,9 @@ const processBlobStorageExport = async (config: {
         // For CSV exports, use larger part size to handle big files
         // 100 MB parts support files up to ~1 TB (100 MB × 10,000 AWS limit)
         // This prevents hitting AWS's 10,000 part limit on large exports
-        // uploadStats is a mutable sink the uploader fills live, so the counts
-        // land on the span even when the upload throws. Only the S3 buffered
-        // path populates it; on every other path it stays {0,0,0}, so gate the
-        // telemetry on whether stats are actually produced to avoid reporting
-        // real exports as zero-part uploads.
+        // Mutable sink the uploader fills live (readable even if upload throws).
+        // Only the S3 buffered path populates it; producesUploadStats gates the
+        // telemetry so other paths don't report zero-part uploads.
         const uploadStats = {
           partsUploaded: 0,
           partRetries: 0,
@@ -680,10 +671,8 @@ const processBlobStorageExport = async (config: {
               `rows=${sourceStats.rows} chReadMs=${chReadMs} enrichMs=${enrichMs} ` +
               `gzipCpuMs=${gzipCpuMs} uploadWaitMs=${uploadWaitMs} ` +
               `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${uploadDurationMs} ` +
-              // "configured*" = the resolved tuning, not necessarily what each
-              // backend applied (e.g. the non-buffered S3 path ignores partSize
-              // and uses lib-storage's 5 MiB default). Mirrors the blob.config.*
-              // span attributes; blob.upload.* below are the actual effects.
+              // "configured*" = resolved tuning, not necessarily what the backend
+              // applied; uploadParts/Retries/Failures below are the actual effects.
               `configuredPartSizeBytes=${config.partSizeBytes} configuredMaxConcurrentParts=${config.maxConcurrentParts ?? "default"} ` +
               `configuredMaxPartAttempts=${config.maxPartAttempts ?? "default"} skipEnrichment=${config.skipEnrichment}` +
               (producesUploadStats
@@ -751,8 +740,6 @@ const processBlobStorageExport = async (config: {
               );
             }
           }
-          // Only the S3 buffered path produces these; recording them on other
-          // paths would report real exports as zero-part uploads.
           if (producesUploadStats) {
             span.setAttribute("blob.upload.parts", uploadStats.partsUploaded);
             span.setAttribute("blob.upload.retries", uploadStats.partRetries);

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -47,8 +47,13 @@ import {
   isEnrichedBlobExportAvailable,
   isEnrichedBlobExportSource,
   resolveBlobExportTuning,
+  DEFAULT_BLOB_EXPORT_PART_SIZE_BYTES,
 } from "@langfuse/shared";
 import { decrypt } from "@langfuse/shared/encryption";
+// LANGFUSE_S3_UPLOAD_ENABLE_BUFFERED lives in the shared env (read by
+// StorageService); used here to gate part-level upload stats, which only the
+// S3 buffered path produces.
+import { env as sharedEnv } from "@langfuse/shared/src/env";
 import { randomUUID } from "crypto";
 import { SpanKind } from "@opentelemetry/api";
 import { env, v4AllowPreviewOptIn } from "../../env";
@@ -61,10 +66,15 @@ export async function* enrichObservationStream(
   modelIdField: string,
   convertLatencyToSeconds: boolean,
   fieldGroups?: ObservationFieldGroupFull[],
+  skipEnrichment: boolean = false,
 ): AsyncGenerator<Record<string, unknown>> {
   const { getModel } = createModelCache(projectId);
 
-  const includeModelId = !fieldGroups || fieldGroups.includes("model");
+  // Only the per-row model-price lookup is skipped when skipEnrichment is true;
+  // latency conversion and metadata-map cleanup below always run, so output is
+  // byte-for-byte unchanged when the flag is off.
+  const includeModelId =
+    !skipEnrichment && (!fieldGroups || fieldGroups.includes("model"));
 
   for await (const row of stream) {
     const enriched: Record<string, unknown> = { ...row };
@@ -275,6 +285,13 @@ const processBlobStorageExport = async (config: {
   convertV4LatencyToSeconds: boolean;
   exportFieldGroups?: ObservationFieldGroupFull[];
   rawPassthrough: boolean;
+  // LFE-10394 upload tuning (resolved + clamped). partSizeBytes always concrete
+  // (100 MB default); concurrency/attempts are undefined unless the operator set
+  // them, so each StorageService backend keeps its native default.
+  partSizeBytes: number;
+  maxConcurrentParts: number | undefined;
+  maxPartAttempts: number | undefined;
+  skipEnrichment: boolean;
   bullmqJobId: string | undefined;
   bullmqAttemptsMade: number;
 }) => {
@@ -323,6 +340,25 @@ const processBlobStorageExport = async (config: {
       }
       span.setAttribute("job.attemptsMade", config.bullmqAttemptsMade);
       span.setAttribute("host.name", WORKER_HOST_ID);
+
+      // Resolved per-project tuning (after clamp/fallback) for correlation.
+      span.setAttribute("blob.config.partSizeBytes", config.partSizeBytes);
+      // Only set when the operator tuned them; otherwise the backend default
+      // applies and there is no single value to report.
+      if (config.maxConcurrentParts !== undefined) {
+        span.setAttribute(
+          "blob.config.maxConcurrentParts",
+          config.maxConcurrentParts,
+        );
+      }
+      if (config.maxPartAttempts !== undefined) {
+        span.setAttribute(
+          "blob.config.maxPartAttempts",
+          config.maxPartAttempts,
+        );
+      }
+      span.setAttribute("blob.config.skipEnrichment", config.skipEnrichment);
+      span.setAttribute("blob.config.rawPassthrough", config.rawPassthrough);
 
       // Event-loop delay during the stream: if it spikes, lock renewal can't
       // fire and the job re-enqueues as stalled (LFE-10063). Torn down below.
@@ -504,6 +540,7 @@ const processBlobStorageExport = async (config: {
                 "model_id",
                 false, // v3 query already returns latency in seconds
                 exportFieldGroups,
+                config.skipEnrichment,
               );
               break;
             case "scores":
@@ -529,6 +566,7 @@ const processBlobStorageExport = async (config: {
                 "model_id",
                 config.convertV4LatencyToSeconds,
                 exportFieldGroups,
+                config.skipEnrichment,
               );
               break;
             default:
@@ -560,6 +598,19 @@ const processBlobStorageExport = async (config: {
         // For CSV exports, use larger part size to handle big files
         // 100 MB parts support files up to ~1 TB (100 MB × 10,000 AWS limit)
         // This prevents hitting AWS's 10,000 part limit on large exports
+        // uploadStats is a mutable sink the uploader fills live, so the counts
+        // land on the span even when the upload throws. Only the S3 buffered
+        // path populates it; on every other path it stays {0,0,0}, so gate the
+        // telemetry on whether stats are actually produced to avoid reporting
+        // real exports as zero-part uploads.
+        const uploadStats = {
+          partsUploaded: 0,
+          partRetries: 0,
+          partFailures: 0,
+        };
+        const producesUploadStats =
+          config.type !== BlobStorageIntegrationType.AZURE_BLOB_STORAGE &&
+          sharedEnv.LANGFUSE_S3_UPLOAD_ENABLE_BUFFERED === "true";
         let uploadStartMs: number | undefined;
         let uploadDurationMsFinal: number | undefined;
         try {
@@ -569,7 +620,10 @@ const processBlobStorageExport = async (config: {
             fileName: filePath,
             fileType: uploadContentType,
             data: fileStream,
-            partSizeBytes: 100 * 1024 * 1024, // 100 MB part size
+            partSizeBytes: config.partSizeBytes,
+            maxConcurrentParts: config.maxConcurrentParts,
+            maxPartAttempts: config.maxPartAttempts,
+            stats: uploadStats,
           });
           // Record at the upload boundary so a throw in the `finally` below
           // can't miscount a real success as a failure.
@@ -625,7 +679,16 @@ const processBlobStorageExport = async (config: {
               `path=${passthroughEligible ? "passthrough" : "standard"} ` +
               `rows=${sourceStats.rows} chReadMs=${chReadMs} enrichMs=${enrichMs} ` +
               `gzipCpuMs=${gzipCpuMs} uploadWaitMs=${uploadWaitMs} ` +
-              `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${uploadDurationMs}` +
+              `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${uploadDurationMs} ` +
+              // "configured*" = the resolved tuning, not necessarily what each
+              // backend applied (e.g. the non-buffered S3 path ignores partSize
+              // and uses lib-storage's 5 MiB default). Mirrors the blob.config.*
+              // span attributes; blob.upload.* below are the actual effects.
+              `configuredPartSizeBytes=${config.partSizeBytes} configuredMaxConcurrentParts=${config.maxConcurrentParts ?? "default"} ` +
+              `configuredMaxPartAttempts=${config.maxPartAttempts ?? "default"} skipEnrichment=${config.skipEnrichment}` +
+              (producesUploadStats
+                ? ` uploadParts=${uploadStats.partsUploaded} uploadRetries=${uploadStats.partRetries} uploadFailures=${uploadStats.partFailures}`
+                : "") +
               (gzipStats && compressedCounter
                 ? ` gzipLevel=${gzipStats.level} compressedBytes=${compressedCounter.bytes}`
                 : ""),
@@ -687,6 +750,13 @@ const processBlobStorageExport = async (config: {
                 stageTags,
               );
             }
+          }
+          // Only the S3 buffered path produces these; recording them on other
+          // paths would report real exports as zero-part uploads.
+          if (producesUploadStats) {
+            span.setAttribute("blob.upload.parts", uploadStats.partsUploaded);
+            span.setAttribute("blob.upload.retries", uploadStats.partRetries);
+            span.setAttribute("blob.upload.failures", uploadStats.partFailures);
           }
           if (compressedCounter) {
             span.setAttribute("blob.compressedBytes", compressedCounter.bytes);
@@ -900,7 +970,9 @@ export const handleBlobStorageIntegrationProjectJob = async (
     // Per-project export tuning (set via DB directly; no UI/tRPC write path).
     // Malformed/absent column resolves to defaults — never throws.
     const { resolved: exportTuning, warnings: exportTuningWarnings } =
-      resolveBlobExportTuning(blobStorageIntegration.exportTuning);
+      resolveBlobExportTuning(blobStorageIntegration.exportTuning, {
+        partSizeBytes: DEFAULT_BLOB_EXPORT_PART_SIZE_BYTES,
+      });
     for (const warning of exportTuningWarnings) {
       logger.warn(
         `[BLOB INTEGRATION] exportTuning for project ${projectId}: ${warning}`,
@@ -928,6 +1000,10 @@ export const handleBlobStorageIntegrationProjectJob = async (
       exportFieldGroups:
         blobStorageIntegration.exportFieldGroups as ObservationFieldGroupFull[],
       rawPassthrough: exportTuning.rawPassthrough,
+      partSizeBytes: exportTuning.partSizeBytes,
+      maxConcurrentParts: exportTuning.maxConcurrentParts,
+      maxPartAttempts: exportTuning.maxPartAttempts,
+      skipEnrichment: exportTuning.skipEnrichment,
       bullmqJobId: job.id,
       bullmqAttemptsMade: job.attemptsMade,
     };


### PR DESCRIPTION
## What does this PR do?

Makes the blob-storage export upload knobs tunable **per project via the database**, with no redeploy, plus an optional enrichment skip. Production telemetry showed the upload phase dominates wall-clock for large exports and per-row model-price enrichment is costly for v3 observations; this lets us experiment per project.

Adds a nullable `BlobStorageIntegration.exportTuning` JSON column read at job time with **clamp-and-fallback** semantics (never throws). A null/absent/malformed column reproduces today's behaviour byte-for-byte.

- **Postgres**: `export_tuning JSONB` column (+ additive migration).
- **Shared** (`features/analytics-integrations`, client-safe): `BlobExportTuningSchema` (strict write schema for a future UI) + pure `resolveBlobExportTuning(raw, defaults) → { resolved, warnings }`. Out-of-range numbers are **clamped**; wrong-typed/missing values **fall back** to env/100 MB defaults; the worker logs each warning. Bounds: partSizeBytes 5 MiB–5 GiB (default 100 MiB), maxConcurrentParts 1–32, maxPartAttempts 1–10. Original env-derived ranges kept as code comments for orientation/revert.
- **StorageService.uploadFileBuffered**: optional `maxConcurrentParts` / `maxPartAttempts` overrides (default to env) + a caller-owned mutable stats sink; returns `UploadPartStats` (S3) or `undefined` (Azure/GCS/OCI). Azure maps part size → block size and concurrency → upload concurrency, and warns when `maxPartAttempts` is set (no Azure SDK knob). `partSize` now also flows through the non-buffered S3 path.
- **BufferedStreamUploader**: `partsUploaded` / `partRetries` / `partFailures` counters in the sink, readable even when `upload()` throws.
- **Worker**: resolves tuning, conditional `skipEnrichment` (drops only `input_price`/`output_price`/`total_price`; latency ms→s + metadata cleanup unchanged), and records `blob.config.*` + `blob.upload.*` on the `blob-export-table` span (in `finally`) plus the success log.

Note: per-project speed tuning + part stats require `LANGFUSE_S3_UPLOAD_ENABLE_BUFFERED=true`.

Fixes LFE-10394

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Added tests: resolver units, BufferedStreamUploader counters (incl. stats-survive-throw), `skipEnrichment` byte-for-byte regression, job-handler wiring.
- Verified locally: `pnpm turbo typecheck` (shared/worker/web), full lint, `db:generate`, targeted vitest suites all pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces per-project blob export tuning via an `export_tuning` JSONB column on `blob_storage_integrations`, allowing operators to override `partSizeBytes`, `maxConcurrentParts`, `maxPartAttempts`, and `skipEnrichment` on a per-project basis without touching env vars.

- A new `resolveBlobExportTuning` module provides clamp-and-fallback read semantics (never throws; out-of-range values are clamped and logged, malformed values fall back to env/100 MiB defaults) paired with a strict Zod write schema for a future settings UI path.
- `BufferedStreamUploader` gains an optional mutable `stats` sink that is populated live so upload counters (parts, retries, failures) land on the OTel span and success log even when the upload throws; `uploadFileBuffered` across all storage backends is updated to accept and thread through the new per-call knobs.
- `enrichObservationStream` gains a `skipEnrichment` flag that bypasses the per-row model-price lookup, which can meaningfully reduce ClickHouse/DB round-trips for projects that do not need pricing fields in their export.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The migration is additive (nullable JSONB, no default), all existing rows fall back to current behaviour, and the new tuning path is well-guarded with clamp-and-fallback semantics that never throw.

The core wiring — resolving tuning from the DB column, threading it through to the uploader, and recording live stats on the span — is correct and well-tested. The one logic gap is in `resolveNumber`: the `clamped !== value` guard fires for in-range floats (e.g. 5.5 rounds to 6) and emits a misleading "out of range" warning in the operator log. This is cosmetic in practice since the write schema enforces integers, but could confuse on-call engineers who manually inspect a JSONB row with a float value. No data loss or incorrect upload behaviour results from it.

`blob-export-tuning.ts` — the `resolveNumber` warning message for rounded floats. Everything else looks solid.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as handleBlobStorageIntegrationProjectJob
    participant DB as Postgres (blob_storage_integrations)
    participant Resolver as resolveBlobExportTuning
    participant Export as processBlobStorageExport
    participant Enrich as enrichObservationStream
    participant Storage as StorageService.uploadFileBuffered
    participant Uploader as BufferedStreamUploader

    Job->>Handler: job.data.payload.projectId
    Handler->>DB: findUnique (includes exportTuning JSONB)
    DB-->>Handler: "{ exportTuning, ... }"
    Handler->>Resolver: resolveBlobExportTuning(exportTuning, envDefaults)
    Resolver-->>Handler: "{ resolved: tuning, warnings }"
    Handler->>Handler: log tuningWarnings
    Handler->>Export: "processBlobStorageExport({ tuning, ... })"
    Export->>Export: "span.setAttribute blob.config.*"
    Export->>Enrich: enrichObservationStream(stream, ..., tuning.skipEnrichment)
    Enrich-->>Export: enriched rows (price fields absent if skipEnrichment)
    Export->>Storage: "uploadFileBuffered({ partSizeBytes, maxConcurrentParts, maxPartAttempts, stats })"
    Storage->>Uploader: "new BufferedStreamUploader({ ..., stats })"
    Uploader-->>Uploader: mutate stats.partsUploaded / partRetries / partFailures live
    Uploader-->>Storage: UploadPartStats
    Storage-->>Export: "UploadPartStats | undefined"
    Export->>Export: "span.setAttribute blob.upload.* (from mutable stats sink)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as handleBlobStorageIntegrationProjectJob
    participant DB as Postgres (blob_storage_integrations)
    participant Resolver as resolveBlobExportTuning
    participant Export as processBlobStorageExport
    participant Enrich as enrichObservationStream
    participant Storage as StorageService.uploadFileBuffered
    participant Uploader as BufferedStreamUploader

    Job->>Handler: job.data.payload.projectId
    Handler->>DB: findUnique (includes exportTuning JSONB)
    DB-->>Handler: "{ exportTuning, ... }"
    Handler->>Resolver: resolveBlobExportTuning(exportTuning, envDefaults)
    Resolver-->>Handler: "{ resolved: tuning, warnings }"
    Handler->>Handler: log tuningWarnings
    Handler->>Export: "processBlobStorageExport({ tuning, ... })"
    Export->>Export: "span.setAttribute blob.config.*"
    Export->>Enrich: enrichObservationStream(stream, ..., tuning.skipEnrichment)
    Enrich-->>Export: enriched rows (price fields absent if skipEnrichment)
    Export->>Storage: "uploadFileBuffered({ partSizeBytes, maxConcurrentParts, maxPartAttempts, stats })"
    Storage->>Uploader: "new BufferedStreamUploader({ ..., stats })"
    Uploader-->>Uploader: mutate stats.partsUploaded / partRetries / partFailures live
    Uploader-->>Storage: UploadPartStats
    Storage-->>Export: "UploadPartStats | undefined"
    Export->>Export: "span.setAttribute blob.upload.* (from mutable stats sink)"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/features/analytics-integrations/blob-export-tuning.ts:93-100
The warning fires whenever the rounded+clamped result differs from the raw input, which means an in-range float like `5.5` triggers "5.5 out of range [5, 5242880000]; clamped to 6". The value is not out of range — it was just rounded. An operator reading the warning log would incorrectly infer the stored value was outside the allowed bounds. Splitting the condition separates the two cases and produces accurate messages.

```suggestion
  const rounded = Math.round(value);
  const clamped = Math.min(bound.max, Math.max(bound.min, rounded));
  if (rounded !== value) {
    warnings.push(
      `${field}: ${value} is not an integer; rounded to ${rounded}`,
    );
  }
  if (clamped !== rounded) {
    warnings.push(
      `${field}: ${rounded} out of range [${bound.min}, ${bound.max}]; clamped to ${clamped}`,
    );
  }
  return clamped;
```

### Issue 2 of 2
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:67-73
`createModelCache` is called unconditionally at the top of the generator, even when `skipEnrichment=true` means `getModel` will never be invoked. The cache setup is currently cheap, but co-locating the guard with the flag makes the skip semantics self-documenting and avoids any future regression if `createModelCache` gains side effects (e.g., a warm-up query).

```suggestion
  // Only the per-row model-price lookup is skipped when skipEnrichment is true;
  // latency conversion and metadata-map cleanup below always run, so output is
  // byte-for-byte unchanged when the flag is off.
  const includeModelId =
    !skipEnrichment && (!fieldGroups || fieldGroups.includes("model"));
  const { getModel } = includeModelId
    ? createModelCache(projectId)
    : { getModel: async (_: string | null | undefined) => null };
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): per-project blob export tu..."](https://github.com/langfuse/langfuse/commit/5f8e95ef2150e2c97031a8938a71d5560b45d803) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38605506)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->