### PR TITLE
docs: add Scarf web traffic pixel to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,5 +377,5 @@ The telemetry does not include raw traces, prompts, observations, scores, or dat
 
 For Langfuse OSS, you can opt out by setting `TELEMETRY_ENABLED=false`.
 
-<!-- Scarf pixel — cookie-free, privacy-friendly analytics for README views (no cookies, no IP/PII stored). https://docs.scarf.sh/web-traffic/ . The `page` parameter is recommended by Scarf for GitHub READMEs, where GitHub's Camo image proxy otherwise obscures the source page. -->
+<!-- Scarf pixel — cookie-free, privacy-friendly analytics for README views (no cookies, no IP/PII stored). https://docs.scarf.sh/web-traffic/ -->
 <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=51a1912d-b16d-43a0-80b7-c3d6ab43e1a7&page=README.md" />

--- a/README.md
+++ b/README.md
@@ -376,3 +376,6 @@ This helps us to:
 The telemetry does not include raw traces, prompts, observations, scores, or dataset contents. We document the exact fields that are collected, where they are sent, and the implementation reference in our [telemetry docs](https://langfuse.com/self-hosting/security/telemetry).
 
 For Langfuse OSS, you can opt out by setting `TELEMETRY_ENABLED=false`.
+
+<!-- Scarf pixel — cookie-free, privacy-friendly analytics for README views (no cookies, no IP/PII stored). https://docs.scarf.sh/web-traffic/ . The `page` parameter is recommended by Scarf for GitHub READMEs, where GitHub's Camo image proxy otherwise obscures the source page. -->
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=51a1912d-b16d-43a0-80b7-c3d6ab43e1a7&page=README.md" />


### PR DESCRIPTION
## What does this PR do?

Adds a cookie-free [Scarf](https://docs.scarf.sh/web-traffic/) web traffic pixel at the end of the README so the project can count anonymous README/documentation views. Scarf sets no cookies and stores no IP/PII, so no consent is required.

```html
<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=51a1912d-b16d-43a0-80b7-c3d6ab43e1a7&page=README.md" />
```

- `referrerpolicy="no-referrer-when-downgrade"` is required by Scarf — it infers the viewed page from the `Referer` header.
- `&page=README.md` is included per Scarf's guidance for GitHub READMEs, where GitHub's Camo image proxy otherwise obscures the source page. It makes the view attributable despite the proxy.

Fixes # (N/A)

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Notes for reviewers

- Only `README.md` is changed (3 lines added at the end). No code paths affected.
- The companion website/docs pixel is a separate PR in `langfuse/langfuse-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a cookie-free Scarf web traffic pixel to the end of `README.md` to enable anonymous view counting for the repository page. No code, configuration, or behavior is changed.

- Appends a single `<img>` tag pointing to `static.scarf.sh` with a repository-specific pixel ID and `referrerpolicy="no-referrer-when-downgrade"` as required by Scarf.
- Includes an HTML comment explaining the intent and linking to Scarf's documentation; the `&page=README.md` query parameter is added per Scarf's guidance for GitHub READMEs where Camo proxying would otherwise obscure the source page.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a documentation-only change that appends a standard analytics pixel to the README. No application code, configuration, or behavior is affected.

Only README.md is touched — three lines added at the end with no modifications to existing content. The pixel tag is correctly formed with the attributes Scarf requires, and GitHub's Camo proxy means end-user IPs are not exposed to the third-party host.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Visitor
    participant Camo as GitHub Camo Proxy
    participant Scarf as Scarf static.scarf.sh

    Visitor->>Camo: Views README.md on github.com
    Camo->>Scarf: "GET /a.png?x-pxid=...&page=README.md"
    Note over Camo,Scarf: Referer header set to github.com/langfuse/langfuse
    Scarf-->>Camo: 1x1 transparent pixel response
    Camo-->>Visitor: Proxied pixel
    Note over Visitor,Scarf: Visitor IP is never exposed to Scarf due to Camo proxy
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Visitor
    participant Camo as GitHub Camo Proxy
    participant Scarf as Scarf static.scarf.sh

    Visitor->>Camo: Views README.md on github.com
    Camo->>Scarf: "GET /a.png?x-pxid=...&page=README.md"
    Note over Camo,Scarf: Referer header set to github.com/langfuse/langfuse
    Scarf-->>Camo: 1x1 transparent pixel response
    Camo-->>Visitor: Proxied pixel
    Note over Visitor,Scarf: Visitor IP is never exposed to Scarf due to Camo proxy
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Scarf web traffic pixel to REA..."](https://github.com/langfuse/langfuse/commit/b0297dd62ac7e2960c273eb371ebeedf7dcce3a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38619493)</sub>

<!-- /greptile_comment -->