### PR TITLE
fix(tracing): send batchIO I/O queries as POST to avoid HTTP 431

### DIFF
--- a/web/src/components/trace/api/usePrefetchObservation.ts
+++ b/web/src/components/trace/api/usePrefetchObservation.ts
@@ -1,4 +1,4 @@
-import { api } from "@/src/utils/api";
+import { api, sendAsPostOption } from "@/src/utils/api";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
 export type UsePrefetchObservationParams = {
@@ -32,6 +32,7 @@ export function usePrefetchObservation({
           truncated: false, // Must match useLogViewObservationIO for cache hit
         },
         {
+          ...sendAsPostOption,
           staleTime: 5 * 60 * 1000, // 5 minutes
         },
       );

--- a/web/src/components/trace/components/TraceLogView/useLogViewObservationIO.ts
+++ b/web/src/components/trace/components/TraceLogView/useLogViewObservationIO.ts
@@ -7,7 +7,7 @@
 
 import { useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { api } from "@/src/utils/api";
+import { api, sendAsPostOption } from "@/src/utils/api";
 import { type FlatLogItem } from "./log-view-types";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 
@@ -60,6 +60,7 @@ export function useLogViewObservationIO({
       truncated: false,
     },
     {
+      ...sendAsPostOption,
       enabled: enabled && isBetaEnabled,
       staleTime: Infinity,
       refetchOnWindowFocus: false,

--- a/web/src/features/batch-actions/components/RunEvaluationDialog/index.tsx
+++ b/web/src/features/batch-actions/components/RunEvaluationDialog/index.tsx
@@ -6,7 +6,7 @@ import {
   BatchEvalSourceTable as SourceTable,
   getEvalTargetObjectFromSourceTable,
 } from "@langfuse/shared";
-import { api } from "@/src/utils/api";
+import { api, sendAsPostOption } from "@/src/utils/api";
 import {
   Dialog,
   DialogBody,
@@ -119,6 +119,7 @@ export function RunEvaluationDialog(props: RunEvaluationDialogProps) {
       truncated: false,
     },
     {
+      ...sendAsPostOption,
       enabled:
         isBetaEnabled &&
         Boolean(

--- a/web/src/features/evals/hooks/usePreviewData.ts
+++ b/web/src/features/evals/hooks/usePreviewData.ts
@@ -3,7 +3,7 @@ import {
   isExperimentTarget,
 } from "@/src/features/evals/utils/typeHelpers";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
-import { api, type RouterOutputs } from "@/src/utils/api";
+import { api, sendAsPostOption, type RouterOutputs } from "@/src/utils/api";
 import {
   EvalTargetObject,
   extractValueFromObject,
@@ -200,6 +200,7 @@ function useEventPreview({
       truncated: false,
     },
     {
+      ...sendAsPostOption,
       enabled: enabled && !!observationId && !!traceId && !!timestamp,
     },
   );
@@ -247,6 +248,7 @@ function useExperimentPreview({
       truncated: false,
     },
     {
+      ...sendAsPostOption,
       enabled: enabled && !!observationId && !!traceId && !!timestamp,
     },
   );

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -1,4 +1,4 @@
-import { api } from "@/src/utils/api";
+import { api, sendAsPostOption } from "@/src/utils/api";
 import { useMemo } from "react";
 import {
   type FilterState,
@@ -111,6 +111,7 @@ export function useEventsTableData({
 
   // Fetch I/O data
   const ioDataQuery = api.events.batchIO.useQuery(batchIOPayload!, {
+    ...sendAsPostOption,
     enabled: observations.isSuccess && batchIOPayload !== null,
     refetchOnWindowFocus: false,
     staleTime: 0,

--- a/web/src/features/events/hooks/useEventsTraceData.ts
+++ b/web/src/features/events/hooks/useEventsTraceData.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { api } from "@/src/utils/api";
+import { api, sendAsPostOption } from "@/src/utils/api";
 import {
   adaptEventsToTraceFormat,
   type AdaptedTraceData,
@@ -113,6 +113,7 @@ export function useEventsTraceData(
       truncated: false,
     },
     {
+      ...sendAsPostOption,
       enabled:
         enabled && !!primaryObservation && !!timeRange && !!eventsQuery.data,
       staleTime: 60 * 1000,

--- a/web/src/features/experiments/hooks/useExperimentItemsTableData.ts
+++ b/web/src/features/experiments/hooks/useExperimentItemsTableData.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { type FilterState } from "@langfuse/shared";
-import { api } from "@/src/utils/api";
+import { api, sendAsPostOption } from "@/src/utils/api";
 import {
   type ExperimentItemsTableRow,
   type ExperimentOutputData,
@@ -118,6 +118,7 @@ export function useExperimentItemsTableData({
 
   // Fetch IO data for visible items
   const batchIOQuery = api.experiments.batchIO.useQuery(batchIOPayload!, {
+    ...sendAsPostOption,
     enabled: hasSelectedRuns && itemsQuery.isSuccess && batchIOPayload !== null,
     refetchOnWindowFocus: false,
     staleTime: 0,

--- a/web/src/hooks/useParsedObservation.ts
+++ b/web/src/hooks/useParsedObservation.ts
@@ -13,7 +13,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useMemo, useEffect } from "react";
-import { api } from "@/src/utils/api";
+import { api, sendAsPostOption } from "@/src/utils/api";
 import { useV4Beta } from "@/src/features/events/hooks/useV4Beta";
 import { type EventBatchIOOutput } from "@/src/features/events/server/eventsRouter";
 import {
@@ -231,6 +231,7 @@ export function useParsedObservation({
       truncated: false,
     },
     {
+      ...sendAsPostOption,
       enabled: isBetaEnabled,
       staleTime: 5 * 60 * 1000, // 5 minutes
       select: (data) => data[0], // Extract single result from batch

--- a/web/src/pages/api/trpc/[trpc].ts
+++ b/web/src/pages/api/trpc/[trpc].ts
@@ -18,6 +18,13 @@ export const config = {
 export default createNextApiHandler({
   router: appRouter,
   createContext: createTRPCContext,
+  // Allow queries to be sent as POST. The client only does this for `*.batchIO`
+  // queries, whose per-row payload would otherwise inflate the GET URL and trip
+  // HTTP 431 (see `POST_QUERY_PATHS` in src/utils/api.ts). This flag is
+  // handler-wide (tRPC has no per-procedure option), but it only widens the
+  // accepted method for queries (read-only); mutations remain POST-only, so the
+  // GET-mutation protection is unchanged.
+  allowMethodOverride: true,
   onError: ({ path, error }) => {
     const { logLevel, shouldTrace } = getTRPCErrorReporting(error);
     const message = `tRPC route failed on ${path ?? "<no-path>"}: ${error.message}`;

--- a/web/src/pages/api/trpc/[trpc].ts
+++ b/web/src/pages/api/trpc/[trpc].ts
@@ -18,12 +18,13 @@ export const config = {
 export default createNextApiHandler({
   router: appRouter,
   createContext: createTRPCContext,
-  // Allow queries to be sent as POST. The client only does this for `*.batchIO`
-  // queries, whose per-row payload would otherwise inflate the GET URL and trip
-  // HTTP 431 (see `POST_QUERY_PATHS` in src/utils/api.ts). This flag is
-  // handler-wide (tRPC has no per-procedure option), but it only widens the
-  // accepted method for queries (read-only); mutations remain POST-only, so the
-  // GET-mutation protection is unchanged.
+  // Allow queries to be sent as POST. The client only does this for the
+  // `*.batchIO` I/O queries, whose per-row payload would otherwise inflate the
+  // GET URL and trip HTTP 431 (queries opt in via the `sendAsPost` context flag;
+  // see `sendAsPostOption` in src/utils/api.ts). This flag is handler-wide (tRPC
+  // has no per-procedure option), but it only widens the accepted method for
+  // queries (read-only); mutations remain POST-only, so the GET-mutation
+  // protection is unchanged.
   allowMethodOverride: true,
   onError: ({ path, error }) => {
     const { logLevel, shouldTrace } = getTRPCErrorReporting(error);

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -13,6 +13,7 @@ import {
   loggerLink,
   splitLink,
   TRPCClientError,
+  type Operation,
   type TRPCLink,
 } from "@trpc/client";
 import { QueryCache } from "@tanstack/react-query";
@@ -154,6 +155,28 @@ if (vitest && typeof vitest === "object") {
 /* eslint-enable @repo/no-in-source-vitest */
 
 /**
+ * tRPC serializes query input into the GET URL. For reads whose input scales with
+ * the number of rows (the `*.batchIO` I/O fetches), that URL grows large (~6KB at
+ * 50 rows, ~12KB at 100) and — together with per-user cookies (NextAuth session
+ * JWT, PostHog, ...) — can exceed the request line/header budget enforced by
+ * browsers and reverse proxies, failing with HTTP 431 (Request Header Fields Too
+ * Large). Because cookie size varies per user, it reproduces for some and not
+ * others.
+ *
+ * A query opts into being sent as POST (payload in the body, URL stays small) by
+ * setting the `sendAsPost` context flag at the call site: merge `sendAsPostOption`
+ * into its query options, e.g. `useQuery(input, { ...sendAsPostOption, enabled })`.
+ * The server accepts query-over-POST via `allowMethodOverride` (see
+ * src/pages/api/trpc/[trpc].ts); mutations stay POST-only.
+ */
+export const sendAsPostOption = {
+  trpc: { context: { sendAsPost: true } },
+} as const;
+
+const shouldSendQueryAsPost = (op: Operation): boolean =>
+  op.context.sendAsPost === true;
+
+/**
  * Creates a unique hash for an error to track it for debouncing; implementation hashes based on the tRPC path and http status
  */
 const getErrorHash = (error: unknown): string => {
@@ -251,6 +274,66 @@ const buildIdLink = (): TRPCLink<AppRouter> => () => {
   };
 };
 
+// HTTP statuses returned when a request's URL/headers are too large for the
+// browser or an upstream proxy. The response body is usually not a tRPC
+// envelope, so these are otherwise hard to diagnose.
+const REQUEST_TOO_LARGE_STATUSES = [414, 431];
+
+// Logs request-size context to the console when a GET-routed query fails because
+// its URL was too large. tRPC serializes query input into the GET URL, so an
+// oversized input (a long list, a wide filter selection, ...) can trip HTTP 414
+// (URI Too Long) or 431 (Request Header Fields Too Large). Surfacing the path and
+// approximate URL size makes such failures diagnosable from a console screenshot
+// and points at the fix (send the query as POST). `*.batchIO` and mutations are
+// already POST, so the URL is not the culprit for them and they are skipped.
+const requestTooLargeDiagnosticsLink = (): TRPCLink<AppRouter> => () => {
+  return ({ next, op }) => {
+    return observable((observer) => {
+      const unsubscribe = next(op).subscribe({
+        next(value) {
+          observer.next(value);
+        },
+        error(err) {
+          const sentAsGet =
+            op.type === "query" && op.context.sendAsPost !== true;
+          const status =
+            err.meta?.response instanceof Response
+              ? err.meta.response.status
+              : undefined;
+
+          if (
+            sentAsGet &&
+            status !== undefined &&
+            REQUEST_TOO_LARGE_STATUSES.includes(status)
+          ) {
+            try {
+              const encodedInput = encodeURIComponent(
+                JSON.stringify(superjson.serialize(op.input)),
+              );
+              const approxUrlBytes =
+                `${getBaseUrl()}/api/trpc/${op.path}?input=`.length +
+                encodedInput.length;
+              console.error(
+                `[tRPC] "${op.path}" failed with HTTP ${status}: GET request too large ` +
+                  `(~${approxUrlBytes} bytes of URL, plus cookies/headers). Large query ` +
+                  `inputs should be sent as POST — see POST_QUERY_PATHS in src/utils/api.ts.`,
+                { path: op.path, status, approxUrlBytes },
+              );
+            } catch {
+              // diagnostics only — never throw from the logging path
+            }
+          }
+          observer.error(err);
+        },
+        complete() {
+          observer.complete();
+        },
+      });
+      return unsubscribe;
+    });
+  };
+};
+
 const shouldSilenceError = (
   meta: Record<string, unknown>,
   error: Error,
@@ -281,6 +364,7 @@ export const api = createTRPCNext<AppRouter>({
        */
       links: [
         buildIdLink(),
+        requestTooLargeDiagnosticsLink(),
         loggerLink({
           // Only enable in development - production logs would be captured by Sentry
           // in an unreadable format. We handle 5xx errors via captureException() in
@@ -297,10 +381,20 @@ export const api = createTRPCNext<AppRouter>({
 
             return skipBatch || alwaysSkipBatch;
           },
-          // when condition is true, use normal request
-          true: httpLink({
-            url: `${getBaseUrl()}/api/trpc`,
-            transformer: superjson,
+          // when condition is true, use normal request. Route the oversized
+          // `*.batchIO` queries through POST so their per-row payload does not
+          // inflate the GET URL and trip HTTP 431. See `shouldSendQueryAsPost`.
+          true: splitLink({
+            condition: shouldSendQueryAsPost,
+            true: httpLink({
+              url: `${getBaseUrl()}/api/trpc`,
+              transformer: superjson,
+              methodOverride: "POST",
+            }),
+            false: httpLink({
+              url: `${getBaseUrl()}/api/trpc`,
+              transformer: superjson,
+            }),
           }),
           // when condition is false, use batching
           false: httpBatchLink({

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -313,10 +313,14 @@ const requestTooLargeDiagnosticsLink = (): TRPCLink<AppRouter> => () => {
               const approxUrlBytes =
                 `${getBaseUrl()}/api/trpc/${op.path}?input=`.length +
                 encodedInput.length;
+              // Keep the format string constant (no interpolation) and pass the
+              // dynamic values as a structured argument — they remain visible and
+              // expandable in the console without risking format-string injection.
               console.error(
-                `[tRPC] "${op.path}" failed with HTTP ${status}: GET request too large ` +
-                  `(~${approxUrlBytes} bytes of URL, plus cookies/headers). Large query ` +
-                  `inputs should be sent as POST — see POST_QUERY_PATHS in src/utils/api.ts.`,
+                "[tRPC] a query sent as GET failed because the request URL was " +
+                  "too large (HTTP 414/431). Large query inputs should be sent as " +
+                  "POST — add { ...sendAsPostOption } to the query's options (see " +
+                  "sendAsPostOption in src/utils/api.ts).",
                 { path: op.path, status, approxUrlBytes },
               );
             } catch {


### PR DESCRIPTION
The events `*.batchIO` queries fetch I/O for every visible table row, so their input carries one {id, traceId} per row. tRPC serializes query input into the GET URL, so the URL grows with page size (~6KB at 50 rows, ~12KB at 100). Together with per-user cookies (NextAuth session JWT, PostHog), this can exceed the request line + header budget enforced by browsers and reverse proxies, failing with HTTP 431 (Request Header Fields Too Large). It reproduced for users with larger cookies — and for anyone at limit=100 — surfacing as the "Unexpected Response" toast on the tracing table.

These queries now opt into POST (payload travels in the body, URL stays small) via a `sendAsPost` tRPC context flag at each call site (`sendAsPostOption`). The server accepts query-over-POST via `allowMethodOverride`; mutations remain POST-only, so the GET-mutation protection is unchanged. Also adds a console diagnostic that logs the offending procedure path and approximate URL size when a GET query fails with 414/431, so future offenders are visible from a console screenshot.

LFE-10401

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes HTTP 431 errors on the tracing table by routing `*.batchIO` queries — whose input payload scales with page size — through POST instead of GET, keeping the URL small regardless of row count or cookie volume.

- Introduces `sendAsPostOption` (`{ trpc: { context: { sendAsPost: true } } }`) and a nested `splitLink` in the tRPC client that routes flagged queries through an `httpLink` with `methodOverride: "POST"`. The server-side handler is updated with `allowMethodOverride: true` to accept query-over-POST, while mutations remain POST-only and the existing GET-mutation protection is unchanged.
- Eight call sites across hooks (`useEventsTableData`, `useExperimentItemsTableData`, `useParsedObservation`, `usePrefetchObservation`, `useLogViewObservationIO`, `usePreviewData`, `useEventsTraceData`, `RunEvaluationDialog`) now spread `sendAsPostOption`.
- A `requestTooLargeDiagnosticsLink` is added to the link chain; it logs the procedure path and approximate URL size to the console whenever a GET query fails with HTTP 414 or 431, helping diagnose future offenders.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the routing logic is correct and all batchIO call sites are updated.

The fix is well-scoped: alwaysSkipBatch = true guarantees every query reaches the inner splitLink where sendAsPost is evaluated, so the POST routing is never bypassed. The only issue found is the diagnostic console.error pointing developers to a non-existent POST_QUERY_PATHS identifier rather than sendAsPostOption, which would make the log hint misleading when the next 414/431 appears.

web/src/utils/api.ts — the stale symbol reference in the console.error message at line 319.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Hook as React Hook (*.batchIO)
    participant SplitA as splitLink (alwaysSkipBatch)
    participant SplitB as splitLink (shouldSendQueryAsPost)
    participant POST as httpLink methodOverride POST
    participant GET as httpLink default GET
    participant Server as tRPC Server allowMethodOverride true

    Hook->>SplitA: "useQuery({ ...sendAsPostOption })"
    SplitA-->>SplitA: "alwaysSkipBatch=true → true branch"
    SplitA->>SplitB: "op.context.sendAsPost = true"
    SplitB-->>SplitB: "sendAsPost===true → true branch"
    SplitB->>POST: route to POST httpLink
    POST->>Server: POST /api/trpc/events.batchIO
    Server-->>POST: 200 OK (input read from body)
    POST-->>Hook: result

    Note over Hook,GET: Queries without sendAsPostOption
    Hook->>SplitA: "useQuery({}) normal query"
    SplitA->>SplitB: op.context.sendAsPost undefined
    SplitB-->>SplitB: "sendAsPost !== true → false branch"
    SplitB->>GET: route to GET httpLink
    GET->>Server: "GET /api/trpc/some.query?input=..."
    Server-->>GET: 200 OK
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Hook as React Hook (*.batchIO)
    participant SplitA as splitLink (alwaysSkipBatch)
    participant SplitB as splitLink (shouldSendQueryAsPost)
    participant POST as httpLink methodOverride POST
    participant GET as httpLink default GET
    participant Server as tRPC Server allowMethodOverride true

    Hook->>SplitA: "useQuery({ ...sendAsPostOption })"
    SplitA-->>SplitA: "alwaysSkipBatch=true → true branch"
    SplitA->>SplitB: "op.context.sendAsPost = true"
    SplitB-->>SplitB: "sendAsPost===true → true branch"
    SplitB->>POST: route to POST httpLink
    POST->>Server: POST /api/trpc/events.batchIO
    Server-->>POST: 200 OK (input read from body)
    POST-->>Hook: result

    Note over Hook,GET: Queries without sendAsPostOption
    Hook->>SplitA: "useQuery({}) normal query"
    SplitA->>SplitB: op.context.sendAsPost undefined
    SplitB-->>SplitB: "sendAsPost !== true → false branch"
    SplitB->>GET: route to GET httpLink
    GET->>Server: "GET /api/trpc/some.query?input=..."
    Server-->>GET: 200 OK
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/utils/api.ts:319
The log message references `POST_QUERY_PATHS` which doesn't exist; the actual pattern is `sendAsPostOption`.

```suggestion
                  `inputs should be sent as POST — add { ...sendAsPostOption } to the useQuery options (see sendAsPostOption in src/utils/api.ts).`,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tracing): send batchIO I/O queries a..."](https://github.com/langfuse/langfuse/commit/a3cffac1b86f6de991dd70d4037bee3c8ae094c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38620640)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->