### PR TITLE
fix(evals): enhance evaluator onboarding

### DIFF
--- a/web/src/components/onboarding/EvaluatorsOnboarding.tsx
+++ b/web/src/components/onboarding/EvaluatorsOnboarding.tsx
@@ -3,7 +3,7 @@ import {
   SplashScreen,
   type ValueProposition,
 } from "@/src/components/ui/splash-screen";
-import { Bot, Gauge, Zap, BarChart4, Code2 } from "lucide-react";
+import { Bot, Gauge, Zap, BarChart4 } from "lucide-react";
 import { useIsCodeEvalEnabled } from "@/src/features/evals/hooks/useIsCodeEvalEnabled";
 import { EvalTemplateSourceCodeLanguage } from "@langfuse/shared";
 
@@ -46,25 +46,30 @@ export function EvaluatorsOnboarding({ projectId }: EvaluatorsOnboardingProps) {
   ];
 
   if (enabled) {
-    const evaluatorTypes: ValueProposition[] = [
-      {
-        title: "LLM-as-a-judge evaluators",
-        description:
-          "Use an LLM to score outputs against natural-language criteria.",
-        icon: <Bot className="h-4 w-4" />,
-      },
-      {
-        title: "Code evaluators",
-        description: `Write ${codeEvaluatorLanguageDescription} logic for deterministic, custom scoring.`,
-        icon: <Code2 className="h-4 w-4" />,
-      },
-    ];
-
     return (
       <SplashScreen
         title="Get started with evaluations"
-        description="Use evaluators to score traces and observations automatically. Langfuse supports two evaluator types:"
-        valuePropositions={evaluatorTypes}
+        description={
+          <>
+            Use evaluators to score traces and observations automatically.
+            Langfuse supports two evaluator types:
+            <ul className="text-muted-foreground mx-auto mt-2 max-w-2xl list-disc space-y-2 pl-5 text-sm">
+              <li>
+                <span className="text-foreground font-medium">
+                  LLM-as-a-judge evaluators
+                </span>{" "}
+                use an LLM to score outputs against natural-language criteria.
+              </li>
+              <li>
+                <span className="text-foreground font-medium">
+                  Code evaluators
+                </span>{" "}
+                use {codeEvaluatorLanguageDescription} logic for deterministic,
+                custom scoring.
+              </li>
+            </ul>
+          </>
+        }
         primaryAction={{
           label: "Create Evaluator",
           href: `/project/${projectId}/evals/new`,

--- a/web/src/components/onboarding/EvaluatorsOnboarding.tsx
+++ b/web/src/components/onboarding/EvaluatorsOnboarding.tsx
@@ -53,7 +53,7 @@ export function EvaluatorsOnboarding({ projectId }: EvaluatorsOnboardingProps) {
           <>
             Use evaluators to score traces and observations automatically.
             Langfuse supports two evaluator types:
-            <ul className="text-muted-foreground mx-auto mt-2 max-w-2xl list-disc space-y-2 pl-5 text-sm">
+            <ul className="text-muted-foreground mx-auto mt-2 max-w-2xl list-disc space-y-2 pl-5 text-left text-sm">
               <li>
                 <span className="text-foreground font-medium">
                   LLM-as-a-judge evaluators

--- a/web/src/components/ui/splash-screen.tsx
+++ b/web/src/components/ui/splash-screen.tsx
@@ -28,7 +28,7 @@ export interface Step {
 
 export interface SplashScreenProps {
   title: string;
-  description: string;
+  description: string | React.ReactNode;
   waitingFor?: string;
   image?: {
     src: string;
@@ -118,7 +118,7 @@ export function SplashScreen({
           </StatusBadge>
         )}
         <h2 className="mb-2 text-2xl font-bold">{title}</h2>
-        <p className="text-muted-foreground">{description}</p>
+        <div className="text-muted-foreground">{description}</div>
       </div>
 
       <div className="mb-8 flex w-full flex-wrap justify-center gap-4">

--- a/web/src/features/evals/components/default-eval-model-setup.tsx
+++ b/web/src/features/evals/components/default-eval-model-setup.tsx
@@ -23,9 +23,21 @@ import {
 import { Label } from "@/src/components/ui/label";
 import { Input } from "@/src/components/ui/input";
 
-export function DefaultEvalModelSetup({ projectId }: { projectId: string }) {
+type DefaultEvalModelSuccessMessage = {
+  title: string;
+  description: string;
+};
+
+function useDefaultEvalModelSetup({
+  projectId,
+  onSuccess,
+  successMessage,
+}: {
+  projectId: string;
+  onSuccess?: () => void;
+  successMessage: DefaultEvalModelSuccessMessage;
+}) {
   const utils = api.useUtils();
-  const [isEditing, setIsEditing] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
   const hasWriteAccess = useHasProjectAccess({
@@ -51,17 +63,14 @@ export function DefaultEvalModelSetup({ projectId }: { projectId: string }) {
   const { mutateAsync: upsertDefaultModel, isPending: isUpsertLoading } =
     api.defaultLlmModel.upsertDefaultModel.useMutation({
       onSuccess: () => {
-        showSuccessToast({
-          title: "Default evaluation model updated",
-          description: "All running evaluators will use the new model.",
-        });
+        showSuccessToast(successMessage);
 
         utils.defaultLlmModel.fetchDefaultModel.invalidate({ projectId });
         setFormError(null);
-        setIsEditing(false);
+        onSuccess?.();
       },
       onError: (error) => {
-        setFormError(error.message as string);
+        setFormError(error.message);
       },
     });
 
@@ -75,7 +84,77 @@ export function DefaultEvalModelSetup({ projectId }: { projectId: string }) {
     });
   };
 
-  if (isDefaultModelLoading) {
+  return {
+    availableModels,
+    availableProviders,
+    executeUpsertMutation,
+    formError,
+    hasWriteAccess,
+    isDefaultModelLoading,
+    isUpsertLoading,
+    modelParams,
+    providerModelCombinations,
+    selectedModel,
+    setModelParamEnabled,
+    setFormError,
+    updateModelParamValue,
+  };
+}
+
+function DefaultEvalModelFields({
+  setup,
+  errorClassName = "text-red w-full text-center",
+}: {
+  setup: ReturnType<typeof useDefaultEvalModelSetup>;
+  errorClassName?: string;
+}) {
+  return (
+    <>
+      <ModelParameters
+        customHeader={
+          <p className="leading-none font-medium">LLM connection</p>
+        }
+        modelParams={setup.modelParams}
+        availableModels={setup.availableModels}
+        providerModelCombinations={setup.providerModelCombinations}
+        availableProviders={setup.availableProviders}
+        updateModelParamValue={setup.updateModelParamValue}
+        setModelParamEnabled={setup.setModelParamEnabled}
+        formDisabled={!setup.hasWriteAccess}
+      />
+      <p className="text-muted-foreground text-xs">
+        Select a model which supports function calling.
+      </p>
+      {setup.formError ? (
+        <p className={errorClassName}>
+          <span className="font-bold">Error:</span> {setup.formError}
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+export function DefaultEvalModelSetup({
+  projectId,
+  onSuccess,
+}: {
+  projectId: string;
+  onSuccess?: () => void;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const setup = useDefaultEvalModelSetup({
+    projectId,
+    onSuccess: () => {
+      setIsEditing(false);
+      onSuccess?.();
+    },
+    successMessage: {
+      title: "Default evaluation model updated",
+      description: "All running evaluators will use the new model.",
+    },
+  });
+
+  if (setup.isDefaultModelLoading) {
     return <Skeleton className="h-[500px] w-full" />;
   }
 
@@ -84,16 +163,15 @@ export function DefaultEvalModelSetup({ projectId }: { projectId: string }) {
       <Card className="mt-3 flex flex-col gap-6">
         <CardContent>
           <p className="my-2 text-lg font-semibold">
-            Set default evaluator model
+            Set up LLM connection to use for evaluations
           </p>
           <ManageDefaultEvalModel
             projectId={projectId}
             variant="color-coded"
             setUpMessage={
               <>
-                No default model set. LLM-as-a-judge evaluations require an LLM
-                connection for scoring. This default is used by all templates
-                that don&apos;t specify their own model.{" "}
+                LLM-as-a-judge evaluations require an LLM connection for
+                scoring. You can also specify a custom model for each evaluator.{" "}
                 <a
                   href="https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge#how-llm-as-a-judge-works"
                   target="_blank"
@@ -111,7 +189,7 @@ export function DefaultEvalModelSetup({ projectId }: { projectId: string }) {
       </Card>
 
       <div className="mt-2 flex justify-end gap-2">
-        {selectedModel && (
+        {setup.selectedModel && (
           <DeleteEvaluationModelButton
             projectId={projectId}
             scope="evalDefaultModel:CUD"
@@ -123,69 +201,91 @@ export function DefaultEvalModelSetup({ projectId }: { projectId: string }) {
           onOpenChange={(open) => {
             setIsEditing(open);
             if (!open) {
-              setFormError(null);
+              setup.setFormError(null);
             }
           }}
         >
           <DialogTrigger asChild>
             <Button
-              disabled={!hasWriteAccess}
+              disabled={!setup.hasWriteAccess}
               onClick={() => {
                 setIsEditing(true);
               }}
             >
               <Pencil className="mr-2 h-4 w-4" />
-              {selectedModel ? "Edit" : "Set up"}
+              {setup.selectedModel ? "Edit" : "Set up"}
             </Button>
           </DialogTrigger>
           <DialogContent className="px-3 py-10">
-            <ModelParameters
-              customHeader={
-                <p className="leading-none font-medium">
-                  Default model configuration
-                </p>
-              }
-              {...{
-                modelParams,
-                availableModels,
-                providerModelCombinations,
-                availableProviders,
-                updateModelParamValue,
-                setModelParamEnabled,
-              }}
-              formDisabled={!hasWriteAccess}
-            />
-            <div className="text-muted-foreground my-2 text-xs">
-              Select a model which supports function calling.
-            </div>
             <div className="flex flex-col gap-2">
+              <DefaultEvalModelFields setup={setup} />
               <div className="mt-2 flex justify-end gap-2">
                 <Button variant="outline" onClick={() => setIsEditing(false)}>
                   Cancel
                 </Button>
-                {selectedModel ? (
+                {setup.selectedModel ? (
                   <UpdateButton
                     projectId={projectId}
-                    isLoading={isUpsertLoading}
-                    executeUpsertMutation={executeUpsertMutation}
+                    isLoading={setup.isUpsertLoading}
+                    executeUpsertMutation={setup.executeUpsertMutation}
                   />
                 ) : (
                   <Button
-                    disabled={!hasWriteAccess || !modelParams.provider.value}
-                    onClick={executeUpsertMutation}
+                    disabled={
+                      !setup.hasWriteAccess || !setup.modelParams.provider.value
+                    }
+                    onClick={setup.executeUpsertMutation}
                   >
                     Save
                   </Button>
                 )}
               </div>
-              {formError ? (
-                <p className="text-red w-full text-center">
-                  <span className="font-bold">Error:</span> {formError}
-                </p>
-              ) : null}
             </div>
           </DialogContent>
         </Dialog>
+      </div>
+    </>
+  );
+}
+
+export function InlineDefaultEvalModelSetup({
+  projectId,
+  onSuccess,
+  submitLabel = "Save",
+}: {
+  projectId: string;
+  onSuccess?: () => void;
+  submitLabel?: string;
+}) {
+  const setup = useDefaultEvalModelSetup({
+    projectId,
+    onSuccess,
+    successMessage: {
+      title: "Default evaluation model set",
+      description: "LLM-as-a-judge evaluators can now use this model.",
+    },
+  });
+
+  if (setup.isDefaultModelLoading) {
+    return <Skeleton className="h-[360px] w-full" />;
+  }
+
+  return (
+    <>
+      <div className="space-y-3">
+        <DefaultEvalModelFields
+          setup={setup}
+          errorClassName="text-red w-full text-center text-sm"
+        />
+      </div>
+      <div className="flex w-full justify-end">
+        <Button
+          loading={setup.isUpsertLoading}
+          disabled={!setup.hasWriteAccess || !setup.modelParams.provider.value}
+          onClick={setup.executeUpsertMutation}
+        >
+          {submitLabel}
+        </Button>
       </div>
     </>
   );

--- a/web/src/features/evals/components/evaluator-selector.tsx
+++ b/web/src/features/evals/components/evaluator-selector.tsx
@@ -3,12 +3,7 @@ import {
   EvalTemplateType,
   type EvalTemplate,
 } from "@langfuse/shared";
-import {
-  AlertCircle,
-  CheckIcon,
-  ExternalLink,
-  ExternalLinkIcon,
-} from "lucide-react";
+import { AlertCircle, CheckIcon } from "lucide-react";
 import {
   InputCommand,
   InputCommandEmpty,
@@ -101,6 +96,7 @@ interface EvaluatorSelectorProps {
   projectId: string;
   evalTemplates: EvalTemplate[];
   selectedTemplateId?: string;
+  showMissingProviderWarning?: boolean;
   onTemplateSelect: (
     templateId: string,
     name: string,
@@ -112,6 +108,7 @@ export function EvaluatorSelector({
   projectId,
   evalTemplates,
   selectedTemplateId,
+  showMissingProviderWarning = true,
   onTemplateSelect,
 }: EvaluatorSelectorProps) {
   const [search, setSearch] = useState("");
@@ -167,9 +164,9 @@ export function EvaluatorSelector({
   const hasResults =
     filteredTemplates.langfuse.length > 0 ||
     filteredTemplates.custom.length > 0;
-
   const { isTemplateInvalid } = useSingleTemplateValidation({
     projectId,
+    enabled: showMissingProviderWarning,
   });
 
   return (
@@ -205,7 +202,6 @@ export function EvaluatorSelector({
                       );
                     }}
                     className={cn(
-                      "group",
                       templateData.some((t) => t.id === selectedTemplateId) &&
                         "bg-secondary",
                     )}
@@ -225,7 +221,7 @@ export function EvaluatorSelector({
                       </TooltipTrigger>
                       <TooltipContent
                         side="right"
-                        className="max-h-[300px] max-w-[400px] overflow-y-auto"
+                        className="max-h-[70dvh] w-[720px] max-w-[calc(100vw-3rem)] overflow-y-auto"
                       >
                         <TemplatePreviewTooltipContent
                           template={latestVersion}
@@ -241,41 +237,17 @@ export function EvaluatorSelector({
                           <p>Requires project-level evaluation model</p>
                           <Link
                             href={`/project/${projectId}/evals/default-model`}
-                            className="mt-2 flex items-center gap-1 text-blue-600 hover:underline"
+                            className="mt-2 block text-blue-600 hover:underline"
                             target="_blank"
                             rel="noopener noreferrer"
                           >
-                            <ExternalLinkIcon className="h-3 w-3" />
                             Configure default model
                           </Link>
                         </TooltipContent>
                       </Tooltip>
                     )}
-                    {templateData.some((t) => t.id === selectedTemplateId) ? (
-                      <>
-                        <Link
-                          href={`/project/${projectId}/evals/templates/${latestVersion.id}`}
-                          target="_blank"
-                          className="ml-auto opacity-0 group-hover:opacity-100 hover:opacity-100"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                          }}
-                        >
-                          <ExternalLink className="h-4 w-4" />
-                        </Link>
-                        <CheckIcon className={cn("ml-2 h-4 w-4")} />
-                      </>
-                    ) : (
-                      <Link
-                        href={`/project/${projectId}/evals/templates/${latestVersion.id}`}
-                        target="_blank"
-                        className="ml-auto opacity-0 group-hover:opacity-100 hover:opacity-100"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                      >
-                        <ExternalLink className="h-4 w-4" />
-                      </Link>
+                    {templateData.some((t) => t.id === selectedTemplateId) && (
+                      <CheckIcon className="ml-auto h-4 w-4" />
                     )}
                   </InputCommandItem>
                 );
@@ -304,7 +276,6 @@ export function EvaluatorSelector({
                       );
                     }}
                     className={cn(
-                      "group",
                       templateData.some((t) => t.id === selectedTemplateId) &&
                         "bg-secondary",
                     )}
@@ -324,7 +295,7 @@ export function EvaluatorSelector({
                       </TooltipTrigger>
                       <TooltipContent
                         side="right"
-                        className="max-h-[300px] max-w-[400px] overflow-y-auto"
+                        className="max-h-[70dvh] w-[720px] max-w-[calc(100vw-3rem)] overflow-y-auto"
                       >
                         <TemplatePreviewTooltipContent
                           template={latestVersion}
@@ -343,41 +314,17 @@ export function EvaluatorSelector({
                           <p>Requires project-level evaluation model</p>
                           <Link
                             href={`/project/${projectId}/evals/default-model`}
-                            className="mt-2 flex items-center gap-1 text-blue-600 hover:underline"
+                            className="mt-2 block text-blue-600 hover:underline"
                             target="_blank"
                             rel="noopener noreferrer"
                           >
-                            <ExternalLinkIcon className="h-3 w-3" />
                             Configure default model
                           </Link>
                         </TooltipContent>
                       </Tooltip>
                     )}
-                    {templateData.some((t) => t.id === selectedTemplateId) ? (
-                      <>
-                        <Link
-                          href={`/project/${projectId}/evals/templates/${latestVersion.id}`}
-                          target="_blank"
-                          className="ml-auto opacity-0 group-hover:opacity-100 hover:opacity-100"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                          }}
-                        >
-                          <ExternalLink className="h-4 w-4" />
-                        </Link>
-                        <CheckIcon className={cn("ml-2 h-4 w-4")} />
-                      </>
-                    ) : (
-                      <Link
-                        href={`/project/${projectId}/evals/templates/${latestVersion.id}`}
-                        target="_blank"
-                        className="ml-auto opacity-0 group-hover:opacity-100 hover:opacity-100"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                      >
-                        <ExternalLink className="h-4 w-4" />
-                      </Link>
+                    {templateData.some((t) => t.id === selectedTemplateId) && (
+                      <CheckIcon className="ml-auto h-4 w-4" />
                     )}
                   </InputCommandItem>
                 );

--- a/web/src/features/evals/components/select-evaluator-list.tsx
+++ b/web/src/features/evals/components/select-evaluator-list.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type ReactNode, useEffect, useState } from "react";
+import { Fragment, type ReactNode, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import { api } from "@/src/utils/api";
 import {
@@ -42,6 +42,7 @@ type CreateEvaluatorStep = "connection" | "define";
 
 export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
   const router = useRouter();
+  const createDialogSessionRef = useRef(0);
   const [isCreateTemplateOpen, setIsCreateTemplateOpen] = useState(false);
   const [customEvaluatorType, setCustomEvaluatorType] = useState<
     typeof EvalTemplateType.LLM_AS_JUDGE | typeof EvalTemplateType.CODE | null
@@ -85,6 +86,7 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
     setCustomEvaluatorType(type);
     setUseLlmCreateWizard(shouldUseWizard);
     setCreateEvaluatorStep(shouldUseWizard ? "connection" : "define");
+    createDialogSessionRef.current += 1;
     setIsCreateTemplateOpen(true);
   };
 
@@ -110,6 +112,7 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
       handleSelectEvaluator(template);
     }
   };
+  const createDialogSession = createDialogSessionRef.current;
 
   return (
     <>
@@ -188,6 +191,7 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
         onOpenChange={(open) => {
           setIsCreateTemplateOpen(open);
           if (!open) {
+            createDialogSessionRef.current += 1;
             setCustomEvaluatorType(null);
             setCreateEvaluatorStep("define");
             setUseLlmCreateWizard(false);
@@ -218,6 +222,9 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
               hasDefaultEvalModel={hasDefaultEvalModel}
               onStepChange={setCreateEvaluatorStep}
               onProviderConfigured={() => {
+                if (createDialogSessionRef.current !== createDialogSession) {
+                  return;
+                }
                 setDefaultModelConfiguredInDialog(true);
                 setCreateEvaluatorStep("define");
               }}
@@ -228,6 +235,11 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
                   customEvaluatorType={EvalTemplateType.LLM_AS_JUDGE}
                   shouldUseDefaultModel={shouldUseDefaultModel}
                   onSuccess={(newTemplate) => {
+                    if (
+                      createDialogSessionRef.current !== createDialogSession
+                    ) {
+                      return;
+                    }
                     setIsCreateTemplateOpen(false);
                     setCustomEvaluatorType(null);
                     setUseLlmCreateWizard(false);
@@ -247,6 +259,9 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
                 customEvaluatorType ?? EvalTemplateType.LLM_AS_JUDGE
               }
               onSuccess={(newTemplate) => {
+                if (createDialogSessionRef.current !== createDialogSession) {
+                  return;
+                }
                 setIsCreateTemplateOpen(false);
                 setCustomEvaluatorType(null);
                 utils.evals.allTemplates.invalidate();

--- a/web/src/features/evals/components/select-evaluator-list.tsx
+++ b/web/src/features/evals/components/select-evaluator-list.tsx
@@ -1,19 +1,19 @@
-import { useState } from "react";
+import { Fragment, type ReactNode, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { api } from "@/src/utils/api";
 import {
   Dialog,
+  DialogBody,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/src/components/ui/dialog";
 import { Button } from "@/src/components/ui/button";
-import { Bot, Code2 } from "lucide-react";
+import { Bot, Check, Code2 } from "lucide-react";
 import { EvaluatorSelector } from "./evaluator-selector";
 import { EvalTemplateForm } from "./template-form";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
-import { SetupDefaultEvalModelCard } from "@/src/features/evals/components/set-up-default-eval-model-card";
-import { useTemplateValidation } from "@/src/features/evals/hooks/useTemplateValidation";
 import { Card } from "@/src/components/ui/card";
 import { Skeleton } from "@/src/components/ui/skeleton";
 import {
@@ -24,10 +24,21 @@ import {
 import { getDefaultCodeEvalSource } from "@/src/features/evals/utils/code-eval-template-starter-examples";
 import { useIsCodeEvalEnabled } from "@/src/features/evals/hooks/useIsCodeEvalEnabled";
 import { CODE_EVAL_ESCAPE_CONFIRM_MESSAGE } from "@/src/features/evals/utils/code-eval-template-utils";
+import { InlineDefaultEvalModelSetup } from "@/src/features/evals/components/default-eval-model-setup";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/src/components/ui/breadcrumb";
 
 type SelectEvaluatorListProps = {
   projectId: string;
 };
+
+type CreateEvaluatorStep = "connection" | "define";
 
 export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
   const router = useRouter();
@@ -35,18 +46,17 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
   const [customEvaluatorType, setCustomEvaluatorType] = useState<
     typeof EvalTemplateType.LLM_AS_JUDGE | typeof EvalTemplateType.CODE | null
   >(null);
+  const [createEvaluatorStep, setCreateEvaluatorStep] =
+    useState<CreateEvaluatorStep>("define");
+  const [useLlmCreateWizard, setUseLlmCreateWizard] = useState(false);
+  const [defaultModelConfiguredInDialog, setDefaultModelConfiguredInDialog] =
+    useState(false);
   const codeEvalCapabilities = useIsCodeEvalEnabled();
   const { enabled: isCodeEvalEnabled } = codeEvalCapabilities;
 
   const handleSelectEvaluator = (template: EvalTemplate) => {
     router.push(`/project/${projectId}/evals/new?evaluator=${template.id}`);
   };
-
-  const { isSelectionValid, selectedTemplate, setSelectedTemplate } =
-    useTemplateValidation({
-      projectId,
-      onValidSelection: handleSelectEvaluator,
-    });
 
   // Fetch templates
   const templates = api.evals.allTemplates.useQuery(
@@ -59,18 +69,45 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
   );
 
   const utils = api.useUtils();
+  const defaultModel = api.defaultLlmModel.fetchDefaultModel.useQuery(
+    { projectId },
+    { enabled: Boolean(projectId) },
+  );
+  const hasDefaultEvalModel =
+    Boolean(defaultModel.data) || defaultModelConfiguredInDialog;
 
   const handleOpenCreateEvaluator = (
     type: typeof EvalTemplateType.LLM_AS_JUDGE | typeof EvalTemplateType.CODE,
   ) => {
+    const shouldUseWizard =
+      type === EvalTemplateType.LLM_AS_JUDGE && !hasDefaultEvalModel;
+
     setCustomEvaluatorType(type);
+    setUseLlmCreateWizard(shouldUseWizard);
+    setCreateEvaluatorStep(shouldUseWizard ? "connection" : "define");
     setIsCreateTemplateOpen(true);
   };
+
+  useEffect(() => {
+    if (
+      isCreateTemplateOpen &&
+      customEvaluatorType === EvalTemplateType.LLM_AS_JUDGE &&
+      useLlmCreateWizard &&
+      defaultModel.data
+    ) {
+      setCreateEvaluatorStep("define");
+    }
+  }, [
+    customEvaluatorType,
+    defaultModel.data,
+    isCreateTemplateOpen,
+    useLlmCreateWizard,
+  ]);
 
   const handleTemplateSelect = (templateId: string) => {
     const template = templates.data?.templates.find((t) => t.id === templateId);
     if (template) {
-      setSelectedTemplate(template);
+      handleSelectEvaluator(template);
     }
   };
 
@@ -134,7 +171,7 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
                   <EvaluatorSelector
                     projectId={projectId}
                     evalTemplates={templates.data?.templates || []}
-                    selectedTemplateId={selectedTemplate?.id || undefined}
+                    showMissingProviderWarning={false}
                     onTemplateSelect={(templateId) =>
                       handleTemplateSelect(templateId)
                     }
@@ -142,12 +179,6 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
                 </div>
               )}
             </div>
-
-            {!isSelectionValid && (
-              <div className="px-4">
-                <SetupDefaultEvalModelCard projectId={projectId} />
-              </div>
-            )}
           </Card>
         </div>
       </div>
@@ -158,6 +189,9 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
           setIsCreateTemplateOpen(open);
           if (!open) {
             setCustomEvaluatorType(null);
+            setCreateEvaluatorStep("define");
+            setUseLlmCreateWizard(false);
+            setDefaultModelConfiguredInDialog(false);
           }
         }}
       >
@@ -171,48 +205,193 @@ export function SelectEvaluatorList({ projectId }: SelectEvaluatorListProps) {
         >
           <DialogHeader>
             <DialogTitle>Create new evaluator</DialogTitle>
+            {useLlmCreateWizard ? (
+              <DialogDescription>
+                Set up an LLM connection first, then define the evaluator.
+              </DialogDescription>
+            ) : null}
           </DialogHeader>
-          <EvalTemplateForm
-            key={customEvaluatorType ?? "custom-evaluator"}
-            projectId={projectId}
-            preventRedirect={true}
-            isEditing={true}
-            useDialog={true}
-            templateTypeSelectorMode={
-              customEvaluatorType === EvalTemplateType.CODE
-                ? "code-only"
-                : "hidden"
-            }
-            preFilledFormValues={{
-              name: "",
-              type: customEvaluatorType ?? EvalTemplateType.LLM_AS_JUDGE,
-              prompt: "",
-              vars: [],
-              ...(customEvaluatorType === EvalTemplateType.CODE
-                ? {
-                    sourceCode: getDefaultCodeEvalSource(
-                      EvalTemplateSourceCodeLanguage.TYPESCRIPT,
-                    ),
-                    sourceCodeLanguage:
-                      EvalTemplateSourceCodeLanguage.TYPESCRIPT,
-                  }
-                : {}),
-            }}
-            onFormSuccess={(newTemplate) => {
-              setIsCreateTemplateOpen(false);
-              setCustomEvaluatorType(null);
-              utils.evals.allTemplates.invalidate();
-              if (newTemplate) {
-                setSelectedTemplate(newTemplate);
+          {useLlmCreateWizard ? (
+            <CreateLlmEvaluatorWizard
+              projectId={projectId}
+              activeStep={createEvaluatorStep}
+              hasDefaultEvalModel={hasDefaultEvalModel}
+              onStepChange={setCreateEvaluatorStep}
+              onProviderConfigured={() => {
+                setDefaultModelConfiguredInDialog(true);
+                setCreateEvaluatorStep("define");
+              }}
+              renderEvalTemplateForm={(shouldUseDefaultModel) => (
+                <CreateEvaluatorTemplateForm
+                  key={`llm-${shouldUseDefaultModel ? "default" : "custom"}`}
+                  projectId={projectId}
+                  customEvaluatorType={EvalTemplateType.LLM_AS_JUDGE}
+                  shouldUseDefaultModel={shouldUseDefaultModel}
+                  onSuccess={(newTemplate) => {
+                    setIsCreateTemplateOpen(false);
+                    setCustomEvaluatorType(null);
+                    setUseLlmCreateWizard(false);
+                    utils.evals.allTemplates.invalidate();
+                    if (newTemplate) {
+                      handleSelectEvaluator(newTemplate);
+                    }
+                  }}
+                />
+              )}
+            />
+          ) : (
+            <CreateEvaluatorTemplateForm
+              key={customEvaluatorType ?? "custom-evaluator"}
+              projectId={projectId}
+              customEvaluatorType={
+                customEvaluatorType ?? EvalTemplateType.LLM_AS_JUDGE
               }
-              showSuccessToast({
-                title: "Evaluator created successfully",
-                description: "You can now use this evaluator.",
-              });
-            }}
-          />
+              onSuccess={(newTemplate) => {
+                setIsCreateTemplateOpen(false);
+                setCustomEvaluatorType(null);
+                utils.evals.allTemplates.invalidate();
+                if (newTemplate) {
+                  handleSelectEvaluator(newTemplate);
+                }
+              }}
+            />
+          )}
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+function CreateLlmEvaluatorWizard({
+  projectId,
+  activeStep,
+  hasDefaultEvalModel,
+  onStepChange,
+  onProviderConfigured,
+  renderEvalTemplateForm,
+}: {
+  projectId: string;
+  activeStep: CreateEvaluatorStep;
+  hasDefaultEvalModel: boolean;
+  onStepChange: (step: CreateEvaluatorStep) => void;
+  onProviderConfigured: () => void;
+  renderEvalTemplateForm: (shouldUseDefaultModel: boolean) => ReactNode;
+}) {
+  const steps: Array<{ id: CreateEvaluatorStep; label: string }> = [
+    { id: "connection", label: "Set up LLM connection" },
+    { id: "define", label: "Define evaluator" },
+  ];
+  const shouldUseDefaultModel = hasDefaultEvalModel;
+
+  return (
+    <>
+      <Breadcrumb className="px-4 py-2">
+        <BreadcrumbList>
+          {steps.map((step, index) => {
+            const isActive = step.id === activeStep;
+            const isComplete = step.id === "connection" && hasDefaultEvalModel;
+            const canNavigateToStep =
+              step.id === "connection" || hasDefaultEvalModel;
+
+            return (
+              <Fragment key={step.id}>
+                <BreadcrumbItem>
+                  {isActive ? (
+                    <BreadcrumbPage className="flex items-center font-semibold">
+                      {isComplete ? (
+                        <Check className="text-dark-green mr-1.5 h-3.5 w-3.5" />
+                      ) : null}
+                      {index + 1}. {step.label}
+                    </BreadcrumbPage>
+                  ) : !canNavigateToStep ? (
+                    <BreadcrumbPage className="text-muted-foreground flex items-center">
+                      {index + 1}. {step.label}
+                    </BreadcrumbPage>
+                  ) : (
+                    <BreadcrumbLink
+                      onClick={() => onStepChange(step.id)}
+                      className="flex cursor-pointer items-center"
+                    >
+                      {isComplete ? (
+                        <Check className="text-dark-green mr-1.5 h-3.5 w-3.5" />
+                      ) : null}
+                      {index + 1}. {step.label}
+                    </BreadcrumbLink>
+                  )}
+                </BreadcrumbItem>
+                {index < steps.length - 1 ? <BreadcrumbSeparator /> : null}
+              </Fragment>
+            );
+          })}
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      {activeStep === "connection" ? (
+        <DialogBody className="space-y-4">
+          <p className="text-muted-foreground text-sm">
+            LLM-as-a-judge evaluators need an LLM connection for scoring. Set a
+            project default connection now to continue defining the evaluator.
+          </p>
+          <InlineDefaultEvalModelSetup
+            projectId={projectId}
+            onSuccess={onProviderConfigured}
+            submitLabel="Save and continue"
+          />
+        </DialogBody>
+      ) : (
+        renderEvalTemplateForm(shouldUseDefaultModel)
+      )}
+    </>
+  );
+}
+
+function CreateEvaluatorTemplateForm({
+  projectId,
+  customEvaluatorType,
+  shouldUseDefaultModel,
+  onSuccess,
+}: {
+  projectId: string;
+  customEvaluatorType:
+    | typeof EvalTemplateType.LLM_AS_JUDGE
+    | typeof EvalTemplateType.CODE;
+  shouldUseDefaultModel?: boolean;
+  onSuccess: (newTemplate?: EvalTemplate) => void;
+}) {
+  return (
+    <EvalTemplateForm
+      projectId={projectId}
+      preventRedirect={true}
+      isEditing={true}
+      useDialog={true}
+      templateTypeSelectorMode={
+        customEvaluatorType === EvalTemplateType.CODE ? "code-only" : "hidden"
+      }
+      preFilledFormValues={{
+        name: "",
+        type: customEvaluatorType,
+        prompt: "",
+        vars: [],
+        ...(customEvaluatorType === EvalTemplateType.LLM_AS_JUDGE &&
+        shouldUseDefaultModel !== undefined
+          ? { shouldUseDefaultModel }
+          : {}),
+        ...(customEvaluatorType === EvalTemplateType.CODE
+          ? {
+              sourceCode: getDefaultCodeEvalSource(
+                EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+              ),
+              sourceCodeLanguage: EvalTemplateSourceCodeLanguage.TYPESCRIPT,
+            }
+          : {}),
+      }}
+      onFormSuccess={(newTemplate) => {
+        onSuccess(newTemplate);
+        showSuccessToast({
+          title: "Evaluator created successfully",
+          description: "You can now use this evaluator.",
+        });
+      }}
+    />
   );
 }

--- a/web/src/features/evals/components/select-evaluator-list.tsx
+++ b/web/src/features/evals/components/select-evaluator-list.tsx
@@ -1,6 +1,7 @@
 import { Fragment, type ReactNode, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import { api } from "@/src/utils/api";
+import { cn } from "@/src/utils/tailwind";
 import {
   Dialog,
   DialogBody,
@@ -341,21 +342,22 @@ function CreateLlmEvaluatorWizard({
         </BreadcrumbList>
       </Breadcrumb>
 
-      {activeStep === "connection" ? (
-        <DialogBody className="space-y-4">
-          <p className="text-muted-foreground text-sm">
-            LLM-as-a-judge evaluators need an LLM connection for scoring. Set a
-            project default connection now to continue defining the evaluator.
-          </p>
-          <InlineDefaultEvalModelSetup
-            projectId={projectId}
-            onSuccess={onProviderConfigured}
-            submitLabel="Save and continue"
-          />
-        </DialogBody>
-      ) : (
-        renderEvalTemplateForm(shouldUseDefaultModel)
-      )}
+      <DialogBody
+        className={cn("space-y-4", activeStep !== "connection" && "hidden")}
+      >
+        <p className="text-muted-foreground text-sm">
+          LLM-as-a-judge evaluators need an LLM connection for scoring. Set a
+          project default connection now to continue defining the evaluator.
+        </p>
+        <InlineDefaultEvalModelSetup
+          projectId={projectId}
+          onSuccess={onProviderConfigured}
+          submitLabel="Save and continue"
+        />
+      </DialogBody>
+      <div className={cn(activeStep !== "define" && "hidden")}>
+        {renderEvalTemplateForm(shouldUseDefaultModel)}
+      </div>
     </>
   );
 }

--- a/web/src/features/evals/components/template-form.tsx
+++ b/web/src/features/evals/components/template-form.tsx
@@ -186,6 +186,7 @@ export type EvalTemplateFormPreFill = {
       maxTemperature: number;
     };
   };
+  shouldUseDefaultModel?: boolean;
 };
 
 export const InnerEvalTemplateForm = (props: {
@@ -212,9 +213,9 @@ export const InnerEvalTemplateForm = (props: {
 
   // Determine if we should use default model or custom model
   // If existing template has no provider, it was using default model
-  const isExistingUsingDefault = props.preFilledFormValues?.selectedModel
-    ? false
-    : true;
+  const shouldUseDefaultModel =
+    props.preFilledFormValues?.shouldUseDefaultModel ??
+    (props.preFilledFormValues?.selectedModel ? false : true);
 
   const { data: defaultModel } = api.defaultLlmModel.fetchDefaultModel.useQuery(
     { projectId: props.projectId },
@@ -278,7 +279,7 @@ export const InnerEvalTemplateForm = (props: {
       categories: outputDefinitionFormValues.categories,
       shouldAllowMultipleMatches:
         outputDefinitionFormValues.shouldAllowMultipleMatches,
-      shouldUseDefaultModel: isExistingUsingDefault,
+      shouldUseDefaultModel,
     },
   });
 

--- a/web/src/features/evals/hooks/useSingleTemplateValidation.ts
+++ b/web/src/features/evals/hooks/useSingleTemplateValidation.ts
@@ -13,12 +13,15 @@ export type TemplateValidationInput = Pick<
 
 export function useSingleTemplateValidation({
   projectId,
+  enabled = true,
 }: {
   projectId: string;
+  enabled?: boolean;
 }) {
   const codeEvalCapabilities = useIsCodeEvalEnabled();
   const { data: defaultModel } = api.defaultLlmModel.fetchDefaultModel.useQuery(
     { projectId },
+    { enabled: enabled && !!projectId },
   );
 
   const templateRequiresDefaultModel = (
@@ -30,6 +33,8 @@ export function useSingleTemplateValidation({
   };
 
   const isTemplateInvalid = (template: TemplateValidationInput): boolean => {
+    if (!enabled) return false;
+
     if (isCodeEvalTemplate(template)) {
       return !shouldShowEvalTemplate(template, codeEvalCapabilities);
     }

--- a/web/src/features/evals/pages/new-evaluator.tsx
+++ b/web/src/features/evals/pages/new-evaluator.tsx
@@ -15,32 +15,39 @@ import { getMaintainer } from "@/src/features/evals/utils/typeHelpers";
 import { MaintainerTooltip } from "@/src/features/evals/components/maintainer-tooltip";
 import { DefaultEvalModelSetup } from "@/src/features/evals/components/default-eval-model-setup";
 import { useIsCodeEvalEnabled } from "@/src/features/evals/hooks/useIsCodeEvalEnabled";
-import { shouldShowEvalTemplate } from "@/src/features/evals/utils/code-eval-template-utils";
+import {
+  isCodeEvalTemplate,
+  shouldShowEvalTemplate,
+} from "@/src/features/evals/utils/code-eval-template-utils";
 import { Alert, AlertDescription, AlertTitle } from "@/src/components/ui/alert";
 import { Button } from "@/src/components/ui/button";
+import { useState } from "react";
+import { Skeleton } from "@/src/components/ui/skeleton";
 
 // Multi-step setup process
-// 0. Set up default model (optional, only if no default model exists): /project/:projectId/evals/new
 // 1. Select Evaluator: /project/:projectId/evals/new
-// 2. Configure Evaluator: /project/:projectId/evals/new?evaluator=:evaluatorId
+// 2. Set up LLM connection (only after selecting an evaluator that needs it): /project/:projectId/evals/new?evaluator=:evaluatorId
+// 3. Configure Evaluator: /project/:projectId/evals/new?evaluator=:evaluatorId
 export default function NewEvaluatorPage() {
   const router = useRouter();
   const projectId = router.query.projectId as string;
   const evaluatorId = router.query.evaluator as string | undefined;
+  const [defaultModelConfiguredInFlow, setDefaultModelConfiguredInFlow] =
+    useState(false);
   const codeEvalCapabilities = useIsCodeEvalEnabled();
-  const { enabled: isCodeEvalEnabled } = codeEvalCapabilities;
 
   const hasDefaultModelReadAccess = useHasProjectAccess({
     projectId,
     scope: "evalDefaultModel:read",
   });
 
-  const { data: defaultModel } = api.defaultLlmModel.fetchDefaultModel.useQuery(
+  const defaultModelQuery = api.defaultLlmModel.fetchDefaultModel.useQuery(
     { projectId },
     { enabled: hasDefaultModelReadAccess && !!projectId },
   );
 
-  const hasDefaultModel = !!defaultModel;
+  const hasDefaultModel =
+    !!defaultModelQuery.data || defaultModelConfiguredInFlow;
 
   const hasAccess = useHasProjectAccess({
     projectId,
@@ -99,12 +106,33 @@ export default function NewEvaluatorPage() {
     );
   };
 
-  // Determine starting step:
-  // - Step 2: Configure evaluator (when template already selected via evaluatorId)
-  // - Step 1: Select template (when default model exists or code evals enabled)
-  // - Step 0: Set up default model first
-  const canSkipDefaultModel = isCodeEvalEnabled || hasDefaultModel;
-  const stepInt = evaluatorId ? 2 : canSkipDefaultModel ? 1 : 0;
+  const selectedTemplateUsesDefaultModel = Boolean(
+    currentTemplate &&
+    !isCodeEvalTemplate(currentTemplate) &&
+    (!currentTemplate.provider || !currentTemplate.model),
+  );
+  const isCheckingDefaultModel = Boolean(
+    selectedTemplateUsesDefaultModel &&
+    defaultModelQuery.isLoading &&
+    !defaultModelConfiguredInFlow,
+  );
+  const shouldSetupDefaultModel = Boolean(
+    selectedTemplateUsesDefaultModel &&
+    !hasDefaultModel &&
+    !isCheckingDefaultModel,
+  );
+  const step = !evaluatorId
+    ? "select"
+    : isCheckingDefaultModel
+      ? "loading"
+      : shouldSetupDefaultModel
+        ? "defaultModel"
+        : "run";
+  const selectedTemplateIsLlm = Boolean(
+    currentTemplate && !isCodeEvalTemplate(currentTemplate),
+  );
+  const isProviderStepActive = step === "defaultModel" || step === "loading";
+  const isProviderStepComplete = step === "run" && selectedTemplateIsLlm;
 
   if (!hasAccess) {
     return <div>You do not have access to this page.</div>;
@@ -126,51 +154,49 @@ export default function NewEvaluatorPage() {
     >
       <Breadcrumb className="mb-3">
         <BreadcrumbList>
-          {!hasDefaultModel && (
-            <>
-              <BreadcrumbItem>
-                <BreadcrumbPage
-                  className={cn(
-                    stepInt !== 0
-                      ? "text-muted-foreground"
-                      : "text-foreground font-semibold",
-                  )}
-                >
-                  0. Set up default model
-                  {stepInt > 0 && (
-                    <Check className="ml-1 inline-block h-3 w-3" />
-                  )}
-                </BreadcrumbPage>
-              </BreadcrumbItem>
-              <BreadcrumbSeparator />
-            </>
-          )}
           <BreadcrumbItem
             className="hover:cursor-pointer"
             onClick={() => router.push(`/project/${projectId}/evals/new`)}
           >
             <BreadcrumbPage
               className={cn(
-                stepInt !== 1
+                step !== "select"
                   ? "text-muted-foreground"
                   : "text-foreground font-semibold",
               )}
             >
               1. Select Evaluator
-              {stepInt > 1 && <Check className="ml-1 inline-block h-3 w-3" />}
+              {step !== "select" && (
+                <Check className="ml-1 inline-block h-3 w-3" />
+              )}
             </BreadcrumbPage>
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>
             <BreadcrumbPage
               className={cn(
-                stepInt !== 2
+                isProviderStepActive
+                  ? "text-foreground font-semibold"
+                  : "text-muted-foreground",
+              )}
+            >
+              2. Set up LLM connection
+              {isProviderStepComplete && (
+                <Check className="ml-1 inline-block h-3 w-3" />
+              )}
+            </BreadcrumbPage>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage
+              className={cn(
+                step !== "run"
                   ? "text-muted-foreground"
                   : "text-foreground font-semibold",
               )}
             >
               <div className="flex flex-row">
-                2. Run Evaluator
+                3. Run Evaluator
                 {currentTemplate && (
                   <div className="flex flex-row gap-2">
                     <span>
@@ -187,20 +213,28 @@ export default function NewEvaluatorPage() {
         </BreadcrumbList>
       </Breadcrumb>
       {
-        // 0. Set up default model
-        stepInt === 0 && projectId && (
-          <DefaultEvalModelSetup projectId={projectId} />
-        )
-      }
-      {
         // 1. Select Evaluator
-        stepInt === 1 && projectId && (
+        step === "select" && projectId && (
           <SelectEvaluatorList projectId={projectId} />
         )
       }
       {
-        // 2. Run Evaluator
-        stepInt === 2 && evaluatorId && projectId && (
+        // 2. Set up LLM connection, when the selected evaluator requires it
+        step === "defaultModel" && projectId && (
+          <DefaultEvalModelSetup
+            projectId={projectId}
+            onSuccess={() => setDefaultModelConfiguredInFlow(true)}
+          />
+        )
+      }
+      {
+        // Wait until the default-model check finishes before deciding whether
+        // to run the evaluator setup or show the default-model form.
+        step === "loading" && <Skeleton className="h-[500px] w-full" />
+      }
+      {
+        // 3. Run Evaluator
+        step === "run" && evaluatorId && projectId && (
           <div className="flex flex-col gap-4">
             {hasNewerTemplate && latestTemplate && currentTemplate ? (
               <Alert variant="info">


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enhances the evaluator onboarding flow with a guided multi-step wizard. When a user creates an LLM-as-a-judge evaluator without a default LLM connection configured, a two-step in-dialog wizard now prompts them to set up the connection before defining the evaluator. The `new-evaluator.tsx` page similarly defers the "Set up LLM connection" step until after an evaluator is selected, showing it only when the chosen template requires the default model.

- Extracts `useDefaultEvalModelSetup` and adds `InlineDefaultEvalModelSetup` to share model-setup logic between the existing dialog and the new inline wizard step.
- Replaces the old `useTemplateValidation` hook (which was a blocking gate before selection) with per-evaluator detection in `new-evaluator.tsx`, using a `\"loading\"` skeleton state while the default-model query is in flight.
- Adds `showMissingProviderWarning` prop to `EvaluatorSelector` / `useSingleTemplateValidation` so the provider warning tooltips can be disabled on the selector-list screen where the wizard handles missing providers instead.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The onboarding wizard logic is functionally sound; the two breadcrumb issues are purely presentational and don't affect data flow or correctness.

The wizard correctly gates LLM evaluator creation on a configured default model, handles the loading/loaded/missing states cleanly, and properly invalidates and re-fetches the default model query throughout. The two noted issues concern how breadcrumb step 2 is styled and labelled for edge cases (code evaluators and custom-model LLM evaluators); neither causes incorrect data to be saved or navigation to go wrong.

web/src/features/evals/pages/new-evaluator.tsx — breadcrumb step-2 visibility and completion-state logic for non-default-model evaluators.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits /evals/new] --> B{evaluatorId in URL?}
    B -- No --> C[step = 'select'\nShow SelectEvaluatorList]
    C --> D{User clicks 'Create from scratch'\nLLM type}
    D -- No default model --> E[Open dialog\nuseLlmCreateWizard = true\nstep = 'connection']
    D -- Default model exists --> F[Open dialog\nuseLlmCreateWizard = false\nstep = 'define']
    E --> G[InlineDefaultEvalModelSetup\nSave and continue]
    G --> H[onProviderConfigured\ndefaultModelConfiguredInDialog = true\nstep = 'define']
    H --> I[CreateEvaluatorTemplateForm\nshouldUseDefaultModel = true]
    F --> I
    I --> J[EvalTemplate created\nrouter.push to ?evaluator=ID]
    C --> K{User clicks existing template}
    K --> J
    B -- Yes --> L{defaultModelQuery\nisLoading?}
    L -- Yes --> M[step = 'loading'\nShow Skeleton]
    M --> L
    L -- No --> N{Template uses\ndefault model?}
    N -- No / Code eval --> O[step = 'run'\nShow RunEvaluatorForm]
    N -- Yes & hasDefaultModel --> O
    N -- Yes & no default model --> P[step = 'defaultModel'\nShow DefaultEvalModelSetup]
    P --> Q[onSuccess\ndefaultModelConfiguredInFlow = true]
    Q --> O
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User visits /evals/new] --> B{evaluatorId in URL?}
    B -- No --> C[step = 'select'\nShow SelectEvaluatorList]
    C --> D{User clicks 'Create from scratch'\nLLM type}
    D -- No default model --> E[Open dialog\nuseLlmCreateWizard = true\nstep = 'connection']
    D -- Default model exists --> F[Open dialog\nuseLlmCreateWizard = false\nstep = 'define']
    E --> G[InlineDefaultEvalModelSetup\nSave and continue]
    G --> H[onProviderConfigured\ndefaultModelConfiguredInDialog = true\nstep = 'define']
    H --> I[CreateEvaluatorTemplateForm\nshouldUseDefaultModel = true]
    F --> I
    I --> J[EvalTemplate created\nrouter.push to ?evaluator=ID]
    C --> K{User clicks existing template}
    K --> J
    B -- Yes --> L{defaultModelQuery\nisLoading?}
    L -- Yes --> M[step = 'loading'\nShow Skeleton]
    M --> L
    L -- No --> N{Template uses\ndefault model?}
    N -- No / Code eval --> O[step = 'run'\nShow RunEvaluatorForm]
    N -- Yes & hasDefaultModel --> O
    N -- Yes & no default model --> P[step = 'defaultModel'\nShow DefaultEvalModelSetup]
    P --> Q[onSuccess\ndefaultModelConfiguredInFlow = true]
    Q --> O
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/evals/pages/new-evaluator.tsx:134-135
**Breadcrumb step 2 always visible for code evaluators**

The three-step breadcrumb now always shows "2. Set up LLM connection" regardless of evaluator type. For code evaluators, `isProviderStepActive` is always `false` and `isProviderStepComplete` is always `false` (`selectedTemplateIsLlm = false`), so the step renders as permanently muted with no checkmark. A code evaluator user landing on step 3 sees an incomplete-looking step 2 with no indication that it was intentionally skipped. Consider conditionally rendering step 2 only when the selected template is an LLM type.

### Issue 2 of 2
web/src/features/evals/pages/new-evaluator.tsx:131-135
**Step 2 checkmark appears for LLM evaluators with inline model config**

`isProviderStepComplete` is `true` whenever `step === "run" && selectedTemplateIsLlm`. For an LLM template that already carries its own `provider`/`model` fields (custom model, not default), `selectedTemplateUsesDefaultModel` is `false`, so `step` jumps directly to `"run"` — meaning the user never visits step 2, yet the breadcrumb renders a completion checkmark on it. A user who selects a pre-configured custom-model evaluator will see step 2 ticked off without having done anything there, which may be confusing. Consider scoping the completion indicator to cases where the default-model step was actually traversed (e.g. `hasDefaultModel && selectedTemplateUsesDefaultModel`).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): improve session management i..."](https://github.com/langfuse/langfuse/commit/05abc35684515e895b16d0d81dec28b8a832e3cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38627719)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->