### PR TITLE
feat(worker): count started/incomplete blob export attempts (LFE-10407)

### DIFF
--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -15,8 +15,7 @@ const originalCloudRegion = vi.hoisted(() => {
   return cloudRegion;
 });
 
-// Override only recordIncrement so the per-table attempt counter (LFE-10407) is
-// assertable; every real CH/storage export helper stays intact.
+// Override only recordIncrement so the attempt counter is assertable.
 const mockRecordIncrement = vi.hoisted(() => vi.fn());
 vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
   const actual =

--- a/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
+++ b/worker/src/__tests__/blobStorageIntegrationProcessing.test.ts
@@ -15,6 +15,15 @@ const originalCloudRegion = vi.hoisted(() => {
   return cloudRegion;
 });
 
+// Override only recordIncrement so the per-table attempt counter (LFE-10407) is
+// assertable; every real CH/storage export helper stays intact.
+const mockRecordIncrement = vi.hoisted(() => vi.fn());
+vi.mock("@langfuse/shared/src/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@langfuse/shared/src/server")>();
+  return { ...actual, recordIncrement: mockRecordIncrement };
+});
+
 import { env } from "../env";
 import { randomUUID } from "crypto";
 import {
@@ -335,11 +344,28 @@ describe("BlobStorageIntegrationProcessingJob", () => {
       ]);
 
       // When
+      mockRecordIncrement.mockClear();
       await handleBlobStorageIntegrationProjectJob({
         data: { payload: { projectId } },
       } as Job);
 
       // Then
+      // Each of the 4 tables emits a started + success attempt counter (LFE-10407).
+      for (const table of [
+        "traces",
+        "observations",
+        "scores",
+        "observations_v2",
+      ]) {
+        for (const outcome of ["started", "success"]) {
+          expect(mockRecordIncrement).toHaveBeenCalledWith(
+            "langfuse.blobstorage.table_export.count",
+            1,
+            { outcome, table, projectId },
+          );
+        }
+      }
+
       const files = await s3StorageService.listFiles(s3Prefix);
       const projectFiles = files.filter((f) => f.file.includes(projectId));
 

--- a/worker/src/__tests__/inFlightExports.unit.test.ts
+++ b/worker/src/__tests__/inFlightExports.unit.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// The tracker only needs a logger; stub the heavy shared server barrel.
+const mockRecordIncrement = vi.hoisted(() => vi.fn());
+
+// The tracker only needs a logger + metric sink; stub the heavy shared barrel.
 vi.mock("@langfuse/shared/src/server", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  recordIncrement: mockRecordIncrement,
 }));
 
 import {
@@ -11,6 +14,7 @@ import {
   getInFlightBlobExportCount,
   logInFlightBlobExportsOnShutdown,
   resetInFlightBlobExports,
+  BLOB_TABLE_EXPORT_METRIC,
 } from "../features/blobstorage/inFlightExports";
 
 const makeEntry = (table: string) => ({
@@ -24,7 +28,10 @@ const makeEntry = (table: string) => ({
 
 describe("inFlightExports", () => {
   // Singleton registry — drain it so tests are order-independent.
-  beforeEach(() => resetInFlightBlobExports());
+  beforeEach(() => {
+    resetInFlightBlobExports();
+    mockRecordIncrement.mockClear();
+  });
 
   it("tracks and clears in-flight exports by handle", () => {
     expect(getInFlightBlobExportCount()).toBe(0);
@@ -57,5 +64,39 @@ describe("inFlightExports", () => {
     const h = registerInFlightBlobExport(makeEntry("traces"));
     expect(() => logInFlightBlobExportsOnShutdown()).not.toThrow();
     unregisterInFlightBlobExport(h);
+  });
+
+  it("emits an aborted increment per in-flight export on shutdown", () => {
+    // Empty registry: nothing to abort.
+    logInFlightBlobExportsOnShutdown();
+    expect(mockRecordIncrement).not.toHaveBeenCalled();
+
+    const h1 = registerInFlightBlobExport(makeEntry("observations_v2"));
+    const h2 = registerInFlightBlobExport(makeEntry("scores"));
+
+    logInFlightBlobExportsOnShutdown();
+
+    expect(mockRecordIncrement).toHaveBeenCalledTimes(2);
+    expect(mockRecordIncrement).toHaveBeenCalledWith(
+      BLOB_TABLE_EXPORT_METRIC,
+      1,
+      {
+        outcome: "aborted",
+        table: "observations_v2",
+        projectId: "p-1",
+      },
+    );
+    expect(mockRecordIncrement).toHaveBeenCalledWith(
+      BLOB_TABLE_EXPORT_METRIC,
+      1,
+      {
+        outcome: "aborted",
+        table: "scores",
+        projectId: "p-1",
+      },
+    );
+
+    unregisterInFlightBlobExport(h1);
+    unregisterInFlightBlobExport(h2);
   });
 });

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -17,6 +17,7 @@ import {
   getCurrentSpan,
   instrumentAsync,
   recordGauge,
+  recordIncrement,
   BlobStorageIntegrationProcessingQueue,
   queryClickhouse,
   QueueJobs,
@@ -30,6 +31,8 @@ import {
 import {
   registerInFlightBlobExport,
   unregisterInFlightBlobExport,
+  BLOB_TABLE_EXPORT_METRIC,
+  type BlobTableExportOutcome,
 } from "./inFlightExports";
 import { WORKER_HOST_ID } from "../../utils/hostId";
 import {
@@ -317,6 +320,14 @@ const processBlobStorageExport = async (config: {
         startedAt: Date.now(),
       });
 
+      // Count the attempt. Without a matching success/failure/aborted later, the
+      // residual surfaces silent hard kills (OOM/ungraceful death). See LFE-10407.
+      recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
+        outcome: "started" satisfies BlobTableExportOutcome,
+        table: config.table,
+        projectId: config.projectId,
+      });
+
       try {
         const blobStorageProps = getFileTypeProperties(config.fileType);
 
@@ -456,7 +467,18 @@ const processBlobStorageExport = async (config: {
             span.setAttribute("blob.compressedBytes", compressedCounter.bytes);
           }
         }
+
+        recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
+          outcome: "success" satisfies BlobTableExportOutcome,
+          table: config.table,
+          projectId: config.projectId,
+        });
       } catch (error) {
+        recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
+          outcome: "failure" satisfies BlobTableExportOutcome,
+          table: config.table,
+          projectId: config.projectId,
+        });
         logger.error(
           `[BLOB INTEGRATION] Error exporting ${config.table} for project ${config.projectId} ` +
             `(jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${WORKER_HOST_ID})`,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -320,16 +320,14 @@ const processBlobStorageExport = async (config: {
         startedAt: Date.now(),
       });
 
-      // Count the attempt. Without a matching success/failure/aborted later, the
-      // residual surfaces silent hard kills (OOM/ungraceful death). See LFE-10407.
       recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
         outcome: "started" satisfies BlobTableExportOutcome,
         table: config.table,
         projectId: config.projectId,
       });
 
-      // Declared outside the try so the catch can tell a real upload success
-      // (followed by a later throw) from an actual export failure. See below.
+      // Outside the try so the catch can distinguish a real upload success from
+      // a failure.
       let uploadSucceeded = false;
 
       try {
@@ -447,10 +445,8 @@ const processBlobStorageExport = async (config: {
             data: fileStream,
             partSizeBytes: 100 * 1024 * 1024, // 100 MB part size
           });
-          // Record success the instant the upload resolves, so the terminal
-          // counter reflects the upload outcome rather than whatever happens in
-          // the span-attribute `finally` below. A throwing setAttribute would
-          // otherwise propagate to the outer catch and miscount a real success.
+          // Record at the upload boundary so a throw in the `finally` below
+          // can't miscount a real success as a failure.
           uploadSucceeded = true;
           recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
             outcome: "success" satisfies BlobTableExportOutcome,
@@ -482,9 +478,7 @@ const processBlobStorageExport = async (config: {
           }
         }
       } catch (error) {
-        // Guard against double-counting: if the upload already succeeded and a
-        // later step threw, the `success` increment has fired — don't also emit
-        // `failure`.
+        // Skip if `success` already fired (a later step threw post-upload).
         if (!uploadSucceeded) {
           recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
             outcome: "failure" satisfies BlobTableExportOutcome,

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -328,6 +328,10 @@ const processBlobStorageExport = async (config: {
         projectId: config.projectId,
       });
 
+      // Declared outside the try so the catch can tell a real upload success
+      // (followed by a later throw) from an actual export failure. See below.
+      let uploadSucceeded = false;
+
       try {
         const blobStorageProps = getFileTypeProperties(config.fileType);
 
@@ -443,6 +447,16 @@ const processBlobStorageExport = async (config: {
             data: fileStream,
             partSizeBytes: 100 * 1024 * 1024, // 100 MB part size
           });
+          // Record success the instant the upload resolves, so the terminal
+          // counter reflects the upload outcome rather than whatever happens in
+          // the span-attribute `finally` below. A throwing setAttribute would
+          // otherwise propagate to the outer catch and miscount a real success.
+          uploadSucceeded = true;
+          recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
+            outcome: "success" satisfies BlobTableExportOutcome,
+            table: config.table,
+            projectId: config.projectId,
+          });
 
           logger.info(
             `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
@@ -467,18 +481,17 @@ const processBlobStorageExport = async (config: {
             span.setAttribute("blob.compressedBytes", compressedCounter.bytes);
           }
         }
-
-        recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
-          outcome: "success" satisfies BlobTableExportOutcome,
-          table: config.table,
-          projectId: config.projectId,
-        });
       } catch (error) {
-        recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
-          outcome: "failure" satisfies BlobTableExportOutcome,
-          table: config.table,
-          projectId: config.projectId,
-        });
+        // Guard against double-counting: if the upload already succeeded and a
+        // later step threw, the `success` increment has fired — don't also emit
+        // `failure`.
+        if (!uploadSucceeded) {
+          recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
+            outcome: "failure" satisfies BlobTableExportOutcome,
+            table: config.table,
+            projectId: config.projectId,
+          });
+        }
         logger.error(
           `[BLOB INTEGRATION] Error exporting ${config.table} for project ${config.projectId} ` +
             `(jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${WORKER_HOST_ID})`,

--- a/worker/src/features/blobstorage/inFlightExports.ts
+++ b/worker/src/features/blobstorage/inFlightExports.ts
@@ -1,12 +1,9 @@
 import { logger, recordIncrement } from "@langfuse/shared/src/server";
 import { WORKER_HOST_ID } from "../../utils/hostId";
 
-// Per-table export attempt counter. `started` fires when an attempt begins,
-// `success`/`failure` on graceful completion, `aborted` for exports interrupted
-// by a SIGTERM drain. The residual `started - success - failure - aborted` over
-// a window counts silent hard kills (OOM/ungraceful death), which emit nothing
-// at all. Defined here (the leaf module) so the handler can import it without a
-// cycle. See LFE-10407.
+// Per-table attempt counter. Residual `started - success - failure - aborted`
+// counts silent hard kills (OOM) that emit nothing. Lives here to avoid an
+// import cycle with the handler. See LFE-10407.
 export const BLOB_TABLE_EXPORT_METRIC =
   "langfuse.blobstorage.table_export.count";
 
@@ -68,10 +65,7 @@ export const logInFlightBlobExportsOnShutdown = (): void => {
         `window=[${entry.minTimestamp}, ${entry.maxTimestamp}] ` +
         `elapsedMs=${now - entry.startedAt}`,
     );
-    // Count the shutdown interruption so it's subtracted from the hard-kill
-    // residual. Note: an export that still completes within the grace period
-    // also emits `success`, so `aborted` slightly overcounts for cheap tables;
-    // the expensive exports that dominate the thrash never finish in time.
+    // May double with `success` if the export finishes within the grace period.
     recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
       outcome: "aborted" satisfies BlobTableExportOutcome,
       table: entry.table,

--- a/worker/src/features/blobstorage/inFlightExports.ts
+++ b/worker/src/features/blobstorage/inFlightExports.ts
@@ -1,5 +1,20 @@
-import { logger } from "@langfuse/shared/src/server";
+import { logger, recordIncrement } from "@langfuse/shared/src/server";
 import { WORKER_HOST_ID } from "../../utils/hostId";
+
+// Per-table export attempt counter. `started` fires when an attempt begins,
+// `success`/`failure` on graceful completion, `aborted` for exports interrupted
+// by a SIGTERM drain. The residual `started - success - failure - aborted` over
+// a window counts silent hard kills (OOM/ungraceful death), which emit nothing
+// at all. Defined here (the leaf module) so the handler can import it without a
+// cycle. See LFE-10407.
+export const BLOB_TABLE_EXPORT_METRIC =
+  "langfuse.blobstorage.table_export.count";
+
+export type BlobTableExportOutcome =
+  | "started"
+  | "success"
+  | "failure"
+  | "aborted";
 
 export type InFlightBlobExport = {
   jobId: string | undefined;
@@ -53,5 +68,14 @@ export const logInFlightBlobExportsOnShutdown = (): void => {
         `window=[${entry.minTimestamp}, ${entry.maxTimestamp}] ` +
         `elapsedMs=${now - entry.startedAt}`,
     );
+    // Count the shutdown interruption so it's subtracted from the hard-kill
+    // residual. Note: an export that still completes within the grace period
+    // also emits `success`, so `aborted` slightly overcounts for cheap tables;
+    // the expensive exports that dominate the thrash never finish in time.
+    recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
+      outcome: "aborted" satisfies BlobTableExportOutcome,
+      table: entry.table,
+      projectId: entry.projectId,
+    });
   }
 };


### PR DESCRIPTION
## What does this PR do?

Adds explicit, forward-only instrumentation so blob-export **attempts** and **non-completions** become countable. Today observability shows what succeeded plus a few discrete failures, but exports that start and never finish — especially hard kills (OOM / ungraceful death) — emit nothing at all, so a project can thrash for hours while dashboards look idle.

This introduces one per-table counter, `langfuse.blobstorage.table_export.count`, tagged `{outcome, table, projectId}` with `outcome ∈ {started, success, failure, aborted}`:

- `started` — at the start of each table export (per attempt, so retries/thrash are visible)
- `success` — after the upload completes
- `failure` — on any caught error in the export body
- `aborted` — per in-flight export on graceful SIGTERM drain

The residual `started − success − failure − aborted` over a window counts **silent hard kills**, which run no code at death time and are invisible today. A heartbeat age-gauge (survival-time of killed attempts) was intentionally deferred — the counter already makes kills countable; the gauge can be a fast-follow if the delta proves insufficient.

Addresses LFE-10407. Builds on the per-table span + in-flight registry from LFE-10388.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- Added a unit test (`inFlightExports.unit.test.ts`) asserting the `aborted` increment on shutdown, and extended the MinIO integration test to assert `started`/`success` for all four tables.
- `pnpm turbo run lint typecheck --filter=worker` passes; unit tests pass locally.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds forward-only observability counters (`langfuse.blobstorage.table_export.count` tagged `{outcome, table, projectId}`) to make blob-export hard kills (OOM / ungraceful death) visible as a positive residual `started − success − failure − aborted` in a time window — filling a gap where today those events emit nothing at all.

- `started` fires on every attempt; `success`/`failure` fire on graceful completion; `aborted` fires per-entry during SIGTERM drain (before `closeWorkers()`), letting graceful-shutdown cases produce a non-positive residual that doesn't obscure the hard-kill signal.
- The acknowledged double-count for exports that complete within the SIGTERM grace period is correctly characterised in code comments and is harmless to the arithmetic: graceful shutdowns yield `residual ≤ 0`, hard kills yield `residual > 0`.
- Test coverage spans a new unit test for the `aborted` path and an extended MinIO integration test asserting `started`+`success` for all four tables.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the instrumentation is additive and fire-and-forget, so a malfunction in metric emission cannot affect the blob-export data path itself.

The accounting logic is correct and the acknowledged double-count for graceful-shutdown completions is harmless to the hard-kill signal. The one finding worth watching is that recordIncrement("success") sits after the inner span-attribute finally block: if that block ever throws, the outer catch would misclassify a completed upload as failure in the counter. This is unlikely given span.setAttribute is effectively infallible, but the placement makes the boundary implicit.

The success/failure boundary in handleBlobStorageIntegrationProjectJob.ts around lines 455–490 is the one area that would benefit from a second look.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as processBlobStorageExport
    participant Registry as inFlightExports Map
    participant Metrics as recordIncrement
    participant Storage as Blob Storage
    participant Shutdown as onShutdown

    Job->>Handler: processBlobStorageExport(config)
    Handler->>Registry: registerInFlightBlobExport(entry) → handle
    Handler->>Metrics: "started {table, projectId}"

    alt Upload succeeds
        Handler->>Storage: uploadFileBuffered(...)
        Storage-->>Handler: ok
        Handler->>Metrics: "success {table, projectId}"
    else Upload fails
        Handler->>Storage: uploadFileBuffered(...)
        Storage-->>Handler: error
        Handler->>Metrics: "failure {table, projectId}"
    end

    Handler->>Registry: unregisterInFlightBlobExport(handle)

    Note over Shutdown,Registry: SIGTERM path (runs before closeWorkers)
    Shutdown->>Registry: logInFlightBlobExportsOnShutdown()
    loop each in-flight entry
        Registry->>Metrics: "aborted {table, projectId}"
    end
    Shutdown->>Job: WorkerManager.closeWorkers() [grace period]
    Note over Handler,Metrics: exports finishing in grace window also emit success (acknowledged overcount)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as BullMQ Job
    participant Handler as processBlobStorageExport
    participant Registry as inFlightExports Map
    participant Metrics as recordIncrement
    participant Storage as Blob Storage
    participant Shutdown as onShutdown

    Job->>Handler: processBlobStorageExport(config)
    Handler->>Registry: registerInFlightBlobExport(entry) → handle
    Handler->>Metrics: "started {table, projectId}"

    alt Upload succeeds
        Handler->>Storage: uploadFileBuffered(...)
        Storage-->>Handler: ok
        Handler->>Metrics: "success {table, projectId}"
    else Upload fails
        Handler->>Storage: uploadFileBuffered(...)
        Storage-->>Handler: error
        Handler->>Metrics: "failure {table, projectId}"
    end

    Handler->>Registry: unregisterInFlightBlobExport(handle)

    Note over Shutdown,Registry: SIGTERM path (runs before closeWorkers)
    Shutdown->>Registry: logInFlightBlobExportsOnShutdown()
    loop each in-flight entry
        Registry->>Metrics: "aborted {table, projectId}"
    end
    Shutdown->>Job: WorkerManager.closeWorkers() [grace period]
    Note over Handler,Metrics: exports finishing in grace window also emit success (acknowledged overcount)
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:473-477
**`success` metric is silently swapped for `failure` if the inner `finally` throws**

The `recordIncrement("success")` call sits outside the inner `try/finally` but still inside the outer `try`. If any `span.setAttribute` call inside the inner `finally` (lines 456–470) throws, the exception propagates to the outer `catch`, which emits `failure` — even though `uploadFileBuffered` actually completed. The real upload would be counted as a failure in dashboards. In practice `span.setAttribute` is effectively infallible, but moving `recordIncrement("success")` into the inner `finally` block (guarded by a dedicated success flag) would make the boundary explicit and rule out this class of mismatch entirely.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): count started/incomplete b..."](https://github.com/langfuse/langfuse/commit/6c8f8dbd87f9146906e5501a65237b17fd4cd751) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38629075)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->