### PR TITLE
fix(slack): prepend basePath to OAuth callback redirects

### DIFF
--- a/web/src/features/slack/server/oauth-handlers.ts
+++ b/web/src/features/slack/server/oauth-handlers.ts
@@ -10,6 +10,7 @@ import { getServerAuthSession } from "@/src/server/auth";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
 import { prisma } from "@langfuse/shared/src/db";
 import { setPendingInstallClaimCookie } from "@/src/features/slack/server/pendingInstallClaimCookie";
+import { getSafeRedirectPath } from "@/src/utils/redirect";
 
 /**
  * SlackOAuthHandlers
@@ -74,7 +75,7 @@ export async function handleCallback(
               "Slack OAuth callback completed without a team id or name",
               { projectId, teamId },
             );
-            res.redirect("/slack/direct-setup");
+            res.redirect(getSafeRedirectPath("/slack/direct-setup"));
             return;
           }
 
@@ -90,7 +91,7 @@ export async function handleCallback(
               logger.error("Slack OAuth callback could not issue claim token", {
                 teamId,
               });
-              res.redirect("/slack/direct-setup");
+              res.redirect(getSafeRedirectPath("/slack/direct-setup"));
               return;
             }
             // Deliver the claim as an httpOnly cookie bound to this browser
@@ -102,7 +103,7 @@ export async function handleCallback(
             const onboardingUrl = `/slack/direct-setup?team_id=${encodeURIComponent(
               teamId,
             )}&team_name=${encodeURIComponent(teamName)}`;
-            res.redirect(onboardingUrl);
+            res.redirect(getSafeRedirectPath(onboardingUrl));
             return;
           }
 
@@ -145,7 +146,7 @@ export async function handleCallback(
 
           // Redirect to project-specific Slack settings page
           const redirectUrl = `/project/${projectId}/settings/integrations/slack?success=true&team_name=${encodeURIComponent(teamName)}`;
-          res.redirect(redirectUrl);
+          res.redirect(getSafeRedirectPath(redirectUrl));
         },
 
         failure: async (error) => {


### PR DESCRIPTION
## Problem

The server-side `res.redirect()` calls in the Slack OAuth callback (`web/src/features/slack/server/oauth-handlers.ts`) use raw root-relative paths (`/slack/direct-setup`, `/project/.../settings/integrations/slack`). Next.js Pages Router does **not** auto-prepend `NEXT_PUBLIC_BASE_PATH` to `res.redirect()` — only client-side `next/router` does. So on self-hosted deployments with a basePath set (e.g. `/langfuse`), a successful OAuth callback redirects the browser outside the basePath and lands on a 404.

Affects both the Marketplace install flow and the in-app "Connect" flow. Cloud is unaffected (no basePath).

## Fix

Wrap all four redirect targets in the existing `getSafeRedirectPath()` helper (`web/src/utils/redirect.ts`), which prepends `NEXT_PUBLIC_BASE_PATH` (and guards open redirects). Query strings pass through unchanged; no-op when no basePath is configured. Same convention already used by `pages/api/auth/[...nextauth].ts`.

## Context

Addresses a review comment on #14350 (`r3442068279`) raised after that PR merged; done as a standalone follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Slack OAuth callback redirects on self-hosted deployments where `NEXT_PUBLIC_BASE_PATH` is configured. Without the fix, `res.redirect()` in the Pages Router would emit root-relative paths (e.g., `/slack/direct-setup`) that land outside the basePath, resulting in 404s.

- All four `res.redirect()` calls in `oauth-handlers.ts` are wrapped in the existing `getSafeRedirectPath()` helper, which prepends `NEXT_PUBLIC_BASE_PATH` and blocks open redirects.
- The helper already handles query strings correctly (they pass through unchanged), and the `failure` callback is unaffected since it returns JSON rather than a redirect.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, additive wrapper around existing redirect calls with no logic changes to the OAuth flow itself.

The fix is minimal: four call sites each gain a single getSafeRedirectPath() wrapper. The helper is already tested and used in the auth flow. Cloud deployments (no basePath) see no behavioral change since the helper is a no-op when NEXT_PUBLIC_BASE_PATH is unset. No new code paths or state mutations are introduced.

No files require special attention. The only changed file is oauth-handlers.ts, and the modification is straightforward.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant SlackAPI as Slack
    participant OAuthCallback as /api/public/slack/oauth
    participant getSafeRedirectPath

    Browser->>SlackAPI: Initiate OAuth
    SlackAPI->>OAuthCallback: "GET /api/public/slack/oauth?code=...&state=..."
    OAuthCallback->>OAuthCallback: handleCallback()

    alt Missing teamId or teamName
        OAuthCallback->>getSafeRedirectPath: getSafeRedirectPath("/slack/direct-setup")
        getSafeRedirectPath-->>OAuthCallback: "{basePath}/slack/direct-setup"
        OAuthCallback->>Browser: "302 {basePath}/slack/direct-setup"
    else Marketplace flow (no projectId)
        OAuthCallback->>OAuthCallback: issuePendingInstallationClaim()
        OAuthCallback->>getSafeRedirectPath: "getSafeRedirectPath("/slack/direct-setup?team_id=...")"
        getSafeRedirectPath-->>OAuthCallback: "{basePath}/slack/direct-setup?team_id=..."
        OAuthCallback->>Browser: "302 {basePath}/slack/direct-setup?..."
    else In-app Connect flow (projectId present)
        OAuthCallback->>OAuthCallback: auditLog()
        OAuthCallback->>getSafeRedirectPath: "getSafeRedirectPath("/project/{id}/settings/integrations/slack?success=true")"
        getSafeRedirectPath-->>OAuthCallback: "{basePath}/project/{id}/settings/integrations/slack?..."
        OAuthCallback->>Browser: "302 {basePath}/project/{id}/settings/integrations/slack?..."
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant SlackAPI as Slack
    participant OAuthCallback as /api/public/slack/oauth
    participant getSafeRedirectPath

    Browser->>SlackAPI: Initiate OAuth
    SlackAPI->>OAuthCallback: "GET /api/public/slack/oauth?code=...&state=..."
    OAuthCallback->>OAuthCallback: handleCallback()

    alt Missing teamId or teamName
        OAuthCallback->>getSafeRedirectPath: getSafeRedirectPath("/slack/direct-setup")
        getSafeRedirectPath-->>OAuthCallback: "{basePath}/slack/direct-setup"
        OAuthCallback->>Browser: "302 {basePath}/slack/direct-setup"
    else Marketplace flow (no projectId)
        OAuthCallback->>OAuthCallback: issuePendingInstallationClaim()
        OAuthCallback->>getSafeRedirectPath: "getSafeRedirectPath("/slack/direct-setup?team_id=...")"
        getSafeRedirectPath-->>OAuthCallback: "{basePath}/slack/direct-setup?team_id=..."
        OAuthCallback->>Browser: "302 {basePath}/slack/direct-setup?..."
    else In-app Connect flow (projectId present)
        OAuthCallback->>OAuthCallback: auditLog()
        OAuthCallback->>getSafeRedirectPath: "getSafeRedirectPath("/project/{id}/settings/integrations/slack?success=true")"
        getSafeRedirectPath-->>OAuthCallback: "{basePath}/project/{id}/settings/integrations/slack?..."
        OAuthCallback->>Browser: "302 {basePath}/project/{id}/settings/integrations/slack?..."
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(slack): prepend basePath to OAuth ca..."](https://github.com/langfuse/langfuse/commit/a2805edc15f5dde72c9a0e6cfe3f7bc798026835) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38633752)</sub>

<!-- /greptile_comment -->