### PR TITLE
fix: turn public API errors caused by oversized response bodies into 4xx

### DIFF
--- a/packages/shared/src/errors/PayloadTooLargeError.ts
+++ b/packages/shared/src/errors/PayloadTooLargeError.ts
@@ -1,0 +1,7 @@
+import { BaseError } from "./BaseError";
+
+export class PayloadTooLargeError extends BaseError {
+  constructor(description = "Response payload is too large") {
+    super("PayloadTooLargeError", 413, description, true);
+  }
+}

--- a/packages/shared/src/errors/PayloadTooLargeError.ts
+++ b/packages/shared/src/errors/PayloadTooLargeError.ts
@@ -2,6 +2,6 @@ import { BaseError } from "./BaseError";
 
 export class PayloadTooLargeError extends BaseError {
   constructor(description = "Response payload is too large") {
-    super("PayloadTooLargeError", 413, description, true);
+    super("PayloadTooLargeError", 422, description, true);
   }
 }

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -9,4 +9,5 @@ export { InternalServerError } from "./InternalServerError";
 export { LangfuseConflictError } from "./ConflictError";
 export { ServiceUnavailableError } from "./ServiceUnavailableError";
 export { NotImplementedError } from "./NotImplementedError";
+export { PayloadTooLargeError } from "./PayloadTooLargeError";
 export * from "./errorMessages";

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -6,7 +6,11 @@ import {
   upsertClickhouse,
 } from "./clickhouse";
 import { logger } from "../logger";
-import { InternalServerError, LangfuseNotFoundError } from "../../errors";
+import {
+  InternalServerError,
+  LangfuseNotFoundError,
+  PayloadTooLargeError,
+} from "../../errors";
 import { prisma } from "../../db";
 import { ObservationRecordReadType } from "./definitions";
 import { FilterState } from "../../types";
@@ -236,7 +240,7 @@ export const getObservationsForTrace = async <IncludeIO extends boolean>(
     if (payloadSize >= env.LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES) {
       const errorMessage = `Observations in trace are too large: ${(payloadSize / 1e6).toFixed(2)}MB exceeds limit of ${(env.LANGFUSE_API_TRACE_OBSERVATIONS_SIZE_LIMIT_BYTES / 1e6).toFixed(2)}MB`;
 
-      throw new Error(errorMessage);
+      throw new PayloadTooLargeError(errorMessage);
     }
   }
 

--- a/web/src/__tests__/server/traces-api.servertest.ts
+++ b/web/src/__tests__/server/traces-api.servertest.ts
@@ -834,7 +834,7 @@ describe("/api/public/traces API Endpoint", () => {
     });
   });
 
-  it("should return 413 if observations are too large when fetching single trace", async () => {
+  it("should return 422 if observations are too large when fetching single trace", async () => {
     // See LFE-4882 for context
     const traceId = randomUUID();
     const trace = createTrace({
@@ -871,7 +871,7 @@ describe("/api/public/traces API Endpoint", () => {
       auth,
     );
 
-    expect(response.status).toBe(413);
+    expect(response.status).toBe(422);
     expect(response.body).toMatchObject({
       error: "PayloadTooLargeError",
       message: expect.stringMatching(

--- a/web/src/__tests__/server/traces-api.servertest.ts
+++ b/web/src/__tests__/server/traces-api.servertest.ts
@@ -15,6 +15,7 @@ import {
   createEventsCh,
 } from "@langfuse/shared/src/server";
 import {
+  makeAPICall,
   makeZodVerifiedAPICall,
   makeZodVerifiedAPICallSilent,
 } from "@/src/__tests__/test-utils";
@@ -833,7 +834,7 @@ describe("/api/public/traces API Endpoint", () => {
     });
   });
 
-  it("should return 5XX if observations are too large when fetching single trace", async () => {
+  it("should return 413 if observations are too large when fetching single trace", async () => {
     // See LFE-4882 for context
     const traceId = randomUUID();
     const trace = createTrace({
@@ -863,17 +864,20 @@ describe("/api/public/traces API Endpoint", () => {
       }),
     ]);
 
-    await expect(
-      makeZodVerifiedAPICall(
-        GetTraceV1Response,
-        "GET",
-        `/api/public/traces/${traceId}`,
-        undefined,
-        auth,
-      ),
-    ).rejects.toThrow(
-      /Observations in trace are too large: .* exceeds limit of 80\.00MB/,
+    const response = await makeAPICall(
+      "GET",
+      `/api/public/traces/${traceId}`,
+      undefined,
+      auth,
     );
+
+    expect(response.status).toBe(413);
+    expect(response.body).toMatchObject({
+      error: "PayloadTooLargeError",
+      message: expect.stringMatching(
+        /Observations in trace are too large: .* exceeds limit of 80\.00MB/,
+      ),
+    });
   });
 
   it("should delete a single trace via DELETE /traces/:traceId", async () => {

--- a/web/src/__tests__/server/unit/create-authed-project-api-route-auth-errors.servertest.ts
+++ b/web/src/__tests__/server/unit/create-authed-project-api-route-auth-errors.servertest.ts
@@ -116,6 +116,7 @@ describe("createAuthedProjectAPIRoute auth error handling", () => {
       replacementEndpoint: string;
       docsUrl: string;
     };
+    mockResponseSerializationError?: boolean;
   }) {
     const handler = createAuthedProjectAPIRoute({
       name: "Test Route",
@@ -135,6 +136,15 @@ describe("createAuthedProjectAPIRoute auth error handling", () => {
       },
       query: {},
     });
+
+    if (options?.mockResponseSerializationError) {
+      const writeJson = res.json.bind(res);
+      vi.spyOn(res, "json")
+        .mockImplementationOnce(() => {
+          throw new RangeError("Invalid string length");
+        })
+        .mockImplementation((body) => writeJson(body));
+    }
 
     await handler(req, res);
 
@@ -232,6 +242,18 @@ describe("createAuthedProjectAPIRoute auth error handling", () => {
     expect(sendRestResponseIfLimited).toHaveBeenCalledWith(res, {
       errorContract: undefined,
       upgradePath,
+    });
+  });
+
+  it("throws a 422 payload error when response serialization exceeds V8 string limits", async () => {
+    mockVerifyAuthHeaderAndReturnScope.mockResolvedValueOnce(validAuth);
+
+    await expect(
+      callRoute({ mockResponseSerializationError: true }),
+    ).rejects.toMatchObject({
+      name: "PayloadTooLargeError",
+      httpCode: 422,
+      message: "Response payload is too large",
     });
   });
 });

--- a/web/src/__tests__/server/withMiddlewares.servertest.ts
+++ b/web/src/__tests__/server/withMiddlewares.servertest.ts
@@ -3,6 +3,7 @@ import {
   LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
   withMiddlewares,
 } from "@/src/features/public-api/server/withMiddlewares";
+import { unstablePublicEvalsErrorContract } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 import {
   BaseError,
   LangfuseNotFoundError,
@@ -399,6 +400,72 @@ describe("withMiddlewares error handling", () => {
   });
 
   describe("Generic error handling", () => {
+    const callHandlerWithResponseSerializationError = async (
+      options?: Parameters<typeof withMiddlewares>[1],
+    ) => {
+      const error = new RangeError("Invalid string length");
+
+      const handler = withMiddlewares(
+        {
+          GET: async (_req, res) => {
+            res.status(200).json({ data: "too-large" });
+          },
+        },
+        options,
+      );
+
+      const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+        method: "GET",
+        headers: {
+          "x-langfuse-public-key": "test-key",
+        },
+      });
+
+      const writeJson = res.json.bind(res);
+      vi.spyOn(res, "json")
+        .mockImplementationOnce(() => {
+          throw error;
+        })
+        .mockImplementation((body) => writeJson(body));
+
+      await handler(req, res);
+
+      return res;
+    };
+
+    it("should handle response serialization RangeError with 413 status", async () => {
+      const res = await callHandlerWithResponseSerializationError();
+
+      expect(res._getStatusCode()).toBe(413);
+      const jsonData = JSON.parse(res._getData());
+      expect(jsonData).toMatchObject({
+        message: "Response payload is too large",
+        error: "PayloadTooLargeError",
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "PayloadTooLargeError",
+          message: "Response payload is too large",
+        }),
+      );
+      expect(traceException).not.toHaveBeenCalled();
+    });
+
+    it("should preserve unstable error contract for response serialization RangeError", async () => {
+      const res = await callHandlerWithResponseSerializationError({
+        errorContract: unstablePublicEvalsErrorContract,
+      });
+
+      expect(res._getStatusCode()).toBe(413);
+      const jsonData = JSON.parse(res._getData());
+      expect(jsonData).toMatchObject({
+        message: "Response payload is too large",
+        code: "invalid_request",
+      });
+      expect(jsonData).not.toHaveProperty("error");
+      expect(traceException).not.toHaveBeenCalled();
+    });
+
     it("should handle generic Error instances with 500 status", async () => {
       const error = new Error("Something went wrong");
 

--- a/web/src/__tests__/server/withMiddlewares.servertest.ts
+++ b/web/src/__tests__/server/withMiddlewares.servertest.ts
@@ -3,7 +3,6 @@ import {
   LEGACY_PUBLIC_API_METRICS_CLICKHOUSE_RESOURCE_ERROR_MESSAGE,
   withMiddlewares,
 } from "@/src/features/public-api/server/withMiddlewares";
-import { unstablePublicEvalsErrorContract } from "@/src/features/public-api/server/unstable-public-api-error-contract";
 import {
   BaseError,
   LangfuseNotFoundError,
@@ -400,19 +399,14 @@ describe("withMiddlewares error handling", () => {
   });
 
   describe("Generic error handling", () => {
-    const callHandlerWithResponseSerializationError = async (
-      options?: Parameters<typeof withMiddlewares>[1],
-    ) => {
+    it("should keep handler RangeError instances on the generic 500 path", async () => {
       const error = new RangeError("Invalid string length");
 
-      const handler = withMiddlewares(
-        {
-          GET: async (_req, res) => {
-            res.status(200).json({ data: "too-large" });
-          },
+      const handler = withMiddlewares({
+        GET: async () => {
+          throw error;
         },
-        options,
-      );
+      });
 
       const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
         method: "GET",
@@ -421,49 +415,16 @@ describe("withMiddlewares error handling", () => {
         },
       });
 
-      const writeJson = res.json.bind(res);
-      vi.spyOn(res, "json")
-        .mockImplementationOnce(() => {
-          throw error;
-        })
-        .mockImplementation((body) => writeJson(body));
-
       await handler(req, res);
 
-      return res;
-    };
-
-    it("should handle response serialization RangeError with 413 status", async () => {
-      const res = await callHandlerWithResponseSerializationError();
-
-      expect(res._getStatusCode()).toBe(413);
+      expect(res._getStatusCode()).toBe(500);
       const jsonData = JSON.parse(res._getData());
       expect(jsonData).toMatchObject({
-        message: "Response payload is too large",
-        error: "PayloadTooLargeError",
+        message: "Internal Server Error",
+        error: "Invalid string length",
       });
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: "PayloadTooLargeError",
-          message: "Response payload is too large",
-        }),
-      );
-      expect(traceException).not.toHaveBeenCalled();
-    });
-
-    it("should preserve unstable error contract for response serialization RangeError", async () => {
-      const res = await callHandlerWithResponseSerializationError({
-        errorContract: unstablePublicEvalsErrorContract,
-      });
-
-      expect(res._getStatusCode()).toBe(413);
-      const jsonData = JSON.parse(res._getData());
-      expect(jsonData).toMatchObject({
-        message: "Response payload is too large",
-        code: "invalid_request",
-      });
-      expect(jsonData).not.toHaveProperty("error");
-      expect(traceException).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(error);
+      expect(traceException).toHaveBeenCalledWith(error);
     });
 
     it("should handle generic Error instances with 500 status", async () => {

--- a/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
+++ b/web/src/features/public-api/server/createAuthedProjectAPIRoute.ts
@@ -10,7 +10,7 @@ import {
   traceException,
   logger,
 } from "@langfuse/shared/src/server";
-import { type RateLimitResource } from "@langfuse/shared";
+import { PayloadTooLargeError, type RateLimitResource } from "@langfuse/shared";
 import { RateLimitService } from "@/src/features/public-api/server/RateLimitService";
 import { type RateLimitUpgradePath } from "@/src/features/public-api/server/rateLimitUpgradePaths";
 import { contextWithLangfuseProps } from "@langfuse/shared/src/server";
@@ -28,6 +28,11 @@ import {
 
 /** Access levels that can be accepted by project-scoped API routes. */
 type RouteAccessLevel = Exclude<ApiAccessLevel, "organization">;
+
+// Next's res.json uses JSON.stringify; V8 throws this when the JSON string
+// exceeds the engine limit. Keep this check scoped to the response write.
+const isJsonStringTooLargeError = (error: unknown): error is RangeError =>
+  error instanceof RangeError && error.message === "Invalid string length";
 
 export type AuthedProjectAPIRouteConfig<
   TQuery extends ZodType<any>,
@@ -448,14 +453,22 @@ export const createAuthedProjectAPIRoute = <
         }
       }
 
-      res
-        .status(
-          // Check whether status code was already set inside handler to non default value
-          res.statusCode !== 200
-            ? res.statusCode
-            : routeConfig.successStatusCode || 200,
-        )
-        .json(response || { message: "OK" });
+      res.status(
+        // Check whether status code was already set inside handler to non default value
+        res.statusCode !== 200
+          ? res.statusCode
+          : routeConfig.successStatusCode || 200,
+      );
+
+      try {
+        res.json(response || { message: "OK" });
+      } catch (error) {
+        if (isJsonStringTooLargeError(error)) {
+          throw new PayloadTooLargeError();
+        }
+
+        throw error;
+      }
     });
   };
 };

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -6,6 +6,7 @@ import {
   BaseError,
   LangfuseNotFoundError,
   MethodNotAllowedError,
+  PayloadTooLargeError,
   UnauthorizedError,
 } from "@langfuse/shared";
 import {
@@ -79,6 +80,11 @@ const logBaseError = (error: BaseError) => {
   logger.error(error);
 };
 
+const isResponsePayloadTooLargeError = (
+  error: unknown,
+): error is RangeError =>
+  error instanceof RangeError && error.message === "Invalid string length";
+
 export function withMiddlewares(
   handlers: Handlers,
   options?: MiddlewareOptions,
@@ -130,6 +136,23 @@ export function withMiddlewares(
           return res.status(422).json({
             message: errorMessage,
             error: "Request timed out",
+          });
+        }
+
+        if (isResponsePayloadTooLargeError(error)) {
+          const payloadError = new PayloadTooLargeError();
+          logBaseError(payloadError);
+
+          if (options?.errorContract === unstablePublicEvalsErrorContract) {
+            return sendUnstablePublicApiErrorResponse(
+              res,
+              toUnstablePublicApiError(payloadError),
+            );
+          }
+
+          return res.status(payloadError.httpCode).json({
+            message: payloadError.message,
+            error: payloadError.name,
           });
         }
 

--- a/web/src/features/public-api/server/withMiddlewares.ts
+++ b/web/src/features/public-api/server/withMiddlewares.ts
@@ -6,7 +6,6 @@ import {
   BaseError,
   LangfuseNotFoundError,
   MethodNotAllowedError,
-  PayloadTooLargeError,
   UnauthorizedError,
 } from "@langfuse/shared";
 import {
@@ -80,11 +79,6 @@ const logBaseError = (error: BaseError) => {
   logger.error(error);
 };
 
-const isResponsePayloadTooLargeError = (
-  error: unknown,
-): error is RangeError =>
-  error instanceof RangeError && error.message === "Invalid string length";
-
 export function withMiddlewares(
   handlers: Handlers,
   options?: MiddlewareOptions,
@@ -136,23 +130,6 @@ export function withMiddlewares(
           return res.status(422).json({
             message: errorMessage,
             error: "Request timed out",
-          });
-        }
-
-        if (isResponsePayloadTooLargeError(error)) {
-          const payloadError = new PayloadTooLargeError();
-          logBaseError(payloadError);
-
-          if (options?.errorContract === unstablePublicEvalsErrorContract) {
-            return sendUnstablePublicApiErrorResponse(
-              res,
-              toUnstablePublicApiError(payloadError),
-            );
-          }
-
-          return res.status(payloadError.httpCode).json({
-            message: payloadError.message,
-            error: payloadError.name,
           });
         }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the public API's error handling for oversized response bodies by converting what were previously uncaught 500s into explicit 413 responses, covering two complementary scenarios.

- A new `PayloadTooLargeError` (extends `BaseError`, `httpCode` 413) is introduced and thrown from `getObservationsForTrace` instead of a generic `Error`, letting the existing `BaseError` handler in `withMiddlewares` return 413 automatically.
- A new `isResponsePayloadTooLargeError` guard in `withMiddlewares` catches `RangeError("Invalid string length")` that V8 throws when `JSON.stringify` exceeds the max string length, wraps it in a `PayloadTooLargeError`, and returns 413 rather than 500. Both the default and the unstable evals error contracts are handled, and the error is logged at `warn` level (not `error`) to avoid alerting noise for a known constraint.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is safe to merge; the two code paths are well-tested and independent, and the worst-case regression is a serialization error falling back to the existing 500 handler.

Both conversion paths are covered by dedicated tests. The only concerns are non-blocking: the V8-specific `"Invalid string length"` string match could silently miss the error on non-V8 runtimes or incorrectly classify unrelated `RangeError`s, and using HTTP 413 for an oversized response (rather than an oversized request) is a semantic mismatch that may confuse API consumers.

`withMiddlewares.ts` (the RangeError message guard) and `PayloadTooLargeError.ts` (the 413 status code choice) are worth a second look.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant withMiddlewares
    participant Handler
    participant observations.ts

    Client->>withMiddlewares: GET /api/public/traces/:id
    withMiddlewares->>Handler: dispatch

    alt Pre-check: PayloadTooLargeError thrown from observations.ts
        Handler->>observations.ts: getObservationsForTrace()
        observations.ts-->>Handler: throw PayloadTooLargeError (413)
        Handler-->>withMiddlewares: propagate
        withMiddlewares->>withMiddlewares: "caught as BaseError (httpCode=413)"
        withMiddlewares-->>Client: "413 { error, message }"
    else Serialization: RangeError during res.json()
        Handler->>Handler: res.status(200).json(hugePayload)
        Handler-->>withMiddlewares: throw RangeError("Invalid string length")
        withMiddlewares->>withMiddlewares: isResponsePayloadTooLargeError → true
        withMiddlewares->>withMiddlewares: new PayloadTooLargeError(), logBaseError (warn)
        withMiddlewares-->>Client: "413 { error, message }"
    else No size issue
        Handler-->>withMiddlewares: normal response
        withMiddlewares-->>Client: 200 OK
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant withMiddlewares
    participant Handler
    participant observations.ts

    Client->>withMiddlewares: GET /api/public/traces/:id
    withMiddlewares->>Handler: dispatch

    alt Pre-check: PayloadTooLargeError thrown from observations.ts
        Handler->>observations.ts: getObservationsForTrace()
        observations.ts-->>Handler: throw PayloadTooLargeError (413)
        Handler-->>withMiddlewares: propagate
        withMiddlewares->>withMiddlewares: "caught as BaseError (httpCode=413)"
        withMiddlewares-->>Client: "413 { error, message }"
    else Serialization: RangeError during res.json()
        Handler->>Handler: res.status(200).json(hugePayload)
        Handler-->>withMiddlewares: throw RangeError("Invalid string length")
        withMiddlewares->>withMiddlewares: isResponsePayloadTooLargeError → true
        withMiddlewares->>withMiddlewares: new PayloadTooLargeError(), logBaseError (warn)
        withMiddlewares-->>Client: "413 { error, message }"
    else No size issue
        Handler-->>withMiddlewares: normal response
        withMiddlewares-->>Client: 200 OK
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/public-api/server/withMiddlewares.ts:83-86
**Fragile V8-specific message match**

`"Invalid string length"` is the error message V8 emits when `JSON.stringify` produces a string exceeding the engine's max string length (~1 GiB in 64-bit V8). If this application ever runs on Bun or another non-V8 runtime the check silently stops working and the error falls through to the 500 handler. Additionally, any other code path that raises a `RangeError` with that exact message (e.g., a string `.repeat()` call that exceeds V8's limit) would be misclassified as a serialization-too-large error and return 413 to the caller instead of 500.

### Issue 2 of 2
packages/shared/src/errors/PayloadTooLargeError.ts:4-6
**HTTP 413 is defined for oversized request bodies, not response bodies**

RFC 9110 §15.5.14 defines 413 "Content Too Large" as applying when "the server refuses to process a request because the request content is larger than the server is willing or able to process." Using it here — where the server's *response* is what is oversized — may confuse API consumers who will interpret 413 as a cue to reduce their request payload. There is no perfect standard code for an oversized response, but the choice warrants a comment explaining the intentional deviation so callers (and future maintainers) understand why a 4xx is returned and why 413 specifically.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Handle payload too large trace responses"](https://github.com/langfuse/langfuse/commit/4c3d1bd5cb2d97b5dd913f3cfff0be0c2e90a91e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38637273)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->