### PR TITLE
feat(blob-storage): log non-reversible S3 credential shape on signing failures

### DIFF
--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -675,9 +675,14 @@ class S3StorageService implements StorageService {
       // Non-reversible shape of the credentials (length + character-class
       // flags, never the value) so a SignatureDoesNotMatch can be triaged as a
       // truncated/altered/mismatched secret without another round of re-pasting.
+      // Derived from the same AND-gated `credentials` the S3Client received, not
+      // raw params: when only one of id/secret is set, the SDK falls back to the
+      // default credential chain, and the shape must report `absent` to match —
+      // otherwise a partial config logs a phantom empty-secret for creds the SDK
+      // never used.
       credentials: summarizeCredentialShape(
-        params.accessKeyId,
-        params.secretAccessKey,
+        credentials?.accessKeyId,
+        credentials?.secretAccessKey,
       ),
     });
 

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -28,6 +28,7 @@ import { S3ChunkedUploadStrategy } from "./S3ChunkedUploadStrategy";
 import {
   buildS3RequestDiagnostics,
   isS3SigningError,
+  summarizeCredentialShape,
   type S3SigningDiagnosticsContext,
 } from "./s3SigningDiagnostics";
 import * as objectstorage from "oci-objectstorage";
@@ -671,6 +672,13 @@ class S3StorageService implements StorageService {
       endpoint: params.endpoint,
       region: params.region,
       forcePathStyle: params.forcePathStyle,
+      // Non-reversible shape of the credentials (length + character-class
+      // flags, never the value) so a SignatureDoesNotMatch can be triaged as a
+      // truncated/altered/mismatched secret without another round of re-pasting.
+      credentials: summarizeCredentialShape(
+        params.accessKeyId,
+        params.secretAccessKey,
+      ),
     });
 
     // Create a separate client for generating presigned URLs

--- a/packages/shared/src/server/services/s3SigningDiagnostics.test.ts
+++ b/packages/shared/src/server/services/s3SigningDiagnostics.test.ts
@@ -3,6 +3,7 @@ import {
   buildS3RequestDiagnostics,
   classifyContentSha256Mode,
   isS3SigningError,
+  summarizeCredentialShape,
   summarizeS3Error,
   summarizeS3SigningHeaders,
 } from "./s3SigningDiagnostics";
@@ -161,6 +162,81 @@ describe("buildS3RequestDiagnostics", () => {
     expect(diagnostics.request.method).toBeUndefined();
     expect(diagnostics.request.contentSha256Mode).toBe("absent");
     expect(diagnostics.error.message).toBe("boom");
+  });
+});
+
+describe("summarizeCredentialShape", () => {
+  // A representative GCS HMAC secret: 40 chars, base64 alphabet, no whitespace.
+  const cleanGcsSecret = "Ab3+/Cd4ef5GH6ij7KL8mn9OP0qr1ST2uv3WX4yz";
+
+  it("reports a clean GCS HMAC credential pair", () => {
+    const shape = summarizeCredentialShape(
+      "GOOG1EXAMPLEACCESSKEYID",
+      cleanGcsSecret,
+    );
+
+    expect(shape).toEqual({
+      accessKeyIdPresent: true,
+      accessKeyIdLength: 23,
+      accessKeyIdType: "gcs-hmac",
+      secretPresent: true,
+      secretLength: 40,
+      secretLooksBase64: true,
+      secretHasWhitespace: false,
+      secretHasSurroundingWhitespace: false,
+      secretHasNonAscii: false,
+    });
+  });
+
+  it("flags a truncated secret (wrong length, the SignatureDoesNotMatch tell)", () => {
+    const shape = summarizeCredentialShape(
+      "GOOG1EXAMPLE",
+      cleanGcsSecret.slice(0, 20),
+    );
+    expect(shape.secretLength).toBe(20);
+    expect(shape.secretPresent).toBe(true);
+  });
+
+  it("flags stray surrounding whitespace from a sloppy paste", () => {
+    const shape = summarizeCredentialShape(
+      "GOOG1EXAMPLE",
+      `  ${cleanGcsSecret}\n`,
+    );
+    expect(shape.secretHasWhitespace).toBe(true);
+    expect(shape.secretHasSurroundingWhitespace).toBe(true);
+  });
+
+  it("flags a non-breaking space that trim() would not strip", () => {
+    // U+00A0 (NBSP) is whitespace-like but trim() leaves it: a common paste
+    // hazard that yields SignatureDoesNotMatch with otherwise-correct keys.
+    const nbsp = String.fromCharCode(0x00a0);
+    const shape = summarizeCredentialShape(
+      "GOOG1EXAMPLE",
+      `${cleanGcsSecret}${nbsp}`,
+    );
+    expect(shape.secretHasNonAscii).toBe(true);
+    expect(shape.secretLooksBase64).toBe(false);
+  });
+
+  it("classifies an AWS-style access key id (wrong-provider paste)", () => {
+    const shape = summarizeCredentialShape(
+      "AKIAIOSFODNN7EXAMPLE",
+      cleanGcsSecret,
+    );
+    expect(shape.accessKeyIdType).toBe("aws");
+  });
+
+  it("handles absent credentials (host/instance-role) without throwing", () => {
+    const shape = summarizeCredentialShape(undefined, undefined);
+    expect(shape.accessKeyIdPresent).toBe(false);
+    expect(shape.accessKeyIdType).toBe("absent");
+    expect(shape.secretPresent).toBe(false);
+    expect(shape.secretLength).toBe(0);
+  });
+
+  it("never embeds the secret value", () => {
+    const shape = summarizeCredentialShape("GOOG1EXAMPLE", cleanGcsSecret);
+    expect(JSON.stringify(shape)).not.toContain(cleanGcsSecret);
   });
 });
 

--- a/packages/shared/src/server/services/s3SigningDiagnostics.test.ts
+++ b/packages/shared/src/server/services/s3SigningDiagnostics.test.ts
@@ -206,15 +206,33 @@ describe("summarizeCredentialShape", () => {
     expect(shape.secretHasSurroundingWhitespace).toBe(true);
   });
 
-  it("flags a non-breaking space that trim() would not strip", () => {
-    // U+00A0 (NBSP) is whitespace-like but trim() leaves it: a common paste
-    // hazard that yields SignatureDoesNotMatch with otherwise-correct keys.
+  it("flags a trailing non-breaking space across every relevant signal", () => {
+    // U+00A0 (NBSP) is a Unicode space separator: ECMAScript WhiteSpace
+    // includes it, so `\s` matches it and `trim()` strips it. A trailing NBSP
+    // therefore lights up all three signals — assert each so none regresses.
     const nbsp = String.fromCharCode(0x00a0);
     const shape = summarizeCredentialShape(
       "GOOG1EXAMPLE",
       `${cleanGcsSecret}${nbsp}`,
     );
+    expect(shape.secretHasWhitespace).toBe(true);
+    expect(shape.secretHasSurroundingWhitespace).toBe(true);
     expect(shape.secretHasNonAscii).toBe(true);
+    expect(shape.secretLooksBase64).toBe(false);
+  });
+
+  it("flags a non-ascii character that the whitespace checks miss", () => {
+    // The reason secretHasNonAscii exists separately: a non-whitespace unicode
+    // char (here a “smart” double quote, U+201C) is neither matched by `\s`
+    // nor stripped by `trim()`, so only secretHasNonAscii catches it.
+    const smartQuote = String.fromCharCode(0x201c);
+    const shape = summarizeCredentialShape(
+      "GOOG1EXAMPLE",
+      `${smartQuote}${cleanGcsSecret}`,
+    );
+    expect(shape.secretHasNonAscii).toBe(true);
+    expect(shape.secretHasWhitespace).toBe(false);
+    expect(shape.secretHasSurroundingWhitespace).toBe(false);
     expect(shape.secretLooksBase64).toBe(false);
   });
 

--- a/packages/shared/src/server/services/s3SigningDiagnostics.ts
+++ b/packages/shared/src/server/services/s3SigningDiagnostics.ts
@@ -12,16 +12,83 @@
  * credentials.
  *
  * These helpers summarize the *signing inputs* of the request that failed so
- * the difference shows up in logs. They never read credentials (no
- * `Authorization` header), the secret, or the payload — only the framing
- * headers and the structured error fields.
+ * the difference shows up in logs. They never log the credential values (no
+ * `Authorization` header, no secret) or the payload — only the framing
+ * headers, the structured error fields, and a non-reversible *shape* of the
+ * credentials (length + character-class flags; see {@link S3CredentialShape}).
  */
+
+/**
+ * Non-reversible *shape* of the configured S3 credentials. Surfaced so a
+ * `SignatureDoesNotMatch` can be triaged when the operator insists the
+ * key/secret are correct and re-pasting them has not helped.
+ *
+ * `SignatureDoesNotMatch` (vs `InvalidAccessKeyId`/`AccessDenied`) means the
+ * backend matched the access key id but the HMAC computed from the secret did
+ * not — i.e. the stored secret is not the partner of the stored access key.
+ * The usual culprits are a truncated or altered paste (wrong length, stray
+ * whitespace, a non-breaking space / smart character that `trim()` leaves) or a
+ * secret from a different/rotated key pair. These fields expose exactly those
+ * signals without ever logging the credential value: only the length, whether
+ * it matches the base64 alphabet, and whitespace/non-ascii flags.
+ *
+ * The access key id is an identifier (sent in plaintext in every signed
+ * request's `Authorization` header), not a secret; even so we never log it
+ * verbatim — we classify it (`gcs-hmac` for `GOOG…`, `aws` for `AKIA`/`ASIA`)
+ * so a key pasted into the wrong provider's field is obvious.
+ */
+export interface S3CredentialShape {
+  accessKeyIdPresent: boolean;
+  accessKeyIdLength: number;
+  accessKeyIdType: "gcs-hmac" | "aws" | "other" | "absent";
+  secretPresent: boolean;
+  secretLength: number;
+  secretLooksBase64: boolean;
+  secretHasWhitespace: boolean;
+  secretHasSurroundingWhitespace: boolean;
+  secretHasNonAscii: boolean;
+}
+
+function classifyAccessKeyIdType(
+  id: string,
+): Exclude<S3CredentialShape["accessKeyIdType"], "absent"> {
+  if (id.startsWith("GOOG")) return "gcs-hmac";
+  if (/^A(KIA|SIA)/.test(id)) return "aws";
+  return "other";
+}
+
+/**
+ * Summarize the credential pair without exposing either value. Null-safe so
+ * host/instance-role configs (no explicit credentials) report `absent` rather
+ * than throwing.
+ */
+export function summarizeCredentialShape(
+  accessKeyId: string | undefined,
+  secretAccessKey: string | undefined,
+): S3CredentialShape {
+  const id = accessKeyId ?? "";
+  const secret = secretAccessKey ?? "";
+  return {
+    accessKeyIdPresent: id.length > 0,
+    accessKeyIdLength: id.length,
+    accessKeyIdType: id.length === 0 ? "absent" : classifyAccessKeyIdType(id),
+    secretPresent: secret.length > 0,
+    secretLength: secret.length,
+    secretLooksBase64:
+      secret.length > 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(secret),
+    secretHasWhitespace: /\s/.test(secret),
+    secretHasSurroundingWhitespace: secret !== secret.trim(),
+    // Anything outside printable ASCII (0x20–0x7E): NBSP, smart quotes, etc.
+    secretHasNonAscii: /[^\x20-\x7e]/.test(secret),
+  };
+}
 
 export interface S3SigningDiagnosticsContext {
   bucketName: string;
   endpoint?: string;
   region?: string;
   forcePathStyle: boolean;
+  credentials?: S3CredentialShape;
 }
 
 /**

--- a/packages/shared/src/server/services/s3SigningDiagnostics.ts
+++ b/packages/shared/src/server/services/s3SigningDiagnostics.ts
@@ -27,10 +27,14 @@
  * backend matched the access key id but the HMAC computed from the secret did
  * not — i.e. the stored secret is not the partner of the stored access key.
  * The usual culprits are a truncated or altered paste (wrong length, stray
- * whitespace, a non-breaking space / smart character that `trim()` leaves) or a
- * secret from a different/rotated key pair. These fields expose exactly those
- * signals without ever logging the credential value: only the length, whether
- * it matches the base64 alphabet, and whitespace/non-ascii flags.
+ * whitespace, or a stray non-ascii character such as a "smart" quote or
+ * zero-width space that survives `trim()`) or a secret from a different/rotated
+ * key pair. These fields expose exactly those signals without ever logging the
+ * credential value: only the length, whether it matches the base64 alphabet,
+ * and whitespace/non-ascii flags. (Note: a non-breaking space is a Unicode
+ * space separator, so it is caught by both the whitespace flags and
+ * `secretHasNonAscii`; `secretHasNonAscii` earns its keep on non-whitespace
+ * characters the others miss.)
  *
  * The access key id is an identifier (sent in plaintext in every signed
  * request's `Authorization` header), not a secret; even so we never log it


### PR DESCRIPTION
## What does this PR do?

> PR title must follow Conventional Commits, for example `feat(web): add trace filters` or `fix: handle empty dataset names`.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/langfuse/langfuse/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project (`pnpm run format`)
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing S3 signing diagnostics by adding a non-reversible credential "shape" (length, base64 charset check, whitespace flags, provider-type classification) that is logged alongside request framing details when a `SignatureDoesNotMatch` or related signing error is caught. The credential values themselves are never surfaced.

- Introduces `S3CredentialShape` and `summarizeCredentialShape` in `s3SigningDiagnostics.ts`; the shape is purely diagnostic metadata computed once at client construction and stored in the middleware context.
- Wires the shape into `addS3SigningDiagnosticsMiddleware` in `StorageService.ts` via a single new `credentials` property on `S3SigningDiagnosticsContext`.
- Test coverage is comprehensive across the main paths; the NBSP test comment contains a factual error (modern JS `trim()` does strip U+00A0) and the test is missing assertions on `secretHasSurroundingWhitespace` and `secretHasWhitespace`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the change is additive and diagnostic-only; no credential values are exposed in logs.

The credential shape computation is correct and the values logged are genuinely non-reversible. The only gap is a misleading comment in the NBSP test that attributes the detection to secretHasNonAscii alone, when secretHasSurroundingWhitespace and secretHasWhitespace would also fire in modern Node.js — leaving those code paths untested. This doesn't affect runtime behaviour but could mislead future maintainers or mask a regression in those flags.

packages/shared/src/server/services/s3SigningDiagnostics.test.ts — the NBSP test case needs corrected comment and additional assertions.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant S3StorageService
    participant summarizeCredentialShape
    participant S3Client
    participant addS3SigningDiagnosticsMiddleware
    participant logger

    Caller->>S3StorageService: new S3StorageService(params)
    S3StorageService->>summarizeCredentialShape: (params.accessKeyId, params.secretAccessKey)
    summarizeCredentialShape-->>S3StorageService: S3CredentialShape (length, flags, type)
    S3StorageService->>S3Client: new S3Client(credentials, endpoint, region, ...)
    S3StorageService->>addS3SigningDiagnosticsMiddleware: "(client, { bucketName, endpoint, region, credentials: S3CredentialShape })"

    Caller->>S3Client: putObject / upload
    S3Client-->>addS3SigningDiagnosticsMiddleware: request fails (SignatureDoesNotMatch)
    addS3SigningDiagnosticsMiddleware->>logger: "warn({ request headers, error fields, credentials shape })"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant S3StorageService
    participant summarizeCredentialShape
    participant S3Client
    participant addS3SigningDiagnosticsMiddleware
    participant logger

    Caller->>S3StorageService: new S3StorageService(params)
    S3StorageService->>summarizeCredentialShape: (params.accessKeyId, params.secretAccessKey)
    summarizeCredentialShape-->>S3StorageService: S3CredentialShape (length, flags, type)
    S3StorageService->>S3Client: new S3Client(credentials, endpoint, region, ...)
    S3StorageService->>addS3SigningDiagnosticsMiddleware: "(client, { bucketName, endpoint, region, credentials: S3CredentialShape })"

    Caller->>S3Client: putObject / upload
    S3Client-->>addS3SigningDiagnosticsMiddleware: request fails (SignatureDoesNotMatch)
    addS3SigningDiagnosticsMiddleware->>logger: "warn({ request headers, error fields, credentials shape })"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
packages/shared/src/server/services/s3SigningDiagnostics.test.ts:209-219
**Incorrect trim() claim for NBSP, missing assertion**

The comment states "U+00A0 (NBSP) is whitespace-like but `trim()` leaves it", but this is wrong for modern JavaScript. ECMAScript defines U+00A0 as a `<USP>` (Unicode Space Separator), which is included in the spec's WhiteSpace production, so `String.prototype.trim()` in Node.js 18+ V8 **does** strip NBSP. As a result, `secretHasSurroundingWhitespace` will be `true` for a secret that ends with NBSP — not just `secretHasNonAscii` — but the test never asserts `secretHasSurroundingWhitespace`, leaving that code path unverified. Additionally, `secretHasWhitespace` (via `\s`, which also matches NBSP) would be `true` here, and that's equally unasserted.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(blob-storage): log non-reversible S..."](https://github.com/langfuse/langfuse/commit/082f3106e0f23cce682c9f76b0809393c9f80e76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38641256)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->