### PR TITLE
chore: introduing a metric indicating how many projects are experiencing ingestion failures

### DIFF
--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -297,6 +297,11 @@ const EnvSchema = z.object({
     .number()
     .positive()
     .default(3600), // 1 hour
+  LANGFUSE_INGEST_FAILURE_PROJECT_TTL_SECONDS: z.coerce
+    .number()
+    .int()
+    .gt(60)
+    .default(3600), // 1 hour
   LANGFUSE_S3_CORE_DATA_EXPORT_IS_ENABLED: z
     .enum(["true", "false"])
     .default("false"),

--- a/packages/shared/src/server/index.ts
+++ b/packages/shared/src/server/index.ts
@@ -105,6 +105,7 @@ export * from "./redis/entityChangeQueue";
 export * from "./redis/eventPropagationQueue";
 export * from "./redis/otelProjectTracking";
 export * from "./redis/s3SlowdownTracking";
+export * from "./redis/ingestionFailureTracking";
 export * from "./auth/types";
 export * from "./queues";
 export * from "./orderByToPrisma";

--- a/packages/shared/src/server/ingestion/processEventBatch.ts
+++ b/packages/shared/src/server/ingestion/processEventBatch.ts
@@ -42,6 +42,7 @@ import {
   isS3SlowDownError,
   markProjectS3Slowdown,
 } from "../redis/s3SlowdownTracking";
+import { markProjectIngestFailure } from "../redis/ingestionFailureTracking";
 
 let s3StorageServiceClient: StorageService;
 
@@ -300,8 +301,16 @@ export const processEventBatch = async (
               error: result.reason,
             },
           );
-          // Fire and forget - don't await, don't block the error flow
           markProjectS3Slowdown(authCheck.scope.projectId!).catch(() => {});
+          markProjectIngestFailure(authCheck.scope.projectId!, {
+            source: "process_event_batch",
+            reason: "s3_slowdown",
+          });
+        } else {
+          markProjectIngestFailure(authCheck.scope.projectId!, {
+            source: "process_event_batch",
+            reason: "s3_upload_error",
+          });
         }
 
         logger.error("Failed to upload event to S3", {

--- a/packages/shared/src/server/redis/ingestionFailureTracking.ts
+++ b/packages/shared/src/server/redis/ingestionFailureTracking.ts
@@ -1,0 +1,130 @@
+import { env } from "../../env";
+import { recordGauge, traceException } from "../instrumentation";
+import { logger } from "../logger";
+import { redis } from "./redis";
+
+export const INGESTION_FAILURE_ACTIVE_PROJECTS_KEY =
+  "langfuse:ingestion-failure:active-projects";
+const INGESTION_FAILURE_ACTIVE_PROJECTS_METRIC =
+  "langfuse.ingestion.project_failure.active_projects";
+
+const MARK_RATE_LIMIT_WINDOW_MS = 60_000;
+const MAX_PROJECT_MARKS_PER_WINDOW = 100;
+
+const recentProjectMarks = new Map<string, number>();
+
+export type IngestionFailureSource =
+  | "process_event_batch"
+  | "ingestion_queue"
+  | "otel_ingestion_queue"
+  | "public_ingestion_api"
+  | "public_otel_api";
+
+export type IngestionFailureReason =
+  | "api_internal_error"
+  | "processing_error"
+  | "publish_failed"
+  | "s3_slowdown"
+  | "s3_upload_error";
+
+function shouldRecordProjectMark(projectId: string, now: number): boolean {
+  for (const [cachedProjectId, cachedAt] of recentProjectMarks) {
+    if (now - cachedAt >= MARK_RATE_LIMIT_WINDOW_MS) {
+      recentProjectMarks.delete(cachedProjectId);
+    }
+  }
+
+  if (recentProjectMarks.has(projectId)) {
+    return false;
+  }
+
+  if (recentProjectMarks.size >= MAX_PROJECT_MARKS_PER_WINDOW) {
+    return false;
+  }
+
+  recentProjectMarks.set(projectId, now);
+  return true;
+}
+
+function logMarkFailure(
+  projectId: string,
+  tags: {
+    source: IngestionFailureSource;
+    reason?: IngestionFailureReason;
+  },
+  error: unknown,
+): void {
+  logger.error("Failed to mark project ingestion failure", {
+    projectId,
+    source: tags.source,
+    reason: tags.reason,
+    error,
+  });
+  traceException(error);
+}
+
+export function markProjectIngestFailure(
+  projectId: string,
+  tags: {
+    source: IngestionFailureSource;
+    reason?: IngestionFailureReason;
+  },
+): void {
+  if (!redis) return;
+
+  const now = Date.now();
+  if (!shouldRecordProjectMark(projectId, now)) return;
+
+  const ttlSeconds = env.LANGFUSE_INGEST_FAILURE_PROJECT_TTL_SECONDS;
+  const expiresAtMs = now + ttlSeconds * 1000;
+
+  try {
+    redis
+      .pipeline()
+      .zadd(INGESTION_FAILURE_ACTIVE_PROJECTS_KEY, expiresAtMs, projectId)
+      .expire(INGESTION_FAILURE_ACTIVE_PROJECTS_KEY, ttlSeconds + 60)
+      .exec()
+      .then((results) => {
+        const commandError = results?.find(([error]) => error)?.[0];
+        if (commandError) {
+          logMarkFailure(projectId, tags, commandError);
+        }
+      })
+      .catch((error) => {
+        logMarkFailure(projectId, tags, error);
+      });
+  } catch (error) {
+    logMarkFailure(projectId, tags, error);
+  }
+}
+
+export async function updateActiveIngestFailureProjectsMetric(): Promise<
+  number | null
+> {
+  if (!redis) return null;
+
+  try {
+    const results = await redis
+      .pipeline()
+      .zremrangebyscore(INGESTION_FAILURE_ACTIVE_PROJECTS_KEY, 0, Date.now())
+      .zcard(INGESTION_FAILURE_ACTIVE_PROJECTS_KEY)
+      .exec();
+
+    const commandError = results?.find(([error]) => error)?.[0];
+    if (commandError) throw commandError;
+
+    const activeProjects = Number(results?.[1]?.[1] ?? 0);
+
+    recordGauge(INGESTION_FAILURE_ACTIVE_PROJECTS_METRIC, activeProjects, {
+      unit: "projects",
+    });
+
+    return activeProjects;
+  } catch (error) {
+    logger.error("Failed to record active ingestion failure projects", {
+      error,
+    });
+    traceException(error);
+    return null;
+  }
+}

--- a/web/src/pages/api/public/ingestion.ts
+++ b/web/src/pages/api/public/ingestion.ts
@@ -8,6 +8,7 @@ import {
   getCurrentSpan,
   contextWithLangfuseProps,
   eventTypes,
+  markProjectIngestFailure,
 } from "@langfuse/shared/src/server";
 import { telemetry } from "@/src/features/telemetry";
 import { jsonSchema } from "@langfuse/shared";
@@ -53,6 +54,8 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
+  let projectIdForIngestFailure: string | undefined;
+
   try {
     await runMiddleware(req, res, cors);
 
@@ -88,6 +91,8 @@ export default async function handler(
         "Missing projectId in scope. Are you using an organization key?",
       );
     }
+    const projectId = authCheck.scope.projectId;
+    projectIdForIngestFailure = projectId;
 
     if (authCheck.scope.isIngestionSuspended) {
       throw new ForbiddenError(
@@ -97,64 +102,80 @@ export default async function handler(
 
     const ctx = contextWithLangfuseProps({
       headers: req.headers,
-      projectId: authCheck.scope.projectId,
+      projectId,
       apiKeyId: authCheck.scope.apiKeyId,
     });
     // Execute the rest of the handler within the context
     return opentelemetry.context.with(ctx, async () => {
       try {
-        const rateLimitCheck =
-          await RateLimitService.getInstance().rateLimitRequest(
-            authCheck.scope,
-            "ingestion",
-          );
+        try {
+          const rateLimitCheck =
+            await RateLimitService.getInstance().rateLimitRequest(
+              authCheck.scope,
+              "ingestion",
+            );
 
-        if (rateLimitCheck?.isRateLimited()) {
-          return rateLimitCheck.sendRestResponseIfLimited(res);
+          if (rateLimitCheck?.isRateLimited()) {
+            return rateLimitCheck.sendRestResponseIfLimited(res);
+          }
+        } catch (e) {
+          // If rate-limiter returns an error, we log it and continue processing.
+          // This allows us to fail open instead of reject requests.
+          logger.error("Error while rate limiting", e);
         }
-      } catch (e) {
-        // If rate-limiter returns an error, we log it and continue processing.
-        // This allows us to fail open instead of reject requests.
-        logger.error("Error while rate limiting", e);
-      }
 
-      const batchType = z.object({
-        batch: z.array(z.unknown()),
-        metadata: jsonSchema.nullish(),
-      });
-
-      const parsedSchema = batchType.safeParse(req.body);
-
-      if (!parsedSchema.success) {
-        logger.info("Invalid request data", parsedSchema.error);
-        return res.status(400).json({
-          message: "Invalid request data",
-          errors: parsedSchema.error.issues.map((issue) => issue.message),
+        const batchType = z.object({
+          batch: z.array(z.unknown()),
+          metadata: jsonSchema.nullish(),
         });
+
+        const parsedSchema = batchType.safeParse(req.body);
+
+        if (!parsedSchema.success) {
+          logger.info("Invalid request data", parsedSchema.error);
+          return res.status(400).json({
+            message: "Invalid request data",
+            errors: parsedSchema.error.issues.map((issue) => issue.message),
+          });
+        }
+
+        await telemetry();
+
+        // V4 events_only mode: refuse trace/observation events because their
+        // writes would land in the legacy ClickHouse tables this deployment no
+        // longer reads. Scores and SDK logs are unaffected and pass through.
+        // Reject per-event so a mixed batch still processes its score events.
+        const { batchForProcessing, rejectedErrors } = filterBatchForEventsOnly(
+          parsedSchema.data.batch,
+          env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only",
+        );
+
+        const result = await processEventBatch(batchForProcessing, authCheck);
+        if (rejectedErrors.length > 0) {
+          result.errors = [...result.errors, ...rejectedErrors];
+        }
+        return res.status(207).json(result);
+      } catch (error) {
+        if (!(error instanceof BaseError && error.isUserError())) {
+          markProjectIngestFailure(projectId, {
+            source: "public_ingestion_api",
+            reason: "api_internal_error",
+          });
+        }
+        throw error;
       }
-
-      await telemetry();
-
-      // V4 events_only mode: refuse trace/observation events because their
-      // writes would land in the legacy ClickHouse tables this deployment no
-      // longer reads. Scores and SDK logs are unaffected and pass through.
-      // Reject per-event so a mixed batch still processes its score events.
-      const { batchForProcessing, rejectedErrors } = filterBatchForEventsOnly(
-        parsedSchema.data.batch,
-        env.LANGFUSE_MIGRATION_V4_WRITE_MODE === "events_only",
-      );
-
-      const result = await processEventBatch(batchForProcessing, authCheck);
-      if (rejectedErrors.length > 0) {
-        result.errors = [...result.errors, ...rejectedErrors];
-      }
-      return res.status(207).json(result);
     });
   } catch (error: unknown) {
     if (error instanceof BaseError) {
       if (!error.isUserError()) {
         logger.error(error);
         traceException(error);
+        if (projectIdForIngestFailure) {
+          markProjectIngestFailure(projectIdForIngestFailure, {
+            source: "public_ingestion_api",
+            reason: "api_internal_error",
+          });
+        }
       }
 
       return res.status(error.httpCode).json({
@@ -173,6 +194,13 @@ export default async function handler(
 
     logger.error("error_handling_ingestion_event", error);
     traceException(error);
+
+    if (projectIdForIngestFailure) {
+      markProjectIngestFailure(projectIdForIngestFailure, {
+        source: "public_ingestion_api",
+        reason: "api_internal_error",
+      });
+    }
 
     if (isPrismaException(error)) {
       return res.status(500).json({

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -2,6 +2,7 @@ import { withMiddlewares } from "@/src/features/public-api/server/withMiddleware
 import { createAuthedProjectAPIRoute } from "@/src/features/public-api/server/createAuthedProjectAPIRoute";
 import {
   logger,
+  markProjectIngestFailure,
   OtelIngestionProcessor,
   markProjectAsOtelUser,
 } from "@langfuse/shared/src/server";
@@ -184,7 +185,15 @@ export default withMiddlewares({
 
       // At this point, we have the raw OpenTelemetry Span body. We upload the full batch to S3
       // and the OtelIngestionProcessor logic will handle processing in the worker container.
-      return processor.publishToOtelIngestionQueue(resourceSpans);
+      try {
+        return await processor.publishToOtelIngestionQueue(resourceSpans);
+      } catch (error) {
+        markProjectIngestFailure(auth.scope.projectId, {
+          source: "public_otel_api",
+          reason: "publish_failed",
+        });
+        throw error;
+      }
     },
   }),
 });

--- a/worker/src/__tests__/ingestionFailureTracking.test.ts
+++ b/worker/src/__tests__/ingestionFailureTracking.test.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { env } from "@langfuse/shared/src/env";
+import {
+  INGESTION_FAILURE_ACTIVE_PROJECTS_KEY,
+  markProjectIngestFailure,
+  redis,
+  updateActiveIngestFailureProjectsMetric,
+} from "@langfuse/shared/src/server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+async function waitForActiveProjectCount(expected: number): Promise<void> {
+  if (!redis) throw new Error("Redis must be configured");
+
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const count = await redis.zcard(INGESTION_FAILURE_ACTIVE_PROJECTS_KEY);
+    if (count === expected) return;
+    await sleep(10);
+  }
+
+  expect(await redis.zcard(INGESTION_FAILURE_ACTIVE_PROJECTS_KEY)).toBe(
+    expected,
+  );
+}
+
+describe("ingestion failure tracking", () => {
+  beforeAll(async () => {
+    if (!redis) {
+      throw new Error("Redis must be configured for worker integration tests");
+    }
+
+    await redis.del(INGESTION_FAILURE_ACTIVE_PROJECTS_KEY);
+  });
+
+  afterAll(async () => {
+    await redis?.del(INGESTION_FAILURE_ACTIVE_PROJECTS_KEY);
+  });
+
+  it("tracks active projects in Redis, caps distinct local projects per minute, and prunes expired projects", async () => {
+    if (!redis) throw new Error("Redis must be configured");
+    expect(env.LANGFUSE_INGEST_FAILURE_PROJECT_TTL_SECONDS).toBeGreaterThan(60);
+
+    const projectPrefix = `project-${randomUUID()}`;
+    const startedAt = Date.now();
+
+    for (let i = 0; i < 650; i++) {
+      markProjectIngestFailure(`${projectPrefix}-noisy`, {
+        source: "otel_ingestion_queue",
+        reason: "processing_error",
+      });
+    }
+
+    for (let i = 0; i < 150; i++) {
+      markProjectIngestFailure(`${projectPrefix}-${i}`, {
+        source: "otel_ingestion_queue",
+        reason: "processing_error",
+      });
+    }
+
+    await waitForActiveProjectCount(100);
+
+    const firstScore = await redis.zscore(
+      INGESTION_FAILURE_ACTIVE_PROJECTS_KEY,
+      `${projectPrefix}-noisy`,
+    );
+    expect(Number(firstScore)).toBeGreaterThanOrEqual(
+      startedAt + env.LANGFUSE_INGEST_FAILURE_PROJECT_TTL_SECONDS * 1000,
+    );
+    await expect(
+      redis.zscore(
+        INGESTION_FAILURE_ACTIVE_PROJECTS_KEY,
+        `${projectPrefix}-98`,
+      ),
+    ).resolves.not.toBeNull();
+    await expect(
+      redis.zscore(
+        INGESTION_FAILURE_ACTIVE_PROJECTS_KEY,
+        `${projectPrefix}-99`,
+      ),
+    ).resolves.toBeNull();
+
+    await redis.zadd(
+      INGESTION_FAILURE_ACTIVE_PROJECTS_KEY,
+      Date.now() - 1,
+      `${projectPrefix}-expired`,
+    );
+
+    await expect(updateActiveIngestFailureProjectsMetric()).resolves.toBe(100);
+    await expect(
+      redis.zscore(
+        INGESTION_FAILURE_ACTIVE_PROJECTS_KEY,
+        `${projectPrefix}-expired`,
+      ),
+    ).resolves.toBeNull();
+    expect(
+      await redis.ttl(INGESTION_FAILURE_ACTIVE_PROJECTS_KEY),
+    ).toBeGreaterThan(0);
+  });
+});

--- a/worker/src/features/queue-metrics-runner/index.ts
+++ b/worker/src/features/queue-metrics-runner/index.ts
@@ -4,6 +4,7 @@ import {
   QueueName,
   convertQueueNameToMetricName,
   recordGauge,
+  updateActiveIngestFailureProjectsMetric,
   logger,
 } from "@langfuse/shared/src/server";
 
@@ -65,6 +66,17 @@ export class QueueMetricsRunner extends PeriodicRunner {
     // (e.g. CloudUsageMeteringQueue.getInstance() enqueues cron jobs).
     const registeredNames = new Set(WorkerManager.getRegisteredQueueNames());
     const promises: Promise<void>[] = [];
+
+    promises.push(
+      updateActiveIngestFailureProjectsMetric()
+        .then(() => undefined)
+        .catch((err) => {
+          logger.error(
+            "Queue metrics: failed to record active ingestion failure projects",
+            err,
+          );
+        }),
+    );
 
     // Non-sharded queues: only poll queues with registered workers
     for (const queueName of Object.values(QueueName)) {

--- a/worker/src/queues/ingestionQueue.ts
+++ b/worker/src/queues/ingestionQueue.ts
@@ -8,6 +8,7 @@ import {
   IngestionEventType,
   isS3SlowDownError,
   logger,
+  markProjectIngestFailure,
   markProjectS3Slowdown,
   QueueName,
   rawEventBucketPrefix,
@@ -324,6 +325,15 @@ export const ingestionQueueProcessorBuilder = (
           { projectId, error: e },
         );
         await markProjectS3Slowdown(projectId);
+        markProjectIngestFailure(projectId, {
+          source: "ingestion_queue",
+          reason: "s3_slowdown",
+        });
+      } else {
+        markProjectIngestFailure(job.data.payload.authCheck.scope.projectId, {
+          source: "ingestion_queue",
+          reason: "processing_error",
+        });
       }
 
       logger.error(

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -7,6 +7,7 @@ import {
   getS3EventStorageClient,
   type IngestionEventType,
   logger,
+  markProjectIngestFailure,
   OtelIngestionProcessor,
   processEventBatch,
   QueueName,
@@ -562,6 +563,11 @@ export const otelIngestionQueueProcessorBuilder = (
         });
         return;
       }
+
+      markProjectIngestFailure(job.data.payload.authCheck.scope.projectId, {
+        source: "otel_ingestion_queue",
+        reason: "processing_error",
+      });
 
       logger.error(
         `Failed job otel ingestion processing for ${job.data.payload.authCheck.scope.projectId}`,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new Redis-backed metric (`langfuse.ingestion.project_failure.active_projects`) that tracks the number of distinct projects currently experiencing ingestion failures. A sorted set stores each failing project ID with its expiry timestamp as the score; a periodic `QueueMetricsRunner` job prunes expired entries and emits the gauge.

- **`ingestionFailureTracking.ts`** — new module with an in-process `Map`-based rate limiter (≤ 100 distinct projects/minute per process) to throttle Redis writes, plus `markProjectIngestFailure` (fire-and-forget, called at every failure site) and `updateActiveIngestFailureProjectsMetric` (awaited by the worker's periodic runner).
- **Failure call sites added** — `processEventBatch`, `ingestionQueue`, `otelIngestionQueue`, `public/ingestion`, and `public/otel` routes all call `markProjectIngestFailure`; `ForbiddenError` (auth/suspension) is correctly excluded from the OTel queue path.
- **Env var** — `LANGFUSE_INGEST_FAILURE_PROJECT_TTL_SECONDS` (default 3600 s, must be > 60) controls how long a project remains in the "active failures" window.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all changes are additive observability instrumentation that cannot affect the ingestion hot path (fire-and-forget Redis writes with full internal error handling).

The core tracking logic is correct and well-tested. The in-process rate limiter is intentionally per-process, Map mutation during iteration is spec-safe but non-obvious, the test duplicates the Redis key string instead of importing it (meaning a key rename would make the test vacuous), and the `.gt(60)` env constraint is unexplained. None of these affect runtime correctness today.

`packages/shared/src/server/redis/ingestionFailureTracking.ts` for the rate-limiter design comments, and `packages/shared/src/server/redis/ingestionFailureTracking.test.ts` for the hardcoded key constant.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant WebAPI as Web API / OTel API
    participant PEBW as processEventBatch / Worker Queue
    participant RateLimiter as In-Process RateLimiter<br/>(recentProjectMarks Map)
    participant Redis as Redis Sorted Set<br/>(langfuse:ingestion-failure:active-projects)
    participant QMR as QueueMetricsRunner<br/>(worker)
    participant OTel as OTel Gauge

    Client->>WebAPI: POST /api/public/ingestion
    WebAPI->>PEBW: processEventBatch()
    PEBW-->>PEBW: S3 upload fails
    PEBW->>RateLimiter: shouldRecordProjectMark(projectId)
    alt not rate-limited
        RateLimiter-->>PEBW: true
        PEBW->>Redis: "ZADD score=expiresAtMs + EXPIRE key ttlSeconds+60"
    else rate-limited (same project within 60s)
        RateLimiter-->>PEBW: false (skip)
    end

    Note over PEBW,Redis: Same flow applies for ingestionQueue,<br/>otelIngestionQueue, public APIs

    loop Every LANGFUSE_QUEUE_METRICS_INTERVAL_MS
        QMR->>Redis: ZREMRANGEBYSCORE 0 now (prune expired)
        QMR->>Redis: ZCARD (count active)
        Redis-->>QMR: activeProjects count
        QMR->>OTel: recordGauge(active_projects)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant WebAPI as Web API / OTel API
    participant PEBW as processEventBatch / Worker Queue
    participant RateLimiter as In-Process RateLimiter<br/>(recentProjectMarks Map)
    participant Redis as Redis Sorted Set<br/>(langfuse:ingestion-failure:active-projects)
    participant QMR as QueueMetricsRunner<br/>(worker)
    participant OTel as OTel Gauge

    Client->>WebAPI: POST /api/public/ingestion
    WebAPI->>PEBW: processEventBatch()
    PEBW-->>PEBW: S3 upload fails
    PEBW->>RateLimiter: shouldRecordProjectMark(projectId)
    alt not rate-limited
        RateLimiter-->>PEBW: true
        PEBW->>Redis: "ZADD score=expiresAtMs + EXPIRE key ttlSeconds+60"
    else rate-limited (same project within 60s)
        RateLimiter-->>PEBW: false (skip)
    end

    Note over PEBW,Redis: Same flow applies for ingestionQueue,<br/>otelIngestionQueue, public APIs

    loop Every LANGFUSE_QUEUE_METRICS_INTERVAL_MS
        QMR->>Redis: ZREMRANGEBYSCORE 0 now (prune expired)
        QMR->>Redis: ZCARD (count active)
        Redis-->>QMR: activeProjects count
        QMR->>OTel: recordGauge(active_projects)
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
packages/shared/src/server/redis/ingestionFailureTracking.ts:30-47
**Map mutation during iteration**

The cleanup loop deletes entries from `recentProjectMarks` while iterating it with `for...of`. The ECMAScript spec guarantees this is safe for `Map` (already-visited entries are fine; not-yet-visited deleted entries are simply skipped), but it is non-obvious and can surprise readers. A common alternative is to collect stale keys first and delete them in a second pass, which makes the intent clearer and eliminates the subtle reliance on Map iteration semantics.

### Issue 2 of 4
packages/shared/src/server/redis/ingestionFailureTracking.ts:11-14
**Per-process rate limit is not globally shared**

`recentProjectMarks` is a module-level singleton scoped to a single Node.js process. In a scaled-out deployment (multiple web-server replicas plus multiple worker replicas), each process independently enforces the 100-distinct-projects-per-minute cap. A project experiencing failures across N processes can therefore trigger up to N Redis `ZADD` + `EXPIRE` pairs per minute rather than 1. The sorted-set entry count stays bounded (one member per project, `ZADD` just updates the score for existing members), so metric correctness is preserved, but Redis write volume could be significantly higher than the cap implies in large deployments. A comment noting this design trade-off would help future maintainers avoid surprises.

### Issue 3 of 4
packages/shared/src/server/redis/ingestionFailureTracking.test.ts:13
**Hardcoded key constant diverges from production**

`ACTIVE_PROJECTS_KEY` is defined here as a literal string rather than importing the private `INGESTION_FAILURE_ACTIVE_PROJECTS_KEY` constant from the module under test. If the production key is renamed, the test will still pass (it reads and cleans its own key) while silently verifying nothing — the `waitForActiveProjectCount` polls would time out or resolve with 0 instead of 100, likely causing a flaky failure rather than a clear compile-time error. Exporting the key (or using a shared constant) would make the coupling explicit.

### Issue 4 of 4
packages/shared/src/env.ts:300-304
**`.gt(60)` lower bound is exclusive but unexplained**

The validator rejects the value `60` with a Zod parse error, while `61` is the minimum that passes. A brief inline comment explaining why values ≤ 60 are excluded (e.g., "must exceed the per-process rate-limiter window of 60 s so that at least one refresh is guaranteed before the Redis key's TTL fires") would save a future operator from a confusing startup failure when trying to set a short TTL for testing.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: introduing a metric indicating ho..."](https://github.com/langfuse/langfuse/commit/ab11a82f45aeaf69437d7fc5d9c1fef75bda40c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38643156)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->