### PR TITLE
chore(deps): bump undici 7.28

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -140,7 +140,7 @@
     "oci-objectstorage": "^2.125.0",
     "safe-regex2": "^5.0.0",
     "slackify-markdown": "^5.0.0",
-    "undici": "^7.24.6",
+    "undici": "^7.28.0",
     "uuid": "^14.0.0",
     "winston": "^3.15.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,8 +303,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       undici:
-        specifier: ^7.24.6
-        version: 7.25.0
+        specifier: ^7.28.0
+        version: 7.28.0
       uuid:
         specifier: ^14.0.0
         version: 14.0.0
@@ -11024,8 +11024,8 @@ packages:
     resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-json@0.8.0:
@@ -18096,7 +18096,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.25.0
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -23266,7 +23266,7 @@ snapshots:
 
   undici@7.24.5: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unicode-emoji-json@0.8.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ minimumReleaseAge: 7200
 # the exclusions are temporary so that we can set the 5 day limit without downgrading packages.
 # this list is version-specific
 minimumReleaseAgeExclude:
+  - undici@7.28.0
   - "form-data@2.5.6||4.0.6"
   - esbuild@0.28.1
   - "@esbuild/aix-ppc64@0.28.1"


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps the direct `undici` dependency in `packages/shared` from `^7.24.6` to `^7.28.0` to patch three security CVEs (CVE-2026-9678 cross-user information disclosure, CVE-2026-12151 WebSocket-based DoS, CVE-2026-9697 TLS certificate validation bypass), and adds a `minimumReleaseAgeExclude` entry to fast-track the new version past the workspace's 7200-second release-age gate.

- `packages/shared/package.json` and `pnpm-lock.yaml` are updated to resolve `undici@7.28.0` for the direct dependency.
- `pnpm-workspace.yaml` adds `undici@7.28.0` to the `minimumReleaseAgeExclude` list so the security patch is not blocked by the release-age check.
- A second copy of undici (`7.24.5`) remains in the lockfile as a transitive dependency pulled in by `release-it@20.2.0`; this is a dev-only tool and does not affect production, but it is pinned to a version the patch set targets.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The production dependency is correctly patched; the only open concern is a dev-only transitive dependency that still pins undici to the vulnerable range.

The direct undici bump and lockfile update are correct for the production dependency. The release-it transitive snapshot still resolves undici@7.24.5, and because release-it makes outbound HTTP calls to GitHub during deploys, CVE-2026-9678 and CVE-2026-9697 are reachable in that context.

pnpm-lock.yaml — the undici@7.24.5 snapshot for release-it@20.2.0 should be reviewed to determine whether an override or release-it upgrade can close the gap.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **CVE-2026-9678** (cross-user information disclosure via shared cache) and **CVE-2026-9697** (TLS certificate bypass via SOCKS5 `ProxyAgent`) are patched by the direct-dep bump to `undici@7.28.0` in `packages/shared`.
- **CVE-2026-12151** (WebSocket DoS) is also addressed by `undici@7.28.0`, per the Node.js June 2026 security release.
- `undici@7.24.5` still present in `pnpm-lock.yaml` as a transitive dep of `release-it@20.2.0` — this is a devDependency used only at release time, so production exposure is limited, but the snapshot remains vulnerable to all three CVEs if undici is exercised during the release workflow.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[packages/shared] -->|direct dep| B[undici 7.28.0 - patched]
    C[release-it 20.2.0] -->|transitive dep| D[undici 7.24.5 - still vulnerable]
    C -->|devDependency| E[CI Release Workflow]
    B -->|production| F[Langfuse App]
    style B fill:#22c55e,color:#fff
    style D fill:#f59e0b,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[packages/shared] -->|direct dep| B[undici 7.28.0 - patched]
    C[release-it 20.2.0] -->|transitive dep| D[undici 7.24.5 - still vulnerable]
    C -->|devDependency| E[CI Release Workflow]
    B -->|production| F[Langfuse App]
    style B fill:#22c55e,color:#fff
    style D fill:#f59e0b,color:#fff
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
pnpm-lock.yaml:23267
**Vulnerable undici version remaining as transitive dep**

`undici@7.24.5` is still resolved in the lockfile as a transitive dependency of `release-it@20.2.0` (snapshot at line 22288). All three CVEs this PR targets (CVE-2026-9678, CVE-2026-12151, CVE-2026-9697) affect versions below 7.28.0. While `release-it` is a devDependency and not shipped to production, it does make HTTP/HTTPS calls to GitHub and other endpoints during releases, so the shared-cache disclosure (CVE-2026-9678) and TLS bypass (CVE-2026-9697) are reachable during CI/CD workflows. Consider overriding the transitive version via a `pnpm.overrides` entry or checking whether a newer `release-it` resolves a patched version.

### Issue 2 of 2
pnpm-workspace.yaml:12
**`minimumReleaseAgeExclude` list growing without cleanup**

The comment above this block describes these entries as "temporary" and "version-specific," but there is no automated mechanism to remove them once the release-age window passes. The list already has 3 entries (`form-data`, `esbuild`, and now `undici@7.28.0`). Consider adding a follow-up ticket or a periodic review step to prune stale exclusions so the list does not become permanent boilerplate.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump undici 7.28"](https://github.com/langfuse/langfuse/commit/0f096c908aa9c0901c952aca2a88639802bb330e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38648116)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->