### PR TITLE
chore(ci): rename secret to CLAUDE_API_KEY as it already exists in repo

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -102,7 +102,7 @@ jobs:
           API_TIMEOUT_MS: "900000"
           BASH_DEFAULT_TIMEOUT_MS: "120000"
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
           github_token: ${{ github.token }}
           display_report: "true"
           prompt: |


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the `model-price-audit` workflow to reference the `CLAUDE_API_KEY` repository secret instead of `ANTHROPIC_API_KEY`, aligning it with the secret name that already exists in the repo.

- Renames the `anthropic_api_key` input to `claude-code-action` from `secrets.ANTHROPIC_API_KEY` to `secrets.CLAUDE_API_KEY` in `.github/workflows/model-price-audit.yml`.
- No other workflows in `.github/workflows/` referenced `ANTHROPIC_API_KEY`, so there are no remaining inconsistencies.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Single-line secret reference rename with no logic changes; safe to merge.

The change is a one-line rename of a GitHub Actions secret reference. No other workflows in the repository referenced the old secret name, and the action's interface (anthropic_api_key parameter) is unchanged. The only risk is that CLAUDE_API_KEY must be present in repository secrets, which the PR description confirms.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Secrets as Repo Secrets
    participant CCA as claude-code-action

    GH->>Secrets: lookup CLAUDE_API_KEY
    Secrets-->>GH: key value
    GH->>CCA: "anthropic_api_key = CLAUDE_API_KEY"
    CCA-->>GH: audit result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant Secrets as Repo Secrets
    participant CCA as claude-code-action

    GH->>Secrets: lookup CLAUDE_API_KEY
    Secrets-->>GH: key value
    GH->>CCA: "anthropic_api_key = CLAUDE_API_KEY"
    CCA-->>GH: audit result
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): rename secret to CLAUDE\_API\_K..."](https://github.com/langfuse/langfuse/commit/d6a5df1dd7182a110ad872e51071407350867029) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38651420)</sub>

<!-- /greptile_comment -->