### PR TITLE
chore: revert CODEOWNERS for GitHub config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
 # Currently inactive
 # * @langfuse/maintainers
-
-# Require maintainer review for GitHub configuration changes
-.github/ @langfuse/maintainers


### PR DESCRIPTION
## What changed

Reverts PR #13616 by removing the CODEOWNERS entries that were added for GitHub configuration files.

## Verification

- prettier --check "**/*.{js,jsx,ts,tsx,css}" --experimental-cli
- turbo run lint

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reverts the CODEOWNERS additions from PR #13616, removing the rule that required `@langfuse/maintainers` approval for changes to `.github/` configuration files.

- The two removed lines enforced mandatory maintainer review on all `.github/` directory changes; after this revert, no files in the repo have active code owners (the global `* @langfuse/maintainers` rule remains commented out).
- The change has no runtime impact — CODEOWNERS only affects GitHub PR review requirements.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — removing these three lines from CODEOWNERS has no runtime effect and only relaxes the GitHub review requirement for `.github/` directory changes.

The change is a minimal config-file revert with no logic or runtime implications. The only effect is that future PRs touching `.github/` will no longer automatically request a maintainer review, which appears to be the deliberate intent.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened targeting .github/ files] --> B{CODEOWNERS check}
    B -- Before revert --> C[Requires @langfuse/maintainers review]
    B -- After revert --> D[No mandatory reviewer assigned]
    C --> E[Maintainer approves → merge]
    D --> F[Any approver → merge]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR opened targeting .github/ files] --> B{CODEOWNERS check}
    B -- Before revert --> C[Requires @langfuse/maintainers review]
    B -- After revert --> D[No mandatory reviewer assigned]
    C --> E[Maintainer approves → merge]
    D --> F[Any approver → merge]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: revert CODEOWNERS for GitHub conf..."](https://github.com/langfuse/langfuse/commit/a2e7d72b79b0db7de86f2dd6b4773cbe6c270994) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38653028)</sub>

<!-- /greptile_comment -->