### PR TITLE
feat(agents): add repo agent standards

### DIFF
--- a/.agents/skills/create-repo-agent/SKILL.md
+++ b/.agents/skills/create-repo-agent/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: create-repo-agent
+description: Use when designing, implementing, reviewing, or hardening Langfuse repo-owned autonomous agents, especially GitHub Actions that invoke Claude, Codex, or another LLM agent on a schedule or workflow_dispatch, create pull requests, update workflow prompts or allowlists, handle GitHub tokens/secrets, use untrusted web content, or self-improve repo agent instructions.
+---
+
+# Create Repo Agent
+
+## Purpose
+
+Build repo agents that can run unattended without granting the model broad write credentials, arbitrary shell, or uncontrolled network access. The default architecture is a read-only audit job that produces a validated bundle plus a separate publisher job that owns GitHub writes.
+
+Use this skill together with the domain skill for the files the agent will maintain. For example, a pricing agent must also use `add-model-price`.
+
+## Required Reading
+
+For every repo agent task, read these references before designing or editing:
+
+1. `references/security-standards.md`
+2. `references/workflow-blueprint.md` when implementing or changing a GitHub Actions workflow
+3. `references/review-checklist.md` before final review or PR publication
+
+## Workflow
+
+1. Define the exact maintenance objective, allowed files, external sources, expected no-change behavior, and PR ownership.
+2. Choose the least-capable runtime: prefer a scheduled/manual GitHub Action with read-only repository checkout and no write credentials in the LLM step.
+3. Encode the prompt with explicit allowed edit surfaces, hard constraints, source-evidence requirements, and structured output.
+4. Give the agent only scoped file tools, domain-scoped fetch tools, and exact deterministic validator commands.
+5. Validate the diff independently of the agent, including untracked files, path allowlists, `git diff --check`, line-count limits, and domain-specific validators.
+6. Publish from a separate job or step after validation, using a bot credential only for branch push and PR create/update.
+7. If self-improvement is allowed, constrain it to named workflow or skill-reference files and require security invariants to remain unchanged.
+8. Run agent setup checks when `.agents/**` changes, then publish a normal human-reviewable PR.
+
+## Non-Negotiables
+
+- Never expose a write-capable GitHub token, PAT, GitHub App token, OIDC token, SSH key, cloud credential, or package-publishing token to the LLM agent step.
+- Never rely on prompt instructions as the only security boundary. Enforce file and command limits outside the agent.
+- Never stage a directory wholesale. Stage only the validated file list.
+- Never ignore untracked files in diff validation.
+- Never let self-improvement bypass the same diff allowlist and human PR review as normal edits.
+- Never grant arbitrary `Bash`, `curl`, `wget`, `gh`, `git push`, package-manager, interpreter, environment-dump, or process-inspection tools to the LLM agent.
+- Never add `id-token: write` unless the agent truly needs OIDC and the trust relationship is reviewed explicitly.

--- a/.agents/skills/create-repo-agent/agents/openai.yaml
+++ b/.agents/skills/create-repo-agent/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Repo Agent"
+  short_description: "Build hardened repo agents for this repository."
+  default_prompt: "Use $create-repo-agent when designing, implementing, or reviewing a scheduled repo agent."

--- a/.agents/skills/create-repo-agent/references/review-checklist.md
+++ b/.agents/skills/create-repo-agent/references/review-checklist.md
@@ -1,0 +1,108 @@
+# Repo Agent Review Checklist
+
+Use this checklist before merging any repo-agent workflow, skill, or self-improvement change.
+
+## Block Merge If
+
+- The LLM step has a write-capable GitHub token, PAT, GitHub App token, SSH key, cloud credential, package token, or OIDC token.
+- The LLM step has arbitrary shell, broad interpreter, package-manager, `curl`, `wget`, `gh`, `git push`, or broad network access.
+- The workflow relies on prompt instructions as the only guardrail for file scope, command scope, or publishing.
+- Diff validation ignores untracked files.
+- The workflow stages a directory instead of a validated file list.
+- The publish path can push files not covered by the allowlist.
+- Self-improvement can edit security boundaries without path allowlists, invariant prompts, and human PR review.
+- Manual inputs are interpolated before validation.
+- The agent can change generated files, dependency locks, package manager config, CI trust settings, or secrets without an explicit task and dedicated review.
+
+## Scope And Objective
+
+- The objective is narrow enough for a scheduled or manually dispatched maintenance agent.
+- The no-change path is explicitly defined and treated as success.
+- The allowed files are exact paths or narrow globs.
+- The agent has a domain skill or reference docs for the business logic.
+- The PR title, branch name, and reviewer behavior are deterministic.
+
+## Credentials And Permissions
+
+- Top-level or audit-job permissions are minimal, usually `contents: read`.
+- Checkout uses `persist-credentials: false`.
+- The LLM step receives only the model API key and, if needed by the action, read-only `${{ github.token }}`.
+- Write credentials are present only in the publish job.
+- Secrets are scoped to individual steps, not broad job env, unless there is a concrete reason.
+- No secret values, env dumps, or full sensitive logs are uploaded.
+- `id-token: write` is absent unless explicitly justified and reviewed.
+
+## Tool Allowlist
+
+- File tools are scoped to exact paths or narrow globs.
+- Network tools are scoped to official domains.
+- Shell tools are exact deterministic validator commands.
+- There is no broad `Bash(node:*)`, `Bash(python:*)`, `Bash(curl:*)`, `Bash(gh:*)`, `Bash(git:*)`, or package-manager access.
+- The agent cannot push, create PRs, install dependencies, publish packages, inspect all env vars, or modify git config.
+
+## Prompt And Output
+
+- The prompt names all required repo skills and references.
+- The prompt states allowed edit surfaces and hard constraints.
+- The prompt requires source evidence and concrete calculations where relevant.
+- The prompt tells the agent to leave uncertain findings unchanged.
+- The prompt requires deterministic validation before finishing.
+- The structured output schema includes summary, changed objects, unresolved findings, validation, and self-improvement fields when applicable.
+- The job summary renders structured output in a reviewable format.
+
+## Diff And Validation
+
+- Changed files are computed from tracked and untracked changes.
+- Every changed file is checked against the same anchored allowlist before staging and after staging.
+- Untracked files are intent-added before diff checks.
+- `git diff --check` runs on changed files.
+- A changed-line cap rejects non-surgical diffs.
+- Domain-specific validators run before staging.
+- Staged blobs are compared to worktree files after `git add`.
+- Staged machine-readable files are validated from `git show ":path"`.
+- `git diff --cached --check` runs before commit.
+- Validators run again after the local commit or bundle step.
+
+## Publish Path
+
+- The publish job runs only after validated changes.
+- The publish job does not invoke the LLM.
+- Git hooks are disabled for bot commit paths.
+- The publish job imports a validated bundle or equivalent artifact, not a mutable workspace with unvalidated files.
+- The bot branch is force-pushed intentionally and only to the expected repo.
+- Existing PRs are updated instead of creating duplicates.
+- Reviewer requests are non-fatal.
+
+## Self-Improvement
+
+- Self-improvement is explicitly enabled by the workflow.
+- The allowed self-edit files are named.
+- The prompt lists security invariants that must remain unchanged.
+- Diff validation includes self-edit files but no broader paths.
+- Structured output lists each workflow or skill-reference improvement.
+- The PR body makes self-improvement visible to reviewers.
+- The change does not loosen tools, tokens, permissions, or publish boundaries without a direct, reviewed reason.
+
+## Operational Fit
+
+- The schedule is not too frequent for provider rate limits, model cost, or reviewer attention.
+- `timeout-minutes`, max turns, and max budget bound runaway loops.
+- Manual dispatch inputs are sufficient for safe debugging without making the agent arbitrary.
+- No-change runs are cheap and legible.
+- Failure modes leave enough summary context for maintainers without exposing secrets.
+
+## Verification Commands
+
+For workflow-only changes, run at least:
+
+- YAML parsing or a workflow linter when available.
+- `bash -n` against embedded shell scripts if extracted or linted.
+- `git diff --check`.
+
+For `.agents/**` changes, also run:
+
+- `pnpm run agents:sync`
+- `pnpm run agents:check`
+- The skill-creator quick validator for new or changed skills.
+
+For domain files, run the domain-specific validators and targeted tests named by the domain skill.

--- a/.agents/skills/create-repo-agent/references/security-standards.md
+++ b/.agents/skills/create-repo-agent/references/security-standards.md
@@ -1,0 +1,104 @@
+# Repo Agent Security Standards
+
+Use these standards for every Langfuse repo-owned autonomous agent. They are intentionally stricter than a normal CI workflow because an LLM step consumes untrusted instructions, web pages, source files, and prior outputs.
+
+Official references:
+
+- GitHub Actions security hardening: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
+- GitHub automatic token authentication: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
+- GitHub Actions secrets: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
+- Claude Code permissions: https://code.claude.com/docs/en/permissions
+
+## Threat Model
+
+- Treat provider web pages, GitHub issues, PR comments, release notes, generated files, package scripts, and previous agent outputs as untrusted input.
+- Assume prompt injection can ask the agent to leak secrets, loosen its own permissions, edit unrelated files, open broader network access, or hide malicious changes in formatting churn.
+- Assume the agent can make mistakes even when acting in good faith. Independent validation must catch wrong files, oversized diffs, invalid generated artifacts, and missing domain-specific checks.
+- Treat self-improvement as code execution policy change. It is useful, but it is never exempt from review, path allowlists, and security invariants.
+
+## Credential Model
+
+- The LLM agent step should receive only the model-provider API key required to run the agent and, if the action requires it, the read-only `${{ github.token }}`.
+- Set workflow or job `permissions` to the minimum necessary. For read-only audit jobs, use `contents: read`.
+- Pass `github_token: ${{ github.token }}` explicitly to LLM actions that otherwise try to discover a token from the environment, and keep the job permission read-only.
+- Do not pass `secrets.GH_ACCESS_TOKEN`, write-scoped PATs, GitHub App private keys, SSH keys, cloud credentials, package-registry tokens, or OIDC tokens to the LLM step.
+- Keep write credentials in a separate publish job or post-validation step that does not invoke the LLM agent.
+- Put each secret only on the step that needs it. Do not define broad job-level secret env vars.
+- Do not echo secrets, dump environment variables, enable full agent logs, or upload unredacted agent transcripts as artifacts.
+- Do not add `id-token: write` unless there is a reviewed OIDC trust boundary and the agent's objective cannot be met without it.
+
+## Tool Permissions
+
+- Prefer scoped `Read`, `Edit`, and `Write` tools for exact paths or path globs.
+- Prefer domain-scoped `WebFetch` for official sources instead of shell network tools.
+- Prefer exact `Bash(command ...)` entries only for deterministic, repo-owned validators or simple non-sensitive commands such as `date -u +%Y-%m-%dT00:00:00.000Z`.
+- Do not allow broad shell patterns such as `Bash(*)`, `Bash(node:*)`, `Bash(python:*)`, `Bash(curl:*)`, `Bash(wget:*)`, `Bash(gh:*)`, `Bash(git:*)`, `Bash(pnpm:*)`, or `Bash(npm:*)`.
+- Do not allow shell readers or environment/process inspection commands such as `cat`, `sed`, `grep`, `rg`, `jq`, `env`, `printenv`, `ps`, or `ls` unless the exact command is required and safe. File reads should go through scoped read tools.
+- Do not allow `git push`, PR creation, GitHub API calls, package installs, package publishing, dependency updates, or arbitrary interpreters in the LLM step.
+- If a deterministic validator is needed, keep it in the repository, review it as normal code, and allow only that exact command.
+- Keep WebFetch domains to official sources for the domain. If the agent discovers a new official domain, it may propose a workflow self-improvement PR if self-improvement is enabled.
+
+## Prompt Contract
+
+Every repo-agent prompt must state:
+
+- The agent's objective and explicit no-change behavior.
+- The files it may read and edit.
+- The official sources it may use.
+- The hard constraints it must not violate.
+- The validators it must run before finishing.
+- The expected structured output schema.
+- The evidence required for any change, including source URLs and conversion calculations when applicable.
+
+Do not rely on the prompt as the enforcement layer. The prompt guides the model; the workflow must still enforce file, command, token, and publish boundaries.
+
+## Diff Enforcement
+
+Independent diff validation must run after the agent and before publishing:
+
+- Build `changed_files` from both `git diff --name-only` and `git ls-files --others --exclude-standard`.
+- Use an anchored exact-path allowlist regex. Do not allow broad directories unless the task requires creating named files under that directory and the regex prevents traversal.
+- Run `git add -N -- "${untracked_files[@]}"` before `git diff --check` and line-count checks when untracked files exist.
+- Run `git diff --check -- "${changed_files[@]}"`.
+- Cap changed lines for surgical agents. The cap should match the task; pricing-style maintenance should stay small.
+- Run domain validators on worktree files before staging.
+- Stage only the validated file list with `git add -- "${changed_files[@]}"`.
+- Re-check `git diff --cached --name-only` against the same allowlist.
+- Compare staged blobs against worktree contents to catch clean/smudge filters, generated mutation, or staging surprises.
+- Run staged-blob validation for files with machine-readable schemas, especially JSON.
+- Run `git diff --cached --check -- "${staged_files[@]}"` before commit.
+
+## Publish Boundary
+
+Use a two-phase architecture for agents that create PRs:
+
+- Phase 1: audit job. It checks out code with `persist-credentials: false`, runs the LLM with read-only permissions, validates the diff, commits locally with hooks disabled, and uploads a git bundle plus PR body artifact.
+- Phase 2: publish job. It downloads the bundle, imports it into a clean temporary repo, pushes the bot branch with a write-scoped bot secret, and creates or updates the PR.
+- The publish job must not invoke the LLM.
+- The publish job should clear global/system git config where practical and disable hooks for any commit or push-adjacent git operation.
+- Reviewer assignment should be non-fatal so a missing reviewer permission does not fail an otherwise valid maintenance PR.
+
+## Self-Improvement
+
+Self-improvement is allowed only when the workflow explicitly opts in.
+
+- Limit self-improvement to named files, usually the workflow itself and repo-owned skill reference files.
+- Keep self-improvements surgical: prompt clarity, official domain allowlists, exact validator/tool entries, input defaults, timeout/budget settings, and output schema improvements.
+- Require the final output to list every self-improvement and why it improves future runs.
+- Preserve security invariants: read-only audit job, no write token in the LLM step, separate publisher, explicit token permissions, path allowlists, input validation, staged-blob checks, hook-disabled commit path, and human PR review.
+- Do not let self-improvement add arbitrary shell/network tools, write job permissions, `id-token: write`, package-manager tools, `gh`, `git push`, or broad file globs.
+- If a needed self-improvement would violate an invariant, the agent must report it as unresolved instead of applying it.
+
+## Logging And Artifacts
+
+- Prefer summarized agent reports over full transcripts.
+- Do not upload full stdout/stderr if it may contain environment data or secrets.
+- Upload only the artifacts needed for publishing or review, such as a git bundle and PR body.
+- Set short artifact retention for bot handoff artifacts.
+- Summaries should include changed files, changed business objects, source URLs, unresolved findings, validation commands, and self-improvements.
+
+## Source Pinning And Updates
+
+- Pin third-party actions by full commit SHA and keep the comment with the version tag when useful.
+- Review third-party action changes before bumping the pinned SHA.
+- Do not auto-update action pins from inside the agent unless that is the explicit objective and the workflow includes dedicated validation for it.

--- a/.agents/skills/create-repo-agent/references/workflow-blueprint.md
+++ b/.agents/skills/create-repo-agent/references/workflow-blueprint.md
@@ -1,0 +1,168 @@
+# GitHub Actions Repo Agent Blueprint
+
+Use this blueprint when implementing or changing a scheduled/manual repo agent in `.github/workflows/**`.
+
+## Top-Level Shape
+
+- `name`: explicit maintenance task name.
+- `on.schedule`: use a predictable low-noise cadence.
+- `on.workflow_dispatch.inputs`: keep inputs small and validate every input before interpolation into agent args.
+- `permissions`: default to `contents: read`.
+- `concurrency`: one stable group per agent, usually `cancel-in-progress: true`.
+- `env`: branch names and PR titles only; do not put secrets in top-level env.
+
+## Audit Job
+
+The audit job is the only job that invokes the LLM agent.
+
+- Guard the job with `if: github.repository == 'langfuse/langfuse'` for repo-owned automations.
+- Use a bounded `timeout-minutes`.
+- Use `actions/checkout` with `persist-credentials: false` and the minimum required `fetch-depth`.
+- Set up only the runtimes needed by deterministic validators.
+- Validate `workflow_dispatch` inputs before they are used in prompts or CLI args.
+- Run cheap deterministic pre-checks before invoking the model.
+- Pass only the model API key and read-only `${{ github.token }}` to the LLM action.
+- Set agent timeout and budget controls where supported, such as max turns, max budget, API timeout, and shell timeout.
+- Use `--no-session-persistence` unless session reuse is required and reviewed.
+- Use a strict `--allowedTools` list.
+- Use structured JSON output and render it into the job summary.
+
+## Workflow Dispatch Input Validation
+
+- Prefer `type: choice` for model names, modes, environments, or other enumerations.
+- For freeform numeric inputs, validate with a regex and numeric range before using the value.
+- For string inputs that become CLI args, validate against an allowlist regex or choice set.
+- Do not interpolate unchecked manual inputs into shell commands, JSON, branch names, file paths, or LLM CLI arguments.
+
+## Agent Prompt Template
+
+Include these sections in the prompt:
+
+```text
+You are running Langfuse's scheduled <task> audit.
+
+Read and follow:
+- <domain skill>
+- <domain references>
+
+Allowed edit surface:
+- <exact file>
+- <restricted glob>
+
+Task:
+1. <business audit goal>
+2. Make only surgical edits with official evidence.
+3. Report uncertainty without changing code.
+4. Update approved skill references when durable learnings are discovered.
+5. Optionally update this workflow only for future prompt/tool/domain/validation improvements.
+6. Run deterministic validation before finishing.
+
+Hard constraints:
+- Do not change generated files.
+- Do not change package manager files.
+- Do not run git push or create a PR.
+- Do not add broad wildcard behavior.
+- Preserve security invariants for workflow self-improvement.
+
+Final response:
+- No diff: report no changes and unresolved findings.
+- Diff: list changed business objects, source URLs, calculations, self-improvements, and validation commands.
+```
+
+Tailor the business rules to the domain skill. Do not leave vague permissions such as "update relevant files".
+
+## Allowed Tools
+
+Start with no shell or network tools, then add only what the task requires:
+
+- Exact `Read` paths for source files, skill docs, and the workflow if self-improvement is enabled.
+- Exact `Edit` paths for mutable files.
+- `Write` only for approved new files under a narrow path, such as skill reference markdown files.
+- Domain-scoped `WebFetch` for official provider documentation and pricing pages.
+- Exact deterministic validator commands.
+
+Do not add broad shell, package-manager, GitHub CLI, git write, curl/wget, or interpreter access to the LLM step.
+
+## Diff Validation Job Steps
+
+After the LLM step:
+
+```bash
+mapfile -t changed_files < <(
+  {
+    git diff --name-only
+    git ls-files --others --exclude-standard
+  } | sort -u
+)
+```
+
+Then:
+
+- Exit cleanly if there are no changes.
+- Check every path against an anchored allowlist regex.
+- Intent-to-add untracked files before diff checks.
+- Run domain validators.
+- Run `git diff --check -- "${changed_files[@]}"`.
+- Compute a changed-line count and reject oversized diffs.
+- Write a diff stat to the job summary.
+
+## Commit And Bundle Preparation
+
+Prepare the PR artifact inside the audit job only after diff validation:
+
+- Recompute `changed_files`.
+- Re-run the same allowlist.
+- Intent-to-add untracked files.
+- Re-run domain validators and `git diff --check`.
+- Configure bot author.
+- Create the bot branch with hooks disabled.
+- Stage only `changed_files`.
+- Verify `git diff --cached --name-only` against the allowlist.
+- Compare each staged blob to the worktree file.
+- Validate staged machine-readable files from `git show ":path"`.
+- Run `git diff --cached --check`.
+- Commit with `git -c core.hooksPath=/dev/null commit --no-verify`.
+- Re-run validators.
+- Create a git bundle for the bot branch.
+- Create a PR body artifact with scope, validation, diff stat, and agent summary.
+
+## Publish Job
+
+The publish job owns GitHub writes:
+
+- It runs only when the audit job reports changes.
+- It downloads the bundle and PR body artifact.
+- It imports the bundle into a clean temporary repository.
+- It pushes the bot branch with `GH_ACCESS_TOKEN` or another reviewed bot secret.
+- It creates or updates a PR against `main`.
+- It requests reviewers non-fatally with `|| true`.
+- It prints the PR URL to the job summary.
+
+The publish job must not run the LLM or process new untrusted web content.
+
+## Self-Improvement Pattern
+
+If self-improvement is enabled:
+
+- Add the workflow file to the prompt's allowed edit surface.
+- Add exact `Read` and `Edit` tools for that workflow file.
+- Add the workflow file to all diff and staging allowlists.
+- Add a structured output field such as `workflowUpdates`.
+- Add prompt constraints listing invariants that must be preserved.
+- Keep self-improvement changes in the same PR as the business changes, or in a no-business-change PR if the only useful outcome is agent improvement.
+
+Reasonable self-improvements:
+
+- Adding a newly discovered official provider documentation domain.
+- Tightening prompt wording after an ambiguous run.
+- Adding an exact validator command already present in the repo.
+- Adjusting max-turn defaults or timeouts based on observed legitimate needs.
+- Adding a structured output field that improves reviewability.
+
+Do not use self-improvement for:
+
+- Broadening shell access.
+- Granting write permissions to the audit job.
+- Adding OIDC or package-manager access.
+- Removing validators or allowlists.
+- Editing unrelated workflows or generated files.

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -14,9 +14,9 @@ on:
           - sonnet
           - opus
       max_turns:
-        description: "Maximum Claude Code agent turns (1-20)"
+        description: "Maximum Claude Code agent turns (1-50)"
         required: false
-        default: "8"
+        default: "20"
       max_budget_usd:
         description: "Maximum Claude API spend for the audit (whole USD, 1-20)"
         required: false
@@ -57,7 +57,7 @@ jobs:
       - name: Validate workflow inputs
         env:
           CLAUDE_MODEL: ${{ github.event.inputs.claude_model || 'sonnet' }}
-          CLAUDE_MAX_TURNS: ${{ github.event.inputs.max_turns || '8' }}
+          CLAUDE_MAX_TURNS: ${{ github.event.inputs.max_turns || '20' }}
           CLAUDE_MAX_BUDGET_USD: ${{ github.event.inputs.max_budget_usd || '5' }}
         run: |
           set -euo pipefail
@@ -70,8 +70,8 @@ jobs:
               ;;
           esac
 
-          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 20 ]; then
-            echo "::error::max_turns must be a whole number between 1 and 20"
+          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 50 ]; then
+            echo "::error::max_turns must be a whole number between 1 and 50"
             exit 1
           fi
 
@@ -115,6 +115,7 @@ jobs:
             - .agents/skills/add-model-price/references/workflow-and-validation.md
 
             Allowed edit surface:
+            - .github/workflows/model-price-audit.yml
             - worker/src/constants/default-model-prices.json
             - packages/shared/src/server/llm/types.ts
             - .agents/skills/add-model-price/references/*.md
@@ -124,8 +125,9 @@ jobs:
             2. Make only surgical edits with official provider evidence.
             3. If a finding is uncertain or cannot be represented safely in Langfuse's pricing schema, leave the code unchanged and report it.
             4. If you learn durable provider-source URLs, pricing-page quirks, model-ID variants, or recurring audit rules that would help future audits, update only the pricing skill reference files under `.agents/skills/add-model-price/references/*.md`.
-            5. Re-run the deterministic validation script before finishing.
-            6. If you change any `matchPattern`, run the bundled match-pattern tester with representative accepted and rejected model IDs before finishing.
+            5. If the audit reveals that future runs need a sharper prompt, narrower or broader official provider WebFetch domains, exact deterministic tools, input defaults, validation gates, or publish guardrails, update only `.github/workflows/model-price-audit.yml` with a surgical self-improvement and explain the reason in your final output.
+            6. Re-run the deterministic validation script before finishing.
+            7. If you change any `matchPattern`, run the bundled match-pattern tester with representative accepted and rejected model IDs before finishing.
 
             Hard constraints:
             - Do not change generated files.
@@ -133,19 +135,21 @@ jobs:
             - Do not run git push or create a PR.
             - Do not add broad future-model wildcard regexes.
             - Do not edit `.agents/skills/add-model-price/SKILL.md` or `.agents/skills/add-model-price/scripts/**`.
+            - Workflow self-improvements must preserve the schedule/manual triggers, repo guard, read-only audit permissions, explicit read-only GitHub token, separate publish job, secret names, input validation, diff allowlist, hook-disabled commit path, staged-blob checks, artifact handoff, and non-fatal reviewer request.
+            - Do not grant the audit job write permissions, `id-token: write`, package-manager tools, arbitrary shell tools, arbitrary network tools, `gh`, or `git push`.
             - Keep the first entry in every selectable model array unchanged unless the audit explicitly changes the default model.
             - Use the allowed exact `date -u +%Y-%m-%dT00:00:00.000Z` command if you need the current timestamp.
 
             Final response:
             - If there is no diff, say that no pricing changes were made and list the notable unresolved findings.
-            - If there is a diff, list every changed model, the official source URL, the provider unit price, the converted per-token value, and the validation commands run.
+            - If there is a diff, list every changed model, the official source URL, the provider unit price, the converted per-token value, every workflow or skill-reference improvement, and the validation commands run.
           claude_args: |
             --model ${{ github.event.inputs.claude_model || 'sonnet' }}
-            --max-turns ${{ github.event.inputs.max_turns || '8' }}
+            --max-turns ${{ github.event.inputs.max_turns || '20' }}
             --max-budget-usd ${{ github.event.inputs.max_budget_usd || '5' }}
             --no-session-persistence
-            --allowedTools "Read(/worker/src/constants/default-model-prices.json),Read(/packages/shared/src/server/llm/types.ts),Read(/.agents/skills/add-model-price/SKILL.md),Read(/.agents/skills/add-model-price/references/*.md),Edit(/worker/src/constants/default-model-prices.json),Edit(/packages/shared/src/server/llm/types.ts),Edit(/.agents/skills/add-model-price/references/*.md),Write(/.agents/skills/add-model-price/references/*.md),WebFetch(domain:platform.claude.com),WebFetch(domain:docs.anthropic.com),WebFetch(domain:openai.com),WebFetch(domain:ai.google.dev),WebFetch(domain:aws.amazon.com),WebFetch(domain:azure.microsoft.com),Bash(date -u +%Y-%m-%dT00:00:00.000Z),Bash(node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs),Bash(node .agents/skills/add-model-price/scripts/test-match-pattern.mjs:*)"
-            --json-schema '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string"},"changedModels":{"type":"array","items":{"type":"string"}},"skillReferenceUpdates":{"type":"array","items":{"type":"string"}},"unresolvedFindings":{"type":"array","items":{"type":"string"}},"validation":{"type":"array","items":{"type":"string"}}},"required":["summary","changedModels","skillReferenceUpdates","unresolvedFindings","validation"]}'
+            --allowedTools "Read(/.github/workflows/model-price-audit.yml),Read(/worker/src/constants/default-model-prices.json),Read(/packages/shared/src/server/llm/types.ts),Read(/.agents/skills/add-model-price/SKILL.md),Read(/.agents/skills/add-model-price/references/*.md),Edit(/.github/workflows/model-price-audit.yml),Edit(/worker/src/constants/default-model-prices.json),Edit(/packages/shared/src/server/llm/types.ts),Edit(/.agents/skills/add-model-price/references/*.md),Write(/.agents/skills/add-model-price/references/*.md),WebFetch(domain:platform.claude.com),WebFetch(domain:docs.anthropic.com),WebFetch(domain:openai.com),WebFetch(domain:ai.google.dev),WebFetch(domain:aws.amazon.com),WebFetch(domain:azure.microsoft.com),Bash(date -u +%Y-%m-%dT00:00:00.000Z),Bash(node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs),Bash(node .agents/skills/add-model-price/scripts/test-match-pattern.mjs:*)"
+            --json-schema '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string"},"changedModels":{"type":"array","items":{"type":"string"}},"skillReferenceUpdates":{"type":"array","items":{"type":"string"}},"workflowUpdates":{"type":"array","items":{"type":"string"}},"unresolvedFindings":{"type":"array","items":{"type":"string"}},"validation":{"type":"array","items":{"type":"string"}}},"required":["summary","changedModels","skillReferenceUpdates","workflowUpdates","unresolvedFindings","validation"]}'
 
       - name: Write Claude audit summary
         env:
@@ -171,6 +175,9 @@ jobs:
               "",
               "Skill reference updates:",
               list(output.skillReferenceUpdates),
+              "",
+              "Workflow updates:",
+              list(output.workflowUpdates),
               "",
               "Unresolved findings:",
               list(output.unresolvedFindings),
@@ -206,7 +213,7 @@ jobs:
             exit 0
           fi
 
-          allowed_file_regex='^(worker/src/constants/default-model-prices\.json|packages/shared/src/server/llm/types\.ts|\.agents/skills/add-model-price/references/[^/]+\.md)$'
+          allowed_file_regex='^(\.github/workflows/model-price-audit\.yml|worker/src/constants/default-model-prices\.json|packages/shared/src/server/llm/types\.ts|\.agents/skills/add-model-price/references/[^/]+\.md)$'
           for changed_file in "${changed_files[@]}"; do
             if [[ ! "$changed_file" =~ $allowed_file_regex ]]; then
               echo "::error::Claude changed a file outside the allowed pricing surface: $changed_file"
@@ -255,7 +262,7 @@ jobs:
             exit 0
           fi
 
-          allowed_file_regex='^(worker/src/constants/default-model-prices\.json|packages/shared/src/server/llm/types\.ts|\.agents/skills/add-model-price/references/[^/]+\.md)$'
+          allowed_file_regex='^(\.github/workflows/model-price-audit\.yml|worker/src/constants/default-model-prices\.json|packages/shared/src/server/llm/types\.ts|\.agents/skills/add-model-price/references/[^/]+\.md)$'
           for changed_file in "${changed_files[@]}"; do
             if [[ ! "$changed_file" =~ $allowed_file_regex ]]; then
               echo "::error::Refusing to stage a file outside the allowed pricing surface: $changed_file"
@@ -317,7 +324,7 @@ jobs:
             echo "## Scope"
             echo
             echo "- Audits default model pricing data with official provider evidence."
-            echo "- Edits are restricted to pricing JSON, shared selectable model lists, and pricing skill reference docs."
+            echo "- Edits are restricted to pricing JSON, shared selectable model lists, pricing skill reference docs, and this audit workflow."
             echo
             echo "## Validation"
             echo

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -14,13 +14,13 @@ on:
           - sonnet
           - opus
       max_turns:
-        description: "Maximum Claude Code agent turns (1-50)"
+        description: "Maximum Claude Code agent turns (1-500)"
         required: false
-        default: "20"
+        default: "250"
       max_budget_usd:
         description: "Maximum Claude API spend for the audit (whole USD, 1-20)"
         required: false
-        default: "5"
+        default: "15"
 
 permissions:
   contents: read
@@ -57,8 +57,8 @@ jobs:
       - name: Validate workflow inputs
         env:
           CLAUDE_MODEL: ${{ github.event.inputs.claude_model || 'sonnet' }}
-          CLAUDE_MAX_TURNS: ${{ github.event.inputs.max_turns || '20' }}
-          CLAUDE_MAX_BUDGET_USD: ${{ github.event.inputs.max_budget_usd || '5' }}
+          CLAUDE_MAX_TURNS: ${{ github.event.inputs.max_turns || '250' }}
+          CLAUDE_MAX_BUDGET_USD: ${{ github.event.inputs.max_budget_usd || '15' }}
         run: |
           set -euo pipefail
 
@@ -71,12 +71,12 @@ jobs:
           esac
 
           if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 50 ]; then
-            echo "::error::max_turns must be a whole number between 1 and 50"
+            echo "::error::max_turns must be a whole number between 1 and 500"
             exit 1
           fi
 
           if [[ ! "$CLAUDE_MAX_BUDGET_USD" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_BUDGET_USD" -gt 20 ]; then
-            echo "::error::max_budget_usd must be a whole USD amount between 1 and 20"
+            echo "::error::max_budget_usd must be a whole USD amount between 1 and 15"
             exit 1
           fi
 
@@ -145,8 +145,8 @@ jobs:
             - If there is a diff, list every changed model, the official source URL, the provider unit price, the converted per-token value, every workflow or skill-reference improvement, and the validation commands run.
           claude_args: |
             --model ${{ github.event.inputs.claude_model || 'sonnet' }}
-            --max-turns ${{ github.event.inputs.max_turns || '20' }}
-            --max-budget-usd ${{ github.event.inputs.max_budget_usd || '5' }}
+            --max-turns ${{ github.event.inputs.max_turns || '250' }}
+            --max-budget-usd ${{ github.event.inputs.max_budget_usd || '15' }}
             --no-session-persistence
             --allowedTools "Read(/.github/workflows/model-price-audit.yml),Read(/worker/src/constants/default-model-prices.json),Read(/packages/shared/src/server/llm/types.ts),Read(/.agents/skills/add-model-price/SKILL.md),Read(/.agents/skills/add-model-price/references/*.md),Edit(/.github/workflows/model-price-audit.yml),Edit(/worker/src/constants/default-model-prices.json),Edit(/packages/shared/src/server/llm/types.ts),Edit(/.agents/skills/add-model-price/references/*.md),Write(/.agents/skills/add-model-price/references/*.md),WebFetch(domain:platform.claude.com),WebFetch(domain:docs.anthropic.com),WebFetch(domain:openai.com),WebFetch(domain:ai.google.dev),WebFetch(domain:aws.amazon.com),WebFetch(domain:azure.microsoft.com),Bash(date -u +%Y-%m-%dT00:00:00.000Z),Bash(node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs),Bash(node .agents/skills/add-model-price/scripts/test-match-pattern.mjs:*)"
             --json-schema '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string"},"changedModels":{"type":"array","items":{"type":"string"}},"skillReferenceUpdates":{"type":"array","items":{"type":"string"}},"workflowUpdates":{"type":"array","items":{"type":"string"}},"unresolvedFindings":{"type":"array","items":{"type":"string"}},"validation":{"type":"array","items":{"type":"string"}}},"required":["summary","changedModels","skillReferenceUpdates","workflowUpdates","unresolvedFindings","validation"]}'


### PR DESCRIPTION
## Summary

- Increase the model price audit default max turns to 20 and validate manual dispatch values up to 50.
- Allow the model price audit agent to make surgical self-improvements to `.github/workflows/model-price-audit.yml`, with invariant prompts, scoped Claude tools, structured `workflowUpdates` output, and diff/staging allowlist coverage.
- Add the `create-repo-agent` skill with security standards, a workflow blueprint, and a review checklist for future scheduled repo agents.

## Validation

- `./node_modules/.bin/prettier --check .github/workflows/model-price-audit.yml .agents/skills/create-repo-agent/SKILL.md .agents/skills/create-repo-agent/agents/openai.yaml .agents/skills/create-repo-agent/references/security-standards.md .agents/skills/create-repo-agent/references/workflow-blueprint.md .agents/skills/create-repo-agent/references/review-checklist.md`
- `python3 .agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/create-repo-agent`
- `node scripts/agents/sync-agent-shims.mjs --check`
- Ruby YAML parse plus embedded `bash -n` checks for `.github/workflows/model-price-audit.yml`
- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
- `uvx zizmor .github/workflows/model-price-audit.yml`
- `git diff --cached --check`

Note: the normal git commit hook was interrupted during slow `pnpm install` package download retries after the request to push without waiting; the commit was created with hooks disabled after the targeted checks above passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `create-repo-agent` skill (security standards, workflow blueprint, review checklist) and extends `model-price-audit.yml` to allow surgical self-improvement of the workflow file. Two validation inconsistencies were introduced into the workflow that need to be fixed before merging.

- **New skill**: `.agents/skills/create-repo-agent/` documents security standards, a workflow blueprint, and a review checklist for future scheduled repo agents. The content is thorough and internally consistent.
- **Workflow self-improvement**: The agent is now allowed to edit `.github/workflows/model-price-audit.yml` itself, with the file added to the prompt's allowed surface, the tool allowlist, the diff allowlist, and the `workflowUpdates` structured output field.
- **Validation bugs**: The `max_turns` default was changed to `250` but the existing regex `^[1-9][0-9]?$` only accepts 1–99 — this will break every scheduled run. Separately, the `max_budget_usd` error message was updated to say "1 and 15" while the numeric guard still rejects values over 20.
</details>

<details><summary><h3>Confidence Score: 1/5</h3></summary>

The workflow will fail on every scheduled run due to the default value of 250 not matching its own validation regex — the agent will never be invoked until this is corrected.

The new default `max_turns` of `250` is a three-digit number that will never pass the `^[1-9][0-9]?$` regex guarding it, so every cron-triggered execution exits at the validation step before the agent runs. The `max_budget_usd` error message also diverges from the enforced upper bound.

`.github/workflows/model-price-audit.yml` — both the `max_turns` default/description/error-message cluster and the `max_budget_usd` error message need to be corrected before the workflow is functional on schedule.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/model-price-audit.yml:60-76
**Default value 250 fails its own regex — every scheduled run will break**

The regex `^[1-9][0-9]?$` matches only 1- or 2-digit integers (range 1–99). The new default of `250` is a 3-digit number and will never match, so the `! "$CLAUDE_MAX_TURNS" =~ ...` branch is always `true` and the validation step always exits 1. Every scheduled (non-`workflow_dispatch`) run will fail at this step before the agent is ever invoked.

The PR description says the intent was to raise the default to **20** and cap manual dispatch at **50** — both numbers are ≤ 2 digits and would pass the regex. The values `250`/`500` throughout this hunk look like accidental extra zeros (`20→250`, `50→500`). Three affected locations: line 60 (`default: '250'`), line 64 in the description (`1-500`), and line 74 in the error message (`between 1 and 500`).

### Issue 2 of 2
.github/workflows/model-price-audit.yml:78-79
The error message says "between 1 and 15" but the guard still enforces `-gt 20`, so a value of 16–20 will be rejected with a message that doesn't match what's actually being validated. Either raise the cap to match the message or lower it.

```suggestion
          if [[ ! "$CLAUDE_MAX_BUDGET_USD" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_BUDGET_USD" -gt 15 ]; then
            echo "::error::max_budget_usd must be a whole USD amount between 1 and 15"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into hassiebbot/repo..."](https://github.com/langfuse/langfuse/commit/57e6ce99a73f888ad83668f50c9d4f1d2fd0cf35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38656666)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->