### PR TITLE
fix(ci-model-price-audit): max turns check 

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -70,7 +70,7 @@ jobs:
               ;;
           esac
 
-          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 50 ]; then
+          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 500 ]; then
             echo "::error::max_turns must be a whole number between 1 and 500"
             exit 1
           fi


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the upper bound of the `CLAUDE_MAX_TURNS` validation from 50 to 500 to align with the workflow's documented input range ("1–500") and default of 250. However, the accompanying regex `^[1-9][0-9]?$` was not updated, leaving it capped at 1–99.

- The change correctly fixes the numeric ceiling check (`-gt 50` → `-gt 500`), but the regex still rejects any three-digit value, including the default `250`.
- On scheduled runs `max_turns` falls back to `'250'`, causing the \"Validate workflow inputs\" step to always exit with an error — so the weekly audit has been broken since the default was raised.
- The regex should be widened to `^[1-9][0-9]{0,2}$` (matching 1–999, constrained to ≤500 by the existing numeric check) to make the fix complete.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR fixes the numeric ceiling but leaves the regex broken, causing every scheduled run to fail at input validation before the Claude agent is invoked.

The only changed line corrects the `-gt 50` → `-gt 500` bound, but the regex `^[1-9][0-9]?$` that gates the same condition still accepts only 1–99. Because the workflow's default value is 250 and scheduled executions resolve to that default, the validation step exits with an error on every automated run.

.github/workflows/model-price-audit.yml — the regex on line 73 needs to be widened alongside the numeric-ceiling change.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow triggered\nscheduled or manual] --> B{github.event.inputs.max_turns\nprovided?}
    B -- yes --> C[Use provided value]
    B -- no --> D[Fallback: '250']
    C --> E[CLAUDE_MAX_TURNS set]
    D --> E
    E --> F{Regex check\n^1-9 0-9?$\nmatches?}
    F -- no, e.g. '250' has 3 digits --> G[exit 1 validation fails]
    F -- yes, only 1-99 passes --> H{Numeric check\ngt 500?}
    H -- yes --> G
    H -- no --> I[Validation passes]
    I --> J[Run Claude audit agent\n--max-turns 250]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Workflow triggered\nscheduled or manual] --> B{github.event.inputs.max_turns\nprovided?}
    B -- yes --> C[Use provided value]
    B -- no --> D[Fallback: '250']
    C --> E[CLAUDE_MAX_TURNS set]
    D --> E
    E --> F{Regex check\n^1-9 0-9?$\nmatches?}
    F -- no, e.g. '250' has 3 digits --> G[exit 1 validation fails]
    F -- yes, only 1-99 passes --> H{Numeric check\ngt 500?}
    H -- yes --> G
    H -- no --> I[Validation passes]
    I --> J[Run Claude audit agent\n--max-turns 250]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/model-price-audit.yml:73-75
**Regex only allows 1–99, default is 250**

The regex `^[1-9][0-9]?$` matches exactly one leading digit (1–9) plus an *optional* second digit (0–9), so it accepts values 1–99 only. The default `max_turns` value is `'250'` (line 19), and on scheduled runs `github.event.inputs.max_turns` is empty, so `CLAUDE_MAX_TURNS` resolves to `'250'`. Because `250` has three digits it fails the regex match, the `if` condition is true, and the step exits with an error — meaning the scheduled audit job has been broken since the default was raised to 250. The `-gt 500` fix corrects the numeric ceiling but the regex must also be widened to match three-digit values.

### Issue 2 of 2
.github/workflows/model-price-audit.yml:73-76
The regex needs to allow three-digit values so that the default `250` and any value in the 100–500 range passes validation.

```suggestion
          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]{0,2}$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 500 ]; then
            echo "::error::max_turns must be a whole number between 1 and 500"
            exit 1
          fi
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["push"](https://github.com/langfuse/langfuse/commit/91850438033b6aa9b2c41c7fcf6728a281c1c741) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38657204)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->