### PR TITLE
fix(ci-model-prices): max turns check

### DIFF
--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -70,7 +70,7 @@ jobs:
               ;;
           esac
 
-          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 500 ]; then
+          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9][0-9]?$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 500 ]; then
             echo "::error::max_turns must be a whole number between 1 and 500"
             exit 1
           fi

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -70,7 +70,7 @@ jobs:
               ;;
           esac
 
-          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 50 ]; then
+          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 500 ]; then
             echo "::error::max_turns must be a whole number between 1 and 500"
             exit 1
           fi


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR raises the `max_turns` ceiling for the model-price-audit Claude agent from 50 to 500 (with a default of 250) by updating the input validation regex and the upper-bound arithmetic check.

- The regex was changed from `^[1-9][0-9]?$` to `^[1-9][0-9][0-9]?$`, but the second `[0-9]` group is now required rather than optional, so single-digit values 1–9 fail validation even though the input description and error message both advertise a range of 1–500. The fix is `^[1-9][0-9]{0,2}$`.
- No other files are changed; the publish/PR-creation job and all security guardrails are untouched.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change introduces a validation gap: single-digit max_turns values (1-9) are now incorrectly rejected, contradicting the documented input range of 1-500.

The regex as written makes the middle digit mandatory, so any user who passes max_turns=1 through max_turns=9 will hit a validation error even though the workflow's own description and error message say those values are valid. This is a concrete, reproducible breakage on an explicit code path introduced by this PR.

.github/workflows/model-price-audit.yml — the Validate workflow inputs step needs the corrected regex.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Input: max_turns] --> B{Regex check}
    B -- No match --> E[Error: invalid input]
    B -- Match --> C{Value greater than 500?}
    C -- Yes --> E
    C -- No --> D[Valid: proceed with audit]
    A1[Values 1 to 9] -- Incorrectly rejected --> E
    A2[Values 10 to 500] --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Input: max_turns] --> B{Regex check}
    B -- No match --> E[Error: invalid input]
    B -- Match --> C{Value greater than 500?}
    C -- Yes --> E
    C -- No --> D[Valid: proceed with audit]
    A1[Values 1 to 9] -- Incorrectly rejected --> E
    A2[Values 10 to 500] --> B
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/model-price-audit.yml:73
The updated regex `^[1-9][0-9][0-9]?$` makes the second `[0-9]` group mandatory, so single-digit values 1–9 no longer match and are rejected with an error — even though the input description and error message both claim the valid range is 1–500. The correct fix is to keep the second group optional (0–2 trailing digits after the leading 1-9 digit).

```suggestion
          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]{0,2}$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 500 ]; then
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into fix-workflow"](https://github.com/langfuse/langfuse/commit/fd2d60b02bbaf8047acbf660219c65d56b79b33a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38657612)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->