### PR TITLE
fix(agents): add model price audit dry run

### DIFF
--- a/.agents/skills/create-repo-agent/references/review-checklist.md
+++ b/.agents/skills/create-repo-agent/references/review-checklist.md
@@ -88,6 +88,7 @@ Use this checklist before merging any repo-agent workflow, skill, or self-improv
 - The schedule is not too frequent for provider rate limits, model cost, or reviewer attention.
 - `timeout-minutes`, max turns, and max budget bound runaway loops.
 - Manual dispatch inputs are sufficient for safe debugging without making the agent arbitrary.
+- Manual dry-run mode can skip the model step and exercise no-change plus allowlisted mock-diff paths without publishing.
 - No-change runs are cheap and legible.
 - Failure modes leave enough summary context for maintainers without exposing secrets.
 

--- a/.agents/skills/create-repo-agent/references/workflow-blueprint.md
+++ b/.agents/skills/create-repo-agent/references/workflow-blueprint.md
@@ -7,6 +7,7 @@ Use this blueprint when implementing or changing a scheduled/manual repo agent i
 - `name`: explicit maintenance task name.
 - `on.schedule`: use a predictable low-noise cadence.
 - `on.workflow_dispatch.inputs`: keep inputs small and validate every input before interpolation into agent args.
+- Include a manual dry-run input for new agents. It should skip the model step, emit synthetic structured output, and optionally create a safe allowlisted mock diff so validation, artifact, and no-publish paths can be debugged without model spend.
 - `permissions`: default to `contents: read`.
 - `concurrency`: one stable group per agent, usually `cancel-in-progress: true`.
 - `env`: branch names and PR titles only; do not put secrets in top-level env.
@@ -21,6 +22,7 @@ The audit job is the only job that invokes the LLM agent.
 - Set up only the runtimes needed by deterministic validators.
 - Validate `workflow_dispatch` inputs before they are used in prompts or CLI args.
 - Run cheap deterministic pre-checks before invoking the model.
+- Generate any ignored local agent shims required by validators before running `--check` commands in a clean Actions checkout.
 - Pass only the model API key and read-only `${{ github.token }}` to the LLM action.
 - Set agent timeout and budget controls where supported, such as max turns, max budget, API timeout, and shell timeout.
 - Use `--no-session-persistence` unless session reuse is required and reviewed.
@@ -33,6 +35,7 @@ The audit job is the only job that invokes the LLM agent.
 - For freeform numeric inputs, validate with a regex and numeric range before using the value.
 - For string inputs that become CLI args, validate against an allowlist regex or choice set.
 - Do not interpolate unchecked manual inputs into shell commands, JSON, branch names, file paths, or LLM CLI arguments.
+- Dry-run inputs should be choices such as `off`, `no_changes`, and `mock_allowlisted_diff`. Dry runs must skip the LLM action and must not publish a PR.
 
 ## Agent Prompt Template
 
@@ -166,3 +169,16 @@ Do not use self-improvement for:
 - Adding OIDC or package-manager access.
 - Removing validators or allowlists.
 - Editing unrelated workflows or generated files.
+
+## Dry-Run Pattern
+
+Use dry-run mode to debug the workflow machinery around an agent without invoking the model:
+
+- Add a `workflow_dispatch` choice input with `off` as the default.
+- Validate the input before using it.
+- Guard the LLM action with `if: <dry-run-mode> == 'off'`.
+- Add a mock step for dry runs that writes the same structured output shape as the LLM action.
+- Provide a no-change mode to test clean exits.
+- Provide an allowlisted mock-diff mode to test diff validation, staging, commit, bundle creation, and artifact upload.
+- Skip the publish job for every dry-run mode, even when the mock diff produces a bundle.
+- Make dry-run summaries explicit so maintainers never confuse synthetic output with a real provider audit.

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -21,6 +21,15 @@ on:
         description: "Maximum Claude API spend for the audit (whole USD, 1-20)"
         required: false
         default: "15"
+      dry_run_mode:
+        description: "Debug mode: skip Claude and use synthetic output"
+        required: false
+        default: "off"
+        type: choice
+        options:
+          - off
+          - no_changes
+          - mock_workflow_diff
 
 permissions:
   contents: read
@@ -41,6 +50,7 @@ jobs:
     outputs:
       has_changes: ${{ steps.prepare.outputs.has_changes }}
       branch_name: ${{ steps.prepare.outputs.branch_name }}
+      dry_run_mode: ${{ steps.validate-inputs.outputs.dry_run_mode }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -55,10 +65,12 @@ jobs:
           package-manager-cache: false
 
       - name: Validate workflow inputs
+        id: validate-inputs
         env:
           CLAUDE_MODEL: ${{ github.event.inputs.claude_model || 'sonnet' }}
           CLAUDE_MAX_TURNS: ${{ github.event.inputs.max_turns || '250' }}
           CLAUDE_MAX_BUDGET_USD: ${{ github.event.inputs.max_budget_usd || '15' }}
+          AUDIT_DRY_RUN_MODE: ${{ github.event.inputs.dry_run_mode || 'off' }}
         run: |
           set -euo pipefail
 
@@ -70,19 +82,32 @@ jobs:
               ;;
           esac
 
-          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9][0-9]?$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 500 ]; then
+          if [[ ! "$CLAUDE_MAX_TURNS" =~ ^[1-9][0-9]{0,2}$ ]] || [ "$CLAUDE_MAX_TURNS" -gt 500 ]; then
             echo "::error::max_turns must be a whole number between 1 and 500"
             exit 1
           fi
 
           if [[ ! "$CLAUDE_MAX_BUDGET_USD" =~ ^[1-9][0-9]?$ ]] || [ "$CLAUDE_MAX_BUDGET_USD" -gt 20 ]; then
-            echo "::error::max_budget_usd must be a whole USD amount between 1 and 15"
+            echo "::error::max_budget_usd must be a whole USD amount between 1 and 20"
             exit 1
           fi
+
+          case "$AUDIT_DRY_RUN_MODE" in
+            off | no_changes | mock_workflow_diff) ;;
+            *)
+              echo "::error::dry_run_mode must be one of: off, no_changes, mock_workflow_diff"
+              exit 1
+              ;;
+          esac
+
+          echo "dry_run_mode=$AUDIT_DRY_RUN_MODE" >> "$GITHUB_OUTPUT"
 
       - name: Run pre-audit checks
         run: |
           set -euo pipefail
+
+          node scripts/agents/sync-agent-shims.mjs
+          node scripts/agents/sync-agent-shims.mjs --check
 
           node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs \
             > "$RUNNER_TEMP/pricing-validation-before.txt"
@@ -97,6 +122,7 @@ jobs:
 
       - name: Run Claude price audit
         id: claude-audit
+        if: steps.validate-inputs.outputs.dry_run_mode == 'off'
         uses: anthropics/claude-code-action@4d7e1f0cd85743fdc93b1c8040ab54395da024e2 # v1.0.149
         env:
           API_TIMEOUT_MS: "900000"
@@ -151,9 +177,56 @@ jobs:
             --allowedTools "Read(/.github/workflows/model-price-audit.yml),Read(/worker/src/constants/default-model-prices.json),Read(/packages/shared/src/server/llm/types.ts),Read(/.agents/skills/add-model-price/SKILL.md),Read(/.agents/skills/add-model-price/references/*.md),Edit(/.github/workflows/model-price-audit.yml),Edit(/worker/src/constants/default-model-prices.json),Edit(/packages/shared/src/server/llm/types.ts),Edit(/.agents/skills/add-model-price/references/*.md),Write(/.agents/skills/add-model-price/references/*.md),WebFetch(domain:platform.claude.com),WebFetch(domain:docs.anthropic.com),WebFetch(domain:openai.com),WebFetch(domain:ai.google.dev),WebFetch(domain:aws.amazon.com),WebFetch(domain:azure.microsoft.com),Bash(date -u +%Y-%m-%dT00:00:00.000Z),Bash(node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs),Bash(node .agents/skills/add-model-price/scripts/test-match-pattern.mjs:*)"
             --json-schema '{"type":"object","additionalProperties":false,"properties":{"summary":{"type":"string"},"changedModels":{"type":"array","items":{"type":"string"}},"skillReferenceUpdates":{"type":"array","items":{"type":"string"}},"workflowUpdates":{"type":"array","items":{"type":"string"}},"unresolvedFindings":{"type":"array","items":{"type":"string"}},"validation":{"type":"array","items":{"type":"string"}}},"required":["summary","changedModels","skillReferenceUpdates","workflowUpdates","unresolvedFindings","validation"]}'
 
-      - name: Write Claude audit summary
+      - name: Mock Claude price audit
+        id: mock-claude-audit
+        if: steps.validate-inputs.outputs.dry_run_mode != 'off'
         env:
-          STRUCTURED_OUTPUT: ${{ steps.claude-audit.outputs.structured_output }}
+          DRY_RUN_MODE: ${{ steps.validate-inputs.outputs.dry_run_mode }}
+        run: |
+          set -euo pipefail
+
+          if [ "$DRY_RUN_MODE" = "mock_workflow_diff" ]; then
+            {
+              echo
+              echo "# Dry-run mock diff generated by workflow_dispatch; publish job is skipped."
+            } >> .github/workflows/model-price-audit.yml
+          fi
+
+          node <<'NODE' > "$RUNNER_TEMP/claude-model-price-audit-mock.json"
+          const mode = process.env.DRY_RUN_MODE;
+          const output = {
+            summary:
+              mode === "mock_workflow_diff"
+                ? "Dry run: skipped Claude and created a mock workflow diff to exercise validation, commit, bundle, and artifact upload steps."
+                : "Dry run: skipped Claude and created no repository diff to exercise the no-change path.",
+            changedModels: [],
+            skillReferenceUpdates: [],
+            workflowUpdates:
+              mode === "mock_workflow_diff"
+                ? [
+                    ".github/workflows/model-price-audit.yml - appended a dry-run-only comment so downstream diff handling can be debugged without spending Claude budget.",
+                  ]
+                : [],
+            unresolvedFindings: [],
+            validation: [
+              "dry_run_mode=" + mode,
+              "Claude action was skipped; downstream workflow steps used synthetic structured output.",
+            ],
+          };
+
+          process.stdout.write(JSON.stringify(output));
+          NODE
+
+          {
+            echo "structured_output<<JSON"
+            cat "$RUNNER_TEMP/claude-model-price-audit-mock.json"
+            echo
+            echo "JSON"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write audit summary
+        env:
+          STRUCTURED_OUTPUT: ${{ steps.claude-audit.outputs.structured_output || steps.mock-claude-audit.outputs.structured_output }}
         run: |
           set -euo pipefail
 
@@ -190,7 +263,7 @@ jobs:
           NODE
 
           {
-            echo "## Claude audit summary"
+            echo "## Model price audit summary"
             echo
             cat "$RUNNER_TEMP/claude-model-price-audit.txt"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -247,6 +320,8 @@ jobs:
 
       - name: Prepare pull request artifact
         id: prepare
+        env:
+          DRY_RUN_MODE: ${{ steps.validate-inputs.outputs.dry_run_mode }}
         run: |
           set -euo pipefail
 
@@ -321,6 +396,12 @@ jobs:
           {
             echo "Automated default model price audit."
             echo
+            if [ "$DRY_RUN_MODE" != "off" ]; then
+              echo "**Dry run mode:** \`$DRY_RUN_MODE\`"
+              echo
+              echo "This artifact was generated to debug post-agent workflow steps. The publish job is skipped for dry runs."
+              echo
+            fi
             echo "## Scope"
             echo
             echo "- Audits default model pricing data with official provider evidence."
@@ -360,7 +441,7 @@ jobs:
 
   publish:
     needs: audit
-    if: needs.audit.outputs.has_changes == 'true'
+    if: needs.audit.outputs.has_changes == 'true' && needs.audit.outputs.dry_run_mode == 'off'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

- Fix the current model price audit failure by generating ignored local agent shims before running `sync-agent-shims.mjs --check` in a clean Actions checkout.
- Add `dry_run_mode` to manual dispatch so maintainers can skip Claude and use synthetic structured output.
- Support `no_changes` and `mock_workflow_diff`; mock diffs exercise validation, staging, bundle, and artifact upload, while publish is skipped for dry runs.
- Fix `max_turns` validation so the advertised `1-500` range accepts one- and two-digit values.
- Document dry-run expectations in the `create-repo-agent` workflow blueprint/checklist.

## Validation

- `./node_modules/.bin/prettier --check .github/workflows/model-price-audit.yml .agents/skills/create-repo-agent/references/workflow-blueprint.md .agents/skills/create-repo-agent/references/review-checklist.md`
- `python3 .agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/create-repo-agent`
- `node scripts/agents/sync-agent-shims.mjs && node scripts/agents/sync-agent-shims.mjs --check`
- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
- Ruby YAML parse plus embedded `bash -n` checks for `.github/workflows/model-price-audit.yml`
- `uvx zizmor .github/workflows/model-price-audit.yml`
- `git diff --check`
- Actions dry run `mock_workflow_diff`: https://github.com/langfuse/langfuse/actions/runs/27830510431
- Actions dry run `no_changes`: https://github.com/langfuse/langfuse/actions/runs/27830553824

Note: local macOS Bash is too old to execute the workflow’s `mapfile` runtime path exactly, so the runtime path was verified in GitHub Actions.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a model price audit CI failure by ensuring agent shims are generated before `sync-agent-shims.mjs --check` runs in a clean Actions checkout, and adds a `dry_run_mode` dispatch input so maintainers can exercise the full post-agent workflow machinery without invoking Claude or publishing a PR.

- **Shim ordering fix**: `node scripts/agents/sync-agent-shims.mjs` (generate) is now called before `node scripts/agents/sync-agent-shims.mjs --check` in the pre-audit step, resolving the CI failure caused by missing shims in a fresh checkout.
- **Dry-run mode**: A new `dry_run_mode` choice input (`off` / `no_changes` / `mock_workflow_diff`) is validated via an allowlist `case` statement, guards the Claude action with `if: ... == 'off'`, provides a mutually exclusive mock step that writes the same structured-output shape, and hard-blocks the `publish` job for any non-`off` mode.
- **Error message fix**: Corrects the `max_budget_usd` validation error from "1 and 15" to "1 and 20" to match the actual enforcement limit.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The dry-run guard is enforced at both the step level (if condition) and the job level (publish condition), so synthetic output cannot accidentally trigger a real PR push.

The changes are focused and mechanically correct. Shim generation is added before the check, the dry_run_mode allowlist is validated before the output is set, the two agent steps are mutually exclusive, STRUCTURED_OUTPUT fallback works because skipped step outputs are empty strings (falsy in GHA expressions), and the publish block is enforced at the job if level rather than relying on step-level logic alone.

No files require special attention. The workflow file is the most complex change but all new paths have been accounted for.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger: schedule / workflow_dispatch] --> B[validate-inputs\nvalidates model, turns, budget, dry_run_mode\noutputs: dry_run_mode]
    B --> C[Run pre-audit checks\n1. sync-agent-shims.mjs - generate shims first\n2. sync-agent-shims.mjs --check\n3. validate-pricing-file.mjs]
    C --> D{dry_run_mode == 'off'?}
    D -- yes --> E[Run Claude price audit\nclaude-audit step]
    D -- no --> F[Mock Claude price audit\nmock-claude-audit step\nif mock_workflow_diff: append comment to YML]
    E --> G[Write audit summary\nSTRUCTURED_OUTPUT = claude OR mock output]
    F --> G
    G --> H[Validate audit diff\nallowlist check, diff size 700 lines]
    H --> I[Prepare pull request artifact\nstage, commit, bundle]
    I --> J{has_changes == 'true'?}
    J -- no --> K[End: no artifact]
    J -- yes --> L[Upload artifact]
    L --> M{publish job:\nhas_changes == 'true' AND\ndry_run_mode == 'off'?}
    M -- yes --> N[Push branch and create PR]
    M -- no --> O[End: artifact uploaded, PR skipped]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Trigger: schedule / workflow_dispatch] --> B[validate-inputs\nvalidates model, turns, budget, dry_run_mode\noutputs: dry_run_mode]
    B --> C[Run pre-audit checks\n1. sync-agent-shims.mjs - generate shims first\n2. sync-agent-shims.mjs --check\n3. validate-pricing-file.mjs]
    C --> D{dry_run_mode == 'off'?}
    D -- yes --> E[Run Claude price audit\nclaude-audit step]
    D -- no --> F[Mock Claude price audit\nmock-claude-audit step\nif mock_workflow_diff: append comment to YML]
    E --> G[Write audit summary\nSTRUCTURED_OUTPUT = claude OR mock output]
    F --> G
    G --> H[Validate audit diff\nallowlist check, diff size 700 lines]
    H --> I[Prepare pull request artifact\nstage, commit, bundle]
    I --> J{has_changes == 'true'?}
    J -- no --> K[End: no artifact]
    J -- yes --> L[Upload artifact]
    L --> M{publish job:\nhas_changes == 'true' AND\ndry_run_mode == 'off'?}
    M -- yes --> N[Push branch and create PR]
    M -- no --> O[End: artifact uploaded, PR skipped]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agents): add model price audit dry r..."](https://github.com/langfuse/langfuse/commit/54ad20c55885880f2f189922d4a9d633055670da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38659945)</sub>

<!-- /greptile_comment -->