### PR TITLE
fix(agents): avoid boolean dry-run choice

### DIFF
--- a/.agents/skills/create-repo-agent/references/review-checklist.md
+++ b/.agents/skills/create-repo-agent/references/review-checklist.md
@@ -12,6 +12,7 @@ Use this checklist before merging any repo-agent workflow, skill, or self-improv
 - The publish path can push files not covered by the allowlist.
 - Self-improvement can edit security boundaries without path allowlists, invariant prompts, and human PR review.
 - Manual inputs are interpolated before validation.
+- `workflow_dispatch` choice values use YAML boolean-like tokens such as `off`, `on`, `yes`, `no`, `true`, or `false`.
 - The agent can change generated files, dependency locks, package manager config, CI trust settings, or secrets without an explicit task and dedicated review.
 
 ## Scope And Objective

--- a/.agents/skills/create-repo-agent/references/workflow-blueprint.md
+++ b/.agents/skills/create-repo-agent/references/workflow-blueprint.md
@@ -35,7 +35,7 @@ The audit job is the only job that invokes the LLM agent.
 - For freeform numeric inputs, validate with a regex and numeric range before using the value.
 - For string inputs that become CLI args, validate against an allowlist regex or choice set.
 - Do not interpolate unchecked manual inputs into shell commands, JSON, branch names, file paths, or LLM CLI arguments.
-- Dry-run inputs should be choices such as `off`, `no_changes`, and `mock_allowlisted_diff`. Dry runs must skip the LLM action and must not publish a PR.
+- Dry-run inputs should use YAML-safe choice values such as `disabled`, `no_changes`, and `mock_allowlisted_diff`. Avoid boolean-like YAML tokens such as `off`, `on`, `yes`, `no`, `true`, and `false`; GitHub may parse or render them as booleans. Dry runs must skip the LLM action and must not publish a PR.
 
 ## Agent Prompt Template
 
@@ -174,7 +174,7 @@ Do not use self-improvement for:
 
 Use dry-run mode to debug the workflow machinery around an agent without invoking the model:
 
-- Add a `workflow_dispatch` choice input with `off` as the default.
+- Add a `workflow_dispatch` choice input with a YAML-safe disabled value as the default.
 - Validate the input before using it.
 - Guard the LLM action with `if: <dry-run-mode> == 'off'`.
 - Add a mock step for dry runs that writes the same structured output shape as the LLM action.

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -2,7 +2,10 @@ name: Default Model Price Audit
 
 on:
   schedule:
-    - cron: "17 5 * * 1"
+    # Tuesday and Friday evening in San Francisco.
+    # 02:17 UTC is 19:17 PDT and 18:17 PST.
+    - cron: "17 2 * * 3"
+    - cron: "17 2 * * 6"
   workflow_dispatch:
     inputs:
       claude_model:
@@ -24,10 +27,10 @@ on:
       dry_run_mode:
         description: "Debug mode: skip Claude and use synthetic output"
         required: false
-        default: "off"
+        default: "disabled"
         type: choice
         options:
-          - off
+          - disabled
           - no_changes
           - mock_workflow_diff
 
@@ -70,7 +73,7 @@ jobs:
           CLAUDE_MODEL: ${{ github.event.inputs.claude_model || 'sonnet' }}
           CLAUDE_MAX_TURNS: ${{ github.event.inputs.max_turns || '250' }}
           CLAUDE_MAX_BUDGET_USD: ${{ github.event.inputs.max_budget_usd || '15' }}
-          AUDIT_DRY_RUN_MODE: ${{ github.event.inputs.dry_run_mode || 'off' }}
+          AUDIT_DRY_RUN_MODE: ${{ github.event.inputs.dry_run_mode || 'disabled' }}
         run: |
           set -euo pipefail
 
@@ -93,9 +96,12 @@ jobs:
           fi
 
           case "$AUDIT_DRY_RUN_MODE" in
-            off | no_changes | mock_workflow_diff) ;;
+            disabled | no_changes | mock_workflow_diff) ;;
+            false)
+              AUDIT_DRY_RUN_MODE="disabled"
+              ;;
             *)
-              echo "::error::dry_run_mode must be one of: off, no_changes, mock_workflow_diff"
+              echo "::error::dry_run_mode must be one of: disabled, no_changes, mock_workflow_diff"
               exit 1
               ;;
           esac
@@ -122,7 +128,7 @@ jobs:
 
       - name: Run Claude price audit
         id: claude-audit
-        if: steps.validate-inputs.outputs.dry_run_mode == 'off'
+        if: steps.validate-inputs.outputs.dry_run_mode == 'disabled'
         uses: anthropics/claude-code-action@4d7e1f0cd85743fdc93b1c8040ab54395da024e2 # v1.0.149
         env:
           API_TIMEOUT_MS: "900000"
@@ -179,7 +185,7 @@ jobs:
 
       - name: Mock Claude price audit
         id: mock-claude-audit
-        if: steps.validate-inputs.outputs.dry_run_mode != 'off'
+        if: steps.validate-inputs.outputs.dry_run_mode != 'disabled'
         env:
           DRY_RUN_MODE: ${{ steps.validate-inputs.outputs.dry_run_mode }}
         run: |
@@ -396,7 +402,7 @@ jobs:
           {
             echo "Automated default model price audit."
             echo
-            if [ "$DRY_RUN_MODE" != "off" ]; then
+            if [ "$DRY_RUN_MODE" != "disabled" ]; then
               echo "**Dry run mode:** \`$DRY_RUN_MODE\`"
               echo
               echo "This artifact was generated to debug post-agent workflow steps. The publish job is skipped for dry runs."
@@ -441,7 +447,7 @@ jobs:
 
   publish:
     needs: audit
-    if: needs.audit.outputs.has_changes == 'true' && needs.audit.outputs.dry_run_mode == 'off'
+    if: needs.audit.outputs.has_changes == 'true' && needs.audit.outputs.dry_run_mode == 'disabled'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

- Replace the `dry_run_mode` normal value from `off` to `disabled` so GitHub does not parse/render it as YAML boolean `false`.
- Accept legacy `false` as an alias for `disabled` in validation to avoid stale UI/manual dispatch failures.
- Change the model price audit cron to run Tuesday and Friday evening in San Francisco: Wednesday/Saturday `02:17 UTC`, which is `19:17 PDT` and `18:17 PST`.
- Update `create-repo-agent` docs/checklist to avoid boolean-like `workflow_dispatch` choice values.

## Root Cause

Run https://github.com/langfuse/langfuse/actions/runs/27830663465/job/82366335414 failed because the workflow option `- off` was rendered by GitHub as `false`, but validation only accepted `off`, `no_changes`, and `mock_workflow_diff`.

## Validation

- `./node_modules/.bin/prettier --check .github/workflows/model-price-audit.yml .agents/skills/create-repo-agent/references/workflow-blueprint.md .agents/skills/create-repo-agent/references/review-checklist.md`
- `python3 .agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/create-repo-agent`
- `node scripts/agents/sync-agent-shims.mjs && node scripts/agents/sync-agent-shims.mjs --check`
- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
- Ruby YAML parse plus embedded `bash -n` checks for `.github/workflows/model-price-audit.yml`
- `bash -c` validation that legacy `false` normalizes to `disabled`
- `uvx zizmor .github/workflows/model-price-audit.yml`
- `git diff --check`
- Actions dry run `mock_workflow_diff`: https://github.com/langfuse/langfuse/actions/runs/27831041110