### PR TITLE
fix(agents): use patch artifact for model price audit

### DIFF
--- a/.agents/skills/create-repo-agent/SKILL.md
+++ b/.agents/skills/create-repo-agent/SKILL.md
@@ -7,7 +7,7 @@ description: Use when designing, implementing, reviewing, or hardening Langfuse 
 
 ## Purpose
 
-Build repo agents that can run unattended without granting the model broad write credentials, arbitrary shell, or uncontrolled network access. The default architecture is a read-only audit job that produces a validated bundle plus a separate publisher job that owns GitHub writes.
+Build repo agents that can run unattended without granting the model broad write credentials, arbitrary shell, or uncontrolled network access. The default architecture is a read-only audit job that produces a validated patch artifact plus a separate publisher job that owns GitHub writes.
 
 Use this skill together with the domain skill for the files the agent will maintain. For example, a pricing agent must also use `add-model-price`.
 

--- a/.agents/skills/create-repo-agent/references/review-checklist.md
+++ b/.agents/skills/create-repo-agent/references/review-checklist.md
@@ -62,14 +62,15 @@ Use this checklist before merging any repo-agent workflow, skill, or self-improv
 - Staged blobs are compared to worktree files after `git add`.
 - Staged machine-readable files are validated from `git show ":path"`.
 - `git diff --cached --check` runs before commit.
-- Validators run again after the local commit or bundle step.
+- Validators run again after the local commit and before patch artifact creation.
 
 ## Publish Path
 
 - The publish job runs only after validated changes.
 - The publish job does not invoke the LLM.
 - Git hooks are disabled for bot commit paths.
-- The publish job imports a validated bundle or equivalent artifact, not a mutable workspace with unvalidated files.
+- The publish job applies a validated patch artifact to the triggering base commit, not a mutable workspace with unvalidated files.
+- The publish job re-checks the applied commit's changed files against the same path allowlist before pushing.
 - The bot branch is force-pushed intentionally and only to the expected repo.
 - Existing PRs are updated instead of creating duplicates.
 - Reviewer requests are non-fatal.
@@ -89,7 +90,7 @@ Use this checklist before merging any repo-agent workflow, skill, or self-improv
 - The schedule is not too frequent for provider rate limits, model cost, or reviewer attention.
 - `timeout-minutes`, max turns, and max budget bound runaway loops.
 - Manual dispatch inputs are sufficient for safe debugging without making the agent arbitrary.
-- Manual dry-run mode can skip the model step and exercise no-change plus allowlisted mock-diff paths without publishing.
+- Manual dry-run mode can skip the model step and exercise no-change plus allowlisted mock-diff patch paths without publishing.
 - No-change runs are cheap and legible.
 - Failure modes leave enough summary context for maintainers without exposing secrets.
 

--- a/.agents/skills/create-repo-agent/references/security-standards.md
+++ b/.agents/skills/create-repo-agent/references/security-standards.md
@@ -72,10 +72,11 @@ Independent diff validation must run after the agent and before publishing:
 
 Use a two-phase architecture for agents that create PRs:
 
-- Phase 1: audit job. It checks out code with `persist-credentials: false`, runs the LLM with read-only permissions, validates the diff, commits locally with hooks disabled, and uploads a git bundle plus PR body artifact.
-- Phase 2: publish job. It downloads the bundle, imports it into a clean temporary repo, pushes the bot branch with a write-scoped bot secret, and creates or updates the PR.
+- Phase 1: audit job. It checks out code with `persist-credentials: false`, runs the LLM with read-only permissions, validates the diff, commits locally with hooks disabled, and uploads a `git format-patch --binary` artifact plus PR body artifact.
+- Phase 2: publish job. It downloads the patch, applies it to the triggering base commit in a clean temporary repo, pushes the bot branch with a write-scoped bot secret, and creates or updates the PR.
 - The publish job must not invoke the LLM.
 - The publish job should clear global/system git config where practical and disable hooks for any commit or push-adjacent git operation.
+- The publish job should re-check the applied commit's changed files against the same path allowlist before pushing.
 - Reviewer assignment should be non-fatal so a missing reviewer permission does not fail an otherwise valid maintenance PR.
 
 ## Self-Improvement
@@ -93,7 +94,7 @@ Self-improvement is allowed only when the workflow explicitly opts in.
 
 - Prefer summarized agent reports over full transcripts.
 - Do not upload full stdout/stderr if it may contain environment data or secrets.
-- Upload only the artifacts needed for publishing or review, such as a git bundle and PR body.
+- Upload only the artifacts needed for publishing or review, such as a patch file and PR body.
 - Set short artifact retention for bot handoff artifacts.
 - Summaries should include changed files, changed business objects, source URLs, unresolved findings, validation commands, and self-improvements.
 

--- a/.agents/skills/create-repo-agent/references/security-standards.md
+++ b/.agents/skills/create-repo-agent/references/security-standards.md
@@ -72,8 +72,8 @@ Independent diff validation must run after the agent and before publishing:
 
 Use a two-phase architecture for agents that create PRs:
 
-- Phase 1: audit job. It checks out code with `persist-credentials: false`, runs the LLM with read-only permissions, validates the diff, commits locally with hooks disabled, and uploads a `git format-patch --binary` artifact plus PR body artifact.
-- Phase 2: publish job. It downloads the patch, applies it to the triggering base commit in a clean temporary repo, pushes the bot branch with a write-scoped bot secret, and creates or updates the PR.
+- Phase 1: audit job. It checks out code with `persist-credentials: false`, runs the LLM with read-only permissions, validates the diff, commits locally with hooks disabled, and uploads a `git format-patch` artifact plus PR body artifact.
+- Phase 2: publish job. It downloads the patch, fetches enough source-ref history to find the triggering commit, applies the patch to that exact commit in a clean temporary repo, pushes the bot branch with a write-scoped bot secret, and creates or updates the PR.
 - The publish job must not invoke the LLM.
 - The publish job should clear global/system git config where practical and disable hooks for any commit or push-adjacent git operation.
 - The publish job should re-check the applied commit's changed files against the same path allowlist before pushing.

--- a/.agents/skills/create-repo-agent/references/workflow-blueprint.md
+++ b/.agents/skills/create-repo-agent/references/workflow-blueprint.md
@@ -126,7 +126,7 @@ Prepare the PR artifact inside the audit job only after diff validation:
 - Run `git diff --cached --check`.
 - Commit with `git -c core.hooksPath=/dev/null commit --no-verify`.
 - Re-run validators.
-- Create a patch with `git format-patch --binary -1 --stdout HEAD`.
+- Create a patch with `git format-patch -1 --stdout HEAD`; use `--binary` only when the allowlist intentionally permits binary files.
 - Verify the patch file exists and is not empty.
 - Create a PR body artifact with scope, validation, diff stat, and agent summary.
 
@@ -136,7 +136,7 @@ The publish job owns GitHub writes:
 
 - It runs only when the audit job reports changes.
 - It downloads the patch and PR body artifact.
-- It fetches the triggering base commit into a clean temporary repository.
+- It fetches sufficient source-ref history into a clean temporary repository and checks out the triggering commit SHA exactly.
 - It applies the patch with `git am --3way`.
 - It re-checks the applied commit's changed files against the same path allowlist and runs `git diff --check HEAD^ HEAD`.
 - It pushes the bot branch with `GH_ACCESS_TOKEN` or another reviewed bot secret.

--- a/.agents/skills/create-repo-agent/references/workflow-blueprint.md
+++ b/.agents/skills/create-repo-agent/references/workflow-blueprint.md
@@ -7,7 +7,7 @@ Use this blueprint when implementing or changing a scheduled/manual repo agent i
 - `name`: explicit maintenance task name.
 - `on.schedule`: use a predictable low-noise cadence.
 - `on.workflow_dispatch.inputs`: keep inputs small and validate every input before interpolation into agent args.
-- Include a manual dry-run input for new agents. It should skip the model step, emit synthetic structured output, and optionally create a safe allowlisted mock diff so validation, artifact, and no-publish paths can be debugged without model spend.
+- Include a manual dry-run input for new agents. It should skip the model step, emit synthetic structured output, and optionally create a safe allowlisted mock diff so validation, patch artifact, and no-publish paths can be debugged without model spend.
 - `permissions`: default to `contents: read`.
 - `concurrency`: one stable group per agent, usually `cancel-in-progress: true`.
 - `env`: branch names and PR titles only; do not put secrets in top-level env.
@@ -109,7 +109,7 @@ Then:
 - Compute a changed-line count and reject oversized diffs.
 - Write a diff stat to the job summary.
 
-## Commit And Bundle Preparation
+## Commit And Patch Preparation
 
 Prepare the PR artifact inside the audit job only after diff validation:
 
@@ -126,7 +126,8 @@ Prepare the PR artifact inside the audit job only after diff validation:
 - Run `git diff --cached --check`.
 - Commit with `git -c core.hooksPath=/dev/null commit --no-verify`.
 - Re-run validators.
-- Create a git bundle for the bot branch.
+- Create a patch with `git format-patch --binary -1 --stdout HEAD`.
+- Verify the patch file exists and is not empty.
 - Create a PR body artifact with scope, validation, diff stat, and agent summary.
 
 ## Publish Job
@@ -134,8 +135,10 @@ Prepare the PR artifact inside the audit job only after diff validation:
 The publish job owns GitHub writes:
 
 - It runs only when the audit job reports changes.
-- It downloads the bundle and PR body artifact.
-- It imports the bundle into a clean temporary repository.
+- It downloads the patch and PR body artifact.
+- It fetches the triggering base commit into a clean temporary repository.
+- It applies the patch with `git am --3way`.
+- It re-checks the applied commit's changed files against the same path allowlist and runs `git diff --check HEAD^ HEAD`.
 - It pushes the bot branch with `GH_ACCESS_TOKEN` or another reviewed bot secret.
 - It creates or updates a PR against `main`.
 - It requests reviewers non-fatally with `|| true`.
@@ -176,9 +179,9 @@ Use dry-run mode to debug the workflow machinery around an agent without invokin
 
 - Add a `workflow_dispatch` choice input with a YAML-safe disabled value as the default.
 - Validate the input before using it.
-- Guard the LLM action with `if: <dry-run-mode> == 'off'`.
+- Guard the LLM action with an explicit disabled-mode check, for example `if: <dry-run-mode> == 'disabled'`.
 - Add a mock step for dry runs that writes the same structured output shape as the LLM action.
 - Provide a no-change mode to test clean exits.
-- Provide an allowlisted mock-diff mode to test diff validation, staging, commit, bundle creation, and artifact upload.
-- Skip the publish job for every dry-run mode, even when the mock diff produces a bundle.
+- Provide an allowlisted mock-diff mode to test diff validation, staging, commit, patch creation, and artifact upload.
+- Skip the publish job for every dry-run mode, even when the mock diff produces a patch artifact.
 - Make dry-run summaries explicit so maintainers never confuse synthetic output with a real provider audit.

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -203,7 +203,7 @@ jobs:
           const output = {
             summary:
               mode === "mock_workflow_diff"
-                ? "Dry run: skipped Claude and created a mock workflow diff to exercise validation, commit, bundle, and artifact upload steps."
+                ? "Dry run: skipped Claude and created a mock workflow diff to exercise validation, commit, patch, and artifact upload steps."
                 : "Dry run: skipped Claude and created no repository diff to exercise the no-change path.",
             changedModels: [],
             skillReferenceUpdates: [],
@@ -397,7 +397,8 @@ jobs:
           git -c core.hooksPath=/dev/null commit --no-verify -m "$PR_TITLE"
           node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs
           node scripts/agents/sync-agent-shims.mjs --check
-          git bundle create "$RUNNER_TEMP/model-price-audit.bundle" "$BOT_BRANCH"
+          git format-patch --binary -1 --stdout HEAD > "$RUNNER_TEMP/model-price-audit.patch"
+          test -s "$RUNNER_TEMP/model-price-audit.patch"
 
           {
             echo "Automated default model price audit."
@@ -419,6 +420,7 @@ jobs:
             echo "- \`node scripts/agents/sync-agent-shims.mjs --check\`"
             echo "- \`git diff --check\`"
             echo "- staged pricing blob validation"
+            echo "- patch artifact generated with \`git format-patch --binary -1\`"
             echo
             echo "## Diff Stat"
             echo
@@ -440,7 +442,7 @@ jobs:
         with:
           name: model-price-audit-pr
           path: |
-            ${{ runner.temp }}/model-price-audit.bundle
+            ${{ runner.temp }}/model-price-audit.patch
             ${{ runner.temp }}/model-price-audit-pr-body.md
           if-no-files-found: error
           retention-days: 1
@@ -466,13 +468,37 @@ jobs:
 
           GIT_BIN="$(command -v git)"
           GH_BIN="$(command -v gh)"
-          BUNDLE_PATH="$RUNNER_TEMP/model-price-audit-pr/model-price-audit.bundle"
+          PATCH_PATH="$RUNNER_TEMP/model-price-audit-pr/model-price-audit.patch"
           BODY_PATH="$RUNNER_TEMP/model-price-audit-pr/model-price-audit-pr-body.md"
           PUSH_REPO="$RUNNER_TEMP/push-model-price-audit"
+          SOURCE_REPO_URL="https://github.com/${GITHUB_REPOSITORY}.git"
 
           mkdir -p "$PUSH_REPO"
           "$GIT_BIN" -C "$PUSH_REPO" init -q
-          "$GIT_BIN" -C "$PUSH_REPO" fetch --no-tags "$BUNDLE_PATH" "$BRANCH_NAME:refs/heads/$BRANCH_NAME"
+          "$GIT_BIN" -C "$PUSH_REPO" fetch --no-tags --depth=1 "$SOURCE_REPO_URL" "$GITHUB_REF"
+          fetched_sha="$("$GIT_BIN" -C "$PUSH_REPO" rev-parse FETCH_HEAD)"
+          if [ "$fetched_sha" != "$GITHUB_SHA" ]; then
+            echo "::error::Fetched $GITHUB_REF at $fetched_sha, expected triggering SHA $GITHUB_SHA"
+            exit 1
+          fi
+          "$GIT_BIN" -C "$PUSH_REPO" checkout -q -b "$BRANCH_NAME" FETCH_HEAD
+          "$GIT_BIN" -C "$PUSH_REPO" config user.name "langfuse-bot"
+          "$GIT_BIN" -C "$PUSH_REPO" config user.email "langfuse-bot@langfuse.com"
+          GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \
+            -C "$PUSH_REPO" \
+            -c core.hooksPath=/dev/null \
+            am --3way "$PATCH_PATH"
+
+          allowed_file_regex='^(\.github/workflows/model-price-audit\.yml|worker/src/constants/default-model-prices\.json|packages/shared/src/server/llm/types\.ts|\.agents/skills/add-model-price/references/[^/]+\.md)$'
+          mapfile -t applied_files < <("$GIT_BIN" -C "$PUSH_REPO" diff-tree --no-commit-id --name-only -r HEAD | sort -u)
+          for applied_file in "${applied_files[@]}"; do
+            if [[ ! "$applied_file" =~ $allowed_file_regex ]]; then
+              echo "::error::Refusing to push a patch that changes a file outside the allowed pricing surface: $applied_file"
+              exit 1
+            fi
+          done
+
+          "$GIT_BIN" -C "$PUSH_REPO" diff --check HEAD^ HEAD
 
           GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \
             -C "$PUSH_REPO" \

--- a/.github/workflows/model-price-audit.yml
+++ b/.github/workflows/model-price-audit.yml
@@ -397,7 +397,7 @@ jobs:
           git -c core.hooksPath=/dev/null commit --no-verify -m "$PR_TITLE"
           node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs
           node scripts/agents/sync-agent-shims.mjs --check
-          git format-patch --binary -1 --stdout HEAD > "$RUNNER_TEMP/model-price-audit.patch"
+          git format-patch -1 --stdout HEAD > "$RUNNER_TEMP/model-price-audit.patch"
           test -s "$RUNNER_TEMP/model-price-audit.patch"
 
           {
@@ -420,7 +420,7 @@ jobs:
             echo "- \`node scripts/agents/sync-agent-shims.mjs --check\`"
             echo "- \`git diff --check\`"
             echo "- staged pricing blob validation"
-            echo "- patch artifact generated with \`git format-patch --binary -1\`"
+            echo "- patch artifact generated with \`git format-patch -1\`"
             echo
             echo "## Diff Stat"
             echo
@@ -475,13 +475,12 @@ jobs:
 
           mkdir -p "$PUSH_REPO"
           "$GIT_BIN" -C "$PUSH_REPO" init -q
-          "$GIT_BIN" -C "$PUSH_REPO" fetch --no-tags --depth=1 "$SOURCE_REPO_URL" "$GITHUB_REF"
-          fetched_sha="$("$GIT_BIN" -C "$PUSH_REPO" rev-parse FETCH_HEAD)"
-          if [ "$fetched_sha" != "$GITHUB_SHA" ]; then
-            echo "::error::Fetched $GITHUB_REF at $fetched_sha, expected triggering SHA $GITHUB_SHA"
+          "$GIT_BIN" -C "$PUSH_REPO" fetch --no-tags --depth=100 "$SOURCE_REPO_URL" "$GITHUB_REF"
+          if ! "$GIT_BIN" -C "$PUSH_REPO" cat-file -e "$GITHUB_SHA^{commit}"; then
+            echo "::error::Triggering commit $GITHUB_SHA was not found in the fetched $GITHUB_REF history"
             exit 1
           fi
-          "$GIT_BIN" -C "$PUSH_REPO" checkout -q -b "$BRANCH_NAME" FETCH_HEAD
+          "$GIT_BIN" -C "$PUSH_REPO" checkout -q -b "$BRANCH_NAME" "$GITHUB_SHA"
           "$GIT_BIN" -C "$PUSH_REPO" config user.name "langfuse-bot"
           "$GIT_BIN" -C "$PUSH_REPO" config user.email "langfuse-bot@langfuse.com"
           GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null "$GIT_BIN" \


### PR DESCRIPTION
## Summary

- Replace the model price audit handoff artifact from a full `git bundle` to a `git format-patch --binary -1` patch plus PR body.
- Update the publish job to fetch the triggering ref, verify it matches `GITHUB_SHA`, apply the patch with `git am --3way`, re-check the applied commit path allowlist, and push the bot branch.
- Update the `create-repo-agent` skill standards to document patch artifacts as the default handoff for repo agents.

## Why

The previous artifact contained `model-price-audit.bundle`, which bundled all Git objects reachable from the bot branch. A tiny 3-file pricing update produced a 55 MB artifact. The patch approach keeps surgical updates in the KB range.

## Validation

- `./node_modules/.bin/prettier --check .github/workflows/model-price-audit.yml .agents/skills/create-repo-agent/SKILL.md .agents/skills/create-repo-agent/references/security-standards.md .agents/skills/create-repo-agent/references/workflow-blueprint.md .agents/skills/create-repo-agent/references/review-checklist.md`
- `python3 .agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/create-repo-agent`
- `node scripts/agents/sync-agent-shims.mjs && node scripts/agents/sync-agent-shims.mjs --check`
- `node .agents/skills/add-model-price/scripts/validate-pricing-file.mjs`
- Ruby YAML parse plus embedded `bash -n` checks for `.github/workflows/model-price-audit.yml`
- `uvx zizmor .github/workflows/model-price-audit.yml`
- `git diff --check`
- Actions dry run `mock_workflow_diff`: https://github.com/langfuse/langfuse/actions/runs/27834603549
- Dry-run artifact size: 1,433 bytes
- Local publish-step simulation: downloaded the dry-run patch artifact, fetched the branch ref, verified the fetched SHA, applied with `git am --3way`, checked changed files, and ran `git diff --check HEAD^ HEAD`