### PR TITLE
fix(score-analytics): keep numeric histogram buckets within real data range

### DIFF
--- a/web/src/__tests__/server/score-comparison-analytics.servertest.ts
+++ b/web/src/__tests__/server/score-comparison-analytics.servertest.ts
@@ -285,6 +285,99 @@ describe("Score Comparison Analytics tRPC", () => {
       ).toBeGreaterThanOrEqual(0);
       expect(result.samplingMetadata.actualSampleSize).toBe(1); // Matches matchedCount
       expect(result.samplingMetadata.samplingExpression).toBeNull();
+
+      // Bounds are derived from the actual data and stay within the data range
+      expect(result.bounds).not.toBeNull();
+      expect(result.bounds?.globalMin).toBe(0.8);
+      expect(result.bounds?.globalMax).toBe(0.9);
+    });
+
+    // Regression test for #13331: when comparing two numeric scores that share
+    // no attachment points, there are no matched pairs and the heatmap is empty.
+    // The bounds row must still be returned so the frontend can label histogram
+    // buckets with the real data range instead of estimating it from mean ± std
+    // (which produced an out-of-range x-axis, e.g. -0.08 to 1.70 for [0, 1] data).
+    it("should return data bounds even when there are no matched pairs", async () => {
+      const now = new Date();
+      const fromTimestamp = new Date(now.getTime() - 3600000);
+      const toTimestamp = new Date(now.getTime() + 3600000);
+
+      const scoreName1 = `test-bounds-score1-${v4()}`;
+      const scoreName2 = `test-bounds-score2-${v4()}`;
+
+      // Two numeric scores bounded to [0, 1], each on its own set of traces so
+      // they never match. score1 spans 0.2..0.9, score2 spans 0.1..1.0.
+      const scores = [
+        createTraceScore({
+          project_id: projectId,
+          trace_id: v4(),
+          observation_id: null,
+          name: scoreName1,
+          source: "ANNOTATION",
+          data_type: "NUMERIC",
+          value: 0.2,
+          timestamp: now.getTime(),
+        }),
+        createTraceScore({
+          project_id: projectId,
+          trace_id: v4(),
+          observation_id: null,
+          name: scoreName1,
+          source: "ANNOTATION",
+          data_type: "NUMERIC",
+          value: 0.9,
+          timestamp: now.getTime(),
+        }),
+        createTraceScore({
+          project_id: projectId,
+          trace_id: v4(),
+          observation_id: null,
+          name: scoreName2,
+          source: "ANNOTATION",
+          data_type: "NUMERIC",
+          value: 0.1,
+          timestamp: now.getTime(),
+        }),
+        createTraceScore({
+          project_id: projectId,
+          trace_id: v4(),
+          observation_id: null,
+          name: scoreName2,
+          source: "ANNOTATION",
+          data_type: "NUMERIC",
+          value: 1.0,
+          timestamp: now.getTime(),
+        }),
+      ];
+
+      await createScoresCh(scores);
+
+      const result = await getScoreComparisonAnalyticsWithPreflight({
+        projectId,
+        score1: { name: scoreName1, dataType: "NUMERIC", source: "ANNOTATION" },
+        score2: { name: scoreName2, dataType: "NUMERIC", source: "ANNOTATION" },
+        fromTimestamp,
+        toTimestamp,
+        interval: { count: 1, unit: "day" },
+        nBins: 10,
+      });
+
+      // No shared attachment points -> no matched pairs, empty heatmap.
+      expect(result.counts.matchedCount).toBe(0);
+      expect(result.heatmap).toEqual([]);
+
+      // Bounds are still available and reflect the real per-score data ranges.
+      expect(result.bounds).not.toBeNull();
+      expect(result.bounds?.min1).toBe(0.2);
+      expect(result.bounds?.max1).toBe(0.9);
+      expect(result.bounds?.min2).toBe(0.1);
+      expect(result.bounds?.max2).toBe(1.0);
+      expect(result.bounds?.globalMin).toBe(0.1);
+      expect(result.bounds?.globalMax).toBe(1.0);
+
+      // Crucially, the global range never overshoots the real [0, 1] data range.
+      expect(result.bounds?.globalMin).toBeGreaterThanOrEqual(0);
+      expect(result.bounds?.globalMax).toBeLessThanOrEqual(1);
     });
 
     // Test 2: Returns empty results when no scores exist

--- a/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.clienttest.tsx
+++ b/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.clienttest.tsx
@@ -43,6 +43,23 @@ function ScoreAnalyticsProbe({
   );
 }
 
+function NumericScoreAnalyticsProbe() {
+  const result = useScoreAnalyticsQuery({
+    projectId: "project-test",
+    score1: { name: "accuracy-a", dataType: "NUMERIC", source: "API" },
+    score2: { name: "accuracy-b", dataType: "NUMERIC", source: "API" },
+    fromTimestamp: new Date("2026-02-01T00:00:00.000Z"),
+    toTimestamp: new Date("2026-02-02T00:00:00.000Z"),
+    interval: { count: 1, unit: "day" },
+  });
+
+  return (
+    <div data-testid="bin-labels">
+      {JSON.stringify(result.data?.distribution?.binLabelsGlobal ?? null)}
+    </div>
+  );
+}
+
 describe("useScoreAnalyticsQuery", () => {
   afterEach(() => {
     mockedUseQuery.mockReset();
@@ -179,5 +196,90 @@ describe("useScoreAnalyticsQuery", () => {
 
     expect(distribution.score1).toEqual(distribution.score2);
     expect(distribution.score2Categories).toEqual(["False", "True"]);
+  });
+
+  it("keeps numeric bin labels within the real data bounds when there are no matched pairs", () => {
+    // Regression test for #13331: when comparing two numeric scores that share
+    // no attachment points (matchedCount = 0), the heatmap is empty. The bin
+    // labels must be derived from the actual data bounds returned by the
+    // backend, NOT estimated from mean ± 3·std (which produced an x-axis of
+    // roughly -0.08 to 1.70 for scores bounded to [0, 1]).
+    mockedUseQuery.mockReturnValue({
+      data: {
+        counts: { score1Total: 20, score2Total: 20, matchedCount: 0 },
+        // No matched pairs -> heatmap is empty, so the fallback path runs.
+        heatmap: [],
+        confusionMatrix: [],
+        statistics: {
+          matchedCount: 0,
+          mean1: 0.81,
+          mean2: 0.79,
+          std1: 0.29,
+          std2: 0.29,
+          pearsonCorrelation: null,
+          mae: null,
+          rmse: null,
+          spearmanCorrelation: null,
+        },
+        // Real data bounds, always available even without matched pairs.
+        bounds: {
+          globalMin: 0,
+          globalMax: 1,
+          min1: 0,
+          max1: 1,
+          min2: 0,
+          max2: 1,
+        },
+        timeSeries: [],
+        distribution1: [{ binIndex: 0, count: 10 }],
+        distribution2: [{ binIndex: 9, count: 10 }],
+        stackedDistribution: [],
+        stackedDistributionMatched: [],
+        score2Categories: [],
+        timeSeriesMatched: [],
+        distribution1Matched: [],
+        distribution2Matched: [],
+        distribution1Individual: [{ binIndex: 0, count: 10 }],
+        distribution2Individual: [{ binIndex: 9, count: 10 }],
+        timeSeriesCategorical1: [],
+        timeSeriesCategorical2: [],
+        timeSeriesCategorical1Matched: [],
+        timeSeriesCategorical2Matched: [],
+        samplingMetadata: {
+          isSampled: false,
+          samplingMethod: "none",
+          samplingRate: 1,
+          estimatedTotalMatches: 0,
+          actualSampleSize: 0,
+          samplingExpression: null,
+        },
+        metadata: {
+          mode: "two",
+          isSameScore: false,
+          dataType: "NUMERIC",
+        },
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<NumericScoreAnalyticsProbe />);
+    const binLabels: string[] | null = JSON.parse(
+      screen.getByTestId("bin-labels").textContent ?? "null",
+    );
+
+    expect(binLabels).not.toBeNull();
+    expect(binLabels).toHaveLength(10);
+
+    // Parse every numeric edge out of the labels (e.g. "0.90 - 1.00").
+    const edges = (binLabels ?? []).flatMap((label) =>
+      label.split(" - ").map((part) => Number.parseFloat(part)),
+    );
+
+    // Buckets must stay inside the real [0, 1] data range, never overshoot into
+    // the -0.08..1.70 range produced by the mean ± 3·std estimate.
+    expect(Math.min(...edges)).toBeCloseTo(0, 5);
+    expect(Math.max(...edges)).toBeCloseTo(1, 5);
+    expect(edges.every((edge) => edge >= -1e-9 && edge <= 1 + 1e-9)).toBe(true);
   });
 });

--- a/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts
+++ b/web/src/features/score-analytics/hooks/useScoreAnalyticsQuery.ts
@@ -418,8 +418,39 @@ export function useScoreAnalyticsQuery(
           nBins,
         });
       }
-      // Fallback: Calculate bounds from statistics when heatmap is empty
-      // This handles the case when matchedCount = 0 (no paired observations)
+      // Preferred fallback: use the real data bounds returned by the backend.
+      // These are computed across all filtered scores (not just matched pairs),
+      // so they are available even when matchedCount = 0 and the heatmap is
+      // empty. Using them keeps the histogram x-axis aligned with the actual
+      // bins (which are also computed from these bounds) and within the real
+      // data range, instead of overshooting via the mean ± std estimate below.
+      else if (
+        apiData.bounds &&
+        apiData.bounds.globalMin !== null &&
+        apiData.bounds.globalMax !== null
+      ) {
+        const globalMin = apiData.bounds.globalMin;
+        const globalMax = apiData.bounds.globalMax;
+        // Individual score may have no numeric data of its own; fall back to the
+        // global range so labels stay defined and consistent.
+        binLabelsIndividual1 = generateBinLabels({
+          min: apiData.bounds.min1 ?? globalMin,
+          max: apiData.bounds.max1 ?? globalMax,
+          nBins,
+        });
+        binLabelsIndividual2 = generateBinLabels({
+          min: apiData.bounds.min2 ?? globalMin,
+          max: apiData.bounds.max2 ?? globalMax,
+          nBins,
+        });
+        binLabelsGlobal = generateBinLabels({
+          min: globalMin,
+          max: globalMax,
+          nBins,
+        });
+      }
+      // Last-resort fallback: estimate bounds from statistics when neither the
+      // heatmap nor the data bounds are available (e.g. no numeric data at all).
       else if (
         apiData.statistics &&
         apiData.statistics.mean1 !== null &&

--- a/web/src/features/score-analytics/server/buildScoreComparisonQuery.ts
+++ b/web/src/features/score-analytics/server/buildScoreComparisonQuery.ts
@@ -684,6 +684,27 @@ export function buildScoreComparisonQuery(params: {
 
     UNION ALL
 
+    -- Bounds row: always emitted (even when there are no matched pairs and the
+    -- heatmap is empty) so the frontend can label numeric histogram buckets with
+    -- the real data range instead of estimating it from mean ± std.
+    SELECT
+      'bounds' as result_type,
+      CAST(global_min AS Nullable(Float64)) as col1,
+      CAST(global_max AS Nullable(Float64)) as col2,
+      CAST(min1 AS Nullable(Float64)) as col3,
+      CAST(max1 AS Nullable(Float64)) as col4,
+      CAST(min2 AS Nullable(Float64)) as col5,
+      CAST(max2 AS Nullable(Float64)) as col6,
+      CAST(NULL AS Nullable(Float64)) as col7,
+      CAST(NULL AS Nullable(Float64)) as col8,
+      CAST(NULL AS Nullable(String)) as col9,
+      CAST(NULL AS Nullable(String)) as col10,
+      CAST(NULL AS Nullable(Float64)) as col11,
+      CAST(NULL AS Nullable(Float64)) as col12
+    FROM bounds
+
+    UNION ALL
+
     SELECT
       'heatmap' as result_type,
       CAST(bin_x AS Float64) as col1,

--- a/web/src/features/score-analytics/server/scoreAnalyticsRouter.ts
+++ b/web/src/features/score-analytics/server/scoreAnalyticsRouter.ts
@@ -369,6 +369,7 @@ export const scoreAnalyticsRouter = createTRPCRouter({
 
       // Parse results by result_type
       const countsRow = results.find((r) => r.result_type === "counts");
+      const boundsRow = results.find((r) => r.result_type === "bounds");
       const heatmapRows = results.filter((r) => r.result_type === "heatmap");
       const confusionRows = results.filter(
         (r) => r.result_type === "confusion",
@@ -425,6 +426,19 @@ export const scoreAnalyticsRouter = createTRPCRouter({
           score2Total: countsRow?.col2 ?? 0,
           matchedCount: countsRow?.col3 ?? 0,
         },
+        // Real data bounds for numeric scores, computed across all filtered
+        // scores (not just matched pairs). Available even when matchedCount = 0,
+        // unlike the heatmap which only carries bounds for matched data.
+        bounds: boundsRow
+          ? {
+              globalMin: boundsRow.col1,
+              globalMax: boundsRow.col2,
+              min1: boundsRow.col3,
+              max1: boundsRow.col4,
+              min2: boundsRow.col5,
+              max2: boundsRow.col6,
+            }
+          : null,
         heatmap: heatmapRows.map((row) => ({
           binX: row.col1 ?? 0,
           binY: row.col2 ?? 0,


### PR DESCRIPTION
## Summary

Fixes #13331.

In **Scores → Analytics**, when comparing two numeric scores, the distribution chart x-axis could show buckets outside the valid range of the data. For example, two accuracy evals bounded to `[0, 1]` rendered an x-axis from roughly **-0.08 to 1.70**.

## Root cause

The histogram bins themselves are computed correctly by the backend, using the `bounds` CTE (real per-score and global `min`/`max` across **all** filtered scores). However, those bounds were only surfaced to the frontend through the **heatmap** result rows.

The heatmap is built from `matched_scores`, so when the two compared scores share no attachment point (trace/observation/session/run), there are **no matched pairs** and the heatmap is empty. In that case the frontend fell back to estimating the bin labels from `mean ± 3·std`:

- score1: `0.81 ± 3·0.29` → `-0.06 … 1.68`
- score2: `0.79 ± 3·0.29` → `-0.08 … 1.66`
- global: `-0.08 … 1.70` ← exactly the reported x-axis

So the bars were placed using the real global bounds, but the **axis was labelled** with the mean ± std estimate — both out of range and inconsistent with the actual binning.

## Fix

1. **`buildScoreComparisonQuery.ts`** — emit the existing `bounds` CTE as its own result row, so the real `globalMin/globalMax/min1/max1/min2/max2` are always available (even when `matchedCount = 0`).
2. **`scoreAnalyticsRouter.ts`** — expose `bounds` on the analytics output.
3. **`useScoreAnalyticsQuery.ts`** — generate numeric bin labels from these real data bounds. The `mean ± std` estimate is kept only as a last resort when no bounds are available at all.

This keeps the x-axis aligned with the actual bins and within the real data range, matching the already-correct single-score view. It does not change the working matched-pairs path (heatmap bounds are unchanged).

## Notes / scope

This fix clamps the axis to the **actual data range**, which is what the single-score view already does and what resolves the reported bug. Clamping further to a score's *configured* `min`/`max` (from the score config) would be a separate, larger enhancement and is intentionally out of scope here.

## Testing

- **New client regression test** (`useScoreAnalyticsQuery.clienttest.tsx`): reproduces the no-matched-pairs scenario and asserts the bin labels stay within `[0, 1]`. Verified it **fails before** the fix (produces `-0.08`) and **passes after**.
- **New server integration test** (`score-comparison-analytics.servertest.ts`): two numeric scores on disjoint traces → `matchedCount = 0`, empty heatmap, and `bounds` still returned with the correct per-score/global ranges.
- `pnpm --filter web run typecheck`: clean.
- ESLint + Prettier: clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in the Scores → Analytics comparison view where the histogram x-axis could display buckets outside the real data range (e.g., `-0.08 to 1.70` for scores bounded to `[0, 1]`). The root cause was that the frontend fell back to estimating bin label bounds via `mean ± 3·std` whenever the heatmap was empty (which happens when the two compared scores share no attachment points).

- **`buildScoreComparisonQuery.ts`**: Adds a new `'bounds'` result row to the UNION ALL so the real `globalMin/globalMax/min1/max1/min2/max2` (from the existing `bounds` CTE that drives all binning) are always returned, even when `matchedCount = 0`.
- **`scoreAnalyticsRouter.ts`**: Parses the new row and exposes a `bounds` field on the API response.
- **`useScoreAnalyticsQuery.ts`**: Inserts a new fallback tier that uses these real data bounds before falling back to the `mean ± std` estimate, keeping the x-axis aligned with the actual bins.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is additive (a new UNION ALL row that was always computed but never surfaced) and is guarded by null checks at every layer.

The change is minimal and well-scoped: the bounds CTE already existed and drove all histogram binning; the PR just exposes it as a dedicated result row so the frontend can consume it directly. The three-tier fallback logic in the hook (heatmap → bounds → mean±std) is correct and each tier is independently null-guarded. Both a server integration test and a client unit regression test are included that verify the exact bug scenario (no matched pairs) and pass after the fix.

No files require special attention. All changed files are straightforward and well-tested.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant FE as Frontend (useScoreAnalyticsQuery)
    participant Router as scoreAnalyticsRouter
    participant CH as ClickHouse

    FE->>Router: getScoreComparisonAnalytics(score1, score2, ...)
    Router->>CH: UNION ALL query (counts, bounds, heatmap, stats, distributions, ...)
    CH-->>Router: result rows (result_type per row)

    note over Router: boundsRow = results.find(r => r.result_type === 'bounds')<br/>Always present — even when matchedCount = 0

    Router-->>FE: "{ counts, bounds: {globalMin, globalMax, min1, max1, min2, max2}, heatmap, ... }"

    alt heatmap has rows (matched pairs exist)
        FE->>FE: binLabels from heatmap[0] min/max/globalMin/globalMax
    else bounds returned and globalMin/Max non-null (NEW)
        FE->>FE: binLabels from bounds.min1/max1, bounds.min2/max2, bounds.globalMin/globalMax
    else last resort
        FE->>FE: binLabels from mean ± 3·std estimate
    end

    FE->>FE: render histogram with correct x-axis range
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant FE as Frontend (useScoreAnalyticsQuery)
    participant Router as scoreAnalyticsRouter
    participant CH as ClickHouse

    FE->>Router: getScoreComparisonAnalytics(score1, score2, ...)
    Router->>CH: UNION ALL query (counts, bounds, heatmap, stats, distributions, ...)
    CH-->>Router: result rows (result_type per row)

    note over Router: boundsRow = results.find(r => r.result_type === 'bounds')<br/>Always present — even when matchedCount = 0

    Router-->>FE: "{ counts, bounds: {globalMin, globalMax, min1, max1, min2, max2}, heatmap, ... }"

    alt heatmap has rows (matched pairs exist)
        FE->>FE: binLabels from heatmap[0] min/max/globalMin/globalMax
    else bounds returned and globalMin/Max non-null (NEW)
        FE->>FE: binLabels from bounds.min1/max1, bounds.min2/max2, bounds.globalMin/globalMax
    else last resort
        FE->>FE: binLabels from mean ± 3·std estimate
    end

    FE->>FE: render histogram with correct x-axis range
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(score-analytics): keep numeric histo..."](https://github.com/langfuse/langfuse/commit/fbf2348c4f9e95761202c2c3c97a3b912007c585) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38780079)</sub>

<!-- /greptile_comment -->