### PR TITLE
feat(worker): instrument gzip cost + tunable level for blob export (LFE-10402)

### DIFF
--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
@@ -4,32 +4,32 @@ import { resolveBlobExportTuning } from "./blob-export-tuning";
 describe("resolveBlobExportTuning", () => {
   it("defaults to rawPassthrough=false for null/undefined", () => {
     expect(resolveBlobExportTuning(null)).toEqual({
-      resolved: { rawPassthrough: false },
+      resolved: { rawPassthrough: false, gzipLevel: undefined },
       warnings: [],
     });
     expect(resolveBlobExportTuning(undefined)).toEqual({
-      resolved: { rawPassthrough: false },
+      resolved: { rawPassthrough: false, gzipLevel: undefined },
       warnings: [],
     });
   });
 
   it("honors rawPassthrough=true", () => {
     expect(resolveBlobExportTuning({ rawPassthrough: true })).toEqual({
-      resolved: { rawPassthrough: true },
+      resolved: { rawPassthrough: true, gzipLevel: undefined },
       warnings: [],
     });
   });
 
   it("honors rawPassthrough=false explicitly", () => {
     expect(resolveBlobExportTuning({ rawPassthrough: false })).toEqual({
-      resolved: { rawPassthrough: false },
+      resolved: { rawPassthrough: false, gzipLevel: undefined },
       warnings: [],
     });
   });
 
   it("defaults rawPassthrough when the key is absent from a valid object", () => {
     expect(resolveBlobExportTuning({})).toEqual({
-      resolved: { rawPassthrough: false },
+      resolved: { rawPassthrough: false, gzipLevel: undefined },
       warnings: [],
     });
   });
@@ -41,20 +41,67 @@ describe("resolveBlobExportTuning", () => {
       maxConcurrentParts: 8,
       skipEnrichment: true,
     });
-    expect(result.resolved).toEqual({ rawPassthrough: true });
+    expect(result.resolved).toEqual({
+      rawPassthrough: true,
+      gzipLevel: undefined,
+    });
     expect(result.warnings).toEqual([]);
   });
 
   it("falls back to defaults and warns on a wrong-typed rawPassthrough", () => {
     const result = resolveBlobExportTuning({ rawPassthrough: "yes" });
-    expect(result.resolved).toEqual({ rawPassthrough: false });
+    expect(result.resolved).toEqual({
+      rawPassthrough: false,
+      gzipLevel: undefined,
+    });
     expect(result.warnings.length).toBe(1);
   });
 
   it("falls back to defaults and warns on a non-object column", () => {
     const result = resolveBlobExportTuning("garbage");
-    expect(result.resolved).toEqual({ rawPassthrough: false });
+    expect(result.resolved).toEqual({
+      rawPassthrough: false,
+      gzipLevel: undefined,
+    });
     expect(result.warnings.length).toBe(1);
+  });
+
+  it("honors a valid gzipLevel and keeps rawPassthrough independent", () => {
+    expect(
+      resolveBlobExportTuning({ rawPassthrough: true, gzipLevel: 1 }),
+    ).toEqual({
+      resolved: { rawPassthrough: true, gzipLevel: 1 },
+      warnings: [],
+    });
+    // level 0 (store) is valid
+    expect(resolveBlobExportTuning({ gzipLevel: 0 })).toEqual({
+      resolved: { rawPassthrough: false, gzipLevel: 0 },
+      warnings: [],
+    });
+    expect(resolveBlobExportTuning({ gzipLevel: 9 })).toEqual({
+      resolved: { rawPassthrough: false, gzipLevel: 9 },
+      warnings: [],
+    });
+  });
+
+  it("clamps an out-of-range gzipLevel to default without disabling rawPassthrough", () => {
+    const tooHigh = resolveBlobExportTuning({
+      rawPassthrough: true,
+      gzipLevel: 12,
+    });
+    expect(tooHigh.resolved).toEqual({
+      rawPassthrough: true,
+      gzipLevel: undefined,
+    });
+    expect(tooHigh.warnings.length).toBe(1);
+
+    const negative = resolveBlobExportTuning({ gzipLevel: -1 });
+    expect(negative.resolved.gzipLevel).toBeUndefined();
+    expect(negative.warnings.length).toBe(1);
+
+    const fractional = resolveBlobExportTuning({ gzipLevel: 3.5 });
+    expect(fractional.resolved.gzipLevel).toBeUndefined();
+    expect(fractional.warnings.length).toBe(1);
   });
 
   it("never throws", () => {

--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
@@ -32,12 +32,20 @@ export const BlobExportTuningSchema = z.object({
   // >= RAW_PASSTHROUGH_MIN_CLICKHOUSE_VERSION (see above) for mid-stream failure
   // detection. Do not enable on older self-hosted ClickHouse.
   rawPassthrough: z.boolean().optional(),
+  // LFE-10402 gzip tuning: zlib deflate level for compressed exports. Lower
+  // levels trade output size for markedly less worker CPU (the gzip step is the
+  // dominant remaining cost on large passthrough exports). Only honored when the
+  // integration has compression enabled. zlib accepts 0 (store, no compression)
+  // through 9 (max); absent / out-of-range falls back to the zlib default (6).
+  gzipLevel: z.number().optional(),
 });
 
 export type BlobExportTuning = z.infer<typeof BlobExportTuningSchema>;
 
 export type ResolvedBlobExportTuning = {
   rawPassthrough: boolean;
+  // undefined => use the zlib default (6); a concrete 0-9 otherwise.
+  gzipLevel: number | undefined;
 };
 
 /**
@@ -50,7 +58,10 @@ export function resolveBlobExportTuning(raw: unknown): {
   resolved: ResolvedBlobExportTuning;
   warnings: string[];
 } {
-  const defaults: ResolvedBlobExportTuning = { rawPassthrough: false };
+  const defaults: ResolvedBlobExportTuning = {
+    rawPassthrough: false,
+    gzipLevel: undefined,
+  };
 
   if (raw === null || raw === undefined) {
     return { resolved: defaults, warnings: [] };
@@ -66,8 +77,28 @@ export function resolveBlobExportTuning(raw: unknown): {
     };
   }
 
+  const warnings: string[] = [];
+
+  // Clamp-to-default rather than fail: a bad gzipLevel must not also disable a
+  // valid rawPassthrough. An out-of-range / non-integer level is dropped (zlib
+  // default applies) with a warning the caller logs.
+  let gzipLevel: number | undefined;
+  const rawLevel = parsed.data.gzipLevel;
+  if (rawLevel !== undefined) {
+    if (Number.isInteger(rawLevel) && rawLevel >= 0 && rawLevel <= 9) {
+      gzipLevel = rawLevel;
+    } else {
+      warnings.push(
+        `Ignoring out-of-range gzipLevel ${rawLevel} (expected integer 0-9), using zlib default`,
+      );
+    }
+  }
+
   return {
-    resolved: { rawPassthrough: parsed.data.rawPassthrough ?? false },
-    warnings: [],
+    resolved: {
+      rawPassthrough: parsed.data.rawPassthrough ?? false,
+      gzipLevel,
+    },
+    warnings,
   };
 }

--- a/worker/src/features/blobstorage/gzipStream.test.ts
+++ b/worker/src/features/blobstorage/gzipStream.test.ts
@@ -36,8 +36,9 @@ describe("TimedGzip", () => {
     const { output, stats } = await runGzip(Readable.from([input]), 6);
 
     expect(gunzipSync(output).equals(input)).toBe(true);
-    // Real compression work was attributed to the gzip step.
-    expect(stats.activeMs).toBeGreaterThanOrEqual(0);
+    // Real compression work was attributed to the gzip step: zlib offloads each
+    // write to the libuv threadpool, so the write->callback delta is always > 0.
+    expect(stats.activeMs).toBeGreaterThan(0);
     // It actually compressed (input is highly repetitive).
     expect(output.length).toBeLessThan(input.length);
   });
@@ -50,7 +51,7 @@ describe("TimedGzip", () => {
     const { output, stats } = await runGzip(Readable.from(chunks), 1);
 
     expect(gunzipSync(output).equals(expected)).toBe(true);
-    expect(stats.activeMs).toBeGreaterThanOrEqual(0);
+    expect(stats.activeMs).toBeGreaterThan(0);
   });
 
   it("level 0 stores without shrinking but still wraps in valid gzip", async () => {

--- a/worker/src/features/blobstorage/gzipStream.test.ts
+++ b/worker/src/features/blobstorage/gzipStream.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { pipeline, Readable, Writable } from "stream";
+import { promisify } from "util";
+import { gunzipSync } from "zlib";
+import { TimedGzip, type GzipStats } from "./gzipStream";
+
+const pipelineAsync = promisify(pipeline);
+
+const collect = (chunks: Buffer[]): Writable =>
+  new Writable({
+    write(chunk: Buffer, _enc, cb) {
+      chunks.push(Buffer.from(chunk));
+      cb();
+    },
+  });
+
+// Drives `source` through TimedGzip, collects the compressed output, and
+// returns the concatenated gzip buffer alongside the populated stats.
+async function runGzip(
+  source: Readable,
+  level: number | undefined,
+): Promise<{ output: Buffer; stats: GzipStats }> {
+  const stats: GzipStats = { level: level ?? 6, activeMs: 0 };
+  const chunks: Buffer[] = [];
+  await pipelineAsync(source, new TimedGzip(level, stats), collect(chunks));
+  return { output: Buffer.concat(chunks), stats };
+}
+
+describe("TimedGzip", () => {
+  it("produces a valid gzip stream that round-trips back to the input", async () => {
+    const input = Buffer.from(
+      Array.from({ length: 5000 }, (_, i) => `{"row":${i},"v":"x".}\n`).join(
+        "",
+      ),
+    );
+    const { output, stats } = await runGzip(Readable.from([input]), 6);
+
+    expect(gunzipSync(output).equals(input)).toBe(true);
+    // Real compression work was attributed to the gzip step.
+    expect(stats.activeMs).toBeGreaterThanOrEqual(0);
+    // It actually compressed (input is highly repetitive).
+    expect(output.length).toBeLessThan(input.length);
+  });
+
+  it("round-trips multi-chunk input and accumulates active time across chunks", async () => {
+    const chunks = Array.from({ length: 50 }, (_, i) =>
+      Buffer.from(`chunk-${i}-`.repeat(2000)),
+    );
+    const expected = Buffer.concat(chunks);
+    const { output, stats } = await runGzip(Readable.from(chunks), 1);
+
+    expect(gunzipSync(output).equals(expected)).toBe(true);
+    expect(stats.activeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("level 0 stores without shrinking but still wraps in valid gzip", async () => {
+    // Near-random data: level 0 must not expand it the way a real codec would
+    // try to, and must still gunzip cleanly.
+    const input = Buffer.from("abcdefghij".repeat(1000));
+    const { output } = await runGzip(Readable.from([input]), 0);
+    expect(gunzipSync(output).equals(input)).toBe(true);
+  });
+
+  it("higher level yields a smaller (or equal) output than level 1", async () => {
+    const input = Buffer.from(
+      Array.from(
+        { length: 8000 },
+        (_, i) => `{"id":${i},"name":"item-${i % 50}"}`,
+      ).join("\n"),
+    );
+    const fast = await runGzip(Readable.from([input]), 1);
+    const best = await runGzip(Readable.from([input]), 9);
+    expect(best.output.length).toBeLessThanOrEqual(fast.output.length);
+    // Both still decompress to the original.
+    expect(gunzipSync(fast.output).equals(input)).toBe(true);
+    expect(gunzipSync(best.output).equals(input)).toBe(true);
+  });
+
+  it("propagates upstream errors so the pipeline aborts", async () => {
+    const boom = new Error("upstream failed");
+    const source = new Readable({
+      read() {
+        this.destroy(boom);
+      },
+    });
+    const stats: GzipStats = { level: 6, activeMs: 0 };
+    await expect(
+      pipelineAsync(source, new TimedGzip(6, stats), collect([])),
+    ).rejects.toThrow("upstream failed");
+  });
+
+  it("uses the zlib default when level is undefined", async () => {
+    const input = Buffer.from("default-level-".repeat(3000));
+    const { output } = await runGzip(Readable.from([input]), undefined);
+    expect(gunzipSync(output).equals(input)).toBe(true);
+  });
+});

--- a/worker/src/features/blobstorage/gzipStream.ts
+++ b/worker/src/features/blobstorage/gzipStream.ts
@@ -14,7 +14,7 @@ export type GzipStats = {
   activeMs: number;
 };
 
-// zlib's default compression level (Z_DEFAULT_COMPRESSION === 6). Surfaced
+// zlib resolves Z_DEFAULT_COMPRESSION (-1) to compression level 6. Surfaced
 // explicitly so the gauge reports the real level even when none is configured.
 export const ZLIB_DEFAULT_LEVEL = 6;
 

--- a/worker/src/features/blobstorage/gzipStream.ts
+++ b/worker/src/features/blobstorage/gzipStream.ts
@@ -1,0 +1,81 @@
+import { Transform } from "stream";
+import { createGzip, type Gzip } from "zlib";
+
+export type GzipStats = {
+  // zlib level actually used (the resolved tuning level, or the zlib default
+  // when none was configured). Recorded so a measurement can be tied to a level.
+  level: number;
+  // Active compression time, summed per input chunk as the latency from handing
+  // the chunk to zlib until zlib reports it consumed (zlib offloads to the libuv
+  // threadpool). This isolates compression work from the idle gaps spent waiting
+  // on the next ClickHouse row; under sustained downstream backpressure it also
+  // absorbs upload-wait, which is itself a useful "gzip is not the bottleneck"
+  // signal. Use together with input/output bytes to derive throughput + ratio.
+  activeMs: number;
+};
+
+// zlib's default compression level (Z_DEFAULT_COMPRESSION === 6). Surfaced
+// explicitly so the gauge reports the real level even when none is configured.
+export const ZLIB_DEFAULT_LEVEL = 6;
+
+/**
+ * Streaming gzip wrapper that attributes compression cost to the gzip step
+ * alone (LFE-10402). It owns a zlib gzip instance, times each chunk's
+ * write→consumed latency into `stats.activeMs`, and forwards the compressed
+ * output while honouring backpressure (pauses the inner stream when the
+ * readable side fills, resumes on the next `_read`). Errors from the inner gzip
+ * surface through the wrapper so `pipeline` aborts the upload as before.
+ */
+export class TimedGzip extends Transform {
+  private readonly gzip: Gzip;
+
+  constructor(
+    level: number | undefined,
+    private readonly stats: GzipStats,
+  ) {
+    super();
+    this.gzip = level === undefined ? createGzip() : createGzip({ level });
+    this.gzip.on("data", (chunk: Buffer) => {
+      if (!this.push(chunk)) this.gzip.pause();
+    });
+    this.gzip.on("error", (err: Error) => this.destroy(err));
+  }
+
+  _read() {
+    this.gzip.resume();
+  }
+
+  _transform(
+    chunk: Buffer,
+    _encoding: string,
+    callback: (error?: Error | null) => void,
+  ) {
+    const startedAt = performance.now();
+    this.gzip.write(chunk, (err) => {
+      this.stats.activeMs += performance.now() - startedAt;
+      callback(err);
+    });
+  }
+
+  _flush(callback: (error?: Error | null) => void) {
+    const startedAt = performance.now();
+    // Complete the flush only once the inner gzip has emitted every byte (its
+    // readable `end`), so the final block + gzip trailer are pushed downstream
+    // before this Transform ends its own readable side. Resolving on `end`
+    // alone — rather than the `end()` write-callback — avoids truncating the
+    // last chunk when output trails the writable `finish`.
+    this.gzip.once("end", () => {
+      this.stats.activeMs += performance.now() - startedAt;
+      callback();
+    });
+    this.gzip.end();
+    // Ensure the readable side is flowing so the trailing `data`/`end` fire even
+    // if downstream had paused us right before flush.
+    this.gzip.resume();
+  }
+
+  _destroy(error: Error | null, callback: (error: Error | null) => void) {
+    this.gzip.destroy(error ?? undefined);
+    callback(error);
+  }
+}

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1,5 +1,4 @@
 import { pipeline, Transform, type Readable } from "stream";
-import { createGzip } from "zlib";
 import { monitorEventLoopDelay } from "perf_hooks";
 import { Job } from "bullmq";
 import { prisma } from "@langfuse/shared/src/db";
@@ -19,6 +18,7 @@ import {
   getCurrentSpan,
   instrumentAsync,
   recordGauge,
+  recordHistogram,
   recordIncrement,
   BlobStorageIntegrationProcessingQueue,
   queryClickhouse,
@@ -36,6 +36,7 @@ import {
   BLOB_TABLE_EXPORT_METRIC,
   type BlobTableExportOutcome,
 } from "./inFlightExports";
+import { TimedGzip, ZLIB_DEFAULT_LEVEL, type GzipStats } from "./gzipStream";
 import { WORKER_HOST_ID } from "../../utils/hostId";
 import {
   BlobStorageIntegrationType,
@@ -268,6 +269,9 @@ const processBlobStorageExport = async (config: {
   table: "traces" | "observations" | "scores" | "observations_v2"; // observations_v2 is the events table
   fileType: BlobStorageIntegrationFileType;
   compressed: boolean;
+  // zlib level for the gzip step; undefined => zlib default (6). Only relevant
+  // when `compressed` is true.
+  gzipLevel: number | undefined;
   convertV4LatencyToSeconds: boolean;
   exportFieldGroups?: ObservationFieldGroupFull[];
   rawPassthrough: boolean;
@@ -394,6 +398,10 @@ const processBlobStorageExport = async (config: {
 
         const serializedCounter = new ByteCounter();
         const compressedCounter = config.compressed ? new ByteCounter() : null;
+        // Paired with compressedCounter: both exist iff compression is on.
+        const gzipStats: GzipStats | null = compressedCounter
+          ? { level: config.gzipLevel ?? ZLIB_DEFAULT_LEVEL, activeMs: 0 }
+          : null;
 
         // Both paths tally rows in JS via countedStream (the passthrough yields
         // raw row text rather than parsed objects, but still iterates).
@@ -427,21 +435,22 @@ const processBlobStorageExport = async (config: {
           const dataStream = countedStream(rawRows, sourceStats);
           const jsonlNewline = createRawJsonlNewlineTransform();
 
-          fileStream = compressedCounter
-            ? pipeline(
-                dataStream,
-                jsonlNewline,
-                serializedCounter,
-                createGzip(),
-                compressedCounter,
-                pipelineCallback,
-              )
-            : pipeline(
-                dataStream,
-                jsonlNewline,
-                serializedCounter,
-                pipelineCallback,
-              );
+          fileStream =
+            compressedCounter && gzipStats
+              ? pipeline(
+                  dataStream,
+                  jsonlNewline,
+                  serializedCounter,
+                  new TimedGzip(config.gzipLevel, gzipStats),
+                  compressedCounter,
+                  pipelineCallback,
+                )
+              : pipeline(
+                  dataStream,
+                  jsonlNewline,
+                  serializedCounter,
+                  pipelineCallback,
+                );
         } else {
           let rawStream: AsyncGenerator<Record<string, unknown>>;
 
@@ -495,21 +504,22 @@ const processBlobStorageExport = async (config: {
           const dataStream = countedStream(rawStream, sourceStats);
           const formatTransform = streamTransformations[config.fileType]();
 
-          fileStream = compressedCounter
-            ? pipeline(
-                dataStream,
-                formatTransform,
-                serializedCounter,
-                createGzip(),
-                compressedCounter,
-                pipelineCallback,
-              )
-            : pipeline(
-                dataStream,
-                formatTransform,
-                serializedCounter,
-                pipelineCallback,
-              );
+          fileStream =
+            compressedCounter && gzipStats
+              ? pipeline(
+                  dataStream,
+                  formatTransform,
+                  serializedCounter,
+                  new TimedGzip(config.gzipLevel, gzipStats),
+                  compressedCounter,
+                  pipelineCallback,
+                )
+              : pipeline(
+                  dataStream,
+                  formatTransform,
+                  serializedCounter,
+                  pipelineCallback,
+                );
         }
 
         // Upload the file to cloud storage
@@ -540,7 +550,11 @@ const processBlobStorageExport = async (config: {
               `jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${WORKER_HOST_ID} ` +
               `path=${passthroughEligible ? "passthrough" : "standard"} ` +
               `rows=${sourceStats.rows} sourceWaitMs=${Math.round(sourceStats.sourceWaitMs)} ` +
-              `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${Math.round(performance.now() - uploadStartMs)}`,
+              `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${Math.round(performance.now() - uploadStartMs)}` +
+              (gzipStats && compressedCounter
+                ? ` gzipLevel=${gzipStats.level} gzipActiveMs=${Math.round(gzipStats.activeMs)} ` +
+                  `compressedBytes=${compressedCounter.bytes}`
+                : ""),
           );
         } finally {
           span.setAttribute("blob.rows", sourceStats.rows);
@@ -557,6 +571,50 @@ const processBlobStorageExport = async (config: {
           }
           if (compressedCounter) {
             span.setAttribute("blob.compressedBytes", compressedCounter.bytes);
+          }
+          if (gzipStats && compressedCounter) {
+            // Gauge the cost of the gzip step so a level change (or moving
+            // compression off the worker) can be evaluated against real data.
+            const activeMs = Math.round(gzipStats.activeMs);
+            // Input/output ratio (>1 = shrank); guard div-by-zero on empty exports.
+            const ratio =
+              compressedCounter.bytes > 0
+                ? serializedCounter.bytes / compressedCounter.bytes
+                : 0;
+            // Compression throughput over uncompressed input bytes.
+            const throughputMbPerSec =
+              gzipStats.activeMs > 0
+                ? serializedCounter.bytes / (gzipStats.activeMs * 1000)
+                : 0;
+
+            span.setAttribute("blob.gzip.level", gzipStats.level);
+            span.setAttribute("blob.gzip.activeMs", activeMs);
+            span.setAttribute("blob.gzip.ratio", Number(ratio.toFixed(3)));
+            span.setAttribute(
+              "blob.gzip.throughputMbPerSec",
+              Number(throughputMbPerSec.toFixed(2)),
+            );
+
+            const metricTags = {
+              table: config.table,
+              path: passthroughEligible ? "passthrough" : "standard",
+              gzipLevel: gzipStats.level,
+            };
+            recordHistogram(
+              "langfuse.blob_export.gzip.active_ms",
+              activeMs,
+              metricTags,
+            );
+            recordHistogram(
+              "langfuse.blob_export.gzip.ratio",
+              ratio,
+              metricTags,
+            );
+            recordHistogram(
+              "langfuse.blob_export.gzip.throughput_mb_per_sec",
+              throughputMbPerSec,
+              metricTags,
+            );
           }
         }
       } catch (error) {
@@ -745,6 +803,7 @@ export const handleBlobStorageIntegrationProjectJob = async (
       type: blobStorageIntegration.type,
       fileType: blobStorageIntegration.fileType,
       compressed: blobStorageIntegration.compressed,
+      gzipLevel: exportTuning.gzipLevel,
       convertV4LatencyToSeconds,
       exportFieldGroups:
         blobStorageIntegration.exportFieldGroups as ObservationFieldGroupFull[],


### PR DESCRIPTION
## What does this PR do?

Makes the blob-export **gzip step measurable and tunable in the worker** — the pragmatic alternative to moving compression into ClickHouse. (Moving gzip to CH is a poor fit: the typed `@clickhouse/client` decompresses HTTP-compressed responses transparently, and bypassing it to stream raw gzip bytes would discard the mid-stream exception detection the passthrough path depends on, and shift CPU onto the more-contended CH cluster.)

Stacked on #14425.

- **`TimedGzip`** (`worker/src/features/blobstorage/gzipStream.ts`): a `Transform` wrapping zlib that attributes compression cost to the gzip step alone by summing each chunk's *write→consumed* latency into `stats.activeMs`. This isolates compression work from the idle gaps spent awaiting the next ClickHouse row (whole-stage wall-clock would just track the streaming pipeline duration). Honours backpressure (pause/resume) and forwards errors so `pipeline` still aborts the upload. Used by both the passthrough and standard compressed pipelines.
- **Instrumentation:** per export it records span attributes `blob.gzip.{level,activeMs,ratio,throughputMbPerSec}`, histograms `langfuse.blob_export.gzip.{active_ms,ratio,throughput_mb_per_sec}` (tagged `table`/`path`/`gzipLevel`), and the same fields on the success log line for at-a-glance reading.
- **`exportTuning.gzipLevel`:** a new optional knob on `BlobExportTuningSchema`, resolved with clamp-to-default (integer 0–9; out-of-range warns and falls back to the zlib default **without** disabling `rawPassthrough`). Plumbed through to `TimedGzip`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
  - `TimedGzip` round-trip / backpressure / error-propagation (infra-free) + resolver coverage for `gzipLevel`.
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings (`pnpm run lint`, typecheck)

> Compressed-path integration tests (`blobStorageIntegrationProcessing.test.ts`) are MinIO-dependent and run in CI; they exercise `TimedGzip` end-to-end there.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR instruments the blob export gzip step with per-chunk timing and a tunable compression level. A new `TimedGzip` Transform replaces the bare `createGzip()` call, measuring write-to-consumed latency into a `GzipStats` struct that feeds three new OTel histograms and span attributes after each upload.

- **`gzipStream.ts`**: New `TimedGzip` Transform wraps a zlib `Gzip` instance, wires manual backpressure via `data`/`pause`/`_read`+`resume`, and accumulates `activeMs` per chunk. `ZLIB_DEFAULT_LEVEL = 6` is exported so callers can report the effective level even when none is configured.
- **`blob-export-tuning.ts`**: Adds a `gzipLevel` field to `BlobExportTuning` (and its resolved type), validated as a 0–9 integer with a clamp-to-default strategy that avoids also resetting a valid `rawPassthrough` when the level is out-of-range.
- **`handleBlobStorageIntegrationProjectJob.ts`**: Threads `gzipLevel` from resolved tuning through `processBlobStorageExport` and emits `gzip.active_ms`, `gzip.ratio`, and `gzip.throughput_mb_per_sec` histograms tagged with table and path.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The gzip instrumentation is well-contained, both export paths (passthrough and standard) are instrumented identically, and the tuning knob degrades gracefully to the zlib default on any invalid input.

The `TimedGzip` Transform is cleanly implemented with correct backpressure wiring, and the `_flush` waits on the inner `end` event before completing — eliminating the truncation risk that would exist if it resolved on the writable `finish` alone. The `gzipLevel` validation in `resolveBlobExportTuning` correctly uses a clamp-to-default strategy so a misconfigured level cannot inadvertently disable a valid `rawPassthrough`. The throughput formula (`bytes / (activeMs * 1000)`) yields the correct MB/s unit. Tests cover round-trips, multi-chunk input, level 0 (store mode), compression ordering, upstream error propagation, and the undefined-level fallback. Imports are all at module level.

No files require special attention. `gzipStream.ts` and `handleBlobStorageIntegrationProjectJob.ts` are the core changes and both look correct.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ClickHouse rows] --> B[countedStream]
    B --> C{rawPassthrough?}
    C -- yes --> D[createRawJsonlNewlineTransform]
    C -- no --> E[streamTransformations\nformat transform]
    D --> F[serializedCounter\nByteCounter]
    E --> F
    F --> G{compressed?}
    G -- yes --> H["TimedGzip\n(config.gzipLevel)\n↳ times write→consumed per chunk\n↳ pauses inner gzip on backpressure"]
    H --> I[compressedCounter\nByteCounter]
    I --> J[Upload to blob storage]
    G -- no --> J
    J --> K[Metrics / OTel span]
    K --> L["gzip.active_ms histogram\ngzip.ratio histogram\ngzip.throughput_mb_per_sec histogram"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ClickHouse rows] --> B[countedStream]
    B --> C{rawPassthrough?}
    C -- yes --> D[createRawJsonlNewlineTransform]
    C -- no --> E[streamTransformations\nformat transform]
    D --> F[serializedCounter\nByteCounter]
    E --> F
    F --> G{compressed?}
    G -- yes --> H["TimedGzip\n(config.gzipLevel)\n↳ times write→consumed per chunk\n↳ pauses inner gzip on backpressure"]
    H --> I[compressedCounter\nByteCounter]
    I --> J[Upload to blob storage]
    G -- no --> J
    J --> K[Metrics / OTel span]
    K --> L["gzip.active_ms histogram\ngzip.ratio histogram\ngzip.throughput_mb_per_sec histogram"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): instrument gzip cost + tun..."](https://github.com/langfuse/langfuse/commit/7d7ac301babd45bb4461327f7882670631527c96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38792831)</sub>

<!-- /greptile_comment -->