### PR TITLE
fix(worker): re-apply S3 upload prefix when replaying OTel events

### DIFF
--- a/packages/shared/src/server/ingestion/eventBucketPath.ts
+++ b/packages/shared/src/server/ingestion/eventBucketPath.ts
@@ -116,3 +116,17 @@ export function rawEventBucketPrefix(params: {
 }): string {
   return `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${params.projectId}/${params.entityType}/${params.rawEntityIdSegment}/`;
 }
+
+/**
+ * Reconstruct the full S3 object key for an OTel event from a key parsed by
+ * `parseEventKey` (which is RELATIVE to `LANGFUSE_S3_EVENT_UPLOAD_PREFIX`).
+ *
+ * Unlike standard events — whose download path is rebuilt from
+ * `rawEventBucketPrefix` + eventId — OTel events are downloaded by their
+ * `fileKey` verbatim, so the upload prefix must be re-applied here. Without
+ * this, replay GetObject calls miss whenever `LANGFUSE_S3_EVENT_UPLOAD_PREFIX`
+ * is non-empty.
+ */
+export function rawOtelEventBucketPath(relativeKey: string): string {
+  return `${env.LANGFUSE_S3_EVENT_UPLOAD_PREFIX}${relativeKey}`;
+}

--- a/worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts
+++ b/worker/src/scripts/replayIngestionEvents/s3-ingestion-event-replay.ts
@@ -21,6 +21,7 @@ import {
   QueueJobs,
   QueueName,
   rawEventBucketPrefix,
+  rawOtelEventBucketPath,
   SecondaryIngestionQueue,
   TQueueJobTypes,
 } from "@langfuse/shared/src/server";
@@ -348,7 +349,10 @@ async function convertCsvToJsonl(
             },
           },
           data: {
-            fileKey: keyValue,
+            // OTel events are downloaded by fileKey verbatim, so re-apply the
+            // upload prefix (parseEventKey strips it). Mirrors how the standard
+            // branch below rebuilds its path via rawEventBucketPrefix.
+            fileKey: rawOtelEventBucketPath(keyValue),
           },
         };
 


### PR DESCRIPTION
Fixes #14427

### Problem
The ingestion replay script's OTEL branch sets the queued job's `data.fileKey` to the `parseEventKey` output **verbatim**, which is **relative to** `LANGFUSE_S3_EVENT_UPLOAD_PREFIX` (the `^otel/…` regex matches the prefix-stripped key). OTEL events are then downloaded by `fileKey` verbatim — unlike standard events, whose path is rebuilt via `rawEventBucketPrefix` (which incorporates the prefix). So when `LANGFUSE_S3_EVENT_UPLOAD_PREFIX` is non-empty, every replayed OTEL job fails with `Failed to download file from S3`, and observations cannot be recovered. There's no key form that both classifies as OTEL *and* resolves on download (the full key makes `parseEventKey` misclassify it as a standard event with `projectId="events"`).

### Fix
Add `rawOtelEventBucketPath()` next to `rawEventBucketPrefix()` in `eventBucketPath.ts`, and use it in the replay's OTEL branch to re-apply `LANGFUSE_S3_EVENT_UPLOAD_PREFIX` to the OTEL `fileKey`. Mirrors how the standard branch reconstructs its path; no change to the live ingest/upload path.

```diff
  data: {
-   fileKey: keyValue,
+   fileKey: rawOtelEventBucketPath(keyValue),
  },
```

### How it was found / verified
Self-hosted v3 with `LANGFUSE_S3_EVENT_UPLOAD_PREFIX=events/`. Replaying OTEL keys produced jobs whose `data.fileKey` was `otel/<project>/…` while the actual object is at `events/otel/<project>/…` → `Failed to download file from S3`, landing in `bull:otel-ingestion-queue:failed`. Standard (trace/score) replay was unaffected because `rawEventBucketPrefix` already incorporates the prefix.

### Notes
- Open to relocating the fix if you'd prefer it elsewhere (e.g. apply the prefix on the OTEL download path, or have `parseEventKey` carry the absolute key) — happy to adjust.
- Verified against the live failure; I haven't run the full monorepo test suite locally, so relying on CI here.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the S3 upload prefix not being re-applied to OTel `fileKey` values during ingestion replay, by introducing `rawOtelEventBucketPath()` in `eventBucketPath.ts` and using it in the operator replay script. This mirrors the existing pattern used for standard events via `rawEventBucketPrefix`.

- `rawOtelEventBucketPath(relativeKey)` is added alongside `rawEventBucketPrefix` and properly re-exported via the shared barrel, making it available to both the script and any future callers.
- The operator script fix is correct and handles the empty-prefix case (`\"\"`) safely, reverting to the previous (already-working) behavior.
- The admin replay endpoint at `web/src/pages/api/admin/ingestion-replay.ts` has the identical bug (`data: { fileKey: key }` without prefix re-application) and was not updated in this PR; OTel replays triggered from the admin UI will still fail with a non-empty prefix.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The operator script fix is correct, but the admin replay endpoint has the exact same missing-prefix bug and was not updated; merging as-is leaves the admin UI replay broken for any self-hosted deployment with a non-empty S3 event upload prefix.

The new `rawOtelEventBucketPath` function and its use in the operator script are correct and complete. However, `web/src/pages/api/admin/ingestion-replay.ts` has a parallel OTel replay path that still does `data: { fileKey: key }` without re-applying the prefix, so the same download failure occurs whenever `LANGFUSE_S3_EVENT_UPLOAD_PREFIX` is non-empty and a user triggers a replay from the admin endpoint.

web/src/pages/api/admin/ingestion-replay.ts — the OTel branch at line 150 needs the same `rawOtelEventBucketPath(key)` fix that was applied to the operator script.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Script as Replay Script / Admin API
    participant Parse as parseEventKey()
    participant Path as rawOtelEventBucketPath()
    participant Queue as OtelIngestionQueue (BullMQ)
    participant Worker as OtelIngestionQueue Processor
    participant S3 as S3 / MinIO

    Script->>Parse: keyValue (relative, e.g. "otel/proj/...")
    Parse-->>Script: "{ kind: "otel", projectId }"

    alt BEFORE fix (admin API still does this)
        Script->>Queue: "enqueue { fileKey: keyValue }"
        Queue->>Worker: "job with fileKey = "otel/proj/...""
        Worker->>S3: GET "otel/proj/..." ❌ (missing prefix)
        S3-->>Worker: NoSuchKey / 404
    end

    alt AFTER fix (operator script)
        Script->>Path: rawOtelEventBucketPath(keyValue)
        Path-->>Script: "events/otel/proj/..." (prefix prepended)
        Script->>Queue: "enqueue { fileKey: "events/otel/proj/..." }"
        Queue->>Worker: "job with fileKey = "events/otel/proj/...""
        Worker->>S3: GET "events/otel/proj/..." ✅
        S3-->>Worker: file contents
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Script as Replay Script / Admin API
    participant Parse as parseEventKey()
    participant Path as rawOtelEventBucketPath()
    participant Queue as OtelIngestionQueue (BullMQ)
    participant Worker as OtelIngestionQueue Processor
    participant S3 as S3 / MinIO

    Script->>Parse: keyValue (relative, e.g. "otel/proj/...")
    Parse-->>Script: "{ kind: "otel", projectId }"

    alt BEFORE fix (admin API still does this)
        Script->>Queue: "enqueue { fileKey: keyValue }"
        Queue->>Worker: "job with fileKey = "otel/proj/...""
        Worker->>S3: GET "otel/proj/..." ❌ (missing prefix)
        S3-->>Worker: NoSuchKey / 404
    end

    alt AFTER fix (operator script)
        Script->>Path: rawOtelEventBucketPath(keyValue)
        Path-->>Script: "events/otel/proj/..." (prefix prepended)
        Script->>Queue: "enqueue { fileKey: "events/otel/proj/..." }"
        Queue->>Worker: "job with fileKey = "events/otel/proj/...""
        Worker->>S3: GET "events/otel/proj/..." ✅
        S3-->>Worker: file contents
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): re-apply S3 upload prefix w..."](https://github.com/langfuse/langfuse/commit/f385917917fd7170e3cfae8e0a8c35f803349c8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38846348)</sub>

<!-- /greptile_comment -->