### PR TITLE
Add script to find large Python files

### DIFF
--- a/find_large_py_files.py
+++ b/find_large_py_files.py
@@ -1,0 +1,83 @@
+"""Find Python files larger than a size threshold.
+
+Usage:
+    python3 find_large_py_files.py [ROOT] [--min-size-mb 1]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+BYTES_PER_MB = 1_048_576
+
+
+def human_readable_size(size_bytes: int) -> str:
+    """Return a size in bytes formatted as megabytes."""
+    return f"{size_bytes / BYTES_PER_MB:.2f} MB"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Recursively find .py files larger than a size threshold."
+    )
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default=".",
+        help="Directory tree to scan. Defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--min-size-mb",
+        type=float,
+        default=1.0,
+        help="Minimum file size in MB, where 1 MB is 1,048,576 bytes. Defaults to 1.",
+    )
+    return parser.parse_args()
+
+
+def warn_os_error(error: OSError) -> None:
+    print(f"warning: cannot access {error.filename}: {error.strerror}", file=sys.stderr)
+
+
+def iter_large_python_files(root: Path, min_size_bytes: int):
+    def on_walk_error(error: OSError) -> None:
+        warn_os_error(error)
+
+    for dirpath, dirnames, filenames in os.walk(root, onerror=on_walk_error):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            if not filename.endswith(".py"):
+                continue
+
+            path = Path(dirpath) / filename
+            try:
+                size = path.stat().st_size
+            except OSError as error:
+                warn_os_error(error)
+                continue
+
+            if size > min_size_bytes:
+                yield path, size
+
+
+def main() -> int:
+    args = parse_args()
+    if args.min_size_mb < 0:
+        print("error: --min-size-mb must be non-negative", file=sys.stderr)
+        return 2
+
+    root = Path(args.root)
+    min_size_bytes = int(args.min_size_mb * BYTES_PER_MB)
+
+    for path, size in iter_large_python_files(root, min_size_bytes):
+        print(f"{path}\t{human_readable_size(size)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `find_large_py_files.py`, a standalone CLI script that recursively scans a directory tree for `.py` files larger than a configurable size threshold.
- Print each matching path with its size in MB.
- Continue scanning when directory or file access errors occur, reporting warnings to stderr instead of crashing.

## Usage
```bash
python3 find_large_py_files.py
python3 find_large_py_files.py /path/to/project
python3 find_large_py_files.py /path/to/project --min-size-mb 5
```

By default, the script scans the current directory and uses a 1 MB threshold, where 1 MB is 1,048,576 bytes.

## Verification
- `python3 -m py_compile find_large_py_files.py`
- Created temporary `.py` and non-`.py` files and verified only matching Python files above the threshold were printed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a standalone Python CLI script (`find_large_py_files.py`) to the repository root that recursively scans a directory tree and prints `.py` files exceeding a configurable size threshold (default 1 MB).

- The script gracefully handles `OSError` from both `os.walk` and `path.stat()`, reporting warnings to stderr without crashing, and exposes `--min-size-mb` and an optional root-path argument.
- A missing guard for invalid/non-existent root paths causes the script to exit successfully with no output when given a bad path, making it indistinguishable from a clean scan that found nothing.
- Two minor polish items: the one-liner `on_walk_error` wrapper can be replaced by passing `warn_os_error` directly to `onerror=`, and the MB-to-bytes conversion should use `round()` instead of `int()` to avoid truncation.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The script is a new, self-contained utility that does not touch any existing code paths, so merging it carries no risk to the rest of the codebase. The missing root-path validation makes the tool misleading in practice — a mistyped path looks identical to a successful empty scan.

The script never validates that the supplied root path exists or is a directory. A caller who mistypes the path gets exit code 0 and no output, with no way to tell whether the scan ran at all. For a diagnostic tool this is a real usability defect.

find_large_py_files.py — specifically the section just before the `iter_large_python_files` call in `main()` where root-path validation is absent.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
find_large_py_files.py:67-68
**Silent empty output on invalid root path**

`os.walk` on a non-existent or non-directory path silently yields nothing and never calls `onerror`, so a user who passes a typo'd path will see no output and no error message and exit with code `0`. This makes it impossible to distinguish "no large files found" from "nothing was scanned because the path was wrong."

A quick `if not root.exists(): …` or `if not root.is_dir(): …` guard before the walk would surface the problem immediately.

### Issue 2 of 3
find_large_py_files.py:47-50
The nested `on_walk_error` is a single-line wrapper that just forwards the call to `warn_os_error`. Since both functions share the same `(OSError) -> None` signature, `warn_os_error` can be passed directly to `onerror=`, removing the indirection.

```suggestion
    for dirpath, dirnames, filenames in os.walk(root, onerror=warn_os_error):
```

### Issue 3 of 3
find_large_py_files.py:74
`int()` truncates floating-point values, so `int(0.1 * 1_048_576)` yields `104857` instead of the mathematically correct `104858` (since `0.1 * 1048576 = 104857.6`). Using `round()` makes the conversion consistent with what a user would expect.

```suggestion
    min_size_bytes = round(args.min_size_mb * BYTES_PER_MB)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add script to find large Python files"](https://github.com/langfuse/langfuse/commit/57215b25fa0d0ad91e1bfbeb1e26838ad01a61ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38888381)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->