### PR TITLE
fix: resolve traces metrics query with clickhouse analyzer

### DIFF
--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -431,14 +431,21 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
                   column: "timestamp_to_date",
                   order: orderBy.order,
                 },
-                { column: "timestamp", order: orderBy.order },
+                orderBy,
                 { column: "event_ts", order: "DESC" as "DESC" },
               ]
-            : null,
-          orderBy ?? null,
+            : [orderBy ?? null],
         ].flat(),
         orderByCols,
       );
+
+      const shouldWrapDefaultDedupQuery =
+        defaultOrder && ["metrics", "rows", "identifiers"].includes(select);
+
+      const innerSelect = shouldWrapDefaultDedupQuery
+        ? `${sqlSelect},
+            t.event_ts as _event_ts`
+        : sqlSelect;
 
       // complex query ahead:
       // - we only join scores and observations if we really need them to speed up default views
@@ -447,10 +454,10 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
       // - we order by todate(timestamp), event_ts desc per default and do not use FINAL.
       //   In this case, CH is able to read the data only from the latest date from disk and filtering them in memory. No need to read all data e.g. for 1 month from disk.
 
-      const query = `
+      const baseQuery = `
         ${observationsAndScoresCTE}
 
-        SELECT ${sqlSelect}
+        SELECT ${innerSelect}
         -- FINAL is used for non default ordering.
         FROM traces t  ${defaultOrder || select === "count" ? "" : "FINAL"}
         ${select === "metrics" || requiresObservationsJoin ? `LEFT JOIN observations_stats o on o.project_id = t.project_id and o.trace_id = t.id` : ""}
@@ -458,6 +465,24 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
         WHERE t.project_id = {projectId: String}
         ${tracesFilterRes ? `AND ${tracesFilterRes.query}` : ""}
         ${search.query}
+      `;
+
+      const wrappedDefaultOrderQuery = `
+        SELECT *
+        FROM (
+          ${baseQuery}
+        ) result
+        ${chOrderBy
+          .replaceAll("t.event_ts", "result._event_ts")
+          .replaceAll("t.timestamp", "result.timestamp")}
+        LIMIT 1 BY result.id, result.project_id
+        ${limit !== undefined && page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
+      `;
+
+      const query = shouldWrapDefaultDedupQuery
+        ? wrappedDefaultOrderQuery
+        : `
+        ${baseQuery}
         ${chOrderBy}
         -- This is used for metrics and row queries. Count has only one result.
         -- This is only used for default ordering. Otherwise, we use final.

--- a/packages/shared/src/server/services/traces-ui-table-service.ts
+++ b/packages/shared/src/server/services/traces-ui-table-service.ts
@@ -423,19 +423,18 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
           clickhouseTableName: "traces",
         },
       ];
+      const defaultOrderByEntries = defaultOrder
+        ? [
+            {
+              column: "timestamp_to_date",
+              order: orderBy.order,
+            },
+            orderBy,
+            { column: "event_ts", order: "DESC" as "DESC" },
+          ]
+        : [orderBy ?? null];
       const chOrderBy = orderByToClickhouseSql(
-        [
-          defaultOrder
-            ? [
-                {
-                  column: "timestamp_to_date",
-                  order: orderBy.order,
-                },
-                orderBy,
-                { column: "event_ts", order: "DESC" as "DESC" },
-              ]
-            : [orderBy ?? null],
-        ].flat(),
+        defaultOrderByEntries,
         orderByCols,
       );
 
@@ -472,9 +471,26 @@ async function getTracesTableGeneric(props: FetchTracesTableProps) {
         FROM (
           ${baseQuery}
         ) result
-        ${chOrderBy
-          .replaceAll("t.event_ts", "result._event_ts")
-          .replaceAll("t.timestamp", "result.timestamp")}
+        ${orderByToClickhouseSql(defaultOrderByEntries, [
+          {
+            clickhouseSelect: "toDate(result.timestamp)",
+            uiTableName: "timestamp_to_date",
+            uiTableId: "timestamp_to_date",
+            clickhouseTableName: "traces",
+          },
+          {
+            clickhouseSelect: "result.timestamp",
+            uiTableName: "timestamp",
+            uiTableId: "timestamp",
+            clickhouseTableName: "traces",
+          },
+          {
+            clickhouseSelect: "result._event_ts",
+            uiTableName: "event_ts",
+            uiTableId: "event_ts",
+            clickhouseTableName: "traces",
+          },
+        ])}
         LIMIT 1 BY result.id, result.project_id
         ${limit !== undefined && page !== undefined ? `LIMIT {limit: Int32} OFFSET {offset: Int32}` : ""}
       `;


### PR DESCRIPTION
Wrap the default-order query before LIMIT 1 BY to avoid ClickHouse analyzer failures and remove the duplicated timestamp sort key.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

It updates the traces metrics query for the default timestamp-ordered path when ClickHouse analyzer is enabled. The previous query shape combined CTEs, joins, ORDER BY, and LIMIT 1 BY in a single select, which could trigger a type-mismatch error while resolving aggregated observation columns.

This change wraps the default-order query path for traces metrics, rows, and identifiers in an outer select before applying deduplication, which avoids the analyzer edge case. It also removes the duplicated timestamp sort key from the default ordering while keeping event_ts as the deduplication tie-breaker.

Fixes #14431

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (restructures existing code without changing behavior, e.g. simplify logic, split modules, reduce duplication)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't checked if my changes generate no new warnings (`npm run lint`)
- I haven't checked if new and existing unit tests pass locally with my changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a ClickHouse new-analyzer incompatibility in the traces metrics query by splitting the combined CTE + ORDER BY + LIMIT 1 BY query into an inner `baseQuery` and an outer wrapping SELECT, and removes the duplicate `timestamp` sort key from the default-ordering path.

- For `metrics`, `rows`, and `identifiers` selects with default timestamp ordering, the query is now restructured as an outer `SELECT * FROM (baseQuery) result … LIMIT 1 BY result.id, result.project_id` with column references in the ORDER BY rewritten via `replaceAll`.
- The `event_ts` column is projected as `_event_ts` in the inner query so it remains accessible for deduplication tie-breaking in the outer scope.
- The `LIMIT 1 BY` guard remaining in the `else` branch of the fallback query is now dead code (the condition that would trigger it is identical to `shouldWrapDefaultDedupQuery`), and the ORDER BY rewrite relies on string substitution that could silently break if column expressions change.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a targeted query restructure for one code path; the logic is sound and the ClickHouse fix addresses a real analyzer failure, but the replaceAll-based ORDER BY rewrite is fragile and could silently produce wrong SQL if column expressions expand.

The wrapped-query approach correctly isolates the CTE + JOIN from the deduplication step, and _event_ts is properly aliased so the outer ORDER BY can reference it. Two minor concerns remain: the LIMIT 1 BY in the else branch is now unreachable dead code, and the replaceAll substitution is a substring match that would silently corrupt any future column expression sharing that prefix. Neither breaks anything today, but the string replacement is a maintenance hazard.

packages/shared/src/server/services/traces-ui-table-service.ts — specifically the ORDER BY string-rewrite logic and the now-dead LIMIT 1 BY in the fallback branch.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getTracesTableGeneric called] --> B{defaultOrder?}
    B -- No --> C[Build chOrderBy from custom orderBy]
    C --> D{select type?}
    D -- count --> E[baseQuery + chOrderBy, no LIMIT 1 BY]
    D -- metrics/rows/identifiers --> F[baseQuery + chOrderBy + FINAL]
    B -- Yes --> G[Build chOrderBy: timestamp_to_date, timestamp, event_ts DESC]
    G --> H{shouldWrapDefaultDedupQuery?\ndefaultOrder and select in metrics/rows/identifiers}
    H -- No, select=count --> I[baseQuery + chOrderBy, no LIMIT 1 BY]
    H -- Yes --> J[innerSelect adds t.event_ts as _event_ts]
    J --> K[baseQuery — no ORDER BY, no LIMIT]
    K --> L[wrappedDefaultOrderQuery:\nSELECT * FROM baseQuery result\n+ chOrderBy with t.* replaced by result.*\n+ LIMIT 1 BY result.id, result.project_id\n+ LIMIT/OFFSET]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getTracesTableGeneric called] --> B{defaultOrder?}
    B -- No --> C[Build chOrderBy from custom orderBy]
    C --> D{select type?}
    D -- count --> E[baseQuery + chOrderBy, no LIMIT 1 BY]
    D -- metrics/rows/identifiers --> F[baseQuery + chOrderBy + FINAL]
    B -- Yes --> G[Build chOrderBy: timestamp_to_date, timestamp, event_ts DESC]
    G --> H{shouldWrapDefaultDedupQuery?\ndefaultOrder and select in metrics/rows/identifiers}
    H -- No, select=count --> I[baseQuery + chOrderBy, no LIMIT 1 BY]
    H -- Yes --> J[innerSelect adds t.event_ts as _event_ts]
    J --> K[baseQuery — no ORDER BY, no LIMIT]
    K --> L[wrappedDefaultOrderQuery:\nSELECT * FROM baseQuery result\n+ chOrderBy with t.* replaced by result.*\n+ LIMIT 1 BY result.id, result.project_id\n+ LIMIT/OFFSET]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/services/traces-ui-table-service.ts:487-489
**Dead code — `LIMIT 1 BY` in the fallback branch can never fire**

`shouldWrapDefaultDedupQuery` is defined as `defaultOrder && ["metrics", "rows", "identifiers"].includes(select)`, which is exactly the condition guarding `LIMIT 1 BY id, project_id` on line 489. When the `else` branch is reached, at least one of those predicates is `false`, so the ternary at line 489 is always `""`. The comment on lines 487–488 is therefore stale and could be confusing to future maintainers.

### Issue 2 of 2
packages/shared/src/server/services/traces-ui-table-service.ts:475-477
**Brittle string-replacement to rewrite ORDER BY column references**

`replaceAll("t.timestamp", "result.timestamp")` rewrites the expression `toDate(t.timestamp)` correctly today, but any future column whose SQL expression contains `t.timestamp` as a substring (e.g. `t.timestamp_bucket`, `t.timestamp_ms`) would be silently corrupted. A more robust approach would be to build the outer ORDER BY from the already-structured `orderByCols` definitions rather than doing text substitution on the rendered SQL string.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve traces metrics query with c..."](https://github.com/langfuse/langfuse/commit/41a5919a80e28fc456e31a750cfd53d502e4786d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38971056)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->