### PR TITLE
chore(deps): undici 7.28 override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   esbuild: 0.28.1
+  undici@7: 7.28.0
   zod: 4.3.6
   nanoid: ^3.3.8
   katex: ^0.16.21
@@ -307,7 +308,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       undici:
-        specifier: ^7.28.0
+        specifier: 7.28.0
         version: 7.28.0
       uuid:
         specifier: ^14.0.0
@@ -11044,10 +11045,6 @@ packages:
 
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
-
-  undici@7.24.5:
-    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
-    engines: {node: '>=20.18.1'}
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
@@ -22330,7 +22327,7 @@ snapshots:
       proxy-agent: 7.0.0
       semver: 7.7.4
       tinyglobby: 0.2.15
-      undici: 7.24.5
+      undici: 7.28.0
       url-join: 5.0.0
       wildcard-match: 5.1.4
       yargs-parser: 22.0.0
@@ -23313,8 +23310,6 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@7.10.0: {}
-
-  undici@7.24.5: {}
 
   undici@7.28.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,6 +58,7 @@ allowBuilds:
   "@scarf/scarf": false
 overrides:
   esbuild: "0.28.1"
+  "undici@7": 7.28.0
   zod: 4.3.6
   nanoid: ^3.3.8
   katex: ^0.16.21


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a pnpm workspace override pinning all `undici@7` transitive dependencies to `7.28.0`, addressing a security audit concern where `release-it` was resolving to `undici@7.24.5`.

- Adds `"undici@7": 7.28.0` to both `pnpm-workspace.yaml` and the `overrides` section of `pnpm-lock.yaml`, forcing all `undici@7` resolutions workspace-wide to `7.28.0`.
- Removes the `undici@7.24.5` package entry from the lock file and updates the `release-it@20.2.0` snapshot to use `undici@7.28.0` instead.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow dependency override that deduplicates undici@7 to a single patched version with no logic changes.

The only changes are to lock and workspace config files. The override correctly uses pnpm's scoped syntax, the lock file is internally consistent (old 7.24.5 entry removed, all snapshots updated to 7.28.0), and no application code is touched.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into nimar/override-..."](https://github.com/langfuse/langfuse/commit/2c75b229c5e05e3ace770d851be88b9f8a67b7cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38986336)</sub>

<!-- /greptile_comment -->