### PR TITLE
fix(events): compute trace latency without end times

### DIFF
--- a/web/src/features/events/lib/eventsToTraceAdapter.clienttest.ts
+++ b/web/src/features/events/lib/eventsToTraceAdapter.clienttest.ts
@@ -105,4 +105,46 @@ describe("adaptEventsToTraceFormat", () => {
       safeKey: "output-value",
     });
   });
+
+  it("falls back to the latest start time when computing trace latency without end times", () => {
+    const result = adaptEventsToTraceFormat({
+      events: [
+        createEvent({
+          id: "obs-1",
+          startTime: new Date("2024-01-01T00:00:00.000Z"),
+          endTime: null,
+        }),
+        createEvent({
+          id: "obs-2",
+          parentObservationId: "obs-1",
+          startTime: new Date("2024-01-01T00:00:03.000Z"),
+          endTime: null,
+        }),
+      ],
+      traceId: "trace-1",
+    });
+
+    expect(result.trace.latency).toBe(3);
+  });
+
+  it("uses the latest start time when it is after the latest end time", () => {
+    const result = adaptEventsToTraceFormat({
+      events: [
+        createEvent({
+          id: "obs-1",
+          startTime: new Date("2024-01-01T00:00:00.000Z"),
+          endTime: new Date("2024-01-01T00:00:01.000Z"),
+        }),
+        createEvent({
+          id: "obs-2",
+          parentObservationId: "obs-1",
+          startTime: new Date("2024-01-01T00:00:03.000Z"),
+          endTime: null,
+        }),
+      ],
+      traceId: "trace-1",
+    });
+
+    expect(result.trace.latency).toBe(3);
+  });
 });

--- a/web/src/features/events/lib/eventsToTraceAdapter.clienttest.ts
+++ b/web/src/features/events/lib/eventsToTraceAdapter.clienttest.ts
@@ -127,6 +127,27 @@ describe("adaptEventsToTraceFormat", () => {
     expect(result.trace.latency).toBe(3);
   });
 
+  it("keeps trace latency unknown when events have identical start times and no end times", () => {
+    const result = adaptEventsToTraceFormat({
+      events: [
+        createEvent({
+          id: "obs-1",
+          startTime: new Date("2024-01-01T00:00:00.000Z"),
+          endTime: null,
+        }),
+        createEvent({
+          id: "obs-2",
+          parentObservationId: "obs-1",
+          startTime: new Date("2024-01-01T00:00:00.000Z"),
+          endTime: null,
+        }),
+      ],
+      traceId: "trace-1",
+    });
+
+    expect(result.trace.latency).toBeUndefined();
+  });
+
   it("uses the latest start time when it is after the latest end time", () => {
     const result = adaptEventsToTraceFormat({
       events: [

--- a/web/src/features/events/lib/eventsToTraceAdapter.ts
+++ b/web/src/features/events/lib/eventsToTraceAdapter.ts
@@ -81,7 +81,8 @@ export function adaptEventsToTraceFormat(params: {
   const latestEnd =
     endTimes.length > 0 ? Math.max(...endTimes.map((d) => d.getTime())) : null;
   const latestTimestamp =
-    events.length > 1
+    events.length > 1 &&
+    (latestEnd !== null || latestStart !== earliest.startTime.getTime())
       ? Math.max(latestStart, latestEnd ?? latestStart)
       : (latestEnd ?? undefined);
   const latencyMs =

--- a/web/src/features/events/lib/eventsToTraceAdapter.ts
+++ b/web/src/features/events/lib/eventsToTraceAdapter.ts
@@ -74,14 +74,20 @@ export function adaptEventsToTraceFormat(params: {
 
   const traceTags = latestTaggedEvent?.traceTags;
 
+  const latestStart = sorted[sorted.length - 1]!.startTime.getTime();
   const endTimes = events
     .map((e) => e.endTime)
     .filter((t): t is Date => t !== null);
   const latestEnd =
     endTimes.length > 0 ? Math.max(...endTimes.map((d) => d.getTime())) : null;
-  const latencyMs = latestEnd
-    ? latestEnd - earliest.startTime.getTime()
-    : undefined;
+  const latestTimestamp =
+    events.length > 1
+      ? Math.max(latestStart, latestEnd ?? latestStart)
+      : (latestEnd ?? undefined);
+  const latencyMs =
+    latestTimestamp !== undefined
+      ? latestTimestamp - earliest.startTime.getTime()
+      : undefined;
 
   // Create synthetic trace from observations
   const trace: SyntheticTrace = {


### PR DESCRIPTION
## Summary
- Compute synthetic trace latency from the latest observation timestamp when event-table observations have missing end times.
- Add regression coverage for traces where observations have no or partial `endTime` values.

Fixes #12736

## Test plan
- `pnpm --filter @langfuse/shared db:generate`
- `pnpm --filter @langfuse/shared build`
- `pnpm --filter web test-client src/features/events/lib/eventsToTraceAdapter.clienttest.ts`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes trace latency computation in the events-table adapter by falling back to the latest observation `startTime` when `endTime` values are absent, addressing a case where multi-observation traces would show no latency at all.

- **`eventsToTraceAdapter.ts`**: Introduces `latestStart` (the largest `startTime` across all sorted events) and uses `Math.max(latestStart, latestEnd ?? latestStart)` as the effective trace end when `events.length > 1`, replacing the old hard-dependency on `endTime`.
- **`eventsToTraceAdapter.clienttest.ts`**: Adds two regression tests — one for fully-missing `endTime` values and one for a mixed scenario where the last observation's `startTime` exceeds the last known `endTime`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is self-contained and safe to merge; the only realistic concern is an obscure corner case that produces 0s latency instead of unknown.

The fix is straightforward and the two new tests cover the intended scenarios well. The one uncovered edge case — multiple observations with identical start times and no end times — would display latency = 0 rather than undefined, which could mislead users but is unlikely in production data.

web/src/features/events/lib/eventsToTraceAdapter.ts — the events.length > 1 guard and the zero-latency corner case it leaves open.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[adaptEventsToTraceFormat] --> B{events.length === 0?}
    B -- yes --> C[throw Error]
    B -- no --> D[Sort by startTime → earliest / latestStart]
    D --> E[Collect non-null endTimes → latestEnd]
    E --> F{events.length > 1?}
    F -- yes --> G["latestTimestamp = Max(latestStart, latestEnd ?? latestStart)"]
    F -- no --> H["latestTimestamp = latestEnd ?? undefined"]
    G --> I{latestTimestamp defined?}
    H --> I
    I -- yes --> J["latencyMs = latestTimestamp − earliest.startTime"]
    I -- no --> K[latencyMs = undefined]
    J --> L["trace.latency = latencyMs / 1000"]
    K --> M[trace.latency = undefined]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[adaptEventsToTraceFormat] --> B{events.length === 0?}
    B -- yes --> C[throw Error]
    B -- no --> D[Sort by startTime → earliest / latestStart]
    D --> E[Collect non-null endTimes → latestEnd]
    E --> F{events.length > 1?}
    F -- yes --> G["latestTimestamp = Max(latestStart, latestEnd ?? latestStart)"]
    F -- no --> H["latestTimestamp = latestEnd ?? undefined"]
    G --> I{latestTimestamp defined?}
    H --> I
    I -- yes --> J["latencyMs = latestTimestamp − earliest.startTime"]
    I -- no --> K[latencyMs = undefined]
    J --> L["trace.latency = latencyMs / 1000"]
    K --> M[trace.latency = undefined]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/events/lib/eventsToTraceAdapter.ts:83-86
When `events.length > 1` but every observation shares an identical `startTime` and none has an `endTime`, `Math.max(latestStart, latestStart)` equals `earliest.startTime`, so `latencyMs` becomes `0` and `trace.latency` is reported as `0s`. This is subtly incorrect — it signals "instantaneous" when the duration is actually unknown. The same trace with only one event (single-event path) correctly returns `undefined`. The guard should additionally require that `latestStart` differs from `earliest.startTime` before committing to the start-spread estimate.

```suggestion
  const latestTimestamp =
    events.length > 1 && (latestEnd !== null || latestStart !== earliest.startTime.getTime())
      ? Math.max(latestStart, latestEnd ?? latestStart)
      : (latestEnd ?? undefined);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(events): compute trace latency witho..."](https://github.com/langfuse/langfuse/commit/6080bd00ee0b837de683ef2f9de57055349f3623) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38989330)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->