### PR TITLE
fix(events): always allow v3/v4 toggle for Langfuse Cloud admins

### DIFF
--- a/web/src/features/events/lib/v4Rollout.clienttest.ts
+++ b/web/src/features/events/lib/v4Rollout.clienttest.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { canToggleV4 } from "./v4Rollout";
+
+describe("canToggleV4", () => {
+  const originalRegion = process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION;
+
+  // A user/org created after the rollout date is auto-enabled, so the toggle
+  // is hidden for them under the normal date-based rollout.
+  const postRolloutContext = {
+    organizations: [
+      { id: "org-new", createdAt: new Date("2026-05-01T00:00:00.000Z") },
+    ],
+  };
+
+  beforeEach(() => {
+    // Force a non-DEV cloud region so the DEV short-circuit does not apply.
+    process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = "US";
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION = originalRegion;
+  });
+
+  it("hides the toggle for a new (auto-enabled) non-admin user", () => {
+    expect(canToggleV4(postRolloutContext)).toBe(false);
+  });
+
+  it("always allows the toggle for a Langfuse Cloud admin, even when new", () => {
+    expect(
+      canToggleV4(postRolloutContext, { isLangfuseCloudAdmin: true }),
+    ).toBe(true);
+  });
+
+  it("does not change behavior for a non-admin when the flag is false", () => {
+    expect(
+      canToggleV4(postRolloutContext, { isLangfuseCloudAdmin: false }),
+    ).toBe(false);
+  });
+});

--- a/web/src/features/events/lib/v4Rollout.ts
+++ b/web/src/features/events/lib/v4Rollout.ts
@@ -37,8 +37,23 @@ export function shouldAutoEnableV4({
   return oldestOrganizationCreatedAt >= V4_DEFAULT_ENABLED_FROM_AT;
 }
 
-export function canToggleV4(context: V4RolloutContext): boolean {
+type CanToggleV4Options = {
+  // Langfuse Cloud staff superusers (the instance-level `User.admin` flag, not a
+  // customer's org/project ADMIN role) need the toggle on any tenant's project
+  // so they can reproduce v3/v4 behavior — even when their own account is new
+  // enough that the date-based rollout would otherwise auto-enable and lock it.
+  isLangfuseCloudAdmin?: boolean;
+};
+
+export function canToggleV4(
+  context: V4RolloutContext,
+  options: CanToggleV4Options = {},
+): boolean {
   if (process.env.NEXT_PUBLIC_LANGFUSE_CLOUD_REGION === "DEV") {
+    return true;
+  }
+
+  if (options.isLangfuseCloudAdmin) {
     return true;
   }
 

--- a/web/src/server/api/routers/userAccount.ts
+++ b/web/src/server/api/routers/userAccount.ts
@@ -269,18 +269,21 @@ export const userAccountRouter = createTRPCRouter({
         });
       }
 
-      const userCanToggleV4 = canToggleV4({
-        userCreatedAt: userRolloutState.createdAt,
-        organizations: userRolloutState.organizationMemberships.map(
-          (membership) => ({
-            id: membership.organization.id,
-            createdAt: membership.organization.createdAt,
-          }),
-        ),
-        excludedOrganizationIds: env.NEXT_PUBLIC_DEMO_ORG_ID
-          ? [env.NEXT_PUBLIC_DEMO_ORG_ID]
-          : [],
-      });
+      const userCanToggleV4 = canToggleV4(
+        {
+          userCreatedAt: userRolloutState.createdAt,
+          organizations: userRolloutState.organizationMemberships.map(
+            (membership) => ({
+              id: membership.organization.id,
+              createdAt: membership.organization.createdAt,
+            }),
+          ),
+          excludedOrganizationIds: env.NEXT_PUBLIC_DEMO_ORG_ID
+            ? [env.NEXT_PUBLIC_DEMO_ORG_ID]
+            : [],
+        },
+        { isLangfuseCloudAdmin: ctx.session.user.admin === true },
+      );
 
       if (!userCanToggleV4) {
         return {

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -848,20 +848,24 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                     canToggleV4:
                       v4WriteMode === "dual" && dualPreviewAvailable
                         ? isLangfuseCloud
-                          ? canToggleV4({
-                              userCreatedAt: dbUser.createdAt,
-                              organizations: dbUser.organizationMemberships.map(
-                                (orgMembership) => ({
-                                  id: orgMembership.organization.id,
-                                  createdAt:
-                                    orgMembership.organization.createdAt,
-                                }),
-                              ),
-                              excludedOrganizationIds:
-                                env.NEXT_PUBLIC_DEMO_ORG_ID
-                                  ? [env.NEXT_PUBLIC_DEMO_ORG_ID]
-                                  : [],
-                            })
+                          ? canToggleV4(
+                              {
+                                userCreatedAt: dbUser.createdAt,
+                                organizations:
+                                  dbUser.organizationMemberships.map(
+                                    (orgMembership) => ({
+                                      id: orgMembership.organization.id,
+                                      createdAt:
+                                        orgMembership.organization.createdAt,
+                                    }),
+                                  ),
+                                excludedOrganizationIds:
+                                  env.NEXT_PUBLIC_DEMO_ORG_ID
+                                    ? [env.NEXT_PUBLIC_DEMO_ORG_ID]
+                                    : [],
+                              },
+                              { isLangfuseCloudAdmin: dbUser.admin },
+                            )
                           : true
                         : false,
                     canCreateOrganizations: canCreateOrganizations(


### PR DESCRIPTION
Cloud staff superusers (instance-level User.admin) need to switch between v3 and v4 on any tenant to reproduce behavior. Previously a new admin account fell under the date-based rollout, which auto-enabled v4 and hid the toggle. Add an isLangfuseCloudAdmin override to canToggleV4 and thread it through both the session callback (UI visibility) and the toggle mutation (server enforcement) so they stay in sync.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `isLangfuseCloudAdmin` override to `canToggleV4` so that instance-level superusers (`User.admin`) always see the v3/v4 toggle on Langfuse Cloud, bypassing the date-based auto-enable rollout that would otherwise lock new accounts onto v4. The fix is threaded through both the NextAuth session callback (UI visibility) and the `setV4BetaEnabled` tRPC mutation (server enforcement) so the two surfaces stay in sync.

- `v4Rollout.ts` gains a two-field `CanToggleV4Options` type and an early-return for `isLangfuseCloudAdmin` placed after the existing `DEV` short-circuit.
- Both call sites (`auth.ts` and `userAccount.ts`) now forward the admin flag; the outer `isLangfuseCloud` / write-mode gates are preserved, so self-hosted instances are completely unaffected.
- A new `clienttest` file covers the three relevant toggle cases for the admin override.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the admin override is correctly gated behind `isLangfuseCloud` and the write-mode checks, so self-hosted deployments and non-dual-write Cloud deployments are untouched.

The change is small and well-scoped. The only notable gap is that `auth.ts` passes `dbUser.admin` directly while `userAccount.ts` uses `=== true`; this is a style inconsistency rather than a functional defect since the Prisma field is non-nullable. Both call sites produce identical runtime behavior today.

No files require special attention. The two call sites of `canToggleV4` — `auth.ts` and `userAccount.ts` — should be checked together if the `admin` field type ever changes.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/server/auth.ts:867
Minor inconsistency with the sibling call site in `userAccount.ts`: that file uses `ctx.session.user.admin === true` (explicit equality, defensively handles any non-boolean values in the session shape), while here `dbUser.admin` is passed directly. Since `admin` is a non-nullable Prisma `Boolean`, both are equivalent today, but aligning the pattern makes the intent clearer and guards against future schema changes.

```suggestion
                              { isLangfuseCloudAdmin: dbUser.admin === true },
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(events): always allow v3/v4 toggle f..."](https://github.com/langfuse/langfuse/commit/f9a6dfbce8c4f42494f8b4e89ef317cf649b8906) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38995207)</sub>

<!-- /greptile_comment -->