### PR TITLE
fix(widgets): add score comment filter

### DIFF
--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -819,6 +819,12 @@ const createScoreSpecificDimensions = (
     type: "string",
     description: "Origin of the score. Can be API, ANNOTATION, or EVAL.",
   },
+  comment: {
+    sql: `${tableAlias}.comment`,
+    alias: "comment",
+    type: "string",
+    description: "Comment attached to the score.",
+  },
   dataType: {
     sql: `${tableAlias}.data_type`,
     alias: "dataType",

--- a/packages/shared/src/tableDefinitions/mapDashboards.ts
+++ b/packages/shared/src/tableDefinitions/mapDashboards.ts
@@ -41,6 +41,12 @@ export const dashboardColumnDefinitions: UiColumnMappings = [
   },
   {
     clickhouseTableName: "scores",
+    clickhouseSelect: "comment",
+    uiTableId: "scoreComment",
+    uiTableName: "Score Comment",
+  },
+  {
+    clickhouseTableName: "scores",
     clickhouseSelect: "data_type",
     uiTableId: "scoreDataType",
     uiTableName: "Scores Data Type",

--- a/web/src/__tests__/dashboard-ui-table-mapping.clienttest.ts
+++ b/web/src/__tests__/dashboard-ui-table-mapping.clienttest.ts
@@ -1,0 +1,26 @@
+import { mapWidgetUiTableFilterToView } from "@/src/features/dashboard/lib/dashboardUiTableToViewMapping";
+
+describe("dashboard UI table filter mapping", () => {
+  it.each(["scores-numeric", "scores-categorical"] as const)(
+    "maps Score Comment filters on %s to the score comment field",
+    (view) => {
+      expect(
+        mapWidgetUiTableFilterToView(view, [
+          {
+            column: "Score Comment",
+            operator: "is not null",
+            value: "",
+            type: "string",
+          },
+        ]),
+      ).toEqual([
+        {
+          column: "comment",
+          operator: "is not null",
+          value: "",
+          type: "string",
+        },
+      ]);
+    },
+  );
+});

--- a/web/src/__tests__/dashboard-ui-table-mapping.clienttest.ts
+++ b/web/src/__tests__/dashboard-ui-table-mapping.clienttest.ts
@@ -1,4 +1,8 @@
-import { mapWidgetUiTableFilterToView } from "@/src/features/dashboard/lib/dashboardUiTableToViewMapping";
+import {
+  mapLegacyUiTableFilterToView,
+  mapViewFilterToUiTableFilter,
+  mapWidgetUiTableFilterToView,
+} from "@/src/features/dashboard/lib/dashboardUiTableToViewMapping";
 
 describe("dashboard UI table filter mapping", () => {
   it.each(["scores-numeric", "scores-categorical"] as const)(
@@ -8,6 +12,52 @@ describe("dashboard UI table filter mapping", () => {
         mapWidgetUiTableFilterToView(view, [
           {
             column: "Score Comment",
+            operator: "is not null",
+            value: "",
+            type: "string",
+          },
+        ]),
+      ).toEqual([
+        {
+          column: "comment",
+          operator: "is not null",
+          value: "",
+          type: "string",
+        },
+      ]);
+    },
+  );
+
+  it.each(["scores-numeric", "scores-categorical"] as const)(
+    "maps stored score comment filters on %s back to the editor label",
+    (view) => {
+      expect(
+        mapViewFilterToUiTableFilter(view, [
+          {
+            column: "comment",
+            operator: "is not null",
+            value: "",
+            type: "string",
+          },
+        ]),
+      ).toEqual([
+        {
+          column: "Score Comment",
+          operator: "is not null",
+          value: "",
+          type: "string",
+        },
+      ]);
+    },
+  );
+
+  it.each(["scores-numeric", "scores-categorical"] as const)(
+    "maps legacy scoreComment filters on %s to the score comment field",
+    (view) => {
+      expect(
+        mapLegacyUiTableFilterToView(view, [
+          {
+            column: "scoreComment",
             operator: "is not null",
             value: "",
             type: "string",

--- a/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.ts
+++ b/web/src/features/dashboard/lib/dashboardUiTableToViewMapping.ts
@@ -170,6 +170,10 @@ const viewFilterDefinitions: Record<
       sourceSpec("Score Source", { uiTableId: "scoreSource" }),
     ),
     defineField(
+      "comment",
+      sourceSpec("Score Comment", { uiTableId: "scoreComment" }),
+    ),
+    defineField(
       "value",
       sourceSpec("Score Value", {
         uiTableId: "value",
@@ -218,6 +222,10 @@ const viewFilterDefinitions: Record<
     defineField(
       "source",
       sourceSpec("Score Source", { uiTableId: "scoreSource" }),
+    ),
+    defineField(
+      "comment",
+      sourceSpec("Score Comment", { uiTableId: "scoreComment" }),
     ),
     defineField(
       "stringValue",

--- a/web/src/features/widgets/components/widgetFilterColumns.ts
+++ b/web/src/features/widgets/components/widgetFilterColumns.ts
@@ -156,6 +156,15 @@ const getWidgetFilterColumnSpecs = ({
           internal: "internalValue",
         },
       },
+      {
+        column: {
+          name: "Score Comment",
+          id: "scoreComment",
+          type: "string",
+          internal: "internalValue",
+          nullable: true,
+        },
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- Expose score comments as a filterable dimension for numeric and categorical score dashboard widgets.
- Map the legacy/widget UI label `Score Comment` to the query engine `comment` field.
- Add regression coverage for score comment filter mapping.

Fixes #14075

## Test plan
- `pnpm --filter web test-client src/__tests__/dashboard-ui-table-mapping.clienttest.ts`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `comment` as a filterable dimension on `scores-numeric` and `scores-categorical` dashboard widgets, exposing it through the full filter stack: query data model, ClickHouse column mapping, UI↔view mapping layer, and the widget filter column specs.

- **`dataModel.ts`**: Adds a `comment` string dimension to `createScoreSpecificDimensions`, mapping to `${tableAlias}.comment` in ClickHouse.
- **`mapDashboards.ts` / `widgetFilterColumns.ts`**: Registers `Score Comment` with ID `scoreComment` consistently alongside the existing `Score Source` entry for both score view types.
- **`dashboardUiTableToViewMapping.ts`**: Wires `"Score Comment"` / `"scoreComment"` → `"comment"` for both `scores-numeric` and `scores-categorical`; the reverse path (view → UI label) is handled automatically by the shared `mapViewFilterToUiTableFilter` function.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is a well-scoped, additive feature — a new nullable string filter dimension wired consistently through five layers — with no modifications to existing paths and a new test covering the primary forward-mapping flow.

All five changed files follow established patterns exactly. The `comment` field is added consistently in the data model, ClickHouse mapping, UI↔view translation layer, and widget column spec. The `nullable: true` flag is valid and appropriate. The only gap is that the test does not exercise the reverse mapping or the legacy stored-filter path, but the underlying logic for those paths is identical to already-tested fields and is not structurally changed by this PR.

No files require special attention. The test file would benefit from two additional cases for completeness.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Widget Filter UI
    participant Mapper as dashboardUiTableToViewMapping
    participant DM as dataModel (query engine)
    participant CH as ClickHouse

    UI->>Mapper: "filter { column: "Score Comment", operator: "is not null" }"
    Mapper->>Mapper: matchesFilterMapping("Score Comment" → viewName: "comment")
    Mapper-->>DM: "filter { column: "comment", operator: "is not null" }"
    DM->>CH: WHERE s.comment IS NOT NULL
    CH-->>DM: score rows
    DM-->>UI: aggregated widget data

    Note over UI,Mapper: Reverse path (saved filter → editor)
    Mapper->>Mapper: mapViewFilterToUiTableFilter("comment" → "Score Comment")
    Mapper-->>UI: "filter { column: "Score Comment" }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Widget Filter UI
    participant Mapper as dashboardUiTableToViewMapping
    participant DM as dataModel (query engine)
    participant CH as ClickHouse

    UI->>Mapper: "filter { column: "Score Comment", operator: "is not null" }"
    Mapper->>Mapper: matchesFilterMapping("Score Comment" → viewName: "comment")
    Mapper-->>DM: "filter { column: "comment", operator: "is not null" }"
    DM->>CH: WHERE s.comment IS NOT NULL
    CH-->>DM: score rows
    DM-->>UI: aggregated widget data

    Note over UI,Mapper: Reverse path (saved filter → editor)
    Mapper->>Mapper: mapViewFilterToUiTableFilter("comment" → "Score Comment")
    Mapper-->>UI: "filter { column: "Score Comment" }"
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/dashboard-ui-table-mapping.clienttest.ts:1-26
**Test coverage gap: reverse mapping not exercised**

The test only verifies the forward path (`"Score Comment"` → `"comment"`), but `mapViewFilterToUiTableFilter` (used in `normalizeStoredWidgetFiltersForEditor` when reopening a saved widget) is not covered. If the reverse lookup regresses — for example, if the `uiTableName` key in the definition ever drifts — a saved widget whose stored filter has `column: "comment"` would silently display a blank label instead of `"Score Comment"`. Similarly, the `uiTableId`-keyed path (`column: "scoreComment"`) used by the legacy stored-filter branch is untested. Consider adding one test case for `mapViewFilterToUiTableFilter` (or `normalizeStoredWidgetFiltersForEditor`) and one for the stored-filter path via `mapLegacyUiTableFilterToView`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(widgets): add score comment filter"](https://github.com/langfuse/langfuse/commit/ab94f30f6f6dec09a408d01a14a26a6d261877d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38996413)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->