### PR TITLE
fix(rbac): add datasets read permission

### DIFF
--- a/web/src/__tests__/server/datasets-trpc.servertest.ts
+++ b/web/src/__tests__/server/datasets-trpc.servertest.ts
@@ -87,6 +87,20 @@ describe("datasets trpc", () => {
       ).resolves.toEqual([]);
     });
 
+    it("allows viewers to read dataset item media", async () => {
+      const { project, caller } = await prepare({
+        projectRole: "VIEWER",
+        admin: false,
+      });
+
+      await expect(
+        caller.datasets.itemMediaByItemId({
+          projectId: project.id,
+          datasetItemId: v4(),
+        }),
+      ).resolves.toEqual([]);
+    });
+
     it("rejects dataset reads when the project role lacks datasets:read", async () => {
       const { project, caller } = await prepare({
         projectRole: "NONE",
@@ -95,6 +109,20 @@ describe("datasets trpc", () => {
 
       await expect(
         caller.datasets.allDatasetMeta({ projectId: project.id }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("rejects dataset item media reads when the project role lacks datasets:read", async () => {
+      const { project, caller } = await prepare({
+        projectRole: "NONE",
+        admin: false,
+      });
+
+      await expect(
+        caller.datasets.itemMediaByItemId({
+          projectId: project.id,
+          datasetItemId: v4(),
+        }),
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
     });
   });

--- a/web/src/__tests__/server/datasets-trpc.servertest.ts
+++ b/web/src/__tests__/server/datasets-trpc.servertest.ts
@@ -1,6 +1,6 @@
 import { appRouter } from "@/src/server/api/root";
 import { createInnerTRPCContext } from "@/src/server/api/trpc";
-import { prisma } from "@langfuse/shared/src/db";
+import { prisma, type Role } from "@langfuse/shared/src/db";
 import { createOrgProjectAndApiKey } from "@langfuse/shared/src/server";
 import type { Session } from "next-auth";
 import { v4 } from "uuid";
@@ -8,7 +8,10 @@ import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 
 const orgIds: string[] = [];
 
-async function prepare() {
+async function prepare({
+  projectRole = "ADMIN",
+  admin = true,
+}: { projectRole?: Role; admin?: boolean } = {}) {
   const { project, org } = await createOrgProjectAndApiKey();
 
   const session: Session = {
@@ -28,7 +31,7 @@ async function prepare() {
           projects: [
             {
               id: project.id,
-              role: "ADMIN",
+              role: projectRole,
               retentionDays: 30,
               deletedAt: null,
               name: project.name,
@@ -43,7 +46,7 @@ async function prepare() {
         excludeClickhouseRead: false,
         templateFlag: true,
       },
-      admin: true,
+      admin,
     },
     environment: {
       enableExperimentalFeatures: false,
@@ -69,6 +72,30 @@ describe("datasets trpc", () => {
       where: {
         id: { in: orgIds },
       },
+    });
+  });
+
+  describe("datasets RBAC", () => {
+    it("allows viewers to read dataset metadata", async () => {
+      const { project, caller } = await prepare({
+        projectRole: "VIEWER",
+        admin: false,
+      });
+
+      await expect(
+        caller.datasets.allDatasetMeta({ projectId: project.id }),
+      ).resolves.toEqual([]);
+    });
+
+    it("rejects dataset reads when the project role lacks datasets:read", async () => {
+      const { project, caller } = await prepare({
+        projectRole: "NONE",
+        admin: false,
+      });
+
+      await expect(
+        caller.datasets.allDatasetMeta({ projectId: project.id }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
     });
   });
 

--- a/web/src/components/layouts/routes.tsx
+++ b/web/src/components/layouts/routes.tsx
@@ -183,6 +183,7 @@ export const ROUTES: Route[] = [
     pathname: `/project/[projectId]/datasets`,
     icon: Database,
     productModule: "datasets",
+    projectRbacScopes: ["datasets:read"],
     group: RouteGroup.Evaluation,
     section: RouteSection.Main,
   },

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -283,6 +283,12 @@ export const datasetRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const dataset = await ctx.prisma.dataset.findFirst({
         where: {
           projectId: input.projectId,
@@ -296,6 +302,12 @@ export const datasetRouter = createTRPCRouter({
   allDatasetMeta: protectedProjectProcedure
     .input(z.object({ projectId: z.string() }))
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       return ctx.prisma.dataset.findMany({
         where: {
           projectId: input.projectId,
@@ -318,6 +330,12 @@ export const datasetRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       // pathFilter: SQL WHERE clause to filter datasets by folder (e.g., "AND d.name LIKE 'folder/%'")
       const pathFilter = buildPathPrefixFilter(input.pathPrefix);
 
@@ -380,6 +398,12 @@ export const datasetRouter = createTRPCRouter({
   allDatasetsMetrics: protectedProjectProcedure
     .input(z.object({ projectId: z.string(), datasetIds: z.array(z.string()) }))
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       if (input.datasetIds.length === 0) return { metrics: [] };
 
       // Get dataset runs metrics
@@ -427,7 +451,13 @@ export const datasetRouter = createTRPCRouter({
         filter: z.array(singleFilter).nullable(),
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const count = await getDatasetRunItemsCountCh({
         projectId: input.projectId,
         filter: input.filter ?? [],
@@ -442,6 +472,12 @@ export const datasetRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       return ctx.prisma.dataset.findUnique({
         where: {
           id_projectId: {
@@ -471,6 +507,12 @@ export const datasetRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const run = await ctx.prisma.datasetRuns.findUnique({
         where: {
           id_projectId: {
@@ -498,6 +540,12 @@ export const datasetRouter = createTRPCRouter({
   baseRunDataByDatasetId: protectedProjectProcedure
     .input(z.object({ projectId: z.string(), datasetId: z.string() }))
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       return ctx.prisma.datasetRuns.findMany({
         where: { datasetId: input.datasetId, projectId: input.projectId },
         select: {
@@ -512,6 +560,12 @@ export const datasetRouter = createTRPCRouter({
   runsByDatasetId: protectedProjectProcedure
     .input(datasetRunsTableSchema)
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       // Use helper function to determine if we need DRI metrics
       if (!requiresClickhouseLookups(input.filter ?? [])) {
         const [runs, totalRuns] = await Promise.all([
@@ -570,7 +624,13 @@ export const datasetRouter = createTRPCRouter({
 
   runsByDatasetIdMetrics: protectedProjectProcedure
     .input(datasetRunTableMetricsSchema)
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       // Get runs that have metrics (only runs with dataset_run_items_rmt)
       const runsWithMetrics = await getDatasetRunsTableMetricsCh({
         projectId: input.projectId,
@@ -625,7 +685,13 @@ export const datasetRouter = createTRPCRouter({
         timestampFilter: timeFilter.optional(),
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const { timestampFilter } = input;
 
       const [numericScoreNames, categoricalScoreNames] = await Promise.all([
@@ -657,7 +723,13 @@ export const datasetRouter = createTRPCRouter({
         timestampFilter: timeFilter.optional(),
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const { projectId, timestampFilter } = input;
 
       const [numericScoreNames, categoricalScoreNames] = await Promise.all([
@@ -686,7 +758,13 @@ export const datasetRouter = createTRPCRouter({
         version: z.date().optional(),
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const item = await getDatasetItemById({
         projectId: input.projectId,
         datasetItemId: input.datasetItemId,
@@ -707,7 +785,13 @@ export const datasetRouter = createTRPCRouter({
         version: z.date().optional(),
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const item = await getDatasetItemById({
         projectId: input.projectId,
         datasetItemId: input.datasetItemId,
@@ -719,7 +803,13 @@ export const datasetRouter = createTRPCRouter({
     }),
   countItemsByDatasetId: protectedProjectProcedure
     .input(z.object({ projectId: z.string(), datasetId: z.string() }))
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       return await getDatasetItemsCount({
         projectId: input.projectId,
         filterState: createDatasetItemFilterState({
@@ -729,7 +819,13 @@ export const datasetRouter = createTRPCRouter({
     }),
   listDatasetVersions: protectedProjectProcedure
     .input(z.object({ projectId: z.string(), datasetId: z.string() }))
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       return await listDatasetVersions({
         projectId: input.projectId,
         datasetId: input.datasetId,
@@ -743,7 +839,13 @@ export const datasetRouter = createTRPCRouter({
         itemId: z.string(),
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       return await getDatasetItemVersionHistory({
         projectId: input.projectId,
         datasetId: input.datasetId,
@@ -758,7 +860,13 @@ export const datasetRouter = createTRPCRouter({
         version: z.date(),
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       return await getDatasetItemChangesSinceVersion({
         projectId: input.projectId,
         datasetId: input.datasetId,
@@ -778,6 +886,12 @@ export const datasetRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       return await fetchDatasetItems({
         projectId: input.projectId,
         datasetId: input.datasetId,
@@ -1309,7 +1423,13 @@ export const datasetRouter = createTRPCRouter({
         ...optionalPaginationZod,
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const { datasetItemId, datasetId } = input;
 
       const filter = [
@@ -1392,6 +1512,12 @@ export const datasetRouter = createTRPCRouter({
       }),
     )
     .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const {
         datasetRunId,
         datasetItemIds,
@@ -1487,7 +1613,13 @@ export const datasetRouter = createTRPCRouter({
         ...paginationZod,
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const { filterByRun, datasetId, projectId, runIds, limit, page } = input;
 
       if (runIds.length === 0) {
@@ -1552,7 +1684,13 @@ export const datasetRouter = createTRPCRouter({
           .nullish(),
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const { filterByRun, datasetId, projectId, runIds } = input;
 
       // Rely on clickhouse to return only dataset item count that match the filters
@@ -1576,7 +1714,13 @@ export const datasetRouter = createTRPCRouter({
         observationId: z.string().optional(),
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       const items = await getDatasetItems({
         projectId: input.projectId,
         filterState: createDatasetItemFilterState({

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -905,7 +905,13 @@ export const datasetRouter = createTRPCRouter({
         datasetItemValidFrom: z.date().optional(),
       }),
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      throwIfNoProjectAccess({
+        session: ctx.session,
+        projectId: input.projectId,
+        scope: "datasets:read",
+      });
+
       let validFrom = input.datasetItemValidFrom;
       if (!validFrom) {
         const item = await getDatasetItemById({

--- a/web/src/features/rbac/constants/projectAccessRights.ts
+++ b/web/src/features/rbac/constants/projectAccessRights.ts
@@ -31,6 +31,7 @@ export const projectScopes = [
 
   "integrations:CRUD",
 
+  "datasets:read",
   "datasets:CUD",
 
   "prompts:CUD",
@@ -102,6 +103,7 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "scores:CUD",
     "scoreConfigs:CUD",
     "scoreConfigs:read",
+    "datasets:read",
     "datasets:CUD",
     "prompts:CUD",
     "prompts:read",
@@ -157,6 +159,7 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "scores:CUD",
     "scoreConfigs:CUD",
     "scoreConfigs:read",
+    "datasets:read",
     "datasets:CUD",
     "prompts:CUD",
     "prompts:read",
@@ -207,6 +210,7 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "scores:CUD",
     "scoreConfigs:CUD",
     "scoreConfigs:read",
+    "datasets:read",
     "datasets:CUD",
     "prompts:CUD",
     "prompts:read",
@@ -247,6 +251,7 @@ export const projectRoleAccessRights: Record<Role, ProjectScope[]> = {
     "evalJob:read",
     "evalJobExecution:read",
     "evalDefaultModel:read",
+    "datasets:read",
     "llmApiKeys:read",
     "llmSchemas:read",
     "llmTools:read",


### PR DESCRIPTION
## Summary

- Add a `datasets:read` project RBAC scope and grant it to existing project roles that should retain dataset read access.
- Enforce `datasets:read` on dataset tRPC read endpoints and gate the Datasets navbar entry with the same scope.
- Add dataset RBAC coverage for viewer read access and missing-scope rejection.

## Linear

- [LFE-10436](https://linear.app/langfuse/issue/LFE-10436/missing-datasetsread-permission)

## Major Decisions

- Keep public API key behavior unchanged; this change only affects user/session-backed project RBAC.
- Keep remote experiment configuration reads on `datasets:CUD` because they expose writable remote experiment setup, not ordinary dataset content.

## Impacted Packages

- `web`

## Checks

- `pnpm --filter web exec vitest run --project server-isolated src/__tests__/server/datasets-trpc.servertest.ts`
- `pnpm --filter web exec eslint src/features/rbac/constants/projectAccessRights.ts src/components/layouts/routes.tsx src/features/datasets/server/dataset-router.ts src/__tests__/server/datasets-trpc.servertest.ts --max-warnings 0`
- `pnpm --filter web run typecheck`
- Commit hook: Prettier check + `turbo run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `datasets:read` project RBAC scope and enforces it on all 24 dataset tRPC read endpoints, gates the Datasets navbar entry, and grants the scope to OWNER, ADMIN, MEMBER, and VIEWER roles while leaving NONE with no dataset access. The `getRemoteExperiment` query is intentionally kept on `datasets:CUD` to restrict access to writable remote experiment configuration.

- `projectAccessRights.ts`: adds `datasets:read` to the scope list and assigns it to OWNER, ADMIN, MEMBER, and VIEWER roles.
- `dataset-router.ts`: every `.query()` handler gets a `throwIfNoProjectAccess` check for `datasets:read` (25 read endpoints total); mutation handlers remain on `datasets:CUD` unchanged.
- `routes.tsx`: Datasets navbar entry now gated by `datasets:read`, preventing the menu item from appearing for NONE-role users.
- `datasets-trpc.servertest.ts`: two new tests — VIEWER can read, NONE is rejected with FORBIDDEN.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

All 24 existing read endpoints are now consistently guarded; the two affected roles (VIEWER + NONE) behave exactly as intended and backward compatibility for OWNER/ADMIN/MEMBER is preserved.

Every tRPC .query() handler in the dataset router has a throwIfNoProjectAccess check with datasets:read. OWNER, ADMIN, MEMBER, and VIEWER all retain read access; NONE users are correctly blocked. Mutations continue to require datasets:CUD unchanged. The getRemoteExperiment query staying on datasets:CUD is an intentional, documented design decision. The two new integration tests cover the key VIEWER-allow and NONE-deny paths. No scope, migration, or contract is broken by this change.

No files require special attention; the changes are mechanical and consistent across the router.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tRPC dataset read request] --> B{protectedProjectProcedure}
    B -->|no session| C[UNAUTHORIZED]
    B -->|session present| D{throwIfNoProjectAccess\ndatasets:read}
    D -->|OWNER / ADMIN / MEMBER / VIEWER| E[Execute DB / CH query]
    D -->|NONE role or missing scope| F[FORBIDDEN]
    E --> G[Return dataset data]

    H[tRPC dataset mutation] --> I{protectedProjectProcedure}
    I -->|session present| J{throwIfNoProjectAccess\ndatasets:CUD}
    J -->|OWNER / ADMIN / MEMBER| K[Execute mutation]
    J -->|VIEWER / NONE| L[FORBIDDEN]

    M[getRemoteExperiment query] --> N{throwIfNoProjectAccess\ndatasets:CUD}
    N -->|OWNER / ADMIN / MEMBER| O[Return remote experiment config]
    N -->|VIEWER / NONE| P[FORBIDDEN]

    Q[Datasets nav entry] --> R{useHasProjectAccess\ndatasets:read}
    R -->|granted| S[Show nav item]
    R -->|denied| T[Hide nav item]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[tRPC dataset read request] --> B{protectedProjectProcedure}
    B -->|no session| C[UNAUTHORIZED]
    B -->|session present| D{throwIfNoProjectAccess\ndatasets:read}
    D -->|OWNER / ADMIN / MEMBER / VIEWER| E[Execute DB / CH query]
    D -->|NONE role or missing scope| F[FORBIDDEN]
    E --> G[Return dataset data]

    H[tRPC dataset mutation] --> I{protectedProjectProcedure}
    I -->|session present| J{throwIfNoProjectAccess\ndatasets:CUD}
    J -->|OWNER / ADMIN / MEMBER| K[Execute mutation]
    J -->|VIEWER / NONE| L[FORBIDDEN]

    M[getRemoteExperiment query] --> N{throwIfNoProjectAccess\ndatasets:CUD}
    N -->|OWNER / ADMIN / MEMBER| O[Return remote experiment config]
    N -->|VIEWER / NONE| P[FORBIDDEN]

    Q[Datasets nav entry] --> R{useHasProjectAccess\ndatasets:read}
    R -->|granted| S[Show nav item]
    R -->|denied| T[Hide nav item]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rbac): add datasets read permission"](https://github.com/langfuse/langfuse/commit/3ac5b38b2d2b261164e10a6454b35f4deca9658a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38997752)</sub>

<!-- /greptile_comment -->