### PR TITLE
feat(ingestion): persist Langfuse SDK headers

### DIFF
--- a/packages/shared/clickhouse/scripts/dev-tables.sh
+++ b/packages/shared/clickhouse/scripts/dev-tables.sh
@@ -245,6 +245,9 @@ CREATE TABLE IF NOT EXISTS events_full
     telemetry_sdk_language LowCardinality(String),
     telemetry_sdk_name String,
     telemetry_sdk_version String,
+    langfuse_sdk_name LowCardinality(Nullable(String)),
+    langfuse_sdk_version Nullable(String),
+    langfuse_ingestion_version LowCardinality(Nullable(String)),
 
     -- Generic props
     blob_storage_file_path String,
@@ -373,6 +376,9 @@ CREATE TABLE IF NOT EXISTS events_core
     telemetry_sdk_language LowCardinality(String),
     telemetry_sdk_name String,
     telemetry_sdk_version String,
+    langfuse_sdk_name LowCardinality(Nullable(String)),
+    langfuse_sdk_version Nullable(String),
+    langfuse_ingestion_version LowCardinality(Nullable(String)),
 
     -- Generic props
     blob_storage_file_path String,
@@ -408,7 +414,16 @@ SETTINGS
     enable_full_text_index = 1;
      -- cache_populated_by_fetch = 1; -- Not available in OSS ClickHouse
 
+ALTER TABLE events_full ADD COLUMN IF NOT EXISTS langfuse_sdk_name LowCardinality(Nullable(String)) AFTER telemetry_sdk_version;
+ALTER TABLE events_full ADD COLUMN IF NOT EXISTS langfuse_sdk_version Nullable(String) AFTER langfuse_sdk_name;
+ALTER TABLE events_full ADD COLUMN IF NOT EXISTS langfuse_ingestion_version LowCardinality(Nullable(String)) AFTER langfuse_sdk_version;
+
+ALTER TABLE events_core ADD COLUMN IF NOT EXISTS langfuse_sdk_name LowCardinality(Nullable(String)) AFTER telemetry_sdk_version;
+ALTER TABLE events_core ADD COLUMN IF NOT EXISTS langfuse_sdk_version Nullable(String) AFTER langfuse_sdk_name;
+ALTER TABLE events_core ADD COLUMN IF NOT EXISTS langfuse_ingestion_version LowCardinality(Nullable(String)) AFTER langfuse_sdk_version;
+
 -- Materialized view to populate events_core from events_full.
+DROP VIEW IF EXISTS events_core_mv;
 CREATE MATERIALIZED VIEW IF NOT EXISTS events_core_mv TO events_core AS
 SELECT
     project_id,
@@ -471,6 +486,9 @@ SELECT
     telemetry_sdk_language,
     telemetry_sdk_name,
     telemetry_sdk_version,
+    langfuse_sdk_name,
+    langfuse_sdk_version,
+    langfuse_ingestion_version,
     blob_storage_file_path,
     event_bytes,
     created_at,

--- a/packages/shared/src/server/llm/internalTraceEvents.ts
+++ b/packages/shared/src/server/llm/internalTraceEvents.ts
@@ -82,6 +82,9 @@ export type InternalTraceEventInput = {
   telemetrySdkLanguage?: string;
   telemetrySdkName?: string;
   telemetrySdkVersion?: string;
+  langfuseSdkName?: string | null;
+  langfuseSdkVersion?: string | null;
+  langfuseIngestionVersion?: string | null;
   blobStorageFilePath?: string;
   eventRaw?: string;
   eventBytes?: number;

--- a/packages/shared/src/server/otel/index.ts
+++ b/packages/shared/src/server/otel/index.ts
@@ -1,1 +1,2 @@
 export * from "./OtelIngestionProcessor";
+export * from "./sdkHeaders";

--- a/packages/shared/src/server/otel/sdkHeaders.ts
+++ b/packages/shared/src/server/otel/sdkHeaders.ts
@@ -1,0 +1,82 @@
+export type LangfuseSdkHeaders = {
+  sdkName?: string;
+  sdkVersion?: string;
+  ingestionVersion?: string;
+};
+
+export type NormalizedLangfuseSdkHeaders = {
+  langfuseSdkName?: string;
+  langfuseSdkVersion?: string;
+  langfuseIngestionVersion?: string;
+};
+
+export function normalizeLangfuseSdkName(
+  sdkName: string | null | undefined,
+): string | undefined {
+  const normalized = sdkName?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+export function extractBaseLangfuseSdkVersion(sdkVersion: string): string {
+  const version = sdkVersion.trim();
+
+  // Standard semver / semver pre-release / build metadata.
+  if (/^v?\d+\.\d+\.\d+(?:[-+].+)?$/i.test(version)) {
+    return version.split(/[-+]/)[0].replace(/^v/i, "");
+  }
+
+  // Python PEP 440 pre-release shorthand: 4.0.0a1, 4.0.0b1, 4.0.0rc1.
+  const pep440Match = version.match(/^(v?\d+\.\d+\.\d+)(?:a|b|rc)\d+$/i);
+  if (pep440Match?.[1]) {
+    return pep440Match[1].replace(/^v/i, "");
+  }
+
+  return version;
+}
+
+export function normalizeLangfuseSdkVersion(
+  sdkVersion: string | null | undefined,
+): string | undefined {
+  const normalized = sdkVersion?.trim();
+  if (!normalized) return undefined;
+
+  return extractBaseLangfuseSdkVersion(normalized);
+}
+
+export function normalizeLangfuseIngestionVersion(
+  ingestionVersion: string | null | undefined,
+): string | undefined {
+  const normalized = ingestionVersion?.trim();
+  if (!normalized) return undefined;
+
+  if (/^\d+$/.test(normalized)) {
+    return String(Number.parseInt(normalized, 10));
+  }
+
+  return normalized;
+}
+
+export function parseLangfuseIngestionVersion(
+  ingestionVersion: string | null | undefined,
+): number | undefined | null {
+  const normalized = ingestionVersion?.trim();
+  if (!normalized) return undefined;
+
+  if (!/^\d+$/.test(normalized)) {
+    return null;
+  }
+
+  return Number.parseInt(normalized, 10);
+}
+
+export function normalizeLangfuseSdkHeaders(
+  headers: LangfuseSdkHeaders,
+): NormalizedLangfuseSdkHeaders {
+  return {
+    langfuseSdkName: normalizeLangfuseSdkName(headers.sdkName),
+    langfuseSdkVersion: normalizeLangfuseSdkVersion(headers.sdkVersion),
+    langfuseIngestionVersion: normalizeLangfuseIngestionVersion(
+      headers.ingestionVersion,
+    ),
+  };
+}

--- a/packages/shared/src/server/repositories/definitions.ts
+++ b/packages/shared/src/server/repositories/definitions.ts
@@ -716,6 +716,9 @@ export const eventRecordBaseSchema = z.object({
   telemetry_sdk_language: z.string().nullish(),
   telemetry_sdk_name: z.string().nullish(),
   telemetry_sdk_version: z.string().nullish(),
+  langfuse_sdk_name: z.string().nullish(),
+  langfuse_sdk_version: z.string().nullish(),
+  langfuse_ingestion_version: z.string().nullish(),
 
   // Generic props
   blob_storage_file_path: z.string(),

--- a/packages/shared/src/server/test-utils/tracing-factory.ts
+++ b/packages/shared/src/server/test-utils/tracing-factory.ts
@@ -289,6 +289,9 @@ export const createEvent = (
     telemetry_sdk_language: null,
     telemetry_sdk_name: null,
     telemetry_sdk_version: null,
+    langfuse_sdk_name: null,
+    langfuse_sdk_version: null,
+    langfuse_ingestion_version: null,
 
     // Generic props
     blob_storage_file_path: "",

--- a/web/src/pages/api/public/otel/v1/traces/index.ts
+++ b/web/src/pages/api/public/otel/v1/traces/index.ts
@@ -5,6 +5,7 @@ import {
   markProjectIngestFailure,
   OtelIngestionProcessor,
   markProjectAsOtelUser,
+  parseLangfuseIngestionVersion,
 } from "@langfuse/shared/src/server";
 import { z } from "zod";
 import { $root } from "@/src/pages/api/public/otel/otlp-proto/generated/root";
@@ -18,9 +19,19 @@ function getLangfuseHeader(
   name: string,
 ): string | undefined {
   const hyphenVal = headers[name];
-  if (typeof hyphenVal === "string") return hyphenVal;
+  const hyphenString = Array.isArray(hyphenVal) ? hyphenVal[0] : hyphenVal;
+  if (typeof hyphenString === "string") {
+    const value = hyphenString.trim();
+    if (value) return value;
+  }
   const underscoreVal = headers[name.replaceAll("-", "_")];
-  if (typeof underscoreVal === "string") return underscoreVal;
+  const underscoreString = Array.isArray(underscoreVal)
+    ? underscoreVal[0]
+    : underscoreVal;
+  if (typeof underscoreString === "string") {
+    const value = underscoreString.trim();
+    if (value) return value;
+  }
   return undefined;
 }
 
@@ -146,12 +157,11 @@ export default withMiddlewares({
 
       // Reject unsupported future ingestion versions (> 4)
       // Lower versions are valid but use dual write (path A)
-      const parsedIngestionVersion = ingestionVersion
-        ? parseInt(ingestionVersion, 10)
-        : undefined;
+      const parsedIngestionVersion =
+        parseLangfuseIngestionVersion(ingestionVersion);
       if (
-        parsedIngestionVersion !== undefined &&
-        (isNaN(parsedIngestionVersion) || parsedIngestionVersion > 4)
+        parsedIngestionVersion === null ||
+        (parsedIngestionVersion !== undefined && parsedIngestionVersion > 4)
       ) {
         res.status(400);
         return {

--- a/worker/src/queues/__tests__/otelDirectEventWrite.test.ts
+++ b/worker/src/queues/__tests__/otelDirectEventWrite.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { normalizeLangfuseSdkHeaders } from "@langfuse/shared/src/server";
 import {
   checkHeaderBasedDirectWrite,
   checkSdkVersionRequirements,
@@ -22,6 +23,11 @@ describe("checkHeaderBasedDirectWrite", () => {
       input: { sdkName: "python", sdkVersion: "4.2.1" },
       expected: true,
       label: "python 4.2.1 (above minimum)",
+    },
+    {
+      input: { sdkName: " Python ", sdkVersion: " v4.0.0 " },
+      expected: true,
+      label: "python with casing, spaces, and v prefix",
     },
     {
       input: { sdkName: "python", sdkVersion: "3.9.0" },
@@ -109,6 +115,16 @@ describe("checkHeaderBasedDirectWrite", () => {
       label: "ingestionVersion '4'",
     },
     {
+      input: { ingestionVersion: "04" },
+      expected: true,
+      label: "ingestionVersion with leading zero",
+    },
+    {
+      input: { ingestionVersion: "4abc" },
+      expected: false,
+      label: "malformed ingestionVersion",
+    },
+    {
       input: {
         ingestionVersion: "4",
         sdkName: undefined,
@@ -146,6 +162,36 @@ describe("checkHeaderBasedDirectWrite", () => {
     },
   ])("$label → $expected", ({ input, expected }) => {
     expect(checkHeaderBasedDirectWrite(input)).toBe(expected);
+  });
+});
+
+describe("normalizeLangfuseSdkHeaders", () => {
+  it("normalizes persisted Langfuse SDK header values", () => {
+    expect(
+      normalizeLangfuseSdkHeaders({
+        sdkName: " Python ",
+        sdkVersion: " v4.0.0-rc.1+build.7 ",
+        ingestionVersion: "04",
+      }),
+    ).toEqual({
+      langfuseSdkName: "python",
+      langfuseSdkVersion: "4.0.0",
+      langfuseIngestionVersion: "4",
+    });
+  });
+
+  it("keeps malformed but present versions visible while dropping empty headers", () => {
+    expect(
+      normalizeLangfuseSdkHeaders({
+        sdkName: "",
+        sdkVersion: "not-a-version",
+        ingestionVersion: "4abc",
+      }),
+    ).toEqual({
+      langfuseSdkName: undefined,
+      langfuseSdkVersion: "not-a-version",
+      langfuseIngestionVersion: "4abc",
+    });
   });
 });
 

--- a/worker/src/queues/otelIngestionQueue.ts
+++ b/worker/src/queues/otelIngestionQueue.ts
@@ -6,9 +6,13 @@ import {
   getCurrentSpan,
   getS3EventStorageClient,
   type IngestionEventType,
+  extractBaseLangfuseSdkVersion,
   logger,
   markProjectIngestFailure,
+  normalizeLangfuseSdkHeaders,
+  normalizeLangfuseSdkName,
   OtelIngestionProcessor,
+  parseLangfuseIngestionVersion,
   processEventBatch,
   QueueName,
   recordDistribution,
@@ -62,13 +66,14 @@ export function checkHeaderBasedDirectWrite(params: {
 
   // Check x-langfuse-ingestion-version (>= 4 means direct write eligible).
   // Values > 4 are rejected at the API route, so anything reaching here is valid.
-  const parsed = ingestionVersion ? parseInt(ingestionVersion, 10) : NaN;
-  if (!isNaN(parsed) && parsed >= 4) {
+  const parsed = parseLangfuseIngestionVersion(ingestionVersion);
+  if (parsed !== null && parsed !== undefined && parsed >= 4) {
     return true;
   }
 
   // Check Langfuse SDK name + version
-  if (!sdkName || !sdkVersion) {
+  const normalizedSdkName = normalizeLangfuseSdkName(sdkName);
+  if (!normalizedSdkName || !sdkVersion) {
     return false;
   }
 
@@ -76,13 +81,13 @@ export function checkHeaderBasedDirectWrite(params: {
     // compareVersions returns null when current >= minimum (no update needed).
     // Strip pre-release/build metadata so that e.g. 4.0.0-rc.1 qualifies as 4.0.0.
     // Also normalize Python PEP440 shorthand (e.g. 4.0.0b1, 4.0.0rc1) to the core version.
-    const baseVersion = extractBaseSdkVersion(sdkVersion);
+    const baseVersion = extractBaseLangfuseSdkVersion(sdkVersion);
 
-    if (sdkName === "python") {
+    if (normalizedSdkName === "python") {
       return compareVersions(baseVersion, "v4.0.0") === null;
     }
 
-    if (sdkName === "javascript") {
+    if (normalizedSdkName === "javascript") {
       return compareVersions(baseVersion, "v5.0.0") === null;
     }
   } catch {
@@ -92,23 +97,6 @@ export function checkHeaderBasedDirectWrite(params: {
   }
 
   return false;
-}
-
-function extractBaseSdkVersion(sdkVersion: string): string {
-  const version = sdkVersion.trim();
-
-  // Standard semver / semver pre-release / build metadata
-  if (/^v?\d+\.\d+\.\d+(?:[-+].+)?$/i.test(version)) {
-    return version.split(/[-+]/)[0];
-  }
-
-  // Python PEP 440 pre-release shorthand: 4.0.0a1, 4.0.0b1, 4.0.0rc1
-  const pep440Match = version.match(/^(v?\d+\.\d+\.\d+)(?:a|b|rc)\d+$/i);
-  if (pep440Match?.[1]) {
-    return pep440Match[1];
-  }
-
-  return version;
 }
 
 /**
@@ -474,6 +462,11 @@ export const otelIngestionQueueProcessorBuilder = (
       // Determine what processing is needed
       const shouldWriteToEventsTable =
         v4WritesToEventsTable(env) && useDirectEventWrite;
+      const langfuseSdkHeaders = normalizeLangfuseSdkHeaders({
+        sdkName: job.data.payload.sdkName,
+        sdkVersion: job.data.payload.sdkVersion,
+        ingestionVersion: job.data.payload.ingestionVersion,
+      });
 
       const evalConfigs = await fetchObservationEvalConfigs(projectId).catch(
         (error) => {
@@ -542,6 +535,13 @@ export const otelIngestionQueueProcessorBuilder = (
           // Step 3: Write to events table (independent of eval scheduling)
           if (shouldWriteToEventsTable) {
             try {
+              eventRecord.langfuse_sdk_name =
+                langfuseSdkHeaders.langfuseSdkName ?? null;
+              eventRecord.langfuse_sdk_version =
+                langfuseSdkHeaders.langfuseSdkVersion ?? null;
+              eventRecord.langfuse_ingestion_version =
+                langfuseSdkHeaders.langfuseIngestionVersion ?? null;
+
               ingestionService.writeEventRecord(eventRecord);
             } catch (error) {
               traceException(error);

--- a/worker/src/services/IngestionService/index.ts
+++ b/worker/src/services/IngestionService/index.ts
@@ -351,6 +351,9 @@ export class IngestionService {
       telemetry_sdk_language: eventData.telemetrySdkLanguage,
       telemetry_sdk_name: eventData.telemetrySdkName,
       telemetry_sdk_version: eventData.telemetrySdkVersion,
+      langfuse_sdk_name: eventData.langfuseSdkName,
+      langfuse_sdk_version: eventData.langfuseSdkVersion,
+      langfuse_ingestion_version: eventData.langfuseIngestionVersion,
 
       // Storage
       blob_storage_file_path: fileKey,


### PR DESCRIPTION
## What changed

- Added normalized Langfuse SDK header metadata fields for direct OTel event writes: `langfuse_sdk_name`, `langfuse_sdk_version`, and `langfuse_ingestion_version`.
- Kept existing OTLP instrumentation fields (`scope_*`, `telemetry_sdk_*`) unchanged.
- Tightened OTel API header parsing for whitespace, array-valued headers, underscore variants, SDK-name casing, and malformed ingestion-version values.
- Updated the local events table definitions and `events_core_mv` projection so `events_core` receives the new columns from `events_full`.

## Notes

- No historical backfill is included; existing rows remain null.
- The SDK version is stored as a normalized string, not as a numeric semver decomposition.
- Dual-write rows continue to leave these fields null because the values are only attached before direct `events_full` writes.

## Verification

- `pnpm --filter=worker exec vitest run src/queues/__tests__/otelDirectEventWrite.test.ts`
- `pnpm --filter=@langfuse/shared typecheck`
- `pnpm --filter=worker typecheck`
- `pnpm --filter=web typecheck`
- `pnpm --filter=@langfuse/shared lint`
- `pnpm --filter=worker lint`
- `pnpm --filter=web lint`
- `bash -n packages/shared/clickhouse/scripts/dev-tables.sh`