### PR TITLE
chore(worker): add derived uploadWaitMs timer to blob export pipeline (LFE-10441)

### DIFF
--- a/worker/src/features/blobstorage/gzipStream.ts
+++ b/worker/src/features/blobstorage/gzipStream.ts
@@ -2,16 +2,14 @@ import { Transform } from "stream";
 import { createGzip, type Gzip } from "zlib";
 
 export type GzipStats = {
-  // zlib level actually used (the resolved tuning level, or the zlib default
-  // when none was configured). Recorded so a measurement can be tied to a level.
   level: number;
-  // Active compression time, summed per input chunk as the latency from handing
-  // the chunk to zlib until zlib reports it consumed (zlib offloads to the libuv
-  // threadpool). This isolates compression work from the idle gaps spent waiting
-  // on the next ClickHouse row; under sustained downstream backpressure it also
-  // absorbs upload-wait, which is itself a useful "gzip is not the bottleneck"
-  // signal. Use together with input/output bytes to derive throughput + ratio.
+  // Wall-clock time from handing a chunk to zlib until the write callback fires.
+  // Includes both compression CPU and downstream backpressure pauses.
   activeMs: number;
+  // Subset of activeMs spent waiting for the downstream consumer (S3 upload) to
+  // drain. Measured as the gap between push() returning false (gzip.pause()) and
+  // the next _read() call (gzip.resume()). Pure gzip CPU ≈ activeMs - backpressureMs.
+  backpressureMs: number;
 };
 
 // zlib resolves Z_DEFAULT_COMPRESSION (-1) to compression level 6. Surfaced
@@ -28,6 +26,7 @@ export const ZLIB_DEFAULT_LEVEL = 6;
  */
 export class TimedGzip extends Transform {
   private readonly gzip: Gzip;
+  private bpStart: number | null = null;
 
   constructor(
     level: number | undefined,
@@ -36,12 +35,23 @@ export class TimedGzip extends Transform {
     super();
     this.gzip = level === undefined ? createGzip() : createGzip({ level });
     this.gzip.on("data", (chunk: Buffer) => {
-      if (!this.push(chunk)) this.gzip.pause();
+      if (!this.push(chunk)) {
+        this.gzip.pause();
+        if (this.bpStart === null) this.bpStart = performance.now();
+      }
     });
     this.gzip.on("error", (err: Error) => this.destroy(err));
   }
 
+  private creditBackpressure() {
+    if (this.bpStart !== null) {
+      this.stats.backpressureMs += performance.now() - this.bpStart;
+      this.bpStart = null;
+    }
+  }
+
   _read() {
+    this.creditBackpressure();
     this.gzip.resume();
   }
 
@@ -69,8 +79,9 @@ export class TimedGzip extends Transform {
       callback();
     });
     this.gzip.end();
-    // Ensure the readable side is flowing so the trailing `data`/`end` fire even
-    // if downstream had paused us right before flush.
+    // Credit any outstanding backpressure before resuming, so the interval
+    // between the last pause and this resume is not lost or mis-attributed.
+    this.creditBackpressure();
     this.gzip.resume();
   }
 

--- a/worker/src/features/blobstorage/gzipStream.ts
+++ b/worker/src/features/blobstorage/gzipStream.ts
@@ -6,9 +6,10 @@ export type GzipStats = {
   // Wall-clock time from handing a chunk to zlib until the write callback fires.
   // Includes both compression CPU and downstream backpressure pauses.
   activeMs: number;
-  // Subset of activeMs spent waiting for the downstream consumer (S3 upload) to
-  // drain. Measured as the gap between push() returning false (gzip.pause()) and
-  // the next _read() call (gzip.resume()). Pure gzip CPU ≈ activeMs - backpressureMs.
+  // Time spent waiting for the downstream consumer (S3 upload) to drain.
+  // Measured independently as the gap between push() returning false
+  // (gzip.pause()) and the next _read() call (gzip.resume()).
+  // Pure gzip CPU ≈ max(0, activeMs - backpressureMs).
   backpressureMs: number;
 };
 

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -401,12 +401,19 @@ const processBlobStorageExport = async (config: {
         const compressedCounter = config.compressed ? new ByteCounter() : null;
         // Paired with compressedCounter: both exist iff compression is on.
         const gzipStats: GzipStats | null = compressedCounter
-          ? { level: config.gzipLevel ?? ZLIB_DEFAULT_LEVEL, activeMs: 0 }
+          ? {
+              level: config.gzipLevel ?? ZLIB_DEFAULT_LEVEL,
+              activeMs: 0,
+              backpressureMs: 0,
+            }
           : null;
 
         // Both paths tally rows in JS via countedStream (the passthrough yields
         // raw row text rather than parsed objects, but still iterates).
         const sourceStats = { rows: 0, sourceWaitMs: 0 };
+        // When enrichment is active, chStats isolates ClickHouse read wait from
+        // enrichment CPU. enrichMs = sourceStats.sourceWaitMs - chStats.sourceWaitMs.
+        let chStats: { rows: number; sourceWaitMs: number } | null = null;
 
         const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
         const heartbeatTags = {
@@ -482,12 +489,16 @@ const processBlobStorageExport = async (config: {
               );
               break;
             case "observations":
+              chStats = { rows: 0, sourceWaitMs: 0 };
               rawStream = enrichObservationStream(
-                getObservationsForBlobStorageExport(
-                  config.projectId,
-                  config.minTimestamp,
-                  config.maxTimestamp,
-                  exportFieldGroups,
+                countedStream(
+                  getObservationsForBlobStorageExport(
+                    config.projectId,
+                    config.minTimestamp,
+                    config.maxTimestamp,
+                    exportFieldGroups,
+                  ),
+                  chStats,
                 ),
                 config.projectId,
                 "model_id",
@@ -503,12 +514,16 @@ const processBlobStorageExport = async (config: {
               );
               break;
             case "observations_v2": // observations_v2 is the events table
+              chStats = { rows: 0, sourceWaitMs: 0 };
               rawStream = enrichObservationStream(
-                getEventsForBlobStorageExport(
-                  config.projectId,
-                  config.minTimestamp,
-                  config.maxTimestamp,
-                  exportFieldGroups,
+                countedStream(
+                  getEventsForBlobStorageExport(
+                    config.projectId,
+                    config.minTimestamp,
+                    config.maxTimestamp,
+                    exportFieldGroups,
+                  ),
+                  chStats,
                 ),
                 config.projectId,
                 "model_id",
@@ -546,6 +561,7 @@ const processBlobStorageExport = async (config: {
         // 100 MB parts support files up to ~1 TB (100 MB × 10,000 AWS limit)
         // This prevents hitting AWS's 10,000 part limit on large exports
         let uploadStartMs: number | undefined;
+        let uploadDurationMsFinal: number | undefined;
         try {
           uploadStartMs = performance.now();
 
@@ -558,6 +574,7 @@ const processBlobStorageExport = async (config: {
           // Record at the upload boundary so a throw in the `finally` below
           // can't miscount a real success as a failure.
           uploadSucceeded = true;
+          uploadDurationMsFinal = Math.round(performance.now() - uploadStartMs);
           recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {
             outcome: "success" satisfies BlobTableExportOutcome,
             table: config.table,
@@ -582,46 +599,99 @@ const processBlobStorageExport = async (config: {
             );
           }
 
+          const uploadDurationMs = uploadDurationMsFinal;
+          const chReadMs = Math.round(
+            chStats ? chStats.sourceWaitMs : sourceStats.sourceWaitMs,
+          );
+          const enrichMs = chStats
+            ? Math.max(
+                0,
+                Math.round(sourceStats.sourceWaitMs - chStats.sourceWaitMs),
+              )
+            : 0;
+          const gzipCpuMs = gzipStats
+            ? Math.round(gzipStats.activeMs - gzipStats.backpressureMs)
+            : 0;
+          const uploadWaitMs = gzipStats
+            ? Math.round(gzipStats.backpressureMs)
+            : Math.max(0, uploadDurationMs - chReadMs - enrichMs);
+
           logger.info(
             `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
               `jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${WORKER_HOST_ID} ` +
               `path=${passthroughEligible ? "passthrough" : "standard"} ` +
-              `rows=${sourceStats.rows} sourceWaitMs=${Math.round(sourceStats.sourceWaitMs)} ` +
-              `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${Math.round(performance.now() - uploadStartMs)}` +
+              `rows=${sourceStats.rows} chReadMs=${chReadMs} enrichMs=${enrichMs} ` +
+              `gzipCpuMs=${gzipCpuMs} uploadWaitMs=${uploadWaitMs} ` +
+              `serializedBytes=${serializedCounter.bytes} uploadDurationMs=${uploadDurationMs}` +
               (gzipStats && compressedCounter
-                ? ` gzipLevel=${gzipStats.level} gzipActiveMs=${Math.round(gzipStats.activeMs)} ` +
-                  `compressedBytes=${compressedCounter.bytes}`
+                ? ` gzipLevel=${gzipStats.level} compressedBytes=${compressedCounter.bytes}`
                 : ""),
           );
         } finally {
           span.setAttribute("blob.rows", sourceStats.rows);
-          span.setAttribute(
-            "blob.sourceWaitMs",
-            Math.round(sourceStats.sourceWaitMs),
+          const finalChReadMs = Math.round(
+            chStats ? chStats.sourceWaitMs : sourceStats.sourceWaitMs,
           );
+          const finalEnrichMs = Math.round(
+            chStats ? sourceStats.sourceWaitMs - chStats.sourceWaitMs : 0,
+          );
+          span.setAttribute("blob.chReadMs", finalChReadMs);
+          span.setAttribute("blob.enrichMs", finalEnrichMs);
           span.setAttribute("blob.serializedBytes", serializedCounter.bytes);
           if (uploadStartMs !== undefined) {
-            span.setAttribute(
-              "blob.uploadDurationMs",
-              Math.round(performance.now() - uploadStartMs),
-            );
+            const totalUploadMs =
+              uploadDurationMsFinal ??
+              Math.round(performance.now() - uploadStartMs);
+            span.setAttribute("blob.uploadDurationMs", totalUploadMs);
+            if (uploadSucceeded) {
+              const finalGzipCpuMs = gzipStats
+                ? Math.round(gzipStats.activeMs - gzipStats.backpressureMs)
+                : 0;
+              const finalUploadWaitMs = gzipStats
+                ? Math.round(gzipStats.backpressureMs)
+                : Math.max(0, totalUploadMs - finalChReadMs - finalEnrichMs);
+              span.setAttribute("blob.gzipCpuMs", finalGzipCpuMs);
+              span.setAttribute("blob.uploadWaitMs", finalUploadWaitMs);
+              const stageTags = {
+                table: config.table,
+                path: passthroughEligible ? "passthrough" : "standard",
+                compressed: config.compressed ? "true" : "false",
+              };
+              recordHistogram(
+                "langfuse.blob_export.ch_read_ms",
+                finalChReadMs,
+                stageTags,
+              );
+              recordHistogram(
+                "langfuse.blob_export.enrich_ms",
+                finalEnrichMs,
+                stageTags,
+              );
+              recordHistogram(
+                "langfuse.blob_export.gzip_cpu_ms",
+                finalGzipCpuMs,
+                stageTags,
+              );
+              recordHistogram(
+                "langfuse.blob_export.upload_wait_ms",
+                finalUploadWaitMs,
+                stageTags,
+              );
+            }
           }
           if (compressedCounter) {
             span.setAttribute("blob.compressedBytes", compressedCounter.bytes);
           }
           if (gzipStats && compressedCounter) {
-            // Gauge the cost of the gzip step so a level change (or moving
-            // compression off the worker) can be evaluated against real data.
             const activeMs = Math.round(gzipStats.activeMs);
-            // Input/output ratio (>1 = shrank); guard div-by-zero on empty exports.
             const ratio =
               compressedCounter.bytes > 0
                 ? serializedCounter.bytes / compressedCounter.bytes
                 : 0;
-            // Compression throughput over uncompressed input bytes.
+            const pureGzipMs = gzipStats.activeMs - gzipStats.backpressureMs;
             const throughputMbPerSec =
-              gzipStats.activeMs > 0
-                ? serializedCounter.bytes / (gzipStats.activeMs * 1000)
+              pureGzipMs > 0
+                ? serializedCounter.bytes / (pureGzipMs * 1000)
                 : 0;
 
             span.setAttribute("blob.gzip.level", gzipStats.level);

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -610,7 +610,10 @@ const processBlobStorageExport = async (config: {
               )
             : 0;
           const gzipCpuMs = gzipStats
-            ? Math.round(gzipStats.activeMs - gzipStats.backpressureMs)
+            ? Math.max(
+                0,
+                Math.round(gzipStats.activeMs - gzipStats.backpressureMs),
+              )
             : 0;
           const uploadWaitMs = gzipStats
             ? Math.round(gzipStats.backpressureMs)
@@ -645,7 +648,10 @@ const processBlobStorageExport = async (config: {
             span.setAttribute("blob.uploadDurationMs", totalUploadMs);
             if (uploadSucceeded) {
               const finalGzipCpuMs = gzipStats
-                ? Math.round(gzipStats.activeMs - gzipStats.backpressureMs)
+                ? Math.max(
+                    0,
+                    Math.round(gzipStats.activeMs - gzipStats.backpressureMs),
+                  )
                 : 0;
               const finalUploadWaitMs = gzipStats
                 ? Math.round(gzipStats.backpressureMs)
@@ -688,7 +694,10 @@ const processBlobStorageExport = async (config: {
               compressedCounter.bytes > 0
                 ? serializedCounter.bytes / compressedCounter.bytes
                 : 0;
-            const pureGzipMs = gzipStats.activeMs - gzipStats.backpressureMs;
+            const pureGzipMs = Math.max(
+              0,
+              gzipStats.activeMs - gzipStats.backpressureMs,
+            );
             const throughputMbPerSec =
               pureGzipMs > 0
                 ? serializedCounter.bytes / (pureGzipMs * 1000)

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -635,9 +635,12 @@ const processBlobStorageExport = async (config: {
           const finalChReadMs = Math.round(
             chStats ? chStats.sourceWaitMs : sourceStats.sourceWaitMs,
           );
-          const finalEnrichMs = Math.round(
-            chStats ? sourceStats.sourceWaitMs - chStats.sourceWaitMs : 0,
-          );
+          const finalEnrichMs = chStats
+            ? Math.max(
+                0,
+                Math.round(sourceStats.sourceWaitMs - chStats.sourceWaitMs),
+              )
+            : 0;
           span.setAttribute("blob.chReadMs", finalChReadMs);
           span.setAttribute("blob.enrichMs", finalEnrichMs);
           span.setAttribute("blob.serializedBytes", serializedCounter.bytes);


### PR DESCRIPTION
## What does this PR do?

Derives `uploadWaitMs = uploadDurationMs - sourceWaitMs - gzipActiveMs` to complete the three non-overlapping per-stage timers for the blob export pipeline. This reveals S3 backpressure as the remaining time after ClickHouse read and gzip compression are accounted for.

Emitted as:
- Log field (`uploadWaitMs=...`)
- Span attribute (`blob.uploadWaitMs`)
- Histogram metric (`langfuse.blob_export.upload_wait_ms`, tagged by table + path)

## Type of change
- [x] Chore (non-breaking change which does not add functionality but improves observability)

## Checklist
- [x] Lint passes
- [x] Typecheck passes
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an `uploadWaitMs` derived timer to the blob export pipeline, computed as `uploadDurationMs - sourceWaitMs - gzipActiveMs`. This surfaces S3 backpressure as the residual time once ClickHouse read and gzip compression are accounted for.

- Emits `uploadWaitMs` in the success log line and a new `blob.uploadWaitMs` span attribute for tracing visibility.
- Adds a `langfuse.blob_export.upload_wait_ms` histogram tagged by table and path, recorded inside the `finally` block alongside the existing span attribute writes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is purely additive observability instrumentation with no functional impact on the export pipeline itself.

The histogram recording lands inside the `finally` block, so every failed upload injects a measurement into `langfuse.blob_export.upload_wait_ms`. Since the intent is to track S3 backpressure, failure-path data will skew the metric over time, particularly under elevated error rates. The log field and span attribute also derive from two separate `performance.now()` calls, giving marginally different values for what should be the same quantity.

worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts — the `finally` block around lines 577–594 needs review for the histogram placement and the duplicated `performance.now()` capture.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CH as ClickHouse
    participant W as Worker
    participant GZ as Gzip
    participant S3 as S3 / BlobStorage
    participant OBS as Observability (Span + Histogram)

    W->>CH: Stream rows (sourceWaitMs accumulates)
    CH-->>W: Row data
    W->>GZ: Compress (gzipActiveMs accumulates)
    GZ-->>W: Compressed bytes
    W->>S3: uploadFileBuffered (uploadStartMs set)
    S3-->>W: Upload complete
    Note over W: uploadDurationMs = now() - uploadStartMs
    Note over W: uploadWaitMs = uploadDurationMs - sourceWaitMs - gzipActiveMs
    W->>W: logger.info (uploadWaitMs, uploadDurationMs)
    W->>OBS: finally block: span.setAttribute blob.uploadDurationMs (totalUploadMs re-captured)
    W->>OBS: span.setAttribute blob.uploadWaitMs (derivedUploadWaitMs)
    W->>OBS: recordHistogram langfuse.blob_export.upload_wait_ms
    Note over OBS: finally fires on both success and failure paths
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CH as ClickHouse
    participant W as Worker
    participant GZ as Gzip
    participant S3 as S3 / BlobStorage
    participant OBS as Observability (Span + Histogram)

    W->>CH: Stream rows (sourceWaitMs accumulates)
    CH-->>W: Row data
    W->>GZ: Compress (gzipActiveMs accumulates)
    GZ-->>W: Compressed bytes
    W->>S3: uploadFileBuffered (uploadStartMs set)
    S3-->>W: Upload complete
    Note over W: uploadDurationMs = now() - uploadStartMs
    Note over W: uploadWaitMs = uploadDurationMs - sourceWaitMs - gzipActiveMs
    W->>W: logger.info (uploadWaitMs, uploadDurationMs)
    W->>OBS: finally block: span.setAttribute blob.uploadDurationMs (totalUploadMs re-captured)
    W->>OBS: span.setAttribute blob.uploadWaitMs (derivedUploadWaitMs)
    W->>OBS: recordHistogram langfuse.blob_export.upload_wait_ms
    Note over OBS: finally fires on both success and failure paths
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:587-594
**Histogram recorded on failed uploads**

`recordHistogram` is inside `finally`, so it fires regardless of whether `uploadFileBuffered` succeeded or threw. On a failed upload, `totalUploadMs` accumulates time through error propagation and any cleanup, making `derivedUploadWaitMs` a meaningless reading for the intended purpose (measuring S3 backpressure). This will pollute the `langfuse.blob_export.upload_wait_ms` aggregate with failure-path data. Gating on `uploadSucceeded` (or moving the call to the success branch, as is done for `BLOB_TABLE_EXPORT_METRIC`) would keep the metric clean.

### Issue 2 of 2
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:548-585
**Divergent `uploadWaitMs` values between log and span**

`uploadDurationMs` (line 548–550) and `totalUploadMs` (line 578) are captured from two separate `performance.now()` calls. The log emits the earlier snapshot while the span attribute `blob.uploadWaitMs` and histogram use the later one. Although the gap is typically sub-millisecond, correlating log lines with span data will show slightly different values for `uploadDurationMs` / `uploadWaitMs`, which can be confusing during incident investigation. Capturing `uploadDurationMs` once in the success block and passing it into the `finally` block (or reusing the already-captured variable) would guarantee both signals refer to the same measurement.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): add derived uploadWaitMs ..."](https://github.com/langfuse/langfuse/commit/28a55f1a3d41146a3a903498429532201536f645) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39027962)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->