### PR TITLE
chore(worker): blob export heartbeat gauge (LFE-10063)

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -348,6 +348,7 @@ const processBlobStorageExport = async (config: {
       // Outside the try so the catch can distinguish a real upload success from
       // a failure.
       let uploadSucceeded = false;
+      let heartbeat: ReturnType<typeof setInterval> | undefined;
 
       try {
         const blobStorageProps = getFileTypeProperties(config.fileType);
@@ -406,6 +407,24 @@ const processBlobStorageExport = async (config: {
         // Both paths tally rows in JS via countedStream (the passthrough yields
         // raw row text rather than parsed objects, but still iterates).
         const sourceStats = { rows: 0, sourceWaitMs: 0 };
+
+        const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
+        const heartbeatTags = {
+          table: config.table,
+          projectId: config.projectId,
+        };
+        heartbeat = setInterval(() => {
+          recordGauge(
+            "langfuse.blobstorage.export_heartbeat.rows",
+            sourceStats.rows,
+            heartbeatTags,
+          );
+          recordGauge(
+            "langfuse.blobstorage.export_heartbeat.serialized_bytes",
+            serializedCounter.bytes,
+            heartbeatTags,
+          );
+        }, HEARTBEAT_INTERVAL_MS);
 
         let fileStream: Readable;
 
@@ -633,6 +652,7 @@ const processBlobStorageExport = async (config: {
         );
         throw error;
       } finally {
+        clearInterval(heartbeat);
         unregisterInFlightBlobExport(inFlightHandle);
 
         // ns → ms; the histogram yields NaN/Infinity with zero samples.


### PR DESCRIPTION
## What does this PR do?

Adds two Datadog gauge metrics emitted every 5 minutes during blob export streaming:
- `langfuse.blobstorage.export_heartbeat.rows` — rows processed so far
- `langfuse.blobstorage.export_heartbeat.serialized_bytes` — bytes serialized so far

Both tagged with `table` and `projectId`. Only fires for exports running >5 min, so short exports produce zero heartbeat noise. Enables alerting on stuck exports (heartbeat stops without a success/failure terminal metric).

## Type of change
- [x] Chore (refactor, observability, CI)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I've checked that lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two Datadog gauge heartbeat metrics (`langfuse.blobstorage.export_heartbeat.rows` and `langfuse.blobstorage.export_heartbeat.serialized_bytes`) emitted on a 5-minute `setInterval` during blob export streaming, enabling alerting on stuck or stalled exports.

- The interval is started after `sourceStats` and `serializedCounter` are initialized, so the closure references are valid, and `clearInterval` is reliably called in the `finally` block to prevent timer leaks.
- `HEARTBEAT_INTERVAL_MS` is defined as a function-scoped constant; promoting it to a module-level constant would improve reusability, but is a minor style concern.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only adds a heartbeat timer for observability with no logic changes to the export path itself.

The interval is set up after its closure dependencies (sourceStats, serializedCounter) are fully initialized, the clearInterval call lives in the finally block so no timer leak is possible even on error, and recordGauge is already imported at the top of the module. No functional paths are altered.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): add 5-min heartbeat gauge..."](https://github.com/langfuse/langfuse/commit/0cc2570fb917ea885f87fc7c09228c3da754e3a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39032585)</sub>

<!-- /greptile_comment -->