### PR TITLE
chore(worker): add counter metrics for blob export bytes (LFE-10442)

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -545,6 +545,25 @@ const processBlobStorageExport = async (config: {
             projectId: config.projectId,
           });
 
+          const byteTags = {
+            table: config.table,
+            projectId: config.projectId,
+            path: passthroughEligible ? "passthrough" : "standard",
+            gzipLevel: config.gzipLevel ?? ZLIB_DEFAULT_LEVEL,
+          };
+          recordIncrement(
+            "langfuse.blob_export.serialized_bytes",
+            serializedCounter.bytes,
+            byteTags,
+          );
+          if (compressedCounter) {
+            recordIncrement(
+              "langfuse.blob_export.compressed_bytes",
+              compressedCounter.bytes,
+              byteTags,
+            );
+          }
+
           logger.info(
             `[BLOB INTEGRATION] Successfully exported ${config.table} for project ${config.projectId}: ` +
               `jobId=${config.bullmqJobId} attemptsMade=${config.bullmqAttemptsMade} host=${WORKER_HOST_ID} ` +

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -549,18 +549,17 @@ const processBlobStorageExport = async (config: {
             table: config.table,
             projectId: config.projectId,
             path: passthroughEligible ? "passthrough" : "standard",
-            gzipLevel: config.gzipLevel ?? ZLIB_DEFAULT_LEVEL,
           };
           recordIncrement(
             "langfuse.blob_export.serialized_bytes",
             serializedCounter.bytes,
             byteTags,
           );
-          if (compressedCounter) {
+          if (compressedCounter && gzipStats) {
             recordIncrement(
               "langfuse.blob_export.compressed_bytes",
               compressedCounter.bytes,
-              byteTags,
+              { ...byteTags, gzipLevel: gzipStats.level },
             );
           }
 


### PR DESCRIPTION
## What does this PR do?

Adds two **counter** metrics emitted on each successful blob storage export in `handleBlobStorageIntegrationProjectJob.ts`:

- `langfuse.blob_export.serialized_bytes` — uncompressed bytes read from ClickHouse
- `langfuse.blob_export.compressed_bytes` — compressed bytes uploaded to S3 (= egress volume)

Tags: `table`, `projectId`, `path` (passthrough/standard), `gzipLevel`.

This enables Datadog queries like `sum:langfuse.blob_export.compressed_bytes{*}.as_count()` for total S3 egress cost monitoring across projects and environments.

The values were already logged and set as OTel span attributes — this PR promotes them to first-class Datadog counters for aggregation and alerting.

## Type of change

- [x] Chore (refactor, observability, non-user-facing)

## Checklist

- [x] Follows existing `recordIncrement` / `recordHistogram` patterns in the blob exporter
- [x] Lint passes
- [x] Typecheck passes
- [x] `compressed_bytes` counter is only emitted when compression is enabled (guarded by `compressedCounter` check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Promotes two byte-size metrics for blob storage exports from logged attributes/span attributes to first-class Datadog counters. Both `langfuse.blob_export.serialized_bytes` (uncompressed ClickHouse bytes) and `langfuse.blob_export.compressed_bytes` (S3-uploaded compressed bytes) are emitted via `recordIncrement` after a successful upload, guarded correctly so the compressed counter is only sent when compression is active.

- Adds `byteTags` (`table`, `projectId`, `path`, `gzipLevel`) and two `recordIncrement` calls inside the `uploadSucceeded` block, consistently with the existing `BLOB_TABLE_EXPORT_METRIC` pattern.
- The `compressed_bytes` emission is correctly gated on `if (compressedCounter)`, matching the pipeline's compression flag.
- `gzipLevel` is included in `byteTags` for both metrics regardless of whether compression is enabled; uncompressed exports will carry `gzipLevel: ZLIB_DEFAULT_LEVEL` (-1) on the `serialized_bytes` counter, diverging from the pattern used by the existing gzip histograms which only include that tag when compression is active.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is additive-only observability: it emits two new counters after a successful upload and does not alter the upload, compression, or error-handling paths. Safe to merge.

The upload and stream pipelines are untouched; the new recordIncrement calls sit after uploadSucceeded = true and cannot affect the export outcome. The one open question is the gzipLevel tag being included on serialized_bytes for uncompressed exports (where it carries a zlib sentinel value of -1), which may confuse Datadog queries that filter by that tag — but it does not affect correctness of the export itself.

worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts — specifically the byteTags construction around line 548 and whether gzipLevel should be omitted when compression is off.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Worker as BlobStorage Worker
    participant CH as ClickHouse
    participant Pipeline as Stream Pipeline
    participant S3 as S3 / Blob Storage
    participant DD as Datadog

    Worker->>CH: getXxxForBlobStorageExport()
    CH-->>Pipeline: rawStream
    Pipeline->>Pipeline: countedStream (rows)
    Pipeline->>Pipeline: serializedCounter (bytes before gzip)
    alt compression enabled
        Pipeline->>Pipeline: TimedGzip (gzip)
        Pipeline->>Pipeline: compressedCounter (bytes after gzip)
    end
    Pipeline->>S3: uploadFileBuffered()
    S3-->>Worker: success
    Worker->>DD: "recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {outcome, table, projectId})"
    Worker->>DD: recordIncrement(serialized_bytes, byteTags)
    opt "compressedCounter != null"
        Worker->>DD: recordIncrement(compressed_bytes, byteTags)
    end
    Worker->>DD: recordHistogram(gzip metrics) [if compression on]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Worker as BlobStorage Worker
    participant CH as ClickHouse
    participant Pipeline as Stream Pipeline
    participant S3 as S3 / Blob Storage
    participant DD as Datadog

    Worker->>CH: getXxxForBlobStorageExport()
    CH-->>Pipeline: rawStream
    Pipeline->>Pipeline: countedStream (rows)
    Pipeline->>Pipeline: serializedCounter (bytes before gzip)
    alt compression enabled
        Pipeline->>Pipeline: TimedGzip (gzip)
        Pipeline->>Pipeline: compressedCounter (bytes after gzip)
    end
    Pipeline->>S3: uploadFileBuffered()
    S3-->>Worker: success
    Worker->>DD: "recordIncrement(BLOB_TABLE_EXPORT_METRIC, 1, {outcome, table, projectId})"
    Worker->>DD: recordIncrement(serialized_bytes, byteTags)
    opt "compressedCounter != null"
        Worker->>DD: recordIncrement(compressed_bytes, byteTags)
    end
    Worker->>DD: recordHistogram(gzip metrics) [if compression on]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts:548-565
**`gzipLevel` tag attached to `serialized_bytes` even when compression is disabled**

`byteTags` always includes `gzipLevel: config.gzipLevel ?? ZLIB_DEFAULT_LEVEL`, so the `langfuse.blob_export.serialized_bytes` metric is tagged with a gzip level for every export — including uncompressed ones where the value is `ZLIB_DEFAULT_LEVEL` (Node.js zlib `-1`). `-1` means "use default compression level" in zlib semantics, not "no compression", so a Datadog query filtered on `gzipLevel:-1` would silently mix uncompressed exports with any that happen to have no explicit level configured. The existing gzip histograms at line 617 only include `gzipLevel` inside the `gzipStats && compressedCounter` guard, keeping the tag absent when compression is off — the new counters diverge from that pattern.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(worker): add counter metrics for b..."](https://github.com/langfuse/langfuse/commit/e3d08b66257ad880ac9a69e8e0450a1102516b66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39035434)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->