### PR TITLE
chore: update Scarf pixel ID to new org

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,4 +378,4 @@ The telemetry does not include raw traces, prompts, observations, scores, or dat
 For Langfuse OSS, you can opt out by setting `TELEMETRY_ENABLED=false`.
 
 <!-- Scarf pixel — cookie-free, privacy-friendly analytics for README views (no cookies, no IP/PII stored). https://docs.scarf.sh/web-traffic/ -->
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=51a1912d-b16d-43a0-80b7-c3d6ab43e1a7&page=README.md" />
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5f9b700f-ee94-4940-b005-e72def008ffa&page=README.md" />


### PR DESCRIPTION
## What does this PR do?

Points the README's Scarf web traffic pixel at our **new Scarf organization's** pixel ID. We moved orgs, so the previously merged pixel ID needs to be swapped.

```diff
- ...static.scarf.sh/a.png?x-pxid=51a1912d-b16d-43a0-80b7-c3d6ab43e1a7&page=README.md
+ ...static.scarf.sh/a.png?x-pxid=5f9b700f-ee94-4940-b005-e72def008ffa&page=README.md
```

Single-line change in `README.md` (the `&page=README.md` parameter is kept). No other changes.

Fixes # (N/A)

## Type of change

- [x] Chore (tooling, dependencies, CI, workflows, repo upkeep, or other maintenance work)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Notes for reviewers

- The Scarf README pixel was added in #14392 (merged). This only updates the ID after the org move.
- New pixel resolves: `GET …?x-pxid=5f9b700f… → 200 image/png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the Scarf web traffic pixel ID in `README.md` to point to the new Scarf organization after an org migration, replacing the previously merged pixel UUID.

- Swaps the `x-pxid` query parameter from `51a1912d-b16d-43a0-80b7-c3d6ab43e1a7` to `5f9b700f-ee94-4940-b005-e72def008ffa` in the single tracking `<img>` tag at the bottom of `README.md`.
- All other attributes (`referrerpolicy`, `&page=README.md`) remain unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a single UUID swap in a README tracking pixel with no functional code changes.

The only change is replacing one Scarf pixel UUID with another in a README comment tag. The surrounding HTML attributes are preserved, and no application code, configuration, or logic is touched.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser as GitHub / Browser
    participant Scarf as static.scarf.sh

    Browser->>Scarf: "GET /a.png?x-pxid=5f9b700f-ee94-4940-b005-e72def008ffa&page=README.md"
    Note over Scarf: Resolves to new Scarf org pixel
    Scarf-->>Browser: 200 image/png (1x1 tracking pixel)
    Note over Browser: Cookie-free, no PII recorded
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser as GitHub / Browser
    participant Scarf as static.scarf.sh

    Browser->>Scarf: "GET /a.png?x-pxid=5f9b700f-ee94-4940-b005-e72def008ffa&page=README.md"
    Note over Scarf: Resolves to new Scarf org pixel
    Scarf-->>Browser: 200 image/png (1x1 tracking pixel)
    Note over Browser: Cookie-free, no PII recorded
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update Scarf pixel ID to new org"](https://github.com/langfuse/langfuse/commit/629edb073e7b64337c42c9e41fe1453fcb227891) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39058119)</sub>

<!-- /greptile_comment -->