### PR TITLE
fix: improve filter validation on metrics endpoints

### DIFF
--- a/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.filterValidation.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { FilterCondition } from "../../../types";
+import type { QueryType, ViewVersion } from "../types";
+import { QueryBuilder } from "./queryBuilder";
+
+// QueryBuilder.build checks the OTEL FINAL optimization before filter lowering.
+// Mock it so these validation tests stay unit-level and do not need ClickHouse.
+vi.mock("../../../server/queries/clickhouse-sql/query-options", () => ({
+  shouldSkipObservationsFinal: vi.fn().mockResolvedValue(false),
+}));
+
+const baseQuery = {
+  view: "observations",
+  dimensions: [],
+  metrics: [{ measure: "count", aggregation: "count" }],
+  filters: [],
+  timeDimension: null,
+  fromTimestamp: "2025-01-01T00:00:00.000Z",
+  toTimestamp: "2025-01-02T00:00:00.000Z",
+  orderBy: null,
+} as QueryType;
+
+const buildQueryWithFilter = (
+  filter: FilterCondition,
+  queryOverrides: Partial<QueryType> = {},
+  version: ViewVersion = "v1",
+) =>
+  new QueryBuilder(undefined, version).build(
+    {
+      ...baseQuery,
+      ...queryOverrides,
+      filters: [filter],
+    } as QueryType,
+    "test-project",
+  );
+
+describe("queryBuilder filter type validation", () => {
+  it.each([
+    {
+      name: "arrayOptions on scalar string dimension",
+      filter: {
+        column: "sessionId",
+        operator: "any of",
+        value: ["session-a"],
+        type: "arrayOptions",
+      },
+      expectedMessage:
+        "Filter type 'arrayOptions' is not supported for dimension type 'string'",
+    },
+    {
+      name: "number on scalar string dimension",
+      filter: {
+        column: "name",
+        operator: ">",
+        value: 1,
+        type: "number",
+      },
+      expectedMessage:
+        "Filter type 'number' is not supported for dimension type 'string'",
+    },
+    {
+      name: "string on numeric dimension",
+      filter: {
+        column: "value",
+        operator: "contains",
+        value: "1",
+        type: "string",
+      },
+      queryOverrides: {
+        view: "scores-numeric",
+      },
+      expectedMessage:
+        "Filter type 'string' is not supported for dimension type 'number'",
+    },
+    {
+      name: "string on time dimension",
+      filter: {
+        column: "start_time",
+        operator: "=",
+        value: "2025-01-01",
+        type: "string",
+      },
+      expectedMessage:
+        "Filter type 'string' is not supported for time dimension 'start_time'",
+    },
+    {
+      name: "stringOptions on query array dimension",
+      filter: {
+        column: "tags",
+        operator: "any of",
+        value: ["tag-a"],
+        type: "stringOptions",
+      },
+      expectedMessage:
+        "Filter type 'stringOptions' is not supported for dimension type 'string[]'. Expected 'arrayOptions'.",
+    },
+  ])(
+    "rejects incompatible filter type: $name",
+    async ({ filter, queryOverrides, expectedMessage }) => {
+      await expect(
+        buildQueryWithFilter(
+          filter as FilterCondition,
+          queryOverrides as Partial<QueryType> | undefined,
+        ),
+      ).rejects.toThrow(expectedMessage);
+    },
+  );
+
+  it.each([
+    {
+      name: "arrayOptions on string array dimension",
+      filter: {
+        column: "tags",
+        operator: "all of",
+        value: ["tag-a", "tag-b"],
+        type: "arrayOptions",
+      },
+    },
+    {
+      name: "arrayOptions on arrayString dimension",
+      filter: {
+        column: "toolNames",
+        operator: "any of",
+        value: ["search"],
+        type: "arrayOptions",
+      },
+    },
+  ])("allows compatible filter type: $name", async ({ filter }) => {
+    const { query } = await buildQueryWithFilter(filter as FilterCondition);
+
+    expect(query).toContain("has");
+  });
+});

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -23,6 +23,12 @@ import { getViewDeclaration } from "../dataModel";
 import { InvalidRequestError } from "../../../errors";
 import { env } from "../../../env";
 import { NULL_IF_EMPTY_RE } from "./nullIfEmptyFilter";
+import {
+  getCompatibleFilterTypes,
+  isFilterColumnType,
+  type CompatibleFilterType,
+  type FilterColumnType,
+} from "../../../server/queries/clickhouse-sql/filterTypeCompatibility";
 
 type AppliedDimensionType = {
   table: string;
@@ -50,6 +56,51 @@ type MappedFilters = {
   whereFilters: Filter[];
   whereRawParts: RawSqlPart[];
 };
+
+const isQueryArrayDimensionType = (dimensionType: string | undefined) =>
+  dimensionType === "string[]" || dimensionType === "arrayString";
+
+const getFilterColumnTypeForQueryDimension = (
+  dimensionType: string | undefined,
+): FilterColumnType | null => {
+  if (isQueryArrayDimensionType(dimensionType)) {
+    return "arrayOptions";
+  }
+
+  if (dimensionType === "null" || dimensionType === "positionInTrace") {
+    return null;
+  }
+
+  return isFilterColumnType(dimensionType) ? dimensionType : null;
+};
+
+const getCompatibleFilterTypesForQueryDimension = (
+  dimensionType: string | undefined,
+): readonly CompatibleFilterType[] | null => {
+  const filterColumnType = getFilterColumnTypeForQueryDimension(dimensionType);
+
+  if (!filterColumnType) {
+    return null;
+  }
+
+  // Query array dimensions are ClickHouse Array(String) expressions. The shared
+  // table also allows stringOptions for legacy UI array columns, but metrics
+  // queries must use arrayOptions so QueryBuilder generates hasAny/hasAll in SQL.
+  if (isQueryArrayDimensionType(dimensionType)) {
+    return ["arrayOptions"];
+  }
+
+  return getCompatibleFilterTypes(filterColumnType);
+};
+
+const formatExpectedFilterTypes = (
+  filterTypes: readonly CompatibleFilterType[],
+) =>
+  filterTypes.length === 1
+    ? `'${filterTypes[0]}'`
+    : filterTypes
+        .map((filterType) => `'${filterType}'`)
+        .join(filterTypes.length === 2 ? " or " : ", ");
 
 type AppliedBucketingDimension =
   | { type: "none" }
@@ -271,24 +322,50 @@ export class QueryBuilder {
   ) {
     for (const filter of filters) {
       // Validate filters on dimension fields
-      if (filter.column in view.dimensions) {
-        const dimension = view.dimensions[filter.column];
+      const dimension = this.resolveDimension(filter.column, view);
 
-        // Array fields (like tags) validation
-        if (dimension.type === "string[]") {
-          if (filter.type === "string") {
-            throw new InvalidRequestError(
-              `Invalid filter for field '${filter.column}': Array fields require type 'arrayOptions', not 'string'. ` +
-                `Use operators like 'any of', 'all of', or 'none of' with an array of values.`,
-            );
-          }
+      if (dimension) {
+        const compatibleFilterTypes = getCompatibleFilterTypesForQueryDimension(
+          dimension.type,
+        );
 
-          // Additional validation: ensure value is array for arrayOptions
-          if (filter.type === "arrayOptions" && !Array.isArray(filter.value)) {
-            throw new InvalidRequestError(
-              `Invalid filter for field '${filter.column}': arrayOptions type requires an array of values, not '${typeof filter.value}'.`,
-            );
-          }
+        if (!compatibleFilterTypes) {
+          throw new InvalidRequestError(
+            `Invalid query dimension '${filter.column}': Unsupported dimension type '${dimension.type ?? "undefined"}'.`,
+          );
+        }
+
+        if (filter.type === "null") {
+          continue;
+        }
+
+        if (!compatibleFilterTypes.includes(filter.type)) {
+          throw new InvalidRequestError(
+            `Invalid filter for field '${filter.column}': Filter type '${filter.type}' is not supported for dimension type '${dimension.type ?? "string"}'. ` +
+              `Expected ${formatExpectedFilterTypes(compatibleFilterTypes)}.`,
+          );
+        }
+
+        if (filter.type === "arrayOptions" && !Array.isArray(filter.value)) {
+          throw new InvalidRequestError(
+            `Invalid filter for field '${filter.column}': arrayOptions type requires an array of values, not '${typeof filter.value}'.`,
+          );
+        }
+      }
+
+      // Special validation for time dimension filters
+      else if (filter.column === view.timeDimension) {
+        const compatibleFilterTypes: CompatibleFilterType[] = ["datetime"];
+
+        if (filter.type === "null") {
+          continue;
+        }
+
+        if (!compatibleFilterTypes.includes(filter.type)) {
+          throw new InvalidRequestError(
+            `Invalid filter for field '${filter.column}': Filter type '${filter.type}' is not supported for time dimension '${view.timeDimension}'. ` +
+              `Expected ${formatExpectedFilterTypes(compatibleFilterTypes)}.`,
+          );
         }
       }
 

--- a/packages/shared/src/server/queries/clickhouse-sql/filterTypeCompatibility.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/filterTypeCompatibility.ts
@@ -1,8 +1,11 @@
 import type { ColumnDefinition } from "../../../tableDefinitions";
 import type { FilterCondition } from "../../../types";
 
+export type FilterColumnType = ColumnDefinition["type"];
+export type CompatibleFilterType = FilterCondition["type"];
+
 export const COMPATIBLE_FILTER_TYPES: Partial<
-  Record<ColumnDefinition["type"], FilterCondition["type"][]>
+  Record<FilterColumnType, readonly CompatibleFilterType[]>
 > = {
   string: ["string", "stringOptions"],
   stringOptions: ["string", "stringOptions"],
@@ -14,3 +17,22 @@ export const COMPATIBLE_FILTER_TYPES: Partial<
   numberObject: ["numberObject"],
   categoryOptions: ["categoryOptions", "stringOptions"],
 };
+
+const FILTER_COLUMN_TYPES_WITHOUT_COMPATIBLE_FILTERS = [
+  "null",
+  "positionInTrace",
+] as const satisfies readonly FilterColumnType[];
+
+export const isFilterColumnType = (
+  type: string | undefined,
+): type is FilterColumnType =>
+  typeof type === "string" &&
+  (Object.hasOwn(COMPATIBLE_FILTER_TYPES, type) ||
+    FILTER_COLUMN_TYPES_WITHOUT_COMPATIBLE_FILTERS.some(
+      (filterColumnType) => filterColumnType === type,
+    ));
+
+export const getCompatibleFilterTypes = (
+  columnType: FilterColumnType,
+): readonly CompatibleFilterType[] | null =>
+  COMPATIBLE_FILTER_TYPES[columnType] ?? null;

--- a/web/src/__tests__/server/metrics-api.servertest.ts
+++ b/web/src/__tests__/server/metrics-api.servertest.ts
@@ -531,9 +531,10 @@ describe("/api/public/metrics API Endpoint", () => {
       expect(response.body).toMatchObject({
         error: "InvalidRequestError",
         message: expect.stringContaining(
-          "Array fields require type 'arrayOptions', not 'string'",
+          "Filter type 'string' is not supported for dimension type 'string[]'",
         ),
       });
+      expect(response.body.message).toContain("Expected 'arrayOptions'.");
     });
 
     it("should return 400 error for invalid metadata filters", async () => {
@@ -568,6 +569,54 @@ describe("/api/public/metrics API Endpoint", () => {
           "Metadata filters require type 'stringObject'",
         ),
       });
+    });
+
+    it("should return 400 when arrayOptions is used on scalar sessionId", async () => {
+      const invalidSessionIdTypeQuery = {
+        view: "observations",
+        dimensions: [{ field: "name" }],
+        metrics: [{ measure: "count", aggregation: "count" }],
+        filters: [
+          {
+            column: "tags",
+            operator: "all of",
+            value: ["test-tag"],
+            type: "arrayOptions",
+          },
+          {
+            column: "type",
+            operator: "=",
+            value: "GENERATION",
+            type: "string",
+          },
+          {
+            column: "sessionId",
+            operator: "any of",
+            value: [randomUUID()],
+            type: "arrayOptions",
+          },
+        ],
+        timeDimension: null,
+        fromTimestamp: yesterday.toISOString(),
+        toTimestamp: tomorrow.toISOString(),
+        orderBy: null,
+      };
+
+      const response = await makeAPICall(
+        "GET",
+        `/api/public/metrics?query=${encodeURIComponent(JSON.stringify(invalidSessionIdTypeQuery))}`,
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body).toMatchObject({
+        error: "InvalidRequestError",
+        message: expect.stringContaining(
+          "Filter type 'arrayOptions' is not supported for dimension type 'string'",
+        ),
+      });
+      expect(response.body.message).toContain(
+        "Expected 'string' or 'stringOptions'.",
+      );
     });
 
     it("should work correctly with proper array field filter configuration", async () => {

--- a/web/src/__tests__/server/metrics-v2-api.servertest.ts
+++ b/web/src/__tests__/server/metrics-v2-api.servertest.ts
@@ -665,9 +665,10 @@ describe("/api/public/v2/metrics API Endpoint", () => {
       expect(response.body).toMatchObject({
         error: "InvalidRequestError",
         message: expect.stringContaining(
-          "Array fields require type 'arrayOptions', not 'string'",
+          "Filter type 'string' is not supported for dimension type 'string[]'",
         ),
       });
+      expect(response.body.message).toContain("Expected 'arrayOptions'.");
     });
 
     it("should return 400 error for invalid metadata filters", async () => {


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the previous ad-hoc array-field filter validation in `QueryBuilder` with a systematic, type-compatibility-driven approach. It centralises the logic in `filterTypeCompatibility.ts` and covers all dimension types, the time dimension, and the `metadata` special case consistently.

- `filterTypeCompatibility.ts` gains two exported helpers — `isFilterColumnType` (runtime guard) and `getCompatibleFilterTypes` — and two new type aliases, enabling the query builder to validate any filter against its dimension's declared type.
- `queryBuilder.ts` replaces the narrow `string[]`-only check with `getCompatibleFilterTypesForQueryDimension`, which maps every recognised dimension type (including the `"string[]"`/`"arrayString"` → `arrayOptions` coercion and the `datetime`-only time-dimension path) to its allowed filter types, then throws a descriptive `InvalidRequestError` on mismatch.
- Both metrics-api server tests and a new unit-test suite (`queryBuilder.filterValidation.test.ts`) cover the happy path and key rejection cases; integration-test error-message assertions are updated to match the new format.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the changes tighten filter validation and are well-exercised by new unit tests and updated integration tests; no currently-reachable dimension type in the view declarations is mishandled by the new logic.

All dimension types used in the view declarations ('string', 'string[]', 'arrayString', 'number') are correctly handled by the new compatibility table. The 'integer'/'decimal' types exist only in the measures section, which is intentionally not filterable. Two minor observations remain: the error-message formatter doesn't add 'or' before the last item for 3+ types (unreachable today but fragile), and null-check filters on 'null'/'positionInTrace' dimension types are now rejected before the filter.type === 'null' bypass can fire, which is a silent behaviour change from the previous no-validation path.

packages/shared/src/features/query/server/queryBuilder.ts — the ordering of the unsupported-dimension-type guard relative to the null-filter bypass warrants a second look; packages/shared/src/server/queries/clickhouse-sql/filterTypeCompatibility.ts — the isFilterColumnType runtime guard should stay in sync as new column definition types are added.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Filter submitted] --> B{resolveDimension found?}
    B -- yes --> C[getCompatibleFilterTypesForQueryDimension]
    B -- no --> D{column == timeDimension?}
    D -- yes --> E[compatibleTypes = datetime]
    D -- no --> F{column == metadata?}
    F -- yes --> G[Validate stringObject + key + string value]
    F -- no --> H[No validation - passes through]

    C --> I{isQueryArrayDimensionType?}
    I -- yes --> J[return arrayOptions only]
    I -- no --> K{isFilterColumnType?}
    K -- yes --> L[getCompatibleFilterTypes from COMPATIBLE_FILTER_TYPES]
    K -- no --> M[return null]

    M --> N[throw Unsupported dimension type]
    J --> O{filter.type == null?}
    L --> O
    E --> P{filter.type == null?}
    O -- yes --> Q[continue - skip]
    O -- no --> R{filter.type in compatibleTypes?}
    P -- yes --> Q
    P -- no --> S{filter.type == datetime?}
    R -- yes --> T[valid - proceed]
    R -- no --> U[throw InvalidRequestError]
    S -- yes --> T
    S -- no --> U
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Filter submitted] --> B{resolveDimension found?}
    B -- yes --> C[getCompatibleFilterTypesForQueryDimension]
    B -- no --> D{column == timeDimension?}
    D -- yes --> E[compatibleTypes = datetime]
    D -- no --> F{column == metadata?}
    F -- yes --> G[Validate stringObject + key + string value]
    F -- no --> H[No validation - passes through]

    C --> I{isQueryArrayDimensionType?}
    I -- yes --> J[return arrayOptions only]
    I -- no --> K{isFilterColumnType?}
    K -- yes --> L[getCompatibleFilterTypes from COMPATIBLE_FILTER_TYPES]
    K -- no --> M[return null]

    M --> N[throw Unsupported dimension type]
    J --> O{filter.type == null?}
    L --> O
    E --> P{filter.type == null?}
    O -- yes --> Q[continue - skip]
    O -- no --> R{filter.type in compatibleTypes?}
    P -- yes --> Q
    P -- no --> S{filter.type == datetime?}
    R -- yes --> T[valid - proceed]
    R -- no --> U[throw InvalidRequestError]
    S -- yes --> T
    S -- no --> U
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/features/query/server/queryBuilder.ts:96-103
**Missing conjunction for 3+ filter types in error message**

`formatExpectedFilterTypes` uses `" or "` as the join separator only when there are exactly 2 types; for 3 or more it falls back to `", "` without an "or" before the last entry. The resulting message would read `Expected 'a', 'b', 'c'.` instead of `Expected 'a', 'b', or 'c'.`. No existing `COMPATIBLE_FILTER_TYPES` entry currently has more than 2 values, so this path can't be triggered today, but the function is easy to extend incorrectly.

### Issue 2 of 2
packages/shared/src/features/query/server/queryBuilder.ts:332-340
**`"null"` filter type bypass fires after the unsupported-dimension-type check**

The `filter.type === "null"` early-continue on line 338 only fires when `compatibleFilterTypes` is non-null. For dimension types that resolve to `null` (i.e. `"null"` and `"positionInTrace"`), the `!compatibleFilterTypes` branch on line 332 throws `"Unsupported dimension type"` first, so a null-check filter on those columns is now rejected. Before this PR no validation was applied to those columns at all. This is likely intentional (those dimension types are explicitly listed as having no compatible filter types), but it's a silent breaking change worth documenting, or the `filter.type === "null"` bypass could be moved above the `!compatibleFilterTypes` guard if null-checks on any dimension should always be permissible.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: improve filter validation on metric..."](https://github.com/langfuse/langfuse/commit/7301989560e9982091972dae74b33a0c46ccaa6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39073307)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->