### PR TITLE
fix: remove item and page counts from the events UI path

### DIFF
--- a/web/src/components/table/data-table-multi-select-actions/data-table-select-all-banner.tsx
+++ b/web/src/components/table/data-table-multi-select-actions/data-table-select-all-banner.tsx
@@ -9,7 +9,7 @@ export function DataTableSelectAllBanner({
   pageSize,
   totalCount,
 }: MultiSelect) {
-  const totalPages = totalCount ? Math.ceil(totalCount / pageSize) : 0;
+  const totalPages = totalCount ? Math.ceil(totalCount / pageSize) : null;
 
   return (
     <div className="bg-light-blue/40 dark:bg-light-blue/50 @container mb-2 flex flex-wrap items-center justify-center gap-2 rounded-sm p-2">
@@ -17,7 +17,7 @@ export function DataTableSelectAllBanner({
         <span className="text-sm">
           All{" "}
           <span className="font-semibold">
-            {numberFormatter(totalCount ?? 0, 0)}
+            {totalCount === null ? "matching" : numberFormatter(totalCount, 0)}
           </span>{" "}
           items are selected.{" "}
           <Button
@@ -42,8 +42,12 @@ export function DataTableSelectAllBanner({
               setSelectAll(true);
             }}
           >
-            Select all {numberFormatter(totalCount ?? 0, 0)} items across{" "}
-            {numberFormatter(totalPages, 0)} pages
+            {totalCount === null || totalPages === null
+              ? "Select all matching items"
+              : `Select all ${numberFormatter(
+                  totalCount,
+                  0,
+                )} items across ${numberFormatter(totalPages, 0)} pages`}
           </Button>
         </span>
       )}

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -58,7 +58,8 @@ interface DataTableProps<TData, TValue> {
   columns: LangfuseColumnDef<TData, TValue>[];
   data: AsyncTableData<TData[]>;
   pagination?: {
-    totalCount: number | null; // null if loading
+    totalCount: number | null; // null if loading or intentionally unknown
+    hasNextPage?: boolean;
     onChange: OnChangeFn<PaginationState>;
     state: PaginationState;
     options?: number[];
@@ -230,6 +231,34 @@ export function DataTable<TData extends object, TValue>({
     [columns],
   );
 
+  // Some high-volume tables intentionally skip an exact count query and only
+  // return whether the current page has a next page. TanStack still needs a
+  // synthetic pageCount to enable/disable navigation and to reuse its generic
+  // out-of-range page reset behavior.
+  const paginationPageCount = (() => {
+    if (!pagination || pagination.state.pageSize === undefined) {
+      return -1;
+    }
+    if (pagination.totalCount !== null) {
+      return Math.ceil(
+        Number(pagination.totalCount) / pagination.state.pageSize,
+      );
+    }
+    if (typeof pagination.hasNextPage !== "boolean") {
+      return -1;
+    }
+    if (
+      !data.isLoading &&
+      !data.isError &&
+      (data.data?.length ?? 0) === 0 &&
+      pagination.state.pageIndex > 0 &&
+      !pagination.hasNextPage
+    ) {
+      return pagination.state.pageIndex;
+    }
+    return pagination.state.pageIndex + (pagination.hasNextPage ? 2 : 1);
+  })();
+
   const table = useReactTable({
     data: data.data ?? [],
     columns,
@@ -238,13 +267,7 @@ export function DataTable<TData extends object, TValue>({
     getFilteredRowModel: getFilteredRowModel(),
     getCoreRowModel: getCoreRowModel(),
     manualPagination: pagination !== undefined,
-    pageCount:
-      pagination?.totalCount === null ||
-      pagination?.state.pageSize === undefined
-        ? -1
-        : Math.ceil(
-            Number(pagination?.totalCount) / pagination?.state.pageSize,
-          ),
+    pageCount: paginationPageCount,
     onPaginationChange: pagination?.onChange,
     onRowSelectionChange: setRowSelection,
     onColumnVisibilityChange: onColumnVisibilityChange,

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -508,6 +508,9 @@ export default function ObservationsEventsTable({
   const {
     observations,
     totalCount,
+    isTotalCountLoading,
+    isTotalCountError,
+    hasMore,
     handleAddToAnnotationQueue,
     dataUpdatedAt,
     ioLoading,
@@ -618,6 +621,12 @@ export default function ObservationsEventsTable({
     setSelectedRows({});
   };
 
+  const isSelectAllCountUnavailable = isTotalCountLoading || isTotalCountError;
+  const selectAllCountUnavailableReason = isTotalCountLoading
+    ? "Counting selected observations."
+    : isTotalCountError
+      ? "Could not count selected observations. Clear selection and try again."
+      : undefined;
   const tableActions: TableAction[] = [
     ...(hasTraceDeletionEntitlement
       ? [
@@ -656,6 +665,8 @@ export default function ObservationsEventsTable({
       label: "Add to Dataset",
       description: "Add selected observations to a dataset",
       customDialog: true,
+      disabled: isSelectAllCountUnavailable,
+      disabledReason: selectAllCountUnavailableReason,
       accessCheck: {
         scope: "datasets:CUD",
       },
@@ -667,6 +678,8 @@ export default function ObservationsEventsTable({
       description: "Run evaluations on selected observations.",
       customDialog: true,
       icon: <LightbulbIcon className="h-4 w-4 sm:mr-2" />,
+      disabled: isSelectAllCountUnavailable,
+      disabledReason: selectAllCountUnavailableReason,
       accessCheck: {
         scope: "evalJob:CUD",
       },
@@ -1445,10 +1458,9 @@ export default function ObservationsEventsTable({
     return Object.keys(selectedRows).filter((id) => rowIds.has(id));
   }, [observations.rows, selectedRows]);
 
-  const selectedObservationCount =
-    selectAll && totalCount !== null
-      ? totalCount
-      : selectedObservationIds.length;
+  const selectedObservationCount = selectAll
+    ? totalCount
+    : selectedObservationIds.length;
 
   const exampleObservation = useMemo(() => {
     const firstId = selectedObservationIds[0];
@@ -1649,6 +1661,9 @@ export default function ObservationsEventsTable({
                   ? undefined
                   : {
                       totalCount,
+                      hasNextPage: hasMore,
+                      hideTotalCount: true,
+                      canJumpPages: false,
                       onChange: (updater) => {
                         const newState =
                           typeof updater === "function"

--- a/web/src/features/events/hooks/useEventsTableData.ts
+++ b/web/src/features/events/hooks/useEventsTableData.ts
@@ -76,12 +76,17 @@ export function useEventsTableData({
 
   const observations = api.events.all.useQuery(getAllPayload, {
     refetchOnWindowFocus: true,
+    placeholderData: (prev) => prev,
     meta: {
       silentHttpCodes, // Turns off red bubble
     },
   });
 
   const batchIOPayload = useMemo(() => {
+    if (observations.isPlaceholderData) {
+      return null;
+    }
+
     const validObservations =
       observations.data?.observations?.filter(
         (o) => o.id && o.traceId && o.startTime,
@@ -107,7 +112,11 @@ export function useEventsTableData({
       minStartTime,
       maxStartTime,
     };
-  }, [observations.data?.observations, projectId]);
+  }, [
+    observations.data?.observations,
+    observations.isPlaceholderData,
+    projectId,
+  ]);
 
   // Fetch I/O data
   const ioDataQuery = api.events.batchIO.useQuery(batchIOPayload!, {
@@ -130,7 +139,7 @@ export function useEventsTableData({
   // Memoize joined data to prevent infinite re-renders
   // Handle loading, error, and success states
   const joinedData = useMemo(() => {
-    if (observations.isLoading) {
+    if (observations.isLoading || observations.isPlaceholderData) {
       return { status: "loading" as const, rows: undefined };
     }
 
@@ -149,18 +158,30 @@ export function useEventsTableData({
     );
   }, [
     observations.isLoading,
+    observations.isPlaceholderData,
     observations.isError,
     observations.data?.observations,
     ioDataQuery.data,
     isSilencedError,
   ]);
 
-  // Fetch total count
+  // Fetch the exact count only after the user selects all matching rows.
   const totalCountQuery = api.events.countAll.useQuery(getCountPayload, {
+    enabled: selectAll,
     refetchOnWindowFocus: true,
   });
 
-  const totalCount = totalCountQuery.data?.totalCount ?? null;
+  const totalCount = selectAll
+    ? (totalCountQuery.data?.totalCount ?? null)
+    : null;
+  const isTotalCountLoading =
+    selectAll && totalCount === null && totalCountQuery.isFetching;
+  const isTotalCountError =
+    selectAll &&
+    totalCount === null &&
+    totalCountQuery.isError &&
+    !totalCountQuery.isFetching;
+  const hasMore = observations.data?.hasMore ?? false;
 
   // Add to queue mutation
   const addToQueueMutation = api.annotationQueueItems.createMany.useMutation({
@@ -211,8 +232,10 @@ export function useEventsTableData({
   return {
     observations: joinedData,
     dataUpdatedAt: observations.dataUpdatedAt,
-    totalCountQuery,
     totalCount,
+    isTotalCountLoading,
+    isTotalCountError,
+    hasMore,
     addToQueueMutation,
     handleAddToAnnotationQueue,
     ioLoading: ioDataQuery.isLoading,

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -88,7 +88,7 @@ export const eventsRouter = createTRPCRouter({
       });
 
       if (hasNoMatches) {
-        return { observations: [] };
+        return { observations: [], hasMore: false };
       }
 
       return instrumentAsync(

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -105,17 +105,21 @@ export async function getEventList(params: GetObservationsListParams) {
     searchQuery: params.searchQuery,
     searchType: params.searchType,
     orderBy: params.orderBy,
-    limit: params.limit,
+    limit: params.limit + 1,
     offset: (params.page - 1) * params.limit, // Page is 1-indexed (page 1 = offset 0)
     selectIOAndMetadata: false, // Exclude I/O for performance - fetched separately via batchIO endpoint
     renderingProps: { truncated: true, shouldJsonParse: false },
   };
 
-  const observations =
+  const fetchedObservations =
     await getObservationsWithModelDataFromEventsTable(queryOpts);
+  const hasMore = fetchedObservations.length > params.limit;
+  const observations = hasMore
+    ? fetchedObservations.slice(0, params.limit)
+    : fetchedObservations;
 
   if (observations.length === 0) {
-    return { observations };
+    return { observations, hasMore };
   }
 
   const traceIds = Array.from(
@@ -214,7 +218,7 @@ export async function getEventList(params: GetObservationsListParams) {
       : {},
   }));
 
-  return { observations: observationsWithScores };
+  return { observations: observationsWithScores, hasMore };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Stop fetching the exact events count up front and only resolve it when select-all is used
- Add `hasMore` pagination handling so the table can page without a total count
- Update select-all banner and bulk actions to reflect the unknown-count state

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR defers the expensive `countAll` query for the events table so it only fires when the user explicitly triggers "select all", and adds `hasMore`-based pagination so the table can page forward without knowing the total row count upfront.

- **Server**: `eventsService.ts` fetches `limit + 1` rows and trims back to `limit`, setting `hasMore = fetchedObservations.length > limit`; both the normal and early-return paths now include `hasMore` in the response.
- **Client hook**: `countAll` is now gated on `selectAll`; `totalCount` is `null` until select-all is triggered and the count resolves; `hasMore` is derived from the page response.
- **DataTable**: a new `paginationPageCount` IIFE handles three cases — known total count, `hasNextPage`-only sliding count, and an empty non-first page that returns `pageIndex` to signal out-of-range to TanStack and disable forward navigation.
- **UI text**: the select-all banner and bulk-action buttons gracefully degrade to "matching" / "Select all matching items" when the count is unknown.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core pagination and deferred-count logic is correct and the existing disabled-state guards prevent null counts from reaching the dialogs.

The `paginationPageCount` IIFE and the `hasMore` + `limit+1` fetch pattern are both sound. The two dialogs fall back to `totalCount ?? 0` but are shielded by `isSelectAllCountLoading`; this is a latent fragility rather than a current bug. No data loss or broken user flows were found.

`EventsTable.tsx` around the `totalCount ?? 0` dialog props (lines 1739 and 1760), and the new `paginationPageCount` IIFE in `data-table.tsx` (lines 231–259).
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as EventsTable
    participant Hook as useEventsTableData
    participant Router as eventsRouter
    participant Service as eventsService

    Note over UI,Service: Normal pagination (no select-all)
    UI->>Hook: request page N
    Hook->>Router: api.events.all (limit+1 records)
    Router->>Service: getEventList(limit+1)
    Service-->>Router: "{ observations[0..limit-1], hasMore }"
    Router-->>Hook: "{ observations, hasMore }"
    Hook-->>UI: "rows + hasMore (totalCount=null)"
    UI->>UI: "paginationPageCount = pageIndex + (hasMore ? 2 : 1)"

    Note over UI,Service: User triggers select-all
    UI->>UI: setSelectAll(true)
    Hook->>Router: api.events.countAll (enabled: selectAll)
    Router-->>Hook: "{ totalCount: N }"
    Hook-->>UI: "totalCount=N, hasMore unchanged"
    UI->>UI: Dialogs enabled, banner shows All N matching items
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as EventsTable
    participant Hook as useEventsTableData
    participant Router as eventsRouter
    participant Service as eventsService

    Note over UI,Service: Normal pagination (no select-all)
    UI->>Hook: request page N
    Hook->>Router: api.events.all (limit+1 records)
    Router->>Service: getEventList(limit+1)
    Service-->>Router: "{ observations[0..limit-1], hasMore }"
    Router-->>Hook: "{ observations, hasMore }"
    Hook-->>UI: "rows + hasMore (totalCount=null)"
    UI->>UI: "paginationPageCount = pageIndex + (hasMore ? 2 : 1)"

    Note over UI,Service: User triggers select-all
    UI->>UI: setSelectAll(true)
    Hook->>Router: api.events.countAll (enabled: selectAll)
    Router-->>Hook: "{ totalCount: N }"
    Hook-->>UI: "totalCount=N, hasMore unchanged"
    UI->>UI: Dialogs enabled, banner shows All N matching items
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/events/components/EventsTable.tsx:1739-1760
**`totalCount ?? 0` silently passes zero when count is still loading**

Both `RunEvaluationDialog` and `AddObservationsToDatasetDialog` receive `totalCount={totalCount ?? 0}`. When `selectAll` is `true` and the `countAll` query is still in-flight, `totalCount` is `null`, so the dialogs would initialise with `totalCount = 0`. The `isSelectAllCountLoading` guard on the triggering actions prevents this today, but any future code path that opens either dialog without that guard (e.g. a keyboard shortcut or a refactor) would silently submit zero as the total. Passing `totalCount={totalCount}` and letting each dialog handle `null` explicitly would be safer.

### Issue 2 of 2
web/src/components/table/data-table.tsx:244-250
**Out-of-range page index on empty non-first pages**

When the current page has no rows and there is no next page, the IIFE returns `pagination.state.pageIndex` as `pageCount`. Because TanStack Table treats valid pages as `0 … pageCount-1`, the current page (e.g. page index 3 against `pageCount = 3`) is technically out of range. `autoResetPageIndex: false` prevents an automatic reset, so the user stays on the empty page with only "previous" available — which is the intended UX. This is fine for the current use-case, but a comment above the block would help future readers understand why a value lower than `pageIndex + 1` is intentional rather than a bug.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove eager events countAll query"](https://github.com/langfuse/langfuse/commit/c88e781cd90f5b2497e98369d21f13e72e4b44b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39076766)</sub>

<!-- /greptile_comment -->