### PR TITLE
fix(scim): gate SCIM Users provisioning behind admin-api entitlement

### DIFF
--- a/web/src/__tests__/server/scim-api.servertest.ts
+++ b/web/src/__tests__/server/scim-api.servertest.ts
@@ -1273,7 +1273,13 @@ describe("SCIM API", () => {
 
       beforeEach(async () => {
         const org = await prisma.organization.create({
-          data: { name: `scim-last-owner-${randomUUID().substring(0, 8)}` },
+          data: {
+            name: `scim-last-owner-${randomUUID().substring(0, 8)}`,
+            // Team plan carries the `admin-api` entitlement that gates SCIM, so
+            // these requests reach the last-OWNER guard rather than the plan
+            // check.
+            cloudConfig: { plan: "Team" },
+          },
         });
         scopedOrgId = org.id;
 
@@ -1473,6 +1479,161 @@ describe("SCIM API", () => {
         } finally {
           await prisma.user.deleteMany({ where: { id: secondOwner.id } });
         }
+      });
+    });
+  });
+
+  // SCIM provisioning is gated behind the `admin-api` entitlement, matching the
+  // sibling organization admin REST endpoints (memberships, projects, apiKeys).
+  // Plans without that entitlement (e.g. Hobby) must be rejected before any
+  // user account is created or any membership is mutated.
+  describe("Entitlement gating (admin-api)", () => {
+    const PLAN_DETAIL = "This feature is not available on your current plan.";
+
+    let hobbyOrgId: string;
+    let hobbyPublicKey: string;
+    let hobbySecretKey: string;
+
+    let teamOrgId: string;
+    let teamPublicKey: string;
+    let teamSecretKey: string;
+
+    beforeAll(async () => {
+      // Hobby has no `admin-api` entitlement → SCIM must be blocked.
+      const hobbyOrg = await prisma.organization.create({
+        data: {
+          name: `scim-gate-hobby-${randomUUID().substring(0, 8)}`,
+          cloudConfig: { plan: "Hobby" },
+        },
+      });
+      hobbyOrgId = hobbyOrg.id;
+      hobbyPublicKey = `pk-lf-org-${randomUUID().substring(0, 8)}`;
+      hobbySecretKey = `sk-lf-org-${randomUUID().substring(0, 8)}`;
+      await createAndAddApiKeysToDb({
+        prisma,
+        entityId: hobbyOrgId,
+        scope: "ORGANIZATION",
+        predefinedKeys: {
+          publicKey: hobbyPublicKey,
+          secretKey: hobbySecretKey,
+        },
+      });
+
+      // Team carries `admin-api` → positive control that the gate does not
+      // over-block entitled plans.
+      const teamOrg = await prisma.organization.create({
+        data: {
+          name: `scim-gate-team-${randomUUID().substring(0, 8)}`,
+          cloudConfig: { plan: "Team" },
+        },
+      });
+      teamOrgId = teamOrg.id;
+      teamPublicKey = `pk-lf-org-${randomUUID().substring(0, 8)}`;
+      teamSecretKey = `sk-lf-org-${randomUUID().substring(0, 8)}`;
+      await createAndAddApiKeysToDb({
+        prisma,
+        entityId: teamOrgId,
+        scope: "ORGANIZATION",
+        predefinedKeys: {
+          publicKey: teamPublicKey,
+          secretKey: teamSecretKey,
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await prisma.organization.deleteMany({
+        where: { id: { in: [hobbyOrgId, teamOrgId] } },
+      });
+    });
+
+    it("POST /Users is rejected on a plan without admin-api and creates no account", async () => {
+      const uniqueEmail = `scim.gate.${randomUUID().substring(0, 8)}@example.com`;
+      const result = await makeAPICall(
+        "POST",
+        "/api/public/scim/Users",
+        {
+          schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+          userName: uniqueEmail,
+          name: { formatted: "Backdoor" },
+          password: "Backdoor2026!",
+          roles: ["OWNER"],
+          active: true,
+        },
+        createBasicAuthHeader(hobbyPublicKey, hobbySecretKey),
+      );
+
+      expect(result.status).toBe(403);
+      expect(result.body.detail).toBe(PLAN_DETAIL);
+
+      // The blocked request must not have created the user account.
+      const user = await prisma.user.findUnique({
+        where: { email: uniqueEmail.toLowerCase() },
+      });
+      expect(user).toBeNull();
+    });
+
+    it("GET /Users is rejected on a plan without admin-api", async () => {
+      const result = await makeAPICall(
+        "GET",
+        "/api/public/scim/Users",
+        undefined,
+        createBasicAuthHeader(hobbyPublicKey, hobbySecretKey),
+      );
+
+      expect(result.status).toBe(403);
+      expect(result.body.detail).toBe(PLAN_DETAIL);
+    });
+
+    it("PUT /Users/{id} is rejected on a plan without admin-api (before user lookup)", async () => {
+      const result = await makeAPICall(
+        "PUT",
+        `/api/public/scim/Users/${randomUUID()}`,
+        {
+          schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+          userName: "someone@example.com",
+          active: true,
+          roles: ["OWNER"],
+        },
+        createBasicAuthHeader(hobbyPublicKey, hobbySecretKey),
+      );
+
+      expect(result.status).toBe(403);
+      expect(result.body.detail).toBe(PLAN_DETAIL);
+    });
+
+    it("DELETE /Users/{id} is rejected on a plan without admin-api", async () => {
+      const result = await makeAPICall(
+        "DELETE",
+        `/api/public/scim/Users/${randomUUID()}`,
+        undefined,
+        createBasicAuthHeader(hobbyPublicKey, hobbySecretKey),
+      );
+
+      expect(result.status).toBe(403);
+      expect(result.body.detail).toBe(PLAN_DETAIL);
+    });
+
+    it("POST /Users still succeeds on a plan with admin-api", async () => {
+      const uniqueEmail = `scim.gate.ok.${randomUUID().substring(0, 8)}@example.com`;
+      const result = await makeAPICall(
+        "POST",
+        "/api/public/scim/Users",
+        {
+          schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+          userName: uniqueEmail,
+          name: { formatted: "Allowed User" },
+          active: true,
+        },
+        createBasicAuthHeader(teamPublicKey, teamSecretKey),
+      );
+
+      expect(result.status).toBe(201);
+      expect(result.body.userName).toBe(uniqueEmail);
+
+      // Cleanup the account created by the positive-control request.
+      await prisma.user.deleteMany({
+        where: { email: uniqueEmail.toLowerCase() },
       });
     });
   });

--- a/web/src/pages/api/public/scim/Users/[id].ts
+++ b/web/src/pages/api/public/scim/Users/[id].ts
@@ -5,6 +5,7 @@ import { Prisma, prisma, type User, type Role } from "@langfuse/shared/src/db";
 import { logger, redis } from "@langfuse/shared/src/server";
 import { z } from "zod";
 import { type NextApiRequest, type NextApiResponse } from "next";
+import { hasEntitlementBasedOnPlan } from "@/src/features/entitlements/server/hasEntitlement";
 
 // Parse the first valid role from a SCIM `roles` array. Returns undefined when
 // the attribute is absent, empty, or unparsable, which the provisioning logic
@@ -356,6 +357,23 @@ export default async function handler(
       schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
       detail:
         "Invalid API key. Organization-scoped API key required for this operation.",
+      status: 403,
+    });
+  }
+
+  // Gate SCIM provisioning behind the `admin-api` entitlement, matching the
+  // sibling organization admin endpoints (memberships, projects, apiKeys).
+  // Without this, any org-scoped key could mutate memberships and roles on
+  // plans that do not include the feature.
+  if (
+    !hasEntitlementBasedOnPlan({
+      plan: authCheck.scope.plan,
+      entitlement: "admin-api",
+    })
+  ) {
+    return res.status(403).json({
+      schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+      detail: "This feature is not available on your current plan.",
       status: 403,
     });
   }

--- a/web/src/pages/api/public/scim/Users/index.ts
+++ b/web/src/pages/api/public/scim/Users/index.ts
@@ -8,6 +8,7 @@ import { hashPassword } from "@/src/features/auth-credentials/lib/credentialsSer
 import { z } from "zod";
 import { type Role } from "@langfuse/shared";
 import { auditLog } from "@/src/features/audit-logs/auditLog";
+import { hasEntitlementBasedOnPlan } from "@/src/features/entitlements/server/hasEntitlement";
 
 export default async function handler(
   req: NextApiRequest,
@@ -49,6 +50,23 @@ export default async function handler(
       schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
       detail:
         "Invalid API key. Organization-scoped API key required for this operation.",
+      status: 403,
+    });
+  }
+
+  // Gate SCIM provisioning behind the `admin-api` entitlement, matching the
+  // sibling organization admin endpoints (memberships, projects, apiKeys).
+  // Without this, any org-scoped key could create users and assign roles on
+  // plans that do not include the feature.
+  if (
+    !hasEntitlementBasedOnPlan({
+      plan: authCheck.scope.plan,
+      entitlement: "admin-api",
+    })
+  ) {
+    return res.status(403).json({
+      schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
+      detail: "This feature is not available on your current plan.",
       status: 403,
     });
   }


### PR DESCRIPTION
The SCIM Users endpoints (POST /api/public/scim/Users and the [id] route's GET/PUT/PATCH/DELETE) only checked for an organization-scoped API key. Unlike the sibling organization admin REST endpoints (memberships, projects, apiKeys), they had no entitlement gate, so any org-scoped key — on any plan — could create user accounts (with a caller-set password) and assign org roles up to OWNER, then mutate memberships.

Add the same `hasEntitlementBasedOnPlan({ entitlement: "admin-api" })` check used by the sibling routes, placed right after the org-scope check, returning a SCIM-formatted 403 when the plan lacks the entitlement.

Tests: add an "Entitlement gating (admin-api)" block asserting 403 (and no account creation) for POST/GET/PUT/DELETE on a Hobby-plan org plus a positive control on a Team-plan org; give the last-OWNER block's org a Team plan so it still reaches the guard rather than the new gate.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gates the SCIM Users endpoints (`POST /api/public/scim/Users` and the `[id]` route's GET/PUT/PATCH/DELETE) behind the `admin-api` entitlement check, consistent with the sibling organization admin REST endpoints for memberships, projects, and API keys.

- Both handlers now call `hasEntitlementBasedOnPlan({ plan: authCheck.scope.plan, entitlement: "admin-api" })` immediately after the org-scope check and return a SCIM-formatted 403 when the plan lacks the entitlement, preventing user creation and membership mutation on un-entitled plans (e.g. Hobby, OSS).
- Tests add a Hobby-plan org that verifies 403 rejection (with a no-account-creation assertion for POST) and a Team-plan positive-control for POST; the last-OWNER test suite's org is promoted to Team plan so it still reaches the last-OWNER guard.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the entitlement gate is correctly placed before any DB reads or writes in both handlers, and the change is additive with no risk of breaking entitled plans.

The implementation is straightforward and mirrors existing patterns precisely. The one gap is that PATCH /Users/{id} is not exercised in the new entitlement-gate test block, so a future regression in that specific method path would not be caught by these tests. Everything else — placement of the check, SCIM error format, and positive-control coverage — is correct.

web/src/__tests__/server/scim-api.servertest.ts — the entitlement-gate describe block is missing a PATCH /Users/{id} test case.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant IdP as Identity Provider
    participant API as SCIM Endpoint
    participant Auth as ApiAuthService
    participant Ent as hasEntitlementBasedOnPlan
    participant DB as Database

    IdP->>API: SCIM request (org API key)
    API->>Auth: verifyAuthHeaderAndReturnScope
    Auth-->>API: "{validKey, scope: {plan, orgId, ...}}"
    alt invalid key
        API-->>IdP: 401 Unauthorized
    end
    alt not org-scoped key
        API-->>IdP: 403 (org key required)
    end
    API->>Ent: hasEntitlementBasedOnPlan(plan, "admin-api")
    alt plan lacks admin-api (e.g. Hobby, OSS)
        Ent-->>API: false
        API-->>IdP: 403 SCIM Error (plan gate)
    else plan has admin-api (e.g. Team, Enterprise)
        Ent-->>API: true
        API->>DB: user lookup / membership mutation
        DB-->>API: result
        API-->>IdP: 2xx / 4xx SCIM response
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant IdP as Identity Provider
    participant API as SCIM Endpoint
    participant Auth as ApiAuthService
    participant Ent as hasEntitlementBasedOnPlan
    participant DB as Database

    IdP->>API: SCIM request (org API key)
    API->>Auth: verifyAuthHeaderAndReturnScope
    Auth-->>API: "{validKey, scope: {plan, orgId, ...}}"
    alt invalid key
        API-->>IdP: 401 Unauthorized
    end
    alt not org-scoped key
        API-->>IdP: 403 (org key required)
    end
    API->>Ent: hasEntitlementBasedOnPlan(plan, "admin-api")
    alt plan lacks admin-api (e.g. Hobby, OSS)
        Ent-->>API: false
        API-->>IdP: 403 SCIM Error (plan gate)
    else plan has admin-api (e.g. Team, Enterprise)
        Ent-->>API: true
        API->>DB: user lookup / membership mutation
        DB-->>API: result
        API-->>IdP: 2xx / 4xx SCIM response
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/scim-api.servertest.ts:1482-1640
**PATCH /Users/{id} missing from entitlement-gate tests**

The new "Entitlement gating (admin-api)" block covers POST, GET (list), PUT, and DELETE on a Hobby org, but `PATCH /Users/{id}` is never tested. The code gate in `[id].ts` sits at the handler level and covers all four methods equally, so the implementation is correct — but the gap in test coverage means a future refactor that accidentally moves the check *after* the method dispatch would not be caught. A minimal `it("PATCH /Users/{id} is rejected on a plan without admin-api", ...)` mirroring the DELETE test (using `randomUUID()` as the ID) would close this gap.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(scim): gate SCIM Users provisioning ..."](https://github.com/langfuse/langfuse/commit/51d94a7fc77184e91950229f99a55c8ead099c80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39081109)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->