### PR TITLE
fix(web): align region selector icons

### DIFF
--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -73,8 +73,19 @@ export function CloudRegionSwitch({
           <SelectContent>
             {regions.map((region) => (
               <SelectItem key={region.name} value={region.name}>
-                <span className="mr-2 text-xl leading-none">{region.flag}</span>
-                {region.name}
+                <span className="flex items-center gap-2">
+                  <span
+                    className={
+                      // The HIPAA symbol glyph sits lower than flag emojis in the same font.
+                      region.name === "HIPAA"
+                        ? "-translate-y-[3px] text-xl leading-none"
+                        : "-translate-y-px text-xl leading-none"
+                    }
+                  >
+                    {region.flag}
+                  </span>
+                  <span>{region.name}</span>
+                </span>
               </SelectItem>
             ))}
           </SelectContent>


### PR DESCRIPTION
## Summary

- Align the region selector icon and label as a centered row.
- Add a scoped HIPAA glyph correction while keeping the existing region icon unchanged.

## Linear

- [LFE-10447](https://linear.app/langfuse/issue/LFE-10447/region-selector-icons-look-off)

## Screenshots

Before:
<img width="482" height="146" alt="image" src="https://github.com/user-attachments/assets/b420b52b-cda7-44dc-907e-980cf17a97cb" />

After:
<img width="482" height="135" alt="image" src="https://github.com/user-attachments/assets/ab3a43c3-964e-479a-9276-af41835e1966" />

## Major Decisions

- Kept the HIPAA medical symbol and applied the offset only in the render path because the glyph sits lower than the flag emojis in the same font.

## Review Focus

- Visual alignment of the selected region and expanded dropdown rows.
- Confirm the scoped transform does not affect region switching behavior.

## Notes

- Pre-commit hook passed `prettier --check` and `turbo run lint`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns the region selector dropdown so each option renders its icon and label as a centered flex row, and applies a scoped vertical-translate correction to the HIPAA ⚕️ glyph to compensate for its lower baseline relative to flag emoji sequences.

- Wraps each `SelectItem` child in a `flex items-center gap-2` span so the icon and region name are always baseline-aligned.
- Adds a conditional `-translate-y-[3px]` class only when `region.name === "HIPAA"` to correct the ⚕️ glyph's descending baseline; all other glyphs get the existing `-translate-y-px` nudge.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a purely visual layout fix with no changes to region switching logic, routing, or data handling.

The diff is limited to how each SelectItem renders its icon and label. The HIPAA-specific translate offset is scoped to a string comparison against a constant defined in cloudRegions.ts, so it cannot accidentally fire for other regions. Region selection, hostname navigation, and PostHog capture are all untouched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SelectItem rendered] --> B{region.name === 'HIPAA'?}
    B -- Yes --> C[Apply -translate-y-3px + text-xl leading-none]
    B -- No --> D[Apply -translate-y-px + text-xl leading-none]
    C --> E[Render flag/glyph span]
    D --> E
    E --> F[Render region name span]
    F --> G[flex items-center gap-2 parent span]
    G --> H[SelectItem displays aligned icon + label]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SelectItem rendered] --> B{region.name === 'HIPAA'?}
    B -- Yes --> C[Apply -translate-y-3px + text-xl leading-none]
    B -- No --> D[Apply -translate-y-px + text-xl leading-none]
    C --> E[Render flag/glyph span]
    D --> E
    E --> F[Render region name span]
    F --> G[flex items-center gap-2 parent span]
    G --> H[SelectItem displays aligned icon + label]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): align region selector icons"](https://github.com/langfuse/langfuse/commit/7211b4264437da9d69ef21dd9001d78d6fc95b5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39103937)</sub>

<!-- /greptile_comment -->