### PR TITLE
fix: ensure filter options queries are time bounded

### DIFF
--- a/web/src/__tests__/server/repositories/event-repository.servertest.ts
+++ b/web/src/__tests__/server/repositories/event-repository.servertest.ts
@@ -13,6 +13,11 @@ import {
   getLatestSdkVersionInfoFromEvents,
   getTracesIdentifierForSessionFromEvents,
 } from "@langfuse/shared/src/server";
+import {
+  getEventFilterNumericRange,
+  getEventFilterOptions,
+  getEventFilterValuePage,
+} from "@/src/features/events/server/eventsService";
 import { prisma } from "@langfuse/shared/src/db";
 import { randomUUID } from "crypto";
 import { env } from "@/src/env.mjs";
@@ -510,6 +515,206 @@ describe("Clickhouse Events Repository Test", () => {
       });
 
       expect(count).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  maybe("getEventFilterOptions", () => {
+    it("applies a default 30 day startTime bound when none is provided", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const now = Date.now();
+      const recentLevel = "WARNING";
+      const oldLevel = "ERROR";
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "recent-filter-option-event",
+          level: recentLevel,
+          start_time: (now - 7 * 24 * 60 * 60 * 1000) * 1000,
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "old-filter-option-event",
+          level: oldLevel,
+          start_time: (now - 45 * 24 * 60 * 60 * 1000) * 1000,
+        }),
+      ]);
+
+      await waitForExpect(async () => {
+        const options = await getEventFilterOptions({
+          projectId: uniqueProjectId,
+        });
+        expect(options.level.map((level) => level.value)).toContain(
+          recentLevel,
+        );
+      });
+
+      const defaultOptions = await getEventFilterOptions({
+        projectId: uniqueProjectId,
+      });
+      const defaultLevels = defaultOptions.level.map((level) => level.value);
+
+      expect(defaultLevels).toContain(recentLevel);
+      expect(defaultLevels).not.toContain(oldLevel);
+
+      const upperOnlyOptions = await getEventFilterOptions({
+        projectId: uniqueProjectId,
+        startTimeFilter: [
+          {
+            column: "startTime",
+            type: "datetime",
+            operator: "<=",
+            value: new Date(now),
+          },
+        ],
+      });
+      const upperOnlyLevels = upperOnlyOptions.level.map(
+        (level) => level.value,
+      );
+
+      expect(upperOnlyLevels).toContain(recentLevel);
+      expect(upperOnlyLevels).not.toContain(oldLevel);
+
+      await waitForExpect(async () => {
+        const explicitOptions = await getEventFilterOptions({
+          projectId: uniqueProjectId,
+          startTimeFilter: [
+            {
+              column: "startTime",
+              type: "datetime",
+              operator: ">=",
+              value: new Date(now - 60 * 24 * 60 * 60 * 1000),
+            },
+          ],
+        });
+        const explicitLevels = explicitOptions.level.map(
+          (level) => level.value,
+        );
+
+        expect(explicitLevels).toContain(recentLevel);
+        expect(explicitLevels).toContain(oldLevel);
+      });
+    });
+
+    it("applies the default startTime bound to paged and numeric filter values", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const now = Date.now();
+      const dayMs = 24 * 60 * 60 * 1000;
+      const recentLevel = "WARNING";
+      const oldLevel = "ERROR";
+      const recentStart = now - 7 * dayMs;
+      const oldStart = now - 45 * dayMs;
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "recent-filter-value-event",
+          level: recentLevel,
+          start_time: recentStart * 1000,
+          end_time: (recentStart + 1000) * 1000,
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "old-filter-value-event",
+          level: oldLevel,
+          start_time: oldStart * 1000,
+          end_time: (oldStart + 10_000) * 1000,
+        }),
+      ]);
+
+      await waitForExpect(async () => {
+        const page = await getEventFilterValuePage({
+          projectId: uniqueProjectId,
+          column: "level",
+          limit: 10,
+          offset: 0,
+        });
+
+        expect(page.values.map((level) => level.value)).toContain(recentLevel);
+      });
+
+      const page = await getEventFilterValuePage({
+        projectId: uniqueProjectId,
+        column: "level",
+        limit: 10,
+        offset: 0,
+      });
+      const levels = page.values.map((level) => level.value);
+
+      expect(levels).toContain(recentLevel);
+      expect(levels).not.toContain(oldLevel);
+
+      await waitForExpect(async () => {
+        const range = await getEventFilterNumericRange({
+          projectId: uniqueProjectId,
+          column: "latency",
+        });
+
+        expect(range).not.toBeNull();
+        expect(Number(range?.count)).toBe(1);
+        expect(Number(range?.min)).toBeCloseTo(1, 3);
+        expect(Number(range?.max)).toBeCloseTo(1, 3);
+      });
+    });
+
+    it("uses the monitor window to scope monitor filter option queries", async () => {
+      const uniqueProjectId = randomUUID();
+      const traceId = randomUUID();
+      const now = Date.now();
+      const recentLevel = "WARNING";
+      const oldLevel = "ERROR";
+
+      await createEventsCh([
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "recent-monitor-filter-option-event",
+          level: recentLevel,
+          start_time: (now - 60 * 1000) * 1000,
+        }),
+        createEvent({
+          id: randomUUID(),
+          span_id: randomUUID(),
+          project_id: uniqueProjectId,
+          trace_id: traceId,
+          type: "SPAN",
+          name: "old-monitor-filter-option-event",
+          level: oldLevel,
+          start_time: (now - 10 * 60 * 1000) * 1000,
+        }),
+      ]);
+
+      await waitForExpect(async () => {
+        const options = await getEventFilterOptions({
+          projectId: uniqueProjectId,
+          monitorWindow: "5m",
+        });
+        const levels = options.level.map((level) => level.value);
+
+        expect(levels).toContain(recentLevel);
+        expect(levels).not.toContain(oldLevel);
+      });
     });
   });
 

--- a/web/src/__tests__/server/sessions-trpc-events-only.servertest.ts
+++ b/web/src/__tests__/server/sessions-trpc-events-only.servertest.ts
@@ -96,6 +96,7 @@ maybe("sessions trpc (events_only write mode)", () => {
   // the session is countable (ClickHouse insert visibility can lag).
   const seedSessionEvent = async (sessionId: string) => {
     const traceId = randomUUID();
+    const startTime = new Date();
     await createEventsCh([
       createEvent({
         id: traceId,
@@ -106,7 +107,7 @@ maybe("sessions trpc (events_only write mode)", () => {
         type: "SPAN",
         session_id: sessionId,
         user_id: "user-a",
-        start_time: Date.now() * 1000,
+        start_time: startTime.getTime() * 1000,
       }),
     ]);
 
@@ -118,7 +119,7 @@ maybe("sessions trpc (events_only write mode)", () => {
       expect(rows[0]?.session_id).toBe(sessionId);
     });
 
-    return traceId;
+    return { traceId, startTime };
   };
 
   it("forces events_only write mode", () => {
@@ -134,7 +135,7 @@ maybe("sessions trpc (events_only write mode)", () => {
     });
     expect(before).toBeNull();
 
-    await seedSessionEvent(sessionId);
+    const { startTime } = await seedSessionEvent(sessionId);
 
     const result = await caller.sessions.byIdWithScoresFromEvents({
       projectId,
@@ -145,6 +146,12 @@ maybe("sessions trpc (events_only write mode)", () => {
     expect(result.bookmarked).toBe(false);
     expect(result.public).toBe(false);
     expect(result.countTraces).toBeGreaterThanOrEqual(1);
+    expect(
+      Math.abs(result.minTimestamp.getTime() - startTime.getTime()),
+    ).toBeLessThan(1000);
+    expect(
+      Math.abs(result.maxTimestamp.getTime() - startTime.getTime()),
+    ).toBeLessThan(1000);
   });
 
   it("bookmark creates the trace_sessions row on demand and round-trips", async () => {

--- a/web/src/components/session/index.tsx
+++ b/web/src/components/session/index.tsx
@@ -76,12 +76,14 @@ import { createSessionDetailStore } from "@/src/components/session/sessionDetail
 import {
   areDetailPageListsEqual,
   asCommentCounts,
+  type EventSession,
   getStringFilterOptions,
   isMultiValueOptionRecord,
   type EventFilterOptions,
   type EventSessionTrace,
   type LegacySessionTrace,
 } from "@/src/components/session/sessionDetailPageTypes";
+import { getSessionFilterOptionsStartTimeFilters } from "@/src/components/session/sessionFilterOptions";
 
 // some projects have thousands of users in a session, paginate to avoid rendering all at once
 const INITIAL_USERS_DISPLAY_COUNT = 10;
@@ -504,17 +506,6 @@ export const SessionEventsPage: React.FC<{
   sessionId: string;
   projectId: string;
 }> = ({ sessionId, projectId }) => {
-  const router = useRouter();
-  const { setDetailPageList, detailPagelists } = useDetailPageLists();
-  const userSession = useSession();
-  const parentRef = useRef<HTMLDivElement>(null);
-  const defaultPresetAppliedRef = useRef(false);
-
-  // Reset default preset flag when session changes (e.g., navigating between sessions)
-  useEffect(() => {
-    defaultPresetAppliedRef.current = false;
-  }, [sessionId]);
-
   const session = api.sessions.byIdWithScoresFromEvents.useQuery(
     {
       sessionId,
@@ -531,6 +522,86 @@ export const SessionEventsPage: React.FC<{
       },
     },
   );
+
+  const tracesQuery = api.sessions.tracesFromEvents.useQuery(
+    { projectId, sessionId },
+    {
+      enabled: !!projectId && !!sessionId,
+      retry(failureCount, error) {
+        if (
+          error.data?.code === "UNAUTHORIZED" ||
+          error.data?.code === "NOT_FOUND"
+        )
+          return false;
+        return failureCount < 3;
+      },
+    },
+  );
+
+  if (session.error?.data?.code === "UNAUTHORIZED")
+    return <ErrorPage message="You do not have access to this session." />;
+
+  if (session.error?.data?.code === "NOT_FOUND")
+    return (
+      <ErrorPage
+        title="Session not found"
+        message="The session is either still being processed or has been deleted."
+        additionalButton={{
+          label: "Retry",
+          onClick: () => window.location.reload(),
+        }}
+      />
+    );
+
+  if (!session.data) {
+    return (
+      <Page
+        headerProps={{
+          title: sessionId,
+          itemType: "SESSION",
+          breadcrumb: [
+            {
+              name: "Sessions",
+              href: `/project/${projectId}/sessions`,
+            },
+          ],
+        }}
+      >
+        <div className="h-full p-4">
+          <JsonSkeleton className="h-full w-full" numRows={8} />
+        </div>
+      </Page>
+    );
+  }
+
+  return (
+    <LoadedSessionEventsPage
+      sessionId={sessionId}
+      projectId={projectId}
+      session={session.data}
+      traces={tracesQuery.data}
+      isTracesSuccess={tracesQuery.isSuccess}
+    />
+  );
+};
+
+const LoadedSessionEventsPage: React.FC<{
+  sessionId: string;
+  projectId: string;
+  session: EventSession;
+  traces: EventSessionTrace[] | undefined;
+  isTracesSuccess: boolean;
+}> = ({ sessionId, projectId, session, traces, isTracesSuccess }) => {
+  const router = useRouter();
+  const { setDetailPageList, detailPagelists } = useDetailPageLists();
+  const userSession = useSession();
+  const parentRef = useRef<HTMLDivElement>(null);
+  const defaultPresetAppliedRef = useRef(false);
+
+  // Reset default preset flag when session changes (e.g., navigating between sessions)
+  useEffect(() => {
+    defaultPresetAppliedRef.current = false;
+  }, [sessionId]);
 
   const [showCorrections, setShowCorrections] = useLocalStorage(
     "showCorrections",
@@ -567,7 +638,7 @@ export const SessionEventsPage: React.FC<{
       objectId: sessionId,
       objectType: "SESSION",
     },
-    { enabled: session.isSuccess && userSession.status === "authenticated" },
+    { enabled: userSession.status === "authenticated" },
   );
 
   const traceCommentCounts =
@@ -576,23 +647,8 @@ export const SessionEventsPage: React.FC<{
         projectId,
         sessionId,
       },
-      { enabled: session.isSuccess && userSession.status === "authenticated" },
+      { enabled: userSession.status === "authenticated" },
     );
-
-  const tracesQuery = api.sessions.tracesFromEvents.useQuery(
-    { projectId, sessionId },
-    {
-      enabled: !!projectId && !!sessionId,
-      retry(failureCount, error) {
-        if (
-          error.data?.code === "UNAUTHORIZED" ||
-          error.data?.code === "NOT_FOUND"
-        )
-          return false;
-        return failureCount < 3;
-      },
-    },
-  );
 
   const peekNavigationConfig = React.useMemo(
     () => ({
@@ -610,19 +666,14 @@ export const SessionEventsPage: React.FC<{
     usePeekNavigation(peekNavigationConfig);
 
   useEffect(() => {
-    if (!tracesQuery.isSuccess) return;
-    const nextList = tracesQuery.data.map((t: EventSessionTrace) => ({
+    if (!isTracesSuccess || !traces) return;
+    const nextList = traces.map((t: EventSessionTrace) => ({
       id: t.id,
       params: { timestamp: t.timestamp.toISOString() },
     }));
     if (areDetailPageListsEqual(detailPagelists.traces, nextList)) return;
     setDetailPageList("traces", nextList);
-  }, [
-    tracesQuery.isSuccess,
-    tracesQuery.data,
-    setDetailPageList,
-    detailPagelists.traces,
-  ]);
+  }, [isTracesSuccess, traces, setDetailPageList, detailPagelists.traces]);
 
   const sessionEventsTableName = "session-events";
   const sessionFilterStorageKey = buildSidebarFilterQueryStorageKey({
@@ -663,18 +714,14 @@ export const SessionEventsPage: React.FC<{
     [urlFiltersQuery, sessionFilterStorageKey, projectId],
   );
 
-  // Decode time filters from URL/session filter state for scoping filter options
-  const timeFiltersForOptions = React.useMemo(() => {
-    const allFilters = decodeAndNormalizeFilters(
+  const timeFiltersForOptions = getSessionFilterOptionsStartTimeFilters({
+    filterState: decodeAndNormalizeFilters(
       filtersQuery,
       sessionEventsFilterConfig.columnDefinitions,
-    );
-    return allFilters.filter(
-      (f) =>
-        (f.column === "Start Time" || f.column === "startTime") &&
-        f.type === "datetime",
-    );
-  }, [filtersQuery, sessionEventsFilterConfig.columnDefinitions]);
+    ),
+    minTimestamp: session.minTimestamp,
+    maxTimestamp: session.maxTimestamp,
+  });
 
   const { filterOptions, isFilterOptionsPending } = useEventsFilterOptions({
     projectId,
@@ -885,28 +932,13 @@ export const SessionEventsPage: React.FC<{
   ]);
 
   const virtualizer = useVirtualizer({
-    count: tracesQuery.data?.length ?? 0,
+    count: traces?.length ?? 0,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 320,
     overscan: SESSION_VIRTUALIZER_OVERSCAN,
-    getItemKey: (index) => tracesQuery.data?.[index]?.id ?? index,
+    getItemKey: (index) => traces?.[index]?.id ?? index,
   });
   const virtualItems = virtualizer.getVirtualItems();
-
-  if (session.error?.data?.code === "UNAUTHORIZED")
-    return <ErrorPage message="You do not have access to this session." />;
-
-  if (session.error?.data?.code === "NOT_FOUND")
-    return (
-      <ErrorPage
-        title="Session not found"
-        message="The session is either still being processed or has been deleted."
-        additionalButton={{
-          label: "Retry",
-          onClick: () => window.location.reload(),
-        }}
-      />
-    );
 
   return (
     <SessionDetailStoreProvider store={sessionDetailStore}>
@@ -926,13 +958,13 @@ export const SessionEventsPage: React.FC<{
                 key="star"
                 projectId={projectId}
                 sessionId={sessionId}
-                value={session.data?.bookmarked ?? false}
+                value={session.bookmarked}
                 size="icon-xs"
               />
               <PublishSessionSwitch
                 projectId={projectId}
                 sessionId={sessionId}
-                isPublic={session.data?.public ?? false}
+                isPublic={session.public}
                 key="publish"
                 size="icon-xs"
               />
@@ -971,10 +1003,10 @@ export const SessionEventsPage: React.FC<{
                     type: "session",
                     sessionId,
                   }}
-                  scores={session.data?.scores ?? []}
+                  scores={session.scores}
                   scoreMetadata={{
                     projectId: projectId,
-                    environment: session.data?.environment,
+                    environment: session.environment,
                   }}
                   buttonVariant="outline"
                 />
@@ -1030,22 +1062,18 @@ export const SessionEventsPage: React.FC<{
             <Separator orientation="vertical" className="h-6" />
 
             {/* Stats */}
+            <Badge variant="outline">Total traces: {session.countTraces}</Badge>
             <Badge variant="outline">
-              Total traces: {session.data?.countTraces ?? 0}
+              Total cost: {usdFormatter(session.totalCost ?? 0, 2)}
             </Badge>
-            {session.data && (
-              <Badge variant="outline">
-                Total cost: {usdFormatter(session.data.totalCost ?? 0, 2)}
-              </Badge>
-            )}
 
             {/* Users */}
-            {session.data?.users?.length ? (
-              <SessionUsers projectId={projectId} users={session.data.users} />
+            {session.users?.length ? (
+              <SessionUsers projectId={projectId} users={session.users} />
             ) : null}
 
             {/* Scores */}
-            <SessionScores scores={session.data?.scores ?? []} />
+            <SessionScores scores={session.scores} />
           </div>
           <div ref={parentRef} className="flex-1 overflow-auto p-4">
             <div
@@ -1056,7 +1084,7 @@ export const SessionEventsPage: React.FC<{
               }}
             >
               {virtualItems.map((virtualItem) => {
-                const trace = tracesQuery.data?.[virtualItem.index];
+                const trace = traces?.[virtualItem.index];
                 if (!trace) return null;
 
                 return (

--- a/web/src/components/session/sessionDetailPageTypes.ts
+++ b/web/src/components/session/sessionDetailPageTypes.ts
@@ -4,6 +4,8 @@ import { type SingleValueOption } from "@langfuse/shared";
 
 export type LegacySessionTrace =
   RouterOutputs["sessions"]["byIdWithScores"]["traces"][number];
+export type EventSession =
+  RouterOutputs["sessions"]["byIdWithScoresFromEvents"];
 export type EventSessionTrace =
   RouterOutputs["sessions"]["tracesFromEvents"][number];
 export type CommentCounts = Map<string, number>;

--- a/web/src/components/session/sessionFilterOptions.clienttest.ts
+++ b/web/src/components/session/sessionFilterOptions.clienttest.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { type FilterState } from "@langfuse/shared";
+import { getSessionFilterOptionsStartTimeFilters } from "./sessionFilterOptions";
+
+describe("getSessionFilterOptionsStartTimeFilters", () => {
+  const minTimestamp = new Date("2026-06-01T00:00:00.000Z");
+  const maxTimestamp = new Date("2026-06-02T00:00:00.000Z");
+
+  it("uses the session time range when no explicit startTime filter exists", () => {
+    expect(
+      getSessionFilterOptionsStartTimeFilters({
+        filterState: [],
+        minTimestamp,
+        maxTimestamp,
+      }),
+    ).toEqual([
+      {
+        column: "startTime",
+        type: "datetime",
+        operator: ">=",
+        value: minTimestamp,
+      },
+      {
+        column: "startTime",
+        type: "datetime",
+        operator: "<=",
+        value: maxTimestamp,
+      },
+    ]);
+  });
+
+  it("uses explicit startTime filters when they include a lower bound", () => {
+    const explicitFilters: FilterState = [
+      {
+        column: "Start Time",
+        type: "datetime",
+        operator: ">=",
+        value: new Date("2026-05-01T00:00:00.000Z"),
+      },
+      {
+        column: "Start Time",
+        type: "datetime",
+        operator: "<=",
+        value: new Date("2026-05-03T00:00:00.000Z"),
+      },
+    ];
+
+    expect(
+      getSessionFilterOptionsStartTimeFilters({
+        filterState: explicitFilters,
+        minTimestamp,
+        maxTimestamp,
+      }),
+    ).toEqual(explicitFilters);
+  });
+
+  it("adds the session lower bound while preserving upper-only filters", () => {
+    const upperBound = {
+      column: "startTime" as const,
+      type: "datetime" as const,
+      operator: "<=" as const,
+      value: new Date("2026-05-03T00:00:00.000Z"),
+    };
+
+    expect(
+      getSessionFilterOptionsStartTimeFilters({
+        filterState: [upperBound],
+        minTimestamp,
+        maxTimestamp,
+      }),
+    ).toEqual([
+      {
+        column: "startTime",
+        type: "datetime",
+        operator: ">=",
+        value: minTimestamp,
+      },
+      upperBound,
+    ]);
+  });
+});

--- a/web/src/components/session/sessionFilterOptions.ts
+++ b/web/src/components/session/sessionFilterOptions.ts
@@ -1,0 +1,45 @@
+import { type FilterState, type TimeFilter } from "@langfuse/shared";
+
+export const isSessionStartTimeFilter = (
+  filter: FilterState[number],
+): filter is TimeFilter =>
+  (filter.column === "Start Time" || filter.column === "startTime") &&
+  filter.type === "datetime";
+
+const isLowerBoundStartTimeFilter = (filter: TimeFilter) =>
+  filter.operator === ">=" || filter.operator === ">";
+
+export const getSessionFilterOptionsStartTimeFilters = ({
+  filterState,
+  minTimestamp,
+  maxTimestamp,
+}: {
+  filterState: FilterState;
+  minTimestamp: Date;
+  maxTimestamp: Date;
+}): TimeFilter[] => {
+  const explicitStartTimeFilters = filterState.filter(isSessionStartTimeFilter);
+
+  if (explicitStartTimeFilters.some(isLowerBoundStartTimeFilter)) {
+    return explicitStartTimeFilters;
+  }
+
+  return [
+    {
+      column: "startTime",
+      type: "datetime",
+      operator: ">=",
+      value: minTimestamp,
+    },
+    ...(explicitStartTimeFilters.length > 0
+      ? explicitStartTimeFilters
+      : [
+          {
+            column: "startTime" as const,
+            type: "datetime" as const,
+            operator: "<=" as const,
+            value: maxTimestamp,
+          },
+        ]),
+  ];
+};

--- a/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
+++ b/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
@@ -2,16 +2,31 @@ import { api } from "@/src/utils/api";
 import {
   type ExperimentEvalOptions,
   type ObservationEvalOptions,
+  type TimeFilter,
 } from "@langfuse/shared";
 import { useMemo } from "react";
+
+const EVAL_FILTER_OPTIONS_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+const getLowerBoundTimeFilter = (
+  column: "timestamp" | "startTime",
+  value: Date,
+): TimeFilter[] => [{ column, type: "datetime", operator: ">=", value }];
 
 export function useEvalConfigFilterOptions({
   projectId,
 }: {
   projectId: string;
 }) {
+  const filterOptionsFrom = useMemo(
+    () => new Date(Date.now() - EVAL_FILTER_OPTIONS_LOOKBACK_MS),
+    [],
+  );
+
   const traceFilterOptionsResponse = api.traces.filterOptions.useQuery(
-    { projectId },
+    {
+      projectId,
+      timestampFilter: getLowerBoundTimeFilter("timestamp", filterOptionsFrom),
+    },
     {
       trpc: { context: { skipBatch: true } },
       refetchOnMount: false,
@@ -25,6 +40,7 @@ export function useEvalConfigFilterOptions({
     api.projects.environmentFilterOptions.useQuery(
       {
         projectId,
+        fromTimestamp: filterOptionsFrom,
       },
       {
         trpc: { context: { skipBatch: true } },
@@ -39,6 +55,7 @@ export function useEvalConfigFilterOptions({
     api.generations.filterOptions.useQuery({
       projectId,
       observationType: "ALL",
+      startTimeFilter: getLowerBoundTimeFilter("startTime", filterOptionsFrom),
     });
 
   const traceFilterOptions = useMemo(() => {

--- a/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
+++ b/web/src/features/evals/hooks/useEvalConfigFilterOptions.ts
@@ -7,6 +7,20 @@ import {
 import { useMemo } from "react";
 
 const EVAL_FILTER_OPTIONS_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+const evalFilterOptionsQueryOptions = {
+  trpc: { context: { skipBatch: true } },
+  refetchOnMount: false,
+  refetchOnWindowFocus: false,
+  refetchOnReconnect: false,
+  staleTime: Infinity,
+} as const;
+
+const getBucketedEvalFilterOptionsFrom = () => {
+  const date = new Date(Date.now() - EVAL_FILTER_OPTIONS_LOOKBACK_MS);
+  date.setUTCHours(0, 0, 0, 0);
+  return date;
+};
+
 const getLowerBoundTimeFilter = (
   column: "timestamp" | "startTime",
   value: Date,
@@ -18,7 +32,7 @@ export function useEvalConfigFilterOptions({
   projectId: string;
 }) {
   const filterOptionsFrom = useMemo(
-    () => new Date(Date.now() - EVAL_FILTER_OPTIONS_LOOKBACK_MS),
+    () => getBucketedEvalFilterOptionsFrom(),
     [],
   );
 
@@ -27,13 +41,7 @@ export function useEvalConfigFilterOptions({
       projectId,
       timestampFilter: getLowerBoundTimeFilter("timestamp", filterOptionsFrom),
     },
-    {
-      trpc: { context: { skipBatch: true } },
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      staleTime: Infinity,
-    },
+    evalFilterOptionsQueryOptions,
   );
 
   const environmentFilterOptionsResponse =
@@ -42,21 +50,21 @@ export function useEvalConfigFilterOptions({
         projectId,
         fromTimestamp: filterOptionsFrom,
       },
-      {
-        trpc: { context: { skipBatch: true } },
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-        staleTime: Infinity,
-      },
+      evalFilterOptionsQueryOptions,
     );
 
   const observationsFilterOptionsResponse =
-    api.generations.filterOptions.useQuery({
-      projectId,
-      observationType: "ALL",
-      startTimeFilter: getLowerBoundTimeFilter("startTime", filterOptionsFrom),
-    });
+    api.generations.filterOptions.useQuery(
+      {
+        projectId,
+        observationType: "ALL",
+        startTimeFilter: getLowerBoundTimeFilter(
+          "startTime",
+          filterOptionsFrom,
+        ),
+      },
+      evalFilterOptionsQueryOptions,
+    );
 
   const traceFilterOptions = useMemo(() => {
     // Normalize API response to match TraceOptions type (count should be number, not string)

--- a/web/src/features/events/server/eventsRouter.ts
+++ b/web/src/features/events/server/eventsRouter.ts
@@ -10,6 +10,7 @@ import {
   paginationZod,
   timeFilter,
 } from "@langfuse/shared";
+import { MonitorWindowSchema } from "@langfuse/shared/monitors";
 import {
   toDomainArrayWithStringifiedMetadata,
   toDomainWithStringifiedMetadata,
@@ -153,6 +154,7 @@ export const eventsRouter = createTRPCRouter({
       zodSchema.object({
         projectId: zodSchema.string(),
         startTimeFilter: zodSchema.array(timeFilter).optional(),
+        monitorWindow: MonitorWindowSchema.optional(),
         isRootObservation: zodSchema.boolean().optional(),
         hasParentObservation: zodSchema.boolean().optional(),
       }),
@@ -168,6 +170,7 @@ export const eventsRouter = createTRPCRouter({
           return getEventFilterOptions({
             projectId: input.projectId,
             startTimeFilter: input.startTimeFilter,
+            monitorWindow: input.monitorWindow,
             isRootObservation:
               input.isRootObservation ??
               (input.hasParentObservation !== undefined

--- a/web/src/features/events/server/eventsService.ts
+++ b/web/src/features/events/server/eventsService.ts
@@ -34,9 +34,15 @@ import {
   getObservationsBatchIOFromEventsTable,
   getScoresForObservations,
   getScoresForTraces,
+  logger,
   traceException,
 } from "@langfuse/shared/src/server";
 import { type timeFilter, type FilterState } from "@langfuse/shared";
+import {
+  monitorEvaluationOffsetMs,
+  type MonitorWindow,
+  windowToMs,
+} from "@langfuse/shared/monitors";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
 import { assertUnreachable } from "@/src/utils/types";
 
@@ -78,6 +84,7 @@ interface GetObservationsCountParams {
 interface GetObservationsFilterOptionsParams {
   projectId: string;
   startTimeFilter?: TimeFilter[];
+  monitorWindow?: MonitorWindow;
   isRootObservation?: boolean;
   hasParentObservation?: boolean;
   observationType?: string;
@@ -93,6 +100,112 @@ type GroupedEventsFilterOptions = {
   limit?: number;
   offset?: number;
   orderBy?: string;
+};
+
+const OBSERVATIONS_TO_TRACE_INTERVAL_MS = 2 * 24 * 60 * 60 * 1000;
+const SCORE_TO_TRACE_OBSERVATIONS_INTERVAL_MS = 60 * 60 * 1000;
+const EVENT_FILTER_OPTIONS_SCORE_LOOKBACK_BUFFER_MS =
+  OBSERVATIONS_TO_TRACE_INTERVAL_MS + SCORE_TO_TRACE_OBSERVATIONS_INTERVAL_MS;
+const EVENT_FILTER_OPTIONS_DEFAULT_LOOKBACK_DAYS = 30;
+const EVENT_FILTER_OPTIONS_DEFAULT_LOOKBACK_MS =
+  EVENT_FILTER_OPTIONS_DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+
+const isEventFilterOptionsLowerBoundStartTimeFilter = (filter: TimeFilter) =>
+  (filter.column === "startTime" || filter.column === "Start Time") &&
+  (filter.operator === ">=" || filter.operator === ">");
+
+const hasEventFilterOptionsLowerBoundStartTimeFilter = (
+  filters?: TimeFilter[],
+) => filters?.some(isEventFilterOptionsLowerBoundStartTimeFilter) ?? false;
+
+const getDefaultEventFilterOptionsStartTimeFilter = (): TimeFilter[] => [
+  {
+    column: "startTime",
+    type: "datetime",
+    operator: ">=",
+    value: new Date(Date.now() - EVENT_FILTER_OPTIONS_DEFAULT_LOOKBACK_MS),
+  },
+];
+
+const getMonitorWindowStartTimeFilter = (
+  monitorWindow: MonitorWindow,
+): TimeFilter[] => {
+  const windowMs = Number(windowToMs(monitorWindow));
+  const to = new Date(Date.now() - monitorEvaluationOffsetMs);
+  const from = new Date(to.getTime() - windowMs);
+
+  return [
+    {
+      column: "startTime",
+      type: "datetime",
+      operator: ">=",
+      value: from,
+    },
+    {
+      column: "startTime",
+      type: "datetime",
+      operator: "<=",
+      value: to,
+    },
+  ];
+};
+
+const ensureStartTimeFilterForEventFilterOptions = <
+  TParams extends GetObservationsFilterOptionsParams,
+>(
+  params: TParams,
+): TParams => {
+  if (hasEventFilterOptionsLowerBoundStartTimeFilter(params.startTimeFilter)) {
+    return params;
+  }
+
+  if (params.monitorWindow) {
+    return {
+      ...params,
+      startTimeFilter: [
+        ...getMonitorWindowStartTimeFilter(params.monitorWindow),
+        ...(params.startTimeFilter ?? []),
+      ],
+    };
+  }
+
+  logger.warn(
+    "events.filterOptions called without lower startTimeFilter; applying default lookback",
+    {
+      projectId: params.projectId,
+      defaultLookbackDays: EVENT_FILTER_OPTIONS_DEFAULT_LOOKBACK_DAYS,
+    },
+  );
+
+  return {
+    ...params,
+    startTimeFilter: [
+      ...getDefaultEventFilterOptionsStartTimeFilter(),
+      // Preserve upper-only bounds while adding the missing lower bound.
+      ...(params.startTimeFilter ?? []),
+    ],
+  } as TParams;
+};
+
+const toScoreTimestampFilters = (
+  startTimeFilter: TimeFilter[] | undefined,
+  column: "Timestamp" | "timestamp",
+): FilterCondition[] => {
+  return (startTimeFilter ?? []).flatMap((filter) => {
+    if (!isEventFilterOptionsLowerBoundStartTimeFilter(filter)) return [];
+
+    return [
+      {
+        column,
+        operator: filter.operator,
+        value: new Date(
+          filter.value.getTime() -
+            EVENT_FILTER_OPTIONS_SCORE_LOOKBACK_BUFFER_MS,
+        ),
+        type: "datetime",
+      },
+    ];
+  });
 };
 
 /**
@@ -297,25 +410,17 @@ const getEventFilterOptionsScope = (
       : []),
   ];
 
-  // Map startTimeFilter to Timestamp column for trace queries
-  const traceTimestampFilters =
-    startTimeFilter && startTimeFilter.length > 0
-      ? startTimeFilter.map((f) => ({
-          column: "Timestamp" as const,
-          operator: f.operator,
-          value: f.value,
-          type: "datetime" as const,
-        }))
-      : [];
-  const traceScoreTimestampFilters: FilterCondition[] =
-    startTimeFilter && startTimeFilter.length > 0
-      ? startTimeFilter.map((f) => ({
-          column: "timestamp",
-          operator: f.operator,
-          value: f.value,
-          type: "datetime",
-        }))
-      : [];
+  // Derive score-table timestamp filters from observation startTime filters.
+  // This is not a 1:1 remap: score loading allows trace/score timestamp skew,
+  // and upper observation bounds would hide backfilled scores data queries use.
+  const traceTimestampFilters = toScoreTimestampFilters(
+    startTimeFilter,
+    "Timestamp",
+  );
+  const traceScoreTimestampFilters = toScoreTimestampFilters(
+    startTimeFilter,
+    "timestamp",
+  );
 
   return {
     eventsFilter,
@@ -344,8 +449,9 @@ export async function getEventFilterValuePage(
     offset: number;
   },
 ) {
-  const { projectId, column, limit, offset } = params;
-  const { eventsFilter } = getEventFilterOptionsScope(params);
+  const scopedParams = ensureStartTimeFilterForEventFilterOptions(params);
+  const { projectId, column, limit, offset } = scopedParams;
+  const { eventsFilter } = getEventFilterOptionsScope(scopedParams);
   const queryLimit = limit + 1;
 
   const createResultFromGroupedQuery = async <T>(
@@ -478,8 +584,9 @@ export async function getEventFilterNumericRange(
     >;
   },
 ) {
-  const { projectId, column } = params;
-  const { eventsFilter } = getEventFilterOptionsScope(params);
+  const scopedParams = ensureStartTimeFilterForEventFilterOptions(params);
+  const { projectId, column } = scopedParams;
+  const { eventsFilter } = getEventFilterOptionsScope(scopedParams);
 
   return getEventsNumericStatsByFilterColumn(projectId, eventsFilter, column);
 }
@@ -490,9 +597,10 @@ export async function getEventFilterNumericRange(
 export async function getEventFilterOptions(
   params: GetObservationsFilterOptionsParams,
 ) {
-  const { projectId } = params;
+  const scopedParams = ensureStartTimeFilterForEventFilterOptions(params);
+  const { projectId } = scopedParams;
   const { eventsFilter, traceTimestampFilters, traceScoreTimestampFilters } =
-    getEventFilterOptionsScope(params);
+    getEventFilterOptionsScope(scopedParams);
 
   const [
     numericScoreNames,

--- a/web/src/features/monitors/components/MonitorForm.tsx
+++ b/web/src/features/monitors/components/MonitorForm.tsx
@@ -254,6 +254,7 @@ export const MonitorForm = ({
 
   /** watched is the live snapshot of form values used to derive preview state, dropdown contents, and placeholders. */
   const watched = useWatch({ control: form.control });
+  const monitorWindow = (watched.window ?? "5m") as MonitorWindow;
 
   // Push the live name up to the host (e.g. the edit page header) so the page
   // title can mirror it as the user types instead of waiting for save.
@@ -263,7 +264,10 @@ export const MonitorForm = ({
 
   /** eventsFilterOptions loads the events v2 filter dictionary (environments, tags, models, …) for the picked view. */
   const eventsFilterOptions = api.events.filterOptions.useQuery(
-    { projectId },
+    {
+      projectId,
+      monitorWindow,
+    },
     {
       trpc: { context: { skipBatch: true } },
       staleTime: Infinity,

--- a/web/src/features/monitors/components/MonitorForm.tsx
+++ b/web/src/features/monitors/components/MonitorForm.tsx
@@ -270,7 +270,7 @@ export const MonitorForm = ({
     },
     {
       trpc: { context: { skipBatch: true } },
-      staleTime: Infinity,
+      staleTime: 60 * 1000,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
     },

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -682,6 +682,26 @@ export function WidgetForm({
   const eventsFilterOptions = api.events.filterOptions.useQuery(
     {
       projectId,
+      startTimeFilter: dateRange
+        ? [
+            {
+              column: "startTime" as const,
+              type: "datetime" as const,
+              operator: ">=" as const,
+              value: dateRange.from,
+            },
+            ...(dateRange.to
+              ? [
+                  {
+                    column: "startTime" as const,
+                    type: "datetime" as const,
+                    operator: "<=" as const,
+                    value: dateRange.to,
+                  },
+                ]
+              : []),
+          ]
+        : undefined,
     },
     {
       trpc: {

--- a/web/src/features/widgets/components/WidgetForm.tsx
+++ b/web/src/features/widgets/components/WidgetForm.tsx
@@ -62,6 +62,7 @@ import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { showSuccessToast } from "@/src/features/notifications/showSuccessToast";
 import {
   type FilterState,
+  type TimeFilter,
   ObservationLevelDomain,
   ObservationTypeDomain,
 } from "@langfuse/shared";
@@ -118,6 +119,17 @@ type ChartType = {
 };
 
 type ChartConfig = WidgetChartConfig;
+
+const getDateRangeFilter = (
+  column: "timestamp" | "startTime",
+  dateRange?: { from: Date; to: Date },
+): TimeFilter[] | undefined =>
+  dateRange
+    ? [
+        { column, type: "datetime", operator: ">=", value: dateRange.from },
+        { column, type: "datetime", operator: "<=", value: dateRange.to },
+      ]
+    : undefined;
 
 const chartTypes: ChartType[] = [
   {
@@ -646,6 +658,7 @@ export function WidgetForm({
   const traceFilterOptions = api.traces.filterOptions.useQuery(
     {
       projectId,
+      timestampFilter: getDateRangeFilter("timestamp", dateRange),
     },
     {
       trpc: {
@@ -664,6 +677,7 @@ export function WidgetForm({
   const generationsFilterOptions = api.generations.filterOptions.useQuery(
     {
       projectId,
+      startTimeFilter: getDateRangeFilter("startTime", dateRange),
     },
     {
       trpc: {
@@ -682,26 +696,7 @@ export function WidgetForm({
   const eventsFilterOptions = api.events.filterOptions.useQuery(
     {
       projectId,
-      startTimeFilter: dateRange
-        ? [
-            {
-              column: "startTime" as const,
-              type: "datetime" as const,
-              operator: ">=" as const,
-              value: dateRange.from,
-            },
-            ...(dateRange.to
-              ? [
-                  {
-                    column: "startTime" as const,
-                    type: "datetime" as const,
-                    operator: "<=" as const,
-                    value: dateRange.to,
-                  },
-                ]
-              : []),
-          ]
-        : undefined,
+      startTimeFilter: getDateRangeFilter("startTime", dateRange),
     },
     {
       trpc: {

--- a/web/src/server/api/routers/sessions.ts
+++ b/web/src/server/api/routers/sessions.ts
@@ -47,6 +47,7 @@ import {
   getEventsGroupedByUserId,
   getEventsGroupedByTraceTags,
   hasAnySessionFromEventsTable,
+  parseClickhouseUTCDateTimeFormat,
 } from "@langfuse/shared/src/server";
 import chunk from "lodash/chunk";
 import { aggregateScores } from "@/src/features/scores/lib/aggregateScores";
@@ -722,6 +723,12 @@ export const sessionRouter = createTRPCRouter({
         totalCost: sessionMetrics
           ? Number(sessionMetrics.session_total_cost)
           : 0,
+        minTimestamp: parseClickhouseUTCDateTimeFormat(
+          sessionMetrics.min_timestamp,
+        ),
+        maxTimestamp: parseClickhouseUTCDateTimeFormat(
+          sessionMetrics.max_timestamp,
+        ),
         environment: sessionMetrics?.environment,
         scores: toDomainArrayWithStringifiedMetadata(validatedScores),
       };


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a server-side safety net to `getEventFilterOptions` so that filter-option queries against ClickHouse are always time-bounded. When a caller omits `startTimeFilter`, a default 30-day lookback is injected and a warning is logged; callers that supply an explicit filter are unaffected.

- **`eventsService.ts`**: Introduces `applyDefaultStartTimeFilterForEventFilterOptions` which injects a 30-day `startTime >= now-30d` filter and logs a `warn` when none is provided; `getEventFilterOptions` now passes `scopedParams` through this helper before building the ClickHouse filter set.
- **`WidgetForm.tsx`**: Threads the widget form's `dateRange` through as a `startTimeFilter` so the 30-day fallback is never triggered from this call site.
- **`events-filter-options.servertest.ts`**: New unit-test file covering the default-lookback path and the explicit-filter-preserved path.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The change is safe for most call sites but silently narrows the filter-option data returned to MonitorForm, which calls without a time range and now receives only 30-day results.

MonitorForm is an existing caller of `events.filterOptions` that never passes `startTimeFilter`. After this PR it will always receive 30-day-bounded filter options and emit a server-side warning on every load. A user configuring a monitor could be unable to select environments, model names, or other filter values that existed more than 30 days ago but are valid today — the dropdown would show an incomplete list without any visible explanation. This represents a real change in behavior for an important configuration surface that the PR did not update.

web/src/features/monitors/components/MonitorForm.tsx needs an explicit `startTimeFilter` (or a sufficiently long lookback) to avoid displaying an incomplete filter-option list when configuring monitors.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Client: api.events.filterOptions.useQuery()"] --> B{"startTimeFilter\nprovided?"}
    B -- "yes (WidgetForm, useDashboardFilterOptions,\nuseEventsFilterOptions)" --> C["applyDefaultStartTimeFilterForEventFilterOptions\nreturns params unchanged"]
    B -- "no (MonitorForm)" --> D["logger.warn()\napplies 30-day default startTimeFilter"]
    C --> E["getEventFilterOptionsScope(scopedParams)\nbuilds eventsFilter, traceTimestampFilters,\ntraceScoreTimestampFilters"]
    D --> E
    E --> F["ClickHouse: ~21 parallel queries\ntime-bounded by startTimeFilter"]
    F --> G["Return filter options to client"]

    H["getEventFilterValuePage(params)"] --> I["getEventFilterOptionsScope(params)\nNO default time-bound applied"]
    J["getEventFilterNumericRange(params)"] --> I
    I --> K["ClickHouse: potentially unbounded query"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Client: api.events.filterOptions.useQuery()"] --> B{"startTimeFilter\nprovided?"}
    B -- "yes (WidgetForm, useDashboardFilterOptions,\nuseEventsFilterOptions)" --> C["applyDefaultStartTimeFilterForEventFilterOptions\nreturns params unchanged"]
    B -- "no (MonitorForm)" --> D["logger.warn()\napplies 30-day default startTimeFilter"]
    C --> E["getEventFilterOptionsScope(scopedParams)\nbuilds eventsFilter, traceTimestampFilters,\ntraceScoreTimestampFilters"]
    D --> E
    E --> F["ClickHouse: ~21 parallel queries\ntime-bounded by startTimeFilter"]
    F --> G["Return filter options to client"]

    H["getEventFilterValuePage(params)"] --> I["getEventFilterOptionsScope(params)\nNO default time-bound applied"]
    J["getEventFilterNumericRange(params)"] --> I
    I --> K["ClickHouse: potentially unbounded query"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/events/server/eventsService.ts:358-380
**`getEventFilterValuePage` and `getEventFilterNumericRange` remain unbounded**

Both functions call `getEventFilterOptionsScope(params)` directly, bypassing `applyDefaultStartTimeFilterForEventFilterOptions`. If a caller passes no `startTimeFilter`, the underlying ClickHouse queries will scan across the entire project's event history — the same pattern this PR intends to guard against in `getEventFilterOptions`. The two functions handle per-column filter-value pagination and numeric ranges, which can be expensive on large projects.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: ensure filter options queries are t..."](https://github.com/langfuse/langfuse/commit/8b845281c6abcec372d7a635edefcce325737686) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39107278)</sub>

<!-- /greptile_comment -->