### PR TITLE
fix(evals): restore JSONPath filter expressions in variable mappings

### DIFF
--- a/packages/shared/src/features/batchAction/applyFieldMapping.ts
+++ b/packages/shared/src/features/batchAction/applyFieldMapping.ts
@@ -65,7 +65,11 @@ export function evaluateJsonPath(data: unknown, jsonPath: string): unknown {
     path: jsonPath,
     json: parsed as string | object,
     wrap: false,
-    eval: false,
+    // `eval: "safe"` enables filter expressions (e.g. `$[?(@.role=="user")]`)
+    // via jsonpath-plus's sandboxed evaluator, matching `testJsonPath` above.
+    // `eval: false` disabled all filter expressions; "safe" keeps RCE
+    // protection (no Function/vm) while restoring this functionality.
+    eval: "safe",
   });
 
   return result;

--- a/packages/shared/src/features/evals/utilities.ts
+++ b/packages/shared/src/features/evals/utilities.ts
@@ -63,7 +63,11 @@ function parseJsonDefault(selectedColumn: unknown, jsonSelector: string) {
   const result = JSONPath({
     path: jsonSelector,
     json: selectedColumn as any, // JSONPath accepts unknown but types are strict
-    eval: false,
+    // `eval: "safe"` enables filter expressions (e.g. `$[?(@.role=="user")]`)
+    // via jsonpath-plus's sandboxed evaluator. `eval: false` disabled all
+    // filter expressions; "safe" keeps RCE protection (no Function/vm) while
+    // restoring this functionality.
+    eval: "safe",
   });
 
   if (!Array.isArray(result) || result.length === 0) {

--- a/web/src/__tests__/server/unit/validateEvaluatorVariableMappings.servertest.ts
+++ b/web/src/__tests__/server/unit/validateEvaluatorVariableMappings.servertest.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { validateEvaluatorVariableMappings } from "@/src/features/evals/server/unstable-public-api/validation";
+import type { PublicEvaluationRuleMappingType } from "@/src/features/public-api/types/unstable-public-evals-contract";
+
+describe("validateEvaluatorVariableMappings", () => {
+  it("accepts JSONPath filter expressions in variable mappings", () => {
+    // Only `source`, `variable`, and `jsonPath` are read by the validator.
+    const mappings = [
+      {
+        source: "input",
+        variable: "query",
+        jsonPath: '$[?(@.role=="user")]',
+      },
+    ] as unknown as PublicEvaluationRuleMappingType[];
+
+    expect(() =>
+      validateEvaluatorVariableMappings({
+        mappings,
+        variables: ["query"],
+        target: "observation",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/web/src/features/evals/server/unstable-public-api/validation.ts
+++ b/web/src/features/evals/server/unstable-public-api/validation.ts
@@ -284,7 +284,11 @@ function validateJsonPath(params: {
     JSONPath({
       path: jsonPath,
       json: {},
-      eval: false,
+      // `eval: "safe"` enables filter expressions (e.g. `$[?(@.role=="user")]`)
+      // via jsonpath-plus's sandboxed evaluator. `eval: false` disabled all
+      // filter expressions; "safe" keeps RCE protection (no Function/vm) while
+      // restoring this functionality.
+      eval: "safe",
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/worker/src/__tests__/applyFieldMapping.test.ts
+++ b/worker/src/__tests__/applyFieldMapping.test.ts
@@ -112,6 +112,14 @@ describe("applyFieldMapping", () => {
       ).toBeUndefined();
     });
 
+    it("should evaluate filter expressions like $.messages[?(@.role=='user')]", () => {
+      const result = evaluateJsonPath(
+        sampleObservation.input,
+        '$.messages[?(@.role=="user")]',
+      );
+      expect(result).toEqual([{ role: "user", content: "What is 2+2?" }]);
+    });
+
     it("should handle string data (auto-parse JSON)", () => {
       const jsonString = '{"nested": {"value": 42}}';
       expect(evaluateJsonPath(jsonString, "$.nested.value")).toBe(42);

--- a/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
+++ b/worker/src/features/evaluation/__tests__/extractValueFromObject.test.ts
@@ -45,6 +45,45 @@ describe("extractValueFromObject", () => {
     });
   });
 
+  describe("JSONPath filter expressions", () => {
+    it('should return matching elements for filter expression $[?(@.role=="user")]', () => {
+      const obj = {
+        data: JSON.stringify([
+          { role: "user", content: "hi" },
+          { role: "assistant", content: "hello" },
+          { role: "user", content: "bye" },
+        ]),
+      };
+
+      const result = extractValueFromObject(
+        obj,
+        "data",
+        '$[?(@.role=="user")]',
+      );
+      expect(result.error).toBeNull();
+      expect(result.value).toEqual([
+        { role: "user", content: "hi" },
+        { role: "user", content: "bye" },
+      ]);
+    });
+
+    it("rejects constructor-based code execution in filter expressions", () => {
+      const obj = { data: JSON.stringify([{ role: "user" }]) };
+
+      // Classic jsonpath-plus RCE vector via the constructor chain. The
+      // sandboxed "safe" evaluator must reject it rather than execute it, so the
+      // expression errors and never resolves to a filtered match.
+      const result = extractValueFromObject(
+        obj,
+        "data",
+        '$[?(@.constructor.constructor("return true")())]',
+      );
+
+      expect(result.error).not.toBeNull();
+      expect(result.value).not.toEqual([{ role: "user" }]);
+    });
+  });
+
   describe("JSONPath single element access (backward compat)", () => {
     it("should preserve unsafe integers as strings when applying a selector", () => {
       const obj = {


### PR DESCRIPTION
## What does this PR do?

Restores JSONPath **filter expressions** (e.g. `$[?(@.role=="user")]`) in evaluator variable mappings, which are currently rejected with:

> Eval `[?(expr)]` prevented in JSONPath expression.

#12829 set `eval: false` on the `jsonpath-plus` calls to mitigate RCE (CVE-2024-21534, CVE-2025-1302), but that also disables **all** filter expressions — making a common LLM-as-a-judge use case (e.g. filtering messages by role before passing them to the judge) unusable.

This switches the three `eval: false` call sites to **`eval: "safe"`**. jsonpath-plus 10.x's `"safe"` sandboxed evaluator (its own default) supports filter expressions **without** using `Function`/`vm`, so the RCE protection the original change added is preserved while filters work again.

Sites changed:
- `packages/shared/src/features/evals/utilities.ts` — variable mapping extraction (runtime)
- `web/src/features/evals/server/unstable-public-api/validation.ts` — variable mapping validation (public API; this is what emits the error above)
- `packages/shared/src/features/batchAction/applyFieldMapping.ts` — batch-action field mapping (also aligns `evaluateJsonPath` with the already-`safe` `testJsonPath` in the same file)

Note on security: I verified empirically that in jsonpath-plus 10.3.0 the classic `constructor.constructor(...)` RCE vector is rejected in **both** `"safe"` and `true` modes; `"safe"` additionally avoids any JS eval engine. A test asserts the constructor-based payload stays rejected.

Fixes #14258

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Self-reviewed the code.

## Checklist

- [x] Added tests proving the fix is effective (filter expressions resolve; constructor-based RCE payload rejected)
- [x] New and existing unit tests pass locally; `pnpm run typecheck` and `pnpm run lint` are clean
- [x] Commented the non-obvious change (why `"safe"` rather than `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores JSONPath filter expressions (e.g. `$[?(@.role=="user")]`) in evaluator variable mappings by switching three `eval: false` call sites to `eval: "safe"` in jsonpath-plus 10.3.0. The original `eval: false` setting, introduced to mitigate CVE-2024-21534 / CVE-2025-1302, inadvertently disabled all filter expressions; `eval: "safe"` re-enables them while relying on 10.3.0's input sanitisation to block `constructor.constructor()` RCE vectors.

- `utilities.ts`, `applyFieldMapping.ts`, and `validation.ts` each replace `eval: false` with `eval: "safe"` and matching inline comments.
- New tests cover the filter-expression happy path across all three call sites and a constructor-chain RCE rejection test for the `utilities.ts` path.
- The code comments state `eval: "safe"` avoids `Function`/`vm`; this is accurate only in browsers — in Node.js `eval: "safe"` is equivalent to native mode and does use `vm.Script`. The real protection comes from 10.3.0's parser-level sanitisation, not the eval mode, and the comments should reflect that to avoid misleading future maintainers.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the functional fix is correct and the constructor RCE guard is empirically verified by the new test against jsonpath-plus 10.3.0.

The three call sites now match the behaviour of `testJsonPath`, which was already using the same default. The added test confirms filter expressions resolve and the classic constructor chain is still rejected. The only gap is that the inline comments misattribute where the security comes from (10.3.0 input sanitisation, not an absence of vm), which could mislead a future maintainer upgrading the dependency. The `applyFieldMapping` test suite also lacks a parallel RCE rejection assertion. Neither issue affects correctness today.

The three files containing the inaccurate "no Function/vm" comment (`utilities.ts`, `applyFieldMapping.ts`, `validation.ts`) and `applyFieldMapping.test.ts` which is missing a constructor-RCE rejection test.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User-supplied JSONPath expression] --> B{Contains filter expression?}
    B -- No --> C[Direct JSONPath evaluation]
    B -- Yes --> D{eval mode}
    D -- "eval: false (before PR)" --> E["❌ Throws: eval prevented in JSONPath expression"]
    D -- "eval: 'safe' (after PR)" --> F[jsonpath-plus 10.3.0 input sanitizer]
    F -- "constructor.constructor() detected" --> G["❌ Throws: RCE vector rejected"]
    F -- "Safe expression" --> H["✅ vm.Script execution (Node.js)"]
    H --> I[Returns filtered results]
    C --> I
    I --> J[Evaluator / batch-action result]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User-supplied JSONPath expression] --> B{Contains filter expression?}
    B -- No --> C[Direct JSONPath evaluation]
    B -- Yes --> D{eval mode}
    D -- "eval: false (before PR)" --> E["❌ Throws: eval prevented in JSONPath expression"]
    D -- "eval: 'safe' (after PR)" --> F[jsonpath-plus 10.3.0 input sanitizer]
    F -- "constructor.constructor() detected" --> G["❌ Throws: RCE vector rejected"]
    F -- "Safe expression" --> H["✅ vm.Script execution (Node.js)"]
    H --> I[Returns filtered results]
    C --> I
    I --> J[Evaluator / batch-action result]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/features/evals/utilities.ts:66-70
**Inaccurate security comment — "no Function/vm" is Node.js-false**

The comment says `eval: "safe"` keeps RCE protection "no Function/vm", but in Node.js (the runtime for all three changed call sites) `eval: "safe"` is documented as equivalent to `native` mode and *does* execute filter expressions through `vm.Script`. The actual protection against the `constructor.constructor()` RCE vector comes from jsonpath-plus 10.3.0's input sanitisation (the patch for CVE-2025-1302), not from avoiding the vm module. The same inaccurate claim appears verbatim in `applyFieldMapping.ts` and `validation.ts`. Future maintainers may incorrectly conclude that the browser-style CSP sandbox is active server-side, which could lead to incorrect reasoning if they ever upgrade to a release that changes that sanitisation.

### Issue 2 of 2
worker/src/__tests__/applyFieldMapping.test.ts:115-121
**Missing constructor-RCE rejection test for this code path**

`extractValueFromObject.test.ts` covers both the filter-expression happy path *and* the constructor-chain rejection (lines 70–84 of that file). The new test here only covers the happy path for `evaluateJsonPath`. Adding a parallel `constructor.constructor(...)` rejection assertion to this file would give the same regression guardrail for the `applyFieldMapping` code path, ensuring the protection is caught should anything change in either the version pin or the eval mode for this function specifically.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(evals): restore JSONPath filter expr..."](https://github.com/langfuse/langfuse/commit/7c7b87a2d5c5793f160a0514aba6987d0613af7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39111786)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->