### PR TITLE
fix(llm): apply runtime timeout to OpenAI calls

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -93,6 +93,7 @@ jobs:
             llm_connections:
               - 'packages/shared/package.json'
               - 'packages/shared/src/server/llm/fetchLLMCompletion.ts'
+              - 'packages/shared/src/server/llm/utils.ts'
 
   lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -93,6 +93,7 @@ jobs:
             llm_connections:
               - 'packages/shared/package.json'
               - 'packages/shared/src/server/llm/fetchLLMCompletion.ts'
+              - 'packages/shared/src/server/llm/secureLlmFetch.ts'
               - 'packages/shared/src/server/llm/utils.ts'
 
   lint:

--- a/packages/shared/src/server/llm/utils.ts
+++ b/packages/shared/src/server/llm/utils.ts
@@ -8,6 +8,7 @@ const ExtraHeaderSchema = z.record(z.string(), z.string());
 export const RUNTIME_TIMEOUT_ADAPTERS = new Set([
   LLMAdapter.VertexAI,
   LLMAdapter.GoogleAIStudio,
+  LLMAdapter.OpenAI,
 ]);
 
 export async function executeWithRuntimeTimeout<T>({


### PR DESCRIPTION
## Summary

- Extend the runtime timeout adapter allowlist from #13037 to OpenAI-compatible LLM calls.
- This applies the existing `LANGFUSE_FETCH_LLM_COMPLETION_TIMEOUT_MS` hard wrapper around OpenAI `fetchLLMCompletion` calls, covering custom base URL endpoints that can otherwise keep worker slots occupied.

## Linear

- None

## Major Decisions

- Reused the existing `executeWithRuntimeTimeout` adapter allowlist instead of adding eval-specific plumbing. This keeps the change surgical and matches the timeout mechanism introduced in https://github.com/langfuse/langfuse/pull/13037.

## Review Focus

- Confirm that applying the hard runtime timeout to all OpenAI-adapter `fetchLLMCompletion` callers is acceptable, not only LLM-as-judge.

## Validation

- `pnpm --dir worker exec vitest run src/__tests__/fetchLLMCompletionTimeout.test.ts`
- Commit hooks passed: Prettier + `turbo run lint`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the `RUNTIME_TIMEOUT_ADAPTERS` allowlist to include `LLMAdapter.OpenAI`, wrapping all `fetchLLMCompletion` call paths for the OpenAI adapter in the existing `executeWithRuntimeTimeout` `Promise.race` guard.

- `LLMAdapter.OpenAI` is added to `RUNTIME_TIMEOUT_ADAPTERS` in `packages/shared/src/server/llm/utils.ts`, enabling the outer hard-timeout for non-streaming invocations, streaming acquisition, tool calls, and structured output calls.
- The OpenAI adapter already sets SDK-level timeouts (`configuration.timeout` and top-level `timeout`) so this adds a defense-in-depth layer targeting custom base URL endpoints that may not respect the SDK timeout (e.g. via a custom `secureLlmFetch`).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is a targeted one-liner that reuses a well-tested mechanism already in production for VertexAI and GoogleAIStudio adapters, with no new code paths introduced.

The OpenAI adapter already sets SDK-level timeouts; the runtime wrapper adds defense-in-depth for custom base URL endpoints where the SDK timeout may not fire reliably. The two non-blocking suggestions (Azure coverage, new unit tests) do not affect correctness of the existing change.

No files require special attention. The single changed line in `packages/shared/src/server/llm/utils.ts` is straightforward, and the companion test file (`worker/src/__tests__/fetchLLMCompletionTimeout.test.ts`) has no OpenAI-specific test cases yet.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fetchLLMCompletion called\nwith LLMAdapter.OpenAI] --> B{RUNTIME_TIMEOUT_ADAPTERS\n.has adapter?}
    B -- "After PR: YES" --> C[Create AbortController\nAttach signal to runConfig]
    B -- "Before PR: NO" --> D[No AbortController\nNo runtime timeout]
    C --> E[executeWithRuntimeTimeout\nPromise.race vs setTimeout]
    D --> F[Call chatModel directly\nSDK-level timeout only]
    E --> G{Timeout fires\nbefore SDK responds?}
    G -- YES --> H[Abort signal fired\nReject with LLMCompletionError\nnon-retryable]
    G -- NO --> I[Clear timeout\nReturn result]
    F --> J[SDK configuration.timeout\nor top-level timeout fires]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[fetchLLMCompletion called\nwith LLMAdapter.OpenAI] --> B{RUNTIME_TIMEOUT_ADAPTERS\n.has adapter?}
    B -- "After PR: YES" --> C[Create AbortController\nAttach signal to runConfig]
    B -- "Before PR: NO" --> D[No AbortController\nNo runtime timeout]
    C --> E[executeWithRuntimeTimeout\nPromise.race vs setTimeout]
    D --> F[Call chatModel directly\nSDK-level timeout only]
    E --> G{Timeout fires\nbefore SDK responds?}
    G -- YES --> H[Abort signal fired\nReject with LLMCompletionError\nnon-retryable]
    G -- NO --> I[Clear timeout\nReturn result]
    F --> J[SDK configuration.timeout\nor top-level timeout fires]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/shared/src/server/llm/utils.ts:8-12
**`LLMAdapter.Azure` not covered by the runtime timeout**

The `AzureChatOpenAI` branch also configures `timeout: timeoutMs` at both the SDK level (`configuration.timeout`) and the model level, and it accepts a custom `baseURL`-equivalent (`azureOpenAIBasePath`) that can point to arbitrary HTTPS endpoints — the same scenario that motivated this PR for the `OpenAI` adapter. Omitting `LLMAdapter.Azure` means a stalled Azure endpoint won't be caught by the `Promise.race` guard. If the motivation here is to protect worker slots from unresponsive custom endpoints, Azure is in the same boat and may be worth including.

### Issue 2 of 2
packages/shared/src/server/llm/utils.ts:8-12
**No test coverage for the new OpenAI timeout path**

`fetchLLMCompletionTimeout.test.ts` has two tests that verify the runtime timeout fires for `VertexAI` (non-streaming and streaming) but no equivalent tests for `LLMAdapter.OpenAI`. The test structure already mocks LangChain models and fake timers, so adding a parallel pair of tests (`ChatOpenAI` mock returning a never-resolving promise) would confirm the `Promise.race` guard is wired correctly for the new adapter entry.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(llm): apply runtime timeout to OpenA..."](https://github.com/langfuse/langfuse/commit/f91e4859f1d3bad32ee0029de9f914c3b3acd201) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39143468)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->