### PR TITLE
feat(auth): add invite-only signup mode

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -60,6 +60,7 @@ OTEL_SERVICE_NAME="langfuse"
 # AUTH_IGNORE_ACCOUNT_FIELDS=foo,bar
 # AUTH_DISABLE_USERNAME_PASSWORD=true
 # AUTH_DISABLE_SIGNUP=true
+# AUTH_SIGNUP_MODE=open # open, disabled, invite-only
 # AUTH_SESSION_MAX_AGE=43200 # 30 days in minutes (default)
 
 # SSO, each group is optional

--- a/web/src/__tests__/server/unit/signupPolicy.servertest.ts
+++ b/web/src/__tests__/server/unit/signupPolicy.servertest.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getEffectiveSignupMode,
+  normalizeSignupEmail,
+  validateSignupModeEligibilityForMode,
+} from "@/src/features/auth/lib/signupMode";
+
+describe("signupPolicy", () => {
+  describe("getEffectiveSignupMode", () => {
+    it("defaults to open signup", () => {
+      expect(getEffectiveSignupMode({})).toBe("open");
+    });
+
+    it("uses AUTH_SIGNUP_MODE when no legacy disable flag is set", () => {
+      expect(getEffectiveSignupMode({ authSignupMode: "invite-only" })).toBe(
+        "invite-only",
+      );
+      expect(getEffectiveSignupMode({ authSignupMode: "disabled" })).toBe(
+        "disabled",
+      );
+    });
+
+    it("lets existing disable flags override AUTH_SIGNUP_MODE", () => {
+      expect(
+        getEffectiveSignupMode({
+          authDisableSignup: "true",
+          authSignupMode: "invite-only",
+        }),
+      ).toBe("disabled");
+
+      expect(
+        getEffectiveSignupMode({
+          authSignupMode: "invite-only",
+          nextPublicSignUpDisabled: "true",
+        }),
+      ).toBe("disabled");
+    });
+  });
+
+  it("normalizes signup email addresses before invitation lookup", () => {
+    expect(normalizeSignupEmail("  New.User@Example.COM ")).toBe(
+      "new.user@example.com",
+    );
+  });
+
+  describe("validateSignupModeEligibilityForMode", () => {
+    it("allows open signup without checking invitations", async () => {
+      const hasPendingInvitation = vi.fn();
+
+      await expect(
+        validateSignupModeEligibilityForMode({
+          email: "user@example.com",
+          signupMode: "open",
+          hasPendingInvitation,
+        }),
+      ).resolves.toBeNull();
+      expect(hasPendingInvitation).not.toHaveBeenCalled();
+    });
+
+    it("blocks disabled signup without checking invitations", async () => {
+      const hasPendingInvitation = vi.fn();
+
+      await expect(
+        validateSignupModeEligibilityForMode({
+          email: "user@example.com",
+          signupMode: "disabled",
+          hasPendingInvitation,
+        }),
+      ).resolves.toBe("Sign up is disabled.");
+      expect(hasPendingInvitation).not.toHaveBeenCalled();
+    });
+
+    it("requires a pending invitation in invite-only mode", async () => {
+      await expect(
+        validateSignupModeEligibilityForMode({
+          email: "user@example.com",
+          signupMode: "invite-only",
+          hasPendingInvitation: vi.fn().mockResolvedValue(false),
+        }),
+      ).resolves.toBe("Sign up requires an invitation.");
+
+      await expect(
+        validateSignupModeEligibilityForMode({
+          email: "user@example.com",
+          signupMode: "invite-only",
+          hasPendingInvitation: vi.fn().mockResolvedValue(true),
+        }),
+      ).resolves.toBeNull();
+    });
+  });
+});

--- a/web/src/env.mjs
+++ b/web/src/env.mjs
@@ -255,6 +255,10 @@ export const env = createEnv({
     AUTH_IGNORE_ACCOUNT_FIELDS: z.string().optional(),
     AUTH_DISABLE_USERNAME_PASSWORD: z.enum(["true", "false"]).optional(),
     AUTH_DISABLE_SIGNUP: z.enum(["true", "false"]).optional(),
+    AUTH_SIGNUP_MODE: z
+      .enum(["open", "disabled", "invite-only"])
+      .optional()
+      .default("open"),
     AUTH_EMAIL_VERIFICATION_REQUIRED: z
       .enum(["true", "false"])
       .default("false"),
@@ -714,6 +718,7 @@ export const env = createEnv({
       process.env.AUTH_DOMAINS_WITH_SSO_ENFORCEMENT,
     AUTH_DISABLE_USERNAME_PASSWORD: process.env.AUTH_DISABLE_USERNAME_PASSWORD,
     AUTH_DISABLE_SIGNUP: process.env.AUTH_DISABLE_SIGNUP,
+    AUTH_SIGNUP_MODE: process.env.AUTH_SIGNUP_MODE,
     AUTH_EMAIL_VERIFICATION_REQUIRED:
       process.env.AUTH_EMAIL_VERIFICATION_REQUIRED,
     AUTH_SESSION_MAX_AGE: process.env.AUTH_SESSION_MAX_AGE,

--- a/web/src/features/auth-credentials/server/signupApiHandler.ts
+++ b/web/src/features/auth-credentials/server/signupApiHandler.ts
@@ -6,6 +6,7 @@ import { ENTERPRISE_SSO_REQUIRED_MESSAGE } from "@/src/features/auth/constants";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { logger } from "@langfuse/shared/src/server";
 import { isEmailVerificationRequired } from "@/src/features/auth-credentials/lib/credentialsUtils";
+import { validateSignupModeEligibility } from "@/src/features/auth/lib/signupPolicy";
 
 export function getSSOBlockedDomains() {
   return (
@@ -24,13 +25,9 @@ export async function validateSignupEligibility({
 }: {
   email: string;
 }): Promise<string | null> {
-  // Block if disabled by env
-  if (
-    env.NEXT_PUBLIC_SIGN_UP_DISABLED === "true" ||
-    env.AUTH_DISABLE_SIGNUP === "true"
-  ) {
-    return "Sign up is disabled.";
-  }
+  const signupModeError = await validateSignupModeEligibility({ email });
+  if (signupModeError) return signupModeError;
+
   if (env.AUTH_DISABLE_USERNAME_PASSWORD === "true") {
     return "Sign up with email and password is disabled for this instance. Please use SSO.";
   }

--- a/web/src/features/auth/lib/signupMode.ts
+++ b/web/src/features/auth/lib/signupMode.ts
@@ -1,0 +1,46 @@
+export const signupModes = ["open", "disabled", "invite-only"] as const;
+
+export type SignupMode = (typeof signupModes)[number];
+
+export type SignupModeConfig = {
+  authDisableSignup?: "true" | "false";
+  authSignupMode?: SignupMode;
+  nextPublicSignUpDisabled?: "true" | "false";
+};
+
+export function getEffectiveSignupMode(
+  config: SignupModeConfig = {},
+): SignupMode {
+  if (
+    config.nextPublicSignUpDisabled === "true" ||
+    config.authDisableSignup === "true"
+  ) {
+    return "disabled";
+  }
+
+  return config.authSignupMode ?? "open";
+}
+
+export function normalizeSignupEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+export async function validateSignupModeEligibilityForMode({
+  email,
+  signupMode,
+  hasPendingInvitation,
+}: {
+  email: string;
+  signupMode: SignupMode;
+  hasPendingInvitation: (email: string) => Promise<boolean>;
+}) {
+  if (signupMode === "disabled") {
+    return "Sign up is disabled.";
+  }
+
+  if (signupMode === "invite-only" && !(await hasPendingInvitation(email))) {
+    return "Sign up requires an invitation.";
+  }
+
+  return null;
+}

--- a/web/src/features/auth/lib/signupPolicy.ts
+++ b/web/src/features/auth/lib/signupPolicy.ts
@@ -1,0 +1,54 @@
+import { env } from "@/src/env.mjs";
+import {
+  getEffectiveSignupMode as getEffectiveSignupModeFromConfig,
+  normalizeSignupEmail,
+  validateSignupModeEligibilityForMode,
+  type SignupModeConfig,
+} from "@/src/features/auth/lib/signupMode";
+
+export {
+  normalizeSignupEmail,
+  signupModes,
+  validateSignupModeEligibilityForMode,
+  type SignupMode,
+  type SignupModeConfig,
+} from "@/src/features/auth/lib/signupMode";
+
+const getSignupModeConfig = (): SignupModeConfig => ({
+  authDisableSignup: env.AUTH_DISABLE_SIGNUP,
+  authSignupMode: env.AUTH_SIGNUP_MODE,
+  nextPublicSignUpDisabled: env.NEXT_PUBLIC_SIGN_UP_DISABLED,
+});
+
+export function getEffectiveSignupMode(
+  config: SignupModeConfig = getSignupModeConfig(),
+): ReturnType<typeof getEffectiveSignupModeFromConfig> {
+  return getEffectiveSignupModeFromConfig(config);
+}
+
+export async function hasPendingMembershipInvitation(email: string) {
+  const { prisma } = await import("@langfuse/shared/src/db");
+
+  const invitation = await prisma.membershipInvitation.findFirst({
+    where: {
+      email: normalizeSignupEmail(email),
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return Boolean(invitation);
+}
+
+export async function validateSignupModeEligibility({
+  email,
+}: {
+  email: string;
+}) {
+  return validateSignupModeEligibilityForMode({
+    email,
+    signupMode: getEffectiveSignupMode(),
+    hasPendingInvitation: hasPendingMembershipInvitation,
+  });
+}

--- a/web/src/pages/auth/sign-in.tsx
+++ b/web/src/pages/auth/sign-in.tsx
@@ -45,6 +45,10 @@ import { AuthProviderButton } from "@/src/features/auth/components/AuthProviderB
 import { cn } from "@/src/utils/tailwind";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
 import { getSafeRedirectPath } from "@/src/utils/redirect";
+import {
+  getEffectiveSignupMode,
+  type SignupMode,
+} from "@/src/features/auth/lib/signupPolicy";
 
 const credentialAuthForm = z.object({
   email: z.email(),
@@ -91,6 +95,7 @@ export type PageProps = {
   };
   runningOnHuggingFaceSpaces: boolean;
   signUpDisabled: boolean;
+  signUpMode: SignupMode;
   emailVerificationRequired: boolean;
 };
 
@@ -98,6 +103,8 @@ export type PageProps = {
 
 export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
   const sso: boolean = await isAnySsoConfigured();
+  const signUpMode = getEffectiveSignupMode();
+
   return {
     props: {
       authProviders: {
@@ -174,7 +181,8 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
             : false,
         sso,
       },
-      signUpDisabled: env.AUTH_DISABLE_SIGNUP === "true",
+      signUpDisabled: signUpMode === "disabled",
+      signUpMode,
       emailVerificationRequired: isEmailVerificationRequired(),
       runningOnHuggingFaceSpaces: env.NEXTAUTH_URL?.replace(
         "/api/auth",
@@ -225,8 +233,7 @@ export function SSOButtons({
       });
   };
 
-  // Only show separator if credentials are enabled (for sign-in) or if action is sign-up (which always has the form)
-  const showSeparator = authProviders.credentials || action !== "sign in";
+  const showSeparator = authProviders.credentials;
 
   return (
     // any authprovider from props is enabled
@@ -534,6 +541,7 @@ const signInErrors = [
 export default function SignIn({
   authProviders,
   signUpDisabled,
+  signUpMode,
   runningOnHuggingFaceSpaces,
 }: PageProps) {
   const router = useRouter();
@@ -861,6 +869,7 @@ export default function SignIn({
           </div>
 
           {!signUpDisabled &&
+          signUpMode === "open" &&
           env.NEXT_PUBLIC_SIGN_UP_DISABLED !== "true" &&
           authProviders.credentials ? (
             <p className="text-muted-foreground mt-10 text-center text-sm">

--- a/web/src/pages/auth/sign-up.tsx
+++ b/web/src/pages/auth/sign-up.tsx
@@ -38,6 +38,13 @@ export { getServerSideProps } from "@/src/pages/auth/sign-in";
 
 type NextAuthProvider = NonNullable<Parameters<typeof signIn>[0]>;
 
+function hasStaticSsoProviders(authProviders: PageProps["authProviders"]) {
+  return Object.entries(authProviders).some(
+    ([name, enabled]) =>
+      Boolean(enabled) && name !== "credentials" && name !== "sso",
+  );
+}
+
 // Schema for the verified signup flow (email + name only, no password)
 const signupVerifyFormSchema = z.object({
   name: StringNoHTMLNonEmpty.refine((value) => noUrlCheck(value), {
@@ -54,6 +61,7 @@ export default function SignUp({
   authProviders,
   runningOnHuggingFaceSpaces,
   emailVerificationRequired,
+  signUpMode,
 }: PageProps) {
   useHuggingFaceRedirect(runningOnHuggingFaceSpaces);
 
@@ -62,6 +70,7 @@ export default function SignUp({
       <VerifiedSignupFlow
         authProviders={authProviders}
         emailVerificationRequired={emailVerificationRequired}
+        signUpMode={signUpMode}
       />
     );
   }
@@ -70,13 +79,18 @@ export default function SignUp({
     <StandardSignupFlow
       authProviders={authProviders}
       emailVerificationRequired={emailVerificationRequired}
+      signUpMode={signUpMode}
     />
   );
 }
 
 function StandardSignupFlow({
   authProviders,
-}: Pick<PageProps, "authProviders" | "emailVerificationRequired">) {
+  signUpMode,
+}: Pick<
+  PageProps,
+  "authProviders" | "emailVerificationRequired" | "signUpMode"
+>) {
   const { isLangfuseCloud } = useLangfuseCloudRegion();
   const router = useRouter();
   const capture = usePostHogClientCapture();
@@ -90,12 +104,15 @@ function StandardSignupFlow({
     ? getSafeRedirectPath(queryTargetPath)
     : undefined;
 
+  const hasStaticSsoProvider = hasStaticSsoProviders(authProviders);
+  const isInviteOnlySignup = signUpMode === "invite-only";
+
   const [formError, setFormError] = useState<string | null>(null);
 
   // Two-step login flow: ask for email first, detect SSO, then either redirect to SSO or reveal password field.
   // Skip this flow when no SSO is configured - show password field immediately
   const [showPasswordStep, setShowPasswordStep] = useState<boolean>(
-    !authProviders.sso,
+    !authProviders.sso && authProviders.credentials,
   );
   const [continueLoading, setContinueLoading] = useState<boolean>(false);
   const [lastUsedAuthMethod, setLastUsedAuthMethod] =
@@ -166,7 +183,16 @@ function StandardSignupFlow({
         return; // stop further execution – page redirect expected
       }
 
-      // No SSO – fall back to password step
+      if (!authProviders.credentials) {
+        setFormError(
+          authProviders.sso || hasStaticSsoProvider
+            ? "No sign-in method available for this email. Please use one of the available SSO options."
+            : "Password-based sign-up is disabled. Please contact your administrator.",
+        );
+        return;
+      }
+
+      // No SSO - fall back to password step
       setShowPasswordStep(true);
 
       // Auto-focus password input when password step becomes visible
@@ -219,6 +245,18 @@ function StandardSignupFlow({
     } catch {
       setFormError("An error occurred. Please try again.");
     }
+  }
+
+  if (isInviteOnlySignup && !emailParam) {
+    return (
+      <SignupPageShell>
+        <div className="text-muted-foreground text-center text-sm">
+          Sign up requires an invitation. Please use the invitation link sent by
+          your administrator.
+        </div>
+        <SignupFooter />
+      </SignupPageShell>
+    );
   }
 
   return (
@@ -314,10 +352,17 @@ function StandardSignupFlow({
 
 function VerifiedSignupFlow({
   authProviders,
-}: Pick<PageProps, "authProviders" | "emailVerificationRequired">) {
+  signUpMode,
+}: Pick<
+  PageProps,
+  "authProviders" | "emailVerificationRequired" | "signUpMode"
+>) {
   const router = useRouter();
   const capture = usePostHogClientCapture();
   const emailParam = router.query.email as string | undefined;
+  const isInviteOnlySignup = signUpMode === "invite-only";
+  const hasAnySsoProvider =
+    authProviders.sso || hasStaticSsoProviders(authProviders);
 
   const [formError, setFormError] = useState<string | null>(null);
   const [phase, setPhase] = useState<SignupPhase>("form");
@@ -338,6 +383,46 @@ function VerifiedSignupFlow({
       email: emailParam ?? "",
     },
   });
+
+  if (isInviteOnlySignup && !emailParam) {
+    return (
+      <SignupPageShell>
+        <div className="text-muted-foreground text-center text-sm">
+          Sign up requires an invitation. Please use the invitation link sent by
+          your administrator.
+        </div>
+        <SignupFooter />
+      </SignupPageShell>
+    );
+  }
+
+  if (!authProviders.credentials) {
+    return (
+      <SignupPageShell>
+        {emailParam ? (
+          <div className="text-muted-foreground text-center text-sm">
+            You have been invited as{" "}
+            <span className="text-primary font-semibold">{emailParam}</span>.
+            {hasAnySsoProvider
+              ? " Please sign up with an SSO provider to accept the invitation."
+              : " Sign-up is disabled because no authentication methods are enabled. Please contact your administrator."}
+          </div>
+        ) : !hasAnySsoProvider ? (
+          <div className="text-muted-foreground text-center text-sm">
+            Sign-up is disabled because no authentication methods are enabled.
+            Please contact your administrator.
+          </div>
+        ) : null}
+        <SSOButtons
+          authProviders={authProviders}
+          action="sign up"
+          lastUsedMethod={lastUsedAuthMethod}
+          onProviderSelect={setLastUsedAuthMethod}
+        />
+        <SignupFooter />
+      </SignupPageShell>
+    );
+  }
 
   async function onVerifiedSubmit(
     values: z.infer<typeof signupVerifyFormSchema>,

--- a/web/src/server/auth.ts
+++ b/web/src/server/auth.ts
@@ -65,6 +65,7 @@ import { getSSOBlockedDomains } from "@/src/features/auth-credentials/server/sig
 import { createSupportEmailHash } from "@/src/features/support-chat/createSupportEmailHash";
 import { canToggleV4 } from "@/src/features/events/lib/v4Rollout";
 import { canCreateOrganizations } from "@/src/features/organizations/server/canCreateOrganizations";
+import { validateSignupModeEligibility } from "@/src/features/auth/lib/signupPolicy";
 
 const staticProviders: Provider[] = [
   CredentialsProvider({
@@ -596,17 +597,18 @@ const extendedPrismaAdapter: Adapter = {
   async createUser(profile: Omit<AdapterUser, "id">) {
     if (!prismaAdapter.createUser)
       throw new Error("createUser not implemented");
-    if (
-      env.NEXT_PUBLIC_SIGN_UP_DISABLED === "true" ||
-      env.AUTH_DISABLE_SIGNUP === "true"
-    ) {
-      throw new Error("Sign up is disabled.");
-    }
     if (!profile.email) {
       throw new Error(
         "Cannot create db user as login profile does not contain an email: " +
           JSON.stringify(profile),
       );
+    }
+
+    const signupModeError = await validateSignupModeEligibility({
+      email: profile.email,
+    });
+    if (signupModeError) {
+      throw new Error(signupModeError);
     }
 
     const user = await prismaAdapter.createUser(profile);


### PR DESCRIPTION
## Summary
- add AUTH_SIGNUP_MODE=open|disabled|invite-only while preserving existing disable flags as overrides
- gate password, verified-email, and SSO-created users on pending membership invitations in invite-only mode
- hide the public signup entry point for invite-only deployments and keep credential fields hidden when password auth is disabled

Fixes #14145

## Testing
- pnpm --filter=@langfuse/shared run db:generate
- pnpm --filter=@langfuse/shared run build
- VITEST_SHARED_CONTEXT=1 DATABASE_URL=postgresql://user:pass@localhost:5432/langfuse_test NEXTAUTH_URL=http://localhost:3000 SALT=00000000000000000000000000000000 CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_USER=default CLICKHOUSE_PASSWORD=password pnpm --filter=web exec vitest run --project server-unit src/__tests__/server/unit/signupPolicy.servertest.ts
- DATABASE_URL=postgresql://user:pass@localhost:5432/langfuse_test NEXTAUTH_URL=http://localhost:3000 SALT=00000000000000000000000000000000 CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_USER=default CLICKHOUSE_PASSWORD=password pnpm --filter=web run typecheck
- DATABASE_URL=postgresql://user:pass@localhost:5432/langfuse_test NEXTAUTH_URL=http://localhost:3000 SALT=00000000000000000000000000000000 CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_USER=default CLICKHOUSE_PASSWORD=password pnpm --filter=web run lint

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new `AUTH_SIGNUP_MODE` environment variable (`open` | `disabled` | `invite-only`) and wires it through both the credentials and SSO signup paths. Legacy `AUTH_DISABLE_SIGNUP` / `NEXT_PUBLIC_SIGN_UP_DISABLED` flags are preserved as overrides for backward compatibility.

- A thin two-module design (`signupMode.ts` for pure logic, `signupPolicy.ts` for env + DB wiring) is used. Invite-only access is gated by checking for a pending `MembershipInvitation` row for the registering email, correctly applied in both the credentials API handler and the NextAuth `createUser` adapter hook (covering SSO first-time logins).
- The sign-up UI conditionally shows an "invitation required" splash when `signUpMode === "invite-only"` and no `email` query param is present, and the sign-in "No account yet?" link is hidden for non-`open` modes.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; both the credentials and SSO auth paths are correctly gated in invite-only mode with no apparent bypass.

The core invite-only enforcement is applied in the right places (credentials API handler and the NextAuth createUser adapter), and the legacy flags continue to work as documented. The two findings are cleanup items: a dynamic import inside a function that violates the team's import rule, and a now-redundant client-side env check in sign-in.tsx. Neither affects runtime correctness.

signupPolicy.ts for the dynamic import placement, and sign-in.tsx for the redundant env check.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant UI as Sign-up Page
    participant API as /api/auth/signup
    participant GSP as getServerSideProps
    participant SP as signupPolicy.ts
    participant SM as signupMode.ts
    participant DB as membershipInvitation (DB)
    participant NA as NextAuth Adapter

    U->>GSP: GET /auth/sign-up
    GSP->>SP: getEffectiveSignupMode()
    SP->>SM: getEffectiveSignupMode(config)
    SM-->>SP: "open | disabled | invite-only"
    GSP-->>UI: signUpMode prop

    alt invite-only mode, no emailParam
        UI-->>U: Invitation required splash
    else credentials signup
        U->>API: "POST /api/auth/signup {email, password}"
        API->>SP: "validateSignupModeEligibility({email})"
        SP->>SM: validateSignupModeEligibilityForMode(...)
        SM->>SP: hasPendingMembershipInvitation(email)
        SP->>DB: "findFirst where email = normalize(email)"
        DB-->>SP: invitation or null
        SP-->>SM: true or false
        SM-->>API: null (ok) or error string
        API-->>U: 200 OK or 422 error
    else SSO first-time login
        U->>NA: OAuth callback
        NA->>SP: "createUser -> validateSignupModeEligibility({email})"
        SP->>DB: "findFirst where email = normalize(email)"
        DB-->>SP: invitation or null
        SP-->>NA: null (ok) or throws Error
        NA-->>U: session created or error page
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant UI as Sign-up Page
    participant API as /api/auth/signup
    participant GSP as getServerSideProps
    participant SP as signupPolicy.ts
    participant SM as signupMode.ts
    participant DB as membershipInvitation (DB)
    participant NA as NextAuth Adapter

    U->>GSP: GET /auth/sign-up
    GSP->>SP: getEffectiveSignupMode()
    SP->>SM: getEffectiveSignupMode(config)
    SM-->>SP: "open | disabled | invite-only"
    GSP-->>UI: signUpMode prop

    alt invite-only mode, no emailParam
        UI-->>U: Invitation required splash
    else credentials signup
        U->>API: "POST /api/auth/signup {email, password}"
        API->>SP: "validateSignupModeEligibility({email})"
        SP->>SM: validateSignupModeEligibilityForMode(...)
        SM->>SP: hasPendingMembershipInvitation(email)
        SP->>DB: "findFirst where email = normalize(email)"
        DB-->>SP: invitation or null
        SP-->>SM: true or false
        SM-->>API: null (ok) or error string
        API-->>U: 200 OK or 422 error
    else SSO first-time login
        U->>NA: OAuth callback
        NA->>SP: "createUser -> validateSignupModeEligibility({email})"
        SP->>DB: "findFirst where email = normalize(email)"
        DB-->>SP: invitation or null
        SP-->>NA: null (ok) or throws Error
        NA-->>U: session created or error page
    end
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/auth/lib/signupPolicy.ts:29-30
**Dynamic import inside function body**

`prisma` is imported dynamically inside `hasPendingMembershipInvitation` rather than at the top of the module. The team's custom rule requires all imports to be placed at module level instead of inside functions or methods. This pattern also means the module graph is re-evaluated on every call, which can be surprising during testing.

### Issue 2 of 2
web/src/pages/auth/sign-in.tsx:871-874
**Redundant client-side env check**

`env.NEXT_PUBLIC_SIGN_UP_DISABLED !== "true"` is now redundant. `getEffectiveSignupMode()` already maps `NEXT_PUBLIC_SIGN_UP_DISABLED === "true"` to `"disabled"`, and `signUpDisabled` is set to `signUpMode === "disabled"` in `getServerSideProps`. When that flag is set, `!signUpDisabled` is already `false`, so the inline env check can never provide additional protection and can be removed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(auth): add invite-only signup mode"](https://github.com/langfuse/langfuse/commit/602bc5a0d1ae92587d66ea57f6d9e66b521e37c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39201285)</sub>

**Context used:**

- Rule used - Move imports to the top of the module instead of p... ([source](https://app.greptile.com/personal-org-4986/-/custom-context?memory=c960fc07-9928-409f-a18b-a780cbdded12))

**Learned From**
[langfuse/langfuse-python#1387](https://github.com/langfuse/langfuse-python/pull/1387)

<!-- /greptile_comment -->