### PR TITLE
fix(worker): trace llm fetch failures

### DIFF
--- a/packages/shared/src/server/llm/errors.ts
+++ b/packages/shared/src/server/llm/errors.ts
@@ -37,8 +37,9 @@ export class LLMCompletionError extends Error {
     message: string;
     responseStatusCode?: number;
     isRetryable?: boolean;
+    cause?: unknown;
   }) {
-    super(params.message);
+    super(params.message, { cause: params.cause });
 
     this.name = LLMCompletionErrorName;
     this.responseStatusCode = params.responseStatusCode ?? 500;

--- a/packages/shared/src/server/llm/fetchLLMCompletion.ts
+++ b/packages/shared/src/server/llm/fetchLLMCompletion.ts
@@ -925,6 +925,7 @@ export async function fetchLLMCompletion(
       message,
       responseStatusCode,
       isRetryable,
+      cause: e,
     });
   } finally {
     await processTracedEvents();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -966,6 +966,9 @@ importers:
       '@opentelemetry/instrumentation-ioredis':
         specifier: ^0.67.0
         version: 0.67.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici':
+        specifier: ^0.29.0
+        version: 0.29.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-winston':
         specifier: ^0.63.0
         version: 0.63.0(@opentelemetry/api@1.9.1)
@@ -3155,6 +3158,12 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.29.0':
+    resolution: {integrity: sha512-SnA+0XgGc595jtnwFVfWy7Vgfr5hle4D5YKIlm0U4z8aK9YoCZVUn1xAkVZ2evaJyykiDF50FBzr1XZ0uj8CPA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
 
   '@opentelemetry/instrumentation-winston@0.63.0':
     resolution: {integrity: sha512-NFMHLYODph0rWGfT/QLv75hCsu1sxVAV79L8HduBCMo181jOTSRZHaqxfrvDtFOsvgYBaiUBa7Ga50w47wM3FA==}
@@ -14216,6 +14225,15 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/redis-common': 0.38.3
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.29.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color

--- a/worker/package.json
+++ b/worker/package.json
@@ -40,6 +40,7 @@
     "@opentelemetry/instrumentation-express": "^0.67.0",
     "@opentelemetry/instrumentation-http": "^0.219.0",
     "@opentelemetry/instrumentation-ioredis": "^0.67.0",
+    "@opentelemetry/instrumentation-undici": "^0.29.0",
     "@opentelemetry/instrumentation-winston": "^0.63.0",
     "@opentelemetry/resource-detector-aws": "^2.19.0",
     "@opentelemetry/resource-detector-container": "^0.8.10",

--- a/worker/src/__tests__/fetchLLMCompletionErrors.test.ts
+++ b/worker/src/__tests__/fetchLLMCompletionErrors.test.ts
@@ -43,8 +43,9 @@ class MockLLMCompletionError extends Error {
     message: string;
     responseStatusCode?: number;
     isRetryable?: boolean;
+    cause?: unknown;
   }) {
-    super(params.message);
+    super(params.message, { cause: params.cause });
     this.name = "LLMCompletionError";
     this.responseStatusCode = params.responseStatusCode ?? 500;
     this.isRetryable = params.isRetryable ?? false;
@@ -131,8 +132,8 @@ describe("fetchLLMCompletion provider error classification", () => {
 
     anthropicInvokeMock.mockRejectedValue(wrappedError);
 
-    await expect(
-      fetchLLMCompletion({
+    try {
+      await fetchLLMCompletion({
         streaming: false,
         messages: [
           {
@@ -151,12 +152,16 @@ describe("fetchLLMCompletion provider error classification", () => {
         llmConnection: {
           secretKey: encrypt("anthropic-api-key"),
         },
-      }),
-    ).rejects.toMatchObject({
-      name: "LLMCompletionError",
-      responseStatusCode: 401,
-      isRetryable: false,
-    });
+      });
+      throw new Error("Expected fetchLLMCompletion to throw");
+    } catch (e) {
+      expect(e).toMatchObject({
+        name: "LLMCompletionError",
+        responseStatusCode: 401,
+        isRetryable: false,
+      });
+      expect((e as Error).cause).toBe(wrappedError);
+    }
   });
 
   it("forwards Anthropic options and normalizes sampling params for Claude on Vertex", async () => {

--- a/worker/src/__tests__/fetchLLMCompletionErrors.test.ts
+++ b/worker/src/__tests__/fetchLLMCompletionErrors.test.ts
@@ -153,7 +153,7 @@ describe("fetchLLMCompletion provider error classification", () => {
           secretKey: encrypt("anthropic-api-key"),
         },
       });
-      throw new Error("Expected fetchLLMCompletion to throw");
+      expect.fail("Expected fetchLLMCompletion to throw");
     } catch (e) {
       expect(e).toMatchObject({
         name: "LLMCompletionError",

--- a/worker/src/instrumentation.ts
+++ b/worker/src/instrumentation.ts
@@ -3,6 +3,7 @@ import { NodeSDK } from "@opentelemetry/sdk-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { IORedisInstrumentation } from "@opentelemetry/instrumentation-ioredis";
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
+import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
 import { ExpressInstrumentation } from "@opentelemetry/instrumentation-express";
 import { PrismaInstrumentation } from "@prisma/instrumentation";
 import { WinstonInstrumentation } from "@opentelemetry/instrumentation-winston";
@@ -22,6 +23,14 @@ dd.init({
   runtimeMetrics: true,
   plugins: false,
 });
+
+const getUndiciRequestUrl = (origin: string, path: string) => {
+  try {
+    return new URL(path, origin);
+  } catch {
+    return null;
+  }
+};
 
 const sdk = new NodeSDK({
   resource: resourceFromAttributes({
@@ -51,6 +60,29 @@ const sdk = new NodeSDK({
           path = "/_next/static/*";
         }
         span.updateName(`${req?.method} ${path}`);
+      },
+    }),
+    new UndiciInstrumentation({
+      requireParentforSpans: true,
+      ignoreRequestHook: (request) => {
+        const url = getUndiciRequestUrl(request.origin, request.path);
+        return url?.hostname === "127.0.0.1" || url?.hostname === "localhost";
+      },
+      startSpanHook: (request) => {
+        const url = getUndiciRequestUrl(request.origin, request.path);
+
+        return url
+          ? {
+              "url.full": `${url.origin}${url.pathname}`,
+              "url.query": "",
+            }
+          : {};
+      },
+      requestHook: (span, request) => {
+        const url = getUndiciRequestUrl(request.origin, request.path);
+        if (url) {
+          span.updateName(`${request.method} ${url.pathname}`);
+        }
       },
     }),
     new ExpressInstrumentation(),


### PR DESCRIPTION
## Summary

- Add worker-side OTel undici/fetch instrumentation so outbound OpenAI/LiteLLM HTTP attempts show up under existing worker traces.
- Preserve the original provider/LangChain error as `LLMCompletionError.cause`, making wrapped LLM failures easier to debug in Datadog.

## Linear

- None

## Major Decisions

- Added undici instrumentation only to the worker path, since the incident involved worker LLM-as-judge execution.
- Kept spans parent-only, filtered localhost, stripped query strings from `url.full`, and blanked `url.query` to avoid leaking sensitive URL data.

## Review Focus

- Confirm worker-only undici instrumentation is the right scope, or whether web should get the same instrumentation for playground, LLM connection tests, and natural-language filter LLM calls.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds worker-side undici/fetch OTel instrumentation so outbound HTTP calls to LLM providers (OpenAI, LiteLLM) appear as child spans under existing worker traces, and preserves the original provider error as `LLMCompletionError.cause` for better Datadog debugging.

- `UndiciInstrumentation` is wired into the worker's OTel SDK with parent-only span creation, localhost filtering, query-string sanitization on `url.full`, and cleaned span naming via `requestHook`.
- `LLMCompletionError` gains an optional `cause` field passed through `super()`, and `fetchLLMCompletion` now forwards the caught exception as that cause; a test is updated to assert reference equality on `.cause`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the error-cause chain and undici instrumentation changes are isolated to observability plumbing and do not alter any business logic paths.

The `cause` propagation in `LLMCompletionError` and the test update are straightforward. The undici instrumentation introduces two open questions: whether `startSpanHook` attributes survive the instrumentation's own later `setAttribute` calls (which could silently undo the query-string sanitization), and whether IPv6 loopback traffic is adequately excluded. Neither would break functionality, but the query-string concern means sensitive URL parameters could still appear in traces despite the stated goal of stripping them.

worker/src/instrumentation.ts — the `startSpanHook` query sanitization and the localhost filter logic deserve a second look.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BullMQ as BullMQ Job
    participant Worker as Worker (OTel Trace)
    participant Undici as Node.js fetch / undici
    participant LLM as OpenAI / LiteLLM

    BullMQ->>Worker: Dispatch eval job (active span)
    Worker->>Undici: HTTP request to LLM provider
    Note over Undici: UndiciInstrumentation<br/>requireParentforSpans=true<br/>creates child span
    Note over Undici: ignoreRequestHook<br/>skip localhost/127.0.0.1
    Note over Undici: startSpanHook<br/>strip url.query, sanitize url.full
    Note over Undici: requestHook<br/>rename span to METHOD /path
    Undici->>LLM: HTTP request
    LLM-->>Undici: Response or error
    alt LLM error
        Undici-->>Worker: throw original error
        Worker->>Worker: "catch - new LLMCompletionError({cause: e})"
        Note over Worker: cause chain preserved for Datadog
    else Success
        Undici-->>Worker: LLM response
    end
    Worker-->>BullMQ: Result / error
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BullMQ as BullMQ Job
    participant Worker as Worker (OTel Trace)
    participant Undici as Node.js fetch / undici
    participant LLM as OpenAI / LiteLLM

    BullMQ->>Worker: Dispatch eval job (active span)
    Worker->>Undici: HTTP request to LLM provider
    Note over Undici: UndiciInstrumentation<br/>requireParentforSpans=true<br/>creates child span
    Note over Undici: ignoreRequestHook<br/>skip localhost/127.0.0.1
    Note over Undici: startSpanHook<br/>strip url.query, sanitize url.full
    Note over Undici: requestHook<br/>rename span to METHOD /path
    Undici->>LLM: HTTP request
    LLM-->>Undici: Response or error
    alt LLM error
        Undici-->>Worker: throw original error
        Worker->>Worker: "catch - new LLMCompletionError({cause: e})"
        Note over Worker: cause chain preserved for Datadog
    else Success
        Undici-->>Worker: LLM response
    end
    Worker-->>BullMQ: Result / error
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
worker/src/instrumentation.ts:67-70
**IPv6 localhost not excluded from traces**

The `ignoreRequestHook` checks for `"127.0.0.1"` and `"localhost"` but not `"::1"` (IPv6 loopback). If any internal service resolves to the IPv6 loopback address, those requests will not be filtered and will appear as traced spans. This is consistent with how `HttpInstrumentation` is configured above (line 54 also only checks `"127.0.0.1"`), but both could be extended to cover IPv6.

### Issue 2 of 2
worker/src/instrumentation.ts:71-79
**`url.full` sanitization in `startSpanHook` may be overwritten**

The undici instrumentation sets its standard semantic-convention attributes (including `url.full` with the full URL + query string) via `span.setAttribute` calls in its internal `request:create` handler, which fires AFTER `startSpanHook` populates the span's initial attributes. If that is the case, the query-string-stripped `url.full` returned here gets silently overwritten before the span is exported, and API keys or other sensitive parameters in the query string would still leak.

The `requestHook` fires after standard attributes are set (as evidenced by the community issue showing `span.attributes['url.full']` is already populated there). Adding `span.setAttribute('url.full', ...)` and `span.setAttribute('url.query', '')` inside `requestHook` would guarantee the sanitization sticks regardless of hook ordering.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): trace llm fetch failures"](https://github.com/langfuse/langfuse/commit/de8899a7ec07cb2665e002901bb68bc5a5de2c35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39238355)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->