### PR TITLE
fix(agent): Add user email to trace metadata

### DIFF
--- a/web/src/__tests__/server/in-app-agent-stream.servertest.ts
+++ b/web/src/__tests__/server/in-app-agent-stream.servertest.ts
@@ -431,7 +431,7 @@ describe("createAgUiStream", () => {
         langfuseTracing: {
           environment: "langfuse-in-app-agent",
           metadata: { langfuse_project_id: "project-1" },
-          userId: "user-1",
+          user: { id: "user-1" },
           traceId: "0123456789abcdef0123456789abcdef",
           targetProjectId: "project-1",
         },

--- a/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
+++ b/web/src/__tests__/server/unit/in-app-agent-instrumentation.servertest.ts
@@ -110,7 +110,10 @@ describe("InAppAgentInstrumentation", () => {
     expect(mocks.getInternalTracingHandler).toHaveBeenCalledWith(
       expect.objectContaining({
         environment: "prod",
-        metadata: { langfuse_project_id: "project-1" },
+        metadata: {
+          langfuse_project_id: "project-1",
+          langfuse_user_email: "user@example.com",
+        },
         targetProjectId: "project-1",
         traceId,
         traceName: "in-app-agent",
@@ -210,6 +213,7 @@ describe("InAppAgentInstrumentation", () => {
         },
         metadata: {
           langfuse_project_id: "project-1",
+          langfuse_user_email: "user@example.com",
           prompt_name: "in-app-agent-system-prompt",
           prompt_version: 3,
         },
@@ -219,6 +223,7 @@ describe("InAppAgentInstrumentation", () => {
       expect.objectContaining({
         metadata: {
           langfuse_project_id: "project-1",
+          langfuse_user_email: "user@example.com",
           prompt_name: "in-app-agent-system-prompt",
           prompt_version: 3,
         },
@@ -230,6 +235,7 @@ describe("InAppAgentInstrumentation", () => {
       input: "hello",
       metadata: {
         langfuse_project_id: "project-1",
+        langfuse_user_email: "user@example.com",
         prompt_name: "in-app-agent-system-prompt",
         prompt_version: 3,
       },
@@ -395,6 +401,7 @@ function createInstrumentation(
     input: { ...input, ...overrides },
     metadata: { langfuse_project_id: "project-1" },
     userId: "user-1",
+    userEmail: "user@example.com",
     traceId,
     targetProjectId: "project-1",
     environment: "prod",

--- a/web/src/ee/features/in-app-agent/server/handler.ts
+++ b/web/src/ee/features/in-app-agent/server/handler.ts
@@ -350,7 +350,10 @@ export default async function handler(request: Request) {
                   ? {
                       targetProjectId,
                       environment: "langfuse-in-app-agent",
-                      userId: auth.userId,
+                      user: {
+                        id: auth.userId,
+                        email: auth.user.email,
+                      },
                       traceId: conversation.id,
                       metadata: {
                         langfuse_ai_feature: "in-app-agent",

--- a/web/src/ee/features/in-app-agent/server/instrumentation.ts
+++ b/web/src/ee/features/in-app-agent/server/instrumentation.ts
@@ -10,7 +10,10 @@ import { compactTextMessageChunks } from "@/src/ee/features/in-app-agent/server/
 export type InAppAgentTracingConfig = {
   environment: string;
   metadata: Record<string, unknown>;
-  userId: string;
+  user: {
+    id: string;
+    email?: string | null;
+  };
   traceId: string;
   targetProjectId: string;
   prompt?: InAppAgentPromptMetadata;
@@ -61,7 +64,8 @@ export function createInAppAgentInstrumentation({
     return new InAppAgentInstrumentation({
       input,
       metadata: tracing.metadata,
-      userId: tracing.userId,
+      userId: tracing.user.id,
+      userEmail: tracing.user.email,
       traceId: tracing.traceId,
       targetProjectId: tracing.targetProjectId,
       environment: tracing.environment,
@@ -99,6 +103,7 @@ export class InAppAgentInstrumentation {
     input: AgUiRunAgentInput;
     metadata: Record<string, unknown>;
     userId: string;
+    userEmail?: string | null;
     traceId: string;
     targetProjectId: string;
     environment: string;
@@ -106,6 +111,7 @@ export class InAppAgentInstrumentation {
   }) {
     this.metadata = {
       ...params.metadata,
+      ...(params.userEmail ? { langfuse_user_email: params.userEmail } : {}),
       ...(params.prompt
         ? {
             prompt_name: params.prompt.name,


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the in-app agent's Langfuse tracing to include the authenticated user's email address in trace metadata, alongside the already-captured user ID. The `InAppAgentTracingConfig` type is refactored from a flat `userId` string to a `user: { id, email? }` object, and the email (when present) is spread into the `langfuse_user_email` metadata key.

- **Type refactor**: `InAppAgentTracingConfig.userId` is replaced with a `user: { id: string; email?: string | null }` object; the inner `InAppAgentInstrumentation` class still uses flat `userId`/`userEmail` constructor params, bridged by `createInAppAgentInstrumentation`.
- **Metadata enrichment**: `langfuse_user_email` is conditionally added to trace/generation metadata when a non-empty email is available, matching the existing `langfuse_user_id` metadata field.
- **Tests updated**: Unit tests for `InAppAgentInstrumentation` verify the new metadata key; stream-level tests adopt the new `user` object shape.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is narrowly scoped to adding an optional email field to trace metadata, with correct null guarding and no risk of runtime errors from the access path.

The implementation is straightforward and null/undefined email is guarded correctly throughout. The stream-level test doesn't exercise the email path end-to-end, meaning a regression in the bridging code would only be caught by the lower-level unit test.

web/src/__tests__/server/in-app-agent-stream.servertest.ts — no test variant covers a non-null email flowing through the full stream path.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/in-app-agent-stream.servertest.ts:431-437
**Stream-level email coverage missing**

The stream test adopts the new `user` object shape but leaves `email` absent, so there is no integration-level assertion that a non-null email flows all the way through `createAgUiStream` into the `langfuse_user_email` metadata key. The unit test in `in-app-agent-instrumentation.servertest.ts` covers the `InAppAgentInstrumentation` class directly, but a bug in the bridge inside `createInAppAgentInstrumentation` (e.g. forgetting to pass `userEmail`) would be invisible at this level. Consider adding a variant of this test with `user: { id: "user-1", email: "user@example.com" }` and asserting the metadata field.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Add user email to trace meta..."](https://github.com/langfuse/langfuse/commit/b59a3323db26c3f455029364d5b1b2ad02009851) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39240613)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->