### PR TITLE
fix(llm): enforce runtime timeout for all providers

### DIFF
--- a/packages/shared/src/server/llm/utils.ts
+++ b/packages/shared/src/server/llm/utils.ts
@@ -5,11 +5,9 @@ import { LLMAdapter } from "./types";
 
 const ExtraHeaderSchema = z.record(z.string(), z.string());
 
-export const RUNTIME_TIMEOUT_ADAPTERS = new Set([
-  LLMAdapter.VertexAI,
-  LLMAdapter.GoogleAIStudio,
-  LLMAdapter.OpenAI,
-]);
+export const RUNTIME_TIMEOUT_ADAPTERS = new Set<LLMAdapter>(
+  Object.values(LLMAdapter),
+);
 
 export async function executeWithRuntimeTimeout<T>({
   enabled,


### PR DESCRIPTION
## Summary

- Enforce the existing runtime execution timeout for every LLM adapter instead of only VertexAI, Google AI Studio, and OpenAI.
- Derive the timeout adapter set from `LLMAdapter` values so Anthropic, Azure, and Bedrock are covered as well.

## Linear

- None

## Major Decisions

- Kept timeout enforcement behind `RUNTIME_TIMEOUT_ADAPTERS` instead of removing the gate entirely, so we can still opt specific providers out in the future if needed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends runtime execution timeouts to all LLM adapters (Anthropic, Azure, Bedrock, in addition to VertexAI, GoogleAIStudio, OpenAI) by deriving `RUNTIME_TIMEOUT_ADAPTERS` from `Object.values(LLMAdapter)` rather than a hand-maintained list.

- The hard-coded three-adapter set is replaced with a dynamic derivation from the `LLMAdapter` enum, so any future adapter is automatically covered without a manual update.
- The `RUNTIME_TIMEOUT_ADAPTERS` gate is intentionally preserved so individual providers can be opted out later if needed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-liner that closes a gap where Anthropic, Azure, and Bedrock calls could hang indefinitely.

The change replaces a manually maintained three-entry set with Object.values(LLMAdapter). For a TypeScript string enum, Object.values returns only the string values, so the Set is populated correctly and .has() behaviour is unchanged for the previously covered adapters. The executeWithRuntimeTimeout logic itself is unmodified. No migration, schema change, or state is involved.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(llm): enforce runtime timeout for al..."](https://github.com/langfuse/langfuse/commit/564468181a29793b8cb33505ba567bd42faaa98e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39248492)</sub>

<!-- /greptile_comment -->