### PR TITLE
fix(worker): add compressed tag to serialized_bytes counter (LFE-10442)

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -585,6 +585,7 @@ const processBlobStorageExport = async (config: {
             table: config.table,
             projectId: config.projectId,
             path: passthroughEligible ? "passthrough" : "standard",
+            compressed: compressedCounter ? "true" : "false",
           };
           recordIncrement(
             "langfuse.blob_export.serialized_bytes",


### PR DESCRIPTION
## What does this PR do?

Adds a `compressed: true/false` tag to the `langfuse.blob_export.serialized_bytes` StatsD counter.

**Why:** The existing counters can't answer "total bytes exported to S3" because `serialized_bytes` mixes compressed and uncompressed exports, and `compressed_bytes` only fires for gzipped uploads. With this tag:

- **Now:** `sum:langfuse.blob_export.serialized_bytes{*}.as_count()` is a good proxy for total S3 volume (compressed bytes are negligible)
- **Later:** precise egress cost = `serialized_bytes{compressed:false} + compressed_bytes` 

## Type of change

- [x] Patch (non-breaking change which fixes an issue)

## Checklist

- [x] Lint (`pnpm run lint`)
- [x] Typecheck (`pnpm run typecheck`)
- [x] One-line diff, no behavioral change beyond metric tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This patch adds a `compressed: "true"/"false"` tag to the `langfuse.blob_export.serialized_bytes` StatsD counter so that compressed and uncompressed export volumes can be distinguished in dashboards.

- The tag value is derived from `compressedCounter`, a `ByteCounter` that is non-null exactly when `config.compressed` is true, making the ternary logically equivalent to reading `config.compressed` directly.
- The same `byteTags` object is already shared with the `compressed_bytes` counter, so the new field is consistent with the existing tagging convention.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single tag added to an existing metric call with no effect on data flow or upload behavior.

The only modified line adds `compressed: compressedCounter ? "true" : "false"` to a tags object that is passed to `recordIncrement`. `compressedCounter` is null when compression is off and a `ByteCounter` instance when it is on, so the tag correctly reflects the runtime state. The upload pipeline, byte counting, and all other logic are untouched.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PS as processBlobStorageExport
    participant SC as serializedCounter (ByteCounter)
    participant CC as compressedCounter (ByteCounter|null)
    participant ST as storageService.uploadFileBuffered
    participant SM as StatsD (recordIncrement)

    PS->>SC: stream data through serializedCounter
    alt "config.compressed = true"
        PS->>CC: stream through gzip + compressedCounter
    end
    PS->>ST: upload fileStream to S3
    ST-->>PS: upload success

    PS->>SM: "serialized_bytes {table, projectId, path, compressed:"true"|"false"}"
    alt "compressedCounter && gzipStats"
        PS->>SM: "compressed_bytes {table, projectId, path, compressed:"true", gzipLevel}"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PS as processBlobStorageExport
    participant SC as serializedCounter (ByteCounter)
    participant CC as compressedCounter (ByteCounter|null)
    participant ST as storageService.uploadFileBuffered
    participant SM as StatsD (recordIncrement)

    PS->>SC: stream data through serializedCounter
    alt "config.compressed = true"
        PS->>CC: stream through gzip + compressedCounter
    end
    PS->>ST: upload fileStream to S3
    ST-->>PS: upload success

    PS->>SM: "serialized_bytes {table, projectId, path, compressed:"true"|"false"}"
    alt "compressedCounter && gzipStats"
        PS->>SM: "compressed_bytes {table, projectId, path, compressed:"true", gzipLevel}"
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): add compressed tag to seria..."](https://github.com/langfuse/langfuse/commit/6d8411f622c6776b65764ce619dd1ad0bcbaceee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39249214)</sub>

<!-- /greptile_comment -->