### PR TITLE
fix(agent): Add custom PostHog events for in-app agent

### DIFF
--- a/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx
@@ -30,6 +30,7 @@ import { useHasEntitlement } from "@/src/features/entitlements/hooks";
 import { showErrorToast } from "@/src/features/notifications/showErrorToast";
 import { api } from "@/src/utils/api";
 import { createInAppAgentScreenContext } from "@/src/ee/features/in-app-agent/context";
+import { usePostHogClientCapture } from "@/src/features/posthog-analytics/usePostHogClientCapture";
 
 const SELECTED_CONVERSATION_STORAGE_KEY_PREFIX =
   "langfuse:in-app-ai-agent-selected-conversation";
@@ -172,6 +173,7 @@ function InAppAiAgentProviderInner({
   setOpen,
 }: InAppAiAgentProviderInnerProps) {
   const utils = api.useUtils();
+  const capture = usePostHogClientCapture();
   const [selectedConversationId, setSelectedConversationId] = useSessionStorage<
     string | null
   >(`${SELECTED_CONVERSATION_STORAGE_KEY_PREFIX}:${projectId}`, null);
@@ -528,6 +530,10 @@ function InAppAiAgentProviderInner({
 
         agent.addMessage(userMessage);
         setMessages(agent.messages.filter(isAgentConversationMessage));
+        if (isNewConversation) {
+          capture("in_app_agent:new_chat_started");
+        }
+        capture("in_app_agent:new_chat_turn");
         startedRun = true;
         runAgent(agent, conversationId);
         return true;
@@ -544,6 +550,7 @@ function InAppAiAgentProviderInner({
     },
     [
       conversationQuery.data,
+      capture,
       ensureSubscription,
       getOrCreateAgent,
       isSelectedConversationHydrating,

--- a/web/src/features/posthog-analytics/usePostHogClientCapture.ts
+++ b/web/src/features/posthog-analytics/usePostHogClientCapture.ts
@@ -220,6 +220,7 @@ export const events = {
     "message_sent",
     "community_hours_click",
   ], // also used on landing page for consistency
+  in_app_agent: ["new_chat_started", "new_chat_turn"],
   cmd_k_menu: ["opened", "search_entered", "navigated"],
   spend_alert: ["created", "updated", "deleted"],
   sidebar: ["book_a_call_clicked", "v4_beta_toggled"],


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds PostHog analytics tracking to the in-app AI agent feature, capturing two new events (`in_app_agent:new_chat_started` and `in_app_agent:new_chat_turn`) when a user submits a message.

- Registers the new `in_app_agent` event group in `usePostHogClientCapture.ts` so both events pass the type-safe allowlist.
- In `InAppAiAgentProvider`, calls `capture` for each submitted message, with an additional `new_chat_started` event when the conversation is brand-new; `capture` is correctly added to the `useCallback` dependency array.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — changes are additive analytics instrumentation with no effect on business logic or data persistence.

Both changed files are straightforward: a new event group is registered in the allowlist, and two capture calls are inserted in the happy path of message submission. The event ordering (turn before start for new conversations) and the unstable capture reference causing unnecessary useCallback invalidations are worth tidying up but neither breaks any existing behavior.

The capture stability issue is in usePostHogClientCapture.ts, but the event ordering fix belongs in InAppAiAgentProvider.tsx at the two capture call sites.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/ee/features/in-app-agent/components/InAppAiAgentProvider.tsx:533-536
**Event ordering: `new_chat_turn` fires before `new_chat_started`**

For new conversations, both events fire in the same tick but `new_chat_turn` lands in PostHog with a slightly earlier timestamp than `new_chat_started`. Any funnel or session analysis that assumes `new_chat_started` precedes the first `new_chat_turn` will see the pair in reverse order. Swapping the two `capture` calls (emit `new_chat_started` first, then `new_chat_turn`) would match the logical sequence.

### Issue 2 of 2
web/src/features/posthog-analytics/usePostHogClientCapture.ts:234-247
**`capture` is a new function reference on every render**

`usePostHogClientCapture` declares `capture` as a plain function inside the hook body, so it produces a fresh object reference on every render. Adding it to a `useCallback` dependency array (as done in `InAppAiAgentProvider`) will cause that callback to be recreated on every render, defeating memoization. Wrapping the inner function with `useCallback` (depending only on `posthog`) would make the reference stable.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent): Add custom PostHog events fo..."](https://github.com/langfuse/langfuse/commit/31dc01abaacbd319c1686e2778f60554754d71f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39253621)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->