### PR TITLE
fix(otel): map OpenInference total cost

### DIFF
--- a/packages/shared/src/server/otel/OtelIngestionProcessor.ts
+++ b/packages/shared/src/server/otel/OtelIngestionProcessor.ts
@@ -2588,9 +2588,16 @@ export class OtelIngestionProcessor {
     );
     if (fromAttribute !== null) return fromAttribute;
 
-    if (attributes["gen_ai.usage.cost"]) {
-      return { total: attributes["gen_ai.usage.cost"] };
+    const genAiUsageCost = attributes["gen_ai.usage.cost"];
+    if (genAiUsageCost != null && genAiUsageCost !== "") {
+      return { total: genAiUsageCost };
     }
+
+    const openInferenceTotalCost = attributes["llm.cost.total"];
+    if (openInferenceTotalCost != null && openInferenceTotalCost !== "") {
+      return { total: openInferenceTotalCost };
+    }
+
     return {};
   }
 

--- a/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
+++ b/web/src/__tests__/server/api/otel/otelMapping.servertest.ts
@@ -3065,6 +3065,18 @@ describe("OTel Resource Span Mapping", () => {
         },
       ],
       [
+        "should extract cost from OpenInference llm.cost.total",
+        {
+          entity: "observation",
+          otelAttributeKey: "llm.cost.total",
+          otelAttributeValue: {
+            doubleValue: 0.000151,
+          },
+          entityAttributeKey: "costDetails.total",
+          entityAttributeValue: 0.000151,
+        },
+      ],
+      [
         "should not treat usage.cost as usage",
         {
           entity: "observation",


### PR DESCRIPTION
## Summary
- map OpenInference `llm.cost.total` into OTel observation cost details
- preserve existing precedence for `langfuse.observation.cost_details` and `gen_ai.usage.cost`
- add regression coverage for the Claude Agent SDK/OpenInference cost attribute

## Root Cause
The Claude Agent SDK OpenInference instrumentor emits the run-level cost as `llm.cost.total` on the parent AGENT span. Langfuse only extracted `langfuse.observation.cost_details` and `gen_ai.usage.cost`, so session/trace rollups that aggregate `cost_details.total` could see zero or partial totals.

## Impacted Packages
- `packages/shared`
- `web`

## Verification
- `pnpm --filter @langfuse/shared run build`
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/langfuse_dummy' DIRECT_URL='postgresql://postgres:postgres@localhost:5432/langfuse_dummy' NEXTAUTH_URL='http://localhost:3000' SALT='0123456789abcdef0123456789abcdef' CLICKHOUSE_URL='http://localhost:8123' CLICKHOUSE_USER='default' CLICKHOUSE_PASSWORD='password' LANGFUSE_S3_EVENT_UPLOAD_BUCKET='dummy-bucket' NODE_ENV='test' pnpm --filter web exec vitest run --project server src/__tests__/server/api/otel/otelMapping.servertest.ts`
- `pnpm --filter @langfuse/shared exec eslint src/server/otel/OtelIngestionProcessor.ts --max-warnings 0`
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/langfuse_dummy' DIRECT_URL='postgresql://postgres:postgres@localhost:5432/langfuse_dummy' NEXTAUTH_URL='http://localhost:3000' SALT='0123456789abcdef0123456789abcdef' CLICKHOUSE_URL='http://localhost:8123' CLICKHOUSE_USER='default' CLICKHOUSE_PASSWORD='password' LANGFUSE_S3_EVENT_UPLOAD_BUCKET='dummy-bucket' NODE_ENV='test' pnpm --filter web exec eslint src/__tests__/server/api/otel/otelMapping.servertest.ts --max-warnings 0`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR maps the OpenInference `llm.cost.total` span attribute into Langfuse's observation cost details, fixing missing cost rollups for sessions instrumented by the Claude Agent SDK. The existing `langfuse.observation.cost_details` → `gen_ai.usage.cost` → `llm.cost.total` precedence chain is correctly encoded in `extractCostDetails`.

- `OtelIngestionProcessor.extractCostDetails` now falls back to `attributes[\"llm.cost.total\"]` when neither of the two higher-priority cost attributes is present, and the guard was tightened from a truthy check to `!= null && !== \"\"` for `gen_ai.usage.cost` as well (correctly letting zero-cost observations through).
- A regression test covering the new attribute key is added to `otelMapping.servertest.ts`, though no test exercises the simultaneous presence of `gen_ai.usage.cost` and `llm.cost.total` to verify the declared precedence holds.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The change is a well-contained fallback in a single private method and does not affect the two higher-priority extraction paths.

The logic is straightforward and the downstream CostDetails Zod schema acts as a safety net, silently dropping any non-numeric values before they reach storage. The only gap is the absence of a test that verifies gen_ai.usage.cost still wins when both cost attributes appear on the same span.

The test file could use a precedence-covering case for when both gen_ai.usage.cost and llm.cost.total are present simultaneously.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OTel Span Attributes] --> B[extractCostDetails]
    B --> C{langfuse.observation.cost_details present?}
    C -- yes --> D[Return parsed JSON object]
    C -- no --> E{gen_ai.usage.cost not null or empty?}
    E -- yes --> F[Return total = gen_ai.usage.cost]
    E -- no --> G{llm.cost.total not null or empty? NEW}
    G -- yes --> H[Return total = llm.cost.total]
    G -- no --> I[Return empty object]
    D --> J[CostDetails Zod schema - filter valid non-negative numbers]
    F --> J
    H --> J
    I --> J
    J --> K[Stored as provided_cost_details or cost_details]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[OTel Span Attributes] --> B[extractCostDetails]
    B --> C{langfuse.observation.cost_details present?}
    C -- yes --> D[Return parsed JSON object]
    C -- no --> E{gen_ai.usage.cost not null or empty?}
    E -- yes --> F[Return total = gen_ai.usage.cost]
    E -- no --> G{llm.cost.total not null or empty? NEW}
    G -- yes --> H[Return total = llm.cost.total]
    G -- no --> I[Return empty object]
    D --> J[CostDetails Zod schema - filter valid non-negative numbers]
    F --> J
    H --> J
    I --> J
    J --> K[Stored as provided_cost_details or cost_details]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/__tests__/server/api/otel/otelMapping.servertest.ts:3067-3078
**Missing precedence test for simultaneous attributes**

The new test confirms that `llm.cost.total` is extracted when it is the only cost attribute present, but there is no test for the case where both `gen_ai.usage.cost` and `llm.cost.total` appear on the same span. The PR description explicitly promises that `gen_ai.usage.cost` wins in that situation — without a test exercising both keys at once, a future refactor could inadvertently reverse the priority and the existing suite would not catch it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(otel): map OpenInference total cost"](https://github.com/langfuse/langfuse/commit/c8714d162ba4ae3ba3902064e97e3abdfb186711) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39277091)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->