### PR TITLE
chore(web): Add `no-unneccessary-cn` eslint rule

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,12 +1,14 @@
 import { default as noTailwindOverflowScroll } from "./rules/no-tailwind-overflow-scroll.js";
 import { default as noInSourceVitest } from "./rules/no-in-source-vitest.js";
 import { default as noStyleProps } from "./rules/no-style-props.js";
+import { default as noUnneccessaryCn } from "./rules/no-unneccessary-cn.js";
 
 export const plugin = {
   rules: {
     "no-in-source-vitest": noInSourceVitest,
     "no-style-props": noStyleProps,
     "no-tailwind-overflow-scroll": noTailwindOverflowScroll,
+    "no-unneccessary-cn": noUnneccessaryCn,
   },
 };
 

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,14 +1,14 @@
 import { default as noTailwindOverflowScroll } from "./rules/no-tailwind-overflow-scroll.js";
 import { default as noInSourceVitest } from "./rules/no-in-source-vitest.js";
 import { default as noStyleProps } from "./rules/no-style-props.js";
-import { default as noUnneccessaryCn } from "./rules/no-unneccessary-cn.js";
+import { default as noUnnecessaryCn } from "./rules/no-unnecessary-cn.js";
 
 export const plugin = {
   rules: {
     "no-in-source-vitest": noInSourceVitest,
     "no-style-props": noStyleProps,
     "no-tailwind-overflow-scroll": noTailwindOverflowScroll,
-    "no-unneccessary-cn": noUnneccessaryCn,
+    "no-unnecessary-cn": noUnnecessaryCn,
   },
 };
 

--- a/packages/eslint-plugin/src/rules/no-unneccessary-cn.test.ts
+++ b/packages/eslint-plugin/src/rules/no-unneccessary-cn.test.ts
@@ -1,0 +1,115 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import * as typescriptEslintParser from "@typescript-eslint/parser";
+import rule from "./no-unneccessary-cn.js";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: typescriptEslintParser,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+const options = [{ importPath: "@/src/utils/tailwind" }] as const;
+
+ruleTester.run("no-unneccessary-cn", rule, {
+  valid: [
+    {
+      code: `import { cn } from "@/src/utils/tailwind";
+             const className = cn("flex", props.className);`,
+      options,
+    },
+    {
+      code: `import { cn } from "@/src/utils/tailwind";
+             const className = cn(condition && "flex");`,
+      options,
+    },
+    {
+      code: `import { cn } from "@/src/utils/tailwind";
+             const className = cn(classes);`,
+      options,
+    },
+    {
+      code: 'import { cn } from "@/src/utils/tailwind";\nconst className = cn(`flex ${size}`);',
+      options,
+    },
+    {
+      code: `import { cn } from "./other";
+             const className = cn("flex");`,
+      options,
+    },
+    {
+      code: `import * as tailwind from "@/src/utils/tailwind";
+             const className = tailwind.cn("flex");`,
+      options,
+    },
+    {
+      code: `function cn(value: string) { return value; }
+             const className = cn("flex");`,
+      options,
+    },
+    {
+      code: `import { cn } from "@/src/utils/tailwind";
+             const className = cn(1);`,
+      options,
+    },
+    {
+      code: `import { cn } from "@/src/utils/tailwind";
+             function getClassName(cn: (value: string) => string) {
+               return cn("flex");
+             }`,
+      options,
+    },
+    {
+      code: `import { cn } from "@/src/utils/tailwind";
+             {
+               const cn = (value: string) => value;
+               const className = cn("flex");
+             }`,
+      options,
+    },
+    {
+      code: `import { cn } from "@/src/utils/tailwind";
+             {
+               const className = cn("flex", "gap-2");
+             }`,
+      options,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { cn } from "@/src/utils/tailwind";
+             const className = cn("flex");`,
+      output: `import { cn } from "@/src/utils/tailwind";
+             const className = "flex";`,
+      options,
+      errors: [{ messageId: "unnecessaryCn" }],
+    },
+    {
+      code: `import { cn } from "@/src/utils/tailwind";
+             const element = <div className={cn("flex")} />;`,
+      output: `import { cn } from "@/src/utils/tailwind";
+             const element = <div className="flex" />;`,
+      options,
+      errors: [{ messageId: "unnecessaryCn" }],
+    },
+    {
+      code: `import { cn as cx } from "@/src/utils/tailwind";
+             const className = cx("flex");`,
+      output: `import { cn as cx } from "@/src/utils/tailwind";
+             const className = "flex";`,
+      options,
+      errors: [{ messageId: "unnecessaryCn" }],
+    },
+    {
+      code: 'import { cn } from "@/src/utils/tailwind";\nconst className = cn(`flex`);',
+      output:
+        'import { cn } from "@/src/utils/tailwind";\nconst className = `flex`;',
+      options,
+      errors: [{ messageId: "unnecessaryCn" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-unneccessary-cn.ts
+++ b/packages/eslint-plugin/src/rules/no-unneccessary-cn.ts
@@ -1,0 +1,109 @@
+import { AST_NODE_TYPES, type TSESLint } from "@typescript-eslint/utils";
+import { createRule } from "../util.js";
+
+type Options = [{ importPath: string }];
+type MessageIds = "unnecessaryCn";
+
+const rule = createRule<Options, MessageIds>({
+  name: "no-unneccessary-cn",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Disallow cn() calls with only one string argument.",
+    },
+    fixable: "code",
+    schema: {
+      type: "array",
+      minItems: 1,
+      maxItems: 1,
+      items: [
+        {
+          type: "object",
+          additionalProperties: false,
+          required: ["importPath"],
+          properties: {
+            importPath: { type: "string", minLength: 1 },
+          },
+        },
+      ],
+    },
+    messages: {
+      unnecessaryCn: "Use the string directly instead of wrapping it in cn().",
+    },
+  },
+  defaultOptions: [{ importPath: "" }],
+  create(context, [{ importPath }]) {
+    const cnImports = new Map<string, TSESLint.Scope.Variable>();
+    const sourceCode = context.sourceCode;
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== importPath) return;
+
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+            specifier.imported.type === AST_NODE_TYPES.Identifier &&
+            specifier.imported.name === "cn"
+          ) {
+            const [variable] = sourceCode.getDeclaredVariables(specifier);
+            cnImports.set(specifier.local.name, variable!);
+          }
+        }
+      },
+      CallExpression(node) {
+        if (
+          node.callee.type !== AST_NODE_TYPES.Identifier ||
+          !cnImports.has(node.callee.name) ||
+          node.arguments.length !== 1
+        ) {
+          return;
+        }
+
+        const reference = sourceCode
+          .getScope(node)
+          .references.find((candidate) => candidate.identifier === node.callee);
+        if (reference?.resolved !== cnImports.get(node.callee.name)) {
+          return;
+        }
+
+        const [argument] = node.arguments;
+        if (
+          argument.type !== AST_NODE_TYPES.Literal &&
+          !(
+            argument.type === AST_NODE_TYPES.TemplateLiteral &&
+            argument.expressions.length === 0
+          )
+        ) {
+          return;
+        }
+
+        if (argument.type === AST_NODE_TYPES.Literal) {
+          if (typeof argument.value !== "string") return;
+        }
+
+        context.report({
+          node,
+          messageId: "unnecessaryCn",
+          fix(fixer) {
+            if (
+              argument.type === AST_NODE_TYPES.Literal &&
+              typeof argument.value === "string" &&
+              node.parent.type === AST_NODE_TYPES.JSXExpressionContainer &&
+              node.parent.parent.type === AST_NODE_TYPES.JSXAttribute
+            ) {
+              return fixer.replaceText(
+                node.parent,
+                sourceCode.getText(argument),
+              );
+            }
+
+            return fixer.replaceText(node, sourceCode.getText(argument));
+          },
+        });
+      },
+    };
+  },
+});
+
+export default rule;

--- a/packages/eslint-plugin/src/rules/no-unnecessary-cn.test.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-cn.test.ts
@@ -1,6 +1,6 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
 import * as typescriptEslintParser from "@typescript-eslint/parser";
-import rule from "./no-unneccessary-cn.js";
+import rule from "./no-unnecessary-cn.js";
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -15,7 +15,7 @@ const ruleTester = new RuleTester({
 
 const options = [{ importPath: "@/src/utils/tailwind" }] as const;
 
-ruleTester.run("no-unneccessary-cn", rule, {
+ruleTester.run("no-unnecessary-cn", rule, {
   valid: [
     {
       code: `import { cn } from "@/src/utils/tailwind";
@@ -93,6 +93,13 @@ ruleTester.run("no-unneccessary-cn", rule, {
              const element = <div className={cn("flex")} />;`,
       output: `import { cn } from "@/src/utils/tailwind";
              const element = <div className="flex" />;`,
+      options,
+      errors: [{ messageId: "unnecessaryCn" }],
+    },
+    {
+      code: 'import { cn } from "@/src/utils/tailwind";\nconst element = <div className={cn(`flex`)} />;',
+      output:
+        'import { cn } from "@/src/utils/tailwind";\nconst element = <div className="flex" />;',
       options,
       errors: [{ messageId: "unnecessaryCn" }],
     },

--- a/packages/eslint-plugin/src/rules/no-unnecessary-cn.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-cn.ts
@@ -5,7 +5,7 @@ type Options = [{ importPath: string }];
 type MessageIds = "unnecessaryCn";
 
 const rule = createRule<Options, MessageIds>({
-  name: "no-unneccessary-cn",
+  name: "no-unnecessary-cn",
   meta: {
     type: "suggestion",
     docs: {
@@ -87,15 +87,15 @@ const rule = createRule<Options, MessageIds>({
           messageId: "unnecessaryCn",
           fix(fixer) {
             if (
-              argument.type === AST_NODE_TYPES.Literal &&
-              typeof argument.value === "string" &&
               node.parent.type === AST_NODE_TYPES.JSXExpressionContainer &&
               node.parent.parent.type === AST_NODE_TYPES.JSXAttribute
             ) {
-              return fixer.replaceText(
-                node.parent,
-                sourceCode.getText(argument),
-              );
+              const replacement =
+                argument.type === AST_NODE_TYPES.TemplateLiteral
+                  ? JSON.stringify(argument.quasis[0].value.cooked)
+                  : sourceCode.getText(argument);
+
+              return fixer.replaceText(node.parent, replacement);
             }
 
             return fixer.replaceText(node, sourceCode.getText(argument));

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -61,6 +61,17 @@ export default [
     },
   },
 
+  {
+    name: "langfuse/web/no-unneccessary-cn",
+    files: ["src/**/*.{ts,tsx}"],
+    rules: {
+      "@repo/no-unneccessary-cn": [
+        "warn",
+        { importPath: "@/src/utils/tailwind" },
+      ],
+    },
+  },
+
   // Design-system component APIs must use explicit variants instead of styling escape hatches.
   {
     name: "langfuse/web/design-system-no-style-props",

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -62,10 +62,10 @@ export default [
   },
 
   {
-    name: "langfuse/web/no-unneccessary-cn",
+    name: "langfuse/web/no-unnecessary-cn",
     files: ["src/**/*.{ts,tsx}"],
     rules: {
-      "@repo/no-unneccessary-cn": [
+      "@repo/no-unnecessary-cn": [
         "warn",
         { importPath: "@/src/utils/tailwind" },
       ],

--- a/web/src/components/ChatMessages/ChatMessageComponent.tsx
+++ b/web/src/components/ChatMessages/ChatMessageComponent.tsx
@@ -274,9 +274,7 @@ export const ChatMessageComponent: React.FC<ChatMessageProps> = ({
         >
           <GripVertical className="h-3 w-3" />
         </div>
-        <CardContent
-          className={cn("flex flex-1 flex-row items-center gap-2 p-0 pl-1")}
-        >
+        <CardContent className="flex flex-1 flex-row items-center gap-2 p-0 pl-1">
           <div className="bg-background sticky top-0 bottom-0 z-10 flex w-16 shrink-0 flex-col gap-1">
             {isPlaceholder ? (
               <span className="bg-accent text-muted-foreground inline-flex h-6 w-full items-center justify-center rounded-md px-4 font-mono text-[9px]">

--- a/web/src/components/ItemBadge.tsx
+++ b/web/src/components/ItemBadge.tsx
@@ -64,7 +64,7 @@ const iconMap = {
   EXPERIMENT: FlaskConical,
 } as const;
 
-const iconVariants = cva(cn("h-4 w-4"), {
+const iconVariants = cva("h-4 w-4", {
   variants: {
     type: {
       TRACE: "text-dark-green",

--- a/web/src/components/layouts/container-page.tsx
+++ b/web/src/components/layouts/container-page.tsx
@@ -13,9 +13,7 @@ const containerLayoutClassName =
 
 const ContainerPage = ({ children, headerProps }: SettingsContainerProps) => {
   return (
-    <div
-      className={cn("min-h-screen-with-banner relative flex flex-1 flex-col")}
-    >
+    <div className="min-h-screen-with-banner relative flex flex-1 flex-col">
       <header className="sticky top-0 z-50 w-full">
         <PageHeader {...headerProps} container />
       </header>

--- a/web/src/components/nav/nav-main.tsx
+++ b/web/src/components/nav/nav-main.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/src/components/ui/sidebar";
 import Link from "next/link";
 import { type ReactNode } from "react";
-import { cn } from "@/src/utils/tailwind";
 import { type RouteGroup } from "@/src/components/layouts/routes";
 
 export type NavMainItem = {
@@ -36,11 +35,7 @@ function NavItemContent({ item }: { item: NavMainItem }) {
       <span>{item.title}</span>
       {item.label &&
         (typeof item.label === "string" ? (
-          <span
-            className={cn(
-              "-my-0.5 self-center rounded-sm border px-1 py-0.5 text-xs leading-none break-keep whitespace-nowrap",
-            )}
-          >
+          <span className="-my-0.5 self-center rounded-sm border px-1 py-0.5 text-xs leading-none break-keep whitespace-nowrap">
             {item.label}
           </span>
         ) : (

--- a/web/src/components/table/data-table.tsx
+++ b/web/src/components/table/data-table.tsx
@@ -352,7 +352,7 @@ export function DataTable<TData extends object, TValue>({
         )}
       >
         <div
-          className={cn("relative min-h-full w-full overflow-auto border-t")}
+          className="relative min-h-full w-full overflow-auto border-t"
           style={{ ...columnSizeVars }}
         >
           <Table>
@@ -507,11 +507,7 @@ export function DataTable<TData extends object, TValue>({
         </div>
       </div>
       {!hidePagination && pagination !== undefined ? (
-        <div
-          className={cn(
-            "bg-background sticky bottom-0 z-10 flex w-full justify-end border-t py-2 pr-2 font-medium",
-          )}
-        >
+        <div className="bg-background sticky bottom-0 z-10 flex w-full justify-end border-t py-2 pr-2 font-medium">
           <DataTablePagination
             table={table}
             isLoading={data.isLoading}

--- a/web/src/components/trace/components/IOPreview/components/ChatMessage.tsx
+++ b/web/src/components/trace/components/IOPreview/components/ChatMessage.tsx
@@ -79,12 +79,12 @@ export function ChatMessage({
   // Placeholder message
   if (isPlaceholderMessage(message)) {
     return (
-      <div className={cn("hover:bg-muted transition-colors")}>
+      <div className="hover:bg-muted transition-colors">
         <div style={{ display: shouldRenderMarkdown ? "block" : "none" }}>
           <MarkdownJsonView
             title="Placeholder"
             content={message.name || "Unnamed placeholder"}
-            customCodeHeaderClassName={cn("bg-primary-foreground")}
+            customCodeHeaderClassName="bg-primary-foreground"
           />
         </div>
         <div style={{ display: shouldRenderMarkdown ? "none" : "block" }}>
@@ -101,7 +101,7 @@ export function ChatMessage({
   // JSON-only message (non-ChatML object)
   if (isOnlyJsonMessage(message)) {
     return (
-      <div className={cn("hover:bg-muted transition-colors")}>
+      <div className="hover:bg-muted transition-colors">
         <PrettyJsonView
           title={title || (isOutputMessage ? "Output" : "Input")}
           json={message.json}
@@ -114,7 +114,7 @@ export function ChatMessage({
   // User toggled to show passthrough JSON
   if (showTableView) {
     return (
-      <div className={cn("hover:bg-muted transition-colors")}>
+      <div className="hover:bg-muted transition-colors">
         <PrettyJsonView
           title={title}
           json={message.json}
@@ -133,7 +133,7 @@ export function ChatMessage({
     toolCalls.length > 0
   ) {
     return (
-      <div className={cn("hover:bg-muted transition-colors")}>
+      <div className="hover:bg-muted transition-colors">
         <MarkdownJsonViewHeader
           title={title}
           handleOnValueChange={() => {}}
@@ -176,7 +176,7 @@ export function ChatMessage({
     );
 
     return (
-      <div className={cn("hover:bg-muted transition-colors")}>
+      <div className="hover:bg-muted transition-colors">
         {/* Markdown view */}
         <div style={{ display: shouldRenderMarkdown ? "block" : "none" }}>
           <MarkdownJsonView
@@ -225,7 +225,7 @@ export function ChatMessage({
   // Fallback: message with additional data but no content
   if (hasAdditionalData(message)) {
     return (
-      <div className={cn("hover:bg-muted transition-colors")}>
+      <div className="hover:bg-muted transition-colors">
         <PrettyJsonView
           title={title || (isOutputMessage ? "Output" : "Input")}
           json={message}

--- a/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
+++ b/web/src/components/trace/components/IOPreview/components/CorrectedOutputField.tsx
@@ -267,9 +267,7 @@ export function CorrectedOutputField({
             <button
               onClick={handleEdit}
               disabled={!hasAccess}
-              className={cn(
-                "text-muted-foreground hover:bg-muted/50 w-full cursor-pointer rounded-md border px-3 py-4 text-center text-xs transition-colors",
-              )}
+              className="text-muted-foreground hover:bg-muted/50 w-full cursor-pointer rounded-md border px-3 py-4 text-center text-xs transition-colors"
             >
               Click to add corrected output
             </button>

--- a/web/src/components/ui/MarkdownViewer.tsx
+++ b/web/src/components/ui/MarkdownViewer.tsx
@@ -479,7 +479,7 @@ export function MarkdownView({
   );
 
   return (
-    <div className={cn("overflow-hidden")} key={theme}>
+    <div className="overflow-hidden" key={theme}>
       {title ? (
         <>
           <MarkdownJsonViewHeader

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -18,9 +18,7 @@ const Checkbox = React.forwardRef<
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
-    >
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
       <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>

--- a/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
+++ b/web/src/ee/features/in-app-agent/components/InAppAgentMessage.tsx
@@ -580,9 +580,7 @@ function FeedbackButton({
       aria-pressed={isSelected}
       disabled={disabled}
       onClick={onClick}
-      className={cn(
-        "text-muted-foreground/50 hover:text-muted-foreground rounded-md p-1 disabled:cursor-not-allowed",
-      )}
+      className="text-muted-foreground/50 hover:text-muted-foreground rounded-md p-1 disabled:cursor-not-allowed"
     >
       {children}
     </button>

--- a/web/src/features/cloud-status-notification/components/CloudStatusMenu.tsx
+++ b/web/src/features/cloud-status-notification/components/CloudStatusMenu.tsx
@@ -1,5 +1,4 @@
 import { api } from "@/src/utils/api";
-import { cn } from "@/src/utils/tailwind";
 import Link from "next/link";
 import { SidebarMenuButton } from "@/src/components/ui/sidebar";
 import { useLangfuseCloudRegion } from "@/src/features/organizations/hooks";
@@ -34,16 +33,8 @@ export function CloudStatusMenu() {
         rel="noopener noreferrer"
       >
         <div className="relative mx-1 flex h-2 w-2 items-center justify-center">
-          <span
-            className={cn(
-              "absolute inline-flex h-2 w-2 animate-ping rounded-full bg-yellow-500 opacity-75",
-            )}
-          ></span>
-          <span
-            className={cn(
-              "relative inline-flex h-2 w-2 rounded-full bg-yellow-600",
-            )}
-          ></span>
+          <span className="absolute inline-flex h-2 w-2 animate-ping rounded-full bg-yellow-500 opacity-75"></span>
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-yellow-600"></span>
         </div>
         Status
       </Link>

--- a/web/src/features/comments/CommentCountIcon.tsx
+++ b/web/src/features/comments/CommentCountIcon.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@/src/utils/tailwind";
 import { MessageCircleMore } from "lucide-react";
 
 export function CommentCountIcon({ count }: { count?: number }) {
@@ -7,11 +6,7 @@ export function CommentCountIcon({ count }: { count?: number }) {
   return (
     <span className="relative mr-1 text-xs">
       <MessageCircleMore className="h-4 w-4" />
-      <span
-        className={cn(
-          "border-muted-foreground bg-muted-foreground text-muted dark:bg-muted dark:text-muted-foreground absolute -top-0.5 left-2.5 flex max-h-[0.8rem] min-w-[0.8rem] items-center justify-center rounded-sm border px-[0.2rem] text-[8px] shadow-xs",
-        )}
-      >
+      <span className="border-muted-foreground bg-muted-foreground text-muted dark:bg-muted dark:text-muted-foreground absolute -top-0.5 left-2.5 flex max-h-[0.8rem] min-w-[0.8rem] items-center justify-center rounded-sm border px-[0.2rem] text-[8px] shadow-xs">
         {count > 99 ? "99+" : count}
       </span>
     </span>

--- a/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
+++ b/web/src/features/datasets/components/NewDatasetItemFromExistingObject.tsx
@@ -140,7 +140,7 @@ export const NewDatasetItemFromExistingObject = (props: {
                   setIsFormOpen(true);
                 }}
               >
-                <PlusIcon size={16} className={cn("mr-2")} aria-hidden="true" />
+                <PlusIcon size={16} className="mr-2" aria-hidden="true" />
                 Add to more datasets
               </DropdownMenuItem>
             </DropdownMenuContent>
@@ -169,7 +169,7 @@ export const NewDatasetItemFromExistingObject = (props: {
           ) : null}
           Add to datasets
           {!hasAccess ? (
-            <LockIcon className={cn("ml-1.5 h-3 w-3")} aria-hidden="true" />
+            <LockIcon className="ml-1.5 h-3 w-3" aria-hidden="true" />
           ) : null}
         </Button>
       )}

--- a/web/src/features/events/components/EventsTable.tsx
+++ b/web/src/features/events/components/EventsTable.tsx
@@ -800,7 +800,7 @@ export default function ObservationsEventsTable({
           <MemoizedIOTableCell
             isLoading={false}
             data={value}
-            className={cn("bg-accent-light-green")}
+            className="bg-accent-light-green"
             singleLine={rowHeight === "s"}
           />
         ) : null;

--- a/web/src/features/experiments/components/steps/PromptModelStep.tsx
+++ b/web/src/features/experiments/components/steps/PromptModelStep.tsx
@@ -264,7 +264,7 @@ export const PromptModelStep: React.FC<PromptModelStepProps> = ({
             {form.formState.errors.modelConfig && (
               <p
                 id="modelConfig"
-                className={cn("text-destructive text-sm font-medium")}
+                className="text-destructive text-sm font-medium"
               >
                 {[
                   form.formState.errors.modelConfig?.model?.message,

--- a/web/src/features/filters/components/filter-builder.tsx
+++ b/web/src/features/filters/components/filter-builder.tsx
@@ -203,11 +203,7 @@ export function PopoverFilterBuilder({
             >
               <FilterIcon className="h-4 w-4" />
               {filterState.length > 0 && (
-                <span
-                  className={cn(
-                    "bg-input absolute top-0 -right-1 flex h-4 min-w-4 items-center justify-center rounded-sm px-1 text-xs shadow-xs",
-                  )}
-                >
+                <span className="bg-input absolute top-0 -right-1 flex h-4 min-w-4 items-center justify-center rounded-sm px-1 text-xs shadow-xs">
                   {filterState.length}
                 </span>
               )}

--- a/web/src/features/filters/components/multi-select.tsx
+++ b/web/src/features/filters/components/multi-select.tsx
@@ -208,7 +208,7 @@ export function MultiSelect({
                           : "opacity-50 [&_svg]:invisible",
                       )}
                     >
-                      <Check className={cn("h-4 w-4")} />
+                      <Check className="h-4 w-4" />
                     </div>
                     <div className="font-medium">
                       {allSelectedState ? "Deselect All" : "Select All"}
@@ -248,7 +248,7 @@ export function MultiSelect({
                           : "opacity-50 [&_svg]:invisible",
                       )}
                     >
-                      <Check className={cn("h-4 w-4")} />
+                      <Check className="h-4 w-4" />
                     </div>
                     <div
                       className={cn(

--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -667,7 +667,7 @@ export function CreateLLMApiKeyForm({
   return (
     <Form {...form}>
       <form
-        className={cn("flex flex-col gap-4 overflow-auto")}
+        className="flex flex-col gap-4 overflow-auto"
         onSubmit={(e) => {
           e.stopPropagation(); // Prevent event bubbling to parent forms
           form.handleSubmit(onSubmit)(e);

--- a/web/src/features/score-analytics/lib/ScoreChartTooltip.tsx
+++ b/web/src/features/score-analytics/lib/ScoreChartTooltip.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@/src/utils/tailwind";
 import {
   type IntervalConfig,
   type TimeRange,
@@ -114,14 +113,14 @@ export function ScoreChartTooltip({
   return (
     <div className="border-border bg-background rounded-md border opacity-100 shadow-lg">
       {/* Header with timestamp/label */}
-      <div className={cn("border-border border-b px-3 py-1.5")}>
-        <p className={cn("text-muted-foreground text-sm font-medium")}>
+      <div className="border-border border-b px-3 py-1.5">
+        <p className="text-muted-foreground text-sm font-medium">
           {formattedLabel}
         </p>
       </div>
 
       {/* Data series with values */}
-      <div className={cn("space-y-1 px-3 py-1.5")}>
+      <div className="space-y-1 px-3 py-1.5">
         {sortedPayload.map((entry, index) => {
           // Get series label from config using the Bar's dataKey
           const seriesKey = String(entry.name ?? entry.dataKey ?? "");

--- a/web/src/features/table/components/TableActionMenu.tsx
+++ b/web/src/features/table/components/TableActionMenu.tsx
@@ -9,7 +9,6 @@ import {
 } from "@/src/features/table/types";
 import { TableActionDialog } from "@/src/features/table/components/TableActionDialog";
 import { type BatchExportTableName } from "@langfuse/shared";
-import { cn } from "@/src/utils/tailwind";
 import { numberFormatter } from "@/src/utils/numbers";
 import {
   Tooltip,
@@ -87,7 +86,7 @@ export function TableActionMenu({
                   key={action.id}
                   variant="outline"
                   size="sm"
-                  className={cn("h-8")}
+                  className="h-8"
                   title={action.label}
                   disabled={action.disabled}
                   onClick={() => handleActionSelect(action)}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a custom ESLint rule `no-unnecessary-cn` that detects and auto-fixes `cn()` calls with only a single string (or expression-free template literal) argument, then applies the rule across the `web` package to remove ~20 such occurrences.

- **New rule** (`packages/eslint-plugin/src/rules/no-unnecessary-cn.ts`): Uses ESLint scope analysis to correctly track `cn` imports (including aliases and shadowing), and fixes both JSX-attribute contexts (removes the `{…}` container and converts template literals to quoted strings) and non-JSX contexts (leaves the argument as-is). Tests cover all major paths including aliased imports, shadowing, and template literals in JSX.
- **Codebase cleanup**: All existing violations are fixed and unused `cn` imports are removed from the affected files.
- **ESLint config** (`web/eslint.config.mjs`): Rule is registered as `"warn"` so future violations surface without blocking CI immediately.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are purely cosmetic Tailwind class string simplifications driven by a well-tested, scope-aware ESLint rule with no behavioral impact.

The new rule correctly tracks `cn` imports through scope analysis (aliasing, shadowing), the auto-fix handles JSX and non-JSX contexts cleanly, and the test suite covers all meaningful code paths including the template-literal-in-JSX case. Codebase changes are mechanical unwraps with no logic changes.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CallExpression visited] --> B{callee is Identifier\nand in cnImports?}
    B -- No --> Z[Skip]
    B -- Yes --> C{exactly 1 argument?}
    C -- No --> Z
    C -- Yes --> D{reference resolves\nto tracked cn import?}
    D -- No --> Z
    D -- Yes --> E{argument is Literal string\nor no-expr TemplateLiteral?}
    E -- No --> Z
    E -- Yes --> F[Report unnecessaryCn]
    F --> G{parent is JSXExpressionContainer\ninside JSXAttribute?}
    G -- Yes --> H{argument is TemplateLiteral?}
    H -- Yes --> I["replacement = JSON.stringify(quasis[0].value.cooked)\nreplaceText(JSXExpressionContainer, replacement)"]
    H -- No --> J["replacement = sourceCode.getText(argument)\nreplaceText(JSXExpressionContainer, replacement)"]
    G -- No --> K["replaceText(CallExpression, sourceCode.getText(argument))"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[CallExpression visited] --> B{callee is Identifier\nand in cnImports?}
    B -- No --> Z[Skip]
    B -- Yes --> C{exactly 1 argument?}
    C -- No --> Z
    C -- Yes --> D{reference resolves\nto tracked cn import?}
    D -- No --> Z
    D -- Yes --> E{argument is Literal string\nor no-expr TemplateLiteral?}
    E -- No --> Z
    E -- Yes --> F[Report unnecessaryCn]
    F --> G{parent is JSXExpressionContainer\ninside JSXAttribute?}
    G -- Yes --> H{argument is TemplateLiteral?}
    H -- Yes --> I["replacement = JSON.stringify(quasis[0].value.cooked)\nreplaceText(JSXExpressionContainer, replacement)"]
    H -- No --> J["replacement = sourceCode.getText(argument)\nreplaceText(JSXExpressionContainer, replacement)"]
    G -- No --> K["replaceText(CallExpression, sourceCode.getText(argument))"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(web): Autofix \`no-unneccessary-..."](https://github.com/langfuse/langfuse/commit/0ff0ac0bcbe1744709482dc98058b1b4f524d3eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39271988)</sub>

<!-- /greptile_comment -->