### PR TITLE
chore(docker): statically set ddtrace version

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -145,13 +145,10 @@ RUN adduser --system --uid ${UID} nextjs
 
 RUN npm install -g --no-package-lock --no-save prisma@6.19.3
 
-COPY --from=builder --chown=nextjs:nodejs /app/web/package.json .
-
 # Install dd-trace only if NEXT_PUBLIC_LANGFUSE_CLOUD_REGION is configured
 ARG NEXT_PUBLIC_LANGFUSE_CLOUD_REGION
 RUN if [ -n "$NEXT_PUBLIC_LANGFUSE_CLOUD_REGION" ]; then \
-    DD_TRACE_VERSION="$(node -p 'require("./package.json").dependencies["dd-trace"]')"; \
-    npm install --no-package-lock --no-save "dd-trace@${DD_TRACE_VERSION}"; \
+    npm install --no-package-lock --no-save dd-trace@5.109.0; \
     fi
 
 # npm is only used for the installs above; remove it from the final runtime image.
@@ -161,6 +158,7 @@ RUN rm -rf /usr/local/lib/node_modules/npm && \
 COPY --from=migrate-builder /out/migrate /usr/bin/migrate
 
 COPY --from=builder --chown=nextjs:nodejs /app/web/next.config.mjs .
+COPY --from=builder --chown=nextjs:nodejs /app/web/package.json .
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the dynamic `dd-trace` version resolution (reading from `package.json` at Docker build time) with a hardcoded `dd-trace@5.109.0` in the runner stage, and moves the now-unnecessary `package.json` COPY instruction to after the npm install steps.

- The conditional `dd-trace` install in the runner stage now pins `dd-trace@5.109.0` directly instead of extracting the version from `package.json`, eliminating the need to copy that file before the install step.
- The `package.json` COPY is relocated to after the npm cleanup (`rm -rf npm`) since it is no longer a build-time input to the install command, only a runtime artifact needed by the application.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the Dockerfile logic is correct and the layer ordering change is valid. The hardcoded dd-trace version will need to be kept in sync with package.json manually going forward.

The change does exactly what it intends: it removes the dependency on reading dd-trace's version out of package.json at build time. The package.json COPY relocation is correct since the file is no longer a build-time input to the install step. The only notable risk is that dd-trace@5.109.0 is now decoupled from what package.json declares — a future bump in package.json will not be reflected in the Docker image unless this line is updated too.

web/Dockerfile line 151 — the hardcoded dd-trace version will need manual updates whenever web/package.json changes the dd-trace dependency.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runner stage starts] --> B[npm install prisma@6.19.3]
    B --> C{NEXT_PUBLIC_LANGFUSE_CLOUD_REGION set?}
    C -- Yes --> D["npm install dd-trace@5.109.0 (hardcoded)"]
    C -- No --> E[skip dd-trace install]
    D --> F[rm -rf npm/npx]
    E --> F
    F --> G[COPY migrate binary]
    G --> H[COPY next.config.mjs]
    H --> I[COPY package.json]
    I --> J[COPY .next/standalone, static, public]
    J --> K[COPY prisma, clickhouse, entrypoint]
    K --> L{CMD: cloud region set?}
    L -- Yes --> M["node --import dd-trace/initialize.mjs server.js"]
    L -- No --> N[node server.js]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[runner stage starts] --> B[npm install prisma@6.19.3]
    B --> C{NEXT_PUBLIC_LANGFUSE_CLOUD_REGION set?}
    C -- Yes --> D["npm install dd-trace@5.109.0 (hardcoded)"]
    C -- No --> E[skip dd-trace install]
    D --> F[rm -rf npm/npx]
    E --> F
    F --> G[COPY migrate binary]
    G --> H[COPY next.config.mjs]
    H --> I[COPY package.json]
    I --> J[COPY .next/standalone, static, public]
    J --> K[COPY prisma, clickhouse, entrypoint]
    K --> L{CMD: cloud region set?}
    L -- Yes --> M["node --import dd-trace/initialize.mjs server.js"]
    L -- No --> N[node server.js]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/Dockerfile:151
**Version drift between Dockerfile and package.json**

`dd-trace@5.109.0` is now decoupled from the version declared in `web/package.json`. If `package.json` bumps `dd-trace` (e.g., for a security fix or new feature), the runner stage will silently keep installing `5.109.0` until this line is updated manually. Consider adding an inline comment like `# keep in sync with web/package.json dd-trace dependency` to make the coupling explicit, or wire a CI lint step that validates both values agree.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(docker): statically set ddtrace ve..."](https://github.com/langfuse/langfuse/commit/c38c4d6e452e5f7fcc2437a2cd0d056cac1f2e21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39274619)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->