### PR TITLE
chore(deps): bump dompurify to 3.4.11

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,8 +657,8 @@ importers:
         specifier: ^8.0.4
         version: 8.0.4
       dompurify:
-        specifier: ^3.4.9
-        version: 3.4.9
+        specifier: ^3.4.11
+        version: 3.4.11
       fastest-levenshtein:
         specifier: ^1.0.16
         version: 1.0.16
@@ -7034,8 +7034,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -18263,7 +18263,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -20489,7 +20489,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       es-toolkit: 1.45.1
       katex: 0.16.45
       khroma: 2.1.0
@@ -21451,7 +21451,7 @@ snapshots:
       '@posthog/core': 1.35.1
       '@posthog/types': 1.390.0
       core-js: 3.38.1
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       fflate: 0.4.8
       preact: 10.28.2
       query-selector-shadow-dom: 1.0.1

--- a/web/package.json
+++ b/web/package.json
@@ -126,7 +126,7 @@
     "dd-trace": "5.109.0",
     "decimal.js": "^10.4.3",
     "diff": "^8.0.4",
-    "dompurify": "^3.4.9",
+    "dompurify": "^3.4.11",
     "fastest-levenshtein": "^1.0.16",
     "https-proxy-agent": "^7.0.6",
     "ioredis": "^5.10.1",


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps `dompurify` from `3.4.9` to `3.4.11` in the `web` package, updating both the version specifier in `package.json` and all corresponding entries in `pnpm-lock.yaml`.

- `web/package.json` updates the specifier from `^3.4.9` to `^3.4.11`; the lock file consistently replaces the resolved version and SHA-512 integrity hash across the `dompurify` package entry and its two snapshot usages (mermaid and `@posthog/core`)
- No other dependencies or source files are modified; the change is minimal and mechanically correct
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

A targeted bump of a single XSS-sanitization library with no source-code changes; the lock file is fully consistent with the new version.

The only change is the resolved version and integrity hash for dompurify in both package.json and pnpm-lock.yaml. All three snapshot locations in the lock file are updated in step, no other dependencies are touched, and there are no source-file edits that could introduce regressions.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["web/package.json\ndompurify 3.4.9 to 3.4.11"] --> B["pnpm-lock.yaml"]
    B --> C["dompurify 3.4.11 package entry\nSHA-512 integrity updated"]
    C --> D["mermaid snapshot\n3.4.9 to 3.4.11"]
    C --> E["posthog/core snapshot\n3.4.9 to 3.4.11"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["web/package.json\ndompurify 3.4.9 to 3.4.11"] --> B["pnpm-lock.yaml"]
    B --> C["dompurify 3.4.11 package entry\nSHA-512 integrity updated"]
    C --> D["mermaid snapshot\n3.4.9 to 3.4.11"]
    C --> E["posthog/core snapshot\n3.4.9 to 3.4.11"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into nimar/bump-domp..."](https://github.com/langfuse/langfuse/commit/0c6f750169ee7bece55de3cb1ab32c89cec63888) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39277467)</sub>

<!-- /greptile_comment -->