### PR TITLE
chore(skill): add git command to pkg upgrade

### DIFF
--- a/.agents/skills/pnpm-upgrade-package/SKILL.md
+++ b/.agents/skills/pnpm-upgrade-package/SKILL.md
@@ -53,6 +53,10 @@ Use this skill for interactive dependency bumps in Langfuse.
   locally installed exact peer dependencies.
 - Finish with `pnpm why -r <package>` to confirm that only the intended version
   remains in the workspace.
+- In the final response, include a copy-pasteable human commit command using
+  the resolved package name and target version. Use a branch-safe package slug
+  for scoped packages, but keep the exact package name in the commit message:
+  `git switch -C deps/bump-<package-slug>-to-<version> && git commit -m "chore(deps): bump <package> to <version>" --no-verify`
 
 ## Quick Commands
 
@@ -72,3 +76,5 @@ Use this skill for interactive dependency bumps in Langfuse.
   `pnpm -r up <package>@<version>`
 - Verify temporary override removal:
   remove the override, then run `pnpm install` and `pnpm dedupe`
+- Human commit helper:
+  `git switch -C deps/bump-<package-slug>-to-<version> && git commit -m "chore(deps): bump <package> to <version>" --no-verify`


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the `pnpm-upgrade-package` agent skill to surface a copy-pasteable git commit command at the end of every dependency-bump workflow. The command creates a conventionally-named branch and commits the changes with `--no-verify`.

- A new instruction in "Apply This Skill" tells the agent to include the commit helper in its final response, and the identical template is also added to the "Quick Commands" reference — creating two places that must stay in sync.
- The commit helper uses `--no-verify`, which skips all pre-commit and commit-msg hooks; this is convenient but will silently bypass any security or linting hooks the repository enforces at commit time.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change with no runtime impact; safe to merge, though the `--no-verify` default and duplicated template are worth addressing before this becomes the established pattern for all future dep bumps.

The change is confined to a Markdown skill file and cannot break any running code. The two points worth noting are that `--no-verify` is baked in as the default (not an opt-in escape hatch), and the same command string lives in two separate sections, so a future template tweak would require two edits to stay consistent.

`SKILL.md` — the duplicated command block and the unconditional `--no-verify` flag.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent: pnpm-upgrade-package skill invoked] --> B[Run check-release-age-window.mjs]
    B --> C{Package directly declared?}
    C -->|No| D[pnpm why -r to find parent]
    C -->|Yes| E[Bump package]
    D --> E
    E --> F[pnpm dedupe]
    F --> G[pnpm why -r to verify single version]
    G --> H[Final response: include human commit helper]
    H --> I["git switch -C deps/bump-slug-to-version"]
    I --> J["git commit -m 'chore(deps): bump ...' --no-verify"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Agent: pnpm-upgrade-package skill invoked] --> B[Run check-release-age-window.mjs]
    B --> C{Package directly declared?}
    C -->|No| D[pnpm why -r to find parent]
    C -->|Yes| E[Bump package]
    D --> E
    E --> F[pnpm dedupe]
    F --> G[pnpm why -r to verify single version]
    G --> H[Final response: include human commit helper]
    H --> I["git switch -C deps/bump-slug-to-version"]
    I --> J["git commit -m 'chore(deps): bump ...' --no-verify"]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.agents/skills/pnpm-upgrade-package/SKILL.md:56-57
**`--no-verify` skips all hook layers, including security hooks**

`--no-verify` suppresses both `pre-commit` and `commit-msg` hooks. For repos that run secret-scanning, license checkers, or other security-oriented hooks at commit time, presenting this flag as the recommended copy-paste command means contributors will bypass those checks for every dependency bump. Considering that dep bumps sometimes pull in new files (e.g., patched lockfiles, added `overrides`), this is worth a conscious opt-in rather than a default. Consider documenting the flag as an optional escape hatch (`# add --no-verify only if pre-commit hooks block a lockfile-only change`) rather than baking it into the primary template.

### Issue 2 of 2
.agents/skills/pnpm-upgrade-package/SKILL.md:79-80
**Duplicated command template — single source of truth risk**

The git commit helper command appears verbatim in two places: once in the "Apply This Skill" narrative (lines 56–57) and again in the "Quick Commands" section (lines 79–80). If the branch prefix, commit prefix, or flags change in the future, both locations need to be updated in sync. A comment like `# see the commit helper in Quick Commands below` in the prose, pointing to one canonical entry, would eliminate the duplication risk.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(skill): add git command to pkg upg..."](https://github.com/langfuse/langfuse/commit/d43fb11ef02a73b33a0cb768ede14c243fcb4d56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39277766)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->