### PR TITLE
fix(blob): preserve GCS Details field through error wrapping

### DIFF
--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -95,7 +95,20 @@ function handleStorageError(err: unknown, operation: string): never {
     );
   }
   // For other errors, throw with the original cause preserved
-  throw new Error(`Failed to ${operation}`, { cause: err });
+  const wrapped = new Error(`Failed to ${operation}`, { cause: err });
+  // Preserve provider-specific details (e.g. GCS <Details> XML element)
+  // so they surface when Winston spreads the error's enumerable properties.
+  if (
+    err &&
+    typeof err === "object" &&
+    "Details" in err &&
+    typeof (err as { Details?: unknown }).Details === "string"
+  ) {
+    (wrapped as unknown as { Details: string }).Details = (
+      err as { Details: string }
+    ).Details;
+  }
+  throw wrapped;
 }
 
 function createS3RequestHandler(

--- a/packages/shared/src/server/services/s3SigningDiagnostics.test.ts
+++ b/packages/shared/src/server/services/s3SigningDiagnostics.test.ts
@@ -104,7 +104,23 @@ describe("summarizeS3Error", () => {
       requestId: "req-123",
       extendedRequestId: "ext-456",
       message: "The request signature we calculated",
+      details: undefined,
     });
+  });
+
+  it("extracts GCS-specific Details from the XML error body", () => {
+    const err = Object.assign(new Error("Invalid argument."), {
+      name: "InvalidArgument",
+      Code: "InvalidArgument",
+      Details: "Multipart upload is not supported in Rapid storage class.",
+      $fault: "client",
+      $metadata: { httpStatusCode: 400 },
+    });
+
+    const summary = summarizeS3Error(err);
+    expect(summary.details).toBe(
+      "Multipart upload is not supported in Rapid storage class.",
+    );
   });
 
   it("never throws on non-object errors", () => {

--- a/packages/shared/src/server/services/s3SigningDiagnostics.ts
+++ b/packages/shared/src/server/services/s3SigningDiagnostics.ts
@@ -164,6 +164,7 @@ export interface S3ErrorSummary {
   requestId?: string;
   extendedRequestId?: string;
   message?: string;
+  details?: string;
 }
 
 /**
@@ -179,6 +180,7 @@ export function summarizeS3Error(err: unknown): S3ErrorSummary {
     name?: string;
     message?: string;
     Code?: string;
+    Details?: string;
     $fault?: string;
     $metadata?: {
       httpStatusCode?: number;
@@ -194,6 +196,7 @@ export function summarizeS3Error(err: unknown): S3ErrorSummary {
     requestId: e.$metadata?.requestId,
     extendedRequestId: e.$metadata?.extendedRequestId,
     message: e.message,
+    details: e.Details,
   };
 }
 

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -1178,12 +1178,23 @@ function extractStorageErrorMessage(error: unknown): string {
   // handleStorageError wraps SDK errors via { cause: sdkError }
   // Unwrap to get the raw SDK message (S3/Azure/GCS)
   const cause = error.cause;
-  if (cause instanceof Error) {
-    return cause.message.slice(0, 1000);
-  }
+  const message = cause instanceof Error ? cause.message : error.message;
 
-  // Fallback: ClickHouse errors or other non-wrapped errors
-  return error.message.slice(0, 1000);
+  // GCS returns a <Details> XML element with the real rejection reason
+  // (e.g. "Multipart upload is not supported in Rapid storage class.").
+  // handleStorageError preserves it as an enumerable property.
+  const errorDetails = (error as unknown as { Details?: unknown }).Details;
+  const causeDetails = (cause as unknown as { Details?: unknown } | undefined)
+    ?.Details;
+  const details =
+    typeof errorDetails === "string"
+      ? errorDetails
+      : typeof causeDetails === "string"
+        ? causeDetails
+        : undefined;
+
+  const full = details ? `${message} Details: ${details}` : message;
+  return full.slice(0, 1000);
 }
 
 function formatErrorChain(error: unknown): string {


### PR DESCRIPTION
## What does this PR do?

When GCS returns an S3-compatible error with a `<Details>` XML element (e.g. "Multipart upload is not supported in Rapid storage class."), the AWS SDK deserializes it as an enumerable `Details` property on the exception. Two gaps prevented this from reaching operators:

1. **Datadog logs (web validation path):** `handleStorageError` wraps SDK errors in a plain `Error({ cause })`, dropping enumerable properties like `Details`. The worker path logs the raw SDK error directly so `Details` appears as `custom.Details`, but the web validation path only sees the wrapped error.

2. **Postgres `lastError`:** `extractStorageErrorMessage` only extracted `.message` from the cause chain, never looking at `.Details`. So `lastError` stored `"Invalid argument."` instead of the actionable GCS reason.

**Changes:**
- `handleStorageError` now copies the `Details` property from the original error onto the wrapped error, so it surfaces in all `logger.error()` calls (Datadog)
- `extractStorageErrorMessage` now appends the `Details` field to the persisted `lastError` in Postgres (e.g. `"Invalid argument. Details: Multipart upload is not supported in Rapid storage class."`)
- `S3ErrorSummary` in `s3SigningDiagnostics.ts` now includes `details` for structured extraction
- Added test case for GCS-specific Details extraction

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Tests added/updated
- [x] Lint passes
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)