### PR TITLE
refactor(web): Enable `tailwindcss/enforces-negative-arbitrary-values`

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -52,12 +52,12 @@ export default [
           ],
         },
       ],
+      "tailwindcss/enforces-negative-arbitrary-values": "warn",
       // TODO: Enable these rule later
       "tailwindcss/classnames-order": "off",
       "tailwindcss/enforces-shorthand": "off",
       "tailwindcss/no-unnecessary-arbitrary-value": "off",
       "tailwindcss/no-contradicting-classname": "off",
-      "tailwindcss/enforces-negative-arbitrary-values": "off",
     },
   },
 

--- a/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
+++ b/web/src/features/auth/components/AuthCloudRegionSwitch.tsx
@@ -78,7 +78,7 @@ export function CloudRegionSwitch({
                     className={
                       // The HIPAA symbol glyph sits lower than flag emojis in the same font.
                       region.name === "HIPAA"
-                        ? "-translate-y-[3px] text-xl leading-none"
+                        ? "translate-y-[-3px] text-xl leading-none"
                         : "-translate-y-px text-xl leading-none"
                     }
                   >


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables the `tailwindcss/enforces-negative-arbitrary-values` ESLint rule (set to `"warn"`) in the web package's ESLint config and fixes the one existing violation it surfaced.

- The ESLint rule is activated by moving it from `"off"` to `"warn"` in `web/eslint.config.mjs`.
- In `AuthCloudRegionSwitch.tsx`, the class `-translate-y-[3px]` (dash-prefixed negative) is rewritten as `translate-y-[-3px]` (negative inside brackets) to match the rule's preferred convention; both produce identical CSS output.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely a lint rule activation with a single mechanical class rename that produces identical CSS.

Both files contain straightforward, low-risk changes: enabling a Tailwind ESLint rule and renaming one class token to comply with it. The renamed class produces the exact same CSS, so no visual or behavioral regression is possible.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ESLint runs on web/"] --> B{"tailwindcss/enforces-negative-arbitrary-values"}
    B -->|"was: off"| C["No check performed"]
    B -->|"now: warn"| D["Checks for -utility-[value] pattern"]
    D --> E{"-translate-y-[3px] found?"}
    E -->|"Yes → violation"| F["Rewrite to translate-y[-3px]"]
    F --> G["Same CSS output:\ntranslateY(-3px)"]
    E -->|"No violations"| H["Pass"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["ESLint runs on web/"] --> B{"tailwindcss/enforces-negative-arbitrary-values"}
    B -->|"was: off"| C["No check performed"]
    B -->|"now: warn"| D["Checks for -utility-[value] pattern"]
    D --> E{"-translate-y-[3px] found?"}
    E -->|"Yes → violation"| F["Rewrite to translate-y[-3px]"]
    F --> G["Same CSS output:\ntranslateY(-3px)"]
    E -->|"No violations"| H["Pass"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(web): Enable \`tailwindcss/enfor..."](https://github.com/langfuse/langfuse/commit/0ee354470e9faa9fcb844d7747ce3dbd8b325a0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39316339)</sub>

<!-- /greptile_comment -->