### PR TITLE
fix(ui): expand sidebar filter sections with active URL filters on load

### DIFF
--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useCallback, useMemo, useEffect, useState } from "react";
+import { useCallback, useMemo, useEffect, useRef, useState } from "react";
 import { StringParam, useQueryParam } from "use-query-params";
 import {
   type FilterState,
@@ -548,6 +548,48 @@ export function useSidebarFilterState(
       : stateLocationType === "memory"
         ? memoryFilterState
         : urlFilterState;
+
+  // LFE-10164: When arriving via a URL/deep link that already carries applied
+  // filters, expand the sidebar sections that have an active filter. Sidebar
+  // sections are collapsed by default; without this, a bookmarked/shared link
+  // would render its active facets collapsed. This runs once on initial load
+  // (guarded by a ref) so it only seeds the default state and never overrides
+  // subsequent manual expand/collapse. Sections without an active filter keep
+  // their default state.
+  //
+  // We key off `explicitFilterState` (the URL/memory/peek-authored filters),
+  // which already excludes the implicit hidden-environment default — so the
+  // managed-environment section is only auto-expanded when the user actually
+  // authored an environment filter.
+  const hasSeededExpansionFromActiveFilters = useRef(false);
+  useEffect(() => {
+    if (hasSeededExpansionFromActiveFilters.current) return;
+    hasSeededExpansionFromActiveFilters.current = true;
+
+    if (explicitFilterState.length === 0) return;
+
+    const facetColumns = new Set(config.facets.map((facet) => facet.column));
+    const activeFacetColumns = explicitFilterState
+      .map((filter) => filter.column)
+      .filter((column) => facetColumns.has(column));
+    if (activeFacetColumns.length === 0) return;
+
+    setExpandedString((current) => {
+      const expanded = current.split(",").filter(Boolean);
+      const expandedSet = new Set(expanded);
+      const next = [...expanded];
+      for (const column of activeFacetColumns) {
+        if (!expandedSet.has(column)) {
+          expandedSet.add(column);
+          next.push(column);
+        }
+      }
+      return next.length === expanded.length ? current : next.join(",");
+    });
+    // Intentionally runs only on initial mount; the ref guard prevents re-seeding
+    // after later filter changes so manual collapse is respected.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const managedEnvironmentPolicyConfig = useMemo(
     () => buildManagedEnvironmentPolicyConfig(implicitDefaultConfig),

--- a/web/src/features/filters/hooks/useSidebarFilterState.tsx
+++ b/web/src/features/filters/hooks/useSidebarFilterState.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useCallback, useMemo, useEffect, useRef, useState } from "react";
+import { useCallback, useMemo, useEffect, useState } from "react";
 import { StringParam, useQueryParam } from "use-query-params";
 import {
   type FilterState,
@@ -439,6 +439,12 @@ export function useSidebarFilterState(
   const setPeekTableState = peekContext?.setTableState;
 
   const FILTER_EXPANDED_STORAGE_KEY = `${config.tableName}-filters-expanded`;
+  // Tracks which active-filter columns we have already auto-expanded once, so a
+  // section the user later collapsed is never re-expanded — even across remounts
+  // (route navigation away-and-back, tab reload). It shares the session lifecycle
+  // of the expanded state itself, so the "already reconciled" knowledge survives
+  // exactly as long as the manual collapse it must respect. See LFE-10164 below.
+  const FILTER_SEEDED_STORAGE_KEY = `${config.tableName}-filters-seeded`;
   const DEFAULT_EXPANDED_FILTERS = config.defaultExpanded ?? [];
 
   const [expandedString, setExpandedString] = useSessionStorage<string>(
@@ -453,6 +459,11 @@ export function useSidebarFilterState(
       setExpandedString(value.join(","));
     },
     [setExpandedString],
+  );
+
+  const [seededString, setSeededString] = useSessionStorage<string>(
+    FILTER_SEEDED_STORAGE_KEY,
+    "",
   );
 
   const normalizedSessionFilterContextId =
@@ -552,33 +563,50 @@ export function useSidebarFilterState(
   // LFE-10164: When arriving via a URL/deep link that already carries applied
   // filters, expand the sidebar sections that have an active filter. Sidebar
   // sections are collapsed by default; without this, a bookmarked/shared link
-  // would render its active facets collapsed. This runs once on initial load
-  // (guarded by a ref) so it only seeds the default state and never overrides
-  // subsequent manual expand/collapse. Sections without an active filter keep
-  // their default state.
+  // would render its active facets collapsed. Sections without an active filter
+  // keep their default state.
+  //
+  // We derive this during render (the "adjust state while rendering when a
+  // derived input changes" pattern, https://react.dev/learn/you-might-not-need-an-effect)
+  // rather than in a mount effect. The mount-effect approach had two defects:
+  //   1. Late-arriving URL params: in the Pages Router `useQueryParam` reads
+  //      `router.query`, which is empty on the first render of a direct
+  //      navigation and only populated on a later render. A one-shot mount
+  //      effect seeded against the empty first render and never re-ran, so
+  //      deep-linked sections stayed collapsed. Reconciling during render means
+  //      the moment the filters actually appear (a later render) we seed them.
+  //   2. Remount re-seed: a per-mount guard re-expanded a section the user had
+  //      deliberately collapsed whenever the page remounted. We instead persist
+  //      which columns have already been auto-expanded (`seededString`, same
+  //      session lifecycle as the expanded state) and only expand columns that
+  //      are newly active and not yet reconciled, so a collapsed section is
+  //      never re-expanded.
   //
   // We key off `explicitFilterState` (the URL/memory/peek-authored filters),
   // which already excludes the implicit hidden-environment default — so the
   // managed-environment section is only auto-expanded when the user actually
   // authored an environment filter.
-  const hasSeededExpansionFromActiveFilters = useRef(false);
-  useEffect(() => {
-    if (hasSeededExpansionFromActiveFilters.current) return;
-    hasSeededExpansionFromActiveFilters.current = true;
-
-    if (explicitFilterState.length === 0) return;
-
-    const facetColumns = new Set(config.facets.map((facet) => facet.column));
-    const activeFacetColumns = explicitFilterState
-      .map((filter) => filter.column)
-      .filter((column) => facetColumns.has(column));
-    if (activeFacetColumns.length === 0) return;
-
+  const seededSet = useMemo(
+    () => new Set(seededString.split(",").filter(Boolean)),
+    [seededString],
+  );
+  const facetColumnSet = useMemo(
+    () => new Set(config.facets.map((facet) => facet.column)),
+    [config.facets],
+  );
+  const newlyActiveFacetColumns = explicitFilterState
+    .map((filter) => filter.column)
+    .filter((column) => facetColumnSet.has(column) && !seededSet.has(column));
+  if (newlyActiveFacetColumns.length > 0) {
+    // setState-during-render (not an effect): React discards this render and
+    // re-renders synchronously with the updated state before painting. The
+    // updates are idempotent — once a column is in `seededSet` it is no longer
+    // "newly active", so this branch does not re-run for it on the next render.
     setExpandedString((current) => {
       const expanded = current.split(",").filter(Boolean);
       const expandedSet = new Set(expanded);
       const next = [...expanded];
-      for (const column of activeFacetColumns) {
+      for (const column of newlyActiveFacetColumns) {
         if (!expandedSet.has(column)) {
           expandedSet.add(column);
           next.push(column);
@@ -586,10 +614,19 @@ export function useSidebarFilterState(
       }
       return next.length === expanded.length ? current : next.join(",");
     });
-    // Intentionally runs only on initial mount; the ref guard prevents re-seeding
-    // after later filter changes so manual collapse is respected.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    setSeededString((current) => {
+      const seeded = current.split(",").filter(Boolean);
+      const seededColumnSet = new Set(seeded);
+      const next = [...seeded];
+      for (const column of newlyActiveFacetColumns) {
+        if (!seededColumnSet.has(column)) {
+          seededColumnSet.add(column);
+          next.push(column);
+        }
+      }
+      return next.length === seeded.length ? current : next.join(",");
+    });
+  }
 
   const managedEnvironmentPolicyConfig = useMemo(
     () => buildManagedEnvironmentPolicyConfig(implicitDefaultConfig),

--- a/web/src/features/filters/sidebarFilterSessionPersistence.clienttest.tsx
+++ b/web/src/features/filters/sidebarFilterSessionPersistence.clienttest.tsx
@@ -6,6 +6,11 @@ import { encodeFiltersGeneric } from "./lib/filter-query-encoding";
 import { buildSidebarFilterQueryStorageKey } from "./lib/persistedSidebarFilterQuery";
 
 const queryParamStore = new Map<string, unknown>();
+// Values placed here are NOT visible on the first render; they are applied on
+// mount via the query-param setter, reproducing the Next.js Pages Router race
+// where `router.query` is empty on the first render and only populated on a
+// later (hydration) render. See the deep-link expansion tests below.
+const deferredQueryParams = new Map<string, unknown>();
 
 vi.mock("use-query-params", async () => {
   const React = require("react");
@@ -50,6 +55,17 @@ vi.mock("use-query-params", async () => {
 
         queryParamStore.set(key, value);
       }, [key, value]);
+
+      // Apply a deferred value once, on mount: this lands the param on a later
+      // render than the first, simulating Pages Router query hydration.
+      React.useEffect(() => {
+        if (deferredQueryParams.has(key)) {
+          const deferred = deferredQueryParams.get(key);
+          deferredQueryParams.delete(key);
+          setQueryValue(deferred);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
 
       return [value, setQueryValue] as const;
     },
@@ -124,6 +140,119 @@ function SessionPersistenceHarness(props: { contextId?: string | null }) {
     </div>
   );
 }
+
+// Reports the expanded state of the single "name" facet and lets a test
+// collapse it. Used to assert the LFE-10164 deep-link expansion behavior.
+function ExpansionHarness() {
+  const queryFilter = useSidebarFilterState(TEST_FILTER_CONFIG, TEST_OPTIONS, {
+    stateLocation: "urlAndSessionStorage",
+  });
+
+  const nameFacet = queryFilter.filters.find((f) => f.column === "name");
+
+  return (
+    <div>
+      <pre data-testid="name-expanded">{String(nameFacet?.expanded)}</pre>
+      <pre data-testid="expanded-list">
+        {JSON.stringify(queryFilter.expanded)}
+      </pre>
+      <button
+        data-testid="collapse-name"
+        onClick={() =>
+          queryFilter.onExpandedChange(
+            queryFilter.expanded.filter((c) => c !== "name"),
+          )
+        }
+      >
+        Collapse name
+      </button>
+    </div>
+  );
+}
+
+describe("useSidebarFilterState deep-link expansion (LFE-10164)", () => {
+  const encodedFilterA = encodeFiltersGeneric(FILTER_A);
+  const EXPANDED_STORAGE_KEY = `${TEST_FILTER_CONFIG.tableName}-filters-expanded`;
+  const SEEDED_STORAGE_KEY = `${TEST_FILTER_CONFIG.tableName}-filters-seeded`;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    queryParamStore.clear();
+    deferredQueryParams.clear();
+  });
+
+  const getNameExpanded = () =>
+    screen.getByTestId("name-expanded").textContent === "true";
+
+  it("expands a facet section whose filter arrives on the first render", async () => {
+    queryParamStore.set("filter", encodedFilterA);
+
+    render(<ExpansionHarness />);
+
+    await waitFor(() => {
+      expect(getNameExpanded()).toBe(true);
+    });
+    expect(
+      JSON.parse(sessionStorage.getItem(SEEDED_STORAGE_KEY) ?? '""'),
+    ).toContain("name");
+  });
+
+  it("expands a facet section whose URL filter only arrives on a later render (Pages Router race)", async () => {
+    // Empty on first render; the filter param lands on a later render. The old
+    // one-shot mount effect seeded against the empty first render and never
+    // re-ran, leaving the section collapsed. The during-render reconciliation
+    // must expand it once the filter actually arrives.
+    deferredQueryParams.set("filter", encodedFilterA);
+
+    render(<ExpansionHarness />);
+
+    // Section starts collapsed (no filter on first render).
+    expect(getNameExpanded()).toBe(false);
+
+    // Once the deferred filter arrives, the section expands.
+    await waitFor(() => {
+      expect(getNameExpanded()).toBe(true);
+    });
+  });
+
+  it("does not re-expand a section the user collapsed, even though the URL filter is still active", async () => {
+    // Filter already active and already auto-expanded once in this session.
+    queryParamStore.set("filter", encodedFilterA);
+    sessionStorage.setItem(EXPANDED_STORAGE_KEY, JSON.stringify(""));
+    sessionStorage.setItem(SEEDED_STORAGE_KEY, JSON.stringify("name"));
+
+    render(<ExpansionHarness />);
+
+    // The seeded marker records that "name" was already reconciled, so the
+    // collapsed state is preserved instead of being re-expanded.
+    await waitFor(() => {
+      expect(screen.getByTestId("expanded-list").textContent).toBe("[]");
+    });
+    expect(getNameExpanded()).toBe(false);
+  });
+
+  it("keeps a manual collapse after it is reconciled within the same mount", async () => {
+    queryParamStore.set("filter", encodedFilterA);
+
+    render(<ExpansionHarness />);
+
+    // Auto-expanded on arrival.
+    await waitFor(() => {
+      expect(getNameExpanded()).toBe(true);
+    });
+
+    // User collapses it.
+    fireEvent.click(screen.getByTestId("collapse-name"));
+
+    // It stays collapsed; the still-active filter does not re-expand it.
+    await waitFor(() => {
+      expect(getNameExpanded()).toBe(false);
+    });
+    // Give any stray re-render a chance to (incorrectly) re-seed.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(getNameExpanded()).toBe(false);
+  });
+});
 
 describe("useSidebarFilterState session persistence", () => {
   const encodedFilterA = encodeFiltersGeneric(FILTER_A);


### PR DESCRIPTION
## What does this PR do?

When a table is opened via a URL with applied filters (bookmark / deep link), the sidebar filter sections rendered **collapsed** even though those filters were active. This seeds the initial expanded state so sections with an active URL-derived filter open on load; sections without one stay collapsed, and manual expand/collapse afterward is unaffected.

Implemented in the shared `useSidebarFilterState` hook (a one-time, mount-only, additive seed via a ref guard — never overrides later user toggles), so it applies to all sidebar-filter tables. Filter client tests pass (101/101); verified manually on the observations table.

LFE-10164

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks
- [x] Self-reviewed the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a UX bug where sidebar filter sections rendered collapsed on load even when the user arrived via a deep link or bookmark with pre-applied URL filters. The fix is isolated to `useSidebarFilterState`, applying to all sidebar-filter tables.

- Adds a mount-only `useEffect` guarded by a `useRef` that reads `explicitFilterState` at first render, finds which filter columns correspond to known facets, and calls `setExpandedString` with a functional update to additively expand those sections without clobbering existing expanded state.
- Uses `explicitFilterState` (not `effectiveFilterState`) so the implicit managed-environment default is excluded — the environment section only auto-expands when the user explicitly authored an environment filter.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change is additive, isolated to a single hook, and touches no data-mutation paths.

The seeding logic is well-structured — functional update, deduplication via Set, and a ref guard that prevents repeated seeding. Two non-blocking edge cases exist: the mount-time closure over explicitFilterState could read an empty value on Pages Router, and the instance-scoped ref resets on every remount causing re-expansion after a manual collapse. Neither path causes data loss or breakage.

web/src/features/filters/hooks/useSidebarFilterState.tsx — specifically the new useEffect block around lines 565-592.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component Mounts] --> B{hasSeededExpansion .current?}
    B -- true --> C[Return early]
    B -- false --> D[Set ref = true]
    D --> E{explicitFilterState length === 0?}
    E -- yes --> F[Return early]
    E -- no --> G[Build facetColumns Set from config.facets]
    G --> H[Filter active columns to known facets]
    H --> I{activeFacetColumns length === 0?}
    I -- yes --> J[Return early]
    I -- no --> K[setExpandedString functional update]
    K --> L{Column already in expandedSet?}
    L -- yes --> M[Skip]
    L -- no --> N[Add to next and expandedSet]
    N --> L
    M --> O{Any new columns added?}
    N --> O
    O -- no --> P[Return same string reference]
    O -- yes --> Q[Return next.join comma]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Component Mounts] --> B{hasSeededExpansion .current?}
    B -- true --> C[Return early]
    B -- false --> D[Set ref = true]
    D --> E{explicitFilterState length === 0?}
    E -- yes --> F[Return early]
    E -- no --> G[Build facetColumns Set from config.facets]
    G --> H[Filter active columns to known facets]
    H --> I{activeFacetColumns length === 0?}
    I -- yes --> J[Return early]
    I -- no --> K[setExpandedString functional update]
    K --> L{Column already in expandedSet?}
    L -- yes --> M[Skip]
    L -- no --> N[Add to next and expandedSet]
    N --> L
    M --> O{Any new columns added?}
    N --> O
    O -- no --> P[Return same string reference]
    O -- yes --> Q[Return next.join comma]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/features/filters/hooks/useSidebarFilterState.tsx:565-592
**Stale-closure race on first render with Pages Router**

The effect captures `explicitFilterState` in a `[]`-dependency closure and fires synchronously after the very first render. In Next.js Pages Router, `useQueryParam` reads from `router.query`, which is **empty on the first render** for direct-navigation pages and is only populated on the second (client-side hydration) render. On that first render `explicitFilterState` will be `[]`, the early-return fires (`explicitFilterState.length === 0`), and then the ref guard is already `true` — so when the URL params arrive on the second render the effect never re-fires and the expansion seeding is permanently skipped for that page load.

For first-time deep-link visitors (no prior session storage state to fall back to) on Pages Router tables, the sidebar sections will remain collapsed even though filters are active. If this codebase has migrated fully to App Router the issue does not apply, since `useSearchParams()` is synchronous there — but that assumption is worth confirming.

### Issue 2 of 2
web/src/features/filters/hooks/useSidebarFilterState.tsx:564
**Re-expansion fires on every remount, overriding a manual collapse**

`hasSeededExpansionFromActiveFilters` lives on the component instance, so it resets to `false` whenever the component unmounts and remounts (e.g., navigating away and back to the same deep link). Each new mount re-seeds the expansion for any active-filter columns, regardless of whether the user had previously collapsed those sections. A user who deliberately folds a section, navigates away, and returns to the same filtered URL will have the section re-expanded.

Whether this is the intended behaviour depends on product requirements. If manual collapse should survive cross-navigation in the same session (session storage is already used for this), you'd want to guard on a session-storage flag rather than an instance ref — or simply accept the current behavior if "always show active sections on arrival" is the desired UX.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): expand sidebar filter sections ..."](https://github.com/langfuse/langfuse/commit/cbb6bce9d3625c5616374a11d09d1fa0334ee06f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39325097)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->