### PR TITLE
fix(ai-features): drop temperature/top_p for Bedrock NL filter (Opus 4.8 rejects them)

### DIFF
--- a/web/src/features/natural-language-filters/server/utils.ts
+++ b/web/src/features/natural-language-filters/server/utils.ts
@@ -7,13 +7,19 @@ import { z } from "zod";
 let langfuseClient: Langfuse | null = null;
 
 export function getDefaultModelParams() {
+  // Intentionally omit `temperature` and `top_p`: newer Bedrock models such as
+  // Claude Opus 4.8 reject these inference params with a ValidationException
+  // ("'temperature' is deprecated for this model"), which surfaces as a 500 on
+  // `naturalLanguageFilters.createCompletion`. Omitting them is robust across
+  // models (older models simply fall back to their defaults), and NL filter
+  // generation works fine at model defaults. We only cap output length.
+  // Note: the param keys are `max_tokens`/`top_p` (snake_case) per ModelParams;
+  // the previous camelCase `maxTokens`/`topP` were silently dropped.
   return {
     provider: "bedrock",
     adapter: LLMAdapter.Bedrock,
     model: env.LANGFUSE_AWS_BEDROCK_MODEL ?? "",
-    temperature: 0.1,
-    maxTokens: 1000,
-    topP: 0.9,
+    max_tokens: 1000,
   };
 }
 


### PR DESCRIPTION
## Bug (LFE-10468)

In production (langfuse-prod EU), the sidebar **"Filter with AI"** (the legacy natural-language filter, tRPC path `naturalLanguageFilters.createCompletion`) returns **"Internal Server Error"**.

## Root cause

The AI-features Bedrock model in production is `eu.anthropic.claude-opus-4-8` (Claude Opus 4.8), which **rejects** the `temperature` and `top_p` inference params. `getDefaultModelParams()` in `web/src/features/natural-language-filters/server/utils.ts` hardcoded `temperature: 0.1`, so Bedrock Converse returned:

```
ValidationException: The model returned the following errors: 'temperature' is deprecated for this model.
```

and the request 500s.

## Confirmation evidence

Confirmed via AWS Bedrock Converse on `eu.anthropic.claude-opus-4-8` (eu-west-1):

- with `temperature` -> `ValidationException: ... 'temperature' is deprecated for this model.`
- with `top_p` -> `'top_p' is deprecated for this model`
- with neither -> success

## Local vs prod model difference

It works in local dev only because local is configured with `claude-3-haiku`, which still accepts these params. Production uses Claude Opus 4.8, which does not.

## Fix

Drop `temperature` and `top_p` from `getDefaultModelParams()`:

- Omitting them is robust across models (older models simply fall back to their defaults), and NL filter generation works fine at model defaults.
- Keep an output cap using the **correct** snake_case field name `max_tokens: 1000`, per the `ModelParams`/`ModelConfig` type. The previous camelCase `maxTokens`/`topP` were **not valid keys** on that type and were silently dropped today (never applied), so removing them changes nothing behaviorally beyond fixing the field name.

The single consumer is `fetchLLMCompletion`, which constructs `ChatBedrockConverse` with `temperature: modelParams.temperature`, `topP: modelParams.top_p`, `maxTokens: modelParams.max_tokens`. Undefined values are omitted from the Bedrock request, which is exactly what we want.

Refs LFE-10468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a production 500 on the "Filter with AI" sidebar by removing `temperature` and `top_p` from the hardcoded Bedrock model params in `getDefaultModelParams()`. Claude Opus 4.8 (the EU-prod model) rejects those inference params with a `ValidationException`; omitting them is safe for all models. The PR also renames `maxTokens` → `max_tokens` so the output-token cap is actually applied for the first time.

- **Removes `temperature: 0.1`** — Opus 4.8 raises `ValidationException: 'temperature' is deprecated for this model`, which caused the tRPC `naturalLanguageFilters.createCompletion` endpoint to 500 in production.
- **Removes `topP`** — was already silently dropped (wrong camelCase key, not a valid `ModelConfig` field) and would also be rejected by Opus 4.8; dropping it is safe.
- **Fixes `maxTokens` → `max_tokens`** — correct snake_case field per `ModelConfig`; the 1,000-token output cap now actually reaches `ChatBedrockConverse`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change removes inference parameters that actively crash the production endpoint and fixes a silent no-op in the token cap.

The single changed function had three stale or broken field values. Removing temperature directly unblocks the production 500 on Opus 4.8. Removing topP/renaming to top_p-omitted is safe since it was already silently dropped. Adding max_tokens at the correct key name is a straightforward correctness fix. The downstream consumer (fetchLLMCompletion) passes undefined values transparently to ChatBedrockConverse, which omits them from the Bedrock request — exactly the desired behavior.

No files require special attention. utils.ts is the only changed file and the patch is narrow and well-contained.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ai-features): drop temperature/top\_p..."](https://github.com/langfuse/langfuse/commit/5dab2ade532fe6f66c82673a956d19b658cce478) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39326861)</sub>

<!-- /greptile_comment -->