### PR TITLE
fix(traces): Prevent text overflow in trace view

### DIFF
--- a/web/src/components/ui/CodeJsonViewer.tsx
+++ b/web/src/components/ui/CodeJsonViewer.tsx
@@ -91,7 +91,7 @@ export function JSONView(props: {
     <>
       <div
         className={cn(
-          "io-message-content flex gap-2 text-xs wrap-break-word whitespace-pre-wrap",
+          "io-message-content flex max-w-full min-w-0 gap-2 text-xs wrap-break-word whitespace-pre-wrap",
           props.borderless ? "" : "p-2",
           props.title === "assistant" || props.title === "Output"
             ? "bg-accent-light-green dark:border-accent-dark-green"
@@ -107,7 +107,7 @@ export function JSONView(props: {
           <Skeleton className="h-3 w-3/4" />
         ) : promptReferenceProjectId && typeof parsedJson === "string" ? (
           <code
-            className="wrap-break-word whitespace-pre-wrap"
+            className="max-w-full min-w-0 wrap-break-word whitespace-pre-wrap"
             dir="auto"
             style={{ unicodeBidi: "plaintext" }}
           >
@@ -115,6 +115,7 @@ export function JSONView(props: {
           </code>
         ) : (
           <div
+            className="max-w-full min-w-0 flex-1 overflow-hidden"
             onClick={() => {
               // If externally collapsed and user clicks to expand, sync the state
               if (props.externalJsonCollapsed && props.onToggleCollapse) {
@@ -140,7 +141,7 @@ export function JSONView(props: {
               displaySize={isCollapsed ? "collapsed" : "expanded"}
               matchesURL={true}
               customizeCopy={(node) => stringifyJsonNode(node)}
-              className="w-full"
+              className="w-full max-w-full min-w-0"
             />
           </div>
         )}
@@ -167,7 +168,7 @@ export function JSONView(props: {
   return (
     <div
       className={cn(
-        "flex max-h-full min-h-0 flex-col",
+        "flex max-h-full min-h-0 max-w-full min-w-0 flex-col",
         props.className,
         props.scrollable ? "overflow-hidden" : "",
       )}
@@ -199,8 +200,8 @@ export function JSONView(props: {
         />
       ) : null}
       {props.scrollable ? (
-        <div className="flex h-full min-h-0 overflow-hidden rounded-sm border">
-          <div className="max-h-full min-h-0 w-full overflow-y-auto">
+        <div className="flex h-full min-h-0 max-w-full overflow-hidden rounded-sm border">
+          <div className="max-h-full min-h-0 w-full max-w-full min-w-0 overflow-y-auto">
             {body}
           </div>
         </div>
@@ -268,7 +269,7 @@ export function CodeView(props: {
   return (
     <div
       className={cn(
-        "flex max-w-full flex-col",
+        "flex max-w-full min-w-0 flex-col",
         props.className,
         props.scrollable && "max-h-full min-h-0",
       )}
@@ -290,7 +291,7 @@ export function CodeView(props: {
       </>
       <div
         className={cn(
-          "relative flex flex-col gap-2 rounded-md border",
+          "relative flex max-w-full min-w-0 flex-col gap-2 overflow-hidden rounded-md border",
           props.scrollable ? "max-h-full min-h-0 overflow-hidden" : "",
         )}
       >
@@ -306,7 +307,7 @@ export function CodeView(props: {
         )}
         <code
           className={cn(
-            "relative flex-1 px-4 py-3 font-mono text-xs wrap-break-word whitespace-pre-wrap",
+            "relative max-w-full min-w-0 flex-1 px-4 py-3 font-mono text-xs wrap-break-word whitespace-pre-wrap",
             isCollapsed ? `line-clamp-6` : "block",
             props.scrollable ? "overflow-y-auto" : "",
           )}


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes text overflow in the trace/IO view by systematically applying `min-w-0` and `max-w-full` Tailwind classes to flex containers and their children in `CodeJsonViewer.tsx`. The `min-w-0` is the standard fix for flex children overflowing their parent, since flex items default to `min-width: auto`.

- **`JSONView`**: Adds `max-w-full min-w-0` to the outer wrapper, both scrollable inner divs, the `io-message-content` row, the prompt-reference `<code>` element, and the `React18JsonView` wrapper div (which also gains `flex-1 overflow-hidden` to ensure it fills and clips correctly).
- **`CodeView`**: Adds `min-w-0` to the outer wrapper, the inner border container (plus `overflow-hidden`), and the `<code>` element.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Pure Tailwind class additions with no logic changes; the standard flex-overflow pattern is applied consistently across all affected containers.

All changes are additive CSS utility classes. The `min-w-0` / `max-w-full` pattern is well-established for fixing flex overflow, and the additions are applied uniformly to every relevant container in both `JSONView` and `CodeView`. No logic, state, or API surface is altered.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["JSONView root div\n(max-w-full min-w-0)"]
    A --> B["MarkdownJsonViewHeader"]
    A --> C["Scrollable wrapper div\n(max-w-full)"]
    C --> D["Scroll inner div\n(max-w-full min-w-0)"]
    D --> E["body fragment"]
    A --> E2["body fragment (non-scrollable)"]
    E --> F["io-message-content div\n(max-w-full min-w-0)"]
    E2 --> F
    F --> G{Content type}
    G -- "prompt ref string" --> H["code element\n(max-w-full min-w-0)"]
    G -- "JSON / other" --> I["wrapper div\n(max-w-full min-w-0 flex-1 overflow-hidden)"]
    I --> J["React18JsonView\n(w-full max-w-full min-w-0)"]
    K["CodeView root div\n(max-w-full min-w-0)"]
    K --> L["border container\n(max-w-full min-w-0 overflow-hidden)"]
    L --> M["code element\n(max-w-full min-w-0)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["JSONView root div\n(max-w-full min-w-0)"]
    A --> B["MarkdownJsonViewHeader"]
    A --> C["Scrollable wrapper div\n(max-w-full)"]
    C --> D["Scroll inner div\n(max-w-full min-w-0)"]
    D --> E["body fragment"]
    A --> E2["body fragment (non-scrollable)"]
    E --> F["io-message-content div\n(max-w-full min-w-0)"]
    E2 --> F
    F --> G{Content type}
    G -- "prompt ref string" --> H["code element\n(max-w-full min-w-0)"]
    G -- "JSON / other" --> I["wrapper div\n(max-w-full min-w-0 flex-1 overflow-hidden)"]
    I --> J["React18JsonView\n(w-full max-w-full min-w-0)"]
    K["CodeView root div\n(max-w-full min-w-0)"]
    K --> L["border container\n(max-w-full min-w-0 overflow-hidden)"]
    L --> M["code element\n(max-w-full min-w-0)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traces): Prevent text overflow in tr..."](https://github.com/langfuse/langfuse/commit/87b4ecc0af65c0f09cb7f75deb1f0df1f4864132) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39328681)</sub>

<!-- /greptile_comment -->