### PR TITLE
chore(web): make Storybook render like the app (#__next scaffold + overlay layers + CSS)

### DIFF
--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -2,7 +2,12 @@ import { definePreview } from "@storybook/nextjs-vite";
 import addonA11y from "@storybook/addon-a11y";
 import { useEffect, type ReactNode } from "react";
 import { TooltipProvider } from "../src/components/ui/tooltip";
+import { LAYER_ORDER } from "../src/components/ui/layer";
 import "../src/styles/globals.css";
+// Mirror the global CSS that _app.tsx imports so vendored components
+// (react18-json-view, streamdown markdown) render identically to the app.
+import "react18-json-view/src/style.css";
+import "streamdown/styles.css";
 
 function StorybookThemeProvider({
   children,
@@ -19,8 +24,34 @@ function StorybookThemeProvider({
     };
   }, [theme]);
 
+  // Reproduce the app's DOM scaffold so the layout rules in globals.css that are
+  // scoped to `div#__next` / `div#__next > div` (height: 100%) and
+  // `div#__next { isolation: isolate }` actually apply — the app's tables live
+  // inside `#__next > div`, and without this scaffold Storybook only loosely
+  // approximated the height/isolation/stacking context (see _document.tsx +
+  // _app.tsx). `#__next` is given a real viewport height so the `height: 100%`
+  // chain has something to resolve against.
   return (
-    <div className="bg-background text-foreground min-h-screen">{children}</div>
+    <>
+      <div
+        id="__next"
+        className="bg-background text-foreground"
+        style={{ height: "100vh" }}
+      >
+        <div>{children}</div>
+      </div>
+      {/* Overlay layer containers, declared exactly like _document.tsx: a
+          <div data-overlay-root> sibling AFTER #__next (so it paints on top by
+          DOM order), holding one <div data-layer={name}/> per LAYER_ORDER. This
+          is what the layer system (components/ui/layer.tsx) portals toasts /
+          tooltips / peek into; without it those overlays are absent in
+          Storybook. Positioning/isolation comes from globals.css. */}
+      <div data-overlay-root>
+        {LAYER_ORDER.map((name) => (
+          <div key={name} data-layer={name} />
+        ))}
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

Components (e.g. tables) render differently in Storybook than in the app — typography, spacing, random differences — which makes it impossible to catch/fix visual bugs in the harness.

`preview.tsx` now reproduces the app's DOM/CSS context: wraps every story in the real `<div id="__next"><div>…</div></div>` scaffold (so the `globals.css` rules scoped to `#__next` / `#__next > div` — `height:100%` + `isolation:isolate` — actually apply), renders the `data-overlay-root` + `LAYER_ORDER` containers like `_document.tsx` (so the layer system works), and imports the same global CSS `_app.tsx` loads (`react18-json-view`, `streamdown`).

Verified: computed styles on the shared `DataTable` (font-family/size/weight/line-height/padding/border/header-height) are now byte-identical between Storybook and the app.

LFE-10467

## Type of change
- [x] Chore (tooling / repo upkeep)

## Mandatory Tasks
- [x] Self-reviewed the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes Storybook rendering fidelity by making `preview.tsx` reproduce the app's real DOM scaffold and CSS context so computed styles match the live app exactly.

- Wraps every story in `<div id="__next"><div>…</div></div>` (mirroring `_document.tsx`'s `<Main />` output) with `height: 100vh` so the `height: 100%` chain in `globals.css` resolves correctly, and adds `isolation: isolate` scoping via the existing CSS selector.
- Adds sibling `<div data-overlay-root>` with per-layer containers (matching `_document.tsx` exactly) so `<Layer>` portals (tooltips, peek panels) have their target containers in Storybook.
- Imports `react18-json-view` and `streamdown` stylesheets that `_app.tsx` also imports, ensuring vendor component styles are present.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Storybook-only configuration change with no effect on production code paths.

The change is confined to `preview.tsx`, a Storybook harness file that has no impact on the production build. The DOM scaffold added exactly mirrors `_document.tsx` and `_app.tsx`, the CSS imports match what `_app.tsx` already loads, and the overlay layer containers are copied verbatim from the document template. All top-level import placement follows the repository convention. No production logic is touched.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Storybook["Storybook Canvas (preview.tsx)"]
        direction TB
        Decorator["decorator(Story, context)"]
        STP["StorybookThemeProvider\n(theme: light | dark)"]
        Next["div#__next (height:100vh)"]
        Inner["div (mirrors #__next > div)"]
        TP["TooltipProvider"]
        Story["Story"]
        Overlay["div data-overlay-root"]
        Layer["div data-layer per LAYER_ORDER"]

        Decorator --> STP
        STP --> Next
        Next --> Inner
        Inner --> TP
        TP --> Story
        STP --> Overlay
        Overlay --> Layer
    end

    subgraph App["Real Next.js App"]
        direction TB
        Body["body"]
        MainNext["div#__next (Next.js Main)"]
        MainInner["div (app layout)"]
        OverlayReal["div data-overlay-root"]
        LayerReal["div data-layer per LAYER_ORDER"]

        Body --> MainNext
        MainNext --> MainInner
        Body --> OverlayReal
        OverlayReal --> LayerReal
    end

    STP -. mirrors .-> Body
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Storybook["Storybook Canvas (preview.tsx)"]
        direction TB
        Decorator["decorator(Story, context)"]
        STP["StorybookThemeProvider\n(theme: light | dark)"]
        Next["div#__next (height:100vh)"]
        Inner["div (mirrors #__next > div)"]
        TP["TooltipProvider"]
        Story["Story"]
        Overlay["div data-overlay-root"]
        Layer["div data-layer per LAYER_ORDER"]

        Decorator --> STP
        STP --> Next
        Next --> Inner
        Inner --> TP
        TP --> Story
        STP --> Overlay
        Overlay --> Layer
    end

    subgraph App["Real Next.js App"]
        direction TB
        Body["body"]
        MainNext["div#__next (Next.js Main)"]
        MainInner["div (app layout)"]
        OverlayReal["div data-overlay-root"]
        LayerReal["div data-layer per LAYER_ORDER"]

        Body --> MainNext
        MainNext --> MainInner
        Body --> OverlayReal
        OverlayReal --> LayerReal
    end

    STP -. mirrors .-> Body
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(table): make storybook render like ..."](https://github.com/langfuse/langfuse/commit/73f6b6c3cd66b07379114054399dbc7c720b5a16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39337045)</sub>

<!-- /greptile_comment -->