### PR TITLE
fix(web): contain long provider error in New LLM Connection modal

### DIFF
--- a/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
+++ b/web/src/features/public-api/components/CreateLLMApiKeyForm.tsx
@@ -1377,7 +1377,7 @@ export function CreateLLMApiKeyForm({
         </DialogBody>
 
         <DialogFooter>
-          <div className="flex flex-col gap-4">
+          <div className="flex min-w-0 flex-col gap-4">
             {showOtherModelInfo ? (
               <Button
                 type="button"
@@ -1396,7 +1396,11 @@ export function CreateLLMApiKeyForm({
               </Button>
             )}
             {form.formState.errors.root && (
-              <FormMessage>{form.formState.errors.root.message}</FormMessage>
+              <div className="max-h-32 overflow-y-auto">
+                <FormMessage className="break-words wrap-anywhere">
+                  {form.formState.errors.root.message}
+                </FormMessage>
+              </div>
             )}
           </div>
         </DialogFooter>


### PR DESCRIPTION
Fixes LF-2200.

The provider verification error in the **New LLM Connection** modal (Settings → LLM Connections) was rendered as an unconstrained paragraph in the dialog footer. A long provider error with unbreakable URL tokens (e.g. an OpenAI quota error) overflowed past the modal's left, right, and bottom edges.

**Fix** (`web/src/features/public-api/components/CreateLLMApiKeyForm.tsx`):
- Wrap long URLs with `break-words wrap-anywhere` so they break inside the modal.
- Cap the error region with `max-h-32 overflow-y-auto` so a very long error scrolls inside the dialog instead of growing past the bottom edge.
- Add `min-w-0` to the footer column so it can shrink rather than forcing horizontal overflow.

The `Create connection` button stays in place.

Verified with Playwright on a local dev instance by mocking a long quota error from `llmApiKey.test`: before, the error spilled past the modal on the left/right/bottom; after, it wraps and scrolls fully contained (footer + error inside the dialog bounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an overflow bug in the New LLM Connection modal where a long provider error message (e.g. an OpenAI quota error with an unbreakable URL) would spill outside the dialog bounds horizontally and vertically.

- `min-w-0` is added to the footer flex column so it can shrink below its natural content width, preventing horizontal overflow.
- The error `FormMessage` is wrapped in a `max-h-32 overflow-y-auto` div to cap vertical growth and add scrolling, and `break-words wrap-anywhere` is applied to handle mid-word line breaks for long URLs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is narrowly scoped to CSS classes in a single dialog footer, with no logic, data, or API changes. Safe to merge.

Only three Tailwind utility classes are added/changed in a visual-only component. The redundant `break-words` alongside `wrap-anywhere` is harmless at runtime since `wrap-anywhere` wins the cascade.

No files require special attention.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DialogFooter] --> B["div.flex.min-w-0.flex-col.gap-4"]
    B --> C{showOtherModelInfo?}
    C -- Yes --> D["Button: Select an adapter"]
    C -- No --> E["Button: Create connection / Save changes"]
    B --> F{form.formState.errors.root?}
    F -- Yes --> G["div.max-h-32.overflow-y-auto"]
    G --> H["FormMessage.wrap-anywhere\n(error text wraps and scrolls)"]
    F -- No --> I[Nothing rendered]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[DialogFooter] --> B["div.flex.min-w-0.flex-col.gap-4"]
    B --> C{showOtherModelInfo?}
    C -- Yes --> D["Button: Select an adapter"]
    C -- No --> E["Button: Create connection / Save changes"]
    B --> F{form.formState.errors.root?}
    F -- Yes --> G["div.max-h-32.overflow-y-auto"]
    G --> H["FormMessage.wrap-anywhere\n(error text wraps and scrolls)"]
    F -- No --> I[Nothing rendered]
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
web/src/features/public-api/components/CreateLLMApiKeyForm.tsx:1400
Both `break-words` (`overflow-wrap: break-word`) and `wrap-anywhere` (`overflow-wrap: anywhere`) target the same CSS property. Since they have equal specificity, the one generated later in Tailwind's stylesheet wins — which will be `wrap-anywhere`. The `break-words` class is therefore redundant here. `wrap-anywhere` is the right choice (it also factors in mid-word breaks when computing the element's intrinsic size, which is what you want for long URLs), so `break-words` can be dropped.

```suggestion
                <FormMessage className="wrap-anywhere">
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): contain long provider error in..."](https://github.com/langfuse/langfuse/commit/41382cbcee85173ddc26220a3450875b78fdb3f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39498487)</sub>

<!-- /greptile_comment -->