### PR TITLE
fix(prompts): auto-scroll the new-version editor on selection drag

### DIFF
--- a/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.tsx
@@ -31,6 +31,7 @@ import {
 } from "@langfuse/shared";
 import { lightTheme } from "@/src/components/editor/light-theme";
 import { darkTheme } from "@/src/components/editor/dark-theme";
+import { autoScrollOnSelectionDrag } from "@/src/components/editor/autoScrollOnSelectionDrag";
 
 // Custom language mode for prompts that highlights mustache variables and prompt dependency tags
 const promptLanguage = StreamLanguage.define({
@@ -465,6 +466,9 @@ export function CodeMirrorEditor({
       // `editable` DOM facet alone does not always prevent paste (see CM6
       // EditorState.readOnly vs EditorView.editable).
       ...(!editable ? [EditorState.readOnly.of(true)] : []),
+      // Restore native-textarea-like auto-scroll when a selection drag reaches
+      // the editor's top/bottom edge (CodeMirror doesn't do this on its own).
+      autoScrollOnSelectionDrag(),
       searchHighlightingSupport,
       search(),
       // RTL/bidi support - must be early for proper line decoration

--- a/web/src/components/editor/CodeMirrorEditor.tsx
+++ b/web/src/components/editor/CodeMirrorEditor.tsx
@@ -468,7 +468,10 @@ export function CodeMirrorEditor({
       ...(!editable ? [EditorState.readOnly.of(true)] : []),
       // Restore native-textarea-like auto-scroll when a selection drag reaches
       // the editor's top/bottom edge (CodeMirror doesn't do this on its own).
-      autoScrollOnSelectionDrag(),
+      // Editable-only: read-only editors (JSON viewers, version panels) already
+      // auto-scroll natively, and we don't want their window-level mousemove/
+      // mouseup capture listeners registering on every drag.
+      ...(editable ? [autoScrollOnSelectionDrag()] : []),
       searchHighlightingSupport,
       search(),
       // RTL/bidi support - must be early for proper line decoration

--- a/web/src/components/editor/PromptLinkingEditor.tsx
+++ b/web/src/components/editor/PromptLinkingEditor.tsx
@@ -12,6 +12,7 @@ type PromptLinkingEditorProps = {
   onChange?: (value: string) => void;
   onBlur?: () => void;
   minHeight?: number | string;
+  maxHeight?: number | string;
   className?: string;
 };
 
@@ -20,6 +21,7 @@ export function PromptLinkingEditor({
   onChange,
   onBlur,
   minHeight,
+  maxHeight = "60vh",
   className,
 }: PromptLinkingEditorProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -61,6 +63,7 @@ export function PromptLinkingEditor({
         onBlur={onBlur}
         mode="prompt"
         minHeight={minHeight}
+        maxHeight={maxHeight}
         className={className}
         editorRef={editorRef}
       />

--- a/web/src/components/editor/autoScrollOnSelectionDrag.ts
+++ b/web/src/components/editor/autoScrollOnSelectionDrag.ts
@@ -1,0 +1,120 @@
+import { EditorView } from "@uiw/react-codemirror";
+import { type Extension } from "@codemirror/state";
+
+// Distance (px) from the scroller's top/bottom edge within which a drag starts
+// auto-scrolling. Also covers the case where the pointer is dragged past the
+// edge entirely (negative distance), which is the standard "drag to select
+// beyond the visible text" gesture.
+const EDGE_THRESHOLD_PX = 24;
+// Maximum scroll speed in px per animation frame at/over the edge. The speed
+// ramps from 0 at the threshold up to this value as the pointer approaches and
+// passes the edge.
+const MAX_SCROLL_STEP_PX = 16;
+
+/**
+ * CodeMirror does not natively auto-scroll the editor when a text-selection
+ * drag reaches the top or bottom edge of its scroll container (`.cm-scroller`).
+ * Plain `<textarea>`/`<code>` elements get this from the browser for free, which
+ * is why the read-only prompt viewer scrolls on drag but the editor does not.
+ *
+ * This extension restores the standard behavior: while the primary button is
+ * held down after a mousedown inside the editor, if the pointer sits near or
+ * past the scroller's top/bottom edge we continuously scroll the scroller in
+ * that direction and extend the selection to the new pointer position, so the
+ * selection keeps growing as the content scrolls.
+ *
+ * The gesture-tracking listeners are attached to `window` for the duration of
+ * the drag so scrolling continues even when the pointer leaves the editor
+ * bounds (the common case when dragging "past" the edge).
+ */
+export function autoScrollOnSelectionDrag(): Extension {
+  return EditorView.domEventHandlers({
+    mousedown(event, view) {
+      // Only react to the primary (left) button selection drag.
+      if (event.button !== 0) return false;
+
+      const scroller = view.scrollDOM;
+      let lastClientX = event.clientX;
+      let lastClientY = event.clientY;
+      let frame: number | null = null;
+
+      const step = () => {
+        frame = null;
+        const rect = scroller.getBoundingClientRect();
+        const distanceFromTop = lastClientY - rect.top;
+        const distanceFromBottom = rect.bottom - lastClientY;
+
+        let delta = 0;
+        if (distanceFromTop < EDGE_THRESHOLD_PX) {
+          // Near/above the top edge: scroll up. Ramp speed as we approach and
+          // pass the edge, clamped to the max step.
+          const intensity = Math.min(
+            1,
+            (EDGE_THRESHOLD_PX - distanceFromTop) / EDGE_THRESHOLD_PX,
+          );
+          delta = -Math.ceil(intensity * MAX_SCROLL_STEP_PX);
+        } else if (distanceFromBottom < EDGE_THRESHOLD_PX) {
+          // Near/below the bottom edge: scroll down.
+          const intensity = Math.min(
+            1,
+            (EDGE_THRESHOLD_PX - distanceFromBottom) / EDGE_THRESHOLD_PX,
+          );
+          delta = Math.ceil(intensity * MAX_SCROLL_STEP_PX);
+        }
+
+        if (delta === 0) return; // Pointer back inside the safe zone; idle.
+
+        const before = scroller.scrollTop;
+        scroller.scrollTop = before + delta;
+        if (scroller.scrollTop === before) {
+          // Hit the top/bottom of the document; nothing more to scroll.
+          return;
+        }
+
+        // Extend the selection to the position under the (clamped) pointer so
+        // the highlighted range keeps growing with the scroll. Clamp Y into the
+        // scroller so posAtCoords resolves to the first/last visible line.
+        const rectAfter = scroller.getBoundingClientRect();
+        const clampedY = Math.max(
+          rectAfter.top + 1,
+          Math.min(rectAfter.bottom - 1, lastClientY),
+        );
+        const pos = view.posAtCoords({ x: lastClientX, y: clampedY });
+        if (pos !== null) {
+          view.dispatch({
+            selection: { anchor: view.state.selection.main.anchor, head: pos },
+          });
+        }
+
+        frame = requestAnimationFrame(step);
+      };
+
+      const onMove = (e: MouseEvent) => {
+        // Drag ended elsewhere without us seeing mouseup (e.g. button released
+        // off-window); stop if no buttons are pressed.
+        if (e.buttons === 0) {
+          stop();
+          return;
+        }
+        lastClientX = e.clientX;
+        lastClientY = e.clientY;
+        if (frame === null) frame = requestAnimationFrame(step);
+      };
+
+      const stop = () => {
+        if (frame !== null) {
+          cancelAnimationFrame(frame);
+          frame = null;
+        }
+        window.removeEventListener("mousemove", onMove, true);
+        window.removeEventListener("mouseup", stop, true);
+      };
+
+      window.addEventListener("mousemove", onMove, true);
+      window.addEventListener("mouseup", stop, true);
+
+      // Don't consume the event; CodeMirror still drives normal selection.
+      return false;
+    },
+  });
+}

--- a/web/src/components/editor/autoScrollOnSelectionDrag.ts
+++ b/web/src/components/editor/autoScrollOnSelectionDrag.ts
@@ -34,16 +34,20 @@ export function autoScrollOnSelectionDrag(): Extension {
       if (event.button !== 0) return false;
 
       // Only drive selection ourselves for a plain single-range character drag.
-      // For advanced gestures — alt+drag rectangular selection (multi-range) and
-      // double/triple-click word/line selection (`detail > 1`, boundary-snapped) —
-      // a single-range `{anchor, head}` dispatch would collapse the rectangle and
-      // drop the snapping. In those modes we still auto-scroll but leave selection
-      // extension to CodeMirror's own `pointerSelection` (the scroll moves content
-      // under the pointer; CM's next mousemove extends with the right granularity).
+      // For advanced gestures — alt+drag rectangular selection (multi-range),
+      // double/triple-click word/line selection (`detail > 1`, boundary-snapped),
+      // and mod+click multi-cursor (Cmd on macOS / Ctrl elsewhere, which adds a
+      // new selection range) — a single-range `{anchor, head}` dispatch would
+      // collapse the rectangle/multi-cursor and drop the snapping. In those modes
+      // we still auto-scroll but leave selection extension to CodeMirror's own
+      // `pointerSelection` (the scroll moves content under the pointer; CM's next
+      // mousemove extends with the right granularity).
       const driveSelection =
         view.state.selection.ranges.length === 1 &&
         event.detail === 1 &&
-        !event.altKey;
+        !event.altKey &&
+        !event.metaKey &&
+        !event.ctrlKey;
 
       const scroller = view.scrollDOM;
       let lastClientX = event.clientX;

--- a/web/src/components/editor/autoScrollOnSelectionDrag.ts
+++ b/web/src/components/editor/autoScrollOnSelectionDrag.ts
@@ -112,8 +112,10 @@ export function autoScrollOnSelectionDrag(): Extension {
 
       const onMove = (e: MouseEvent) => {
         // Drag ended elsewhere without us seeing mouseup (e.g. button released
-        // off-window); stop if no buttons are pressed.
-        if (e.buttons === 0) {
+        // off-window); stop once the primary button is released. Only the
+        // primary bit matters — a secondary/middle button held or released
+        // mid-drag must not end the gesture.
+        if ((e.buttons & 1) === 0) {
           stop();
           return;
         }
@@ -128,11 +130,19 @@ export function autoScrollOnSelectionDrag(): Extension {
           frame = null;
         }
         window.removeEventListener("mousemove", onMove, true);
-        window.removeEventListener("mouseup", stop, true);
+        window.removeEventListener("mouseup", onUp, true);
+      };
+
+      // Only the primary button's release ends the gesture; releasing a stray
+      // secondary/middle button mid-drag must not tear down auto-scroll while
+      // the primary is still held. `stop` itself stays callable without an
+      // event for the `onMove` (off-window release) path.
+      const onUp = (e: MouseEvent) => {
+        if (e.button === 0) stop();
       };
 
       window.addEventListener("mousemove", onMove, true);
-      window.addEventListener("mouseup", stop, true);
+      window.addEventListener("mouseup", onUp, true);
 
       // Don't consume the event; CodeMirror still drives normal selection.
       return false;

--- a/web/src/components/editor/autoScrollOnSelectionDrag.ts
+++ b/web/src/components/editor/autoScrollOnSelectionDrag.ts
@@ -67,12 +67,17 @@ class AutoScrollOnSelectionDrag {
     // we still auto-scroll but leave selection extension to CodeMirror's own
     // `pointerSelection` (the scroll moves content under the pointer; CM's next
     // mousemove extends with the right granularity).
-    const driveSelection =
-      view.state.selection.ranges.length === 1 &&
-      event.detail === 1 &&
-      !event.altKey &&
-      !event.metaKey &&
-      !event.ctrlKey;
+    //
+    // Captured at mousedown: the modifier/detail flags correctly identify "not a
+    // multi-range *gesture*" — they describe this click and won't change during
+    // the drag. The `ranges.length === 1` half is deliberately NOT captured
+    // here: this handler runs before CM's `pointerSelection` commits, so the
+    // selection still reflects the pre-click state (e.g. a stale 2-range
+    // multi-cursor that a plain click is about to collapse to one range). We
+    // therefore re-read `ranges.length` live inside `step()`, immediately before
+    // the dispatch, instead of trusting this pre-click snapshot.
+    const isSingleRangeGesture =
+      event.detail === 1 && !event.altKey && !event.metaKey && !event.ctrlKey;
 
     const scroller = view.scrollDOM;
     let lastClientX = event.clientX;
@@ -113,7 +118,14 @@ class AutoScrollOnSelectionDrag {
       // highlighted range keeps growing with the scroll. Clamp Y into the
       // scroller so posAtCoords resolves to the first/last visible line. Only
       // for the plain single-range drag; advanced gestures are left to CM.
-      if (scrolled && driveSelection) {
+      // `ranges.length` is read live here (not captured at mousedown) so a
+      // pre-click multi-cursor that a plain click has since collapsed to one
+      // range is handled correctly — by dispatch time the selection is current.
+      if (
+        scrolled &&
+        isSingleRangeGesture &&
+        view.state.selection.ranges.length === 1
+      ) {
         const rectAfter = scroller.getBoundingClientRect();
         const clampedY = Math.max(
           rectAfter.top + 1,

--- a/web/src/components/editor/autoScrollOnSelectionDrag.ts
+++ b/web/src/components/editor/autoScrollOnSelectionDrag.ts
@@ -1,4 +1,4 @@
-import { EditorView } from "@uiw/react-codemirror";
+import { type EditorView, ViewPlugin } from "@uiw/react-codemirror";
 import { type Extension } from "@codemirror/state";
 
 // Distance (px) from the scroller's top/bottom edge within which a drag starts
@@ -17,139 +17,187 @@ const MAX_SCROLL_STEP_PX = 16;
  * Plain `<textarea>`/`<code>` elements get this from the browser for free, which
  * is why the read-only prompt viewer scrolls on drag but the editor does not.
  *
- * This extension restores the standard behavior: while the primary button is
- * held down after a mousedown inside the editor, if the pointer sits near or
- * past the scroller's top/bottom edge we continuously scroll the scroller in
- * that direction and extend the selection to the new pointer position, so the
+ * This plugin restores the standard behavior: while the primary button is held
+ * down after a mousedown inside the editor, if the pointer sits near or past
+ * the scroller's top/bottom edge we continuously scroll the scroller in that
+ * direction and extend the selection to the new pointer position, so the
  * selection keeps growing as the content scrolls.
  *
  * The gesture-tracking listeners are attached to `window` for the duration of
  * the drag so scrolling continues even when the pointer leaves the editor
- * bounds (the common case when dragging "past" the edge).
+ * bounds (the common case when dragging "past" the edge). Because those
+ * window-level listeners and the `requestAnimationFrame` loop are our own side
+ * effect — `EditorView` only manages handlers it registered on its own DOM —
+ * they must be torn down explicitly if the view is destroyed mid-drag (parent
+ * re-render, route change, dialog/sheet close while the primary button is still
+ * held). We therefore live as a `ViewPlugin` and tear down the active drag from
+ * its `destroy()` hook, mirroring how CodeMirror's own `MouseSelection` cleans
+ * up. The normal end-of-gesture teardown still runs on the primary `mouseup`
+ * (or when `onMove` sees the primary button released).
  */
-export function autoScrollOnSelectionDrag(): Extension {
-  return EditorView.domEventHandlers({
-    mousedown(event, view) {
-      // Only react to the primary (left) button selection drag.
-      if (event.button !== 0) return false;
+class AutoScrollOnSelectionDrag {
+  // Cleanup for the currently active drag, if any. There is at most one active
+  // drag at a time: starting a new one stops the prior, and the gesture clears
+  // this back to null when it ends. The view's `destroy()` invokes it.
+  private activeStop: (() => void) | null = null;
 
-      // Only drive selection ourselves for a plain single-range character drag.
-      // For advanced gestures — alt+drag rectangular selection (multi-range),
-      // double/triple-click word/line selection (`detail > 1`, boundary-snapped),
-      // and mod+click multi-cursor (Cmd on macOS / Ctrl elsewhere, which adds a
-      // new selection range) — a single-range `{anchor, head}` dispatch would
-      // collapse the rectangle/multi-cursor and drop the snapping. In those modes
-      // we still auto-scroll but leave selection extension to CodeMirror's own
-      // `pointerSelection` (the scroll moves content under the pointer; CM's next
-      // mousemove extends with the right granularity).
-      const driveSelection =
-        view.state.selection.ranges.length === 1 &&
-        event.detail === 1 &&
-        !event.altKey &&
-        !event.metaKey &&
-        !event.ctrlKey;
+  constructor(private readonly view: EditorView) {}
 
-      const scroller = view.scrollDOM;
-      let lastClientX = event.clientX;
-      let lastClientY = event.clientY;
-      let frame: number | null = null;
+  // Wired as the plugin's `mousedown` event handler (see `eventHandlers`
+  // below). CodeMirror registers/unregisters this on the editor DOM itself, so
+  // it preserves the original `domEventHandlers({ mousedown })` semantics:
+  // it's non-consuming (CodeMirror still drives normal selection) and is torn
+  // down with the view automatically.
+  mousedown(event: MouseEvent) {
+    const view = this.view;
 
-      const step = () => {
+    // Only react to the primary (left) button selection drag.
+    if (event.button !== 0) return;
+
+    // Tear down any prior drag before starting a new one so there is only ever
+    // one set of window listeners / rAF loop tracked at a time.
+    if (this.activeStop !== null) this.activeStop();
+
+    // Only drive selection ourselves for a plain single-range character drag.
+    // For advanced gestures — alt+drag rectangular selection (multi-range),
+    // double/triple-click word/line selection (`detail > 1`, boundary-snapped),
+    // and mod+click multi-cursor (Cmd on macOS / Ctrl elsewhere, which adds a
+    // new selection range) — a single-range `{anchor, head}` dispatch would
+    // collapse the rectangle/multi-cursor and drop the snapping. In those modes
+    // we still auto-scroll but leave selection extension to CodeMirror's own
+    // `pointerSelection` (the scroll moves content under the pointer; CM's next
+    // mousemove extends with the right granularity).
+    const driveSelection =
+      view.state.selection.ranges.length === 1 &&
+      event.detail === 1 &&
+      !event.altKey &&
+      !event.metaKey &&
+      !event.ctrlKey;
+
+    const scroller = view.scrollDOM;
+    let lastClientX = event.clientX;
+    let lastClientY = event.clientY;
+    let frame: number | null = null;
+
+    const step = () => {
+      frame = null;
+      const rect = scroller.getBoundingClientRect();
+      const distanceFromTop = lastClientY - rect.top;
+      const distanceFromBottom = rect.bottom - lastClientY;
+
+      let delta = 0;
+      if (distanceFromTop < EDGE_THRESHOLD_PX) {
+        // Near/above the top edge: scroll up. Ramp speed as we approach and
+        // pass the edge, clamped to the max step.
+        const intensity = Math.min(
+          1,
+          (EDGE_THRESHOLD_PX - distanceFromTop) / EDGE_THRESHOLD_PX,
+        );
+        delta = -Math.ceil(intensity * MAX_SCROLL_STEP_PX);
+      } else if (distanceFromBottom < EDGE_THRESHOLD_PX) {
+        // Near/below the bottom edge: scroll down.
+        const intensity = Math.min(
+          1,
+          (EDGE_THRESHOLD_PX - distanceFromBottom) / EDGE_THRESHOLD_PX,
+        );
+        delta = Math.ceil(intensity * MAX_SCROLL_STEP_PX);
+      }
+
+      if (delta === 0) return; // Pointer back inside the safe zone; idle.
+
+      const before = scroller.scrollTop;
+      scroller.scrollTop = before + delta;
+      const scrolled = scroller.scrollTop !== before;
+
+      // Extend the selection to the position under the (clamped) pointer so the
+      // highlighted range keeps growing with the scroll. Clamp Y into the
+      // scroller so posAtCoords resolves to the first/last visible line. Only
+      // for the plain single-range drag; advanced gestures are left to CM.
+      if (scrolled && driveSelection) {
+        const rectAfter = scroller.getBoundingClientRect();
+        const clampedY = Math.max(
+          rectAfter.top + 1,
+          Math.min(rectAfter.bottom - 1, lastClientY),
+        );
+        const pos = view.posAtCoords({ x: lastClientX, y: clampedY });
+        if (pos !== null) {
+          view.dispatch({
+            selection: {
+              anchor: view.state.selection.main.anchor,
+              head: pos,
+            },
+          });
+        }
+      }
+
+      // Keep the loop alive while the pointer is past the edge (`delta !== 0`),
+      // even if the scroller is already at the top/bottom and didn't move.
+      // Otherwise, if the pointer is held still past the edge, no mousemove
+      // fires to restart the loop and scrolling never resumes when the user
+      // drags back — native textareas resume immediately. This only runs during
+      // an active drag and ends on mouseup (or when delta returns to 0).
+      frame = requestAnimationFrame(step);
+    };
+
+    const onMove = (e: MouseEvent) => {
+      // Drag ended elsewhere without us seeing mouseup (e.g. button released
+      // off-window); stop once the primary button is released. Only the primary
+      // bit matters — a secondary/middle button held or released mid-drag must
+      // not end the gesture.
+      if ((e.buttons & 1) === 0) {
+        stop();
+        return;
+      }
+      lastClientX = e.clientX;
+      lastClientY = e.clientY;
+      if (frame === null) frame = requestAnimationFrame(step);
+    };
+
+    const stop = () => {
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
         frame = null;
-        const rect = scroller.getBoundingClientRect();
-        const distanceFromTop = lastClientY - rect.top;
-        const distanceFromBottom = rect.bottom - lastClientY;
+      }
+      window.removeEventListener("mousemove", onMove, true);
+      window.removeEventListener("mouseup", onUp, true);
+      // Clear the plugin-tracked handle if this drag still owns it, so a later
+      // `destroy()` doesn't call a stale stop and a new drag starts clean.
+      if (this.activeStop === stop) this.activeStop = null;
+    };
 
-        let delta = 0;
-        if (distanceFromTop < EDGE_THRESHOLD_PX) {
-          // Near/above the top edge: scroll up. Ramp speed as we approach and
-          // pass the edge, clamped to the max step.
-          const intensity = Math.min(
-            1,
-            (EDGE_THRESHOLD_PX - distanceFromTop) / EDGE_THRESHOLD_PX,
-          );
-          delta = -Math.ceil(intensity * MAX_SCROLL_STEP_PX);
-        } else if (distanceFromBottom < EDGE_THRESHOLD_PX) {
-          // Near/below the bottom edge: scroll down.
-          const intensity = Math.min(
-            1,
-            (EDGE_THRESHOLD_PX - distanceFromBottom) / EDGE_THRESHOLD_PX,
-          );
-          delta = Math.ceil(intensity * MAX_SCROLL_STEP_PX);
-        }
+    // Only the primary button's release ends the gesture; releasing a stray
+    // secondary/middle button mid-drag must not tear down auto-scroll while the
+    // primary is still held. `stop` itself stays callable without an event for
+    // the `onMove` (off-window release) and `destroy()` paths.
+    const onUp = (e: MouseEvent) => {
+      if (e.button === 0) stop();
+    };
 
-        if (delta === 0) return; // Pointer back inside the safe zone; idle.
+    window.addEventListener("mousemove", onMove, true);
+    window.addEventListener("mouseup", onUp, true);
 
-        const before = scroller.scrollTop;
-        scroller.scrollTop = before + delta;
-        const scrolled = scroller.scrollTop !== before;
+    // Track this drag so the view's `destroy()` can tear it down if the editor
+    // unmounts before the primary button is released.
+    this.activeStop = stop;
 
-        // Extend the selection to the position under the (clamped) pointer so
-        // the highlighted range keeps growing with the scroll. Clamp Y into the
-        // scroller so posAtCoords resolves to the first/last visible line. Only
-        // for the plain single-range drag; advanced gestures are left to CM.
-        if (scrolled && driveSelection) {
-          const rectAfter = scroller.getBoundingClientRect();
-          const clampedY = Math.max(
-            rectAfter.top + 1,
-            Math.min(rectAfter.bottom - 1, lastClientY),
-          );
-          const pos = view.posAtCoords({ x: lastClientX, y: clampedY });
-          if (pos !== null) {
-            view.dispatch({
-              selection: {
-                anchor: view.state.selection.main.anchor,
-                head: pos,
-              },
-            });
-          }
-        }
+    // Don't consume the event; CodeMirror still drives normal selection.
+  }
 
-        // Keep the loop alive while the pointer is past the edge (`delta !== 0`),
-        // even if the scroller is already at the top/bottom and didn't move.
-        // Otherwise, if the pointer is held still past the edge, no mousemove
-        // fires to restart the loop and scrolling never resumes when the user
-        // drags back — native textareas resume immediately. This only runs
-        // during an active drag and ends on mouseup (or when delta returns to 0).
-        frame = requestAnimationFrame(step);
-      };
+  destroy() {
+    // View destroyed mid-drag (parent re-render, route change, dialog/sheet
+    // close while the primary button is still held): tear down the active
+    // drag's window listeners and rAF loop. CodeMirror removes the `mousedown`
+    // handler it registered for us.
+    if (this.activeStop !== null) this.activeStop();
+  }
+}
 
-      const onMove = (e: MouseEvent) => {
-        // Drag ended elsewhere without us seeing mouseup (e.g. button released
-        // off-window); stop once the primary button is released. Only the
-        // primary bit matters — a secondary/middle button held or released
-        // mid-drag must not end the gesture.
-        if ((e.buttons & 1) === 0) {
-          stop();
-          return;
-        }
-        lastClientX = e.clientX;
-        lastClientY = e.clientY;
-        if (frame === null) frame = requestAnimationFrame(step);
-      };
-
-      const stop = () => {
-        if (frame !== null) {
-          cancelAnimationFrame(frame);
-          frame = null;
-        }
-        window.removeEventListener("mousemove", onMove, true);
-        window.removeEventListener("mouseup", onUp, true);
-      };
-
-      // Only the primary button's release ends the gesture; releasing a stray
-      // secondary/middle button mid-drag must not tear down auto-scroll while
-      // the primary is still held. `stop` itself stays callable without an
-      // event for the `onMove` (off-window release) path.
-      const onUp = (e: MouseEvent) => {
-        if (e.button === 0) stop();
-      };
-
-      window.addEventListener("mousemove", onMove, true);
-      window.addEventListener("mouseup", onUp, true);
-
-      // Don't consume the event; CodeMirror still drives normal selection.
-      return false;
+export function autoScrollOnSelectionDrag(): Extension {
+  return ViewPlugin.fromClass(AutoScrollOnSelectionDrag, {
+    eventHandlers: {
+      mousedown(event) {
+        this.mousedown(event);
+      },
     },
   });
 }

--- a/web/src/components/editor/autoScrollOnSelectionDrag.ts
+++ b/web/src/components/editor/autoScrollOnSelectionDrag.ts
@@ -33,6 +33,18 @@ export function autoScrollOnSelectionDrag(): Extension {
       // Only react to the primary (left) button selection drag.
       if (event.button !== 0) return false;
 
+      // Only drive selection ourselves for a plain single-range character drag.
+      // For advanced gestures — alt+drag rectangular selection (multi-range) and
+      // double/triple-click word/line selection (`detail > 1`, boundary-snapped) —
+      // a single-range `{anchor, head}` dispatch would collapse the rectangle and
+      // drop the snapping. In those modes we still auto-scroll but leave selection
+      // extension to CodeMirror's own `pointerSelection` (the scroll moves content
+      // under the pointer; CM's next mousemove extends with the right granularity).
+      const driveSelection =
+        view.state.selection.ranges.length === 1 &&
+        event.detail === 1 &&
+        !event.altKey;
+
       const scroller = view.scrollDOM;
       let lastClientX = event.clientX;
       let lastClientY = event.clientY;
@@ -66,26 +78,35 @@ export function autoScrollOnSelectionDrag(): Extension {
 
         const before = scroller.scrollTop;
         scroller.scrollTop = before + delta;
-        if (scroller.scrollTop === before) {
-          // Hit the top/bottom of the document; nothing more to scroll.
-          return;
-        }
+        const scrolled = scroller.scrollTop !== before;
 
         // Extend the selection to the position under the (clamped) pointer so
         // the highlighted range keeps growing with the scroll. Clamp Y into the
-        // scroller so posAtCoords resolves to the first/last visible line.
-        const rectAfter = scroller.getBoundingClientRect();
-        const clampedY = Math.max(
-          rectAfter.top + 1,
-          Math.min(rectAfter.bottom - 1, lastClientY),
-        );
-        const pos = view.posAtCoords({ x: lastClientX, y: clampedY });
-        if (pos !== null) {
-          view.dispatch({
-            selection: { anchor: view.state.selection.main.anchor, head: pos },
-          });
+        // scroller so posAtCoords resolves to the first/last visible line. Only
+        // for the plain single-range drag; advanced gestures are left to CM.
+        if (scrolled && driveSelection) {
+          const rectAfter = scroller.getBoundingClientRect();
+          const clampedY = Math.max(
+            rectAfter.top + 1,
+            Math.min(rectAfter.bottom - 1, lastClientY),
+          );
+          const pos = view.posAtCoords({ x: lastClientX, y: clampedY });
+          if (pos !== null) {
+            view.dispatch({
+              selection: {
+                anchor: view.state.selection.main.anchor,
+                head: pos,
+              },
+            });
+          }
         }
 
+        // Keep the loop alive while the pointer is past the edge (`delta !== 0`),
+        // even if the scroller is already at the top/bottom and didn't move.
+        // Otherwise, if the pointer is held still past the edge, no mousemove
+        // fires to restart the loop and scrolling never resumes when the user
+        // drags back — native textareas resume immediately. This only runs
+        // during an active drag and ends on mouseup (or when delta returns to 0).
         frame = requestAnimationFrame(step);
       };
 


### PR DESCRIPTION
The prompt **New version** text editor (CodeMirror) did not scroll when you dragged a text selection past its top/bottom edge — standard editor behavior that works in the read-only prompt **view** (plain `<code>` in an `overflow-y-auto` box, scrolled natively by the browser).

**Root cause (view vs edit):**
- The edit editor (`PromptLinkingEditor` → `CodeMirrorEditor`) had only `minHeight` and no `maxHeight`, so its `.cm-scroller` grew to the full content height and was never an independent scroll region.
- Even when bounded, CodeMirror doesn't implement auto-scroll-on-edge during a selection drag (the browser only does this for native `<textarea>`/`<code>`).

**Fix:**
- Bound the prompt editor height (`maxHeight` default `60vh`) so it scrolls internally like the view.
- Add a reusable CodeMirror extension `autoScrollOnSelectionDrag`, wired into `CodeMirrorEditor`, that scrolls `.cm-scroller` and extends the selection while the pointer is held near/past the top or bottom edge during a drag (window-level listeners so it keeps scrolling past the edge).

**Verification:** Seeded a 127-line prompt with 3 versions; Playwright drag-to-edge confirms the editor auto-scrolls down (+1566px) and up (back to 0) with the selection following.

LFE-6868

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes missing auto-scroll-on-edge behaviour in the prompt new-version CodeMirror editor by bounding the editor height (`maxHeight = "60vh"` default in `PromptLinkingEditor`) and adding a custom `autoScrollOnSelectionDrag` CodeMirror extension that scrolls `.cm-scroller` and extends the selection while the pointer is held near or past the editor edge during a drag.

- **`autoScrollOnSelectionDrag.ts`** — new extension using `EditorView.domEventHandlers` to register per-drag window-level `mousemove`/`mouseup` capture listeners; uses a rAF loop to scroll and dispatch selection updates, cleaning up on `mouseup` or `buttons === 0`.
- **`PromptLinkingEditor.tsx`** — new `maxHeight` prop with `"60vh"` default; this intentionally changes the visual height of all existing prompt editors to create an internal scroll region.
- **`CodeMirrorEditor.tsx`** — wires `autoScrollOnSelectionDrag()` into the memoised extensions array for every editor instance (including read-only).
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; changes are scoped to editor UX with no data mutations or API calls, and the window listeners are properly cleaned up in all normal code paths.

The core logic — per-drag closure, rAF lifecycle, cleanup via mouseup and buttons===0 guard — is sound. Two small edge cases exist: the rAF loop permanently idles when the scroll boundary is hit mid-drag, and the extension attaches to read-only editors without documentation of that intent.

autoScrollOnSelectionDrag.ts — the rAF idle-on-boundary behaviour and unconditional read-only-editor coverage are worth a second look.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant EditorDOM
    participant WindowListeners
    participant RAF as requestAnimationFrame
    participant CMView as CodeMirror View

    User->>EditorDOM: "mousedown (button=0)"
    EditorDOM->>WindowListeners: addEventListener mousemove (capture)
    EditorDOM->>WindowListeners: addEventListener mouseup (capture)

    loop Drag gesture
        User->>WindowListeners: mousemove
        WindowListeners->>RAF: "schedule step() if frame===null"
        RAF->>CMView: getBoundingClientRect()
        alt pointer near/past edge
            RAF->>CMView: "scroller.scrollTop += delta"
            RAF->>CMView: posAtCoords(clampedX, clampedY)
            CMView-->>RAF: pos
            RAF->>CMView: dispatch selection(anchor→pos)
            RAF->>RAF: schedule next step()
        else pointer in safe zone
            RAF-->>RAF: return (no next frame)
        end
    end

    User->>WindowListeners: mouseup
    WindowListeners->>RAF: cancelAnimationFrame
    WindowListeners->>WindowListeners: removeEventListener mousemove
    WindowListeners->>WindowListeners: removeEventListener mouseup
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant EditorDOM
    participant WindowListeners
    participant RAF as requestAnimationFrame
    participant CMView as CodeMirror View

    User->>EditorDOM: "mousedown (button=0)"
    EditorDOM->>WindowListeners: addEventListener mousemove (capture)
    EditorDOM->>WindowListeners: addEventListener mouseup (capture)

    loop Drag gesture
        User->>WindowListeners: mousemove
        WindowListeners->>RAF: "schedule step() if frame===null"
        RAF->>CMView: getBoundingClientRect()
        alt pointer near/past edge
            RAF->>CMView: "scroller.scrollTop += delta"
            RAF->>CMView: posAtCoords(clampedX, clampedY)
            CMView-->>RAF: pos
            RAF->>CMView: dispatch selection(anchor→pos)
            RAF->>RAF: schedule next step()
        else pointer in safe zone
            RAF-->>RAF: return (no next frame)
        end
    end

    User->>WindowListeners: mouseup
    WindowListeners->>RAF: cancelAnimationFrame
    WindowListeners->>WindowListeners: removeEventListener mousemove
    WindowListeners->>WindowListeners: removeEventListener mouseup
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
web/src/components/editor/autoScrollOnSelectionDrag.ts:30-34
**Extension active on read-only editors**

`autoScrollOnSelectionDrag` is added unconditionally to every `CodeMirrorEditor` instance (including those with `editable={false}`) because the call site in `CodeMirrorEditor.tsx` is outside the `!editable` guard. On every primary-button `mousedown` — even in a JSON viewer or a read-only prompt version panel — window-level `mousemove` and `mouseup` capture listeners are registered. The selection `view.dispatch` also fires on read-only views during a drag-to-edge (though `EditorState.readOnly` only blocks *document* changes, not selection changes, so it won't error). If the intent is to provide this behaviour only for editable editors, the extension call should be gated similarly to `EditorState.readOnly.of(true)`. If it is intentionally global (auto-scroll is useful when copying from read-only editors), a brief comment clarifying that would help future readers.

### Issue 2 of 2
web/src/components/editor/autoScrollOnSelectionDrag.ts:65-72
**RAF loop stalls when scroller hits the boundary while pointer stays past the edge**

When `delta !== 0` but `scroller.scrollTop` does not change (already at the top or bottom), `step` returns without scheduling the next `requestAnimationFrame`. At that point `frame` is `null`. If the pointer never moves again (user holds it past the edge), `onMove` is never re-triggered, so the loop is permanently stopped — the user has to wiggle the mouse to restart scrolling. Compare this to native `<textarea>` behaviour, where the scroll-at-edge loop continues to fire (doing nothing once the document ends, but resuming immediately if the user scrolls back). This is an edge-case but worth noting given the PR's stated goal of matching native behaviour.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(prompts): auto-scroll the new-versio..."](https://github.com/langfuse/langfuse/commit/cb8e5f4a7ad19a6706ed47c60fd1164176a0cdcf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39498491)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->