### PR TITLE
refactor(worker): replace compressed tag with source enum on blob export metrics

### DIFF
--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -56,6 +56,13 @@ import { randomUUID } from "crypto";
 import { SpanKind } from "@opentelemetry/api";
 import { env, v4AllowPreviewOptIn } from "../../env";
 
+export const BlobExportFormat = {
+  JSON_GZIP: "json-gzip",
+  JSON_RAW: "json-raw",
+} as const;
+export type BlobExportFormat =
+  (typeof BlobExportFormat)[keyof typeof BlobExportFormat];
+
 export const BLOB_STORAGE_LAG_BUFFER_MS = 20 * 60 * 1000; // 20-minute lag buffer
 
 export async function* enrichObservationStream(
@@ -626,11 +633,14 @@ const processBlobStorageExport = async (config: {
             projectId: config.projectId,
           });
 
+          const exportFormat: BlobExportFormat = config.compressed
+            ? BlobExportFormat.JSON_GZIP
+            : BlobExportFormat.JSON_RAW;
           const byteTags = {
             table: config.table,
             projectId: config.projectId,
             path: passthroughEligible ? "passthrough" : "standard",
-            compressed: compressedCounter ? "true" : "false",
+            source: exportFormat,
           };
           recordIncrement(
             "langfuse.blob_export.serialized_bytes",
@@ -714,10 +724,13 @@ const processBlobStorageExport = async (config: {
                 : Math.max(0, totalUploadMs - finalChReadMs - finalEnrichMs);
               span.setAttribute("blob.gzipCpuMs", finalGzipCpuMs);
               span.setAttribute("blob.uploadWaitMs", finalUploadWaitMs);
+              const finalExportFormat: BlobExportFormat = config.compressed
+                ? BlobExportFormat.JSON_GZIP
+                : BlobExportFormat.JSON_RAW;
               const stageTags = {
                 table: config.table,
                 path: passthroughEligible ? "passthrough" : "standard",
-                compressed: config.compressed ? "true" : "false",
+                source: finalExportFormat,
               };
               recordHistogram(
                 "langfuse.blob_export.ch_read_ms",

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -57,11 +57,41 @@ import { SpanKind } from "@opentelemetry/api";
 import { env, v4AllowPreviewOptIn } from "../../env";
 
 export const BlobExportFormat = {
-  JSON_GZIP: "json-gzip",
   JSON_RAW: "json-raw",
+  JSON_GZIP: "json-gzip",
+  CSV_RAW: "csv-raw",
+  CSV_GZIP: "csv-gzip",
+  JSONL_RAW: "jsonl-raw",
+  JSONL_GZIP: "jsonl-gzip",
 } as const;
 export type BlobExportFormat =
   (typeof BlobExportFormat)[keyof typeof BlobExportFormat];
+
+const FORMAT_LOOKUP: Record<
+  BlobStorageIntegrationFileType,
+  { raw: BlobExportFormat; gzip: BlobExportFormat }
+> = {
+  [BlobStorageIntegrationFileType.JSON]: {
+    raw: BlobExportFormat.JSON_RAW,
+    gzip: BlobExportFormat.JSON_GZIP,
+  },
+  [BlobStorageIntegrationFileType.CSV]: {
+    raw: BlobExportFormat.CSV_RAW,
+    gzip: BlobExportFormat.CSV_GZIP,
+  },
+  [BlobStorageIntegrationFileType.JSONL]: {
+    raw: BlobExportFormat.JSONL_RAW,
+    gzip: BlobExportFormat.JSONL_GZIP,
+  },
+};
+
+function resolveBlobExportFormat(
+  fileType: BlobStorageIntegrationFileType,
+  compressed: boolean,
+): BlobExportFormat {
+  const entry = FORMAT_LOOKUP[fileType];
+  return compressed ? entry.gzip : entry.raw;
+}
 
 export const BLOB_STORAGE_LAG_BUFFER_MS = 20 * 60 * 1000; // 20-minute lag buffer
 
@@ -633,9 +663,10 @@ const processBlobStorageExport = async (config: {
             projectId: config.projectId,
           });
 
-          const exportFormat: BlobExportFormat = config.compressed
-            ? BlobExportFormat.JSON_GZIP
-            : BlobExportFormat.JSON_RAW;
+          const exportFormat = resolveBlobExportFormat(
+            config.fileType,
+            config.compressed,
+          );
           const byteTags = {
             table: config.table,
             projectId: config.projectId,
@@ -724,9 +755,10 @@ const processBlobStorageExport = async (config: {
                 : Math.max(0, totalUploadMs - finalChReadMs - finalEnrichMs);
               span.setAttribute("blob.gzipCpuMs", finalGzipCpuMs);
               span.setAttribute("blob.uploadWaitMs", finalUploadWaitMs);
-              const finalExportFormat: BlobExportFormat = config.compressed
-                ? BlobExportFormat.JSON_GZIP
-                : BlobExportFormat.JSON_RAW;
+              const finalExportFormat = resolveBlobExportFormat(
+                config.fileType,
+                config.compressed,
+              );
               const stageTags = {
                 table: config.table,
                 path: passthroughEligible ? "passthrough" : "standard",


### PR DESCRIPTION
## What does this PR do?

Replaces the `compressed:true|false` metric tag on blob export metrics with a `source` tag using a `BlobExportFormat` enum. The format is derived from `fileType + compressed` via a lookup table, making it easy to extend with future export formats.

### Enum values
`json-raw`, `json-gzip`, `csv-raw`, `csv-gzip`, `jsonl-raw`, `jsonl-gzip`

### Affected metrics
- `langfuse.blob_export.serialized_bytes` — `compressed` tag → `source` tag
- `langfuse.blob_export.compressed_bytes` — gains `source` tag (via shared `byteTags`)
- `langfuse.blob_export.ch_read_ms`, `enrich_ms`, `gzip_cpu_ms`, `upload_wait_ms` histograms — `compressed` tag → `source` tag

### Type of change
- [x] Refactor (no functional change)

### Checklist
- [x] Typecheck passes (`pnpm turbo run typecheck --filter=worker`)
- [x] Lint passes (pre-commit hook)
- [ ] Datadog dashboard `blob-export-dashboard.json` updated separately (`compressed:false` → `source:json-raw`, `compressed:true` → `source:json-gzip`) — reimport after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)