### PR TITLE
fix(blob-storage): buffer Azure Blob downloads before decoding to UTF-8

### DIFF
--- a/packages/shared/src/server/services/StorageService.test.ts
+++ b/packages/shared/src/server/services/StorageService.test.ts
@@ -1,0 +1,102 @@
+import { Readable } from "stream";
+
+import { describe, expect, it } from "vitest";
+
+import { StorageServiceFactory } from "./StorageService";
+
+/**
+ * Regression tests for the Azure Blob download path.
+ *
+ * `AzureBlobStorageService.streamToString` used to decode each download
+ * stream chunk individually with `data.toString()` and concatenate the
+ * resulting strings. Node.js stream chunk boundaries can fall in the middle
+ * of a multibyte UTF-8 sequence, so any character straddling a boundary was
+ * split and decoded as invalid bytes, producing U+FFFD. The fix aggregates
+ * the raw Buffers and decodes once at the end.
+ */
+describe("AzureBlobStorageService.streamToString", () => {
+  // streamToString is private; reach it through the Azure instance for a
+  // focused unit test without standing up a real Azure backend (the
+  // constructor does not perform any network calls).
+  const getStreamToString = () => {
+    const service = StorageServiceFactory.getInstance({
+      accessKeyId: "test-account",
+      secretAccessKey: Buffer.from("test-secret-key").toString("base64"),
+      bucketName: "test-container",
+      endpoint: "https://test.blob.core.windows.net",
+      region: undefined,
+      forcePathStyle: false,
+      useAzureBlob: true,
+      awsSse: undefined,
+      awsSseKmsKeyId: undefined,
+    });
+
+    return (chunks: Buffer[]): Promise<string> =>
+      (
+        service as unknown as {
+          streamToString(stream: NodeJS.ReadableStream): Promise<string>;
+        }
+      ).streamToString(streamFromChunks(chunks));
+  };
+
+  // Emits each provided buffer as its own discrete "data" chunk, so we can
+  // reproduce exact chunk boundaries.
+  const streamFromChunks = (chunks: Buffer[]): Readable => {
+    let index = 0;
+    return new Readable({
+      read() {
+        if (index < chunks.length) {
+          this.push(chunks[index++]);
+        } else {
+          this.push(null);
+        }
+      },
+    });
+  };
+
+  const splitBufferAt = (buffer: Buffer, offset: number): Buffer[] => [
+    buffer.subarray(0, offset),
+    buffer.subarray(offset),
+  ];
+
+  it("reassembles a 3-byte character split across a chunk boundary", async () => {
+    const streamToString = getStreamToString();
+    const text = "について の ご相談"; // の = E3 81 AE
+    const buffer = Buffer.from(text, "utf-8");
+    const splitOffset = buffer.indexOf(Buffer.from("の", "utf-8")) + 1; // inside の
+
+    const result = await streamToString(splitBufferAt(buffer, splitOffset));
+
+    expect(result).toBe(text);
+    expect(result).not.toContain("�");
+  });
+
+  it("handles a boundary at every byte (worst case)", async () => {
+    const streamToString = getStreamToString();
+    const text = "支払いは退院後になります。🙂 café";
+    const buffer = Buffer.from(text, "utf-8");
+    const oneBytePerChunk = Array.from(buffer, (byte) => Buffer.from([byte]));
+
+    const result = await streamToString(oneBytePerChunk);
+
+    expect(result).toBe(text);
+  });
+
+  it("leaves ASCII-only content unchanged", async () => {
+    const streamToString = getStreamToString();
+    const text = "plain ascii payload";
+    const buffer = Buffer.from(text, "utf-8");
+
+    const result = await streamToString(splitBufferAt(buffer, 4));
+
+    expect(result).toBe(text);
+  });
+
+  it("returns an empty string for an empty stream", async () => {
+    const streamToString = getStreamToString();
+
+    const result = await streamToString([]);
+
+    expect(result).toBe("");
+  });
+});

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -500,12 +500,12 @@ class AzureBlobStorageService implements StorageService {
     readableStream: NodeJS.ReadableStream,
   ): Promise<string> {
     return new Promise((resolve, reject) => {
-      const chunks: string[] = [];
+      const chunks: Buffer[] = [];
       readableStream.on("data", (data) => {
-        chunks.push(data.toString());
+        chunks.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
       });
       readableStream.on("end", () => {
-        resolve(chunks.join(""));
+        resolve(Buffer.concat(chunks).toString("utf-8"));
       });
       readableStream.on("error", reject);
     });


### PR DESCRIPTION
## What does this PR do?

`AzureBlobStorageService.streamToString` decoded each download stream chunk individually with `data.toString()` and concatenated the resulting strings. Node.js stream chunk boundaries can fall inside a multibyte UTF-8 sequence, so any character straddling a boundary was split and decoded as invalid bytes, producing the replacement character U+FFFD (`�`). The corrupted text is persisted (not just a display issue), so it also degrades downstream consumers such as LLM-as-a-judge evaluations that read the stored text.

This aggregates the raw `Buffer` chunks and decodes once at the end, matching the existing `OCIObjectStorageService` implementation. The bug is Azure-specific; the S3 / S3-compatible / GCS / OCI read paths already decode correctly.

Adds a regression test that reproduces the corruption by splitting a multibyte character across chunk boundaries (fails before the fix, passes after).

Fixes #14471

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Self-reviewed
- [x] Read the contributing guide and followed the style guidelines (`pnpm run format`)
- [x] Added a regression test that proves the fix (fails before, passes after)
- [x] `lint`, `prettier`, and the targeted test pass locally

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a multibyte UTF-8 corruption bug in `AzureBlobStorageService.streamToString` by collecting raw `Buffer` chunks and decoding once at the end, instead of calling `.toString()` on each individual chunk. It also adds four targeted regression tests that reproduce the corruption by splitting multibyte characters across chunk boundaries.

- **Core fix** (`StorageService.ts`): `chunks: string[]` → `chunks: Buffer[]`, decoding moved from per-chunk `data.toString()` to a final `Buffer.concat(chunks).toString("utf-8")`. This now matches the existing OCI implementation.
- **Regression tests** (`StorageService.test.ts`): Covers a 3-byte character split, worst-case one-byte-per-chunk, ASCII-only, and empty-stream scenarios against the private `streamToString` method via type casting.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, targeted fix to a well-understood bug with no side effects on other storage backends.

The fix is four lines touching only the Azure download path, brings the implementation in line with the already-correct OCI counterpart in the same file, and is covered by four regression tests that directly reproduce the original corruption scenario.

No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant AzureBlobStorageService
    participant ReadableStream

    Caller->>AzureBlobStorageService: download(path)
    AzureBlobStorageService->>ReadableStream: blobClient.download()
    Note over AzureBlobStorageService: streamToString(readableStreamBody)
    loop per chunk
        ReadableStream-->>AzureBlobStorageService: data event (Buffer)
        Note over AzureBlobStorageService: BEFORE: chunk.toString() → string concat<br/>AFTER: push raw Buffer into chunks[]
    end
    ReadableStream-->>AzureBlobStorageService: end event
    Note over AzureBlobStorageService: Buffer.concat(chunks).toString("utf-8")<br/>Single decode — no split-sequence corruption
    AzureBlobStorageService-->>Caller: string (correctly decoded UTF-8)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant AzureBlobStorageService
    participant ReadableStream

    Caller->>AzureBlobStorageService: download(path)
    AzureBlobStorageService->>ReadableStream: blobClient.download()
    Note over AzureBlobStorageService: streamToString(readableStreamBody)
    loop per chunk
        ReadableStream-->>AzureBlobStorageService: data event (Buffer)
        Note over AzureBlobStorageService: BEFORE: chunk.toString() → string concat<br/>AFTER: push raw Buffer into chunks[]
    end
    ReadableStream-->>AzureBlobStorageService: end event
    Note over AzureBlobStorageService: Buffer.concat(chunks).toString("utf-8")<br/>Single decode — no split-sequence corruption
    AzureBlobStorageService-->>Caller: string (correctly decoded UTF-8)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(blob-storage): buffer Azure Blob dow..."](https://github.com/langfuse/langfuse/commit/b908a0ffdcc814f9328931909e23ac8cf8555af8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39505677)</sub>

<!-- /greptile_comment -->