### PR TITLE
feat(shared): add parquet flag to blob export tuning (LFE-10463)

### DIFF
--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.test.ts
@@ -21,6 +21,7 @@ function resolved(
 ): ResolvedBlobExportTuning {
   return {
     rawPassthrough: false,
+    parquet: false,
     gzipLevel: undefined,
     partSizeBytes: DEFAULTS.partSizeBytes,
     maxConcurrentParts: undefined,
@@ -118,6 +119,63 @@ describe("resolveBlobExportTuning", () => {
           skipEnrichment: true,
         }),
       );
+      expect(warnings).toEqual([]);
+    });
+  });
+
+  describe("parquet (LFE-10463)", () => {
+    it("honors parquet=true", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { parquet: true },
+        DEFAULTS,
+      );
+      expect(res).toEqual(resolved({ parquet: true }));
+      expect(warnings).toEqual([]);
+    });
+
+    it("honors parquet=false explicitly", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { parquet: false },
+        DEFAULTS,
+      );
+      expect(res.parquet).toBe(false);
+      expect(warnings).toEqual([]);
+    });
+
+    it("defaults parquet to false when absent", () => {
+      expect(resolveBlobExportTuning({}, DEFAULTS).resolved.parquet).toBe(
+        false,
+      );
+    });
+
+    it("falls back to false and warns on a wrong-typed parquet", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { parquet: "yes" },
+        DEFAULTS,
+      );
+      expect(res.parquet).toBe(false);
+      expect(warnings.some((w) => w.includes("expected a boolean"))).toBe(true);
+    });
+
+    it("takes precedence over rawPassthrough: parquet wins, rawPassthrough forced false, with a warning", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { parquet: true, rawPassthrough: true },
+        DEFAULTS,
+      );
+      expect(res.parquet).toBe(true);
+      expect(res.rawPassthrough).toBe(false);
+      expect(warnings.some((w) => w.includes("parquet takes precedence"))).toBe(
+        true,
+      );
+    });
+
+    it("leaves rawPassthrough untouched when parquet is not set", () => {
+      const { resolved: res, warnings } = resolveBlobExportTuning(
+        { rawPassthrough: true },
+        DEFAULTS,
+      );
+      expect(res.parquet).toBe(false);
+      expect(res.rawPassthrough).toBe(true);
       expect(warnings).toEqual([]);
     });
   });
@@ -334,6 +392,12 @@ describe("BlobExportTuningSchema (write schema)", () => {
       BlobExportTuningSchema.safeParse({ rawPassthrough: true, gzipLevel: 6 })
         .success,
     ).toBe(true);
+  });
+
+  it("accepts parquet", () => {
+    expect(BlobExportTuningSchema.safeParse({ parquet: true }).success).toBe(
+      true,
+    );
   });
 
   it("rejects out-of-range values (writes reject; reads clamp)", () => {

--- a/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
+++ b/packages/shared/src/features/analytics-integrations/blob-export-tuning.ts
@@ -60,6 +60,14 @@ export const BlobExportTuningSchema = z.object({
   // >= RAW_PASSTHROUGH_MIN_CLICKHOUSE_VERSION (see above) for mid-stream failure
   // detection. Do not enable on older self-hosted ClickHouse.
   rawPassthrough: z.boolean().optional(),
+  // LFE-10463 Parquet export path: stream ClickHouse's native `FORMAT Parquet`
+  // bytes straight to upload, offloading columnar encoding + compression to
+  // ClickHouse query threads (no worker gzip). When set, produces `.parquet`
+  // files for all tables and overrides both `fileType` and `compressed`. Takes
+  // precedence over `rawPassthrough` (resolved below). Like rawPassthrough it
+  // relies on mid-stream exception tagging, so the same ClickHouse
+  // >= RAW_PASSTHROUGH_MIN_CLICKHOUSE_VERSION caveat applies on self-hosted.
+  parquet: z.boolean().optional(),
   // LFE-10402 gzip tuning: zlib deflate level for compressed exports. Lower
   // levels trade output size for markedly less worker CPU. Only honored when the
   // integration has compression enabled. zlib accepts 0 (store) through 9 (max);
@@ -99,6 +107,9 @@ export interface BlobExportTuningDefaults {
 
 export type ResolvedBlobExportTuning = {
   rawPassthrough: boolean;
+  // LFE-10463. When true the export uses ClickHouse-native `FORMAT Parquet`;
+  // forces `rawPassthrough` to false (parquet wins) — see resolver below.
+  parquet: boolean;
   // undefined => use the zlib default (6); a concrete 0-9 otherwise.
   gzipLevel: number | undefined;
   partSizeBytes: number;
@@ -240,6 +251,7 @@ export function resolveBlobExportTuning(
 
   const fallback: ResolvedBlobExportTuning = {
     rawPassthrough: false,
+    parquet: false,
     gzipLevel: undefined,
     partSizeBytes: defaults.partSizeBytes,
     maxConcurrentParts: undefined,
@@ -260,13 +272,29 @@ export function resolveBlobExportTuning(
 
   const obj = raw as Record<string, unknown>;
 
+  const parquet = resolveBoolean("parquet", obj.parquet, warnings);
+  let rawPassthrough = resolveBoolean(
+    "rawPassthrough",
+    obj.rawPassthrough,
+    warnings,
+  );
+
+  // LFE-10463: Parquet is a distinct execution path (ClickHouse-native
+  // `FORMAT Parquet`) that supersedes the JSONEachRow raw-passthrough path.
+  // Enabling both is a misconfiguration; honor parquet and disable
+  // rawPassthrough with a warning rather than letting the handler pick one
+  // silently.
+  if (parquet && rawPassthrough) {
+    rawPassthrough = false;
+    warnings.push(
+      "parquet and rawPassthrough are both enabled; parquet takes precedence, ignoring rawPassthrough",
+    );
+  }
+
   return {
     resolved: {
-      rawPassthrough: resolveBoolean(
-        "rawPassthrough",
-        obj.rawPassthrough,
-        warnings,
-      ),
+      rawPassthrough,
+      parquet,
       gzipLevel: resolveGzipLevel(obj.gzipLevel, warnings),
       partSizeBytes: resolveNumber(
         "partSizeBytes",


### PR DESCRIPTION
## What does this PR do?

Phase 1 of the Parquet blob-export format (LFE-10463): the shared-types groundwork.

Adds a `parquet` boolean to the per-project blob-export tuning contract:

- `parquet: z.boolean().optional()` on `BlobExportTuningSchema` (the write-validation schema).
- `parquet: boolean` on `ResolvedBlobExportTuning`, defaulting to `false`.
- `resolveBlobExportTuning()` resolves it like the other booleans, and enforces precedence: when both `parquet` and `rawPassthrough` are enabled it keeps `parquet`, forces `rawPassthrough` to `false`, and emits a warning — they are mutually exclusive ClickHouse execution paths.

Schema + resolver only. No export path consumes the flag yet; Phase 2 wires the `exec()`-based Parquet streaming util, the per-table repository functions, and the job-handler dispatch.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

- [x] Added unit tests covering the new `parquet` flag, the wrong-typed/absent cases, and the parquet-over-rawPassthrough precedence.
- [x] Existing and new unit tests pass locally (`vitest` — 35 passing); `pnpm run lint` passes repo-wide.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `parquet` boolean flag to the `BlobExportTuningSchema` and resolver, enabling a ClickHouse-native `FORMAT Parquet` export path as an alternative to the existing JSONEachRow raw-passthrough. When both `parquet` and `rawPassthrough` are set, `parquet` wins and `rawPassthrough` is forced to false with a warning.

- Adds `parquet: z.boolean().optional()` to the Zod write schema and `parquet: boolean` to the `ResolvedBlobExportTuning` type, with appropriate fallback in the resolver.
- Implements conflict resolution so that `parquet: true` overrides `rawPassthrough: true`, matching the comment that these are mutually exclusive execution paths.
- Ships comprehensive tests covering the new flag in isolation, the conflict case, wrong-type fall-back, and the interaction with `rawPassthrough` only (no parquet).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This change is safe to merge — it only extends the shared resolver/schema module with a new flag, adds conflict-resolution logic for two boolean fields, and does not touch any job handler or I/O path.

The change is well-scoped: a new optional boolean field in a Zod schema, an extra field in a plain TypeScript type, and a short resolver block. The fallback is false (no behaviour change for existing configs), the conflict logic is straightforward, and tests cover the key paths including wrong-type input and the parquet-wins conflict case. No existing test needs updating because the resolved() helper baseline was also updated to include parquet: false.

No files require special attention. Both changed files are self-contained within the blob-export-tuning module.
</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveBlobExportTuning called] --> B{raw is null/undefined?}
    B -- yes --> C[Return fallback defaults\nparquet:false, rawPassthrough:false]
    B -- no --> D{raw is object?}
    D -- no --> E[Warn: expected an object\nReturn fallback]
    D -- yes --> F[resolveBoolean parquet]
    F --> G[resolveBoolean rawPassthrough]
    G --> H{parquet=true AND\nrawPassthrough=true?}
    H -- yes --> I[Force rawPassthrough=false\nPush warning: parquet takes precedence]
    H -- no --> J[Keep both as resolved]
    I --> K[Build resolved object]
    J --> K
    K --> L[Return resolved + warnings]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[resolveBlobExportTuning called] --> B{raw is null/undefined?}
    B -- yes --> C[Return fallback defaults\nparquet:false, rawPassthrough:false]
    B -- no --> D{raw is object?}
    D -- no --> E[Warn: expected an object\nReturn fallback]
    D -- yes --> F[resolveBoolean parquet]
    F --> G[resolveBoolean rawPassthrough]
    G --> H{parquet=true AND\nrawPassthrough=true?}
    H -- yes --> I[Force rawPassthrough=false\nPush warning: parquet takes precedence]
    H -- no --> J[Keep both as resolved]
    I --> K[Build resolved object]
    J --> K
    K --> L[Return resolved + warnings]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(shared): add parquet flag to blob e..."](https://github.com/langfuse/langfuse/commit/f4f2669fd3b646e3a93975e4de55fc728a47e7a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39513701)</sub>

<!-- /greptile_comment -->