### PR TITLE
chore: Enable eslint `no-inferrable-types`

### DIFF
--- a/packages/config-eslint/base.js
+++ b/packages/config-eslint/base.js
@@ -88,6 +88,7 @@ export default tseslint.config(
         },
       ],
       "@typescript-eslint/no-deprecated": "warn",
+      "@typescript-eslint/no-inferrable-types": "warn",
     },
   },
 

--- a/packages/config-eslint/next.js
+++ b/packages/config-eslint/next.js
@@ -104,6 +104,7 @@ export default [
         },
       ],
       "@typescript-eslint/no-deprecated": "warn",
+      "@typescript-eslint/no-inferrable-types": "warn",
       "react/jsx-key": ["error", { warnOnDuplicates: true }],
       "react/no-unused-prop-types": "warn",
     },

--- a/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
+++ b/packages/shared/scripts/seeder/utils/clickhouse-builder.ts
@@ -28,7 +28,7 @@ export class ClickHouseQueryBuilder {
 
   private buildNestedMetadataMapSql(
     baseEntries: string[],
-    rowExpression: string = "number",
+    rowExpression = "number",
   ): string {
     return `map(
           ${baseEntries.join(",\n          ")},
@@ -88,7 +88,7 @@ export class ClickHouseQueryBuilder {
   buildBulkTracesInsert(
     projectId: string,
     count: number,
-    environment: string = "default",
+    environment = "default",
     fileContent?: { heavyMarkdown: string; nestedJson: any; chatMlJson: any },
     opts: {
       numberOfDays: number;
@@ -169,8 +169,8 @@ export class ClickHouseQueryBuilder {
   buildBulkObservationsInsert(
     projectId: string,
     tracesCount: number,
-    observationsPerTrace: number = 5,
-    environment: string = "default",
+    observationsPerTrace = 5,
+    environment = "default",
     fileContent?: { heavyMarkdown: string; nestedJson: any; chatMlJson: any },
     opts: {
       numberOfDays: number;
@@ -301,8 +301,8 @@ export class ClickHouseQueryBuilder {
   buildBulkScoresInsert(
     projectId: string,
     tracesCount: number,
-    scoresPerTrace: number = 2,
-    environment: string = "default",
+    scoresPerTrace = 2,
+    environment = "default",
     opts: {
       numberOfDays: number;
       idPrefix?: string;

--- a/packages/shared/scripts/seeder/utils/data-generators.ts
+++ b/packages/shared/scripts/seeder/utils/data-generators.ts
@@ -64,7 +64,7 @@ export class DataGenerator {
     return array[Math.floor(Math.random() * array.length)];
   }
 
-  private randomBoolean(probability: number = 0.5): boolean {
+  private randomBoolean(probability = 0.5): boolean {
     return Math.random() < probability;
   }
 
@@ -343,7 +343,7 @@ export class DataGenerator {
 
   generateEvaluationObservations(
     traces: TraceRecordInsertType[],
-    observationsPerTrace: number = 5,
+    observationsPerTrace = 5,
     projectId: string,
   ): ObservationRecordInsertType[] {
     const observations: ObservationRecordInsertType[] = [];
@@ -450,7 +450,7 @@ export class DataGenerator {
    */
   generateSyntheticObservations(
     traces: TraceRecordInsertType[],
-    observationsPerTrace: number = 5,
+    observationsPerTrace = 5,
   ): ObservationRecordInsertType[] {
     const observations: ObservationRecordInsertType[] = [];
 
@@ -593,7 +593,7 @@ export class DataGenerator {
   generateSyntheticScores(
     traces: TraceRecordInsertType[],
     observations: ObservationRecordInsertType[],
-    scoresPerTrace: number = 2,
+    scoresPerTrace = 2,
   ): ScoreRecordInsertType[] {
     const scores: ScoreRecordInsertType[] = [];
 

--- a/packages/shared/src/encryption/encryption.ts
+++ b/packages/shared/src/encryption/encryption.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import { env } from "../env";
 
 const ENCRYPTION_KEY: string | undefined = env.ENCRYPTION_KEY; // Must be 256 bits (32 bytes, 64 hex characters)
-const IV_LENGTH: number = 12; // For AES-GCM, this is always 12
+const IV_LENGTH = 12; // For AES-GCM, this is always 12
 
 // Alternatively: openssl rand -hex 32
 export function keyGen() {

--- a/packages/shared/src/features/batchAction/applyFieldMapping.ts
+++ b/packages/shared/src/features/batchAction/applyFieldMapping.ts
@@ -308,7 +308,7 @@ export function applyFullMapping(props: {
  */
 export function generateJsonPathSuggestions(
   data: unknown,
-  prefix: string = "$",
+  prefix = "$",
 ): string[] {
   const suggestions: string[] = [];
 

--- a/packages/shared/src/features/query/dataModel.ts
+++ b/packages/shared/src/features/query/dataModel.ts
@@ -792,7 +792,7 @@ const scoresV2BaseDimensions: DimensionsDeclarationType = {
 // Factory for shared score-specific dimensions (both numeric and categorical)
 const createScoreSpecificDimensions = (
   tableAlias: string,
-  isV2: boolean = false,
+  isV2 = false,
 ): DimensionsDeclarationType => ({
   id: {
     sql: `${tableAlias}.id`,

--- a/packages/shared/src/features/query/server/queryBuilder.ts
+++ b/packages/shared/src/features/query/server/queryBuilder.ts
@@ -531,7 +531,7 @@ export class QueryBuilder {
 
       // Normal dimension or special-case filter: build column mapping
       let clickhouseSelect: string;
-      let queryPrefix: string = "";
+      let queryPrefix = "";
       let clickhouseTableName: string = actualTableName;
       let type: string;
       let emptyEqualsNull: boolean | undefined;
@@ -1514,7 +1514,7 @@ export class QueryBuilder {
   public async build(
     query: QueryType,
     projectId: string,
-    enableSingleLevelOptimization: boolean = false,
+    enableSingleLevelOptimization = false,
   ): Promise<{ query: string; parameters: Record<string, unknown> }> {
     // Run zod validation
     const parseResult = queryModel.safeParse(query);

--- a/packages/shared/src/features/query/server/queryExecutor.ts
+++ b/packages/shared/src/features/query/server/queryExecutor.ts
@@ -97,7 +97,7 @@ export async function executeQuery(
   projectId: string,
   query: QueryType,
   version: ViewVersion = "v1",
-  enableSingleLevelOptimization: boolean = false,
+  enableSingleLevelOptimization = false,
 ): Promise<Array<Record<string, unknown>>> {
   const prepared = await prepareExecuteQuery({
     projectId,

--- a/packages/shared/src/server/otel/utils.ts
+++ b/packages/shared/src/server/otel/utils.ts
@@ -12,7 +12,7 @@ export function isValidDateString(dateString: string): boolean {
  */
 export function flattenJsonToPathArrays(
   obj: Record<string, unknown>,
-  prefix: string = "",
+  prefix = "",
 ): { names: string[]; values: Array<string | null | undefined> } {
   const names: string[] = [];
   const values: Array<string | null | undefined> = [];

--- a/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/event-query-builder.ts
@@ -509,9 +509,9 @@ export type NoProjectIdType = typeof NoProjectId;
 abstract class AbstractQueryBuilder {
   protected whereClauses: string[] = [];
   protected havingClauses: string[] = [];
-  protected orderByClause: string = "";
-  protected limitByClause: string = "";
-  protected limitClause: string = "";
+  protected orderByClause = "";
+  protected limitByClause = "";
+  protected limitClause = "";
   protected params: Record<string, any> = {};
 
   /**
@@ -1005,7 +1005,7 @@ export class EventsQueryBuilder extends BaseEventsQueryBuilder<
   /**
    * Add IO fields with optional truncation
    */
-  selectIO(truncated: boolean = false, charLimit?: number): this {
+  selectIO(truncated = false, charLimit?: number): this {
     this.ioFields = { truncated, charLimit };
     return this;
   }
@@ -1174,7 +1174,7 @@ type AliasedColumns<
 export class EventsAggregationQueryBuilder extends BaseEventsQueryBuilder<
   typeof EVENTS_AGGREGATION_FIELDS
 > {
-  private truncated: boolean = true;
+  private truncated = true;
 
   constructor(options: { projectId: string }) {
     super(EVENTS_AGGREGATION_FIELDS, options);
@@ -1446,9 +1446,9 @@ export class CTEQueryBuilder<
   private cteSchemas: Map<string, CTESchema> = new Map();
   private joins: string[] = [];
   private selectExpressions: string[] = [];
-  private fromClause: string = "";
-  private fromAlias: string = "";
-  private groupByClause: string = "";
+  private fromClause = "";
+  private fromAlias = "";
+  private groupByClause = "";
 
   /**
    * Register a CTE with its schema

--- a/packages/shared/src/server/queries/clickhouse-sql/search.ts
+++ b/packages/shared/src/server/queries/clickhouse-sql/search.ts
@@ -51,10 +51,7 @@ export const clickhouseSearchCondition = ({
 }: ClickhouseSearchConditionOptions) => {
   const prefix = tablePrefix ? `${tablePrefix}.` : "";
 
-  const ilikeWithPrefilter = (
-    col: string,
-    param: string = "{searchString: String}",
-  ) =>
+  const ilikeWithPrefilter = (col: string, param = "{searchString: String}") =>
     // Fast-mode UI search intentionally narrows IO search to token matches
     // before applying ILIKE. This gives ClickHouse an inverted-index lookup,
     // but drops embedded-word substring matches like "foobarneedle".

--- a/packages/shared/src/server/repositories/events.ts
+++ b/packages/shared/src/server/repositories/events.ts
@@ -1309,8 +1309,8 @@ function buildObservationsQueryBase(
 }
 
 function orderByForObservationsQuery(
-  prefix: string = "e",
-  span_id: string = "span_id",
+  prefix = "e",
+  span_id = "span_id",
 ): OrderByEntry[] {
   // Order by to cursor ordering.
   // project_id and potentially other prefixes are injected in the query builder when necessary
@@ -1360,7 +1360,7 @@ function applyCursorPagination(
 async function getObservationsRowsFromBuilder<T>(
   projectId: string,
   queryBuilder: QueryWithParams,
-  operationName: string = "getObservationsFromEventsTableForPublicApi_rows",
+  operationName = "getObservationsFromEventsTableForPublicApi_rows",
   extraTags: Record<string, string> = {},
 ): Promise<Array<T>> {
   const { query, params } = queryBuilder.buildWithParams();
@@ -3579,7 +3579,7 @@ export const getEventsForBlobStorageExportRaw = function (
   minTimestamp: Date,
   maxTimestamp: Date,
   fieldGroups: ObservationFieldGroupFull[] = [...OBSERVATION_FIELD_GROUPS_FULL],
-  convertLatencyToSeconds: boolean = false,
+  convertLatencyToSeconds = false,
 ) {
   return queryClickhouseStreamRawText(
     buildEventsForBlobStorageExportQuery(

--- a/packages/shared/src/server/repositories/observations.ts
+++ b/packages/shared/src/server/repositories/observations.ts
@@ -406,7 +406,7 @@ export const getObservationByIdFromObservationsTable = async ({
 export const getObservationsById = async (
   ids: string[],
   projectId: string,
-  fetchWithInputOutput: boolean = false,
+  fetchWithInputOutput = false,
 ) => {
   const query = `
   SELECT

--- a/packages/shared/src/server/repositories/scores_converters.ts
+++ b/packages/shared/src/server/repositories/scores_converters.ts
@@ -23,7 +23,7 @@ export const convertClickhouseScoreToDomain = <
   DataType extends ScoreDataTypeType = ScoreDataTypeType,
 >(
   record: ScoreRecordReadType,
-  includeMetadataPayload: boolean = true,
+  includeMetadataPayload = true,
 ): ScoreByDataType<DataType> => {
   const baseScore = {
     id: record.id,

--- a/packages/shared/src/server/services/PromptService/index.ts
+++ b/packages/shared/src/server/services/PromptService/index.ts
@@ -404,7 +404,7 @@ export class PromptService {
     logger.debug(`[PromptService] ${message}`, ...args);
   }
 
-  private incrementMetric(name: PromptServiceMetrics, value: number = 1) {
+  private incrementMetric(name: PromptServiceMetrics, value = 1) {
     try {
       this.metricIncrementer?.(name, value);
     } catch (e) {

--- a/packages/shared/src/server/services/SlackService.ts
+++ b/packages/shared/src/server/services/SlackService.ts
@@ -344,9 +344,9 @@ export class SlackService {
    */
   private async getChannelsRecursive(
     client: WebClient,
-    channelTypes: string = "public_channel,private_channel",
+    channelTypes = "public_channel,private_channel",
     cursor?: string,
-    fetchedRecords: number = 0,
+    fetchedRecords = 0,
   ): Promise<SlackChannel[]> {
     try {
       const result = await client.conversations.list({

--- a/packages/shared/src/server/services/StorageService.ts
+++ b/packages/shared/src/server/services/StorageService.ts
@@ -891,7 +891,7 @@ class S3StorageService implements StorageService {
   public async getSignedUrl(
     fileName: string,
     ttlSeconds: number,
-    asAttachment: boolean = true,
+    asAttachment = true,
   ): Promise<string> {
     try {
       return getSignedUrl(
@@ -1149,7 +1149,7 @@ class GoogleCloudStorageService implements StorageService {
   public async getSignedUrl(
     fileName: string,
     ttlSeconds: number,
-    asAttachment: boolean = false,
+    asAttachment = false,
   ): Promise<string> {
     try {
       const file = this.bucket.file(fileName);
@@ -1231,7 +1231,7 @@ class OCIObjectStorageService implements StorageService {
   private clientInit: Promise<void>;
   private bucketName: string;
   private externalEndpoint?: string;
-  private namespaceName: string = "";
+  private namespaceName = "";
 
   constructor(params: {
     bucketName: string;
@@ -1612,7 +1612,7 @@ class OCIObjectStorageService implements StorageService {
   public async getSignedUrl(
     fileName: string,
     ttlSeconds: number,
-    asAttachment: boolean = true,
+    asAttachment = true,
   ): Promise<string> {
     try {
       const { client, namespaceName } = await this.getClientAndNamespace();

--- a/packages/shared/src/utils/unicode.ts
+++ b/packages/shared/src/utils/unicode.ts
@@ -25,7 +25,7 @@ const LOW_SURROGATE_END = 0xdfff;
  */
 export function decodeUnicodeEscapesOnly(
   input: string,
-  greedy: boolean = false,
+  greedy = false,
 ): string {
   if (input.indexOf("\\") === -1) return input;
 

--- a/web/src/__tests__/json-utils.clienttest.ts
+++ b/web/src/__tests__/json-utils.clienttest.ts
@@ -525,7 +525,7 @@ describe("Comparison: Recursive vs Iterative", () => {
 
 describe("Performance Comparison", () => {
   // Helper to generate nested JSON strings
-  const generateNestedJson = (depth: number, breadth: number = 3): any => {
+  const generateNestedJson = (depth: number, breadth = 3): any => {
     if (depth === 0) {
       return { value: "leaf" };
     }
@@ -737,10 +737,7 @@ describe("Performance Comparison", () => {
 
   describe("Large Object Performance", () => {
     // Helper to create large objects with many keys
-    const createLargeObject = (
-      numKeys: number,
-      nestingDepth: number = 2,
-    ): any => {
+    const createLargeObject = (numKeys: number, nestingDepth = 2): any => {
       const obj: any = {};
 
       for (let i = 0; i < numKeys; i++) {

--- a/web/src/__tests__/server/clickhouseSearchCondition.servertest.ts
+++ b/web/src/__tests__/server/clickhouseSearchCondition.servertest.ts
@@ -14,7 +14,7 @@ const maybeEventsTable =
     ? describe
     : describe.skip;
 
-const alphabeticSearchToken = (index: number, prefix: string = "needle") =>
+const alphabeticSearchToken = (index: number, prefix = "needle") =>
   `${prefix}${String.fromCharCode(97 + Math.floor(index / 26))}${String.fromCharCode(97 + (index % 26))}`;
 
 const searchFixture = `

--- a/web/src/__tests__/server/mcp-helpers.ts
+++ b/web/src/__tests__/server/mcp-helpers.ts
@@ -267,8 +267,8 @@ export function verifyToolAnnotations(
  */
 export async function waitFor(
   condition: () => Promise<boolean>,
-  timeoutMs: number = 5000,
-  intervalMs: number = 100,
+  timeoutMs = 5000,
+  intervalMs = 100,
 ): Promise<void> {
   const startTime = Date.now();
 

--- a/web/src/components/trace/contexts/json-expansion-utils.clienttest.ts
+++ b/web/src/components/trace/contexts/json-expansion-utils.clienttest.ts
@@ -235,7 +235,7 @@ describe("json-expansion-utils", () => {
     // Helper to generate expansion state from observation keys
     const generateExpansionState = (
       observationKeys: string[],
-      nestedPathsPerKey: number = 0,
+      nestedPathsPerKey = 0,
     ): Record<string, boolean> => {
       const state: Record<string, boolean> = {};
       const nestedPaths = ["input", "output", "metadata", "messages", "config"];
@@ -257,7 +257,7 @@ describe("json-expansion-utils", () => {
     // Helper to generate normalized state for denormalization tests
     const generateNormalizedState = (
       count: number,
-      nestedPathsPerKey: number = 0,
+      nestedPathsPerKey = 0,
     ): Record<string, boolean> => {
       const state: Record<string, boolean> = {};
       const names = [

--- a/web/src/components/ui/PrettyJsonView.tsx
+++ b/web/src/components/ui/PrettyJsonView.tsx
@@ -728,7 +728,7 @@ function JsonPrettyTable({
   const expandRowsWithLazyLoading = useCallback(
     (
       rowFilter: (rows: Row<JsonTableRow>[]) => Row<JsonTableRow>[],
-      shouldCollapse: boolean = false,
+      shouldCollapse = false,
     ) => {
       if (shouldCollapse) {
         onExpandedChange({});

--- a/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/utils/extractSchemaFields.ts
+++ b/web/src/features/batch-actions/components/AddObservationsToDatasetDialog/utils/extractSchemaFields.ts
@@ -60,7 +60,7 @@ type JSONSchemaObject = {
  */
 export function extractSchemaFields(
   schema: unknown,
-  maxDepth: number = 3,
+  maxDepth = 3,
 ): SchemaField[] {
   if (!isJsonSchemaObject(schema)) {
     return [];

--- a/web/src/features/datasets/server/dataset-router.ts
+++ b/web/src/features/datasets/server/dataset-router.ts
@@ -1352,7 +1352,7 @@ export const datasetRouter = createTRPCRouter({
           },
         })
       ).map((d) => d.name);
-      let counter: number = 0;
+      let counter = 0;
       const duplicateDatasetName = (pCounter: number) =>
         pCounter === 0
           ? `${dataset.name} (copy)`

--- a/web/src/features/models/utils.ts
+++ b/web/src/features/models/utils.ts
@@ -2,7 +2,7 @@ import Decimal from "decimal.js";
 
 export const getMaxDecimals = (
   value: number | undefined,
-  scaleMultiplier: number = 1,
+  scaleMultiplier = 1,
 ) => {
   return (
     new Decimal(value ?? 0)

--- a/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
+++ b/web/src/features/playground/page/components/JumpToPlaygroundButton.tsx
@@ -280,7 +280,7 @@ const parseGeneration = (
     output: string | null;
   },
   modelToProviderMap: Record<string, string>,
-  includeOutput: boolean = false,
+  includeOutput = false,
 ): PlaygroundCache => {
   if (!isGenerationLike(generation.type)) return null;
 

--- a/web/src/features/playground/page/context/index.tsx
+++ b/web/src/features/playground/page/context/index.tsx
@@ -728,7 +728,7 @@ async function getChatCompletionWithTools(
   messages: ChatMessageWithIdNoPlaceholders[],
   modelParams: UIModelParams,
   tools: unknown[],
-  streaming: boolean = false,
+  streaming = false,
 ): Promise<ToolCallResponse & { reasoning?: string }> {
   if (!projectId) throw Error("Project ID is not set");
 
@@ -773,7 +773,7 @@ async function getChatCompletionWithStructuredOutput(
   messages: ChatMessageWithId[],
   modelParams: UIModelParams,
   structuredOutputSchema: PlaygroundSchema | null,
-  streaming: boolean = false,
+  streaming = false,
 ): Promise<string> {
   if (!projectId) throw Error("Project ID is not set");
 

--- a/web/src/features/rbac/server/allInvitesRoutes.ts
+++ b/web/src/features/rbac/server/allInvitesRoutes.ts
@@ -29,7 +29,7 @@ async function getInvites(
   query:
     | z.infer<typeof orgLevelInviteQuery>
     | (z.infer<typeof projectLevelInviteQuery> & { orgId: string }),
-  showAllOrgMembers: boolean = true,
+  showAllOrgMembers = true,
 ) {
   const where: Prisma.MembershipInvitationWhereInput = {
     orgId: query.orgId,

--- a/web/src/features/rbac/server/allMembersRoutes.ts
+++ b/web/src/features/rbac/server/allMembersRoutes.ts
@@ -29,7 +29,7 @@ async function getMembers(
   query:
     | z.infer<typeof orgLevelMemberQuery>
     | (z.infer<typeof projectLevelMemberQuery> & { orgId: string }),
-  showAllOrgMembers: boolean = true,
+  showAllOrgMembers = true,
 ) {
   // Build common where clause to ensure consistency between findMany and count queries
   const whereClause = {

--- a/web/src/features/score-analytics/lib/color-scales.ts
+++ b/web/src/features/score-analytics/lib/color-scales.ts
@@ -32,9 +32,9 @@ export type HeatmapColorVariant = keyof typeof HEATMAP_BASE_COLORS;
  */
 export function generateMonoColorScale(
   baseColor: { l: number; c: number; h: number },
-  steps: number = 10,
-  minLightness: number = 30,
-  maxLightness: number = 95,
+  steps = 10,
+  minLightness = 30,
+  maxLightness = 95,
 ): string[] {
   const colors: string[] = [];
   const lightnessRange = maxLightness - minLightness;
@@ -63,7 +63,7 @@ export function getColorFromMonoScale(
   min: number,
   max: number,
   variant: HeatmapColorVariant = "chart1",
-  steps: number = 10,
+  steps = 10,
 ): string {
   const baseColor = HEATMAP_BASE_COLORS[variant];
   const scale = generateMonoColorScale(baseColor, steps);
@@ -105,7 +105,7 @@ export function getContrastColor(oklchColor: string): "black" | "white" {
  */
 export function getHoverColor(
   oklchColor: string,
-  chromaMultiplier: number = 2.5,
+  chromaMultiplier = 2.5,
 ): string {
   // Parse OKLCH color
   const match = oklchColor.match(
@@ -345,8 +345,8 @@ function mixColorsInOklab(
   baseColor: string,
   mixColor: string,
   percentage: number,
-  minPercentage: number = 0.1,
-  maxPercentage: number = 1.0,
+  minPercentage = 0.1,
+  maxPercentage = 1.0,
 ): string {
   // Clamp percentage to [min, max] range
   const clampedPercentage = Math.max(
@@ -374,9 +374,9 @@ function mixColorsInOklab(
 export function getMonochromeScale(
   baseColor: string,
   steps: number,
-  mixColor: string = "white",
-  minPercentage: number = 0.1,
-  maxPercentage: number = 1.0,
+  mixColor = "white",
+  minPercentage = 0.1,
+  maxPercentage = 1.0,
 ): string[] {
   const baseHex = extractHslToHex(baseColor);
   const colors: string[] = [];

--- a/web/src/hooks/useDashboardQueryScheduler.tsx
+++ b/web/src/hooks/useDashboardQueryScheduler.tsx
@@ -109,12 +109,7 @@ export const useDashboardQueryScheduler = ({
   }, [maxConcurrent]);
 
   const register = useCallback(
-    (
-      id: string,
-      priority: number,
-      isEligible: boolean = true,
-      runKey: string = id,
-    ) => {
+    (id: string, priority: number, isEligible = true, runKey: string = id) => {
       const existingItem = itemsRef.current.get(id);
 
       if (!existingItem) {

--- a/web/src/hooks/useDebounce.tsx
+++ b/web/src/hooks/useDebounce.tsx
@@ -3,7 +3,7 @@ import { useLayoutEffect, useMemo, useRef } from "react";
 function debounce<T extends (...args: any[]) => any>(
   func: T,
   timeout: number,
-  executeFirstCall: boolean = false,
+  executeFirstCall = false,
 ): (...args: Parameters<T>) => ReturnType<T> | undefined {
   let timer: ReturnType<typeof setTimeout> | null = null;
   let result: ReturnType<T> | undefined;
@@ -30,8 +30,8 @@ function debounce<T extends (...args: any[]) => any>(
 
 export function useDebounce<T extends (...args: any[]) => any>(
   callback: T,
-  delay: number = 600,
-  executeFirstCall: boolean = true,
+  delay = 600,
+  executeFirstCall = true,
 ): (...args: Parameters<T>) => ReturnType<T> | undefined {
   const callbackRef = useRef(callback);
   useLayoutEffect(() => {

--- a/web/src/hooks/usePaginationState.ts
+++ b/web/src/hooks/usePaginationState.ts
@@ -20,8 +20,8 @@ export function usePaginationState(
 
 // Implementation
 export function usePaginationState(
-  defaultPageOrIndex: number = 1,
-  defaultLimitOrSize: number = 50,
+  defaultPageOrIndex = 1,
+  defaultLimitOrSize = 50,
   paramNames?: { page: "page" | "pageIndex"; limit: "limit" | "pageSize" },
 ): readonly [
   { page: number; limit: number } | PaginationState,

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -217,10 +217,7 @@ const shouldShowToast = (error: unknown): boolean => {
   return true;
 };
 
-const handleTrpcError = (
-  error: unknown,
-  shouldSilenceError: boolean = false,
-) => {
+const handleTrpcError = (error: unknown, shouldSilenceError = false) => {
   if (error instanceof TRPCClientError) {
     const httpStatus: number =
       typeof error.data?.httpStatus === "number" ? error.data.httpStatus : 500;

--- a/web/src/utils/date-range-utils.ts
+++ b/web/src/utils/date-range-utils.ts
@@ -480,9 +480,9 @@ function getIntervalDuration(interval: IntervalConfig): number {
 export function getOptimalInterval(
   fromDate: Date,
   toDate: Date,
-  targetPoints: number = 13,
-  minPoints: number = 10,
-  maxPoints: number = 16,
+  targetPoints = 13,
+  minPoints = 10,
+  maxPoints = 16,
 ): IntervalConfig {
   const durationMs = toDate.getTime() - fromDate.getTime();
 

--- a/web/src/utils/dates.ts
+++ b/web/src/utils/dates.ts
@@ -35,7 +35,7 @@ export const setEndOfDay = (date: Date) => {
 export const intervalInSeconds = (start: Date, end: Date | null) =>
   end ? (end.getTime() - start.getTime()) / 1000 : 0;
 
-export const formatIntervalSeconds = (seconds: number, scale: number = 2) => {
+export const formatIntervalSeconds = (seconds: number, scale = 2) => {
   const hrs = Math.floor(seconds / 3600);
   const mins = Math.floor((seconds % 3600) / 60);
   const secs = Math.floor(seconds % 60);

--- a/web/src/utils/numbers.ts
+++ b/web/src/utils/numbers.ts
@@ -61,8 +61,8 @@ export const latencyFormatter = (milliseconds?: number): string => {
 
 export const usdFormatter = (
   number?: number | bigint | Decimal,
-  minimumFractionDigits: number = 2,
-  maximumFractionDigits: number = 6,
+  minimumFractionDigits = 2,
+  maximumFractionDigits = 6,
 ) => {
   const numberToFormat = number instanceof Decimal ? number.toNumber() : number;
   return new Intl.NumberFormat("en-US", {

--- a/web/src/utils/string.ts
+++ b/web/src/utils/string.ts
@@ -2,7 +2,7 @@ export function lastCharacters(str: string, n: number) {
   return str.substring(str.length - n);
 }
 
-export function truncate(str: string, n: number = 16) {
+export function truncate(str: string, n = 16) {
   // '...' suffix if the string is longer than n
   if (str.length > n) {
     return str.substring(0, n) + "...";

--- a/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
+++ b/worker/src/features/blobstorage/handleBlobStorageIntegrationProjectJob.ts
@@ -101,7 +101,7 @@ export async function* enrichObservationStream(
   modelIdField: string,
   convertLatencyToSeconds: boolean,
   fieldGroups?: ObservationFieldGroupFull[],
-  skipEnrichment: boolean = false,
+  skipEnrichment = false,
 ): AsyncGenerator<Record<string, unknown>> {
   const { getModel } = createModelCache(projectId);
 

--- a/worker/src/features/evaluation/evalService.ts
+++ b/worker/src/features/evaluation/evalService.ts
@@ -439,7 +439,7 @@ export const createEvalJobs = async ({
       });
     } else {
       // If the event is not a DatasetRunItemUpsertEventType and the trace has no special filters, we can already assume it's present
-      let exists: boolean = false;
+      let exists = false;
       let timestamp: Date | undefined = undefined;
       if (!("datasetItemId" in event) && traceFilter.length === 0) {
         exists = true;

--- a/worker/src/features/health/index.ts
+++ b/worker/src/features/health/index.ts
@@ -41,7 +41,7 @@ export const checkContainerHealth = async (
   });
 };
 
-let sigtermReceived: boolean = false;
+let sigtermReceived = false;
 
 export const setSigtermReceived = () => {
   logger.info("Set sigterm received to true");


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enables the `@typescript-eslint/no-inferrable-types` ESLint rule (as a warning) in both the base and Next.js ESLint configs, then mechanically removes all type annotations that TypeScript can already infer from their literal default values across the codebase.

- **ESLint config**: `no-inferrable-types: warn` added to `packages/config-eslint/base.js` and `packages/config-eslint/next.js`.
- **~41 source files updated**: Explicit primitive type annotations (`string`, `number`, `boolean`) stripped from function parameters and local/class variable declarations wherever TypeScript can trivially infer them from a literal default (e.g., `param: string = \"foo\"` → `param = \"foo\"`).
- **Non-literal defaults preserved**: Cases where the default is a variable reference (e.g., `runKey: string = id`) correctly retain the explicit annotation, as the rule does not flag non-literal initializers.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are mechanical type-annotation removals with no functional impact.

Every change in this PR is a trivially inferred-type removal: TypeScript produces the same type (e.g. string, number, boolean) whether the annotation is present or not, since the default values are primitive literals. Non-literal defaults such as runKey: string = id are left untouched, which is the correct behaviour of the rule. No logic paths, runtime values, or public API shapes are altered.

No files require special attention. The change to packages/shared/src/encryption/encryption.ts narrows IV_LENGTH from type number to the literal type 12 (standard TypeScript const narrowing), but this constant is only used as a crypto parameter and is never widened or compared, so the narrower type is harmless.
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: Fix \`no-inferrrable-types\` iss..."](https://github.com/langfuse/langfuse/commit/281052adc6d565b7abe1a879049bea105c8cf2b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39517406)</sub>

<!-- /greptile_comment -->